### PR TITLE
style(web): Simplify single cask badge

### DIFF
--- a/apps/web/src/components/singleCaskChip.tsx
+++ b/apps/web/src/components/singleCaskChip.tsx
@@ -1,23 +1,19 @@
 import classNames from "@peated/web/lib/classNames";
 import type { ComponentPropsWithoutRef } from "react";
-import Chip from "./chip";
 
 export default function SingleCaskChip({
   className,
 }: Pick<ComponentPropsWithoutRef<"span">, "className">) {
   return (
-    <Chip
-      as="span"
-      size="compact"
-      color="accent"
+    <span
       className={classNames(
-        "shrink-0 !justify-start gap-1 rounded-full font-medium",
+        "inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full border border-amber-800/60 bg-amber-950/40 text-[10px] font-semibold uppercase leading-none text-amber-200",
         className,
       )}
       title="Single cask"
     >
-      <span className="h-1.5 w-1.5 rounded-full bg-amber-300/90" />
-      <span>Single Cask</span>
-    </Chip>
+      <span aria-hidden="true">S</span>
+      <span className="sr-only">Single cask</span>
+    </span>
   );
 }


### PR DESCRIPTION
Simplify the single cask marker in bottle lists and headers.

The existing chip used a full text pill with a leading dot, which made the single-cask state heavier than the adjacent favorite and tasted icons. This switches the marker to a compact amber monogram so it reads like a peer status affordance while keeping the full label available via hover text and screen-reader text.

I considered using `SC`, but the single-letter treatment stays legible at the current 16px size without widening layouts. Opening this as a draft for a quick visual sanity check across the bottle surfaces that render the marker.