### PR TITLE
test(classifier): Add production-miss eval provenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 - Backend testing policy: `docs/development/backend-testing.md`
 - Before finalizing non-trivial code changes, run the full test suite with `pnpm test`; targeted tests are additive, not a substitute
 - Classifier/repair changes: preserve `docs/architecture/whisky-identity-model.md`; brand/entity identity is not prefix matching
+- Production-miss classifier evals must verify the real bottle online, state the exact Peated DB outcome, and encode that provenance in the fixture; do not substitute a generalized pretend case for the observed bottle.
 - oRPC route conventions: `docs/development/orpc-routes.md`
 - oRPC client usage: `docs/development/orpc-client.md`
 - Schema conventions: `docs/development/schema-conventions.md`

--- a/apps/server/src/orpc/routes/admin/review-workbench-stats.test.ts
+++ b/apps/server/src/orpc/routes/admin/review-workbench-stats.test.ts
@@ -39,6 +39,10 @@ function toDateKey(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+function hoursSince(date: Date): number {
+  return Math.round(((Date.now() - date.getTime()) / 3_600_000) * 10) / 10;
+}
+
 async function createProposalFixture(
   {
     createdAt,
@@ -151,10 +155,11 @@ describe("GET /admin/review-workbench/stats", () => {
       },
       { bottleId: bottle.id, storePrice: fixtures.StorePrice },
     );
+    const oldestActionableEnteredQueueAt = daysAgoAt(4, 9);
     await createProposalFixture(
       {
         createdAt: todayQueueErroredAt,
-        enteredQueueAt: daysAgoAt(4, 9),
+        enteredQueueAt: oldestActionableEnteredQueueAt,
         status: "errored",
       },
       { bottleId: bottle.id, storePrice: fixtures.StorePrice },
@@ -215,6 +220,9 @@ describe("GET /admin/review-workbench/stats", () => {
       olderThan72Hours: 1,
     });
     expect(result.snapshot.backlog.oldestHours).not.toBeNull();
-    expect(result.snapshot.backlog.oldestHours!).toBeGreaterThanOrEqual(95);
+    expect(result.snapshot.backlog.oldestHours!).toBeCloseTo(
+      hoursSince(oldestActionableEnteredQueueAt),
+      0,
+    );
   });
 });

--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -259,6 +259,28 @@ evals. It forwards extra Vitest args to the package runner and uses the
 `vitest-evals` reporter configured in
 `packages/bottle-classifier/vitest.evals.config.mts`.
 
+Production-miss eval checklist:
+
+1. Preserve the exact observed case: source title, URL, extracted identity,
+   current assignment, local candidates, and the failing classifier or
+   automation outcome.
+2. Verify the real bottle online before deciding the expected result. Prefer
+   producer or brand pages, official shops, and reputable independent sources.
+   Do not use retailer SEO text alone as proof of canonical identity.
+3. Decide the Peated DB action before encoding the eval: exact `bottleId`,
+   exact `releaseId` or `null`, whether to create a `bottle_release`, whether a
+   parent split is required, and which exact source facts stay in
+   `bottle_observation`.
+4. Encode the expected outcome for the exact real bottle. For existing matches,
+   expected ids should be the actual Peated ids. For create paths, expected
+   drafts should describe the canonical bottle or release that should exist.
+5. Add fixture `provenance.source = "production_miss"` with
+   `verifiedSourceUrls` and `dbOutcome` so the web verification and intended DB
+   result remain attached to the regression.
+6. If a family can fail in both directions, add paired positive and negative
+   fixtures. Do not move brand- or family-specific semantics into deterministic
+   code just to satisfy the eval.
+
 Local setup for live evals:
 
 - put `OPENAI_API_KEY` in the repo-root `.env` or `.env.local`

--- a/packages/bottle-classifier/AGENTS.md
+++ b/packages/bottle-classifier/AGENTS.md
@@ -44,6 +44,8 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 - `exact_cask` needs strong marketed identity signals such as SMWS codes, cask numbers, or barrel numbers.
 - Model-sensitive behavior changes should update realistic eval fixtures; add unit tests only for deterministic invariants changed to support them.
 - Creation requires external web evidence. Never invent evidence or create without source support.
