### PR TITLE
fix(bottles): Add brand/distillery repair tooling

### DIFF
--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -11,7 +11,10 @@ import {
   applyRepairBackfillProposals,
   type BatchApplicableRepairBackfillProposalType,
 } from "@peated/server/lib/applyRepairBackfillProposals";
-import { upsertBottleAlias } from "@peated/server/lib/db";
+import {
+  findEntityByExactNameOrAlias,
+  upsertBottleAlias,
+} from "@peated/server/lib/db";
 import { fixBadReviewEntities } from "@peated/server/lib/fixBadReviewEntities";
 import { formatBottleName } from "@peated/server/lib/format";
 import {
@@ -27,6 +30,7 @@ import {
   type RepairBackfillProposal,
   type RepairBackfillProposalType,
 } from "@peated/server/lib/repairBackfillProposals";
+import { repairBottleBrandDistilleryAssignments } from "@peated/server/lib/repairBottleBrandDistilleryAssignments";
 import { getAutomationModeratorUser } from "@peated/server/lib/systemUser";
 import { routerClient } from "@peated/server/orpc/router";
 import { runJob } from "@peated/server/worker/client";
@@ -132,6 +136,35 @@ function formatReleaseRepairReviewSummaryLine(
   candidate: LegacyReleaseRepairCandidate,
 ) {
   return `[release/${candidate.repairMode}] ${candidate.legacyBottle.fullName} -> ${candidate.proposedParent.fullName}`;
+}
+
+async function resolveEntityReference(
+  value: string,
+  {
+    label,
+    requiredType,
+  }: {
+    label: string;
+    requiredType?: "brand" | "distiller" | "bottler";
+  },
+) {
+  const entity = /^\d+$/.test(value)
+    ? await db.query.entities.findFirst({
+        where: eq(entities.id, Number.parseInt(value, 10)),
+      })
+    : await findEntityByExactNameOrAlias(db, value);
+
+  if (!entity) {
+    throw new Error(`${label} not found: ${value}`);
+  }
+
+  if (requiredType && !entity.type.includes(requiredType)) {
+    throw new Error(
+      `${label} must include entity type "${requiredType}": ${entity.name}`,
+    );
+  }
+
+  return entity;
 }
 
 subcommand
@@ -650,5 +683,82 @@ subcommand
         hasResults = true;
       }
       offset += step;
+    }
+  });
+
+subcommand
+  .command("repair-brand-distillery")
+  .description(
+    "Preview or apply bulk bottle brand/distillery identity repairs without renaming bottle titles",
+  )
+  .requiredOption("--from-brand <entity>", "Source brand entity name or id")
+  .requiredOption("--to-brand <entity>", "Target brand entity name or id")
+  .option(
+    "--distillery <entity>",
+    "Distillery entity name or id to ensure on repaired bottles",
+  )
+  .option("--limit <number>", "Maximum number of bottles to scan")
+  .option("--query <query>", "Filter candidate bottles by full name", "")
+  .option(
+    "--execute",
+    "Actually apply the repair. Without this flag the command only previews.",
+  )
+  .argument("[bottleIds...]")
+  .action(async (bottleIds: string[], options) => {
+    const fromBrand = await resolveEntityReference(options.fromBrand, {
+      label: "Source brand",
+      requiredType: "brand",
+    });
+    const toBrand = await resolveEntityReference(options.toBrand, {
+      label: "Target brand",
+      requiredType: "brand",
+    });
+    const distillery = options.distillery
+      ? await resolveEntityReference(options.distillery, {
+          label: "Distillery",
+          requiredType: "distiller",
+        })
+      : null;
+
+    let limit: number | undefined;
+    if (options.limit !== undefined) {
+      const parsedLimit = Number.parseInt(options.limit, 10);
+      if (
+        !Number.isFinite(parsedLimit) ||
+        Number.isNaN(parsedLimit) ||
+        parsedLimit <= 0
+      ) {
+        throw new Error(`Invalid limit: ${options.limit}`);
+      }
+      limit = parsedLimit;
+    }
+
+    const result = await repairBottleBrandDistilleryAssignments({
+      bottleIds: bottleIds.map((value: string) => Number.parseInt(value, 10)),
+      distilleryId: distillery?.id ?? null,
+      dryRun: !options.execute,
+      fromBrand,
+      limit,
+      query: options.query,
+      toBrand,
+      user: options.execute ? await getAutomationModeratorUser() : undefined,
+    });
+
+    console.log(
+      `${options.execute ? "Applied" : "Previewed"} bottle brand/distillery repairs: ${result.summary.total}`,
+    );
+    console.log(
+      `planned=${result.summary.planned} applied=${result.summary.applied} failed=${result.summary.failed} seriesCreated=${result.summary.seriesCreated} seriesReused=${result.summary.seriesReused}`,
+    );
+
+    for (const item of result.items) {
+      console.log(`[${item.status}] ${item.bottleFullName} (${item.bottleId})`);
+      console.log(`  ${item.message}`);
+    }
+
+    if (options.execute && result.summary.failed > 0) {
+      throw new Error(
+        `${result.summary.failed} bottle repair(s) failed during execution.`,
+      );
     }
   });

