### PR TITLE
docs(bottles): Define normalization contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,11 +67,12 @@ Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
 
 - Any new doc added under `docs/` must also be added to this index in `AGENTS.md`
 - `docs/architecture/account-policies.md`
-- `docs/architecture/rating-systems.md`
 - `docs/architecture/bottle-classifier.md`
 - `docs/architecture/bottle-creation-alias-system.md`
-- `docs/architecture/entity-classifier.md`
+- `docs/architecture/bottle-normalization-contract.md`
 - `docs/architecture/bottle-normalization-examples.md`
+- `docs/architecture/entity-classifier.md`
+- `docs/architecture/rating-systems.md`
 - `docs/architecture/whisky-identity-model.md`
 - `docs/development/backend-testing.md`
 - `docs/development/frontend-testing.md`

--- a/docs/architecture/bottle-creation-alias-system.md
+++ b/docs/architecture/bottle-creation-alias-system.md
@@ -10,6 +10,12 @@ are useful but not normalized to Peated's bottle and release model. The system
 should use cheap deterministic checks when they are safe, and should rely on the
 reviewed bottle classifier when semantic identity is unresolved.
 
+Related policy:
+
+- [Whisky Identity Model](./whisky-identity-model.md)
+- [Bottle Normalization Contract](./bottle-normalization-contract.md)
+- [Bottle Classifier](./bottle-classifier.md)
+
 ## Goals
 
 - Reuse prior accepted matches without paying for a classifier call.
@@ -145,13 +151,14 @@ creates canonical identity, or creates an alias.
 All source references should follow the same conceptual pipeline.
 
 1. Preserve raw source facts.
-2. Check exact accepted aliases for the raw reference string.
-3. Apply closed-form deterministic resolvers only when available.
-4. If no accepted match exists, retrieve candidates.
-5. Run the classifier.
-6. Validate classifier output structurally.
-7. Apply shared automation policy.
-8. Persist the result, queue review, or leave unresolved.
+2. Build the workflow's deterministic alias key from the source reference.
+3. Check exact accepted aliases for that key.
+4. Apply closed-form deterministic resolvers only when available.
+5. If no accepted match exists, retrieve candidates.
+6. Run the classifier.
+7. Validate classifier output structurally.
+8. Apply shared automation policy.
+9. Persist the result, queue review, or leave unresolved.
 
 Candidate retrieval may use:
 
@@ -167,16 +174,20 @@ Candidate retrieval may use:
 Candidate retrieval is not a final decision. It supplies evidence to the
 classifier.
 
-### Raw Alias Rule
+### Alias Key Rule
 
-For no-agent exact matching, lookup the raw source reference string first.
-Mechanically normalized names may collapse release detail, age wording, cask
-markers, or batch codes before the classifier has reviewed the full reference.
+For no-agent exact matching, the alias lookup key and the alias write key must
+be the same accepted reference string for that workflow.
 
-Normalized text can still be used for storage, search, retrieval, or classifier
-evidence. It should not create a deterministic assignment unless the normalized
-string already exists as an accepted alias and the caller has explicitly chosen
-that lookup as safe for the workflow.
+That key may be raw source text or an identity-preserving normalized form. The
+normalization must satisfy the
+[Bottle Normalization Contract](./bottle-normalization-contract.md): it can make
+the text comparable, but it cannot infer age, year, batch, cask, release, brand,
+or entity identity.
+
+Lossy or semantic normalized text can still be used for storage, search,
+retrieval, or classifier evidence. It must not create a deterministic assignment
+unless that exact string has already been accepted as an alias.
 
 ## Classifier Ownership
 
@@ -227,9 +238,9 @@ Store price ingestion should:
 1. Preserve the raw retailer listing name and URL.
 2. Normalize the stored price name only for the price record's display/search
    needs.
-3. Try exact accepted alias lookup on the raw listing name.
+3. Build the deterministic alias key from the listing name.
 4. If an alias target exists, assign the price immediately and write/update the
-   raw listing alias as `source_approved`.
+   same alias key as `source_approved`.
 5. If no alias target exists, create/update the price without a bottle target
    and enqueue resolver work.
 
@@ -242,10 +253,10 @@ store-specific packaging, SEO, exclusive wording, or partial release detail.
 Review ingestion should:
 
 1. Preserve the raw review title and issue.
