### PR TITLE
fix(repairs): Review queue parent decisions with classifier

### DIFF
--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -451,7 +451,7 @@ subcommand
       `By type: release=${result.summary.byType.release}, age=${result.summary.byType.age}, canon=${result.summary.byType.canon}`,
     );
     console.log(
-      `Release modes: existing_parent=${result.summary.byRepairMode.release.existing_parent}, create_parent=${result.summary.byRepairMode.release.create_parent}, blocked_alias_conflict=${result.summary.byRepairMode.release.blocked_alias_conflict}, blocked_dirty_parent=${result.summary.byRepairMode.release.blocked_dirty_parent}`,
+      `Release modes: existing_parent=${result.summary.byRepairMode.release.existing_parent}, create_parent=${result.summary.byRepairMode.release.create_parent}, blocked_classifier=${result.summary.byRepairMode.release.blocked_classifier}, blocked_alias_conflict=${result.summary.byRepairMode.release.blocked_alias_conflict}, blocked_dirty_parent=${result.summary.byRepairMode.release.blocked_dirty_parent}`,
     );
     console.log(
       `Age modes: existing_release=${result.summary.byRepairMode.age.existing_release}, create_release=${result.summary.byRepairMode.age.create_release}`,

--- a/apps/server/src/lib/applyLegacyReleaseRepair.ts
+++ b/apps/server/src/lib/applyLegacyReleaseRepair.ts
@@ -1,4 +1,3 @@
-import { classifyBottleReference } from "@peated/server/agents/bottleClassifier/classifyBottleReference";
 import { db, type AnyTransaction } from "@peated/server/db";
 import type { Bottle, BottleRelease, User } from "@peated/server/db/schema";
 import {
@@ -35,6 +34,11 @@ import {
   resolveLegacyReleaseRepairNameScope,
   resolveLegacyReleaseRepairParentMatch,
 } from "@peated/server/lib/legacyReleaseRepairCandidates";
+import {
+  reviewLegacyCreateParentResolutionWithClassifier,
+  type ClassifierReviewedCreateParentResolution,
+  type LegacyReleaseRepairClassifierParentCandidate,
+} from "@peated/server/lib/legacyReleaseRepairClassifier";
 import { logError } from "@peated/server/lib/log";
 import { stripDuplicateBrandPrefixFromBottleName } from "@peated/server/lib/normalize";
 import { pushJob } from "@peated/server/worker/client";
@@ -87,19 +91,6 @@ type ResolvedLegacyReleaseRepairParent = {
   bottle: Bottle;
   createdParent: boolean;
 };
-
-type ClassifierReviewedCreateParentResolution =
-  | {
-      parentBottle: Bottle;
-      resolution: "reuse_existing_parent";
-    }
-  | {
-      resolution: "allow_create_parent";
-    }
-  | {
-      message: string;
-      resolution: "blocked";
-    };
 
 type LegacyBottleRepairSnapshot = RepairBottle;
 
@@ -360,140 +351,6 @@ async function createParentBottleForRepair(
     aliasName: alias.name,
     bottle: parentBottle,
     createdParent: true,
-  };
-}
-
-async function reviewCreateParentResolutionWithClassifier({
-  legacyBottle,
-  legacyBottleId,
-  parentRows,
-}: {
-  legacyBottle: LegacyBottleRepairSnapshot;
-  legacyBottleId: number;
-  parentRows: Bottle[];
-}): Promise<ClassifierReviewedCreateParentResolution> {
-  const [brand] = await db
-    .select({
-      name: entities.name,
-      shortName: entities.shortName,
-    })
-    .from(entities)
-    .where(eq(entities.id, legacyBottle.brandId))
-    .limit(1);
-
-  const initialCandidates = parentRows
-    .filter((row) => row.id !== legacyBottleId)
-    .map((row) => ({
-      kind: "bottle" as const,
-      bottleId: row.id,
-      releaseId: null,
-      alias: null,
-      fullName: row.fullName,
-      bottleFullName: row.fullName,
-      brand: brand?.name ?? brand?.shortName ?? null,
-      bottler: null,
-      series: null,
-      distillery: [],
-      category: row.category,
-      statedAge: row.statedAge,
-      edition: row.edition,
-      caskStrength: row.caskStrength,
-      singleCask: row.singleCask,
-      abv: row.abv,
-      vintageYear: row.vintageYear,
-      releaseYear: row.releaseYear,
-      caskType: row.caskType,
-      caskSize: row.caskSize,
-      caskFill: row.caskFill,
-      score: null,
-      source: ["repair_parent"],
-    }));
-
-  const classification = await classifyBottleReference({
-    reference: {
-      name: legacyBottle.fullName,
-    },
-    extractedIdentity: {
-      brand: brand?.name ?? brand?.shortName ?? null,
-      bottler: null,
-      expression: null,
-      series: null,
-      distillery: [],
-      category: legacyBottle.category,
-      stated_age: legacyBottle.statedAge,
-      abv: legacyBottle.abv,
-      release_year: legacyBottle.releaseYear,
-      vintage_year: legacyBottle.vintageYear,
-      cask_type: legacyBottle.caskType,
-      cask_size: legacyBottle.caskSize,
-      cask_fill: legacyBottle.caskFill,
-      cask_strength: legacyBottle.caskStrength,
-      single_cask: legacyBottle.singleCask,
-      edition: legacyBottle.edition,
-    },
-    initialCandidates,
-  });
-
-  if (classification.status === "ignored") {
-    return {
-      resolution: "blocked",
-      message: `Classifier could not review parent resolution: ${classification.reason}`,
-    };
-  }
-
-  const { decision } = classification;
-  if (decision.identityScope === "exact_cask") {
-    return {
-      resolution: "blocked",
-      message:
-        "Classifier treated this bottle as exact-cask identity, so release repair cannot safely create a reusable parent bottle.",
-    };
-  }
-
-  if (decision.action === "match" || decision.action === "create_release") {
-    const parentBottleId =
-      decision.action === "match"
-        ? decision.matchedBottleId
-        : decision.parentBottleId;
-
-    const parentBottle =
-      parentRows.find((row) => row.id === parentBottleId) ?? null;
-
-    if (!parentBottle) {
-      return {
-        resolution: "blocked",
-        message:
-          "Classifier pointed at a bottle outside the reviewed repair parent set.",
-      };
-    }
-
-    if (hasBottleLevelReleaseTraits(parentBottle)) {
-      return {
-        resolution: "blocked",
-        message:
-          "Classifier found a reusable parent candidate, but that bottle still has bottle-level release traits.",
-      };
-    }
-
-    return {
-      resolution: "reuse_existing_parent",
-      parentBottle,
-    };
-  }
-
-  if (
-    decision.action === "create_bottle" ||
-    decision.action === "create_bottle_and_release"
-  ) {
-    return {
-      resolution: "allow_create_parent",
-    };
-  }
-
-  return {
-    resolution: "blocked",
-    message:
-      "Classifier could not verify whether this repair should reuse an existing parent bottle or create a new one.",
   };
 }
 
@@ -1070,13 +927,12 @@ export async function applyLegacyReleaseRepair({
       });
 
       if (parentMode === "create_parent") {
-        classifierResolution = await reviewCreateParentResolutionWithClassifier(
-          {
+        classifierResolution =
+          await reviewLegacyCreateParentResolutionWithClassifier({
             legacyBottle,
-            legacyBottleId,
-            parentRows,
-          },
-        );
+            parentRows:
+              parentRows as LegacyReleaseRepairClassifierParentCandidate[],
+          });
       }
     }
   }

