### PR TITLE
fix(classifier): reuse parent bottles for dirty releases

### DIFF
--- a/apps/server/src/lib/bottleReferenceCandidates.ts
+++ b/apps/server/src/lib/bottleReferenceCandidates.ts
@@ -1,5 +1,7 @@
+import { deriveLegacyReleaseRepairIdentity } from "@peated/bottle-classifier/legacyReleaseRepairIdentity";
 import {
   normalizeBottle,
+  normalizeBottleBatchNumber,
   normalizeString,
 } from "@peated/bottle-classifier/normalize";
 import {
@@ -405,6 +407,35 @@ function buildQueryText(
   return Array.from(new Set(parts.filter(Boolean))).join(" ");
 }
 
+function buildExactSearchNameVariants(normalizedName: string) {
+  const variants = [normalizedName];
+  const batchSuffixMatch = normalizedName.match(/\s+\((batch [^)]+)\)\s*$/i);
+
+  if (batchSuffixMatch?.[1]) {
+    variants.push(
+      normalizedName.replace(
+        /\s+\((batch [^)]+)\)\s*$/i,
+        ` ${batchSuffixMatch[1]}`,
+      ),
+    );
+  }
+
+  return variants;
+}
+
+function buildExactSearchNames(
+  normalizedNames: Array<null | string | undefined>,
+) {
+  return Array.from(
+    new Set(
+      normalizedNames
+        .filter((value): value is string => Boolean(value))
+        .flatMap((value) => buildExactSearchNameVariants(value))
+        .map((value) => value.toLowerCase()),
+    ),
+  );
+}
+
 function normalizeIdentityText(value: string | null | undefined) {
   if (!value) {
     return "";
@@ -419,6 +450,154 @@ function normalizeComparableText(value: string | null | undefined) {
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+type ParentSearchSignals = {
+  edition: string | null;
+  releaseYear: number | null;
+  statedAge: number | null;
+  vintageYear: number | null;
+};
+
+function getParentSearchSignals({
+  searchName,
+  extractedLabel,
+}: {
+  searchName: string;
+  extractedLabel: BottleReferenceIdentity | null;
+}): ParentSearchSignals {
+  const normalizedSearchName = normalizeBottle({ name: searchName });
+  const derivedLegacyReleaseIdentity = deriveLegacyReleaseRepairIdentity({
+    fullName: searchName,
+    edition: extractedLabel?.edition ?? null,
+    releaseYear: extractedLabel?.release_year ?? null,
+  });
+
+  return {
+    edition:
+      extractedLabel?.edition ?? derivedLegacyReleaseIdentity?.edition ?? null,
+    releaseYear:
+      extractedLabel?.release_year ??
+      derivedLegacyReleaseIdentity?.releaseYear ??
+      normalizedSearchName.releaseYear ??
+      null,
+    statedAge:
+      extractedLabel?.stated_age ?? normalizedSearchName.statedAge ?? null,
+    vintageYear:
+      extractedLabel?.vintage_year ?? normalizedSearchName.vintageYear ?? null,
+  };
+}
+
+function stripReleaseIdentityFromSearchName(
+  name: string,
+  signals: ParentSearchSignals,
+) {
+  let strippedName = normalizeString(name);
+
+  if (signals.edition) {
+    const normalizedEdition = normalizeBottleBatchNumber(
+      normalizeString(signals.edition),
+    );
+    const escapedEdition = escapeRegExp(normalizedEdition);
+
+    strippedName = strippedName
+      .replace(new RegExp(`\\s*\\(${escapedEdition}\\)\\s*$`, "i"), " ")
+      .replace(new RegExp(`\\b${escapedEdition}\\b`, "i"), " ");
+  }
+
+  if (signals.statedAge !== null) {
+    strippedName = strippedName.replace(
+      new RegExp(`\\b${signals.statedAge}-year-old\\b`, "i"),
+      " ",
+    );
+  }
+
+  if (signals.releaseYear !== null) {
+    strippedName = strippedName.replace(
+      new RegExp(`\\b${signals.releaseYear}\\s+release\\b`, "i"),
+      " ",
+    );
+  }
+
+  if (signals.vintageYear !== null) {
+    strippedName = strippedName.replace(
+      new RegExp(`\\b${signals.vintageYear}\\s+vintage\\b`, "i"),
+      " ",
+    );
+  }
+
+  return strippedName
+    .replace(/\s{2,}/g, " ")
+    .replace(/\s*[-,(]+\s*$/g, "")
+    .trim();
+}
+
+function buildParentCandidateSearchContext({
+  input,
+  extractedLabel,
+  normalizedName,
+}: {
+  input: BottleCandidateSearchInput;
+  extractedLabel: BottleReferenceIdentity | null;
+  normalizedName: string;
+}) {
+  const signals = getParentSearchSignals({
+    searchName: normalizedName,
+    extractedLabel,
+  });
+  const hasParentSearchSignal =
+    signals.edition !== null ||
+    signals.statedAge !== null ||
+    signals.releaseYear !== null ||
+    signals.vintageYear !== null;
+
+  if (!hasParentSearchSignal) {
+    return null;
+  }
+
+  const strippedQuery = stripReleaseIdentityFromSearchName(
+    normalizedName,
+    signals,
+  );
+  const strippedExpression = extractedLabel?.expression
+    ? stripReleaseIdentityFromSearchName(extractedLabel.expression, signals)
+    : null;
+  const parentInput: BottleCandidateSearchInput = {
+    ...input,
+    query: strippedQuery || input.query,
+    expression: strippedExpression || null,
+    stated_age: null,
+    abv: null,
+    cask_type: null,
+    cask_size: null,
+    cask_fill: null,
+    cask_strength: null,
+    single_cask: null,
+    edition: null,
+    vintage_year: null,
+    release_year: null,
+  };
+  const parentLabel = buildSearchLabel(parentInput);
+  const parentSearchName = buildRawSearchName(parentInput);
+
+  if (!parentSearchName) {
+    return null;
+  }
+
+  const parentNormalizedName = getNormalizedPriceName(parentSearchName);
+  if (parentNormalizedName.toLowerCase() === normalizedName.toLowerCase()) {
+    return null;
+  }
+
+  return {
+    exactSearchNames: buildExactSearchNames([
+      parentNormalizedName,
+      parentInput.query ? getNormalizedPriceName(parentInput.query) : null,
+    ]),
+    extractedLabel: parentLabel,
+    normalizedName: parentNormalizedName,
+    queryText: buildQueryText(parentNormalizedName, parentLabel),
+  };
 }
 
 function containsComparablePhrase(haystack: string, needle: string) {
@@ -1470,14 +1649,16 @@ export async function searchBottleCandidates(
 
   const extractedLabel = buildSearchLabel(input);
   const normalizedName = getNormalizedPriceName(searchName);
-  const exactSearchNames = Array.from(
-    new Set(
-      [normalizedName, input.query ? getNormalizedPriceName(input.query) : null]
-        .filter((value): value is string => Boolean(value))
-        .map((value) => value.toLowerCase()),
-    ),
-  );
+  const exactSearchNames = buildExactSearchNames([
+    normalizedName,
+    input.query ? getNormalizedPriceName(input.query) : null,
+  ]);
   const queryText = buildQueryText(normalizedName, extractedLabel);
+  const parentSearchContext = buildParentCandidateSearchContext({
+    input,
+    extractedLabel,
+    normalizedName,
+  });
   const candidates = new Map<string, BottleCandidate>();
 
   const [
@@ -1487,6 +1668,11 @@ export async function searchBottleCandidates(
     releaseTextCandidates,
     brandCandidates,
     exactCandidate,
+    parentVectorCandidates,
+    parentTextCandidates,
+    parentReleaseTextCandidates,
+    parentBrandCandidates,
+    parentExactCandidate,
   ] = await Promise.all([
     input.currentBottleId
       ? runCandidateLookupSafely(
@@ -1530,6 +1716,54 @@ export async function searchBottleCandidates(
       null as BottleCandidate | null,
       async () => await getExactBottleCandidateByNames(exactSearchNames),
     ),
+    parentSearchContext
+      ? runCandidateLookupSafely(
+          "parent_vector",
+          searchName,
+          [] as BottleCandidate[],
+          async () => await getVectorCandidates(parentSearchContext.queryText),
+        )
+      : Promise.resolve([] as BottleCandidate[]),
+    parentSearchContext
+      ? runCandidateLookupSafely(
+          "parent_text",
+          searchName,
+          [] as BottleCandidate[],
+          async () => await getTextCandidates(parentSearchContext.queryText),
+        )
+      : Promise.resolve([] as BottleCandidate[]),
+    parentSearchContext
+      ? runCandidateLookupSafely(
+          "parent_release_text",
+          searchName,
+          [] as BottleCandidate[],
+          async () =>
+            await getReleaseTextCandidates(parentSearchContext.queryText),
+        )
+      : Promise.resolve([] as BottleCandidate[]),
+    parentSearchContext
+      ? runCandidateLookupSafely(
+          "parent_brand",
+          searchName,
+          [] as BottleCandidate[],
+          async () =>
+            await getBrandCandidates(
+              parentSearchContext.normalizedName,
+              parentSearchContext.extractedLabel,
+            ),
+        )
+      : Promise.resolve([] as BottleCandidate[]),
+    parentSearchContext
+      ? runCandidateLookupSafely(
+          "parent_exact",
+          searchName,
+          null as BottleCandidate | null,
+          async () =>
+            await getExactBottleCandidateByNames(
+              parentSearchContext.exactSearchNames,
+            ),
+        )
+      : Promise.resolve(null as BottleCandidate | null),
   ]);
 
   if (currentCandidate) {
@@ -1549,6 +1783,21 @@ export async function searchBottleCandidates(
   }
   if (exactCandidate) {
     mergeBottleCandidate(candidates, exactCandidate);
+  }
+  for (const candidate of parentVectorCandidates) {
+    mergeBottleCandidate(candidates, candidate);
+  }
+  for (const candidate of parentTextCandidates) {
+    mergeBottleCandidate(candidates, candidate);
+  }
+  for (const candidate of parentReleaseTextCandidates) {
+    mergeBottleCandidate(candidates, candidate);
+  }
+  for (const candidate of parentBrandCandidates) {
+    mergeBottleCandidate(candidates, candidate);
+  }
+  if (parentExactCandidate) {
+    mergeBottleCandidate(candidates, parentExactCandidate);
   }
 
   const enrichedCandidates = await enrichBottleCandidates(

--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -197,9 +197,8 @@ describe("priceMatching", () => {
     fixtures,
   }) => {
     config.OPENAI_API_KEY = "test-openai-key";
-    const { getOpenAIEmbedding } = await import(
-      "@peated/server/lib/openaiEmbeddings"
-    );
+    const { getOpenAIEmbedding } =
+      await import("@peated/server/lib/openaiEmbeddings");
     vi.mocked(getOpenAIEmbedding).mockRejectedValue(
       new Error("Embeddings unavailable"),
     );
@@ -323,9 +322,8 @@ describe("priceMatching", () => {
   test("normalizes string bottle ids returned from raw candidate queries", async () => {
     config.OPENAI_API_KEY = "test-openai-key";
 
-    const { getOpenAIEmbedding } = await import(
-      "@peated/server/lib/openaiEmbeddings"
-    );
+    const { getOpenAIEmbedding } =
+      await import("@peated/server/lib/openaiEmbeddings");
     vi.mocked(getOpenAIEmbedding).mockResolvedValue([0.1, 0.2, 0.3]);
 
     const executeSpy = vi.spyOn(db, "execute") as any;
@@ -373,12 +371,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const bottle = await fixtures.Bottle();
     const price = await fixtures.StorePrice({
       bottleId: null,
@@ -455,12 +451,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const brand = await fixtures.Entity({
       name: "Wild Turkey",
       type: ["brand", "distiller"],
@@ -573,12 +567,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const brand = await fixtures.Entity({
       name: "Wild Turkey",
       type: ["brand", "distiller"],
@@ -698,12 +690,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const bottle = await fixtures.Bottle();
     const price = await fixtures.StorePrice({
       bottleId: null,
@@ -784,12 +774,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const candidateBottle = await fixtures.Bottle();
     const price = await fixtures.StorePrice({
       bottleId: null,
@@ -883,12 +871,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: null,
       name: "Local Only Create Candidate",
@@ -966,12 +952,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: null,
       name: "Normalized Draft Candidate",
@@ -1061,12 +1045,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: null,
       name: "Normalized Release Draft Candidate",
@@ -1179,12 +1161,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: null,
       name: "Spirit Category Candidate",
@@ -1308,12 +1288,10 @@ describe("priceMatching", () => {
   test("does not auto-create from empty web evidence", async ({ fixtures }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: null,
       name: "Empty Evidence Candidate",
@@ -1399,12 +1377,10 @@ describe("priceMatching", () => {
   test("auto ignores clearly non-whisky listings", async ({ fixtures }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: null,
       name: "Tito's Handmade Vodka",
@@ -1425,12 +1401,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: null,
       name: "Skrewball Peanut Butter Whiskey",
@@ -1503,12 +1477,10 @@ describe("priceMatching", () => {
       url: "https://smws.example/rw6-5-existing",
     });
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
 
     const proposal = await resolveStorePriceMatchProposal(price.id);
     const updatedPrice = await db.query.storePrices.findFirst({
@@ -1560,12 +1532,10 @@ describe("priceMatching", () => {
       url: "https://smws.example/rw6-5-new",
     });
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
 
     const proposal = await resolveStorePriceMatchProposal(price.id);
     const updatedPrice = await db.query.storePrices.findFirst({
@@ -1669,12 +1639,10 @@ describe("priceMatching", () => {
       })
       .returning();
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
 
     const proposal = await resolveStorePriceMatchProposal(price.id, {
       force: true,
@@ -1744,12 +1712,10 @@ describe("priceMatching", () => {
       url: "https://smws.example/rw6-5-name-invariant",
     });
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
 
     const proposal = await resolveStorePriceMatchProposal(price.id);
     const createdBottle = await db.query.bottles.findFirst({
@@ -1786,12 +1752,10 @@ describe("priceMatching", () => {
       mod: true,
     });
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: null,
       name: "Auto Create Candidate",
@@ -1910,12 +1874,10 @@ describe("priceMatching", () => {
       mod: true,
     });
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: null,
       name: "Retry Auto Create Candidate",
@@ -2054,12 +2016,10 @@ describe("priceMatching", () => {
     });
 
     const currentBottle = await fixtures.Bottle();
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: currentBottle.id,
       name: "Replacement Create Candidate",
@@ -2192,12 +2152,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference, BottleClassificationError } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference, BottleClassificationError } =
+      await import("@peated/server/agents/bottleClassifier");
     const bottle = await fixtures.Bottle();
     await fixtures.BottleAlias({
       bottleId: bottle.id,
@@ -2298,9 +2256,8 @@ describe("priceMatching", () => {
   test("includes structured bottle fields in candidate search text", async () => {
     config.OPENAI_API_KEY = "test-openai-key";
 
-    const { getOpenAIEmbedding } = await import(
-      "@peated/server/lib/openaiEmbeddings"
-    );
+    const { getOpenAIEmbedding } =
+      await import("@peated/server/lib/openaiEmbeddings");
     vi.mocked(getOpenAIEmbedding).mockResolvedValue([0.1, 0.2, 0.3]);
 
     const executeSpy = vi.spyOn(db, "execute") as any;
@@ -2524,6 +2481,133 @@ describe("priceMatching", () => {
     );
   });
 
+  test("adds a reusable parent candidate for age-statement listings", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    const brand = await fixtures.Entity({
+      name: "The Macallan",
+      type: ["brand"],
+    });
+    const cleanParent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Sherry Oak",
+      category: "single_malt",
+      statedAge: null,
+    });
+    const dirtyAgeBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Sherry Oak 30-year-old",
+      category: "single_malt",
+      statedAge: 30,
+    });
+    await fixtures.BottleAlias({
+      bottleId: dirtyAgeBottle.id,
+      name: "The Macallan Sherry Oak Single Malt Scotch 30-year-old",
+    });
+
+    const candidates = await findBottleMatchCandidates({
+      query: "The Macallan Sherry Oak Single Malt Scotch 30-year-old",
+      brand: brand.name,
+      bottler: null,
+      expression: "Sherry Oak",
+      series: null,
+      distillery: [],
+      category: "single_malt",
+      stated_age: 30,
+      abv: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+      vintage_year: null,
+      release_year: null,
+      currentBottleId: null,
+      limit: 15,
+    });
+
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          bottleId: dirtyAgeBottle.id,
+          source: expect.arrayContaining(["exact"]),
+        }),
+        expect.objectContaining({
+          bottleId: cleanParent.id,
+          releaseId: null,
+        }),
+      ]),
+    );
+  });
+
+  test("finds buggy batch aliases and still surfaces the reusable parent bottle", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    const brand = await fixtures.Entity({
+      name: "Penelope",
+      type: ["brand"],
+    });
+    const cleanParent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Bourbon Barrel Strength Straight Bourbon Whiskey",
+      category: "bourbon",
+      statedAge: null,
+      edition: null,
+    });
+    const legacyBatchBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Bourbon Barrel Strength Straight Bourbon Whiskey (Batch 11)",
+      category: "bourbon",
+      statedAge: null,
+      edition: "Batch 11",
+    });
+    await fixtures.BottleAlias({
+      bottleId: legacyBatchBottle.id,
+      name: "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey Batch 11",
+    });
+
+    const candidates = await findBottleMatchCandidates({
+      query:
+        "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey (Batch 11)",
+      brand: brand.name,
+      bottler: null,
+      expression: "Bourbon Barrel Strength Straight Bourbon Whiskey",
+      series: null,
+      distillery: [],
+      category: "bourbon",
+      stated_age: null,
+      abv: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: "Batch 11",
+      vintage_year: null,
+      release_year: null,
+      currentBottleId: null,
+      limit: 15,
+    });
+
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          bottleId: legacyBatchBottle.id,
+          source: expect.arrayContaining(["exact"]),
+        }),
+        expect.objectContaining({
+          bottleId: cleanParent.id,
+          releaseId: null,
+        }),
+      ]),
+    );
+  });
+
   test("does not treat edition substring collisions as matching evidence", async () => {
     config.OPENAI_API_KEY = undefined;
 
@@ -2652,9 +2736,8 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: null,
       name: "Presearch Candidate",
@@ -2700,9 +2783,8 @@ describe("priceMatching", () => {
       })
       .returning();
 
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
 
     const result = await resolveStorePriceMatchProposal(price.id);
 
@@ -2732,12 +2814,10 @@ describe("priceMatching", () => {
       reviewedAt: new Date("2026-03-10T13:00:00.000Z"),
     });
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
 
     vi.mocked(extractFromText).mockResolvedValue({
       brand: "Retry Brand",
@@ -2821,12 +2901,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       bottleId: null,
       name: "Draft Candidate",
@@ -2940,12 +3018,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const brand = await fixtures.Entity({
       name: "Canonical Brand",
       shortName: "Brand Short",
@@ -3099,12 +3175,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const bottle = await fixtures.Bottle();
     const price = await fixtures.StorePrice({
       name: "Unknown Suggested Candidate",
@@ -3187,12 +3261,10 @@ describe("priceMatching", () => {
   }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } = await import(
-      "@peated/server/agents/whisky/labelExtractor"
-    );
-    const { classifyBottleReference } = await import(
-      "@peated/server/agents/bottleClassifier"
-    );
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
       name: "Retry Lease Candidate",
       imageUrl: null,

--- a/packages/bottle-classifier/src/classifier.eval.fixtures.ts
+++ b/packages/bottle-classifier/src/classifier.eval.fixtures.ts
@@ -105,6 +105,26 @@ const glenglassaughRareCaskParent = buildBottleCandidate({
   source: ["exact"],
 });
 
+const macallanSherryOakParent = buildBottleCandidate({
+  bottleId: 54082,
+  fullName: "The Macallan Sherry Oak",
+  brand: "The Macallan",
+  category: "single_malt",
+  score: 0.9,
+  source: ["text"],
+});
+
+const macallanSherryOakLegacy30 = buildBottleCandidate({
+  bottleId: 54083,
+  alias: "The Macallan Sherry Oak Single Malt Scotch 30-year-old",
+  fullName: "The Macallan Sherry Oak 30-year-old",
+  brand: "The Macallan",
+  category: "single_malt",
+  statedAge: 30,
+  score: 1,
+  source: ["exact"],
+});
+
 const taleOfIceCream = buildBottleCandidate({
   bottleId: 43236,
   fullName: "Glenmorangie A Tale of Ice Cream",
@@ -124,6 +144,26 @@ const cadbollEstateParent = buildBottleCandidate({
   statedAge: 15,
   score: 0.91,
   source: ["text"],
+});
+
+const penelopeBarrelStrengthParent = buildBottleCandidate({
+  bottleId: 54068,
+  fullName: "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey",
+  brand: "Penelope",
+  category: "bourbon",
+  score: 0.89,
+  source: ["text"],
+});
+
+const penelopeLegacyBatch11 = buildBottleCandidate({
+  bottleId: 54069,
+  alias: "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey Batch 11",
+  fullName:
+    "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey (Batch 11)",
+  brand: "Penelope",
+  category: "bourbon",
+  score: 1,
+  source: ["exact"],
 });
 
 const cadbollEstateLegacyBatch4 = buildBottleCandidate({
@@ -500,6 +540,54 @@ export const EVAL_CASES: ClassifierEvalCase[] = [
       parentBottleId: 2457,
       summary:
         "Treat the differing 35-year age as release-specific because the matched parent bottle only carries a dirty structured age, not a marketed 40-year statement in its name.",
+    },
+  },
+  {
+    name: "store listing: redirects a dirty Macallan age statement to the reusable parent bottle",
+    input: {
+      reference: {
+        name: "The Macallan Sherry Oak Single Malt Scotch 30-year-old",
+        url: "https://shop.example/products/macallan-sherry-oak-30",
+      },
+      extractedIdentity: buildExtractedIdentity({
+        brand: "The Macallan",
+        expression: "Sherry Oak",
+        category: "single_malt",
+        stated_age: 30,
+      }),
+      initialCandidates: [macallanSherryOakLegacy30, macallanSherryOakParent],
+    },
+    expected: {
+      status: "classified",
+      action: "create_release",
+      identityScope: "product",
+      parentBottleId: 54082,
+      summary:
+        "Treat the local 30-year-old bottle row as a dirty release-like candidate and create a 30-year-old child release beneath the reusable Macallan Sherry Oak parent bottle instead.",
+    },
+  },
+  {
+    name: "store listing: redirects a Penelope batch bottle to the reusable parent bottle",
+    input: {
+      reference: {
+        name: "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey (Batch 11)",
+        url: "https://shop.example/products/penelope-batch-11",
+      },
+      extractedIdentity: buildExtractedIdentity({
+        brand: "Penelope",
+        expression: "Bourbon Barrel Strength Straight Bourbon Whiskey",
+        category: "bourbon",
+        edition: "Batch 11",
+      }),
+      initialCandidates: [penelopeLegacyBatch11, penelopeBarrelStrengthParent],
+    },
+    expected: {
+      status: "classified",
+      action: "create_release",
+      identityScope: "product",
+      parentBottleId: 54068,
+      summary:
+        "Treat the legacy Penelope Batch 11 bottle hit as release-like and create Batch 11 beneath the reusable Penelope Barrel Strength parent bottle instead.",
     },
   },
   {

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -156,6 +156,112 @@ const glenglassaughRareCaskParentCandidate: BottleCandidate = {
   source: ["exact"],
 };
 
+const macallanSherryOakParentCandidate: BottleCandidate = {
+  bottleId: 54082,
+  releaseId: null,
+  kind: "bottle",
+  alias: null,
+  fullName: "The Macallan Sherry Oak",
+  bottleFullName: "The Macallan Sherry Oak",
+  brand: "The Macallan",
+  bottler: null,
+  series: null,
+  distillery: [],
+  category: "single_malt",
+  statedAge: null,
+  edition: null,
+  caskStrength: null,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: null,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 0.9,
+  source: ["text"],
+};
+
+const macallanSherryOakLegacy30Candidate: BottleCandidate = {
+  bottleId: 54083,
+  releaseId: null,
+  kind: "bottle",
+  alias: "The Macallan Sherry Oak Single Malt Scotch 30-year-old",
+  fullName: "The Macallan Sherry Oak 30-year-old",
+  bottleFullName: "The Macallan Sherry Oak 30-year-old",
+  brand: "The Macallan",
+  bottler: null,
+  series: null,
+  distillery: [],
+  category: "single_malt",
+  statedAge: 30,
+  edition: null,
+  caskStrength: null,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: null,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 1,
+  source: ["exact"],
+};
+
+const penelopeBarrelStrengthParentCandidate: BottleCandidate = {
+  bottleId: 54068,
+  releaseId: null,
+  kind: "bottle",
+  alias: null,
+  fullName: "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey",
+  bottleFullName: "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey",
+  brand: "Penelope",
+  bottler: null,
+  series: null,
+  distillery: [],
+  category: "bourbon",
+  statedAge: null,
+  edition: null,
+  caskStrength: null,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: null,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 0.89,
+  source: ["text"],
+};
+
+const penelopeLegacyBatch11Candidate: BottleCandidate = {
+  bottleId: 54069,
+  releaseId: null,
+  kind: "bottle",
+  alias: "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey Batch 11",
+  fullName:
+    "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey (Batch 11)",
+  bottleFullName:
+    "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey (Batch 11)",
+  brand: "Penelope",
+  bottler: null,
+  series: null,
+  distillery: [],
+  category: "bourbon",
+  statedAge: null,
+  edition: null,
+  caskStrength: null,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: null,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 1,
+  source: ["exact"],
+};
+
 const taleOfIceCreamCandidate: BottleCandidate = {
   bottleId: 43236,
   releaseId: null,
@@ -907,6 +1013,86 @@ describe("createBottleClassifier", () => {
     });
   });
 
+  test("redirects a dirty Macallan age-statement bottle match to the reusable parent bottle", async () => {
+    const extractedIdentity: BottleExtractedDetails = {
+      brand: "The Macallan",
+      bottler: null,
+      expression: "Sherry Oak",
+      series: null,
+      distillery: [],
+      category: "single_malt",
+      stated_age: 30,
+      abv: null,
+      release_year: null,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    };
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "match",
+          confidence: 95,
+          rationale: "The title maps to the existing 30-year-old local bottle.",
+          identityScope: "product",
+          observation: null,
+          matchedBottleId: 54083,
+          matchedReleaseId: null,
+          parentBottleId: null,
+          candidateBottleIds: [54083, 54082],
+          proposedBottle: null,
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [],
+          candidates: [
+            macallanSherryOakLegacy30Candidate,
+            macallanSherryOakParentCandidate,
+          ],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: {
+        name: "The Macallan Sherry Oak Single Malt Scotch 30-year-old",
+      },
+      extractedIdentity,
+      initialCandidates: [
+        macallanSherryOakLegacy30Candidate,
+        macallanSherryOakParentCandidate,
+      ],
+    });
+
+    expect(result.status).toBe("classified");
+    if (result.status !== "classified") {
+      throw new Error("Expected a classified result");
+    }
+
+    expect(result.decision).toMatchObject({
+      action: "create_release",
+      parentBottleId: 54082,
+      identityScope: "product",
+      proposedRelease: {
+        edition: null,
+        statedAge: 30,
+      },
+    });
+    expect(result.decision.rationale).toContain(
+      "legacy release-like bottle candidate",
+    );
+  });
+
   test("promotes dirty-parent bottle-and-release creation into create_release instead of exact-cask bottle creation", async () => {
     const extractedIdentity: BottleExtractedDetails = {
       brand: "Glenglassaugh",
@@ -1393,6 +1579,86 @@ describe("createBottleClassifier", () => {
       identityScope: "product",
       proposedRelease: {
         edition: "Batch 4",
+      },
+    });
+    expect(result.decision.rationale).toContain(
+      "legacy release-like bottle candidate",
+    );
+  });
+
+  test("redirects a Penelope batch bottle match to the reusable parent bottle", async () => {
+    const extractedIdentity: BottleExtractedDetails = {
+      brand: "Penelope",
+      bottler: null,
+      expression: "Bourbon Barrel Strength Straight Bourbon Whiskey",
+      series: null,
+      distillery: [],
+      category: "bourbon",
+      stated_age: null,
+      abv: null,
+      release_year: null,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: "Batch 11",
+    };
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "match",
+          confidence: 96,
+          rationale:
+            "The title matches the existing local Batch 11 bottle candidate.",
+          identityScope: "product",
+          observation: null,
+          matchedBottleId: 54069,
+          matchedReleaseId: null,
+          parentBottleId: null,
+          candidateBottleIds: [54069, 54068],
+          proposedBottle: null,
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [],
+          candidates: [
+            penelopeLegacyBatch11Candidate,
+            penelopeBarrelStrengthParentCandidate,
+          ],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: {
+        name: "Penelope Bourbon Barrel Strength Straight Bourbon Whiskey (Batch 11)",
+      },
+      extractedIdentity,
+      initialCandidates: [
+        penelopeLegacyBatch11Candidate,
+        penelopeBarrelStrengthParentCandidate,
+      ],
+    });
+
+    expect(result.status).toBe("classified");
+    if (result.status !== "classified") {
+      throw new Error("Expected a classified result");
+    }
+
+    expect(result.decision).toMatchObject({
+      action: "create_release",
+      parentBottleId: 54068,
+      identityScope: "product",
+      proposedRelease: {
+        edition: "Batch 11",
       },
     });
     expect(result.decision.rationale).toContain(

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -585,6 +585,42 @@ function candidateNameMatchesReferenceVariants({
   });
 }
 
+function candidateNameMatchesReferenceVariantsIgnoringStatedAge({
+  referenceName,
+  extractedIdentity,
+  candidateNames,
+}: {
+  referenceName: string;
+  extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
+  candidateNames: string[];
+}): boolean {
+  if (
+    extractedIdentity?.stated_age === null ||
+    extractedIdentity?.stated_age === undefined
+  ) {
+    return false;
+  }
+
+  const strippedReferenceName = stripComparablePhrase(
+    normalizeComparableText(referenceName),
+    `${extractedIdentity.stated_age}-year-old`,
+  )
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!strippedReferenceName) {
+    return false;
+  }
+
+  return candidateNameMatchesReferenceVariants({
+    referenceName: strippedReferenceName,
+    extractedIdentity: {
+      ...extractedIdentity,
+      stated_age: null,
+    },
+    candidateNames,
+  });
+}
+
 function textHasLegacyReleaseLikeNameSignals(
   value: string | null | undefined,
 ): boolean {
@@ -615,6 +651,33 @@ function candidateLooksLikeLegacyReleaseBottle(
     textHasLegacyReleaseLikeNameSignals(candidate.alias) ||
     textHasLegacyReleaseLikeNameSignals(candidate.fullName) ||
     textHasLegacyReleaseLikeNameSignals(candidate.bottleFullName),
+  );
+}
+
+function candidateLooksLikeDirtyAgeReleaseBottle({
+  candidate,
+  extractedIdentity,
+}: {
+  candidate: BottleCandidate | null | undefined;
+  extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
+}): boolean {
+  if (
+    !candidate ||
+    candidate.kind === "release" ||
+    candidate.releaseId !== null ||
+    extractedIdentity?.stated_age === null ||
+    extractedIdentity?.stated_age === undefined ||
+    candidate.statedAge === null ||
+    candidate.statedAge === undefined ||
+    candidate.statedAge !== extractedIdentity.stated_age
+  ) {
+    return false;
+  }
+
+  return getBottleTargetNameCandidates(candidate).some((name) =>
+    new RegExp(`\\b${candidate.statedAge}-year-old\\b`, "i").test(
+      normalizeComparableText(name),
+    ),
   );
 }
 
@@ -907,7 +970,16 @@ function resolvePromotableParentBottleTarget({
     return null;
   }
 
-  if (!candidateLooksLikeLegacyReleaseBottle(target)) {
+  const looksLikeDirtyAgeReleaseBottle =
+    candidateLooksLikeDirtyAgeReleaseBottle({
+      candidate: target,
+      extractedIdentity: artifacts.extractedIdentity,
+    });
+
+  if (
+    !candidateLooksLikeLegacyReleaseBottle(target) &&
+    !looksLikeDirtyAgeReleaseBottle
+  ) {
     return target;
   }
 
@@ -927,12 +999,19 @@ function resolvePromotableParentBottleTarget({
           extractedLabel: artifacts.extractedIdentity,
         }).length === 0,
     )
-    .filter((candidate) =>
-      candidateNameMatchesReferenceVariants({
-        referenceName: reference.name,
-        extractedIdentity: artifacts.extractedIdentity,
-        candidateNames: getBottleTargetNameCandidates(candidate),
-      }),
+    .filter(
+      (candidate) =>
+        candidateNameMatchesReferenceVariants({
+          referenceName: reference.name,
+          extractedIdentity: artifacts.extractedIdentity,
+          candidateNames: getBottleTargetNameCandidates(candidate),
+        }) ||
+        (looksLikeDirtyAgeReleaseBottle &&
+          candidateNameMatchesReferenceVariantsIgnoringStatedAge({
+            referenceName: reference.name,
+            extractedIdentity: artifacts.extractedIdentity,
+            candidateNames: getBottleTargetNameCandidates(candidate),
+          })),
     )
     .sort((left, right) => (right.score ?? 0) - (left.score ?? 0));
 
@@ -1161,23 +1240,35 @@ function maybePromoteBottleMatchToCreateRelease({
     targetCandidate: parentTarget,
     extractedLabel: artifacts.extractedIdentity,
   });
-  const hasExactishLocalName = candidateNameMatchesReferenceVariants({
-    referenceName: reference.name,
-    extractedIdentity: artifacts.extractedIdentity,
-    candidateNames: getTargetNameCandidates(parentTarget, {
-      action: "match",
-      confidence: decision.confidence,
-      rationale: decision.rationale,
-      candidateBottleIds,
-      identityScope: decision.identityScope ?? "product",
-      observation,
-      matchedBottleId: parentTarget.bottleId,
-      matchedReleaseId: null,
-      parentBottleId: null,
-      proposedBottle: null,
-      proposedRelease: null,
-    }),
+  const parentTargetNameCandidates = getTargetNameCandidates(parentTarget, {
+    action: "match",
+    confidence: decision.confidence,
+    rationale: decision.rationale,
+    candidateBottleIds,
+    identityScope: decision.identityScope ?? "product",
+    observation,
+    matchedBottleId: parentTarget.bottleId,
+    matchedReleaseId: null,
+    parentBottleId: null,
+    proposedBottle: null,
+    proposedRelease: null,
   });
+  const hasExactishLocalName =
+    candidateNameMatchesReferenceVariants({
+      referenceName: reference.name,
+      extractedIdentity: artifacts.extractedIdentity,
+      candidateNames: parentTargetNameCandidates,
+    }) ||
+    (target &&
+      candidateLooksLikeDirtyAgeReleaseBottle({
+        candidate: target,
+        extractedIdentity: artifacts.extractedIdentity,
+      }) &&
+      candidateNameMatchesReferenceVariantsIgnoringStatedAge({
+        referenceName: reference.name,
+        extractedIdentity: artifacts.extractedIdentity,
+        candidateNames: parentTargetNameCandidates,
+      }));
   const hasSupportiveWebEvidence = hasSupportiveWebEvidenceForTarget({
     target: parentTarget,
     decision: {


### PR DESCRIPTION
Keep price queue matching aligned with release repairs for dirty release-like bottle rows.

The price queue was often surfacing only the dirty exact bottle hit, which meant the classifier did not see the reusable parent bottle that release repairs already rely on. This adds exact alias variants for batch names and a second parent-oriented candidate search pass with release identity stripped from the search text.

On the classifier side, dirty marketed-age bottle rows now participate in the same parent-promotion path, so cases like Macallan Sherry Oak 30-year-old and Penelope Batch 11 resolve to create_release beneath the reusable parent bottle instead of staying matched to the dirty standalone row.

I reran `pnpm --filter @peated/bottle-classifier test` and `pnpm --filter @peated/server test -- src/lib/priceMatching.test.ts` on the committed branch.