### PR TITLE
feat(collections): Add profile library

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,15 @@ Load some mock data:
 pnpm cli mocks load-all you@example.com
 ```
 
-Run the dev server, which spins up both the `web` and the `api` services:
+Run the dev server, which spins up the `web`, API, and worker services:
 
 ```
-npm run dev
+pnpm dev
 ```
+
+The worker requires Redis. The default local Redis URL is
+`redis://@localhost:16379`, matching `docker-compose.yml`. For API-only local
+checks, use `pnpm dev:server:api`.
 
 ## Runbooks
 

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -8,13 +8,13 @@ export default {
         ? "development"
         : "test",
   DEBUG: !!process.env.DEBUG,
-  PORT: process.env.PORT || 4000,
+  PORT: Number(process.env.PORT || "4300"),
   HOST: process.env.HOST || "localhost",
-  CORS_HOST: process.env.CORS_HOST || "http://localhost:3000",
+  CORS_HOST: process.env.CORS_HOST || "http://localhost:3200",
   JWT_SECRET: process.env.JWT_SECRET || "",
-  API_SERVER: process.env.API_SERVER || "http://localhost:4000",
-  URL_PREFIX: process.env.URL_PREFIX || "http://localhost:3000",
-  REDIS_URL: process.env.REDIS_URL || "redis://@localhost:6379",
+  API_SERVER: process.env.API_SERVER || "http://localhost:4300",
+  URL_PREFIX: process.env.URL_PREFIX || "http://localhost:3200",
+  REDIS_URL: process.env.REDIS_URL || "redis://@localhost:16379",
 
   SKIP_EMAIL_VERIFICATION: !!process.env.SKIP_EMAIL_VERIFICATION,
 

--- a/apps/server/src/lib/db.ts
+++ b/apps/server/src/lib/db.ts
@@ -1,11 +1,11 @@
 import { normalizeEntityName } from "@peated/bottle-classifier/normalize";
 import { type CatalogVerificationCreationSource } from "@peated/catalog-verifier";
 import type { InferSelectModel, Table } from "drizzle-orm";
-import { and, eq, getTableColumns, inArray, sql } from "drizzle-orm";
+import { and, eq, getTableColumns, inArray, ne, sql } from "drizzle-orm";
 import type { PgTableWithColumns, TableConfig } from "drizzle-orm/pg-core";
 import { type z } from "zod";
 import type { AnyDatabase } from "../db";
-import type { BottleAlias, Entity, EntityType } from "../db/schema";
+import type { BottleAlias, Collection, Entity, EntityType } from "../db/schema";
 import {
   bottleAliases,
   changes,
@@ -24,6 +24,32 @@ export type UpsertOutcome<T> =
       created: boolean;
     }
   | undefined;
+
+export const reservedCollectionSlugs = ["default", "library"] as const;
+
+export type ReservedCollectionSlug = (typeof reservedCollectionSlugs)[number];
+export type ReservedCollection = Pick<Collection, "id" | "createdById">;
+
+export const RESERVED_COLLECTIONS: Record<
+  ReservedCollectionSlug,
+  {
+    name: string;
+  }
+> = {
+  // `default` is the historical API token for the user-facing Favorites list.
+  default: {
+    name: "Default",
+  },
+  library: {
+    name: "Library",
+  },
+};
+
+export function isReservedCollectionSlug(
+  value: unknown,
+): value is ReservedCollectionSlug {
+  return reservedCollectionSlugs.includes(value as ReservedCollectionSlug);
+}
 
 export function coerceToUpsert({
   country,
@@ -340,16 +366,46 @@ export const upsertEntity = async ({
   throw new Error("We should never hit this case in upsert");
 };
 
-export const getDefaultCollection = async (db: AnyDatabase, userId: number) => {
-  return (
+/**
+ * Resolve a reserved saved-bottle collection alias for a user. Writes can opt
+ * into creation; reads stay lookup-only. The historical `default` alias keeps a
+ * compatibility fallback to the user's earliest non-Library collection.
+ */
+export const getReservedCollection = async (
+  db: AnyDatabase,
+  userId: number,
+  slug: ReservedCollectionSlug,
+  { create = false }: { create?: boolean } = {},
+): Promise<ReservedCollection | null> => {
+  const collectionConfig = RESERVED_COLLECTIONS[slug];
+  const collection =
     (await db.query.collections.findFirst({
-      where: (collections, { eq }) => eq(collections.createdById, userId),
-    })) ||
+      where: (collections, { and, eq }) =>
+        and(
+          eq(collections.createdById, userId),
+          sql`LOWER(${collections.name}) = ${collectionConfig.name.toLowerCase()}`,
+        ),
+    })) || null;
+
+  if (collection || !create) {
+    return (
+      collection ||
+      (slug === "default" ? getLegacyDefaultCollection(db, userId) : null)
+    );
+  }
+
+  const legacyDefault =
+    slug === "default" ? await getLegacyDefaultCollection(db, userId) : null;
+  if (legacyDefault) {
+    return legacyDefault;
+  }
+
+  return (
     (
       await db
         .insert(collections)
         .values({
-          name: "Default",
+          name: collectionConfig.name,
           createdById: userId,
         })
         .onConflictDoNothing()
@@ -359,11 +415,39 @@ export const getDefaultCollection = async (db: AnyDatabase, userId: number) => {
       where: (collections, { eq }) =>
         and(
           eq(collections.createdById, userId),
-          sql`LOWER(${collections.name}) = 'default'`,
+          sql`LOWER(${collections.name}) = ${collectionConfig.name.toLowerCase()}`,
         ),
-    }))
+    })) ||
+    null
   );
 };
