### PR TITLE
feat(repairs): Promote reviewed release reuse to automation

### DIFF
--- a/apps/server/src/lib/applyRepairBackfillProposals.test.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.test.ts
@@ -438,8 +438,8 @@ describe("applyRepairBackfillProposals", () => {
     });
 
     expect(preview.summary).toEqual({
-      total: 2,
-      planned: 2,
+      total: 3,
+      planned: 3,
       applied: 0,
       failed: 0,
     });
@@ -447,6 +447,11 @@ describe("applyRepairBackfillProposals", () => {
       expect.objectContaining({
         type: "release",
         bottleId: 11,
+        status: "planned",
+      }),
+      expect.objectContaining({
+        type: "release",
+        bottleId: 13,
         status: "planned",
       }),
       expect.objectContaining({
@@ -464,9 +469,13 @@ describe("applyRepairBackfillProposals", () => {
       user,
     });
 
-    expect(applyLegacyReleaseRepairMock).toHaveBeenCalledTimes(1);
-    expect(applyLegacyReleaseRepairMock).toHaveBeenCalledWith({
+    expect(applyLegacyReleaseRepairMock).toHaveBeenCalledTimes(2);
+    expect(applyLegacyReleaseRepairMock).toHaveBeenNthCalledWith(1, {
       legacyBottleId: 11,
+      user,
+    });
+    expect(applyLegacyReleaseRepairMock).toHaveBeenNthCalledWith(2, {
+      legacyBottleId: 13,
       user,
     });
     expect(applyDirtyParentAgeRepairMock).toHaveBeenCalledTimes(1);
@@ -475,9 +484,9 @@ describe("applyRepairBackfillProposals", () => {
       user,
     });
     expect(execution.summary).toEqual({
-      total: 2,
+      total: 3,
       planned: 0,
-      applied: 2,
+      applied: 3,
       failed: 0,
     });
     expect(execution.items).toEqual([
@@ -486,6 +495,11 @@ describe("applyRepairBackfillProposals", () => {
         bottleId: 11,
         status: "applied",
         releaseId: 31,
+      }),
+      expect.objectContaining({
+        type: "release",
+        bottleId: 13,
+        status: "applied",
       }),
       expect.objectContaining({
         type: "age",

--- a/apps/server/src/lib/applyRepairBackfillProposals.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.ts
@@ -207,7 +207,8 @@ function isAutomationEligibleReleaseRepairCandidate(
 } {
   return (
     candidate.repairMode === "existing_parent" &&
-    candidate.parentResolutionSource === "heuristic_exact"
+    (candidate.parentResolutionSource === "heuristic_exact" ||
+      candidate.parentResolutionSource === "classifier_review_persisted")
   );
 }
 

--- a/apps/server/src/lib/repairBackfillProposals.test.ts
+++ b/apps/server/src/lib/repairBackfillProposals.test.ts
@@ -541,10 +541,8 @@ describe("getRepairBackfillProposals", () => {
         expect.objectContaining({
           type: "release",
           bottle: expect.objectContaining({ id: 13 }),
-          automationEligible: false,
-          automationBlockers: [
-            "release repair has a persisted classifier-reviewed reusable parent, but unattended apply still revalidates live at execution time",
-          ],
+          automationEligible: true,
+          automationBlockers: [],
           parentResolutionSource: "classifier_review_persisted",
         }),
         expect.objectContaining({
@@ -680,23 +678,23 @@ describe("getRepairBackfillProposals", () => {
     });
 
     expect(result.summary).toEqual({
-      total: 2,
-      automationEligible: 2,
+      total: 3,
+      automationEligible: 3,
       automationBlocked: 0,
       byType: {
-        release: 1,
+        release: 2,
         age: 1,
         canon: 0,
       },
       byActionability: {
-        apply: 2,
+        apply: 3,
         blocked: 0,
         manual: 0,
       },
       byParentResolutionSource: {
         release: {
           classifier_review_live: 0,
-          classifier_review_persisted: 0,
+          classifier_review_persisted: 1,
           heuristic_exact: 1,
           heuristic_variant: 0,
           none: 0,
@@ -704,7 +702,7 @@ describe("getRepairBackfillProposals", () => {
       },
       byRepairMode: {
         release: {
-          existing_parent: 1,
+          existing_parent: 2,
           create_parent: 0,
           blocked_classifier: 0,
           blocked_alias_conflict: 0,
@@ -719,19 +717,27 @@ describe("getRepairBackfillProposals", () => {
         },
       },
     });
-    expect(result.proposals).toEqual([
-      expect.objectContaining({
-        type: "release",
-        bottle: expect.objectContaining({ id: 11 }),
-        automationEligible: true,
-        parentResolutionSource: "heuristic_exact",
-      }),
-      expect.objectContaining({
-        type: "age",
-        bottle: expect.objectContaining({ id: 21 }),
-        automationEligible: true,
-      }),
-    ]);
+    expect(result.proposals).toEqual(
+      expect.arrayContaining<RepairBackfillProposal>([
+        expect.objectContaining({
+          type: "release",
+          bottle: expect.objectContaining({ id: 11 }),
+          automationEligible: true,
+          parentResolutionSource: "heuristic_exact",
+        }),
+        expect.objectContaining({
+          type: "release",
+          bottle: expect.objectContaining({ id: 13 }),
+          automationEligible: true,
+          parentResolutionSource: "classifier_review_persisted",
+        }),
+        expect.objectContaining({
+          type: "age",
+          bottle: expect.objectContaining({ id: 21 }),
+          automationEligible: true,
+        }),
+      ]),
+    );
   });
 
   test("keeps paging until it finds the requested automation-eligible release proposals", async () => {

--- a/apps/server/src/lib/repairBackfillProposals.ts
+++ b/apps/server/src/lib/repairBackfillProposals.ts
@@ -186,7 +186,8 @@ function isAutomationEligibleReleaseRepairCandidate(
 } {
   return (
     candidate.repairMode === "existing_parent" &&
-    candidate.parentResolutionSource === "heuristic_exact"
+    (candidate.parentResolutionSource === "heuristic_exact" ||
+      candidate.parentResolutionSource === "classifier_review_persisted")
   );
 }
 
@@ -200,12 +201,6 @@ function getReleaseRepairProposalAutomationAssessment(
       if (candidate.parentResolutionSource === "heuristic_variant") {
         automationBlockers.push(
           "release repair only has an exactish reusable parent match",
-        );
-      } else if (
-        candidate.parentResolutionSource === "classifier_review_persisted"
-      ) {
-        automationBlockers.push(
-          "release repair has a persisted classifier-reviewed reusable parent, but unattended apply still revalidates live at execution time",
         );
       } else if (
         candidate.parentResolutionSource === "classifier_review_live"


### PR DESCRIPTION
Promote persisted classifier-reviewed reusable-parent release repairs into the unattended-safe subset now that apply-time release repair invalidates stale stored reviews against both legacy bottle inputs and the reviewed parent candidate set.

Before the stale-review fix, keeping reviewed reusable-parent rows out of `automationOnly` was the right conservative policy because the apply path still revalidated everything live. That is no longer true. Stored reviewed reuse now matches the actual write-time safety model, so leaving it permanently excluded would keep the batch repair boundary narrower than the system’s real correctness guarantees.

This change only widens automation for reviewed reusable-parent release repairs. It does not promote reviewed create-parent repairs, heuristic variant reuse, or live-only classifier reuse. The shared proposal summary and batch-apply behavior now agree on that narrower reviewed-safe subset.

Refs #329