### PR TITLE
fix(server): guard release repair parent reuse by category

### DIFF
--- a/apps/server/src/lib/applyLegacyReleaseRepair.ts
+++ b/apps/server/src/lib/applyLegacyReleaseRepair.ts
@@ -314,6 +314,7 @@ async function resolveParentBottleForRepair(
 
   const parentMode = getLegacyReleaseRepairParentMode(parentRows, {
     proposedParentFullName,
+    sourceCategory: legacyBottle.category,
   });
 
   if (parentMode === "blocked_dirty_parent") {
@@ -333,6 +334,7 @@ async function resolveParentBottleForRepair(
 
   const parentBottle = resolveLegacyReleaseRepairParentMatch(parentRows, {
     proposedParentFullName,
+    sourceCategory: legacyBottle.category,
   }).parent;
 
   if (!parentBottle) {

--- a/apps/server/src/lib/applyLegacyReleaseRepair.ts
+++ b/apps/server/src/lib/applyLegacyReleaseRepair.ts
@@ -314,7 +314,6 @@ async function resolveParentBottleForRepair(
 
   const parentMode = getLegacyReleaseRepairParentMode(parentRows, {
     proposedParentFullName,
-    sourceCategory: legacyBottle.category,
   });
 
   if (parentMode === "blocked_dirty_parent") {
@@ -334,7 +333,6 @@ async function resolveParentBottleForRepair(
 
   const parentBottle = resolveLegacyReleaseRepairParentMatch(parentRows, {
     proposedParentFullName,
-    sourceCategory: legacyBottle.category,
   }).parent;
 
   if (!parentBottle) {

--- a/apps/server/src/lib/legacyReleaseRepairCandidates.ts
+++ b/apps/server/src/lib/legacyReleaseRepairCandidates.ts
@@ -47,12 +47,21 @@ const GENERIC_PARENT_NAME_TOKENS = new Set([
   "yr",
   "yrs",
 ]);
+const DISTINCT_CATEGORY_NAME_MARKERS = [
+  "bourbon",
+  "rye",
+  "scotch",
+  "irish",
+  "japanese",
+  "canadian",
+] as const;
 
 type LegacyReleaseRepairBottle = Omit<
   Pick<
     Bottle,
     | "id"
     | "brandId"
+    | "category"
     | "fullName"
     | "edition"
     | "releaseYear"
@@ -70,6 +79,7 @@ export type LegacyReleaseRepairParentCandidate = Pick<
   | "caskFill"
   | "caskSize"
   | "caskStrength"
+  | "category"
   | "edition"
   | "fullName"
   | "id"
@@ -146,6 +156,13 @@ function getTastingCount(value: null | number | undefined): number {
   return value ?? 0;
 }
 
+function hasConflictingValue<TValue>(
+  left: null | TValue,
+  right: null | TValue,
+): boolean {
+  return left !== null && right !== null && left !== right;
+}
+
 function getLegacyReleaseRepairModePriority(
   value: LegacyReleaseRepairParentMode,
 ): number {
@@ -168,6 +185,28 @@ function getComparableParentNameTokens(fullName: string): string[] {
     .filter(
       (token) => token.length > 0 && !GENERIC_PARENT_NAME_TOKENS.has(token),
     );
+}
+
+function getDistinctCategoryNameMarkers(fullName: string) {
+  const normalizedFullName = normalizeString(fullName).toLowerCase();
+
+  return DISTINCT_CATEGORY_NAME_MARKERS.filter((marker) =>
+    normalizedFullName.match(new RegExp(`\\b${marker}\\b`, "i")),
+  );
+}
+
+function hasConflictingCategoryNameMarkers(
+  sourceFullName: string,
+  targetFullName: string,
+) {
+  const sourceMarkers = getDistinctCategoryNameMarkers(sourceFullName);
+  const targetMarkers = getDistinctCategoryNameMarkers(targetFullName);
+
+  return (
+    sourceMarkers.length > 0 &&
+    targetMarkers.length > 0 &&
+    !sourceMarkers.some((marker) => targetMarkers.includes(marker))
+  );
 }
 
 function tokenSetsMatchExactly(left: string[], right: string[]): boolean {
@@ -195,6 +234,27 @@ function hasExactLegacyReleaseRepairParentName(
   proposedParentFullName: string,
 ): boolean {
   return fullName.toLowerCase() === proposedParentFullName.toLowerCase();
+}
+
+function canReuseLegacyReleaseRepairParent(
+  row: LegacyReleaseRepairParentCandidate,
+  {
+    proposedParentFullName,
+    sourceCategory,
+  }: {
+    proposedParentFullName: string;
+    sourceCategory: Bottle["category"];
+  },
+) {
+  if (hasConflictingValue(row.category, sourceCategory)) {
+    return false;
+  }
+
+  if (hasConflictingCategoryNameMarkers(row.fullName, proposedParentFullName)) {
+    return false;
+  }
+
+  return true;
 }
 
 export function hasVariantLegacyReleaseRepairParentName(
@@ -262,9 +322,11 @@ export function resolveLegacyReleaseRepairParentMatch<
   {
     currentLegacyBottleId,
     proposedParentFullName,
+    sourceCategory,
   }: {
     currentLegacyBottleId?: number;
     proposedParentFullName: string;
+    sourceCategory: Bottle["category"];
   },
 ): {
   exactParent: null | TRow;
@@ -276,7 +338,12 @@ export function resolveLegacyReleaseRepairParentMatch<
 } {
   const candidateRows = rows.filter(
     (row) =>
-      currentLegacyBottleId === undefined || row.id !== currentLegacyBottleId,
+      (currentLegacyBottleId === undefined ||
+        row.id !== currentLegacyBottleId) &&
+      canReuseLegacyReleaseRepairParent(row, {
+        proposedParentFullName,
+        sourceCategory,
+      }),
   );
   const exactRows = candidateRows.filter((row) =>
     hasExactLegacyReleaseRepairParentName(row.fullName, proposedParentFullName),
@@ -320,6 +387,7 @@ export function getLegacyReleaseRepairParentMode<
     currentLegacyBottleId,
     parentAlias,
     proposedParentFullName,
+    sourceCategory,
   }: {
     currentLegacyBottleId?: number;
     parentAlias?: {
@@ -327,11 +395,13 @@ export function getLegacyReleaseRepairParentMode<
       releaseId: number | null;
     } | null;
     proposedParentFullName: string;
+    sourceCategory: Bottle["category"];
   },
 ): LegacyReleaseRepairParentMode {
   const parentMatch = resolveLegacyReleaseRepairParentMatch(rows, {
     currentLegacyBottleId,
     proposedParentFullName,
+    sourceCategory,
   });
 
   if (parentMatch.exactParent) {
@@ -368,14 +438,17 @@ export function getLegacyReleaseRepairBlockingParent<
   {
     currentLegacyBottleId,
     proposedParentFullName,
+    sourceCategory,
   }: {
     currentLegacyBottleId?: number;
     proposedParentFullName: string;
+    sourceCategory: Bottle["category"];
   },
 ): null | TRow {
   const parentMatch = resolveLegacyReleaseRepairParentMatch(rows, {
     currentLegacyBottleId,
     proposedParentFullName,
+    sourceCategory,
   });
 
   return (
@@ -574,6 +647,7 @@ export async function getLegacyReleaseRepairCandidates({
     .select({
       id: bottles.id,
       brandId: bottles.brandId,
+      category: bottles.category,
       fullName: bottles.fullName,
       edition: bottles.edition,
       releaseYear: bottles.releaseYear,
@@ -634,6 +708,7 @@ export async function getLegacyReleaseRepairCandidates({
           .select({
             id: bottles.id,
             fullName: bottles.fullName,
+            category: bottles.category,
             totalTastings: bottles.totalTastings,
             edition: bottles.edition,
             releaseYear: bottles.releaseYear,
@@ -660,6 +735,7 @@ export async function getLegacyReleaseRepairCandidates({
             brandId: bottles.brandId,
             id: bottles.id,
             fullName: bottles.fullName,
+            category: bottles.category,
             totalTastings: bottles.totalTastings,
             edition: bottles.edition,
             releaseYear: bottles.releaseYear,
@@ -813,6 +889,7 @@ export async function getLegacyReleaseRepairCandidates({
         {
           currentLegacyBottleId: candidate.bottle.id,
           proposedParentFullName: candidate.proposedParentFullName,
+          sourceCategory: candidate.bottle.category,
         },
       );
       const parent = parentMatch.parent;
@@ -821,6 +898,7 @@ export async function getLegacyReleaseRepairCandidates({
         {
           currentLegacyBottleId: candidate.bottle.id,
           proposedParentFullName: candidate.proposedParentFullName,
+          sourceCategory: candidate.bottle.category,
         },
       );
       const repairMode = getLegacyReleaseRepairParentMode(
@@ -829,6 +907,7 @@ export async function getLegacyReleaseRepairCandidates({
           currentLegacyBottleId: candidate.bottle.id,
           parentAlias,
           proposedParentFullName: candidate.proposedParentFullName,
+          sourceCategory: candidate.bottle.category,
         },
       );
 

--- a/apps/server/src/lib/legacyReleaseRepairCandidates.ts
+++ b/apps/server/src/lib/legacyReleaseRepairCandidates.ts
@@ -156,13 +156,6 @@ function getTastingCount(value: null | number | undefined): number {
   return value ?? 0;
 }
 
-function hasConflictingValue<TValue>(
-  left: null | TValue,
-  right: null | TValue,
-): boolean {
-  return left !== null && right !== null && left !== right;
-}
-
 function getLegacyReleaseRepairModePriority(
   value: LegacyReleaseRepairParentMode,
 ): number {
@@ -240,16 +233,10 @@ function canReuseLegacyReleaseRepairParent(
   row: LegacyReleaseRepairParentCandidate,
   {
     proposedParentFullName,
-    sourceCategory,
   }: {
     proposedParentFullName: string;
-    sourceCategory: Bottle["category"];
   },
 ) {
-  if (hasConflictingValue(row.category, sourceCategory)) {
-    return false;
-  }
-
   if (hasConflictingCategoryNameMarkers(row.fullName, proposedParentFullName)) {
     return false;
   }
@@ -322,11 +309,9 @@ export function resolveLegacyReleaseRepairParentMatch<
   {
     currentLegacyBottleId,
     proposedParentFullName,
-    sourceCategory,
   }: {
     currentLegacyBottleId?: number;
     proposedParentFullName: string;
-    sourceCategory: Bottle["category"];
   },
 ): {
   exactParent: null | TRow;
@@ -342,7 +327,6 @@ export function resolveLegacyReleaseRepairParentMatch<
         row.id !== currentLegacyBottleId) &&
       canReuseLegacyReleaseRepairParent(row, {
         proposedParentFullName,
-        sourceCategory,
       }),
   );
   const exactRows = candidateRows.filter((row) =>
@@ -387,7 +371,6 @@ export function getLegacyReleaseRepairParentMode<
     currentLegacyBottleId,
     parentAlias,
     proposedParentFullName,
-    sourceCategory,
   }: {
     currentLegacyBottleId?: number;
     parentAlias?: {
@@ -395,13 +378,11 @@ export function getLegacyReleaseRepairParentMode<
       releaseId: number | null;
     } | null;
     proposedParentFullName: string;
-    sourceCategory: Bottle["category"];
   },
 ): LegacyReleaseRepairParentMode {
   const parentMatch = resolveLegacyReleaseRepairParentMatch(rows, {
     currentLegacyBottleId,
     proposedParentFullName,
-    sourceCategory,
   });
 
   if (parentMatch.exactParent) {
@@ -438,17 +419,14 @@ export function getLegacyReleaseRepairBlockingParent<
   {
     currentLegacyBottleId,
     proposedParentFullName,
-    sourceCategory,
   }: {
     currentLegacyBottleId?: number;
     proposedParentFullName: string;
-    sourceCategory: Bottle["category"];
   },
 ): null | TRow {
   const parentMatch = resolveLegacyReleaseRepairParentMatch(rows, {
     currentLegacyBottleId,
     proposedParentFullName,
-    sourceCategory,
   });
 
   return (
@@ -889,7 +867,6 @@ export async function getLegacyReleaseRepairCandidates({
         {
           currentLegacyBottleId: candidate.bottle.id,
           proposedParentFullName: candidate.proposedParentFullName,
-          sourceCategory: candidate.bottle.category,
         },
       );
       const parent = parentMatch.parent;
@@ -898,7 +875,6 @@ export async function getLegacyReleaseRepairCandidates({
         {
           currentLegacyBottleId: candidate.bottle.id,
           proposedParentFullName: candidate.proposedParentFullName,
-          sourceCategory: candidate.bottle.category,
         },
       );
       const repairMode = getLegacyReleaseRepairParentMode(
@@ -907,7 +883,6 @@ export async function getLegacyReleaseRepairCandidates({
           currentLegacyBottleId: candidate.bottle.id,
           parentAlias,
           proposedParentFullName: candidate.proposedParentFullName,
-          sourceCategory: candidate.bottle.category,
         },
       );
 

--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -32,6 +32,7 @@ function createLegacyBottleMock(overrides: Record<string, unknown>) {
   return {
     id: 1,
     brandId: 1,
+    category: null,
     fullName: "Legacy Bottle",
     edition: null,
     releaseYear: null,

--- a/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
+++ b/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
@@ -565,6 +565,57 @@ describe("POST /bottles/:bottle/apply-release-repair", () => {
     });
   });
 
+  test("reuses the existing parent when the legacy bottle category is dirty", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({
+      name: "Rock Town",
+      totalBottles: 2,
+    });
+    const parentBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Arkansas Rye",
+      category: "rye",
+      totalTastings: 120,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Arkansas Rye (Batch 1)",
+      category: "bourbon",
+      totalTastings: 9,
+    });
+    const mod = await fixtures.User({ mod: true });
+
+    const result = await routerClient.bottles.applyReleaseRepair(
+      {
+        bottle: legacyBottle.id,
+      },
+      { context: { user: mod } },
+    );
+
+    expect(result.parentBottleId).toBe(parentBottle.id);
+
+    const [release] = await db
+      .select()
+      .from(bottleReleases)
+      .where(eq(bottleReleases.id, result.releaseId));
+    expect(release).toMatchObject({
+      bottleId: parentBottle.id,
+      edition: "Batch 1",
+    });
+
+    const refreshedParent = await db.query.bottles.findFirst({
+      where: eq(bottles.id, parentBottle.id),
+    });
+    expect(refreshedParent).toMatchObject({
+      id: parentBottle.id,
+      name: "Arkansas Rye",
+      fullName: "Rock Town Arkansas Rye",
+      category: "rye",
+      numReleases: 1,
+    });
+  });
+
   test("prefers the longest brand prefix when deriving a created parent name", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
+++ b/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
@@ -513,6 +513,58 @@ describe("POST /bottles/:bottle/apply-release-repair", () => {
     expect(existingParents.map((row) => row.id)).toEqual([parentBottle.id]);
   });
 
+  test("creates a new parent when the only generic variant conflicts on category markers", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({
+      name: "Rock Town",
+      totalBottles: 2,
+    });
+    const bourbonParent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Arkansas Bourbon",
+      category: null,
+      totalTastings: 120,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Arkansas Rye (Batch 1)",
+      category: "rye",
+      totalTastings: 9,
+    });
+    const mod = await fixtures.User({ mod: true });
+
+    const result = await routerClient.bottles.applyReleaseRepair(
+      {
+        bottle: legacyBottle.id,
+      },
+      { context: { user: mod } },
+    );
+
+    expect(result.parentBottleId).not.toBe(bourbonParent.id);
+
+    const [parentBottle] = await db
+      .select()
+      .from(bottles)
+      .where(eq(bottles.id, result.parentBottleId));
+    expect(parentBottle).toMatchObject({
+      id: result.parentBottleId,
+      brandId: brand.id,
+      name: "Arkansas Rye",
+      fullName: "Rock Town Arkansas Rye",
+      category: "rye",
+    });
+
+    const [release] = await db
+      .select()
+      .from(bottleReleases)
+      .where(eq(bottleReleases.id, result.releaseId));
+    expect(release).toMatchObject({
+      bottleId: parentBottle.id,
+      edition: "Batch 1",
+    });
+  });
+
   test("prefers the longest brand prefix when deriving a created parent name", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
@@ -201,6 +201,50 @@ describe("GET /bottles/release-repair-candidates", () => {
     });
   });
 
+  test("reuses the correct parent even when the legacy bottle category is dirty", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Rock Town" });
+    const parent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Arkansas Rye",
+      category: "rye",
+      totalTastings: 80,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Arkansas Rye (Batch 1)",
+      category: "bourbon",
+      totalTastings: 8,
+    });
+    const user = await fixtures.User({ mod: true });
+
+    const result = await routerClient.bottles.releaseRepairCandidates(
+      {
+        query: "Rock Town Arkansas Rye",
+      },
+      { context: { user } },
+    );
+
+    expect(
+      result.results.find(
+        (candidate) => candidate.legacyBottle.id === legacyBottle.id,
+      ),
+    ).toMatchObject({
+      hasExactParent: true,
+      repairMode: "existing_parent",
+      proposedParent: {
+        id: parent.id,
+        fullName: parent.fullName,
+      },
+      releaseIdentity: {
+        edition: "Batch 1",
+        releaseYear: null,
+        markerSources: ["name_batch"],
+      },
+    });
+  });
+
   test("keeps singleton create-parent repairs in the candidate list", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
@@ -157,6 +157,50 @@ describe("GET /bottles/release-repair-candidates", () => {
     });
   });
 
+  test("does not reuse a cross-category generic variant as the parent repair target", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Rock Town" });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Arkansas Bourbon",
+      category: null,
+      totalTastings: 80,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Arkansas Rye (Batch 1)",
+      category: "rye",
+      totalTastings: 8,
+    });
+    const user = await fixtures.User({ mod: true });
+
+    const result = await routerClient.bottles.releaseRepairCandidates(
+      {
+        query: "Rock Town Arkansas",
+      },
+      { context: { user } },
+    );
+
+    expect(
+      result.results.find(
+        (candidate) => candidate.legacyBottle.id === legacyBottle.id,
+      ),
+    ).toMatchObject({
+      hasExactParent: false,
+      repairMode: "create_parent",
+      proposedParent: {
+        id: null,
+        fullName: "Rock Town Arkansas Rye",
+      },
+      releaseIdentity: {
+        edition: "Batch 1",
+        releaseYear: null,
+        markerSources: ["name_batch"],
+      },
+    });
+  });
+
   test("keeps singleton create-parent repairs in the candidate list", async ({
     fixtures,
   }) => {


### PR DESCRIPTION
Guard release-repair parent selection against cross-category false positives.

The repair queue was willing to reuse a same-brand generic variant even when the source bottle and candidate parent implied different categories. That produced bad suggestions like `Rock Town Arkansas Rye (Batch 1)` being steered toward `Rock Town Arkansas Bourbon`.

This adds shared category conflict checks to legacy release-repair parent selection, using structured category when available and name markers as a fallback. The apply path now uses the same guard as the candidate queue, so we avoid both suggesting and applying the wrong reusable parent.

I kept this in the repair workflow rather than the classifier because the bug was in parent reuse, not bottle classification.

Refs #311