### PR TITLE
feat(cli): add repair backfill proposal export

### DIFF
--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -14,11 +14,74 @@ import {
   formatCategoryName,
 } from "@peated/server/lib/format";
 import { normalizeBottle } from "@peated/server/lib/normalize";
+import {
+  getRepairBackfillProposals,
+  type RepairBackfillProposal,
+  type RepairBackfillProposalType,
+} from "@peated/server/lib/repairBackfillProposals";
 import { routerClient } from "@peated/server/orpc/router";
 import { runJob } from "@peated/server/worker/client";
 import { and, asc, eq, inArray, isNull, ne } from "drizzle-orm";
 
 const subcommand = program.command("bottles");
+const REPAIR_BACKFILL_PROPOSAL_TYPES = ["release", "age", "canon"] as const;
+const REPAIR_BACKFILL_PROPOSAL_FORMATS = ["summary", "json"] as const;
+
+function parseRepairBackfillProposalTypes(
+  value: string,
+): RepairBackfillProposalType[] {
+  if (value === "all") {
+    return [...REPAIR_BACKFILL_PROPOSAL_TYPES];
+  }
+
+  const types = Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  );
+
+  if (types.length === 0) {
+    throw new Error(
+      "Repair proposal types must include one of: release, age, canon, all.",
+    );
+  }
+
+  for (const type of types) {
+    if (!REPAIR_BACKFILL_PROPOSAL_TYPES.includes(type as never)) {
+      throw new Error(
+        `Unknown repair proposal type: ${type}. Expected one of: release, age, canon, all.`,
+      );
+    }
+  }
+
+  return types as RepairBackfillProposalType[];
+}
+
+function parseRepairBackfillProposalFormat(value: string): "json" | "summary" {
+  if (!REPAIR_BACKFILL_PROPOSAL_FORMATS.includes(value as never)) {
+    throw new Error(
+      `Unknown repair proposal format: ${value}. Expected one of: summary, json.`,
+    );
+  }
+
+  return value as "json" | "summary";
+}
+
+function formatRepairBackfillProposalSummaryLine(
+  proposal: RepairBackfillProposal,
+) {
+  switch (proposal.type) {
+    case "release":
+      return `[release/${proposal.repairMode}/${proposal.actionability}] ${proposal.bottle.fullName} -> ${proposal.proposedParent.fullName}`;
+    case "age":
+      return `[age/${proposal.repairMode}/${proposal.actionability}] ${proposal.bottle.fullName} -> ${proposal.targetRelease.fullName}`;
+    case "canon":
+      return `[canon/${proposal.actionability}] ${proposal.bottle.fullName} -> ${proposal.targetBottle.fullName}`;
+  }
+}
 
 subcommand
   .command("normalize")
@@ -284,6 +347,77 @@ subcommand
         hasResults = true;
       }
       offset += step;