+- Production-miss evals require the exact observed input, independent web verification of the real bottle, and an explicit Peated DB outcome before the expected result is encoded. Use fixture `provenance.source = "production_miss"` with `verifiedSourceUrls` and `dbOutcome`.
+- Expected eval outcomes must name the exact Peated bottle/release ids, exact create action, and auto-verification expectation when those are known. Do not replace a production miss with a generalized or pretend outcome.
 - Live evals are expensive; run full evals only when explicitly asked or when doing an intentional scoped eval pass.
 - Replay JSON under `.vitest-evals/recordings/` is an eval artifact, not a local cache. Commit only deliberate replay changes tied to an eval fixture or harness change.
 - Live evals load the repo-root `.env.local`.

--- a/packages/bottle-classifier/README.md
+++ b/packages/bottle-classifier/README.md
@@ -173,6 +173,16 @@ When changing classifier behavior:
 5. Do not solve one failed family by teaching the prompt that exact family name. Generalize the rule in prompt or policy, and use eval fixtures to hold the concrete regression.
 6. Run package typecheck, focused unit tests, and fixture validation for routine changes. Run live evals only when explicitly requested or when doing an intentional scoped eval pass.
 
+When adding an eval from a real production miss:
+
+1. Start with the exact observed input: listing title, URL, extracted identity, local candidates, current assignment, and the failing classifier or automation outcome.
+2. Web-verify the real bottle before writing the expected result. Use authoritative sources first, such as the producer/brand page or official shop, then a reputable independent source when available. Treat retailer copy as the source listing, not proof by itself.
+3. Decide the Peated DB outcome explicitly: exact `bottleId`, exact `releaseId` or `null`, whether a `bottle_release` should be created, whether a parent split is required, and which source facts should remain observation-only.
+4. Apply `docs/architecture/whisky-identity-model.md`: bottle-first when the product identity is clear, release only for reusable canonical variants, and preserve exact listing details as observations when they are not canonical identity.
+5. Encode the concrete regression, not a generalized pretend case. The fixture should name the real product, carry the real Peated ids or create expectation, and include `expected.confidenceBand` / `expected.verifyEligible` when downstream automation depends on the confidence band.
+6. Add `provenance.source = "production_miss"` with `verifiedSourceUrls` and `dbOutcome` so future reviewers can see the web verification and the intended DB action without rediscovering it from memory.
+7. If the family is ambiguous enough to regress in both directions, add paired positive and negative fixtures rather than a one-sided example.
+
 When adding a new bottle family or edge case:
 
 - add both a positive and a negative example when the family is ambiguous enough to regress

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/store-listing-matches-hudson-back-room-deal-peated-scotch-barrel-finished-as-bottle-identity.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/store-listing-matches-hudson-back-room-deal-peated-scotch-barrel-finished-as-bottle-identity.json
@@ -1,0 +1,164 @@
+{
+  "id": "store-listing-matches-hudson-back-room-deal-peated-scotch-barrel-finished-as-bottle-identity",
+  "name": "store listing: matches Hudson Back Room Deal Peated Scotch Barrel Finished as bottle identity",
+  "input": {
+    "reference": {
+      "name": "Hudson Whiskey Back Room Deal New York Straight Rye Whiskey Finished In Peated Scotch Barrels",
+      "url": "https://woodencork.com/collections/whiskey/products/hudson-whiskey-back-room-deal-new-york-straight-rye-whiskey-finished-in-peated-scotch-barrels?utm=peated"
+    },
+    "extractedIdentity": {
+      "brand": "Hudson Whiskey",
+      "bottler": null,
+      "expression": "Back Room Deal",
+      "series": null,
+      "distillery": ["Hudson"],
+      "category": "rye",
+      "stated_age": null,
+      "abv": null,
+      "release_year": null,
+      "vintage_year": null,
+      "cask_type": "Peated Scotch Barrels",
+      "cask_size": null,
+      "cask_fill": null,
+      "cask_strength": null,
+      "single_cask": null,
+      "edition": null
+    },
+    "initialCandidates": [
+      {
+        "kind": "bottle",
+        "bottleId": 11904,
+        "releaseId": null,
+        "alias": null,
+        "fullName": "Hudson Whiskey Back Room Deal Peated Scotch Barrel Finished",
+        "bottleFullName": "Hudson Whiskey Back Room Deal Peated Scotch Barrel Finished",
+        "brand": "Hudson",
+        "bottler": null,
+        "series": null,
+        "distillery": [],
+        "category": "rye",
+        "statedAge": null,
+        "edition": null,
+        "caskStrength": null,
+        "singleCask": null,
+        "abv": null,
+        "vintageYear": null,
+        "releaseYear": null,
+        "caskType": null,
+        "caskSize": null,
+        "caskFill": null,
+        "score": 1,
+        "source": ["text"]
+      },
+      {
+        "kind": "bottle",
+        "bottleId": 17226,
+        "releaseId": null,
+        "alias": "Hudson Manhattan Straight Rye (Batch 5)",
+        "fullName": "Hudson Manhattan Rye Whiskey",
+        "bottleFullName": "Hudson Manhattan Rye Whiskey",
+        "brand": "Hudson",
+        "bottler": null,
+        "series": null,
+        "distillery": [],
+        "category": "rye",
+        "statedAge": null,
+        "edition": "Batch 5",
+        "caskStrength": null,
+        "singleCask": null,
+        "abv": null,
+        "vintageYear": null,
+        "releaseYear": null,
+        "caskType": null,
+        "caskSize": null,
+        "caskFill": null,
+        "score": 0.6679750018368795,
+        "source": ["vector", "release"]
+      },
+      {
+        "kind": "release",
+        "bottleId": 17226,
+        "releaseId": 278,
+        "alias": "Hudson Manhattan Rye Whiskey - Batch 5",
+        "fullName": "Hudson Manhattan Rye Whiskey - Batch 5",
+        "bottleFullName": "Hudson Manhattan Rye Whiskey",
+        "brand": "Hudson",
+        "bottler": null,
+        "series": null,
+        "distillery": [],
+        "category": "rye",
+        "statedAge": null,
+        "edition": "Batch 5",
+        "caskStrength": null,
+        "singleCask": null,
+        "abv": null,
+        "vintageYear": null,
+        "releaseYear": null,
+        "caskType": null,
+        "caskSize": null,
+        "caskFill": null,
+        "score": 0.6532670600221517,
+        "source": ["vector", "release"]
+      }
+    ]
+  },
+  "searchResponses": [
+    {
+      "when": ["hudson", "back room deal"],
+      "results": [
+        {
+          "kind": "bottle",
+          "bottleId": 11904,
+          "releaseId": null,
+          "alias": null,
+          "fullName": "Hudson Whiskey Back Room Deal Peated Scotch Barrel Finished",
+          "bottleFullName": "Hudson Whiskey Back Room Deal Peated Scotch Barrel Finished",
+          "brand": "Hudson",
+          "bottler": null,
+          "series": null,
+          "distillery": [],
+          "category": "rye",
+          "statedAge": null,
+          "edition": null,
+          "caskStrength": null,
+          "singleCask": null,
+          "abv": null,
+          "vintageYear": null,
+          "releaseYear": null,
+          "caskType": null,
+          "caskSize": null,
+          "caskFill": null,
+          "score": 1,
+          "source": ["text"]
+        }
+      ]
+    }
+  ],
+  "provenance": {
+    "source": "production_miss",
+    "verifiedSourceUrls": [
+      "https://www.hudsonwhiskey.com/en-US/our-range/",
+      "https://shop.hudsonwhiskey.com/products/Hudson-Back-Room-Deal-p667109531",
+      "https://whiskyadvocate.com/Hudson-Whiskey-Back-Room-Deal-Peated-Scotch-Barrel-Finished-46",
+      "https://distiller.com/spirits/hudson-whiskey-back-room-deal"
+    ],
+    "dbOutcome": {
+      "bottleId": 11904,
+      "releaseId": null,
+      "createsBottle": false,
+      "createsRelease": false,
+      "summary": "Assign the store price to bottle 11904 with releaseId null. Do not create a bottle_release or a separate generic Back Room Deal parent; preserve the listing's peated Scotch barrel finish wording as source observation evidence."
+    },
+    "notes": "Hudson treats Back Room Deal as a named range product: New York Straight Rye Whiskey finished in peated Scotch barrels at 46% ABV. The finish is part of the marketed bottle identity, not a child-release discriminator."
+  },
+  "expected": {
+    "status": "classified",
+    "action": "match",
+    "identityScope": "product",
+    "matchedBottleId": 11904,
+    "matchedReleaseId": null,
+    "confidenceBand": "auto_verification",
+    "verifyEligible": true,
+    "summary": "Match the exact local Hudson Back Room Deal Peated Scotch Barrel Finished bottle. The peated Scotch barrel finish is part of this bottle identity, so the correct result is product-scope bottle 11904 with no child release."
+  }
+}

