### PR TITLE
fix(prices): Route bottle metadata mismatches to repair review

### DIFF
--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -1313,6 +1313,181 @@ describe("priceMatching", () => {
     expect(proposal.confidence).toBe(95);
   });
 
+  test("routes same-bottle create drafts into correction review when the current bottle metadata is wrong", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
+    const brand = await fixtures.Entity({
+      name: "The Whistler",
+      type: ["brand", "bottler"],
+    });
+    const currentBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Bodega Cask",
+      category: "blend",
+      distillerIds: [],
+    });
+    const price = await fixtures.StorePrice({
+      bottleId: currentBottle.id,
+      releaseId: null,
+      name: "The Whistler Bodega Cask Single Malt Irish Whiskey",
+      imageUrl: null,
+      url: "https://shop.example/the-whistler-bodega-cask",
+    });
+
+    vi.mocked(extractFromText).mockResolvedValue({
+      brand: "The Whistler",
+      bottler: null,
+      expression: "Bodega Cask",
+      series: null,
+      distillery: ["Boann Distillery"],
+      category: "single_malt",
+      stated_age: null,
+      abv: null,
+      release_year: null,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    });
+    vi.mocked(classifyBottleReference).mockResolvedValue(
+      buildMockBottleReferenceClassification({
+        decision: {
+          action: "create_new",
+          confidence: 92,
+          rationale:
+            "The local bottle shares the base name, but the stored category conflicts with authoritative evidence.",
+          suggestedBottleId: null,
+          candidateBottleIds: [currentBottle.id],
+          proposedBottle: {
+            name: "Bodega Cask",
+            series: null,
+            category: "single_malt",
+            edition: null,
+            statedAge: null,
+            caskStrength: null,
+            singleCask: null,
+            abv: null,
+            vintageYear: null,
+            releaseYear: null,
+            caskType: null,
+            caskSize: null,
+            caskFill: null,
+            brand: {
+              id: brand.id,
+              name: "The Whistler",
+            },
+            distillers: [
+              {
+                id: null,
+                name: "Boann Distillery",
+              },
+            ],
+            bottler: null,
+          },
+        },
+        extractedLabel: {
+          brand: "The Whistler",
+          bottler: null,
+          expression: "Bodega Cask",
+          series: null,
+          distillery: ["Boann Distillery"],
+          category: "single_malt",
+          stated_age: null,
+          abv: null,
+          release_year: null,
+          vintage_year: null,
+          cask_type: null,
+          cask_size: null,
+          cask_fill: null,
+          cask_strength: null,
+          single_cask: null,
+          edition: null,
+        },
+        searchEvidence: [
+          {
+            provider: "openai",
+            query: '"The Whistler Bodega Cask" single malt',
+            summary:
+              "Official and critic sources describe The Whistler Bodega Cask as a single malt from Boann Distillery.",
+            results: [
+              {
+                title: "The Whistler Bodega Cask - Whiskybase",
+                url: "https://www.whiskybase.com/whiskies/whisky/167533/the-whistler-bodega-cask",
+                domain: "whiskybase.com",
+                description:
+                  "Category: Single Malt. Distillery: Boann Distillery.",
+                extraSnippets: [],
+              },
+              {
+                title:
+                  "Whiskey Review: The Whistler Bodega Cask Irish Single Malt",
+                url: "https://thewhiskeywash.com/reviews/whiskey-review-the-whistler-bodega-cask-irish-single-malt/",
+                domain: "thewhiskeywash.com",
+                description:
+                  "Reviewing The Whistler Bodega Cask Irish Single Malt.",
+                extraSnippets: [],
+              },
+            ],
+          },
+        ],
+        candidateBottles: [
+          {
+            bottleId: currentBottle.id,
+            alias: "The Whistler Bodega Cask",
+            fullName: currentBottle.fullName,
+            brand: "The Whistler",
+            bottler: null,
+            series: null,
+            distillery: [],
+            category: "blend",
+            statedAge: null,
+            edition: null,
+            caskStrength: null,
+            singleCask: null,
+            abv: null,
+            vintageYear: null,
+            releaseYear: null,
+            caskType: null,
+            caskSize: null,
+            caskFill: null,
+            score: 0.97,
+            source: ["exact"],
+          },
+        ],
+        resolvedEntities: [],
+      }),
+    );
+
+    const proposal = await resolveStorePriceMatchProposal(price.id);
+
+    expect(proposal.status).toBe("pending_review");
+    expect(proposal.proposalType).toBe("correction");
+    expect(proposal.currentBottleId).toBe(currentBottle.id);
+    expect(proposal.suggestedBottleId).toBe(currentBottle.id);
+    expect(proposal.proposedBottle).toMatchObject({
+      name: "Bodega Cask",
+      category: "single_malt",
+      brand: {
+        name: "The Whistler",
+      },
+      distillers: [
+        {
+          name: "Boann Distillery",
+        },
+      ],
+    });
+    expect(proposal.rationale).toContain("existing-bottle repair");
+  });
+
   test("persists normalized proposed bottle drafts from the classifier", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/priceMatchingAutomation.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.ts
@@ -1234,18 +1234,25 @@ export function getStorePriceMatchAutomationAssessment({
   creationTarget,
   searchEvidence,
 }: MatchAutomationInput): StorePriceMatchAutomationAssessment {
-  if (action === "create_new" && (proposedBottle || proposedRelease)) {
+  if (
+    (action === "create_new" || action === "correction") &&
+    (proposedBottle || proposedRelease)
+  ) {
+    const createScore = getCreateNewScore({
+      proposedBottle,
+      proposedRelease: proposedRelease ?? null,
+      creationTarget: creationTarget ?? null,
+      candidateBottles,
+      searchEvidence,
+      extractedLabel,
+      price,
+    });
+
     return {
       modelConfidence,
-      ...getCreateNewScore({
-        proposedBottle,
-        proposedRelease: proposedRelease ?? null,
-        creationTarget: creationTarget ?? null,
-        candidateBottles,
-        searchEvidence,
-        extractedLabel,
-        price,
-      }),
+      ...createScore,
+      automationEligible:
+        action === "create_new" ? createScore.automationEligible : false,
     };
   }
 

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -66,6 +66,7 @@ import type {
   ExtractedBottleDetailsSchema,
   PriceMatchCandidateSchema,
   PriceMatchSearchEvidenceSchema,
+  ProposedBottleSchema,
   ProposedReleaseSchema,
   StorePriceMatchDecisionSchema,
 } from "@peated/server/schemas";
@@ -82,6 +83,7 @@ const WHISKY_LISTING_KEYWORDS =
 type ExtractedBottleDetails = z.infer<typeof ExtractedBottleDetailsSchema>;
 type PriceMatchCandidate = z.infer<typeof PriceMatchCandidateSchema>;
 type SearchEvidence = z.infer<typeof PriceMatchSearchEvidenceSchema>;
+type ProposedBottle = z.infer<typeof ProposedBottleSchema>;
 type ProposedRelease = z.infer<typeof ProposedReleaseSchema>;
 type StorePriceMatchDecision = z.infer<typeof StorePriceMatchDecisionSchema>;
 type StorePriceMatchProposalForReview = StorePriceMatchProposal & {
@@ -118,6 +120,63 @@ function shouldAutoIgnoreTrivialNonWhiskyListing(name: string): boolean {
   return (
     NON_WHISKY_LISTING_KEYWORDS.test(normalizedName) &&
     !WHISKY_LISTING_KEYWORDS.test(normalizedName)
+  );
+}
+
+function normalizeComparableText(value: string | null | undefined): string {
+  if (!value) {
+    return "";
+  }
+
+  return normalizeString(value).toLowerCase().replace(/_/g, " ").trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function containsComparablePhrase(haystack: string, needle: string): boolean {
+  if (!haystack || !needle) {
+    return false;
+  }
+
+  const pattern = new RegExp(
+    `(^|[^a-z0-9])${escapeRegExp(needle)}($|[^a-z0-9])`,
+  );
+
+  return pattern.test(haystack);
+}
+
+function textsOverlap(
+  left: string | null | undefined,
+  right: string | null | undefined,
+): boolean {
+  const normalizedLeft = normalizeComparableText(left);
+  const normalizedRight = normalizeComparableText(right);
+
+  if (!normalizedLeft || !normalizedRight) {
+    return false;
+  }
+
+  return (
+    normalizedLeft === normalizedRight ||
+    containsComparablePhrase(normalizedLeft, normalizedRight) ||
+    containsComparablePhrase(normalizedRight, normalizedLeft)
+  );
+}
+
+function listMatchesExpectedValue(
+  actualValues: string[],
+  expectedValues: string[],
+): boolean {
+  if (!actualValues.length || !expectedValues.length) {
+    return false;
+  }
+
+  return expectedValues.every((expectedValue) =>
+    actualValues.some((actualValue) =>
+      textsOverlap(actualValue, expectedValue),
+    ),
   );
 }
 
@@ -168,12 +227,232 @@ function normalizeClassifierDecisionForPriceMatching(
   };
 }
 
+function appendRationale(
+  rationale: string | null | undefined,
+  addition: string,
+): string {
+  const trimmedAddition = addition.trim();
+  if (!rationale) {
+    return trimmedAddition;
+  }
+
+  const trimmedRationale = rationale.trim();
+  if (!trimmedRationale) {
+    return trimmedAddition;
+  }
+
+  return `${trimmedRationale} ${trimmedAddition}`;
+}
+
+function candidateMatchesRepairDraftIdentity(
+  candidate: PriceMatchCandidate,
+  proposedBottle: ProposedBottle,
+): boolean {
+  const proposedFullName =
+    `${proposedBottle.brand.name} ${proposedBottle.name}`.trim();
+  const candidateNames = [
+    candidate.alias,
+    candidate.bottleFullName,
+    candidate.fullName,
+  ].filter((value): value is string => Boolean(value));
+
+  const brandMatches =
+    textsOverlap(candidate.brand, proposedBottle.brand.name) ||
+    candidateNames.some((value) =>
+      textsOverlap(value, proposedBottle.brand.name),
+    );
+  const nameMatches = candidateNames.some(
+    (value) =>
+      textsOverlap(value, proposedBottle.name) ||
+      textsOverlap(value, proposedFullName),
+  );
+
+  if (!brandMatches || !nameMatches) {
+    return false;
+  }
+
+  if (!proposedBottle.series) {
+    return true;
+  }
+
+  return (
+    textsOverlap(candidate.series, proposedBottle.series.name) ||
+    candidateNames.some((value) =>
+      textsOverlap(value, proposedBottle.series?.name),
+    )
+  );
+}
+
+function candidateNeedsExistingBottleRepair(
+  candidate: PriceMatchCandidate,
+  proposedBottle: ProposedBottle,
+): boolean {
+  if (
+    proposedBottle.category !== null &&
+    candidate.category !== proposedBottle.category
+  ) {
+    return true;
+  }
+
+  if (
+    proposedBottle.series &&
+    !textsOverlap(candidate.series, proposedBottle.series.name)
+  ) {
+    return true;
+  }
+
+  if (
+    proposedBottle.bottler &&
+    !textsOverlap(candidate.bottler, proposedBottle.bottler.name)
+  ) {
+    return true;
+  }
+
+  if (
+    proposedBottle.distillers.length > 0 &&
+    !listMatchesExpectedValue(
+      candidate.distillery,
+      proposedBottle.distillers.map((distiller) => distiller.name),
+    )
+  ) {
+    return true;
+  }
+
+  if (
+    proposedBottle.statedAge !== null &&
+    candidate.statedAge !== proposedBottle.statedAge
+  ) {
+    return true;
+  }
+
+  if (
+    proposedBottle.edition &&
+    !textsOverlap(candidate.edition, proposedBottle.edition)
+  ) {
+    return true;
+  }
+
+  if (
+    proposedBottle.caskType !== null &&
+    candidate.caskType !== proposedBottle.caskType
+  ) {
+    return true;
+  }
+
+  if (
+    proposedBottle.caskSize !== null &&
+    candidate.caskSize !== proposedBottle.caskSize
+  ) {
+    return true;
+  }
+
+  if (
+    proposedBottle.caskFill !== null &&
+    candidate.caskFill !== proposedBottle.caskFill
+  ) {
+    return true;
+  }
+
+  if (
+    proposedBottle.caskStrength !== null &&
+    candidate.caskStrength !== proposedBottle.caskStrength
+  ) {
+    return true;
+  }
+
+  if (
+    proposedBottle.singleCask !== null &&
+    candidate.singleCask !== proposedBottle.singleCask
+  ) {
+    return true;
+  }
+
+  if (proposedBottle.abv !== null && candidate.abv !== proposedBottle.abv) {
+    return true;
+  }
+
+  if (
+    proposedBottle.vintageYear !== null &&
+    candidate.vintageYear !== proposedBottle.vintageYear
+  ) {
+    return true;
+  }
+
+  if (
+    proposedBottle.releaseYear !== null &&
+    candidate.releaseYear !== proposedBottle.releaseYear
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function maybeBuildExistingBottleRepairDecision({
+  price,
+  decision,
+  candidates,
+}: {
+  price: Pick<StorePrice, "bottleId" | "releaseId">;
+  decision: Extract<BottleClassificationDecision, { action: "create_bottle" }>;
+  candidates: PriceMatchCandidate[];
+}): StorePriceMatchDecision | null {
+  if (
+    price.bottleId === null ||
+    price.releaseId !== null ||
+    !decision.proposedBottle
+  ) {
+    return null;
+  }
+
+  const currentBottleCandidate =
+    candidates.find(
+      (candidate) =>
+        candidate.bottleId === price.bottleId &&
+        (candidate.releaseId == null || candidate.kind === "bottle"),
+    ) ?? null;
+  if (!currentBottleCandidate) {
+    return null;
+  }
+
+  if (
+    !candidateMatchesRepairDraftIdentity(
+      currentBottleCandidate,
+      decision.proposedBottle,
+    ) ||
+    !candidateNeedsExistingBottleRepair(
+      currentBottleCandidate,
+      decision.proposedBottle,
+    )
+  ) {
+    return null;
+  }
+
+  return {
+    action: "correction",
+    confidence: decision.confidence,
+    rationale: appendRationale(
+      decision.rationale,
+      "The current bottle appears to be the right base identity, but its stored bottle metadata conflicts with the extracted traits. Review this as an existing-bottle repair instead of creating a duplicate bottle.",
+    ),
+    candidateBottleIds: decision.candidateBottleIds,
+    suggestedBottleId: price.bottleId,
+    suggestedReleaseId: null,
+    parentBottleId: null,
+    creationTarget: null,
+    proposedBottle: decision.proposedBottle,
+    proposedRelease: null,
+  };
+}
+
 function toStorePriceMatchDecision({
   price,
   decision,
+  candidates,
 }: {
   price: Pick<StorePrice, "bottleId" | "releaseId">;
   decision: BottleClassificationDecision;
+  candidates: PriceMatchCandidate[];
 }): StorePriceMatchDecision {
   if (decision.action === "match") {
     const action =
@@ -198,6 +477,15 @@ function toStorePriceMatchDecision({
   }
 
   if (decision.action === "create_bottle") {
+    const existingBottleRepair = maybeBuildExistingBottleRepairDecision({
+      price,
+      decision,
+      candidates,
+    });
+    if (existingBottleRepair) {
+      return existingBottleRepair;
+    }
+
     return {
       action: "create_new",
       confidence: decision.confidence,
@@ -1095,6 +1383,7 @@ export async function resolveStorePriceMatchProposal(
     const decision = toStorePriceMatchDecision({
       price,
       decision: classifierDecision,
+      candidates,
     });
     const automationAssessment = getStorePriceMatchAutomationAssessment({
       action: decision.action,

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -135,6 +135,161 @@ describe("price match queue", () => {
     });
   });
 
+  test("serializes same-bottle correction proposals with repair drafts", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const brand = await fixtures.Entity({
+      name: "The Whistler",
+      type: ["brand", "bottler"],
+    });
+    const currentBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Bodega Cask",
+      category: "blend",
+      distillerIds: [],
+    });
+    const price = await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "The Whistler Bodega Cask Single Malt Irish Whiskey",
+      bottleId: currentBottle.id,
+    });
+
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "correction",
+        confidence: 92,
+        currentBottleId: currentBottle.id,
+        suggestedBottleId: currentBottle.id,
+        candidateBottles: [
+          {
+            bottleId: currentBottle.id,
+            fullName: currentBottle.fullName,
+            alias: currentBottle.fullName,
+            brand: "The Whistler",
+            bottler: null,
+            series: null,
+            distillery: [],
+            category: "blend",
+            statedAge: null,
+            edition: null,
+            caskStrength: null,
+            singleCask: null,
+            abv: null,
+            vintageYear: null,
+            releaseYear: null,
+            caskType: null,
+            caskSize: null,
+            caskFill: null,
+            score: 0.99,
+            source: ["exact"],
+          },
+        ],
+        extractedLabel: {
+          brand: "The Whistler",
+          bottler: null,
+          expression: "Bodega Cask",
+          series: null,
+          distillery: ["Boann Distillery"],
+          category: "single_malt",
+          stated_age: null,
+          abv: null,
+          release_year: null,
+          vintage_year: null,
+          cask_type: null,
+          cask_size: null,
+          cask_fill: null,
+          cask_strength: null,
+          single_cask: null,
+          edition: null,
+        },
+        proposedBottle: {
+          name: "Bodega Cask",
+          series: null,
+          category: "single_malt",
+          edition: null,
+          statedAge: null,
+          caskStrength: null,
+          singleCask: null,
+          abv: null,
+          vintageYear: null,
+          releaseYear: null,
+          caskType: null,
+          caskSize: null,
+          caskFill: null,
+          brand: {
+            id: brand.id,
+            name: "The Whistler",
+          },
+          distillers: [
+            {
+              id: null,
+              name: "Boann Distillery",
+            },
+          ],
+          bottler: null,
+        },
+        searchEvidence: [
+          {
+            provider: "openai",
+            query: '"The Whistler Bodega Cask" single malt',
+            summary:
+              "Official and critic sources describe The Whistler Bodega Cask as a single malt from Boann Distillery.",
+            results: [
+              {
+                title:
+                  "Whiskey Review: The Whistler Bodega Cask Irish Single Malt",
+                url: "https://thewhiskeywash.com/reviews/whiskey-review-the-whistler-bodega-cask-irish-single-malt/",
+                domain: "thewhiskeywash.com",
+                description:
+                  "Reviewing The Whistler Bodega Cask Irish Single Malt.",
+                extraSnippets: [],
+              },
+            ],
+          },
+        ],
+        rationale:
+          "The current bottle appears to be the right base identity, but its stored bottle metadata conflicts with the extracted traits.",
+      })
+      .returning();
+
+    const result = await routerClient.prices.matchQueue.list(
+      {},
+      { context: { user } },
+    );
+    const queueItem = result.results.find((item) => item.id === proposal.id);
+
+    expect(queueItem).toMatchObject({
+      proposalType: "correction",
+      currentBottle: {
+        id: currentBottle.id,
+      },
+      suggestedBottle: {
+        id: currentBottle.id,
+      },
+      proposedBottle: {
+        name: "Bodega Cask",
+        category: "single_malt",
+        distillers: [
+          {
+            name: "Boann Distillery",
+          },
+        ],
+      },
+      differentiatingAttributes: expect.arrayContaining(["distillery"]),
+      webEvidenceChecks: expect.arrayContaining([
+        expect.objectContaining({
+          attribute: "distillery",
+          expectedValue: "Boann Distillery",
+        }),
+      ]),
+    });
+  });
+
   test("filters queue items by kind and orders ties by newest id", async ({
     fixtures,
   }) => {

--- a/apps/server/src/schemas/priceMatches.test.ts
+++ b/apps/server/src/schemas/priceMatches.test.ts
@@ -239,7 +239,7 @@ describe("StorePriceMatchDecisionSchema", () => {
     ).toBe(false);
   });
 
-  test("requires a proposed bottle only for create_new", () => {
+  test("allows proposed bottle drafts only for create_new and correction", () => {
     expect(
       StorePriceMatchDecisionSchema.safeParse({
         action: "create_new",
@@ -280,6 +280,37 @@ describe("StorePriceMatchDecisionSchema", () => {
         },
       }).success,
     ).toBe(false);
+
+    expect(
+      StorePriceMatchDecisionSchema.safeParse({
+        action: "correction",
+        confidence: 91,
+        rationale: null,
+        suggestedBottleId: 1,
+        candidateBottleIds: [1],
+        proposedBottle: {
+          name: "Example Bottle",
+          series: null,
+          category: "single_malt",
+          edition: null,
+          statedAge: null,
+          caskStrength: null,
+          singleCask: null,
+          abv: null,
+          vintageYear: null,
+          releaseYear: null,
+          caskType: null,
+          caskSize: null,
+          caskFill: null,
+          brand: {
+            id: null,
+            name: "Example Brand",
+          },
+          distillers: [],
+          bottler: null,
+        },
+      }).success,
+    ).toBe(true);
   });
 
   test("rejects fractional ids in classifier output", () => {

--- a/apps/server/src/schemas/priceMatches.ts
+++ b/apps/server/src/schemas/priceMatches.ts
@@ -335,7 +335,7 @@ export const StorePriceMatchDecisionSchema = z.discriminatedUnion("action", [
     suggestedReleaseId: z.number().int().nullable().optional(),
     parentBottleId: z.null().optional(),
     creationTarget: z.null().optional(),
-    proposedBottle: z.null().default(null),
+    proposedBottle: ProposedBottleSchema.nullable().default(null),
     proposedRelease: z.null().optional(),
   }),
   StorePriceMatchCreateNewDecisionSchema,

--- a/apps/web/src/app/(admin)/admin/(default)/queue/queueItemCard.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/queueItemCard.tsx
@@ -18,6 +18,11 @@ type RecommendationField = {
   value: ReactNode;
   fullWidth?: boolean;
 };
+type RepairChange = {
+  label: string;
+  current: string;
+  proposed: string;
+};
 type RecommendationBottle = {
   fullName?: string;
   brand: { name: string };
@@ -26,6 +31,14 @@ type RecommendationBottle = {
   category: string | null;
   edition: string | null;
   statedAge: number | null;
+  abv: number | null;
+  caskStrength: boolean | null;
+  singleCask: boolean | null;
+  vintageYear: number | null;
+  releaseYear: number | null;
+  caskType: string | null;
+  caskSize: string | null;
+  caskFill: string | null;
   distillers: Array<{ name: string }>;
   bottler: { name: string } | null;
 };
@@ -128,7 +141,9 @@ function getEvidenceBadges(item: QueueItem): string[] {
     badges.push("automation ready");
   }
 
-  if (item.currentBottle && item.proposalType === "correction") {
+  if (isRepairProposal(item)) {
+    badges.push("repair draft");
+  } else if (item.currentBottle && item.proposalType === "correction") {
     badges.push("current assignment differs");
   }
 
@@ -182,6 +197,10 @@ function getRecommendationHeading(item: QueueItem): string {
     return "Review Status";
   }
 
+  if (isRepairProposal(item)) {
+    return "Recommended Repair";
+  }
+
   return "Recommended Outcome";
 }
 
@@ -214,6 +233,29 @@ function formatAbv(value: number | null): string | null {
 
 function formatAge(value: number | null): string | null {
   return value === null ? null : `${value} years`;
+}
+
+function formatFlag(value: boolean | null): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return value ? "Yes" : "No";
+}
+
+function formatRepairValue(value: string | null): string {
+  return value ?? "unknown";
+}
+
+function isRepairProposal(item: QueueItem): boolean {
+  return (
+    item.proposalType === "correction" &&
+    !!item.currentBottle &&
+    !!item.suggestedBottle &&
+    item.currentBottle.id === item.suggestedBottle.id &&
+    !!item.proposedBottle &&
+    !item.proposedRelease
+  );
 }
 
 function getBottleTitle(bottle: RecommendationBottle): string {
@@ -385,6 +427,85 @@ function getBottlingFields(
   return fields;
 }
 
+function getBottleRepairChanges(
+  currentBottle: RecommendationBottle,
+  proposedBottle: RecommendationBottle,
+): RepairChange[] {
+  const changes: RepairChange[] = [];
+  const pushChange = (
+    label: string,
+    current: string | null,
+    proposed: string | null,
+  ) => {
+    if ((current ?? null) === (proposed ?? null)) {
+      return;
+    }
+
+    changes.push({
+      label,
+      current: formatRepairValue(current),
+      proposed: formatRepairValue(proposed),
+    });
+  };
+
+  pushChange("Brand", currentBottle.brand.name, proposedBottle.brand.name);
+  pushChange("Bottle Name", currentBottle.name, proposedBottle.name);
+  pushChange(
+    "Series",
+    currentBottle.series?.name ?? null,
+    proposedBottle.series?.name ?? null,
+  );
+  pushChange("Category", currentBottle.category, proposedBottle.category);
+  pushChange(
+    "Distillery",
+    currentBottle.distillers.map((distiller) => distiller.name).join(", ") ||
+      null,
+    proposedBottle.distillers.map((distiller) => distiller.name).join(", ") ||
+      null,
+  );
+  pushChange(
+    "Bottler",
+    currentBottle.bottler?.name ?? null,
+    proposedBottle.bottler?.name ?? null,
+  );
+  pushChange(
+    "Age",
+    formatAge(currentBottle.statedAge),
+    formatAge(proposedBottle.statedAge),
+  );
+  pushChange("Edition", currentBottle.edition, proposedBottle.edition);
+  pushChange(
+    "ABV",
+    formatAbv(currentBottle.abv),
+    formatAbv(proposedBottle.abv),
+  );
+  pushChange(
+    "Cask Strength",
+    formatFlag(currentBottle.caskStrength),
+    formatFlag(proposedBottle.caskStrength),
+  );
+  pushChange(
+    "Single Cask",
+    formatFlag(currentBottle.singleCask),
+    formatFlag(proposedBottle.singleCask),
+  );
+  pushChange("Cask", currentBottle.caskType, proposedBottle.caskType);
+  pushChange("Cask Size", currentBottle.caskSize, proposedBottle.caskSize);
+  pushChange("Cask Fill", currentBottle.caskFill, proposedBottle.caskFill);
+  pushChange(
+    "Vintage Year",
+    currentBottle.vintageYear?.toString() ?? null,
+    proposedBottle.vintageYear?.toString() ?? null,
+  );
+  pushChange(
+    "Release Year",
+    currentBottle.releaseYear?.toString() ?? null,
+    proposedBottle.releaseYear?.toString() ?? null,
+  );
+
+  return changes;
+}
+
 function RecommendationSection({
   label,
   title,
@@ -469,10 +590,59 @@ function renderRecommendationOutcome(item: QueueItem): ReactNode {
         item.suggestedRelease.id,
       )
     : undefined;
+  const repairChanges =
+    isRepairProposal(item) && item.currentBottle && item.proposedBottle
+      ? getBottleRepairChanges(item.currentBottle, item.proposedBottle)
+      : [];
 
   if (!bottle && !release) {
     return (
       <div className="mt-2 text-sm text-slate-300">No strong suggestion.</div>
+    );
+  }
+
+  if (isRepairProposal(item) && item.currentBottle && item.proposedBottle) {
+    return (
+      <div className="mt-3 space-y-3">
+        <RecommendationSection
+          label="Existing Bottle"
+          title={getBottleTitle(item.currentBottle)}
+          href={`/bottles/${item.currentBottle.id}`}
+          fields={getBottleFields(item.currentBottle)}
+          placeholder="No bottle identified"
+        />
+
+        <div className="rounded-lg border border-slate-800 bg-slate-950/50 p-3">
+          <div className="text-muted text-[11px] font-semibold uppercase tracking-wide">
+            Proposed Changes
+          </div>
+          {repairChanges.length > 0 ? (
+            <dl className="mt-3 space-y-3 text-sm">
+              {repairChanges.map((change) => (
+                <div key={`repair-${change.label}`}>
+                  <dt className="text-muted text-xs uppercase tracking-wide">
+                    {change.label}
+                  </dt>
+                  <dd className="mt-1 text-slate-100">
+                    <span className="text-slate-400">{change.current}</span>
+                    {" -> "}
+                    <span>{change.proposed}</span>
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          ) : (
+            <div className="mt-1 text-sm text-slate-300">
+              No bottle field changes were captured.
+            </div>
+          )}
+        </div>
+
+        <div className="text-xs text-slate-400">
+          Edit the current bottle, then retry this proposal to confirm the
+          repaired metadata.
+        </div>
+      </div>
     );
   }
 
@@ -588,14 +758,23 @@ export default function QueueItemCard({
   const evidenceBadges = getEvidenceBadges(item);
   const extractedLabelSummary = getExtractedLabelSummary(item);
   const topCandidates = getTopCandidates(item);
+  const repairProposal = isRepairProposal(item);
   const isProcessing = item.isProcessing;
   const canApproveMatch =
-    item.status === "pending_review" && !!item.suggestedBottle && !isProcessing;
+    item.status === "pending_review" &&
+    !!item.suggestedBottle &&
+    !repairProposal &&
+    !isProcessing;
   const canCreateBottle =
     item.status === "pending_review" &&
+    item.proposalType === "create_new" &&
     (!!item.proposedBottle || !!item.proposedRelease) &&
     !isProcessing;
   const createProposalActions = getCreateProposalActions(item, returnTo);
+  const repairEditHref =
+    repairProposal && item.currentBottle
+      ? `/bottles/${item.currentBottle.id}/edit`
+      : null;
   const queuedAt = formatTimestamp(item.createdAt);
   const processingQueuedAt = formatTimestamp(item.processingQueuedAt);
   const processingExpiresAt = formatTimestamp(item.processingExpiresAt);
@@ -968,10 +1147,18 @@ export default function QueueItemCard({
                 </Button>
               ) : null}
 
+              {repairEditHref ? (
+                <Button href={repairEditHref} color="highlight" fullWidth>
+                  Edit Bottle
+                </Button>
+              ) : null}
+
               <Button
                 fullWidth
                 color={
-                  canApproveMatch || canCreateBottle ? "default" : "primary"
+                  canApproveMatch || canCreateBottle || repairEditHref
+                    ? "default"
+                    : "primary"
                 }
                 onClick={() => {
                   onChooseBottle(item);

--- a/packages/bottle-classifier/src/normalizationCorpus.ts
+++ b/packages/bottle-classifier/src/normalizationCorpus.ts
@@ -129,6 +129,23 @@ export const BOTTLE_NORMALIZATION_CORPUS: BottleNormalizationCorpusExample[] = [
       "Official single-distillery bottlings can use a consumer brand that differs from the local bottle title's distillery qualifier. Brand-led Jura wording should still resolve to the Isle of Jura 12-year-old bottle family.",
   },
   {
+    id: "whistler-bodega-cask-single-malt",
+    inputName: "The Whistler Bodega Cask Single Malt Irish Whiskey",
+    expectedBottleName: "The Whistler Bodega Cask",
+    peatedBottleIds: [12953],
+    liveEvalCoverage: "required",
+    liveEvalSummary:
+      "Keep The Whistler Bodega Cask at bottle identity when the source clearly says single malt, even if the only local bottle is mislabeled as a blend. Do not force a wrong existing match or invent a different bottle identity.",
+    expectation: {
+      handlingStrategy: "classifier_required",
+      classifierExpectation: "bottle",
+      deterministicReleaseExpectation: "none",
+      releaseIdentity: null,
+    },
+    notes:
+      "Real local-data repair case. The bottle identity is correct, but the stored local category can be wrong, so the classifier should preserve the canonical bottle identity without collapsing into a false-positive match.",
+  },
+  {
     id: "springbank-batch-release",
     inputName: "Springbank 12 Cask Strength Batch 24",
     expectedBottleName: "Springbank 12 Cask Strength",


### PR DESCRIPTION
Route same-bottle metadata mismatches into repair review instead of create-new.

Bottle labels are noisy human input, and we have cases like The Whistler Bodega Cask where the local bottle identity is correct but the stored bottle metadata is wrong. Previously the classifier could only express that outcome as a create-new draft, which pushed the flow toward duplicate bottle creation. This rewrites same-identity create drafts into correction proposals with a bottle repair draft and keeps them review-only.

The admin queue now renders those proposals as explicit existing-bottle repairs with current-versus-proposed field diffs and an edit path back to the bottle. I considered auto-applying the repair draft to the existing bottle, but that is too aggressive for nondeterministic retailer labels. Keeping this in the queue makes the likely fix obvious without mutating bottle data behind a moderator's back.

Added regression coverage for the Whistler Bodega Cask case in price matching, queue serialization, schema parsing, and the normalization corpus.