### PR TITLE
feat(web): Add single cask visual markers

### DIFF
--- a/apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/releases/releaseTable.tsx
+++ b/apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/releases/releaseTable.tsx
@@ -7,6 +7,7 @@ import CollectionAction from "@peated/web/components/collectionAction";
 import EmptyActivity from "@peated/web/components/emptyActivity";
 import Link from "@peated/web/components/link";
 import PaginationButtons from "@peated/web/components/paginationButtons";
+import SingleCaskChip from "@peated/web/components/singleCaskChip";
 import Table from "@peated/web/components/table";
 import {
   formatBottlingName,
@@ -67,12 +68,15 @@ function ReleaseTableSection({
           sort: "edition",
           sortDefaultOrder: "asc",
           value: (item) => (
-            <Link
-              className="hover:underline"
-              href={getBottleBottlingPath(bottleId, item.id)}
-            >
-              {formatBottlingName(item)}
-            </Link>
+            <div className="flex flex-wrap items-center gap-2">
+              <Link
+                className="hover:underline"
+                href={getBottleBottlingPath(bottleId, item.id)}
+              >
+                {formatBottlingName(item)}
+              </Link>
+              {item.singleCask && <SingleCaskChip />}
+            </div>
           ),
         },
         {

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/bottlings/[bottlingId]/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/bottlings/[bottlingId]/page.tsx
@@ -6,6 +6,7 @@ import Heading from "@peated/web/components/heading";
 import Link from "@peated/web/components/link";
 import Markdown from "@peated/web/components/markdown";
 import PageHeader from "@peated/web/components/pageHeader";
+import SingleCaskChip from "@peated/web/components/singleCaskChip";
 import {
   formatBottlingName,
   getBottleBottlingsPath,
@@ -70,9 +71,14 @@ export default async function Page({
     <div className="w-full p-3 lg:py-0">
       <PageHeader
         icon={BottleIcon}
-        title={formatBottlingName(bottling) || bottling.fullName}
+        title={
+          <div className="flex flex-wrap items-center justify-center gap-2 lg:justify-start">
+            <span>{formatBottlingName(bottling) || bottling.fullName}</span>
+            {bottling.singleCask && <SingleCaskChip />}
+          </div>
+        }
         titleExtra={
-          <div className="text-muted flex items-center gap-x-2 truncate">
+          <div className="text-muted flex flex-wrap items-center gap-x-2 gap-y-1">
             <span>Bottling of</span>
             <Link href={`/bottles/${bottle.id}`} className="hover:underline">
               {bottle.fullName}

--- a/apps/web/src/components/bottleCard.tsx
+++ b/apps/web/src/components/bottleCard.tsx
@@ -11,6 +11,7 @@ import classNames from "../lib/classNames";
 import BottleLink from "./bottleLink";
 import Join from "./join";
 import type { Option } from "./selectField";
+import SingleCaskChip from "./singleCaskChip";
 
 type EntityOption = Option & {
   shortName?: string;
@@ -147,10 +148,18 @@ export default function BottleCard({
             {bottle.hasTasted && (
               <CheckBadgeIcon className="inline w-4" aria-hidden="true" />
             )}
+            {!release && bottle.singleCask && <SingleCaskChip />}
           </div>
         </div>
       }
-      release={release ? <div>{formatBottlingName(release)}</div> : null}
+      release={
+        release ? (
+          <div className="flex flex-wrap items-center gap-2">
+            <span>{formatBottlingName(release)}</span>
+            {release.singleCask && <SingleCaskChip />}
+          </div>
+        ) : null
+      }
       category={
         <div>
           {bottle.category && (

--- a/apps/web/src/components/bottleHeader.tsx
+++ b/apps/web/src/components/bottleHeader.tsx
@@ -4,6 +4,7 @@ import BottleIcon from "@peated/web/assets/bottle.svg";
 import Link from "@peated/web/components/link";
 import BottleMetadata from "./bottleMetadata";
 import PageHeader from "./pageHeader";
+import SingleCaskChip from "./singleCaskChip";
 
 export default function BottleHeader({
   bottle,
@@ -16,13 +17,13 @@ export default function BottleHeader({
     <PageHeader
       icon={BottleIcon}
       title={
-        <div className="flex gap-x-2">
+        <div className="flex flex-wrap items-center gap-2">
           {href ? (
             <Link href={href} className="hover:underline">
               {bottle.fullName}
             </Link>
           ) : (
-            <div className="flex gap-x-2">
+            <div className="flex flex-wrap items-center gap-2">
               <Link
                 href={`/entities/${bottle.brand.id}`}
                 className="hover:underline"
@@ -32,6 +33,7 @@ export default function BottleHeader({
               {bottle.name}
             </div>
           )}
+          {bottle.singleCask && <SingleCaskChip />}
         </div>
       }
       titleExtra={

--- a/apps/web/src/components/bottleTable.tsx
+++ b/apps/web/src/components/bottleTable.tsx
@@ -13,6 +13,7 @@ import type { ComponentProps } from "react";
 import { formatBottlingName } from "../lib/bottlings";
 import BottleLink from "./bottleLink";
 import SimpleRatingIndicator from "./simpleRatingIndicator";
+import SingleCaskChip from "./singleCaskChip";
 import Table from "./table";
 
 type BottleRow = {
@@ -68,11 +69,17 @@ export default function BottleTable({
                   {item.bottle.hasTasted && (
                     <CheckBadgeIcon className="h-4 w-4" aria-hidden="true" />
                   )}
+                  {!item.release && item.bottle.singleCask && (
+                    <SingleCaskChip />
+                  )}
                 </div>
                 <div className="text-muted flex flex-col gap-y-1 text-sm">
                   {item.release && (
-                    <div>
-                      Specific Bottling: {formatBottlingName(item.release)}
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span>
+                        Specific Bottling: {formatBottlingName(item.release)}
+                      </span>
+                      {item.release.singleCask && <SingleCaskChip />}
                     </div>
                   )}
                   {item.bottle.category && (

--- a/apps/web/src/components/singleCaskChip.tsx
+++ b/apps/web/src/components/singleCaskChip.tsx
@@ -1,0 +1,17 @@
+import classNames from "@peated/web/lib/classNames";
+import type { ComponentPropsWithoutRef } from "react";
+import Chip from "./chip";
+
+export default function SingleCaskChip({
+  className,
+}: Pick<ComponentPropsWithoutRef<"span">, "className">) {
+  return (
+    <Chip
+      as="span"
+      size="small"
+      className={classNames("shrink-0 align-middle", className)}
+    >
+      Single Cask
+    </Chip>
+  );
+}


### PR DESCRIPTION
Add subtle `Single Cask` markers across the bottle and bottling identity surfaces.

Single-cask status is meaningful when scanning releases and selected bottlings, but today it mostly lives in detail fields. This surfaces it in the places users already compare identity: release rows, bottle tables/cards, and the bottle and bottling headers.

The marker stays intentionally muted and is only driven by the structured `singleCask` fields on bottles and releases. That keeps it aligned with the current design language and avoids implying rarity, premium status, or exact-cask identity.

Validated locally with `pnpm --filter @peated/web typecheck` and `pnpm test`.