### PR TITLE
feat(admin): Add review workbench for repairs

### DIFF
--- a/apps/web/src/app/(admin)/admin/(default)/age-repairs/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/age-repairs/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import AdminWorkstreamTabs from "@peated/web/components/admin/workstreamTabs";
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
 import { useFlashMessages } from "@peated/web/components/flash";
@@ -121,22 +122,24 @@ export default function Page() {
             href: "/admin",
           },
           {
-            name: "Age Repairs",
+            name: "Parent Age Repairs",
             href: "/admin/age-repairs",
             current: true,
           },
         ]}
       />
 
-      <SimpleHeader>Age Repairs</SimpleHeader>
+      <SimpleHeader>Parent Age Repairs</SimpleHeader>
 
       <div className="mb-6 space-y-4">
         <div className="rounded-xl border border-slate-800 bg-slate-950 px-4 py-4 text-sm text-slate-300">
-          High-confidence parent bottles whose structured bottle-level age is
-          dirty because child releases already carry different ages. Applying a
-          repair creates or reuses the former parent-age release, moves direct
-          bottle-scoped rows onto it, and clears the parent age.
+          Use this queue when the parent bottle still carries a release-specific
+          age that belongs on a child release. Applying a repair creates or
+          reuses the former parent-age release, moves direct bottle-scoped rows
+          onto it, and clears the parent age.
         </div>
+
+        <AdminWorkstreamTabs />
 
         <Form
           action={pathname}
@@ -148,7 +151,7 @@ export default function Page() {
                 type="text"
                 name="query"
                 defaultValue={currentQuery}
-                placeholder="Search dirty parent bottle names"
+                placeholder="Search parent bottle names"
               />
             </div>
             <div className="flex gap-2">
@@ -275,7 +278,7 @@ export default function Page() {
       ) : (
         <div className="rounded-xl border border-slate-800 bg-slate-950 p-10">
           <div className="text-sm text-slate-400">
-            No dirty parent age repairs found.
+            No parent age repairs found.
           </div>
         </div>
       )}

--- a/apps/web/src/app/(admin)/admin/(default)/canon-repairs/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/canon-repairs/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import AdminWorkstreamTabs from "@peated/web/components/admin/workstreamTabs";
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
 import EmptyActivity from "@peated/web/components/emptyActivity";
@@ -53,22 +54,24 @@ export default function Page() {
             href: "/admin",
           },
           {
-            name: "Canon Repairs",
+            name: "Bottle Name Repairs",
             href: "/admin/canon-repairs",
             current: true,
           },
         ]}
       />
 
-      <SimpleHeader>Canon Repairs</SimpleHeader>
+      <SimpleHeader>Bottle Name Repairs</SimpleHeader>
 
       <div className="mb-6 space-y-4">
         <div className="rounded-xl border border-slate-800 bg-slate-950 px-4 py-4 text-sm text-slate-300">
-          High-confidence same-brand bottle variants where the current canonical
-          bottle name likely needs to be merged into an existing cleaner target.
-          This queue links directly into the existing moderator merge flow with
-          the suggested target preselected.
+          Use this queue when two bottle records are really the same bottle and
+          the cleaner existing name should win. This is a merge and naming
+          cleanup workflow, not a bottle versus release split. The suggested
+          target opens directly into the existing moderator merge flow.
         </div>
+
+        <AdminWorkstreamTabs />
 
         <Form
           action={pathname}
