### PR TITLE
Fix confusing UX for closing dialog overlay

### DIFF
--- a/apps/web/src/styles/index.css
+++ b/apps/web/src/styles/index.css
@@ -117,15 +117,19 @@
   }
 
   .dialog-panel {
-    @apply relative h-screen min-h-full min-w-full overflow-hidden overflow-y-auto text-left;
+    @apply relative h-screen min-h-full min-w-full cursor-pointer overflow-hidden overflow-y-auto text-left backdrop-blur-md;
 
-    background-color: rgba(15, 23, 42, 1);
+    background-color: rgba(15, 23, 42, 0.65);
     background-image: linear-gradient(
       to right,
-      rgba(15, 23, 42, 1),
-      rgba(0, 0, 0, 1),
-      rgba(15, 23, 42, 1)
+      rgba(15, 23, 42, 0.65),
+      rgba(0, 0, 0, 0.65),
+      rgba(15, 23, 42, 0.65)
     );
+
+    img {
+      @apply cursor-auto rounded-lg;
+    }
   }
 
   .range {


### PR DESCRIPTION
When clicking an image, the overlay makes it look like the image is on a new page, but you're unable to navigate back in history. This has resulting in me closing the tab and realizing I just closed out the entire app. To resolve this, I adjusted the design to make it more apparent that the image is being displayed in a dialog overlay and that it can be closed by clicking outside of it.

## Before

![image](https://github.com/dcramer/peated/assets/6979737/8caebc06-19ad-4143-a87c-6f7ee0f2cead)

## After

![image](https://github.com/dcramer/peated/assets/6979737/5533b113-3e01-4016-8d7f-e032a5df536d)
