### PR TITLE
fix(release-repairs): Align dirty parent blocking

### DIFF
--- a/apps/server/src/lib/applyLegacyReleaseRepair.ts
+++ b/apps/server/src/lib/applyLegacyReleaseRepair.ts
@@ -506,6 +506,7 @@ async function resolveParentBottleForRepair(
 
   const parentMode = getLegacyReleaseRepairParentMode(parentRows, {
     proposedParentFullName,
+    release: releaseInput,
   });
 
   if (parentMode === "blocked_dirty_parent") {
@@ -566,6 +567,7 @@ async function resolveParentBottleForRepair(
 
   const parentBottle = resolveLegacyReleaseRepairParentMatch(parentRows, {
     proposedParentFullName,
+    release: releaseInput,
   }).parent;
 
   if (!parentBottle) {
@@ -1042,6 +1044,18 @@ export async function applyLegacyReleaseRepair({
       });
       const parentMode = getLegacyReleaseRepairParentMode(parentRows, {
         proposedParentFullName: repairIdentity.proposedParentFullName,
+        release: {
+          edition: repairIdentity.edition,
+          statedAge: legacyBottle.statedAge,
+          abv: legacyBottle.abv,
+          releaseYear: repairIdentity.releaseYear,
+          vintageYear: legacyBottle.vintageYear,
+          singleCask: legacyBottle.singleCask,
+          caskStrength: legacyBottle.caskStrength,
+          caskFill: legacyBottle.caskFill,
+          caskType: legacyBottle.caskType,
+          caskSize: legacyBottle.caskSize,
+        },
       });
 
       if (parentMode === "create_parent") {

--- a/apps/server/src/lib/legacyReleaseRepairCandidates.ts
+++ b/apps/server/src/lib/legacyReleaseRepairCandidates.ts
@@ -145,19 +145,45 @@ function getLegacyReleaseRepairModePriority(
   }
 }
 
-function getCandidateReleaseIdentity(candidate: LegacyReleaseRepairCandidate) {
+function getLegacyReleaseRepairCandidateReleaseIdentity({
+  legacyBottle,
+  releaseIdentity,
+}: {
+  legacyBottle: Pick<
+    LegacyReleaseRepairBottle,
+    | "abv"
+    | "caskFill"
+    | "caskSize"
+    | "caskStrength"
+    | "caskType"
+    | "singleCask"
+    | "statedAge"
+    | "vintageYear"
+  >;
+  releaseIdentity: Pick<
+    LegacyReleaseRepairCandidate["releaseIdentity"],
+    "edition" | "releaseYear"
+  >;
+}) {
   return {
-    edition: candidate.releaseIdentity.edition,
-    statedAge: candidate.legacyBottle.statedAge,
-    abv: candidate.legacyBottle.abv,
-    releaseYear: candidate.releaseIdentity.releaseYear,
-    vintageYear: candidate.legacyBottle.vintageYear,
-    singleCask: candidate.legacyBottle.singleCask,
-    caskStrength: candidate.legacyBottle.caskStrength,
-    caskFill: candidate.legacyBottle.caskFill,
-    caskType: candidate.legacyBottle.caskType,
-    caskSize: candidate.legacyBottle.caskSize,
+    edition: releaseIdentity.edition,
+    statedAge: legacyBottle.statedAge,
+    abv: legacyBottle.abv,
+    releaseYear: releaseIdentity.releaseYear,
+    vintageYear: legacyBottle.vintageYear,
+    singleCask: legacyBottle.singleCask,
+    caskStrength: legacyBottle.caskStrength,
+    caskFill: legacyBottle.caskFill,
+    caskType: legacyBottle.caskType,
+    caskSize: legacyBottle.caskSize,
   };
+}
+
+function getCandidateReleaseIdentity(candidate: LegacyReleaseRepairCandidate) {
+  return getLegacyReleaseRepairCandidateReleaseIdentity({
+    legacyBottle: candidate.legacyBottle,
+    releaseIdentity: candidate.releaseIdentity,
+  });
 }
 
 function sortLegacyReleaseRepairCandidates(
@@ -582,11 +608,19 @@ async function listHeuristicLegacyReleaseRepairCandidates(query = "") {
         ).values(),
       );
       const parentAlias = parentAliasByName.get(parentKey) ?? null;
+      const candidateRelease = getLegacyReleaseRepairCandidateReleaseIdentity({
+        legacyBottle: candidate.bottle,
+        releaseIdentity: {
+          edition: candidate.edition,
+          releaseYear: candidate.releaseYear,
+        },
+      });
       const parentMatch = resolveLegacyReleaseRepairParentMatch(
         parentRowsForCandidate,
         {
           currentLegacyBottleId: candidate.bottle.id,
           proposedParentFullName: candidate.proposedParentFullName,
+          release: candidateRelease,
         },
       );
       const parent = parentMatch.parent;
@@ -595,6 +629,7 @@ async function listHeuristicLegacyReleaseRepairCandidates(query = "") {
         {
           currentLegacyBottleId: candidate.bottle.id,
           proposedParentFullName: candidate.proposedParentFullName,
+          release: candidateRelease,
         },
       );
       const repairMode = getLegacyReleaseRepairParentMode(
@@ -603,6 +638,7 @@ async function listHeuristicLegacyReleaseRepairCandidates(query = "") {
           currentLegacyBottleId: candidate.bottle.id,
           parentAlias,
           proposedParentFullName: candidate.proposedParentFullName,
+          release: candidateRelease,
         },
       );
 

--- a/apps/server/src/lib/legacyReleaseRepairClassifier.ts
+++ b/apps/server/src/lib/legacyReleaseRepairClassifier.ts
@@ -133,6 +133,18 @@ export async function reviewLegacyCreateParentResolutionWithClassifier({
   const resolution = resolveLegacyCreateParentClassification({
     classification,
     parentRows,
+    release: {
+      edition: legacyBottle.edition,
+      statedAge: legacyBottle.statedAge,
+      abv: legacyBottle.abv,
+      releaseYear: legacyBottle.releaseYear,
+      vintageYear: legacyBottle.vintageYear,
+      singleCask: legacyBottle.singleCask,
+      caskStrength: legacyBottle.caskStrength,
+      caskFill: legacyBottle.caskFill,
+      caskType: legacyBottle.caskType,
+      caskSize: legacyBottle.caskSize,
+    },
   });
 
   if (resolution.resolution === "reuse_existing_parent") {

--- a/apps/server/src/lib/legacyReleaseRepairReviews.ts
+++ b/apps/server/src/lib/legacyReleaseRepairReviews.ts
@@ -235,6 +235,18 @@ export async function refreshLegacyReleaseRepairReview({
     currentLegacyBottleId: legacyBottle.id,
     parentAlias,
     proposedParentFullName: repairIdentity.proposedParentFullName,
+    release: {
+      edition: repairIdentity.edition,
+      statedAge: legacyBottle.statedAge,
+      abv: legacyBottle.abv,
+      releaseYear: repairIdentity.releaseYear,
+      vintageYear: legacyBottle.vintageYear,
+      singleCask: legacyBottle.singleCask,
+      caskStrength: legacyBottle.caskStrength,
+      caskFill: legacyBottle.caskFill,
+      caskType: legacyBottle.caskType,
+      caskSize: legacyBottle.caskSize,
+    },
   });
 
   if (heuristicRepairMode !== "create_parent") {

--- a/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
+++ b/apps/server/src/orpc/routes/bottles/apply-release-repair.test.ts
@@ -1534,4 +1534,34 @@ describe("POST /bottles/:bottle/apply-release-repair", () => {
       `[Error: Exact parent bottle still contains bottle-level release traits.]`,
     );
   });
+
+  test("rejects repair when the exact-name parent still carries non-marker release traits", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Kilkerran" });
+    const dirtyParent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Heavily Peated",
+      abv: 58.4,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Heavily Peated (Batch 10)",
+      abv: 58.4,
+    });
+    const mod = await fixtures.User({ mod: true });
+
+    const err = await waitError(
+      routerClient.bottles.applyReleaseRepair(
+        {
+          bottle: legacyBottle.id,
+        },
+        { context: { user: mod } },
+      ),
+    );
+
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Exact parent bottle still contains bottle-level release traits.]`,
+    );
+  });
 });

--- a/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
+++ b/apps/server/src/orpc/routes/bottles/release-repair-candidates.test.ts
@@ -929,6 +929,51 @@ describe("GET /bottles/release-repair-candidates", () => {
     });
   });
 
+  test("flags exact-name parents that still carry non-marker release traits as blocked", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Kilkerran" });
+    const dirtyParent = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Heavily Peated",
+      abv: 58.4,
+      totalTastings: 40,
+    });
+    const legacyBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Heavily Peated (Batch 10)",
+      abv: 58.4,
+      totalTastings: 10,
+    });
+    const user = await fixtures.User({ mod: true });
+
+    const result = await routerClient.bottles.releaseRepairCandidates(
+      {
+        query: "Heavily Peated",
+      },
+      { context: { user } },
+    );
+
+    expect(
+      result.results.find(
+        (candidate) => candidate.legacyBottle.id === legacyBottle.id,
+      ),
+    ).toMatchObject({
+      blockingParent: {
+        id: dirtyParent.id,
+        fullName: dirtyParent.fullName,
+        totalTastings: dirtyParent.totalTastings,
+      },
+      hasExactParent: false,
+      repairMode: "blocked_dirty_parent",
+      proposedParent: {
+        id: null,
+        fullName: dirtyParent.fullName,
+      },
+      siblingLegacyBottles: [],
+    });
+  });
+
   test("ignores formatting-only parent matches when release identity is only structured", async ({
     fixtures,
   }) => {

--- a/packages/bottle-classifier/src/legacyReleaseRepairIdentity.test.ts
+++ b/packages/bottle-classifier/src/legacyReleaseRepairIdentity.test.ts
@@ -123,6 +123,35 @@ describe("release-repair parent matching", () => {
     ).toBe("blocked_alias_conflict");
   });
 
+  test("blocks parents with non-marker release traits when the child repair would still conflict", () => {
+    const dirtyParent = buildParentCandidate({
+      id: 24,
+      fullName: "Kilkerran Heavily Peated",
+      abv: 58.4,
+      totalTastings: 18,
+    });
+
+    expect(
+      getLegacyReleaseRepairParentMode([dirtyParent], {
+        proposedParentFullName: "Kilkerran Heavily Peated",
+        release: {
+          edition: "Batch 10",
+          abv: 58.4,
+        },
+      }),
+    ).toBe("blocked_dirty_parent");
+
+    expect(
+      getLegacyReleaseRepairBlockingParent([dirtyParent], {
+        proposedParentFullName: "Kilkerran Heavily Peated",
+        release: {
+          edition: "Batch 10",
+          abv: 58.4,
+        },
+      }),
+    ).toEqual(dirtyParent);
+  });
+
   test("falls back to create-parent when no reusable or blocked parent exists", () => {
     expect(
       getLegacyReleaseRepairParentMode([], {
@@ -142,6 +171,10 @@ describe("release-repair parent matching", () => {
     expect(
       getLegacyReleaseRepairParentMode([stableParent], {
         proposedParentFullName: "Springbank 12 Cask Strength",
+        release: {
+          edition: "Batch 24",
+          caskStrength: true,
+        },
       }),
     ).toBe("existing_parent");
   });

--- a/packages/bottle-classifier/src/legacyReleaseRepairIdentity.ts
+++ b/packages/bottle-classifier/src/legacyReleaseRepairIdentity.ts
@@ -19,6 +19,10 @@ import {
   normalizeBottleBatchNumber,
   normalizeString,
 } from "./normalize";
+import {
+  hasBlockingBottleLevelReleaseTraits,
+  type ReleaseIdentityInput,
+} from "./releaseIdentity";
 
 export const LEGACY_RELEASE_BATCH_MARKER_PATTERN =
   "batch(?:\\s*(?:no\\.?|number|#))?\\s*(?:[a-z]*\\d[a-z0-9.-]*)";
@@ -95,6 +99,8 @@ export type LegacyReleaseRepairParentMode =
   | "blocked_dirty_parent";
 
 export type LegacyReleaseRepairParentMatchType = "exact" | "variant";
+
+type LegacyReleaseRepairCandidateRelease = Partial<ReleaseIdentityInput>;
 
 const LEGACY_RELEASE_DIRTY_PARENT_NAME_PATTERN = new RegExp(
   `\\b(?:${LEGACY_RELEASE_MARKER_PATTERN}|[0-9]{4}\\s+vintage)\\b`,
@@ -204,11 +210,11 @@ export function hasVariantLegacyReleaseRepairParentName(
 
 export function pickBestLegacyReleaseRepairParent<
   TRow extends LegacyReleaseRepairParentCandidate,
->(rows: TRow[]): null | TRow {
+>(rows: TRow[], release?: LegacyReleaseRepairCandidateRelease): null | TRow {
   let bestRow: null | TRow = null;
 
   for (const row of rows) {
-    if (hasDirtyLegacyReleaseRepairParent(row)) {
+    if (hasDirtyLegacyReleaseRepairParent(row, release)) {
       continue;
     }
 
@@ -226,11 +232,11 @@ export function pickBestLegacyReleaseRepairParent<
 
 function pickBestDirtyLegacyReleaseRepairParent<
   TRow extends LegacyReleaseRepairParentCandidate,
->(rows: TRow[]): null | TRow {
+>(rows: TRow[], release?: LegacyReleaseRepairCandidateRelease): null | TRow {
   let bestRow: null | TRow = null;
 
   for (const row of rows) {
-    if (!hasDirtyLegacyReleaseRepairParent(row)) {
+    if (!hasDirtyLegacyReleaseRepairParent(row, release)) {
       continue;
     }
 
@@ -253,9 +259,11 @@ export function resolveLegacyReleaseRepairParentMatch<
   {
     currentLegacyBottleId,
     proposedParentFullName,
+    release,
   }: {
     currentLegacyBottleId?: number;
     proposedParentFullName: string;
+    release?: LegacyReleaseRepairCandidateRelease;
   },
 ): {
   exactParent: null | TRow;
@@ -276,7 +284,7 @@ export function resolveLegacyReleaseRepairParentMatch<
   const exactRows = candidateRows.filter((row) =>
     hasExactLegacyReleaseRepairParentName(row.fullName, proposedParentFullName),
   );
-  const exactParent = pickBestLegacyReleaseRepairParent(exactRows);
+  const exactParent = pickBestLegacyReleaseRepairParent(exactRows, release);
 
   if (exactParent) {
     return {
@@ -295,7 +303,7 @@ export function resolveLegacyReleaseRepairParentMatch<
       proposedParentFullName,
     ),
   );
-  const variantParent = pickBestLegacyReleaseRepairParent(variantRows);
+  const variantParent = pickBestLegacyReleaseRepairParent(variantRows, release);
 
   return {
     exactParent: null,
@@ -315,6 +323,7 @@ export function getLegacyReleaseRepairParentMode<
     currentLegacyBottleId,
     parentAlias,
     proposedParentFullName,
+    release,
   }: {
     currentLegacyBottleId?: number;
     parentAlias?: {
@@ -322,11 +331,13 @@ export function getLegacyReleaseRepairParentMode<
       releaseId: number | null;
     } | null;
     proposedParentFullName: string;
+    release?: LegacyReleaseRepairCandidateRelease;
   },
 ): LegacyReleaseRepairParentMode {
   const parentMatch = resolveLegacyReleaseRepairParentMatch(rows, {
     currentLegacyBottleId,
     proposedParentFullName,
+    release,
   });
 
   if (parentMatch.exactParent) {
@@ -334,7 +345,9 @@ export function getLegacyReleaseRepairParentMode<
   }
 
   if (
-    parentMatch.exactRows.some((row) => hasDirtyLegacyReleaseRepairParent(row))
+    parentMatch.exactRows.some((row) =>
+      hasDirtyLegacyReleaseRepairParent(row, release),
+    )
   ) {
     return "blocked_dirty_parent";
   }
@@ -345,7 +358,7 @@ export function getLegacyReleaseRepairParentMode<
 
   if (
     parentMatch.variantRows.some((row) =>
-      hasDirtyLegacyReleaseRepairParent(row),
+      hasDirtyLegacyReleaseRepairParent(row, release),
     )
   ) {
     return "blocked_dirty_parent";
@@ -369,36 +382,71 @@ export function getLegacyReleaseRepairBlockingParent<
   {
     currentLegacyBottleId,
     proposedParentFullName,
+    release,
   }: {
     currentLegacyBottleId?: number;
     proposedParentFullName: string;
+    release?: LegacyReleaseRepairCandidateRelease;
   },
 ): null | TRow {
   const parentMatch = resolveLegacyReleaseRepairParentMatch(rows, {
     currentLegacyBottleId,
     proposedParentFullName,
+    release,
   });
 
   return (
-    pickBestDirtyLegacyReleaseRepairParent(parentMatch.exactRows) ??
-    pickBestDirtyLegacyReleaseRepairParent(parentMatch.variantRows)
+    pickBestDirtyLegacyReleaseRepairParent(parentMatch.exactRows, release) ??
+    pickBestDirtyLegacyReleaseRepairParent(parentMatch.variantRows, release)
   );
 }
 
 export function hasDirtyLegacyReleaseRepairParent(
   row: Pick<
     LegacyReleaseRepairParentCandidate,
-    "edition" | "fullName" | "releaseYear" | "vintageYear"
+    | "abv"
+    | "caskFill"
+    | "caskSize"
+    | "caskStrength"
+    | "caskType"
+    | "edition"
+    | "fullName"
+    | "releaseYear"
+    | "singleCask"
+    | "vintageYear"
   >,
+  release?: LegacyReleaseRepairCandidateRelease,
 ) {
-  return Boolean(
+  if (
     row.edition ||
     row.releaseYear ||
     row.vintageYear ||
-    LEGACY_RELEASE_DIRTY_PARENT_NAME_PATTERN.test(
-      normalizeString(row.fullName),
-    ),
-  );
+    LEGACY_RELEASE_DIRTY_PARENT_NAME_PATTERN.test(normalizeString(row.fullName))
+  ) {
+    return true;
+  }
+
+  if (!release) {
+    return false;
+  }
+
+  return hasBlockingBottleLevelReleaseTraits({
+    bottle: {
+      abv: row.abv,
+      caskFill: row.caskFill,
+      caskSize: row.caskSize,
+      caskStrength: row.caskStrength,
+      caskType: row.caskType,
+      edition: row.edition,
+      fullName: row.fullName,
+      name: row.fullName,
+      releaseYear: row.releaseYear,
+      singleCask: row.singleCask,
+      statedAge: null,
+      vintageYear: row.vintageYear,
+    },
+    release,
+  });
 }
 
 /**

--- a/packages/bottle-classifier/src/legacyReleaseRepairResolution.ts
+++ b/packages/bottle-classifier/src/legacyReleaseRepairResolution.ts
@@ -3,6 +3,7 @@ import {
   hasDirtyLegacyReleaseRepairParent,
   type LegacyReleaseRepairParentCandidate,
 } from "./legacyReleaseRepairIdentity";
+import type { ReleaseIdentityInput } from "./releaseIdentity";
 
 export type LegacyReleaseRepairClassifierBlockedReason =
   | "classifier_ignored"
@@ -33,9 +34,11 @@ export function resolveLegacyCreateParentClassification<
 >({
   classification,
   parentRows,
+  release,
 }: {
   classification: BottleClassificationResult;
   parentRows: TRow[];
+  release?: Partial<ReleaseIdentityInput>;
 }): LegacyReleaseRepairClassifierResolution<TRow> {
   if (classification.status === "ignored") {
     return {
@@ -68,7 +71,7 @@ export function resolveLegacyCreateParentClassification<
       };
     }
 
-    if (hasDirtyLegacyReleaseRepairParent(parentBottle)) {
+    if (hasDirtyLegacyReleaseRepairParent(parentBottle, release)) {
       return {
         resolution: "blocked",
         reason: "classifier_dirty_parent_candidate",


### PR DESCRIPTION
Align dirty parent blocking across release repair discovery and apply-time validation

The release repair queue only treated explicit edition and year markers as dirty-parent signals. That let moderators see a reusable parent candidate that still failed later when child release creation rejected other bottle-level release traits such as ABV or cask metadata.

I considered only tightening the queue, but that would still leave classifier review, stored review reuse, and apply-time repair validation out of sync. This change threads the candidate release identity through the shared legacy repair parent helpers so every path uses the same release-aware blocker.

The result is that these cases now surface as dirty-parent blockers instead of broken apply actions, with regression coverage for the shared helper and the server repair routes, including a non-marker ABV conflict case. Validated with `pnpm test`.