+    }
+  });
+
+subcommand
+  .command("dump-repair-proposals")
+  .description(
+    "Dump high-confidence repair/backfill proposals across release, age, and canon queues",
+  )
+  .option(
+    "--type <type>",
+    "Comma-separated proposal types: release, age, canon, or all",
+    "all",
+  )
+  .option("--format <format>", "Output format: summary or json", "summary")
+  .option(
+    "--limit <number>",
+    "Maximum number of proposals to collect per type",
+    "100",
+  )
+  .option("--query <query>", "Filter proposals by bottle name", "")
+  .option(
+    "--only-actionable",
+    "Only include proposals that can be applied directly today",
+  )
+  .action(async (options) => {
+    const perTypeLimit = Number.parseInt(options.limit, 10);
+    if (!Number.isFinite(perTypeLimit) || perTypeLimit <= 0) {
+      throw new Error(`Invalid limit: ${options.limit}`);
+    }
+
+    const types = parseRepairBackfillProposalTypes(options.type);
+    const format = parseRepairBackfillProposalFormat(options.format);
+    const result = await getRepairBackfillProposals({
+      onlyActionable: Boolean(options.onlyActionable),
+      perTypeLimit,
+      query: options.query,
+      types,
+    });
+
+    if (format === "json") {
+      console.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    console.log(`Repair backfill proposals: ${result.summary.total}`);
+    console.log(
+      `Types: ${types.join(", ")} | Per-type limit: ${perTypeLimit} | Query: ${options.query || "(none)"}`,
+    );
+    console.log(
+      `Actionability: apply=${result.summary.byActionability.apply}, blocked=${result.summary.byActionability.blocked}, manual=${result.summary.byActionability.manual}`,
+    );
+    console.log(
+      `By type: release=${result.summary.byType.release}, age=${result.summary.byType.age}, canon=${result.summary.byType.canon}`,
+    );
+
+    if (result.proposals.length === 0) {
+      return;
+    }
+
+    console.log("");
+    console.log("Top proposals:");
+    for (const proposal of result.proposals.slice(0, 25)) {
+      console.log(formatRepairBackfillProposalSummaryLine(proposal));
+      console.log(`  ${proposal.adminHref}`);
+    }
+
+    if (result.proposals.length > 25) {
+      console.log("");
+      console.log(
+        `... ${result.proposals.length - 25} more proposal(s) omitted. Use --format json for the full output.`,
+      );
     }
   });
 

--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -1,0 +1,351 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { getCanonRepairCandidates } from "@peated/server/lib/canonRepairCandidates";
+import { getDirtyParentAgeRepairCandidates } from "@peated/server/lib/dirtyParentAgeRepairCandidates";
+import { getLegacyReleaseRepairCandidates } from "@peated/server/lib/legacyReleaseRepairCandidates";
+import {
+  getRepairBackfillProposals,
+  type RepairBackfillProposal,
+} from "@peated/server/lib/repairBackfillProposals";
+
+vi.mock("@peated/server/lib/canonRepairCandidates", () => ({
+  getCanonRepairCandidates: vi.fn(),
+}));
+
+vi.mock("@peated/server/lib/dirtyParentAgeRepairCandidates", () => ({
+  getDirtyParentAgeRepairCandidates: vi.fn(),
+}));
+
+vi.mock("@peated/server/lib/legacyReleaseRepairCandidates", () => ({
+  getLegacyReleaseRepairCandidates: vi.fn(),
+}));
+
+const getLegacyReleaseRepairCandidatesMock = vi.mocked(
+  getLegacyReleaseRepairCandidates,
+);
+const getDirtyParentAgeRepairCandidatesMock = vi.mocked(
+  getDirtyParentAgeRepairCandidates,
+);
+const getCanonRepairCandidatesMock = vi.mocked(getCanonRepairCandidates);
+
+function createLegacyBottleMock(overrides: Record<string, unknown>) {
+  return {
+    id: 1,
+    brandId: 1,
+    fullName: "Legacy Bottle",
+    edition: null,
+    releaseYear: null,
+    numReleases: 0,
+    totalTastings: null,
+    ...overrides,
+  };
+}
+
+function createAgeBottleMock(overrides: Record<string, unknown>) {
+  return {
+    id: 1,
+    fullName: "Dirty Parent",
+    name: "Dirty Parent",
+    statedAge: 40,
+    numReleases: 1,
+    totalTastings: 0,
+    edition: null,
+    releaseYear: null,
+    vintageYear: null,
+    abv: null,
+    singleCask: null,
+    caskStrength: null,
+    caskFill: null,
+    caskType: null,
+    caskSize: null,
+    ...overrides,
+  };
+}
+
+describe("getRepairBackfillProposals", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+
+    getDirtyParentAgeRepairCandidatesMock.mockResolvedValue({
+      results: [
+        {
+          bottle: createAgeBottleMock({
+            id: 21,
+            fullName: "Glenglassaugh 1978 Rare Cask Release",
+            name: "Rare Cask Release",
+            statedAge: 40,
+            numReleases: 2,
+            totalTastings: 9,
+          }),
+          conflictingReleases: [
+            {
+              id: 22,
+              fullName: "Glenglassaugh 1978 Rare Cask Release - Batch 1",
+              statedAge: 35,
+              totalTastings: 4,
+            },
+          ],
+          repairMode: "create_release",
+          targetRelease: {
+            id: null,
+            fullName: "Glenglassaugh 1978 Rare Cask Release 40-year-old",
+            statedAge: 40,
+            totalTastings: null,
+          },
+        },
+      ],
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+    });
+
+    getCanonRepairCandidatesMock.mockResolvedValue({
+      results: [
+        {
+          bottle: {
+            id: 31,
+            fullName: "Elijah Craig Barrel Proof Kentucky Straight Bourbon",
+            numReleases: 0,
+            totalTastings: 3,
+          },
+          targetBottle: {
+            id: 32,
+            fullName: "Elijah Craig Barrel Proof",
+            numReleases: 5,
+            totalTastings: 24,
+          },
+          variantBottles: [],
+        },
+      ],
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+    });
+  });
+
+  test("collects paginated release proposals and normalizes summary counts", async () => {
+    getLegacyReleaseRepairCandidatesMock
+      .mockResolvedValueOnce({
+        results: [
+          {
+            blockingAlias: null,
+            blockingParent: null,
+            legacyBottle: createLegacyBottleMock({
+              id: 11,
+              fullName: "Aberlour A'bunadh Batch 32",
+              edition: "Batch 32",
+              totalTastings: 12,
+            }),
+            proposedParent: {
+              id: 12,
+              fullName: "Aberlour A'bunadh",
+              totalTastings: 200,
+            },
+            releaseIdentity: {
+              edition: "Batch 32",
+              releaseYear: null,
+              markerSources: ["name_batch"],
+            },
+            siblingLegacyBottles: [
+              {
+                id: 13,
+                fullName: "Aberlour A'bunadh Batch 31",
+              },
+            ],
+            hasExactParent: true,
+            repairMode: "existing_parent",
+          },
+        ],
+        rel: {
+          nextCursor: 2,
+          prevCursor: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        results: [
+          {
+            blockingAlias: {
+              name: "Lagavulin Distillers Edition",
+              bottleId: 42,
+              bottleFullName: "Lagavulin Distillers Edition",
+              releaseId: null,
+              releaseFullName: null,
+            },
+            blockingParent: null,
+            legacyBottle: createLegacyBottleMock({
+              id: 41,
+              fullName: "Lagavulin Distillers Edition 2011 Release",
+              edition: "2011 Release",
+              releaseYear: 2011,
+              totalTastings: 8,
+            }),
+            proposedParent: {
+              id: null,
+              fullName: "Lagavulin Distillers Edition",
+              totalTastings: null,
+            },
+            releaseIdentity: {
+              edition: "2011 Release",
+              releaseYear: 2011,
+              markerSources: ["structured_edition"],
+            },
+            siblingLegacyBottles: [],
+            hasExactParent: false,
+            repairMode: "blocked_alias_conflict",
+          },
+        ],
+        rel: {
+          nextCursor: null,
+          prevCursor: 1,
+        },
+      });
+
+    const result = await getRepairBackfillProposals({
+      perTypeLimit: 2,
+    });
+
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(1, {
+      cursor: 1,
+      limit: 2,
+      query: "",
+    });
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(2, {
+      cursor: 2,
+      limit: 1,
+      query: "",
+    });
+    expect(result.summary).toEqual({
+      total: 4,
+      byType: {
+        release: 2,
+        age: 1,
+        canon: 1,
+      },
+      byActionability: {
+        apply: 2,
+        blocked: 1,
+        manual: 1,
+      },
+    });
+    expect(result.proposals).toEqual(
+      expect.arrayContaining<RepairBackfillProposal>([
+        expect.objectContaining({
+          type: "release",
+          actionability: "apply",
+          adminHref:
+            "/admin/release-repairs?query=Aberlour%20A'bunadh%20Batch%2032",
+          siblingCount: 1,
+        }),
+        expect.objectContaining({
+          type: "release",
+          actionability: "blocked",
+          adminHref:
+            "/admin/release-repairs?query=Lagavulin%20Distillers%20Edition%202011%20Release",
+          blockingAlias: expect.objectContaining({
+            name: "Lagavulin Distillers Edition",
+          }),
+        }),
+        expect.objectContaining({
+          type: "age",
+          adminHref:
+            "/admin/age-repairs?query=Glenglassaugh%201978%20Rare%20Cask%20Release",
+        }),
+        expect.objectContaining({
+          type: "canon",
+          actionability: "manual",
+          adminHref:
+            "/admin/canon-repairs?query=Elijah%20Craig%20Barrel%20Proof%20Kentucky%20Straight%20Bourbon",
+        }),
+      ]),
+    );
+  });
+
+  test("can filter down to directly applyable repair proposals", async () => {
+    getLegacyReleaseRepairCandidatesMock.mockResolvedValue({
+      results: [
+        {
+          blockingAlias: null,
+          blockingParent: null,
+          legacyBottle: createLegacyBottleMock({
+            id: 11,
+            fullName: "Aberlour A'bunadh Batch 32",
+            edition: "Batch 32",
+            totalTastings: 12,
+          }),
+          proposedParent: {
+            id: 12,
+            fullName: "Aberlour A'bunadh",
+            totalTastings: 200,
+          },
+          releaseIdentity: {
+            edition: "Batch 32",
+            releaseYear: null,
+            markerSources: ["name_batch"],
+          },
+          siblingLegacyBottles: [],
+          hasExactParent: true,
+          repairMode: "existing_parent",
+        },
+        {
+          blockingAlias: null,
+          blockingParent: {
+            id: 17,
+            fullName: "Dirty Parent",
+            totalTastings: 10,
+          },
+          legacyBottle: createLegacyBottleMock({
+            id: 16,
+            fullName: "Dirty Parent Batch 4",
+            edition: "Batch 4",
+            totalTastings: 5,
+          }),
+          proposedParent: {
+            id: 17,
+            fullName: "Dirty Parent",
+            totalTastings: 10,
+          },
+          releaseIdentity: {
+            edition: "Batch 4",
+            releaseYear: null,
+            markerSources: ["name_batch"],
+          },
+          siblingLegacyBottles: [],
+          hasExactParent: true,
+          repairMode: "blocked_dirty_parent",
+        },
+      ],
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+    });
+
+    const result = await getRepairBackfillProposals({
+      onlyActionable: true,
+      types: ["release", "canon"],
+    });
+
+    expect(result.summary).toEqual({
+      total: 1,
+      byType: {
+        release: 1,
+        age: 0,
+        canon: 0,
+      },
+      byActionability: {
+        apply: 1,
+        blocked: 0,
+        manual: 0,
+      },
+    });
+    expect(result.proposals).toEqual([
+      expect.objectContaining({
+        type: "release",
+        actionability: "apply",
+        repairMode: "existing_parent",
+      }),
+    ]);
+  });
+});

