### PR TITLE
Add pwacompat to auto insert meta/link tags

### DIFF
--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -80,6 +80,7 @@ unregisterServiceWorkers();
 export const links: LinksFunction = () => [
   { rel: "manifest", href: "/resources/manifest.webmanifest" },
   { rel: "stylesheet", href: stylesheetUrl },
+  { rel: "stylesheet", href: stylesheetUrl },
   { rel: "icon", type: "image/png", href: glyphUrl },
   {
     rel: "mask-icon",
@@ -261,6 +262,11 @@ function Document({
             defer
           ></script>
         )}
+        <script
+          async
+          src="https://unpkg.com/pwacompat"
+          crossOrigin="anonymous"
+        ></script>
       </head>
       <body className="h-full">
         <LoadingIndicator />

--- a/apps/web/app/routes/resources.manifest[.]webmanifest.ts
+++ b/apps/web/app/routes/resources.manifest[.]webmanifest.ts
@@ -38,11 +38,11 @@ export async function loader() {
           type: "image/png",
           density: "4.0",
         },
-        // {
-        //   src: "logo512.png",
-        //   type: "image/png",
-        //   sizes: "512x512",
-        // },
+        {
+          src: "/logo512.png",
+          sizes: "512x512",
+          type: "image/png",
+        },
       ],
     },
     {


### PR DESCRIPTION
A browser will show your custom splash screen so long as you [meet the following requirements](https://developers.google.com/web/tools/lighthouse/audits/custom-splash-screen) in your web app manifest:

- The name property is set to the name of your PWA.
- The background_color property is set to a valid CSS color value.
- The icons array specifies an icon that is at least 512px by 512px.
- The icon exists and is a PNG.

So I uncommented the 512 png in the manifest file.

Then I added a script link to the PWACompat - "the Web App Manifest for all browsers". Much like google fonts it determines your device/browser and makes the relevant changes. https://developer.chrome.com/blog/pwacompat
