### PR TITLE
Optimize loaders to share Query cache

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -7,6 +7,7 @@ import FastifyMultipart from "@fastify/multipart";
 import { shutdownClient } from "@peated/server/jobs/client";
 import { fastifyTRPCPlugin } from "@trpc/server/adapters/fastify";
 import { fastify } from "fastify";
+import { setTimeout } from "node:timers/promises";
 import config from "./config";
 import { MAX_FILESIZE } from "./constants";
 import { injectAuth } from "./middleware/auth";
@@ -48,6 +49,13 @@ export default async function buildFastify(options = {}) {
     },
     ...options,
   });
+
+  if (config.ENV === "development") {
+    console.log("Adding 300ms delay to all requests");
+    app.addHook("onRequest", async (request, reply) => {
+      await setTimeout(300);
+    });
+  }
 
   app.addHook("preHandler", (request, reply, done) => {
     // default

--- a/apps/web/app/hooks/useSingletonQueryClient.ts
+++ b/apps/web/app/hooks/useSingletonQueryClient.ts
@@ -1,0 +1,23 @@
+import { QueryClient } from "@tanstack/react-query";
+
+let queryClient: QueryClient | null = null;
+
+export function getQueryClient(): QueryClient {
+  if (queryClient === null) {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          networkMode: "offlineFirst",
+          // suspense: true,
+          retry: false,
+          // cacheTime: 0,
+        },
+      },
+    });
+  }
+  return queryClient;
+}
+
+export default function useSingletonQueryClient() {
+  return getQueryClient();
+}

--- a/apps/web/app/lib/isomorphicLoader.ts
+++ b/apps/web/app/lib/isomorphicLoader.ts
@@ -1,4 +1,5 @@
 import { makeTRPCClient } from "@peated/server/lib/trpc";
