### PR TITLE
feat(admin): add canon repair merge queue

### DIFF
--- a/apps/server/src/lib/canonRepairCandidates.ts
+++ b/apps/server/src/lib/canonRepairCandidates.ts
@@ -1,0 +1,261 @@
+import { db } from "@peated/server/db";
+import { bottles, type Bottle } from "@peated/server/db/schema";
+import { hasBottleLevelReleaseTraits } from "@peated/server/lib/bottleSchemaRules";
+import { hasVariantLegacyReleaseRepairParentName } from "@peated/server/lib/legacyReleaseRepairCandidates";
+import { normalizeString } from "@peated/server/lib/normalize";
+import { desc } from "drizzle-orm";
+
+const MAX_SCAN_LIMIT = 2000;
+
+type CanonRepairBottle = Pick<
+  Bottle,
+  | "abv"
+  | "id"
+  | "brandId"
+  | "bottlerId"
+  | "caskFill"
+  | "caskSize"
+  | "caskStrength"
+  | "caskType"
+  | "category"
+  | "edition"
+  | "fullName"
+  | "name"
+  | "numReleases"
+  | "releaseYear"
+  | "seriesId"
+  | "singleCask"
+  | "statedAge"
+  | "totalTastings"
+  | "vintageYear"
+>;
+
+export type CanonRepairCandidate = {
+  bottle: {
+    id: number;
+    fullName: string;
+    numReleases: number;
+    totalTastings: null | number;
+  };
+  targetBottle: {
+    id: number;
+    fullName: string;
+    numReleases: number;
+    totalTastings: null | number;
+  };
+  variantBottles: Array<{
+    id: number;
+    fullName: string;
+    numReleases: number;
+    totalTastings: null | number;
+  }>;
+};
+
+function getTastingCount(value: null | number | undefined): number {
+  return value ?? 0;
+}
+
+function getNormalizedWordCount(fullName: string): number {
+  return normalizeString(fullName).split(/\s+/).filter(Boolean).length;
+}
+
+function compareCanonRepairTargetQuality(
+  left: Pick<CanonRepairBottle, "fullName" | "id" | "totalTastings">,
+  right: Pick<CanonRepairBottle, "fullName" | "id" | "totalTastings">,
+): number {
+  const wordDiff =
+    getNormalizedWordCount(left.fullName) -
+    getNormalizedWordCount(right.fullName);
+  if (wordDiff !== 0) {
+    return wordDiff;
+  }
+
+  const charDiff =
+    normalizeString(left.fullName).length -
+    normalizeString(right.fullName).length;
+  if (charDiff !== 0) {
+    return charDiff;
+  }
+
+  const tastingDiff =
+    getTastingCount(right.totalTastings) - getTastingCount(left.totalTastings);
+  if (tastingDiff !== 0) {
+    return tastingDiff;
+  }
+
+  return left.id - right.id;
+}
+
+function hasConflictingValue<TValue>(
+  left: null | TValue,
+  right: null | TValue,
+): boolean {
+  return left !== null && right !== null && left !== right;
+}
+
+function canCanonRepairPair(
+  source: CanonRepairBottle,
+  target: CanonRepairBottle,
+) {
+  if (source.id === target.id || source.brandId !== target.brandId) {
+    return false;
+  }
+
+  if (
+    hasBottleLevelReleaseTraits(source) ||
+    hasBottleLevelReleaseTraits(target) ||
+    !hasVariantLegacyReleaseRepairParentName(source.fullName, target.fullName)
+  ) {
+    return false;
+  }
+
+  if (
+    hasConflictingValue(source.category, target.category) ||
+    hasConflictingValue(source.bottlerId, target.bottlerId) ||
+    hasConflictingValue(source.seriesId, target.seriesId) ||
+    hasConflictingValue(source.statedAge, target.statedAge)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+function canonRepairCandidateMatchesQuery(
+  candidate: CanonRepairCandidate,
+  normalizedQuery: string,
+) {
+  return [
+    candidate.bottle.fullName,
+    candidate.targetBottle.fullName,
+    ...candidate.variantBottles.map((variant) => variant.fullName),
+  ].some((name) =>
+    normalizeString(name).toLowerCase().includes(normalizedQuery),
+  );
+}
+
+export async function getCanonRepairCandidates({
+  query = "",
+  cursor = 1,
+  limit = 25,
+}: {
+  cursor?: number;
+  limit?: number;
+  query?: string;
+}) {
+  const baseQuery = db
+    .select({
+      id: bottles.id,
+      brandId: bottles.brandId,
+      bottlerId: bottles.bottlerId,
+      abv: bottles.abv,
+      caskFill: bottles.caskFill,
+      caskSize: bottles.caskSize,
+      caskStrength: bottles.caskStrength,
+      caskType: bottles.caskType,
+      category: bottles.category,
+      edition: bottles.edition,
+      fullName: bottles.fullName,
+      name: bottles.name,
+      numReleases: bottles.numReleases,
+      releaseYear: bottles.releaseYear,
+      seriesId: bottles.seriesId,
+      singleCask: bottles.singleCask,
+      statedAge: bottles.statedAge,
+      totalTastings: bottles.totalTastings,
+      vintageYear: bottles.vintageYear,
+    })
+    .from(bottles);
+
+  const rows = await baseQuery
+    .orderBy(desc(bottles.totalTastings), desc(bottles.id))
+    .limit(MAX_SCAN_LIMIT);
+
+  const brandGroups = new Map<number, CanonRepairBottle[]>();
+  for (const row of rows) {
+    const existingRows = brandGroups.get(row.brandId) ?? [];
+    existingRows.push(row);
+    brandGroups.set(row.brandId, existingRows);
+  }
+
+  const candidates: CanonRepairCandidate[] = [];
+
+  for (const row of rows) {
+    if (hasBottleLevelReleaseTraits(row)) {
+      continue;
+    }
+
+    const brandRows = brandGroups.get(row.brandId) ?? [];
+    const variantRows = brandRows.filter((candidate) =>
+      canCanonRepairPair(row, candidate),
+    );
+
+    if (variantRows.length === 0) {
+      continue;
+    }
+
+    const sortedVariantRows = [...variantRows].sort(
+      compareCanonRepairTargetQuality,
+    );
+    const [bestTarget] = sortedVariantRows;
+
+    if (!bestTarget || compareCanonRepairTargetQuality(bestTarget, row) >= 0) {
+      continue;
+    }
+
+    candidates.push({
+      bottle: {
+        id: row.id,
+        fullName: row.fullName,
+        numReleases: row.numReleases,
+        totalTastings: row.totalTastings,
+      },
+      targetBottle: {
+        id: bestTarget.id,
+        fullName: bestTarget.fullName,
+        numReleases: bestTarget.numReleases,
+        totalTastings: bestTarget.totalTastings,
+      },
+      variantBottles: sortedVariantRows
+        .filter((candidate) => candidate.id !== bestTarget.id)
+        .map((candidate) => ({
+          id: candidate.id,
+          fullName: candidate.fullName,
+          numReleases: candidate.numReleases,
+          totalTastings: candidate.totalTastings,
+        })),
+    });
+  }
+
+  candidates.sort((left, right) => {
+    const tastingDiff =
+      getTastingCount(right.bottle.totalTastings) -
+      getTastingCount(left.bottle.totalTastings);
+    if (tastingDiff !== 0) {
+      return tastingDiff;
+    }
+
+    return right.bottle.id - left.bottle.id;
+  });
+
+  const normalizedQuery = normalizeString(query).toLowerCase().trim();
+  const filteredCandidates = normalizedQuery
+    ? candidates.filter((candidate) =>
+        canonRepairCandidateMatchesQuery(candidate, normalizedQuery),
+      )
+    : candidates;
+
+  const start = Math.max(0, (cursor - 1) * limit);
+  const results = filteredCandidates.slice(start, start + limit);
+  const nextCursor =
+    start + limit < filteredCandidates.length ? cursor + 1 : null;
+  const prevCursor = cursor > 1 ? cursor - 1 : null;
+
+  return {
+    results,
+    rel: {
+      nextCursor,
+      prevCursor,
+    },
+  };
+}

--- a/apps/server/src/lib/canonRepairCandidates.ts
+++ b/apps/server/src/lib/canonRepairCandidates.ts
@@ -3,7 +3,7 @@ import { bottles, type Bottle } from "@peated/server/db/schema";
 import { hasBottleLevelReleaseTraits } from "@peated/server/lib/bottleSchemaRules";
 import { hasVariantLegacyReleaseRepairParentName } from "@peated/server/lib/legacyReleaseRepairCandidates";
 import { normalizeString } from "@peated/server/lib/normalize";
-import { desc, inArray, sql } from "drizzle-orm";
+import { desc, eq, sql } from "drizzle-orm";
 
 const MAX_SCAN_LIMIT = 2000;
 
@@ -214,8 +214,7 @@ export async function getCanonRepairCandidates({
       .where(
         sql`${bottles.fullName} ILIKE ${`%${escapeLikePattern(query)}%`} ESCAPE '\\'`,
       )
-      .orderBy(desc(bottles.totalTastings), desc(bottles.id))
-      .limit(MAX_SCAN_LIMIT);
+      .orderBy(desc(bottles.totalTastings), desc(bottles.id));
 
     if (queryRows.length === 0) {
       return {
@@ -227,14 +226,32 @@ export async function getCanonRepairCandidates({
       };
     }
 
-    rows = await baseQuery
-      .where(
-        inArray(
-          bottles.brandId,
-          Array.from(new Set(queryRows.map((row) => row.brandId))),
-        ),
-      )
-      .orderBy(desc(bottles.totalTastings), desc(bottles.id));
+    const rowsById = new Map<number, CanonRepairBottle>();
+    for (const row of queryRows) {
+      rowsById.set(row.id, row);
+    }
+
+    for (const brandId of new Set(queryRows.map((row) => row.brandId))) {
+      const brandRows = await baseQuery
+        .where(eq(bottles.brandId, brandId))
+        .orderBy(desc(bottles.totalTastings), desc(bottles.id))
+        .limit(MAX_SCAN_LIMIT);
+
+      for (const row of brandRows) {
+        rowsById.set(row.id, row);
+      }
+    }
+
+    rows = Array.from(rowsById.values()).sort((left, right) => {
+      const tastingDiff =
+        getTastingCount(right.totalTastings) -
+        getTastingCount(left.totalTastings);
+      if (tastingDiff !== 0) {
+        return tastingDiff;
+      }
+
+      return right.id - left.id;
+    });
   } else {
     rows = await baseQuery
       .orderBy(desc(bottles.totalTastings), desc(bottles.id))

--- a/apps/server/src/lib/canonRepairCandidates.ts
+++ b/apps/server/src/lib/canonRepairCandidates.ts
@@ -214,7 +214,8 @@ export async function getCanonRepairCandidates({
       .where(
         sql`${bottles.fullName} ILIKE ${`%${escapeLikePattern(query)}%`} ESCAPE '\\'`,
       )
-      .orderBy(desc(bottles.totalTastings), desc(bottles.id));
+      .orderBy(desc(bottles.totalTastings), desc(bottles.id))
+      .limit(MAX_SCAN_LIMIT);
 
     if (queryRows.length === 0) {
       return {

--- a/apps/server/src/lib/canonRepairCandidates.ts
+++ b/apps/server/src/lib/canonRepairCandidates.ts
@@ -3,7 +3,7 @@ import { bottles, type Bottle } from "@peated/server/db/schema";
 import { hasBottleLevelReleaseTraits } from "@peated/server/lib/bottleSchemaRules";
 import { hasVariantLegacyReleaseRepairParentName } from "@peated/server/lib/legacyReleaseRepairCandidates";
 import { normalizeString } from "@peated/server/lib/normalize";
-import { desc } from "drizzle-orm";
+import { desc, inArray, sql } from "drizzle-orm";
 
 const MAX_SCAN_LIMIT = 2000;
 
@@ -51,6 +51,13 @@ export type CanonRepairCandidate = {
   }>;
 };
 
+function escapeLikePattern(value: string) {
+  return value
+    .replaceAll("\\", "\\\\")
+    .replaceAll("%", "\\%")
+    .replaceAll("_", "\\_");
+}
+
 function getTastingCount(value: null | number | undefined): number {
   return value ?? 0;
 }
@@ -93,6 +100,37 @@ function hasConflictingValue<TValue>(
   return left !== null && right !== null && left !== right;
 }
 
+const DISTINCT_CATEGORY_NAME_MARKERS = [
+  "bourbon",
+  "rye",
+  "scotch",
+  "irish",
+  "japanese",
+  "canadian",
+] as const;
+
+function getDistinctCategoryNameMarkers(fullName: string) {
+  const normalizedFullName = normalizeString(fullName).toLowerCase();
+
+  return DISTINCT_CATEGORY_NAME_MARKERS.filter((marker) =>
+    normalizedFullName.match(new RegExp(`\\b${marker}\\b`, "i")),
+  );
+}
+
+function hasConflictingCategoryNameMarkers(
+  source: Pick<CanonRepairBottle, "fullName">,
+  target: Pick<CanonRepairBottle, "fullName">,
+) {
+  const sourceMarkers = getDistinctCategoryNameMarkers(source.fullName);
+  const targetMarkers = getDistinctCategoryNameMarkers(target.fullName);
+
+  return (
+    sourceMarkers.length > 0 &&
+    targetMarkers.length > 0 &&
+    !sourceMarkers.some((marker) => targetMarkers.includes(marker))
+  );
+}
+
 function canCanonRepairPair(
   source: CanonRepairBottle,
   target: CanonRepairBottle,
@@ -113,7 +151,8 @@ function canCanonRepairPair(
     hasConflictingValue(source.category, target.category) ||
     hasConflictingValue(source.bottlerId, target.bottlerId) ||
     hasConflictingValue(source.seriesId, target.seriesId) ||
-    hasConflictingValue(source.statedAge, target.statedAge)
+    hasConflictingValue(source.statedAge, target.statedAge) ||
+    hasConflictingCategoryNameMarkers(source, target)
   ) {
     return false;
   }
@@ -167,9 +206,40 @@ export async function getCanonRepairCandidates({
     })
     .from(bottles);
 
-  const rows = await baseQuery
-    .orderBy(desc(bottles.totalTastings), desc(bottles.id))
-    .limit(MAX_SCAN_LIMIT);
+  const normalizedQuery = normalizeString(query).toLowerCase().trim();
+  let rows: CanonRepairBottle[];
+
+  if (normalizedQuery) {
+    const queryRows = await baseQuery
+      .where(
+        sql`${bottles.fullName} ILIKE ${`%${escapeLikePattern(query)}%`} ESCAPE '\\'`,
+      )
+      .orderBy(desc(bottles.totalTastings), desc(bottles.id))
+      .limit(MAX_SCAN_LIMIT);
+
+    if (queryRows.length === 0) {
+      return {
+        results: [],
+        rel: {
+          nextCursor: null,
+          prevCursor: cursor > 1 ? cursor - 1 : null,
+        },
+      };
+    }
+
+    rows = await baseQuery
+      .where(
+        inArray(
+          bottles.brandId,
+          Array.from(new Set(queryRows.map((row) => row.brandId))),
+        ),
+      )
+      .orderBy(desc(bottles.totalTastings), desc(bottles.id));
+  } else {
+    rows = await baseQuery
+      .orderBy(desc(bottles.totalTastings), desc(bottles.id))
+      .limit(MAX_SCAN_LIMIT);
+  }
 
   const brandGroups = new Map<number, CanonRepairBottle[]>();
   for (const row of rows) {
@@ -238,7 +308,6 @@ export async function getCanonRepairCandidates({
     return right.bottle.id - left.bottle.id;
   });
 
-  const normalizedQuery = normalizeString(query).toLowerCase().trim();
   const filteredCandidates = normalizedQuery
     ? candidates.filter((candidate) =>
         canonRepairCandidateMatchesQuery(candidate, normalizedQuery),

--- a/apps/server/src/orpc/routes/bottles/canon-repair-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/canon-repair-candidates.test.ts
@@ -1,0 +1,122 @@
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+describe("GET /bottles/canon-repair-candidates", () => {
+  test("requires moderator access", async ({ fixtures }) => {
+    const user = await fixtures.User({ mod: false });
+
+    const err = await waitError(
+      routerClient.bottles.canonRepairCandidates({}, { context: { user } }),
+    );
+
+    expect(err).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("lists same-brand generic wording variant merge candidates", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Elijah Craig" });
+    const user = await fixtures.User({ mod: true });
+    const targetBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Barrel Proof",
+      category: "bourbon",
+      totalTastings: 24,
+    });
+    const sourceBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Barrel Proof Kentucky Straight Bourbon",
+      category: "bourbon",
+      totalTastings: 3,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Toast",
+      category: "bourbon",
+      totalTastings: 50,
+    });
+
+    const { results } = await routerClient.bottles.canonRepairCandidates(
+      {},
+      { context: { user } },
+    );
+
+    expect(results).toMatchObject([
+      {
+        bottle: {
+          id: sourceBottle.id,
+          fullName: sourceBottle.fullName,
+        },
+        targetBottle: {
+          id: targetBottle.id,
+          fullName: targetBottle.fullName,
+        },
+      },
+    ]);
+  });
+
+  test("filters by query against the current bottle name", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Elijah Craig" });
+    const user = await fixtures.User({ mod: true });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Barrel Proof",
+      category: "bourbon",
+      totalTastings: 24,
+    });
+    const sourceBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Barrel Proof Kentucky Straight Bourbon",
+      category: "bourbon",
+      totalTastings: 3,
+    });
+
+    const matchingResults = await routerClient.bottles.canonRepairCandidates(
+      {
+        query: "Kentucky",
+      },
+      { context: { user } },
+    );
+    const emptyResults = await routerClient.bottles.canonRepairCandidates(
+      {
+        query: "Nomatch",
+      },
+      { context: { user } },
+    );
+
+    expect(matchingResults.results.map((result) => result.bottle.id)).toEqual([
+      sourceBottle.id,
+    ]);
+    expect(emptyResults.results).toEqual([]);
+  });
+
+  test("does not surface release-like bottles as canon repair candidates", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Aberlour" });
+    const user = await fixtures.User({ mod: true });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      name: "A'bunadh",
+      category: "single_malt",
+      totalTastings: 50,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      name: "A'bunadh",
+      edition: "Batch 31",
+      category: "single_malt",
+      totalTastings: 3,
+    });
+
+    const { results } = await routerClient.bottles.canonRepairCandidates(
+      {},
+      { context: { user } },
+    );
+
+    expect(results).toEqual([]);
+  });
+});

--- a/apps/server/src/orpc/routes/bottles/canon-repair-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/canon-repair-candidates.test.ts
@@ -1,3 +1,5 @@
+import { db } from "@peated/server/db";
+import { bottles } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { describe, expect, test } from "vitest";
@@ -93,6 +95,48 @@ describe("GET /bottles/canon-repair-candidates", () => {
     expect(emptyResults.results).toEqual([]);
   });
 
+  test("search still finds candidates when they fall below the default unfiltered scan cap", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Elijah Craig" });
+    const noiseBrand = await fixtures.Entity({ name: "Noise Brand" });
+    const user = await fixtures.User({ mod: true });
+
+    await db.insert(bottles).values(
+      Array.from({ length: 2000 }, (_, index) => ({
+        brandId: noiseBrand.id,
+        createdById: user.id,
+        fullName: `Noise Brand Noise ${index + 1}`,
+        name: `Noise ${index + 1}`,
+        totalTastings: 5000 - index,
+      })),
+    );
+
+    await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Barrel Proof",
+      category: "bourbon",
+      totalTastings: 1,
+    });
+    const sourceBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Barrel Proof Kentucky Straight Bourbon",
+      category: "bourbon",
+      totalTastings: 1,
+    });
+
+    const matchingResults = await routerClient.bottles.canonRepairCandidates(
+      {
+        query: "Kentucky",
+      },
+      { context: { user } },
+    );
+
+    expect(matchingResults.results.map((result) => result.bottle.id)).toContain(
+      sourceBottle.id,
+    );
+  });
+
   test("does not surface release-like bottles as canon repair candidates", async ({
     fixtures,
   }) => {
@@ -110,6 +154,32 @@ describe("GET /bottles/canon-repair-candidates", () => {
       edition: "Batch 31",
       category: "single_malt",
       totalTastings: 3,
+    });
+
+    const { results } = await routerClient.bottles.canonRepairCandidates(
+      {},
+      { context: { user } },
+    );
+
+    expect(results).toEqual([]);
+  });
+
+  test("does not surface category-only wording conflicts when one side lacks structured category", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Brand" });
+    const user = await fixtures.User({ mod: true });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Special Bourbon",
+      category: null,
+      totalTastings: 20,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Special Rye",
+      category: "rye",
+      totalTastings: 10,
     });
 
     const { results } = await routerClient.bottles.canonRepairCandidates(

--- a/apps/server/src/orpc/routes/bottles/canon-repair-candidates.ts
+++ b/apps/server/src/orpc/routes/bottles/canon-repair-candidates.ts
@@ -1,0 +1,60 @@
+import { getCanonRepairCandidates } from "@peated/server/lib/canonRepairCandidates";
+import { procedure } from "@peated/server/orpc";
+import { requireMod } from "@peated/server/orpc/middleware";
+import { z } from "zod";
+
+const CanonRepairCandidateSchema = z.object({
+  bottle: z.object({
+    id: z.number(),
+    fullName: z.string(),
+    numReleases: z.number(),
+    totalTastings: z.number().nullable(),
+  }),
+  targetBottle: z.object({
+    id: z.number(),
+    fullName: z.string(),
+    numReleases: z.number(),
+    totalTastings: z.number().nullable(),
+  }),
+  variantBottles: z.array(
+    z.object({
+      id: z.number(),
+      fullName: z.string(),
+      numReleases: z.number(),
+      totalTastings: z.number().nullable(),
+    }),
+  ),
+});
+
+export default procedure
+  .use(requireMod)
+  .route({
+    method: "GET",
+    path: "/bottles/canon-repair-candidates",
+    summary: "List canonical bottle merge repair candidates",
+    description:
+      "Retrieve moderator-facing audit candidates for likely wrong canonical bottle names that should be merged into an existing same-brand target bottle.",
+    spec: (spec) => ({
+      ...spec,
+      operationId: "listBottleCanonRepairCandidates",
+    }),
+  })
+  .input(
+    z.object({
+      query: z.coerce.string().default(""),
+      cursor: z.coerce.number().gte(1).default(1),
+      limit: z.coerce.number().gte(1).lte(100).default(25),
+    }),
+  )
+  .output(
+    z.object({
+      results: z.array(CanonRepairCandidateSchema),
+      rel: z.object({
+        nextCursor: z.number().nullable(),
+        prevCursor: z.number().nullable(),
+      }),
+    }),
+  )
+  .handler(async function ({ input }) {
+    return await getCanonRepairCandidates(input);
+  });

--- a/apps/server/src/orpc/routes/bottles/index.ts
+++ b/apps/server/src/orpc/routes/bottles/index.ts
@@ -3,6 +3,7 @@ import ageRepairCandidates from "./age-repair-candidates";
 import applyAgeRepair from "./apply-age-repair";
 import applyDirtyParentReleaseRepair from "./apply-dirty-parent-release-repair";
 import applyReleaseRepair from "./apply-release-repair";
+import canonRepairCandidates from "./canon-repair-candidates";
 import create from "./create";
 import delete_ from "./delete";
 import details from "./details";
@@ -23,6 +24,7 @@ export default base.tag("bottles").router({
   list,
   create,
   update,
+  canonRepairCandidates,
   ageRepairCandidates,
   applyAgeRepair,
   applyDirtyParentReleaseRepair,

--- a/apps/web/src/app/(admin)/admin/(default)/canon-repairs/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/canon-repairs/page.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
+import Button from "@peated/web/components/button";
+import EmptyActivity from "@peated/web/components/emptyActivity";
+import Form from "@peated/web/components/form";
+import PaginationButtons from "@peated/web/components/paginationButtons";
+import SimpleHeader from "@peated/web/components/simpleHeader";
+import TextInput from "@peated/web/components/textInput";
+import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { buildQueryString } from "@peated/web/lib/urls";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { usePathname, useSearchParams } from "next/navigation";
+
+function formatTastingCount(value: null | number): string {
+  return (value ?? 0).toLocaleString();
+}
+
+function buildCanonRepairHref(
+  pathname: string,
+  searchParams: URLSearchParams,
+  nextParams: Record<string, null | number | string | undefined>,
+): string {
+  const queryString = buildQueryString(searchParams, nextParams);
+  return queryString ? `${pathname}?${queryString}` : pathname;
+}
+
+export default function Page() {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentQuery = searchParams.get("query") ?? "";
+  const queryParams = useApiQueryParams({
+    defaults: {
+      limit: 25,
+    },
+    numericFields: ["cursor", "limit"],
+  });
+
+  const orpc = useORPC();
+  const { data: candidateList } = useSuspenseQuery(
+    orpc.bottles.canonRepairCandidates.queryOptions({
+      input: queryParams,
+    }),
+  );
+
+  return (
+    <>
+      <Breadcrumbs
+        pages={[
+          {
+            name: "Admin",
+            href: "/admin",
+          },
+          {
+            name: "Canon Repairs",
+            href: "/admin/canon-repairs",
+            current: true,
+          },
+        ]}
+      />
+
+      <SimpleHeader>Canon Repairs</SimpleHeader>
+
+      <div className="mb-6 space-y-4">
+        <div className="rounded-xl border border-slate-800 bg-slate-950 px-4 py-4 text-sm text-slate-300">
+          High-confidence same-brand bottle variants where the current canonical
+          bottle name likely needs to be merged into an existing cleaner target.
+          This queue links directly into the existing moderator merge flow with
+          the suggested target preselected.
+        </div>
+
+        <Form
+          action={pathname}
+          className="mb-0 rounded-xl border border-slate-800 bg-slate-950 px-4 py-4"
+        >
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+            <div className="min-w-0 flex-1">
+              <TextInput
+                type="text"
+                name="query"
+                defaultValue={currentQuery}
+                placeholder="Search bottle names"
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button type="submit" color="primary">
+                Search
+              </Button>
+              {currentQuery ? (
+                <Button
+                  href={buildCanonRepairHref(pathname, searchParams, {
+                    query: null,
+                    cursor: null,
+                  })}
+                >
+                  Clear
+                </Button>
+              ) : null}
+            </div>
+          </div>
+        </Form>
+      </div>
+
+      <div className="space-y-4">
+        {candidateList.results.length === 0 ? (
+          <EmptyActivity>
+            {currentQuery
+              ? "No canon repair candidates matched that search."
+              : "No canon repair candidates right now."}
+          </EmptyActivity>
+        ) : (
+          candidateList.results.map((candidate) => (
+            <div
+              key={candidate.bottle.id}
+              className="rounded-xl border border-slate-800 bg-slate-950 p-5"
+            >
+              <div className="mb-4 flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+                <div className="space-y-2">
+                  <div className="inline-flex rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1 text-xs font-medium uppercase tracking-wide text-amber-200">
+                    Same-brand wording variant
+                  </div>
+                  <div>
+                    <h2 className="text-lg font-semibold text-white">
+                      {candidate.bottle.fullName}
+                    </h2>
+                    <p className="text-sm text-slate-400">
+                      {formatTastingCount(candidate.bottle.totalTastings)}{" "}
+                      tastings on the current bottle,{" "}
+                      {candidate.bottle.numReleases} child releases
+                    </p>
+                  </div>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button href={`/bottles/${candidate.bottle.id}`}>
+                    Open Current Bottle
+                  </Button>
+                  <Button href={`/bottles/${candidate.targetBottle.id}`}>
+                    Open Suggested Target
+                  </Button>
+                  <Button
+                    color="primary"
+                    href={`/bottles/${candidate.bottle.id}/merge?other=${candidate.targetBottle.id}&direction=mergeInto`}
+                  >
+                    Open Merge
+                  </Button>
+                </div>
+              </div>
+
+              <div className="grid gap-4 lg:grid-cols-2">
+                <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                  <div className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+                    Current Canon Bottle
+                  </div>
+                  <div className="text-base font-medium text-white">
+                    {candidate.bottle.fullName}
+                  </div>
+                  <div className="mt-1 text-sm text-slate-400">
+                    {formatTastingCount(candidate.bottle.totalTastings)}{" "}
+                    tastings and {candidate.bottle.numReleases} releases
+                    currently live on this row.
+                  </div>
+                </div>
+
+                <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/10 p-4">
+                  <div className="mb-2 text-xs font-medium uppercase tracking-wide text-emerald-200">
+                    Suggested Merge Target
+                  </div>
+                  <div className="text-base font-medium text-white">
+                    {candidate.targetBottle.fullName}
+                  </div>
+                  <div className="mt-1 text-sm text-slate-300">
+                    {formatTastingCount(candidate.targetBottle.totalTastings)}{" "}
+                    tastings and {candidate.targetBottle.numReleases} releases
+                    on the proposed canonical target.
+                  </div>
+                </div>
+              </div>
+
+              {candidate.variantBottles.length > 0 ? (
+                <div className="mt-4 rounded-xl border border-slate-800 bg-slate-900/60 p-4">
+                  <div className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-400">
+                    Other Variant Bottles
+                  </div>
+                  <div className="space-y-1 text-sm text-slate-300">
+                    {candidate.variantBottles.map((variant) => (
+                      <div key={variant.id}>
+                        {variant.fullName} ·{" "}
+                        {formatTastingCount(variant.totalTastings)} tastings ·{" "}
+                        {variant.numReleases} releases
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          ))
+        )}
+
+        <PaginationButtons rel={candidateList.rel} />
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
@@ -47,12 +47,17 @@ export default function MergeBottle({
   const prefilledOtherBottleId = Number(searchParams.get("other") ?? 0) || null;
   const prefilledDirection =
     searchParams.get("direction") === "mergeFrom" ? "mergeFrom" : "mergeInto";
+  const prefillKey = prefilledOtherBottleId
+    ? `${prefilledOtherBottleId}:${prefilledDirection}`
+    : null;
 
   const [otherBottleName, setOtherBottleName] = useState<string>("Other");
   const [selectedOtherBottle, setSelectedOtherBottle] = useState<Option | null>(
     null,
   );
-  const [hasAppliedPrefill, setHasAppliedPrefill] = useState(false);
+  const [appliedPrefillKey, setAppliedPrefillKey] = useState<null | string>(
+    null,
+  );
 
   const { data: prefilledOtherBottle } = useQuery({
     ...orpc.bottles.details.queryOptions({
@@ -87,7 +92,8 @@ export default function MergeBottle({
   useEffect(() => {
     if (
       !prefilledOtherBottle ||
-      hasAppliedPrefill ||
+      !prefillKey ||
+      appliedPrefillKey === prefillKey ||
       dirtyFields.bottleId ||
       dirtyFields.direction
     ) {
@@ -103,11 +109,12 @@ export default function MergeBottle({
     setOtherBottleName(prefilledOtherBottle.fullName);
     setValue("bottleId", prefilledOtherBottle.id, { shouldDirty: false });
     setValue("direction", prefilledDirection, { shouldDirty: false });
-    setHasAppliedPrefill(true);
+    setAppliedPrefillKey(prefillKey);
   }, [
+    appliedPrefillKey,
     dirtyFields.bottleId,
     dirtyFields.direction,
-    hasAppliedPrefill,
+    prefillKey,
     prefilledDirection,
     prefilledOtherBottle,
     setValue,

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
@@ -11,15 +11,17 @@ import FormError from "@peated/web/components/formError";
 import FormHeader from "@peated/web/components/formHeader";
 import Header from "@peated/web/components/header";
 import Layout from "@peated/web/components/layout";
+import type { Option } from "@peated/web/components/selectField";
 import { useModRequired } from "@peated/web/hooks/useAuthRequired";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import {
   useMutation,
+  useQuery,
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
 import type { SubmitHandler } from "react-hook-form";
 import { Controller, useForm } from "react-hook-form";
 import type { z } from "zod";
@@ -35,14 +37,29 @@ export default function MergeBottle({
 
   const orpc = useORPC();
   const queryClient = useQueryClient();
+  const searchParams = useSearchParams();
   const { data: bottle } = useSuspenseQuery(
     orpc.bottles.details.queryOptions({ input: { bottle: Number(bottleId) } }),
   );
   const { flash } = useFlashMessages();
 
   const router = useRouter();
+  const prefilledOtherBottleId = Number(searchParams.get("other") ?? 0) || null;
+  const prefilledDirection =
+    searchParams.get("direction") === "mergeFrom" ? "mergeFrom" : "mergeInto";
 
   const [otherBottleName, setOtherBottleName] = useState<string>("Other");
+  const [selectedOtherBottle, setSelectedOtherBottle] = useState<Option | null>(
+    null,
+  );
+  const [hasAppliedPrefill, setHasAppliedPrefill] = useState(false);
+
+  const { data: prefilledOtherBottle } = useQuery({
+    ...orpc.bottles.details.queryOptions({
+      input: { bottle: prefilledOtherBottleId ?? 0 },
+    }),
+    enabled: prefilledOtherBottleId !== null,
+  });
 
   const bottleMergeMutation = useMutation({
     ...orpc.bottles.merge.mutationOptions(),
@@ -58,13 +75,43 @@ export default function MergeBottle({
   const {
     control,
     handleSubmit,
-    formState: { errors, isSubmitting },
+    setValue,
+    formState: { dirtyFields, errors, isSubmitting },
   } = useForm<FormSchemaType>({
     resolver: zodResolver(BottleMergeSchema),
     defaultValues: {
-      direction: "mergeInto",
+      direction: prefilledDirection,
     },
   });
+
+  useEffect(() => {
+    if (
+      !prefilledOtherBottle ||
+      hasAppliedPrefill ||
+      dirtyFields.bottleId ||
+      dirtyFields.direction
+    ) {
+      return;
+    }
+
+    const nextBottle = {
+      id: prefilledOtherBottle.id,
+      name: prefilledOtherBottle.fullName,
+    };
+
+    setSelectedOtherBottle(nextBottle);
+    setOtherBottleName(prefilledOtherBottle.fullName);
+    setValue("bottleId", prefilledOtherBottle.id, { shouldDirty: false });
+    setValue("direction", prefilledDirection, { shouldDirty: false });
+    setHasAppliedPrefill(true);
+  }, [
+    dirtyFields.bottleId,
+    dirtyFields.direction,
+    hasAppliedPrefill,
+    prefilledDirection,
+    prefilledOtherBottle,
+    setValue,
+  ]);
 
   const onSubmit: SubmitHandler<FormSchemaType> = async (data) => {
     await bottleMergeMutation.mutateAsync(
@@ -114,8 +161,10 @@ export default function MergeBottle({
                 error={errors.bottleId}
                 label="Other Bottle"
                 required
+                value={selectedOtherBottle}
                 onChange={(value) => {
                   onChange(value?.id);
+                  setSelectedOtherBottle(value ?? null);
                   setOtherBottleName(value?.name || "Other");
                 }}
                 onResults={(results) => {

--- a/apps/web/src/components/admin/sidebar.tsx
+++ b/apps/web/src/components/admin/sidebar.tsx
@@ -41,6 +41,12 @@ export default function AdminSidebar() {
                     Badges
                   </SidebarLink>
                   <SidebarLink
+                    href="/admin/canon-repairs"
+                    active={pathname.startsWith("/admin/canon-repairs")}
+                  >
+                    Canon Repairs
+                  </SidebarLink>
+                  <SidebarLink
                     href="/admin/age-repairs"
                     active={pathname.startsWith("/admin/age-repairs")}
                   >


### PR DESCRIPTION
Add a moderator-facing canon repair queue for likely wrong parent bottle names.

We have the release-repair and age-repair flows on main now, but the remaining cleanup gap is cases where canon is simply the wrong bottle row and the right fix is to merge into an existing same-brand target. This adds an audit route plus `/admin/canon-repairs`, and it links directly into the existing merge flow with the suggested target prefilled so moderators do not have to rediscover the merge target manually.

The merge page now treats URL-provided suggestions as one-shot prefills so async lookup cannot overwrite moderator edits after they start changing the form. The candidate search also applies query filtering after canon-variant grouping so source-only searches like `Kentucky` still find `Elijah Craig Barrel Proof Kentucky Straight Bourbon` even when the reusable target is `Elijah Craig Barrel Proof`.

Refs #311