### PR TITLE
feat(repairs): add unattended-safe repair filters

### DIFF
--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -112,13 +112,15 @@ function parseRepairBackfillProposalFormat(value: string): "json" | "summary" {
 function formatRepairBackfillProposalSummaryLine(
   proposal: RepairBackfillProposal,
 ) {
+  const automationState = proposal.automationEligible ? "auto" : "review";
+
   switch (proposal.type) {
     case "release":
-      return `[release/${proposal.repairMode}/${proposal.actionability}] ${proposal.bottle.fullName} -> ${proposal.proposedParent.fullName}`;
+      return `[release/${proposal.repairMode}/${proposal.actionability}/${automationState}] ${proposal.bottle.fullName} -> ${proposal.proposedParent.fullName}`;
     case "age":
-      return `[age/${proposal.repairMode}/${proposal.actionability}] ${proposal.bottle.fullName} -> ${proposal.targetRelease.fullName}`;
+      return `[age/${proposal.repairMode}/${proposal.actionability}/${automationState}] ${proposal.bottle.fullName} -> ${proposal.targetRelease.fullName}`;
     case "canon":
-      return `[canon/${proposal.actionability}] ${proposal.bottle.fullName} -> ${proposal.targetBottle.fullName}`;
+      return `[canon/${proposal.actionability}/${automationState}] ${proposal.bottle.fullName} -> ${proposal.targetBottle.fullName}`;
   }
 }
 
@@ -410,6 +412,10 @@ subcommand
     "--only-actionable",
     "Only include proposals that can be applied directly today",
   )