@@ -106,8 +109,8 @@ export default function Page() {
         {candidateList.results.length === 0 ? (
           <EmptyActivity>
             {currentQuery
-              ? "No canon repair candidates matched that search."
-              : "No canon repair candidates right now."}
+              ? "No bottle name repairs matched that search."
+              : "No bottle name repairs right now."}
           </EmptyActivity>
         ) : (
           candidateList.results.map((candidate) => (

--- a/apps/web/src/app/(admin)/admin/(default)/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/page.tsx
@@ -1,38 +1,152 @@
 "use client";
 
+import WorkbenchCard from "@peated/web/components/admin/workbenchCard";
+import { ADMIN_WORKSTREAMS } from "@peated/web/components/admin/workstreams";
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
+import Link from "@peated/web/components/link";
 import SimpleHeader from "@peated/web/components/simpleHeader";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
-function QueueStats() {
+function getQueueDetail(queueQuery: {
+  data:
+    | {
+        results: Array<{
+          price: {
+            name: string;
+          };
+        }>;
+      }
+    | undefined;
+  isError: boolean;
+  isLoading: boolean;
+}) {
+  if (queueQuery.isLoading) {
+    return "Checking the current listing review queue.";
+  }
+
+  if (queueQuery.isError) {
+    return "Could not load the current listing review queue.";
+  }
+
+  const topListing = queueQuery.data?.results[0]?.price.name;
+  if (!topListing) {
+    return "No actionable listings are waiting for review right now.";
+  }
+
+  return `Top listing waiting for review: ${topListing}`;
+}
+
+function QueueHealthCard({
+  isError,
+  isLoading,
+  queueInfo,
+}: {
+  isError: boolean;
+  isLoading: boolean;
+  queueInfo:
+    | {
+        stats: {
+          active: number;
+          failed: number;
+          wait: number;
+        };
+      }
+    | undefined;
+}) {
+  return (
+    <section className="rounded-xl border border-slate-800 bg-slate-950/80 p-5 shadow-sm">
+      <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+        Background Jobs
+      </div>
+      <h2 className="mt-2 text-lg font-semibold text-white">Queue Health</h2>
+      <p className="mt-2 text-sm text-slate-300">
+        {isError
+          ? "Queue stats are temporarily unavailable."
+          : "Keep an eye on worker pressure while you are reviewing listings and repairs."}
+      </p>
+      <div className="mt-4 grid grid-cols-3 gap-3 text-center">
+        {[
+          {
+            label: "Waiting",
+            value: isLoading
+              ? "..."
+              : isError
+                ? "\u2014"
+                : (queueInfo?.stats.wait ?? 0),
+          },
+          {
+            label: "Active",
+            value: isLoading
+              ? "..."
+              : isError
+                ? "\u2014"
+                : (queueInfo?.stats.active ?? 0),
+          },
+          {
+            label: "Failed",
+            value: isLoading
+              ? "..."
+              : isError
+                ? "\u2014"
+                : (queueInfo?.stats.failed ?? 0),
+          },
+        ].map((item) => (
+          <div
+            key={item.label}
+            className="rounded-lg border border-slate-800 bg-slate-900/60 px-3 py-4"
+          >
+            <div className="text-xl font-semibold text-white">{item.value}</div>
+            <div className="mt-1 text-xs uppercase tracking-wide text-slate-400">
+              {item.label}
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export default function Admin() {
   const orpc = useORPC();
-  const { data } = useSuspenseQuery(
+  const incomingListings = ADMIN_WORKSTREAMS.find(
+    (workstream) => workstream.id === "queue",
+  )!;
+  const bottleNameRepairs = ADMIN_WORKSTREAMS.find(
+    (workstream) => workstream.id === "canon-repairs",
+  )!;
+  const bottleReleaseRepairs = ADMIN_WORKSTREAMS.find(
+    (workstream) => workstream.id === "release-repairs",
+  )!;
+  const ageRepairs = ADMIN_WORKSTREAMS.find(
+    (workstream) => workstream.id === "age-repairs",
+  )!;
+
+  const queueQuery = useQuery(
+    orpc.prices.matchQueue.list.queryOptions({
+      input: {
+        cursor: 1,
+        kind: null,
+        limit: 1,
+        query: "",
+        sort: "priority",
+        state: "actionable",
+      },
+    }),
+  );
+  const queueInfoQuery = useQuery(
     orpc.admin.queueInfo.queryOptions({
       refetchInterval: 5000,
     }),
   );
 
-  return (
-    <>
-      <SimpleHeader>Async Tasks</SimpleHeader>
-      <div className="my-6 grid grid-cols-4 items-center gap-3 text-center">
-        {Object.entries(data.stats).map(([name, count]) => {
-          return (
-            <div className="mr-4 pr-3 text-center" key={name}>
-              <span className="block text-xl font-bold uppercase tracking-wide text-white">
-                {count.toLocaleString()}
-              </span>
-              <span className="text-muted text-sm">{name}</span>
-            </div>
-          );
-        })}
-      </div>
-    </>
-  );
-}
+  const actionableCount = queueQuery.isError
+    ? null
+    : (queueQuery.data?.stats.actionableCount ?? 0);
+  const processingCount = queueQuery.isError
+    ? null
+    : (queueQuery.data?.stats.processingCount ?? 0);
 
-export default function Admin() {
   return (
     <>
       <Breadcrumbs
@@ -40,12 +154,165 @@ export default function Admin() {
           {
             name: "Admin",
             href: "/admin",
+            current: true,
           },
         ]}
       />
 
-      <div>
-        <QueueStats />
+      <SimpleHeader>Review Workbench</SimpleHeader>
+
+      <div className="space-y-6">
+        <section className="grid gap-4 xl:grid-cols-[minmax(0,1.8fr)_340px]">
+          <div className="rounded-xl border border-slate-800 bg-slate-950/80 p-5 shadow-sm">
+            <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+              Start Here
+            </div>
+            <h2 className="mt-2 text-lg font-semibold text-white">
+              Pick the queue by the change you need to make.
+            </h2>
+            <p className="mt-2 max-w-3xl text-sm text-slate-300">
+              Incoming listings and catalog repairs use different tools. Start
+              with the listing queue when retailer data is wrong or unmatched.
+              Switch to a repair queue when the bottle record itself needs to be
+              merged, split, or cleaned up.
+            </p>
+
+            <div className="mt-4 grid gap-3 lg:grid-cols-2">
+              <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Incoming work
+                </div>
+                <div className="mt-1 text-sm text-slate-300">
+                  Review new or changed store listings in{" "}
+                  <Link
+                    href={incomingListings.href}
+                    className="font-medium text-white underline"
+                  >
+                    {incomingListings.pageTitle}
+                  </Link>
+                  .
+                </div>
+              </div>
+              <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Duplicate bottle name
+                </div>
+                <div className="mt-1 text-sm text-slate-300">
+                  Merge wording variants in{" "}
+                  <Link
+                    href={bottleNameRepairs.href}
+                    className="font-medium text-white underline"
+                  >
+                    {bottleNameRepairs.pageTitle}
+                  </Link>
+                  .
+                </div>
+              </div>
+              <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Bottle still contains release detail
+                </div>
+                <div className="mt-1 text-sm text-slate-300">
+                  Split parent and child records in{" "}
+                  <Link
+                    href={bottleReleaseRepairs.href}
+                    className="font-medium text-white underline"
+                  >
+                    {bottleReleaseRepairs.pageTitle}
+                  </Link>
+                  .
+                </div>
+              </div>
+              <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+                <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Parent age is dirty
+                </div>
+                <div className="mt-1 text-sm text-slate-300">
+                  Move release-specific ages in{" "}
+                  <Link
+                    href={ageRepairs.href}
+                    className="font-medium text-white underline"
+                  >
+                    {ageRepairs.pageTitle}
+                  </Link>
+                  .
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <QueueHealthCard
+            isError={queueInfoQuery.isError}
+            isLoading={queueInfoQuery.isLoading}
+            queueInfo={queueInfoQuery.data}
+          />
+        </section>
+
+        <section className="grid gap-4 xl:grid-cols-2">
+          <WorkbenchCard
+            badges={
+              queueQuery.isError
+                ? [
+                    {
+                      label: "Unavailable",
+                      tone: "amber",
+                    },
+                  ]
+                : [
+                    {
+                      label: queueQuery.isLoading
+                        ? "Loading"
+                        : `${actionableCount} actionable`,
+                      tone: queueQuery.isLoading
+                        ? "slate"
+                        : actionableCount && actionableCount > 0
+                          ? "amber"
+                          : "emerald",
+                    },
+                    {
+                      label: queueQuery.isLoading
+                        ? "Loading"
+                        : `${processingCount} processing`,
+                      tone: queueQuery.isLoading
+                        ? "slate"
+                        : processingCount && processingCount > 0
+                          ? "sky"
+                          : "slate",
+                    },
+                  ]
+            }
+            detail={getQueueDetail(queueQuery)}
+            href={incomingListings.href}
+            hrefLabel="Open Incoming Listings"
+            summary={incomingListings.summary}
+            title={incomingListings.pageTitle}
+            whenToUse={incomingListings.whenToUse}
+          />
+          <WorkbenchCard
+            detail="Open this queue to review the current merge candidates and pick the cleaner bottle name."
+            href={bottleNameRepairs.href}
+            hrefLabel="Open Bottle Name Repairs"
+            summary={bottleNameRepairs.summary}
+            title={bottleNameRepairs.pageTitle}
+            whenToUse={bottleNameRepairs.whenToUse}
+          />
+          <WorkbenchCard
+            detail="Open this queue to review the current parent and release split candidates."
+            href={bottleReleaseRepairs.href}
+            hrefLabel="Open Bottle / Release Repairs"
+            summary={bottleReleaseRepairs.summary}
+            title={bottleReleaseRepairs.pageTitle}
+            whenToUse={bottleReleaseRepairs.whenToUse}
+          />
+          <WorkbenchCard
+            detail="Open this queue to review parent bottles whose age should move onto a child release."
+            href={ageRepairs.href}
+            hrefLabel="Open Parent Age Repairs"
+            summary={ageRepairs.summary}
+            title={ageRepairs.pageTitle}
+            whenToUse={ageRepairs.whenToUse}
+          />
+        </section>
       </div>
     </>
   );

--- a/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import AdminWorkstreamTabs from "@peated/web/components/admin/workstreamTabs";
+import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
 import { useFlashMessages } from "@peated/web/components/flash";
 import Form from "@peated/web/components/form";
@@ -217,9 +219,33 @@ export default function Page() {
 
   return (
     <>
-      <SimpleHeader>Price Match Queue</SimpleHeader>
+      <Breadcrumbs
+        pages={[
+          {
+            name: "Admin",
+            href: "/admin",
+          },
+          {
+            name: "Incoming Listings",
+            href: "/admin/queue",
+            current: true,
+          },
+        ]}
+      />
+
+      <SimpleHeader>Incoming Listings</SimpleHeader>
 
       <div className="mb-6 space-y-4">
+        <div className="rounded-xl border border-slate-800 bg-slate-950 px-4 py-4 text-sm text-slate-300">
+          Review new or changed retailer listings here. Use this queue when the
+          listing is unmatched, misclassified, or needs a bottle or bottling
+          decision. If the underlying catalog bottle itself is wrong, switch to
+          one of the repair queues below instead of forcing the listing to carry
+          that cleanup.
+        </div>
+
+        <AdminWorkstreamTabs />
+
         <Form
           action={pathname}
           className="mb-0 rounded-xl border border-slate-800 bg-slate-950 px-4 py-4"
@@ -235,7 +261,7 @@ export default function Page() {
                 type="text"
                 name="query"
                 defaultValue={currentQuery}
-                placeholder="Search queue by listing name"
+                placeholder="Search incoming listings"
               />
             </div>
             <div className="flex gap-2">

--- a/apps/web/src/app/(admin)/admin/(default)/release-repairs/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/release-repairs/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import AdminWorkstreamTabs from "@peated/web/components/admin/workstreamTabs";
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
 import ConfirmationButton from "@peated/web/components/confirmationButton";
@@ -271,22 +272,25 @@ export default function Page() {
             href: "/admin",
           },
           {
-            name: "Release Repairs",
+            name: "Bottle / Release Repairs",
             href: "/admin/release-repairs",
             current: true,
           },
         ]}
       />
 
-      <SimpleHeader>Release Repairs</SimpleHeader>
+      <SimpleHeader>Bottle / Release Repairs</SimpleHeader>
 
       <div className="mb-6 space-y-4">
         <div className="rounded-xl border border-slate-800 bg-slate-950 px-4 py-4 text-sm text-slate-300">
-          High-confidence legacy bottles that likely need to be split into a
-          reusable parent bottle plus child releases. Existing-parent and
-          create-parent candidates can be applied directly here. Blocked
-          parent-name alias conflicts still need manual follow-up.
+          Use this queue when one bottle record is actually carrying reusable
+          parent identity plus release-level detail. Existing-parent and
+          create-parent candidates can be applied directly here. If the problem
+          is only duplicate bottle wording, use Bottle Name Repairs instead.
+          Blocked parent-name alias conflicts still need manual follow-up.
         </div>
+
+        <AdminWorkstreamTabs />
 
         <Form
           action={pathname}
@@ -298,7 +302,7 @@ export default function Page() {
                 type="text"
                 name="query"
                 defaultValue={currentQuery}
-                placeholder="Search legacy bottle names"
+                placeholder="Search bottle or parent names"
               />
             </div>
             <div className="flex gap-2">
@@ -563,8 +567,8 @@ export default function Page() {
       ) : (
         <EmptyActivity>
           {currentQuery
-            ? "No legacy release repair candidates match the current search."
-            : "No legacy release repair candidates found."}
+            ? "No bottle or release repairs match the current search."
+            : "No bottle or release repairs found."}
         </EmptyActivity>
       )}
 

--- a/apps/web/src/components/admin/sidebar.tsx
+++ b/apps/web/src/components/admin/sidebar.tsx
@@ -4,6 +4,7 @@ import Button from "@peated/web/components/button";
 import HeaderLogo from "@peated/web/components/headerLogo";
 import SidebarLink from "@peated/web/components/sidebarLink";
 import { usePathname } from "next/navigation";
+import { ADMIN_WORKSTREAMS } from "./workstreams";
 
 export default function AdminSidebar() {
   const pathname = usePathname();
@@ -23,34 +24,41 @@ export default function AdminSidebar() {
                 </Button>
               </li>
               <li>
+                <div className="px-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Workbench
+                </div>
                 <ul role="list" className="-mx-2 space-y-1">
-                  <SidebarLink
-                    href="/admin/queue"
-                    active={pathname.startsWith("/admin/queue")}
-                  >
-                    Queue
+                  <SidebarLink href="/admin" active={pathname === "/admin"}>
+                    Review Workbench
                   </SidebarLink>
                 </ul>
               </li>
               <li>
+                <div className="px-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Review Flow
+                </div>
+                <ul role="list" className="-mx-2 space-y-1">
+                  {ADMIN_WORKSTREAMS.map((workstream) => (
+                    <SidebarLink
+                      key={workstream.id}
+                      href={workstream.href}
+                      active={pathname.startsWith(workstream.href)}
+                    >
+                      {workstream.sidebarLabel}
+                    </SidebarLink>
+                  ))}
+                </ul>
+              </li>
+              <li>
+                <div className="px-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                  Admin Tools
+                </div>
                 <ul role="list" className="-mx-2 space-y-1">
                   <SidebarLink
                     href="/admin/badges"
                     active={pathname.startsWith("/admin/badges")}
                   >
                     Badges
-                  </SidebarLink>
-                  <SidebarLink
-                    href="/admin/canon-repairs"
-                    active={pathname.startsWith("/admin/canon-repairs")}
-                  >
-                    Canon Repairs
-                  </SidebarLink>
-                  <SidebarLink
-                    href="/admin/age-repairs"
-                    active={pathname.startsWith("/admin/age-repairs")}
-                  >
-                    Age Repairs
                   </SidebarLink>
                   <SidebarLink
                     href="/admin/events"
@@ -63,12 +71,6 @@ export default function AdminSidebar() {
                     active={pathname.startsWith("/admin/locations")}
                   >
                     Locations
-                  </SidebarLink>
-                  <SidebarLink
-                    href="/admin/release-repairs"
-                    active={pathname.startsWith("/admin/release-repairs")}
-                  >
-                    Release Repairs
                   </SidebarLink>
                   <SidebarLink
                     href="/admin/sites"

--- a/apps/web/src/components/admin/workbenchCard.tsx
+++ b/apps/web/src/components/admin/workbenchCard.tsx
@@ -1,0 +1,84 @@
+import Button from "@peated/web/components/button";
+import classNames from "@peated/web/lib/classNames";
+
+type BadgeTone = "amber" | "emerald" | "sky" | "slate";
+
+type WorkbenchCardBadge = {
+  label: string;
+  tone?: BadgeTone;
+};
+
+type Props = {
+  badges?: WorkbenchCardBadge[];
+  detail: string;
+  href: string;
+  hrefLabel: string;
+  summary: string;
+  title: string;
+  whenToUse: string;
+};
+
+function getBadgeClassName(tone: BadgeTone) {
+  switch (tone) {
+    case "amber":
+      return "border-amber-800 bg-amber-950/60 text-amber-200";
+    case "emerald":
+      return "border-emerald-800 bg-emerald-950/60 text-emerald-200";
+    case "sky":
+      return "border-sky-800 bg-sky-950/60 text-sky-200";
+    case "slate":
+      return "border-slate-700 bg-slate-900 text-slate-200";
+  }
+}
+
+export default function WorkbenchCard({
+  badges = [],
+  detail,
+  href,
+  hrefLabel,
+  summary,
+  title,
+  whenToUse,
+}: Props) {
+  return (
+    <article className="rounded-xl border border-slate-800 bg-slate-950/80 p-5 shadow-sm">
+      <div className="flex h-full flex-col gap-4">
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-2">
+            {badges.map((badge) => (
+              <span
+                key={badge.label}
+                className={classNames(
+                  "rounded-full border px-2.5 py-1 text-xs font-semibold uppercase tracking-wide",
+                  getBadgeClassName(badge.tone ?? "slate"),
+                )}
+              >
+                {badge.label}
+              </span>
+            ))}
+          </div>
+
+          <div>
+            <h2 className="text-lg font-semibold text-white">{title}</h2>
+            <p className="mt-2 text-sm text-slate-300">{summary}</p>
+          </div>
+        </div>
+
+        <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-3 text-sm text-slate-300">
+          <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+            Best for
+          </div>
+          <div className="mt-1">{whenToUse}</div>
+        </div>
+
+        <div className="min-h-11 text-sm text-slate-400">{detail}</div>
+
+        <div className="mt-auto">
+          <Button href={href} color="primary">
+            {hrefLabel}
+          </Button>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/apps/web/src/components/admin/workstreamTabs.tsx
+++ b/apps/web/src/components/admin/workstreamTabs.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from "@peated/web/components/link";
+import Tabs, { TabItem } from "@peated/web/components/tabs";
+import { ADMIN_WORKSTREAMS } from "./workstreams";
+
+export default function AdminWorkstreamTabs() {
+  return (
+    <div className="overflow-x-auto rounded-xl border border-slate-800 bg-slate-950 px-4">
+      <Tabs border fullWidth noMargin>
+        {ADMIN_WORKSTREAMS.map((workstream) => (
+          <TabItem
+            key={workstream.id}
+            as={Link}
+            controlled
+            href={workstream.href}
+          >
+            {workstream.sidebarLabel}
+          </TabItem>
+        ))}
+      </Tabs>
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/workstreams.ts
+++ b/apps/web/src/components/admin/workstreams.ts
@@ -1,0 +1,51 @@
+export type AdminWorkstream = {
+  href: string;
+  id: "age-repairs" | "canon-repairs" | "queue" | "release-repairs";
+  pageTitle: string;
+  sidebarLabel: string;
+  summary: string;
+  whenToUse: string;
+};
+
+export const ADMIN_WORKSTREAMS: AdminWorkstream[] = [
+  {
+    id: "queue",
+    href: "/admin/queue",
+    pageTitle: "Incoming Listings",
+    sidebarLabel: "Incoming Listings",
+    summary:
+      "Review new or changed retailer listings and approve the bottle or bottling assignment.",
+    whenToUse:
+      "Use this when a listing is wrong or unmatched, but the catalog bottle itself may still be correct.",
+  },
+  {
+    id: "canon-repairs",
+    href: "/admin/canon-repairs",
+    pageTitle: "Bottle Name Repairs",
+    sidebarLabel: "Bottle Name Repairs",
+    summary:
+      "Merge same-brand wording variants into the cleaner existing bottle record.",
+    whenToUse:
+      "Use this when two bottle records represent the same bottle and one name should win.",
+  },
+  {
+    id: "release-repairs",
+    href: "/admin/release-repairs",
+    pageTitle: "Bottle / Release Repairs",
+    sidebarLabel: "Bottle / Release Repairs",
+    summary:
+      "Split legacy bottles into a reusable parent bottle plus child releases.",
+    whenToUse:
+      "Use this when the current bottle record still contains batch, edition, or year-level release identity.",
+  },
+  {
+    id: "age-repairs",
+    href: "/admin/age-repairs",
+    pageTitle: "Parent Age Repairs",
+    sidebarLabel: "Parent Age Repairs",
+    summary:
+      "Move a release-specific age off the parent bottle and onto the right child release.",
+    whenToUse:
+      "Use this when the bottle-level age is dirty because child releases already carry conflicting ages.",
+  },
+];


### PR DESCRIPTION
Add a review workbench for the admin repair flow.

The admin queue and repair surfaces had drifted into a confusing set of pages with overlapping names and very little guidance about which tool to use for which kind of cleanup. This reorganizes the sidebar around the review flow, adds a shared workstream switcher across the queue and repair pages, and turns `/admin` into a workbench that explains where to start.

The follow-up dashboard changes keep the landing page lightweight and operationally honest. It now summarizes the incoming listing queue and queue health without preloading the heavier repair candidate scans, and it shows unavailable states when those summary requests fail instead of implying the queues are empty.