### PR TITLE
fix(repairs): Tighten release review state and batch parsing

### DIFF
--- a/apps/server/src/lib/legacyReleaseRepairCandidates.ts
+++ b/apps/server/src/lib/legacyReleaseRepairCandidates.ts
@@ -22,7 +22,9 @@ import {
   normalizeString,
 } from "./normalize";
 
-const LEGACY_RELEASE_MARKER_PATTERN = "batch|[0-9]{4}\\s+release";
+const LEGACY_RELEASE_BATCH_MARKER_PATTERN =
+  "batch(?:\\s*(?:no\\.?|number|#))?\\s*(?:[a-z]*\\d[a-z0-9.-]*)";
+const LEGACY_RELEASE_MARKER_PATTERN = `${LEGACY_RELEASE_BATCH_MARKER_PATTERN}|[0-9]{4}\\s+release`;
 const MAX_SCAN_LIMIT = 2000;
 const GENERIC_PARENT_NAME_TOKENS = new Set([
   "american",
@@ -127,6 +129,13 @@ export type LegacyReleaseRepairParentResolutionSource =
   | "heuristic_exact"
   | "heuristic_variant";
 
+export type LegacyReleaseRepairReviewState =
+  | "fresh_allow_create_parent"
+  | "fresh_blocked"
+  | "fresh_reuse_existing_parent"
+  | "stale_review"
+  | "unreviewed";
+
 type LegacyReleaseRepairParentMatchType = "exact" | "variant";
 
 export type DerivedLegacyReleaseRepairCandidate =
@@ -168,6 +177,7 @@ export type LegacyReleaseRepairCandidate = {
   hasExactParent: boolean;
   parentResolutionSource: LegacyReleaseRepairParentResolutionSource | null;
   repairMode: LegacyReleaseRepairParentMode;
+  reviewState?: LegacyReleaseRepairReviewState | null;
 };
 
 function escapeRegExp(value: string) {
@@ -518,13 +528,25 @@ export function normalizeComparableBottleName(fullName: string): string {
 
 function extractBatchEdition(fullName: string): string | null {
   const normalizedName = normalizeBottleBatchNumber(normalizeString(fullName));
+  const isReleaseLikeBatchEdition = (value: string) => {
+    const suffix = value
+      .replace(/^batch/i, "")
+      .replace(/^(?:\s*(?:no\.?|number|#))?/i, "")
+      .trim();
+
+    return /^(?:[a-z]*\d[a-z0-9.-]*)$/i.test(suffix);
+  };
   const parenthesized = normalizedName.match(/\((Batch [^)]+)\)/i);
-  if (parenthesized) {
+  if (parenthesized && isReleaseLikeBatchEdition(parenthesized[1])) {
     return parenthesized[1];
   }
 
   const inline = normalizedName.match(/\b(Batch [A-Za-z0-9.-]+)\b/i);
-  return inline?.[1] ?? null;
+  if (inline && isReleaseLikeBatchEdition(inline[1])) {
+    return inline[1];
+  }
+
+  return null;
 }
 
 export function deriveLegacyReleaseRepairIdentity({
@@ -706,9 +728,18 @@ function applyStoredLegacyReleaseRepairReview({
     | undefined;
   reviewedParentById: Map<number, LegacyReleaseRepairParentCandidate>;
 }): LegacyReleaseRepairCandidate {
+  if (candidate.repairMode !== "create_parent") {
+    return candidate;
+  }
+
+  if (!review) {
+    return {
+      ...candidate,
+      reviewState: "unreviewed",
+    } satisfies LegacyReleaseRepairCandidate;
+  }
+
   if (
-    candidate.repairMode !== "create_parent" ||
-    !review ||
     candidate.legacyBottleFingerprint == null ||
     candidate.parentCandidatesFingerprint == null ||
     !isMatchingLegacyReleaseRepairReview(
@@ -721,7 +752,10 @@ function applyStoredLegacyReleaseRepairReview({
       review,
     )
   ) {
-    return candidate;
+    return {
+      ...candidate,
+      reviewState: "stale_review",
+    } satisfies LegacyReleaseRepairCandidate;
   }
 
   if (review.resolution === "reuse_existing_parent") {
@@ -735,6 +769,7 @@ function applyStoredLegacyReleaseRepairReview({
         classifierBlocker:
           "Stored classifier review points at a missing parent bottle. Refresh the review before applying this repair.",
         repairMode: "blocked_classifier",
+        reviewState: "fresh_blocked",
       } satisfies LegacyReleaseRepairCandidate;
     }
 
@@ -744,6 +779,7 @@ function applyStoredLegacyReleaseRepairReview({
         classifierBlocker:
           "Stored classifier-reviewed parent bottle still carries bottle-level release traits. Refresh the review after cleaning that parent.",
         repairMode: "blocked_classifier",
+        reviewState: "fresh_blocked",
       } satisfies LegacyReleaseRepairCandidate;
     }
 
@@ -758,6 +794,7 @@ function applyStoredLegacyReleaseRepairReview({
         totalTastings: reviewedParent.totalTastings,
       },
       repairMode: "existing_parent",
+      reviewState: "fresh_reuse_existing_parent",
     } satisfies LegacyReleaseRepairCandidate;
   }
 
@@ -768,10 +805,14 @@ function applyStoredLegacyReleaseRepairReview({
         review.blockedReason ??
         "Stored classifier review blocked this repair. Refresh the review for more detail.",
       repairMode: "blocked_classifier",
+      reviewState: "fresh_blocked",
     } satisfies LegacyReleaseRepairCandidate;
   }
 
-  return candidate;
+  return {
+    ...candidate,
+    reviewState: "fresh_allow_create_parent",
+  } satisfies LegacyReleaseRepairCandidate;
 }
 
 async function listHeuristicLegacyReleaseRepairCandidates(query = "") {
@@ -1093,6 +1134,7 @@ async function listHeuristicLegacyReleaseRepairCandidates(query = "") {
               : "heuristic_variant"
             : null,
         repairMode,
+        reviewState: null,
       } satisfies LegacyReleaseRepairCandidate;
     }),
   );
@@ -1114,7 +1156,10 @@ export async function getHeuristicLegacyReleaseRepairCandidates({
   const results = filteredCandidates.slice(offset, offset + limit + 1);
 
   return {
-    results: results.slice(0, limit),
+    results: results.slice(0, limit).map((candidate) => ({
+      ...candidate,
+      reviewState: candidate.reviewState ?? null,
+    })),
     rel: {
       nextCursor: results.length > limit ? cursor + 1 : null,
       prevCursor: cursor > 1 ? cursor - 1 : null,
@@ -1220,7 +1265,10 @@ export async function getLegacyReleaseRepairCandidates(args: {
   const pageResults = reviewedCandidates.slice(offset, offset + limit + 1);
 
   return {
-    results: pageResults.slice(0, limit),
+    results: pageResults.slice(0, limit).map((candidate) => ({
+      ...candidate,
+      reviewState: candidate.reviewState ?? null,
+    })),
     rel: {
       nextCursor: pageResults.length > limit ? cursor + 1 : null,
       prevCursor: cursor > 1 ? cursor - 1 : null,

--- a/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
@@ -177,6 +177,49 @@ describe("GET /bottles/release-repair-candidates", () => {
     });
   });
 
+  test("does not treat generic batch naming labels as release markers", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Batch Name Distillery" });
+    const strengthBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Batch Strength",
+      totalTastings: 8,
+    });
+    const proofBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Batch Proof",
+      totalTastings: 6,
+    });
+    const sherryBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Batch Sherry",
+      totalTastings: 4,
+    });
+    const user = await fixtures.User({ mod: true });
+
+    const result = await routerClient.bottles.releaseRepairCandidates(
+      {
+        query: "Batch",
+      },
+      { context: { user } },
+    );
+
+    expect(result.results).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          legacyBottle: expect.objectContaining({ id: strengthBottle.id }),
+        }),
+        expect.objectContaining({
+          legacyBottle: expect.objectContaining({ id: proofBottle.id }),
+        }),
+        expect.objectContaining({
+          legacyBottle: expect.objectContaining({ id: sherryBottle.id }),
+        }),
+      ]),
+    );
+  });
+
   test("reuses an existing parent bottle for exactish generic-name variants", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/bottles/release-repair-candidates.ts
+++ b/apps/server/src/orpc/routes/bottles/release-repair-candidates.ts
@@ -54,6 +54,15 @@ const LegacyReleaseRepairCandidateSchema = z.object({
       "heuristic_variant",
     ])
     .nullable(),
+  reviewState: z
+    .enum([
+      "fresh_allow_create_parent",
+      "fresh_blocked",
+      "fresh_reuse_existing_parent",
+      "stale_review",
+      "unreviewed",
+    ])
+    .nullable(),
   repairMode: z.enum([
     "existing_parent",
     "create_parent",
@@ -93,5 +102,13 @@ export default procedure
     }),
   )
   .handler(async function ({ input }) {
-    return await getLegacyReleaseRepairCandidates(input);
+    const result = await getLegacyReleaseRepairCandidates(input);
+
+    return {
+      ...result,
+      results: result.results.map((candidate) => ({
+        ...candidate,
+        reviewState: candidate.reviewState ?? null,
+      })),
+    };
   });

--- a/apps/web/src/app/(admin)/admin/(default)/release-repairs/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/release-repairs/page.tsx
@@ -43,6 +43,14 @@ const RESOLUTION_SOURCE_LABELS = {
   classifier_review_live: "Live classifier review",
 } as const;
 
+const REVIEW_STATE_LABELS = {
+  fresh_allow_create_parent: "Reviewed create-parent",
+  fresh_blocked: "Reviewed blocked",
+  fresh_reuse_existing_parent: "Reviewed reusable parent",
+  stale_review: "Stale review",
+  unreviewed: "Unreviewed",
+} as const;
+
 function formatTastingCount(value: null | number): string {
   return (value ?? 0).toLocaleString();
 }
@@ -74,6 +82,25 @@ function getResolutionSourceDescription(
       return "This repair reuses a persisted classifier-reviewed parent decision.";
     case "classifier_review_live":
       return "This repair reuses a live classifier-reviewed parent decision.";
+    case null:
+      return null;
+  }
+}
+
+function getReviewStateDescription(
+  reviewState: keyof typeof REVIEW_STATE_LABELS | null,
+) {
+  switch (reviewState) {
+    case "fresh_allow_create_parent":
+      return "Classifier review still supports creating a new reusable parent bottle.";
+    case "fresh_blocked":
+      return "Stored classifier review currently blocks this repair.";
+    case "fresh_reuse_existing_parent":
+      return "Stored classifier review currently supports reusing an existing parent bottle.";
+    case "stale_review":
+      return "A stored review exists, but the legacy bottle or parent set changed and it needs refresh.";
+    case "unreviewed":
+      return "This create-parent repair has not been classifier-reviewed yet.";
     case null:
       return null;
   }
@@ -315,6 +342,11 @@ export default function Page() {
                         }
                       </span>
                     ) : null}
+                    {candidate.reviewState ? (
+                      <span className="rounded-full border border-sky-800 bg-sky-950 px-2 py-1 text-xs font-medium text-sky-300">
+                        {REVIEW_STATE_LABELS[candidate.reviewState]}
+                      </span>
+                    ) : null}
                     {candidate.releaseIdentity.markerSources.map((source) => (
                       <span
                         key={source}
@@ -451,6 +483,11 @@ export default function Page() {
                       {getResolutionSourceDescription(
                         candidate.parentResolutionSource,
                       )}
+                    </div>
+                  ) : null}
+                  {candidate.reviewState ? (
+                    <div className="mt-3 text-sm text-sky-300">
+                      {getReviewStateDescription(candidate.reviewState)}
                     </div>
                   ) : null}
                   {candidate.blockingAlias ? (


### PR DESCRIPTION
Tighten legacy release repair discovery so generic Batch labels do not get promoted into fake releases, and surface explicit stored-review state in the moderator repair UI.

The repair pipeline was still too eager to treat any `Batch ...` wording as release identity, which meant names like `Batch Strength`, `Batch Proof`, or `Batch Sherry` could show up as release repairs even though those words are part of the bottle name. That is exactly the kind of false-positive heuristic drift the classifier work is supposed to reduce, not reinforce.

This change narrows batch release parsing to release-like batch tokens such as numeric or coded batches, aligns the prefilter with that same rule, and adds route regressions for the generic-label cases. It also threads an explicit `reviewState` field through the release-repair route and admin page so moderators can see whether a create-parent row is unreviewed, stale, freshly blocked, freshly reusable, or still reviewed as create-parent.

Fixes #329