### PR TITLE
ref(repairs): Track release parent resolution source

### DIFF
--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -527,7 +527,7 @@ describe("getRepairBackfillProposals", () => {
           automationBlockers: [
             "release repair has a persisted classifier-reviewed reusable parent, but unattended apply still revalidates live at execution time",
           ],
-          parentResolutionSource: "heuristic_variant",
+          parentResolutionSource: "classifier_review_persisted",
         }),
         expect.objectContaining({
           type: "age",

--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -347,7 +347,7 @@ describe("getRepairBackfillProposals", () => {
           },
           siblingLegacyBottles: [],
           hasExactParent: true,
-          parentResolutionSource: "heuristic_exact",
+          parentResolutionSource: null,
           repairMode: "blocked_dirty_parent",
         },
       ],
@@ -527,6 +527,7 @@ describe("getRepairBackfillProposals", () => {
           automationBlockers: [
             "release repair has a persisted classifier-reviewed reusable parent, but unattended apply still revalidates live at execution time",
           ],
+          parentResolutionSource: "heuristic_variant",
         }),
         expect.objectContaining({
           type: "age",
@@ -696,6 +697,7 @@ describe("getRepairBackfillProposals", () => {
         type: "release",
         bottle: expect.objectContaining({ id: 11 }),
         automationEligible: true,
+        parentResolutionSource: "heuristic_exact",
       }),
       expect.objectContaining({
         type: "age",
@@ -957,7 +959,7 @@ describe("getRepairBackfillProposals", () => {
             },
           ],
           hasExactParent: true,
-          parentResolutionSource: "heuristic_exact",
+          parentResolutionSource: null,
           repairMode: "blocked_dirty_parent",
         },
       ],

--- a/apps/server/src/lib/repairBackfillProposals.ts
+++ b/apps/server/src/lib/repairBackfillProposals.ts
@@ -87,6 +87,12 @@ export type ReleaseRepairBackfillProposal = RepairBackfillProposalBase & {
     markerSources: string[];
     releaseYear: null | number;
   };
+  parentResolutionSource:
+    | "classifier_review_live"
+    | "classifier_review_persisted"
+    | "heuristic_exact"
+    | "heuristic_variant"
+    | null;
   repairMode: LegacyReleaseRepairParentMode;
   siblingCount: number;
   type: "release";
@@ -337,6 +343,7 @@ function toReleaseRepairBackfillProposal(
     blockingParent: candidate.blockingParent,
     proposedParent: candidate.proposedParent,
     releaseIdentity: candidate.releaseIdentity,
+    parentResolutionSource: candidate.parentResolutionSource,
     repairMode: candidate.repairMode,
     siblingCount: candidate.siblingLegacyBottles.length,
     totalTastings: candidate.legacyBottle.totalTastings,

--- a/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
@@ -378,6 +378,7 @@ describe("GET /bottles/release-repair-candidates", () => {
       ),
     ).toMatchObject({
       hasExactParent: false,
+      parentResolutionSource: "classifier_review_live",
       repairMode: "existing_parent",
       proposedParent: {
         id: reusableParent.id,
@@ -428,6 +429,7 @@ describe("GET /bottles/release-repair-candidates", () => {
       ),
     ).toMatchObject({
       hasExactParent: false,
+      parentResolutionSource: "classifier_review_persisted",
       repairMode: "existing_parent",
       proposedParent: {
         id: reusableParent.id,


### PR DESCRIPTION
Expose how reusable release parents were resolved so repair queues and backfill tooling can distinguish exact heuristic reuse from variant and classifier-reviewed reuse without inferring from `hasExactParent` alone. This threads a small source field through legacy release repair candidates, the moderator route schema, and repair proposal serialization.

The motivation is to make the automation boundary explicit. Exact heuristic reuse is still the only unattended-safe release path today, while reviewed and exactish reuse remain visible for operators and later policy changes. Keeping that distinction in the data model is cleaner than overloading booleans or rebuilding the reason from queue state downstream.

This replaces the stale-branch version of the same change with a branch cut directly from `origin/main`, so the diff should now be limited to the source-tracking work itself.

Refs #329