### PR TITLE
fix(classifier): Keep plain matches out of strength families

### DIFF
--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -502,6 +502,193 @@ describe("priceMatching", () => {
     expect(proposal.confidence).toBe(88);
   });
 
+  test("keeps a plain age-statement match instead of drifting into a cask-strength release proposal", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
+    const tomatin = await fixtures.Entity({
+      name: "Tomatin",
+      type: ["brand", "distiller"],
+    });
+    const generic12Bottle = await fixtures.Bottle({
+      brandId: tomatin.id,
+      distillerIds: [tomatin.id],
+      name: "12-year-old",
+      category: "single_malt",
+      statedAge: 12,
+    });
+    const bourbonAndSherryBottle = await fixtures.Bottle({
+      brandId: tomatin.id,
+      distillerIds: [tomatin.id],
+      name: "12-year-old Bourbon & Sherry Casks",
+      category: "single_malt",
+      statedAge: 12,
+    });
+    const caskStrengthBottle = await fixtures.Bottle({
+      brandId: tomatin.id,
+      distillerIds: [tomatin.id],
+      name: "Cask Strength",
+      category: "single_malt",
+      caskStrength: true,
+    });
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      name: "Tomatin Single Malt 12-year-old",
+      imageUrl: null,
+      url: "https://www.totalwine.com/example",
+    });
+
+    vi.mocked(extractFromText).mockResolvedValue({
+      brand: "Tomatin",
+      bottler: null,
+      expression: null,
+      series: null,
+      distillery: ["Tomatin"],
+      category: "single_malt",
+      stated_age: 12,
+      abv: null,
+      release_year: null,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    });
+    vi.mocked(classifyBottleReference).mockResolvedValue(
+      buildMockBottleReferenceClassification({
+        decision: {
+          action: "match_existing",
+          confidence: 95,
+          rationale:
+            "The listing supports the generic 12-year-old bottle, not a cask-strength sibling.",
+          suggestedBottleId: generic12Bottle.id,
+          candidateBottleIds: [
+            generic12Bottle.id,
+            bourbonAndSherryBottle.id,
+            caskStrengthBottle.id,
+          ],
+          proposedBottle: null,
+        },
+        searchEvidence: [],
+        candidateBottles: [
+          {
+            kind: "bottle",
+            bottleId: generic12Bottle.id,
+            releaseId: null,
+            alias: "Tomatin Single Malt 12-year-old",
+            fullName: generic12Bottle.fullName,
+            bottleFullName: generic12Bottle.fullName,
+            brand: "Tomatin",
+            bottler: null,
+            series: null,
+            distillery: ["Tomatin"],
+            category: "single_malt",
+            statedAge: 12,
+            edition: null,
+            caskStrength: null,
+            singleCask: null,
+            abv: null,
+            vintageYear: null,
+            releaseYear: null,
+            caskType: null,
+            caskSize: null,
+            caskFill: null,
+            score: 1,
+            source: ["text"],
+          },
+          {
+            kind: "bottle",
+            bottleId: bourbonAndSherryBottle.id,
+            releaseId: null,
+            alias: null,
+            fullName: bourbonAndSherryBottle.fullName,
+            bottleFullName: bourbonAndSherryBottle.fullName,
+            brand: "Tomatin",
+            bottler: null,
+            series: null,
+            distillery: ["Tomatin"],
+            category: "single_malt",
+            statedAge: 12,
+            edition: null,
+            caskStrength: null,
+            singleCask: null,
+            abv: null,
+            vintageYear: null,
+            releaseYear: null,
+            caskType: null,
+            caskSize: null,
+            caskFill: null,
+            score: 1,
+            source: ["text"],
+          },
+          {
+            kind: "bottle",
+            bottleId: caskStrengthBottle.id,
+            releaseId: null,
+            alias: null,
+            fullName: caskStrengthBottle.fullName,
+            bottleFullName: caskStrengthBottle.fullName,
+            brand: "Tomatin",
+            bottler: null,
+            series: null,
+            distillery: ["Tomatin"],
+            category: "single_malt",
+            statedAge: null,
+            edition: null,
+            caskStrength: true,
+            singleCask: null,
+            abv: null,
+            vintageYear: null,
+            releaseYear: null,
+            caskType: null,
+            caskSize: null,
+            caskFill: null,
+            score: 1,
+            source: ["text"],
+          },
+        ],
+        resolvedEntities: [],
+      }),
+    );
+
+    const proposal = await resolveStorePriceMatchProposal(price.id);
+
+    expect(proposal).toMatchObject({
+      status: "pending_review",
+      proposalType: "match_existing",
+      suggestedBottleId: generic12Bottle.id,
+      suggestedReleaseId: null,
+      parentBottleId: null,
+      creationTarget: null,
+      proposedBottle: null,
+      proposedRelease: null,
+    });
+    expect(proposal.candidateBottles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          bottleId: generic12Bottle.id,
+          fullName: generic12Bottle.fullName,
+        }),
+        expect.objectContaining({
+          bottleId: bourbonAndSherryBottle.id,
+          fullName: bourbonAndSherryBottle.fullName,
+        }),
+        expect.objectContaining({
+          bottleId: caskStrengthBottle.id,
+          fullName: caskStrengthBottle.fullName,
+          caskStrength: true,
+        }),
+      ]),
+    );
+  });
+
   test("auto approves high-confidence matches that reaffirm the current bottle assignment", async ({
     fixtures,
   }) => {

--- a/packages/bottle-classifier/src/classifier.eval.fixtures.ts
+++ b/packages/bottle-classifier/src/classifier.eval.fixtures.ts
@@ -125,6 +125,42 @@ const macallanSherryOakLegacy30 = buildBottleCandidate({
   source: ["exact"],
 });
 
+const tomatinLegacy12 = buildBottleCandidate({
+  bottleId: 65001,
+  alias: "Tomatin Single Malt 12-year-old",
+  fullName: "Tomatin 12-year-old",
+  brand: "Tomatin",
+  distillery: ["Tomatin"],
+  category: "single_malt",
+  statedAge: 12,
+  score: 1,
+  source: ["exact"],
+});
+
+const tomatinCaskStrengthParent = buildBottleCandidate({
+  bottleId: 65002,
+  fullName: "Tomatin Cask Strength",
+  brand: "Tomatin",
+  distillery: ["Tomatin"],
+  category: "single_malt",
+  caskStrength: true,
+  score: 0.82,
+  source: ["text"],
+});
+
+const tomatinBourbonAndSherryCasks = buildBottleCandidate({
+  bottleId: 65003,
+  fullName: "Tomatin 12-year-old Bourbon & Sherry Casks",
+  brand: "Tomatin",
+  distillery: ["Tomatin"],
+  category: "single_malt",
+  statedAge: 12,
+  abv: 43,
+  caskType: null,
+  score: 0.81,
+  source: ["text"],
+});
+
 const taleOfIceCream = buildBottleCandidate({
   bottleId: 43236,
   fullName: "Glenmorangie A Tale of Ice Cream",
@@ -609,6 +645,34 @@ export const EVAL_CASES: ClassifierEvalCase[] = [
       parentBottleId: 54082,
       summary:
         "Treat the local 30-year-old bottle row as a dirty release-like candidate and create a 30-year-old child release beneath the reusable Macallan Sherry Oak parent bottle instead.",
+    },
+  },
+  {
+    name: "store listing: plain Tomatin 12-year-old does not redirect into the cask-strength family",
+    input: {
+      reference: {
+        name: "Tomatin Single Malt 12-year-old",
+        url: "https://shop.example/products/tomatin-12-year-old",
+      },
+      extractedIdentity: buildExtractedIdentity({
+        brand: "Tomatin",
+        distillery: ["Tomatin"],
+        category: "single_malt",
+        stated_age: 12,
+      }),
+      initialCandidates: [
+        tomatinLegacy12,
+        tomatinBourbonAndSherryCasks,
+        tomatinCaskStrengthParent,
+      ],
+    },
+    expected: {
+      status: "classified",
+      action: "match",
+      identityScope: "product",
+      matchedBottleId: 65001,
+      summary:
+        "Keep the plain Tomatin 12-year-old bottle match instead of inventing a child release beneath the unrelated Tomatin Cask Strength family.",
     },
   },
   {

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -208,6 +208,84 @@ const macallanSherryOakLegacy30Candidate: BottleCandidate = {
   source: ["exact"],
 };
 
+const tomatinLegacy12Candidate: BottleCandidate = {
+  bottleId: 65001,
+  releaseId: null,
+  kind: "bottle",
+  alias: "Tomatin Single Malt 12-year-old",
+  fullName: "Tomatin 12-year-old",
+  bottleFullName: "Tomatin 12-year-old",
+  brand: "Tomatin",
+  bottler: null,
+  series: null,
+  distillery: ["Tomatin"],
+  category: "single_malt",
+  statedAge: 12,
+  edition: null,
+  caskStrength: null,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: null,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 1,
+  source: ["exact"],
+};
+
+const tomatinCaskStrengthParentCandidate: BottleCandidate = {
+  bottleId: 65002,
+  releaseId: null,
+  kind: "bottle",
+  alias: null,
+  fullName: "Tomatin Cask Strength",
+  bottleFullName: "Tomatin Cask Strength",
+  brand: "Tomatin",
+  bottler: null,
+  series: null,
+  distillery: ["Tomatin"],
+  category: "single_malt",
+  statedAge: null,
+  edition: null,
+  caskStrength: true,
+  singleCask: null,
+  abv: null,
+  vintageYear: null,
+  releaseYear: null,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 0.82,
+  source: ["text"],
+};
+
+const tomatinBourbonAndSherryCasksCandidate: BottleCandidate = {
+  bottleId: 65003,
+  releaseId: null,
+  kind: "bottle",
+  alias: null,
+  fullName: "Tomatin 12-year-old Bourbon & Sherry Casks",
+  bottleFullName: "Tomatin 12-year-old Bourbon & Sherry Casks",
+  brand: "Tomatin",
+  bottler: null,
+  series: null,
+  distillery: ["Tomatin"],
+  category: "single_malt",
+  statedAge: 12,
+  edition: null,
+  caskStrength: null,
+  singleCask: null,
+  abv: 43,
+  vintageYear: null,
+  releaseYear: null,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  score: 0.81,
+  source: ["text"],
+};
+
 const penelopeBarrelStrengthParentCandidate: BottleCandidate = {
   bottleId: 54068,
   releaseId: null,
@@ -1389,6 +1467,87 @@ describe("createBottleClassifier", () => {
     });
     expect(result.decision.rationale).toContain(
       "legacy release-like bottle candidate",
+    );
+  });
+
+  test("keeps a plain age-statement match instead of redirecting to an unrelated cask-strength family", async () => {
+    const extractedIdentity: BottleExtractedDetails = {
+      brand: "Tomatin",
+      bottler: null,
+      expression: null,
+      series: null,
+      distillery: ["Tomatin"],
+      category: "single_malt",
+      stated_age: 12,
+      abv: null,
+      release_year: null,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    };
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "match",
+          confidence: 95,
+          rationale:
+            "The generic 12-year-old local bottle is the safest match.",
+          identityScope: "product",
+          observation: null,
+          matchedBottleId: 65001,
+          matchedReleaseId: null,
+          parentBottleId: null,
+          candidateBottleIds: [65001, 65002, 65003],
+          proposedBottle: null,
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [],
+          candidates: [
+            tomatinLegacy12Candidate,
+            tomatinBourbonAndSherryCasksCandidate,
+            tomatinCaskStrengthParentCandidate,
+          ],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: {
+        name: "Tomatin Single Malt 12-year-old",
+      },
+      extractedIdentity,
+      initialCandidates: [
+        tomatinLegacy12Candidate,
+        tomatinBourbonAndSherryCasksCandidate,
+        tomatinCaskStrengthParentCandidate,
+      ],
+    });
+
+    expect(result.status).toBe("classified");
+    if (result.status !== "classified") {
+      throw new Error("Expected a classified result");
+    }
+
+    expect(result.decision).toMatchObject({
+      action: "match",
+      matchedBottleId: 65001,
+      matchedReleaseId: null,
+      parentBottleId: null,
+      identityScope: "product",
+    });
+    expect(result.decision.rationale).not.toContain(
+      "Server promoted the bottle match to release creation",
     );
   });
 

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -586,10 +586,12 @@ function candidateNameMatchesReferenceVariants({
   referenceName,
   extractedIdentity,
   candidateNames,
+  allowSafeStrengthPhraseStripping = true,
 }: {
   referenceName: string;
   extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
   candidateNames: string[];
+  allowSafeStrengthPhraseStripping?: boolean;
 }): boolean {
   const referenceTokenVariants = buildReferenceNameTokenVariants({
     referenceName,
@@ -602,9 +604,13 @@ function candidateNameMatchesReferenceVariants({
   return candidateNames.some((candidateName) => {
     const candidateTokenVariants = [
       getComparableNameTokens(candidateName),
-      getComparableNameTokens(
-        stripSafeStrengthPhrases(normalizeComparableText(candidateName)),
-      ),
+      ...(allowSafeStrengthPhraseStripping
+        ? [
+            getComparableNameTokens(
+              stripSafeStrengthPhrases(normalizeComparableText(candidateName)),
+            ),
+          ]
+        : []),
     ].filter((tokens, index, variants) => {
       if (!tokens.length) {
         return false;
@@ -627,10 +633,12 @@ function candidateNameMatchesReferenceVariantsIgnoringStatedAge({
   referenceName,
   extractedIdentity,
   candidateNames,
+  allowSafeStrengthPhraseStripping = true,
 }: {
   referenceName: string;
   extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
   candidateNames: string[];
+  allowSafeStrengthPhraseStripping?: boolean;
 }): boolean {
   if (
     extractedIdentity?.stated_age === null ||
@@ -656,6 +664,7 @@ function candidateNameMatchesReferenceVariantsIgnoringStatedAge({
       stated_age: null,
     },
     candidateNames,
+    allowSafeStrengthPhraseStripping,
   });
 }
 
@@ -1444,12 +1453,14 @@ function resolvePromotableParentBottleTarget({
           referenceName: reference.name,
           extractedIdentity: artifacts.extractedIdentity,
           candidateNames: getBottleTargetNameCandidates(candidate),
+          allowSafeStrengthPhraseStripping: false,
         }) ||
         (looksLikeDirtyAgeReleaseBottle &&
           candidateNameMatchesReferenceVariantsIgnoringStatedAge({
             referenceName: reference.name,
             extractedIdentity: artifacts.extractedIdentity,
             candidateNames: getBottleTargetNameCandidates(candidate),
+            allowSafeStrengthPhraseStripping: false,
           })),
     )
     .sort((left, right) => (right.score ?? 0) - (left.score ?? 0));
@@ -1697,6 +1708,7 @@ function maybePromoteBottleMatchToCreateRelease({
       referenceName: reference.name,
       extractedIdentity: artifacts.extractedIdentity,
       candidateNames: parentTargetNameCandidates,
+      allowSafeStrengthPhraseStripping: false,
     }) ||
     (target &&
       candidateLooksLikeDirtyAgeReleaseBottle({
@@ -1707,6 +1719,7 @@ function maybePromoteBottleMatchToCreateRelease({
         referenceName: reference.name,
         extractedIdentity: artifacts.extractedIdentity,
         candidateNames: parentTargetNameCandidates,
+        allowSafeStrengthPhraseStripping: false,
       }));
   const hasSupportiveWebEvidence = hasSupportiveWebEvidenceForTarget({
     target: parentTarget,
@@ -1784,6 +1797,7 @@ function findReusableParentBottleTargetForCreateRelease({
             referenceName: reference.name,
             extractedIdentity: artifacts.extractedIdentity,
             candidateNames: getBottleTargetNameCandidates(candidate),
+            allowSafeStrengthPhraseStripping: false,
           }) ||
           getBottleTargetNameCandidates(candidate).some(
             (candidateName) =>


### PR DESCRIPTION
Stop the incoming queue from redirecting plain age-statement listings into unrelated cask-strength bottle families.

A Tomatin Single Malt 12-year-old store price was being promoted from a plain bottle match into a create_release proposal under Tomatin Cask Strength. The queue UI was only rendering the stored proposal, so the actual bug lived in classifier review policy. Reusable-parent promotion stripped safe strength phrases while comparing candidate names, which made the cask-strength family look exact-ish enough.

Disable safe-strength stripping in the reusable-parent promotion paths and add regressions at both the classifier and price-matching proposal layers, along with an eval fixture for the Tomatin case. That keeps the generic 12-year-old match in place even when noisy sibling candidates are present.