--- a/apps/server/src/lib/repairBottleBrandDistilleryAssignments.test.ts
+++ b/apps/server/src/lib/repairBottleBrandDistilleryAssignments.test.ts
@@ -1,0 +1,275 @@
+import { db } from "@peated/server/db";
+import {
+  bottleSeries,
+  bottles,
+  bottlesToDistillers,
+  changes,
+} from "@peated/server/db/schema";
+import { repairBottleBrandDistilleryAssignments } from "@peated/server/lib/repairBottleBrandDistilleryAssignments";
+import { and, eq } from "drizzle-orm";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const pushUniqueJobMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@peated/server/worker/client", () => ({
+  pushUniqueJob: pushUniqueJobMock,
+}));
+
+describe("repairBottleBrandDistilleryAssignments", () => {
+  beforeEach(() => {
+    pushUniqueJobMock.mockReset();
+  });
+
+  test("previews Jura-style repairs without mutating bottle data", async ({
+    fixtures,
+  }) => {
+    const fromBrand = await fixtures.Entity({
+      name: "Isle of Jura",
+      type: ["brand", "distiller"],
+    });
+    const toBrand = await fixtures.Entity({
+      name: "Jura",
+      type: ["brand"],
+    });
+    const sourceSeries = await fixtures.BottleSeries({
+      brandId: fromBrand.id,
+      name: "12-year-old",
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: fromBrand.id,
+      name: "12-year-old Single Malt Scotch Whisky",
+      seriesId: sourceSeries.id,
+    });
+    await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      edition: "2024 Release",
+    });
+
+    const result = await repairBottleBrandDistilleryAssignments({
+      distilleryId: fromBrand.id,
+      dryRun: true,
+      fromBrand,
+      toBrand,
+    });
+
+    expect(result.summary).toEqual({
+      applied: 0,
+      failed: 0,
+      planned: 1,
+      seriesCreated: 1,
+      seriesReused: 0,
+      total: 1,
+    });
+    expect(result.items).toEqual([
+      {
+        bottleFullName: bottle.fullName,
+        bottleId: bottle.id,
+        distilleryAdded: true,
+        message:
+          "brand Isle of Jura -> Jura; add distillery Isle of Jura; create series 12-year-old; 1 release(s) reindexed",
+        releaseCount: 1,
+        seriesAction: "create_new",
+        status: "planned",
+      },
+    ]);
+
+    const [unchangedBottle] = await db
+      .select()
+      .from(bottles)
+      .where(eq(bottles.id, bottle.id));
+    expect(unchangedBottle.brandId).toEqual(fromBrand.id);
+    expect(unchangedBottle.seriesId).toEqual(sourceSeries.id);
+
+    const distilleryLinks = await db
+      .select()
+      .from(bottlesToDistillers)
+      .where(eq(bottlesToDistillers.bottleId, bottle.id));
+    expect(distilleryLinks).toHaveLength(0);
+
+    const targetSeries = await db.query.bottleSeries.findFirst({
+      where: and(
+        eq(bottleSeries.brandId, toBrand.id),
+        eq(bottleSeries.name, sourceSeries.name),
+      ),
+    });
+    expect(targetSeries).toBeUndefined();
+    expect(pushUniqueJobMock).not.toHaveBeenCalled();
+  });
+
+  test("repairs the bottle brand, adds the distillery, and creates a target series without renaming the bottle", async ({
+    fixtures,
+  }) => {
+    const systemUser = await fixtures.User({ admin: true });
+    const fromBrand = await fixtures.Entity({
+      name: "Isle of Jura",
+      type: ["brand", "distiller"],
+    });
+    const toBrand = await fixtures.Entity({
+      name: "Jura",
+      type: ["brand"],
+    });
+    const sourceSeries = await fixtures.BottleSeries({
+      brandId: fromBrand.id,
+      name: "12-year-old",
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: fromBrand.id,
+      name: "12-year-old Single Malt Scotch Whisky",
+      seriesId: sourceSeries.id,
+    });
+    const release = await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      edition: "2024 Release",
+    });
+
+    const result = await repairBottleBrandDistilleryAssignments({
+      distilleryId: fromBrand.id,
+      dryRun: false,
+      fromBrand,
+      toBrand,
+      user: systemUser,
+    });
+
+    expect(result.summary).toEqual({
+      applied: 1,
+      failed: 0,
+      planned: 0,
+      seriesCreated: 1,
+      seriesReused: 0,
+      total: 1,
+    });
+
+    const [updatedBottle] = await db
+      .select()
+      .from(bottles)
+      .where(eq(bottles.id, bottle.id));
+    expect(updatedBottle.brandId).toEqual(toBrand.id);
+    expect(updatedBottle.fullName).toEqual(bottle.fullName);
+    expect(updatedBottle.seriesId).not.toEqual(sourceSeries.id);
+
+    const distilleryLinks = await db
+      .select()
+      .from(bottlesToDistillers)
+      .where(eq(bottlesToDistillers.bottleId, bottle.id));
+    expect(distilleryLinks).toHaveLength(1);
+    expect(distilleryLinks[0]?.distillerId).toEqual(fromBrand.id);
+
+    const [reindexedSeries] = await db
+      .select()
+      .from(bottleSeries)
+      .where(eq(bottleSeries.id, updatedBottle.seriesId!));
+    expect(reindexedSeries.brandId).toEqual(toBrand.id);
+    expect(reindexedSeries.name).toEqual(sourceSeries.name);
+
+    const [updatedSourceSeries] = await db
+      .select()
+      .from(bottleSeries)
+      .where(eq(bottleSeries.id, sourceSeries.id));
+    expect(updatedSourceSeries.numReleases).toEqual(0);
+    expect(reindexedSeries.numReleases).toEqual(1);
+
+    const change = await db.query.changes.findFirst({
+      where: and(
+        eq(changes.objectId, bottle.id),
+        eq(changes.objectType, "bottle"),
+        eq(changes.type, "update"),
+      ),
+      orderBy: (changes, { desc }) => [desc(changes.createdAt)],
+    });
+    expect(change?.createdById).toEqual(systemUser.id);
+    expect(change?.data).toEqual({
+      brandId: toBrand.id,
+      distillerIds: [fromBrand.id],
+      seriesId: reindexedSeries.id,
+    });
+
+    expect(pushUniqueJobMock).toHaveBeenCalledWith(
+      "OnBottleChange",
+      { bottleId: bottle.id },
+      { delay: 5000 },
+    );
+    expect(pushUniqueJobMock).toHaveBeenCalledWith(
+      "OnBottleReleaseChange",
+      { releaseId: release.id },
+      { delay: 5000 },
+    );
+    expect(pushUniqueJobMock).toHaveBeenCalledWith(
+      "IndexBottleSeriesSearchVectors",
+      { seriesId: reindexedSeries.id },
+      { delay: 5000 },
+    );
+    expect(pushUniqueJobMock).toHaveBeenCalledWith(
+      "OnEntityChange",
+      { entityId: fromBrand.id },
+      { delay: 5000 },
+    );
+    expect(pushUniqueJobMock).toHaveBeenCalledWith(
+      "OnEntityChange",
+      { entityId: toBrand.id },
+      { delay: 5000 },
+    );
+  });
+
+  test("reuses an existing target-brand series and avoids duplicate distillery links", async ({
+    fixtures,
+  }) => {
+    const systemUser = await fixtures.User({ admin: true });
+    const fromBrand = await fixtures.Entity({
+      name: "Isle of Jura",
+      type: ["brand", "distiller"],
+    });
+    const toBrand = await fixtures.Entity({
+      name: "Jura",
+      type: ["brand"],
+    });
+    const sourceSeries = await fixtures.BottleSeries({
+      brandId: fromBrand.id,
+      name: "Elixir",
+    });
+    const targetSeries = await fixtures.BottleSeries({
+      brandId: toBrand.id,
+      name: "Elixir",
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: fromBrand.id,
+      name: "Elixir",
+      seriesId: sourceSeries.id,
+      distillerIds: [fromBrand.id],
+    });
+
+    const result = await repairBottleBrandDistilleryAssignments({
+      distilleryId: fromBrand.id,
+      dryRun: false,
+      fromBrand,
+      toBrand,
+      user: systemUser,
+    });
+
+    expect(result.summary).toEqual({
+      applied: 1,
+      failed: 0,
+      planned: 0,
+      seriesCreated: 0,
+      seriesReused: 1,
+      total: 1,
+    });
+
+    const [updatedBottle] = await db
+      .select()
+      .from(bottles)
+      .where(eq(bottles.id, bottle.id));
+    expect(updatedBottle.brandId).toEqual(toBrand.id);
+    expect(updatedBottle.seriesId).toEqual(targetSeries.id);
+
+    const distilleryLinks = await db
+      .select()
+      .from(bottlesToDistillers)
+      .where(eq(bottlesToDistillers.bottleId, bottle.id));
+    expect(distilleryLinks).toHaveLength(1);
+    expect(pushUniqueJobMock).not.toHaveBeenCalledWith(
+      "IndexBottleSeriesSearchVectors",
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+});

--- a/apps/server/src/lib/repairBottleBrandDistilleryAssignments.ts
+++ b/apps/server/src/lib/repairBottleBrandDistilleryAssignments.ts
@@ -1,0 +1,473 @@
+import {
+  db as defaultDb,
+  type AnyDatabase,
+  type AnyTransaction,
+} from "@peated/server/db";
+import type { BottleSeries, Entity, User } from "@peated/server/db/schema";
+import {
+  bottleReleases,
+  bottles,
+  bottleSeries,
+  bottlesToDistillers,
+  changes,
+} from "@peated/server/db/schema";
+import { processSeries } from "@peated/server/lib/bottleHelpers";
+import { logError } from "@peated/server/lib/log";
+import { pushUniqueJob } from "@peated/server/worker/client";
+import { and, asc, eq, ilike, inArray, sql } from "drizzle-orm";
+
+type RepairSeriesAction = "none" | "reuse_existing" | "create_new";
+type RepairStatus = "planned" | "applied" | "failed";
+
+export type RepairBottleBrandDistilleryAssignmentItem = {
+  bottleFullName: string;
+  bottleId: number;
+  distilleryAdded: boolean;
+  message: string;
+  releaseCount: number;
+  seriesAction: RepairSeriesAction;
+  status: RepairStatus;
+};
+
+export type RepairBottleBrandDistilleryAssignmentResult = {
+  items: RepairBottleBrandDistilleryAssignmentItem[];
+  summary: {
+    applied: number;
+    failed: number;
+    planned: number;
+    seriesCreated: number;
+    seriesReused: number;
+    total: number;
+  };
+};
+
+type RepairBottleBrandDistilleryAssignmentOptions = {
+  bottleIds?: number[];
+  db?: AnyDatabase;
+  distilleryId?: number | null;
+  dryRun?: boolean;
+  fromBrand: Entity;
+  limit?: number | null;
+  query?: string;
+  toBrand: Entity;
+  user?: Pick<User, "id">;
+};
+
+type CandidateBottle = typeof bottles.$inferSelect;
+type CandidateRelease = Pick<
+  typeof bottleReleases.$inferSelect,
+  "bottleId" | "id"
+>;
+
+function buildSummary(
+  items: RepairBottleBrandDistilleryAssignmentItem[],
+): RepairBottleBrandDistilleryAssignmentResult["summary"] {
+  return items.reduce(
+    (summary, item) => {
+      summary.total += 1;
+
+      if (item.status === "planned") {
+        summary.planned += 1;
+      } else if (item.status === "applied") {
+        summary.applied += 1;
+      } else if (item.status === "failed") {
+        summary.failed += 1;
+      }
+
+      if (item.seriesAction === "create_new") {
+        summary.seriesCreated += 1;
+      } else if (item.seriesAction === "reuse_existing") {
+        summary.seriesReused += 1;
+      }
+
+      return summary;
+    },
+    {
+      applied: 0,
+      failed: 0,
+      planned: 0,
+      seriesCreated: 0,
+      seriesReused: 0,
+      total: 0,
+    },
+  );
+}
+
+async function syncSeriesBottleCount({
+  db,
+  seriesId,
+}: {
+  db: AnyDatabase;
+  seriesId: number;
+}) {
+  await db
+    .update(bottleSeries)
+    .set({
+      numReleases: sql`(
+        SELECT COUNT(*)
+        FROM ${bottles}
+        WHERE ${bottles.seriesId} = ${seriesId}
+      )`,
+    })
+    .where(eq(bottleSeries.id, seriesId));
+}
+
+async function ensureTargetSeries({
+  currentSeries,
+  db,
+  toBrand,
+  userId,
+}: {
+  currentSeries: BottleSeries;
+  db: AnyTransaction;
+  toBrand: Entity;
+  userId: number;
+}) {
+  if (currentSeries.brandId === toBrand.id) {
+    return {
+      created: false,
+      seriesAction: "none" as const,
+      seriesId: currentSeries.id,
+    };
+  }
+
+  const [seriesId, created] = await processSeries({
+    tx: db,
+    series: {
+      description: currentSeries.description,
+      name: currentSeries.name,
+    },
+    brand: toBrand,
+    userId,
+  });
+
+  if (!seriesId) {
+    throw new Error("Failed to resolve target series.");
+  }
+
+  return {
+    created,
+    seriesAction: created
+      ? ("create_new" as const)
+      : ("reuse_existing" as const),
+    seriesId,
+  };
+}
+
+export async function repairBottleBrandDistilleryAssignments({
+  bottleIds = [],
+  db = defaultDb,
+  distilleryId = null,
+  dryRun = true,
+  fromBrand,
+  limit = null,
+  query = "",
+  toBrand,
+  user,
+}: RepairBottleBrandDistilleryAssignmentOptions): Promise<RepairBottleBrandDistilleryAssignmentResult> {
+  if (fromBrand.id === toBrand.id) {
+    throw new Error("Source and target brand must be different.");
+  }
+
+  if (!dryRun && !user) {
+    throw new Error("A user is required to apply bottle brand repairs.");
+  }
+
+  const where = and(
+    eq(bottles.brandId, fromBrand.id),
+    bottleIds.length ? inArray(bottles.id, bottleIds) : undefined,
+    query.trim().length
+      ? ilike(bottles.fullName, `%${query.trim()}%`)
+      : undefined,
+  );
+
+  const bottleQuery = db
+    .select()
+    .from(bottles)
+    .where(where)
+    .orderBy(asc(bottles.id));
+
+  const candidateBottles = (
+    limit ? await bottleQuery.limit(limit) : await bottleQuery
+  ) as CandidateBottle[];
+
+  if (candidateBottles.length === 0) {
+    return {
+      items: [],
+      summary: {
+        applied: 0,
+        failed: 0,
+        planned: 0,
+        seriesCreated: 0,
+        seriesReused: 0,
+        total: 0,
+      },
+    };
+  }
+
+  const candidateBottleIds = candidateBottles.map(({ id }) => id);
+  const candidateSeriesIds = Array.from(
+    new Set(
+      candidateBottles
+        .map((bottle) => bottle.seriesId)
+        .filter((seriesId): seriesId is number => Boolean(seriesId)),
+    ),
+  );
+
+  const [distilleryRows, releaseRows, sourceSeriesRows] = await Promise.all([
+    db
+      .select({
+        bottleId: bottlesToDistillers.bottleId,
+        distilleryId: bottlesToDistillers.distillerId,
+      })
+      .from(bottlesToDistillers)
+      .where(inArray(bottlesToDistillers.bottleId, candidateBottleIds)),
+    candidateBottleIds.length
+      ? db
+          .select({
+            bottleId: bottleReleases.bottleId,
+            id: bottleReleases.id,
+          })
+          .from(bottleReleases)
+          .where(inArray(bottleReleases.bottleId, candidateBottleIds))
+      : Promise.resolve([] as CandidateRelease[]),
+    candidateSeriesIds.length
+      ? db
+          .select()
+          .from(bottleSeries)
+          .where(inArray(bottleSeries.id, candidateSeriesIds))
+      : Promise.resolve([] as BottleSeries[]),
+  ]);
+
+  const distilleryIdsByBottleId = new Map<number, Set<number>>();
+  for (const row of distilleryRows) {
+    const current = distilleryIdsByBottleId.get(row.bottleId) ?? new Set();
+    current.add(row.distilleryId);
+    distilleryIdsByBottleId.set(row.bottleId, current);
+  }
+
+  const releasesByBottleId = new Map<number, CandidateRelease[]>();
+  for (const row of releaseRows) {
+    const current = releasesByBottleId.get(row.bottleId) ?? [];
+    current.push(row);
+    releasesByBottleId.set(row.bottleId, current);
+  }
+
+  const sourceSeriesById = new Map(
+    sourceSeriesRows.map((series) => [series.id, series]),
+  );
+
+  const targetSeriesNameList = Array.from(
+    new Set(
+      sourceSeriesRows.map((series) =>
+        `${toBrand.name} ${series.name}`.toLowerCase(),
+      ),
+    ),
+  );
+
+  const existingTargetSeriesRows =
+    targetSeriesNameList.length > 0
+      ? await db
+          .select()
+          .from(bottleSeries)
+          .where(
+            inArray(sql`LOWER(${bottleSeries.fullName})`, targetSeriesNameList),
+          )
+      : [];
+
+  const existingTargetSeriesByFullName = new Map(
+    existingTargetSeriesRows.map((series) => [
+      series.fullName.toLowerCase(),
+      series,
+    ]),
+  );
+
+  const items: RepairBottleBrandDistilleryAssignmentItem[] = [];
+  const touchedEntityIds = new Set<number>([fromBrand.id, toBrand.id]);
+  if (distilleryId) {
+    touchedEntityIds.add(distilleryId);
+  }
+
+  for (const bottle of candidateBottles) {
+    const bottleDistilleryIds =
+      distilleryIdsByBottleId.get(bottle.id) ?? new Set();
+    const releaseList = releasesByBottleId.get(bottle.id) ?? [];
+    const shouldAddDistillery =
+      distilleryId !== null && !bottleDistilleryIds.has(distilleryId);
+
+    let seriesAction: RepairSeriesAction = "none";
+    const currentSeries = bottle.seriesId
+      ? (sourceSeriesById.get(bottle.seriesId) ?? null)
+      : null;
+
+    if (currentSeries && currentSeries.brandId !== toBrand.id) {
+      const existingTargetSeries = existingTargetSeriesByFullName.get(
+        `${toBrand.name} ${currentSeries.name}`.toLowerCase(),
+      );
+      seriesAction = existingTargetSeries ? "reuse_existing" : "create_new";
+    }
+
+    const baseMessage = [
+      `brand ${fromBrand.name} -> ${toBrand.name}`,
+      shouldAddDistillery && distilleryId
+        ? `add distillery ${
+            fromBrand.id === distilleryId ? fromBrand.name : "link"
+          }`
+        : null,
+      currentSeries && seriesAction !== "none"
+        ? `${seriesAction === "create_new" ? "create" : "reuse"} series ${currentSeries.name}`
+        : null,
+      releaseList.length ? `${releaseList.length} release(s) reindexed` : null,
+    ]
+      .filter(Boolean)
+      .join("; ");
+
+    if (dryRun) {
+      items.push({
+        bottleFullName: bottle.fullName,
+        bottleId: bottle.id,
+        distilleryAdded: shouldAddDistillery,
+        message: baseMessage,
+        releaseCount: releaseList.length,
+        seriesAction,
+        status: "planned",
+      });
+      continue;
+    }
+
+    try {
+      let createdSeriesId: number | null = null;
+      let nextSeriesId = bottle.seriesId ?? null;
+
+      await db.transaction(async (tx) => {
+        if (currentSeries) {
+          const ensuredSeries = await ensureTargetSeries({
+            currentSeries,
+            db: tx,
+            toBrand,
+            userId: user!.id,
+          });
+          nextSeriesId = ensuredSeries.seriesId;
+          seriesAction = ensuredSeries.seriesAction;
+          if (ensuredSeries.created) {
+            createdSeriesId = ensuredSeries.seriesId;
+          }
+        }
+
+        if (shouldAddDistillery && distilleryId) {
+          await tx
+            .insert(bottlesToDistillers)
+            .values({
+              bottleId: bottle.id,
+              distillerId: distilleryId,
+            })
+            .onConflictDoNothing();
+        }
+
+        await tx
+          .update(bottles)
+          .set({
+            brandId: toBrand.id,
+            seriesId: nextSeriesId,
+            updatedAt: sql`NOW()`,
+          })
+          .where(eq(bottles.id, bottle.id));
+
+        if (currentSeries && nextSeriesId !== currentSeries.id) {
+          await syncSeriesBottleCount({
+            db: tx,
+            seriesId: currentSeries.id,
+          });
+        }
+        if (nextSeriesId) {
+          await syncSeriesBottleCount({
+            db: tx,
+            seriesId: nextSeriesId,
+          });
+        }
+
+        await tx.insert(changes).values({
+          objectId: bottle.id,
+          objectType: "bottle",
+          type: "update",
+          displayName: bottle.fullName,
+          createdById: user!.id,
+          data: {
+            brandId: toBrand.id,
+            distillerIds:
+              shouldAddDistillery && distilleryId ? [distilleryId] : undefined,
+            seriesId:
+              nextSeriesId !== bottle.seriesId ? nextSeriesId : undefined,
+          },
+        });
+      });
+
+      await pushUniqueJob(
+        "OnBottleChange",
+        { bottleId: bottle.id },
+        { delay: 5000 },
+      );
+
+      for (const release of releaseList) {
+        await pushUniqueJob(
+          "OnBottleReleaseChange",
+          { releaseId: release.id },
+          { delay: 5000 },
+        );
+      }
+
+      if (createdSeriesId) {
+        await pushUniqueJob(
+          "IndexBottleSeriesSearchVectors",
+          { seriesId: createdSeriesId },
+          { delay: 5000 },
+        );
+      }
+
+      items.push({
+        bottleFullName: bottle.fullName,
+        bottleId: bottle.id,
+        distilleryAdded: shouldAddDistillery,
+        message: baseMessage,
+        releaseCount: releaseList.length,
+        seriesAction,
+        status: "applied",
+      });
+    } catch (err) {
+      logError(err, {
+        bottle: {
+          id: bottle.id,
+        },
+      });
+
+      items.push({
+        bottleFullName: bottle.fullName,
+        bottleId: bottle.id,
+        distilleryAdded: shouldAddDistillery,
+        message: err instanceof Error ? err.message : "Unknown repair failure.",
+        releaseCount: releaseList.length,
+        seriesAction,
+        status: "failed",
+      });
+    }
+  }
+
+  if (!dryRun) {
+    for (const entityId of touchedEntityIds) {
+      try {
+        await pushUniqueJob("OnEntityChange", { entityId }, { delay: 5000 });
+      } catch (err) {
+        logError(err, {
+          entity: {
+            id: entityId,
+          },
+        });
+      }
+    }
+  }
+
+  return {
+    items,
+    summary: buildSummary(items),
+  };
+}


### PR DESCRIPTION
Add a batch repair path for bottles whose brand and distillery identities have been conflated.

We have a number of Jura bottles stored under the `Isle of Jura` brand even though `Jura` is the brand and `Isle of Jura` is the distillery. This adds a reusable repair helper and CLI command that can preview or apply that fix in bulk, starting with a dry run.

The repair reassigns the bottle brand, ensures the expected distillery link exists, and moves bottles into the target brand's equivalent series when needed. It intentionally does not rename bottle titles so we can correct structured identity data first without creating extra title or alias churn.