--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -213,7 +213,7 @@ describe("getRepairBackfillProposals", () => {
     });
     expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(2, {
       cursor: 2,
-      limit: 1,
+      limit: 2,
       query: "",
     });
     expect(result.summary).toEqual({
@@ -347,5 +347,93 @@ describe("getRepairBackfillProposals", () => {
         repairMode: "existing_parent",
       }),
     ]);
+  });
+
+  test("keeps a stable page size across cursor hops above the max page size", async () => {
+    getLegacyReleaseRepairCandidatesMock
+      .mockResolvedValueOnce({
+        results: Array.from({ length: 100 }, (_, index) => ({
+          blockingAlias: null,
+          blockingParent: null,
+          legacyBottle: createLegacyBottleMock({
+            id: index + 1,
+            fullName: `Release Repair ${index + 1}`,
+            edition: `Batch ${index + 1}`,
+            totalTastings: 500 - index,
+          }),
+          proposedParent: {
+            id: 1000,
+            fullName: "Release Repair",
+            totalTastings: 1000,
+          },
+          releaseIdentity: {
+            edition: `Batch ${index + 1}`,
+            releaseYear: null,
+            markerSources: ["name_batch"],
+          },
+          siblingLegacyBottles: [],
+          hasExactParent: true,
+          repairMode: "existing_parent" as const,
+        })),
+        rel: {
+          nextCursor: 2,
+          prevCursor: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        results: Array.from({ length: 100 }, (_, index) => ({
+          blockingAlias: null,
+          blockingParent: null,
+          legacyBottle: createLegacyBottleMock({
+            id: index + 101,
+            fullName: `Release Repair ${index + 101}`,
+            edition: `Batch ${index + 101}`,
+            totalTastings: 400 - index,
+          }),
+          proposedParent: {
+            id: 1000,
+            fullName: "Release Repair",
+            totalTastings: 1000,
+          },
+          releaseIdentity: {
+            edition: `Batch ${index + 101}`,
+            releaseYear: null,
+            markerSources: ["name_batch"],
+          },
+          siblingLegacyBottles: [],
+          hasExactParent: true,
+          repairMode: "existing_parent" as const,
+        })),
+        rel: {
+          nextCursor: null,
+          prevCursor: 1,
+        },
+      });
+
+    const result = await getRepairBackfillProposals({
+      perTypeLimit: 150,
+      types: ["release"],
+    });
+
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(1, {
+      cursor: 1,
+      limit: 100,
+      query: "",
+    });
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(2, {
+      cursor: 2,
+      limit: 100,
+      query: "",
+    });
+    expect(result.summary.total).toBe(150);
+    expect(result.proposals).toHaveLength(150);
+    expect(result.proposals.at(-1)).toEqual(
+      expect.objectContaining({
+        type: "release",
+        bottle: expect.objectContaining({
+          id: 150,
+        }),
+      }),
+    );
   });
 });

