### PR TITLE
fix(repairs): Tighten repair correctness and visibility

### DIFF
--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -442,13 +442,22 @@ subcommand
       `Types: ${types.join(", ")} | Per-type limit: ${perTypeLimit} | Query: ${options.query || "(none)"}`,
     );
     console.log(
-      `Automation eligible: ${result.proposals.filter((proposal) => proposal.automationEligible).length}`,
+      `Automation: eligible=${result.summary.automationEligible}, blocked=${result.summary.automationBlocked}`,
     );
     console.log(
       `Actionability: apply=${result.summary.byActionability.apply}, blocked=${result.summary.byActionability.blocked}, manual=${result.summary.byActionability.manual}`,
     );
     console.log(
       `By type: release=${result.summary.byType.release}, age=${result.summary.byType.age}, canon=${result.summary.byType.canon}`,
+    );
+    console.log(
+      `Release modes: existing_parent=${result.summary.byRepairMode.release.existing_parent}, create_parent=${result.summary.byRepairMode.release.create_parent}, blocked_alias_conflict=${result.summary.byRepairMode.release.blocked_alias_conflict}, blocked_dirty_parent=${result.summary.byRepairMode.release.blocked_dirty_parent}`,
+    );
+    console.log(
+      `Age modes: existing_release=${result.summary.byRepairMode.age.existing_release}, create_release=${result.summary.byRepairMode.age.create_release}`,
+    );
+    console.log(
+      `Canon modes: review_required=${result.summary.byRepairMode.canon.review_required}`,
     );
 
     if (result.proposals.length === 0) {

--- a/apps/server/src/lib/applyLegacyReleaseRepair.ts
+++ b/apps/server/src/lib/applyLegacyReleaseRepair.ts
@@ -1,3 +1,4 @@
+import { classifyBottleReference } from "@peated/server/agents/bottleClassifier/classifyBottleReference";
 import { db, type AnyTransaction } from "@peated/server/db";
 import type { Bottle, BottleRelease, User } from "@peated/server/db/schema";
 import {
@@ -18,7 +19,10 @@ import {
   storePrices,
   tastings,
 } from "@peated/server/db/schema";
-import { getCanonicalReleaseAliasNames } from "@peated/server/lib/bottleSchemaRules";
+import {
+  getCanonicalReleaseAliasNames,
+  hasBottleLevelReleaseTraits,
+} from "@peated/server/lib/bottleSchemaRules";
 import {
   BottleReleaseAlreadyExistsError,
   BottleReleaseCreateBadRequestError,
@@ -83,6 +87,21 @@ type ResolvedLegacyReleaseRepairParent = {
   bottle: Bottle;
   createdParent: boolean;
 };
+
+type ClassifierReviewedCreateParentResolution =
+  | {
+      parentBottle: Bottle;
+      resolution: "reuse_existing_parent";
+    }
+  | {
+      resolution: "allow_create_parent";
+    }
+  | {
+      message: string;
+      resolution: "blocked";
+    };
+
+type LegacyBottleRepairSnapshot = RepairBottle;
 
 function getReleaseInput(legacyBottle: RepairBottle) {
   const repairIdentity = deriveLegacyReleaseRepairIdentity({
@@ -164,6 +183,74 @@ async function getLegacyBottleForRepair(
   }
 
   return legacyBottle satisfies RepairBottle;
+}
+
+async function getLegacyBottleSnapshotForRepair(legacyBottleId: number) {
+  const [legacyBottle] = await db
+    .select({
+      id: bottles.id,
+      name: bottles.name,
+      fullName: bottles.fullName,
+      statedAge: bottles.statedAge,
+      seriesId: bottles.seriesId,
+      category: bottles.category,
+      edition: bottles.edition,
+      abv: bottles.abv,
+      singleCask: bottles.singleCask,
+      caskStrength: bottles.caskStrength,
+      vintageYear: bottles.vintageYear,
+      releaseYear: bottles.releaseYear,
+      caskType: bottles.caskType,
+      caskSize: bottles.caskSize,
+      caskFill: bottles.caskFill,
+      description: bottles.description,
+      imageUrl: bottles.imageUrl,
+      tastingNotes: bottles.tastingNotes,
+      flavorProfile: bottles.flavorProfile,
+      brandId: bottles.brandId,
+      bottlerId: bottles.bottlerId,
+      createdById: bottles.createdById,
+      numReleases: bottles.numReleases,
+      totalTastings: bottles.totalTastings,
+    })
+    .from(bottles)
+    .where(eq(bottles.id, legacyBottleId))
+    .limit(1);
+
+  if (!legacyBottle || legacyBottle.numReleases > 0) {
+    return null;
+  }
+
+  return legacyBottle satisfies LegacyBottleRepairSnapshot;
+}
+
+async function getParentRowsForRepair({
+  legacyBottleId,
+  legacyBottle,
+  proposedParentFullName,
+}: {
+  legacyBottle: Pick<RepairBottle, "brandId">;
+  legacyBottleId: number;
+  proposedParentFullName: string;
+}) {
+  return await db
+    .select()
+    .from(bottles)
+    .where(
+      legacyBottle.brandId
+        ? and(
+            eq(bottles.brandId, legacyBottle.brandId),
+            sql`${bottles.id} != ${legacyBottleId}`,
+          )
+        : and(
+            eq(
+              sql`LOWER(${bottles.fullName})`,
+              proposedParentFullName.toLowerCase(),
+            ),
+            sql`${bottles.id} != ${legacyBottleId}`,
+          ),
+    )
+    .orderBy(sql`${bottles.totalTastings} DESC NULLS LAST`, desc(bottles.id));
 }
 
 async function getProposedParentBottleName(
@@ -276,15 +363,151 @@ async function createParentBottleForRepair(
   };
 }
 
+async function reviewCreateParentResolutionWithClassifier({
+  legacyBottle,
+  legacyBottleId,
+  parentRows,
+}: {
+  legacyBottle: LegacyBottleRepairSnapshot;
+  legacyBottleId: number;
+  parentRows: Bottle[];
+}): Promise<ClassifierReviewedCreateParentResolution> {
+  const [brand] = await db
+    .select({
+      name: entities.name,
+      shortName: entities.shortName,
+    })
+    .from(entities)
+    .where(eq(entities.id, legacyBottle.brandId))
+    .limit(1);
+
+  const initialCandidates = parentRows
+    .filter((row) => row.id !== legacyBottleId)
+    .map((row) => ({
+      kind: "bottle" as const,
+      bottleId: row.id,
+      releaseId: null,
+      alias: null,
+      fullName: row.fullName,
+      bottleFullName: row.fullName,
+      brand: brand?.name ?? brand?.shortName ?? null,
+      bottler: null,
+      series: null,
+      distillery: [],
+      category: row.category,
+      statedAge: row.statedAge,
+      edition: row.edition,
+      caskStrength: row.caskStrength,
+      singleCask: row.singleCask,
+      abv: row.abv,
+      vintageYear: row.vintageYear,
+      releaseYear: row.releaseYear,
+      caskType: row.caskType,
+      caskSize: row.caskSize,
+      caskFill: row.caskFill,
+      score: null,
+      source: ["repair_parent"],
+    }));
+
+  const classification = await classifyBottleReference({
+    reference: {
+      name: legacyBottle.fullName,
+    },
+    extractedIdentity: {
+      brand: brand?.name ?? brand?.shortName ?? null,
+      bottler: null,
+      expression: null,
+      series: null,
+      distillery: [],
+      category: legacyBottle.category,
+      stated_age: legacyBottle.statedAge,
+      abv: legacyBottle.abv,
+      release_year: legacyBottle.releaseYear,
+      vintage_year: legacyBottle.vintageYear,
+      cask_type: legacyBottle.caskType,
+      cask_size: legacyBottle.caskSize,
+      cask_fill: legacyBottle.caskFill,
+      cask_strength: legacyBottle.caskStrength,
+      single_cask: legacyBottle.singleCask,
+      edition: legacyBottle.edition,
+    },
+    initialCandidates,
+  });
+
+  if (classification.status === "ignored") {
+    return {
+      resolution: "blocked",
+      message: `Classifier could not review parent resolution: ${classification.reason}`,
+    };
+  }
+
+  const { decision } = classification;
+  if (decision.identityScope === "exact_cask") {
+    return {
+      resolution: "blocked",
+      message:
+        "Classifier treated this bottle as exact-cask identity, so release repair cannot safely create a reusable parent bottle.",
+    };
+  }
+
+  if (decision.action === "match" || decision.action === "create_release") {
+    const parentBottleId =
+      decision.action === "match"
+        ? decision.matchedBottleId
+        : decision.parentBottleId;
+
+    const parentBottle =
+      parentRows.find((row) => row.id === parentBottleId) ?? null;
+
+    if (!parentBottle) {
+      return {
+        resolution: "blocked",
+        message:
+          "Classifier pointed at a bottle outside the reviewed repair parent set.",
+      };
+    }
+
+    if (hasBottleLevelReleaseTraits(parentBottle)) {
+      return {
+        resolution: "blocked",
+        message:
+          "Classifier found a reusable parent candidate, but that bottle still has bottle-level release traits.",
+      };
+    }
+
+    return {
+      resolution: "reuse_existing_parent",
+      parentBottle,
+    };
+  }
+
+  if (
+    decision.action === "create_bottle" ||
+    decision.action === "create_bottle_and_release"
+  ) {
+    return {
+      resolution: "allow_create_parent",
+    };
+  }
+
+  return {
+    resolution: "blocked",
+    message:
+      "Classifier could not verify whether this repair should reuse an existing parent bottle or create a new one.",
+  };
+}
+
 async function resolveParentBottleForRepair(
   tx: AnyTransaction,
   {
+    classifierResolution,
     distillerIds,
     legacyBottle,
     legacyBottleId,
     proposedParentFullName,
     user,
   }: {
+    classifierResolution: ClassifierReviewedCreateParentResolution | null;
     distillerIds: number[];
     legacyBottle: RepairBottle;
     legacyBottleId: number;
@@ -323,6 +546,42 @@ async function resolveParentBottleForRepair(
   }
 
   if (parentMode === "create_parent") {
+    if (!classifierResolution) {
+      throw new LegacyReleaseRepairBadRequestError(
+        "Classifier review was unavailable for create-parent repair validation.",
+      );
+    }
+
+    if (classifierResolution.resolution === "blocked") {
+      throw new LegacyReleaseRepairBadRequestError(
+        classifierResolution.message,
+      );
+    }
+
+    if (classifierResolution.resolution === "reuse_existing_parent") {
+      const lockedParentBottle =
+        parentRows.find(
+          (row) => row.id === classifierResolution.parentBottle.id,
+        ) ?? null;
+      if (!lockedParentBottle) {
+        throw new LegacyReleaseRepairBadRequestError(
+          "Classifier-reviewed parent bottle is outside the locked repair parent set.",
+        );
+      }
+
+      if (hasBottleLevelReleaseTraits(lockedParentBottle)) {
+        throw new LegacyReleaseRepairBadRequestError(
+          "Classifier-reviewed parent bottle still contains bottle-level release traits.",
+        );
+      }
+
+      return {
+        aliasName: null,
+        bottle: lockedParentBottle,
+        createdParent: false,
+      };
+    }
+
     return createParentBottleForRepair(tx, {
       distillerIds,
       legacyBottle,
@@ -393,9 +652,11 @@ async function backfillExistingReleaseMetadata(
 export async function applyLegacyReleaseRepairInTransaction(
   tx: AnyTransaction,
   {
+    classifierResolution = null,
     legacyBottleId,
     user,
   }: {
+    classifierResolution?: ClassifierReviewedCreateParentResolution | null;
     legacyBottleId: number;
     user: User;
   },
@@ -457,6 +718,7 @@ export async function applyLegacyReleaseRepairInTransaction(
     bottle: parentBottle,
     createdParent,
   } = await resolveParentBottleForRepair(tx, {
+    classifierResolution,
     distillerIds,
     legacyBottle,
     legacyBottleId,
@@ -786,8 +1048,42 @@ export async function applyLegacyReleaseRepair({
   legacyBottleId: number;
   user: User;
 }) {
+  let classifierResolution: ClassifierReviewedCreateParentResolution | null =
+    null;
+  const legacyBottle = await getLegacyBottleSnapshotForRepair(legacyBottleId);
+
+  if (legacyBottle) {
+    const repairIdentity = deriveLegacyReleaseRepairIdentity({
+      fullName: legacyBottle.fullName,
+      edition: legacyBottle.edition,
+      releaseYear: legacyBottle.releaseYear,
+    });
+
+    if (repairIdentity) {
+      const parentRows = await getParentRowsForRepair({
+        legacyBottle,
+        legacyBottleId,
+        proposedParentFullName: repairIdentity.proposedParentFullName,
+      });
+      const parentMode = getLegacyReleaseRepairParentMode(parentRows, {
+        proposedParentFullName: repairIdentity.proposedParentFullName,
+      });
+
+      if (parentMode === "create_parent") {
+        classifierResolution = await reviewCreateParentResolutionWithClassifier(
+          {
+            legacyBottle,
+            legacyBottleId,
+            parentRows,
+          },
+        );
+      }
+    }
+  }
+
   const result = await db.transaction(async (tx) =>
     applyLegacyReleaseRepairInTransaction(tx, {
+      classifierResolution,
       legacyBottleId,
       user,
     }),

--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -219,6 +219,8 @@ describe("getRepairBackfillProposals", () => {
     });
     expect(result.summary).toEqual({
       total: 4,
+      automationEligible: 2,
+      automationBlocked: 2,
       byType: {
         release: 2,
         age: 1,
@@ -228,6 +230,21 @@ describe("getRepairBackfillProposals", () => {
         apply: 2,
         blocked: 1,
         manual: 1,
+      },
+      byRepairMode: {
+        release: {
+          existing_parent: 1,
+          create_parent: 0,
+          blocked_alias_conflict: 1,
+          blocked_dirty_parent: 0,
+        },
+        age: {
+          existing_release: 0,
+          create_release: 1,
+        },
+        canon: {
+          review_required: 1,
+        },
       },
     });
     expect(result.proposals).toEqual(
@@ -330,6 +347,8 @@ describe("getRepairBackfillProposals", () => {
 
     expect(result.summary).toEqual({
       total: 1,
+      automationEligible: 1,
+      automationBlocked: 0,
       byType: {
         release: 1,
         age: 0,
@@ -339,6 +358,21 @@ describe("getRepairBackfillProposals", () => {
         apply: 1,
         blocked: 0,
         manual: 0,
+      },
+      byRepairMode: {
+        release: {
+          existing_parent: 1,
+          create_parent: 0,
+          blocked_alias_conflict: 0,
+          blocked_dirty_parent: 0,
+        },
+        age: {
+          existing_release: 0,
+          create_release: 0,
+        },
+        canon: {
+          review_required: 0,
+        },
       },
     });
     expect(result.proposals).toEqual([
@@ -602,6 +636,8 @@ describe("getRepairBackfillProposals", () => {
 
     expect(result.summary).toEqual({
       total: 2,
+      automationEligible: 2,
+      automationBlocked: 0,
       byType: {
         release: 1,
         age: 1,
@@ -611,6 +647,21 @@ describe("getRepairBackfillProposals", () => {
         apply: 2,
         blocked: 0,
         manual: 0,
+      },
+      byRepairMode: {
+        release: {
+          existing_parent: 1,
+          create_parent: 0,
+          blocked_alias_conflict: 0,
+          blocked_dirty_parent: 0,
+        },
+        age: {
+          existing_release: 1,
+          create_release: 0,
+        },
+        canon: {
+          review_required: 0,
+        },
       },
     });
     expect(result.proposals).toEqual([
@@ -711,6 +762,8 @@ describe("getRepairBackfillProposals", () => {
     });
     expect(result.summary).toEqual({
       total: 1,
+      automationEligible: 1,
+      automationBlocked: 0,
       byType: {
         release: 1,
         age: 0,
@@ -720,6 +773,21 @@ describe("getRepairBackfillProposals", () => {
         apply: 1,
         blocked: 0,
         manual: 0,
+      },
+      byRepairMode: {
+        release: {
+          existing_parent: 1,
+          create_parent: 0,
+          blocked_alias_conflict: 0,
+          blocked_dirty_parent: 0,
+        },
+        age: {
+          existing_release: 0,
+          create_release: 0,
+        },
+        canon: {
+          review_required: 0,
+        },
       },
     });
     expect(result.proposals).toEqual([
@@ -932,6 +1000,8 @@ describe("getRepairBackfillProposals", () => {
 
     expect(result.summary).toEqual({
       total: 3,
+      automationEligible: 1,
+      automationBlocked: 2,
       byType: {
         release: 1,
         age: 1,
@@ -941,6 +1011,21 @@ describe("getRepairBackfillProposals", () => {
         apply: 1,
         blocked: 1,
         manual: 1,
+      },
+      byRepairMode: {
+        release: {
+          existing_parent: 0,
+          create_parent: 0,
+          blocked_alias_conflict: 0,
+          blocked_dirty_parent: 1,
+        },
+        age: {
+          existing_release: 1,
+          create_release: 0,
+        },
+        canon: {
+          review_required: 1,
+        },
       },
     });
 

--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -219,8 +219,8 @@ describe("getRepairBackfillProposals", () => {
     });
     expect(result.summary).toEqual({
       total: 4,
-      automationEligible: 2,
-      automationBlocked: 2,
+      automationEligible: 1,
+      automationBlocked: 3,
       byType: {
         release: 2,
         age: 1,

--- a/apps/server/src/lib/repairBackfillProposals.ts
+++ b/apps/server/src/lib/repairBackfillProposals.ts
@@ -27,7 +27,16 @@ type RepairBackfillProposalAutomationAssessment = {
 };
 
 type RepairBackfillProposalSummary = {
+  automationBlocked: number;
+  automationEligible: number;
   byActionability: Record<RepairBackfillProposalActionability, number>;
+  byRepairMode: {
+    age: Record<AgeRepairBackfillProposal["repairMode"], number>;
+    canon: {
+      review_required: number;
+    };
+    release: Record<ReleaseRepairBackfillProposal["repairMode"], number>;
+  };
   byType: Record<RepairBackfillProposalType, number>;
   total: number;
 };
@@ -368,10 +377,30 @@ function createRepairBackfillProposalSummary(
       summary.total += 1;
       summary.byType[proposal.type] += 1;
       summary.byActionability[proposal.actionability] += 1;
+      if (proposal.automationEligible) {
+        summary.automationEligible += 1;
+      } else {
+        summary.automationBlocked += 1;
+      }
+
+      switch (proposal.type) {
+        case "release":
+          summary.byRepairMode.release[proposal.repairMode] += 1;
+          break;
+        case "age":
+          summary.byRepairMode.age[proposal.repairMode] += 1;
+          break;
+        case "canon":
+          summary.byRepairMode.canon.review_required += 1;
+          break;
+      }
+
       return summary;
     },
     {
       total: 0,
+      automationEligible: 0,
+      automationBlocked: 0,
       byType: {
         release: 0,
         age: 0,
@@ -381,6 +410,21 @@ function createRepairBackfillProposalSummary(
         apply: 0,
         blocked: 0,
         manual: 0,
+      },
+      byRepairMode: {
+        release: {
+          existing_parent: 0,
+          create_parent: 0,
+          blocked_alias_conflict: 0,
+          blocked_dirty_parent: 0,
+        },
+        age: {
+          existing_release: 0,
+          create_release: 0,
+        },
+        canon: {
+          review_required: 0,
+        },
       },
     },
   );

--- a/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
+++ b/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
@@ -19,8 +19,70 @@ import {
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { and, eq, inArray } from "drizzle-orm";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const classifyBottleReferenceMock = vi.hoisted(() => vi.fn());
+
+vi.mock(
+  "@peated/server/agents/bottleClassifier/classifyBottleReference",
+  () => ({
+    classifyBottleReference: classifyBottleReferenceMock,
+  }),
+);
+
+function createClassifierCreateBottleResult() {
+  return {
+    status: "classified" as const,
+    decision: {
+      action: "create_bottle" as const,
+      confidence: 92,
+      rationale: "Local candidates do not show a reusable parent bottle.",
+      candidateBottleIds: [],
+      identityScope: "product" as const,
+      observation: null,
+      matchedBottleId: null,
+      matchedReleaseId: null,
+      parentBottleId: null,
+      proposedBottle: {
+        name: "Classifier Parent",
+        series: null,
+        category: null,
+        edition: null,
+        statedAge: null,
+        caskStrength: null,
+        singleCask: null,
+        abv: null,
+        vintageYear: null,
+        releaseYear: null,
+        caskType: null,
+        caskSize: null,
+        caskFill: null,
+        brand: {
+          id: null,
+          name: "Classifier Brand",
+        },
+        distillers: [],
+        bottler: null,
+      },
+      proposedRelease: null,
+    },
+    artifacts: {
+      extractedIdentity: null,
+      candidates: [],
+      searchEvidence: [],
+      resolvedEntities: [],
+    },
+  };
+}
 
 describe("POST /bottles/:bottle/apply-release-repair", () => {
+  beforeEach(() => {
+    classifyBottleReferenceMock.mockReset();
+    classifyBottleReferenceMock.mockResolvedValue(
+      createClassifierCreateBottleResult(),
+    );
+  });
+
   test("requires moderator access", async ({ fixtures }) => {
     const user = await fixtures.User({ mod: false });
 
@@ -413,6 +475,190 @@ describe("POST /bottles/:bottle/apply-release-repair", () => {
       where: (entities, { eq }) => eq(entities.id, brand.id),
     });
     expect(refreshedBrand?.totalBottles).toBe(1);
+  });
+
+  test("reuses a classifier-reviewed existing parent instead of creating a heuristic duplicate", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({
+      name: "Festival Distillery",
+      totalBottles: 2,
+    });
+    const parentBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Warehouse Sessions",
+      totalTastings: 80,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Warehouse Session (Batch 2)",
+      statedAge: 12,
+      category: "single_malt",
+    });
+    const mod = await fixtures.User({ mod: true });
+
+    classifyBottleReferenceMock.mockResolvedValueOnce({
+      status: "classified",
+      decision: {
+        action: "match",
+        confidence: 95,
+        rationale: "The existing parent bottle is the same product family.",
+        candidateBottleIds: [parentBottle.id],
+        identityScope: "product",
+        observation: null,
+        matchedBottleId: parentBottle.id,
+        matchedReleaseId: null,
+        parentBottleId: null,
+        proposedBottle: null,
+        proposedRelease: null,
+      },
+      artifacts: {
+        extractedIdentity: null,
+        candidates: [],
+        searchEvidence: [],
+        resolvedEntities: [],
+      },
+    });
+
+    const result = await routerClient.bottles.applyReleaseRepair(
+      {
+        bottle: legacyBottle.id,
+      },
+      { context: { user: mod } },
+    );
+
+    expect(result.parentBottleId).toBe(parentBottle.id);
+
+    const brandBottles = await db
+      .select({
+        id: bottles.id,
+      })
+      .from(bottles)
+      .where(eq(bottles.brandId, brand.id));
+    expect(brandBottles.map((row) => row.id).sort((a, b) => a - b)).toEqual([
+      parentBottle.id,
+    ]);
+  });
+
+  test("blocks heuristic create-parent repairs when classifier cannot verify the parent decision", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({
+      name: "Festival Distillery",
+      totalBottles: 1,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Warehouse Session (Batch 2)",
+      statedAge: 12,
+      category: "single_malt",
+    });
+    const mod = await fixtures.User({ mod: true });
+
+    classifyBottleReferenceMock.mockResolvedValueOnce({
+      status: "classified",
+      decision: {
+        action: "no_match",
+        confidence: 41,
+        rationale: "Identity is not strong enough to create or reuse a parent.",
+        candidateBottleIds: [],
+        identityScope: "product",
+        observation: null,
+        matchedBottleId: null,
+        matchedReleaseId: null,
+        parentBottleId: null,
+        proposedBottle: null,
+        proposedRelease: null,
+      },
+      artifacts: {
+        extractedIdentity: null,
+        candidates: [],
+        searchEvidence: [],
+        resolvedEntities: [],
+      },
+    });
+
+    const err = await waitError(
+      routerClient.bottles.applyReleaseRepair(
+        {
+          bottle: legacyBottle.id,
+        },
+        { context: { user: mod } },
+      ),
+    );
+
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Classifier could not verify whether this repair should reuse an existing parent bottle or create a new one.]`,
+    );
+
+    const brandBottles = await db
+      .select({
+        id: bottles.id,
+      })
+      .from(bottles)
+      .where(eq(bottles.brandId, brand.id));
+    expect(brandBottles.map((row) => row.id)).toEqual([legacyBottle.id]);
+  });
+
+  test("blocks classifier redirects to parent bottles outside the reviewed repair parent set", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({
+      name: "Festival Distillery",
+      totalBottles: 1,
+    });
+    const unrelatedBrand = await fixtures.Entity({
+      name: "Other Distillery",
+      totalBottles: 1,
+    });
+    const unrelatedBottle = await fixtures.Bottle({
+      brandId: unrelatedBrand.id,
+      name: "Warehouse Session",
+      totalTastings: 80,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Warehouse Session (Batch 2)",
+      statedAge: 12,
+      category: "single_malt",
+    });
+    const mod = await fixtures.User({ mod: true });
+
+    classifyBottleReferenceMock.mockResolvedValueOnce({
+      status: "classified",
+      decision: {
+        action: "match",
+        confidence: 88,
+        rationale: "Classifier picked an unrelated bottle.",
+        candidateBottleIds: [unrelatedBottle.id],
+        identityScope: "product",
+        observation: null,
+        matchedBottleId: unrelatedBottle.id,
+        matchedReleaseId: null,
+        parentBottleId: null,
+        proposedBottle: null,
+        proposedRelease: null,
+      },
+      artifacts: {
+        extractedIdentity: null,
+        candidates: [],
+        searchEvidence: [],
+        resolvedEntities: [],
+      },
+    });
+
+    const err = await waitError(
+      routerClient.bottles.applyReleaseRepair(
+        {
+          bottle: legacyBottle.id,
+        },
+        { context: { user: mod } },
+      ),
+    );
+
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Classifier pointed at a bottle outside the reviewed repair parent set.]`,
+    );
   });
 
   test("creates a reusable parent bottle for branded generic-name releases", async ({


### PR DESCRIPTION
Tighten legacy release repair correctness by routing heuristic create-parent decisions through classifier review before applying them, and expand repair proposal summaries so the queue shape is easier to measure from the CLI.

The repair pipeline was still carrying some bottle-identity drift relative to the reviewed classifier boundary. In particular, heuristic create-parent release repairs could move forward without a classifier-backed check, while the proposal tooling still only exposed coarse totals. This change keeps release-repair writes conservative and gives us better visibility into how much of the queue is safe, blocked, or still review-heavy.

The classifier-backed repair change is intentionally narrow: it only preflights heuristic create-parent repairs, blocks redirects outside the reviewed same-brand parent set, and avoids doing classifier work while transaction locks are held. The summary changes are included because they support the same follow-up work on repair correctness by showing automation and repair-mode breakdowns directly in the backfill tooling.

Fixes #311