### PR TITLE
fix(bottle-classifier): tighten review and repair rules

### DIFF
--- a/apps/server/src/lib/bottleReferenceCandidates.ts
+++ b/apps/server/src/lib/bottleReferenceCandidates.ts
@@ -1492,7 +1492,12 @@ export async function getBottleCandidateById(
         .from(bottleReleases)
         .innerJoin(bottles, eq(bottles.id, bottleReleases.bottleId))
         .innerJoin(entities, eq(entities.id, bottles.brandId))
-        .where(eq(bottleReleases.id, releaseId))
+        .where(
+          and(
+            eq(bottleReleases.id, releaseId),
+            eq(bottleReleases.bottleId, bottleId),
+          ),
+        )
         .limit(1)
     : await db
         .select({

--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -1488,6 +1488,178 @@ describe("priceMatching", () => {
     expect(proposal.rationale).toContain("existing-bottle repair");
   });
 
+  test("treats same-bottle brand metadata conflicts as existing-bottle repairs", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    const { extractFromText } =
+      await import("@peated/server/agents/whisky/labelExtractor");
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
+    const correctBrand = await fixtures.Entity({
+      type: ["brand"],
+      name: "The Whistler",
+    });
+    const wrongBrand = await fixtures.Entity({
+      type: ["brand"],
+      name: "Boann",
+    });
+    const distillery = await fixtures.Entity({
+      type: ["distiller"],
+      name: "Boann Distillery",
+    });
+    const currentBottle = await fixtures.Bottle({
+      brandId: wrongBrand.id,
+      name: "Bodega Cask",
+      category: "single_malt",
+      distillerIds: [distillery.id],
+    });
+    const price = await fixtures.StorePrice({
+      bottleId: currentBottle.id,
+      releaseId: null,
+      name: "The Whistler Bodega Cask Single Malt Irish Whiskey",
+      imageUrl: null,
+      url: "https://shop.example/the-whistler-bodega-cask",
+    });
+
+    vi.mocked(extractFromText).mockResolvedValue({
+      brand: "The Whistler",
+      bottler: null,
+      expression: "Bodega Cask",
+      series: null,
+      distillery: ["Boann Distillery"],
+      category: "single_malt",
+      stated_age: null,
+      abv: null,
+      release_year: null,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    });
+    vi.mocked(classifyBottleReference).mockResolvedValue(
+      buildMockBottleReferenceClassification({
+        decision: {
+          action: "create_bottle",
+          confidence: 90,
+          rationale:
+            "The current bottle identity looks right, but the stored producer metadata does not match the evidence.",
+          candidateBottleIds: [currentBottle.id],
+          proposedBottle: {
+            name: "Bodega Cask",
+            series: null,
+            category: "single_malt",
+            edition: null,
+            statedAge: null,
+            caskStrength: null,
+            singleCask: null,
+            abv: null,
+            vintageYear: null,
+            releaseYear: null,
+            caskType: null,
+            caskSize: null,
+            caskFill: null,
+            brand: {
+              id: correctBrand.id,
+              name: "The Whistler",
+            },
+            distillers: [
+              {
+                id: distillery.id,
+                name: "Boann Distillery",
+              },
+            ],
+            bottler: null,
+          },
+        },
+        extractedLabel: {
+          brand: "The Whistler",
+          bottler: null,
+          expression: "Bodega Cask",
+          series: null,
+          distillery: ["Boann Distillery"],
+          category: "single_malt",
+          stated_age: null,
+          abv: null,
+          release_year: null,
+          vintage_year: null,
+          cask_type: null,
+          cask_size: null,
+          cask_fill: null,
+          cask_strength: null,
+          single_cask: null,
+          edition: null,
+        },
+        searchEvidence: [
+          {
+            provider: "openai",
+            query: '"The Whistler Bodega Cask"',
+            summary:
+              "Independent sources identify this bottling under The Whistler brand.",
+            results: [
+              {
+                title: "The Whistler Bodega Cask",
+                url: "https://www.whiskybase.com/whiskies/whisky/167533/the-whistler-bodega-cask",
+                domain: "whiskybase.com",
+                description:
+                  "The Whistler Bodega Cask Irish Single Malt from Boann Distillery.",
+                extraSnippets: [],
+              },
+            ],
+          },
+        ],
+        candidateBottles: [
+          {
+            bottleId: currentBottle.id,
+            alias: "The Whistler Bodega Cask",
+            fullName: currentBottle.fullName,
+            brand: "Boann",
+            bottler: null,
+            series: null,
+            distillery: ["Boann Distillery"],
+            category: "single_malt",
+            statedAge: null,
+            edition: null,
+            caskStrength: null,
+            singleCask: null,
+            abv: null,
+            vintageYear: null,
+            releaseYear: null,
+            caskType: null,
+            caskSize: null,
+            caskFill: null,
+            score: 0.96,
+            source: ["exact"],
+          },
+        ],
+        resolvedEntities: [],
+      }),
+    );
+
+    const proposal = await resolveStorePriceMatchProposal(price.id);
+
+    expect(proposal.status).toBe("pending_review");
+    expect(proposal.proposalType).toBe("correction");
+    expect(proposal.currentBottleId).toBe(currentBottle.id);
+    expect(proposal.suggestedBottleId).toBe(currentBottle.id);
+    expect(proposal.proposedBottle).toMatchObject({
+      name: "Bodega Cask",
+      brand: {
+        name: "The Whistler",
+      },
+      distillers: [
+        {
+          name: "Boann Distillery",
+        },
+      ],
+    });
+    expect(proposal.rationale).toContain("existing-bottle repair");
+  });
+
   test("persists normalized proposed bottle drafts from the classifier", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -287,6 +287,10 @@ function candidateNeedsExistingBottleRepair(
   candidate: PriceMatchCandidate,
   proposedBottle: ProposedBottle,
 ): boolean {
+  if (!textsOverlap(candidate.brand, proposedBottle.brand.name)) {
+    return true;
+  }
+
   if (
     proposedBottle.category !== null &&
     candidate.category !== proposedBottle.category

--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -92,6 +92,7 @@ The rule for package-owned deterministic behavior is strict:
 - deterministic helpers may only own structurally safe, effectively zero-ambiguity behavior
 - if the behavior depends on brand context, marketed family meaning, or program semantics, it stays classifier-owned
 - if the input is too sparse to safely infer a canonical bottle, block instead of guessing
+- prompt changes should encode generalized reasoning patterns, not one-off brand tutoring; concrete family regressions belong in eval fixtures
 - the normalization corpus should record real `peatedBottleIds` when an example came from an observed Peated bottle family
 - ambiguous families should use shared `contrastGroup` keys with differing `contrastOutcome` values so the corpus always carries a real positive/negative contrast
 - live eval coverage should stay narrow and explicit; only classifier-owned ambiguity should opt in
@@ -159,6 +160,7 @@ The reviewed `decision` is generic and bottle-centric:
 - `matchedBottleId` and optional `matchedReleaseId` for safe existing matches
 - `parentBottleId` only for `create_release`
 - `proposedBottle` / `proposedRelease` only for create outcomes
+- `no_match` stays generic at this boundary; downstream consumers own any review or clarification workflow
 - `observation` for non-canonical exact details such as selector names, cask numbers, bottle numbers, outturn, and exclusive wording
 
 `artifacts` contains:
@@ -170,7 +172,7 @@ The reviewed `decision` is generic and bottle-centric:
 
 That result is already reviewed for bottle identity. Downstream consumers may apply their own persistence or automation policy on top of it.
 
-Price matching is the main example: it derives `match_existing`, `correction`, and `create_new` proposal semantics from the reviewed classifier result instead of asking the classifier to reason in price-match terms directly.
+Price matching is the main example: it derives `match_existing`, `correction`, and `create_new` proposal semantics from the reviewed classifier result instead of asking the classifier to reason in price-match terms directly. Those downstream correction drafts may repair bottle metadata such as brand, distillery, bottler, series, category, and other bottle fields while keeping the same base bottle identity.
 
 ## Eval Surface
 

--- a/packages/bottle-classifier/AGENTS.md
+++ b/packages/bottle-classifier/AGENTS.md
@@ -30,7 +30,9 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 - Internal adapter-facing modules should stay behind the `internal/*` package namespace.
 - Deterministic validation, downgrades, and `identityScope` rules live in `src/reviewPolicy.ts`.
 - Prompt-only fixes are incomplete when the invariant is deterministic; fix policy and tests together.
+- Do not add brand-specific prompt or extraction examples just to rescue one observed bottle family. Encode the transferable rule, and keep family-specific regressions in eval fixtures.
 - False positive existing matches are worse than conservative create or no-match results.
+- Bounded ambiguity should collapse to conservative `no_match` at this boundary. Downstream consumers own any review workflow.
 - `exact_cask` needs strong marketed identity signals such as SMWS codes, cask numbers, or barrel numbers.
 - Behavior changes should update both unit tests and realistic eval fixtures when model-sensitive.
 - Live evals load the repo-root `.env.local`.

--- a/packages/bottle-classifier/README.md
+++ b/packages/bottle-classifier/README.md
@@ -105,6 +105,7 @@ These are the rules to preserve when iterating on the classifier:
 
 - Raw bottle references go in; reviewed bottle-centric decisions come out.
 - False positive existing matches are worse than conservative `create_*` or `no_match` results.
+- When the safe outcome is still unresolved, return `no_match` instead of inventing a match or create action. Any follow-up review workflow belongs downstream.
 - The model may only match candidate ids that were actually retrieved.
 - Web evidence can support identity, but web search by itself is not canonical identity storage.
 - Retailer wording and SEO noise are weak evidence; official and independent non-retailer sources are stronger.
@@ -117,6 +118,7 @@ These are the rules to preserve when iterating on the classifier:
 - Deterministic fast paths must stay limited to structurally safe behavior that is effectively zero-ambiguity.
 - If the behavior depends on brand context, marketed family meaning, or program semantics, keep it classifier-owned.
 - If the input is too sparse to safely infer a canonical bottle, block or return `no_match` instead of guessing.
+- Prompt and extractor changes must encode transferable reasoning. Do not add brand-specific tutoring examples just to fix one observed family; keep those regressions in eval fixtures instead.
 
 ## File Map
 
@@ -162,7 +164,8 @@ When changing classifier behavior:
 2. Update the normalization corpus when the behavior changes bottle versus release identity boundaries.
 3. Update or add realistic positive and negative eval fixtures when the behavior is model-sensitive.
 4. Keep prompts, schemas, deterministic review logic, and pure normalization helpers aligned. Do not patch around package behavior in the server wrapper.
-5. Re-run package tests and evals before touching downstream consumers.
+5. Do not solve one failed family by teaching the prompt that exact family name. Generalize the rule in prompt or policy, and use eval fixtures to hold the concrete regression.
+6. Re-run package tests and evals before touching downstream consumers.
 
 When adding a new bottle family or edge case:
 

--- a/packages/bottle-classifier/src/classifier.eval.fixtures.ts
+++ b/packages/bottle-classifier/src/classifier.eval.fixtures.ts
@@ -307,6 +307,28 @@ const lagavulinDistillersEdition2023Release = buildBottleCandidate({
   source: ["brand", "release"],
 });
 
+const glengoyneLegacySeriesChapterTwo = buildBottleCandidate({
+  bottleId: 2083,
+  fullName: "Glengoyne The Legacy Series Chapter Two",
+  brand: "Glengoyne",
+  distillery: ["Glengoyne"],
+  category: "single_malt",
+  abv: 48,
+  score: 0.96,
+  source: ["exact"],
+});
+
+const glengoyneLegacySeriesChapterOne = buildBottleCandidate({
+  bottleId: 2460,
+  fullName: "Glengoyne The Legacy Series Chapter One",
+  brand: "Glengoyne",
+  distillery: ["Glengoyne"],
+  category: "single_malt",
+  abv: 48,
+  score: 0.91,
+  source: ["text"],
+});
+
 const smwsa41176Match = buildBottleCandidate({
   bottleId: 650,
   fullName: "SMWS 41.176 Baristaliscious",
@@ -868,6 +890,34 @@ export const EVAL_CASES: ClassifierEvalCase[] = [
       matchedReleaseId: 78,
       summary:
         "Treat Distillers Edition as the stable parent family, use the bare 2023 year as release identity, and match the existing 2023 child release instead of downgrading to no-match.",
+    },
+  },
+  {
+    name: "store listing: creates a reusable Legacy Series parent when only legacy chapter bottles exist locally",
+    input: {
+      reference: {
+        name: "Glengoyne The Legacy Series Chapter Two",
+        url: "https://shop.example/products/glengoyne-legacy-series-chapter-two",
+      },
+      extractedIdentity: buildExtractedIdentity({
+        brand: "Glengoyne",
+        expression: "The Legacy Series",
+        distillery: ["Glengoyne"],
+        category: "single_malt",
+        abv: 48,
+        edition: "Chapter Two",
+      }),
+      initialCandidates: [
+        glengoyneLegacySeriesChapterTwo,
+        glengoyneLegacySeriesChapterOne,
+      ],
+    },
+    expected: {
+      status: "classified",
+      action: "create_bottle_and_release",
+      identityScope: "product",
+      summary:
+        "Treat Glengoyne The Legacy Series as the reusable parent family and Chapter Two as the child release even when the local candidates are only dirty chapter-specific bottle rows.",
     },
   },
   {

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -22,6 +22,7 @@ function createTestClassifier({
   extractedIdentityFromText,
   extractFromImageError,
   searchBottles = vi.fn(async () => [] as BottleCandidate[]),
+  getBottleCandidateById,
   runBottleClassifierAgent,
 }: {
   extractedIdentity?: BottleExtractedDetails | null;
@@ -31,6 +32,10 @@ function createTestClassifier({
   searchBottles?: ReturnType<
     typeof vi.fn<(args: unknown) => Promise<BottleCandidate[]>>
   >;
+  getBottleCandidateById?: (
+    bottleId: number,
+    releaseId: number | null,
+  ) => Promise<BottleCandidate | null>;
   runBottleClassifierAgent?: (
     args: RunBottleClassifierAgentInput,
   ) => Promise<ReasoningResult>;
@@ -42,6 +47,7 @@ function createTestClassifier({
       maxSearchQueries: 2,
       adapters: {
         searchBottles,
+        getBottleCandidateById,
       },
       overrides: {
         extractFromImage: async () => {
@@ -1390,6 +1396,125 @@ describe("createBottleClassifier", () => {
     });
   });
 
+  test("promotes a parent bottle match into a richer create_release even when an unrelated child release already exists", async () => {
+    const heritageCaskStrengthParentCandidate: BottleCandidate = {
+      bottleId: 99001,
+      releaseId: null,
+      kind: "bottle",
+      alias: null,
+      fullName: "Heritage Cask Strength",
+      bottleFullName: "Heritage Cask Strength",
+      brand: "Example Distillery",
+      bottler: null,
+      series: null,
+      distillery: ["Example Distillery"],
+      category: "single_malt",
+      statedAge: 12,
+      edition: null,
+      caskStrength: null,
+      singleCask: null,
+      abv: null,
+      vintageYear: null,
+      releaseYear: null,
+      caskType: null,
+      caskSize: null,
+      caskFill: null,
+      score: 0.95,
+      source: ["exact"],
+    };
+    const heritageCaskStrengthBatch1Candidate: BottleCandidate = {
+      ...heritageCaskStrengthParentCandidate,
+      releaseId: 88001,
+      kind: "release",
+      fullName: "Heritage Cask Strength - Batch 1",
+      edition: "Batch 1",
+      abv: 56.8,
+      caskStrength: true,
+      releaseYear: 2023,
+      caskType: "bourbon",
+      score: 0.82,
+      source: ["text"],
+    };
+    const extractedIdentity: BottleExtractedDetails = {
+      brand: "Example Distillery",
+      bottler: null,
+      expression: "Heritage Cask Strength",
+      series: null,
+      distillery: ["Example Distillery"],
+      category: "single_malt",
+      stated_age: 12,
+      abv: 58.2,
+      release_year: 2024,
+      vintage_year: null,
+      cask_type: "oloroso",
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: true,
+      single_cask: null,
+      edition: "Batch 2",
+    };
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "match",
+          confidence: 94,
+          rationale: "The parent bottle identity is exact.",
+          identityScope: "product",
+          observation: null,
+          matchedBottleId: heritageCaskStrengthParentCandidate.bottleId,
+          matchedReleaseId: null,
+          parentBottleId: null,
+          candidateBottleIds: [heritageCaskStrengthParentCandidate.bottleId],
+          proposedBottle: null,
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [],
+          candidates: [
+            heritageCaskStrengthParentCandidate,
+            heritageCaskStrengthBatch1Candidate,
+          ],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: {
+        name: "Example Distillery Heritage Cask Strength Batch 2",
+      },
+      extractedIdentity,
+      initialCandidates: [
+        heritageCaskStrengthParentCandidate,
+        heritageCaskStrengthBatch1Candidate,
+      ],
+    });
+
+    expect(result.status).toBe("classified");
+    if (result.status !== "classified") {
+      throw new Error("Expected a classified result");
+    }
+
+    expect(result.decision).toMatchObject({
+      action: "create_release",
+      parentBottleId: heritageCaskStrengthParentCandidate.bottleId,
+      identityScope: "product",
+      proposedRelease: {
+        edition: "Batch 2",
+        statedAge: null,
+        abv: 58.2,
+        caskStrength: true,
+        releaseYear: 2024,
+        caskType: "oloroso",
+      },
+    });
+  });
+
   test("redirects a dirty Macallan age-statement bottle match to the reusable parent bottle", async () => {
     const extractedIdentity: BottleExtractedDetails = {
       brand: "The Macallan",
@@ -2274,6 +2399,95 @@ describe("createBottleClassifier", () => {
       identityScope: "product",
     });
     expect(result.decision.rationale).not.toContain(
+      "Server downgraded the existing-match recommendation",
+    );
+  });
+
+  test("does not treat retailer-only off-origin web results as supportive evidence for a parent bottle match", async () => {
+    const extractedIdentity: BottleExtractedDetails = {
+      brand: "Lagavulin",
+      bottler: null,
+      expression: "Distillers Edition",
+      series: null,
+      distillery: ["Lagavulin"],
+      category: "single_malt",
+      stated_age: null,
+      abv: null,
+      release_year: 2023,
+      vintage_year: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      cask_strength: null,
+      single_cask: null,
+      edition: null,
+    };
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "match",
+          confidence: 89,
+          rationale: "The parent bottle is the closest local candidate.",
+          identityScope: "product",
+          observation: null,
+          matchedBottleId: 44006,
+          matchedReleaseId: null,
+          parentBottleId: null,
+          candidateBottleIds: [44006],
+          proposedBottle: null,
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [
+            {
+              provider: "openai",
+              query: '"Lagavulin Distillers Edition 2023"',
+              summary:
+                "Retailer results list Lagavulin Distillers Edition 2023 for sale.",
+              results: [
+                {
+                  title: "Lagavulin Distillers Edition 2023 | Buy Online",
+                  url: "https://www.totalwine.com/spirits/scotch/lagavulin-distillers-edition-2023/p/12345",
+                  domain: "totalwine.com",
+                  description:
+                    "Shop Lagavulin Distillers Edition 2023 online at Total Wine.",
+                  extraSnippets: [],
+                },
+              ],
+            },
+          ],
+          candidates: [lagavulinDistillersEditionParentCandidate],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: {
+        name: "Lagavulin Distiller's Edition 2023 Islay Single Malt Scotch Whisky",
+        url: "https://shop.example/products/lagavulin-distillers-edition-2023",
+      },
+      extractedIdentity,
+      initialCandidates: [lagavulinDistillersEditionParentCandidate],
+    });
+
+    expect(result.status).toBe("classified");
+    if (result.status !== "classified") {
+      throw new Error("Expected a classified result");
+    }
+
+    expect(result.decision).toMatchObject({
+      action: "no_match",
+      matchedBottleId: null,
+      matchedReleaseId: null,
+      parentBottleId: null,
+    });
+    expect(result.decision.rationale).toContain(
       "Server downgraded the existing-match recommendation",
     );
   });

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -126,6 +126,24 @@ function createIgnoredReferenceClassification(
   });
 }
 
+function hydratedCurrentBottleMatchesReference({
+  currentBottle,
+  bottleId,
+  releaseId,
+}: {
+  currentBottle: BottleCandidate | null;
+  bottleId: number;
+  releaseId: number | null;
+}): boolean {
+  if (!currentBottle || currentBottle.bottleId !== bottleId) {
+    return false;
+  }
+
+  return releaseId !== null
+    ? currentBottle.releaseId === releaseId
+    : currentBottle.releaseId === null || currentBottle.kind === "bottle";
+}
+
 export function createBottleClassifier(
   options: CreateBottleClassifierOptions,
 ): BottleClassifier {
@@ -222,7 +240,7 @@ export function createBottleClassifier(
       mergeBottleCandidate(candidateBottles, candidate);
     }
 
-    const currentBottle = reference.currentBottleId
+    const hydratedCurrentBottle = reference.currentBottleId
       ? options.adapters.getBottleCandidateById
         ? await options.adapters.getBottleCandidateById(
             reference.currentBottleId,
@@ -236,6 +254,15 @@ export function createBottleClassifier(
                 : candidate.releaseId === null || candidate.kind === "bottle"),
           ) ?? null)
       : null;
+    const currentBottle =
+      reference.currentBottleId &&
+      hydratedCurrentBottleMatchesReference({
+        currentBottle: hydratedCurrentBottle,
+        bottleId: reference.currentBottleId,
+        releaseId: reference.currentReleaseId ?? null,
+      })
+        ? hydratedCurrentBottle
+        : null;
     if (currentBottle) {
       mergeBottleCandidate(candidateBottles, currentBottle);
     }

--- a/packages/bottle-classifier/src/instructions.ts
+++ b/packages/bottle-classifier/src/instructions.ts
@@ -676,6 +676,8 @@ export function buildWhiskyLabelExtractorInstructions({
       "Age statements should be integers. Normalize age phrases such as `12 Year`, `12 Years Old`, `12 Yr.`, and `12yr` to `stated_age: 12`.",
       "When an age statement belongs in the expression, normalize the phrase to `12-year-old`.",
       "For expression-style fields, follow the bottle's evidenced canonical name. Do not mechanically append retailer style/category words from the title just to make the expression look complete.",
+      "When a stable family phrase is followed by a clearly separate numbered or coded child label, keep the family in `expression` and the varying child label in `edition` instead of collapsing both into one opaque expression.",
+      "Apply that split from the label structure itself, not by memorizing brand-specific examples. If the split is ambiguous, stay less specific instead of guessing.",
       "If `edition`, `release_year`, or `vintage_year` is populated, do not also copy that same batch code or year into `expression`.",
       "Use `release_year` only for explicit release or bottling years, not founding dates or warning text.",
       "If both distillation and bottling years are present, use `vintage_year` for the distillation year and `release_year` for the bottling year.",
@@ -750,6 +752,8 @@ export function buildBottleClassifierInstructions({
     "Local candidates may include structured bottle and release fields such as brand, bottler, distillery, series, category, age, edition, cask type, cask size, cask fill, cask-strength, single-cask, ABV, and release years. Use those fields directly when present instead of inferring everything from the candidate name.",
     "When local candidates already include both a reusable parent bottle and a clean child release under that same bottle, and the extracted release detail uniquely matches the child candidate, prefer matching that existing release over returning a plain parent-bottle match or creating a duplicate release.",
     "For annual-release families such as Distillers Edition, a bare year can be decisive release identity. If one local child release candidate aligns on the correct parent bottle and matching release year, treat that release as the leading existing-match target rather than treating the year as retailer noise.",
+    "If multiple local bottle candidates share the same stable family wording but differ only by likely release-level detail such as a batch code, numbered edition, volume, chapter, or annual release label, treat that as evidence the local data may be storing sibling releases as bottle rows rather than proof that each row is a separate canonical bottle.",
+    "When sibling-specific candidates point to a shared reusable family and no clean parent bottle exists locally, prefer `create_bottle_and_release` over matching one dirty sibling row or collapsing to `no_match`.",
     ...(hasBottleSearch
       ? [
           "When the provided local candidates are thin, conflicting, or missing obvious near matches, call `search_bottles` with the most specific query you can form from the reference and extracted identity.",
@@ -778,6 +782,7 @@ export function buildBottleClassifierInstructions({
     "Missing generic style words like `single malt` are weak evidence. Conflicting age statements, edition codes, or barrel descriptors are strong evidence.",
     "Exact or near-exact ABV is a strong positive signal when the base identity already aligns and competing candidates do not share that ABV.",
     "When ABV sharply separates one candidate from the others, let that raise confidence materially instead of treating it as a minor tiebreaker.",
+    "Apply bottle-versus-release reasoning generically from the evidence in front of you. Do not rely on memorized brand-specific examples to justify a split or a match.",
     "If bottle identity is clear but release identity is not, prefer the bottle-level outcome. Do not force a specific release from weak release evidence.",
     "If the only local candidate is a more specific release or edition than the reference supports, do not match it by default. Treat the candidate as over-specific unless web evidence validates the missing differentiating traits.",
     "Ignore volume, gift-set packaging, added glassware, ratings blurbs, and generic retailer SEO words when deciding bottle identity.",
@@ -887,6 +892,7 @@ export function buildBottleClassifierInstructions({
       "For `create_bottle`, return `proposedBottle` and leave `proposedRelease` and `parentBottleId` null.",
       "For `create_release`, return `parentBottleId` plus `proposedRelease`, and leave `proposedBottle` null.",
       "For `create_bottle_and_release`, return both `proposedBottle` and `proposedRelease` with `parentBottleId = null`.",
+      "For `no_match`, leave match and create fields null.",
       "When bottle identity is certain but release identity is not, prefer `match` or `create_bottle` at the bottle layer instead of inventing a release.",
       "If you return `create_bottle`, `proposedBottle` must include every schema field, using `null` or `[]` when unknown.",
       "For `proposedBottle.name`, follow the bottle's evidenced canonical name, not a mechanically copied source title. Do not append extra style/category words just because they appeared in the source text.",

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -7,6 +7,7 @@ import {
 import { normalizeBottleCreationDrafts } from "./bottleCreationDrafts";
 import {
   BottleClassificationDecisionSchema,
+  CaskTypeEnum,
   type BottleCandidate,
   type BottleClassificationDecision,
   type BottleClassifierAgentDecision,
@@ -19,6 +20,11 @@ import type {
   BottleReference,
 } from "./contract";
 import { BottleClassificationError } from "./error";
+import {
+  AUTHORITATIVE_SOURCE_TIERS,
+  buildProducerIdentityPhrases,
+  classifySourceTier,
+} from "./identityEvidenceCore";
 import { normalizeString } from "./normalize";
 
 const NON_WHISKY_KEYWORDS =
@@ -1492,6 +1498,11 @@ function hasSupportiveWebEvidenceForTarget({
   }
 
   const referenceDomain = getComparableDomain(reference.url ?? null);
+  const producerPhrases = buildProducerIdentityPhrases({
+    proposedBottle: null,
+    extractedLabel: artifacts.extractedIdentity,
+    targetCandidate: target,
+  });
   const targetTokenSets = getTargetNameCandidates(target, decision)
     .map((name) => getComparableNameTokens(name))
     .filter((tokens) => tokens.length > 0);
@@ -1508,6 +1519,15 @@ function hasSupportiveWebEvidenceForTarget({
         (referenceDomain !== null &&
           domainMatches(resultDomain, referenceDomain))
       ) {
+        continue;
+      }
+
+      const sourceTier = classifySourceTier({
+        result,
+        sourceUrl: reference.url ?? "",
+        producerPhrases,
+      });
+      if (!AUTHORITATIVE_SOURCE_TIERS.has(sourceTier)) {
         continue;
       }
 
@@ -1529,6 +1549,76 @@ function hasSupportiveWebEvidenceForTarget({
   }
 
   return false;
+}
+
+function candidateMatchesProposedReleaseDraft({
+  candidate,
+  proposedRelease,
+}: {
+  candidate: BottleCandidate;
+  proposedRelease: ProposedRelease;
+}): boolean {
+  if (candidate.releaseId === null) {
+    return false;
+  }
+
+  const checks: boolean[] = [];
+
+  if (proposedRelease.edition) {
+    checks.push(textsOverlap(candidate.edition, proposedRelease.edition));
+  }
+  if (proposedRelease.statedAge !== null) {
+    checks.push(candidate.statedAge === proposedRelease.statedAge);
+  }
+  if (proposedRelease.abv !== null) {
+    checks.push(candidate.abv === proposedRelease.abv);
+  }
+  if (proposedRelease.caskStrength !== null) {
+    checks.push(candidate.caskStrength === proposedRelease.caskStrength);
+  }
+  if (proposedRelease.singleCask !== null) {
+    checks.push(candidate.singleCask === proposedRelease.singleCask);
+  }
+  if (proposedRelease.vintageYear !== null) {
+    checks.push(candidate.vintageYear === proposedRelease.vintageYear);
+  }
+  if (proposedRelease.releaseYear !== null) {
+    checks.push(candidate.releaseYear === proposedRelease.releaseYear);
+  }
+  if (proposedRelease.caskType !== null) {
+    checks.push(candidate.caskType === proposedRelease.caskType);
+  }
+  if (proposedRelease.caskSize !== null) {
+    checks.push(candidate.caskSize === proposedRelease.caskSize);
+  }
+  if (proposedRelease.caskFill !== null) {
+    checks.push(candidate.caskFill === proposedRelease.caskFill);
+  }
+
+  return checks.length > 0 && checks.every(Boolean);
+}
+
+function findExistingMatchingReleaseCandidates({
+  parentBottleId,
+  proposedRelease,
+  artifacts,
+}: {
+  parentBottleId: number;
+  proposedRelease: ProposedRelease;
+  artifacts: BottleClassificationArtifacts;
+}): BottleCandidate[] {
+  return artifacts.candidates
+    .filter(
+      (candidate) =>
+        candidate.bottleId === parentBottleId && candidate.releaseId !== null,
+    )
+    .filter((candidate) =>
+      candidateMatchesProposedReleaseDraft({
+        candidate,
+        proposedRelease,
+      }),
+    )
+    .sort((left, right) => (right.score ?? 0) - (left.score ?? 0));
 }
 
 function createNoMatchDecision({
@@ -1613,9 +1703,20 @@ function buildReleaseDraftFromExtractedIdentity({
           }))
           ? extractedIdentity.stated_age
           : null,
-      abv: null,
-      caskStrength: null,
-      singleCask: null,
+      abv:
+        extractedIdentity.abv !== null && extractedIdentity.abv !== target.abv
+          ? extractedIdentity.abv
+          : null,
+      caskStrength:
+        extractedIdentity.cask_strength !== null &&
+        extractedIdentity.cask_strength !== target.caskStrength
+          ? extractedIdentity.cask_strength
+          : null,
+      singleCask:
+        extractedIdentity.single_cask !== null &&
+        extractedIdentity.single_cask !== target.singleCask
+          ? extractedIdentity.single_cask
+          : null,
       vintageYear:
         extractedIdentity.vintage_year !== null &&
         extractedIdentity.vintage_year !== target.vintageYear
@@ -1626,9 +1727,29 @@ function buildReleaseDraftFromExtractedIdentity({
         extractedIdentity.release_year !== target.releaseYear
           ? extractedIdentity.release_year
           : null,
-      caskType: null,
-      caskSize: null,
-      caskFill: null,
+      caskType: (() => {
+        if (
+          !extractedIdentity.cask_type ||
+          extractedIdentity.cask_type === target.caskType
+        ) {
+          return null;
+        }
+
+        const parsedCaskType = CaskTypeEnum.safeParse(
+          extractedIdentity.cask_type,
+        );
+        return parsedCaskType.success ? parsedCaskType.data : null;
+      })(),
+      caskSize:
+        extractedIdentity.cask_size !== null &&
+        extractedIdentity.cask_size !== target.caskSize
+          ? extractedIdentity.cask_size
+          : null,
+      caskFill:
+        extractedIdentity.cask_fill !== null &&
+        extractedIdentity.cask_fill !== target.caskFill
+          ? extractedIdentity.cask_fill
+          : null,
       description: null,
       tastingNotes: null,
       imageUrl: null,
@@ -1664,15 +1785,7 @@ function maybePromoteBottleMatchToCreateRelease({
     artifacts,
   });
 
-  if (
-    !parentTarget ||
-    decision.identityScope === "exact_cask" ||
-    artifacts.candidates.some(
-      (candidate) =>
-        candidate.bottleId === parentTarget.bottleId &&
-        candidate.releaseId !== null,
-    )
-  ) {
+  if (!parentTarget || decision.identityScope === "exact_cask") {
     return null;
   }
 
@@ -1682,6 +1795,16 @@ function maybePromoteBottleMatchToCreateRelease({
   });
 
   if (!proposedRelease) {
+    return null;
+  }
+
+  if (
+    findExistingMatchingReleaseCandidates({
+      parentBottleId: parentTarget.bottleId,
+      proposedRelease,
+      artifacts,
+    }).length > 0
+  ) {
     return null;
   }
 
@@ -1897,17 +2020,18 @@ function downgradeUnsafeExistingMatchDecision({
     );
   }
 
+  const downgradedRationale = appendRationale(
+    decision.rationale,
+    `Server downgraded the existing-match recommendation because ${reasons.join(
+      " and ",
+    )}.`,
+  );
   return createNoMatchDecision({
     decision,
     candidateBottleIds: decision.candidateBottleIds,
     observation: decision.observation,
     identityScope: decision.identityScope,
-    rationale: appendRationale(
-      decision.rationale,
-      `Server downgraded the existing-match recommendation because ${reasons.join(
-        " and ",
-      )}.`,
-    ),
+    rationale: downgradedRationale,
   });
 }
 
@@ -2450,27 +2574,24 @@ function sanitizeClassifierDecision({
     };
   }
 
-  return {
-    action: "no_match",
-    confidence: normalizedConfidence,
-    rationale: decision.rationale,
+  return createNoMatchDecision({
+    decision: {
+      confidence: normalizedConfidence,
+      rationale: decision.rationale,
+      identityScope: inferIdentityScope({
+        requestedIdentityScope: decision.identityScope,
+        reference,
+        target: null,
+        extractedIdentity: artifacts.extractedIdentity,
+        proposedBottle: null,
+        hasReleaseIdentity: false,
+        observation,
+      }),
+    },
     candidateBottleIds: filteredCandidateBottleIds,
-    identityScope: inferIdentityScope({
-      requestedIdentityScope: decision.identityScope,
-      reference,
-      target: null,
-      extractedIdentity: artifacts.extractedIdentity,
-      proposedBottle: null,
-      hasReleaseIdentity: false,
-      observation,
-    }),
     observation,
-    matchedBottleId: null,
-    matchedReleaseId: null,
-    parentBottleId: null,
-    proposedBottle: null,
-    proposedRelease: null,
-  };
+    rationale: decision.rationale,
+  });
 }
 
 export function shouldAutoIgnoreBottleReference(


### PR DESCRIPTION
Keep the bottle classifier boundary focused on match, create, and no_match, and leave clarification or correction workflows to downstream proposal handling.

This tightens a few generalized rules that were still too fuzzy in practice. Hydrated current-bottle matches now have to agree on both bottle and release identity, release promotion preserves release-specific traits and only blocks when an actual conflicting child release exists, and retailer-only evidence no longer authoritatively validates release traits.

On the downstream side, same-bottle producer metadata disagreements now become corrections on the existing bottle instead of unnecessary new-bottle proposals, including brand and distillery repairs.

I considered teaching the prompt about specific bottle families, but that would only rescue individual examples. The concrete regressions are covered in evals and tests instead, including Glengoyne Legacy Series Chapter Two, while the rules remain generalized.