### PR TITLE
fix(classifier): Preserve annual release matches

### DIFF
--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -496,6 +496,58 @@ const lagavulinDistillersEdition2023ReleaseCandidate: BottleCandidate = {
   source: ["text", "release"],
 };
 
+const lagavulinDistillersEdition2023SpringReleaseCandidate: BottleCandidate = {
+  bottleId: 44006,
+  releaseId: 79,
+  kind: "release",
+  alias: null,
+  fullName: "Lagavulin Distillers Edition 2023 Spring Release",
+  bottleFullName: "Lagavulin Distillers Edition",
+  brand: "Lagavulin",
+  bottler: null,
+  series: null,
+  distillery: ["Lagavulin"],
+  category: "single_malt",
+  statedAge: null,
+  edition: "Spring Release",
+  caskStrength: null,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: 2023,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 0.94,
+  source: ["text", "release"],
+};
+
+const lagavulinDistillersEdition2023AutumnReleaseCandidate: BottleCandidate = {
+  bottleId: 44006,
+  releaseId: 80,
+  kind: "release",
+  alias: null,
+  fullName: "Lagavulin Distillers Edition 2023 Autumn Release",
+  bottleFullName: "Lagavulin Distillers Edition",
+  brand: "Lagavulin",
+  bottler: null,
+  series: null,
+  distillery: ["Lagavulin"],
+  category: "single_malt",
+  statedAge: null,
+  edition: "Autumn Release",
+  caskStrength: null,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: 2023,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 0.93,
+  source: ["text", "release"],
+};
+
 describe("createBottleClassifier", () => {
   test("auto ignores obvious non-whisky references when extraction fails", async () => {
     const runBottleClassifierAgent = vi.fn();
@@ -1709,6 +1761,163 @@ describe("createBottleClassifier", () => {
       identityScope: "product",
     });
     expect(result.decision.rationale).not.toContain(
+      "Server downgraded the existing-match recommendation",
+    );
+  });
+
+  test("keeps a uniquely supported annual release match without web evidence", async () => {
+    const extractedIdentity: BottleExtractedDetails = {
+      brand: "Lagavulin",
+      bottler: null,
+      expression: "Distillers Edition",
+      series: null,
+      distillery: ["Lagavulin"],
+      category: "single_malt",
+      stated_age: null,
+      abv: null,
+      release_year: 2023,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    };
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "match",
+          confidence: 91,
+          rationale: "The existing 2023 release matches the listing cleanly.",
+          identityScope: "product",
+          observation: null,
+          matchedBottleId: 44006,
+          matchedReleaseId: 78,
+          parentBottleId: null,
+          candidateBottleIds: [44006],
+          proposedBottle: null,
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [],
+          candidates: [
+            lagavulinDistillersEditionParentCandidate,
+            lagavulinDistillersEdition2023ReleaseCandidate,
+          ],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: {
+        name: "Lagavulin Distiller's Edition 2023 Islay Single Malt Scotch Whisky",
+      },
+      extractedIdentity,
+      initialCandidates: [
+        lagavulinDistillersEditionParentCandidate,
+        lagavulinDistillersEdition2023ReleaseCandidate,
+      ],
+    });
+
+    expect(result.status).toBe("classified");
+    if (result.status !== "classified") {
+      throw new Error("Expected a classified result");
+    }
+
+    expect(result.decision).toMatchObject({
+      action: "match",
+      matchedBottleId: 44006,
+      matchedReleaseId: 78,
+      parentBottleId: null,
+      identityScope: "product",
+    });
+    expect(result.decision.rationale).not.toContain(
+      "Server downgraded the existing-match recommendation",
+    );
+  });
+
+  test("downgrades an annual release match when the surfaced sibling releases still tie on the same bare year", async () => {
+    const extractedIdentity: BottleExtractedDetails = {
+      brand: "Lagavulin",
+      bottler: null,
+      expression: "Distillers Edition",
+      series: null,
+      distillery: ["Lagavulin"],
+      category: "single_malt",
+      stated_age: null,
+      abv: null,
+      release_year: 2023,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    };
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "match",
+          confidence: 89,
+          rationale: "One of the 2023 releases appears to match the listing.",
+          identityScope: "product",
+          observation: null,
+          matchedBottleId: 44006,
+          matchedReleaseId: 79,
+          parentBottleId: null,
+          candidateBottleIds: [44006],
+          proposedBottle: null,
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [],
+          candidates: [
+            lagavulinDistillersEditionParentCandidate,
+            lagavulinDistillersEdition2023SpringReleaseCandidate,
+            lagavulinDistillersEdition2023AutumnReleaseCandidate,
+          ],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: {
+        name: "Lagavulin Distiller's Edition 2023 Islay Single Malt Scotch Whisky",
+      },
+      extractedIdentity,
+      initialCandidates: [
+        lagavulinDistillersEditionParentCandidate,
+        lagavulinDistillersEdition2023SpringReleaseCandidate,
+        lagavulinDistillersEdition2023AutumnReleaseCandidate,
+      ],
+    });
+
+    expect(result.status).toBe("classified");
+    if (result.status !== "classified") {
+      throw new Error("Expected a classified result");
+    }
+
+    expect(result.decision).toMatchObject({
+      action: "no_match",
+      matchedBottleId: null,
+      matchedReleaseId: null,
+      parentBottleId: null,
+    });
+    expect(result.decision.rationale).toContain(
       "Server downgraded the existing-match recommendation",
     );
   });

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -970,17 +970,157 @@ function getTargetNameCandidates(
   target: BottleCandidate,
   decision: BottleClassificationDecision,
 ): string[] {
+  const structuredReleaseNames =
+    (decision.action === "match" &&
+      (decision.matchedReleaseId != null || target.kind === "release")) ||
+    target.releaseId != null
+      ? [
+          target.bottleFullName && target.releaseYear != null
+            ? `${target.bottleFullName} ${target.releaseYear}`
+            : null,
+          target.bottleFullName && target.vintageYear != null
+            ? `${target.bottleFullName} ${target.vintageYear}`
+            : null,
+          target.bottleFullName && target.edition
+            ? `${target.bottleFullName} ${target.edition}`
+            : null,
+        ]
+      : [];
   const names =
     decision.action === "match" &&
     (decision.matchedReleaseId != null || target.kind === "release")
-      ? [target.alias, target.fullName]
+      ? [target.alias, target.fullName, ...structuredReleaseNames]
       : [
           target.alias,
           target.bottleFullName ?? target.fullName,
           target.fullName,
+          ...structuredReleaseNames,
         ];
 
   return Array.from(new Set(names.filter(Boolean))) as string[];
+}
+
+type DecisiveReleaseSupportField = "edition" | "releaseYear" | "vintageYear";
+
+function getMatchingDecisiveReleaseSupportFields({
+  candidate,
+  extractedIdentity,
+}: {
+  candidate: BottleCandidate;
+  extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
+}): DecisiveReleaseSupportField[] {
+  if (!extractedIdentity) {
+    return [];
+  }
+
+  const matchedFields: DecisiveReleaseSupportField[] = [];
+
+  if (
+    extractedIdentity.edition &&
+    candidate.edition &&
+    textsOverlap(candidate.edition, extractedIdentity.edition)
+  ) {
+    matchedFields.push("edition");
+  }
+
+  if (
+    extractedIdentity.release_year !== null &&
+    candidate.releaseYear !== null &&
+    candidate.releaseYear === extractedIdentity.release_year
+  ) {
+    matchedFields.push("releaseYear");
+  }
+
+  if (
+    extractedIdentity.vintage_year !== null &&
+    candidate.vintageYear !== null &&
+    candidate.vintageYear === extractedIdentity.vintage_year
+  ) {
+    matchedFields.push("vintageYear");
+  }
+
+  return matchedFields;
+}
+
+function candidateMatchesDecisiveReleaseSupportFields({
+  candidate,
+  extractedIdentity,
+  fields,
+}: {
+  candidate: BottleCandidate;
+  extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
+  fields: DecisiveReleaseSupportField[];
+}): boolean {
+  if (!fields.length || !extractedIdentity) {
+    return false;
+  }
+
+  return fields.every((field) => {
+    switch (field) {
+      case "edition":
+        return Boolean(
+          extractedIdentity.edition &&
+          candidate.edition &&
+          textsOverlap(candidate.edition, extractedIdentity.edition),
+        );
+      case "releaseYear":
+        return (
+          extractedIdentity.release_year !== null &&
+          candidate.releaseYear !== null &&
+          candidate.releaseYear === extractedIdentity.release_year
+        );
+      case "vintageYear":
+        return (
+          extractedIdentity.vintage_year !== null &&
+          candidate.vintageYear !== null &&
+          candidate.vintageYear === extractedIdentity.vintage_year
+        );
+    }
+  });
+}
+
+function hasUniquelySupportedStructuredReleaseMatch({
+  target,
+  artifacts,
+}: {
+  target: BottleCandidate;
+  artifacts: BottleClassificationArtifacts;
+}): boolean {
+  if (target.releaseId == null) {
+    return false;
+  }
+
+  const decisiveFields = getMatchingDecisiveReleaseSupportFields({
+    candidate: target,
+    extractedIdentity: artifacts.extractedIdentity,
+  });
+  if (!decisiveFields.length) {
+    return false;
+  }
+
+  const hasReusableParentCandidate = artifacts.candidates.some(
+    (candidate) =>
+      candidate.bottleId === target.bottleId &&
+      candidate.releaseId === null &&
+      candidate.kind !== "release",
+  );
+  if (!hasReusableParentCandidate) {
+    return false;
+  }
+
+  // A surfaced clean child release can stand on its own when the extracted
+  // release marker uniquely identifies it beneath the same reusable parent.
+  return !artifacts.candidates.some(
+    (candidate) =>
+      candidate.bottleId === target.bottleId &&
+      candidate.releaseId !== null &&
+      candidate.releaseId !== target.releaseId &&
+      candidateMatchesDecisiveReleaseSupportFields({
+        candidate,
+        extractedIdentity: artifacts.extractedIdentity,
+        fields: decisiveFields,
+      }),
+  );
 }
 
 function getBottleTargetNameCandidates(target: BottleCandidate): string[] {
@@ -1437,6 +1577,11 @@ function downgradeUnsafeExistingMatchDecision({
     reference,
     artifacts,
   });
+  const hasStructuredReleaseSupport =
+    hasUniquelySupportedStructuredReleaseMatch({
+      target,
+      artifacts,
+    });
   const identityConflicts = getExistingMatchIdentityConflicts({
     referenceName: reference.name,
     targetCandidate: target,
@@ -1445,7 +1590,9 @@ function downgradeUnsafeExistingMatchDecision({
 
   if (
     !identityConflicts.length &&
-    (hasExactishLocalName || hasSupportiveWebEvidence)
+    (hasExactishLocalName ||
+      hasSupportiveWebEvidence ||
+      hasStructuredReleaseSupport)
   ) {
     return decision;
   }
@@ -1458,7 +1605,11 @@ function downgradeUnsafeExistingMatchDecision({
       )})`,
     );
   }
-  if (!hasExactishLocalName && !hasSupportiveWebEvidence) {
+  if (
+    !hasExactishLocalName &&
+    !hasSupportiveWebEvidence &&
+    !hasStructuredReleaseSupport
+  ) {
     reasons.push(
       "there is no exact alias, no exactish canonical name match, and no supportive off-retailer web evidence for the matched target",
     );


### PR DESCRIPTION
Keep uniquely identified annual release matches in classifier review.

The server review policy was still downgrading existing child release matches for annual-release families like Lagavulin Distillers Edition 2023 when local candidates already included both the reusable parent bottle and the matching child release. Because those rows often lack exact alias coverage and web corroboration can be sparse, the review layer could still turn a correct existing match into no_match.

This keeps the fix scoped to structured release identity. When a matched child release is uniquely identified by release year, vintage year, or edition beneath the same surfaced reusable parent bottle, we now keep that match. If sibling releases still tie on the same decisive marker, the downgrade remains in place.

Added classifier coverage for the positive Lagavulin 2023 path and for the ambiguous sibling-release fallback.