+import { type AppRouter } from "@peated/server/src/trpc/router";
 import { type User } from "@peated/server/types";
 import config from "@peated/web/config";
 import {
@@ -10,12 +11,16 @@ import {
   type LoaderFunctionArgs,
 } from "@remix-run/server-runtime";
 import { captureException } from "@sentry/remix";
+import { QueryClient } from "@tanstack/react-query";
+import { createTRPCQueryUtils } from "@trpc/react-query";
 
 export type IsomorphicContext = {
   request: LoaderFunctionArgs["request"] | ClientLoaderFunctionArgs["request"];
   params: LoaderFunctionArgs["params"] | ClientLoaderFunctionArgs["params"];
   context: {
     trpc: ReturnType<typeof makeTRPCClient>;
+    queryClient: QueryClient;
+    queryUtils: ReturnType<typeof createTRPCQueryUtils<AppRouter>>;
     user: User | null;
   };
   isServer: boolean;
@@ -48,10 +53,16 @@ export function makeIsomorphicLoader<T extends DataFunctionValue>(
       params,
       context: { trpc, user },
     }) {
+      const queryClient = new QueryClient();
+      const queryUtils = createTRPCQueryUtils({
+        queryClient,
+        client: trpc,
+      });
+
       const context: IsomorphicContext = {
         request,
         params,
-        context: { trpc, user },
+        context: { trpc, user, queryUtils, queryClient },
         isServer: true,
       };
       return await callback(context);
@@ -63,10 +74,30 @@ export function makeIsomorphicLoader<T extends DataFunctionValue>(
         captureException,
       );
 
+      const queryClient = new QueryClient({
+        defaultOptions: {
+          queries: {
+            networkMode: "offlineFirst",
+            // suspense: true,
+            retry: false,
+            // cacheTime: 0,
+          },
+        },
+      });
+      const queryUtils = createTRPCQueryUtils({
+        queryClient,
+        client: trpcClient,
+      });
+
       const context: IsomorphicContext = {
         request,
         params,
-        context: { trpc: trpcClient, user: window.REMIX_CONTEXT.user },
+        context: {
+          trpc: trpcClient,
+          user: window.REMIX_CONTEXT.user,
+          queryClient,
+          queryUtils,
+        },
         isServer: false,
       };
       return await callback(context);

--- a/apps/web/app/lib/isomorphicLoader.ts
+++ b/apps/web/app/lib/isomorphicLoader.ts
@@ -20,7 +20,6 @@ export type IsomorphicContext = {
   request: LoaderFunctionArgs["request"] | ClientLoaderFunctionArgs["request"];
   params: LoaderFunctionArgs["params"] | ClientLoaderFunctionArgs["params"];
   context: {
-    trpc: ReturnType<typeof makeTRPCClient>;
     queryClient: QueryClient;
     queryUtils: ReturnType<typeof createTRPCQueryUtils<AppRouter>>;
     user: User | null;
@@ -64,7 +63,7 @@ export function makeIsomorphicLoader<T extends DataFunctionValue>(
       const context: IsomorphicContext = {
         request,
         params,
-        context: { trpc, user, queryUtils, queryClient },
+        context: { user, queryUtils, queryClient },
         isServer: true,
       };
       const rv = await callback(context);
@@ -91,7 +90,6 @@ export function makeIsomorphicLoader<T extends DataFunctionValue>(
         request,
         params,
         context: {
-          trpc: trpcClient,
           user: window.REMIX_CONTEXT.user,
           queryClient,
           queryUtils,

--- a/apps/web/app/lib/isomorphicLoader.ts
+++ b/apps/web/app/lib/isomorphicLoader.ts
@@ -11,8 +11,9 @@ import {
   type LoaderFunctionArgs,
 } from "@remix-run/server-runtime";
 import { captureException } from "@sentry/remix";
-import { QueryClient } from "@tanstack/react-query";
+import type { QueryClient } from "@tanstack/react-query";
 import { createTRPCQueryUtils } from "@trpc/react-query";
+import { getQueryClient } from "../hooks/useSingletonQueryClient";
 
 export type IsomorphicContext = {
   request: LoaderFunctionArgs["request"] | ClientLoaderFunctionArgs["request"];
@@ -53,7 +54,7 @@ export function makeIsomorphicLoader<T extends DataFunctionValue>(
       params,
       context: { trpc, user },
     }) {
-      const queryClient = new QueryClient();
+      const queryClient = getQueryClient();
       const queryUtils = createTRPCQueryUtils({
         queryClient,
         client: trpc,
@@ -74,16 +75,7 @@ export function makeIsomorphicLoader<T extends DataFunctionValue>(
         captureException,
       );
 
-      const queryClient = new QueryClient({
-        defaultOptions: {
-          queries: {
-            networkMode: "offlineFirst",
-            // suspense: true,
-            retry: false,
-            // cacheTime: 0,
-          },
-        },
-      });
+      const queryClient = getQueryClient();
       const queryUtils = createTRPCQueryUtils({
         queryClient,
         client: trpcClient,

--- a/apps/web/app/lib/isomorphicLoader.ts
+++ b/apps/web/app/lib/isomorphicLoader.ts
@@ -12,7 +12,7 @@ import {
   type LoaderFunctionArgs,
 } from "@remix-run/server-runtime";
 import { captureException } from "@sentry/remix";
-import { dehydrate, type QueryClient } from "@tanstack/react-query";
+import { dehydrate } from "@tanstack/react-query";
 import { createTRPCQueryUtils } from "@trpc/react-query";
 import { getQueryClient } from "../hooks/useSingletonQueryClient";
 
@@ -20,7 +20,6 @@ export type IsomorphicContext = {
   request: LoaderFunctionArgs["request"] | ClientLoaderFunctionArgs["request"];
   params: LoaderFunctionArgs["params"] | ClientLoaderFunctionArgs["params"];
   context: {
-    queryClient: QueryClient;
     queryUtils: ReturnType<typeof createTRPCQueryUtils<AppRouter>>;
     user: User | null;
   };
@@ -63,7 +62,7 @@ export function makeIsomorphicLoader<T extends DataFunctionValue>(
       const context: IsomorphicContext = {
         request,
         params,
-        context: { user, queryUtils, queryClient },
+        context: { user, queryUtils },
         isServer: true,
       };
       const rv = await callback(context);
@@ -91,7 +90,6 @@ export function makeIsomorphicLoader<T extends DataFunctionValue>(
         params,
         context: {
           user: window.REMIX_CONTEXT.user,
-          queryClient,
           queryUtils,
         },
         isServer: false,

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -104,6 +104,10 @@ export async function loader({ context }: LoaderFunctionArgs) {
   });
 }
 
+export function shouldRevalidate() {
+  return false;
+}
+
 type LoaderData = {
   sentryTrace?: string;
   sentryBaggage?: string;

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -23,11 +23,7 @@ import {
 } from "@remix-run/react";
 import * as Sentry from "@sentry/remix";
 import { withSentry } from "@sentry/remix";
-import {
-  QueryClient,
-  QueryClientProvider,
-  hydrate,
-} from "@tanstack/react-query";
+import { QueryClientProvider, hydrate } from "@tanstack/react-query";
 import { httpBatchLink } from "@trpc/client";
 import type { ComponentProps, PropsWithChildren } from "react";
 import { useEffect, useState } from "react";
@@ -35,6 +31,7 @@ import { useDehydratedState } from "use-dehydrated-state";
 import LoadingIndicator from "./components/loadingIndicator";
 import { default as config } from "./config";
 import { ApiProvider } from "./hooks/useApi";
+import useSingletonQueryClient from "./hooks/useSingletonQueryClient";
 import { ApiUnauthorized } from "./lib/api";
 import { logError } from "./lib/log";
 import { trpc } from "./lib/trpc";
@@ -128,19 +125,7 @@ export default withSentry(function App() {
     Sentry.setUser(null);
   }
 
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            networkMode: "offlineFirst",
-            // suspense: true,
-            retry: false,
-            // cacheTime: 0,
-          },
-        },
-      }),
-  );
+  const queryClient = useSingletonQueryClient();
 
   const dehydratedState = useDehydratedState();
 

--- a/apps/web/app/root.tsx
+++ b/apps/web/app/root.tsx
@@ -23,7 +23,7 @@ import {
 } from "@remix-run/react";
 import * as Sentry from "@sentry/remix";
 import { withSentry } from "@sentry/remix";
-import { QueryClientProvider, hydrate } from "@tanstack/react-query";
+import { HydrationBoundary, QueryClientProvider } from "@tanstack/react-query";
 import { httpBatchLink } from "@trpc/client";
 import type { ComponentProps, PropsWithChildren } from "react";
 import { useEffect, useState } from "react";
@@ -136,8 +136,6 @@ export default withSentry(function App() {
     };
   });
 
-  hydrate(queryClient, dehydratedState);
-
   return (
     <Document config={config} data={data} accessToken={accessToken} user={user}>
       <GoogleOAuthProvider clientId={config.GOOGLE_CLIENT_ID}>
@@ -147,16 +145,18 @@ export default withSentry(function App() {
           key={accessToken}
         >
           <QueryClientProvider client={queryClient}>
-            <OnlineStatusProvider>
-              <AuthProvider user={user}>
-                <ApiProvider
-                  accessToken={accessToken}
-                  server={config.API_SERVER}
-                >
-                  <Outlet />
-                </ApiProvider>
-              </AuthProvider>
-            </OnlineStatusProvider>
+            <HydrationBoundary state={dehydratedState}>
+              <OnlineStatusProvider>
+                <AuthProvider user={user}>
+                  <ApiProvider
+                    accessToken={accessToken}
+                    server={config.API_SERVER}
+                  >
+                    <Outlet />
+                  </ApiProvider>
+                </AuthProvider>
+              </OnlineStatusProvider>
+            </HydrationBoundary>
           </QueryClientProvider>
         </TRPCProvider>
       </GoogleOAuthProvider>

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -16,7 +16,6 @@ import classNames from "@peated/web/lib/classNames";
 import { trpc } from "@peated/web/lib/trpc";
 import { type SerializeFrom } from "@remix-run/node";
 import { Link, useLoaderData, useLocation } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { Fragment } from "react";
 import { useEventListener } from "usehooks-ts";
 import BottleLink from "../components/bottleLink";
@@ -40,10 +39,10 @@ export const { loader, clientLoader } = makeIsomorphicLoader(
       }),
     ]);
 
-    return json({
+    return {
       tastingList,
       newBottleList,
-    });
+    };
   },
 );
 

--- a/apps/web/app/routes/_index.tsx
+++ b/apps/web/app/routes/_index.tsx
@@ -24,16 +24,16 @@ import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 const defaultViewParam = "global";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, context: { trpc } }) => {
+  async ({ request, context: { queryUtils } }) => {
     const { searchParams } = new URL(request.url);
     const filter = mapFilterParam(searchParams.get("view"));
 
     const [tastingList, newBottleList] = await Promise.all([
-      trpc.tastingList.query({
+      queryUtils.tastingList.ensureData({
         filter,
         limit: 10,
       }),
-      trpc.bottleList.query({
+      queryUtils.bottleList.ensureData({
         limit: 10,
         sort: "-date",
       }),

--- a/apps/web/app/routes/admin.badges._index.tsx
+++ b/apps/web/app/routes/admin.badges._index.tsx
@@ -2,26 +2,25 @@ import BadgeTable from "@peated/web/components/admin/badgeTable";
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
 import EmptyActivity from "@peated/web/components/emptyActivity";
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import type { SitemapFunction } from "remix-sitemap";
+import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const sitemap: SitemapFunction = () => ({
   exclude: true,
 });
 
-export async function loader({
-  request,
-  context: { trpc },
-}: LoaderFunctionArgs) {
-  const { searchParams } = new URL(request.url);
-  const badgeList = await trpc.badgeList.query({
-    sort: "name",
-    ...Object.fromEntries(searchParams.entries()),
-  });
+export const { loader, clientLoader } = makeIsomorphicLoader(
+  async ({ request, context: { queryUtils } }) => {
+    const { searchParams } = new URL(request.url);
+    const badgeList = await queryUtils.badgeList.ensureData({
+      sort: "name",
+      ...Object.fromEntries(searchParams.entries()),
+    });
 
-  return json({ badgeList });
-}
+    return { badgeList };
+  },
+);
 
 export default function AdminBadges() {
   const { badgeList } = useLoaderData<typeof loader>();

--- a/apps/web/app/routes/admin.sites._index.tsx
+++ b/apps/web/app/routes/admin.sites._index.tsx
@@ -1,28 +1,27 @@
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
 import EmptyActivity from "@peated/web/components/emptyActivity";
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import type { SitemapFunction } from "remix-sitemap";
 import Table from "../components/table";
 import TimeSince from "../components/timeSince";
+import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const sitemap: SitemapFunction = () => ({
   exclude: true,
 });
 
-export async function loader({
-  request,
-  context: { trpc },
-}: LoaderFunctionArgs) {
-  const { searchParams } = new URL(request.url);
-  const siteList = await trpc.externalSiteList.query({
-    sort: "name",
-    ...Object.fromEntries(searchParams.entries()),
-  });
+export const { loader, clientLoader } = makeIsomorphicLoader(
+  async ({ request, context: { queryUtils } }) => {
+    const { searchParams } = new URL(request.url);
+    const siteList = await queryUtils.externalSiteList.ensureData({
+      sort: "name",
+      ...Object.fromEntries(searchParams.entries()),
+    });
 
-  return json({ siteList });
-}
+    return { siteList };
+  },
+);
 
 export default function AdminSites() {
   const { siteList } = useLoaderData<typeof loader>();

--- a/apps/web/app/routes/admin.tags.$tagId.tsx
+++ b/apps/web/app/routes/admin.tags.$tagId.tsx
@@ -1,11 +1,7 @@
 import { type ExternalSiteSchema } from "@peated/server/schemas";
 import { toTitleCase } from "@peated/server/src/lib/strings";
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
-import {
-  json,
-  type LoaderFunctionArgs,
-  type MetaFunction,
-} from "@remix-run/node";
+import { type MetaFunction } from "@remix-run/node";
 import { Outlet, useLoaderData } from "@remix-run/react";
 import { useState } from "react";
 import type { SitemapFunction } from "remix-sitemap";
@@ -13,21 +9,21 @@ import invariant from "tiny-invariant";
 import { type z } from "zod";
 import Button from "../components/button";
 import QueryBoundary from "../components/queryBoundary";
+import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const sitemap: SitemapFunction = () => ({
   exclude: true,
 });
 
-export async function loader({
-  params: { tagId },
-  context: { trpc },
-}: LoaderFunctionArgs) {
-  invariant(tagId);
+export const { loader, clientLoader } = makeIsomorphicLoader(
+  async ({ params: { tagId }, context: { queryUtils } }) => {
+    invariant(tagId);
 
-  const tag = await trpc.tagByName.query(tagId);
+    const tag = await queryUtils.tagByName.ensureData(tagId);
 
-  return json({ tag });
-}
+    return { tag };
+  },
+);
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
   if (!data) return [];

--- a/apps/web/app/routes/admin.tags._index.tsx
+++ b/apps/web/app/routes/admin.tags._index.tsx
@@ -1,26 +1,25 @@
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
 import EmptyActivity from "@peated/web/components/emptyActivity";
-import { json, type LoaderFunctionArgs } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
 import type { SitemapFunction } from "remix-sitemap";
 import TagTable from "../components/admin/tagTable";
+import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const sitemap: SitemapFunction = () => ({
   exclude: true,
 });
 
-export async function loader({
-  request,
-  context: { trpc },
-}: LoaderFunctionArgs) {
-  const { searchParams } = new URL(request.url);
-  const tagList = await trpc.tagList.query({
-    ...Object.fromEntries(searchParams.entries()),
-  });
+export const { loader, clientLoader } = makeIsomorphicLoader(
+  async ({ request, context: { queryUtils } }) => {
+    const { searchParams } = new URL(request.url);
+    const tagList = await queryUtils.tagList.ensureData({
+      ...Object.fromEntries(searchParams.entries()),
+    });
 
-  return json({ tagList });
-}
+    return { tagList };
+  },
+);
 
 export default function AdminTags() {
   const { tagList } = useLoaderData<typeof loader>();

--- a/apps/web/app/routes/admin_.sites_.$siteId_.edit.tsx
+++ b/apps/web/app/routes/admin_.sites_.$siteId_.edit.tsx
@@ -1,7 +1,6 @@
 import { type ExternalSiteType } from "@peated/server/types";
 import { type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { useNavigate } from "react-router-dom";
 import type { SitemapFunction } from "remix-sitemap";
 import invariant from "tiny-invariant";
@@ -11,16 +10,16 @@ import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 import { trpc } from "../lib/trpc";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, params: { siteId }, context: { user, trpc } }) => {
+  async ({ request, params: { siteId }, context: { user, queryUtils } }) => {
     invariant(siteId);
 
     if (!user?.admin) return redirectToAuth({ request });
 
-    const site = await trpc.externalSiteByType.query(
+    const site = await queryUtils.externalSiteByType.ensureData(
       siteId as ExternalSiteType,
     );
 
-    return json({ site });
+    return { site };
   },
 );
 

--- a/apps/web/app/routes/admin_.tags_.$tagId_.edit.tsx
+++ b/apps/web/app/routes/admin_.tags_.$tagId_.edit.tsx
@@ -1,6 +1,5 @@
 import { type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { useNavigate } from "react-router-dom";
 import type { SitemapFunction } from "remix-sitemap";
 import invariant from "tiny-invariant";
@@ -10,14 +9,14 @@ import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 import { trpc } from "../lib/trpc";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, params: { tagId }, context: { user, trpc } }) => {
+  async ({ request, params: { tagId }, context: { user, queryUtils } }) => {
     invariant(tagId);
 
     if (!user?.admin) return redirectToAuth({ request });
 
-    const tag = await trpc.tagByName.query(tagId);
+    const tag = await queryUtils.tagByName.ensureData(tagId);
 
-    return json({ tag });
+    return { tag };
   },
 );
 

--- a/apps/web/app/routes/bottles.$bottleId.prices.tsx
+++ b/apps/web/app/routes/bottles.$bottleId.prices.tsx
@@ -1,19 +1,18 @@
 import BetaNotice from "@peated/web/components/betaNotice";
 import TimeSince from "@peated/web/components/timeSince";
 import { useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { bottleId }, context: { trpc } }) => {
+  async ({ params: { bottleId }, context: { queryUtils } }) => {
     invariant(bottleId);
 
-    const priceList = await trpc.bottlePriceList.query({
+    const priceList = await queryUtils.bottlePriceList.ensureData({
       bottle: Number(bottleId),
     });
 
-    return json({ priceList });
+    return { priceList };
   },
 );
 

--- a/apps/web/app/routes/bottles.$bottleId.tastings.tsx
+++ b/apps/web/app/routes/bottles.$bottleId.tastings.tsx
@@ -1,19 +1,18 @@
 import EmptyActivity from "@peated/web/components/emptyActivity";
 import TastingList from "@peated/web/components/tastingList";
 import { useLoaderData, useParams } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { bottleId }, context: { trpc } }) => {
+  async ({ params: { bottleId }, context: { queryUtils } }) => {
     invariant(bottleId);
 
-    const tastingList = await trpc.tastingList.query({
+    const tastingList = await queryUtils.tastingList.ensureData({
       bottle: Number(bottleId),
     });
 
-    return json({ tastingList });
+    return { tastingList };
   },
 );
 

--- a/apps/web/app/routes/bottles.$bottleId.tsx
+++ b/apps/web/app/routes/bottles.$bottleId.tsx
@@ -14,19 +14,19 @@ import { summarize } from "@peated/web/lib/markdown";
 import { trpc } from "@peated/web/lib/trpc";
 import { type MetaFunction } from "@remix-run/node";
 import { Link, Outlet, useLoaderData, useNavigate } from "@remix-run/react";
-import { json, redirect } from "@remix-run/server-runtime";
+import { redirect } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import BottleHeader from "../components/bottleHeader";
 import CollectionAction from "../components/collectionAction";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, params, context: { trpc } }) => {
+  async ({ request, params, context: { queryUtils } }) => {
     invariant(params.bottleId);
 
     const bottleId = Number(params.bottleId);
 
-    const bottle = await trpc.bottleById.query(bottleId);
+    const bottle = await queryUtils.bottleById.ensureData(bottleId);
     // tombstone path - redirect to the absolute url to ensure search engines dont get mad
     if (bottle.id !== bottleId) {
       const location = new URL(request.url);
@@ -37,7 +37,7 @@ export const { loader, clientLoader } = makeIsomorphicLoader(
       return redirect(newPath);
     }
 
-    return json({ bottle });
+    return { bottle };
   },
 );
 

--- a/apps/web/app/routes/bottles.$bottleId_.addTasting.tsx
+++ b/apps/web/app/routes/bottles.$bottleId_.addTasting.tsx
@@ -5,25 +5,24 @@ import { logError } from "@peated/web/lib/log";
 import { trpc } from "@peated/web/lib/trpc";
 import { type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useLocation, useNavigate } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import TastingForm from "../components/tastingForm";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, params: { bottleId }, context: { trpc, user } }) => {
+  async ({ request, params: { bottleId }, context: { queryUtils, user } }) => {
     invariant(bottleId);
 
     if (!user) return redirectToAuth({ request });
 
     const [bottle, suggestedTags] = await Promise.all([
-      trpc.bottleById.query(Number(bottleId)),
-      trpc.bottleSuggestedTagList.query({
+      queryUtils.bottleById.ensureData(Number(bottleId)),
+      queryUtils.bottleSuggestedTagList.ensureData({
         bottle: Number(bottleId),
       }),
     ]);
 
-    return json({ bottle, suggestedTags });
+    return { bottle, suggestedTags };
   },
 );
 

--- a/apps/web/app/routes/bottles.$bottleId_.aliases.tsx
+++ b/apps/web/app/routes/bottles.$bottleId_.aliases.tsx
@@ -1,5 +1,4 @@
 import { useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import BottleHeader from "../components/bottleHeader";
 import Chip from "../components/chip";
@@ -8,18 +7,18 @@ import Tabs from "../components/tabs";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params, context: { trpc } }) => {
+  async ({ params, context: { queryUtils } }) => {
     invariant(params.bottleId);
 
     const bottleId = Number(params.bottleId);
 
     const [aliasList, bottle] = await Promise.all([
-      trpc.bottleAliasList.query({
+      queryUtils.bottleAliasList.ensureData({
         bottle: bottleId,
       }),
-      trpc.bottleById.query(bottleId),
+      queryUtils.bottleById.ensureData(bottleId),
     ]);
-    return json({ aliasList, bottle });
+    return { aliasList, bottle };
   },
 );
 

--- a/apps/web/app/routes/bottles.$bottleId_.edit.tsx
+++ b/apps/web/app/routes/bottles.$bottleId_.edit.tsx
@@ -3,7 +3,6 @@ import Spinner from "@peated/web/components/spinner";
 import { trpc } from "@peated/web/lib/trpc";
 import { type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useNavigate, useParams } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
@@ -16,12 +15,14 @@ export const meta: MetaFunction = () => {
 };
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params, context: { trpc } }) => {
+  async ({ params, context: { queryUtils } }) => {
     invariant(params.bottleId);
 
-    const bottle = await trpc.bottleById.query(Number(params.bottleId));
+    const bottle = await queryUtils.bottleById.ensureData(
+      Number(params.bottleId),
+    );
 
-    return json({ bottle });
+    return { bottle };
   },
 );
 

--- a/apps/web/app/routes/bottles.$bottleId_.merge.tsx
+++ b/apps/web/app/routes/bottles.$bottleId_.merge.tsx
@@ -11,7 +11,6 @@ import Layout from "@peated/web/components/layout";
 import { trpc } from "@peated/web/lib/trpc";
 import { type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useNavigate } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { useState } from "react";
 import type { SubmitHandler } from "react-hook-form";
 import { Controller, useForm } from "react-hook-form";
@@ -30,12 +29,12 @@ export const meta: MetaFunction = () => {
 };
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { bottleId }, context: { trpc } }) => {
+  async ({ params: { bottleId }, context: { queryUtils } }) => {
     invariant(bottleId);
 
-    const bottle = await trpc.bottleById.query(Number(bottleId));
+    const bottle = await queryUtils.bottleById.ensureData(Number(bottleId));
 
-    return json({ bottle });
+    return { bottle };
   },
 );
 

--- a/apps/web/app/routes/bottles._index.tsx
+++ b/apps/web/app/routes/bottles._index.tsx
@@ -12,7 +12,6 @@ import SidebarLink from "@peated/web/components/sidebarLink";
 import { buildQueryString } from "@peated/web/lib/urls";
 import { type MetaFunction, type SerializeFrom } from "@remix-run/node";
 import { useLoaderData, useLocation } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { type SitemapFunction } from "remix-sitemap";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
@@ -42,7 +41,7 @@ export const { loader, clientLoader } = makeIsomorphicLoader(
       "bottler",
       "entity",
     ]);
-    return json({
+    return {
       bottleList: await queryUtils.bottleList.ensureData(
         Object.fromEntries(
           [...searchParams.entries()].map(([k, v]) =>
@@ -50,7 +49,7 @@ export const { loader, clientLoader } = makeIsomorphicLoader(
           ),
         ),
       ),
-    });
+    };
   },
 );
 

--- a/apps/web/app/routes/bottles._index.tsx
+++ b/apps/web/app/routes/bottles._index.tsx
@@ -31,7 +31,7 @@ export const meta: MetaFunction = () => {
 };
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, context: { trpc } }) => {
+  async ({ request, context: { queryUtils } }) => {
     const { searchParams } = new URL(request.url);
     const numericFields = new Set([
       "cursor",
@@ -43,7 +43,7 @@ export const { loader, clientLoader } = makeIsomorphicLoader(
       "entity",
     ]);
     return json({
-      bottleList: await trpc.bottleList.query(
+      bottleList: await queryUtils.bottleList.ensureData(
         Object.fromEntries(
           [...searchParams.entries()].map(([k, v]) =>
             numericFields.has(k) ? [k, Number(v)] : [k, v === "" ? null : v],

--- a/apps/web/app/routes/entities.$entityId.bottles.tsx
+++ b/apps/web/app/routes/entities.$entityId.bottles.tsx
@@ -3,12 +3,11 @@ import BottleTable from "@peated/web/components/bottleTable";
 import QueryBoundary from "@peated/web/components/queryBoundary";
 import { type SerializeFrom } from "@remix-run/node";
 import { useLoaderData, useLocation, useOutletContext } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { entityId }, request, context: { trpc } }) => {
+  async ({ params: { entityId }, request, context: { queryUtils } }) => {
     invariant(entityId);
     const { searchParams } = new URL(request.url);
     const numericFields = new Set([
@@ -21,8 +20,8 @@ export const { loader, clientLoader } = makeIsomorphicLoader(
       "entity",
     ]);
 
-    return json({
-      bottleList: await trpc.bottleList.query({
+    return {
+      bottleList: await queryUtils.bottleList.ensureData({
         ...Object.fromEntries(
           [...searchParams.entries()].map(([k, v]) =>
             numericFields.has(k) ? [k, Number(v)] : [k, v === "" ? null : v],
@@ -30,7 +29,7 @@ export const { loader, clientLoader } = makeIsomorphicLoader(
         ),
         entity: Number(entityId),
       }),
-    });
+    };
   },
 );
 

--- a/apps/web/app/routes/entities.$entityId.tastings.tsx
+++ b/apps/web/app/routes/entities.$entityId.tastings.tsx
@@ -1,19 +1,18 @@
 import EmptyActivity from "@peated/web/components/emptyActivity";
 import TastingList from "@peated/web/components/tastingList";
 import { useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { entityId }, context: { trpc } }) => {
+  async ({ params: { entityId }, context: { queryUtils } }) => {
     invariant(entityId);
 
-    return json({
-      tastingList: await trpc.tastingList.query({
+    return {
+      tastingList: await queryUtils.tastingList.ensureData({
         entity: Number(entityId),
       }),
-    });
+    };
   },
 );
 

--- a/apps/web/app/routes/entities.$entityId.tsx
+++ b/apps/web/app/routes/entities.$entityId.tsx
@@ -16,19 +16,19 @@ import {
   useNavigate,
   useParams,
 } from "@remix-run/react";
-import { json, redirect } from "@remix-run/server-runtime";
+import { redirect } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import EntityHeader from "../components/entityHeader";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 import { trpc } from "../lib/trpc";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, params, context: { trpc } }) => {
+  async ({ request, params, context: { queryUtils } }) => {
     invariant(params.entityId);
 
     const entityId = Number(params.entityId);
 
-    const entity = await trpc.entityById.query(entityId);
+    const entity = await queryUtils.entityById.ensureData(entityId);
     // tombstone path - redirect to the absolute url to ensure search engines dont get mad
     if (entity.id !== entityId) {
       const location = new URL(request.url);
@@ -39,7 +39,7 @@ export const { loader, clientLoader } = makeIsomorphicLoader(
       return redirect(newPath);
     }
 
-    return json({ entity });
+    return { entity };
   },
 );
 

--- a/apps/web/app/routes/entities.$entityId_.aliases.tsx
+++ b/apps/web/app/routes/entities.$entityId_.aliases.tsx
@@ -1,5 +1,4 @@
 import { useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import Chip from "../components/chip";
 import EntityHeader from "../components/entityHeader";
@@ -8,18 +7,18 @@ import Tabs from "../components/tabs";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params, context: { trpc } }) => {
+  async ({ params, context: { queryUtils } }) => {
     invariant(params.entityId);
 
     const entityId = Number(params.entityId);
 
     const [aliasList, entity] = await Promise.all([
-      trpc.entityAliasList.query({
+      queryUtils.entityAliasList.ensureData({
         entity: entityId,
       }),
-      trpc.entityById.query(entityId),
+      queryUtils.entityById.ensureData(entityId),
     ]);
-    return json({ aliasList, entity });
+    return { aliasList, entity };
   },
 );
 

--- a/apps/web/app/routes/entities.$entityId_.edit.tsx
+++ b/apps/web/app/routes/entities.$entityId_.edit.tsx
@@ -2,7 +2,6 @@ import Spinner from "@peated/web/components/spinner";
 import { trpc } from "@peated/web/lib/trpc";
 import { type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useNavigate } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import EntityForm from "../components/entityForm";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
@@ -16,12 +15,12 @@ export const meta: MetaFunction = () => {
 };
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { entityId }, context: { trpc } }) => {
+  async ({ params: { entityId }, context: { queryUtils } }) => {
     invariant(entityId);
 
-    const entity = await trpc.entityById.query(Number(entityId));
+    const entity = await queryUtils.entityById.ensureData(Number(entityId));
 
-    return json({ entity });
+    return { entity };
   },
 );
 

--- a/apps/web/app/routes/entities.$entityId_.merge.tsx
+++ b/apps/web/app/routes/entities.$entityId_.merge.tsx
@@ -11,7 +11,6 @@ import Layout from "@peated/web/components/layout";
 import { trpc } from "@peated/web/lib/trpc";
 import { type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useNavigate } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { useState } from "react";
 import type { SubmitHandler } from "react-hook-form";
 import { Controller, useForm } from "react-hook-form";
@@ -30,12 +29,12 @@ export const meta: MetaFunction = () => {
 };
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { entityId }, context: { trpc } }) => {
+  async ({ params: { entityId }, context: { queryUtils } }) => {
     invariant(entityId);
 
-    const entity = await trpc.entityById.query(Number(entityId));
+    const entity = await queryUtils.entityById.ensureData(Number(entityId));
 
-    return json({ entity });
+    return { entity };
   },
 );
 

--- a/apps/web/app/routes/entities._index.tsx
+++ b/apps/web/app/routes/entities._index.tsx
@@ -8,7 +8,6 @@ import SidebarLink from "@peated/web/components/sidebarLink";
 import { buildQueryString } from "@peated/web/lib/urls";
 import { type MetaFunction, type SerializeFrom } from "@remix-run/node";
 import { useLoaderData, useLocation } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { type SitemapFunction } from "remix-sitemap";
 import Button from "../components/button";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
@@ -28,18 +27,18 @@ export const meta: MetaFunction = () => {
 };
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, context: { trpc } }) => {
+  async ({ request, context: { queryUtils } }) => {
     const { searchParams } = new URL(request.url);
     const numericFields = new Set(["cursor", "limit"]);
-    return json({
-      entityList: await trpc.entityList.query(
+    return {
+      entityList: await queryUtils.entityList.ensureData(
         Object.fromEntries(
           [...searchParams.entries()].map(([k, v]) =>
             numericFields.has(k) ? [k, Number(v)] : [k, v === "" ? null : v],
           ),
         ),
       ),
-    });
+    };
   },
 );
 

--- a/apps/web/app/routes/favorites.tsx
+++ b/apps/web/app/routes/favorites.tsx
@@ -5,7 +5,6 @@ import SimpleHeader from "@peated/web/components/simpleHeader";
 import useAuth from "@peated/web/hooks/useAuth";
 import { type MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { type SitemapFunction } from "remix-sitemap";
 import invariant from "tiny-invariant";
 import { redirectToAuth } from "../lib/auth";
@@ -16,15 +15,15 @@ export const sitemap: SitemapFunction = () => ({
 });
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, context: { trpc, user } }) => {
+  async ({ request, context: { queryUtils, user } }) => {
     if (!user) return redirectToAuth({ request });
 
-    return json({
-      favoriteList: await trpc.collectionBottleList.query({
+    return {
+      favoriteList: await queryUtils.collectionBottleList.ensureData({
         user: "me",
         collection: "default",
       }),
-    });
+    };
   },
 );
 

--- a/apps/web/app/routes/flights.$flightId.tsx
+++ b/apps/web/app/routes/flights.$flightId.tsx
@@ -9,7 +9,6 @@ import Layout from "@peated/web/components/layout";
 import { summarize } from "@peated/web/lib/markdown";
 import type { MetaFunction } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import BottleLink from "../components/bottleLink";
 import Button from "../components/button";
@@ -17,15 +16,15 @@ import useAuth from "../hooks/useAuth";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { flightId }, context: { trpc } }) => {
+  async ({ params: { flightId }, context: { queryUtils } }) => {
     invariant(flightId);
 
-    return json({
-      flight: await trpc.flightById.query(flightId),
-      bottles: await trpc.bottleList.query({
+    return {
+      flight: await queryUtils.flightById.ensureData(flightId),
+      bottles: await queryUtils.bottleList.ensureData({
         flight: flightId,
       }),
-    });
+    };
   },
 );
 

--- a/apps/web/app/routes/flights.$flightId_.edit.tsx
+++ b/apps/web/app/routes/flights.$flightId_.edit.tsx
@@ -2,7 +2,6 @@ import Spinner from "@peated/web/components/spinner";
 import { trpc } from "@peated/web/lib/trpc";
 import { type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useNavigate } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import FlightForm from "../components/flightForm";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
@@ -16,17 +15,17 @@ export const meta: MetaFunction = () => {
 };
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { flightId }, context: { trpc } }) => {
+  async ({ params: { flightId }, context: { queryUtils } }) => {
     invariant(flightId);
 
     const [flight, bottles] = await Promise.all([
-      trpc.flightById.query(flightId),
-      trpc.bottleList.query({
+      queryUtils.flightById.ensureData(flightId),
+      queryUtils.bottleList.ensureData({
         flight: flightId,
       }),
     ]);
 
-    return json({ flight, bottles });
+    return { flight, bottles };
   },
 );
 

--- a/apps/web/app/routes/flights.$flightId_.overlay.tsx
+++ b/apps/web/app/routes/flights.$flightId_.overlay.tsx
@@ -1,7 +1,6 @@
 import { summarize } from "@peated/web/lib/markdown";
 import type { MetaFunction } from "@remix-run/node";
 import { useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import BottleLink from "../components/bottleLink";
 import { Distillers } from "../components/bottleMetadata";
@@ -11,15 +10,20 @@ import QRCodeClient from "../components/qrcode.client";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { flightId }, context: { trpc } }) => {
+  async ({ params: { flightId }, context: { queryUtils } }) => {
     invariant(flightId);
 
-    return json({
-      flight: await trpc.flightById.query(flightId),
-      bottles: await trpc.bottleList.query({
+    const [flight, bottles] = await Promise.all([
+      queryUtils.flightById.ensureData(flightId),
+      queryUtils.bottleList.ensureData({
         flight: flightId,
       }),
-    });
+    ]);
+
+    return {
+      flight,
+      bottles,
+    };
   },
 );
 

--- a/apps/web/app/routes/flights._index.tsx
+++ b/apps/web/app/routes/flights._index.tsx
@@ -4,7 +4,6 @@ import Layout from "@peated/web/components/layout";
 import ListItem from "@peated/web/components/listItem";
 import { type MetaFunction } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { type SitemapFunction } from "remix-sitemap";
 import PageHeader from "../components/pageHeader";
 import PaginationButtons from "../components/paginationButtons";
@@ -16,12 +15,12 @@ export const sitemap: SitemapFunction = () => ({
 });
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, context: { trpc, user } }) => {
+  async ({ request, context: { queryUtils, user } }) => {
     if (!user) return redirectToAuth({ request });
 
-    return json({
-      flightList: await trpc.flightList.query(),
-    });
+    return {
+      flightList: await queryUtils.flightList.ensureData(),
+    };
   },
 );
 

--- a/apps/web/app/routes/friends.tsx
+++ b/apps/web/app/routes/friends.tsx
@@ -10,7 +10,6 @@ import { redirectToAuth } from "@peated/web/lib/auth";
 import { trpc } from "@peated/web/lib/trpc";
 import { type MetaFunction } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { useState } from "react";
 import type { SitemapFunction } from "remix-sitemap";
 import PaginationButtons from "../components/paginationButtons";
@@ -21,12 +20,12 @@ export const sitemap: SitemapFunction = () => ({
 });
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, context: { trpc, user } }) => {
+  async ({ request, context: { queryUtils, user } }) => {
     if (!user) return redirectToAuth({ request });
 
-    return json({
-      friendList: await trpc.friendList.query(),
-    });
+    return {
+      friendList: await queryUtils.friendList.ensureData(),
+    };
   },
 );
 

--- a/apps/web/app/routes/notifications.tsx
+++ b/apps/web/app/routes/notifications.tsx
@@ -5,7 +5,6 @@ import Tabs from "@peated/web/components/tabs";
 import { redirectToAuth } from "@peated/web/lib/auth";
 import type { MetaFunction } from "@remix-run/node";
 import { Link, useLoaderData, useLocation } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { type SitemapFunction } from "remix-sitemap";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
@@ -13,17 +12,17 @@ export const sitemap: SitemapFunction = () => ({
   exclude: true,
 });
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ context: { trpc, user }, request }) => {
+  async ({ context: { queryUtils, user }, request }) => {
     if (!user) return redirectToAuth({ request });
 
     const { searchParams } = new URL(request.url);
 
-    return json({
-      notificationList: await trpc.notificationList.query({
+    return {
+      notificationList: await queryUtils.notificationList.ensureData({
         filter: "unread",
         ...Object.fromEntries(searchParams.entries()),
       }),
-    });
+    };
   },
 );
 

--- a/apps/web/app/routes/settings.tsx
+++ b/apps/web/app/routes/settings.tsx
@@ -17,7 +17,7 @@ import { toBlob } from "@peated/web/lib/blobs";
 import { trpc } from "@peated/web/lib/trpc";
 import type { MetaFunction } from "@remix-run/node";
 import { useLoaderData, useNavigate } from "@remix-run/react";
-import { json, redirect } from "@remix-run/server-runtime";
+import { redirect } from "@remix-run/server-runtime";
 import { useState } from "react";
 import type { SubmitHandler } from "react-hook-form";
 import { useForm } from "react-hook-form";
@@ -32,10 +32,10 @@ export const sitemap: SitemapFunction = () => ({
 });
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ context: { user, trpc }, request }) => {
+  async ({ context: { user, queryUtils }, request }) => {
     if (!user) return redirectToAuth({ request });
 
-    const userDetails = await trpc.userById.query("me");
+    const userDetails = await queryUtils.userById.ensureData("me");
     if (!userDetails) {
       const url = new URL(request.url);
       return redirect(
@@ -43,7 +43,7 @@ export const { loader, clientLoader } = makeIsomorphicLoader(
       );
     }
 
-    return json({ user: userDetails });
+    return { user: userDetails };
   },
 );
 

--- a/apps/web/app/routes/tastings.$tastingId.tsx
+++ b/apps/web/app/routes/tastings.$tastingId.tsx
@@ -13,17 +13,18 @@ import useAuth from "@peated/web/hooks/useAuth";
 import { trpc } from "@peated/web/lib/trpc";
 import type { MetaFunction } from "@remix-run/react";
 import { useLoaderData, useNavigate } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { AnimatePresence, motion } from "framer-motion";
 import { useState } from "react";
 import invariant from "tiny-invariant";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { tastingId }, context: { trpc } }) => {
+  async ({ params: { tastingId }, context: { queryUtils } }) => {
     invariant(tastingId);
 
-    return json({ tasting: await trpc.tastingById.query(Number(tastingId)) });
+    return {
+      tasting: await queryUtils.tastingById.ensureData(Number(tastingId)),
+    };
   },
 );
 

--- a/apps/web/app/routes/tastings.$tastingId_.edit.tsx
+++ b/apps/web/app/routes/tastings.$tastingId_.edit.tsx
@@ -5,24 +5,23 @@ import { logError } from "@peated/web/lib/log";
 import { trpc } from "@peated/web/lib/trpc";
 import { type MetaFunction } from "@remix-run/node";
 import { useLoaderData, useLocation, useNavigate } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import TastingForm from "../components/tastingForm";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, params: { tastingId }, context: { trpc, user } }) => {
+  async ({ request, params: { tastingId }, context: { queryUtils, user } }) => {
     invariant(tastingId);
 
     if (!user) return redirectToAuth({ request });
 
     // TODO: this would be better if done in parallel
-    const tasting = await trpc.tastingById.query(Number(tastingId));
-    const suggestedTags = await trpc.bottleSuggestedTagList.query({
+    const tasting = await queryUtils.tastingById.ensureData(Number(tastingId));
+    const suggestedTags = await queryUtils.bottleSuggestedTagList.ensureData({
       bottle: Number(tasting.bottle.id),
     });
 
-    return json({ tasting, suggestedTags });
+    return { tasting, suggestedTags };
   },
 );
 

--- a/apps/web/app/routes/tastings.$tastingId_.editImage.tsx
+++ b/apps/web/app/routes/tastings.$tastingId_.editImage.tsx
@@ -63,11 +63,13 @@ export async function action({ context, request, params }: ActionFunctionArgs) {
 }
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ request, params: { tastingId }, context: { trpc, user } }) => {
+  async ({ request, params: { tastingId }, context: { queryUtils, user } }) => {
     invariant(tastingId);
     if (!user) return redirectToAuth({ request });
 
-    return json({ tasting: await trpc.tastingById.query(Number(tastingId)) });
+    return {
+      tasting: await queryUtils.tastingById.ensureData(Number(tastingId)),
+    };
   },
 );
 

--- a/apps/web/app/routes/updates.tsx
+++ b/apps/web/app/routes/updates.tsx
@@ -4,12 +4,11 @@ import Layout from "@peated/web/components/layout";
 import Tabs from "@peated/web/components/tabs";
 import { type MetaFunction } from "@remix-run/node";
 import { Link, useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ context: { trpc } }) => {
-    return json({ changeList: await trpc.changeList.query() });
+  async ({ context: { queryUtils } }) => {
+    return { changeList: await queryUtils.changeList.ensureData() };
   },
 );
 

--- a/apps/web/app/routes/users.$username.favorites.tsx
+++ b/apps/web/app/routes/users.$username.favorites.tsx
@@ -1,20 +1,19 @@
 import BottleTable from "@peated/web/components/bottleTable";
 import EmptyActivity from "@peated/web/components/emptyActivity";
 import { useLoaderData } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { username }, context: { trpc } }) => {
+  async ({ params: { username }, context: { queryUtils } }) => {
     invariant(username);
 
-    return json({
-      favoriteList: await trpc.collectionBottleList.query({
+    return {
+      favoriteList: await queryUtils.collectionBottleList.ensureData({
         user: username,
         collection: "default",
       }),
-    });
+    };
   },
 );
 

--- a/apps/web/app/routes/users.$username.tsx
+++ b/apps/web/app/routes/users.$username.tsx
@@ -12,7 +12,6 @@ import useAuth from "@peated/web/hooks/useAuth";
 import { trpc } from "@peated/web/lib/trpc";
 import { type MetaFunction } from "@remix-run/node";
 import { Link, Outlet, useLoaderData, useSubmit } from "@remix-run/react";
-import { json } from "@remix-run/server-runtime";
 import invariant from "tiny-invariant";
 import { makeIsomorphicLoader } from "../lib/isomorphicLoader";
 
@@ -41,10 +40,10 @@ const UserTagDistribution = ({ userId }: { userId: number }) => {
 };
 
 export const { loader, clientLoader } = makeIsomorphicLoader(
-  async ({ params: { username }, context: { trpc } }) => {
+  async ({ params: { username }, context: { queryUtils } }) => {
     invariant(username);
 
-    return json({ user: await trpc.userById.query(username as string) });
+    return { user: await queryUtils.userById.ensureData(username as string) };
   },
 );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2919,6 +2919,16 @@ packages:
       '@opentelemetry/api': 1.9.0
     dev: false
 
+  /@opentelemetry/core@1.25.0(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-n0B3s8rrqGrasTgNkXLKXzN0fXo+6IYP7M5b7AMsrZM33f/y6DS6kJ0Btd7SespASWq8bgL3taLo0oe0vB52IQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/semantic-conventions': 1.25.0
+    dev: false
+
   /@opentelemetry/core@1.25.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-n0B3s8rrqGrasTgNkXLKXzN0fXo+6IYP7M5b7AMsrZM33f/y6DS6kJ0Btd7SespASWq8bgL3taLo0oe0vB52IQ==}
     engines: {node: '>=14'}
@@ -3177,6 +3187,23 @@ packages:
       - supports-color
     dev: false
 
+  /@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-LPwSIrw+60cheWaXsfGL8stBap/AppKQJFE+qqRvzYrgttXFH2ofoIMxWadeqPTq4BYOXM/C7Bdh/T+B60xnlQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/api-logs': 0.52.0
+      '@types/shimmer': 1.0.5
+      import-in-the-middle: 1.8.0
+      require-in-the-middle: 7.3.0
+      semver: 7.6.2
+      shimmer: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@opentelemetry/instrumentation@0.52.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-LPwSIrw+60cheWaXsfGL8stBap/AppKQJFE+qqRvzYrgttXFH2ofoIMxWadeqPTq4BYOXM/C7Bdh/T+B60xnlQ==}
     engines: {node: '>=14'}
@@ -3197,6 +3224,17 @@ packages:
   /@opentelemetry/redis-common@0.36.2:
     resolution: {integrity: sha512-faYX1N0gpLhej/6nyp6bgRjzAKXn5GOEMYY7YhciSfCoITAktLUtQ36d24QEWNA1/WA1y6qQunCe0OhHRkVl9g==}
     engines: {node: '>=14'}
+    dev: false
+
+  /@opentelemetry/resources@1.25.0(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-iHjydPMYJ+Li1auveJCq2rp5U2h6Mhq8BidiyE0jfVlDTFyR1ny8AfJHfmFzJ/RAM8vT8L7T21kcmGybxZC7lQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.25.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/semantic-conventions': 1.25.0
     dev: false
 
   /@opentelemetry/resources@1.25.0(@opentelemetry/api@1.9.0):
@@ -3222,6 +3260,18 @@ packages:
       lodash.merge: 4.6.2
     dev: false
 
+  /@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.8.0):
+    resolution: {integrity: sha512-6+g2fiRQUG39guCsKVeY8ToeuUf3YUnPkN6DXRA1qDmFLprlLvZm9cS6+chgbW70cZJ406FTtSCDnJwxDC5sGQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+    dependencies:
+      '@opentelemetry/api': 1.8.0
+      '@opentelemetry/core': 1.25.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.25.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/semantic-conventions': 1.25.0
+    dev: false
+
   /@opentelemetry/sdk-trace-base@1.25.0(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-6+g2fiRQUG39guCsKVeY8ToeuUf3YUnPkN6DXRA1qDmFLprlLvZm9cS6+chgbW70cZJ406FTtSCDnJwxDC5sGQ==}
     engines: {node: '>=14'}
@@ -3229,8 +3279,8 @@ packages:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.25.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 1.25.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 1.25.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/resources': 1.25.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/semantic-conventions': 1.25.0
     dev: false
 
@@ -4032,8 +4082,8 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/context-async-hooks': 1.25.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/core': 1.25.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.52.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 1.25.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/instrumentation': 0.52.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/instrumentation-connect': 0.37.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-express': 0.40.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-fastify': 0.37.0(@opentelemetry/api@1.9.0)
@@ -4050,7 +4100,7 @@ packages:
       '@opentelemetry/instrumentation-pg': 0.42.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation-redis-4': 0.40.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 1.25.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.25.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 1.25.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/semantic-conventions': 1.25.0
       '@prisma/instrumentation': 5.15.0
       '@sentry/core': 8.9.2
@@ -4074,9 +4124,9 @@ packages:
       '@opentelemetry/semantic-conventions': ^1.25.0
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 1.25.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.52.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 1.25.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 1.25.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/instrumentation': 0.52.0(@opentelemetry/api@1.8.0)
+      '@opentelemetry/sdk-trace-base': 1.25.0(@opentelemetry/api@1.8.0)
       '@opentelemetry/semantic-conventions': 1.25.0
       '@sentry/core': 8.9.2
       '@sentry/types': 8.9.2
@@ -5041,7 +5091,7 @@ packages:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-lib-source-maps: 5.0.4
@@ -5171,7 +5221,7 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5485,7 +5535,7 @@ packages:
     dependencies:
       '@fastify/error': 3.4.1
       archy: 1.0.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       fastq: 1.17.1
     transitivePeerDependencies:
       - supports-color
@@ -6320,6 +6370,18 @@ packages:
       supports-color: 5.5.0
     dev: false
 
+  /debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.2
+    dev: false
+
   /debug@4.3.4(supports-color@5.5.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -7096,7 +7158,7 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       esbuild: 0.19.12
     transitivePeerDependencies:
       - supports-color
@@ -7874,7 +7936,7 @@ packages:
     hasBin: true
     dependencies:
       commander: 9.5.0
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       generic-pool: 3.7.8
       koa-compose: 4.1.0
       redis-parser: 3.0.0
@@ -8686,7 +8748,7 @@ packages:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -8717,7 +8779,7 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -9206,7 +9268,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -12128,7 +12190,7 @@ packages:
     resolution: {integrity: sha512-wfI3pk7EE80lCIXprqh7ym48IHYdwmAAzESdbU8Q9l7pnRCk9LEhpbOTNKjz6FARLm/Bl5m+4F0ABxOkYUujSQ==}
     engines: {node: '>=12'}
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       extend: 3.0.2
     transitivePeerDependencies:
       - supports-color
@@ -13504,7 +13566,7 @@ packages:
     hasBin: true
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       pathe: 1.1.2
       picocolors: 1.0.0
       vite: 5.2.8(@types/node@20.12.5)
@@ -13548,7 +13610,7 @@ packages:
       vite:
         optional: true
     dependencies:
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       globrex: 0.1.2
       tsconfck: 3.0.3(typescript@5.4.4)
     transitivePeerDependencies:
@@ -13660,7 +13722,7 @@ packages:
       '@vitest/utils': 1.4.0
       acorn-walk: 8.3.2
       chai: 4.4.1
-      debug: 4.3.4(supports-color@5.5.0)
+      debug: 4.3.4
       execa: 8.0.1
       local-pkg: 0.5.0
       magic-string: 0.30.9


### PR DESCRIPTION
This migrates away from direct tRPC bindings in loaders, and instead injects a query client. It does this  to ensure the cache is utilized as best as possible.

The DX is intended to be lower-boilerplate:

```typescript
export const { loader, clientLoader } = makeIsomorphicLoader(
  async ({ request, context: { queryUtils } }) => {
    return {
      bottleList: await queryUtils.bottleList.ensureData(),
    };
  },
);

export default function BottleList() {
  const { bottleList } = useLoaderData<typeof loader>();

  return (
    <Layout rightSidebar={<FilterSidebar />}>
      <QueryBoundary>
        <Content bottleList={bottleList} />
      </QueryBoundary>
    </Layout>
  );
}
```

What this does under the hood is the following:

- On initial hydration, it runs the tRPC call server-side.
- It injects dehydratedState into the JSON serialized payload. Requires us to avoid the `json()` call in the loader - this behavior is ignored if a Response-type is the return value.
- On the client, it populates the QueryClient cache via the dehydrated state, but also simply directly passes the value as a normal loader would.
- Upon client-navigation, it will reuse the QueryClient's cache mechanics, mostly importantly avoid any server-side loader behavior if possible.
