### PR TITLE
fix(classifier): Reduce repair false positives

### DIFF
--- a/apps/server/src/lib/applyLegacyReleaseRepair.ts
+++ b/apps/server/src/lib/applyLegacyReleaseRepair.ts
@@ -7,7 +7,7 @@ import {
 import { stripDuplicateBrandPrefixFromBottleName } from "@peated/bottle-classifier/normalize";
 import {
   getCanonicalReleaseAliasNames,
-  hasBottleLevelReleaseTraits,
+  hasBlockingBottleLevelReleaseTraits,
 } from "@peated/bottle-classifier/releaseIdentity";
 import { db, type AnyTransaction } from "@peated/server/db";
 import type { Bottle, BottleRelease, User } from "@peated/server/db/schema";
@@ -472,6 +472,7 @@ async function resolveParentBottleForRepair(
     legacyBottle,
     legacyBottleId,
     proposedParentFullName,
+    releaseInput,
     user,
   }: {
     classifierResolution: ClassifierReviewedCreateParentResolution | null;
@@ -479,6 +480,7 @@ async function resolveParentBottleForRepair(
     legacyBottle: RepairBottle;
     legacyBottleId: number;
     proposedParentFullName: string;
+    releaseInput: ReturnType<typeof getReleaseInput>["input"];
     user: User;
   },
 ): Promise<ResolvedLegacyReleaseRepairParent> {
@@ -536,7 +538,12 @@ async function resolveParentBottleForRepair(
         );
       }
 
-      if (hasBottleLevelReleaseTraits(lockedParentBottle)) {
+      if (
+        hasBlockingBottleLevelReleaseTraits({
+          bottle: lockedParentBottle,
+          release: releaseInput,
+        })
+      ) {
         throw new LegacyReleaseRepairBadRequestError(
           "Classifier-reviewed parent bottle still contains bottle-level release traits.",
         );
@@ -690,6 +697,7 @@ export async function applyLegacyReleaseRepairInTransaction(
     legacyBottle,
     legacyBottleId,
     proposedParentFullName: releaseIdentity.proposedParentFullName,
+    releaseInput,
     user,
   });
   if (parentAliasName) {

--- a/apps/server/src/lib/createBottleRelease.ts
+++ b/apps/server/src/lib/createBottleRelease.ts
@@ -2,7 +2,7 @@ import {
   formatCanonicalReleaseName,
   getCanonicalReleaseAliasNames,
   getResolvedReleaseIdentity,
-  hasBottleLevelReleaseTraits,
+  hasBlockingBottleLevelReleaseTraits,
   hasDirtyBottleLevelStatedAgeConflict,
 } from "@peated/bottle-classifier/releaseIdentity";
 import { db, type AnyTransaction } from "@peated/server/db";
@@ -59,12 +59,6 @@ export async function createBottleReleaseInTransaction(
     throw new BottleReleaseCreateBadRequestError("Bottle not found.");
   }
 
-  if (hasBottleLevelReleaseTraits(bottle)) {
-    throw new BottleReleaseCreateBadRequestError(
-      "Bottle already stores specific release details on the parent record. A moderator must split or clear those bottle fields before adding child releases.",
-    );
-  }
-
   if (
     bottle.statedAge &&
     input.statedAge &&
@@ -95,9 +89,21 @@ export async function createBottleReleaseInTransaction(
     },
   });
 
+  if (
+    hasBlockingBottleLevelReleaseTraits({
+      bottle,
+      release: resolvedReleaseIdentity,
+    })
+  ) {
+    throw new BottleReleaseCreateBadRequestError(
+      "Bottle already stores specific release details on the parent record. A moderator must split or clear those bottle fields before adding child releases.",
+    );
+  }
+
   const { name, fullName } = formatCanonicalReleaseName({
     bottleName: bottle.name,
     bottleFullName: bottle.fullName,
+    bottleReleaseTraits: bottle,
     bottleStatedAge: bottle.statedAge,
     release: resolvedReleaseIdentity,
   });

--- a/apps/server/src/lib/legacyReleaseRepairCandidates.ts
+++ b/apps/server/src/lib/legacyReleaseRepairCandidates.ts
@@ -10,7 +10,7 @@ import {
   type LegacyReleaseRepairIdentity,
   type LegacyReleaseRepairParentCandidate,
 } from "@peated/bottle-classifier/legacyReleaseRepairIdentity";
-import { hasBottleLevelReleaseTraits } from "@peated/bottle-classifier/releaseIdentity";
+import { hasBlockingBottleLevelReleaseTraits } from "@peated/bottle-classifier/releaseIdentity";
 import { db } from "@peated/server/db";
 import {
   bottleAliases,
@@ -145,6 +145,21 @@ function getLegacyReleaseRepairModePriority(
   }
 }
 
+function getCandidateReleaseIdentity(candidate: LegacyReleaseRepairCandidate) {
+  return {
+    edition: candidate.releaseIdentity.edition,
+    statedAge: candidate.legacyBottle.statedAge,
+    abv: candidate.legacyBottle.abv,
+    releaseYear: candidate.releaseIdentity.releaseYear,
+    vintageYear: candidate.legacyBottle.vintageYear,
+    singleCask: candidate.legacyBottle.singleCask,
+    caskStrength: candidate.legacyBottle.caskStrength,
+    caskFill: candidate.legacyBottle.caskFill,
+    caskType: candidate.legacyBottle.caskType,
+    caskSize: candidate.legacyBottle.caskSize,
+  };
+}
+
 function sortLegacyReleaseRepairCandidates(
   candidates: LegacyReleaseRepairCandidate[],
 ) {
@@ -271,7 +286,15 @@ function applyStoredLegacyReleaseRepairReview({
       } satisfies LegacyReleaseRepairCandidate;
     }
 
-    if (hasBottleLevelReleaseTraits(reviewedParent)) {
+    if (
+      hasBlockingBottleLevelReleaseTraits({
+        bottle: {
+          ...reviewedParent,
+          name: reviewedParent.fullName,
+        },
+        release: getCandidateReleaseIdentity(candidate),
+      })
+    ) {
       return {
         ...candidate,
         classifierBlocker:

--- a/apps/server/src/orpc/routes/bottleReleases/create.test.ts
+++ b/apps/server/src/orpc/routes/bottleReleases/create.test.ts
@@ -527,6 +527,72 @@ describe("POST /bottle-releases", () => {
     expect(updatedBottle.numReleases).toBe(1);
   });
 
+  it("allows inherited marketed parent traits without duplicating them in the release name", async function ({
+    fixtures,
+    defaults,
+  }) {
+    const bottle = await fixtures.Bottle({
+      name: "1972 Single Cask",
+      brandId: (await fixtures.Entity({ name: "Glendronach" })).id,
+      statedAge: 48,
+      singleCask: true,
+    });
+
+    const result = await routerClient.bottleReleases.create(
+      {
+        bottle: bottle.id,
+        edition: "Batch 1",
+        statedAge: 48,
+        singleCask: true,
+      },
+      {
+        context: { user: defaults.user },
+      },
+    );
+
+    expect(result).toMatchObject({
+      bottleId: bottle.id,
+      edition: "Batch 1",
+      statedAge: 48,
+      singleCask: true,
+      fullName: "Glendronach 1972 Single Cask - Batch 1",
+      name: "1972 Single Cask - Batch 1",
+    });
+  });
+
+  it("allows inherited marketed parent traits when the parent uses hyphenated wording", async function ({
+    fixtures,
+    defaults,
+  }) {
+    const bottle = await fixtures.Bottle({
+      name: "1972 Single-Cask",
+      brandId: (await fixtures.Entity({ name: "Glendronach" })).id,
+      statedAge: 48,
+      singleCask: true,
+    });
+
+    const result = await routerClient.bottleReleases.create(
+      {
+        bottle: bottle.id,
+        edition: "Batch 1",
+        statedAge: 48,
+        singleCask: true,
+      },
+      {
+        context: { user: defaults.user },
+      },
+    );
+
+    expect(result).toMatchObject({
+      bottleId: bottle.id,
+      edition: "Batch 1",
+      statedAge: 48,
+      singleCask: true,
+      fullName: "Glendronach 1972 Single-Cask - Batch 1",
+      name: "1972 Single-Cask - Batch 1",
+    });
+  });
+
   it("rejects creating a child release when the parent bottle still stores release details", async function ({
     fixtures,
     defaults,

--- a/apps/server/src/orpc/routes/bottleReleases/update.test.ts
+++ b/apps/server/src/orpc/routes/bottleReleases/update.test.ts
@@ -203,6 +203,49 @@ describe("PATCH /bottle-releases/:release", () => {
     });
   });
 
+  it("rejects clearing inherited marketed parent traits from a child release", async function ({
+    fixtures,
+  }) {
+    const modUser = await fixtures.User({ mod: true });
+    const bottle = await fixtures.Bottle({
+      name: "1972 Single-Cask",
+      brandId: (await fixtures.Entity({ name: "Glendronach" })).id,
+      statedAge: 48,
+      singleCask: true,
+    });
+    const release = await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      edition: "Batch 1",
+      statedAge: 48,
+      singleCask: true,
+    });
+
+    const err = await waitError(
+      routerClient.bottleReleases.update(
+        {
+          release: release.id,
+          singleCask: null,
+        },
+        { context: { user: modUser } },
+      ),
+    );
+
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Bottle already stores specific release details on the parent record. A moderator must split or clear those bottle fields before adding child releases.]`,
+    );
+
+    const [unchangedRelease] = await db
+      .select()
+      .from(bottleReleases)
+      .where(eq(bottleReleases.id, release.id));
+    expect(unchangedRelease).toMatchObject({
+      id: release.id,
+      singleCask: true,
+      fullName: release.fullName,
+      name: release.name,
+    });
+  });
+
   it("throws error if release not found", async function ({ fixtures }) {
     const modUser = await fixtures.User({ mod: true });
 

--- a/apps/server/src/orpc/routes/bottleReleases/update.ts
+++ b/apps/server/src/orpc/routes/bottleReleases/update.ts
@@ -1,6 +1,7 @@
 import {
   formatCanonicalReleaseName,
   getResolvedReleaseIdentity,
+  hasBlockingBottleLevelReleaseTraits,
   hasDirtyBottleLevelStatedAgeConflict,
 } from "@peated/bottle-classifier/releaseIdentity";
 import { db } from "@peated/server/db";
@@ -184,11 +185,24 @@ export default procedure
         release: nextReleaseIdentity,
       });
 
+      if (
+        hasBlockingBottleLevelReleaseTraits({
+          bottle,
+          release: resolvedReleaseIdentity,
+        })
+      ) {
+        throw errors.BAD_REQUEST({
+          message:
+            "Bottle already stores specific release details on the parent record. A moderator must split or clear those bottle fields before adding child releases.",
+        });
+      }
+
       // Always derive the name from the resolved bottle/release identity so a
       // parent bottle age does not get duplicated into the release suffix.
       const { name, fullName } = formatCanonicalReleaseName({
         bottleName: bottle.name,
         bottleFullName: bottle.fullName,
+        bottleReleaseTraits: bottle,
         bottleStatedAge: bottle.statedAge,
         release: resolvedReleaseIdentity,
       });

--- a/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
+++ b/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
@@ -1456,6 +1456,53 @@ describe("POST /bottles/:bottle/apply-release-repair", () => {
     });
   });
 
+  test("reuses a marketed single-cask parent without duplicating the trait in the child release name", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Glendronach" });
+    const mod = await fixtures.User({ mod: true });
+    const parent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "1972 Single Cask",
+      statedAge: 48,
+      singleCask: true,
+      totalTastings: 40,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "1972 Single Cask (Batch 1)",
+      statedAge: 48,
+      singleCask: true,
+      totalTastings: 5,
+      createdById: mod.id,
+    });
+
+    const result = await routerClient.bottles.applyReleaseRepair(
+      {
+        bottle: legacyBottle.id,
+      },
+      { context: { user: mod } },
+    );
+
+    expect(result).toMatchObject({
+      legacyBottleId: legacyBottle.id,
+      parentBottleId: parent.id,
+    });
+
+    const [release] = await db
+      .select()
+      .from(bottleReleases)
+      .where(eq(bottleReleases.id, result.releaseId));
+    expect(release).toMatchObject({
+      bottleId: parent.id,
+      edition: "Batch 1",
+      statedAge: 48,
+      singleCask: true,
+      fullName: "Glendronach 1972 Single Cask - Batch 1",
+      name: "1972 Single Cask - Batch 1",
+    });
+  });
+
   test("rejects repair when the exact-name parent is still release-specific", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/bottles/canon-repair-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/canon-repair-candidates.test.ts
@@ -189,4 +189,30 @@ describe("GET /bottles/canon-repair-candidates", () => {
 
     expect(results).toEqual([]);
   });
+
+  test("does not surface repeated-token marketed variants as canon repairs", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Woodford Reserve" });
+    const user = await fixtures.User({ mod: true });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Double Oaked",
+      category: "bourbon",
+      totalTastings: 30,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Double Double Oaked",
+      category: "bourbon",
+      totalTastings: 10,
+    });
+
+    const { results } = await routerClient.bottles.canonRepairCandidates(
+      {},
+      { context: { user } },
+    );
+
+    expect(results).toEqual([]);
+  });
 });

--- a/packages/bottle-classifier/src/legacyReleaseRepairIdentity.test.ts
+++ b/packages/bottle-classifier/src/legacyReleaseRepairIdentity.test.ts
@@ -167,6 +167,15 @@ describe("release-repair parent matching", () => {
       }),
     ).toBe("create_parent");
   });
+
+  test("does not variant-match when one side repeats a meaningful token", () => {
+    expect(
+      hasVariantLegacyReleaseRepairParentName(
+        "Woodford Reserve Double Double Oaked",
+        "Woodford Reserve Double Oaked",
+      ),
+    ).toBe(false);
+  });
 });
 
 describe("resolveLegacyReleaseRepairNameScope", () => {

--- a/packages/bottle-classifier/src/legacyReleaseRepairIdentity.ts
+++ b/packages/bottle-classifier/src/legacyReleaseRepairIdentity.ts
@@ -137,19 +137,29 @@ function tokenSetsMatchExactly(left: string[], right: string[]): boolean {
     return false;
   }
 
-  const leftSet = new Set(left);
-  const rightSet = new Set(right);
-  if (leftSet.size !== rightSet.size) {
+  if (left.length !== right.length) {
     return false;
   }
 
-  for (const token of leftSet) {
-    if (!rightSet.has(token)) {
+  const rightCounts = new Map<string, number>();
+  for (const token of right) {
+    rightCounts.set(token, (rightCounts.get(token) ?? 0) + 1);
+  }
+
+  for (const token of left) {
+    const count = rightCounts.get(token) ?? 0;
+    if (count === 0) {
       return false;
+    }
+
+    if (count === 1) {
+      rightCounts.delete(token);
+    } else {
+      rightCounts.set(token, count - 1);
     }
   }
 
-  return true;
+  return rightCounts.size === 0;
 }
 
 function getTastingCount(value: null | number | undefined): number {

--- a/packages/bottle-classifier/src/normalizationCorpus.ts
+++ b/packages/bottle-classifier/src/normalizationCorpus.ts
@@ -304,6 +304,38 @@ export const BOTTLE_NORMALIZATION_CORPUS: BottleNormalizationCorpusExample[] = [
     notes: "Stable product wording, not a release split.",
   },
   {
+    id: "woodford-double-oaked",
+    inputName: "Woodford Reserve Double Oaked",
+    expectedBottleName: "Woodford Reserve Double Oaked",
+    liveEvalCoverage: "required",
+    liveEvalSummary:
+      "Treat Woodford Reserve Double Oaked as a distinct bottle identity and avoid mutating it into the separate Double Double Oaked sibling.",
+    expectation: {
+      handlingStrategy: "classifier_required",
+      classifierExpectation: "bottle",
+      deterministicReleaseExpectation: "none",
+      releaseIdentity: null,
+    },
+    notes:
+      "Real sibling bottle family where the repeated Double token is meaningful bottle identity, not release structure.",
+  },
+  {
+    id: "woodford-double-double-oaked",
+    inputName: "Woodford Reserve Double Double Oaked",
+    expectedBottleName: "Woodford Reserve Double Double Oaked",
+    liveEvalCoverage: "required",
+    liveEvalSummary:
+      "Treat Woodford Reserve Double Double Oaked as its own bottle identity and do not collapse the repeated Double wording into Double Oaked.",
+    expectation: {
+      handlingStrategy: "classifier_required",
+      classifierExpectation: "bottle",
+      deterministicReleaseExpectation: "none",
+      releaseIdentity: null,
+    },
+    notes:
+      "Real sibling bottle family where repeated marketed wording must be preserved rather than deduped.",
+  },
+  {
     id: "glenallachie-sherry-cask",
     inputName: "Glenallachie Sherry Cask",
     expectedBottleName: "Glenallachie Sherry Cask",

--- a/packages/bottle-classifier/src/releaseIdentity.test.ts
+++ b/packages/bottle-classifier/src/releaseIdentity.test.ts
@@ -8,6 +8,7 @@ import {
   getCanonicalReleaseAliasNames,
   getReleaseObservationFacts,
   getResolvedReleaseIdentity,
+  hasBlockingBottleLevelReleaseTraits,
   hasBottleLevelReleaseTraits,
   hasDirtyBottleLevelStatedAgeConflict,
   hasExtractedReleaseIdentity,
@@ -46,6 +47,100 @@ describe("releaseIdentity", () => {
       edition: "Batch 24",
       abv: 58.4,
     });
+  });
+
+  test("allows stable marketed parent traits, including hyphenated spellings, to be inherited by child releases", () => {
+    expect(
+      hasBlockingBottleLevelReleaseTraits({
+        bottle: {
+          name: "Glendronach 1972 Single Cask",
+          fullName: "Glendronach 1972 Single Cask",
+          statedAge: 48,
+          singleCask: true,
+        },
+        release: {
+          edition: "Batch 1",
+          statedAge: 48,
+          releaseYear: null,
+          vintageYear: null,
+          abv: null,
+          singleCask: true,
+          caskStrength: null,
+          caskFill: null,
+          caskType: null,
+          caskSize: null,
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      hasBlockingBottleLevelReleaseTraits({
+        bottle: {
+          name: "Warehouse Single-Cask Archive",
+          fullName: "Warehouse Single-Cask Archive",
+          statedAge: 12,
+          singleCask: true,
+        },
+        release: {
+          edition: "Batch 1",
+          statedAge: 12,
+          releaseYear: null,
+          vintageYear: null,
+          abv: null,
+          singleCask: true,
+          caskStrength: null,
+          caskFill: null,
+          caskType: null,
+          caskSize: null,
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      hasBlockingBottleLevelReleaseTraits({
+        bottle: {
+          name: "Warehouse Cask-Strength Archive",
+          fullName: "Warehouse Cask-Strength Archive",
+          statedAge: 12,
+          caskStrength: true,
+        },
+        release: {
+          edition: "Batch 1",
+          statedAge: 12,
+          releaseYear: null,
+          vintageYear: null,
+          abv: null,
+          singleCask: null,
+          caskStrength: true,
+          caskFill: null,
+          caskType: null,
+          caskSize: null,
+        },
+      }),
+    ).toBe(false);
+
+    expect(
+      hasBlockingBottleLevelReleaseTraits({
+        bottle: {
+          name: "Warehouse Archive",
+          fullName: "Warehouse Archive",
+          statedAge: 48,
+          singleCask: true,
+        },
+        release: {
+          edition: "Batch 1",
+          statedAge: 48,
+          releaseYear: null,
+          vintageYear: null,
+          abv: null,
+          singleCask: true,
+          caskStrength: null,
+          caskFill: null,
+          caskType: null,
+          caskSize: null,
+        },
+      }),
+    ).toBe(true);
   });
 
   test("returns only populated release observation facts", () => {
@@ -139,6 +234,34 @@ describe("releaseIdentity", () => {
     ).toEqual({
       name: "Lagavulin Distillers Edition - 2011 Release - 43.0% ABV",
       fullName: "Lagavulin Distillers Edition - 2011 Release - 43.0% ABV",
+    });
+  });
+
+  test("does not duplicate inherited stable parent traits in release naming", () => {
+    expect(
+      formatCanonicalReleaseName({
+        bottleName: "Glendronach 1972 Single Cask",
+        bottleFullName: "Glendronach 1972 Single Cask",
+        bottleReleaseTraits: {
+          singleCask: true,
+        },
+        bottleStatedAge: 48,
+        release: {
+          edition: "Batch 1",
+          statedAge: 48,
+          releaseYear: null,
+          vintageYear: null,
+          abv: null,
+          singleCask: true,
+          caskStrength: null,
+          caskFill: null,
+          caskType: null,
+          caskSize: null,
+        },
+      }),
+    ).toEqual({
+      name: "Glendronach 1972 Single Cask - Batch 1",
+      fullName: "Glendronach 1972 Single Cask - Batch 1",
     });
   });
 

--- a/packages/bottle-classifier/src/releaseIdentity.ts
+++ b/packages/bottle-classifier/src/releaseIdentity.ts
@@ -31,6 +31,9 @@ export type BottleLevelReleaseTraitsInput = Omit<
   "statedAge"
 >;
 
+type BottleReleaseIdentityBottleInput = BottleNameInput &
+  Partial<BottleLevelReleaseTraitsInput>;
+
 type ExtractedReleaseIdentityInput = Pick<
   BottleExtractedDetails,
   | "stated_age"
@@ -79,6 +82,16 @@ export const BOTTLE_LEVEL_RELEASE_TRAIT_FIELDS = [
   "caskType",
   "caskSize",
 ] as const satisfies ReadonlyArray<keyof BottleLevelReleaseTraitsInput>;
+
+const STABLE_BOTTLE_LEVEL_RELEASE_TRAIT_FIELDS = [
+  "singleCask",
+  "caskStrength",
+] as const satisfies ReadonlyArray<
+  Extract<
+    (typeof BOTTLE_LEVEL_RELEASE_TRAIT_FIELDS)[number],
+    keyof ReleaseIdentityInput
+  >
+>;
 
 export const EXTRACTED_RELEASE_IDENTITY_FIELDS = [
   "edition",
@@ -140,6 +153,81 @@ export function hasBottleLevelReleaseTraits(
   bottle: Partial<BottleLevelReleaseTraitsInput>,
 ) {
   return Object.keys(getBottleLevelReleaseTraits(bottle)).length > 0;
+}
+
+function bottleNameMarketsPattern(
+  bottle: BottleNameInput,
+  pattern: RegExp,
+): boolean {
+  return [bottle.name, bottle.fullName].some((name) => {
+    if (typeof name !== "string") {
+      return false;
+    }
+
+    return pattern.test(name);
+  });
+}
+
+function bottleMarketsInheritedReleaseTrait(
+  bottle: BottleNameInput,
+  field: (typeof STABLE_BOTTLE_LEVEL_RELEASE_TRAIT_FIELDS)[number],
+): boolean {
+  switch (field) {
+    case "singleCask":
+      return bottleNameMarketsPattern(
+        bottle,
+        /\b(single[-\s]+cask|single[-\s]+barrel)\b/i,
+      );
+    case "caskStrength":
+      return bottleNameMarketsPattern(
+        bottle,
+        /\b(cask[-\s]+strength|barrel[-\s]+strength|barrel[-\s]+proof|full[-\s]+proof|natural[-\s]+strength|original[-\s]+strength|undiluted|cask[-\s]+bottling)\b/i,
+      );
+  }
+}
+
+function isInheritedBottleLevelReleaseTrait({
+  bottle,
+  field,
+  release,
+}: {
+  bottle: BottleReleaseIdentityBottleInput;
+  field: (typeof STABLE_BOTTLE_LEVEL_RELEASE_TRAIT_FIELDS)[number];
+  release: Partial<ReleaseIdentityInput>;
+}) {
+  return (
+    bottle[field] === true &&
+    release[field] === true &&
+    bottleMarketsInheritedReleaseTrait(bottle, field)
+  );
+}
+
+export function hasBlockingBottleLevelReleaseTraits({
+  bottle,
+  release,
+}: {
+  bottle: BottleReleaseIdentityBottleInput;
+  release: Partial<ReleaseIdentityInput>;
+}) {
+  return BOTTLE_LEVEL_RELEASE_TRAIT_FIELDS.some((field) => {
+    const value = bottle[field];
+    if (value === null || value === undefined) {
+      return false;
+    }
+
+    if (
+      (field === "singleCask" || field === "caskStrength") &&
+      isInheritedBottleLevelReleaseTrait({
+        bottle,
+        field,
+        release,
+      })
+    ) {
+      return false;
+    }
+
+    return true;
+  });
 }
 
 function nameMarketsStatedAge({
@@ -274,11 +362,13 @@ export function getResolvedReleaseIdentity({
 export function formatCanonicalReleaseName({
   bottleName,
   bottleFullName,
+  bottleReleaseTraits,
   bottleStatedAge,
   release,
 }: {
   bottleName: string;
   bottleFullName: string;
+  bottleReleaseTraits?: Partial<BottleLevelReleaseTraitsInput>;
   bottleStatedAge: number | null;
   release: ReleaseIdentityInput;
 }): {
@@ -302,6 +392,22 @@ export function formatCanonicalReleaseName({
       field === "statedAge" &&
       bottleStatedAge !== null &&
       resolvedRelease.statedAge === bottleStatedAge
+    ) {
+      continue;
+    }
+
+    if (
+      (field === "singleCask" || field === "caskStrength") &&
+      isInheritedBottleLevelReleaseTrait({
+        bottle: {
+          name: bottleName,
+          fullName: bottleFullName,
+          statedAge: bottleStatedAge,
+          ...bottleReleaseTraits,
+        },
+        field,
+        release: resolvedRelease,
+      })
     ) {
       continue;
     }


### PR DESCRIPTION
Reduce classifier false positives in repair workflows.

Release repair and bottle release creation were treating parent-marketed stable traits like Single Cask and Cask Strength as blocking parent-level release metadata. That rejected valid repairs such as Glendronach 1972 Single Cask -> Glendronach 1972 Single Cask (Batch 1), and could leave release names and structured identity out of sync after PATCH edits. This change allows those inherited traits when the parent bottle name already markets them, including common hyphenated spellings, while keeping real bottle-level release metadata blocked.

This also fixes same-brand repair matching for repeated meaningful words. Previously the identity matcher compared token sets, so names like Woodford Reserve Double Double Oaked collapsed to the same variant as Double Oaked. The matcher now compares token counts instead, so repeated tokens remain distinct and canon repair candidates stop surfacing that false positive.

The regressions are covered in the classifier unit suite plus create, update, canon-repair-candidates, and apply-release-repair server tests.