### PR TITLE
test(classifier): broaden dirty legacy coverage

### DIFF
--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -437,4 +437,166 @@ describe("getRepairBackfillProposals", () => {
       }),
     );
   });
+
+  test("normalizes blocked release, existing-release age, and manual canon proposals together", async () => {
+    getLegacyReleaseRepairCandidatesMock.mockResolvedValue({
+      results: [
+        {
+          blockingAlias: null,
+          blockingParent: {
+            id: 17,
+            fullName: "Aberlour A'bunadh",
+            totalTastings: 120,
+          },
+          legacyBottle: createLegacyBottleMock({
+            id: 16,
+            fullName: "Aberlour A'bunadh (Batch 4)",
+            edition: "Batch 4",
+            totalTastings: 6,
+          }),
+          proposedParent: {
+            id: 17,
+            fullName: "Aberlour A'bunadh",
+            totalTastings: 120,
+          },
+          releaseIdentity: {
+            edition: "Batch 4",
+            releaseYear: null,
+            markerSources: ["name_batch"],
+          },
+          siblingLegacyBottles: [
+            {
+              id: 15,
+              fullName: "Aberlour A'bunadh (Batch 3)",
+            },
+          ],
+          hasExactParent: true,
+          repairMode: "blocked_dirty_parent",
+        },
+      ],
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+    });
+
+    getDirtyParentAgeRepairCandidatesMock.mockResolvedValue({
+      results: [
+        {
+          bottle: createAgeBottleMock({
+            id: 21,
+            fullName: "Glenglassaugh 1978 Rare Cask Release",
+            name: "Rare Cask Release",
+            statedAge: 40,
+            numReleases: 2,
+            totalTastings: 9,
+          }),
+          conflictingReleases: [
+            {
+              id: 22,
+              fullName: "Glenglassaugh 1978 Rare Cask Release - Batch 1",
+              statedAge: 35,
+              totalTastings: 4,
+            },
+          ],
+          repairMode: "existing_release",
+          targetRelease: {
+            id: 23,
+            fullName: "Glenglassaugh 1978 Rare Cask Release 40-year-old",
+            statedAge: 40,
+            totalTastings: 7,
+          },
+        },
+      ],
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+    });
+
+    getCanonRepairCandidatesMock.mockResolvedValue({
+      results: [
+        {
+          bottle: {
+            id: 31,
+            fullName: "Elijah Craig Barrel Proof Kentucky Straight Bourbon",
+            numReleases: 0,
+            totalTastings: 3,
+          },
+          targetBottle: {
+            id: 32,
+            fullName: "Elijah Craig Barrel Proof",
+            numReleases: 5,
+            totalTastings: 24,
+          },
+          variantBottles: [
+            {
+              id: 33,
+              fullName: "Elijah Craig Barrel Proof Bourbon",
+              numReleases: 0,
+              totalTastings: 2,
+            },
+          ],
+        },
+      ],
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+    });
+
+    const result = await getRepairBackfillProposals({
+      perTypeLimit: 5,
+    });
+
+    expect(result.summary).toEqual({
+      total: 3,
+      byType: {
+        release: 1,
+        age: 1,
+        canon: 1,
+      },
+      byActionability: {
+        apply: 1,
+        blocked: 1,
+        manual: 1,
+      },
+    });
+
+    expect(result.proposals).toEqual(
+      expect.arrayContaining<RepairBackfillProposal>([
+        expect.objectContaining({
+          type: "release",
+          actionability: "blocked",
+          repairMode: "blocked_dirty_parent",
+          blockingParent: expect.objectContaining({
+            id: 17,
+            fullName: "Aberlour A'bunadh",
+          }),
+          siblingCount: 1,
+          adminHref:
+            "/admin/release-repairs?query=Aberlour%20A'bunadh%20(Batch%204)",
+        }),
+        expect.objectContaining({
+          type: "age",
+          actionability: "apply",
+          repairMode: "existing_release",
+          targetRelease: expect.objectContaining({
+            id: 23,
+            fullName: "Glenglassaugh 1978 Rare Cask Release 40-year-old",
+          }),
+          conflictingReleaseCount: 1,
+        }),
+        expect.objectContaining({
+          type: "canon",
+          actionability: "manual",
+          variantCount: 1,
+          targetBottle: expect.objectContaining({
+            id: 32,
+            fullName: "Elijah Craig Barrel Proof",
+          }),
+        }),
+      ]),
+    );
+  });
 });

