### PR TITLE
fix(classifier): Preserve possessive evidence matches

### DIFF
--- a/packages/bottle-classifier/src/classifier.eval.fixtures.ts
+++ b/packages/bottle-classifier/src/classifier.eval.fixtures.ts
@@ -226,6 +226,30 @@ const cadbollEstateBatch4Release = buildBottleCandidate({
   source: ["text"],
 });
 
+const lagavulinDistillersEditionParent = buildBottleCandidate({
+  bottleId: 44006,
+  fullName: "Lagavulin Distillers Edition",
+  brand: "Lagavulin",
+  distillery: ["Lagavulin"],
+  category: "single_malt",
+  score: 0.91,
+  source: ["brand"],
+});
+
+const lagavulinDistillersEdition2023Release = buildBottleCandidate({
+  bottleId: 44006,
+  releaseId: 78,
+  kind: "release",
+  fullName: "Lagavulin Distillers Edition 2023 Release",
+  bottleFullName: "Lagavulin Distillers Edition",
+  brand: "Lagavulin",
+  distillery: ["Lagavulin"],
+  category: "single_malt",
+  releaseYear: 2023,
+  score: 0.95,
+  source: ["brand", "release"],
+});
+
 const smwsa41176Match = buildBottleCandidate({
   bottleId: 650,
   fullName: "SMWS 41.176 Baristaliscious",
@@ -706,6 +730,35 @@ export const EVAL_CASES: ClassifierEvalCase[] = [
       matchedReleaseId: 9102,
       summary:
         "When a clean Batch 4 child release already exists, match that release directly instead of keeping or downgrading a plain parent-bottle match for the Cadboll Estate listing.",
+    },
+  },
+  {
+    name: "store listing: matches an existing annual release under Distillers Edition",
+    input: {
+      reference: {
+        name: "Lagavulin Distiller's Edition 2023 Islay Single Malt Scotch Whisky",
+        url: "https://shop.example/products/lagavulin-distillers-edition-2023",
+      },
+      extractedIdentity: buildExtractedIdentity({
+        brand: "Lagavulin",
+        expression: "Distillers Edition",
+        distillery: ["Lagavulin"],
+        category: "single_malt",
+        release_year: 2023,
+      }),
+      initialCandidates: [
+        lagavulinDistillersEditionParent,
+        lagavulinDistillersEdition2023Release,
+      ],
+    },
+    expected: {
+      status: "classified",
+      action: "match",
+      identityScope: "product",
+      matchedBottleId: 44006,
+      matchedReleaseId: 78,
+      summary:
+        "Treat Distillers Edition as the stable parent family, use the bare 2023 year as release identity, and match the existing 2023 child release instead of downgrading to no-match.",
     },
   },
   {

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -444,6 +444,58 @@ const cadbollEstateBatch4ReleaseCandidate: BottleCandidate = {
   source: ["text"],
 };
 
+const lagavulinDistillersEditionParentCandidate: BottleCandidate = {
+  bottleId: 44006,
+  releaseId: null,
+  kind: "bottle",
+  alias: null,
+  fullName: "Lagavulin Distillers Edition",
+  bottleFullName: "Lagavulin Distillers Edition",
+  brand: "Lagavulin",
+  bottler: null,
+  series: null,
+  distillery: ["Lagavulin"],
+  category: "single_malt",
+  statedAge: null,
+  edition: null,
+  caskStrength: null,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: null,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 0.91,
+  source: ["text"],
+};
+
+const lagavulinDistillersEdition2023ReleaseCandidate: BottleCandidate = {
+  bottleId: 44006,
+  releaseId: 78,
+  kind: "release",
+  alias: null,
+  fullName: "Lagavulin Distillers Edition 2023 Release",
+  bottleFullName: "Lagavulin Distillers Edition",
+  brand: "Lagavulin",
+  bottler: null,
+  series: null,
+  distillery: ["Lagavulin"],
+  category: "single_malt",
+  statedAge: null,
+  edition: null,
+  caskStrength: null,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: 2023,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 0.95,
+  source: ["text", "release"],
+};
+
 describe("createBottleClassifier", () => {
   test("auto ignores obvious non-whisky references when extraction fails", async () => {
     const runBottleClassifierAgent = vi.fn();
@@ -1488,6 +1540,175 @@ describe("createBottleClassifier", () => {
       parentBottleId: null,
     });
     expect(result.decision.rationale).toContain(
+      "Server downgraded the existing-match recommendation",
+    );
+  });
+
+  test("keeps a bottle match when the listing only differs by apostrophe spelling", async () => {
+    const extractedIdentity: BottleExtractedDetails = {
+      brand: "Lagavulin",
+      bottler: null,
+      expression: "Distillers Edition",
+      series: null,
+      distillery: ["Lagavulin"],
+      category: "single_malt",
+      stated_age: null,
+      abv: null,
+      release_year: null,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    };
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "match",
+          confidence: 90,
+          rationale: "The local bottle identity matches the listing cleanly.",
+          identityScope: "product",
+          observation: null,
+          matchedBottleId: 44006,
+          matchedReleaseId: null,
+          parentBottleId: null,
+          candidateBottleIds: [44006],
+          proposedBottle: null,
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [],
+          candidates: [lagavulinDistillersEditionParentCandidate],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: {
+        name: "Lagavulin Distiller's Edition",
+      },
+      extractedIdentity,
+      initialCandidates: [lagavulinDistillersEditionParentCandidate],
+    });
+
+    expect(result.status).toBe("classified");
+    if (result.status !== "classified") {
+      throw new Error("Expected a classified result");
+    }
+
+    expect(result.decision).toMatchObject({
+      action: "match",
+      matchedBottleId: 44006,
+      matchedReleaseId: null,
+      parentBottleId: null,
+      identityScope: "product",
+    });
+    expect(result.decision.rationale).not.toContain(
+      "Server downgraded the existing-match recommendation",
+    );
+  });
+
+  test("keeps a release match when authoritative evidence only mentions the brand in possessive summary text", async () => {
+    const extractedIdentity: BottleExtractedDetails = {
+      brand: "Lagavulin",
+      bottler: null,
+      expression: "Distillers Edition",
+      series: null,
+      distillery: ["Lagavulin"],
+      category: "single_malt",
+      stated_age: null,
+      abv: null,
+      release_year: 2023,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    };
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "match",
+          confidence: 91,
+          rationale: "The existing 2023 release matches the listing cleanly.",
+          identityScope: "product",
+          observation: null,
+          matchedBottleId: 44006,
+          matchedReleaseId: 78,
+          parentBottleId: null,
+          candidateBottleIds: [44006],
+          proposedBottle: null,
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [
+            {
+              provider: "openai",
+              query: '"Lagavulin Distillers Edition 2023"',
+              summary:
+                "Lagavulin's official site lists the Distillers Edition 2023 release.",
+              results: [
+                {
+                  title:
+                    "Distillers Edition 2023 Release | Official Product Page",
+                  url: "https://www.lagavulin.com/en-us/whiskies/distillers-edition-2023",
+                  domain: "lagavulin.com",
+                  description:
+                    "Official product page for the Distillers Edition 2023 release.",
+                  extraSnippets: [],
+                },
+              ],
+            },
+          ],
+          candidates: [
+            lagavulinDistillersEditionParentCandidate,
+            lagavulinDistillersEdition2023ReleaseCandidate,
+          ],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: {
+        name: "Lagavulin Distiller's Edition 2023 Islay Single Malt Scotch Whisky",
+        url: "https://shop.example/products/lagavulin-distillers-edition-2023",
+      },
+      extractedIdentity,
+      initialCandidates: [
+        lagavulinDistillersEditionParentCandidate,
+        lagavulinDistillersEdition2023ReleaseCandidate,
+      ],
+    });
+
+    expect(result.status).toBe("classified");
+    if (result.status !== "classified") {
+      throw new Error("Expected a classified result");
+    }
+
+    expect(result.decision).toMatchObject({
+      action: "match",
+      matchedBottleId: 44006,
+      matchedReleaseId: 78,
+      parentBottleId: null,
+      identityScope: "product",
+    });
+    expect(result.decision.rationale).not.toContain(
       "Server downgraded the existing-match recommendation",
     );
   });

