### PR TITLE
fix(price-matching): Reuse existing auto-create targets

### DIFF
--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -2433,6 +2433,112 @@ describe("priceMatching", () => {
     });
   });
 
+  test("reuses an existing bottle when auto-create collides with a canonical alias", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    await fixtures.User({
+      username: "dcramer",
+      admin: true,
+      mod: true,
+    });
+
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
+    const brand = await fixtures.Entity({
+      name: "Aberfeldy",
+      type: ["brand"],
+    });
+    const distiller = await fixtures.Entity({
+      name: "Aberfeldy Distillery",
+      type: ["distiller"],
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "21-year-old",
+      category: "single_malt",
+      statedAge: 21,
+      distillerIds: [distiller.id],
+    });
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      name: bottle.fullName,
+      imageUrl: null,
+    });
+
+    vi.mocked(classifyBottleReference).mockResolvedValue(
+      buildMockBottleReferenceClassification({
+        decision: {
+          action: "create_new",
+          confidence: 95,
+          rationale: "Official evidence looks like a distinct bottle.",
+          suggestedBottleId: null,
+          candidateBottleIds: [],
+          proposedBottle: {
+            name: "21-year-old",
+            series: null,
+            category: "single_malt",
+            edition: null,
+            statedAge: 21,
+            caskStrength: null,
+            singleCask: null,
+            abv: null,
+            vintageYear: null,
+            releaseYear: null,
+            caskType: null,
+            caskSize: null,
+            caskFill: null,
+            brand: {
+              id: brand.id,
+              name: brand.name,
+            },
+            distillers: [
+              {
+                id: distiller.id,
+                name: distiller.name,
+              },
+            ],
+            bottler: null,
+          },
+        },
+        searchEvidence: [
+          {
+            query: '"Aberfeldy" "21-year-old" official',
+            summary:
+              "The official Aberfeldy page confirms Aberfeldy 21-year-old as a single malt whisky.",
+            results: [
+              {
+                title: "Aberfeldy 21 Year Old",
+                url: "https://www.aberfeldy.com/21-year-old",
+                domain: "aberfeldy.com",
+                description:
+                  "The official Aberfeldy page confirms Aberfeldy 21-year-old as a single malt whisky.",
+                extraSnippets: [],
+              },
+            ],
+          },
+        ],
+        candidateBottles: [],
+        resolvedEntities: [],
+      }),
+    );
+
+    const proposal = await resolveStorePriceMatchProposal(price.id);
+    const updatedPrice = await db.query.storePrices.findFirst({
+      where: eq(storePrices.id, price.id),
+    });
+
+    expect(proposal).toMatchObject({
+      status: "approved",
+      proposalType: "create_new",
+      currentBottleId: bottle.id,
+      suggestedBottleId: bottle.id,
+      error: null,
+    });
+    expect(updatedPrice?.bottleId).toBe(bottle.id);
+  });
+
   test("auto creates new bottles even when replacing an existing assignment", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -34,10 +34,12 @@ import {
 } from "@peated/server/lib/bottleAliases";
 import { buildClassifierCreateInputs } from "@peated/server/lib/classifierDecisionCreateInputs";
 import {
+  BottleAlreadyExistsError,
   createBottleInTransaction,
   finalizeCreatedBottle,
 } from "@peated/server/lib/createBottle";
 import {
+  BottleReleaseAlreadyExistsError,
   createBottleReleaseInTransaction,
   finalizeCreatedBottleRelease,
 } from "@peated/server/lib/createBottleRelease";
@@ -760,6 +762,29 @@ export async function upsertStorePriceMatchProposal({
   return proposal;
 }
 
+async function getExistingBottleReleaseInTransaction(
+  tx: AnyDatabase,
+  {
+    releaseId,
+    bottleId,
+  }: {
+    releaseId: number;
+    bottleId: number;
+  },
+) {
+  const release = await tx.query.bottleReleases.findFirst({
+    where: eq(bottleReleases.id, releaseId),
+  });
+
+  if (!release || release.bottleId !== bottleId) {
+    throw new Error(
+      `Bottle release not found for existing price match proposal result (${releaseId}).`,
+    );
+  }
+
+  return release;
+}
+
 async function createBottleFromStorePriceMatchProposalInTransaction(
   tx: AnyTransaction,
   {
@@ -800,6 +825,11 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
   let createReleaseResult: Awaited<
     ReturnType<typeof createBottleReleaseInTransaction>
   > | null = null;
+  let existingRelease:
+    | Awaited<ReturnType<typeof createBottleReleaseInTransaction>>["release"]
+    | null = null;
+  let resolvedBottleId = proposal.parentBottleId;
+  let resolvedReleaseId: number | null = null;
 
   if (creationTarget === "bottle" || creationTarget === "bottle_and_release") {
     if (!input) {
@@ -808,12 +838,21 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
       );
     }
 
-    createResult = await createBottleInTransaction(tx, {
-      input,
-      context: {
-        user,
-      },
-    });
+    try {
+      createResult = await createBottleInTransaction(tx, {
+        input,
+        context: {
+          user,
+        },
+      });
+      resolvedBottleId = createResult.bottle.id;
+    } catch (err) {
+      if (!(err instanceof BottleAlreadyExistsError)) {
+        throw err;
+      }
+
+      resolvedBottleId = err.bottleId;
+    }
   }
 
   if (creationTarget === "release" || creationTarget === "bottle_and_release") {
@@ -824,9 +863,7 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
     }
 
     const releaseBottleId =
-      creationTarget === "release"
-        ? proposal.parentBottleId
-        : (createResult?.bottle.id ?? null);
+      creationTarget === "release" ? proposal.parentBottleId : resolvedBottleId;
 
     if (!releaseBottleId) {
       throw new Error(
@@ -834,17 +871,31 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
       );
     }
 
-    createReleaseResult = await createBottleReleaseInTransaction(tx, {
-      bottleId: releaseBottleId,
-      input: releaseInput,
-      user,
-    });
+    try {
+      createReleaseResult = await createBottleReleaseInTransaction(tx, {
+        bottleId: releaseBottleId,
+        input: releaseInput,
+        user,
+      });
+      resolvedBottleId = createReleaseResult.release.bottleId;
+      resolvedReleaseId = createReleaseResult.release.id;
+    } catch (err) {
+      if (!(err instanceof BottleReleaseAlreadyExistsError)) {
+        throw err;
+      }
+
+      existingRelease = await getExistingBottleReleaseInTransaction(tx, {
+        releaseId: err.releaseId,
+        bottleId: releaseBottleId,
+      });
+      resolvedBottleId = existingRelease.bottleId;
+      resolvedReleaseId = existingRelease.id;
+    }
   }
 
-  const resolvedBottleId =
-    createResult?.bottle.id ??
-    createReleaseResult?.release.bottleId ??
-    proposal.parentBottleId;
+  if (createResult) {
+    resolvedBottleId = createResult.bottle.id;
+  }
 
   if (!resolvedBottleId) {
     throw new Error(
@@ -857,7 +908,7 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
     {
       proposal,
       bottleId: resolvedBottleId,
-      releaseId: createReleaseResult?.release.id ?? null,
+      releaseId: resolvedReleaseId,
       reviewedById: user.id,
     },
   );
@@ -865,7 +916,10 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
   return {
     createResult,
     createReleaseResult,
+    existingRelease,
     aliasResult,
+    resolvedBottleId,
+    resolvedReleaseId,
   };
 }
 
@@ -918,13 +972,9 @@ export async function createBottleFromStorePriceMatchProposal({
     bottle:
       result.createResult?.bottle ??
       (await db.query.bottles.findFirst({
-        where: eq(
-          bottles.id,
-          result.createReleaseResult?.release.bottleId ??
-            result.aliasResult.alias.bottleId!,
-        ),
+        where: eq(bottles.id, result.resolvedBottleId),
       }))!,
-    release: result.createReleaseResult?.release ?? null,
+    release: result.createReleaseResult?.release ?? result.existingRelease,
   };
 }
 


### PR DESCRIPTION
Handle idempotent auto-create collisions in the price match queue.

Incoming store price matches could take the create_new path even when the canonical bottle or release already existed. When proposal-backed creation hit an existing alias or release identity, the queue persisted "Bottle already exists." as an automation blocker and left the proposal in errored state instead of approving it against the existing target.

This changes proposal-backed bottle and release creation to reuse existing records when duplicate creation is detected, matching the behavior already used in generic bottle reference resolution. It also adds a regression test for an Aberfeldy 21-year-old listing that collides with an existing canonical alias.

Validated with pnpm test.