### PR TITLE
Add tracePropagationTargets for proper tracing

### DIFF
--- a/apps/web/sentry.client.config.ts
+++ b/apps/web/sentry.client.config.ts
@@ -27,6 +27,8 @@ Sentry.init({
   _experiments: {
     enableLogs: true,
   },
+  // needed for proper trace propagation
+  tracePropagationTargets: ["localhost", "https://api.peated.com"],
 });
 
 Sentry.setTag("service", "@peated/web");


### PR DESCRIPTION
There is no `sentry-trace` headers in the outgoing tRPC calls, that is my first guess