-2. Try exact accepted alias lookup on the raw review title.
+2. Build the deterministic alias key from the review title.
 3. If no alias target exists, run the classifier.
 4. If the classifier matches or creates a target, assign the review and create a
-   `classifier_approved` alias for the raw accepted title.
+   `classifier_approved` alias for the same accepted key.
 5. If the classifier cannot resolve the target, store the review unresolved and
    do not create a `bottle_alias` row.
 
@@ -310,7 +321,7 @@ Automation may create or assign a bottle/release only when:
 Automation should leave records unresolved when:
 
 - required identity components conflict
-- the target depends on normalized text alone
+- the target depends on lossy or semantic normalized text alone
 - release detail is present but ambiguous
 - the classifier returns `no_match`, low confidence, or an unsafe create/repair
   decision
@@ -325,17 +336,18 @@ Core deterministic tests should cover:
 - unresolved review does not create a `bottle_alias` row
 - classifier-approved review creates alias provenance
 - source-approved store price creates alias provenance
-- raw exact alias pre-fills store price
-- normalized store-price or review name does not auto-assign unless explicitly
-  looked up as an accepted alias
+- exact accepted alias key pre-fills store price
+- alias lookup and alias write use the same workflow key
+- lossy normalized store-price or review text does not auto-assign unless it was
+  explicitly accepted as an alias
 - canonical release alias preserves release id
 - store listing alias remains bottle-level unless a canonical release alias
   already owns the same text
 - alias upsert preserves existing targets and updates provenance only when the
   target is the same or previously unbound
 - duplicate alias conflicts block unsafe bottle/release creation
-- numeric normalization does not rewrite names like `The Last Drop 42` to
-  `42-year-old` solely because the age field is also 42
+- deterministic normalization follows the
+  [Bottle Normalization Contract](./bottle-normalization-contract.md)
 
 Classifier/eval coverage should include:
 
@@ -355,7 +367,7 @@ Classifier/eval coverage should include:
 4. Remove generated/unresolved alias writes from review ingestion.
 5. Preserve raw source facts on reviews, prices, observations, and decision logs.
 6. Ensure accepted classifier/source/manual assignments write alias provenance.
-7. Keep no-agent lookup limited to exact accepted aliases and closed-form
+7. Keep no-agent lookup limited to exact accepted alias keys and closed-form
    deterministic resolvers.
 8. Expand eval fixtures around normalization failures, release detail, and
    production misses.
@@ -364,8 +376,6 @@ Classifier/eval coverage should include:
 
 ## Open Questions
 
-- Should normalized exact alias lookup be allowed in any ingestion path after raw
-  lookup fails, or should normalized strings always require classifier review?
 - Should legacy unbound aliases be migrated into a separate proposal/evidence
   table once that table exists?
 - Which source-approved flows should be allowed to write release-level aliases,

