### PR TITLE
fix(price-matching): Auto-verify plain age bottle matches

### DIFF
--- a/apps/server/src/lib/priceMatchingAutomation.test.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.test.ts
@@ -387,23 +387,23 @@ describe("priceMatchingAutomation", () => {
     ).toBe(false);
   });
 
-  test("does not auto-approve plain age-statement bottles below the elevated unmatched threshold", () => {
+  test("auto-approves clear plain age-statement bottle matches as a deterministic judgement", () => {
     const assessment = getStorePriceMatchAutomationAssessment({
       action: "match_existing",
-      modelConfidence: 95,
+      modelConfidence: 35,
       price: {
         bottleId: null,
-        name: "Tomatin Single Malt 12-year-old",
-        url: "https://example.com/tomatin",
+        name: "Springbank Aged 25-year-old",
+        url: "https://woodencork.com/products/springbank-aged-25-year-old-750-ml",
       },
-      suggestedBottleId: 12,
+      suggestedBottleId: 469,
       suggestedReleaseId: null,
       extractedLabel: buildExtractedLabel({
-        brand: "Tomatin",
+        brand: "Springbank",
         expression: null,
-        distillery: ["Tomatin"],
-        category: "single_malt",
-        stated_age: 12,
+        distillery: ["Springbank"],
+        category: null,
+        stated_age: 25,
         abv: null,
         cask_type: null,
       }),
@@ -411,28 +411,105 @@ describe("priceMatchingAutomation", () => {
       searchEvidence: [],
       candidateBottles: [
         buildCandidate({
-          bottleId: 12,
-          fullName: "Tomatin 12-year-old",
-          bottleFullName: "Tomatin 12-year-old",
-          brand: "Tomatin",
-          distillery: ["Tomatin"],
+          bottleId: 469,
+          fullName: "Springbank 25-year-old",
+          bottleFullName: "Springbank 25-year-old",
+          brand: "Springbank",
+          bottler: "Springbank",
+          distillery: [],
           category: "single_malt",
-          statedAge: 12,
+          statedAge: 25,
+          abv: null,
+          caskType: null,
+        }),
+        buildCandidate({
+          bottleId: 1563,
+          fullName: "Springbank 25-year-old Limited Edition",
+          bottleFullName: "Springbank 25-year-old Limited Edition",
+          brand: "Springbank",
+          bottler: "Springbank",
+          distillery: [],
+          category: "single_malt",
+          statedAge: 25,
+          abv: null,
+          caskType: null,
+          score: 1,
+          source: ["text"],
+        }),
+      ],
+    });
+
+    expect(assessment.automationBlockers).toEqual([]);
+    expect(assessment.plainAgeBottleAutoVerifyEligible).toBe(true);
+    expect(
+      shouldVerifyStorePriceMatch({
+        action: "match_existing",
+        currentBottleId: null,
+        currentReleaseId: null,
+        suggestedBottleId: 469,
+        suggestedReleaseId: null,
+        modelConfidence: 35,
+        automationBlockers: assessment.automationBlockers,
+        plainAgeBottleAutoVerifyEligible:
+          assessment.plainAgeBottleAutoVerifyEligible,
+      }),
+    ).toBe(true);
+  });
+
+  test("keeps release-specific plain-age listings out of plain-age auto-approval", () => {
+    const assessment = getStorePriceMatchAutomationAssessment({
+      action: "match_existing",
+      modelConfidence: 93,
+      price: {
+        bottleId: null,
+        name: "Springbank 25-year-old Limited Edition",
+        url: "https://example.com/springbank-25-limited",
+      },
+      suggestedBottleId: 469,
+      suggestedReleaseId: null,
+      extractedLabel: buildExtractedLabel({
+        brand: "Springbank",
+        expression: null,
+        distillery: ["Springbank"],
+        category: null,
+        stated_age: 25,
+        edition: "Limited Edition",
+        abv: null,
+        cask_type: null,
+      }),
+      proposedBottle: null,
+      searchEvidence: [],
+      candidateBottles: [
+        buildCandidate({
+          bottleId: 469,
+          fullName: "Springbank 25-year-old",
+          bottleFullName: "Springbank 25-year-old",
+          brand: "Springbank",
+          bottler: "Springbank",
+          distillery: [],
+          category: "single_malt",
+          statedAge: 25,
           abv: null,
           caskType: null,
         }),
       ],
     });
 
+    expect(assessment.plainAgeBottleAutoVerifyEligible).toBe(false);
+    expect(assessment.automationBlockers).toContain(
+      "listing looks release-specific but the suggested target is only a bottle",
+    );
     expect(
       shouldVerifyStorePriceMatch({
         action: "match_existing",
         currentBottleId: null,
         currentReleaseId: null,
-        suggestedBottleId: 12,
+        suggestedBottleId: 469,
         suggestedReleaseId: null,
-        modelConfidence: 95,
+        modelConfidence: 93,
         automationBlockers: assessment.automationBlockers,
+        plainAgeBottleAutoVerifyEligible:
+          assessment.plainAgeBottleAutoVerifyEligible,
       }),
     ).toBe(false);
   });

--- a/apps/server/src/lib/priceMatchingAutomation.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.ts
@@ -15,6 +15,7 @@ import {
   getExistingMatchIdentityConflicts,
   hasSupportiveWebEvidenceForExistingMatch as hasSupportiveBottleEvidence,
   isExistingMatchConfidenceEligibleForVerification,
+  isPlainAgeBottleMatchEligibleForVerification,
 } from "@peated/bottle-classifier/priceMatchingEvidence";
 import type { StorePrice } from "@peated/server/db/schema";
 import type { StorePriceMatchAutomationAssessmentSchema } from "@peated/server/schemas";
@@ -693,7 +694,7 @@ function getExistingMatchAssessment({
   searchEvidence,
 }: {
   modelConfidence: number | null;
-  price: Pick<StorePrice, "url">;
+  price: Pick<StorePrice, "name" | "url">;
   suggestedBottleId: number | null;
   suggestedReleaseId: number | null;
   candidateBottles: PriceMatchCandidate[];
@@ -710,6 +711,7 @@ function getExistingMatchAssessment({
       automationScore: null,
       decisiveMatchAttributes: [] as MatchAttribute[],
       structuredMatchRequiresStatedAge: false,
+      plainAgeBottleAutoVerifyEligible: false,
       automationBlockers: [] as string[],
       differentiatingAttributes: [] as MatchAttribute[],
       webEvidenceChecks: [] as EvidenceCheck[],
@@ -742,12 +744,18 @@ function getExistingMatchAssessment({
     extractedLabel,
     searchEvidence,
   });
+  const plainAgeBottleAutoVerifyEligible =
+    automationBlockers.length === 0 &&
+    isPlainAgeBottleMatchEligibleForVerification({
+      target,
+      candidates: candidateBottles,
+      extractedLabel,
+      referenceName: price.name,
+    });
 
   return {
-    // For existing matches, the reviewed classifier confidence is the only
-    // signal we trust enough to summarize numerically. Downstream automation
-    // still records blockers and matched attributes, but it does not rescore
-    // bottle identity independently of the classifier.
+    // Existing-match score is display/debug context. Verification decisions use
+    // explicit blockers, deterministic lanes, and the legacy confidence gate.
     automationScore:
       modelConfidence === null ? null : clampScore(modelConfidence),
     decisiveMatchAttributes: getExistingMatchDecisiveAttributes({
@@ -757,6 +765,7 @@ function getExistingMatchAssessment({
     structuredMatchRequiresStatedAge:
       extractedLabel?.stated_age !== null &&
       extractedLabel?.stated_age !== undefined,
+    plainAgeBottleAutoVerifyEligible,
     automationBlockers: Array.from(new Set(automationBlockers)),
     differentiatingAttributes: webEvidence.differentiatingAttributes,
     webEvidenceChecks: webEvidence.checks,
@@ -981,6 +990,7 @@ export function getStorePriceMatchAutomationAssessment({
       modelConfidence,
       ...createScore,
       structuredMatchRequiresStatedAge: false,
+      plainAgeBottleAutoVerifyEligible: false,
       automationEligible:
         action === "create_new" ? createScore.automationEligible : false,
     };
@@ -1005,6 +1015,8 @@ export function getStorePriceMatchAutomationAssessment({
       decisiveMatchAttributes: matchAssessment.decisiveMatchAttributes,
       structuredMatchRequiresStatedAge:
         matchAssessment.structuredMatchRequiresStatedAge,
+      plainAgeBottleAutoVerifyEligible:
+        matchAssessment.plainAgeBottleAutoVerifyEligible,
       differentiatingAttributes: matchAssessment.differentiatingAttributes,
       webEvidenceChecks: matchAssessment.webEvidenceChecks,
     };
@@ -1017,6 +1029,7 @@ export function getStorePriceMatchAutomationAssessment({
     automationBlockers: [],
     decisiveMatchAttributes: [],
     structuredMatchRequiresStatedAge: false,
+    plainAgeBottleAutoVerifyEligible: false,
     differentiatingAttributes: [],
     webEvidenceChecks: [],
   };
@@ -1056,6 +1069,7 @@ export function shouldVerifyStorePriceMatch(params: {
   suggestedReleaseId: number | null;
   modelConfidence: number | null;
   automationBlockers: string[];
+  plainAgeBottleAutoVerifyEligible?: boolean;
 }) {
   const {
     action,
@@ -1066,6 +1080,7 @@ export function shouldVerifyStorePriceMatch(params: {
     suggestedBottleId,
     suggestedReleaseId,
     modelConfidence,
+    plainAgeBottleAutoVerifyEligible = false,
   } = params;
 
   if (action !== "match_existing" || suggestedBottleId === null) {
@@ -1074,6 +1089,15 @@ export function shouldVerifyStorePriceMatch(params: {
 
   if (automationBlockers.length > 0) {
     return false;
+  }
+
+  if (
+    currentBottleId === null &&
+    (suggestedReleaseId ?? null) === null &&
+    identityScope !== "exact_cask" &&
+    plainAgeBottleAutoVerifyEligible
+  ) {
+    return true;
   }
 
   if (modelConfidence === null) {

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -666,6 +666,8 @@ function getProposalStatus(
       suggestedReleaseId: decision.suggestedReleaseId ?? null,
       modelConfidence: decision.confidence,
       automationBlockers: automationAssessment.automationBlockers,
+      plainAgeBottleAutoVerifyEligible:
+        automationAssessment.plainAgeBottleAutoVerifyEligible,
     })
   ) {
     return "verified";

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -182,6 +182,7 @@ describe("price match queue", () => {
           automationEligible: false,
           automationBlockers: ["persisted blocker"],
           decisiveMatchAttributes: ["name"],
+          plainAgeBottleAutoVerifyEligible: false,
           differentiatingAttributes: ["distillery"],
           webEvidenceChecks: [
             {

--- a/apps/server/src/orpc/routes/prices/matchQueue/utils.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/utils.ts
@@ -44,6 +44,9 @@ function getPersistedAutomationAssessment(proposal: StorePriceMatchProposal) {
   if (!proposal.automationAssessment) {
     return null;
   }
+  if (!("plainAgeBottleAutoVerifyEligible" in proposal.automationAssessment)) {
+    return null;
+  }
 
   const parsedAssessment = StorePriceMatchAutomationAssessmentSchema.safeParse(
     proposal.automationAssessment,
@@ -328,6 +331,7 @@ export function serializeProposal(
           automationEligible: false,
           automationBlockers: [],
           decisiveMatchAttributes: [],
+          plainAgeBottleAutoVerifyEligible: false,
           differentiatingAttributes: [],
           webEvidenceChecks: [],
         });
@@ -348,6 +352,8 @@ export function serializeProposal(
     automationEligible: automationAssessment.automationEligible,
     automationBlockers: Array.from(new Set(automationBlockers)),
     decisiveMatchAttributes: automationAssessment.decisiveMatchAttributes,
+    plainAgeBottleAutoVerifyEligible:
+      automationAssessment.plainAgeBottleAutoVerifyEligible,
     differentiatingAttributes: automationAssessment.differentiatingAttributes,
     webEvidenceChecks: automationAssessment.webEvidenceChecks,
     currentBottleId: proposal.currentBottleId,

--- a/apps/server/src/schemas/priceMatches.ts
+++ b/apps/server/src/schemas/priceMatches.ts
@@ -197,6 +197,7 @@ export const StorePriceMatchAutomationAssessmentSchema = z.object({
   automationBlockers: z.array(z.string()).default([]),
   decisiveMatchAttributes: z.array(PriceMatchAttributeEnum).default([]),
   structuredMatchRequiresStatedAge: z.boolean().default(false),
+  plainAgeBottleAutoVerifyEligible: z.boolean().default(false),
   differentiatingAttributes: z.array(PriceMatchAttributeEnum).default([]),
   webEvidenceChecks: z.array(PriceMatchEvidenceCheckSchema).default([]),
 });
@@ -452,6 +453,9 @@ export const StorePriceMatchProposalSchema = z.object({
     StorePriceMatchAutomationAssessmentSchema.shape.automationBlockers,
   decisiveMatchAttributes:
     StorePriceMatchAutomationAssessmentSchema.shape.decisiveMatchAttributes,
+  plainAgeBottleAutoVerifyEligible:
+    StorePriceMatchAutomationAssessmentSchema.shape
+      .plainAgeBottleAutoVerifyEligible,
   differentiatingAttributes:
     StorePriceMatchAutomationAssessmentSchema.shape.differentiatingAttributes,
   webEvidenceChecks:

--- a/apps/web/src/app/(admin)/admin/(default)/queue/llmExport.ts
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/llmExport.ts
@@ -176,6 +176,8 @@ export function formatPriceMatchQueueLlmExport(item: QueueItem) {
           eligible: item.automationEligible,
           blockers: item.automationBlockers,
           decisiveMatchAttributes: item.decisiveMatchAttributes,
+          plainAgeBottleAutoVerifyEligible:
+            item.plainAgeBottleAutoVerifyEligible,
           differentiatingAttributes: item.differentiatingAttributes,
         },
         timestamps: {

--- a/packages/bottle-classifier/src/priceMatchingEvidence.ts
+++ b/packages/bottle-classifier/src/priceMatchingEvidence.ts
@@ -299,6 +299,22 @@ function extractedLabelLooksLikePlainAgeStatement(
   );
 }
 
+function bottleCandidateIsPlainAgeAutoVerificationTarget(
+  target: BottleCandidate,
+): boolean {
+  return (
+    target.kind !== "release" &&
+    (target.releaseId ?? null) === null &&
+    target.abv === null &&
+    !target.caskType &&
+    !target.caskSize &&
+    !target.caskFill &&
+    target.caskStrength !== true &&
+    target.singleCask !== true &&
+    targetLooksLikePlainAgeStatementBottle(target)
+  );
+}
+
 function extractedLabelCarriesUnsupportedSpecificity({
   target,
   extractedLabel,
@@ -542,6 +558,34 @@ function candidateMatchesDistillery(
   }
 
   return listMatchesExpectedValue(candidate.distillery, values);
+}
+
+function candidateMatchesPlainAgeStructuredIdentity({
+  candidate,
+  extractedLabel,
+}: {
+  candidate: BottleCandidate;
+  extractedLabel: BottleExtractedDetails | null;
+}): boolean {
+  return (
+    Boolean(extractedLabel?.brand) &&
+    candidateMatchesBrand(candidate, extractedLabel?.brand) &&
+    extractedLabel?.stated_age !== null &&
+    extractedLabel?.stated_age !== undefined &&
+    candidate.statedAge === extractedLabel.stated_age
+  );
+}
+
+function titleSupportsAnyCandidateName({
+  title,
+  candidate,
+}: {
+  title: string;
+  candidate: BottleCandidate;
+}): boolean {
+  return getTargetNameVariants(candidate).some((variant) =>
+    titleSupportsCandidateName(title, variant),
+  );
 }
 
 function buildExistingMatchSupportChecks({
@@ -856,6 +900,42 @@ export function hasAuthoritativeTargetIdentityEvidenceForExistingMatch({
         })
       );
     }),
+  );
+}
+
+export function isPlainAgeBottleMatchEligibleForVerification({
+  target,
+  candidates,
+  extractedLabel,
+  referenceName,
+}: {
+  target: BottleCandidate;
+  candidates: BottleCandidate[];
+  extractedLabel: BottleExtractedDetails | null;
+  referenceName: string;
+}): boolean {
+  if (
+    !extractedLabelLooksLikePlainAgeStatement(extractedLabel) ||
+    !bottleCandidateIsPlainAgeAutoVerificationTarget(target) ||
+    !candidateMatchesPlainAgeStructuredIdentity({
+      candidate: target,
+      extractedLabel,
+    }) ||
+    !titleSupportsAnyCandidateName({ title: referenceName, candidate: target })
+  ) {
+    return false;
+  }
+
+  return !candidates.some(
+    (candidate) =>
+      candidate.bottleId !== target.bottleId &&
+      candidate.kind !== "release" &&
+      (candidate.releaseId ?? null) === null &&
+      candidateMatchesPlainAgeStructuredIdentity({
+        candidate,
+        extractedLabel,
+      }) &&
+      titleSupportsAnyCandidateName({ title: referenceName, candidate }),
   );
 }
 


### PR DESCRIPTION
Add a deterministic auto-verification lane for clean plain age-statement store price matches. When the extracted brand and age match a plain bottle, the source title supports that candidate, and no supported same-brand age competitor exists, the match can verify without relying on model confidence pseudo-precision.

This fixes cases where straightforward retailer titles stayed in review because existing unmatched bottle matches were gated on the legacy high confidence threshold. The numeric classifier confidence remains available for display and the legacy confidence gate, but this narrow path is now an explicit judgement.

The change keeps release-specific listings out of the lane by preserving existing blockers for edition, vintage, cask, ABV, and other release-level traits.