### PR TITLE
Clean up simple rating display

### DIFF
--- a/apps/server/src/orpc/routes/tastings/update.ts
+++ b/apps/server/src/orpc/routes/tastings/update.ts
@@ -136,7 +136,7 @@ export default procedure
         await tx
           .update(bottles)
           .set({
-            avgRating: sql`(SELECT AVG(${tastings.rating}) FROM ${tastings} WHERE ${bottles.id} = ${tastings.bottleId})`,
+            avgRating: sql`(SELECT AVG(${tastings.rating}) FROM ${tastings} WHERE ${bottles.id} = ${tastings.bottleId} AND ${tastings.rating} IS NOT NULL)`,
           })
           .where(eq(bottles.id, newTasting.bottleId));
       }

--- a/apps/web/src/components/bottleTable.tsx
+++ b/apps/web/src/components/bottleTable.tsx
@@ -6,6 +6,7 @@ import type { Bottle, CollectionBottle, PagingRel } from "@peated/server/types";
 import Link from "@peated/web/components/link";
 import type { ComponentProps } from "react";
 import BottleLink from "./bottleLink";
+import SimpleRatingIndicator from "./simpleRatingIndicator";
 import Table from "./table";
 
 export default function BottleTable({
@@ -69,9 +70,10 @@ export default function BottleTable({
         },
         {
           name: "rating",
-          value: (item) => (item.avgRating ? item.avgRating.toFixed(2) : null),
+          value: (item) => <SimpleRatingIndicator avgRating={item.avgRating} />,
           className: "sm:w-1/6",
           sortDefaultOrder: "desc",
+          align: "center",
         },
         {
           name: "age",

--- a/apps/web/src/components/simpleRatingIndicator.tsx
+++ b/apps/web/src/components/simpleRatingIndicator.tsx
@@ -1,0 +1,43 @@
+import { HandThumbDownIcon, HandThumbUpIcon } from "@heroicons/react/20/solid";
+import classNames from "../lib/classNames";
+
+type Props = {
+  avgRating: number | null;
+  className?: string;
+};
+
+export default function SimpleRatingIndicator({ avgRating, className }: Props) {
+  if (avgRating === null || avgRating === undefined) {
+    return null;
+  }
+
+  // Round the rating: < 0.5 = Pass, 0.5-1.49 = Sip, >= 1.5 = Savor
+  let rating: "pass" | "sip" | "savor";
+  if (avgRating < 0.5) {
+    rating = "pass";
+  } else if (avgRating < 1.5) {
+    rating = "sip";
+  } else {
+    rating = "savor";
+  }
+
+  const title = `${avgRating.toFixed(2)} - ${
+    rating === "pass" ? "Pass" : rating === "sip" ? "Sip" : "Savor"
+  }`;
+
+  if (rating === "savor") {
+    return (
+      <div
+        className={classNames("inline-flex gap-0.5", className)}
+        title={title}
+      >
+        <HandThumbUpIcon className="h-4 w-4" />
+        <HandThumbUpIcon className="h-4 w-4" />
+      </div>
+    );
+  }
+
+  const Icon = rating === "pass" ? HandThumbDownIcon : HandThumbUpIcon;
+
+  return <Icon className={classNames("h-4 w-4", className)} title={title} />;
+}

--- a/apps/web/src/components/simpleRatingInput.tsx
+++ b/apps/web/src/components/simpleRatingInput.tsx
@@ -94,13 +94,6 @@ export default forwardRef<HTMLDivElement, Props>(
     return (
       <FormField
         label={label}
-        labelNote={
-          selectedValue !== null && (
-            <div className="text-highlight text-sm font-medium">
-              {ratingOptions.find((o) => o.value === selectedValue)?.label}
-            </div>
-          )
-        }
         htmlFor={`f-${name}`}
         required={required}
         helpText={helpText}


### PR DESCRIPTION
## Summary
- Introduced a new `SimpleRatingIndicator` component that displays ratings using icons instead of numeric values
- Updated the bottle table to use the new indicator component for a cleaner visual presentation
- Removed redundant label note from the simple rating input component

## Changes
The new indicator maps average ratings to visual representations:
- Pass (< 0.5): Single thumbs down icon
- Sip (0.5-1.49): Single thumbs up icon  
- Savor (≥ 1.5): Double thumbs up icons

Each icon includes a tooltip showing the exact numeric rating and category.