--- a/docs/architecture/bottle-normalization-contract.md
+++ b/docs/architecture/bottle-normalization-contract.md
@@ -1,0 +1,125 @@
+# Bottle Normalization Contract
+
+This document defines what deterministic bottle-name normalization is allowed to
+do before alias lookup, duplicate checks, search, or classifier input.
+
+The short version: normalization may make the same reference string easier to
+compare. It must not infer bottle or release identity that the source text did
+not state.
+
+Use this with:
+
+- [Whisky Identity Model](./whisky-identity-model.md)
+- [Bottle Creation And Alias System](./bottle-creation-alias-system.md)
+- [Bottle Normalization Examples](./bottle-normalization-examples.md)
+
+## Goals
+
+- Produce stable comparison keys for deterministic checks.
+- Keep harmless formatting differences from creating duplicate aliases.
+- Preserve identity-bearing tokens for classifier and moderator review.
+- Make unsafe semantic interpretation visible in tests instead of hiding it in
+  string cleanup.
+
+## Non-Goals
+
+- Do not decide bottle-vs-release scope.
+- Do not infer age, vintage year, release year, batch, cask, brand, bottler, or
+  distillery from surrounding metadata.
+- Do not strip retailer-specific detail if doing so could change which bottle or
+  release the text references.
+- Do not replace classifier or moderator judgment for semantic normalization.
+
+## Allowed Transformations
+
+Allowed deterministic normalization is identity-preserving:
+
+- collapse repeated whitespace
+- normalize quote, dash, and separator punctuation when tokens stay present
+- standardize explicit age wording, such as `10 years old` to `10-year-old`
+- normalize obvious ABV spelling and spacing without changing the value
+- trim generic container text only when it is known not to identify the product,
+  such as surrounding whitespace or duplicated category words already excluded
+  by tests
+- preserve capitalization however the display layer needs, as long as matching
+  remains case-insensitive
+
+An allowed transformation should pass this test:
+
+> A reviewer who only sees the normalized string would still know which source
+> words were used to make the deterministic decision.
+
+## Disallowed Transformations
+
+Deterministic normalization must not:
+
+- rewrite a bare number as an age statement
+- decide that a bare year is vintage year or release year
+- turn batch, cask, barrel, bottle number, store-pick, or exclusive wording into
+  release identity
+- remove batch, cask, barrel, store-pick, ABV, edition, vintage, or release-year
+  text before classifier review
+- change brand, bottler, or distillery boundaries by prefix matching
+- treat an extracted metadata field as permission to rewrite the source name
+- create or look up a deterministic alias from a lossy normalized string unless
+  that exact normalized string has already been accepted as an alias
+
+## Stories
+
+### Explicit Age Wording
+
+`Ardbeg 10 years old` may normalize to `Ardbeg 10-year-old`.
+
+The text already states an age. Normalization only standardizes the spelling.
+
+### Bare Number
+
+`The Last Drop 42` must not normalize to `The Last Drop 42-year-old` just
+because an input field or existing row has `statedAge = 42`.
+
+The source name did not state age wording. The classifier or a moderator may
+decide the canonical expression, but deterministic normalization cannot.
+
+### Batch Text
+
+`Springbank 12 Cask Strength Batch 24` should preserve `Batch 24`.
+
+The classifier or moderator may decide whether `Batch 24` belongs on a release.
+Deterministic normalization must not strip or promote it.
+
+### Year Text
+
+`Lagavulin Distillers Edition 2011 Release` should preserve the year wording.
+
+The identity model decides whether `2011` is a release year, vintage year, part
+of the product name, or ambiguous. Normalization only keeps the text comparable.
+
+### Retailer Detail
+
+`Four Roses Single Barrel Barrel Strength OESK Store Pick` should preserve the
+store-pick and barrel-strength wording.
+
+Those details may be observation-only, release identity, or noise. They are not
+safe to remove before review.
+
+## Alias Keys
+
+Alias lookup and alias writes must use the same accepted key for a workflow.
+That key may be raw source text or an identity-preserving normalized form.
+
+If normalization is lossy or semantic, it is not a safe deterministic alias key.
+Use it for search or classifier evidence instead.
+
+## Test Requirements
+
+Deterministic normalization tests should cover:
+
+- explicit age wording normalization
+- bare numbers that are not age statements
+- bare years that are not automatically vintage or release years
+- batch and cask tokens that remain present
+- store-pick and exclusive wording that remains present
+- alias lookup/write consistency for whichever key a workflow accepts
+
+Classifier and eval coverage should cover the harder semantic cases where the
+right output depends on label evidence, sibling releases, or web verification.

--- a/docs/architecture/bottle-normalization-examples.md
+++ b/docs/architecture/bottle-normalization-examples.md
@@ -1,14 +1,13 @@
 # Bottle Normalization Examples
 
-This document is a working corpus for one-time cleanup and future normalization
-decisions. The goal is not to model every edge case up front. The goal is to
-capture real bottle families we see in the wild and make the expected mapping to
-Peated's identity model explicit.
+This document is a working corpus for real bottle families that stress Peated's
+identity model. It is not the normalization policy. The policy lives in
+[Bottle Normalization Contract](./bottle-normalization-contract.md).
 
 Use this alongside:
 
-- `docs/architecture/whisky-identity-model.md`
-- `docs/architecture/bottle-classifier.md`
+- [Whisky Identity Model](./whisky-identity-model.md)
+- [Bottle Classifier](./bottle-classifier.md)
 - `packages/bottle-classifier/src/eval-fixtures/new-bottles/`
 - `packages/bottle-classifier/src/eval-fixtures/legacy-release-repair/`
 
@@ -43,9 +42,10 @@ Use this alongside:
 | `SMWS 6.53`                                         | `SMWS 6.53`                                        | none                             | Society code is part of the bottle identity itself.                                                                                                                       |
 | `Octomore 13.1`                                     | `Octomore 13.1`                                    | none                             | This is generally a distinct bottle expression, not a child release of `Octomore 13`.                                                                                     |
 
-## Practical Rules For Cleanup
+## Practical Rules
 