--- a/packages/bottle-classifier/src/evalFixtureSchemas.ts
+++ b/packages/bottle-classifier/src/evalFixtureSchemas.ts
@@ -18,6 +18,47 @@ export const searchResponseFixtureSchema = z.object({
   results: z.array(BottleCandidateSchema),
 });
 
+const evalFixtureDbOutcomeSchema = z
+  .object({
+    bottleId: z.number().int().positive().nullable().optional(),
+    releaseId: z.number().int().positive().nullable().optional(),
+    createsBottle: z.boolean().optional(),
+    createsRelease: z.boolean().optional(),
+    summary: z.string().min(1),
+  })
+  .strict();
+
+export const evalFixtureProvenanceSchema = z
+  .object({
+    source: z.enum(["production_miss", "curated_regression", "synthetic"]),
+    verifiedSourceUrls: z.array(z.string().url()).optional(),
+    dbOutcome: evalFixtureDbOutcomeSchema.optional(),
+    notes: z.string().min(1).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (
+      value.source === "production_miss" &&
+      (value.verifiedSourceUrls === undefined ||
+        value.verifiedSourceUrls.length === 0)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "`production_miss` fixtures must include verified source URLs.",
+        path: ["verifiedSourceUrls"],
+      });
+    }
+
+    if (value.source === "production_miss" && value.dbOutcome === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "`production_miss` fixtures must include a DB outcome.",
+        path: ["dbOutcome"],
+      });
+    }
+  });
+
 export const classifierEvalExpectationSchema = z.object({
   status: z.enum(["ignored", "classified"]),
   action: z
@@ -55,6 +96,7 @@ export const classifierEvalFixtureSchema = z
       })
       .strict(),
     searchResponses: z.array(searchResponseFixtureSchema).optional(),