--- a/apps/server/src/lib/legacyReleaseRepairCandidates.ts
+++ b/apps/server/src/lib/legacyReleaseRepairCandidates.ts
@@ -6,6 +6,7 @@ import {
   type Bottle,
 } from "@peated/server/db/schema";
 import { hasBottleLevelReleaseTraits } from "@peated/server/lib/bottleSchemaRules";
+import { reviewLegacyCreateParentResolutionWithClassifier } from "@peated/server/lib/legacyReleaseRepairClassifier";
 import { and, desc, eq, isNotNull, isNull, or, sql } from "drizzle-orm";
 import {
   normalizeBottle,
@@ -73,18 +74,33 @@ type LegacyReleaseRepairBottle = Omit<
   totalTastings: null | number;
 };
 
+type LegacyReleaseRepairClassifierInputBottle = LegacyReleaseRepairBottle &
+  Pick<
+    Bottle,
+    | "statedAge"
+    | "abv"
+    | "singleCask"
+    | "caskStrength"
+    | "vintageYear"
+    | "caskType"
+    | "caskSize"
+    | "caskFill"
+  >;
+
 export type LegacyReleaseRepairParentCandidate = Pick<
   Bottle,
   | "abv"
   | "caskFill"
   | "caskSize"
   | "caskStrength"
+  | "caskType"
   | "category"
   | "edition"
   | "fullName"
   | "id"
   | "releaseYear"
   | "singleCask"
+  | "statedAge"
   | "totalTastings"
   | "vintageYear"
 >;
