### PR TITLE
ref(repairs): Add release summary source breakdown

### DIFF
--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -465,6 +465,9 @@ subcommand
       `Release modes: existing_parent=${result.summary.byRepairMode.release.existing_parent}, create_parent=${result.summary.byRepairMode.release.create_parent}, blocked_classifier=${result.summary.byRepairMode.release.blocked_classifier}, blocked_alias_conflict=${result.summary.byRepairMode.release.blocked_alias_conflict}, blocked_dirty_parent=${result.summary.byRepairMode.release.blocked_dirty_parent}`,
     );
     console.log(
+      `Release parent sources: heuristic_exact=${result.summary.byParentResolutionSource.release.heuristic_exact}, heuristic_variant=${result.summary.byParentResolutionSource.release.heuristic_variant}, classifier_review_persisted=${result.summary.byParentResolutionSource.release.classifier_review_persisted}, classifier_review_live=${result.summary.byParentResolutionSource.release.classifier_review_live}, none=${result.summary.byParentResolutionSource.release.none}`,
+    );
+    console.log(
       `Age modes: existing_release=${result.summary.byRepairMode.age.existing_release}, create_release=${result.summary.byRepairMode.age.create_release}`,
     );
     console.log(

--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -243,6 +243,15 @@ describe("getRepairBackfillProposals", () => {
         blocked: 1,
         manual: 1,
       },
+      byParentResolutionSource: {
+        release: {
+          classifier_review_live: 0,
+          classifier_review_persisted: 0,
+          heuristic_exact: 1,
+          heuristic_variant: 0,
+          none: 1,
+        },
+      },
       byRepairMode: {
         release: {
           existing_parent: 1,
@@ -375,6 +384,15 @@ describe("getRepairBackfillProposals", () => {
         apply: 1,
         blocked: 0,
         manual: 0,
+      },
+      byParentResolutionSource: {
+        release: {
+          classifier_review_live: 0,
+          classifier_review_persisted: 0,
+          heuristic_exact: 1,
+          heuristic_variant: 0,
+          none: 0,
+        },
       },
       byRepairMode: {
         release: {
@@ -675,6 +693,15 @@ describe("getRepairBackfillProposals", () => {
         blocked: 0,
         manual: 0,
       },
+      byParentResolutionSource: {
+        release: {
+          classifier_review_live: 0,
+          classifier_review_persisted: 0,
+          heuristic_exact: 1,
+          heuristic_variant: 0,
+          none: 0,
+        },
+      },
       byRepairMode: {
         release: {
           existing_parent: 1,
@@ -806,6 +833,15 @@ describe("getRepairBackfillProposals", () => {
         apply: 1,
         blocked: 0,
         manual: 0,
+      },
+      byParentResolutionSource: {
+        release: {
+          classifier_review_live: 0,
+          classifier_review_persisted: 0,
+          heuristic_exact: 1,
+          heuristic_variant: 0,
+          none: 0,
+        },
       },
       byRepairMode: {
         release: {
@@ -1051,6 +1087,15 @@ describe("getRepairBackfillProposals", () => {
         apply: 1,
         blocked: 1,
         manual: 1,
+      },
+      byParentResolutionSource: {
+        release: {
+          classifier_review_live: 0,
+          classifier_review_persisted: 0,
+          heuristic_exact: 0,
+          heuristic_variant: 0,
+          none: 1,
+        },
       },
       byRepairMode: {
         release: {

--- a/apps/server/src/lib/repairBackfillProposals.ts
+++ b/apps/server/src/lib/repairBackfillProposals.ts
@@ -30,6 +30,15 @@ type RepairBackfillProposalSummary = {
   automationBlocked: number;
   automationEligible: number;
   byActionability: Record<RepairBackfillProposalActionability, number>;
+  byParentResolutionSource: {
+    release: {
+      classifier_review_live: number;
+      classifier_review_persisted: number;
+      heuristic_exact: number;
+      heuristic_variant: number;
+      none: number;
+    };
+  };
   byRepairMode: {
     age: Record<AgeRepairBackfillProposal["repairMode"], number>;
     canon: {
@@ -413,6 +422,9 @@ function createRepairBackfillProposalSummary(
       switch (proposal.type) {
         case "release":
           summary.byRepairMode.release[proposal.repairMode] += 1;
+          summary.byParentResolutionSource.release[
+            proposal.parentResolutionSource ?? "none"
+          ] += 1;
           break;
         case "age":
           summary.byRepairMode.age[proposal.repairMode] += 1;
@@ -437,6 +449,15 @@ function createRepairBackfillProposalSummary(
         apply: 0,
         blocked: 0,
         manual: 0,
+      },
+      byParentResolutionSource: {
+        release: {
+          classifier_review_live: 0,
+          classifier_review_persisted: 0,
+          heuristic_exact: 0,
+          heuristic_variant: 0,
+          none: 0,
+        },
       },
       byRepairMode: {
         release: {


### PR DESCRIPTION
Add release parent-resolution source counts to the repair backfill summary so queue snapshots can distinguish exact heuristic reuse from variant and classifier-reviewed reuse without inspecting individual rows.

This is a small reporting-only follow-up to the persisted review work. The repair proposal summary already tracked release modes and automation totals, but that still hid the part of the queue that matters for the next automation decisions: how many release proposals are exact-safe today versus reviewed-only versus unresolved. Surfacing the source mix directly makes the CLI output more useful for measuring the queue and planning the next tightening step.

The change only affects summary aggregation and the `dump-repair-proposals` CLI output. It does not widen automation policy or alter apply-time repair behavior.

Refs #329