### PR TITLE
ref(repairs): Summarize blocked review reasons

### DIFF
--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -21,7 +21,10 @@ import {
   getHeuristicLegacyReleaseRepairCandidates,
   type LegacyReleaseRepairCandidate,
 } from "@peated/server/lib/legacyReleaseRepairCandidates";
-import { refreshLegacyReleaseRepairReview } from "@peated/server/lib/legacyReleaseRepairReviews";
+import {
+  getLegacyReleaseRepairReviewBlockedReasonCategory,
+  refreshLegacyReleaseRepairReview,
+} from "@peated/server/lib/legacyReleaseRepairReviews";
 import { normalizeBottle } from "@peated/server/lib/normalize";
 import {
   getRepairBackfillProposals,
@@ -519,6 +522,14 @@ subcommand
       blocked: 0,
       reuse_existing_parent: 0,
     };
+    const blockedSummary = {
+      classifier_review_failed: 0,
+      classifier_exact_cask: 0,
+      classifier_outside_parent_set: 0,
+      classifier_dirty_parent_candidate: 0,
+      classifier_unresolved_parent_decision: 0,
+      other: 0,
+    };
 
     while (reviewed < limit) {
       const page = await getHeuristicLegacyReleaseRepairCandidates({
@@ -546,6 +557,13 @@ subcommand
 
         reviewed += 1;
         summary[review.resolution] += 1;
+        if (review.resolution === "blocked") {
+          blockedSummary[
+            getLegacyReleaseRepairReviewBlockedReasonCategory(
+              review.blockedReason,
+            )
+          ] += 1;
+        }
         console.log(formatReleaseRepairReviewSummaryLine(candidate));
         console.log(
           `  reviewed=${review.resolution} parent=${review.reviewedParentBottleId ?? "(create)"} blocked=${review.blockedReason ?? "(none)"}`,
@@ -569,6 +587,11 @@ subcommand
     console.log(
       `reuse_existing_parent=${summary.reuse_existing_parent} allow_create_parent=${summary.allow_create_parent} blocked=${summary.blocked}`,
     );
+    if (summary.blocked > 0) {
+      console.log(
+        `blocked reasons: classifier_review_failed=${blockedSummary.classifier_review_failed} classifier_exact_cask=${blockedSummary.classifier_exact_cask} classifier_outside_parent_set=${blockedSummary.classifier_outside_parent_set} classifier_dirty_parent_candidate=${blockedSummary.classifier_dirty_parent_candidate} classifier_unresolved_parent_decision=${blockedSummary.classifier_unresolved_parent_decision} other=${blockedSummary.other}`,
+      );
+    }
   });
 
 subcommand

--- a/apps/server/src/lib/legacyReleaseRepairReviews.test.ts
+++ b/apps/server/src/lib/legacyReleaseRepairReviews.test.ts
@@ -1,6 +1,9 @@
 import { db } from "@peated/server/db";
 import { bottles, legacyReleaseRepairReviews } from "@peated/server/db/schema";
-import { refreshLegacyReleaseRepairReview } from "@peated/server/lib/legacyReleaseRepairReviews";
+import {
+  getLegacyReleaseRepairReviewBlockedReasonCategory,
+  refreshLegacyReleaseRepairReview,
+} from "@peated/server/lib/legacyReleaseRepairReviews";
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -167,5 +170,41 @@ describe("refreshLegacyReleaseRepairReview", () => {
       .from(bottles)
       .where(eq(bottles.id, exactParent.id));
     expect(parentBottle?.fullName).toBe(exactParent.fullName);
+  });
+});
+
+describe("getLegacyReleaseRepairReviewBlockedReasonCategory", () => {
+  test("buckets the known classifier review blocker messages", () => {
+    expect(
+      getLegacyReleaseRepairReviewBlockedReasonCategory(
+        "Classifier could not review parent resolution: reference is too ambiguous",
+      ),
+    ).toBe("classifier_review_failed");
+    expect(
+      getLegacyReleaseRepairReviewBlockedReasonCategory(
+        "Classifier treated this bottle as exact-cask identity, so release repair cannot safely create a reusable parent bottle.",
+      ),
+    ).toBe("classifier_exact_cask");
+    expect(
+      getLegacyReleaseRepairReviewBlockedReasonCategory(
+        "Classifier pointed at a bottle outside the reviewed repair parent set.",
+      ),
+    ).toBe("classifier_outside_parent_set");
+    expect(
+      getLegacyReleaseRepairReviewBlockedReasonCategory(
+        "Classifier found a reusable parent candidate, but that bottle still has bottle-level release traits.",
+      ),
+    ).toBe("classifier_dirty_parent_candidate");
+    expect(
+      getLegacyReleaseRepairReviewBlockedReasonCategory(
+        "Classifier could not verify whether this repair should reuse an existing parent bottle or create a new one.",
+      ),
+    ).toBe("classifier_unresolved_parent_decision");
+    expect(
+      getLegacyReleaseRepairReviewBlockedReasonCategory("something else"),
+    ).toBe("other");
+    expect(getLegacyReleaseRepairReviewBlockedReasonCategory(null)).toBe(
+      "other",
+    );
   });
 });

--- a/apps/server/src/lib/legacyReleaseRepairReviews.ts
+++ b/apps/server/src/lib/legacyReleaseRepairReviews.ts
@@ -142,6 +142,58 @@ function normalizeReviewRow(
   };
 }
 
+export type LegacyReleaseRepairReviewBlockedReasonCategory =
+  | "classifier_review_failed"
+  | "classifier_exact_cask"
+  | "classifier_outside_parent_set"
+  | "classifier_dirty_parent_candidate"
+  | "classifier_unresolved_parent_decision"
+  | "other";
+
+export function getLegacyReleaseRepairReviewBlockedReasonCategory(
+  blockedReason: null | string,
+): LegacyReleaseRepairReviewBlockedReasonCategory {
+  if (!blockedReason) {
+    return "other";
+  }
+
+  if (
+    blockedReason.startsWith("Classifier could not review parent resolution:")
+  ) {
+    return "classifier_review_failed";
+  }
+
+  if (
+    blockedReason ===
+    "Classifier treated this bottle as exact-cask identity, so release repair cannot safely create a reusable parent bottle."
+  ) {
+    return "classifier_exact_cask";
+  }
+
+  if (
+    blockedReason ===
+    "Classifier pointed at a bottle outside the reviewed repair parent set."
+  ) {
+    return "classifier_outside_parent_set";
+  }
+
+  if (
+    blockedReason ===
+    "Classifier found a reusable parent candidate, but that bottle still has bottle-level release traits."
+  ) {
+    return "classifier_dirty_parent_candidate";
+  }
+
+  if (
+    blockedReason ===
+    "Classifier could not verify whether this repair should reuse an existing parent bottle or create a new one."
+  ) {
+    return "classifier_unresolved_parent_decision";
+  }
+
+  return "other";
+}
+
 export async function refreshLegacyReleaseRepairReview({
   legacyBottleId,
 }: {


### PR DESCRIPTION
Add stable blocker categories to the persisted legacy release review flow and surface those counts in the offline refresh CLI summary.

The refresh command already showed each reviewed row and the coarse resolution counts, but that still made it hard to tell why blocked rows were accumulating. This change keeps the classifier behavior the same and just makes the blocked side of the review queue measurable by bucketing the known blocker messages in one place and printing their counts after a refresh run.

Keeping the categorization in the server review layer also gives later queue or reporting work a single mapping to reuse instead of duplicating string matching in CLI code.

Refs #329