### PR TITLE
fix(queue): Reduce release-specific blocker false positives

### DIFF
--- a/apps/server/src/lib/priceMatchingAutomation.test.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.test.ts
@@ -85,6 +85,96 @@ describe("priceMatchingAutomation", () => {
     expect(assessment.decisiveMatchAttributes).toContain("statedAge");
   });
 
+  test("does not flag a stable age statement as release-specific when the bottle already markets it", () => {
+    const assessment = getStorePriceMatchAutomationAssessment({
+      action: "match_existing",
+      modelConfidence: 88,
+      price: {
+        bottleId: 1,
+        name: "The Whistler How The Years Whistle By 10-year-old Single Malt Irish Whiskey",
+        url: "https://example.com/whistler",
+      },
+      suggestedBottleId: 1,
+      suggestedReleaseId: null,
+      extractedLabel: buildExtractedLabel({
+        brand: "The Whistler",
+        expression: "How The Years Whistle By",
+        distillery: ["The Whistler"],
+        category: "single_malt",
+        stated_age: 10,
+        abv: null,
+        cask_type: null,
+      }),
+      proposedBottle: null,
+      searchEvidence: [],
+      candidateBottles: [
+        buildCandidate({
+          bottleId: 1,
+          fullName:
+            "The Whistler How The Years Whistle By 10-year-old Single Malt Irish Whiskey",
+          bottleFullName:
+            "The Whistler How The Years Whistle By 10-year-old Single Malt Irish Whiskey",
+          brand: "The Whistler",
+          distillery: ["The Whistler"],
+          category: "single_malt",
+          statedAge: 10,
+          abv: null,
+          caskType: null,
+        }),
+      ],
+    });
+
+    expect(assessment.automationBlockers).not.toContain(
+      "listing looks release-specific but the suggested target is only a bottle",
+    );
+    expect(assessment.decisiveMatchAttributes).toContain("statedAge");
+  });
+
+  test("keeps the release-specific blocker when the bottle target does not represent the extracted edition", () => {
+    const assessment = getStorePriceMatchAutomationAssessment({
+      action: "match_existing",
+      modelConfidence: 88,
+      price: {
+        bottleId: 2,
+        name: "Springbank 12-year-old Cask Strength Batch 24",
+        url: "https://example.com/springbank",
+      },
+      suggestedBottleId: 2,
+      suggestedReleaseId: null,
+      extractedLabel: buildExtractedLabel({
+        brand: "Springbank",
+        expression: "12-year-old Cask Strength",
+        distillery: ["Springbank"],
+        category: "single_malt",
+        stated_age: 12,
+        abv: null,
+        cask_type: null,
+        cask_strength: true,
+        edition: "Batch 24",
+      }),
+      proposedBottle: null,
+      searchEvidence: [],
+      candidateBottles: [
+        buildCandidate({
+          bottleId: 2,
+          fullName: "Springbank 12-year-old Cask Strength",
+          bottleFullName: "Springbank 12-year-old Cask Strength",
+          brand: "Springbank",
+          distillery: ["Springbank"],
+          category: "single_malt",
+          statedAge: 12,
+          abv: null,
+          caskType: null,
+          caskStrength: true,
+        }),
+      ],
+    });
+
+    expect(assessment.automationBlockers).toContain(
+      "listing looks release-specific but the suggested target is only a bottle",
+    );
+  });
+
   test("does not treat originating retailer evidence as decisive for auto-create", () => {
     const assessment = getStorePriceMatchAutomationAssessment({
       action: "create_new",

--- a/apps/server/src/lib/priceMatchingAutomation.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.ts
@@ -1,6 +1,5 @@
 import { normalizeString } from "@peated/bottle-classifier/normalize";
 import { hasSupportiveWebEvidenceForExistingMatch as hasSupportiveBottleEvidence } from "@peated/bottle-classifier/priceMatchingEvidence";
-import { hasExtractedReleaseIdentity } from "@peated/bottle-classifier/releaseIdentity";
 import type { StorePrice } from "@peated/server/db/schema";
 import {
   type BottleCandidateSchema,
@@ -462,7 +461,7 @@ function candidateMatchesDistillery(
 function compareCandidateValue(
   attribute: MatchAttribute,
   candidate: PriceMatchCandidate,
-  expectedValue: string | number,
+  expectedValue: string | number | boolean,
 ) {
   switch (attribute) {
     case "brand":
@@ -488,9 +487,15 @@ function compareCandidateValue(
     case "caskFill":
       return textsOverlap(candidate.caskFill, String(expectedValue));
     case "caskStrength":
-      return candidate.caskStrength === (expectedValue === "true");
+      return (
+        candidate.caskStrength ===
+        (expectedValue === true || expectedValue === "true")
+      );
     case "singleCask":
-      return candidate.singleCask === (expectedValue === "true");
+      return (
+        candidate.singleCask ===
+        (expectedValue === true || expectedValue === "true")
+      );
     case "abv":
       return (
         candidate.abv !== null &&
@@ -503,6 +508,103 @@ function compareCandidateValue(
     default:
       return false;
   }
+}
+
+function hasMeaningfulExtractedReleaseValue(
+  value: string | number | boolean | null | undefined,
+): value is string | number | true {
+  if (typeof value === "string") {
+    return value.length > 0;
+  }
+
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  return value !== null && value !== undefined;
+}
+
+function bottleTargetRepresentsExtractedReleaseIdentity({
+  target,
+  attribute,
+  expectedValue,
+}: {
+  target: PriceMatchCandidate;
+  attribute: MatchAttribute;
+  expectedValue: string | number | boolean;
+}) {
+  if (compareCandidateValue(attribute, target, expectedValue)) {
+    return true;
+  }
+
+  return [target.alias, target.bottleFullName, target.fullName]
+    .filter((value): value is string => Boolean(value))
+    .some((value) =>
+      attributeMatchesText(attribute, String(expectedValue), value),
+    );
+}
+
+function listingCarriesReleaseIdentityBeyondBottle({
+  target,
+  extractedLabel,
+}: {
+  target: PriceMatchCandidate;
+  extractedLabel: ExtractedBottleDetails | null;
+}) {
+  const extractedReleaseAttributes = [
+    {
+      attribute: "edition" as const,
+      value: extractedLabel?.edition,
+    },
+    {
+      attribute: "statedAge" as const,
+      value: extractedLabel?.stated_age,
+    },
+    {
+      attribute: "abv" as const,
+      value: extractedLabel?.abv,
+    },
+    {
+      attribute: "releaseYear" as const,
+      value: extractedLabel?.release_year,
+    },
+    {
+      attribute: "vintageYear" as const,
+      value: extractedLabel?.vintage_year,
+    },
+    {
+      attribute: "caskType" as const,
+      value: extractedLabel?.cask_type,
+    },
+    {
+      attribute: "caskSize" as const,
+      value: extractedLabel?.cask_size,
+    },
+    {
+      attribute: "caskFill" as const,
+      value: extractedLabel?.cask_fill,
+    },
+    {
+      attribute: "caskStrength" as const,
+      value: extractedLabel?.cask_strength,
+    },
+    {
+      attribute: "singleCask" as const,
+      value: extractedLabel?.single_cask,
+    },
+  ];
+
+  return extractedReleaseAttributes.some(({ attribute, value }) => {
+    if (!hasMeaningfulExtractedReleaseValue(value)) {
+      return false;
+    }
+
+    return !bottleTargetRepresentsExtractedReleaseIdentity({
+      target,
+      attribute,
+      expectedValue: value,
+    });
+  });
 }
 
 function getCreateNewChecks(
@@ -738,7 +840,10 @@ function getMatchScore({
     score += 6;
   } else if (
     target.releaseId === null &&
-    hasExtractedReleaseIdentity(extractedLabel)
+    listingCarriesReleaseIdentityBeyondBottle({
+      target,
+      extractedLabel,
+    })
   ) {
     score -= 10;
     automationBlockers.push(


### PR DESCRIPTION
Reduce false positives in the listings queue when a bottle match already represents the extracted age or other release-capable traits.

The old automation blocker only checked whether the extractor returned any release identity, so age-statement bottles like The Whistler example were pushed back for review even when the suggested bottle was correct. This change compares extracted release-capable fields against the suggested bottle record and marketed names before treating the listing as release-specific.

The stricter blocker still stays in place for real release detail such as batch labels, and the regression coverage now includes both the stable bottle-age case and a still-blocked batch case.

Validated with the focused `priceMatchingAutomation` test and the full `pnpm test` workspace suite.