### PR TITLE
fix(web): Add compact variant for single cask chips

### DIFF
--- a/apps/web/src/components/chip.tsx
+++ b/apps/web/src/components/chip.tsx
@@ -5,9 +5,9 @@ import { motion } from "framer-motion";
 import type { ElementType, MouseEventHandler } from "react";
 import classNames from "../lib/classNames";
 
-type ChipSize = "small" | "base";
+type ChipSize = "compact" | "small" | "base";
 
-type ChipColor = "default" | "highlight";
+type ChipColor = "default" | "highlight" | "accent";
 
 type Props = {
   active?: boolean;
@@ -24,6 +24,7 @@ export default function Chip<E extends ElementType = typeof defaultElement>({
   size = "base",
   color = "default",
   as,
+  className,
   ...props
 }: PolymorphicProps<E, Props>) {
   const Component = as ?? defaultElement;
@@ -34,6 +35,10 @@ export default function Chip<E extends ElementType = typeof defaultElement>({
 
   let colorClass = "";
   switch (color) {
+    case "accent":
+      colorClass =
+        "border-amber-800/60 bg-amber-950/40 text-amber-200 hover:bg-amber-950/60";
+      break;
     case "highlight":
       colorClass = "border-highlight text-black bg-highlight";
       break;
@@ -52,9 +57,12 @@ export default function Chip<E extends ElementType = typeof defaultElement>({
         active
           ? "border-slate-700 bg-slate-700 text-white hover:bg-slate-700"
           : colorClass,
-        size === "small"
-          ? "min-h-[24px] px-[6px] text-sm"
-          : "min-h-[32px] px-[12px]",
+        size === "compact"
+          ? "min-h-[18px] px-1.5 py-0.5 text-[11px] leading-none"
+          : size === "small"
+            ? "min-h-[24px] px-[6px] text-sm"
+            : "min-h-[32px] px-[12px]",
+        className,
       )}
       onClick={onClick || defaultOnClick}
       {...props}

--- a/apps/web/src/components/singleCaskChip.tsx
+++ b/apps/web/src/components/singleCaskChip.tsx
@@ -8,10 +8,16 @@ export default function SingleCaskChip({
   return (
     <Chip
       as="span"
-      size="small"
-      className={classNames("shrink-0 align-middle", className)}
+      size="compact"
+      color="accent"
+      className={classNames(
+        "shrink-0 !justify-start gap-1 rounded-full font-medium",
+        className,
+      )}
+      title="Single cask"
     >
-      Single Cask
+      <span className="h-1.5 w-1.5 rounded-full bg-amber-300/90" />
+      <span>Single Cask</span>
     </Chip>
   );
 }


### PR DESCRIPTION
Add a compact accent variant to `Chip` and use it for the single-cask marker.

The first pass at the marker leaned on ad hoc overrides and exposed a real bug in `Chip`: passing `className` from a caller could wipe out the component's base styles. That is why the marker rendered mostly unstyled in places like the bottle table.

This follow-up fixes class merging in `Chip`, adds reusable `compact` and `accent` variants, and moves `SingleCaskChip` onto that shared API instead of hand-rolling its appearance.

Follow-up to #355.

Validated locally with `pnpm --filter @peated/web typecheck` and `pnpm test`.