### PR TITLE
Augment names to prioritize releaseYear

### DIFF
--- a/apps/cli/src/commands/users.ts
+++ b/apps/cli/src/commands/users.ts
@@ -34,6 +34,10 @@ subcommand
   .argument("<password>")
   .action(async (email, password) => {
     const [user] = await db.select().from(users).where(eq(users.email, email));
+    if (!user) {
+      throw new Error(`Unknown user: ${email}.`);
+    }
+
     await db
       .update(users)
       .set({ passwordHash: generatePasswordHash(password) })
@@ -48,6 +52,10 @@ subcommand
   .argument("<email>")
   .action(async (email) => {
     const [user] = await db.select().from(users).where(eq(users.email, email));
+    if (!user) {
+      throw new Error(`Unknown user: ${email}.`);
+    }
+
     await db
       .update(users)
       .set({ mod: true, admin: true })
@@ -62,6 +70,9 @@ subcommand
   .argument("<email>")
   .action(async (email) => {
     const [user] = await db.select().from(users).where(eq(users.email, email));
+    if (!user) {
+      throw new Error(`Unknown user: ${email}.`);
+    }
 
     const token = await createAccessToken(user);
 

--- a/apps/mobile/src/components/BottleCard.tsx
+++ b/apps/mobile/src/components/BottleCard.tsx
@@ -9,6 +9,7 @@ import { Text } from "./StyledText";
 type BottleFormData = {
   name: string;
   vintageYear?: number | null;
+  releaseYear?: number | null;
   brand?:
     | {
         id: number;
@@ -71,7 +72,7 @@ export const PreviewBottleCard = ({
   return (
     <BottleCardScaffold
       name={
-        <Text>{`${brand ? `${brand.shortName || brand.name} ${data.name}` : data.name}${data.vintageYear ? ` (${data.vintageYear})` : ""}`}</Text>
+        <Text>{`${brand ? `${brand.shortName || brand.name} ${data.name}` : data.name}${data.releaseYear ? ` (${data.releaseYear})` : ""}`}</Text>
       }
       distillers={
         data.distillers?.length ? (
@@ -108,9 +109,9 @@ export default function BottleCard({
               <Text className="font-bold">{bottle.fullName}</Text>
             </Pressable>
           </Link>
-          {bottle.vintageYear && (
+          {bottle.releaseYear && (
             <Text variant={variant === "highlight" ? "highlight" : "muted"}>
-              ({bottle.vintageYear})
+              ({bottle.releaseYear})
             </Text>
           )}
           {bottle.isFavorite && (

--- a/apps/server/src/lib/bottleFinder.test.ts
+++ b/apps/server/src/lib/bottleFinder.test.ts
@@ -1,7 +1,11 @@
 import { findBottleId, findEntity } from "./bottleFinder";
 
 test("findBottle matches exact", async ({ fixtures }) => {
-  const bottle = await fixtures.Bottle();
+  const bottle = await fixtures.Bottle({
+    name: "Test",
+    vintageYear: null,
+    releaseYear: null,
+  });
   const result = await findBottleId(bottle.fullName);
   expect(result).toBe(bottle.id);
 });

--- a/apps/server/src/lib/bottleHash.ts
+++ b/apps/server/src/lib/bottleHash.ts
@@ -1,13 +1,15 @@
 import { createHash } from "crypto";
-import { type Bottle } from "../db/schema";
 
 export function generateUniqHash(
-  bottle: Partial<Bottle> & {
+  bottle: {
     fullName: string;
-  },
+    vintageYear?: number | null | undefined;
+    releaseYear?: number | null | undefined;
+  } & Record<string, any>,
 ) {
   let hash = createHash("md5");
   hash = hash.update(bottle.fullName.toLowerCase());
   if (bottle.vintageYear) hash = hash.update(`${bottle.vintageYear}`);
+  else if (bottle.releaseYear) hash = hash.update(`${bottle.releaseYear}`);
   return hash.digest("hex");
 }

--- a/apps/server/src/lib/format.ts
+++ b/apps/server/src/lib/format.ts
@@ -6,6 +6,21 @@ import type {
 } from "@peated/server/types";
 import { COLOR_SCALE } from "../constants";
 
+export function formatBottleName({
+  fullName,
+  vintageYear,
+  releaseYear,
+}: {
+  fullName: string;
+  vintageYear?: number | null | undefined;
+  releaseYear?: number | null | undefined;
+} & Record<string, any>) {
+  const bits = [fullName];
+  if (releaseYear) bits.push(`(${releaseYear} Release)`);
+  else if (vintageYear) bits.push(`(${releaseYear} Vintage)`);
+  return bits.join(" ");
+}
+
 export function formatCategoryName(
   value: Category | string | undefined | null,
 ) {

--- a/apps/server/src/lib/normalize.test.ts
+++ b/apps/server/src/lib/normalize.test.ts
@@ -357,6 +357,20 @@ describe("normalizeBottle", () => {
     `);
   });
 
+  test("synergies (1993 Vintage) (2012 Release)", async () => {
+    const rv = normalizeBottle({
+      name: "synergies (1993 Vintage) (2012 Release)",
+    });
+    expect(rv).toMatchInlineSnapshot(`
+      {
+        "name": "synergies",
+        "releaseYear": 2012,
+        "statedAge": null,
+        "vintageYear": 1993,
+      }
+    `);
+  });
+
   test("13-year-old Bottled in Bond (Batch VVS 2024)", async () => {
     const rv = normalizeBottle({
       name: "13-year-old Bottled in Bond (Batch VVS 2024)",
@@ -378,7 +392,7 @@ describe("normalizeBottle", () => {
     });
     expect(rv).toMatchInlineSnapshot(`
       {
-        "name": "26-year-old old, 1976 vintage (distilled at Inchgower)",
+        "name": "26-year-old old (distilled at Inchgower)",
         "releaseYear": null,
         "statedAge": 26,
         "vintageYear": 1976,

--- a/apps/server/src/lib/search.ts
+++ b/apps/server/src/lib/search.ts
@@ -29,7 +29,9 @@ export function buildBottleSearchVector(
   if (bottle.category)
     values.push(new TSVector(formatCategoryName(bottle.category), "C"));
   if (bottle.vintageYear)
-    values.push(new TSVector(`${bottle.vintageYear}`, "B"));
+    values.push(new TSVector(`${bottle.vintageYear} Vintage`, "B"));
+  if (bottle.releaseYear)
+    values.push(new TSVector(`${bottle.releaseYear} Release`, "B"));
   if (bottler) values.push(new TSVector(bottler.name, "C"));
   aliasList?.forEach((a) => values.push(new TSVector(a.name, "A")));
   distillerList?.forEach((a) => values.push(new TSVector(a.name, "B")));

--- a/apps/server/src/trpc/routes/bottleAliasDelete.ts
+++ b/apps/server/src/trpc/routes/bottleAliasDelete.ts
@@ -1,5 +1,6 @@
 import { db } from "@peated/server/db";
 import { bottleAliases, reviews, storePrices } from "@peated/server/db/schema";
+import { formatBottleName } from "@peated/server/lib/format";
 import { TRPCError } from "@trpc/server";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
@@ -25,7 +26,7 @@ export default modProcedure.input(z.string()).mutation(async function ({
 
   if (alias.bottle) {
     const { bottle } = alias;
-    const canonicalName = `${bottle.fullName}${bottle.vintageYear ? ` (${bottle.vintageYear})` : ""}`;
+    const canonicalName = formatBottleName(bottle);
     if (alias.name.toLowerCase() === canonicalName.toLowerCase())
       throw new TRPCError({
         code: "BAD_REQUEST",

--- a/apps/server/src/trpc/routes/bottleAliasList.ts
+++ b/apps/server/src/trpc/routes/bottleAliasList.ts
@@ -1,6 +1,7 @@
 import { db } from "@peated/server/db";
 import type { Bottle } from "@peated/server/db/schema";
 import { bottleAliases, bottles } from "@peated/server/db/schema";
+import { formatBottleName } from "@peated/server/lib/format";
 import { TRPCError } from "@trpc/server";
 import {
   and,
@@ -70,15 +71,15 @@ export default publicProcedure
       .offset(offset)
       .orderBy(asc(bottleAliases.name));
 
+    const canonicalName = bottle ? formatBottleName(bottle) : null;
+
     return {
       results: results.slice(0, limit).map((a) => ({
         name: a.name,
         createdAt: a.createdAt.toISOString(),
         ...(bottle
           ? {
-              isCanonical:
-                `${bottle.fullName}${bottle.vintageYear ? ` (${bottle.vintageYear})` : ""}` ==
-                a.name,
+              isCanonical: canonicalName == a.name,
             }
           : {}),
       })),

--- a/apps/server/src/trpc/routes/bottleCreate.ts
+++ b/apps/server/src/trpc/routes/bottleCreate.ts
@@ -11,6 +11,7 @@ import {
   upsertBottleAlias,
   upsertEntity,
 } from "@peated/server/lib/db";
+import { formatBottleName } from "@peated/server/lib/format";
 import { logError } from "@peated/server/lib/log";
 import { BottleInputSchema } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
@@ -150,9 +151,7 @@ export async function bottleCreate({
       return;
     }
 
-    const aliasName = bottle.vintageYear
-      ? `${bottle.fullName} (${bottle.vintageYear})`
-      : bottle.fullName;
+    const aliasName = formatBottleName(bottle);
 
     await upsertBottleAlias(tx, bottle.id, aliasName);
 

--- a/apps/server/src/trpc/routes/bottleUpdate.test.ts
+++ b/apps/server/src/trpc/routes/bottleUpdate.test.ts
@@ -68,11 +68,6 @@ test("edits a new bottle with new name param", async ({ fixtures }) => {
     .from(bottles)
     .where(eq(bottles.id, data.id));
 
-  expect(
-    omit(bottle, "name", "fullName", "searchVector", "updatedAt", "uniqHash"),
-  ).toEqual(
-    omit(bottle2, "name", "fullName", "searchVector", "updatedAt", "uniqHash"),
-  );
   expect(bottle2.name).toBe("Delicious Wood");
   expect(bottle2.fullName).toBe(`${brand.name} ${bottle2.name}`);
 });
@@ -119,27 +114,6 @@ test("manipulates name to conform with age", async ({ fixtures }) => {
     .from(bottles)
     .where(eq(bottles.id, bottle.id));
 
-  expect(
-    omit(
-      bottle,
-      "name",
-      "fullName",
-      "statedAge",
-      "searchVector",
-      "updatedAt",
-      "uniqHash",
-    ),
-  ).toEqual(
-    omit(
-      bottle2,
-      "name",
-      "fullName",
-      "statedAge",
-      "searchVector",
-      "updatedAt",
-      "uniqHash",
-    ),
-  );
   expect(bottle2.statedAge).toBe(10);
   expect(bottle2.name).toBe("Delicious 10-year-old");
   expect(bottle2.fullName).toBe(`${brand.name} ${bottle2.name}`);
@@ -147,7 +121,11 @@ test("manipulates name to conform with age", async ({ fixtures }) => {
 
 test("fills in statedAge", async ({ fixtures }) => {
   const brand = await fixtures.Entity();
-  const bottle = await fixtures.Bottle({ brandId: brand.id, statedAge: null });
+  const bottle = await fixtures.Bottle({
+    brandId: brand.id,
+    statedAge: null,
+    name: "Delicious",
+  });
 
   const caller = createCaller({
     user: await fixtures.User({ mod: true }),
@@ -162,27 +140,6 @@ test("fills in statedAge", async ({ fixtures }) => {
     .from(bottles)
     .where(eq(bottles.id, bottle.id));
 
-  expect(
-    omit(
-      bottle,
-      "name",
-      "fullName",
-      "statedAge",
-      "searchVector",
-      "updatedAt",
-      "uniqHash",
-    ),
-  ).toEqual(
-    omit(
-      bottle2,
-      "name",
-      "fullName",
-      "statedAge",
-      "searchVector",
-      "updatedAt",
-      "uniqHash",
-    ),
-  );
   expect(bottle2.statedAge).toBe(10);
 });
 
@@ -202,9 +159,6 @@ test("removes statedAge", async ({ fixtures }) => {
     .from(bottles)
     .where(eq(bottles.id, bottle.id));
 
-  expect(omit(bottle, "statedAge", "updatedAt")).toEqual(
-    omit(bottle2, "statedAge", "updatedAt"),
-  );
   expect(bottle2.statedAge).toBeNull();
 });
 
@@ -225,25 +179,6 @@ test("changes brand", async ({ fixtures }) => {
     .from(bottles)
     .where(eq(bottles.id, bottle.id));
 
-  expect(
-    omit(
-      bottle,
-      "brandId",
-      "fullName",
-      "searchVector",
-      "updatedAt",
-      "uniqHash",
-    ),
-  ).toEqual(
-    omit(
-      bottle2,
-      "brandId",
-      "fullName",
-      "searchVector",
-      "updatedAt",
-      "uniqHash",
-    ),
-  );
   expect(bottle2.brandId).toBe(newBrand.id);
   expect(bottle2.fullName).toBe(`${newBrand.name} ${bottle.name}`);
 });
@@ -415,7 +350,11 @@ test("saves cask information", async ({ defaults, fixtures }) => {
 });
 
 test("saves vintage information", async ({ defaults, fixtures }) => {
-  const bottle = await fixtures.Bottle();
+  const bottle = await fixtures.Bottle({
+    name: "Delicious",
+    statedAge: null,
+    releaseYear: null,
+  });
 
   const caller = createCaller({ user: await fixtures.User({ mod: true }) });
   const data = await caller.bottleUpdate({

--- a/apps/server/src/trpc/routes/bottleUpdate.ts
+++ b/apps/server/src/trpc/routes/bottleUpdate.ts
@@ -8,6 +8,7 @@ import {
   entities,
 } from "@peated/server/db/schema";
 import { generateUniqHash } from "@peated/server/lib/bottleHash";
+import { formatBottleName } from "@peated/server/lib/format";
 import { logError } from "@peated/server/lib/log";
 import { BottleInputSchema } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
@@ -81,6 +82,7 @@ export async function bottleUpdate({
           name: d.distiller.name,
         })),
         vintageYear: bottle.vintageYear,
+        releaseYear: bottle.releaseYear,
         ...input,
       },
       ctx,
@@ -244,6 +246,7 @@ export async function bottleUpdate({
                 uniqHash: generateUniqHash({
                   fullName: bottle.fullName,
                   vintageYear: bottle.vintageYear,
+                  releaseYear: bottle.releaseYear,
                   ...bottleUpdateData,
                 }),
                 updatedAt: sql`NOW()`,
@@ -266,9 +269,7 @@ export async function bottleUpdate({
     if (!newBottle) return;
 
     if (bottleData.name) {
-      const aliasName = newBottle.vintageYear
-        ? `${newBottle.fullName} (${newBottle.vintageYear})`
-        : newBottle.fullName;
+      const aliasName = formatBottleName(newBottle);
       const existingAlias = await tx.query.bottleAliases.findFirst({
         where: eq(sql`LOWER(${bottleAliases.name})`, aliasName.toLowerCase()),
       });

--- a/apps/server/src/trpc/routes/reviewCreate.test.ts
+++ b/apps/server/src/trpc/routes/reviewCreate.test.ts
@@ -88,7 +88,11 @@ test("new review with new bottle matching entity", async ({ fixtures }) => {
 
 test("new review with existing bottle", async ({ fixtures }) => {
   const site = await fixtures.ExternalSite();
-  const bottle = await fixtures.Bottle();
+  const bottle = await fixtures.Bottle({
+    name: "Delicious",
+    vintageYear: null,
+    releaseYear: null,
+  });
 
   const caller = createCaller({
     user: await fixtures.User({ admin: true }),

--- a/apps/server/src/worker/jobs/updateEntityStats.test.ts
+++ b/apps/server/src/worker/jobs/updateEntityStats.test.ts
@@ -4,14 +4,18 @@ import { eq } from "drizzle-orm";
 import updateEntityStats from "./updateEntityStats";
 
 test("updates totalBottles", async ({ fixtures }) => {
-  const entity1 = await fixtures.Entity();
-  const entity2 = await fixtures.Entity();
-  const entity3 = await fixtures.Entity();
+  const entity1 = await fixtures.Entity({ name: "A" });
+  const entity2 = await fixtures.Entity({ name: "B" });
+  const entity3 = await fixtures.Entity({ name: "C" });
 
-  await fixtures.Bottle({ brandId: entity1.id });
-  await fixtures.Bottle({ brandId: entity2.id, bottlerId: entity1.id });
-  await fixtures.Bottle({ brandId: entity3.id });
-  await fixtures.Bottle({ distillerIds: [entity1.id, entity2.id] });
+  await fixtures.Bottle({ brandId: entity1.id, name: "A" });
+  await fixtures.Bottle({
+    brandId: entity2.id,
+    name: "B",
+    bottlerId: entity1.id,
+  });
+  await fixtures.Bottle({ brandId: entity3.id, name: "C" });
+  await fixtures.Bottle({ distillerIds: [entity1.id, entity2.id], name: "D" });
 
   updateEntityStats({ entityId: entity1.id });
 

--- a/apps/web/src/app/(admin)/admin/(default)/queue/bottleSelector.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/bottleSelector.tsx
@@ -117,14 +117,15 @@ export default function BottleSelector({
                   >
                     <div className="font-bold">
                       {bottle.fullName}
-                      {bottle.vintageYear && (
-                        <>
-                          {" "}
-                          <span className="text-muted">
-                            ({bottle.vintageYear})
-                          </span>
-                        </>
-                      )}
+                      {bottle.releaseYear ? (
+                        <span className="text-muted">
+                          ({bottle.releaseYear} Release)
+                        </span>
+                      ) : bottle.vintageYear ? (
+                        <span className="text-muted">
+                          ({bottle.vintageYear} Vintage)
+                        </span>
+                      ) : null}
                     </div>
                     <div className="text-muted flex space-x-2">
                       {bottle.distillers.map((distiller) => distiller.name)}

--- a/apps/web/src/app/(default)/(activity)/newBottles.tsx
+++ b/apps/web/src/app/(default)/(activity)/newBottles.tsx
@@ -58,14 +58,6 @@ export default function NewBottles() {
                     >
                       {bottle.fullName}
                     </BottleLink>
-                    {bottle.vintageYear && (
-                      <>
-                        {" "}
-                        <span className="text-muted">
-                          ({bottle.vintageYear})
-                        </span>
-                      </>
-                    )}
                     {bottle.isFavorite && (
                       <StarIcon className="h-4 w-4" aria-hidden="true" />
                     )}
@@ -73,16 +65,21 @@ export default function NewBottles() {
                       <CheckBadgeIcon className="h-4 w-4" aria-hidden="true" />
                     )}
                   </div>
-                  {!!bottle.category && (
-                    <div className="text-muted text-sm">
+                  <div className="text-muted flex gap-x-1 text-sm">
+                    {bottle.category && (
                       <Link
                         href={`/bottles/?category=${bottle.category}`}
                         className="hover:underline"
                       >
                         {formatCategoryName(bottle.category)}
                       </Link>
-                    </div>
-                  )}
+                    )}
+                    {bottle.releaseYear ? (
+                      <span>({bottle.releaseYear} Release)</span>
+                    ) : bottle.vintageYear ? (
+                      <span>({bottle.vintageYear} Vintage)</span>
+                    ) : null}
+                  </div>
                 </td>
               </tr>
             );

--- a/apps/web/src/components/bottleCard.tsx
+++ b/apps/web/src/components/bottleCard.tsx
@@ -1,5 +1,8 @@
 import { CheckBadgeIcon, StarIcon } from "@heroicons/react/20/solid";
-import { formatCategoryName } from "@peated/server/lib/format";
+import {
+  formatBottleName,
+  formatCategoryName,
+} from "@peated/server/lib/format";
 import type { Bottle } from "@peated/server/types";
 import Link from "@peated/web/components/link";
 import type { ComponentPropsWithoutRef } from "react";
@@ -14,6 +17,7 @@ type EntityOption = Option & {
 type BottleFormData = {
   name: string;
   vintageYear?: number | null;
+  releaseYear?: number | null;
   brand?: EntityOption | null | undefined;
   distillers?: EntityOption[] | null | undefined;
   statedAge?: number | null | undefined;
@@ -90,7 +94,10 @@ export const PreviewBottleCard = ({
   const { brand } = data;
   return (
     <BottleScaffold
-      name={`${brand ? `${brand.shortName || brand.name} ${data.name}` : data.name}${data.vintageYear ? ` (${data.vintageYear})` : ""}`}
+      name={formatBottleName({
+        ...data,
+        fullName: `${brand ? `${brand.shortName || brand.name} ` : ""}${data.name}`,
+      })}
       category={data.category ? formatCategoryName(data.category) : null}
       distillers={
         data.distillers?.length
@@ -120,21 +127,32 @@ export default function BottleCard({
       onClick={onClick ? () => onClick(bottle) : undefined}
       name={
         <>
-          <h4 className="truncate font-bold">
+          <h4 className="flex items-center gap-x-1 truncate font-bold">
             <BottleLink bottle={bottle} className="hover:underline">
               {bottle.fullName}
             </BottleLink>
-            {bottle.vintageYear && (
+            {bottle.releaseYear ? (
               <>
-                {" "}
                 <span
                   className={
                     color === "highlight" ? "text-black" : "text-muted"
                   }
                 >
-                  ({bottle.vintageYear})
+                  ({bottle.releaseYear} Release)
                 </span>
               </>
+            ) : (
+              bottle.vintageYear && (
+                <>
+                  <span
+                    className={
+                      color === "highlight" ? "text-black" : "text-muted"
+                    }
+                  >
+                    ({bottle.vintageYear} Vintage)
+                  </span>
+                </>
+              )
             )}
           </h4>
           {bottle.isFavorite && (

--- a/apps/web/src/components/bottleField.tsx
+++ b/apps/web/src/components/bottleField.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { formatBottleName } from "@peated/server/lib/format";
 import { trpc } from "@peated/web/lib/trpc/client";
 import SelectField from "./selectField";
 
@@ -12,7 +13,7 @@ export default function BottleField({
       onQuery={async (query) => {
         const { results } = await trpcUtils.bottleList.fetch({ query });
         return results.map((r) => ({
-          name: r.vintageYear ? `${r.fullName} (${r.vintageYear})` : r.fullName,
+          name: formatBottleName(r),
           id: r.id,
         }));
       }}

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -182,6 +182,7 @@ export default function BottleForm({
             distillers: distillersValue,
             brand: brandValue,
             vintageYear: watch("vintageYear"),
+            releaseYear: watch("releaseYear"),
           }}
         />
       </div>
@@ -292,6 +293,17 @@ export default function BottleForm({
                 multiple
               />
             )}
+          />
+
+          <TextField
+            {...register("releaseYear", {
+              setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
+            })}
+            error={errors.releaseYear}
+            type="number"
+            label="Release Year"
+            placeholder="e.g. 2024"
+            helpText="The year this labeling was released,."
           />
 
           <TextField
@@ -501,17 +513,6 @@ export default function BottleForm({
                 rows={8}
               />
             )}
-
-            <TextField
-              {...register("releaseYear", {
-                setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
-              })}
-              error={errors.releaseYear}
-              type="number"
-              label="Release Year"
-              placeholder="e.g. 2024"
-              helpText="The year this labeling was released."
-            />
           </Collapsable>
         </Fieldset>
       </Form>

--- a/apps/web/src/components/bottleHeader.tsx
+++ b/apps/web/src/components/bottleHeader.tsx
@@ -32,9 +32,11 @@ export default function BottleHeader({
               {bottle.name}
             </div>
           )}
-          {bottle.vintageYear && (
-            <span className="text-muted">({bottle.vintageYear})</span>
-          )}
+          {bottle.releaseYear ? (
+            <span className="text-muted">({bottle.releaseYear} Release)</span>
+          ) : bottle.vintageYear ? (
+            <span className="text-muted">({bottle.vintageYear} Vintage)</span>
+          ) : null}
         </div>
       }
       titleExtra={

--- a/apps/web/src/components/bottleTable.tsx
+++ b/apps/web/src/components/bottleTable.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CheckBadgeIcon, StarIcon } from "@heroicons/react/20/solid";
+import { formatCategoryName } from "@peated/server/lib/format";
 import type { Bottle, CollectionBottle, PagingRel } from "@peated/server/types";
 import Link from "@peated/web/components/link";
 import type { ComponentProps } from "react";
@@ -30,25 +31,37 @@ export default function BottleTable({
           className: "min-w-full sm:w-1/2",
           value: (item) => {
             return (
-              <>
-                <BottleLink
-                  bottle={item}
-                  className="font-medium hover:underline"
-                >
-                  {item.fullName}
-                </BottleLink>
-                {item.vintageYear && (
-                  <>
-                    <span className="text-muted">({item.vintageYear})</span>
-                  </>
-                )}
-                {item.isFavorite && (
-                  <StarIcon className="h-4 w-4" aria-hidden="true" />
-                )}
-                {item.hasTasted && (
-                  <CheckBadgeIcon className="h-4 w-4" aria-hidden="true" />
-                )}
-              </>
+              <div className="flex flex-col justify-center">
+                <div>
+                  <BottleLink
+                    bottle={item}
+                    className="font-medium hover:underline"
+                  >
+                    {item.fullName}
+                  </BottleLink>
+                  {item.isFavorite && (
+                    <StarIcon className="h-4 w-4" aria-hidden="true" />
+                  )}
+                  {item.hasTasted && (
+                    <CheckBadgeIcon className="h-4 w-4" aria-hidden="true" />
+                  )}
+                </div>
+                <div className="text-muted flex gap-x-1 text-sm">
+                  {item.category && (
+                    <Link
+                      href={`/bottles/?category=${item.category}`}
+                      className="hover:underline"
+                    >
+                      {formatCategoryName(item.category)}
+                    </Link>
+                  )}
+                  {item.releaseYear ? (
+                    <span>({item.releaseYear} Release)</span>
+                  ) : item.vintageYear ? (
+                    <span>({item.vintageYear} Vintage)</span>
+                  ) : null}
+                </div>
+              </div>
             );
           },
         },

--- a/apps/web/src/components/definitionList.tsx
+++ b/apps/web/src/components/definitionList.tsx
@@ -1,17 +1,17 @@
 import { type ComponentPropsWithoutRef } from "react";
 
 export function DefinitionTerm(props: ComponentPropsWithoutRef<"dt">) {
-  return <dt className="font-semibold leading-6" {...props} />;
+  return <dt className="mfont-semibold" {...props} />;
 }
 
 export function DefinitionDetails(props: ComponentPropsWithoutRef<"dd">) {
   return (
-    <dd className="text-muted flex items-center gap-x-2 leading-6" {...props} />
+    <dd className="text-muted mb-4 flex items-center gap-x-2" {...props} />
   );
 }
 
 export default function DefinitionList(props: ComponentPropsWithoutRef<"dl">) {
-  return <dl className="grid-cols mb-4 grid grid-cols-1 gap-y-4" {...props} />;
+  return <dl className="grid-cols mb-4 grid grid-cols-1" {...props} />;
 }
 
 DefinitionList.Details = DefinitionDetails;

--- a/apps/web/src/components/priceChanges.tsx
+++ b/apps/web/src/components/priceChanges.tsx
@@ -61,13 +61,22 @@ export default function PriceChanges() {
                       >
                         {bottle.fullName}
                       </BottleLink>
-                      {bottle.vintageYear && (
+                      {bottle.releaseYear ? (
                         <>
                           {" "}
                           <span className="text-muted">
-                            ({bottle.vintageYear})
+                            ({bottle.releaseYear} Release)
                           </span>
                         </>
+                      ) : (
+                        bottle.vintageYear && (
+                          <>
+                            {" "}
+                            <span className="text-muted">
+                              ({bottle.vintageYear} Vintage)
+                            </span>
+                          </>
+                        )
                       )}
                       {bottle.isFavorite && (
                         <StarIcon className="h-4 w-4" aria-hidden="true" />

--- a/apps/web/src/components/search/bottleResult.tsx
+++ b/apps/web/src/components/search/bottleResult.tsx
@@ -31,11 +31,20 @@ export default function BottleResultRow({
             <span className="absolute inset-x-0 -top-px bottom-0" />
             {bottle.fullName}
           </Link>
-          {bottle.vintageYear && (
+          {bottle.releaseYear ? (
             <>
               {" "}
-              <span className="text-muted">({bottle.vintageYear})</span>
+              <span className="text-muted">({bottle.releaseYear} Release)</span>
             </>
+          ) : (
+            bottle.vintageYear && (
+              <>
+                {" "}
+                <span className="text-muted">
+                  ({bottle.vintageYear} Vintage)
+                </span>
+              </>
+            )
           )}
           {bottle.isFavorite && (
             <StarIcon className="h-4 w-4" aria-hidden="true" />

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "description": "",
   "scripts": {
-    "build": "pnpm -r run build",
+    "build": "turbo build",
     "build:docker": "pnpm --filter='!./apps/mobile' --filter='!./apps/web' build",
     "build:packages": "pnpm -r --filter='./packages/*' build",
     "build:mobile": "pnpm build --filter='./apps/mobile'",
@@ -25,7 +25,7 @@
     "tastings": "dotenv -e .env.local -- pnpm --filter='./apps/cli' cli tastings",
     "mocks": "dotenv -e .env.local -- pnpm --filter='./apps/cli' cli mocks",
     "user": "dotenv -e .env.local -- pnpm --filter='./apps/cli' cli users",
-    "typecheck": "turbo typecheck",
+    "typecheck": "turbo typecheck --filter='!./apps/mobile'",
     "lint": "turbo lint",
     "test": "turbo test",
     "test:ci": "CI=true pnpm -r run test:ci",


### PR DESCRIPTION
This shifts the UI to show (X Release) or (X Vintage) [in that prioritization order], and bundles up both aspects on bottle aliases for generated names.

It also adds the release year to uniqHash if vintageYear isnt available. We likely need to change unique hashes to support multiple, in the same guise as bottle aliases, but need to put some more thought into this.