-Use these rules during the cleanup pass:
+Use these rules when adding examples or translating production misses into
+fixtures:
 
 1. Prefer bottle-level identity when the title looks like a stable marketed
    expression.

--- a/docs/architecture/whisky-identity-model.md
+++ b/docs/architecture/whisky-identity-model.md
@@ -2,6 +2,9 @@
 
 This is the source of truth for how Peated models whisky identity.
 
+Deterministic name cleanup is governed by
+[Bottle Normalization Contract](./bottle-normalization-contract.md).
+
 ## Core Objects
 
 - `bottle`: the stable parent product most users rate, search, and collect.
@@ -68,10 +71,6 @@ Observation-only facts by default:
 - `fullName` and aliases are derived reference strings. They are useful evidence, but they can be stale or source-specific and must not prove a brand repair by themselves.
 - A proposed brand repair must be valid after applying it: the resulting bottle and release names should still describe the marketed bottle without duplicated, missing, or stale brand text.
 - Do not automate brand moves where the only difference is a generic product/entity suffix or prefix such as `Bourbon`, `Whiskey`, `Whisky`, `Distillery`, `House`, or `Company`. Those cases are brand-vs-product-vs-entity ambiguity and belong in classifier or manual review.
-- Do not mechanically rewrite a bare numeric expression into an age-statement
-  expression only because `statedAge` has the same value. `The Last Drop 42`
-  with `statedAge = 42` may still have canonical name `42`; explicit age
-  wording, classifier judgment, or moderator review must justify `42-year-old`.
 - Examples: `Yamazaki 12-year-old` stays brand `Yamazaki` even when aliases mention owner `Suntory`; `Belle Meade` should not automatically move to `Belle Meade Bourbon` just because the full bottle name starts with those words.
 
 ## Canonicalization Rules

--- a/docs/development/schema-conventions.md
+++ b/docs/development/schema-conventions.md
@@ -1,6 +1,8 @@
 # Schema Conventions
 
-The authoritative model lives in [docs/architecture/whisky-identity-model.md](/home/dcramer/src/peated/docs/architecture/whisky-identity-model.md). This document focuses on extraction and normalization terms.
+The authoritative model lives in
+[Whisky Identity Model](../architecture/whisky-identity-model.md). This document
+focuses on extraction and normalization terms.
 
 ## Identity Layers
 

--- a/docs/features/store-price-matching.md
+++ b/docs/features/store-price-matching.md
@@ -1,65 +1,28 @@
 # Store Price Matching
 
-This document reflects the store-price matching flow as implemented on March 15, 2026.
+This document describes how store prices are resolved to bottles and releases.
 
-The authoritative identity model lives in [docs/architecture/whisky-identity-model.md](/home/dcramer/src/peated/docs/architecture/whisky-identity-model.md).
+Authoritative policy lives in:
 
-The classifier contract lives in [docs/architecture/bottle-classifier.md](/home/dcramer/src/peated/docs/architecture/bottle-classifier.md).
-Price matching is one consumer of that bottle-classifier boundary.
+- [Whisky Identity Model](../architecture/whisky-identity-model.md)
+- [Bottle Normalization Contract](../architecture/bottle-normalization-contract.md)
+- [Bottle Creation And Alias System](../architecture/bottle-creation-alias-system.md)
+- [Bottle Classifier](../architecture/bottle-classifier.md)
 
-## Core Schema Rules
+Price matching is one consumer of the generic bottle-reference classifier. It
+adds store-price persistence, queueing, moderation, and automation policy around
+that classifier boundary.
 
-These rules are the anchor for matching, automation, aliases, and moderator flows.
+## Local Contract
 
