### PR TITLE
fix(classifier): Favor agent-driven price match approvals

### DIFF
--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -2191,8 +2191,6 @@ describe("priceMatching", () => {
   test("auto ignores clearly non-whisky listings", async ({ fixtures }) => {
     config.OPENAI_API_KEY = undefined;
 
-    const { extractFromText } =
-      await import("@peated/server/agents/whisky/labelExtractor");
     const { classifyBottleReference } =
       await import("@peated/server/agents/bottleClassifier");
     const price = await fixtures.StorePrice({
@@ -2201,11 +2199,17 @@ describe("priceMatching", () => {
       imageUrl: null,
     });
 
-    vi.mocked(extractFromText).mockResolvedValue(null);
+    vi.mocked(classifyBottleReference).mockResolvedValue(
+      buildMockBottleReferenceClassification({
+        status: "ignored",
+        ignoreReason:
+          "Reference is clearly a non-whisky category match and extraction found no whisky identity.",
+      }),
+    );
 
     const proposal = await resolveStorePriceMatchProposal(price.id);
 
-    expect(classifyBottleReference).not.toHaveBeenCalled();
+    expect(classifyBottleReference).toHaveBeenCalledOnce();
     expect(proposal.status).toBe("ignored");
     expect(proposal.proposalType).toBe("no_match");
   });

--- a/apps/server/src/lib/priceMatchingAutomation.test.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.test.ts
@@ -172,6 +172,7 @@ describe("priceMatchingAutomation", () => {
     });
 
     expect(assessment.automationScore).toBe(97);
+    expect(assessment.structuredMatchRequiresStatedAge).toBe(true);
     expect(
       shouldVerifyStorePriceMatch({
         action: "match_existing",
@@ -184,6 +185,8 @@ describe("priceMatchingAutomation", () => {
         modelConfidence: 97,
         automationBlockers: assessment.automationBlockers,
         decisiveMatchAttributes: assessment.decisiveMatchAttributes,
+        structuredMatchRequiresStatedAge:
+          assessment.structuredMatchRequiresStatedAge,
         candidateBottles: [
           buildCandidate({
             bottleId: 25,
@@ -194,6 +197,82 @@ describe("priceMatchingAutomation", () => {
             distillery: ["The Macallan"],
             category: "single_malt",
             statedAge: 12,
+            abv: null,
+            caskType: null,
+            source: ["text", "brand"],
+          }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  test("auto-approves high-confidence NAS bottle matches from structured identity", () => {
+    const assessment = getStorePriceMatchAutomationAssessment({
+      action: "match_existing",
+      modelConfidence: 97,
+      price: {
+        bottleId: null,
+        name: "Wild Turkey Rare Breed Barrel-Proof Kentucky Straight Rye",
+        url: "https://example.com/rare-breed-rye",
+      },
+      suggestedBottleId: 25,
+      suggestedReleaseId: null,
+      extractedLabel: buildExtractedLabel({
+        brand: "Wild Turkey",
+        expression: "Rare Breed",
+        distillery: ["Wild Turkey"],
+        category: "rye",
+        stated_age: null,
+        abv: null,
+        cask_type: null,
+      }),
+      proposedBottle: null,
+      searchEvidence: [],
+      candidateBottles: [
+        buildCandidate({
+          bottleId: 25,
+          fullName: "Wild Turkey Rare Breed Barrel-Proof Kentucky Straight Rye",
+          bottleFullName:
+            "Wild Turkey Rare Breed Barrel-Proof Kentucky Straight Rye",
+          brand: "Wild Turkey",
+          distillery: ["Wild Turkey"],
+          category: "rye",
+          statedAge: null,
+          caskStrength: true,
+          abv: null,
+          caskType: null,
+          source: ["text", "brand"],
+        }),
+      ],
+    });
+
+    expect(assessment.structuredMatchRequiresStatedAge).toBe(false);
+    expect(
+      shouldVerifyStorePriceMatch({
+        action: "match_existing",
+        price: {
+          bottleId: null,
+          releaseId: null,
+        },
+        suggestedBottleId: 25,
+        suggestedReleaseId: null,
+        modelConfidence: 97,
+        automationBlockers: assessment.automationBlockers,
+        decisiveMatchAttributes: assessment.decisiveMatchAttributes,
+        structuredMatchRequiresStatedAge:
+          assessment.structuredMatchRequiresStatedAge,
+        candidateBottles: [
+          buildCandidate({
+            bottleId: 25,
+            fullName:
+              "Wild Turkey Rare Breed Barrel-Proof Kentucky Straight Rye",
+            bottleFullName:
+              "Wild Turkey Rare Breed Barrel-Proof Kentucky Straight Rye",
+            brand: "Wild Turkey",
+            distillery: ["Wild Turkey"],
+            category: "rye",
+            statedAge: null,
+            caskStrength: true,
             abv: null,
             caskType: null,
             source: ["text", "brand"],
@@ -252,6 +331,8 @@ describe("priceMatchingAutomation", () => {
         modelConfidence: 95,
         automationBlockers: assessment.automationBlockers,
         decisiveMatchAttributes: assessment.decisiveMatchAttributes,
+        structuredMatchRequiresStatedAge:
+          assessment.structuredMatchRequiresStatedAge,
         candidateBottles: [
           buildCandidate({
             bottleId: 12,

--- a/apps/server/src/lib/priceMatchingAutomation.test.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.test.ts
@@ -43,6 +43,7 @@ function buildCandidate(
     releaseId: null,
     alias: null,
     fullName: "Example Distillery Port Cask 10 Year",
+    bottleFullName: "Example Distillery Port Cask 10 Year",
     brand: "Example Distillery",
     bottler: null,
     series: null,
@@ -81,7 +82,7 @@ describe("priceMatchingAutomation", () => {
       candidateBottles: [buildCandidate()],
     });
 
-    expect(assessment.automationScore).toBeGreaterThanOrEqual(80);
+    expect(assessment.automationScore).toBe(72);
     expect(assessment.decisiveMatchAttributes).toContain("abv");
     expect(assessment.decisiveMatchAttributes).toContain("statedAge");
   });
@@ -129,6 +130,143 @@ describe("priceMatchingAutomation", () => {
       "listing looks release-specific but the suggested target is only a bottle",
     );
     expect(assessment.decisiveMatchAttributes).toContain("statedAge");
+  });
+
+  test("auto-approves high-confidence stable bottle matches from structured identity even below the raw score threshold", () => {
+    const assessment = getStorePriceMatchAutomationAssessment({
+      action: "match_existing",
+      modelConfidence: 97,
+      price: {
+        bottleId: null,
+        name: "The Macallan Double Cask 12-year-old Single Malt Whisky",
+        url: "https://www.reservebar.com/example",
+      },
+      suggestedBottleId: 25,
+      suggestedReleaseId: null,
+      extractedLabel: buildExtractedLabel({
+        brand: "The Macallan",
+        expression: "Double Cask",
+        distillery: ["Macallan"],
+        category: "single_malt",
+        stated_age: 12,
+        abv: null,
+        cask_type: null,
+      }),
+      proposedBottle: null,
+      searchEvidence: [],
+      candidateBottles: [
+        buildCandidate({
+          bottleId: 25,
+          fullName: "The Macallan 12-year-old Double Cask",
+          bottleFullName: "The Macallan 12-year-old Double Cask",
+          brand: "The Macallan",
+          bottler: "The Macallan",
+          distillery: ["The Macallan"],
+          category: "single_malt",
+          statedAge: 12,
+          abv: null,
+          caskType: null,
+          source: ["text", "brand"],
+        }),
+      ],
+    });
+
+    expect(assessment.automationScore).toBe(97);
+    expect(
+      shouldVerifyStorePriceMatch({
+        action: "match_existing",
+        price: {
+          bottleId: null,
+          releaseId: null,
+        },
+        suggestedBottleId: 25,
+        suggestedReleaseId: null,
+        modelConfidence: 97,
+        automationBlockers: assessment.automationBlockers,
+        decisiveMatchAttributes: assessment.decisiveMatchAttributes,
+        candidateBottles: [
+          buildCandidate({
+            bottleId: 25,
+            fullName: "The Macallan 12-year-old Double Cask",
+            bottleFullName: "The Macallan 12-year-old Double Cask",
+            brand: "The Macallan",
+            bottler: "The Macallan",
+            distillery: ["The Macallan"],
+            category: "single_malt",
+            statedAge: 12,
+            abv: null,
+            caskType: null,
+            source: ["text", "brand"],
+          }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  test("does not auto-approve plain age-statement bottles from high confidence alone", () => {
+    const assessment = getStorePriceMatchAutomationAssessment({
+      action: "match_existing",
+      modelConfidence: 95,
+      price: {
+        bottleId: null,
+        name: "Tomatin Single Malt 12-year-old",
+        url: "https://example.com/tomatin",
+      },
+      suggestedBottleId: 12,
+      suggestedReleaseId: null,
+      extractedLabel: buildExtractedLabel({
+        brand: "Tomatin",
+        expression: null,
+        distillery: ["Tomatin"],
+        category: "single_malt",
+        stated_age: 12,
+        abv: null,
+        cask_type: null,
+      }),
+      proposedBottle: null,
+      searchEvidence: [],
+      candidateBottles: [
+        buildCandidate({
+          bottleId: 12,
+          fullName: "Tomatin 12-year-old",
+          bottleFullName: "Tomatin 12-year-old",
+          brand: "Tomatin",
+          distillery: ["Tomatin"],
+          category: "single_malt",
+          statedAge: 12,
+          abv: null,
+          caskType: null,
+        }),
+      ],
+    });
+
+    expect(
+      shouldVerifyStorePriceMatch({
+        action: "match_existing",
+        price: {
+          bottleId: null,
+          releaseId: null,
+        },
+        suggestedBottleId: 12,
+        suggestedReleaseId: null,
+        modelConfidence: 95,
+        automationBlockers: assessment.automationBlockers,
+        decisiveMatchAttributes: assessment.decisiveMatchAttributes,
+        candidateBottles: [
+          buildCandidate({
+            bottleId: 12,
+            fullName: "Tomatin 12-year-old",
+            bottleFullName: "Tomatin 12-year-old",
+            brand: "Tomatin",
+            distillery: ["Tomatin"],
+            category: "single_malt",
+            statedAge: 12,
+            abv: null,
+            caskType: null,
+          }),
+        ],
+      }),
+    ).toBe(false);
   });
 
   test("keeps the release-specific blocker when the bottle target does not represent the extracted edition", () => {
@@ -437,7 +575,7 @@ describe("priceMatchingAutomation", () => {
     expect(supported).toBe(false);
   });
 
-  test("auto-approves unmatched strong existing matches when automation is already high", () => {
+  test("does not auto-approve unmatched matches from downstream score alone", () => {
     expect(
       shouldVerifyStorePriceMatch({
         action: "match_existing",
@@ -448,9 +586,31 @@ describe("priceMatchingAutomation", () => {
         suggestedBottleId: 1,
         suggestedReleaseId: null,
         modelConfidence: 86,
-        automationScore: 84,
         automationBlockers: [],
+        decisiveMatchAttributes: [],
         candidateBottles: [buildCandidate()],
+      }),
+    ).toBe(false);
+  });
+
+  test("auto-approves the current assignment when an exact alias reaffirms it", () => {
+    expect(
+      shouldVerifyStorePriceMatch({
+        action: "match_existing",
+        price: {
+          bottleId: 1,
+          releaseId: null,
+        },
+        suggestedBottleId: 1,
+        suggestedReleaseId: null,
+        modelConfidence: 72,
+        automationBlockers: [],
+        decisiveMatchAttributes: [],
+        candidateBottles: [
+          buildCandidate({
+            source: ["current", "exact"],
+          }),
+        ],
       }),
     ).toBe(true);
   });
@@ -466,8 +626,8 @@ describe("priceMatchingAutomation", () => {
         suggestedBottleId: 1,
         suggestedReleaseId: null,
         modelConfidence: 97,
-        automationScore: 70,
         automationBlockers: [],
+        decisiveMatchAttributes: [],
         candidateBottles: [
           buildCandidate({
             source: ["exact"],
@@ -488,8 +648,8 @@ describe("priceMatchingAutomation", () => {
         suggestedBottleId: 1,
         suggestedReleaseId: null,
         modelConfidence: 99,
-        automationScore: 74,
         automationBlockers: ["candidate age conflicts with extracted label"],
+        decisiveMatchAttributes: [],
         candidateBottles: [
           buildCandidate({
             source: ["exact"],

--- a/apps/server/src/lib/priceMatchingAutomation.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.ts
@@ -1128,6 +1128,7 @@ export function getStorePriceMatchAutomationAssessment({
     return {
       modelConfidence,
       ...createScore,
+      structuredMatchRequiresStatedAge: false,
       automationEligible:
         action === "create_new" ? createScore.automationEligible : false,
     };
@@ -1198,7 +1199,7 @@ function hasHighConfidenceStructuredMatch(
 ) {
   const matchedAttributes = new Set(decisiveMatchAttributes);
 
-  const requiredAttributes = structuredMatchRequiresStatedAge
+  const requiredAttributes: MatchAttribute[] = structuredMatchRequiresStatedAge
     ? [...HIGH_CONFIDENCE_STRUCTURED_MATCH_REQUIRED_ATTRIBUTES, "statedAge"]
     : HIGH_CONFIDENCE_STRUCTURED_MATCH_REQUIRED_ATTRIBUTES;
 

--- a/apps/server/src/lib/priceMatchingAutomation.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.ts
@@ -1,5 +1,7 @@
-import { normalizeString } from "@peated/bottle-classifier/normalize";
-import { hasSupportiveWebEvidenceForExistingMatch as hasSupportiveBottleEvidence } from "@peated/bottle-classifier/priceMatchingEvidence";
+import {
+  getExistingMatchIdentityConflicts,
+  hasSupportiveWebEvidenceForExistingMatch as hasSupportiveBottleEvidence,
+} from "@peated/bottle-classifier/priceMatchingEvidence";
 import type { StorePrice } from "@peated/server/db/schema";
 import {
   containsComparablePhrase,
@@ -71,10 +73,8 @@ export type StorePriceMatchAutomationAssessment = z.infer<
 >;
 
 const VERIFIED_MATCH_CONFIDENCE_THRESHOLD = 80;
-const UNMATCHED_AUTO_APPROVE_MATCH_SCORE_THRESHOLD =
-  VERIFIED_MATCH_CONFIDENCE_THRESHOLD;
-const HIGH_CONFIDENCE_EXACT_MATCH_SCORE_THRESHOLD = 70;
 const HIGH_CONFIDENCE_EXACT_MATCH_MODEL_CONFIDENCE_THRESHOLD = 95;
+const HIGH_CONFIDENCE_STRUCTURED_MATCH_MODEL_CONFIDENCE_THRESHOLD = 95;
 const AUTO_CREATE_NEW_CONFIDENCE_THRESHOLD = 90;
 const AUTHORITATIVE_SOURCE_TIERS = new Set<SourceTier>(["official", "critic"]);
 const CRITIC_DOMAINS = [
@@ -116,6 +116,13 @@ const WEB_VALIDATED_DIFFERENTIATORS = new Set<MatchAttribute>([
   "vintageYear",
   "releaseYear",
 ]);
+const HIGH_CONFIDENCE_STRUCTURED_MATCH_REQUIRED_ATTRIBUTES: MatchAttribute[] = [
+  "brand",
+  "name",
+  "distillery",
+  "category",
+  "statedAge",
+];
 function clampScore(score: number) {
   return Math.min(100, Math.max(0, Math.round(score)));
 }
@@ -737,16 +744,117 @@ function evaluateSearchEvidenceChecks({
   });
 }
 
-function getMatchScore({
-  price,
+function getExistingMatchDecisiveAttributes({
+  target,
+  extractedLabel,
+}: {
+  target: PriceMatchCandidate;
+  extractedLabel: ExtractedBottleDetails | null;
+}) {
+  const decisiveMatchAttributes = new Set<MatchAttribute>();
+  const label = extractedLabel;
+
+  if (label?.brand && candidateMatchesBrand(target, label.brand)) {
+    decisiveMatchAttributes.add("brand");
+  }
+
+  if (label?.bottler && candidateMatchesBottler(target, label.bottler)) {
+    decisiveMatchAttributes.add("bottler");
+  }
+
+  if (label?.expression && candidateMatchesName(target, label.expression)) {
+    decisiveMatchAttributes.add("name");
+  }
+
+  if (label?.series && candidateMatchesSeries(target, label.series)) {
+    decisiveMatchAttributes.add("series");
+  }
+
+  if (
+    label?.distillery?.length &&
+    candidateMatchesDistillery(target, label.distillery)
+  ) {
+    decisiveMatchAttributes.add("distillery");
+  }
+
+  if (label?.category && target.category === label.category) {
+    decisiveMatchAttributes.add("category");
+  }
+
+  if (
+    label &&
+    label.stated_age !== null &&
+    target.statedAge === label.stated_age
+  ) {
+    decisiveMatchAttributes.add("statedAge");
+  }
+
+  if (label?.edition && textsOverlap(target.edition, label.edition)) {
+    decisiveMatchAttributes.add("edition");
+  }
+
+  if (label?.cask_type && textsOverlap(target.caskType, label.cask_type)) {
+    decisiveMatchAttributes.add("caskType");
+  }
+
+  if (label?.cask_size && textsOverlap(target.caskSize, label.cask_size)) {
+    decisiveMatchAttributes.add("caskSize");
+  }
+
+  if (label?.cask_fill && textsOverlap(target.caskFill, label.cask_fill)) {
+    decisiveMatchAttributes.add("caskFill");
+  }
+
+  if (
+    label &&
+    label.cask_strength !== null &&
+    target.caskStrength === label.cask_strength
+  ) {
+    decisiveMatchAttributes.add("caskStrength");
+  }
+
+  if (
+    label &&
+    label.single_cask !== null &&
+    target.singleCask === label.single_cask
+  ) {
+    decisiveMatchAttributes.add("singleCask");
+  }
+
+  if (label && label.abv !== null && target.abv !== null) {
+    const difference = Math.abs(target.abv - label.abv);
+    if (difference <= 0.4) {
+      decisiveMatchAttributes.add("abv");
+    }
+  }
+
+  if (
+    label &&
+    label.vintage_year !== null &&
+    target.vintageYear === label.vintage_year
+  ) {
+    decisiveMatchAttributes.add("vintageYear");
+  }
+
+  if (
+    label &&
+    label.release_year !== null &&
+    target.releaseYear === label.release_year
+  ) {
+    decisiveMatchAttributes.add("releaseYear");
+  }
+
+  return Array.from(decisiveMatchAttributes);
+}
+
+function getExistingMatchAssessment({
+  modelConfidence,
   suggestedBottleId,
   suggestedReleaseId,
   candidateBottles,
   extractedLabel,
 }: {
-  price: Pick<StorePrice, "bottleId" | "name" | "url"> & {
-    releaseId?: number | null;
-  };
+  modelConfidence: number | null;
   suggestedBottleId: number | null;
   suggestedReleaseId: number | null;
   candidateBottles: PriceMatchCandidate[];
@@ -765,218 +873,37 @@ function getMatchScore({
     };
   }
 
-  let score = 20;
-  const decisiveMatchAttributes = new Set<MatchAttribute>();
   const automationBlockers: string[] = [];
-  const label = extractedLabel;
-
-  if (target.source.includes("exact")) {
-    score += 50;
-    decisiveMatchAttributes.add("name");
-  }
-
   if (
-    price.bottleId &&
-    price.bottleId === target.bottleId &&
-    (price.releaseId ?? null) === (target.releaseId ?? null)
-  ) {
-    score += 10;
-  }
-
-  if (target.kind === "release") {
-    score += 6;
-  } else if (
     target.releaseId === null &&
     listingCarriesReleaseIdentityBeyondBottle({
       target,
       extractedLabel,
     })
   ) {
-    score -= 10;
     automationBlockers.push(
       "listing looks release-specific but the suggested target is only a bottle",
     );
   }
 
-  if (label?.brand && candidateMatchesBrand(target, label.brand)) {
-    score += 8;
-    decisiveMatchAttributes.add("brand");
-  }
-
-  if (label?.bottler && candidateMatchesBottler(target, label.bottler)) {
-    score += 8;
-    decisiveMatchAttributes.add("bottler");
-  } else if (label?.bottler && target.bottler) {
-    score -= 14;
-    automationBlockers.push("candidate bottler conflicts with extracted label");
-  }
-
-  if (label?.expression && candidateMatchesName(target, label.expression)) {
-    score += 12;
-    decisiveMatchAttributes.add("name");
-  }
-
-  if (label?.series && target.series) {
-    if (candidateMatchesSeries(target, label.series)) {
-      score += 8;
-      decisiveMatchAttributes.add("series");
-    } else {
-      score -= 14;
-      automationBlockers.push(
-        "candidate series conflicts with extracted label",
-      );
-    }
-  }
-
-  if (label?.distillery?.length && target.distillery.length) {
-    if (candidateMatchesDistillery(target, label.distillery)) {
-      score += 10;
-      decisiveMatchAttributes.add("distillery");
-    } else {
-      score -= 16;
-      automationBlockers.push(
-        "candidate distillery conflicts with extracted label",
-      );
-    }
-  }
-
-  if (label?.category && target.category) {
-    if (target.category === label.category) {
-      score += 4;
-      decisiveMatchAttributes.add("category");
-    } else {
-      score -= 8;
-      automationBlockers.push(
-        "candidate category conflicts with extracted label",
-      );
-    }
-  }
-
-  if (label && label.stated_age !== null && target.statedAge !== null) {
-    if (target.statedAge === label.stated_age) {
-      score += 12;
-      decisiveMatchAttributes.add("statedAge");
-    } else {
-      score -= 18;
-      automationBlockers.push("candidate age conflicts with extracted label");
-    }
-  }
-
-  if (label?.edition && target.edition) {
-    if (textsOverlap(target.edition, label.edition)) {
-      score += 14;
-      decisiveMatchAttributes.add("edition");
-    } else {
-      score -= 20;
-      automationBlockers.push(
-        "candidate edition conflicts with extracted label",
-      );
-    }
-  }
-
-  if (label?.cask_type && target.caskType) {
-    if (textsOverlap(target.caskType, label.cask_type)) {
-      score += 12;
-      decisiveMatchAttributes.add("caskType");
-    } else {
-      score -= 18;
-      automationBlockers.push(
-        "candidate cask type conflicts with extracted label",
-      );
-    }
-  }
-
-  if (label?.cask_size && target.caskSize) {
-    if (textsOverlap(target.caskSize, label.cask_size)) {
-      score += 6;
-      decisiveMatchAttributes.add("caskSize");
-    } else {
-      score -= 10;
-      automationBlockers.push(
-        "candidate cask size conflicts with extracted label",
-      );
-    }
-  }
-
-  if (label?.cask_fill && target.caskFill) {
-    if (textsOverlap(target.caskFill, label.cask_fill)) {
-      score += 5;
-      decisiveMatchAttributes.add("caskFill");
-    } else {
-      score -= 8;
-      automationBlockers.push(
-        "candidate cask fill conflicts with extracted label",
-      );
-    }
-  }
-
-  if (label && label.cask_strength !== null && target.caskStrength !== null) {
-    if (target.caskStrength === label.cask_strength) {
-      score += 8;
-      decisiveMatchAttributes.add("caskStrength");
-    } else {
-      score -= 14;
-      automationBlockers.push(
-        "candidate cask-strength flag conflicts with extracted label",
-      );
-    }
-  }
-
-  if (label && label.single_cask !== null && target.singleCask !== null) {
-    if (target.singleCask === label.single_cask) {
-      score += 8;
-      decisiveMatchAttributes.add("singleCask");
-    } else {
-      score -= 14;
-      automationBlockers.push(
-        "candidate single-cask flag conflicts with extracted label",
-      );
-    }
-  }
-
-  if (label && label.abv !== null && target.abv !== null) {
-    const difference = Math.abs(target.abv - label.abv);
-    if (difference <= 0.15) {
-      score += 18;
-      decisiveMatchAttributes.add("abv");
-    } else if (difference <= 0.4) {
-      score += 12;
-      decisiveMatchAttributes.add("abv");
-    } else if (difference >= 1) {
-      score -= 20;
-      automationBlockers.push(
-        "candidate ABV materially conflicts with extracted label",
-      );
-    }
-  }
-
-  if (label && label.vintage_year !== null && target.vintageYear !== null) {
-    if (target.vintageYear === label.vintage_year) {
-      score += 8;
-      decisiveMatchAttributes.add("vintageYear");
-    } else {
-      score -= 14;
-      automationBlockers.push(
-        "candidate vintage year conflicts with extracted label",
-      );
-    }
-  }
-
-  if (label && label.release_year !== null && target.releaseYear !== null) {
-    if (target.releaseYear === label.release_year) {
-      score += 8;
-      decisiveMatchAttributes.add("releaseYear");
-    } else {
-      score -= 14;
-      automationBlockers.push(
-        "candidate release year conflicts with extracted label",
-      );
-    }
-  }
+  automationBlockers.push(
+    ...getExistingMatchIdentityConflicts({
+      target,
+      extractedLabel,
+    }),
+  );
 
   return {
-    automationScore: clampScore(score),
-    decisiveMatchAttributes: Array.from(decisiveMatchAttributes),
+    // For existing matches, the reviewed classifier confidence is the only
+    // signal we trust enough to summarize numerically. Downstream automation
+    // still records blockers and matched attributes, but it does not rescore
+    // bottle identity independently of the classifier.
+    automationScore:
+      modelConfidence === null ? null : clampScore(modelConfidence),
+    decisiveMatchAttributes: getExistingMatchDecisiveAttributes({
+      target,
+      extractedLabel,
+    }),
     automationBlockers: Array.from(new Set(automationBlockers)),
   };
 }
@@ -1204,8 +1131,8 @@ export function getStorePriceMatchAutomationAssessment({
   }
 
   if (action === "match_existing" || action === "correction") {
-    const matchScore = getMatchScore({
-      price,
+    const matchAssessment = getExistingMatchAssessment({
+      modelConfidence,
       suggestedBottleId,
       suggestedReleaseId: suggestedReleaseId ?? null,
       candidateBottles,
@@ -1214,10 +1141,10 @@ export function getStorePriceMatchAutomationAssessment({
 
     return {
       modelConfidence,
-      automationScore: matchScore.automationScore,
+      automationScore: matchAssessment.automationScore,
       automationEligible: false,
-      automationBlockers: matchScore.automationBlockers,
-      decisiveMatchAttributes: matchScore.decisiveMatchAttributes,
+      automationBlockers: matchAssessment.automationBlockers,
+      decisiveMatchAttributes: matchAssessment.decisiveMatchAttributes,
       differentiatingAttributes: [],
       webEvidenceChecks: [],
     };
@@ -1259,14 +1186,24 @@ function getSuggestedMatchCandidate({
   );
 }
 
+function hasHighConfidenceStructuredMatch(
+  decisiveMatchAttributes: MatchAttribute[],
+) {
+  const matchedAttributes = new Set(decisiveMatchAttributes);
+
+  return HIGH_CONFIDENCE_STRUCTURED_MATCH_REQUIRED_ATTRIBUTES.every(
+    (attribute) => matchedAttributes.has(attribute),
+  );
+}
+
 export function shouldVerifyStorePriceMatch({
   action,
   price,
   suggestedBottleId,
   suggestedReleaseId,
   modelConfidence,
-  automationScore,
   automationBlockers,
+  decisiveMatchAttributes,
   candidateBottles,
 }: {
   action: MatchAction;
@@ -1276,35 +1213,16 @@ export function shouldVerifyStorePriceMatch({
   suggestedBottleId: number | null;
   suggestedReleaseId: number | null;
   modelConfidence: number | null;
-  automationScore: number | null;
   automationBlockers: string[];
+  decisiveMatchAttributes: MatchAttribute[];
   candidateBottles: PriceMatchCandidate[];
 }) {
-  if (
-    action !== "match_existing" ||
-    suggestedBottleId === null ||
-    automationScore === null
-  ) {
+  if (action !== "match_existing" || suggestedBottleId === null) {
     return false;
   }
 
-  const reaffirmsCurrentAssignment =
-    price.bottleId !== null &&
-    suggestedBottleId === price.bottleId &&
-    (suggestedReleaseId ?? null) === (price.releaseId ?? null);
-  if (
-    reaffirmsCurrentAssignment &&
-    automationScore >= VERIFIED_MATCH_CONFIDENCE_THRESHOLD
-  ) {
-    return true;
-  }
-
-  if (price.bottleId !== null || automationBlockers.length > 0) {
+  if (modelConfidence === null || automationBlockers.length > 0) {
     return false;
-  }
-
-  if (automationScore >= UNMATCHED_AUTO_APPROVE_MATCH_SCORE_THRESHOLD) {
-    return true;
   }
 
   const target = getSuggestedMatchCandidate({
@@ -1313,10 +1231,35 @@ export function shouldVerifyStorePriceMatch({
     candidateBottles,
   });
 
+  const reaffirmsCurrentAssignment =
+    price.bottleId !== null &&
+    suggestedBottleId === price.bottleId &&
+    (suggestedReleaseId ?? null) === (price.releaseId ?? null);
+  if (
+    reaffirmsCurrentAssignment &&
+    (modelConfidence >= VERIFIED_MATCH_CONFIDENCE_THRESHOLD ||
+      target?.source.includes("exact") === true)
+  ) {
+    return true;
+  }
+
+  if (price.bottleId !== null) {
+    return false;
+  }
+
+  if (
+    // Let the classifier break ties for bottle-only matches once the extracted
+    // identity already confirmed the stable bottle fields we trust.
+    suggestedReleaseId === null &&
+    modelConfidence >=
+      HIGH_CONFIDENCE_STRUCTURED_MATCH_MODEL_CONFIDENCE_THRESHOLD &&
+    hasHighConfidenceStructuredMatch(decisiveMatchAttributes)
+  ) {
+    return true;
+  }
+
   return (
     target?.source.includes("exact") === true &&
-    automationScore >= HIGH_CONFIDENCE_EXACT_MATCH_SCORE_THRESHOLD &&
-    modelConfidence !== null &&
     modelConfidence >= HIGH_CONFIDENCE_EXACT_MATCH_MODEL_CONFIDENCE_THRESHOLD
   );
 }

--- a/apps/server/src/lib/priceMatchingAutomation.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.ts
@@ -121,7 +121,6 @@ const HIGH_CONFIDENCE_STRUCTURED_MATCH_REQUIRED_ATTRIBUTES: MatchAttribute[] = [
   "name",
   "distillery",
   "category",
-  "statedAge",
 ];
 function clampScore(score: number) {
   return Math.min(100, Math.max(0, Math.round(score)));
@@ -869,6 +868,7 @@ function getExistingMatchAssessment({
     return {
       automationScore: null,
       decisiveMatchAttributes: [] as MatchAttribute[],
+      structuredMatchRequiresStatedAge: false,
       automationBlockers: [] as string[],
     };
   }
@@ -904,6 +904,9 @@ function getExistingMatchAssessment({
       target,
       extractedLabel,
     }),
+    structuredMatchRequiresStatedAge:
+      extractedLabel?.stated_age !== null &&
+      extractedLabel?.stated_age !== undefined,
     automationBlockers: Array.from(new Set(automationBlockers)),
   };
 }
@@ -1145,6 +1148,8 @@ export function getStorePriceMatchAutomationAssessment({
       automationEligible: false,
       automationBlockers: matchAssessment.automationBlockers,
       decisiveMatchAttributes: matchAssessment.decisiveMatchAttributes,
+      structuredMatchRequiresStatedAge:
+        matchAssessment.structuredMatchRequiresStatedAge,
       differentiatingAttributes: [],
       webEvidenceChecks: [],
     };
@@ -1156,6 +1161,7 @@ export function getStorePriceMatchAutomationAssessment({
     automationEligible: false,
     automationBlockers: [],
     decisiveMatchAttributes: [],
+    structuredMatchRequiresStatedAge: false,
     differentiatingAttributes: [],
     webEvidenceChecks: [],
   };
@@ -1188,11 +1194,16 @@ function getSuggestedMatchCandidate({
 
 function hasHighConfidenceStructuredMatch(
   decisiveMatchAttributes: MatchAttribute[],
+  structuredMatchRequiresStatedAge: boolean,
 ) {
   const matchedAttributes = new Set(decisiveMatchAttributes);
 
-  return HIGH_CONFIDENCE_STRUCTURED_MATCH_REQUIRED_ATTRIBUTES.every(
-    (attribute) => matchedAttributes.has(attribute),
+  const requiredAttributes = structuredMatchRequiresStatedAge
+    ? [...HIGH_CONFIDENCE_STRUCTURED_MATCH_REQUIRED_ATTRIBUTES, "statedAge"]
+    : HIGH_CONFIDENCE_STRUCTURED_MATCH_REQUIRED_ATTRIBUTES;
+
+  return requiredAttributes.every((attribute) =>
+    matchedAttributes.has(attribute),
   );
 }
 
@@ -1204,6 +1215,7 @@ export function shouldVerifyStorePriceMatch({
   modelConfidence,
   automationBlockers,
   decisiveMatchAttributes,
+  structuredMatchRequiresStatedAge = false,
   candidateBottles,
 }: {
   action: MatchAction;
@@ -1215,6 +1227,7 @@ export function shouldVerifyStorePriceMatch({
   modelConfidence: number | null;
   automationBlockers: string[];
   decisiveMatchAttributes: MatchAttribute[];
+  structuredMatchRequiresStatedAge?: boolean;
   candidateBottles: PriceMatchCandidate[];
 }) {
   if (action !== "match_existing" || suggestedBottleId === null) {
@@ -1253,7 +1266,10 @@ export function shouldVerifyStorePriceMatch({
     suggestedReleaseId === null &&
     modelConfidence >=
       HIGH_CONFIDENCE_STRUCTURED_MATCH_MODEL_CONFIDENCE_THRESHOLD &&
-    hasHighConfidenceStructuredMatch(decisiveMatchAttributes)
+    hasHighConfidenceStructuredMatch(
+      decisiveMatchAttributes,
+      structuredMatchRequiresStatedAge,
+    )
   ) {
     return true;
   }

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -1,8 +1,5 @@
 import { inferBottleCreationTarget } from "@peated/bottle-classifier/bottleCreationDrafts";
-import {
-  normalizeBottle,
-  normalizeString,
-} from "@peated/bottle-classifier/normalize";
+import { normalizeBottle } from "@peated/bottle-classifier/normalize";
 import {
   DEFAULT_PRICE_MATCH_CREATION_TARGET,
   getReleaseObservationFacts,
@@ -80,10 +77,6 @@ import type { z } from "zod";
 
 const SMWS_EXTERNAL_SITE_TYPE = "smws";
 const SMWS_BRAND_NAME = "The Scotch Malt Whisky Society";
-const NON_WHISKY_LISTING_KEYWORDS =
-  /\b(vodka|gin|rum|tequila|mezcal|sotol|soju|baijiu|sake|shochu|brandy|cognac|armagnac|liqueur)\b/i;
-const WHISKY_LISTING_KEYWORDS =
-  /\b(whisk(?:e)?y|single malt|single grain|single pot still|bourbon|rye|scotch|malt whisky|malt whiskey)\b/i;
 
 type ExtractedBottleDetails = z.infer<typeof ExtractedBottleDetailsSchema>;
 type PriceMatchCandidate = z.infer<typeof PriceMatchCandidateSchema>;
@@ -115,17 +108,6 @@ export class StorePriceMatchProposalNotReviewableError extends Error {
 function normalizeClassifierConfidence(confidence: number): number {
   const percentageConfidence = confidence <= 1 ? confidence * 100 : confidence;
   return Math.min(100, Math.max(0, Math.round(percentageConfidence)));
-}
-
-function shouldAutoIgnoreTrivialNonWhiskyListing(name: string): boolean {
-  // Keep this fast path limited to obvious non-whisky categories. Flavored
-  // whisky detection intentionally stays model-driven because retailer titles
-  // are too inconsistent for regex heuristics to be reliable there.
-  const normalizedName = normalizeString(name).toLowerCase();
-  return (
-    NON_WHISKY_LISTING_KEYWORDS.test(normalizedName) &&
-    !WHISKY_LISTING_KEYWORDS.test(normalizedName)
-  );
 }
 
 function normalizeClassifierDecisionForPriceMatching(
@@ -551,8 +533,8 @@ function getProposalStatus(
       suggestedBottleId: decision.suggestedBottleId,
       suggestedReleaseId: decision.suggestedReleaseId ?? null,
       modelConfidence: decision.confidence,
-      automationScore: automationAssessment.automationScore,
       automationBlockers: automationAssessment.automationBlockers,
+      decisiveMatchAttributes: automationAssessment.decisiveMatchAttributes,
       candidateBottles: candidates,
     })
   ) {
@@ -1296,17 +1278,6 @@ export async function resolveStorePriceMatchProposal(
     );
     if (trustedSmwsProposal) {
       return trustedSmwsProposal;
-    }
-
-    if (shouldAutoIgnoreTrivialNonWhiskyListing(price.name)) {
-      return await upsertStorePriceMatchProposal({
-        price,
-        extractedLabel,
-        candidates,
-        searchEvidence,
-        statusOverride: "ignored",
-        expectedProcessingToken: processingToken,
-      });
     }
 
     // Price matching consumes the generic bottle classifier and only layers

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -535,6 +535,8 @@ function getProposalStatus(
       modelConfidence: decision.confidence,
       automationBlockers: automationAssessment.automationBlockers,
       decisiveMatchAttributes: automationAssessment.decisiveMatchAttributes,
+      structuredMatchRequiresStatedAge:
+        automationAssessment.structuredMatchRequiresStatedAge,
       candidateBottles: candidates,
     })
   ) {

--- a/apps/server/src/schemas/priceMatches.ts
+++ b/apps/server/src/schemas/priceMatches.ts
@@ -142,6 +142,7 @@ export const StorePriceMatchAutomationAssessmentSchema = z.object({
   automationEligible: z.boolean().default(false),
   automationBlockers: z.array(z.string()).default([]),
   decisiveMatchAttributes: z.array(PriceMatchAttributeEnum).default([]),
+  structuredMatchRequiresStatedAge: z.boolean().default(false),
   differentiatingAttributes: z.array(PriceMatchAttributeEnum).default([]),
   webEvidenceChecks: z.array(PriceMatchEvidenceCheckSchema).default([]),
 });

--- a/packages/bottle-classifier/src/classifier.eval.fixtures.ts
+++ b/packages/bottle-classifier/src/classifier.eval.fixtures.ts
@@ -22,6 +22,8 @@ export type ClassifierEvalExpectation = {
   matchedBottleId?: number | null;
   matchedReleaseId?: number | null;
   parentBottleId?: number | null;
+  proposedBottle?: Record<string, unknown> | null;
+  proposedRelease?: Record<string, unknown> | null;
   summary: string;
 };
 
@@ -561,6 +563,9 @@ export const EVAL_CASES: ClassifierEvalCase[] = [
       action: "create_release",
       identityScope: "product",
       parentBottleId: 620,
+      proposedRelease: {
+        edition: "Batch C923",
+      },
       summary:
         "Treat Batch C923 as release-level detail under the existing Elijah Craig Barrel Proof bottle instead of creating a whole new bottle.",
     },
@@ -665,6 +670,9 @@ export const EVAL_CASES: ClassifierEvalCase[] = [
       action: "create_release",
       identityScope: "product",
       parentBottleId: 54082,
+      proposedRelease: {
+        statedAge: 30,
+      },
       summary:
         "Treat the local 30-year-old bottle row as a dirty release-like candidate and create a 30-year-old child release beneath the reusable Macallan Sherry Oak parent bottle instead.",
     },
@@ -916,6 +924,15 @@ export const EVAL_CASES: ClassifierEvalCase[] = [
       status: "classified",
       action: "create_bottle_and_release",
       identityScope: "product",
+      proposedBottle: {
+        brand: {
+          name: "Glengoyne",
+        },
+        name: "The Legacy Series",
+      },
+      proposedRelease: {
+        edition: "Chapter Two",
+      },
       summary:
         "Treat Glengoyne The Legacy Series as the reusable parent family and Chapter Two as the child release even when the local candidates are only dirty chapter-specific bottle rows.",
     },

--- a/packages/bottle-classifier/src/classifier.eval.test.ts
+++ b/packages/bottle-classifier/src/classifier.eval.test.ts
@@ -110,6 +110,30 @@ function parseClassificationResult(output: string): BottleClassificationResult {
   return JSON.parse(output) as BottleClassificationResult;
 }
 
+function deepContainsSubset(actual: unknown, expected: unknown): boolean {
+  if (expected === null || typeof expected !== "object") {
+    return Object.is(actual, expected);
+  }
+
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || actual.length < expected.length) {
+      return false;
+    }
+
+    return expected.every((value, index) =>
+      deepContainsSubset(actual[index], value),
+    );
+  }
+
+  if (!actual || typeof actual !== "object") {
+    return false;
+  }
+
+  return Object.entries(expected).every(([key, value]) =>
+    deepContainsSubset((actual as Record<string, unknown>)[key], value),
+  );
+}
+
 function createDecisionShapeScorer() {
   return async ({
     output,
@@ -142,6 +166,24 @@ function createDecisionShapeScorer() {
 
       if (expected.parentBottleId !== undefined) {
         checks.push(result.decision.parentBottleId === expected.parentBottleId);
+      }
+
+      if (expected.proposedBottle !== undefined) {
+        checks.push(
+          deepContainsSubset(
+            result.decision.proposedBottle,
+            expected.proposedBottle,
+          ),
+        );
+      }
+
+      if (expected.proposedRelease !== undefined) {
+        checks.push(
+          deepContainsSubset(
+            result.decision.proposedRelease,
+            expected.proposedRelease,
+          ),
+        );
       }
     }
 

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -1595,7 +1595,7 @@ describe("createBottleClassifier", () => {
     );
   });
 
-  test("keeps a plain age-statement match instead of redirecting to an unrelated cask-strength family", async () => {
+  test("keeps a plain age-statement match even when the title abbreviates the age wording", async () => {
     const extractedIdentity: BottleExtractedDetails = {
       brand: "Tomatin",
       bottler: null,
@@ -1649,7 +1649,7 @@ describe("createBottleClassifier", () => {
 
     const result = await classifier.classifyBottleReference({
       reference: {
-        name: "Tomatin Single Malt 12-year-old",
+        name: "Tomatin Single Malt 12 Yr.",
       },
       extractedIdentity,
       initialCandidates: [

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -135,6 +135,42 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+function getComparableAgeStatementPattern(statedAge: number): RegExp {
+  const age = escapeRegExp(String(statedAge));
+
+  return new RegExp(
+    `\\b${age}(?:\\s|-)?(?:year|yr)s?(?:\\s|-)?old\\b|\\b${age}(?:\\s|-)?(?:year|yr)s?\\b|\\b${age}(?:\\s|-)?y(?:\\.?o\\.?)?\\b`,
+    "i",
+  );
+}
+
+function stripComparableAgeStatement(
+  value: string,
+  statedAge: number | null | undefined,
+): string {
+  if (statedAge === null || statedAge === undefined) {
+    return value;
+  }
+
+  return value
+    .replace(getComparableAgeStatementPattern(statedAge), " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function comparableTextMarketsStatedAge(
+  value: string | null | undefined,
+  statedAge: number | null | undefined,
+): boolean {
+  if (!value || statedAge === null || statedAge === undefined) {
+    return false;
+  }
+
+  return getComparableAgeStatementPattern(statedAge).test(
+    normalizeComparableText(value),
+  );
+}
+
 function containsComparablePhrase(haystack: string, needle: string): boolean {
   if (!haystack || !needle) {
     return false;
@@ -653,12 +689,10 @@ function candidateNameMatchesReferenceVariantsIgnoringStatedAge({
     return false;
   }
 
-  const strippedReferenceName = stripComparablePhrase(
+  const strippedReferenceName = stripComparableAgeStatement(
     normalizeComparableText(referenceName),
-    `${extractedIdentity.stated_age}-year-old`,
-  )
-    .replace(/\s+/g, " ")
-    .trim();
+    extractedIdentity.stated_age,
+  );
   if (!strippedReferenceName) {
     return false;
   }
@@ -728,9 +762,7 @@ function candidateLooksLikeDirtyAgeReleaseBottle({
   }
 
   return getBottleTargetNameCandidates(candidate).some((name) =>
-    new RegExp(`\\b${candidate.statedAge}-year-old\\b`, "i").test(
-      normalizeComparableText(name),
-    ),
+    comparableTextMarketsStatedAge(name, candidate.statedAge),
   );
 }
 


### PR DESCRIPTION
Favor classifier-driven decisions for existing price matches instead of rebuilding a second classifier in server automation.

The classifier already decides bottle identity, but the server still had a pre-classifier non-whisky fast path and a downstream match score that could disagree with the reviewed result. That left strong matches pending when the agent had already identified the right bottle but the deterministic follow-up scored them too conservatively.

This removes the server-side ignore fast path, stops using downstream rescoring as an approval gate for existing matches, and narrows auto-verification to classifier confidence plus exact-alias or strongly structured bottle support. The remaining deterministic logic stays focused on blockers and normalization, including broader age-statement comparisons like `12 Yr.` versus `12-year-old`.

I considered patching the misses with more regexes and score tweaks, but that would keep growing flaky deterministic logic around the agent. This keeps the agent as the source of truth for identity decisions and uses eval coverage to assert the shape of create-bottle and create-release outputs more directly.