### PR TITLE
docs(classifier): Update classifier use cases

### DIFF
--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -241,8 +241,10 @@ layer for composition.
 Current consumers include:
 
 - store-price proposal resolution
+- review ingestion and unresolved review backfill through `apps/server/src/lib/bottleReferenceResolution.ts`
+- legacy release-repair parent review through `apps/server/src/lib/legacyReleaseRepairClassifier.ts`
 
-Future consumers should depend on the same classifier contract instead of
+New consumers should depend on the same classifier contract instead of
 re-implementing bottle extraction, candidate search, or LLM policy in parallel.
 
 ## Naming


### PR DESCRIPTION
Update the classifier architecture doc to reflect the current consumer surface.

The use cases section was still framed around store-price proposal resolution even though review ingestion, unresolved review backfill, and legacy release repair now route through the shared classifier boundary.

No behavior change.