### PR TITLE
feat(cli): batch apply repair proposals

### DIFF
--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -487,13 +487,12 @@ subcommand
     }
 
     const types = parseBatchApplicableRepairBackfillProposalTypes(options.type);
-    const user = await getAutomationModeratorUser();
     const result = await applyRepairBackfillProposals({
       dryRun: !options.execute,
       perTypeLimit,
       query: options.query,
       types,
-      user,
+      user: options.execute ? await getAutomationModeratorUser() : undefined,
     });
 
     console.log(

--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -7,6 +7,10 @@ import {
   entities,
   reviews,
 } from "@peated/server/db/schema";
+import {
+  applyRepairBackfillProposals,
+  type BatchApplicableRepairBackfillProposalType,
+} from "@peated/server/lib/applyRepairBackfillProposals";
 import { findEntity } from "@peated/server/lib/bottleFinder";
 import { upsertBottleAlias } from "@peated/server/lib/db";
 import {
@@ -19,6 +23,7 @@ import {
   type RepairBackfillProposal,
   type RepairBackfillProposalType,
 } from "@peated/server/lib/repairBackfillProposals";
+import { getAutomationModeratorUser } from "@peated/server/lib/systemUser";
 import { routerClient } from "@peated/server/orpc/router";
 import { runJob } from "@peated/server/worker/client";
 import { and, asc, eq, inArray, isNull, ne } from "drizzle-orm";
@@ -26,6 +31,7 @@ import { and, asc, eq, inArray, isNull, ne } from "drizzle-orm";
 const subcommand = program.command("bottles");
 const REPAIR_BACKFILL_PROPOSAL_TYPES = ["release", "age", "canon"] as const;
 const REPAIR_BACKFILL_PROPOSAL_FORMATS = ["summary", "json"] as const;
+const APPLICABLE_REPAIR_BACKFILL_PROPOSAL_TYPES = ["release", "age"] as const;
 
 function parseRepairBackfillProposalTypes(
   value: string,
@@ -58,6 +64,39 @@ function parseRepairBackfillProposalTypes(
   }
 
   return types as RepairBackfillProposalType[];
+}
+
+function parseBatchApplicableRepairBackfillProposalTypes(
+  value: string,
+): BatchApplicableRepairBackfillProposalType[] {
+  if (value === "all") {
+    return [...APPLICABLE_REPAIR_BACKFILL_PROPOSAL_TYPES];
+  }
+
+  const types = Array.from(
+    new Set(
+      value
+        .split(",")
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  );
+
+  if (types.length === 0) {
+    throw new Error(
+      "Repair apply types must include one of: release, age, all.",
+    );
+  }
+
+  for (const type of types) {
+    if (!APPLICABLE_REPAIR_BACKFILL_PROPOSAL_TYPES.includes(type as never)) {
+      throw new Error(
+        `Unknown batch-applicable repair proposal type: ${type}. Expected one of: release, age, all.`,
+      );
+    }
+  }
+
+  return types as BatchApplicableRepairBackfillProposalType[];
 }
 
 function parseRepairBackfillProposalFormat(value: string): "json" | "summary" {
@@ -417,6 +456,63 @@ subcommand
       console.log("");
       console.log(
         `... ${result.proposals.length - 25} more proposal(s) omitted. Use --format json for the full output.`,
+      );
+    }
+  });
+
+subcommand
+  .command("apply-repair-proposals")
+  .description(
+    "Preview or apply directly actionable release and age repair proposals in bulk",
+  )
+  .option(
+    "--type <type>",
+    "Comma-separated proposal types: release, age, or all",
+    "all",
+  )
+  .option(
+    "--limit <number>",
+    "Maximum number of proposals to collect per type",
+    "100",
+  )
+  .option("--query <query>", "Filter proposals by bottle name", "")
+  .option(
+    "--execute",
+    "Actually apply the repair proposals. Without this flag the command only previews.",
+  )
+  .action(async (options) => {
+    const perTypeLimit = Number.parseInt(options.limit, 10);
+    if (!Number.isFinite(perTypeLimit) || perTypeLimit <= 0) {
+      throw new Error(`Invalid limit: ${options.limit}`);
+    }
+
+    const types = parseBatchApplicableRepairBackfillProposalTypes(options.type);
+    const user = await getAutomationModeratorUser();
+    const result = await applyRepairBackfillProposals({
+      dryRun: !options.execute,
+      perTypeLimit,
+      query: options.query,
+      types,
+      user,
+    });
+
+    console.log(
+      `${options.execute ? "Applied" : "Previewed"} repair proposals: ${result.summary.total}`,
+    );
+    console.log(
+      `planned=${result.summary.planned} applied=${result.summary.applied} failed=${result.summary.failed}`,
+    );
+
+    for (const item of result.items) {
+      console.log(
+        `[${item.type}/${item.status}] ${item.bottleName} (${item.bottleId})`,
+      );
+      console.log(`  ${item.message}`);
+    }
+
+    if (options.execute && result.summary.failed > 0) {
+      throw new Error(
+        `${result.summary.failed} repair proposal(s) failed during execution.`,
       );
     }
   });

--- a/apps/server/src/lib/applyRepairBackfillProposals.test.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.test.ts
@@ -3,10 +3,15 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 import { applyDirtyParentAgeRepair } from "@peated/server/lib/applyDirtyParentAgeRepair";
 import { applyLegacyReleaseRepair } from "@peated/server/lib/applyLegacyReleaseRepair";
 import { applyRepairBackfillProposals } from "@peated/server/lib/applyRepairBackfillProposals";
-import { getRepairBackfillProposals } from "@peated/server/lib/repairBackfillProposals";
+import { getDirtyParentAgeRepairCandidates } from "@peated/server/lib/dirtyParentAgeRepairCandidates";
+import { getLegacyReleaseRepairCandidates } from "@peated/server/lib/legacyReleaseRepairCandidates";
 
-vi.mock("@peated/server/lib/repairBackfillProposals", () => ({
-  getRepairBackfillProposals: vi.fn(),
+vi.mock("@peated/server/lib/legacyReleaseRepairCandidates", () => ({
+  getLegacyReleaseRepairCandidates: vi.fn(),
+}));
+
+vi.mock("@peated/server/lib/dirtyParentAgeRepairCandidates", () => ({
+  getDirtyParentAgeRepairCandidates: vi.fn(),
 }));
 
 vi.mock("@peated/server/lib/applyLegacyReleaseRepair", () => ({
@@ -19,7 +24,12 @@ vi.mock("@peated/server/lib/applyDirtyParentAgeRepair", () => ({
   applyDirtyParentAgeRepair: vi.fn(),
 }));
 
-const getRepairBackfillProposalsMock = vi.mocked(getRepairBackfillProposals);
+const getLegacyReleaseRepairCandidatesMock = vi.mocked(
+  getLegacyReleaseRepairCandidates,
+);
+const getDirtyParentAgeRepairCandidatesMock = vi.mocked(
+  getDirtyParentAgeRepairCandidates,
+);
 const applyLegacyReleaseRepairMock = vi.mocked(applyLegacyReleaseRepair);
 const applyDirtyParentAgeRepairMock = vi.mocked(applyDirtyParentAgeRepair);
 
@@ -34,182 +44,153 @@ describe("applyRepairBackfillProposals", () => {
     vi.resetAllMocks();
   });
 
-  test("previews directly actionable release and age proposals without mutating", async () => {
-    getRepairBackfillProposalsMock.mockResolvedValue({
-      proposals: [
-        {
-          type: "release",
-          actionability: "apply",
-          adminHref: "/admin/release-repairs?query=Aberlour",
-          bottle: {
-            id: 11,
-            fullName: "Aberlour A'bunadh Batch 32",
-            totalTastings: 10,
-          },
-          blockingAlias: null,
-          blockingParent: null,
-          proposedParent: {
-            id: 12,
-            fullName: "Aberlour A'bunadh",
-            totalTastings: 100,
-          },
-          releaseIdentity: {
-            edition: "Batch 32",
-            markerSources: ["name_batch"],
-            releaseYear: null,
-          },
-          repairMode: "existing_parent",
-          siblingCount: 2,
-          totalTastings: 10,
+  test("previews actionable release repairs across multiple pages without requiring a user", async () => {
+    getLegacyReleaseRepairCandidatesMock
+      .mockResolvedValueOnce({
+        rel: {
+          nextCursor: 2,
+          prevCursor: null,
         },
-        {
-          type: "age",
-          actionability: "apply",
-          adminHref: "/admin/age-repairs?query=Glenglassaugh",
-          bottle: {
-            id: 21,
-            fullName: "Glenglassaugh 1978 Rare Cask Release",
-            statedAge: 40,
-            totalTastings: 9,
+        results: [
+          {
+            legacyBottle: {
+              id: 11,
+              fullName: "Aberlour A'bunadh (Batch 32)",
+            },
+            proposedParent: {
+              id: 12,
+              fullName: "Aberlour A'bunadh",
+              totalTastings: 100,
+            },
+            repairMode: "blocked_alias_conflict",
           },
-          conflictingReleaseCount: 1,
-          repairMode: "create_release",
-          targetRelease: {
-            id: null,
-            fullName: "Glenglassaugh 1978 Rare Cask Release 40-year-old",
-            statedAge: 40,
-            totalTastings: null,
+        ],
+      } as any)
+      .mockResolvedValueOnce({
+        rel: {
+          nextCursor: 3,
+          prevCursor: 1,
+        },
+        results: [
+          {
+            legacyBottle: {
+              id: 13,
+              fullName: "Aberlour A'bunadh (Batch 33)",
+            },
+            proposedParent: {
+              id: 12,
+              fullName: "Aberlour A'bunadh",
+              totalTastings: 100,
+            },
+            repairMode: "blocked_dirty_parent",
           },
-          totalTastings: 9,
+        ],
+      } as any)
+      .mockResolvedValueOnce({
+        rel: {
+          nextCursor: null,
+          prevCursor: 2,
         },
-        {
-          type: "canon",
-          actionability: "manual",
-          adminHref: "/admin/canon-repairs?query=Elijah",
-          bottle: {
-            id: 31,
-            fullName: "Elijah Craig Barrel Proof Kentucky Straight Bourbon",
-            totalTastings: 3,
+        results: [
+          {
+            legacyBottle: {
+              id: 14,
+              fullName: "Aberlour A'bunadh (Batch 34)",
+            },
+            proposedParent: {
+              id: 12,
+              fullName: "Aberlour A'bunadh",
+              totalTastings: 100,
+            },
+            repairMode: "existing_parent",
           },
-          targetBottle: {
-            id: 32,
-            fullName: "Elijah Craig Barrel Proof",
-            totalTastings: 24,
-          },
-          totalTastings: 3,
-          variantCount: 0,
-        },
-      ],
-      summary: {
-        total: 3,
-        byType: {
-          release: 1,
-          age: 1,
-          canon: 1,
-        },
-        byActionability: {
-          apply: 2,
-          blocked: 0,
-          manual: 1,
-        },
+        ],
+      } as any);
+    getDirtyParentAgeRepairCandidatesMock.mockResolvedValue({
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
       },
-    });
+      results: [],
+    } as any);
 
     const result = await applyRepairBackfillProposals({
-      user,
+      perTypeLimit: 1,
+      types: ["release"],
     });
 
-    expect(getRepairBackfillProposalsMock).toHaveBeenCalledWith({
-      onlyActionable: true,
-      perTypeLimit: 100,
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(1, {
+      cursor: 1,
+      limit: 1,
       query: "",
-      types: ["release", "age"],
+    });
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(2, {
+      cursor: 2,
+      limit: 1,
+      query: "",
+    });
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(3, {
+      cursor: 3,
+      limit: 1,
+      query: "",
     });
     expect(applyLegacyReleaseRepairMock).not.toHaveBeenCalled();
-    expect(applyDirtyParentAgeRepairMock).not.toHaveBeenCalled();
     expect(result.summary).toEqual({
-      total: 2,
-      planned: 2,
+      total: 1,
+      planned: 1,
       applied: 0,
       failed: 0,
     });
     expect(result.items).toEqual([
       expect.objectContaining({
+        type: "release",
         status: "planned",
         action: "preview_release_repair",
-        bottleId: 11,
-      }),
-      expect.objectContaining({
-        status: "planned",
-        action: "preview_age_repair",
-        bottleId: 21,
+        bottleId: 14,
       }),
     ]);
   });
 
   test("applies proposals and reports mixed success and failure", async () => {
-    getRepairBackfillProposalsMock.mockResolvedValue({
-      proposals: [
+    getLegacyReleaseRepairCandidatesMock.mockResolvedValue({
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+      results: [
         {
-          type: "release",
-          actionability: "apply",
-          adminHref: "/admin/release-repairs?query=Aberlour",
-          bottle: {
+          legacyBottle: {
             id: 11,
-            fullName: "Aberlour A'bunadh Batch 32",
-            totalTastings: 10,
+            fullName: "Aberlour A'bunadh (Batch 32)",
           },
-          blockingAlias: null,
-          blockingParent: null,
           proposedParent: {
             id: 12,
             fullName: "Aberlour A'bunadh",
             totalTastings: 100,
           },
-          releaseIdentity: {
-            edition: "Batch 32",
-            markerSources: ["name_batch"],
-            releaseYear: null,
-          },
           repairMode: "existing_parent",
-          siblingCount: 2,
-          totalTastings: 10,
         },
+      ],
+    } as any);
+    getDirtyParentAgeRepairCandidatesMock.mockResolvedValue({
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+      results: [
         {
-          type: "age",
-          actionability: "apply",
-          adminHref: "/admin/age-repairs?query=Glenglassaugh",
           bottle: {
             id: 21,
             fullName: "Glenglassaugh 1978 Rare Cask Release",
-            statedAge: 40,
-            totalTastings: 9,
           },
-          conflictingReleaseCount: 1,
           repairMode: "existing_release",
           targetRelease: {
             id: 22,
             fullName: "Glenglassaugh 1978 Rare Cask Release 40-year-old",
-            statedAge: 40,
-            totalTastings: 2,
           },
-          totalTastings: 9,
         },
       ],
-      summary: {
-        total: 2,
-        byType: {
-          release: 1,
-          age: 1,
-          canon: 0,
-        },
-        byActionability: {
-          apply: 2,
-          blocked: 0,
-          manual: 0,
-        },
-      },
-    });
+    } as any);
     applyLegacyReleaseRepairMock.mockResolvedValue({
       legacyBottleId: 11,
       parentBottleId: 12,
@@ -230,11 +211,15 @@ describe("applyRepairBackfillProposals", () => {
       user,
     });
 
-    expect(getRepairBackfillProposalsMock).toHaveBeenCalledWith({
-      onlyActionable: true,
-      perTypeLimit: 50,
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenCalledWith({
+      cursor: 1,
+      limit: 50,
       query: "Rare",
-      types: ["age", "release"],
+    });
+    expect(getDirtyParentAgeRepairCandidatesMock).toHaveBeenCalledWith({
+      cursor: 1,
+      limit: 50,
+      query: "Rare",
     });
     expect(applyLegacyReleaseRepairMock).toHaveBeenCalledWith({
       legacyBottleId: 11,
@@ -252,11 +237,13 @@ describe("applyRepairBackfillProposals", () => {
     });
     expect(result.items).toEqual([
       expect.objectContaining({
+        type: "release",
         status: "applied",
         action: "apply_release_repair",
         releaseId: 13,
       }),
       expect.objectContaining({
+        type: "age",
         status: "failed",
         action: "apply_age_repair",
         message:

--- a/apps/server/src/lib/applyRepairBackfillProposals.test.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.test.ts
@@ -1,0 +1,267 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { applyDirtyParentAgeRepair } from "@peated/server/lib/applyDirtyParentAgeRepair";
+import { applyLegacyReleaseRepair } from "@peated/server/lib/applyLegacyReleaseRepair";
+import { applyRepairBackfillProposals } from "@peated/server/lib/applyRepairBackfillProposals";
+import { getRepairBackfillProposals } from "@peated/server/lib/repairBackfillProposals";
+
+vi.mock("@peated/server/lib/repairBackfillProposals", () => ({
+  getRepairBackfillProposals: vi.fn(),
+}));
+
+vi.mock("@peated/server/lib/applyLegacyReleaseRepair", () => ({
+  LegacyReleaseRepairBadRequestError: class LegacyReleaseRepairBadRequestError extends Error {},
+  applyLegacyReleaseRepair: vi.fn(),
+}));
+
+vi.mock("@peated/server/lib/applyDirtyParentAgeRepair", () => ({
+  DirtyParentAgeRepairBadRequestError: class DirtyParentAgeRepairBadRequestError extends Error {},
+  applyDirtyParentAgeRepair: vi.fn(),
+}));
+
+const getRepairBackfillProposalsMock = vi.mocked(getRepairBackfillProposals);
+const applyLegacyReleaseRepairMock = vi.mocked(applyLegacyReleaseRepair);
+const applyDirtyParentAgeRepairMock = vi.mocked(applyDirtyParentAgeRepair);
+
+const user = {
+  id: 1,
+  mod: true,
+  admin: true,
+} as any;
+
+describe("applyRepairBackfillProposals", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  test("previews directly actionable release and age proposals without mutating", async () => {
+    getRepairBackfillProposalsMock.mockResolvedValue({
+      proposals: [
+        {
+          type: "release",
+          actionability: "apply",
+          adminHref: "/admin/release-repairs?query=Aberlour",
+          bottle: {
+            id: 11,
+            fullName: "Aberlour A'bunadh Batch 32",
+            totalTastings: 10,
+          },
+          blockingAlias: null,
+          blockingParent: null,
+          proposedParent: {
+            id: 12,
+            fullName: "Aberlour A'bunadh",
+            totalTastings: 100,
+          },
+          releaseIdentity: {
+            edition: "Batch 32",
+            markerSources: ["name_batch"],
+            releaseYear: null,
+          },
+          repairMode: "existing_parent",
+          siblingCount: 2,
+          totalTastings: 10,
+        },
+        {
+          type: "age",
+          actionability: "apply",
+          adminHref: "/admin/age-repairs?query=Glenglassaugh",
+          bottle: {
+            id: 21,
+            fullName: "Glenglassaugh 1978 Rare Cask Release",
+            statedAge: 40,
+            totalTastings: 9,
+          },
+          conflictingReleaseCount: 1,
+          repairMode: "create_release",
+          targetRelease: {
+            id: null,
+            fullName: "Glenglassaugh 1978 Rare Cask Release 40-year-old",
+            statedAge: 40,
+            totalTastings: null,
+          },
+          totalTastings: 9,
+        },
+        {
+          type: "canon",
+          actionability: "manual",
+          adminHref: "/admin/canon-repairs?query=Elijah",
+          bottle: {
+            id: 31,
+            fullName: "Elijah Craig Barrel Proof Kentucky Straight Bourbon",
+            totalTastings: 3,
+          },
+          targetBottle: {
+            id: 32,
+            fullName: "Elijah Craig Barrel Proof",
+            totalTastings: 24,
+          },
+          totalTastings: 3,
+          variantCount: 0,
+        },
+      ],
+      summary: {
+        total: 3,
+        byType: {
+          release: 1,
+          age: 1,
+          canon: 1,
+        },
+        byActionability: {
+          apply: 2,
+          blocked: 0,
+          manual: 1,
+        },
+      },
+    });
+
+    const result = await applyRepairBackfillProposals({
+      user,
+    });
+
+    expect(getRepairBackfillProposalsMock).toHaveBeenCalledWith({
+      onlyActionable: true,
+      perTypeLimit: 100,
+      query: "",
+      types: ["release", "age"],
+    });
+    expect(applyLegacyReleaseRepairMock).not.toHaveBeenCalled();
+    expect(applyDirtyParentAgeRepairMock).not.toHaveBeenCalled();
+    expect(result.summary).toEqual({
+      total: 2,
+      planned: 2,
+      applied: 0,
+      failed: 0,
+    });
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        status: "planned",
+        action: "preview_release_repair",
+        bottleId: 11,
+      }),
+      expect.objectContaining({
+        status: "planned",
+        action: "preview_age_repair",
+        bottleId: 21,
+      }),
+    ]);
+  });
+
+  test("applies proposals and reports mixed success and failure", async () => {
+    getRepairBackfillProposalsMock.mockResolvedValue({
+      proposals: [
+        {
+          type: "release",
+          actionability: "apply",
+          adminHref: "/admin/release-repairs?query=Aberlour",
+          bottle: {
+            id: 11,
+            fullName: "Aberlour A'bunadh Batch 32",
+            totalTastings: 10,
+          },
+          blockingAlias: null,
+          blockingParent: null,
+          proposedParent: {
+            id: 12,
+            fullName: "Aberlour A'bunadh",
+            totalTastings: 100,
+          },
+          releaseIdentity: {
+            edition: "Batch 32",
+            markerSources: ["name_batch"],
+            releaseYear: null,
+          },
+          repairMode: "existing_parent",
+          siblingCount: 2,
+          totalTastings: 10,
+        },
+        {
+          type: "age",
+          actionability: "apply",
+          adminHref: "/admin/age-repairs?query=Glenglassaugh",
+          bottle: {
+            id: 21,
+            fullName: "Glenglassaugh 1978 Rare Cask Release",
+            statedAge: 40,
+            totalTastings: 9,
+          },
+          conflictingReleaseCount: 1,
+          repairMode: "existing_release",
+          targetRelease: {
+            id: 22,
+            fullName: "Glenglassaugh 1978 Rare Cask Release 40-year-old",
+            statedAge: 40,
+            totalTastings: 2,
+          },
+          totalTastings: 9,
+        },
+      ],
+      summary: {
+        total: 2,
+        byType: {
+          release: 1,
+          age: 1,
+          canon: 0,
+        },
+        byActionability: {
+          apply: 2,
+          blocked: 0,
+          manual: 0,
+        },
+      },
+    });
+    applyLegacyReleaseRepairMock.mockResolvedValue({
+      legacyBottleId: 11,
+      parentBottleId: 12,
+      releaseId: 13,
+      aliasNames: [],
+    });
+    applyDirtyParentAgeRepairMock.mockRejectedValue(
+      new Error(
+        "Bottle markets its statedAge in the name and cannot use dirty parent age repair.",
+      ),
+    );
+
+    const result = await applyRepairBackfillProposals({
+      dryRun: false,
+      perTypeLimit: 50,
+      query: "Rare",
+      types: ["age", "release"],
+      user,
+    });
+
+    expect(getRepairBackfillProposalsMock).toHaveBeenCalledWith({
+      onlyActionable: true,
+      perTypeLimit: 50,
+      query: "Rare",
+      types: ["age", "release"],
+    });
+    expect(applyLegacyReleaseRepairMock).toHaveBeenCalledWith({
+      legacyBottleId: 11,
+      user,
+    });
+    expect(applyDirtyParentAgeRepairMock).toHaveBeenCalledWith({
+      bottleId: 21,
+      user,
+    });
+    expect(result.summary).toEqual({
+      total: 2,
+      planned: 0,
+      applied: 1,
+      failed: 1,
+    });
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        status: "applied",
+        action: "apply_release_repair",
+        releaseId: 13,
+      }),
+      expect.objectContaining({
+        status: "failed",
+        action: "apply_age_repair",
+        message:
+          "Bottle markets its statedAge in the name and cannot use dirty parent age repair.",
+      }),
+    ]);
+  });
+});

--- a/apps/server/src/lib/applyRepairBackfillProposals.test.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.test.ts
@@ -251,4 +251,104 @@ describe("applyRepairBackfillProposals", () => {
       }),
     ]);
   });
+
+  test("rescans age repairs after applying release repairs during execution", async () => {
+    getLegacyReleaseRepairCandidatesMock.mockResolvedValue({
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+      results: [
+        {
+          legacyBottle: {
+            id: 11,
+            fullName: "Dirty Legacy Release 10-year-old",
+          },
+          proposedParent: {
+            id: 12,
+            fullName: "Dirty Legacy Parent",
+            totalTastings: 100,
+          },
+          repairMode: "existing_parent",
+        },
+      ],
+    } as any);
+    getDirtyParentAgeRepairCandidatesMock.mockImplementation(async () => {
+      expect(applyLegacyReleaseRepairMock).toHaveBeenCalledWith({
+        legacyBottleId: 11,
+        user,
+      });
+
+      return {
+        rel: {
+          nextCursor: null,
+          prevCursor: null,
+        },
+        results: [
+          {
+            bottle: {
+              id: 12,
+              fullName: "Dirty Legacy Parent",
+            },
+            repairMode: "create_release",
+            targetRelease: {
+              id: null,
+              fullName: "Dirty Legacy Parent 12-year-old",
+            },
+          },
+        ],
+      } as any;
+    });
+    applyLegacyReleaseRepairMock.mockResolvedValue({
+      legacyBottleId: 11,
+      parentBottleId: 12,
+      releaseId: 13,
+      aliasNames: [],
+    });
+    applyDirtyParentAgeRepairMock.mockResolvedValue({
+      bottleId: 12,
+      releaseId: 14,
+    } as any);
+
+    const result = await applyRepairBackfillProposals({
+      dryRun: false,
+      perTypeLimit: 10,
+      types: ["release", "age"],
+      user,
+    });
+
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenCalledTimes(1);
+    expect(getDirtyParentAgeRepairCandidatesMock).toHaveBeenCalledTimes(1);
+    expect(
+      applyLegacyReleaseRepairMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      getDirtyParentAgeRepairCandidatesMock.mock.invocationCallOrder[0]!,
+    );
+    expect(applyDirtyParentAgeRepairMock).toHaveBeenCalledWith({
+      bottleId: 12,
+      user,
+    });
+    expect(result.summary).toEqual({
+      total: 2,
+      planned: 0,
+      applied: 2,
+      failed: 0,
+    });
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        type: "release",
+        status: "applied",
+        action: "apply_release_repair",
+        bottleId: 11,
+        releaseId: 13,
+      }),
+      expect.objectContaining({
+        type: "age",
+        status: "applied",
+        action: "apply_age_repair",
+        bottleId: 12,
+        releaseId: 14,
+      }),
+    ]);
+  });
 });

--- a/apps/server/src/lib/applyRepairBackfillProposals.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.ts
@@ -1,0 +1,204 @@
+import type { User } from "@peated/server/db/schema";
+import {
+  applyDirtyParentAgeRepair,
+  DirtyParentAgeRepairBadRequestError,
+} from "@peated/server/lib/applyDirtyParentAgeRepair";
+import {
+  applyLegacyReleaseRepair,
+  LegacyReleaseRepairBadRequestError,
+} from "@peated/server/lib/applyLegacyReleaseRepair";
+import {
+  getRepairBackfillProposals,
+  type AgeRepairBackfillProposal,
+  type ReleaseRepairBackfillProposal,
+  type RepairBackfillProposal,
+  type RepairBackfillProposalType,
+} from "@peated/server/lib/repairBackfillProposals";
+
+export type BatchApplicableRepairBackfillProposalType = "age" | "release";
+
+export type ApplyRepairBackfillProposalItem = {
+  action:
+    | "apply_age_repair"
+    | "apply_release_repair"
+    | "preview_age_repair"
+    | "preview_release_repair";
+  bottleId: number;
+  bottleName: string;
+  message: string;
+  releaseId: number | null;
+  status: "applied" | "failed" | "planned";
+  type: BatchApplicableRepairBackfillProposalType;
+};
+
+export type ApplyRepairBackfillProposalsResult = {
+  items: ApplyRepairBackfillProposalItem[];
+  summary: {
+    applied: number;
+    failed: number;
+    planned: number;
+    total: number;
+  };
+};
+
+type BatchApplicableRepairProposal =
+  | AgeRepairBackfillProposal
+  | ReleaseRepairBackfillProposal;
+
+function isBatchApplicableRepairProposal(
+  proposal: RepairBackfillProposal,
+): proposal is BatchApplicableRepairProposal {
+  return (
+    proposal.actionability === "apply" &&
+    (proposal.type === "release" || proposal.type === "age")
+  );
+}
+
+function createResultSummary(items: ApplyRepairBackfillProposalItem[]) {
+  return items.reduce(
+    (summary, item) => {
+      summary.total += 1;
+      summary[item.status] += 1;
+      return summary;
+    },
+    {
+      total: 0,
+      planned: 0,
+      applied: 0,
+      failed: 0,
+    },
+  );
+}
+
+function createDryRunItem(
+  proposal: BatchApplicableRepairProposal,
+): ApplyRepairBackfillProposalItem {
+  if (proposal.type === "release") {
+    return {
+      type: proposal.type,
+      status: "planned",
+      action: "preview_release_repair",
+      bottleId: proposal.bottle.id,
+      bottleName: proposal.bottle.fullName,
+      releaseId: null,
+      message: `Would move ${proposal.bottle.fullName} under ${proposal.proposedParent.fullName}.`,
+    };
+  }
+
+  return {
+    type: proposal.type,
+    status: "planned",
+    action: "preview_age_repair",
+    bottleId: proposal.bottle.id,
+    bottleName: proposal.bottle.fullName,
+    releaseId: proposal.targetRelease.id,
+    message:
+      proposal.repairMode === "create_release"
+        ? `Would create ${proposal.targetRelease.fullName} from ${proposal.bottle.fullName}.`
+        : `Would move ${proposal.bottle.fullName} into ${proposal.targetRelease.fullName}.`,
+  };
+}
+
+async function applyRepairBackfillProposal(
+  proposal: BatchApplicableRepairProposal,
+  user: User,
+): Promise<ApplyRepairBackfillProposalItem> {
+  try {
+    if (proposal.type === "release") {
+      const result = await applyLegacyReleaseRepair({
+        legacyBottleId: proposal.bottle.id,
+        user,
+      });
+
+      return {
+        type: proposal.type,
+        status: "applied",
+        action: "apply_release_repair",
+        bottleId: proposal.bottle.id,
+        bottleName: proposal.bottle.fullName,
+        releaseId: result.releaseId,
+        message: `Moved ${proposal.bottle.fullName} under ${proposal.proposedParent.fullName}.`,
+      };
+    }
+
+    const result = await applyDirtyParentAgeRepair({
+      bottleId: proposal.bottle.id,
+      user,
+    });
+
+    return {
+      type: proposal.type,
+      status: "applied",
+      action: "apply_age_repair",
+      bottleId: proposal.bottle.id,
+      bottleName: proposal.bottle.fullName,
+      releaseId: result.releaseId,
+      message:
+        proposal.repairMode === "create_release"
+          ? `Created ${proposal.targetRelease.fullName} from ${proposal.bottle.fullName}.`
+          : `Moved ${proposal.bottle.fullName} into ${proposal.targetRelease.fullName}.`,
+    };
+  } catch (err) {
+    if (
+      err instanceof LegacyReleaseRepairBadRequestError ||
+      err instanceof DirtyParentAgeRepairBadRequestError ||
+      err instanceof Error
+    ) {
+      return {
+        type: proposal.type,
+        status: "failed",
+        action:
+          proposal.type === "release"
+            ? "apply_release_repair"
+            : "apply_age_repair",
+        bottleId: proposal.bottle.id,
+        bottleName: proposal.bottle.fullName,
+        releaseId: null,
+        message: err.message,
+      };
+    }
+
+    throw err;
+  }
+}
+
+export async function applyRepairBackfillProposals({
+  dryRun = true,
+  perTypeLimit = 100,
+  query = "",
+  types = ["release", "age"],
+  user,
+}: {
+  dryRun?: boolean;
+  perTypeLimit?: number;
+  query?: string;
+  types?: BatchApplicableRepairBackfillProposalType[];
+  user: User;
+}): Promise<ApplyRepairBackfillProposalsResult> {
+  const proposalTypes = Array.from(
+    new Set(types),
+  ) as RepairBackfillProposalType[];
+  const { proposals } = await getRepairBackfillProposals({
+    onlyActionable: true,
+    perTypeLimit,
+    query,
+    types: proposalTypes,
+  });
+
+  const applicableProposals = proposals.filter(isBatchApplicableRepairProposal);
+  const items: ApplyRepairBackfillProposalItem[] = [];
+
+  for (const proposal of applicableProposals) {
+    if (dryRun) {
+      items.push(createDryRunItem(proposal));
+      continue;
+    }
+
+    items.push(await applyRepairBackfillProposal(proposal, user));
+  }
+
+  return {
+    items,
+    summary: createResultSummary(items),
+  };
+}

--- a/apps/server/src/lib/applyRepairBackfillProposals.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.ts
@@ -8,12 +8,15 @@ import {
   LegacyReleaseRepairBadRequestError,
 } from "@peated/server/lib/applyLegacyReleaseRepair";
 import {
-  getRepairBackfillProposals,
-  type AgeRepairBackfillProposal,
-  type ReleaseRepairBackfillProposal,
-  type RepairBackfillProposal,
-  type RepairBackfillProposalType,
-} from "@peated/server/lib/repairBackfillProposals";
+  getDirtyParentAgeRepairCandidates,
+  type DirtyParentAgeRepairCandidate,
+} from "@peated/server/lib/dirtyParentAgeRepairCandidates";
+import {
+  getLegacyReleaseRepairCandidates,
+  type LegacyReleaseRepairCandidate,
+} from "@peated/server/lib/legacyReleaseRepairCandidates";
+
+const MAX_PAGE_SIZE = 100;
 
 export type BatchApplicableRepairBackfillProposalType = "age" | "release";
 
@@ -41,18 +44,42 @@ export type ApplyRepairBackfillProposalsResult = {
   };
 };
 
-type BatchApplicableRepairProposal =
-  | AgeRepairBackfillProposal
-  | ReleaseRepairBackfillProposal;
+type BatchApplicableReleaseRepairProposal = {
+  bottle: {
+    fullName: string;
+    id: number;
+  };
+  proposedParent: {
+    fullName: string;
+  };
+  repairMode: "create_parent" | "existing_parent";
+  type: "release";
+};
 
-function isBatchApplicableRepairProposal(
-  proposal: RepairBackfillProposal,
-): proposal is BatchApplicableRepairProposal {
-  return (
-    proposal.actionability === "apply" &&
-    (proposal.type === "release" || proposal.type === "age")
-  );
-}
+type BatchApplicableAgeRepairProposal = {
+  bottle: {
+    fullName: string;
+    id: number;
+  };
+  repairMode: "create_release" | "existing_release";
+  targetRelease: {
+    fullName: string;
+    id: number | null;
+  };
+  type: "age";
+};
+
+type BatchApplicableRepairProposal =
+  | BatchApplicableAgeRepairProposal
+  | BatchApplicableReleaseRepairProposal;
+
+type CandidatePage<TCandidate> = {
+  rel: {
+    nextCursor: null | number;
+    prevCursor: null | number;
+  };
+  results: TCandidate[];
+};
 
 function createResultSummary(items: ApplyRepairBackfillProposalItem[]) {
   return items.reduce(
@@ -162,6 +189,101 @@ async function applyRepairBackfillProposal(
   }
 }
 
+function isActionableReleaseRepairCandidate(
+  candidate: LegacyReleaseRepairCandidate,
+): candidate is LegacyReleaseRepairCandidate & {
+  repairMode: "create_parent" | "existing_parent";
+} {
+  return (
+    candidate.repairMode === "create_parent" ||
+    candidate.repairMode === "existing_parent"
+  );
+}
+
+function toApplicableReleaseRepairProposal(
+  candidate: LegacyReleaseRepairCandidate & {
+    repairMode: "create_parent" | "existing_parent";
+  },
+): BatchApplicableReleaseRepairProposal {
+  return {
+    type: "release",
+    bottle: {
+      id: candidate.legacyBottle.id,
+      fullName: candidate.legacyBottle.fullName,
+    },
+    proposedParent: {
+      fullName: candidate.proposedParent.fullName,
+    },
+    repairMode: candidate.repairMode,
+  };
+}
+
+function toApplicableAgeRepairProposal(
+  candidate: DirtyParentAgeRepairCandidate,
+): BatchApplicableAgeRepairProposal {
+  return {
+    type: "age",
+    bottle: {
+      id: candidate.bottle.id,
+      fullName: candidate.bottle.fullName,
+    },
+    repairMode: candidate.repairMode,
+    targetRelease: {
+      id: candidate.targetRelease.id,
+      fullName: candidate.targetRelease.fullName,
+    },
+  };
+}
+
+async function collectApplicableRepairCandidates<TCandidate, TProposal>({
+  fetcher,
+  isApplicable,
+  map,
+  perTypeLimit,
+  query,
+}: {
+  fetcher: (args: {
+    cursor: number;
+    limit: number;
+    query: string;
+  }) => Promise<CandidatePage<TCandidate>>;
+  isApplicable: (candidate: TCandidate) => boolean;
+  map: (candidate: TCandidate) => TProposal;
+  perTypeLimit: number;
+  query: string;
+}) {
+  const proposals: TProposal[] = [];
+  const pageSize = Math.min(MAX_PAGE_SIZE, perTypeLimit);
+  let cursor = 1;
+
+  while (proposals.length < perTypeLimit) {
+    const page = await fetcher({
+      cursor,
+      limit: pageSize,
+      query,
+    });
+
+    for (const candidate of page.results) {
+      if (!isApplicable(candidate)) {
+        continue;
+      }
+
+      proposals.push(map(candidate));
+      if (proposals.length >= perTypeLimit) {
+        break;
+      }
+    }
+
+    if (!page.rel.nextCursor || page.results.length === 0) {
+      break;
+    }
+
+    cursor = page.rel.nextCursor;
+  }
+
+  return proposals;
+}
+
 export async function applyRepairBackfillProposals({
   dryRun = true,
   perTypeLimit = 100,
@@ -173,19 +295,48 @@ export async function applyRepairBackfillProposals({
   perTypeLimit?: number;
   query?: string;
   types?: BatchApplicableRepairBackfillProposalType[];
-  user: User;
+  user?: User;
 }): Promise<ApplyRepairBackfillProposalsResult> {
-  const proposalTypes = Array.from(
-    new Set(types),
-  ) as RepairBackfillProposalType[];
-  const { proposals } = await getRepairBackfillProposals({
-    onlyActionable: true,
-    perTypeLimit,
-    query,
-    types: proposalTypes,
-  });
+  const normalizedTypes = Array.from(new Set(types));
+  const applicableProposals: BatchApplicableRepairProposal[] = [];
 
-  const applicableProposals = proposals.filter(isBatchApplicableRepairProposal);
+  if (normalizedTypes.includes("release")) {
+    applicableProposals.push(
+      ...(await collectApplicableRepairCandidates({
+        fetcher: getLegacyReleaseRepairCandidates,
+        isApplicable: isActionableReleaseRepairCandidate,
+        map: (candidate) =>
+          toApplicableReleaseRepairProposal(
+            candidate as LegacyReleaseRepairCandidate & {
+              repairMode: "create_parent" | "existing_parent";
+            },
+          ),
+        perTypeLimit,
+        query,
+      })),
+    );
+  }
+
+  if (normalizedTypes.includes("age")) {
+    applicableProposals.push(
+      ...(await collectApplicableRepairCandidates({
+        fetcher: getDirtyParentAgeRepairCandidates,
+        isApplicable: () => true,
+        map: toApplicableAgeRepairProposal,
+        perTypeLimit,
+        query,
+      })),
+    );
+  }
+
+  if (!dryRun && !user) {
+    throw new Error(
+      "Automation moderator user is required to execute repair proposals.",
+    );
+  }
+
+  const executionUser = user;
+
   const items: ApplyRepairBackfillProposalItem[] = [];
 
   for (const proposal of applicableProposals) {
@@ -194,7 +345,7 @@ export async function applyRepairBackfillProposals({
       continue;
     }
 
-    items.push(await applyRepairBackfillProposal(proposal, user));
+    items.push(await applyRepairBackfillProposal(proposal, executionUser!));
   }
 
   return {

--- a/apps/server/src/lib/applyRepairBackfillProposals.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.ts
@@ -284,6 +284,43 @@ async function collectApplicableRepairCandidates<TCandidate, TProposal>({
   return proposals;
 }
 
+async function collectApplicableReleaseRepairProposals({
+  perTypeLimit,
+  query,
+}: {
+  perTypeLimit: number;
+  query: string;
+}) {
+  return collectApplicableRepairCandidates({
+    fetcher: getLegacyReleaseRepairCandidates,
+    isApplicable: isActionableReleaseRepairCandidate,
+    map: (candidate) =>
+      toApplicableReleaseRepairProposal(
+        candidate as LegacyReleaseRepairCandidate & {
+          repairMode: "create_parent" | "existing_parent";
+        },
+      ),
+    perTypeLimit,
+    query,
+  });
+}
+
+async function collectApplicableAgeRepairProposals({
+  perTypeLimit,
+  query,
+}: {
+  perTypeLimit: number;
+  query: string;
+}) {
+  return collectApplicableRepairCandidates({
+    fetcher: getDirtyParentAgeRepairCandidates,
+    isApplicable: () => true,
+    map: toApplicableAgeRepairProposal,
+    perTypeLimit,
+    query,
+  });
+}
+
 export async function applyRepairBackfillProposals({
   dryRun = true,
   perTypeLimit = 100,
@@ -298,36 +335,6 @@ export async function applyRepairBackfillProposals({
   user?: User;
 }): Promise<ApplyRepairBackfillProposalsResult> {
   const normalizedTypes = Array.from(new Set(types));
-  const applicableProposals: BatchApplicableRepairProposal[] = [];
-
-  if (normalizedTypes.includes("release")) {
-    applicableProposals.push(
-      ...(await collectApplicableRepairCandidates({
-        fetcher: getLegacyReleaseRepairCandidates,
-        isApplicable: isActionableReleaseRepairCandidate,
-        map: (candidate) =>
-          toApplicableReleaseRepairProposal(
-            candidate as LegacyReleaseRepairCandidate & {
-              repairMode: "create_parent" | "existing_parent";
-            },
-          ),
-        perTypeLimit,
-        query,
-      })),
-    );
-  }
-
-  if (normalizedTypes.includes("age")) {
-    applicableProposals.push(
-      ...(await collectApplicableRepairCandidates({
-        fetcher: getDirtyParentAgeRepairCandidates,
-        isApplicable: () => true,
-        map: toApplicableAgeRepairProposal,
-        perTypeLimit,
-        query,
-      })),
-    );
-  }
 
   if (!dryRun && !user) {
     throw new Error(
@@ -336,16 +343,38 @@ export async function applyRepairBackfillProposals({
   }
 
   const executionUser = user;
-
   const items: ApplyRepairBackfillProposalItem[] = [];
 
-  for (const proposal of applicableProposals) {
-    if (dryRun) {
-      items.push(createDryRunItem(proposal));
-      continue;
-    }
+  if (normalizedTypes.includes("release")) {
+    const releaseProposals = await collectApplicableReleaseRepairProposals({
+      perTypeLimit,
+      query,
+    });
 
-    items.push(await applyRepairBackfillProposal(proposal, executionUser!));
+    for (const proposal of releaseProposals) {
+      if (dryRun) {
+        items.push(createDryRunItem(proposal));
+        continue;
+      }
+
+      items.push(await applyRepairBackfillProposal(proposal, executionUser!));
+    }
+  }
+
+  if (normalizedTypes.includes("age")) {
+    const ageProposals = await collectApplicableAgeRepairProposals({
+      perTypeLimit,
+      query,
+    });
+
+    for (const proposal of ageProposals) {
+      if (dryRun) {
+        items.push(createDryRunItem(proposal));
+        continue;
+      }
+
+      items.push(await applyRepairBackfillProposal(proposal, executionUser!));
+    }
   }
 
   return {


### PR DESCRIPTION
Add a batch-apply layer on top of the repair proposal export from #320.

This introduces a shared server-side executor for directly actionable repair proposals plus a new `peated bottles apply-repair-proposals` CLI command. The command defaults to preview mode and only mutates when `--execute` is passed, so release and dirty-parent-age repairs can be applied in bulk without opening the door to unsafe canon merges.

The proposal export gave us a batched candidate surface, but moderators still had to apply each actionable repair one bottle at a time. This PR closes that gap for the clean subsets we already trust today: release repairs with reusable or creatable parents, and dirty-parent-age repairs. Canon merge proposals remain manual-only.

I also added mocked unit coverage for the batch executor so we verify the two key behaviors: preview mode does not mutate, and execute mode keeps going while reporting mixed success and failure.

Refs #311