+
+export const getDefaultCollection = async (
+  db: AnyDatabase,
+  userId: number,
+): Promise<ReservedCollection | null> =>
+  getReservedCollection(db, userId, "default", { create: true });
+
+async function getLegacyDefaultCollection(
+  db: AnyDatabase,
+  userId: number,
+): Promise<ReservedCollection | null> {
+  // Preserve the historical `default` behavior for users whose earliest
+  // non-Library collection predates the reserved backing name.
+  return (
+    (await db.query.collections.findFirst({
+      where: (collections, { and, eq }) =>
+        and(
+          eq(collections.createdById, userId),
+          ne(
+            sql`LOWER(${collections.name})`,
+            RESERVED_COLLECTIONS.library.name.toLowerCase(),
+          ),
+        ),
+      orderBy: (collections, { asc }) => asc(collections.id),
+    })) || null
+  );
+}
 
 export async function upsertBottleAlias(
   db: AnyDatabase,

--- a/apps/server/src/lib/db.ts
+++ b/apps/server/src/lib/db.ts
@@ -390,7 +390,7 @@ export const getReservedCollection = async (
   if (collection || !create) {
     return (
       collection ||
-      (slug === "default" ? getLegacyDefaultCollection(db, userId) : null)
+      (slug === "default" ? await getLegacyDefaultCollection(db, userId) : null)
     );
   }
 

--- a/apps/server/src/orpc/routes/auth/passkey/authenticate-verify.test.ts
+++ b/apps/server/src/orpc/routes/auth/passkey/authenticate-verify.test.ts
@@ -39,7 +39,7 @@ describe("POST /auth/passkey/authenticate/verify", () => {
           JSON.stringify({
             type: "webauthn.get",
             challenge: "test-challenge",
-            origin: "http://localhost:3000",
+            origin: "http://localhost:3200",
           }),
         ).toString("base64") as any,
         authenticatorData: "mock-auth-data",
@@ -56,7 +56,7 @@ describe("POST /auth/passkey/authenticate/verify", () => {
         credentialDeviceType: "singleDevice",
         credentialBackedUp: false,
         userVerified: true,
-        origin: "http://localhost:3000",
+        origin: "http://localhost:3200",
         rpID: "localhost",
       },
     });
@@ -94,7 +94,7 @@ describe("POST /auth/passkey/authenticate/verify", () => {
           JSON.stringify({
             type: "webauthn.get",
             challenge: "test-challenge",
-            origin: "http://localhost:3000",
+            origin: "http://localhost:3200",
           }),
         ).toString("base64") as any,
         authenticatorData: "mock-auth-data",
@@ -111,7 +111,7 @@ describe("POST /auth/passkey/authenticate/verify", () => {
         credentialDeviceType: "singleDevice",
         credentialBackedUp: false,
         userVerified: true,
-        origin: "http://localhost:3000",
+        origin: "http://localhost:3200",
         rpID: "localhost",
       },
     });
@@ -142,7 +142,7 @@ describe("POST /auth/passkey/authenticate/verify", () => {
           JSON.stringify({
             type: "webauthn.get",
             challenge: "test-challenge",
-            origin: "http://localhost:3000",
+            origin: "http://localhost:3200",
           }),
         ).toString("base64") as any,
         authenticatorData: "mock-auth-data",
@@ -181,7 +181,7 @@ describe("POST /auth/passkey/authenticate/verify", () => {
           JSON.stringify({
             type: "webauthn.get",
             challenge: "test-challenge",
-            origin: "http://localhost:3000",
+            origin: "http://localhost:3200",
           }),
         ).toString("base64") as any,
         authenticatorData: "mock-auth-data",
@@ -198,7 +198,7 @@ describe("POST /auth/passkey/authenticate/verify", () => {
         credentialDeviceType: "singleDevice",
         credentialBackedUp: false,
         userVerified: true,
-        origin: "http://localhost:3000",
+        origin: "http://localhost:3200",
         rpID: "localhost",
       },
     });
@@ -230,7 +230,7 @@ describe("POST /auth/passkey/authenticate/verify", () => {
           JSON.stringify({
             type: "webauthn.get",
             challenge: "test-challenge",
-            origin: "http://localhost:3000",
+            origin: "http://localhost:3200",
           }),
         ).toString("base64") as any,
         authenticatorData: "mock-auth-data",

--- a/apps/server/src/orpc/routes/collections/bottles/create.test.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/create.test.ts
@@ -1,9 +1,9 @@
 import { db } from "@peated/server/db";
-import { collectionBottles } from "@peated/server/db/schema";
+import { collectionBottles, collections } from "@peated/server/db/schema";
 import { getDefaultCollection } from "@peated/server/lib/db";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
 
 describe("POST /users/:user/collections/:collection/bottles", () => {
@@ -36,6 +36,78 @@ describe("POST /users/:user/collections/:collection/bottles", () => {
       .where(eq(collectionBottles.bottleId, bottle.id));
 
     expect(bottleList.length).toBe(1);
+  });
+
+  test("adds bottle to library collection", async ({ fixtures, defaults }) => {
+    const bottle = await fixtures.Bottle();
+
+    await routerClient.collections.bottles.create(
+      {
+        user: "me",
+        collection: "library",
+        bottle: bottle.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    const libraryCollection = await db.query.collections.findFirst({
+      where: (collections, { and, eq }) =>
+        and(
+          eq(collections.createdById, defaults.user.id),
+          eq(collections.name, "Library"),
+        ),
+    });
+    if (!libraryCollection) {
+      throw new Error("Library collection not found");
+    }
+
+    const bottleList = await db
+      .select()
+      .from(collectionBottles)
+      .where(eq(collectionBottles.bottleId, bottle.id));
+
+    expect(bottleList).toHaveLength(1);
+    expect(bottleList[0].collectionId).toBe(libraryCollection.id);
+  });
+
+  test("uses legacy non-library collection for default alias", async ({
+    fixtures,
+    defaults,
+  }) => {
+    const legacyCollection = await fixtures.Collection({
+      name: "Personal Favorites",
+      createdById: defaults.user.id,
+    });
+    await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+    const bottle = await fixtures.Bottle();
+
+    await routerClient.collections.bottles.create(
+      {
+        user: "me",
+        collection: "default",
+        bottle: bottle.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    const bottleList = await db
+      .select()
+      .from(collectionBottles)
+      .where(eq(collectionBottles.bottleId, bottle.id));
+    const defaultCollection = await db.query.collections.findFirst({
+      where: (collections, { and, eq }) =>
+        and(
+          eq(collections.createdById, defaults.user.id),
+          eq(collections.name, "Default"),
+        ),
+    });
+
+    expect(bottleList).toHaveLength(1);
+    expect(bottleList[0].collectionId).toBe(legacyCollection.id);
+    expect(defaultCollection).toBeUndefined();
   });
 
   test("adds multiple bottles without releases to default collection", async ({
@@ -107,6 +179,32 @@ describe("POST /users/:user/collections/:collection/bottles", () => {
       .where(eq(collectionBottles.bottleId, bottle.id));
 
     expect(bottleList.length).toBe(1);
+    expect(bottleList[0].releaseId).toBe(release.id);
+  });
+
+  test("adds bottle with release to library collection", async ({
+    fixtures,
+    defaults,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const release = await fixtures.BottleRelease({ bottleId: bottle.id });
+
+    await routerClient.collections.bottles.create(
+      {
+        user: "me",
+        collection: "library",
+        bottle: bottle.id,
+        release: release.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    const bottleList = await db
+      .select()
+      .from(collectionBottles)
+      .where(eq(collectionBottles.bottleId, bottle.id));
+
+    expect(bottleList).toHaveLength(1);
     expect(bottleList[0].releaseId).toBe(release.id);
   });
 
@@ -219,5 +317,71 @@ describe("POST /users/:user/collections/:collection/bottles", () => {
     expect(err).toMatchInlineSnapshot(
       `[Error: Cannot modify another user's collection.]`,
     );
+  });
+
+  test("prevents modifying another user's library", async ({
+    fixtures,
+    defaults,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const otherUser = await fixtures.User();
+
+    const err = await waitError(() =>
+      routerClient.collections.bottles.create(
+        {
+          user: otherUser.id,
+          collection: "library",
+          bottle: bottle.id,
+        },
+        { context: { user: defaults.user } },
+      ),
+    );
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Cannot modify another user's collection.]`,
+    );
+  });
+
+  test("resolves default and library by reserved name", async ({
+    fixtures,
+    defaults,
+  }) => {
+    const libraryCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+    const defaultCollection = await fixtures.Collection({
+      name: "Default",
+      createdById: defaults.user.id,
+    });
+    const favoriteBottle = await fixtures.Bottle();
+    const libraryBottle = await fixtures.Bottle();
+
+    await routerClient.collections.bottles.create(
+      {
+        user: "me",
+        collection: "default",
+        bottle: favoriteBottle.id,
+      },
+      { context: { user: defaults.user } },
+    );
+    await routerClient.collections.bottles.create(
+      {
+        user: "me",
+        collection: "library",
+        bottle: libraryBottle.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    const bottleList = await db.select().from(collectionBottles);
+
+    expect(
+      bottleList.find((item) => item.bottleId === favoriteBottle.id)
+        ?.collectionId,
+    ).toBe(defaultCollection.id);
+    expect(
+      bottleList.find((item) => item.bottleId === libraryBottle.id)
+        ?.collectionId,
+    ).toBe(libraryCollection.id);
   });
 });

--- a/apps/server/src/orpc/routes/collections/bottles/create.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/create.ts
@@ -6,7 +6,11 @@ import {
   collections,
 } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
-import { getDefaultCollection } from "@peated/server/lib/db";
+import {
+  getReservedCollection,
+  isReservedCollectionSlug,
+  reservedCollectionSlugs,
+} from "@peated/server/lib/db";
 import { procedure } from "@peated/server/orpc";
 import {
   requireAuth,
@@ -29,7 +33,7 @@ export default procedure
   })
   .input(
     CollectionBottleInputSchema.extend({
-      collection: z.union([z.literal("default"), z.coerce.number()]),
+      collection: z.union([z.enum(reservedCollectionSlugs), z.coerce.number()]),
       user: z.union([z.literal("me"), z.coerce.number(), z.string()]),
     }),
   )
@@ -48,13 +52,14 @@ export default procedure
       });
     }
 
-    const collection =
-      input.collection === "default"
-        ? await getDefaultCollection(db, user.id)
-        : await db.query.collections.findFirst({
-            where: (collections, { eq }) =>
-              eq(collections.id, input.collection as number),
-          });
+    const collection = isReservedCollectionSlug(input.collection)
+      ? await getReservedCollection(db, user.id, input.collection, {
+          create: true,
+        })
+      : await db.query.collections.findFirst({
+          where: (collections, { eq }) =>
+            eq(collections.id, input.collection as number),
+        });
 
     if (!collection) {
       throw errors.NOT_FOUND({

--- a/apps/server/src/orpc/routes/collections/bottles/delete.test.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/delete.test.ts
@@ -52,6 +52,41 @@ describe("DELETE /users/:user/collections/:collection/bottles", () => {
     expect(updatedCollection.totalBottles).toBe(0);
   });
 
+  test("delete bottle from library", async ({ fixtures, defaults }) => {
+    const bottle = await fixtures.Bottle();
+    const collection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+      totalBottles: 1,
+    });
+    await db.insert(collectionBottles).values({
+      bottleId: bottle.id,
+      collectionId: collection.id,
+    });
+
+    await routerClient.collections.bottles.delete(
+      {
+        user: "me",
+        collection: "library",
+        bottle: bottle.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    const bottleList = await db
+      .select()
+      .from(collectionBottles)
+      .where(eq(collectionBottles.bottleId, bottle.id));
+
+    expect(bottleList).toHaveLength(0);
+
+    const [updatedCollection] = await db
+      .select()
+      .from(collections)
+      .where(eq(collections.id, collection.id));
+    expect(updatedCollection.totalBottles).toBe(0);
+  });
+
   test("delete bottle with release", async ({ fixtures, defaults }) => {
     const bottle = await fixtures.Bottle();
     const release = await fixtures.BottleRelease({ bottleId: bottle.id });
@@ -290,5 +325,53 @@ describe("DELETE /users/:user/collections/:collection/bottles", () => {
       .from(collectionBottles)
       .where(eq(collectionBottles.bottleId, bottle.id));
     expect(bottleList.length).toBe(0);
+  });
+
+  test("deleting from missing library is a no-op", async ({
+    fixtures,
+    defaults,
+  }) => {
+    const bottle = await fixtures.Bottle();
+
+    await routerClient.collections.bottles.delete(
+      {
+        user: "me",
+        collection: "library",
+        bottle: bottle.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    const libraryCollection = await db.query.collections.findFirst({
+      where: (collections, { and, eq }) =>
+        and(
+          eq(collections.createdById, defaults.user.id),
+          eq(collections.name, "Library"),
+        ),
+    });
+
+    expect(libraryCollection).toBeUndefined();
+  });
+
+  test("prevents deleting from another user's library", async ({
+    fixtures,
+    defaults,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const otherUser = await fixtures.User();
+
+    const err = await waitError(() =>
+      routerClient.collections.bottles.delete(
+        {
+          user: otherUser.id,
+          collection: "library",
+          bottle: bottle.id,
+        },
+        { context: { user: defaults.user } },
+      ),
+    );
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Cannot modify another user's collection.]`,
+    );
   });
 });

--- a/apps/server/src/orpc/routes/collections/bottles/delete.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/delete.ts
@@ -1,7 +1,11 @@
 import { db } from "@peated/server/db";
 import { collectionBottles, collections } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
-import { getDefaultCollection } from "@peated/server/lib/db";
+import {
+  getReservedCollection,
+  isReservedCollectionSlug,
+  reservedCollectionSlugs,
+} from "@peated/server/lib/db";
 import { procedure } from "@peated/server/orpc";
 import {
   requireAuth,
@@ -24,7 +28,7 @@ export default procedure
   })
   .input(
     CollectionBottleInputSchema.extend({
-      collection: z.union([z.coerce.number(), z.literal("default")]),
+      collection: z.union([z.enum(reservedCollectionSlugs), z.coerce.number()]),
       user: z.union([z.literal("me"), z.coerce.number(), z.string()]),
       baseOnly: z.coerce.boolean().optional(),
     }),
@@ -44,15 +48,21 @@ export default procedure
       });
     }
 
-    const collection =
-      input.collection === "default"
-        ? await getDefaultCollection(db, context.user.id)
-        : await db.query.collections.findFirst({
-            where: (collections, { eq }) =>
-              eq(collections.id, input.collection as number),
-          });
+    const reservedCollection = isReservedCollectionSlug(input.collection)
+      ? input.collection
+      : null;
+    const collection = reservedCollection
+      ? await getReservedCollection(db, context.user.id, reservedCollection)
+      : await db.query.collections.findFirst({
+          where: (collections, { eq }) =>
+            eq(collections.id, input.collection as number),
+        });
 
     if (!collection) {
+      if (reservedCollection) {
+        return {};
+      }
+
       throw errors.NOT_FOUND({
         message: "Collection not found.",
       });

--- a/apps/server/src/orpc/routes/collections/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/list.test.ts
@@ -21,6 +21,24 @@ describe("GET /users/:user/collections/:collection/bottles", () => {
     expect(err).toMatchInlineSnapshot(`[Error: User's profile is private.]`);
   });
 
+  test("cannot list private library without friend", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const otherUser = await fixtures.User({ private: true });
+
+    const err = await waitError(() =>
+      routerClient.collections.bottles.list(
+        {
+          user: otherUser.id,
+          collection: "library",
+        },
+        { context: { user: defaults.user } },
+      ),
+    );
+    expect(err).toMatchInlineSnapshot(`[Error: User's profile is private.]`);
+  });
+
   test("can list private with friend", async ({ defaults, fixtures }) => {
     const otherUser = await fixtures.User({ private: true });
     await fixtures.Follow({
@@ -105,6 +123,160 @@ describe("GET /users/:user/collections/:collection/bottles", () => {
     expect(bottle2Result).toBeDefined();
     expect(bottle1Result?.bottle.name).toBe(bottle1.name);
     expect(bottle2Result?.bottle.name).toBe(bottle2.name);
+  });
+
+  test("can list own library bottles with me parameter", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const bottle1 = await fixtures.Bottle();
+    const bottle2 = await fixtures.Bottle();
+    const libraryCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: libraryCollection.id,
+        bottleId: bottle1.id,
+        releaseId: null,
+      },
+      {
+        collectionId: libraryCollection.id,
+        bottleId: bottle2.id,
+        releaseId: null,
+      },
+    ]);
+
+    const { results } = await routerClient.collections.bottles.list(
+      {
+        user: "me",
+        collection: "library",
+      },
+      { context: { user: defaults.user } },
+    );
+
+    expect(results.map((r) => r.bottle.id).sort()).toEqual(
+      [bottle1.id, bottle2.id].sort(),
+    );
+  });
+
+  test("lists legacy non-library collection for default alias", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const favoriteBottle = await fixtures.Bottle();
+    const libraryBottle = await fixtures.Bottle();
+    const legacyCollection = await fixtures.Collection({
+      name: "Personal Favorites",
+      createdById: defaults.user.id,
+    });
+    const libraryCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: legacyCollection.id,
+        bottleId: favoriteBottle.id,
+        releaseId: null,
+      },
+      {
+        collectionId: libraryCollection.id,
+        bottleId: libraryBottle.id,
+        releaseId: null,
+      },
+    ]);
+
+    const { results } = await routerClient.collections.bottles.list(
+      {
+        user: "me",
+        collection: "default",
+      },
+      { context: { user: defaults.user } },
+    );
+
+    expect(results.map((r) => r.bottle.id)).toEqual([favoriteBottle.id]);
+  });
+
+  test("does not create missing reserved collection on read", async ({
+    defaults,
+  }) => {
+    const { results } = await routerClient.collections.bottles.list(
+      {
+        user: "me",
+        collection: "library",
+      },
+      { context: { user: defaults.user } },
+    );
+
+    const libraryCollection = await db.query.collections.findFirst({
+      where: (collections, { and, eq }) =>
+        and(
+          eq(collections.createdById, defaults.user.id),
+          eq(collections.name, "Library"),
+        ),
+    });
+
+    expect(results).toHaveLength(0);
+    expect(libraryCollection).toBeUndefined();
+  });
+
+  test("keeps favorites and library entries independent", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const defaultCollection = await fixtures.Collection({
+      name: "Default",
+      createdById: defaults.user.id,
+    });
+    const libraryCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+
+    await db.insert(collectionBottles).values({
+      collectionId: defaultCollection.id,
+      bottleId: bottle.id,
+      releaseId: null,
+    });
+
+    const favoritesOnly = await routerClient.collections.bottles.list(
+      {
+        user: "me",
+        collection: "default",
+      },
+      { context: { user: defaults.user } },
+    );
+    const emptyLibrary = await routerClient.collections.bottles.list(
+      {
+        user: "me",
+        collection: "library",
+      },
+      { context: { user: defaults.user } },
+    );
+
+    expect(favoritesOnly.results.map((r) => r.bottle.id)).toEqual([bottle.id]);
+    expect(emptyLibrary.results).toHaveLength(0);
+
+    await db.insert(collectionBottles).values({
+      collectionId: libraryCollection.id,
+      bottleId: bottle.id,
+      releaseId: null,
+    });
+
+    const library = await routerClient.collections.bottles.list(
+      {
+        user: "me",
+        collection: "library",
+      },
+      { context: { user: defaults.user } },
+    );
+
+    expect(library.results.map((r) => r.bottle.id)).toEqual([bottle.id]);
   });
 
   test("can filter collection bottles by exact bottle", async ({

--- a/apps/server/src/orpc/routes/collections/bottles/list.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/list.ts
@@ -5,7 +5,11 @@ import {
   collectionBottles,
 } from "@peated/server/db/schema";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
-import { getDefaultCollection } from "@peated/server/lib/db";
+import {
+  getReservedCollection,
+  isReservedCollectionSlug,
+  reservedCollectionSlugs,
+} from "@peated/server/lib/db";
 import { procedure } from "@peated/server/orpc";
 import { CollectionBottleSchema, listResponse } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
@@ -25,7 +29,7 @@ export default procedure
   })
   .input(
     z.object({
-      collection: z.union([z.literal("default"), z.coerce.number()]),
+      collection: z.union([z.enum(reservedCollectionSlugs), z.coerce.number()]),
       user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
       bottle: z.coerce.number().optional(),
       release: z.coerce.number().optional(),
@@ -52,18 +56,30 @@ export default procedure
       });
     }
 
-    const collection =
-      input.collection === "default"
-        ? await getDefaultCollection(db, user.id)
-        : await db.query.collections.findFirst({
-            where: (collections, { and, eq }) =>
-              and(
-                eq(collections.createdById, user.id),
-                eq(collections.id, input.collection as number),
-              ),
-          });
+    const reservedCollection = isReservedCollectionSlug(input.collection)
+      ? input.collection
+      : null;
+    const collection = reservedCollection
+      ? await getReservedCollection(db, user.id, reservedCollection)
+      : await db.query.collections.findFirst({
+          where: (collections, { and, eq }) =>
+            and(
+              eq(collections.createdById, user.id),
+              eq(collections.id, input.collection as number),
+            ),
+        });
 
     if (!collection) {
+      if (reservedCollection) {
+        return {
+          results: [],
+          rel: {
+            nextCursor: null,
+            prevCursor: null,
+          },
+        };
+      }
+
       throw errors.NOT_FOUND({
         message: "Collection not found.",
       });

--- a/apps/server/src/run-server.ts
+++ b/apps/server/src/run-server.ts
@@ -1,29 +1,52 @@
 // make sure to import this _before_ all other code
 import "./sentry";
 
-import { serve } from "@hono/node-server";
+import { createAdaptorServer } from "@hono/node-server";
 import * as Sentry from "@sentry/node";
+import type { AddressInfo } from "node:net";
 import { app } from "./app";
 import config from "./config";
 
-const start = async () => {
-  try {
-    console.info(`API exposed at http://${config.HOST}:${config.PORT}/`);
-
-    serve({
-      fetch: app.fetch,
-      port: config.PORT as number,
-      hostname: config.HOST,
-    });
-  } catch (err) {
-    Sentry.captureException(err);
-    console.error(`Server process received an error: ${err}`, err);
-    process.exit(1);
+const getServerUrl = (address: AddressInfo | string | null) => {
+  if (!address || typeof address === "string") {
+    return `http://${config.HOST}:${config.PORT}/`;
   }
+
+  const host =
+    address.address === "::" || address.address === "0.0.0.0"
+      ? "localhost"
+      : address.address;
+
+  return `http://${host}:${address.port}/`;
+};
+
+const exitWithError = (message: string, err: unknown) => {
+  Sentry.captureException(err);
+  console.error(`${message}: ${err}`, err);
+  process.exit(1);
+};
+
+const start = () => {
+  const server = createAdaptorServer({
+    fetch: app.fetch,
+    hostname: config.HOST,
+  });
+
+  server.on("error", (err) => {
+    exitWithError("Server process received an error", err);
+  });
+
+  server.listen(config.PORT, config.HOST, () => {
+    console.info(`API exposed at ${getServerUrl(server.address())}`);
+  });
 };
 
 process.on("uncaughtException", (err) => {
-  console.error(`uncaughtException received: ${err}`, err);
+  exitWithError("uncaughtException received", err);
+});
+
+process.on("unhandledRejection", (err) => {
+  exitWithError("unhandledRejection received", err);
 });
 
 start();

--- a/apps/server/src/schemas/bottles.ts
+++ b/apps/server/src/schemas/bottles.ts
@@ -189,6 +189,12 @@ export const BottleSchema = z.object({
     .boolean()
     .readonly()
     .describe("Whether the current user has marked this bottle as a favorite"),
+  isLibrary: z
+    .boolean()
+    .readonly()
+    .describe(
+      "Whether the current user has saved this bottle to their library",
+    ),
   hasTasted: z
     .boolean()
     .readonly()
@@ -212,6 +218,7 @@ export const BottleInputSchema = BottleSchema.omit({
   createdAt: true,
   updatedAt: true,
   isFavorite: true,
+  isLibrary: true,
   hasTasted: true,
   numReleases: true,
 }).extend({

--- a/apps/server/src/serializers/bottle.test.ts
+++ b/apps/server/src/serializers/bottle.test.ts
@@ -10,6 +10,7 @@ import {
   entities,
   users,
 } from "../db/schema";
+import { RESERVED_COLLECTIONS } from "../lib/db";
 import { Entity, User } from "../lib/test/fixtures";
 import { BottleSerializer } from "./bottle";
 
@@ -51,7 +52,7 @@ describe("BottleSerializer", () => {
       const [collection] = await db
         .insert(collections)
         .values({
-          name: "Default",
+          name: RESERVED_COLLECTIONS.default.name,
           createdById: favoriter.id,
         })
         .returning();
@@ -66,6 +67,68 @@ describe("BottleSerializer", () => {
       const [result] = await serialize(BottleSerializer, [bottle], viewer);
 
       // The bottle should not be marked as favorite for the viewer
+      expect(result.isFavorite).toBe(false);
+    });
+  });
+
+  describe("isLibrary", () => {
+    it("should reflect the current user's library collection only", async () => {
+      const owner = await User();
+      const viewer = await User();
+
+      const brand = await Entity({
+        name: "Library Brand",
+        type: ["brand"],
+        createdById: owner.id,
+      });
+
+      const [bottle] = await db
+        .insert(bottles)
+        .values({
+          brandId: brand.id,
+          name: "Library Bottle",
+          fullName: "Library Brand Library Bottle",
+          createdById: owner.id,
+        })
+        .returning();
+
+      const [ownerLibrary] = await db
+        .insert(collections)
+        .values({
+          name: RESERVED_COLLECTIONS.library.name,
+          createdById: owner.id,
+        })
+        .returning();
+
+      await db.insert(collectionBottles).values({
+        bottleId: bottle.id,
+        collectionId: ownerLibrary.id,
+      });
+
+      const [otherUserResult] = await serialize(
+        BottleSerializer,
+        [bottle],
+        viewer,
+      );
+
+      expect(otherUserResult.isLibrary).toBe(false);
+
+      const [viewerLibrary] = await db
+        .insert(collections)
+        .values({
+          name: RESERVED_COLLECTIONS.library.name,
+          createdById: viewer.id,
+        })
+        .returning();
+
+      await db.insert(collectionBottles).values({
+        bottleId: bottle.id,
+        collectionId: viewerLibrary.id,
+      });
+
+      const [result] = await serialize(BottleSerializer, [bottle], viewer);
+
+      expect(result.isLibrary).toBe(true);
       expect(result.isFavorite).toBe(false);
     });
   });

--- a/apps/server/src/serializers/bottle.test.ts
+++ b/apps/server/src/serializers/bottle.test.ts
@@ -69,6 +69,44 @@ describe("BottleSerializer", () => {
       // The bottle should not be marked as favorite for the viewer
       expect(result.isFavorite).toBe(false);
     });
+
+    it("should reflect the current user's legacy default collection", async () => {
+      const viewer = await User();
+
+      const brand = await Entity({
+        name: "Legacy Brand",
+        type: ["brand"],
+        createdById: viewer.id,
+      });
+
+      const [bottle] = await db
+        .insert(bottles)
+        .values({
+          brandId: brand.id,
+          name: "Legacy Bottle",
+          fullName: "Legacy Brand Legacy Bottle",
+          createdById: viewer.id,
+        })
+        .returning();
+
+      const [legacyCollection] = await db
+        .insert(collections)
+        .values({
+          name: "Personal Favorites",
+          createdById: viewer.id,
+        })
+        .returning();
+
+      await db.insert(collectionBottles).values({
+        bottleId: bottle.id,
+        collectionId: legacyCollection.id,
+      });
+
+      const [result] = await serialize(BottleSerializer, [bottle], viewer);
+
+      expect(result.isFavorite).toBe(true);
+      expect(result.isLibrary).toBe(false);
+    });
   });
 
   describe("isLibrary", () => {

--- a/apps/server/src/serializers/bottle.ts
+++ b/apps/server/src/serializers/bottle.ts
@@ -13,6 +13,7 @@ import {
   entities,
   tastings,
 } from "../db/schema";
+import { RESERVED_COLLECTIONS } from "../lib/db";
 import { notEmpty } from "../lib/filter";
 import { absoluteUrl } from "../lib/urls";
 import { type BottleSchema } from "../schemas";
@@ -119,7 +120,7 @@ export const BottleSerializer = serializer({
               .where(
                 and(
                   inArray(collectionBottles.bottleId, itemIds),
-                  sql`LOWER(${collections.name}) = 'default'`,
+                  sql`LOWER(${collections.name}) = ${RESERVED_COLLECTIONS.default.name.toLowerCase()}`,
                   eq(collections.createdById, currentUser.id),
                 ),
               )

--- a/apps/server/src/serializers/bottle.ts
+++ b/apps/server/src/serializers/bottle.ts
@@ -13,7 +13,7 @@ import {
   entities,
   tastings,
 } from "../db/schema";
-import { RESERVED_COLLECTIONS, type ReservedCollectionSlug } from "../lib/db";
+import { getReservedCollection, type ReservedCollectionSlug } from "../lib/db";
 import { notEmpty } from "../lib/filter";
 import { absoluteUrl } from "../lib/urls";
 import { type BottleSchema } from "../schemas";
@@ -115,22 +115,24 @@ export const BottleSerializer = serializer({
         return new Set<number>();
       }
 
-      const collectionName = RESERVED_COLLECTIONS[collectionSlug].name;
+      const collection = await getReservedCollection(
+        db,
+        currentUser.id,
+        collectionSlug,
+      );
+      if (!collection) {
+        return new Set<number>();
+      }
 
       return new Set(
         (
           await db
             .selectDistinct({ bottleId: collectionBottles.bottleId })
             .from(collectionBottles)
-            .innerJoin(
-              collections,
-              eq(collectionBottles.collectionId, collections.id),
-            )
             .where(
               and(
                 inArray(collectionBottles.bottleId, itemIds),
-                sql`LOWER(${collections.name}) = ${collectionName.toLowerCase()}`,
-                eq(collections.createdById, currentUser.id),
+                eq(collectionBottles.collectionId, collection.id),
               ),
             )
         ).map((r) => r.bottleId),

--- a/apps/server/src/serializers/bottle.ts
+++ b/apps/server/src/serializers/bottle.ts
@@ -13,7 +13,7 @@ import {
   entities,
   tastings,
 } from "../db/schema";
-import { RESERVED_COLLECTIONS } from "../lib/db";
+import { RESERVED_COLLECTIONS, type ReservedCollectionSlug } from "../lib/db";
 import { notEmpty } from "../lib/filter";
 import { absoluteUrl } from "../lib/urls";
 import { type BottleSchema } from "../schemas";
@@ -22,6 +22,7 @@ import { EntitySerializer } from "./entity";
 
 type Attrs = {
   isFavorite: boolean;
+  isLibrary: boolean;
   hasTasted: boolean;
   numReleases: number;
   brand: ReturnType<(typeof EntitySerializer)["item"]>;
@@ -107,26 +108,39 @@ export const BottleSerializer = serializer({
       else distillersByBottleId[d.bottleId].push(entitiesById[d.distillerId]);
     });
 
-    const favoriteSet = currentUser
-      ? new Set(
-          (
-            await db
-              .selectDistinct({ bottleId: collectionBottles.bottleId })
-              .from(collectionBottles)
-              .innerJoin(
-                collections,
-                eq(collectionBottles.collectionId, collections.id),
-              )
-              .where(
-                and(
-                  inArray(collectionBottles.bottleId, itemIds),
-                  sql`LOWER(${collections.name}) = ${RESERVED_COLLECTIONS.default.name.toLowerCase()}`,
-                  eq(collections.createdById, currentUser.id),
-                ),
-              )
-          ).map((r) => r.bottleId),
-        )
-      : new Set();
+    const getReservedCollectionBottleSet = async (
+      collectionSlug: ReservedCollectionSlug,
+    ) => {
+      if (!currentUser || !itemIds.length) {
+        return new Set<number>();
+      }
+
+      const collectionName = RESERVED_COLLECTIONS[collectionSlug].name;
+
+      return new Set(
+        (
+          await db
+            .selectDistinct({ bottleId: collectionBottles.bottleId })
+            .from(collectionBottles)
+            .innerJoin(
+              collections,
+              eq(collectionBottles.collectionId, collections.id),
+            )
+            .where(
+              and(
+                inArray(collectionBottles.bottleId, itemIds),
+                sql`LOWER(${collections.name}) = ${collectionName.toLowerCase()}`,
+                eq(collections.createdById, currentUser.id),
+              ),
+            )
+        ).map((r) => r.bottleId),
+      );
+    };
+
+    const [favoriteSet, librarySet] = await Promise.all([
+      getReservedCollectionBottleSet("default"),
+      getReservedCollectionBottleSet("library"),
+    ]);
 
     // identify bottles which have a tasting recorded for the current user
     // note: this is contextual based on the query - if they're asking for a flight,
@@ -164,6 +178,7 @@ export const BottleSerializer = serializer({
           item.id,
           {
             isFavorite: favoriteSet.has(item.id),
+            isLibrary: librarySet.has(item.id),
             hasTasted: tastedSet.has(item.id),
             numReleases: releaseCountByBottleId[item.id] ?? 0,
             brand: entitiesById[item.brandId],
@@ -224,6 +239,7 @@ export const BottleSerializer = serializer({
 
       suggestedTags: item.suggestedTags,
       isFavorite: attrs.isFavorite,
+      isLibrary: attrs.isLibrary,
       hasTasted: attrs.hasTasted,
 
       createdAt: item.createdAt.toISOString(),

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -14,7 +14,7 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3200](http://localhost:3200) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -93,11 +93,14 @@ async function handleRpcRequest({ request, response, url }) {
       if (input?.bottle === createdBottleId) {
         sendRpcResponse(
           response,
-          buildBottle({
-            id: createdBottleId,
-            name: createdBottleName,
-            brand: testBrand,
-          }),
+          withCollectionStatus(
+            request,
+            buildBottle({
+              id: createdBottleId,
+              name: createdBottleName,
+              brand: testBrand,
+            }),
+          ),
         );
         return true;
       }
@@ -109,9 +112,12 @@ async function handleRpcRequest({ request, response, url }) {
 
       sendRpcResponse(
         response,
-        input.bottle === existingBottleId
-          ? existingBottle
-          : buildBottleForId(input.bottle),
+        withCollectionStatus(
+          request,
+          input.bottle === existingBottleId
+            ? existingBottle
+            : buildBottleForId(input.bottle),
+        ),
       );
       return true;
     }
@@ -302,6 +308,25 @@ function mutateCollectionBottle(request, input, action) {
   }
 }
 
+/**
+ * Mirrors authenticated bottle status fields from the mock collection state.
+ */
+function withCollectionStatus(request, bottle) {
+  const state = getCollectionState(request);
+
+  return {
+    ...bottle,
+    isFavorite: hasBottleInCollection(state.default, bottle.id),
+    isLibrary: hasBottleInCollection(state.library, bottle.id),
+  };
+}
+
+function hasBottleInCollection(collection, bottleId) {
+  return Array.from(collection.keys()).some((key) =>
+    key.startsWith(`${bottleId}:`),
+  );
+}
+
 function buildBottleForId(id) {
   return buildBottle({
     id,
@@ -315,10 +340,16 @@ function listCollectionBottles(request, input) {
   const entries = Array.from(state[collection].entries());
   const results =
     input?.bottle === undefined
-      ? entries.map(([, entry]) => entry)
+      ? entries.map(([, entry]) => ({
+          ...entry,
+          bottle: withCollectionStatus(request, entry.bottle),
+        }))
       : entries
           .filter(([key]) => key === getCollectionKey(input))
-          .map(([, entry]) => entry);
+          .map(([, entry]) => ({
+            ...entry,
+            bottle: withCollectionStatus(request, entry.bottle),
+          }));
 
   return {
     results,

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -2,6 +2,7 @@ import http from "node:http";
 
 import {
   buildBottle,
+  buildCollectionBottle,
   buildTasting,
   createdBottleId,
   createdBottleName,
@@ -12,6 +13,7 @@ import {
   suggestedTags,
   tastingNotes,
   testBrand,
+  testUser,
 } from "./rpc-fixtures.mjs";
 
 const host = "127.0.0.1";
@@ -24,6 +26,9 @@ const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
   Vary: "Origin",
 };
+
+const collectionStateByToken = new Map();
+let collectionBottleId = 1;
 
 const server = http.createServer(async (request, response) => {
   if (request.method === "OPTIONS") {
@@ -85,21 +90,29 @@ async function handleRpcRequest({ request, response, url }) {
       return true;
     }
     case "bottles/details": {
-      let bottle;
       if (input?.bottle === createdBottleId) {
-        bottle = buildBottle({
-          id: createdBottleId,
-          name: createdBottleName,
-          brand: testBrand,
-        });
-      } else if (input?.bottle === existingBottleId) {
-        bottle = existingBottle;
-      } else {
+        sendRpcResponse(
+          response,
+          buildBottle({
+            id: createdBottleId,
+            name: createdBottleName,
+            brand: testBrand,
+          }),
+        );
+        return true;
+      }
+
+      if (typeof input?.bottle !== "number") {
         sendRpcError(response, "Unexpected bottle details payload");
         return true;
       }
 
-      sendRpcResponse(response, bottle);
+      sendRpcResponse(
+        response,
+        input.bottle === existingBottleId
+          ? existingBottle
+          : buildBottleForId(input.bottle),
+      );
       return true;
     }
     case "bottles/suggestedTags":
@@ -153,12 +166,167 @@ async function handleRpcRequest({ request, response, url }) {
 
       sendRpcResponse(response, buildTasting());
       return true;
+    case "users/details":
+      if (
+        input?.user === "me" ||
+        input?.user === testUser.id ||
+        input?.user === testUser.username
+      ) {
+        sendRpcResponse(response, testUser);
+        return true;
+      }
+
+      sendRpcError(response, "Unexpected user details payload");
+      return true;
+    case "users/badgeList":
+      sendRpcResponse(response, emptyList);
+      return true;
+    case "users/regionList":
+      sendRpcResponse(response, {
+        results: [],
+        totalCount: 0,
+      });
+      return true;
+    case "users/flavorList":
+      sendRpcResponse(response, {
+        results: [],
+        totalCount: 0,
+        totalScore: 0,
+      });
+      return true;
+    case "notifications/count":
+      sendRpcResponse(response, { count: 0 });
+      return true;
+    case "collections/bottles/list":
+      sendRpcResponse(response, listCollectionBottles(request, input));
+      return true;
+    case "collections/bottles/create":
+      mutateCollectionBottle(request, input, "create");
+      sendRpcResponse(response, {});
+      return true;
+    case "collections/bottles/delete":
+      mutateCollectionBottle(request, input, "delete");
+      sendRpcResponse(response, {});
+      return true;
+    case "bottles/tags":
+      if (typeof input?.bottle !== "number") {
+        sendRpcError(response, "Unexpected bottle tags payload");
+        return true;
+      }
+
+      sendRpcResponse(response, {
+        results: [],
+        totalCount: 0,
+      });
+      return true;
     case "comments/list":
+      sendRpcResponse(response, emptyList);
+      return true;
+    case "reviews/list":
+      if (input?.bottle !== undefined && typeof input.bottle !== "number") {
+        sendRpcError(response, "Unexpected reviews list payload");
+        return true;
+      }
+
       sendRpcResponse(response, emptyList);
       return true;
     default:
       return false;
   }
+}
+
+/**
+ * Collection state is isolated by access token so parallel browser projects can
+ * mutate Favorites and Library independently against one mock RPC server.
+ */
+function getCollectionState(request) {
+  const authorization = request.headers.authorization;
+  const token =
+    (Array.isArray(authorization) ? authorization[0] : authorization)?.replace(
+      /^Bearer\s+/i,
+      "",
+    ) ?? "anonymous";
+
+  if (!collectionStateByToken.has(token)) {
+    collectionStateByToken.set(token, {
+      default: new Map(),
+      library: new Map(),
+    });
+  }
+
+  return collectionStateByToken.get(token);
+}
+
+function getCollection(input) {
+  if (input?.collection !== "default" && input?.collection !== "library") {
+    throw new Error(`Unexpected collection ${input?.collection}`);
+  }
+
+  return input.collection;
+}
+
+/**
+ * Match the API's base-bottle versus specific-release distinction in the mock
+ * store key.
+ */
+function getCollectionKey(input) {
+  return `${input?.bottle}:${input?.release ?? "base"}`;
+}
+
+function mutateCollectionBottle(request, input, action) {
+  if (input?.user !== "me" || typeof input?.bottle !== "number") {
+    throw new Error("Unexpected collection mutation payload");
+  }
+
+  const state = getCollectionState(request);
+  const collection = getCollection(input);
+  const entries = state[collection];
+  const key = getCollectionKey(input);
+
+  if (action === "delete") {
+    entries.delete(key);
+    return;
+  }
+
+  if (!entries.has(key)) {
+    entries.set(
+      key,
+      buildCollectionBottle({
+        id: collectionBottleId++,
+        bottle:
+          input.bottle === existingBottleId
+            ? existingBottle
+            : buildBottleForId(input.bottle),
+      }),
+    );
+  }
+}
+
+function buildBottleForId(id) {
+  return buildBottle({
+    id,
+    name: `16-year-old ${id}`,
+  });
+}
+
+function listCollectionBottles(request, input) {
+  const state = getCollectionState(request);
+  const collection = getCollection(input);
+  const entries = Array.from(state[collection].entries());
+  const results =
+    input?.bottle === undefined
+      ? entries.map(([, entry]) => entry)
+      : entries
+          .filter(([key]) => key === getCollectionKey(input))
+          .map(([, entry]) => entry);
+
+  return {
+    results,
+    rel: {
+      nextCursor: null,
+      prevCursor: null,
+    },
+  };
 }
 
 async function readRpcInput(request, url) {

--- a/apps/web/e2e/profile-library.spec.ts
+++ b/apps/web/e2e/profile-library.spec.ts
@@ -43,15 +43,28 @@ test.describe("profile library", () => {
     await expect(libraryButton).toBeVisible();
     await expect(favoritesButton).toBeEnabled();
     await expect(libraryButton).toBeEnabled();
+    await expect(favoritesButton).toHaveAttribute("aria-pressed", "false");
+    await expect(libraryButton).toHaveAttribute("aria-pressed", "false");
 
     await libraryButton.click();
+    await expect(libraryButton).toHaveAttribute("aria-pressed", "true");
+    await expect(favoritesButton).toHaveAttribute("aria-pressed", "false");
 
     await page.goto(`/users/${testUser.username}/library`, {
       waitUntil: "commit",
     });
+    const savedBottleRow = page.locator("tr").filter({
+      hasText: savedBottleName,
+    });
     await expect(
       page.getByRole("link", { name: savedBottleName }).first(),
     ).toBeVisible();
+    await expect(
+      savedBottleRow.getByRole("img", { name: "In Library" }),
+    ).toBeVisible();
+    await expect(
+      savedBottleRow.getByRole("img", { name: "Favorite" }),
+    ).toHaveCount(0);
     await expect(
       page.getByText("No library bottles recorded yet."),
     ).toHaveCount(0);

--- a/apps/web/e2e/profile-library.spec.ts
+++ b/apps/web/e2e/profile-library.spec.ts
@@ -1,0 +1,82 @@
+import { expect, type Page, test } from "@playwright/test";
+
+import { existingBottle, testAccessToken, testUser } from "./rpc-fixtures.mjs";
+import { signIn } from "./session";
+
+test.describe("profile library", () => {
+  test("saves a bottle to Library without adding it to Favorites", async ({
+    context,
+    page,
+  }, testInfo) => {
+    test.setTimeout(90_000);
+
+    const runId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const bottleId =
+      existingBottle.id +
+      (testInfo.project.name.includes("mobile") ? 100_000 : 0) +
+      (Date.now() % 100_000);
+    const savedBottleName = `${existingBottle.brand.name} 16-year-old ${bottleId}`;
+
+    await signIn(context, {
+      accessToken: [
+        testAccessToken,
+        "library",
+        testInfo.project.name,
+        testInfo.workerIndex,
+        testInfo.retry,
+        runId,
+      ].join("-"),
+    });
+
+    await page.goto(`/bottles/${bottleId}`, {
+      waitUntil: "commit",
+    });
+
+    const favoritesButton = page.locator(
+      'button[data-collection-action="favorites"]',
+    );
+    const libraryButton = page.locator(
+      'button[data-collection-action="library"]',
+    );
+
+    await expect(favoritesButton).toBeVisible();
+    await expect(libraryButton).toBeVisible();
+    await expect(favoritesButton).toBeEnabled();
+    await expect(libraryButton).toBeEnabled();
+
+    await libraryButton.click();
+
+    await page.goto(`/users/${testUser.username}/library`, {
+      waitUntil: "commit",
+    });
+    await expect(
+      page.getByRole("link", { name: savedBottleName }).first(),
+    ).toBeVisible();
+    await expect(
+      page.getByText("No library bottles recorded yet."),
+    ).toHaveCount(0);
+
+    await page.goto(`/users/${testUser.username}/favorites`, {
+      waitUntil: "commit",
+    });
+    await expect(page.getByText("No favorites recorded yet.")).toBeVisible();
+    await expect(page.getByRole("link", { name: savedBottleName })).toHaveCount(
+      0,
+    );
+    await expectNoHorizontalOverflow(page);
+  });
+});
+
+async function expectNoHorizontalOverflow(page: Page) {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(
+          () =>
+            document.documentElement.scrollWidth -
+            document.documentElement.clientWidth,
+        ),
+      { message: "page should not create horizontal overflow" },
+    )
+    .toBeLessThanOrEqual(1);
+}

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -14,6 +14,13 @@ export const testUser = {
   mod: false,
   createdAt: timestamp,
   termsAcceptedAt: timestamp,
+  friendStatus: "none",
+  stats: {
+    tastings: 0,
+    bottles: 0,
+    collected: 0,
+    contributions: 0,
+  },
 };
 
 export const testAccessToken = "peated-playwright-access-token";
@@ -46,6 +53,7 @@ export function buildBottle({
   name = "16-year-old",
   brand = testBrand,
   totalTastings = 0,
+  people = 0,
   hasTasted = false,
 } = {}) {
   return {
@@ -87,7 +95,10 @@ export function buildBottle({
       },
     },
     totalTastings,
+    people,
     numReleases: 0,
+    lastPrice: null,
+    createdBy: null,
     createdAt: timestamp,
     updatedAt: timestamp,
     isFavorite: false,
@@ -96,6 +107,17 @@ export function buildBottle({
 }
 
 export const existingBottle = buildBottle();
+
+export function buildCollectionBottle({
+  id = 1,
+  bottle = existingBottle,
+} = {}) {
+  return {
+    id,
+    bottle,
+    release: null,
+  };
+}
 
 export function buildTasting({
   id = createdTastingId,

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -102,6 +102,7 @@ export function buildBottle({
     createdAt: timestamp,
     updatedAt: timestamp,
     isFavorite: false,
+    isLibrary: false,
     hasTasted,
   };
 }

--- a/apps/web/e2e/session.ts
+++ b/apps/web/e2e/session.ts
@@ -7,11 +7,21 @@ export const sessionSecret =
   process.env.SESSION_SECRET ??
   "peated-playwright-session-secret-for-local-browser-tests";
 
-export async function signIn(context: BrowserContext) {
+/**
+ * Seal a local iron-session cookie for e2e tests. Token/user overrides let
+ * specs isolate mock API state while exercising the real session reader.
+ */
+export async function signIn(
+  context: BrowserContext,
+  {
+    accessToken = testAccessToken,
+    user = testUser,
+  }: { accessToken?: string; user?: typeof testUser } = {},
+) {
   const value = await sealData(
     {
-      user: testUser,
-      accessToken: testAccessToken,
+      user,
+      accessToken,
       ts: Date.now(),
     },
     {

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -10,9 +10,9 @@ const nextConfig = {
     DEBUG: process.env.DEBUG ? "true" : "",
     GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID || "",
     SENTRY_DSN: process.env.SENTRY_DSN,
-    API_SERVER: process.env.API_SERVER || "http://localhost:4000",
+    API_SERVER: process.env.API_SERVER || "http://localhost:4300",
     FATHOM_SITE_ID: process.env.FATHOM_SITE_ID,
-    URL_PREFIX: process.env.URL_PREFIX || "http://localhost:3000",
+    URL_PREFIX: process.env.URL_PREFIX || "http://localhost:3200",
 
     VERSION: process.env.VERSION || process.env.VERCEL_GIT_COMMIT_SHA,
     GITHUB_REPO: "https://github.com/dcramer/peated",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -2,7 +2,7 @@
   "name": "@peated/web",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3000",
+    "dev": "next dev -p 3200",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/apps/web/src/app/(default)/(activity)/newBottles.tsx
+++ b/apps/web/src/app/(default)/(activity)/newBottles.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { CheckBadgeIcon, StarIcon } from "@heroicons/react/20/solid";
 import { formatCategoryName } from "@peated/server/lib/format";
 import BottleLink from "@peated/web/components/bottleLink";
+import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -59,12 +59,7 @@ export default function NewBottles() {
                     >
                       {`${bottle.brand.shortName || bottle.brand.name} ${bottle.name}`}
                     </BottleLink>
-                    {bottle.isFavorite && (
-                      <StarIcon className="h-4 w-4" aria-hidden="true" />
-                    )}
-                    {bottle.hasTasted && (
-                      <CheckBadgeIcon className="h-4 w-4" aria-hidden="true" />
-                    )}
+                    <BottleStatusIcons bottle={bottle} />
                   </div>
                   <div className="text-muted flex gap-x-1 text-sm">
                     {bottle.category && (

--- a/apps/web/src/app/(default)/(activity)/priceChanges.tsx
+++ b/apps/web/src/app/(default)/(activity)/priceChanges.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { CheckBadgeIcon, StarIcon } from "@heroicons/react/20/solid";
 import { formatCategoryName } from "@peated/server/lib/format";
 import { type Currency } from "@peated/server/types";
 import BetaNotice from "@peated/web/components/betaNotice";
 import BottleLink from "@peated/web/components/bottleLink";
+import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
 import Price from "@peated/web/components/price";
 import classNames from "@peated/web/lib/classNames";
@@ -64,15 +64,7 @@ export default function PriceChanges() {
                       >
                         {bottle.fullName}
                       </BottleLink>
-                      {bottle.isFavorite && (
-                        <StarIcon className="h-4 w-4" aria-hidden="true" />
-                      )}
-                      {bottle.hasTasted && (
-                        <CheckBadgeIcon
-                          className="h-4 w-4"
-                          aria-hidden="true"
-                        />
-                      )}
+                      <BottleStatusIcons bottle={bottle} />
                     </div>
                     {!!bottle.category && (
                       <div className="text-muted text-sm">

--- a/apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/bottlings/[bottlingId]/page.tsx
+++ b/apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/bottlings/[bottlingId]/page.tsx
@@ -450,7 +450,14 @@ export default async function Page({
           </div>
 
           <div className="flex flex-wrap gap-2 lg:justify-end">
-            <Suspense fallback={<SkeletonButton className="w-10" />}>
+            <Suspense
+              fallback={
+                <>
+                  <SkeletonButton className="w-10" />
+                  <SkeletonButton className="w-10" />
+                </>
+              }
+            >
               <CollectionAction bottleId={bottle.id} releaseId={bottling.id} />
             </Suspense>
             <Button

--- a/apps/web/src/app/(default)/bottles/[bottleId]/layout.tsx
+++ b/apps/web/src/app/(default)/bottles/[bottleId]/layout.tsx
@@ -80,7 +80,14 @@ export default async function Layout({
 
         <div className="my-8 flex flex-col justify-center gap-2 sm:flex-row lg:justify-start">
           <div className="flex flex-grow justify-center gap-4 gap-x-2 lg:justify-start">
-            <Suspense fallback={<SkeletonButton className="w-10" />}>
+            <Suspense
+              fallback={
+                <>
+                  <SkeletonButton className="w-10" />
+                  <SkeletonButton className="w-10" />
+                </>
+              }
+            >
               <CollectionAction bottleId={bottle.id} />
             </Suspense>
 

--- a/apps/web/src/app/(default)/flights/[flightId]/page.tsx
+++ b/apps/web/src/app/(default)/flights/[flightId]/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { CheckBadgeIcon } from "@heroicons/react/20/solid";
-import { ArrowsPointingOutIcon, StarIcon } from "@heroicons/react/24/outline";
+import { ArrowsPointingOutIcon } from "@heroicons/react/24/outline";
 import { formatCategoryName } from "@peated/server/lib/format";
 import BottleLink from "@peated/web/components/bottleLink";
+import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Button from "@peated/web/components/button";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -70,12 +70,7 @@ export default function Page({
                   />
                   <div className="flex items-center gap-x-1 group-hover:underline">
                     <div className="font-semibold">{bottle.fullName}</div>
-                    {bottle.isFavorite && (
-                      <StarIcon className="h-4 w-4" aria-hidden="true" />
-                    )}
-                    {bottle.hasTasted && (
-                      <CheckBadgeIcon className="h-4 w-4" aria-hidden="true" />
-                    )}
+                    <BottleStatusIcons bottle={bottle} />
                   </div>
                   <div className="text-muted text-sm">
                     {formatCategoryName(bottle.category)}

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/loading.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@peated/web/components/defaultLoading";

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
@@ -5,7 +5,7 @@ import EmptyActivity from "@peated/web/components/emptyActivity";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
-export default function UserFavorites({
+export default function UserLibrary({
   params: { username },
 }: {
   params: { username: string };
@@ -15,7 +15,7 @@ export default function UserFavorites({
     orpc.collections.bottles.list.queryOptions({
       input: {
         user: username,
-        collection: "default",
+        collection: "library",
       },
     }),
   );
@@ -23,6 +23,6 @@ export default function UserFavorites({
   return bottles.results.length ? (
     <BottleTable bottleList={bottles.results} rel={bottles.rel} />
   ) : (
-    <EmptyActivity>No favorites recorded yet.</EmptyActivity>
+    <EmptyActivity>No library bottles recorded yet.</EmptyActivity>
   );
 }

--- a/apps/web/src/app/(default)/users/[username]/layout.tsx
+++ b/apps/web/src/app/(default)/users/[username]/layout.tsx
@@ -170,6 +170,14 @@ export default async function Layout({
               >
                 Favorites
               </TabItem>
+              <TabItem
+                as={Link}
+                href={`/users/${user.username}/library`}
+                controlled
+                desktopOnly
+              >
+                Library
+              </TabItem>
             </Tabs>
           </div>
           {children}

--- a/apps/web/src/components/bottleCard.tsx
+++ b/apps/web/src/components/bottleCard.tsx
@@ -1,9 +1,9 @@
-import { CheckBadgeIcon, StarIcon } from "@heroicons/react/20/solid";
 import {
   formatBottleName,
   formatCategoryName,
 } from "@peated/server/lib/format";
 import type { Bottle, BottleRelease } from "@peated/server/types";
+import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
 import type { ComponentPropsWithoutRef } from "react";
 import { formatBottlingName } from "../lib/bottlings";
@@ -142,12 +142,7 @@ export default function BottleCard({
                 {bottle.fullName}
               </BottleLink>
             </h4>
-            {bottle.isFavorite && (
-              <StarIcon className="inline w-4" aria-hidden="true" />
-            )}
-            {bottle.hasTasted && (
-              <CheckBadgeIcon className="inline w-4" aria-hidden="true" />
-            )}
+            <BottleStatusIcons bottle={bottle} className="inline h-4 w-4" />
             {!release && bottle.singleCask && <SingleCaskChip />}
           </div>
         </div>

--- a/apps/web/src/components/bottlePanel.tsx
+++ b/apps/web/src/components/bottlePanel.tsx
@@ -38,7 +38,14 @@ export default function BottlePanel({
       <div className="my-6 flex items-start">
         <div className="h-auto flex-1 lg:w-10/12 lg:flex-auto">
           <div className="flex justify-center gap-4 px-4 lg:justify-start lg:px-0">
-            <Suspense fallback={<SkeletonButton className="w-10" />}>
+            <Suspense
+              fallback={
+                <>
+                  <SkeletonButton className="w-10" />
+                  <SkeletonButton className="w-10" />
+                </>
+              }
+            >
               <CollectionAction bottleId={bottle.id} />
             </Suspense>
 

--- a/apps/web/src/components/bottleStatusIcons.tsx
+++ b/apps/web/src/components/bottleStatusIcons.tsx
@@ -1,0 +1,54 @@
+import {
+  BookOpenIcon,
+  CheckBadgeIcon,
+  StarIcon,
+} from "@heroicons/react/20/solid";
+import type { Bottle } from "@peated/server/types";
+
+type BottleStatusIconsProps = {
+  bottle: Pick<Bottle, "isFavorite" | "isLibrary" | "hasTasted">;
+  className?: string;
+};
+
+export default function BottleStatusIcons({
+  bottle,
+  className = "h-4 w-4",
+}: BottleStatusIconsProps) {
+  return (
+    <>
+      {bottle.isFavorite && (
+        <span
+          role="img"
+          aria-label="Favorite"
+          title="Favorite"
+          className="inline-flex align-text-bottom"
+          data-bottle-status="favorite"
+        >
+          <StarIcon className={className} aria-hidden="true" />
+        </span>
+      )}
+      {bottle.isLibrary && (
+        <span
+          role="img"
+          aria-label="In Library"
+          title="In Library"
+          className="inline-flex align-text-bottom"
+          data-bottle-status="library"
+        >
+          <BookOpenIcon className={className} aria-hidden="true" />
+        </span>
+      )}
+      {bottle.hasTasted && (
+        <span
+          role="img"
+          aria-label="Tasted"
+          title="Tasted"
+          className="inline-flex align-text-bottom"
+          data-bottle-status="tasted"
+        >
+          <CheckBadgeIcon className={className} aria-hidden="true" />
+        </span>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/bottleTable.tsx
+++ b/apps/web/src/components/bottleTable.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { CheckBadgeIcon, StarIcon } from "@heroicons/react/20/solid";
 import { formatCategoryName } from "@peated/server/lib/format";
 import type {
   Bottle,
@@ -8,6 +7,7 @@ import type {
   CollectionBottle,
   PagingRel,
 } from "@peated/server/types";
+import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
 import type { ComponentProps } from "react";
 import { formatBottlingName } from "../lib/bottlings";
@@ -63,12 +63,7 @@ export default function BottleTable({
                     {item.bottle.brand.shortName || item.bottle.brand.name}{" "}
                     {item.bottle.name}
                   </BottleLink>
-                  {item.bottle.isFavorite && (
-                    <StarIcon className="h-4 w-4" aria-hidden="true" />
-                  )}
-                  {item.bottle.hasTasted && (
-                    <CheckBadgeIcon className="h-4 w-4" aria-hidden="true" />
-                  )}
+                  <BottleStatusIcons bottle={item.bottle} />
                   {!item.release && item.bottle.singleCask && (
                     <SingleCaskChip />
                   )}

--- a/apps/web/src/components/button.tsx
+++ b/apps/web/src/components/button.tsx
@@ -21,6 +21,7 @@ type BaseProps = {
   fullHeight?: boolean;
   className?: string;
   title?: string;
+  "aria-pressed"?: boolean | "false" | "true" | "mixed";
   [dataAttribute: `data-${string}`]: string | number | boolean | undefined;
 };
 

--- a/apps/web/src/components/button.tsx
+++ b/apps/web/src/components/button.tsx
@@ -21,6 +21,7 @@ type BaseProps = {
   fullHeight?: boolean;
   className?: string;
   title?: string;
+  [dataAttribute: `data-${string}`]: string | number | boolean | undefined;
 };
 
 type ConditionalProps =

--- a/apps/web/src/components/collectionAction.tsx
+++ b/apps/web/src/components/collectionAction.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import { StarIcon as StarIconFilled } from "@heroicons/react/20/solid";
-import { StarIcon } from "@heroicons/react/24/outline";
-import { isDefinedError } from "@orpc/client";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  BookmarkIcon as BookmarkIconFilled,
+  StarIcon as StarIconFilled,
+} from "@heroicons/react/20/solid";
+import { BookmarkIcon, StarIcon } from "@heroicons/react/24/outline";
+import { isORPCClientError } from "@peated/orpc/client/errors";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import type { ForwardRefExoticComponent, RefAttributes, SVGProps } from "react";
 import useAuth from "../hooks/useAuth";
 import { useORPC } from "../lib/orpc/context";
 import Button from "./button";
@@ -15,16 +23,67 @@ type CollectionActionProps = {
   title?: string;
 };
 
-function CollectionActionAuthenticated({
+type CollectionActionKind = "favorites" | "library";
+
+type CollectionIcon = ForwardRefExoticComponent<
+  Omit<SVGProps<SVGSVGElement>, "ref"> & RefAttributes<SVGSVGElement>
+>;
+
+const COLLECTION_ACTIONS: Record<
+  CollectionActionKind,
+  {
+    collection: "default" | "library";
+    color: "primary" | "default";
+    Icon: CollectionIcon;
+    ActiveIcon: CollectionIcon;
+  }
+> = {
+  favorites: {
+    collection: "default",
+    color: "primary",
+    Icon: StarIcon,
+    ActiveIcon: StarIconFilled,
+  },
+  library: {
+    collection: "library",
+    color: "default",
+    Icon: BookmarkIcon,
+    ActiveIcon: BookmarkIconFilled,
+  },
+};
+
+function getTitle({
+  baseOnly,
+  kind,
+  title,
+}: {
+  baseOnly: boolean;
+  kind: CollectionActionKind;
+  title?: string;
+}) {
+  if (kind === "favorites") {
+    return title ?? (baseOnly ? "Save Bottle" : "Save Specific Bottling");
+  }
+
+  return baseOnly
+    ? "Save Bottle to Library"
+    : "Save Specific Bottling to Library";
+}
+
+function SavedCollectionActionAuthenticated({
   bottleId,
   releaseId,
   size,
   title,
-}: CollectionActionProps) {
+  kind,
+}: CollectionActionProps & { kind: CollectionActionKind }) {
   const orpc = useORPC();
+  const queryClient = useQueryClient();
+  const action = COLLECTION_ACTIONS[kind];
+  const Icon = action.Icon;
+  const ActiveIcon = action.ActiveIcon;
   const baseOnly = releaseId == null;
-  const resolvedTitle =
-    title ?? (baseOnly ? "Save Bottle" : "Save Specific Bottling");
+  const resolvedTitle = getTitle({ baseOnly, kind, title });
   const favoriteBottleMutation = useMutation(
     orpc.collections.bottles.create.mutationOptions(),
   );
@@ -34,25 +93,29 @@ function CollectionActionAuthenticated({
 
   let isCollected = false;
   let isLoading = false;
+  const collectionStatusQuery = orpc.collections.bottles.list.queryOptions({
+    input: {
+      user: "me",
+      collection: action.collection,
+      bottle: bottleId,
+      release: releaseId ?? undefined,
+      baseOnly,
+    },
+    select: (data) => data.results.length > 0,
+  });
   try {
-    const result = useSuspenseQuery(
-      orpc.collections.bottles.list.queryOptions({
-        input: {
-          user: "me",
-          collection: "default",
-          bottle: bottleId,
-          release: releaseId ?? undefined,
-          baseOnly,
-        },
-        select: (data) => data.results.length > 0,
-      }),
-    );
+    const result = useSuspenseQuery(collectionStatusQuery);
     isCollected = result.data;
     isLoading = result.isLoading;
-  } catch (err: any) {
-    if (isDefinedError(err) && err.data?.code === "UNAUTHORIZED") {
+  } catch (err: unknown) {
+    if (isORPCClientError(err) && err.name === "UNAUTHORIZED") {
       return (
-        <CollectionActionUnauthenticated size={size} title={resolvedTitle} />
+        <SavedCollectionActionUnauthenticated
+          releaseId={releaseId}
+          size={size}
+          title={title}
+          kind={kind}
+        />
       );
     }
     throw err;
@@ -66,52 +129,90 @@ function CollectionActionAuthenticated({
   return (
     <Button
       onClick={async () => {
-        isCollected
+        await (isCollected
           ? unfavoriteBottleMutation.mutateAsync({
               bottle: bottleId,
               release: releaseId,
               baseOnly,
               user: "me",
-              collection: "default",
+              collection: action.collection,
             })
           : favoriteBottleMutation.mutateAsync({
               bottle: bottleId,
               release: releaseId,
               user: "me",
-              collection: "default",
-            });
+              collection: action.collection,
+            }));
+        await queryClient.invalidateQueries({
+          queryKey: collectionStatusQuery.queryKey,
+        });
       }}
       disabled={isAnyLoading}
-      color="primary"
+      color={action.color}
       size={size}
       title={resolvedTitle}
+      data-collection-action={kind}
     >
       {isCollected ? (
-        <StarIconFilled className="text-highlight h-4 w-4" aria-hidden="true" />
+        <ActiveIcon className="text-highlight h-4 w-4" aria-hidden="true" />
       ) : (
-        <StarIcon className="h-4 w-4" aria-hidden="true" />
+        <Icon className="h-4 w-4" aria-hidden="true" />
       )}
     </Button>
   );
 }
 
-function CollectionActionUnauthenticated({
+function SavedCollectionActionUnauthenticated({
+  releaseId,
   size,
   title,
-}: Pick<CollectionActionProps, "size" | "title">) {
+  kind,
+}: Pick<CollectionActionProps, "releaseId" | "size" | "title"> & {
+  kind: CollectionActionKind;
+}) {
+  const action = COLLECTION_ACTIONS[kind];
+  const Icon = action.Icon;
+  const resolvedTitle = getTitle({ baseOnly: releaseId == null, kind, title });
+
   return (
-    <Button href="/login" color="primary" size={size} title={title}>
-      <StarIcon className="h-4 w-4" aria-hidden="true" />
+    <Button
+      href="/login"
+      color={action.color}
+      size={size}
+      title={resolvedTitle}
+      data-collection-action={kind}
+    >
+      <Icon className="h-4 w-4" aria-hidden="true" />
     </Button>
   );
 }
 
-export default function CollectionAction(props: CollectionActionProps) {
+function SavedCollectionAction({
+  kind,
+  ...props
+}: CollectionActionProps & { kind: CollectionActionKind }) {
   const { user } = useAuth();
 
   if (!user) {
-    return <CollectionActionUnauthenticated {...props} />;
+    return <SavedCollectionActionUnauthenticated {...props} kind={kind} />;
   }
 
-  return <CollectionActionAuthenticated {...props} />;
+  return <SavedCollectionActionAuthenticated {...props} kind={kind} />;
+}
+
+export function FavoriteAction(props: CollectionActionProps) {
+  return <SavedCollectionAction {...props} kind="favorites" />;
+}
+
+export function LibraryAction(props: CollectionActionProps) {
+  return <SavedCollectionAction {...props} kind="library" />;
+}
+
+export default function SavedCollectionActions(props: CollectionActionProps) {
+  return (
+    <>
+      <FavoriteAction {...props} />
+      <LibraryAction {...props} />
+    </>
+  );
 }

--- a/apps/web/src/components/collectionAction.tsx
+++ b/apps/web/src/components/collectionAction.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import {
-  BookmarkIcon as BookmarkIconFilled,
+  BookOpenIcon as BookOpenIconFilled,
   StarIcon as StarIconFilled,
 } from "@heroicons/react/20/solid";
-import { BookmarkIcon, StarIcon } from "@heroicons/react/24/outline";
+import { BookOpenIcon, StarIcon } from "@heroicons/react/24/outline";
 import { isORPCClientError } from "@peated/orpc/client/errors";
 import {
   useMutation,
@@ -46,9 +46,9 @@ const COLLECTION_ACTIONS: Record<
   },
   library: {
     collection: "library",
-    color: "default",
-    Icon: BookmarkIcon,
-    ActiveIcon: BookmarkIconFilled,
+    color: "primary",
+    Icon: BookOpenIcon,
+    ActiveIcon: BookOpenIconFilled,
   },
 };
 
@@ -151,6 +151,7 @@ function SavedCollectionActionAuthenticated({
       color={action.color}
       size={size}
       title={resolvedTitle}
+      aria-pressed={isCollected}
       data-collection-action={kind}
     >
       {isCollected ? (

--- a/apps/web/src/components/search/bottleResult.tsx
+++ b/apps/web/src/components/search/bottleResult.tsx
@@ -1,7 +1,7 @@
-import { CheckBadgeIcon, StarIcon } from "@heroicons/react/24/outline";
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Bottle } from "@peated/server/types";
 import BottleIcon from "@peated/web/assets/bottle.svg";
+import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
 import { formatBottlingCountLabel } from "@peated/web/lib/bottlings";
 import { type ReactNode } from "react";
@@ -53,12 +53,7 @@ export default function BottleResultRow({
               )}
             </div>
           </Link>
-          {bottle.isFavorite && (
-            <StarIcon className="h-4 w-4" aria-hidden="true" />
-          )}
-          {bottle.hasTasted && (
-            <CheckBadgeIcon className="h-4 w-4" aria-hidden="true" />
-          )}
+          <BottleStatusIcons bottle={bottle} />
         </div>
         <div className="text-muted mt-1 flex gap-x-1 truncate text-sm leading-5">
           {metadata.length ? (

--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -3,9 +3,9 @@ const config = {
   DEBUG: !!process.env.DEBUG,
   GOOGLE_CLIENT_ID: process.env.GOOGLE_CLIENT_ID || "",
   SENTRY_DSN: process.env.SENTRY_DSN,
-  API_SERVER: process.env.API_SERVER || "http://localhost:4000",
+  API_SERVER: process.env.API_SERVER || "http://localhost:4300",
   FATHOM_SITE_ID: process.env.FATHOM_SITE_ID,
-  URL_PREFIX: process.env.URL_PREFIX || "http://localhost:3000",
+  URL_PREFIX: process.env.URL_PREFIX || "http://localhost:3200",
 
   VERSION: process.env.VERSION,
   GITHUB_REPO: "https://github.com/dcramer/peated",

--- a/docs/development/frontend-testing.md
+++ b/docs/development/frontend-testing.md
@@ -64,7 +64,7 @@ Useful overrides:
 ```shell
 PLAYWRIGHT_PORT=3201 pnpm test:e2e
 PLAYWRIGHT_API_PORT=5000 pnpm test:e2e
-PLAYWRIGHT_BASE_URL=http://127.0.0.1:3000 pnpm test:e2e
+PLAYWRIGHT_BASE_URL=http://127.0.0.1:3200 pnpm test:e2e
 ```
 
 `PLAYWRIGHT_BASE_URL` skips starting Next, so only use it when an equivalent

--- a/docs/development/local-ui-verification.md
+++ b/docs/development/local-ui-verification.md
@@ -5,15 +5,20 @@ Use this playbook when validating protected Peated web flows with
 
 ## Servers
 
-- Start the API with `pnpm dev:server`; the local API defaults to
-  `http://localhost:4000`.
-- Start the web app with `pnpm dev:web`.
-- If `localhost:3000` is occupied, use a matched fallback API/web pair so
+- Start the API and worker with `pnpm dev:server`; the local API defaults to
+  `http://localhost:4300`.
+- Start the web app with `pnpm dev:web`; the local web app defaults to
+  `http://localhost:3200`.
+- Ensure Redis is running with `docker compose up -d redis`; the local Redis
+  URL defaults to `redis://@localhost:16379`.
+- For UI checks that intentionally do not need worker jobs, use
+  `pnpm dev:server:api`.
+- If `localhost:3200` is occupied, use a matched fallback API/web pair so
   browser RPC calls pass CORS:
   - API:
-    `PORT=4001 CORS_HOST=http://localhost:3002 API_SERVER=http://localhost:4001 URL_PREFIX=http://localhost:3002 pnpm exec dotenv -e .env.local -- pnpm --filter @peated/server start:api`
+    `PORT=4301 CORS_HOST=http://localhost:3202 API_SERVER=http://localhost:4301 URL_PREFIX=http://localhost:3202 pnpm exec dotenv -e .env.local -- pnpm --filter @peated/server start:api`
   - Web:
-    `API_SERVER=http://localhost:4001 URL_PREFIX=http://localhost:3002 pnpm exec dotenv -e .env.local -- pnpm --dir apps/web exec next dev -p 3002`
+    `API_SERVER=http://localhost:4301 URL_PREFIX=http://localhost:3202 pnpm exec dotenv -e .env.local -- pnpm --dir apps/web exec next dev -p 3202`
 
 ## Login
 

--- a/openspec/changes/add-profile-library/.openspec.yaml
+++ b/openspec/changes/add-profile-library/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-07

--- a/openspec/changes/add-profile-library/design.md
+++ b/openspec/changes/add-profile-library/design.md
@@ -42,13 +42,13 @@ Alternative considered: inline `input.collection === "default" || "library"` che
 
 Extend collection bottle route schemas from `z.literal("default")` to a reserved collection alias enum plus numeric custom collection IDs. Existing custom collection ID behavior remains unchanged.
 
-Profile Favorites and Library pages should use `collections.bottles.list` with `collection: "default"` or `collection: "library"` rather than relying on bottle list filters. This keeps profile pages aligned with the saved-collection API and avoids adding a new `isInLibrary` bottle serializer field just to render the profile tab.
+Profile Favorites and Library pages should use `collections.bottles.list` with `collection: "default"` or `collection: "library"` rather than relying on bottle list filters. This keeps profile pages aligned with the saved-collection API. Bottle responses should also expose contextual `isLibrary` status, parallel to `isFavorite`, so shared bottle label surfaces can render Library markers without extra collection probes.
 
 Alternative considered: add `collection: "favorites" | "library"` to `bottles.list`. That may be useful later for search/filter workflows, but it is not necessary for profile collection pages and would mix saved-collection semantics into the general bottle search endpoint.
 
 ### Add separate action components for Favorites and Library
 
-Keep the existing star/Favorites behavior, then add a Library action using a distinct icon and label, such as Heroicons `BookmarkIcon`. The two controls can share internal toggle plumbing, but the user-facing buttons should remain visually distinct.
+Keep the existing star/Favorites behavior, then add a Library action using a distinct book-like icon and label, such as Heroicons `BookOpenIcon`. The two controls can share internal toggle plumbing, but the user-facing buttons should remain visually distinct.
 
 Alternative considered: replace the single Favorites button with a collection picker. That would scale to arbitrary collections, but it is heavier than this request and less direct for the two first-class actions.
 

--- a/openspec/changes/add-profile-library/design.md
+++ b/openspec/changes/add-profile-library/design.md
@@ -1,0 +1,68 @@
+## Context
+
+Peated already stores saved bottles in the generic `collection` and `collection_bottle` tables. The existing Favorites behavior is implemented through the reserved collection route token `default`, but user-facing copy calls this Favorites and the bottle serializer checks for a collection whose lower-cased name is `default`.
+
+The Library feature should build on that storage model instead of introducing a new table. The main design need is to make reserved collection names explicit so the historical `default` token remains API-compatible while clearly meaning Favorites, and so the new `library` token has the same route behavior.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a first-class Library collection that can be shown on profiles and toggled from bottle/release surfaces.
+- Preserve the existing `default` collection token for Favorites.
+- Make reserved collection resolution centralized and named around user-visible concepts.
+- Keep Favorites and Library independent; saving to one collection MUST NOT imply saving to the other.
+- Reuse the existing profile privacy model, collection bottle serializers, and pagination behavior.
+
+**Non-Goals:**
+
+- Add arbitrary user-defined collection management.
+- Rename or remove the public `default` token.
+- Add a new persistence table for Library.
+- Add release ownership, inventory counts, purchase dates, or cellar-management metadata.
+- Add a top-level `/library` shortcut or primary navigation item; Library is exposed through profile tabs for this change.
+
+## Decisions
+
+### Use reserved collection aliases over new tables
+
+Implement Library as a reserved collection alias backed by `collections.name = "Library"`, parallel to Favorites backed by `collections.name = "Default"`.
+
+Alternative considered: add a dedicated `user_library_bottle` table. That would make Library easier to query by type, but it would duplicate collection behavior, serializers, total counts, release handling, and repair/merge integration already present in `collection_bottle`.
+
+### Centralize reserved collection resolution
+
+Add shared constants and helpers for reserved collections, for example `default` -> Favorites / `Default` and `library` -> Library / `Library`. Keep a compatibility wrapper if existing callers still need `getDefaultCollection`, but document that `default` is the historical API slug for Favorites.
+
+The helper should support lookup and create-on-write modes. Reads of a missing reserved collection can return an empty list without creating rows; creates should lazily create the backing collection. Deletes against a missing reserved collection can be a no-op for reserved aliases.
+
+Alternative considered: inline `input.collection === "default" || "library"` checks in each route. That is smaller initially, but it repeats the same mapping and makes the `default` means Favorites convention easier to lose.
+
+### Keep collection routes as the Library API surface
+
+Extend collection bottle route schemas from `z.literal("default")` to a reserved collection alias enum plus numeric custom collection IDs. Existing custom collection ID behavior remains unchanged.
+
+Profile Favorites and Library pages should use `collections.bottles.list` with `collection: "default"` or `collection: "library"` rather than relying on bottle list filters. This keeps profile pages aligned with the saved-collection API and avoids adding a new `isInLibrary` bottle serializer field just to render the profile tab.
+
+Alternative considered: add `collection: "favorites" | "library"` to `bottles.list`. That may be useful later for search/filter workflows, but it is not necessary for profile collection pages and would mix saved-collection semantics into the general bottle search endpoint.
+
+### Add separate action components for Favorites and Library
+
+Keep the existing star/Favorites behavior, then add a Library action using a distinct icon and label, such as Heroicons `BookmarkIcon`. The two controls can share internal toggle plumbing, but the user-facing buttons should remain visually distinct.
+
+Alternative considered: replace the single Favorites button with a collection picker. That would scale to arbitrary collections, but it is heavier than this request and less direct for the two first-class actions.
+
+## Risks / Trade-offs
+
+- Existing helper behavior may accidentally resolve the wrong collection if it returns the first collection for a user -> use name-based reserved lookup and add tests with both Default and Library present.
+- Creating collections from profile reads can add unexpected rows -> separate read lookup from create-on-write behavior.
+- Two adjacent icon-only buttons can be ambiguous -> use accessible titles/tooltips and distinct icons/active states.
+- Profile Favorites currently has a different query shape than the authenticated Favorites page -> update profile Favorites while adding Library so the two tabs use the same collection API.
+
+## Migration Plan
+
+No schema migration is required. Existing users keep their `Default` collection rows as Favorites. Library rows are created lazily when a user first saves a bottle to Library. If rollback is needed, the `library` reserved alias and UI can be removed without affecting Favorites; existing `Library` collection rows would remain ordinary collection data unless explicitly cleaned up later.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-profile-library/proposal.md
+++ b/openspec/changes/add-profile-library/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Profiles currently expose favorites as the only saved-bottle collection, which limits users who want to distinguish bottles they like from bottles they own, have, or want to catalog. Adding a Library gives profiles a second first-class collection while preserving the existing favorites behavior and API compatibility around the reserved `default` collection token.
+
+## What Changes
+
+- Add a profile Library collection alongside Favorites.
+- Keep the reserved collection token `default` mapped to the user's Favorites collection, and document that mapping in code so future collection work does not treat it as a generic default.
+- Add a reserved `library` collection token that resolves to a user's Library collection.
+- Let authenticated users add and remove bottles or releases from Library using a distinct button and icon from Favorites.
+- Show Library as a profile tab, respecting the same profile visibility rules as Favorites.
+- Add a signed-in user's own Library page or navigation entry only if the implementation keeps parity with the existing signed-in Favorites shortcut.
+- Preserve existing Favorites URLs and API behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `profile-library`: Public profile Library behavior, reserved collection aliases, and bottle save actions for Favorites and Library.
+
+### Modified Capabilities
+
+## Impact
+
+- Backend collection helpers and oRPC collection bottle routes need to resolve both `default` and `library` reserved aliases.
+- Collection list and bottle serialization behavior may need shared constants or helper names so `default` is clearly Favorites.
+- Web bottle action components need a separate Library action with a different icon and labels from Favorites.
+- Profile tabs and collection pages need Library views using existing privacy and pagination behavior.
+- Tests should cover reserved alias resolution, ownership checks, profile visibility, and UI action state for both saved-bottle collections.

--- a/openspec/changes/add-profile-library/specs/profile-library/spec.md
+++ b/openspec/changes/add-profile-library/specs/profile-library/spec.md
@@ -1,0 +1,101 @@
+## ADDED Requirements
+
+### Requirement: Reserved saved collection aliases
+
+The system SHALL support reserved saved-collection aliases where `default` resolves to the user's Favorites collection and `library` resolves to the user's Library collection.
+
+#### Scenario: Favorites alias resolves to Default backing collection
+
+- **WHEN** a caller lists, creates, or deletes collection bottles with collection alias `default`
+- **THEN** the system uses the requested user's Favorites backing collection named `Default`
+
+#### Scenario: Library alias resolves to Library backing collection
+
+- **WHEN** a caller lists, creates, or deletes collection bottles with collection alias `library`
+- **THEN** the system uses the requested user's Library backing collection named `Library`
+
+#### Scenario: Reserved aliases are independent
+
+- **WHEN** a bottle is saved to the user's Favorites collection
+- **THEN** the bottle MUST NOT be treated as saved to the user's Library collection unless it is also saved to `library`
+
+#### Scenario: Custom collection IDs remain supported
+
+- **WHEN** a caller uses a numeric collection identifier
+- **THEN** the system resolves the collection by ID with the same ownership and visibility rules as before
+
+### Requirement: Library collection write behavior
+
+The system SHALL allow authenticated users who accepted the terms of service to add and remove bottles and releases from their own Library collection.
+
+#### Scenario: Add bottle to Library
+
+- **WHEN** an authenticated user adds a bottle with collection alias `library`
+- **THEN** the bottle is present in that user's Library collection
+
+#### Scenario: Add specific release to Library
+
+- **WHEN** an authenticated user adds a bottle release with collection alias `library`
+- **THEN** that release entry is present in that user's Library collection
+
+#### Scenario: Remove bottle from Library
+
+- **WHEN** an authenticated user removes a bottle with collection alias `library`
+- **THEN** the matching bottle entry is removed from that user's Library collection
+
+#### Scenario: Cannot modify another user's Library
+
+- **WHEN** an authenticated user attempts to add to or remove from another user's Library collection
+- **THEN** the system rejects the request with an authorization error
+
+### Requirement: Profile Library tab
+
+The system SHALL expose a Library tab on visible user profiles that lists bottles saved to the user's Library collection.
+
+#### Scenario: View public profile Library
+
+- **WHEN** a visitor opens a visible user's Library profile tab
+- **THEN** the system displays the bottles from that user's Library collection with pagination support
+
+#### Scenario: Empty Library
+
+- **WHEN** a visible user's Library collection has no bottles
+- **THEN** the system displays an empty state for Library
+
+#### Scenario: Private profile Library
+
+- **WHEN** a visitor cannot view a user's private profile
+- **THEN** the system does not expose that user's Library bottle list
+
+### Requirement: Favorites remain profile-visible
+
+The system SHALL keep Favorites available on profiles using the existing Favorites URL and behavior while backing it with the reserved `default` collection alias.
+
+#### Scenario: View profile Favorites
+
+- **WHEN** a visitor opens a visible user's Favorites profile tab
+- **THEN** the system displays bottles from that user's Favorites collection resolved through the `default` alias
+
+#### Scenario: Existing Favorites route compatibility
+
+- **WHEN** a caller uses the existing Favorites page or collection bottle API with collection alias `default`
+- **THEN** the system continues to return Favorites data
+
+### Requirement: Distinct save actions
+
+The system SHALL provide separate bottle save actions for Favorites and Library with distinct icons, labels, and active states.
+
+#### Scenario: Favorite action uses Favorites collection
+
+- **WHEN** a user toggles the Favorites action on a bottle or release
+- **THEN** the system adds or removes that bottle or release from collection alias `default`
+
+#### Scenario: Library action uses Library collection
+
+- **WHEN** a user toggles the Library action on a bottle or release
+- **THEN** the system adds or removes that bottle or release from collection alias `library`
+
+#### Scenario: Unauthenticated save action
+
+- **WHEN** a signed-out visitor activates either save action
+- **THEN** the system directs the visitor to authenticate before saving

--- a/openspec/changes/add-profile-library/specs/profile-library/spec.md
+++ b/openspec/changes/add-profile-library/specs/profile-library/spec.md
@@ -95,6 +95,12 @@ The system SHALL provide separate bottle save actions for Favorites and Library 
 - **WHEN** a user toggles the Library action on a bottle or release
 - **THEN** the system adds or removes that bottle or release from collection alias `library`
 
+#### Scenario: Library status marker on bottle labels
+
+- **GIVEN** an authenticated user has saved a bottle to Library
+- **WHEN** the system renders bottle labels that show saved status markers
+- **THEN** the label includes a filled monochrome Library marker that is distinct from the Favorites marker
+
 #### Scenario: Unauthenticated save action
 
 - **WHEN** a signed-out visitor activates either save action

--- a/openspec/changes/add-profile-library/tasks.md
+++ b/openspec/changes/add-profile-library/tasks.md
@@ -1,0 +1,35 @@
+## 1. Backend Reserved Collections
+
+- [x] 1.1 Add shared reserved collection constants/types for `default` as Favorites and `library` as Library, including a code comment that `default` is the historical API token for Favorites.
+- [x] 1.2 Replace ad hoc default collection lookup with a name-based reserved collection resolver that supports lookup-only, create-on-write, and no-op delete behavior for missing reserved collections.
+- [x] 1.3 Update collection bottle create, delete, and list route schemas to accept both reserved aliases plus numeric collection IDs.
+- [x] 1.4 Update collection bottle create, delete, and list handlers to use the shared resolver while preserving ownership checks for custom collection IDs.
+- [x] 1.5 Update bottle favorite serialization to use the shared Favorites backing name instead of an inline `default` string.
+
+## 2. Backend Tests
+
+- [x] 2.1 Add route tests that create, list, and delete bottles in the `library` reserved collection.
+- [x] 2.2 Add tests proving `default` Favorites and `library` Library entries are independent when the same bottle appears in one or both.
+- [x] 2.3 Add tests that Library rejects writes to another user's collection and respects existing profile visibility on reads.
+- [x] 2.4 Add regression coverage for reserved collection lookup when a user has both `Default` and `Library` rows.
+
+## 3. Web Save Actions
+
+- [x] 3.1 Refactor the existing collection action so Favorites and Library can share mutation/query plumbing without losing distinct labels, icons, and active states.
+- [x] 3.2 Keep the Favorites action using the star icon and `default` alias.
+- [x] 3.3 Add a Library action using a distinct icon, such as `BookmarkIcon`, and the `library` alias.
+- [x] 3.4 Render both actions on bottle and release save surfaces that currently expose Favorites, including unauthenticated login redirects.
+
+## 4. Profile Library UI
+
+- [x] 4.1 Update the profile Favorites page to load Favorites through `collections.bottles.list` with collection alias `default`.
+- [x] 4.2 Add a profile Library tab and route at `/users/[username]/library`.
+- [x] 4.3 Render Library bottles with the existing bottle table, pagination, and an empty state for users with no Library entries.
+- [x] 4.4 Ensure private profile handling continues to block both Favorites and Library through the existing profile layout/route behavior.
+
+## 5. Verification
+
+- [x] 5.1 Run targeted backend collection route tests.
+- [x] 5.2 Run relevant web checks for the changed profile/action files.
+- [x] 5.3 Run `pnpm test` before finalizing the implementation.
+- [x] 5.4 Add and run e2e coverage for saving a bottle to Library and viewing it on the profile Library route without adding it to Favorites.

--- a/openspec/changes/add-profile-library/tasks.md
+++ b/openspec/changes/add-profile-library/tasks.md
@@ -17,8 +17,9 @@
 
 - [x] 3.1 Refactor the existing collection action so Favorites and Library can share mutation/query plumbing without losing distinct labels, icons, and active states.
 - [x] 3.2 Keep the Favorites action using the star icon and `default` alias.
-- [x] 3.3 Add a Library action using a distinct icon, such as `BookmarkIcon`, and the `library` alias.
+- [x] 3.3 Add a Library action using a distinct book-like icon, such as `BookOpenIcon`, and the `library` alias.
 - [x] 3.4 Render both actions on bottle and release save surfaces that currently expose Favorites, including unauthenticated login redirects.
+- [x] 3.5 Render a filled monochrome Library status marker on bottle label surfaces that already show Favorites status.
 
 ## 4. Profile Library UI
 
@@ -33,3 +34,4 @@
 - [x] 5.2 Run relevant web checks for the changed profile/action files.
 - [x] 5.3 Run `pnpm test` before finalizing the implementation.
 - [x] 5.4 Add and run e2e coverage for saving a bottle to Library and viewing it on the profile Library route without adding it to Favorites.
+- [x] 5.5 Extend e2e coverage to prove the profile Library bottle row shows the Library marker and not the Favorites marker.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "dev": "dotenv -e .env.local -- turbo dev",
     "dev:web": "dotenv -e .env.local -- turbo dev --filter=\"./apps/web\"",
     "dev:server": "dotenv -e .env.local -- turbo dev --filter=\"./apps/server\"",
+    "dev:server:api": "dotenv -e .env.local -- pnpm --filter='./apps/server' dev:api",
+    "dev:worker": "dotenv -e .env.local -- pnpm --filter='./apps/server' dev:worker",
     "cli": "dotenv -e .env.local -- pnpm --filter='./apps/cli' cli",
     "db": "dotenv -e .env.local -- pnpm --filter='./apps/cli' cli db",
     "db:migrate": "dotenv -e .env.local -- pnpm --filter='./apps/cli' cli db migrate",

--- a/turbo.json
+++ b/turbo.json
@@ -51,6 +51,7 @@
     "VERCEL_URL",
     "CORS_HOST",
     "DATABASE_URL",
+    "REDIS_URL",
     "JWT_SECRET",
     "SESSION_SECRET",
     "GOOGLE_CLIENT_SECRET",


### PR DESCRIPTION
Add a profile Library collection alongside Favorites so users can save bottles they own or track without also marking them as favorites.

This introduces reserved saved-collection aliases where `default` continues to mean Favorites and `library` maps to the new Library collection. The `default` alias keeps compatibility for users whose historical Favorites backing collection predates the reserved `Default` name by falling back to their earliest non-Library collection.

The web app now renders distinct Favorites and Library save actions, adds a Library tab at `/users/[username]/library`, and covers the flow with desktop/mobile e2e coverage that verifies saving to Library does not populate Favorites.

Local dev defaults and docs move the web/API pair to 3200/4300 with Redis on 16379 so the documented verification setup matches the app configuration.