--- a/packages/bottle-classifier/src/instructions.ts
+++ b/packages/bottle-classifier/src/instructions.ts
@@ -725,6 +725,8 @@ export function buildBottleClassifierInstructions({
     "Local candidates may be either parent bottle targets or child release targets. Use `releaseId` and the candidate `kind` discriminator to tell the difference.",
     "An exact alias can still point at a legacy bottle row that stores batch or annual release detail in the bottle name. If a cleaner parent bottle candidate exists, prefer the parent plus `create_release` instead of matching the legacy specific bottle.",
     "Local candidates may include structured bottle and release fields such as brand, bottler, distillery, series, category, age, edition, cask type, cask size, cask fill, cask-strength, single-cask, ABV, and release years. Use those fields directly when present instead of inferring everything from the candidate name.",
+    "When local candidates already include both a reusable parent bottle and a clean child release under that same bottle, and the extracted release detail uniquely matches the child candidate, prefer matching that existing release over returning a plain parent-bottle match or creating a duplicate release.",
+    "For annual-release families such as Distillers Edition, a bare year can be decisive release identity. If one local child release candidate aligns on the correct parent bottle and matching release year, treat that release as the leading existing-match target rather than treating the year as retailer noise.",
     ...(hasBottleSearch
       ? [
           "When the provided local candidates are thin, conflicting, or missing obvious near matches, call `search_bottles` with the most specific query you can form from the reference and extracted identity.",
@@ -817,6 +819,7 @@ export function buildBottleClassifierInstructions({
             ...(hasOpenAIWebSearch || hasBraveWebSearch
               ? [
                   "When you are leaning toward any create action or `no_match` because local candidates are weak, do at least one web search while search budget remains.",
+                  "When a plausible existing release candidate lacks an exact alias but differs from its parent bottle by a decisive trait such as release year, edition, or batch code, use web search to validate that exact release before falling back to `no_match`.",
                 ]
               : []),
             "If `localSearch.hasExactAliasMatch` is false and you do not have authoritative web evidence, you can still return a create action, but do not assume the server will auto-create it.",
@@ -825,6 +828,7 @@ export function buildBottleClassifierInstructions({
                   "When searching, prioritize official producer, distillery, bottler, or importer domains first, then critics or publications, then broader web if still unresolved.",
                   "Do not treat the originating source page as decisive evidence for differentiating traits such as distillery, bottler, cask finish, cask size, cask fill, ABV, edition, or release year.",
                   "When a candidate may still be right but the source title omitted a canonical trait, search for the exact base bottle name plus the missing trait and prefer authoritative domains that can confirm it.",
+                  "For bare annual releases, search the exact family or expression name plus the year so you can confirm whether the candidate is an existing yearly release rather than a generic parent bottle.",
                   "If the distinctness of the bottle depends on a trait such as `Port Cask Finished`, `Single Cask`, `Barrel Proof`, a specific ABV, `1st Fill`, or `Port Pipe`, the web evidence should explicitly confirm that trait.",
                   "If the raw reference is still just a sparse generic phrase like `Batch Sherry` after extraction and local search, do not invent a branded bottle or release from web similarity alone. Prefer `no_match` unless the source itself provides a strong identity anchor.",
                   `You have a combined hard limit of ${maxSearchQueries} web search calls across all web search tools.`,

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -236,7 +236,7 @@ function domainMatches(hostname: string, domain: string): boolean {
 }
 
 function getComparableNameTokens(value: string | null | undefined): string[] {
-  return normalizeComparableText(value)
+  return normalizeNameTokenizationText(value)
     .replace(/\b\d+(?:\.\d+)?\s?(?:ml|cl|l|oz)\b/g, " ")
     .split(/[^a-z0-9]+/g)
     .filter((token) => token.length > 0 && !GENERIC_NAME_TOKENS.has(token));
@@ -245,10 +245,47 @@ function getComparableNameTokens(value: string | null | undefined): string[] {
 function getStrictComparableNameTokens(
   value: string | null | undefined,
 ): string[] {
-  return normalizeComparableText(value)
+  return normalizeNameTokenizationText(value)
     .replace(/\b\d+(?:\.\d+)?\s?(?:ml|cl|l|oz)\b/g, " ")
     .split(/[^a-z0-9]+/g)
     .filter((token) => token.length > 0);
+}
+
+function normalizeNameTokenizationText(
+  value: string | null | undefined,
+): string {
+  return normalizeComparableText(value)
+    .replace(/\b([a-z0-9]+)'s\b/g, "$1s")
+    .replace(/\b([a-z0-9]+)s'\b/g, "$1s");
+}
+
+function getComparableEvidenceTokens(
+  value: string | null | undefined,
+): string[] {
+  return normalizeComparableText(value)
+    .replace(/\b\d+(?:\.\d+)?\s?(?:ml|cl|l|oz)\b/g, " ")
+    .split(/[^a-z0-9']+/g)
+    .flatMap(expandComparableEvidenceToken)
+    .filter(
+      (token) =>
+        token.length > 0 && token !== "s" && !GENERIC_NAME_TOKENS.has(token),
+    );
+}
+
+function expandComparableEvidenceToken(token: string): string[] {
+  const singularPossessiveMatch = token.match(/^([a-z0-9]+)'s$/);
+  if (singularPossessiveMatch) {
+    const base = singularPossessiveMatch[1];
+    return [base, `${base}s`];
+  }
+
+  const pluralPossessiveMatch = token.match(/^([a-z0-9]+)s'$/);
+  if (pluralPossessiveMatch) {
+    const base = pluralPossessiveMatch[1];
+    return [base, `${base}s`];
+  }
+
+  return [token];
 }
 
 function getReferenceAnchoredCreateTokens({
@@ -1062,7 +1099,7 @@ function hasSupportiveWebEvidenceForTarget({
       }
 
       const resultTokens = new Set(
-        getComparableNameTokens(getSearchEvidenceText(evidence, result)),
+        getComparableEvidenceTokens(getSearchEvidenceText(evidence, result)),
       );
       if (!resultTokens.size) {
         continue;


### PR DESCRIPTION
Preserve possessive brand tokens when review policy checks web evidence for existing classifier matches.

This fixes the Lagavulin Distillers Edition 2023 path where the agent can correctly target the existing annual release, but the server review layer downgrades that recommendation because possessive evidence like `Lagavulin's official site...` drops the base `lagavulin` token during normalization.

Instead of broadening deterministic matching, this keeps the existing apostrophe-folding behavior for local name comparison and adds a separate evidence-token path that expands possessives into both base and suffixed forms. The PR also adds regression coverage for the possessive-summary case and updates the classifier guidance and eval fixtures for annual release families that already have a matching child release.

An alternative would have been to widen downgrade heuristics or special-case Distillers Edition families, but that would move ambiguous bottle reasoning into deterministic policy. Keeping the change at token normalization is narrower and still leaves the match decision with the agent.