-1. `bottle` is the stable parent product.
-2. `bottle_release` is optional and only exists under a bottle.
-3. `store_price` should follow the same shape as tastings and collections:
-   `bottleId` required when matched, `releaseId` optional.
-4. Bottle identity and release identity are not interchangeable.
-5. Exact source facts should be preserved as observations before they are promoted into canonical release identity.
-6. Observation persistence is currently bottle-reference-only.
-
-Bottle identity lives on the parent bottle:
-
-- brand
-- bottler
-- distillery
-- expression / `name`
-- series
-- category
-
-Release identity lives on the child release:
-
-- edition
-- stated age when release-specific
-- ABV
-- release year
-- vintage year
-- single-cask
-- cask-strength
-- cask fill
-- cask type
-- cask size
-
-Observation-first facts:
-
-- exact cask or barrel numbers
-- outturn
-- bottle numbers
-- exclusive wording
-- unmodeled raw maturation text
-
-Operational rule:
-
-- If bottle identity is clear but release identity is not, match the bottle and leave `releaseId = null`.
-- Do not force a release from weak evidence.
-- Preserve the exact source facts as a `bottle_observation` row instead.
-- If a bottle is still carrying a single known release-like identity on itself, do not also create a child `bottle_release`. Split the parent bottle first.
-
-Alias rule:
-
-- Retailer listing aliases are bottle-level evidence unless they exactly match a canonical release alias.
-- Canonical release aliases should come from actual release records, not from arbitrary retailer titles.
+- `store_price.bottleId` is required when a listing is matched.
+- `store_price.releaseId` is optional precision under that bottle.
+- If bottle identity is clear but release identity is weak, match the bottle and
+  leave `releaseId = null`.
+- Preserve exact source facts as `bottle_observation` before promoting them into
+  canonical release identity.
+- Retailer listing aliases stay bottle-level unless the accepted alias key
+  already belongs to a canonical release alias.
 
 ## Goal
 
@@ -99,7 +62,8 @@ This system does not keep a durable per-attempt history. Retrying a proposal ove
 `POST /external-sites/{site}/prices`:
 
 - normalizes the incoming listing name
-- does an exact alias lookup for the raw incoming listing name
+- builds the deterministic alias key from the listing name
+- does an exact alias lookup for that accepted key
 - if an exact alias exists, pre-fills `bottleId` and, when the alias is canonical to a release, `releaseId`
 - enqueues `ResolveStorePriceBottle` only when no exact alias target exists
 - optionally enqueues `CapturePriceImage`
@@ -126,7 +90,7 @@ Every approved bottle-reference match writes one `bottle_observation` keyed by `
 
 That observation stores:
 
-- the raw store title and source URL
+- the store title and source URL
 - the parsed extracted identity
 - the proposal type and creation target
 - normalized release facts when they exist
@@ -250,11 +214,11 @@ For existing-match proposals, that policy should stay thin:
 - the classifier confidence must clear the shared verification threshold
 - reaffirming the current bottle/release assignment uses a lower threshold because the risk is lower; today that threshold is `80`
 - new unmatched matches only verify at the higher bottle-only threshold; today that threshold is `96`
-- the classifier should be the layer that decides when raw-title
+- the classifier should be the layer that decides when listing-title
   reaffirmation, official confirmation, or agent-reviewed corroborating web
   evidence justifies the `96+` confidence band
 
-Evidence such as exact aliases, raw retailer titles, official pages, or
+Evidence such as exact aliases, retailer titles, official pages, or
 agent-reviewed corroborating web confirmation should raise or lower classifier
 confidence upstream rather than creating separate downstream verify heuristics.
 
@@ -318,11 +282,11 @@ Current UI limitation:
 Approving a price proposal does two separate things:
 
 1. updates the matched `store_price` rows for the same site / listing / volume
-2. stores a reusable alias for the listing name
+2. stores a reusable alias for the accepted listing key
 
 Schema-first alias rule:
 
-- price listing aliases should stay bottle-level unless the listing name is exactly a canonical release alias
+- price listing aliases should stay bottle-level unless the accepted listing key is exactly a canonical release alias
 - canonical release aliases should be created from the release record itself
 
 This prevents a retailer-specific title from globally turning into an exact release alias.

--- a/docs/policies/README.md
+++ b/docs/policies/README.md
@@ -37,5 +37,4 @@ Keep policy docs small:
 - state the default rule clearly
 - call out only the meaningful exceptions
 
-Use [policy-template.md](/home/dcramer/src/peated/docs/policies/policy-template.md)
-for new policies.
+Use [policy-template.md](policy-template.md) for new policies.


### PR DESCRIPTION
Add a dedicated bottle normalization contract that defines which deterministic string cleanup is safe before alias lookup, duplicate checks, search, and classifier input. The contract separates identity-preserving formatting from semantic identity decisions like age, year, batch, cask, brand, and release interpretation.

This also reorganizes the surrounding docs so each file has a clearer owner: the normalization examples doc is a corpus, the alias-system spec references the alias-key contract, and the store-price matching doc focuses on workflow instead of repeating the broader whisky identity model. A couple of stale absolute markdown links are replaced with relative links while touching the docs.