+    provenance: evalFixtureProvenanceSchema.optional(),
     expected: classifierEvalExpectationSchema,
   })
   .strict();
@@ -139,6 +181,7 @@ export const realWorldNewBottleFixtureSchema = z
     expectedBottleName: z.string().min(1),
     summary: z.string().min(1),
     peatedBottleIds: z.array(z.number().int().positive()).min(1),
+    provenance: evalFixtureProvenanceSchema.optional(),
     expected: bottleNormalizationExpectationSchema,
   })
   .strict();


### PR DESCRIPTION
Adds a production-miss eval checklist to the classifier docs and agent instructions, and extends fixture schemas so real production misses can carry verified source URLs plus the intended Peated DB outcome.

This makes real-world classifier regressions concrete: future evals should encode the exact observed bottle, the online verification used to decide it, and the bottle/release action expected in our database rather than replacing misses with generalized examples.

The Hudson Back Room Deal failure is now covered by an exact match_existing fixture with verified Hudson and independent sources. Its expected outcome is bottle 11904 with releaseId null, no new release, and source finish wording preserved as observation evidence.

Validated locally with pnpm --filter @peated/bottle-classifier fixtures:validate, pnpm --filter @peated/bottle-classifier test, and pnpm test. The local Node runtime is v24.15.0, so pnpm emitted the existing engine warning for the repo Node 22.14.x requirement.