### PR TITLE
fix(repairs): Tighten stored review freshness

### DIFF
--- a/apps/server/src/lib/applyLegacyReleaseRepair.ts
+++ b/apps/server/src/lib/applyLegacyReleaseRepair.ts
@@ -261,6 +261,7 @@ async function getStoredClassifierResolutionForLegacyReleaseRepair({
   legacyBottle: Pick<
     RepairBottle,
     | "abv"
+    | "brandId"
     | "category"
     | "caskFill"
     | "caskSize"

--- a/apps/server/src/lib/legacyReleaseRepairCandidates.ts
+++ b/apps/server/src/lib/legacyReleaseRepairCandidates.ts
@@ -8,6 +8,9 @@ import {
 } from "@peated/server/db/schema";
 import { hasBottleLevelReleaseTraits } from "@peated/server/lib/bottleSchemaRules";
 import {
+  getLegacyReleaseRepairBottleFingerprint,
+  getLegacyReleaseRepairParentCandidatesFingerprint,
+  isMatchingLegacyReleaseRepairReview,
   isMatchingLegacyReleaseRepairReviewIdentity,
   LEGACY_RELEASE_REPAIR_REVIEW_VERSION,
 } from "@peated/server/lib/legacyReleaseRepairReviewState";
@@ -65,10 +68,18 @@ type LegacyReleaseRepairBottle = Omit<
   Pick<
     Bottle,
     | "id"
+    | "abv"
     | "brandId"
+    | "caskFill"
+    | "caskSize"
+    | "caskStrength"
+    | "caskType"
     | "category"
     | "fullName"
     | "edition"
+    | "singleCask"
+    | "statedAge"
+    | "vintageYear"
     | "releaseYear"
     | "numReleases"
     | "totalTastings"
@@ -137,7 +148,9 @@ export type LegacyReleaseRepairCandidate = {
     totalTastings: number | null;
   };
   classifierBlocker: string | null;
+  legacyBottleFingerprint?: null | string;
   legacyBottle: LegacyReleaseRepairBottle;
+  parentCandidatesFingerprint?: null | string;
   proposedParent: {
     id: number | null;
     fullName: string;
@@ -682,6 +695,8 @@ function applyStoredLegacyReleaseRepairReview({
   review:
     | {
         blockedReason: string | null;
+        legacyBottleFingerprint: null | string;
+        parentCandidatesFingerprint: null | string;
         proposedParentFullName: string;
         releaseEdition: string | null;
         releaseYear: number | null;
@@ -694,7 +709,17 @@ function applyStoredLegacyReleaseRepairReview({
   if (
     candidate.repairMode !== "create_parent" ||
     !review ||
-    !reviewMatchesLegacyReleaseRepairCandidate(candidate, review)
+    candidate.legacyBottleFingerprint == null ||
+    candidate.parentCandidatesFingerprint == null ||
+    !isMatchingLegacyReleaseRepairReview(
+      {
+        legacyBottleFingerprint: candidate.legacyBottleFingerprint,
+        parentCandidatesFingerprint: candidate.parentCandidatesFingerprint,
+        proposedParentFullName: candidate.proposedParent.fullName,
+        releaseIdentity: candidate.releaseIdentity,
+      },
+      review,
+    )
   ) {
     return candidate;
   }
@@ -753,10 +778,18 @@ async function listHeuristicLegacyReleaseRepairCandidates(query = "") {
   const suspiciousBottles = await db
     .select({
       id: bottles.id,
+      abv: bottles.abv,
       brandId: bottles.brandId,
+      caskFill: bottles.caskFill,
+      caskSize: bottles.caskSize,
+      caskStrength: bottles.caskStrength,
+      caskType: bottles.caskType,
       category: bottles.category,
       fullName: bottles.fullName,
       edition: bottles.edition,
+      singleCask: bottles.singleCask,
+      statedAge: bottles.statedAge,
+      vintageYear: bottles.vintageYear,
       releaseYear: bottles.releaseYear,
       numReleases: sql<number>`COALESCE(${bottles.numReleases}, 0)::integer`,
       totalTastings: bottles.totalTastings,
@@ -1031,7 +1064,16 @@ async function listHeuristicLegacyReleaseRepairCandidates(query = "") {
               }
             : null,
         classifierBlocker: null,
+        legacyBottleFingerprint: getLegacyReleaseRepairBottleFingerprint(
+          candidate.bottle,
+        ),
         legacyBottle: candidate.bottle,
+        parentCandidatesFingerprint:
+          getLegacyReleaseRepairParentCandidatesFingerprint(
+            parentRowsForCandidate.filter(
+              (row) => row.id !== candidate.bottle.id,
+            ),
+          ),
         proposedParent: {
           id: parent?.id ?? null,
           fullName: parent?.fullName ?? candidate.proposedParentFullName,

--- a/apps/server/src/lib/legacyReleaseRepairReviewState.ts
+++ b/apps/server/src/lib/legacyReleaseRepairReviewState.ts
@@ -12,6 +12,7 @@ type LegacyReleaseRepairReviewIdentity = {
 
 type LegacyReleaseRepairClassifierInputBottle = {
   abv: null | number;
+  brandId: null | number;
   category: null | string;
   caskFill: null | string;
   caskSize: null | string;
@@ -38,7 +39,6 @@ type LegacyReleaseRepairClassifierInputParent = {
   releaseYear: null | number;
   singleCask: null | boolean;
   statedAge: null | number;
-  totalTastings: null | number;
   vintageYear: null | number;
 };
 
@@ -46,6 +46,7 @@ export function getLegacyReleaseRepairBottleFingerprint(
   bottle: LegacyReleaseRepairClassifierInputBottle,
 ) {
   return sha1(
+    bottle.brandId,
     bottle.fullName,
     bottle.category,
     bottle.edition,
@@ -72,7 +73,6 @@ export function getLegacyReleaseRepairParentCandidatesFingerprint(
         row.id,
         row.fullName,
         row.category,
-        row.totalTastings,
         row.edition,
         row.statedAge,
         row.releaseYear,

--- a/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
+++ b/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
@@ -83,6 +83,7 @@ function createClassifierCreateBottleResult() {
 
 function getLegacyBottleReviewFingerprintInput(legacyBottle: {
   abv?: null | number;
+  brandId?: null | number;
   category?: null | string;
   caskFill?: null | string;
   caskSize?: null | string;
@@ -97,6 +98,7 @@ function getLegacyBottleReviewFingerprintInput(legacyBottle: {
 }) {
   return {
     abv: legacyBottle.abv ?? null,
+    brandId: legacyBottle.brandId ?? null,
     category: legacyBottle.category ?? null,
     caskFill: legacyBottle.caskFill ?? null,
     caskSize: legacyBottle.caskSize ?? null,

--- a/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
@@ -495,6 +495,132 @@ describe("GET /bottles/release-repair-candidates", () => {
     expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   });
 
+  test("ignores stale stored reviews when classifier-relevant legacy bottle traits change", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Trait Drift Distillery" });
+    const reusableParent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Session Archive",
+      category: "single_malt",
+      totalTastings: 30,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Warehouse Session (Batch 1)",
+      category: "single_malt",
+      totalTastings: 6,
+    });
+    const user = await fixtures.User({ mod: true });
+
+    classifyBottleReferenceMock.mockResolvedValue({
+      ...createClassifierCreateBottleResult(),
+      decision: {
+        ...createClassifierCreateBottleResult().decision,
+        action: "match",
+        matchedBottleId: reusableParent.id,
+      },
+    });
+
+    await refreshLegacyReleaseRepairReview({
+      legacyBottleId: legacyBottle.id,
+    });
+
+    await db
+      .update(bottles)
+      .set({
+        category: "bourbon",
+      })
+      .where(eq(bottles.id, legacyBottle.id));
+
+    classifyBottleReferenceMock.mockReset();
+
+    const result = await routerClient.bottles.releaseRepairCandidates(
+      {
+        query: "Warehouse Session",
+      },
+      { context: { user } },
+    );
+
+    expect(
+      result.results.find(
+        (candidate) => candidate.legacyBottle.id === legacyBottle.id,
+      ),
+    ).toMatchObject({
+      hasExactParent: false,
+      repairMode: "create_parent",
+      proposedParent: {
+        id: null,
+        fullName: "Trait Drift Distillery Warehouse Session",
+      },
+    });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
+  });
+
+  test("ignores stale stored reviews when the legacy bottle brand changes", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Original Distillery" });
+    const reassignedBrand = await fixtures.Entity({
+      name: "Reassigned Distillery",
+    });
+    const reusableParent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Session Archive",
+      totalTastings: 30,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Warehouse Session (Batch 1)",
+      totalTastings: 6,
+    });
+    const user = await fixtures.User({ mod: true });
+
+    classifyBottleReferenceMock.mockResolvedValue({
+      ...createClassifierCreateBottleResult(),
+      decision: {
+        ...createClassifierCreateBottleResult().decision,
+        action: "match",
+        matchedBottleId: reusableParent.id,
+      },
+    });
+
+    await refreshLegacyReleaseRepairReview({
+      legacyBottleId: legacyBottle.id,
+    });
+
+    await db
+      .update(bottles)
+      .set({
+        brandId: reassignedBrand.id,
+        fullName: "Reassigned Distillery Warehouse Session (Batch 1)",
+      })
+      .where(eq(bottles.id, legacyBottle.id));
+
+    classifyBottleReferenceMock.mockReset();
+
+    const result = await routerClient.bottles.releaseRepairCandidates(
+      {
+        query: "Warehouse Session",
+      },
+      { context: { user } },
+    );
+
+    expect(
+      result.results.find(
+        (candidate) => candidate.legacyBottle.id === legacyBottle.id,
+      ),
+    ).toMatchObject({
+      hasExactParent: false,
+      repairMode: "create_parent",
+      proposedParent: {
+        id: null,
+        fullName: "Reassigned Distillery Warehouse Session",
+      },
+    });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
+  });
+
   test("blocks create-parent candidates when classifier cannot verify the parent decision", async ({
     fixtures,
   }) => {
@@ -536,6 +662,116 @@ describe("GET /bottles/release-repair-candidates", () => {
         fullName: "Blocked Distillery Warehouse Session",
       },
     });
+  });
+
+  test("ignores stale stored reviews when the reviewed parent candidate set changes", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Parent Drift Distillery" });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Warehouse Session (Batch 1)",
+      totalTastings: 6,
+    });
+    const user = await fixtures.User({ mod: true });
+
+    classifyBottleReferenceMock.mockResolvedValue(
+      createClassifierCreateBottleResult(),
+    );
+
+    await refreshLegacyReleaseRepairReview({
+      legacyBottleId: legacyBottle.id,
+    });
+
+    const reusableParent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Session Archive",
+      totalTastings: 30,
+    });
+
+    classifyBottleReferenceMock.mockReset();
+
+    const result = await routerClient.bottles.releaseRepairCandidates(
+      {
+        query: "Warehouse Session",
+      },
+      { context: { user } },
+    );
+
+    expect(
+      result.results.find(
+        (candidate) => candidate.legacyBottle.id === legacyBottle.id,
+      ),
+    ).toMatchObject({
+      hasExactParent: false,
+      repairMode: "create_parent",
+      proposedParent: {
+        id: null,
+        fullName: "Parent Drift Distillery Warehouse Session",
+      },
+    });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
+  });
+
+  test("keeps stored reviews when only parent tasting counts change", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Stable Review Distillery" });
+    const reusableParent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Session Archive",
+      totalTastings: 30,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Warehouse Session (Batch 1)",
+      totalTastings: 6,
+    });
+    const user = await fixtures.User({ mod: true });
+
+    classifyBottleReferenceMock.mockResolvedValue({
+      ...createClassifierCreateBottleResult(),
+      decision: {
+        ...createClassifierCreateBottleResult().decision,
+        action: "match",
+        matchedBottleId: reusableParent.id,
+      },
+    });
+
+    await refreshLegacyReleaseRepairReview({
+      legacyBottleId: legacyBottle.id,
+    });
+
+    await db
+      .update(bottles)
+      .set({
+        totalTastings: 31,
+      })
+      .where(eq(bottles.id, reusableParent.id));
+
+    classifyBottleReferenceMock.mockReset();
+
+    const result = await routerClient.bottles.releaseRepairCandidates(
+      {
+        query: "Warehouse Session",
+      },
+      { context: { user } },
+    );
+
+    expect(
+      result.results.find(
+        (candidate) => candidate.legacyBottle.id === legacyBottle.id,
+      ),
+    ).toMatchObject({
+      hasExactParent: false,
+      parentResolutionSource: "classifier_review_persisted",
+      repairMode: "existing_parent",
+      proposedParent: {
+        id: reusableParent.id,
+        fullName: reusableParent.fullName,
+      },
+    });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   });
 
   test("reorders stored reviewed candidates before pagination", async ({


### PR DESCRIPTION
Tighten persisted release-repair review reuse so stored classifier decisions only survive changes that are actually irrelevant to classifier correctness.

The queue and apply paths were already moving toward a shared freshness model for persisted reviews, but the fingerprint still missed brand context while also overreacting to parent tasting-count churn. That left two bad outcomes: a bottle could be reassigned to a different brand and still reuse an old stored review, or moderators could lose an otherwise valid stored review because an unrelated parent picked up one more tasting.

This change adds brand context to the legacy-bottle fingerprint, removes `totalTastings` from the parent-candidate fingerprint, and threads the updated freshness inputs through both queue-time and apply-time review reuse. The added regressions cover brand reassignment, classifier-relevant trait drift, parent-set drift, and the non-drift tasting-count case so the persisted-review boundary stays aligned with the actual classifier inputs.

Fixes #329