### PR TITLE
feat(instrument-cache): emit cache spans from query client

### DIFF
--- a/apps/web/app/hooks/useSingletonQueryClient.ts
+++ b/apps/web/app/hooks/useSingletonQueryClient.ts
@@ -1,10 +1,52 @@
+import * as Sentry from "@sentry/remix";
+import type { DataTag, QueryKey } from "@tanstack/react-query";
 import { QueryClient } from "@tanstack/react-query";
 
 let queryClient: QueryClient | null = null;
 
+// Instruments QueryClient, such that emits cache spans indicating
+// hit / miss behaviour of local query cache.
+// TODO: figure out if this data can be attached to parent transaction.
+class InstrumentedQueryClient extends QueryClient {
+  getQueryData<
+    TQueryFnData = unknown,
+    TTaggedQueryKey extends QueryKey = QueryKey,
+    TInferredQueryFnData = TTaggedQueryKey extends DataTag<
+      unknown,
+      infer TaggedValue
+    >
+      ? TaggedValue
+      : TQueryFnData,
+  >(queryKey: TTaggedQueryKey): TInferredQueryFnData | undefined;
+  getQueryData(queryKey: QueryKey) {
+    const options = this.defaultQueryOptions({ queryKey });
+    const cachedQuery = this.getQueryCache().get(options.queryHash);
+    let hit = !!cachedQuery?.state.data;
+    // Create a root transaction to attach cache spans to:
+    Sentry.startSpan(
+      {
+        name: "react-query-transaction",
+      },
+      async () => {
+        // The cache span itself:
+        Sentry.startSpan(
+          {
+            name: options.queryHash,
+            op: "cache.get_item",
+          },
+          (span) => {
+            span.setAttribute("cache.hit", hit);
+          },
+        );
+      },
+    );
+    return cachedQuery?.state.data;
+  }
+}
+
 export function getQueryClient(): QueryClient {
   if (queryClient === null) {
-    queryClient = new QueryClient({
+    queryClient = new InstrumentedQueryClient({
       defaultOptions: {
         queries: {
           networkMode: "offlineFirst",


### PR DESCRIPTION
This PR adds instrumentation of cache spans to the @tanstack/react-query client. I could not find a hook for this, so I subclassed QueryClient, we should be mindful of this contract changing over time:

<img width="690" alt="Screenshot 2024-06-17 at 1 44 50 PM" src="https://github.com/dcramer/peated/assets/194609/55571742-b3fb-43fa-8ae0-6b0a3baa63d0">

Note: in implementing this, I noticed that queries seem to cache for 5 minutes, which is the default garbage collection in the cache, vs., 60 seconds configured for revalidation. I believe this might be due to [revalidateIfStale](https://github.com/TanStack/query/blob/main/packages/query-core/src/queryClient.ts#L145) defaulting to `false`. If this is fixed, the cache span logic also needs to be updated to reflect this.