--- a/apps/server/src/lib/repairBackfillProposals.ts
+++ b/apps/server/src/lib/repairBackfillProposals.ts
@@ -151,13 +151,13 @@ async function collectRepairCandidates<TCandidate>({
   query: string;
 }) {
   const results: TCandidate[] = [];
+  const pageSize = Math.min(MAX_PAGE_SIZE, perTypeLimit);
   let cursor = 1;
 
   while (results.length < perTypeLimit) {
-    const pageLimit = Math.min(MAX_PAGE_SIZE, perTypeLimit - results.length);
     const page = await fetcher({
       cursor,
-      limit: pageLimit,
+      limit: pageSize,
       query,
     });
 
@@ -170,7 +170,7 @@ async function collectRepairCandidates<TCandidate>({
     cursor = page.rel.nextCursor;
   }
 
-  return results;
+  return results.slice(0, perTypeLimit);
 }
 
 function toReleaseRepairBackfillProposal(

--- a/apps/server/src/lib/repairBackfillProposals.ts
+++ b/apps/server/src/lib/repairBackfillProposals.ts
@@ -1,0 +1,327 @@
+import {
+  getCanonRepairCandidates,
+  type CanonRepairCandidate,
+} from "@peated/server/lib/canonRepairCandidates";
+import {
+  getDirtyParentAgeRepairCandidates,
+  type DirtyParentAgeRepairCandidate,
+} from "@peated/server/lib/dirtyParentAgeRepairCandidates";
+import {
+  getLegacyReleaseRepairCandidates,
+  type LegacyReleaseRepairCandidate,
+  type LegacyReleaseRepairParentMode,
+} from "@peated/server/lib/legacyReleaseRepairCandidates";
+
+const DEFAULT_PER_TYPE_LIMIT = 100;
+const MAX_PAGE_SIZE = 100;
+
+export type RepairBackfillProposalType = "age" | "canon" | "release";
+export type RepairBackfillProposalActionability =
+  | "apply"
+  | "blocked"
+  | "manual";
+
+type RepairBackfillProposalSummary = {
+  byActionability: Record<RepairBackfillProposalActionability, number>;
+  byType: Record<RepairBackfillProposalType, number>;
+  total: number;
+};
+
+type RepairBackfillCandidatePage<TCandidate> = {
+  rel: {
+    nextCursor: null | number;
+    prevCursor: null | number;
+  };
+  results: TCandidate[];
+};
+
+type RepairBackfillProposalBase = {
+  actionability: RepairBackfillProposalActionability;
+  adminHref: string;
+  totalTastings: null | number;
+  type: RepairBackfillProposalType;
+};
+
+export type ReleaseRepairBackfillProposal = RepairBackfillProposalBase & {
+  actionability: "apply" | "blocked";
+  bottle: {
+    fullName: string;
+    id: number;
+    totalTastings: null | number;
+  };
+  blockingAlias: null | {
+    bottleFullName: string | null;
+    bottleId: number | null;
+    name: string;
+    releaseFullName: string | null;
+    releaseId: number | null;
+  };
+  blockingParent: null | {
+    fullName: string;
+    id: number;
+    totalTastings: null | number;
+  };
+  proposedParent: {
+    fullName: string;
+    id: number | null;
+    totalTastings: null | number;
+  };
+  releaseIdentity: {
+    edition: null | string;
+    markerSources: string[];
+    releaseYear: null | number;
+  };
+  repairMode: LegacyReleaseRepairParentMode;
+  siblingCount: number;
+  type: "release";
+};
+
+export type AgeRepairBackfillProposal = RepairBackfillProposalBase & {
+  actionability: "apply";
+  bottle: {
+    fullName: string;
+    id: number;
+    statedAge: number;
+    totalTastings: null | number;
+  };
+  conflictingReleaseCount: number;
+  repairMode: "create_release" | "existing_release";
+  targetRelease: {
+    fullName: string;
+    id: number | null;
+    statedAge: number;
+    totalTastings: null | number;
+  };
+  type: "age";
+};
+
+export type CanonRepairBackfillProposal = RepairBackfillProposalBase & {
+  actionability: "manual";
+  bottle: {
+    fullName: string;
+    id: number;
+    totalTastings: null | number;
+  };
+  targetBottle: {
+    fullName: string;
+    id: number;
+    totalTastings: null | number;
+  };
+  type: "canon";
+  variantCount: number;
+};
+
+export type RepairBackfillProposal =
+  | AgeRepairBackfillProposal
+  | CanonRepairBackfillProposal
+  | ReleaseRepairBackfillProposal;
+
+export type RepairBackfillProposalResult = {
+  proposals: RepairBackfillProposal[];
+  summary: RepairBackfillProposalSummary;
+};
+
+function buildAdminHref(pathname: string, query: string) {
+  return `${pathname}?query=${encodeURIComponent(query)}`;
+}
+
+function getProposalTastingCount(proposal: RepairBackfillProposal) {
+  return proposal.totalTastings ?? 0;
+}
+
+function getRepairBackfillProposalActionability(
+  repairMode: LegacyReleaseRepairParentMode,
+): "apply" | "blocked" {
+  return repairMode === "existing_parent" || repairMode === "create_parent"
+    ? "apply"
+    : "blocked";
+}
+
+async function collectRepairCandidates<TCandidate>({
+  fetcher,
+  perTypeLimit,
+  query,
+}: {
+  fetcher: (args: {
+    cursor: number;
+    limit: number;
+    query: string;
+  }) => Promise<RepairBackfillCandidatePage<TCandidate>>;
+  perTypeLimit: number;
+  query: string;
+}) {
+  const results: TCandidate[] = [];
+  let cursor = 1;
+
+  while (results.length < perTypeLimit) {
+    const pageLimit = Math.min(MAX_PAGE_SIZE, perTypeLimit - results.length);
+    const page = await fetcher({
+      cursor,
+      limit: pageLimit,
+      query,
+    });
+
+    results.push(...page.results);
+
+    if (!page.rel.nextCursor || page.results.length === 0) {
+      break;
+    }
+
+    cursor = page.rel.nextCursor;
+  }
+
+  return results;
+}
+
+function toReleaseRepairBackfillProposal(
+  candidate: LegacyReleaseRepairCandidate,
+): ReleaseRepairBackfillProposal {
+  return {
+    type: "release",
+    actionability: getRepairBackfillProposalActionability(candidate.repairMode),
+    adminHref: buildAdminHref(
+      "/admin/release-repairs",
+      candidate.legacyBottle.fullName,
+    ),
+    bottle: {
+      id: candidate.legacyBottle.id,
+      fullName: candidate.legacyBottle.fullName,
+      totalTastings: candidate.legacyBottle.totalTastings,
+    },
+    blockingAlias: candidate.blockingAlias,
+    blockingParent: candidate.blockingParent,
+    proposedParent: candidate.proposedParent,
+    releaseIdentity: candidate.releaseIdentity,
+    repairMode: candidate.repairMode,
+    siblingCount: candidate.siblingLegacyBottles.length,
+    totalTastings: candidate.legacyBottle.totalTastings,
+  };
+}
+
+function toAgeRepairBackfillProposal(
+  candidate: DirtyParentAgeRepairCandidate,
+): AgeRepairBackfillProposal {
+  return {
+    type: "age",
+    actionability: "apply",
+    adminHref: buildAdminHref("/admin/age-repairs", candidate.bottle.fullName),
+    bottle: {
+      id: candidate.bottle.id,
+      fullName: candidate.bottle.fullName,
+      statedAge: candidate.bottle.statedAge,
+      totalTastings: candidate.bottle.totalTastings,
+    },
+    conflictingReleaseCount: candidate.conflictingReleases.length,
+    repairMode: candidate.repairMode,
+    targetRelease: candidate.targetRelease,
+    totalTastings: candidate.bottle.totalTastings,
+  };
+}
+
+function toCanonRepairBackfillProposal(
+  candidate: CanonRepairCandidate,
+): CanonRepairBackfillProposal {
+  return {
+    type: "canon",
+    actionability: "manual",
+    adminHref: buildAdminHref(
+      "/admin/canon-repairs",
+      candidate.bottle.fullName,
+    ),
+    bottle: candidate.bottle,
+    targetBottle: candidate.targetBottle,
+    totalTastings: candidate.bottle.totalTastings,
+    variantCount: candidate.variantBottles.length,
+  };
+}
+
+function createRepairBackfillProposalSummary(
+  proposals: RepairBackfillProposal[],
+): RepairBackfillProposalSummary {
+  return proposals.reduce<RepairBackfillProposalSummary>(
+    (summary, proposal) => {
+      summary.total += 1;
+      summary.byType[proposal.type] += 1;
+      summary.byActionability[proposal.actionability] += 1;
+      return summary;
+    },
+    {
+      total: 0,
+      byType: {
+        release: 0,
+        age: 0,
+        canon: 0,
+      },
+      byActionability: {
+        apply: 0,
+        blocked: 0,
+        manual: 0,
+      },
+    },
+  );
+}
+
+export async function getRepairBackfillProposals({
+  onlyActionable = false,
+  perTypeLimit = DEFAULT_PER_TYPE_LIMIT,
+  query = "",
+  types = ["release", "age", "canon"],
+}: {
+  onlyActionable?: boolean;
+  perTypeLimit?: number;
+  query?: string;
+  types?: RepairBackfillProposalType[];
+} = {}): Promise<RepairBackfillProposalResult> {
+  const normalizedTypes = Array.from(new Set(types));
+  const proposals: RepairBackfillProposal[] = [];
+
+  if (normalizedTypes.includes("release")) {
+    const results = await collectRepairCandidates({
+      fetcher: getLegacyReleaseRepairCandidates,
+      perTypeLimit,
+      query,
+    });
+    proposals.push(...results.map(toReleaseRepairBackfillProposal));
+  }
+
+  if (normalizedTypes.includes("age")) {
+    const results = await collectRepairCandidates({
+      fetcher: getDirtyParentAgeRepairCandidates,
+      perTypeLimit,
+      query,
+    });
+    proposals.push(...results.map(toAgeRepairBackfillProposal));
+  }
+
+  if (normalizedTypes.includes("canon")) {
+    const results = await collectRepairCandidates({
+      fetcher: getCanonRepairCandidates,
+      perTypeLimit,
+      query,
+    });
+    proposals.push(...results.map(toCanonRepairBackfillProposal));
+  }
+
+  const filteredProposals = onlyActionable
+    ? proposals.filter((proposal) => proposal.actionability === "apply")
+    : proposals;
+
+  filteredProposals.sort((left, right) => {
+    const tastingDiff =
+      getProposalTastingCount(right) - getProposalTastingCount(left);
+    if (tastingDiff !== 0) {
+      return tastingDiff;
+    }
+
+    if (left.type !== right.type) {
+      return left.type.localeCompare(right.type);
+    }
+
+    return left.adminHref.localeCompare(right.adminHref);
+  });
+
+  return {
+    proposals: filteredProposals,
+    summary: createRepairBackfillProposalSummary(filteredProposals),
+  };
+}


### PR DESCRIPTION
Add a first bulk/backfill slice on top of the existing repair queues.

This introduces a shared repair proposal aggregator that normalizes high-confidence release, dirty-parent-age, and canon-merge candidates into one exportable model, plus a new `peated bottles dump-repair-proposals` CLI command. The command can filter by repair type, bottle-name query, and direct actionability, and it can print either a concise summary or full JSON for downstream moderation work.

The goal here is to scale legacy cleanup without jumping straight to automatic canon mutation. We already have moderator-safe repair flows, but they are still one-bottle-at-a-time. This PR gives us a batched proposal surface that can be reviewed, exported, and used to drive the next layer of backfill work.

I also fixed the proposal walker to keep a stable page size across cursor hops, so larger per-type limits do not duplicate or skip candidates when they span multiple pages.

Refs #311