### PR TITLE
fix(queue): Split create proposal actions

### DIFF
--- a/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
@@ -10,6 +10,7 @@ import PaginationButtons from "@peated/web/components/paginationButtons";
 import SimpleHeader from "@peated/web/components/simpleHeader";
 import TextInput from "@peated/web/components/textInput";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
+import { getBottleBottlingPath } from "@peated/web/lib/bottlings";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { buildQueryString } from "@peated/web/lib/urls";
 import {
@@ -89,6 +90,9 @@ export default function Page() {
   const resolveMutation = useMutation(
     orpc.prices.matchQueue.resolve.mutationOptions(),
   );
+  const createBottleMutation = useMutation(
+    orpc.prices.matchQueue.createBottle.mutationOptions(),
+  );
   const retryMutation = useMutation(
     orpc.prices.matchQueue.retry.mutationOptions(),
   );
@@ -98,6 +102,7 @@ export default function Page() {
 
   const { flash } = useFlashMessages();
   const isBusy =
+    createBottleMutation.isPending ||
     resolveMutation.isPending ||
     retryMutation.isPending ||
     retryAllMutation.isPending;
@@ -175,6 +180,39 @@ export default function Page() {
           Requeued <strong className="font-bold">{item.price.name}</strong>
         </div>
       ),
+    );
+  }
+
+  async function handleApplyCreateProposal(item: QueueItem): Promise<void> {
+    const created = await createBottleMutation.mutateAsync({
+      proposal: item.id,
+      bottle: item.proposedBottle || undefined,
+      release: item.proposedRelease || undefined,
+    });
+    await refreshQueueList();
+    flash(
+      <div>
+        Created{" "}
+        <Link href={`/bottles/${created.bottle.id}`} className="underline">
+          {created.bottle.fullName}
+        </Link>
+        {created.release ? (
+          <>
+            {" "}
+            and{" "}
+            <Link
+              href={getBottleBottlingPath(
+                created.bottle.id,
+                created.release.id,
+              )}
+              className="underline"
+            >
+              {created.release.fullName}
+            </Link>
+          </>
+        ) : null}{" "}
+        for <strong className="font-bold">{item.price.name}</strong>
+      </div>,
     );
   }
 
@@ -364,6 +402,7 @@ export default function Page() {
               isBusy={isBusy}
               returnTo={returnTo}
               onApproveMatch={handleApproveMatch}
+              onApplyCreateProposal={handleApplyCreateProposal}
               onChooseBottle={(nextProposal) => {
                 setSelectedProposal(nextProposal);
               }}

--- a/apps/web/src/app/(admin)/admin/(default)/queue/queueItemCard.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/queueItemCard.tsx
@@ -51,6 +51,7 @@ type QueueItemCardProps = {
   item: QueueItem;
   returnTo: string;
   onApproveMatch: (item: QueueItem) => Promise<void>;
+  onApplyCreateProposal: (item: QueueItem) => Promise<void>;
   onChooseBottle: (item: QueueItem) => void;
   onIgnore: (item: QueueItem) => Promise<void>;
   onRetry: (item: QueueItem) => Promise<void>;
@@ -521,11 +522,52 @@ function formatSourceTier(
   }
 }
 
+type CreateProposalActions = {
+  applyLabel: string;
+  editHref: string;
+  editLabel: string;
+};
+
+function getCreateProposalActions(
+  item: QueueItem,
+  returnTo: string,
+): CreateProposalActions | null {
+  if (!item.proposedBottle && !item.proposedRelease) {
+    return null;
+  }
+
+  const queryString = `proposal=${item.id}&returnTo=${encodeURIComponent(returnTo)}`;
+
+  switch (item.creationTarget) {
+    case "release":
+      return {
+        applyLabel: "Apply Bottling Draft",
+        editLabel: "Edit Bottling Draft",
+        editHref: item.parentBottle
+          ? `${getNewBottleBottlingPath(item.parentBottle.id)}?${queryString}`
+          : `/addBottle?${queryString}`,
+      };
+    case "bottle_and_release":
+      return {
+        applyLabel: "Apply Create Draft",
+        editLabel: "Edit Create Draft",
+        editHref: `/addBottle?${queryString}`,
+      };
+    default:
+      return {
+        applyLabel: "Apply Bottle Draft",
+        editLabel: "Edit Bottle Draft",
+        editHref: `/addBottle?${queryString}`,
+      };
+  }
+}
+
 export default function QueueItemCard({
   isBusy,
   item,
   returnTo,
   onApproveMatch,
+  onApplyCreateProposal,
   onChooseBottle,
   onIgnore,
   onRetry,
@@ -540,16 +582,7 @@ export default function QueueItemCard({
     item.status === "pending_review" &&
     (!!item.proposedBottle || !!item.proposedRelease) &&
     !isProcessing;
-  const createHref =
-    item.creationTarget === "release" && item.parentBottle
-      ? `${getNewBottleBottlingPath(item.parentBottle.id)}?proposal=${item.id}&returnTo=${encodeURIComponent(returnTo)}`
-      : `/addBottle?proposal=${item.id}&returnTo=${encodeURIComponent(returnTo)}`;
-  const createLabel =
-    item.creationTarget === "release"
-      ? "Create Bottling"
-      : item.creationTarget === "bottle_and_release"
-        ? "Create Bottle + Bottling"
-        : "Create Bottle";
+  const createProposalActions = getCreateProposalActions(item, returnTo);
   const queuedAt = formatTimestamp(item.createdAt);
   const processingQueuedAt = formatTimestamp(item.processingQueuedAt);
   const processingExpiresAt = formatTimestamp(item.processingExpiresAt);
@@ -904,8 +937,21 @@ export default function QueueItemCard({
               ) : null}
 
               {canCreateBottle ? (
-                <Button href={createHref} color="highlight" fullWidth>
-                  {createLabel}
+                <Button
+                  color="highlight"
+                  fullWidth
+                  disabled={isBusy}
+                  onClick={async () => {
+                    await onApplyCreateProposal(item);
+                  }}
+                >
+                  {createProposalActions?.applyLabel ?? "Apply Draft"}
+                </Button>
+              ) : null}
+
+              {canCreateBottle && createProposalActions ? (
+                <Button href={createProposalActions.editHref} fullWidth>
+                  {createProposalActions.editLabel}
                 </Button>
               ) : null}
 


### PR DESCRIPTION
Keep both queue paths for create proposals instead of forcing everything through one behavior.

The queue now exposes an explicit apply action for strong proposal-backed create flows while restoring the prefilled edit path for bottle, bottling, and bottle-plus-bottling drafts. That fixes the regression where release-target proposals could no longer be corrected from the queue before approval.

This also cleans up the action labeling so reviewers can distinguish applying the stored draft from opening the editable form.

Validation:
- pnpm --filter @peated/web typecheck
- pnpm test