### PR TITLE
perf(repairs): Remove live queue classifier fallback

### DIFF
--- a/apps/server/src/lib/legacyReleaseRepairCandidates.ts
+++ b/apps/server/src/lib/legacyReleaseRepairCandidates.ts
@@ -7,7 +7,6 @@ import {
   type Bottle,
 } from "@peated/server/db/schema";
 import { hasBottleLevelReleaseTraits } from "@peated/server/lib/bottleSchemaRules";
-import { reviewLegacyCreateParentResolutionWithClassifier } from "@peated/server/lib/legacyReleaseRepairClassifier";
 import {
   isMatchingLegacyReleaseRepairReviewIdentity,
   LEGACY_RELEASE_REPAIR_REVIEW_VERSION,
@@ -750,106 +749,6 @@ function applyStoredLegacyReleaseRepairReview({
   return candidate;
 }
 
-async function applyLiveLegacyReleaseRepairClassifierReview(
-  candidate: LegacyReleaseRepairCandidate,
-): Promise<LegacyReleaseRepairCandidate> {
-  if (candidate.repairMode !== "create_parent") {
-    return candidate;
-  }
-
-  const [legacyBottle, parentRows] = await Promise.all([
-    db
-      .select({
-        id: bottles.id,
-        brandId: bottles.brandId,
-        category: bottles.category,
-        fullName: bottles.fullName,
-        edition: bottles.edition,
-        statedAge: bottles.statedAge,
-        abv: bottles.abv,
-        singleCask: bottles.singleCask,
-        caskStrength: bottles.caskStrength,
-        vintageYear: bottles.vintageYear,
-        releaseYear: bottles.releaseYear,
-        caskType: bottles.caskType,
-        caskSize: bottles.caskSize,
-        caskFill: bottles.caskFill,
-      })
-      .from(bottles)
-      .where(eq(bottles.id, candidate.legacyBottle.id))
-      .limit(1)
-      .then((rows) => rows[0] ?? null),
-    db
-      .select({
-        id: bottles.id,
-        fullName: bottles.fullName,
-        category: bottles.category,
-        totalTastings: bottles.totalTastings,
-        edition: bottles.edition,
-        statedAge: bottles.statedAge,
-        releaseYear: bottles.releaseYear,
-        vintageYear: bottles.vintageYear,
-        abv: bottles.abv,
-        singleCask: bottles.singleCask,
-        caskStrength: bottles.caskStrength,
-        caskFill: bottles.caskFill,
-        caskType: bottles.caskType,
-        caskSize: bottles.caskSize,
-      })
-      .from(bottles)
-      .where(
-        candidate.legacyBottle.brandId
-          ? and(
-              eq(bottles.brandId, candidate.legacyBottle.brandId),
-              sql`${bottles.id} != ${candidate.legacyBottle.id}`,
-            )
-          : and(
-              eq(
-                sql`LOWER(${bottles.fullName})`,
-                candidate.proposedParent.fullName.toLowerCase(),
-              ),
-              sql`${bottles.id} != ${candidate.legacyBottle.id}`,
-            ),
-      )
-      .orderBy(sql`${bottles.totalTastings} DESC NULLS LAST`, desc(bottles.id)),
-  ]);
-
-  if (!legacyBottle) {
-    return candidate;
-  }
-
-  const classifierResolution =
-    await reviewLegacyCreateParentResolutionWithClassifier({
-      legacyBottle,
-      parentRows,
-    });
-
-  if (classifierResolution.resolution === "reuse_existing_parent") {
-    return {
-      ...candidate,
-      classifierBlocker: null,
-      hasExactParent: false,
-      parentResolutionSource: "classifier_review_live",
-      proposedParent: {
-        id: classifierResolution.parentBottle.id,
-        fullName: classifierResolution.parentBottle.fullName,
-        totalTastings: classifierResolution.parentBottle.totalTastings,
-      },
-      repairMode: "existing_parent",
-    } satisfies LegacyReleaseRepairCandidate;
-  }
-
-  if (classifierResolution.resolution === "blocked") {
-    return {
-      ...candidate,
-      classifierBlocker: classifierResolution.message,
-      repairMode: "blocked_classifier",
-    } satisfies LegacyReleaseRepairCandidate;
-  }
-
-  return candidate;
-}
-
 async function listHeuristicLegacyReleaseRepairCandidates(query = "") {
   const suspiciousBottles = await db
     .select({
@@ -1277,28 +1176,9 @@ export async function getLegacyReleaseRepairCandidates(args: {
 
   const offset = (cursor - 1) * limit;
   const pageResults = reviewedCandidates.slice(offset, offset + limit + 1);
-  const finalPageResults = sortLegacyReleaseRepairCandidates(
-    await Promise.all(
-      pageResults.slice(0, limit).map(async (candidate) => {
-        if (candidate.repairMode !== "create_parent") {
-          return candidate;
-        }
-
-        const review = reviewByBottleId.get(candidate.legacyBottle.id);
-        if (
-          review &&
-          reviewMatchesLegacyReleaseRepairCandidate(candidate, review)
-        ) {
-          return candidate;
-        }
-
-        return await applyLiveLegacyReleaseRepairClassifierReview(candidate);
-      }),
-    ),
-  );
 
   return {
-    results: finalPageResults,
+    results: pageResults.slice(0, limit),
     rel: {
       nextCursor: pageResults.length > limit ? cursor + 1 : null,
       prevCursor: cursor > 1 ? cursor - 1 : null,

--- a/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
@@ -340,11 +340,11 @@ describe("GET /bottles/release-repair-candidates", () => {
     });
   });
 
-  test("falls back to live classifier review when no stored review exists", async ({
+  test("keeps create-parent candidates unresolved when no stored review exists", async ({
     fixtures,
   }) => {
     const brand = await fixtures.Entity({ name: "Fallback Distillery" });
-    const reusableParent = await fixtures.Bottle({
+    await fixtures.Bottle({
       brandId: brand.id,
       name: "Session Archive",
       totalTastings: 30,
@@ -355,15 +355,6 @@ describe("GET /bottles/release-repair-candidates", () => {
       totalTastings: 6,
     });
     const user = await fixtures.User({ mod: true });
-
-    classifyBottleReferenceMock.mockResolvedValue({
-      ...createClassifierCreateBottleResult(),
-      decision: {
-        ...createClassifierCreateBottleResult().decision,
-        action: "match",
-        matchedBottleId: reusableParent.id,
-      },
-    });
 
     const result = await routerClient.bottles.releaseRepairCandidates(
       {
@@ -378,13 +369,14 @@ describe("GET /bottles/release-repair-candidates", () => {
       ),
     ).toMatchObject({
       hasExactParent: false,
-      parentResolutionSource: "classifier_review_live",
-      repairMode: "existing_parent",
+      parentResolutionSource: null,
+      repairMode: "create_parent",
       proposedParent: {
-        id: reusableParent.id,
-        fullName: reusableParent.fullName,
+        id: null,
+        fullName: "Fallback Distillery Warehouse Session",
       },
     });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   });
 
   test("rewrites create-parent candidates to existing-parent when classifier finds a reviewed parent", async ({
@@ -415,6 +407,7 @@ describe("GET /bottles/release-repair-candidates", () => {
     await refreshLegacyReleaseRepairReview({
       legacyBottleId: legacyBottle.id,
     });
+    classifyBottleReferenceMock.mockReset();
 
     const result = await routerClient.bottles.releaseRepairCandidates(
       {
@@ -436,6 +429,7 @@ describe("GET /bottles/release-repair-candidates", () => {
         fullName: reusableParent.fullName,
       },
     });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   });
 
   test("ignores stale stored reviews when the release identity changes", async ({
@@ -474,11 +468,6 @@ describe("GET /bottles/release-repair-candidates", () => {
       })
       .where(eq(bottles.id, legacyBottle.id));
 
-    classifyBottleReferenceMock.mockReset();
-    classifyBottleReferenceMock.mockResolvedValue(
-      createClassifierCreateBottleResult(),
-    );
-
     const result = await routerClient.bottles.releaseRepairCandidates(
       {
         query: "Warehouse Session",
@@ -503,6 +492,7 @@ describe("GET /bottles/release-repair-candidates", () => {
         markerSources: ["name_batch"],
       },
     });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   });
 
   test("blocks create-parent candidates when classifier cannot verify the parent decision", async ({
@@ -581,11 +571,7 @@ describe("GET /bottles/release-repair-candidates", () => {
     await refreshLegacyReleaseRepairReview({
       legacyBottleId: reviewedLegacy.id,
     });
-
     classifyBottleReferenceMock.mockReset();
-    classifyBottleReferenceMock.mockResolvedValue(
-      createClassifierCreateBottleResult(),
-    );
 
     const result = await routerClient.bottles.releaseRepairCandidates(
       {
@@ -609,6 +595,7 @@ describe("GET /bottles/release-repair-candidates", () => {
     expect(result.results[0].legacyBottle.id).not.toBe(
       highPriorityHeuristic.id,
     );
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   });
 
   test("flags sibling clusters behind a dirty exact-name parent as blocked", async ({


### PR DESCRIPTION
Remove the last live classifier fallback from the release repair queue path so the moderator page no longer blocks on synchronous classifier work.

The persisted review work was supposed to keep queue rendering fast by limiting classifier usage to offline refreshes and apply-time validation, but `getLegacyReleaseRepairCandidates` still did a live fallback for visible unresolved `create_parent` rows. That made the admin page pay networked classifier latency during load and is the likely cause of the release-repairs timeout.

This change keeps queue shaping to heuristic candidates plus stored review rewrites only. Unresolved create-parent rows now stay heuristic until an offline review refresh runs, while apply-time repair continues to own the real safety gate.

Refs #329