@@ -99,6 +115,7 @@ export type LegacyReleaseRepairIdentity = {
 export type LegacyReleaseRepairParentMode =
   | "existing_parent"
   | "create_parent"
+  | "blocked_classifier"
   | "blocked_alias_conflict"
   | "blocked_dirty_parent";
 
@@ -106,7 +123,7 @@ type LegacyReleaseRepairParentMatchType = "exact" | "variant";
 
 export type DerivedLegacyReleaseRepairCandidate =
   LegacyReleaseRepairIdentity & {
-    bottle: LegacyReleaseRepairBottle;
+    bottle: LegacyReleaseRepairClassifierInputBottle;
   };
 
 export type LegacyReleaseRepairCandidate = {
@@ -122,6 +139,7 @@ export type LegacyReleaseRepairCandidate = {
     fullName: string;
     totalTastings: number | null;
   };
+  classifierBlocker: string | null;
   legacyBottle: LegacyReleaseRepairBottle;
   proposedParent: {
     id: number | null;
@@ -164,10 +182,12 @@ function getLegacyReleaseRepairModePriority(
       return 0;
     case "create_parent":
       return 1;
-    case "blocked_alias_conflict":
+    case "blocked_classifier":
       return 2;
-    case "blocked_dirty_parent":
+    case "blocked_alias_conflict":
       return 3;
+    case "blocked_dirty_parent":
+      return 4;
   }
 }
 
@@ -531,7 +551,7 @@ export function deriveLegacyReleaseRepairIdentity({
 }
 
 export function deriveLegacyReleaseRepairCandidate(
-  bottle: LegacyReleaseRepairBottle,
+  bottle: LegacyReleaseRepairClassifierInputBottle,
 ): DerivedLegacyReleaseRepairCandidate | null {
   const repairIdentity = deriveLegacyReleaseRepairIdentity({
     fullName: bottle.fullName,
@@ -612,6 +632,46 @@ export function resolveLegacyReleaseRepairNameScope({
   return "parent";
 }
 
+async function applyClassifierReviewToLegacyReleaseRepairCandidate(
+  candidate: LegacyReleaseRepairCandidate,
+  legacyBottle: LegacyReleaseRepairClassifierInputBottle,
+  parentRows: LegacyReleaseRepairParentCandidate[],
+): Promise<LegacyReleaseRepairCandidate> {
+  if (candidate.repairMode !== "create_parent") {
+    return candidate;
+  }
+
+  const classifierResolution =
+    await reviewLegacyCreateParentResolutionWithClassifier({
+      legacyBottle,
+      parentRows,
+    });
+
+  if (classifierResolution.resolution === "reuse_existing_parent") {
+    return {
+      ...candidate,
+      classifierBlocker: null,
+      hasExactParent: false,
+      proposedParent: {
+        id: classifierResolution.parentBottle.id,
+        fullName: classifierResolution.parentBottle.fullName,
+        totalTastings: classifierResolution.parentBottle.totalTastings ?? null,
+      },
+      repairMode: "existing_parent",
+    };
+  }
+
+  if (classifierResolution.resolution === "blocked") {
+    return {
+      ...candidate,
+      classifierBlocker: classifierResolution.message,
+      repairMode: "blocked_classifier",
+    };
+  }
+
+  return candidate;
+}
+
 export async function getLegacyReleaseRepairCandidates({
   query = "",
   cursor = 1,
@@ -629,6 +689,14 @@ export async function getLegacyReleaseRepairCandidates({
       fullName: bottles.fullName,
       edition: bottles.edition,
       releaseYear: bottles.releaseYear,
+      statedAge: bottles.statedAge,
+      abv: bottles.abv,
+      singleCask: bottles.singleCask,
+      caskStrength: bottles.caskStrength,
+      vintageYear: bottles.vintageYear,
+      caskType: bottles.caskType,
+      caskSize: bottles.caskSize,
+      caskFill: bottles.caskFill,
       numReleases: sql<number>`COALESCE(${bottles.numReleases}, 0)::integer`,
       totalTastings: bottles.totalTastings,
     })
@@ -669,10 +737,15 @@ export async function getLegacyReleaseRepairCandidates({
     string,
     DerivedLegacyReleaseRepairCandidate[]
   >();
+  const derivedCandidateByBottleId = new Map<
+    number,
+    DerivedLegacyReleaseRepairCandidate
+  >();
   const brandIds = new Set<number>();
   const parentNames = new Set<string>();
   for (const candidate of derivedCandidates) {
     const parentKey = candidate.proposedParentFullName.toLowerCase();
+    derivedCandidateByBottleId.set(candidate.bottle.id, candidate);
     brandIds.add(candidate.bottle.brandId);
     parentNames.add(parentKey);
     const group = groupedCandidates.get(parentKey) ?? [];
@@ -689,6 +762,7 @@ export async function getLegacyReleaseRepairCandidates({
             category: bottles.category,
             totalTastings: bottles.totalTastings,
             edition: bottles.edition,
+            statedAge: bottles.statedAge,
             releaseYear: bottles.releaseYear,
             vintageYear: bottles.vintageYear,
             abv: bottles.abv,
@@ -716,6 +790,7 @@ export async function getLegacyReleaseRepairCandidates({
             category: bottles.category,
             totalTastings: bottles.totalTastings,
             edition: bottles.edition,
+            statedAge: bottles.statedAge,
             releaseYear: bottles.releaseYear,
             vintageYear: bottles.vintageYear,
             abv: bottles.abv,
@@ -905,6 +980,7 @@ export async function getLegacyReleaseRepairCandidates({
                 totalTastings: blockingParent.totalTastings,
               }
             : null,
+        classifierBlocker: null,
         legacyBottle: candidate.bottle,
         proposedParent: {
           id: parent?.id ?? null,
@@ -945,9 +1021,68 @@ export async function getLegacyReleaseRepairCandidates({
 
   const offset = (cursor - 1) * limit;
   const results = filteredCandidates.slice(offset, offset + limit + 1);
+  const classifierReviewByParentKey = new Map<
+    string,
+    Promise<LegacyReleaseRepairCandidate>
+  >();
+  const reviewedResults = await Promise.all(
+    results
+      .slice(0, limit)
+      .map(async (candidate): Promise<LegacyReleaseRepairCandidate> => {
+        if (candidate.repairMode !== "create_parent") {
+          return candidate;
+        }
+
+        const parentKey = `${candidate.legacyBottle.brandId}:${candidate.proposedParent.fullName.toLowerCase()}`;
+        const cachedReview = classifierReviewByParentKey.get(parentKey);
+        if (cachedReview) {
+          return cachedReview;
+        }
+
+        const parentRowsForCandidate =
+          brandParentRowsByBrandId.get(candidate.legacyBottle.brandId) ?? [];
+        const derivedCandidate = derivedCandidateByBottleId.get(
+          candidate.legacyBottle.id,
+        );
+        if (!derivedCandidate) {
+          return candidate;
+        }
+        const reviewPromise =
+          applyClassifierReviewToLegacyReleaseRepairCandidate(
+            candidate,
+            derivedCandidate.bottle,
+            parentRowsForCandidate.filter(
+              (row) => row.id !== candidate.legacyBottle.id,
+            ),
+          );
+        classifierReviewByParentKey.set(parentKey, reviewPromise);
+        return reviewPromise;
+      }),
+  );
+  reviewedResults.sort((a, b) => {
+    const repairModePriority =
+      getLegacyReleaseRepairModePriority(a.repairMode) -
+      getLegacyReleaseRepairModePriority(b.repairMode);
+    if (repairModePriority !== 0) {
+      return repairModePriority;
+    }
+
+    if (a.siblingLegacyBottles.length !== b.siblingLegacyBottles.length) {
+      return b.siblingLegacyBottles.length - a.siblingLegacyBottles.length;
+    }
+
+    const aTastingCount = getTastingCount(a.legacyBottle.totalTastings);
+    const bTastingCount = getTastingCount(b.legacyBottle.totalTastings);
+
+    if (aTastingCount !== bTastingCount) {
+      return bTastingCount - aTastingCount;
+    }
+
+    return b.legacyBottle.id - a.legacyBottle.id;
+  });
 
   return {
-    results: results.slice(0, limit),
+    results: reviewedResults,
     rel: {
       nextCursor: results.length > limit ? cursor + 1 : null,
       prevCursor: cursor > 1 ? cursor - 1 : null,

--- a/apps/server/src/lib/legacyReleaseRepairClassifier.ts
+++ b/apps/server/src/lib/legacyReleaseRepairClassifier.ts
@@ -1,0 +1,186 @@
+import { classifyBottleReference } from "@peated/server/agents/bottleClassifier/classifyBottleReference";
+import { db } from "@peated/server/db";
+import { bottles, entities, type Bottle } from "@peated/server/db/schema";
+import { hasBottleLevelReleaseTraits } from "@peated/server/lib/bottleSchemaRules";
+import { eq } from "drizzle-orm";
+
+export type LegacyReleaseRepairClassifierBottle = Pick<
+  Bottle,
+  | "abv"
+  | "brandId"
+  | "caskFill"
+  | "caskSize"
+  | "caskStrength"
+  | "category"
+  | "edition"
+  | "fullName"
+  | "id"
+  | "releaseYear"
+  | "singleCask"
+  | "statedAge"
+  | "vintageYear"
+  | "caskType"
+>;
+
+export type LegacyReleaseRepairClassifierParentCandidate = Pick<
+  Bottle,
+  | "abv"
+  | "caskFill"
+  | "caskSize"
+  | "caskStrength"
+  | "category"
+  | "edition"
+  | "fullName"
+  | "id"
+  | "releaseYear"
+  | "singleCask"
+  | "statedAge"
+  | "totalTastings"
+  | "vintageYear"
+  | "caskType"
+>;
+
+export type ClassifierReviewedCreateParentResolution =
+  | {
+      parentBottle: LegacyReleaseRepairClassifierParentCandidate;
+      resolution: "reuse_existing_parent";
+    }
+  | {
+      resolution: "allow_create_parent";
+    }
+  | {
+      message: string;
+      resolution: "blocked";
+    };
+
+export async function reviewLegacyCreateParentResolutionWithClassifier({
+  legacyBottle,
+  parentRows,
+}: {
+  legacyBottle: LegacyReleaseRepairClassifierBottle;
+  parentRows: LegacyReleaseRepairClassifierParentCandidate[];
+}): Promise<ClassifierReviewedCreateParentResolution> {
+  const [brand] = await db
+    .select({
+      name: entities.name,
+      shortName: entities.shortName,
+    })
+    .from(entities)
+    .where(eq(entities.id, legacyBottle.brandId))
+    .limit(1);
+
+  const initialCandidates = parentRows
+    .filter((row) => row.id !== legacyBottle.id)
+    .map((row) => ({
+      kind: "bottle" as const,
+      bottleId: row.id,
+      releaseId: null,
+      alias: null,
+      fullName: row.fullName,
+      bottleFullName: row.fullName,
+      brand: brand?.name ?? brand?.shortName ?? null,
+      bottler: null,
+      series: null,
+      distillery: [],
+      category: row.category,
+      statedAge: row.statedAge,
+      edition: row.edition,
+      caskStrength: row.caskStrength,
+      singleCask: row.singleCask,
+      abv: row.abv,
+      vintageYear: row.vintageYear,
+      releaseYear: row.releaseYear,
+      caskType: row.caskType,
+      caskSize: row.caskSize,
+      caskFill: row.caskFill,
+      score: null,
+      source: ["repair_parent"],
+    }));
+
+  const classification = await classifyBottleReference({
+    reference: {
+      name: legacyBottle.fullName,
+    },
+    extractedIdentity: {
+      brand: brand?.name ?? brand?.shortName ?? null,
+      bottler: null,
+      expression: null,
+      series: null,
+      distillery: [],
+      category: legacyBottle.category,
+      stated_age: legacyBottle.statedAge,
+      abv: legacyBottle.abv,
+      release_year: legacyBottle.releaseYear,
+      vintage_year: legacyBottle.vintageYear,
+      cask_type: legacyBottle.caskType,
+      cask_size: legacyBottle.caskSize,
+      cask_fill: legacyBottle.caskFill,
+      cask_strength: legacyBottle.caskStrength,
+      single_cask: legacyBottle.singleCask,
+      edition: legacyBottle.edition,
+    },
+    initialCandidates,
+  });
+
+  if (classification.status === "ignored") {
+    return {
+      resolution: "blocked",
+      message: `Classifier could not review parent resolution: ${classification.reason}`,
+    };
+  }
+
+  const { decision } = classification;
+  if (decision.identityScope === "exact_cask") {
+    return {
+      resolution: "blocked",
+      message:
+        "Classifier treated this bottle as exact-cask identity, so release repair cannot safely create a reusable parent bottle.",
+    };
+  }
+
+  if (decision.action === "match" || decision.action === "create_release") {
+    const parentBottleId =
+      decision.action === "match"
+        ? decision.matchedBottleId
+        : decision.parentBottleId;
+
+    const parentBottle =
+      parentRows.find((row) => row.id === parentBottleId) ?? null;
+
+    if (!parentBottle) {
+      return {
+        resolution: "blocked",
+        message:
+          "Classifier pointed at a bottle outside the reviewed repair parent set.",
+      };
+    }
+
+    if (hasBottleLevelReleaseTraits(parentBottle)) {
+      return {
+        resolution: "blocked",
+        message:
+          "Classifier found a reusable parent candidate, but that bottle still has bottle-level release traits.",
+      };
+    }
+
+    return {
+      resolution: "reuse_existing_parent",
+      parentBottle,
+    };
+  }
+
+  if (
+    decision.action === "create_bottle" ||
+    decision.action === "create_bottle_and_release"
+  ) {
+    return {
+      resolution: "allow_create_parent",
+    };
+  }
+
+  return {
+    resolution: "blocked",
+    message:
+      "Classifier could not verify whether this repair should reuse an existing parent bottle or create a new one.",
+  };
+}

--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -36,6 +36,14 @@ function createLegacyBottleMock(overrides: Record<string, unknown>) {
     fullName: "Legacy Bottle",
     edition: null,
     releaseYear: null,
+    statedAge: null,
+    abv: null,
+    singleCask: null,
+    caskStrength: null,
+    vintageYear: null,
+    caskType: null,
+    caskSize: null,
+    caskFill: null,
     numReleases: 0,
     totalTastings: null,
     ...overrides,
@@ -133,6 +141,7 @@ describe("getRepairBackfillProposals", () => {
           {
             blockingAlias: null,
             blockingParent: null,
+            classifierBlocker: null,
             legacyBottle: createLegacyBottleMock({
               id: 11,
               fullName: "Aberlour A'bunadh Batch 32",
@@ -175,6 +184,7 @@ describe("getRepairBackfillProposals", () => {
               releaseFullName: null,
             },
             blockingParent: null,
+            classifierBlocker: null,
             legacyBottle: createLegacyBottleMock({
               id: 41,
               fullName: "Lagavulin Distillers Edition 2011 Release",
@@ -235,6 +245,7 @@ describe("getRepairBackfillProposals", () => {
         release: {
           existing_parent: 1,
           create_parent: 0,
+          blocked_classifier: 0,
           blocked_alias_conflict: 1,
           blocked_dirty_parent: 0,
         },
@@ -286,6 +297,7 @@ describe("getRepairBackfillProposals", () => {
         {
           blockingAlias: null,
           blockingParent: null,
+          classifierBlocker: null,
           legacyBottle: createLegacyBottleMock({
             id: 11,
             fullName: "Aberlour A'bunadh Batch 32",
@@ -313,6 +325,7 @@ describe("getRepairBackfillProposals", () => {
             fullName: "Dirty Parent",
             totalTastings: 10,
           },
+          classifierBlocker: null,
           legacyBottle: createLegacyBottleMock({
             id: 16,
             fullName: "Dirty Parent Batch 4",
@@ -363,6 +376,7 @@ describe("getRepairBackfillProposals", () => {
         release: {
           existing_parent: 1,
           create_parent: 0,
+          blocked_classifier: 0,
           blocked_alias_conflict: 0,
           blocked_dirty_parent: 0,
         },
@@ -390,6 +404,7 @@ describe("getRepairBackfillProposals", () => {
         {
           blockingAlias: null,
           blockingParent: null,
+          classifierBlocker: null,
           legacyBottle: createLegacyBottleMock({
             id: 11,
             fullName: "Aberlour A'bunadh Batch 32",
@@ -413,6 +428,7 @@ describe("getRepairBackfillProposals", () => {
         {
           blockingAlias: null,
           blockingParent: null,
+          classifierBlocker: null,
           legacyBottle: createLegacyBottleMock({
             id: 13,
             fullName:
@@ -533,6 +549,7 @@ describe("getRepairBackfillProposals", () => {
         {
           blockingAlias: null,
           blockingParent: null,
+          classifierBlocker: null,
           legacyBottle: createLegacyBottleMock({
             id: 11,
             fullName: "Aberlour A'bunadh Batch 32",
@@ -556,6 +573,7 @@ describe("getRepairBackfillProposals", () => {
         {
           blockingAlias: null,
           blockingParent: null,
+          classifierBlocker: null,
           legacyBottle: createLegacyBottleMock({
             id: 13,
             fullName:
@@ -652,6 +670,7 @@ describe("getRepairBackfillProposals", () => {
         release: {
           existing_parent: 1,
           create_parent: 0,
+          blocked_classifier: 0,
           blocked_alias_conflict: 0,
           blocked_dirty_parent: 0,
         },
@@ -685,6 +704,7 @@ describe("getRepairBackfillProposals", () => {
           {
             blockingAlias: null,
             blockingParent: null,
+            classifierBlocker: null,
             legacyBottle: createLegacyBottleMock({
               id: 11,
               fullName:
@@ -717,6 +737,7 @@ describe("getRepairBackfillProposals", () => {
           {
             blockingAlias: null,
             blockingParent: null,
+            classifierBlocker: null,
             legacyBottle: createLegacyBottleMock({
               id: 12,
               fullName: "Aberlour A'bunadh Batch 32",
@@ -778,6 +799,7 @@ describe("getRepairBackfillProposals", () => {
         release: {
           existing_parent: 1,
           create_parent: 0,
+          blocked_classifier: 0,
           blocked_alias_conflict: 0,
           blocked_dirty_parent: 0,
         },
@@ -805,6 +827,7 @@ describe("getRepairBackfillProposals", () => {
         results: Array.from({ length: 100 }, (_, index) => ({
           blockingAlias: null,
           blockingParent: null,
+          classifierBlocker: null,
           legacyBottle: createLegacyBottleMock({
             id: index + 1,
             fullName: `Release Repair ${index + 1}`,
@@ -834,6 +857,7 @@ describe("getRepairBackfillProposals", () => {
         results: Array.from({ length: 100 }, (_, index) => ({
           blockingAlias: null,
           blockingParent: null,
+          classifierBlocker: null,
           legacyBottle: createLegacyBottleMock({
             id: index + 101,
             fullName: `Release Repair ${index + 101}`,
@@ -897,6 +921,7 @@ describe("getRepairBackfillProposals", () => {
             fullName: "Aberlour A'bunadh",
             totalTastings: 120,
           },
+          classifierBlocker: null,
           legacyBottle: createLegacyBottleMock({
             id: 16,
             fullName: "Aberlour A'bunadh (Batch 4)",
@@ -1016,6 +1041,7 @@ describe("getRepairBackfillProposals", () => {
         release: {
           existing_parent: 0,
           create_parent: 0,
+          blocked_classifier: 0,
           blocked_alias_conflict: 0,
           blocked_dirty_parent: 1,
         },

--- a/apps/server/src/lib/repairBackfillProposals.ts
+++ b/apps/server/src/lib/repairBackfillProposals.ts
@@ -190,6 +190,11 @@ function getReleaseRepairProposalAutomationAssessment(
         "release repair would create a new parent bottle",
       );
       break;
+    case "blocked_classifier":
+      automationBlockers.push(
+        "release repair is blocked until classifier review can verify the parent decision",
+      );
+      break;
     case "blocked_alias_conflict":
       automationBlockers.push("release repair is blocked by an alias conflict");
       break;
@@ -415,6 +420,7 @@ function createRepairBackfillProposalSummary(
         release: {
           existing_parent: 0,
           create_parent: 0,
+          blocked_classifier: 0,
           blocked_alias_conflict: 0,
           blocked_dirty_parent: 0,
         },

--- a/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
@@ -3,9 +3,70 @@ import { bottleAliases, bottles } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq } from "drizzle-orm";
-import { describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const classifyBottleReferenceMock = vi.hoisted(() => vi.fn());
+
+vi.mock(
+  "@peated/server/agents/bottleClassifier/classifyBottleReference",
+  () => ({
+    classifyBottleReference: classifyBottleReferenceMock,
+  }),
+);
+
+function createClassifierCreateBottleResult() {
+  return {
+    status: "classified" as const,
+    decision: {
+      action: "create_bottle" as const,
+      confidence: 92,
+      rationale: "Local candidates do not show a reusable parent bottle.",
+      candidateBottleIds: [],
+      identityScope: "product" as const,
+      observation: null,
+      matchedBottleId: null,
+      matchedReleaseId: null,
+      parentBottleId: null,
+      proposedBottle: {
+        name: "Classifier Parent",
+        series: null,
+        category: null,
+        edition: null,
+        statedAge: null,
+        caskStrength: null,
+        singleCask: null,
+        abv: null,
+        vintageYear: null,
+        releaseYear: null,
+        caskType: null,
+        caskSize: null,
+        caskFill: null,
+        brand: {
+          id: null,
+          name: "Classifier Brand",
+        },
+        distillers: [],
+        bottler: null,
+      },
+      proposedRelease: null,
+    },
+    artifacts: {
+      extractedIdentity: null,
+      candidates: [],
+      searchEvidence: [],
+      resolvedEntities: [],
+    },
+  };
+}
 
 describe("GET /bottles/release-repair-candidates", () => {
+  beforeEach(() => {
+    classifyBottleReferenceMock.mockReset();
+    classifyBottleReferenceMock.mockResolvedValue(
+      createClassifierCreateBottleResult(),
+    );
+  });
+
   test("requires moderator access", async ({ fixtures }) => {
     const user = await fixtures.User({ mod: false });
 
@@ -278,6 +339,92 @@ describe("GET /bottles/release-repair-candidates", () => {
     });
   });
 
+  test("rewrites create-parent candidates to existing-parent when classifier finds a reviewed parent", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Review Distillery" });
+    const reusableParent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Session Archive",
+      totalTastings: 30,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Warehouse Session (Batch 1)",
+      totalTastings: 6,
+    });
+    const user = await fixtures.User({ mod: true });
+
+    classifyBottleReferenceMock.mockResolvedValue({
+      ...createClassifierCreateBottleResult(),
+      decision: {
+        ...createClassifierCreateBottleResult().decision,
+        action: "match",
+        matchedBottleId: reusableParent.id,
+      },
+    });
+
+    const result = await routerClient.bottles.releaseRepairCandidates(
+      {
+        query: "Warehouse Session",
+      },
+      { context: { user } },
+    );
+
+    expect(
+      result.results.find(
+        (candidate) => candidate.legacyBottle.id === legacyBottle.id,
+      ),
+    ).toMatchObject({
+      classifierBlocker: null,
+      hasExactParent: false,
+      repairMode: "existing_parent",
+      proposedParent: {
+        id: reusableParent.id,
+        fullName: reusableParent.fullName,
+      },
+    });
+  });
+
+  test("blocks create-parent candidates when classifier cannot verify the parent decision", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Blocked Distillery" });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Warehouse Session (Batch 1)",
+      totalTastings: 6,
+    });
+    const user = await fixtures.User({ mod: true });
+
+    classifyBottleReferenceMock.mockResolvedValue({
+      status: "ignored" as const,
+      reason: "reference is too ambiguous",
+    });
+
+    const result = await routerClient.bottles.releaseRepairCandidates(
+      {
+        query: "Warehouse Session",
+      },
+      { context: { user } },
+    );
+
+    expect(
+      result.results.find(
+        (candidate) => candidate.legacyBottle.id === legacyBottle.id,
+      ),
+    ).toMatchObject({
+      classifierBlocker:
+        "Classifier could not review parent resolution: reference is too ambiguous",
+      hasExactParent: false,
+      repairMode: "blocked_classifier",
+      proposedParent: {
+        id: null,
+        fullName: "Blocked Distillery Warehouse Session",
+      },
+    });
+  });
+
   test("flags sibling clusters behind a dirty exact-name parent as blocked", async ({
     fixtures,
   }) => {
@@ -546,6 +693,9 @@ describe("GET /bottles/release-repair-candidates", () => {
   test("keeps pagination stable when valid candidates extend past the initial scan window", async ({
     fixtures,
   }) => {
+    classifyBottleReferenceMock.mockResolvedValue(
+      createClassifierCreateBottleResult(),
+    );
     const brand = await fixtures.Entity({
       name: "Pagination Probe Distillery",
     });
@@ -613,5 +763,5 @@ describe("GET /bottles/release-repair-candidates", () => {
     expect(new Set(returnedIds.slice(0, 20))).toEqual(
       new Set(validCandidateIds),
     );
-  });
+  }, 15000);
 });

--- a/apps/server/src/orpc/routes/bottles/release-repair-candidates.ts
+++ b/apps/server/src/orpc/routes/bottles/release-repair-candidates.ts
@@ -20,6 +20,7 @@ const LegacyReleaseRepairCandidateSchema = z.object({
       totalTastings: z.number().nullable(),
     })
     .nullable(),
+  classifierBlocker: z.string().nullable(),
   legacyBottle: z.object({
     id: z.number(),
     fullName: z.string(),
@@ -48,6 +49,7 @@ const LegacyReleaseRepairCandidateSchema = z.object({
   repairMode: z.enum([
     "existing_parent",
     "create_parent",
+    "blocked_classifier",
     "blocked_alias_conflict",
     "blocked_dirty_parent",
   ]),

--- a/apps/web/src/app/(admin)/admin/(default)/release-repairs/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/release-repairs/page.tsx
@@ -31,6 +31,7 @@ const MARKER_LABELS: Record<string, string> = {
 const REPAIR_MODE_LABELS = {
   existing_parent: "Reusable parent exists",
   create_parent: "Needs parent creation",
+  blocked_classifier: "Classifier review blocked",
   blocked_alias_conflict: "Parent alias is blocked",
   blocked_dirty_parent: "Dirty parent blocks repair",
 } as const;
@@ -45,6 +46,8 @@ function getRepairModeDescription(repairMode: keyof typeof REPAIR_MODE_LABELS) {
       return "An existing reusable parent bottle can absorb this legacy release directly.";
     case "create_parent":
       return "A new reusable parent bottle will be created during repair.";
+    case "blocked_classifier":
+      return "Classifier review could not verify whether this legacy bottle should reuse an existing parent or create a new one.";
     case "blocked_alias_conflict":
       return "The proposed parent name is already owned by a different bottle or release alias and needs manual cleanup first.";
     case "blocked_dirty_parent":
@@ -54,6 +57,7 @@ function getRepairModeDescription(repairMode: keyof typeof REPAIR_MODE_LABELS) {
 
 function canApplyRepair(repairMode: keyof typeof REPAIR_MODE_LABELS) {
   return (
+    repairMode !== "blocked_classifier" &&
     repairMode !== "blocked_dirty_parent" &&
     repairMode !== "blocked_alias_conflict"
   );
@@ -428,6 +432,11 @@ export default function Page() {
                         {candidate.blockingParent.fullName}
                       </Link>
                       .
+                    </div>
+                  ) : null}
+                  {candidate.classifierBlocker ? (
+                    <div className="mt-3 text-sm text-amber-300">
+                      {candidate.classifierBlocker}
                     </div>
                   ) : null}
                 </div>


### PR DESCRIPTION
Route legacy release repair queue candidates through the same classifier-backed parent review used at apply time so batch tooling sees the same safety boundary before writes happen.

The repair apply path was already blocking unsafe create-parent decisions, but the queue and backfill tooling were still advertising heuristic create-parent rows as directly actionable. This change moves that classifier-reviewed decision into candidate generation, rewrites create-parent rows to existing-parent when a reviewed reusable parent exists, and introduces an explicit blocked state when classifier review cannot safely verify the decision.

I also extracted the shared repair classifier helper so apply-time repair and queue generation use the same constrained same-brand parent set, and threaded the new state through the admin page and repair proposal summaries so batch work is measuring the right queue shape.

Fixes #311