### PR TITLE
fix(web): Preserve tombstone redirect subpaths

### DIFF
--- a/apps/web/src/app/(default)/bottles/[bottleId]/layout.tsx
+++ b/apps/web/src/app/(default)/bottles/[bottleId]/layout.tsx
@@ -8,6 +8,7 @@ import SkeletonButton from "@peated/web/components/skeletonButton";
 import { summarize } from "@peated/web/lib/markdown";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
 import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
+import { getCanonicalRouteRedirectPath } from "@peated/web/lib/tombstoneRedirect";
 import { redirect } from "next/navigation";
 import { Suspense, type ReactNode } from "react";
 import type { Product, WithContext } from "schema-dts";
@@ -31,12 +32,13 @@ export default async function Layout({
 
   // tombstone path - redirect to the absolute url to ensure search engines dont get mad
   if (bottle.id !== bottleId) {
-    // const newPath = pathname.replace(
-    //   `/bottles/${bottleId}`,
-    //   `/bottles/${bottle.id}`,
-    // );
-    // TODO: this should redirect to subpath
-    return redirect(`/bottles/${bottle.id}/`);
+    return redirect(
+      getCanonicalRouteRedirectPath({
+        currentId: bottleId,
+        canonicalId: bottle.id,
+        collectionPath: "/bottles",
+      }),
+    );
   }
 
   const jsonLd: WithContext<Product> = {

--- a/apps/web/src/app/(default)/entities/[entityId]/layout.tsx
+++ b/apps/web/src/app/(default)/entities/[entityId]/layout.tsx
@@ -4,6 +4,7 @@ import ShareButton from "@peated/web/components/shareButton";
 import { summarize } from "@peated/web/lib/markdown";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
 import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
+import { getCanonicalRouteRedirectPath } from "@peated/web/lib/tombstoneRedirect";
 import { redirect } from "next/navigation";
 import { type ReactNode } from "react";
 import type { Organization, WithContext } from "schema-dts";
@@ -55,12 +56,13 @@ export default async function Layout({
 
   // tombstone path - redirect to the absolute url to ensure search engines dont get mad
   if (entity.id !== entityId) {
-    // const newPath = pathname.replace(
-    //   `/entities/${entityId}`,
-    //   `/entities/${entity.id}`,
-    // );
-    // TODO: this should redirect to subpath
-    return redirect(`/entities/${entity.id}/`);
+    return redirect(
+      getCanonicalRouteRedirectPath({
+        currentId: entityId,
+        canonicalId: entity.id,
+        collectionPath: "/entities",
+      }),
+    );
   }
 
   const jsonLd: WithContext<Organization> = {

--- a/apps/web/src/lib/tombstoneRedirect.ts
+++ b/apps/web/src/lib/tombstoneRedirect.ts
@@ -1,0 +1,46 @@
+import { headers } from "next/headers";
+
+type CanonicalRouteRedirectOptions = {
+  canonicalId: number | string;
+  collectionPath: `/${string}`;
+  currentId: number | string;
+};
+
+function getRequestedPathname() {
+  // Next forwards the rendered request path to app routes via x-invoke-path.
+  const pathname = headers().get("x-invoke-path") ?? headers().get("next-url");
+
+  if (!pathname) {
+    return null;
+  }
+
+  try {
+    return new URL(pathname, "http://n").pathname;
+  } catch {
+    return null;
+  }
+}
+
+export function getCanonicalRouteRedirectPath({
+  canonicalId,
+  collectionPath,
+  currentId,
+}: CanonicalRouteRedirectOptions) {
+  const currentPrefix = `${collectionPath}/${currentId}`;
+  const canonicalPrefix = `${collectionPath}/${canonicalId}`;
+  const requestedPathname = getRequestedPathname();
+
+  if (!requestedPathname) {
+    return `${canonicalPrefix}/`;
+  }
+
+  const suffix = requestedPathname.slice(currentPrefix.length);
+  if (
+    !requestedPathname.startsWith(currentPrefix) ||
+    (suffix && !suffix.startsWith("/"))
+  ) {
+    return `${canonicalPrefix}/`;
+  }
+
+  return `${canonicalPrefix}${suffix || "/"}`;
+}


### PR DESCRIPTION
Preserve the requested subpath when a bottle or entity tombstone resolves to a new canonical id instead of always redirecting to the overview page.

That keeps moved URLs like /bottles/:id/bottlings working, which is the broken case behind this change.

This rewrites only the canonical id segment from the current app-router pathname and centralizes the redirect logic in a shared helper so the bottle and entity layouts stay in sync.

Validated with pnpm test.