### PR TITLE
fix(classifier): Recover web evidence and exact matches

### DIFF
--- a/apps/server/src/agents/bottleClassifier/tools/openaiWebSearch.ts
+++ b/apps/server/src/agents/bottleClassifier/tools/openaiWebSearch.ts
@@ -1,6 +1,10 @@
 import { tool } from "@openai/agents";
 import config from "@peated/server/config";
 import type OpenAI from "openai";
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseIncludable,
+} from "openai/resources/responses/responses";
 import type { BottleSearchEvidence } from "../schemas";
 import { runBraveWebSearch } from "./braveWebSearch";
 import {
@@ -15,6 +19,10 @@ import {
   type BottleWebSearchBudget,
 } from "./sharedWebSearch";
 
+const OPENAI_WEB_SEARCH_RESPONSE_INCLUDES: ResponseIncludable[] = [
+  "web_search_call.action.sources",
+];
+
 function getDeterministicOpenAISettings(model: string): {
   temperature?: number;
 } {
@@ -25,29 +33,118 @@ export function extractOpenAISearchEvidence(
   query: string,
   response: any,
 ): BottleSearchEvidence {
-  const summary = response.output_text?.trim().slice(0, 600) || null;
-  const seen = new Set<string>();
-  const results: BottleSearchEvidence["results"] = [];
+  const outputItems: any[] = Array.isArray(response?.output)
+    ? response.output
+    : [];
+  const messageTexts = outputItems
+    .filter((item: any): item is { content?: unknown[]; type: "message" } => {
+      return item?.type === "message";
+    })
+    .flatMap((item: { content?: unknown[] }) =>
+      Array.isArray(item.content)
+        ? item.content
+            .filter(
+              (
+                content: any,
+              ): content is { text?: string; type: "output_text" } =>
+                content?.type === "output_text",
+            )
+            .map((content: { text?: string }) => content.text?.trim())
+            .filter((value: string | undefined): value is string =>
+              Boolean(value),
+            )
+        : [],
+    );
+  const summary =
+    response.output_text?.trim().slice(0, 600) ||
+    messageTexts.join(" ").trim().slice(0, 600) ||
+    null;
+  const resultsByUrl = new Map<
+    string,
+    BottleSearchEvidence["results"][number]
+  >();
 
-  for (const item of response.output) {
-    if (item.type !== "message") continue;
+  const mergeResult = ({
+    title,
+    url,
+  }: {
+    title?: string | null;
+    url: string | null | undefined;
+  }) => {
+    if (!url) {
+      return;
+    }
 
-    for (const content of item.content) {
-      if (content.type !== "output_text") continue;
+    const normalizedTitle = title?.trim() || url;
+    const existing = resultsByUrl.get(url);
+    if (!existing) {
+      resultsByUrl.set(url, {
+        title: normalizedTitle,
+        url,
+        domain: getResultDomain(url),
+        description: summary,
+        extraSnippets: [],
+      });
+      return;
+    }
 
-      for (const annotation of content.annotations || []) {
-        if (annotation.type !== "url_citation") continue;
-        if (seen.has(annotation.url)) continue;
-        seen.add(annotation.url);
+    if (existing.title === existing.url && normalizedTitle !== url) {
+      existing.title = normalizedTitle;
+    }
 
-        results.push({
-          title: annotation.title || annotation.url,
-          url: annotation.url,
-          domain: getResultDomain(annotation.url),
-          description: summary,
-          extraSnippets: [],
+    existing.description ??= summary;
+  };
+
+  for (const item of outputItems) {
+    if (item?.type === "message") {
+      for (const content of Array.isArray(item.content) ? item.content : []) {
+        if (content?.type !== "output_text") {
+          continue;
+        }
+
+        for (const annotation of Array.isArray(content.annotations)
+          ? content.annotations
+          : []) {
+          if (annotation?.type !== "url_citation") {
+            continue;
+          }
+
+          mergeResult({
+            title: annotation.title,
+            url: annotation.url,
+          });
+        }
+      }
+      continue;
+    }
+
+    if (item?.type !== "web_search_call") {
+      continue;
+    }
+
+    if (item.action?.type === "search") {
+      for (const source of Array.isArray(item.action.sources)
+        ? item.action.sources
+        : []) {
+        if (source?.type !== "url") {
+          continue;
+        }
+
+        mergeResult({
+          url: source.url,
         });
       }
+      continue;
+    }
+
+    if (
+      (item.action?.type === "open_page" ||
+        item.action?.type === "find_in_page") &&
+      typeof item.action.url === "string"
+    ) {
+      mergeResult({
+        url: item.action.url,
+      });
     }
   }
 
@@ -55,7 +152,7 @@ export function extractOpenAISearchEvidence(
     provider: "openai",
     query,
     summary,
-    results,
+    results: Array.from(resultsByUrl.values()),
   });
 }
 
@@ -178,20 +275,19 @@ export function createOpenAIWebSearchTool({
   });
 }
 
-async function runOpenAIWebSearch({
-  client,
+export function buildOpenAIWebSearchRequest({
   query,
   instructions,
   extraContext = null,
 }: {
-  client: OpenAI;
   query: string;
   instructions: string;
   extraContext?: string | null;
-}): Promise<BottleSearchEvidence> {
-  const response = await client.responses.create({
+}): ResponseCreateParamsNonStreaming {
+  return {
     model: config.OPENAI_MODEL,
     instructions,
+    include: OPENAI_WEB_SEARCH_RESPONSE_INCLUDES,
     input: [
       {
         role: "user",
@@ -205,7 +301,27 @@ async function runOpenAIWebSearch({
     ],
     tools: [{ type: "web_search" }],
     ...getDeterministicOpenAISettings(config.OPENAI_MODEL),
-  });
+  };
+}
+
+async function runOpenAIWebSearch({
+  client,
+  query,
+  instructions,
+  extraContext = null,
+}: {
+  client: OpenAI;
+  query: string;
+  instructions: string;
+  extraContext?: string | null;
+}): Promise<BottleSearchEvidence> {
+  const response = await client.responses.create(
+    buildOpenAIWebSearchRequest({
+      query,
+      instructions,
+      extraContext,
+    }),
+  );
 
   return extractOpenAISearchEvidence(query, response);
 }

--- a/apps/server/src/agents/bottleClassifier/tools/webSearch.test.ts
+++ b/apps/server/src/agents/bottleClassifier/tools/webSearch.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 import { extractBraveSearchEvidence } from "./braveWebSearch";
-import { extractOpenAISearchEvidence } from "./openaiWebSearch";
+import {
+  buildOpenAIWebSearchRequest,
+  extractOpenAISearchEvidence,
+} from "./openaiWebSearch";
 import {
   createBottleWebSearchBudget,
   isThinBottleSearchEvidence,
@@ -51,6 +54,105 @@ describe("bottleClassifier web search tools", () => {
         }),
       ],
     });
+  });
+
+  test("extracts OpenAI search evidence from web search call sources when citations are missing", () => {
+    const evidence = extractOpenAISearchEvidence(
+      "lagavulin distillers edition 2023",
+      {
+        output: [
+          {
+            type: "web_search_call",
+            action: {
+              type: "search",
+              query: "lagavulin distillers edition 2023",
+              sources: [
+                {
+                  type: "url",
+                  url: "https://www.malts.com/en-row/products/lagavulin-distillers-edition-single-malt-scotch-whisky",
+                },
+                {
+                  type: "url",
+                  url: "https://www.whiskyadvocate.com/ratings-reviews/lagavulin-distillers-edition-2023/",
+                },
+              ],
+            },
+          },
+          {
+            type: "message",
+            content: [
+              {
+                type: "output_text",
+                text: "OpenAI searched the web and found official plus independent references.",
+                annotations: [],
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(evidence).toMatchObject({
+      provider: "openai",
+      query: "lagavulin distillers edition 2023",
+      summary:
+        "OpenAI searched the web and found official plus independent references.",
+    });
+    expect(evidence.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          domain: "malts.com",
+          url: "https://www.malts.com/en-row/products/lagavulin-distillers-edition-single-malt-scotch-whisky",
+        }),
+        expect.objectContaining({
+          domain: "whiskyadvocate.com",
+          url: "https://www.whiskyadvocate.com/ratings-reviews/lagavulin-distillers-edition-2023/",
+        }),
+      ]),
+    );
+  });
+
+  test("prefers citation titles while deduping against OpenAI web search call sources", () => {
+    const evidence = extractOpenAISearchEvidence("wild turkey rare breed rye", {
+      output_text: "Wild Turkey confirms Rare Breed Rye is barrel proof.",
+      output: [
+        {
+          type: "web_search_call",
+          action: {
+            type: "search",
+            query: "wild turkey rare breed rye",
+            sources: [
+              {
+                type: "url",
+                url: "https://www.wildturkeybourbon.com/products/rare-breed-rye/",
+              },
+            ],
+          },
+        },
+        {
+          type: "message",
+          content: [
+            {
+              type: "output_text",
+              annotations: [
+                {
+                  type: "url_citation",
+                  url: "https://www.wildturkeybourbon.com/products/rare-breed-rye/",
+                  title: "Rare Breed Rye",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(evidence.results).toEqual([
+      expect.objectContaining({
+        title: "Rare Breed Rye",
+        domain: "wildturkeybourbon.com",
+      }),
+    ]);
   });
 
   test("extracts provider-aware evidence from Brave web results", () => {
@@ -164,5 +266,18 @@ describe("bottleClassifier web search tools", () => {
     expect(mergedEvidence.summary).toContain("Four Roses confirms OBSO");
     expect(mergedEvidence.summary).toContain("Breaking Bourbon reviews");
     expect(isThinBottleSearchEvidence(mergedEvidence)).toBe(false);
+  });
+
+  test("requests OpenAI web search sources in the response payload", () => {
+    const request = buildOpenAIWebSearchRequest({
+      query: "lagavulin distillers edition 2023",
+      instructions: "Search the web.",
+    });
+
+    expect(request).toEqual(
+      expect.objectContaining({
+        include: ["web_search_call.action.sources"],
+      }),
+    );
   });
 });

--- a/apps/server/src/lib/bottleReferenceCandidates.ts
+++ b/apps/server/src/lib/bottleReferenceCandidates.ts
@@ -449,7 +449,11 @@ function normalizeIdentityText(value: string | null | undefined) {
 }
 
 function normalizeComparableText(value: string | null | undefined) {
-  return normalizeIdentityText(value).replace(/_/g, " ");
+  return normalizeIdentityText(value)
+    .replace(/'/g, "")
+    .replace(/_/g, " ")
+    .replace(/\s{2,}/g, " ")
+    .trim();
 }
 
 function escapeRegExp(value: string) {
@@ -945,12 +949,28 @@ function getPreferredReleaseMetadata(
   releases: CandidateReleaseMetadataRow[],
   extractedLabel: BottleReferenceIdentity | null,
 ) {
+  const preferredReleaseMatch = getPreferredReleaseMatch(
+    releases,
+    extractedLabel,
+  );
+  return preferredReleaseMatch?.release ?? null;
+}
+
+function getPreferredReleaseMatch(
+  releases: CandidateReleaseMetadataRow[],
+  extractedLabel: BottleReferenceIdentity | null,
+) {
   if (!releases.length) {
     return null;
   }
 
   if (!hasReleaseSpecificIdentity(extractedLabel)) {
-    return releases.length === 1 ? releases[0] : null;
+    return releases.length === 1
+      ? {
+          release: releases[0]!,
+          score: 0,
+        }
+      : null;
   }
 
   const sortedReleases = [...releases]
@@ -964,8 +984,18 @@ function getPreferredReleaseMetadata(
     return null;
   }
 
-  if (sortedReleases[0]!.score > 0 || releases.length === 1) {
-    return sortedReleases[0]!.release;
+  const bestMatch = sortedReleases[0]!;
+  const nextBestMatch = sortedReleases[1];
+
+  if (releases.length === 1) {
+    return bestMatch;
+  }
+
+  if (
+    bestMatch.score > 0 &&
+    (!nextBestMatch || nextBestMatch.score < bestMatch.score)
+  ) {
+    return bestMatch;
   }
 
   return null;
@@ -1061,19 +1091,28 @@ async function enrichBottleCandidates(
     releaseMetadataById.set(row.releaseId, row);
   }
 
+  const enrichedCandidates = new Map<string, BottleCandidate>();
+
   for (const candidate of candidates) {
     const bottleMetadata = bottleMetadataById.get(candidate.bottleId);
     if (!bottleMetadata) {
+      mergeBottleCandidate(enrichedCandidates, candidate);
       continue;
     }
 
-    const preferredRelease =
+    const preferredReleaseMatch =
       candidate.releaseId != null
-        ? (releaseMetadataById.get(candidate.releaseId) ?? null)
-        : getPreferredReleaseMetadata(
+        ? releaseMetadataById.get(candidate.releaseId)
+          ? {
+              release: releaseMetadataById.get(candidate.releaseId)!,
+              score: Number.POSITIVE_INFINITY,
+            }
+          : null
+        : getPreferredReleaseMatch(
             releasesByBottleId.get(candidate.bottleId) ?? [],
             extractedLabel,
           );
+    const preferredRelease = preferredReleaseMatch?.release ?? null;
 
     if (!candidate.brand && bottleMetadata.brand) {
       candidate.brand = bottleMetadata.brand;
@@ -1128,9 +1167,49 @@ async function enrichBottleCandidates(
     ) {
       candidate.source = Array.from(new Set([...candidate.source, "release"]));
     }
+
+    mergeBottleCandidate(enrichedCandidates, candidate);
+
+    if (
+      candidate.releaseId === null &&
+      candidate.kind !== "release" &&
+      preferredReleaseMatch &&
+      preferredReleaseMatch.score > 0
+    ) {
+      const matchedRelease = preferredReleaseMatch.release;
+
+      mergeBottleCandidate(
+        enrichedCandidates,
+        BottleCandidateSchema.parse({
+          kind: "release",
+          bottleId: candidate.bottleId,
+          releaseId: matchedRelease.releaseId,
+          alias: candidate.alias,
+          fullName: matchedRelease.fullName,
+          bottleFullName: candidate.bottleFullName ?? candidate.fullName,
+          brand: candidate.brand,
+          bottler: candidate.bottler,
+          series: candidate.series,
+          distillery: candidate.distillery,
+          category: candidate.category,
+          statedAge: matchedRelease.statedAge ?? candidate.statedAge,
+          edition: matchedRelease.edition,
+          caskStrength: matchedRelease.caskStrength,
+          singleCask: matchedRelease.singleCask,
+          abv: matchedRelease.abv,
+          vintageYear: matchedRelease.vintageYear,
+          releaseYear: matchedRelease.releaseYear,
+          caskType: matchedRelease.caskType,
+          caskSize: matchedRelease.caskSize,
+          caskFill: matchedRelease.caskFill,
+          score: candidate.score,
+          source: Array.from(new Set([...candidate.source, "release"])),
+        }),
+      );
+    }
   }
 
-  return candidates;
+  return Array.from(enrichedCandidates.values());
 }
 
 async function runCandidateLookupSafely<T>(
@@ -1335,6 +1414,10 @@ async function getBrandCandidates(
     return [];
   }
   const expression = extractedLabel.expression || normalizedName;
+  const comparableExpression = normalizeComparableText(expression);
+  const comparableExpressionClause = comparableExpression
+    ? sql`OR LOWER(REPLACE(${bottles.fullName}, ${"'"}, '')) LIKE ${`%${comparableExpression}%`}`
+    : sql``;
 
   const result = await db.execute<{
     bottleId: number;
@@ -1371,7 +1454,10 @@ async function getBrandCandidates(
       LOWER(${entities.name}) = LOWER(${brandName})
       OR LOWER(COALESCE(${entities.shortName}, '')) = LOWER(${brandName})
     )
-      AND ${bottles.fullName} ILIKE ${`%${expression}%`}
+      AND (
+        LOWER(${bottles.fullName}) LIKE LOWER(${`%${expression}%`})
+        ${comparableExpressionClause}
+      )
     ORDER BY ${bottles.fullName} ASC
     LIMIT ${BRAND_CANDIDATE_LIMIT}
   `);
@@ -1466,7 +1552,9 @@ export const getBottleMatchCandidateById = getBottleCandidateById;
 async function getExactBottleCandidate(
   normalizedName: string,
 ): Promise<BottleCandidate | null> {
-  const [exactMatch] = await db
+  const normalizedLowerName = normalizedName.toLowerCase();
+  const comparableName = normalizeComparableText(normalizedName);
+  const exactMatches = await db
     .select({
       bottleId: bottleAliases.bottleId,
       releaseId: bottleAliases.releaseId,
@@ -1510,36 +1598,120 @@ async function getExactBottleCandidate(
     .innerJoin(entities, eq(entities.id, bottles.brandId))
     .where(
       and(
-        eq(sql`LOWER(${bottleAliases.name})`, normalizedName.toLowerCase()),
+        sql`LOWER(${bottleAliases.name}) = ${normalizedLowerName}`,
         eq(bottleAliases.ignored, false),
         isNotNull(bottleAliases.bottleId),
       ),
     )
     .limit(1);
 
-  if (!exactMatch?.bottleId) {
+  const exactMatch = exactMatches[0];
+  if (exactMatch?.bottleId) {
+    return buildBottleCandidate(
+      {
+        bottleId: exactMatch.bottleId,
+        releaseId: exactMatch.releaseId,
+        alias: exactMatch.alias,
+        fullName: exactMatch.fullName,
+        bottleFullName: exactMatch.bottleFullName,
+        brand: exactMatch.brand || null,
+        category: exactMatch.category,
+        statedAge: exactMatch.statedAge,
+        edition: exactMatch.edition,
+        caskStrength: exactMatch.caskStrength,
+        singleCask: exactMatch.singleCask,
+        abv: exactMatch.abv,
+        vintageYear: exactMatch.vintageYear,
+        releaseYear: exactMatch.releaseYear,
+        caskType: exactMatch.caskType,
+        caskSize: exactMatch.caskSize,
+        caskFill: exactMatch.caskFill,
+        score: 1,
+      },
+      "exact",
+    );
+  }
+
+  if (!comparableName || comparableName === normalizedLowerName) {
     return null;
   }
 
+  const comparableMatches = await db
+    .select({
+      bottleId: bottleAliases.bottleId,
+      releaseId: bottleAliases.releaseId,
+      alias: bottleAliases.name,
+      fullName: sql<string>`COALESCE(${bottleReleases.fullName}, ${bottles.fullName})`,
+      bottleFullName: bottles.fullName,
+      brand: entities.name,
+      category: bottles.category,
+      statedAge: sql<
+        number | null
+      >`COALESCE(${bottleReleases.statedAge}, ${bottles.statedAge})`,
+      edition: sql<
+        string | null
+      >`COALESCE(${bottleReleases.edition}, ${bottles.edition})`,
+      caskStrength: sql<
+        boolean | null
+      >`COALESCE(${bottleReleases.caskStrength}, ${bottles.caskStrength})`,
+      singleCask: sql<
+        boolean | null
+      >`COALESCE(${bottleReleases.singleCask}, ${bottles.singleCask})`,
+      abv: sql<number | null>`COALESCE(${bottleReleases.abv}, ${bottles.abv})`,
+      vintageYear: sql<
+        number | null
+      >`COALESCE(${bottleReleases.vintageYear}, ${bottles.vintageYear})`,
+      releaseYear: sql<
+        number | null
+      >`COALESCE(${bottleReleases.releaseYear}, ${bottles.releaseYear})`,
+      caskType: sql<
+        string | null
+      >`COALESCE(${bottleReleases.caskType}, ${bottles.caskType})`,
+      caskSize: sql<
+        string | null
+      >`COALESCE(${bottleReleases.caskSize}, ${bottles.caskSize})`,
+      caskFill: sql<
+        string | null
+      >`COALESCE(${bottleReleases.caskFill}, ${bottles.caskFill})`,
+    })
+    .from(bottleAliases)
+    .innerJoin(bottles, eq(bottles.id, bottleAliases.bottleId))
+    .leftJoin(bottleReleases, eq(bottleReleases.id, bottleAliases.releaseId))
+    .innerJoin(entities, eq(entities.id, bottles.brandId))
+    .where(
+      and(
+        sql`LOWER(REPLACE(${bottleAliases.name}, ${"'"}, '')) = ${comparableName}`,
+        eq(bottleAliases.ignored, false),
+        isNotNull(bottleAliases.bottleId),
+      ),
+    )
+    .limit(2);
+
+  if (comparableMatches.length !== 1) {
+    return null;
+  }
+
+  const comparableMatch = comparableMatches[0]!;
+
   return buildBottleCandidate(
     {
-      bottleId: exactMatch.bottleId,
-      releaseId: exactMatch.releaseId,
-      alias: exactMatch.alias,
-      fullName: exactMatch.fullName,
-      bottleFullName: exactMatch.bottleFullName,
-      brand: exactMatch.brand || null,
-      category: exactMatch.category,
-      statedAge: exactMatch.statedAge,
-      edition: exactMatch.edition,
-      caskStrength: exactMatch.caskStrength,
-      singleCask: exactMatch.singleCask,
-      abv: exactMatch.abv,
-      vintageYear: exactMatch.vintageYear,
-      releaseYear: exactMatch.releaseYear,
-      caskType: exactMatch.caskType,
-      caskSize: exactMatch.caskSize,
-      caskFill: exactMatch.caskFill,
+      bottleId: comparableMatch.bottleId!,
+      releaseId: comparableMatch.releaseId,
+      alias: comparableMatch.alias,
+      fullName: comparableMatch.fullName,
+      bottleFullName: comparableMatch.bottleFullName,
+      brand: comparableMatch.brand || null,
+      category: comparableMatch.category,
+      statedAge: comparableMatch.statedAge,
+      edition: comparableMatch.edition,
+      caskStrength: comparableMatch.caskStrength,
+      singleCask: comparableMatch.singleCask,
+      abv: comparableMatch.abv,
+      vintageYear: comparableMatch.vintageYear,
+      releaseYear: comparableMatch.releaseYear,
+      caskType: comparableMatch.caskType,
+      caskSize: comparableMatch.caskSize,
+      caskFill: comparableMatch.caskFill,
       score: 1,
     },
     "exact",

--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -2,6 +2,7 @@ import config from "@peated/server/config";
 import { db } from "@peated/server/db";
 import {
   bottleAliases,
+  bottleReleases,
   bottles,
   bottlesToDistillers,
   storePriceMatchProposals,
@@ -13,7 +14,7 @@ import {
   resolveStorePriceMatchProposal,
 } from "@peated/server/lib/priceMatching";
 import { findBottleMatchCandidates } from "@peated/server/lib/priceMatchingCandidates";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("@peated/server/agents/whisky/labelExtractor", () => ({
@@ -317,6 +318,61 @@ describe("priceMatching", () => {
         }),
       ]),
     );
+  });
+
+  test("prefers a literal exact alias over apostrophe-normalized fallback matches", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    const brand = await fixtures.Entity({
+      type: ["brand"],
+      name: "Alias Preference Brand",
+    });
+    const literalBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Founder's Cut",
+    });
+    const normalizedBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Founders Cut Reserve",
+    });
+    await fixtures.BottleAlias({
+      bottleId: literalBottle.id,
+      name: "Founder's Cut",
+    });
+    await fixtures.BottleAlias({
+      bottleId: normalizedBottle.id,
+      name: "Founders Cut",
+    });
+
+    const candidates = await findBottleMatchCandidates({
+      query: "Founder's Cut",
+      brand: null,
+      bottler: null,
+      expression: null,
+      series: null,
+      distillery: [],
+      category: null,
+      stated_age: null,
+      abv: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+      vintage_year: null,
+      release_year: null,
+      currentBottleId: null,
+      limit: 15,
+    });
+
+    expect(candidates[0]).toMatchObject({
+      bottleId: literalBottle.id,
+      alias: "Founder's Cut",
+    });
+    expect(candidates[0]?.source).toEqual(expect.arrayContaining(["exact"]));
   });
 
   test("normalizes string bottle ids returned from raw candidate queries", async () => {
@@ -2476,9 +2532,164 @@ describe("priceMatching", () => {
       caskSize: "port_pipe",
       caskFill: "1st_fill",
     });
-    expect(candidate?.source).toEqual(
-      expect.arrayContaining(["exact", "release"]),
+    expect(candidate?.source).toEqual(expect.arrayContaining(["release"]));
+  });
+
+  test("surfaces an existing Distillers Edition release from apostrophe retailer wording without web search", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    const lagavulin = await fixtures.Entity({
+      name: "Lagavulin",
+      shortName: "Lagavulin",
+      type: ["brand", "distiller"],
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: lagavulin.id,
+      distillerIds: [lagavulin.id],
+      name: "Distillers Edition",
+      category: "single_malt",
+    });
+    const release = await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      name: "Distillers Edition 2023 Release",
+      fullName: "Lagavulin Distillers Edition 2023 Release",
+      releaseYear: 2023,
+    });
+
+    // Blank the text-search vectors so this test exercises the local
+    // brand/parent candidate path rather than Postgres full-text matching.
+    await db.execute(
+      sql`UPDATE ${bottles} SET search_vector = NULL WHERE ${bottles.id} = ${bottle.id}`,
     );
+    await db.execute(
+      sql`UPDATE ${bottleReleases} SET search_vector = NULL WHERE ${bottleReleases.id} = ${release.id}`,
+    );
+
+    const candidates = await findBottleMatchCandidates({
+      query:
+        "Lagavulin Distiller's Edition 2023 Islay Single Malt Scotch Whisky",
+      brand: lagavulin.name,
+      bottler: null,
+      expression: "Distiller's Edition",
+      series: null,
+      distillery: [lagavulin.name],
+      category: "single_malt",
+      stated_age: null,
+      abv: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+      vintage_year: null,
+      release_year: 2023,
+      currentBottleId: null,
+      limit: 15,
+    });
+
+    expect(candidates[0]).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: release.id,
+      kind: "release",
+      fullName: release.fullName,
+      releaseYear: 2023,
+    });
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          bottleId: bottle.id,
+          releaseId: release.id,
+          kind: "release",
+          source: expect.arrayContaining(["brand", "release"]),
+        }),
+        expect.objectContaining({
+          bottleId: bottle.id,
+          releaseId: null,
+          kind: "bottle",
+          fullName: bottle.fullName,
+        }),
+      ]),
+    );
+  });
+
+  test("does not synthesize an arbitrary release when multiple releases tie on metadata", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    const lagavulin = await fixtures.Entity({
+      name: "Lagavulin",
+      shortName: "Lagavulin",
+      type: ["brand", "distiller"],
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: lagavulin.id,
+      distillerIds: [lagavulin.id],
+      name: "Distillers Edition",
+      category: "single_malt",
+    });
+    const springRelease = await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      name: "Distillers Edition 2023 Spring Release",
+      fullName: "Lagavulin Distillers Edition 2023 Spring Release",
+      releaseYear: 2023,
+    });
+    const autumnRelease = await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      name: "Distillers Edition 2023 Autumn Release",
+      fullName: "Lagavulin Distillers Edition 2023 Autumn Release",
+      releaseYear: 2023,
+    });
+
+    await db.execute(
+      sql`UPDATE ${bottles} SET search_vector = NULL WHERE ${bottles.id} = ${bottle.id}`,
+    );
+    await db.execute(
+      sql`UPDATE ${bottleReleases} SET search_vector = NULL WHERE ${bottleReleases.id} IN (${springRelease.id}, ${autumnRelease.id})`,
+    );
+
+    const candidates = await findBottleMatchCandidates({
+      query:
+        "Lagavulin Distiller's Edition 2023 Islay Single Malt Scotch Whisky",
+      brand: lagavulin.name,
+      bottler: null,
+      expression: "Distiller's Edition",
+      series: null,
+      distillery: [lagavulin.name],
+      category: "single_malt",
+      stated_age: null,
+      abv: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+      vintage_year: null,
+      release_year: 2023,
+      currentBottleId: null,
+      limit: 15,
+    });
+
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          bottleId: bottle.id,
+          releaseId: null,
+          kind: "bottle",
+          fullName: bottle.fullName,
+        }),
+      ]),
+    );
+    expect(
+      candidates.some(
+        (candidate) =>
+          candidate.bottleId === bottle.id && candidate.kind === "release",
+      ),
+    ).toBe(false);
   });
 
   test("adds a reusable parent candidate for age-statement listings", async ({

--- a/packages/bottle-classifier/src/tools/openaiWebSearch.ts
+++ b/packages/bottle-classifier/src/tools/openaiWebSearch.ts
@@ -1,5 +1,9 @@
 import { tool } from "@openai/agents";
 import type OpenAI from "openai";
+import type {
+  ResponseCreateParamsNonStreaming,
+  ResponseIncludable,
+} from "openai/resources/responses/responses";
 import type { BottleSearchEvidence } from "../classifierTypes";
 import { getDeterministicOpenAISettings } from "../openaiModelSettings";
 import { runBraveWebSearch } from "./braveWebSearch";
@@ -15,33 +19,126 @@ import {
   type BottleWebSearchBudget,
 } from "./sharedWebSearch";
 
+const OPENAI_WEB_SEARCH_RESPONSE_INCLUDES: ResponseIncludable[] = [
+  "web_search_call.action.sources",
+];
+
 export function extractOpenAISearchEvidence(
   query: string,
   response: any,
 ): BottleSearchEvidence {
-  const summary = response.output_text?.trim().slice(0, 600) || null;
-  const seen = new Set<string>();
-  const results: BottleSearchEvidence["results"] = [];
+  const outputItems: any[] = Array.isArray(response?.output)
+    ? response.output
+    : [];
+  const messageTexts = outputItems
+    .filter((item: any): item is { content?: unknown[]; type: "message" } => {
+      return item?.type === "message";
+    })
+    .flatMap((item: { content?: unknown[] }) =>
+      Array.isArray(item.content)
+        ? item.content
+            .filter(
+              (
+                content: any,
+              ): content is { text?: string; type: "output_text" } =>
+                content?.type === "output_text",
+            )
+            .map((content: { text?: string }) => content.text?.trim())
+            .filter((value: string | undefined): value is string =>
+              Boolean(value),
+            )
+        : [],
+    );
+  const summary =
+    response.output_text?.trim().slice(0, 600) ||
+    messageTexts.join(" ").trim().slice(0, 600) ||
+    null;
+  const resultsByUrl = new Map<
+    string,
+    BottleSearchEvidence["results"][number]
+  >();
 
-  for (const item of response.output) {
-    if (item.type !== "message") continue;
+  const mergeResult = ({
+    title,
+    url,
+  }: {
+    title?: string | null;
+    url: string | null | undefined;
+  }) => {
+    if (!url) {
+      return;
+    }
 
-    for (const content of item.content) {
-      if (content.type !== "output_text") continue;
+    const normalizedTitle = title?.trim() || url;
+    const existing = resultsByUrl.get(url);
+    if (!existing) {
+      resultsByUrl.set(url, {
+        title: normalizedTitle,
+        url,
+        domain: getResultDomain(url),
+        description: summary,
+        extraSnippets: [],
+      });
+      return;
+    }
 
-      for (const annotation of content.annotations || []) {
-        if (annotation.type !== "url_citation") continue;
-        if (seen.has(annotation.url)) continue;
-        seen.add(annotation.url);
+    if (existing.title === existing.url && normalizedTitle !== url) {
+      existing.title = normalizedTitle;
+    }
 
-        results.push({
-          title: annotation.title || annotation.url,
-          url: annotation.url,
-          domain: getResultDomain(annotation.url),
-          description: summary,
-          extraSnippets: [],
+    existing.description ??= summary;
+  };
+
+  for (const item of outputItems) {
+    if (item?.type === "message") {
+      for (const content of Array.isArray(item.content) ? item.content : []) {
+        if (content?.type !== "output_text") {
+          continue;
+        }
+
+        for (const annotation of Array.isArray(content.annotations)
+          ? content.annotations
+          : []) {
+          if (annotation?.type !== "url_citation") {
+            continue;
+          }
+
+          mergeResult({
+            title: annotation.title,
+            url: annotation.url,
+          });
+        }
+      }
+      continue;
+    }
+
+    if (item?.type !== "web_search_call") {
+      continue;
+    }
+
+    if (item.action?.type === "search") {
+      for (const source of Array.isArray(item.action.sources)
+        ? item.action.sources
+        : []) {
+        if (source?.type !== "url") {
+          continue;
+        }
+
+        mergeResult({
+          url: source.url,
         });
       }
+      continue;
+    }
+
+    if (
+      (item.action?.type === "open_page" ||
+        item.action?.type === "find_in_page") &&
+      typeof item.action.url === "string"
+    ) {
+      mergeResult({
+        url: item.action.url,
+      });
     }
   }
 
@@ -49,7 +146,7 @@ export function extractOpenAISearchEvidence(
     provider: "openai",
     query,
     summary,
-    results,
+    results: Array.from(resultsByUrl.values()),
   });
 }
 
@@ -176,22 +273,21 @@ export function createOpenAIWebSearchTool({
   });
 }
 
-async function runOpenAIWebSearch({
-  client,
+export function buildOpenAIWebSearchRequest({
   model,
   query,
   instructions,
   extraContext = null,
 }: {
-  client: OpenAI;
   model: string;
   query: string;
   instructions: string;
   extraContext?: string | null;
-}): Promise<BottleSearchEvidence> {
-  const response = await client.responses.create({
+}): ResponseCreateParamsNonStreaming {
+  return {
     model,
     instructions,
+    include: OPENAI_WEB_SEARCH_RESPONSE_INCLUDES,
     input: [
       {
         role: "user",
@@ -205,7 +301,30 @@ async function runOpenAIWebSearch({
     ],
     tools: [{ type: "web_search" }],
     ...getDeterministicOpenAISettings(model),
-  });
+  };
+}
+
+async function runOpenAIWebSearch({
+  client,
+  model,
+  query,
+  instructions,
+  extraContext = null,
+}: {
+  client: OpenAI;
+  model: string;
+  query: string;
+  instructions: string;
+  extraContext?: string | null;
+}): Promise<BottleSearchEvidence> {
+  const response = await client.responses.create(
+    buildOpenAIWebSearchRequest({
+      model,
+      query,
+      instructions,
+      extraContext,
+    }),
+  );
 
   return extractOpenAISearchEvidence(query, response);
 }

--- a/packages/bottle-classifier/src/tools/webSearch.test.ts
+++ b/packages/bottle-classifier/src/tools/webSearch.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "vitest";
+import {
+  buildOpenAIWebSearchRequest,
+  extractOpenAISearchEvidence,
+} from "./openaiWebSearch";
+
+describe("bottleClassifier web search tools", () => {
+  test("extracts OpenAI search evidence from web search call sources when citations are missing", () => {
+    const evidence = extractOpenAISearchEvidence(
+      "lagavulin distillers edition 2023",
+      {
+        output: [
+          {
+            type: "web_search_call",
+            action: {
+              type: "search",
+              query: "lagavulin distillers edition 2023",
+              sources: [
+                {
+                  type: "url",
+                  url: "https://www.malts.com/en-row/products/lagavulin-distillers-edition-single-malt-scotch-whisky",
+                },
+                {
+                  type: "url",
+                  url: "https://www.whiskyadvocate.com/ratings-reviews/lagavulin-distillers-edition-2023/",
+                },
+              ],
+            },
+          },
+          {
+            type: "message",
+            content: [
+              {
+                type: "output_text",
+                text: "OpenAI searched the web and found official plus independent references.",
+                annotations: [],
+              },
+            ],
+          },
+        ],
+      },
+    );
+
+    expect(evidence).toMatchObject({
+      provider: "openai",
+      query: "lagavulin distillers edition 2023",
+      summary:
+        "OpenAI searched the web and found official plus independent references.",
+    });
+    expect(evidence.results).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          domain: "malts.com",
+          url: "https://www.malts.com/en-row/products/lagavulin-distillers-edition-single-malt-scotch-whisky",
+        }),
+        expect.objectContaining({
+          domain: "whiskyadvocate.com",
+          url: "https://www.whiskyadvocate.com/ratings-reviews/lagavulin-distillers-edition-2023/",
+        }),
+      ]),
+    );
+  });
+
+  test("prefers citation titles while deduping against OpenAI web search call sources", () => {
+    const evidence = extractOpenAISearchEvidence("wild turkey rare breed rye", {
+      output_text: "Wild Turkey confirms Rare Breed Rye is barrel proof.",
+      output: [
+        {
+          type: "web_search_call",
+          action: {
+            type: "search",
+            query: "wild turkey rare breed rye",
+            sources: [
+              {
+                type: "url",
+                url: "https://www.wildturkeybourbon.com/products/rare-breed-rye/",
+              },
+            ],
+          },
+        },
+        {
+          type: "message",
+          content: [
+            {
+              type: "output_text",
+              annotations: [
+                {
+                  type: "url_citation",
+                  url: "https://www.wildturkeybourbon.com/products/rare-breed-rye/",
+                  title: "Rare Breed Rye",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(evidence.results).toEqual([
+      expect.objectContaining({
+        title: "Rare Breed Rye",
+        domain: "wildturkeybourbon.com",
+      }),
+    ]);
+  });
+
+  test("requests OpenAI web search sources in the response payload", () => {
+    const request = buildOpenAIWebSearchRequest({
+      model: "gpt-5.4",
+      query: "lagavulin distillers edition 2023",
+      instructions: "Search the web.",
+    });
+
+    expect(request).toEqual(
+      expect.objectContaining({
+        include: ["web_search_call.action.sources"],
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Recover missing classifier web evidence and remove a couple of deterministic fallback paths that could pick the wrong bottle or release.

The OpenAI web-search fallback was trying to read web_search_call.action.sources, but we were never requesting that payload from the Responses API. This PR requests the sources explicitly and teaches both the server and shared package wrappers to recover evidence from search-call sources, page opens, and citations so uncited searches still produce usable evidence.

On the matching side, exact alias lookup now prefers a literal hit before falling back to apostrophe-normalized comparison, and release promotion only happens when the release metadata produces a unique positive winner. I considered adding more hardcoded matching rules here, but kept the deterministic behavior limited to universal normalization and ambiguity rejection so the semantic search and classifier stay responsible for the fuzzy cases.

The regression coverage includes the missing-source OpenAI path, literal alias preference, the Lagavulin Distillers Edition 2023 release surfacing case, and tied-release ambiguity.