### PR TITLE
feat(repairs): Refresh reviews before batch apply

### DIFF
--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -618,6 +618,10 @@ subcommand
     "--automation-only",
     "Only preview or apply the unattended-safe proposal subset",
   )
+  .option(
+    "--refresh-release-reviews",
+    "Refresh persisted release reviews before collecting release proposals",
+  )
   .action(async (options) => {
     const perTypeLimit = Number.parseInt(options.limit, 10);
     if (!Number.isFinite(perTypeLimit) || perTypeLimit <= 0) {
@@ -630,6 +634,7 @@ subcommand
       dryRun: !options.execute,
       perTypeLimit,
       query: options.query,
+      refreshReleaseReviews: Boolean(options.refreshReleaseReviews),
       types,
       user: options.execute ? await getAutomationModeratorUser() : undefined,
     });

--- a/apps/server/src/lib/applyRepairBackfillProposals.test.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.test.ts
@@ -5,6 +5,7 @@ import { applyLegacyReleaseRepair } from "@peated/server/lib/applyLegacyReleaseR
 import { applyRepairBackfillProposals } from "@peated/server/lib/applyRepairBackfillProposals";
 import { getDirtyParentAgeRepairCandidates } from "@peated/server/lib/dirtyParentAgeRepairCandidates";
 import { getLegacyReleaseRepairCandidates } from "@peated/server/lib/legacyReleaseRepairCandidates";
+import { refreshLegacyReleaseRepairReview } from "@peated/server/lib/legacyReleaseRepairReviews";
 
 vi.mock("@peated/server/lib/legacyReleaseRepairCandidates", () => ({
   getLegacyReleaseRepairCandidates: vi.fn(),
@@ -12,6 +13,10 @@ vi.mock("@peated/server/lib/legacyReleaseRepairCandidates", () => ({
 
 vi.mock("@peated/server/lib/dirtyParentAgeRepairCandidates", () => ({
   getDirtyParentAgeRepairCandidates: vi.fn(),
+}));
+
+vi.mock("@peated/server/lib/legacyReleaseRepairReviews", () => ({
+  refreshLegacyReleaseRepairReview: vi.fn(),
 }));
 
 vi.mock("@peated/server/lib/applyLegacyReleaseRepair", () => ({
@@ -30,6 +35,9 @@ const getLegacyReleaseRepairCandidatesMock = vi.mocked(
 const getDirtyParentAgeRepairCandidatesMock = vi.mocked(
   getDirtyParentAgeRepairCandidates,
 );
+const refreshLegacyReleaseRepairReviewMock = vi.mocked(
+  refreshLegacyReleaseRepairReview,
+);
 const applyLegacyReleaseRepairMock = vi.mocked(applyLegacyReleaseRepair);
 const applyDirtyParentAgeRepairMock = vi.mocked(applyDirtyParentAgeRepair);
 
@@ -42,6 +50,7 @@ const user = {
 describe("applyRepairBackfillProposals", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    refreshLegacyReleaseRepairReviewMock.mockResolvedValue(null);
   });
 
   test("previews actionable release repairs across multiple pages without requiring a user", async () => {
@@ -506,6 +515,97 @@ describe("applyRepairBackfillProposals", () => {
         bottleId: 21,
         status: "applied",
         releaseId: 22,
+      }),
+    ]);
+  });
+
+  test("can refresh release reviews before collecting automation-safe release proposals", async () => {
+    getLegacyReleaseRepairCandidatesMock
+      .mockResolvedValueOnce({
+        rel: {
+          nextCursor: null,
+          prevCursor: null,
+        },
+        results: [
+          {
+            legacyBottle: {
+              id: 13,
+              fullName:
+                "Elijah Craig Barrel Proof Kentucky Straight Bourbon (Batch C923)",
+            },
+            proposedParent: {
+              id: null,
+              fullName: "Elijah Craig Barrel Proof",
+              totalTastings: null,
+            },
+            parentResolutionSource: null,
+            repairMode: "create_parent",
+          },
+        ],
+      } as any)
+      .mockResolvedValueOnce({
+        rel: {
+          nextCursor: null,
+          prevCursor: null,
+        },
+        results: [
+          {
+            legacyBottle: {
+              id: 13,
+              fullName:
+                "Elijah Craig Barrel Proof Kentucky Straight Bourbon (Batch C923)",
+            },
+            proposedParent: {
+              id: 14,
+              fullName: "Elijah Craig Barrel Proof",
+              totalTastings: 100,
+            },
+            hasExactParent: false,
+            parentResolutionSource: "classifier_review_persisted",
+            repairMode: "existing_parent",
+          },
+        ],
+      } as any);
+    getDirtyParentAgeRepairCandidatesMock.mockResolvedValue({
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+      results: [],
+    } as any);
+
+    const result = await applyRepairBackfillProposals({
+      automationOnly: true,
+      perTypeLimit: 10,
+      refreshReleaseReviews: true,
+      types: ["release"],
+    });
+
+    expect(refreshLegacyReleaseRepairReviewMock).toHaveBeenCalledTimes(1);
+    expect(refreshLegacyReleaseRepairReviewMock).toHaveBeenCalledWith({
+      legacyBottleId: 13,
+    });
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(1, {
+      cursor: 1,
+      limit: 10,
+      query: "",
+    });
+    expect(getLegacyReleaseRepairCandidatesMock).toHaveBeenNthCalledWith(2, {
+      cursor: 1,
+      limit: 10,
+      query: "",
+    });
+    expect(result.summary).toEqual({
+      total: 1,
+      planned: 1,
+      applied: 0,
+      failed: 0,
+    });
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        type: "release",
+        bottleId: 13,
+        status: "planned",
       }),
     ]);
   });

--- a/apps/server/src/lib/applyRepairBackfillProposals.ts
+++ b/apps/server/src/lib/applyRepairBackfillProposals.ts
@@ -15,6 +15,7 @@ import {
   getLegacyReleaseRepairCandidates,
   type LegacyReleaseRepairCandidate,
 } from "@peated/server/lib/legacyReleaseRepairCandidates";
+import { refreshLegacyReleaseRepairReview } from "@peated/server/lib/legacyReleaseRepairReviews";
 
 const MAX_PAGE_SIZE = 100;
 
@@ -336,6 +337,47 @@ async function collectApplicableReleaseRepairProposals({
   });
 }
 
+async function refreshReleaseRepairReviews({
+  perTypeLimit,
+  query,
+}: {
+  perTypeLimit: number;
+  query: string;
+}) {
+  const pageSize = Math.min(MAX_PAGE_SIZE, perTypeLimit);
+  let cursor = 1;
+  let refreshed = 0;
+
+  while (refreshed < perTypeLimit) {
+    const page = await getLegacyReleaseRepairCandidates({
+      cursor,
+      limit: pageSize,
+      query,
+    });
+
+    for (const candidate of page.results) {
+      if (candidate.repairMode !== "create_parent") {
+        continue;
+      }
+
+      await refreshLegacyReleaseRepairReview({
+        legacyBottleId: candidate.legacyBottle.id,
+      });
+
+      refreshed += 1;
+      if (refreshed >= perTypeLimit) {
+        break;
+      }
+    }
+
+    if (!page.rel.nextCursor || page.results.length === 0) {
+      break;
+    }
+
+    cursor = page.rel.nextCursor;
+  }
+}
+
 async function collectApplicableAgeRepairProposals({
   automationOnly = false,
   perTypeLimit,
@@ -361,6 +403,7 @@ export async function applyRepairBackfillProposals({
   dryRun = true,
   perTypeLimit = 100,
   query = "",
+  refreshReleaseReviews: shouldRefreshReleaseReviews = false,
   types = ["release", "age"],
   user,
 }: {
@@ -368,6 +411,7 @@ export async function applyRepairBackfillProposals({
   dryRun?: boolean;
   perTypeLimit?: number;
   query?: string;
+  refreshReleaseReviews?: boolean;
   types?: BatchApplicableRepairBackfillProposalType[];
   user?: User;
 }): Promise<ApplyRepairBackfillProposalsResult> {
@@ -383,6 +427,13 @@ export async function applyRepairBackfillProposals({
   const items: ApplyRepairBackfillProposalItem[] = [];
 
   if (normalizedTypes.includes("release")) {
+    if (shouldRefreshReleaseReviews) {
+      await refreshReleaseRepairReviews({
+        perTypeLimit,
+        query,
+      });
+    }
+
     const releaseProposals = await collectApplicableReleaseRepairProposals({
       automationOnly,
       perTypeLimit,


### PR DESCRIPTION
Add an optional review-refresh pass to the bulk repair runner so unattended release repair can populate persisted classifier reviews before selecting the automation-safe subset. This keeps the moderator queue fast while making the batch workflow more self-contained.

Right now the system already knows how to persist classifier-reviewed release parent decisions, but operators still have to stitch together a separate refresh step before bulk apply if they want newly reviewed reusable-parent repairs to enter the unattended-safe set. That operational gap is easy to forget and makes the batch workflow feel less trustworthy than the underlying review model.

This change lets `apply-repair-proposals` do that refresh first when requested, then re-read the release queue and collect the reviewed-safe subset from persisted state. The new mock-level regression covers the two-pass flow where an unresolved `create_parent` candidate becomes a persisted reviewed reusable-parent candidate before proposal collection.

One limitation remains in this repo: the `pnpm --filter @peated/server test -- ...applyRepairBackfillProposals.test.ts` wrapper still fails to match that specific file and falls into DB bootstrap, so the focused verification here is server and CLI typecheck plus the existing repair proposal test file.

Fixes #329