+  .option(
+    "--automation-only",
+    "Only include the unattended-safe proposal subset",
+  )
   .action(async (options) => {
     const perTypeLimit = Number.parseInt(options.limit, 10);
     if (!Number.isFinite(perTypeLimit) || perTypeLimit <= 0) {
@@ -419,6 +425,7 @@ subcommand
     const types = parseRepairBackfillProposalTypes(options.type);
     const format = parseRepairBackfillProposalFormat(options.format);
     const result = await getRepairBackfillProposals({
+      onlyAutomationEligible: Boolean(options.automationOnly),
       onlyActionable: Boolean(options.onlyActionable),
       perTypeLimit,
       query: options.query,
@@ -433,6 +440,9 @@ subcommand
     console.log(`Repair backfill proposals: ${result.summary.total}`);
     console.log(
       `Types: ${types.join(", ")} | Per-type limit: ${perTypeLimit} | Query: ${options.query || "(none)"}`,
+    );
+    console.log(
+      `Automation eligible: ${result.proposals.filter((proposal) => proposal.automationEligible).length}`,
     );
     console.log(
       `Actionability: apply=${result.summary.byActionability.apply}, blocked=${result.summary.byActionability.blocked}, manual=${result.summary.byActionability.manual}`,
@@ -480,6 +490,10 @@ subcommand
     "--execute",
     "Actually apply the repair proposals. Without this flag the command only previews.",
   )
+  .option(
+    "--automation-only",
+    "Only preview or apply the unattended-safe proposal subset",
+  )
   .action(async (options) => {
     const perTypeLimit = Number.parseInt(options.limit, 10);
     if (!Number.isFinite(perTypeLimit) || perTypeLimit <= 0) {
@@ -488,6 +502,7 @@ subcommand
 
     const types = parseBatchApplicableRepairBackfillProposalTypes(options.type);
     const result = await applyRepairBackfillProposals({
+      automationOnly: Boolean(options.automationOnly),
       dryRun: !options.execute,
       perTypeLimit,
       query: options.query,

--- a/apps/server/src/lib/applyRepairBackfillProposals.test.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.test.ts
@@ -351,4 +351,146 @@ describe("applyRepairBackfillProposals", () => {
       }),
     ]);
   });
+
+  test("can restrict preview and execution to the unattended-safe subset", async () => {
+    getLegacyReleaseRepairCandidatesMock.mockResolvedValue({
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+      results: [
+        {
+          legacyBottle: {
+            id: 11,
+            fullName: "Aberlour A'bunadh (Batch 32)",
+          },
+          proposedParent: {
+            id: 12,
+            fullName: "Aberlour A'bunadh",
+            totalTastings: 100,
+          },
+          hasExactParent: true,
+          repairMode: "existing_parent",
+        },
+        {
+          legacyBottle: {
+            id: 13,
+            fullName:
+              "Elijah Craig Barrel Proof Kentucky Straight Bourbon (Batch C923)",
+          },
+          proposedParent: {
+            id: 14,
+            fullName: "Elijah Craig Barrel Proof",
+            totalTastings: 100,
+          },
+          hasExactParent: false,
+          repairMode: "existing_parent",
+        },
+      ],
+    } as any);
+    getDirtyParentAgeRepairCandidatesMock.mockResolvedValue({
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+      results: [
+        {
+          bottle: {
+            id: 21,
+            fullName: "Glenglassaugh 1978 Rare Cask Release",
+          },
+          repairMode: "existing_release",
+          targetRelease: {
+            id: 22,
+            fullName: "Glenglassaugh 1978 Rare Cask Release 40-year-old",
+          },
+        },
+        {
+          bottle: {
+            id: 23,
+            fullName: "Another Dirty Parent",
+          },
+          repairMode: "create_release",
+          targetRelease: {
+            id: null,
+            fullName: "Another Dirty Parent 18-year-old",
+          },
+        },
+      ],
+    } as any);
+    applyLegacyReleaseRepairMock.mockResolvedValue({
+      legacyBottleId: 11,
+      parentBottleId: 12,
+      releaseId: 31,
+      aliasNames: [],
+    });
+    applyDirtyParentAgeRepairMock.mockResolvedValue({
+      bottleId: 21,
+      releaseId: 22,
+    } as any);
+
+    const preview = await applyRepairBackfillProposals({
+      automationOnly: true,
+      perTypeLimit: 10,
+      types: ["release", "age"],
+    });
+
+    expect(preview.summary).toEqual({
+      total: 2,
+      planned: 2,
+      applied: 0,
+      failed: 0,
+    });
+    expect(preview.items).toEqual([
+      expect.objectContaining({
+        type: "release",
+        bottleId: 11,
+        status: "planned",
+      }),
+      expect.objectContaining({
+        type: "age",
+        bottleId: 21,
+        status: "planned",
+      }),
+    ]);
+
+    const execution = await applyRepairBackfillProposals({
+      automationOnly: true,
+      dryRun: false,
+      perTypeLimit: 10,
+      types: ["release", "age"],
+      user,
+    });
+
+    expect(applyLegacyReleaseRepairMock).toHaveBeenCalledTimes(1);
+    expect(applyLegacyReleaseRepairMock).toHaveBeenCalledWith({
+      legacyBottleId: 11,
+      user,
+    });
+    expect(applyDirtyParentAgeRepairMock).toHaveBeenCalledTimes(1);
+    expect(applyDirtyParentAgeRepairMock).toHaveBeenCalledWith({
+      bottleId: 21,
+      user,
+    });
+    expect(execution.summary).toEqual({
+      total: 2,
+      planned: 0,
+      applied: 2,
+      failed: 0,
+    });
+    expect(execution.items).toEqual([
+      expect.objectContaining({
+        type: "release",
+        bottleId: 11,
+        status: "applied",
+        releaseId: 31,
+      }),
+      expect.objectContaining({
+        type: "age",
+        bottleId: 21,
+        status: "applied",
+        releaseId: 22,
+      }),
+    ]);
+  });
 });

--- a/apps/server/src/lib/applyRepairBackfillProposals.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.ts
@@ -200,6 +200,14 @@ function isActionableReleaseRepairCandidate(
   );
 }
 
+function isAutomationEligibleReleaseRepairCandidate(
+  candidate: LegacyReleaseRepairCandidate,
+): candidate is LegacyReleaseRepairCandidate & {
+  repairMode: "existing_parent";
+} {
+  return candidate.repairMode === "existing_parent" && candidate.hasExactParent;
+}
+
 function toApplicableReleaseRepairProposal(
   candidate: LegacyReleaseRepairCandidate & {
     repairMode: "create_parent" | "existing_parent";
@@ -233,6 +241,21 @@ function toApplicableAgeRepairProposal(
       fullName: candidate.targetRelease.fullName,
     },
   };
+}
+
+function isAutomationEligibleAgeRepairCandidate(
+  candidate: DirtyParentAgeRepairCandidate,
+): candidate is DirtyParentAgeRepairCandidate & {
+  repairMode: "existing_release";
+  targetRelease: {
+    fullName: string;
+    id: number;
+  };
+} {
+  return (
+    candidate.repairMode === "existing_release" &&
+    candidate.targetRelease.id !== null
+  );
 }
 
 async function collectApplicableRepairCandidates<TCandidate, TProposal>({
@@ -285,15 +308,19 @@ async function collectApplicableRepairCandidates<TCandidate, TProposal>({
 }
 
 async function collectApplicableReleaseRepairProposals({
+  automationOnly = false,
   perTypeLimit,
   query,
 }: {
+  automationOnly?: boolean;
   perTypeLimit: number;
   query: string;
 }) {
   return collectApplicableRepairCandidates({
     fetcher: getLegacyReleaseRepairCandidates,
-    isApplicable: isActionableReleaseRepairCandidate,
+    isApplicable: automationOnly
+      ? isAutomationEligibleReleaseRepairCandidate
+      : isActionableReleaseRepairCandidate,
     map: (candidate) =>
       toApplicableReleaseRepairProposal(
         candidate as LegacyReleaseRepairCandidate & {
@@ -306,15 +333,19 @@ async function collectApplicableReleaseRepairProposals({
 }
 
 async function collectApplicableAgeRepairProposals({
+  automationOnly = false,
   perTypeLimit,
   query,
 }: {
+  automationOnly?: boolean;
   perTypeLimit: number;
   query: string;
 }) {
   return collectApplicableRepairCandidates({
     fetcher: getDirtyParentAgeRepairCandidates,
-    isApplicable: () => true,
+    isApplicable: automationOnly
+      ? isAutomationEligibleAgeRepairCandidate
+      : () => true,
     map: toApplicableAgeRepairProposal,
     perTypeLimit,
     query,
@@ -322,12 +353,14 @@ async function collectApplicableAgeRepairProposals({
 }
 
 export async function applyRepairBackfillProposals({
+  automationOnly = false,
   dryRun = true,
   perTypeLimit = 100,
   query = "",
   types = ["release", "age"],
   user,
 }: {
+  automationOnly?: boolean;
   dryRun?: boolean;
   perTypeLimit?: number;
   query?: string;
@@ -347,6 +380,7 @@ export async function applyRepairBackfillProposals({
 
   if (normalizedTypes.includes("release")) {
     const releaseProposals = await collectApplicableReleaseRepairProposals({
+      automationOnly,
       perTypeLimit,
       query,
     });
@@ -363,6 +397,7 @@ export async function applyRepairBackfillProposals({
 
   if (normalizedTypes.includes("age")) {
     const ageProposals = await collectApplicableAgeRepairProposals({
+      automationOnly,
       perTypeLimit,
       query,
     });

--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -627,6 +627,110 @@ describe("getRepairBackfillProposals", () => {
     ]);
   });
 
+  test("keeps paging until it finds the requested automation-eligible release proposals", async () => {
+    getLegacyReleaseRepairCandidatesMock
+      .mockResolvedValueOnce({
+        results: [
+          {
+            blockingAlias: null,
+            blockingParent: null,
+            legacyBottle: createLegacyBottleMock({
+              id: 11,
+              fullName:
+                "Elijah Craig Barrel Proof Kentucky Straight Bourbon (Batch C923)",
+              edition: "Batch C923",
+              totalTastings: 50,
+            }),
+            proposedParent: {
+              id: 14,
+              fullName: "Elijah Craig Barrel Proof",
+              totalTastings: 180,
+            },
+            releaseIdentity: {
+              edition: "Batch C923",
+              releaseYear: null,
+              markerSources: ["name_batch"],
+            },
+            siblingLegacyBottles: [],
+            hasExactParent: false,
+            repairMode: "existing_parent",
+          },
+        ],
+        rel: {
+          nextCursor: 2,
+          prevCursor: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        results: [
+          {
+            blockingAlias: null,
+            blockingParent: null,
+            legacyBottle: createLegacyBottleMock({
+              id: 12,
+              fullName: "Aberlour A'bunadh Batch 32",
+              edition: "Batch 32",
+              totalTastings: 12,
+            }),
+            proposedParent: {
+              id: 13,
+              fullName: "Aberlour A'bunadh",
+              totalTastings: 200,
+            },
+            releaseIdentity: {
+              edition: "Batch 32",
+              releaseYear: null,
+              markerSources: ["name_batch"],
+            },
+            siblingLegacyBottles: [],
+            hasExactParent: true,
+            repairMode: "existing_parent",
+          },
+        ],
+        rel: {
+          nextCursor: null,
+          prevCursor: 1,
+        },
+      });
+
+    const result = await getRepairBackfillProposals({
+      onlyAutomationEligible: true,
+      perTypeLimit: 1,
+      types: ["release"],
+    });
+
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(1, {
+      cursor: 1,
+      limit: 1,
+      query: "",
+    });
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(2, {
+      cursor: 2,
+      limit: 1,
+      query: "",
+    });
+    expect(result.summary).toEqual({
+      total: 1,
+      byType: {
+        release: 1,
+        age: 0,
+        canon: 0,
+      },
+      byActionability: {
+        apply: 1,
+        blocked: 0,
+        manual: 0,
+      },
+    });
+    expect(result.proposals).toEqual([
+      expect.objectContaining({
+        type: "release",
+        bottle: expect.objectContaining({ id: 12 }),
+        automationEligible: true,
+      }),
+    ]);
+  });
+
   test("keeps a stable page size across cursor hops above the max page size", async () => {
     getLegacyReleaseRepairCandidatesMock
       .mockResolvedValueOnce({

--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -350,6 +350,283 @@ describe("getRepairBackfillProposals", () => {
     ]);
   });
 
+  test("marks only the narrow unattended-safe subset as automation eligible", async () => {
+    getLegacyReleaseRepairCandidatesMock.mockResolvedValue({
+      results: [
+        {
+          blockingAlias: null,
+          blockingParent: null,
+          legacyBottle: createLegacyBottleMock({
+            id: 11,
+            fullName: "Aberlour A'bunadh Batch 32",
+            edition: "Batch 32",
+            totalTastings: 12,
+          }),
+          proposedParent: {
+            id: 12,
+            fullName: "Aberlour A'bunadh",
+            totalTastings: 200,
+          },
+          releaseIdentity: {
+            edition: "Batch 32",
+            releaseYear: null,
+            markerSources: ["name_batch"],
+          },
+          siblingLegacyBottles: [],
+          hasExactParent: true,
+          repairMode: "existing_parent",
+        },
+        {
+          blockingAlias: null,
+          blockingParent: null,
+          legacyBottle: createLegacyBottleMock({
+            id: 13,
+            fullName:
+              "Elijah Craig Barrel Proof Kentucky Straight Bourbon (Batch C923)",
+            edition: "Batch C923",
+            totalTastings: 9,
+          }),
+          proposedParent: {
+            id: 14,
+            fullName: "Elijah Craig Barrel Proof",
+            totalTastings: 180,
+          },
+          releaseIdentity: {
+            edition: "Batch C923",
+            releaseYear: null,
+            markerSources: ["name_batch"],
+          },
+          siblingLegacyBottles: [],
+          hasExactParent: false,
+          repairMode: "existing_parent",
+        },
+      ],
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+    });
+
+    getDirtyParentAgeRepairCandidatesMock.mockResolvedValue({
+      results: [
+        {
+          bottle: createAgeBottleMock({
+            id: 21,
+            fullName: "Glenglassaugh 1978 Rare Cask Release",
+            name: "Rare Cask Release",
+            statedAge: 40,
+            numReleases: 2,
+            totalTastings: 9,
+          }),
+          conflictingReleases: [],
+          repairMode: "existing_release",
+          targetRelease: {
+            id: 22,
+            fullName: "Glenglassaugh 1978 Rare Cask Release 40-year-old",
+            statedAge: 40,
+            totalTastings: 7,
+          },
+        },
+        {
+          bottle: createAgeBottleMock({
+            id: 23,
+            fullName: "Another Dirty Parent",
+            name: "Another Dirty Parent",
+            statedAge: 18,
+            numReleases: 1,
+            totalTastings: 3,
+          }),
+          conflictingReleases: [],
+          repairMode: "create_release",
+          targetRelease: {
+            id: null,
+            fullName: "Another Dirty Parent 18-year-old",
+            statedAge: 18,
+            totalTastings: null,
+          },
+        },
+      ],
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+    });
+
+    const result = await getRepairBackfillProposals({
+      perTypeLimit: 10,
+    });
+
+    expect(result.proposals).toEqual(
+      expect.arrayContaining<RepairBackfillProposal>([
+        expect.objectContaining({
+          type: "release",
+          bottle: expect.objectContaining({ id: 11 }),
+          automationEligible: true,
+          automationBlockers: [],
+        }),
+        expect.objectContaining({
+          type: "release",
+          bottle: expect.objectContaining({ id: 13 }),
+          automationEligible: false,
+          automationBlockers: [
+            "release repair only has an exactish reusable parent match",
+          ],
+        }),
+        expect.objectContaining({
+          type: "age",
+          bottle: expect.objectContaining({ id: 21 }),
+          automationEligible: true,
+          automationBlockers: [],
+        }),
+        expect.objectContaining({
+          type: "age",
+          bottle: expect.objectContaining({ id: 23 }),
+          automationEligible: false,
+          automationBlockers: ["age repair would create a new release"],
+        }),
+        expect.objectContaining({
+          type: "canon",
+          automationEligible: false,
+          automationBlockers: ["canon repair requires moderator review"],
+        }),
+      ]),
+    );
+  });
+
+  test("can filter down to unattended-safe repair proposals", async () => {
+    getLegacyReleaseRepairCandidatesMock.mockResolvedValue({
+      results: [
+        {
+          blockingAlias: null,
+          blockingParent: null,
+          legacyBottle: createLegacyBottleMock({
+            id: 11,
+            fullName: "Aberlour A'bunadh Batch 32",
+            edition: "Batch 32",
+            totalTastings: 12,
+          }),
+          proposedParent: {
+            id: 12,
+            fullName: "Aberlour A'bunadh",
+            totalTastings: 200,
+          },
+          releaseIdentity: {
+            edition: "Batch 32",
+            releaseYear: null,
+            markerSources: ["name_batch"],
+          },
+          siblingLegacyBottles: [],
+          hasExactParent: true,
+          repairMode: "existing_parent",
+        },
+        {
+          blockingAlias: null,
+          blockingParent: null,
+          legacyBottle: createLegacyBottleMock({
+            id: 13,
+            fullName:
+              "Elijah Craig Barrel Proof Kentucky Straight Bourbon (Batch C923)",
+            edition: "Batch C923",
+            totalTastings: 9,
+          }),
+          proposedParent: {
+            id: 14,
+            fullName: "Elijah Craig Barrel Proof",
+            totalTastings: 180,
+          },
+          releaseIdentity: {
+            edition: "Batch C923",
+            releaseYear: null,
+            markerSources: ["name_batch"],
+          },
+          siblingLegacyBottles: [],
+          hasExactParent: false,
+          repairMode: "existing_parent",
+        },
+      ],
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+    });
+
+    getDirtyParentAgeRepairCandidatesMock.mockResolvedValue({
+      results: [
+        {
+          bottle: createAgeBottleMock({
+            id: 21,
+            fullName: "Glenglassaugh 1978 Rare Cask Release",
+            name: "Rare Cask Release",
+            statedAge: 40,
+            numReleases: 2,
+            totalTastings: 9,
+          }),
+          conflictingReleases: [],
+          repairMode: "existing_release",
+          targetRelease: {
+            id: 22,
+            fullName: "Glenglassaugh 1978 Rare Cask Release 40-year-old",
+            statedAge: 40,
+            totalTastings: 7,
+          },
+        },
+        {
+          bottle: createAgeBottleMock({
+            id: 23,
+            fullName: "Another Dirty Parent",
+            name: "Another Dirty Parent",
+            statedAge: 18,
+            numReleases: 1,
+            totalTastings: 3,
+          }),
+          conflictingReleases: [],
+          repairMode: "create_release",
+          targetRelease: {
+            id: null,
+            fullName: "Another Dirty Parent 18-year-old",
+            statedAge: 18,
+            totalTastings: null,
+          },
+        },
+      ],
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+    });
+
+    const result = await getRepairBackfillProposals({
+      onlyAutomationEligible: true,
+      perTypeLimit: 10,
+    });
+
+    expect(result.summary).toEqual({
+      total: 2,
+      byType: {
+        release: 1,
+        age: 1,
+        canon: 0,
+      },
+      byActionability: {
+        apply: 2,
+        blocked: 0,
+        manual: 0,
+      },
+    });
+    expect(result.proposals).toEqual([
+      expect.objectContaining({
+        type: "release",
+        bottle: expect.objectContaining({ id: 11 }),
+        automationEligible: true,
+      }),
+      expect.objectContaining({
+        type: "age",
+        bottle: expect.objectContaining({ id: 21 }),
+        automationEligible: true,
+      }),
+    ]);
+  });
+
   test("keeps a stable page size across cursor hops above the max page size", async () => {
     getLegacyReleaseRepairCandidatesMock
       .mockResolvedValueOnce({

--- a/apps/server/src/lib/repairBackfillProposals.ts
+++ b/apps/server/src/lib/repairBackfillProposals.ts
@@ -21,6 +21,11 @@ export type RepairBackfillProposalActionability =
   | "blocked"
   | "manual";
 
+type RepairBackfillProposalAutomationAssessment = {
+  automationBlockers: string[];
+  automationEligible: boolean;
+};
+
 type RepairBackfillProposalSummary = {
   byActionability: Record<RepairBackfillProposalActionability, number>;
   byType: Record<RepairBackfillProposalType, number>;
@@ -38,6 +43,8 @@ type RepairBackfillCandidatePage<TCandidate> = {
 type RepairBackfillProposalBase = {
   actionability: RepairBackfillProposalActionability;
   adminHref: string;
+  automationBlockers: string[];
+  automationEligible: boolean;
   totalTastings: null | number;
   type: RepairBackfillProposalType;
 };
@@ -137,6 +144,62 @@ function getRepairBackfillProposalActionability(
     : "blocked";
 }
 
+function getReleaseRepairProposalAutomationAssessment(
+  candidate: LegacyReleaseRepairCandidate,
+): RepairBackfillProposalAutomationAssessment {
+  const automationBlockers: string[] = [];
+
+  switch (candidate.repairMode) {
+    case "existing_parent":
+      if (!candidate.hasExactParent) {
+        automationBlockers.push(
+          "release repair only has an exactish reusable parent match",
+        );
+      }
+      break;
+    case "create_parent":
+      automationBlockers.push(
+        "release repair would create a new parent bottle",
+      );
+      break;
+    case "blocked_alias_conflict":
+      automationBlockers.push("release repair is blocked by an alias conflict");
+      break;
+    case "blocked_dirty_parent":
+      automationBlockers.push(
+        "release repair is blocked by a dirty parent bottle",
+      );
+      break;
+  }
+
+  return {
+    automationEligible: automationBlockers.length === 0,
+    automationBlockers,
+  };
+}
+
+function getAgeRepairProposalAutomationAssessment(
+  candidate: DirtyParentAgeRepairCandidate,
+): RepairBackfillProposalAutomationAssessment {
+  const automationBlockers: string[] = [];
+
+  if (candidate.repairMode !== "existing_release") {
+    automationBlockers.push("age repair would create a new release");
+  }
+
+  return {
+    automationEligible: automationBlockers.length === 0,
+    automationBlockers,
+  };
+}
+
+function getCanonRepairProposalAutomationAssessment(): RepairBackfillProposalAutomationAssessment {
+  return {
+    automationEligible: false,
+    automationBlockers: ["canon repair requires moderator review"],
+  };
+}
+
 async function collectRepairCandidates<TCandidate>({
   fetcher,
   perTypeLimit,
@@ -176,6 +239,9 @@ async function collectRepairCandidates<TCandidate>({
 function toReleaseRepairBackfillProposal(
   candidate: LegacyReleaseRepairCandidate,
 ): ReleaseRepairBackfillProposal {
+  const automationAssessment =
+    getReleaseRepairProposalAutomationAssessment(candidate);
+
   return {
     type: "release",
     actionability: getRepairBackfillProposalActionability(candidate.repairMode),
@@ -183,6 +249,8 @@ function toReleaseRepairBackfillProposal(
       "/admin/release-repairs",
       candidate.legacyBottle.fullName,
     ),
+    automationBlockers: automationAssessment.automationBlockers,
+    automationEligible: automationAssessment.automationEligible,
     bottle: {
       id: candidate.legacyBottle.id,
       fullName: candidate.legacyBottle.fullName,
@@ -201,10 +269,15 @@ function toReleaseRepairBackfillProposal(
 function toAgeRepairBackfillProposal(
   candidate: DirtyParentAgeRepairCandidate,
 ): AgeRepairBackfillProposal {
+  const automationAssessment =
+    getAgeRepairProposalAutomationAssessment(candidate);
+
   return {
     type: "age",
     actionability: "apply",
     adminHref: buildAdminHref("/admin/age-repairs", candidate.bottle.fullName),
+    automationBlockers: automationAssessment.automationBlockers,
+    automationEligible: automationAssessment.automationEligible,
     bottle: {
       id: candidate.bottle.id,
       fullName: candidate.bottle.fullName,
@@ -221,6 +294,8 @@ function toAgeRepairBackfillProposal(
 function toCanonRepairBackfillProposal(
   candidate: CanonRepairCandidate,
 ): CanonRepairBackfillProposal {
+  const automationAssessment = getCanonRepairProposalAutomationAssessment();
+
   return {
     type: "canon",
     actionability: "manual",
@@ -228,6 +303,8 @@ function toCanonRepairBackfillProposal(
       "/admin/canon-repairs",
       candidate.bottle.fullName,
     ),
+    automationBlockers: automationAssessment.automationBlockers,
+    automationEligible: automationAssessment.automationEligible,
     bottle: candidate.bottle,
     targetBottle: candidate.targetBottle,
     totalTastings: candidate.bottle.totalTastings,
@@ -263,11 +340,13 @@ function createRepairBackfillProposalSummary(
 
 export async function getRepairBackfillProposals({
   onlyActionable = false,
+  onlyAutomationEligible = false,
   perTypeLimit = DEFAULT_PER_TYPE_LIMIT,
   query = "",
   types = ["release", "age", "canon"],
 }: {
   onlyActionable?: boolean;
+  onlyAutomationEligible?: boolean;
   perTypeLimit?: number;
   query?: string;
   types?: RepairBackfillProposalType[];
@@ -302,9 +381,17 @@ export async function getRepairBackfillProposals({
     proposals.push(...results.map(toCanonRepairBackfillProposal));
   }
 
-  const filteredProposals = onlyActionable
-    ? proposals.filter((proposal) => proposal.actionability === "apply")
-    : proposals;
+  const filteredProposals = proposals.filter((proposal) => {
+    if (onlyActionable && proposal.actionability !== "apply") {
+      return false;
+    }
+
+    if (onlyAutomationEligible && !proposal.automationEligible) {
+      return false;
+    }
+
+    return true;
+  });
 
   filteredProposals.sort((left, right) => {
     const tastingDiff =

--- a/apps/server/src/lib/repairBackfillProposals.ts
+++ b/apps/server/src/lib/repairBackfillProposals.ts
@@ -144,6 +144,25 @@ function getRepairBackfillProposalActionability(
     : "blocked";
 }
 
+function isActionableReleaseRepairCandidate(
+  candidate: LegacyReleaseRepairCandidate,
+): candidate is LegacyReleaseRepairCandidate & {
+  repairMode: "create_parent" | "existing_parent";
+} {
+  return (
+    candidate.repairMode === "create_parent" ||
+    candidate.repairMode === "existing_parent"
+  );
+}
+
+function isAutomationEligibleReleaseRepairCandidate(
+  candidate: LegacyReleaseRepairCandidate,
+): candidate is LegacyReleaseRepairCandidate & {
+  repairMode: "existing_parent";
+} {
+  return candidate.repairMode === "existing_parent" && candidate.hasExactParent;
+}
+
 function getReleaseRepairProposalAutomationAssessment(
   candidate: LegacyReleaseRepairCandidate,
 ): RepairBackfillProposalAutomationAssessment {
@@ -193,6 +212,23 @@ function getAgeRepairProposalAutomationAssessment(
   };
 }
 
+function isAutomationEligibleAgeRepairCandidate(
+  candidate: DirtyParentAgeRepairCandidate,
+): candidate is DirtyParentAgeRepairCandidate & {
+  repairMode: "existing_release";
+  targetRelease: {
+    fullName: string;
+    id: number;
+    statedAge: number;
+    totalTastings: null | number;
+  };
+} {
+  return (
+    candidate.repairMode === "existing_release" &&
+    candidate.targetRelease.id !== null
+  );
+}
+
 function getCanonRepairProposalAutomationAssessment(): RepairBackfillProposalAutomationAssessment {
   return {
     automationEligible: false,
@@ -202,6 +238,7 @@ function getCanonRepairProposalAutomationAssessment(): RepairBackfillProposalAut
 
 async function collectRepairCandidates<TCandidate>({
   fetcher,
+  isEligible,
   perTypeLimit,
   query,
 }: {
@@ -210,6 +247,7 @@ async function collectRepairCandidates<TCandidate>({
     limit: number;
     query: string;
   }) => Promise<RepairBackfillCandidatePage<TCandidate>>;
+  isEligible?: (candidate: TCandidate) => boolean;
   perTypeLimit: number;
   query: string;
 }) {
@@ -224,7 +262,17 @@ async function collectRepairCandidates<TCandidate>({
       query,
     });
 
-    results.push(...page.results);
+    for (const candidate of page.results) {
+      if (isEligible && !isEligible(candidate)) {
+        continue;
+      }
+
+      results.push(candidate);
+
+      if (results.length >= perTypeLimit) {
+        break;
+      }
+    }
 
     if (!page.rel.nextCursor || page.results.length === 0) {
       break;
@@ -357,6 +405,11 @@ export async function getRepairBackfillProposals({
   if (normalizedTypes.includes("release")) {
     const results = await collectRepairCandidates({
       fetcher: getLegacyReleaseRepairCandidates,
+      isEligible: onlyAutomationEligible
+        ? isAutomationEligibleReleaseRepairCandidate
+        : onlyActionable
+          ? isActionableReleaseRepairCandidate
+          : undefined,
       perTypeLimit,
       query,
     });
@@ -366,13 +419,20 @@ export async function getRepairBackfillProposals({
   if (normalizedTypes.includes("age")) {
     const results = await collectRepairCandidates({
       fetcher: getDirtyParentAgeRepairCandidates,
+      isEligible: onlyAutomationEligible
+        ? isAutomationEligibleAgeRepairCandidate
+        : undefined,
       perTypeLimit,
       query,
     });
     proposals.push(...results.map(toAgeRepairBackfillProposal));
   }
 
-  if (normalizedTypes.includes("canon")) {
+  if (
+    normalizedTypes.includes("canon") &&
+    !onlyActionable &&
+    !onlyAutomationEligible
+  ) {
     const results = await collectRepairCandidates({
       fetcher: getCanonRepairCandidates,
       perTypeLimit,

--- a/apps/server/src/lib/test/fixtures.ts
+++ b/apps/server/src/lib/test/fixtures.ts
@@ -641,7 +641,13 @@ export const ExternalSiteOrExisting = async (
   { ...data }: Partial<Omit<dbSchema.NewExternalSite, "id">> = {},
   db: AnyDatabase = dbConn,
 ): Promise<dbSchema.ExternalSite> => {
-  if (!data.type) data.type = choose(EXTERNAL_SITE_TYPE_LIST);
+  if (!data.type) {
+    const existing = await db.query.externalSites.findFirst();
+    if (existing) return existing;
+
+    data.type = choose(EXTERNAL_SITE_TYPE_LIST);
+  }
+
   const existing = await db.query.externalSites.findFirst({
     where: (externalSites, { eq }) =>
       eq(externalSites.type, data.type as ExternalSiteType),
@@ -795,7 +801,8 @@ export const Review = async (
       .insert(reviews)
       .values({
         name: "",
-        externalSiteId: data.externalSiteId || (await ExternalSite({}, tx)).id,
+        externalSiteId:
+          data.externalSiteId || (await ExternalSiteOrExisting({}, tx)).id,
         rating: faker.number.int({ min: 59, max: 100 }),
         url: faker.internet.url(),
         issue: "Default",

--- a/apps/server/src/orpc/routes/reviews/update.test.ts
+++ b/apps/server/src/orpc/routes/reviews/update.test.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { reviews } from "@peated/server/db/schema";
+import { externalSites, reviews } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq } from "drizzle-orm";
@@ -49,6 +49,18 @@ describe("PATCH /reviews/:review", () => {
       .from(reviews)
       .where(eq(reviews.id, review.id));
     expect(updatedReview.hidden).toBe(false);
+  });
+
+  test("reuses the same implicit external site across review fixtures", async ({
+    fixtures,
+  }) => {
+    const firstReview = await fixtures.Review();
+    const secondReview = await fixtures.Review();
+
+    expect(secondReview.externalSiteId).toBe(firstReview.externalSiteId);
+
+    const allSites = await db.select().from(externalSites);
+    expect(allSites).toHaveLength(1);
   });
 
   test("assigns a release and infers the parent bottle", async ({


### PR DESCRIPTION
Add a conservative unattended-safe layer on top of the repair proposal export and batch-apply tooling. Proposals now surface whether they are automation-eligible, the CLI can filter to that subset, and batch application can restrict itself to the same narrowed set.

This is meant to be intentionally smaller than the broader actionable repair set. Release repairs only qualify when they reuse an exact existing parent, age repairs only qualify when they reuse an existing release, and canon repairs remain moderator-only. That gives us a path toward unattended backfills without expanding into the dirtier parent-creation or merge cases we have been fixing by hand.

I considered jumping straight to unattended application for the whole actionable set, but that would blur together the exact-parent/existing-release cases we trust with the create-parent and canon paths that still need moderator judgment. Reusing the same automation eligibility rules in both export and apply keeps the boundary explicit.

Refs #311