--- a/packages/bottle-classifier/src/classifier.eval.fixtures.ts
+++ b/packages/bottle-classifier/src/classifier.eval.fixtures.ts
@@ -221,6 +221,21 @@ const springbank10 = buildBottleCandidate({
   source: ["exact"],
 });
 
+const cadbollEstateBatch4Release = buildBottleCandidate({
+  bottleId: 660,
+  releaseId: 9102,
+  kind: "release",
+  fullName: "Glenmorangie 15-year-old The Cadboll Estate - Batch 4",
+  bottleFullName: "Glenmorangie 15-year-old The Cadboll Estate",
+  brand: "Glenmorangie",
+  distillery: ["Glenmorangie"],
+  category: "single_malt",
+  statedAge: 15,
+  edition: "Batch 4",
+  score: 0.93,
+  source: ["text"],
+});
+
 const smwsa41176Match = buildBottleCandidate({
   bottleId: 650,
   fullName: "SMWS 41.176 Baristaliscious",
@@ -530,6 +545,39 @@ export const EVAL_CASES: ClassifierEvalCase[] = [
     },
   },
   {
+    name: "store listing: noisy extracted age does not fabricate a child release under a marketed-age parent",
+    input: {
+      reference: {
+        name: "Springbank 10-year-old",
+        url: "https://shop.example/products/springbank-10-year-old",
+      },
+      extractedIdentity: buildExtractedIdentity({
+        brand: "Springbank",
+        expression: "10 Year Old",
+        distillery: ["Springbank"],
+        category: "single_malt",
+        stated_age: 12,
+        abv: 46,
+      }),
+      initialCandidates: [springbank10],
+    },
+    searchResponses: [
+      {
+        when: ["springbank", "10"],
+        results: [springbank10],
+      },
+    ],
+    expected: {
+      status: "classified",
+      action: "match",
+      identityScope: "product",
+      matchedBottleId: 640,
+      matchedReleaseId: null,
+      summary:
+        "Treat a noisy differing age extraction conservatively when the matched bottle explicitly markets 10 years in its name, and keep the Springbank 10 Year Old bottle match instead of fabricating a child release.",
+    },
+  },
+  {
     name: "store listing: strips retailer suffix noise and matches the canonical bottle",
     input: {
       reference: {
@@ -581,6 +629,37 @@ export const EVAL_CASES: ClassifierEvalCase[] = [
       matchedBottleId: 43236,
       summary:
         "Treat a standalone article difference plus generic retailer style words as a strong local name variant and keep the Glenmorangie A Tale of Ice Cream bottle match without requiring web evidence.",
+    },
+  },
+  {
+    name: "store listing: matches an existing child release instead of keeping a plain parent-bottle match",
+    input: {
+      reference: {
+        name: "Glenmorangie The Cadboll Estate 15-year-old (Batch 4)",
+        url: "https://shop.example/products/cadboll-estate-batch-4",
+      },
+      extractedIdentity: buildExtractedIdentity({
+        brand: "Glenmorangie",
+        expression: "The Cadboll Estate",
+        distillery: ["Glenmorangie"],
+        category: "single_malt",
+        stated_age: 15,
+        edition: "Batch 4",
+      }),
+      initialCandidates: [
+        cadbollEstateParent,
+        cadbollEstateBatch4Release,
+        cadbollEstateLegacyBatch2,
+      ],
+    },
+    expected: {
+      status: "classified",
+      action: "match",
+      identityScope: "product",
+      matchedBottleId: 660,
+      matchedReleaseId: 9102,
+      summary:
+        "When a clean Batch 4 child release already exists, match that release directly instead of keeping or downgrading a plain parent-bottle match for the Cadboll Estate listing.",
     },
   },
   {


### PR DESCRIPTION
Broaden regression and eval coverage for the dirty legacy repair work we have been landing.

Most of the product behavior in this area is now on main, but a lot of the confidence still lived in route-level anecdotes and one-off fixes. This adds a tighter coverage matrix in two places: classifier eval fixtures for recent dirty-legacy safety cases, and repair proposal export tests for blocked/manual combinations that feed the backfill tooling.

The classifier eval fixtures now cover the marketed-age false-positive path and the case where a clean child release already exists for a release-marked listing. The server-side proposal export test now exercises blocked dirty-parent release repairs, existing-release age repairs, and manual canon repairs together so the exported moderation surface has a denser regression net.

No product behavior changes in this PR.

Refs #311