### PR TITLE
fix(classifier): keep uniquely supported bottle matches

### DIFF
--- a/apps/web/src/app/(admin)/admin/(default)/queue/queueItemCard.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/queueItemCard.tsx
@@ -100,6 +100,10 @@ function formatConfidence(item: QueueItem): string {
 }
 
 function formatAutomationScore(item: QueueItem): string {
+  if (item.status === "errored" || item.proposalType === "no_match") {
+    return "n/a";
+  }
+
   return item.automationScore === null ? "?" : `${item.automationScore}`;
 }
 
@@ -437,6 +441,15 @@ function renderRecommendationOutcome(item: QueueItem): ReactNode {
     return (
       <div className="mt-2 text-sm text-slate-300">
         No recommendation available.
+      </div>
+    );
+  }
+
+  if (item.proposalType === "no_match") {
+    return (
+      <div className="mt-2 text-sm text-slate-300">
+        No safe existing match or create draft was recommended. Use Choose
+        Bottle to resolve it manually.
       </div>
     );
   }

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -288,6 +288,58 @@ const taleOfIceCreamCandidate: BottleCandidate = {
   source: ["text"],
 };
 
+const ledaigStiuireadairCandidate: BottleCandidate = {
+  bottleId: 41258,
+  releaseId: null,
+  kind: "bottle",
+  alias: "Ledaig Stiuireadair",
+  fullName: "Ledaig Stiuireadair",
+  bottleFullName: "Ledaig Stiuireadair",
+  brand: "Ledaig",
+  bottler: null,
+  series: null,
+  distillery: ["Tobermory"],
+  category: "single_malt",
+  statedAge: null,
+  edition: null,
+  caskStrength: null,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: null,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 0.88,
+  source: ["text"],
+};
+
+const ledaigStiuiredairNearDuplicateCandidate: BottleCandidate = {
+  bottleId: 41259,
+  releaseId: null,
+  kind: "bottle",
+  alias: "Ledaig Stiuiredair",
+  fullName: "Ledaig Stiuiredair",
+  bottleFullName: "Ledaig Stiuiredair",
+  brand: "Ledaig",
+  bottler: null,
+  series: null,
+  distillery: ["Tobermory"],
+  category: "single_malt",
+  statedAge: null,
+  edition: null,
+  caskStrength: null,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: null,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 0.84,
+  source: ["vector"],
+};
+
 const redbreastBatchACandidate: BottleCandidate = {
   bottleId: 9101,
   releaseId: null,
@@ -1516,6 +1568,85 @@ describe("createBottleClassifier", () => {
     expect(result.decision).toMatchObject({
       action: "match",
       matchedBottleId: 43236,
+      matchedReleaseId: null,
+      parentBottleId: null,
+      identityScope: "product",
+    });
+    expect(result.decision.rationale).not.toContain(
+      "Server downgraded the existing-match recommendation",
+    );
+  });
+
+  test("keeps a uniquely supported bottle match when the title adds producer context beyond the canonical bottle name", async () => {
+    const extractedIdentity: BottleExtractedDetails = {
+      brand: "Ledaig",
+      bottler: null,
+      expression: "Stiuireadair",
+      series: null,
+      distillery: ["Tobermory"],
+      category: "single_malt",
+      stated_age: null,
+      abv: null,
+      release_year: null,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    };
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "match",
+          confidence: 88,
+          rationale:
+            "The local bottle aligns on brand, distillery, category, and the distinctive expression name.",
+          identityScope: "product",
+          observation: null,
+          matchedBottleId: 41258,
+          matchedReleaseId: null,
+          parentBottleId: null,
+          candidateBottleIds: [41258, 41259],
+          proposedBottle: null,
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [],
+          candidates: [
+            ledaigStiuireadairCandidate,
+            ledaigStiuiredairNearDuplicateCandidate,
+          ],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: {
+        name: "Tobermory Ledaig Stiuireadair Single Malt Scotch Whisky",
+      },
+      extractedIdentity,
+      initialCandidates: [
+        ledaigStiuireadairCandidate,
+        ledaigStiuiredairNearDuplicateCandidate,
+      ],
+    });
+
+    expect(result.status).toBe("classified");
+    if (result.status !== "classified") {
+      throw new Error("Expected a classified result");
+    }
+
+    expect(result.decision).toMatchObject({
+      action: "match",
+      matchedBottleId: 41258,
       matchedReleaseId: null,
       parentBottleId: null,
       identityScope: "product",

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -1001,6 +1001,13 @@ function getTargetNameCandidates(
 }
 
 type DecisiveReleaseSupportField = "edition" | "releaseYear" | "vintageYear";
+type DecisiveBottleSupportField =
+  | "brand"
+  | "bottler"
+  | "series"
+  | "distillery"
+  | "category"
+  | "expression";
 
 function getMatchingDecisiveReleaseSupportFields({
   candidate,
@@ -1116,6 +1123,185 @@ function hasUniquelySupportedStructuredReleaseMatch({
       candidate.releaseId !== null &&
       candidate.releaseId !== target.releaseId &&
       candidateMatchesDecisiveReleaseSupportFields({
+        candidate,
+        extractedIdentity: artifacts.extractedIdentity,
+        fields: decisiveFields,
+      }),
+  );
+}
+
+function candidateMatchesStructuredBottleExpression({
+  candidate,
+  expression,
+}: {
+  candidate: BottleCandidate;
+  expression: string | null | undefined;
+}): boolean {
+  if (!expression) {
+    return false;
+  }
+
+  return getBottleTargetNameCandidates(candidate).some((name) =>
+    textsOverlap(name, expression),
+  );
+}
+
+function getMatchingDecisiveBottleSupportFields({
+  candidate,
+  extractedIdentity,
+}: {
+  candidate: BottleCandidate;
+  extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
+}): DecisiveBottleSupportField[] {
+  if (!extractedIdentity) {
+    return [];
+  }
+
+  const matchedFields: DecisiveBottleSupportField[] = [];
+
+  if (
+    extractedIdentity.brand &&
+    textsOverlap(candidate.brand, extractedIdentity.brand)
+  ) {
+    matchedFields.push("brand");
+  }
+
+  if (
+    extractedIdentity.bottler &&
+    textsOverlap(candidate.bottler, extractedIdentity.bottler)
+  ) {
+    matchedFields.push("bottler");
+  }
+
+  if (
+    extractedIdentity.series &&
+    textsOverlap(candidate.series, extractedIdentity.series)
+  ) {
+    matchedFields.push("series");
+  }
+
+  if (
+    extractedIdentity.distillery?.length &&
+    extractedIdentity.distillery.every((distillery) =>
+      candidate.distillery.some((candidateDistillery) =>
+        textsOverlap(candidateDistillery, distillery),
+      ),
+    )
+  ) {
+    matchedFields.push("distillery");
+  }
+
+  if (
+    extractedIdentity.category &&
+    candidate.category === extractedIdentity.category
+  ) {
+    matchedFields.push("category");
+  }
+
+  if (
+    candidateMatchesStructuredBottleExpression({
+      candidate,
+      expression: extractedIdentity.expression,
+    })
+  ) {
+    matchedFields.push("expression");
+  }
+
+  return matchedFields;
+}
+
+function candidateMatchesDecisiveBottleSupportFields({
+  candidate,
+  extractedIdentity,
+  fields,
+}: {
+  candidate: BottleCandidate;
+  extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
+  fields: DecisiveBottleSupportField[];
+}): boolean {
+  if (!fields.length || !extractedIdentity) {
+    return false;
+  }
+
+  return fields.every((field) => {
+    switch (field) {
+      case "brand":
+        return Boolean(
+          extractedIdentity.brand &&
+          textsOverlap(candidate.brand, extractedIdentity.brand),
+        );
+      case "bottler":
+        return Boolean(
+          extractedIdentity.bottler &&
+          textsOverlap(candidate.bottler, extractedIdentity.bottler),
+        );
+      case "series":
+        return Boolean(
+          extractedIdentity.series &&
+          textsOverlap(candidate.series, extractedIdentity.series),
+        );
+      case "distillery":
+        return Boolean(
+          extractedIdentity.distillery?.length &&
+          extractedIdentity.distillery.every((distillery) =>
+            candidate.distillery.some((candidateDistillery) =>
+              textsOverlap(candidateDistillery, distillery),
+            ),
+          ),
+        );
+      case "category":
+        return (
+          extractedIdentity.category !== null &&
+          extractedIdentity.category !== undefined &&
+          candidate.category === extractedIdentity.category
+        );
+      case "expression":
+        return candidateMatchesStructuredBottleExpression({
+          candidate,
+          expression: extractedIdentity.expression,
+        });
+    }
+  });
+}
+
+function hasUniquelySupportedStructuredBottleMatch({
+  target,
+  artifacts,
+}: {
+  target: BottleCandidate;
+  artifacts: BottleClassificationArtifacts;
+}): boolean {
+  if (
+    target.releaseId !== null ||
+    target.kind === "release" ||
+    candidateLooksLikeLegacyReleaseBottle(target) ||
+    candidateLooksLikeDirtyAgeReleaseBottle({
+      candidate: target,
+      extractedIdentity: artifacts.extractedIdentity,
+    })
+  ) {
+    return false;
+  }
+
+  const decisiveFields = getMatchingDecisiveBottleSupportFields({
+    candidate: target,
+    extractedIdentity: artifacts.extractedIdentity,
+  });
+  if (
+    !decisiveFields.includes("expression") ||
+    !decisiveFields.some((field) =>
+      ["brand", "bottler", "distillery"].includes(field),
+    )
+  ) {
+    return false;
+  }
+
+  // Allow non-exact matches to stand only when the extracted bottle identity
+  // uniquely supports this product-level candidate among the surfaced peers.
+  return !artifacts.candidates.some(
+    (candidate) =>
+      candidate.bottleId !== target.bottleId &&
+      candidateMatchesDecisiveBottleSupportFields({
         candidate,
         extractedIdentity: artifacts.extractedIdentity,
         fields: decisiveFields,
@@ -1582,6 +1768,10 @@ function downgradeUnsafeExistingMatchDecision({
       target,
       artifacts,
     });
+  const hasStructuredBottleSupport = hasUniquelySupportedStructuredBottleMatch({
+    target,
+    artifacts,
+  });
   const identityConflicts = getExistingMatchIdentityConflicts({
     referenceName: reference.name,
     targetCandidate: target,
@@ -1592,7 +1782,8 @@ function downgradeUnsafeExistingMatchDecision({
     !identityConflicts.length &&
     (hasExactishLocalName ||
       hasSupportiveWebEvidence ||
-      hasStructuredReleaseSupport)
+      hasStructuredReleaseSupport ||
+      hasStructuredBottleSupport)
   ) {
     return decision;
   }
@@ -1608,10 +1799,11 @@ function downgradeUnsafeExistingMatchDecision({
   if (
     !hasExactishLocalName &&
     !hasSupportiveWebEvidence &&
-    !hasStructuredReleaseSupport
+    !hasStructuredReleaseSupport &&
+    !hasStructuredBottleSupport
   ) {
     reasons.push(
-      "there is no exact alias, no exactish canonical name match, and no supportive off-retailer web evidence for the matched target",
+      "there is no exact alias, no exactish canonical name match, no uniquely supported structured bottle identity, and no supportive off-retailer web evidence for the matched target",
     );
   }
 


### PR DESCRIPTION
Keep uniquely supported existing bottle matches in classifier review.

The classifier was downgrading some obvious existing bottle matches to `no_match` when the
candidate was not tagged as exact and the retailer title added extra producer context. In
cases like Ledaig Stiuireadair, the extracted identity already uniquely supported one bottle
candidate, so requiring an exactish title match or off-retailer web evidence was too
conservative. That also left the admin queue with no create action and an unclear automation
state.

This teaches the review policy to preserve a non-release bottle match when structured identity
uniquely supports one candidate, adds regression coverage for the duplicate Stiuireadair case,
and makes `no_match` queue rows render as explicit manual-review outcomes instead of ambiguous
`?` automation output.

Validated with `pnpm --filter @peated/bottle-classifier test -- src/classifier.test.ts`,
`pnpm --filter @peated/bottle-classifier typecheck`, and `pnpm --filter @peated/web typecheck`.
I also started `pnpm test`; it reached unrelated server suites and the web production build
without surfacing a regression in the touched areas before I stopped waiting on the full
monorepo run.
