### PR TITLE
fix(prices): Auto-approve direct bottle matches

### DIFF
--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -502,6 +502,129 @@ describe("priceMatching", () => {
     expect(proposal.confidence).toBe(88);
   });
 
+  test("auto approves high-confidence matches that reaffirm the current bottle assignment", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    await fixtures.User({
+      username: "dcramer",
+      admin: true,
+      mod: true,
+    });
+
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
+    const brand = await fixtures.Entity({
+      name: "Example Distillery",
+      type: ["brand", "distiller"],
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: brand.id,
+      distillerIds: [brand.id],
+      name: "Port Cask",
+      category: "single_malt",
+      statedAge: 10,
+      abv: 58.4,
+      caskType: "tawny_port",
+    });
+    const price = await fixtures.StorePrice({
+      bottleId: bottle.id,
+      name: "Example Distillery Port Cask 10 Year",
+      imageUrl: null,
+      url: "https://totalwine.com/example",
+    });
+
+    vi.mocked(extractFromText).mockResolvedValue({
+      brand: "Example Distillery",
+      bottler: null,
+      expression: "Port Cask",
+      series: null,
+      distillery: ["Example Distillery"],
+      category: "single_malt",
+      stated_age: 10,
+      abv: 58.4,
+      release_year: null,
+      vintage_year: null,
+      cask_type: "tawny_port",
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    });
+    vi.mocked(classifyBottleReference).mockResolvedValue(
+      buildMockBottleReferenceClassification({
+        decision: {
+          action: "match_existing",
+          confidence: 72,
+          rationale: "The current bottle identity already matches cleanly.",
+          suggestedBottleId: bottle.id,
+          candidateBottleIds: [bottle.id],
+          proposedBottle: null,
+        },
+        searchEvidence: [],
+        candidateBottles: [
+          {
+            kind: "bottle",
+            bottleId: bottle.id,
+            releaseId: null,
+            alias: "Example Distillery Port Cask 10 Year",
+            fullName: "Example Distillery Port Cask 10 Year",
+            bottleFullName: "Example Distillery Port Cask 10 Year",
+            brand: "Example Distillery",
+            bottler: null,
+            series: null,
+            distillery: ["Example Distillery"],
+            category: "single_malt",
+            statedAge: 10,
+            edition: null,
+            caskStrength: null,
+            singleCask: null,
+            abv: 58.4,
+            vintageYear: null,
+            releaseYear: null,
+            caskType: "tawny_port",
+            caskSize: null,
+            caskFill: null,
+            score: 0.91,
+            source: ["current", "exact"],
+          },
+        ],
+        resolvedEntities: [],
+      }),
+    );
+
+    const proposal = await resolveStorePriceMatchProposal(price.id);
+    const updatedPrice = await db.query.storePrices.findFirst({
+      where: eq(storePrices.id, price.id),
+    });
+    const listingAlias = await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, price.name),
+    });
+    const observation = await db.query.bottleObservations.findFirst({
+      where: (bottleObservations, { eq }) =>
+        eq(bottleObservations.sourceKey, `store_price:${price.id}`),
+    });
+
+    expect(proposal).toMatchObject({
+      status: "approved",
+      proposalType: "match_existing",
+      currentBottleId: bottle.id,
+      suggestedBottleId: bottle.id,
+      reviewedById: expect.any(Number),
+    });
+    expect(updatedPrice?.bottleId).toBe(bottle.id);
+    expect(listingAlias?.bottleId).toBe(bottle.id);
+    expect(observation).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: null,
+      sourceType: "store_price",
+    });
+  });
+
   test("persists classifier-reviewed no_match decisions for unsupported non-exact matches", async ({
     fixtures,
   }) => {
@@ -1531,6 +1654,69 @@ describe("priceMatching", () => {
       name: "SMWS RW6.5 Sauna Smoke",
       imageUrl: null,
       url: "https://smws.example/rw6-5-existing",
+    });
+
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
+
+    const proposal = await resolveStorePriceMatchProposal(price.id);
+    const updatedPrice = await db.query.storePrices.findFirst({
+      where: eq(storePrices.id, price.id),
+    });
+    const listingAlias = await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, price.name),
+    });
+
+    expect(extractFromText).not.toHaveBeenCalled();
+    expect(classifyBottleReference).not.toHaveBeenCalled();
+    expect(proposal).toMatchObject({
+      status: "approved",
+      proposalType: "match_existing",
+      currentBottleId: bottle.id,
+      suggestedBottleId: bottle.id,
+      reviewedById: expect.any(Number),
+    });
+    expect(updatedPrice?.bottleId).toBe(bottle.id);
+    expect(listingAlias?.bottleId).toBe(bottle.id);
+  });
+
+  test("auto approves trusted SMWS matches when the price is already linked to the same bottle", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    await fixtures.User({
+      username: "dcramer",
+      admin: true,
+      mod: true,
+    });
+
+    const site = await fixtures.ExternalSiteOrExisting({ type: "smws" });
+    const brand = await fixtures.Entity({
+      name: "The Scotch Malt Whisky Society",
+      shortName: null,
+      type: ["brand", "bottler"],
+    });
+    const distiller = await fixtures.Entity({
+      name: "Kyrö",
+      type: ["distiller"],
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      distillerIds: [distiller.id],
+      name: "RW6.5 Sauna Smoke",
+      category: "rye",
+      singleCask: true,
+    });
+    const price = await fixtures.StorePrice({
+      externalSiteId: site.id,
+      bottleId: bottle.id,
+      name: "SMWS RW6.5 Sauna Smoke",
+      imageUrl: null,
+      url: "https://smws.example/rw6-5-existing-current",
     });
 
     const { extractFromText } =

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -518,10 +518,6 @@ async function maybeResolveTrustedSmwsStorePriceMatch(
     expectedProcessingToken: processingToken,
   });
 
-  if (existingBottleId && price.bottleId === existingBottleId) {
-    return proposal;
-  }
-
   try {
     const automationUser = await getAutomationModeratorUser();
 
@@ -1076,23 +1072,17 @@ export async function resolveStorePriceMatchProposal(
       expectedProcessingToken: processingToken,
     });
 
-    if (
-      !shouldAutoCreateStorePriceMatchProposal({
-        decision,
-        automationAssessment,
-      })
-    ) {
+    const shouldAutoCreate = shouldAutoCreateStorePriceMatchProposal({
+      decision,
+      automationAssessment,
+    });
+
+    if (proposal.status !== "verified" && !shouldAutoCreate) {
       return proposal;
     }
 
     try {
       const automationUser = await getAutomationModeratorUser();
-      const createInputs = buildStorePriceMatchCreateInputs(decision);
-      if (!createInputs.input && !createInputs.releaseInput) {
-        throw new Error(
-          `Unable to auto-create price match proposal without creation inputs (${proposal.id}).`,
-        );
-      }
 
       if (
         processingToken &&
@@ -1102,6 +1092,31 @@ export async function resolveStorePriceMatchProposal(
         ))
       ) {
         return await reloadStorePriceMatchProposal(proposal.id);
+      }
+
+      if (proposal.status === "verified") {
+        if (!proposal.suggestedBottleId) {
+          throw new Error(
+            `Unable to auto-approve verified price match proposal without a suggested bottle (${proposal.id}).`,
+          );
+        }
+
+        await applyApprovedStorePriceMatch({
+          proposalId: proposal.id,
+          bottleId: proposal.suggestedBottleId,
+          releaseId: proposal.suggestedReleaseId ?? null,
+          reviewedById: automationUser.id,
+          expectedProcessingToken: processingToken,
+        });
+
+        return await reloadStorePriceMatchProposal(proposal.id);
+      }
+
+      const createInputs = buildStorePriceMatchCreateInputs(decision);
+      if (!createInputs.input && !createInputs.releaseInput) {
+        throw new Error(
+          `Unable to auto-create price match proposal without creation inputs (${proposal.id}).`,
+        );
       }
 
       await createBottleFromStorePriceMatchProposal({
@@ -1130,7 +1145,12 @@ export async function resolveStorePriceMatchProposal(
         decision,
         automationAssessment,
         searchEvidence,
-        error: err instanceof Error ? err.message : "Unknown auto-create error",
+        error:
+          err instanceof Error
+            ? err.message
+            : proposal.status === "verified"
+              ? "Unknown auto-approval error"
+              : "Unknown auto-create error",
         statusOverride: "errored",
         expectedProcessingToken: processingToken,
       });

--- a/apps/server/src/lib/priceMatchingStatus.ts
+++ b/apps/server/src/lib/priceMatchingStatus.ts
@@ -1,6 +1,7 @@
 import type { StorePriceMatchProposal } from "@peated/server/db/schema";
 
 export const REVIEWABLE_STORE_PRICE_MATCH_PROPOSAL_STATUSES = [
+  "verified",
   "pending_review",
   "errored",
 ] as const satisfies ReadonlyArray<StorePriceMatchProposal["status"]>;
@@ -13,5 +14,7 @@ export const CLOSED_STORE_PRICE_MATCH_PROPOSAL_STATUSES = [
 export function isReviewableStorePriceMatchProposalStatus(
   status: StorePriceMatchProposal["status"],
 ): status is (typeof REVIEWABLE_STORE_PRICE_MATCH_PROPOSAL_STATUSES)[number] {
-  return status === "pending_review" || status === "errored";
+  return (
+    status === "verified" || status === "pending_review" || status === "errored"
+  );
 }


### PR DESCRIPTION
Auto-approve store price matches that already resolve directly to the current bottle.

We were persisting two kinds of decisive matches as reviewable proposals instead of closing them automatically: trusted SMWS listings that were already linked to the matched bottle, and generic proposals that reached `verified` because the current assignment already matched the classifier result. That left obvious direct matches in the queue even though no moderator action was needed.

This changes both paths to run the normal approval side effects, updates reviewable status handling for `verified`, and adds regression coverage for the SMWS and non-SMWS same-bottle cases. Verified with `pnpm test`.