### PR TITLE
feat(bottles): Add deterministic alias keys

### DIFF
--- a/apps/server/src/lib/bottleAliases.test.ts
+++ b/apps/server/src/lib/bottleAliases.test.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { bottleAliases, reviews } from "@peated/server/db/schema";
+import { bottleAliases, reviews, storePrices } from "@peated/server/db/schema";
 import { assignBottleAliasInTransaction } from "@peated/server/lib/bottleAliases";
 import { eq } from "drizzle-orm";
 
@@ -67,6 +67,58 @@ describe("assignBottleAliasInTransaction", () => {
     expect(updatedReview).toMatchObject({
       bottleId: bottle.id,
       releaseId: release.id,
+    });
+  });
+
+  test("backfills stored reference names that differ from the alias name", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const storedName = `${bottle.fullName} 2011 Release`;
+    const aliasName = `${storedName} Imported Label`;
+    const review = await fixtures.Review({
+      bottleId: null,
+      releaseId: null,
+      name: storedName,
+    });
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      releaseId: null,
+      name: storedName,
+      volume: 750,
+    });
+
+    await db.transaction(async (tx) => {
+      await assignBottleAliasInTransaction(tx, {
+        bottleId: bottle.id,
+        name: aliasName,
+        backfillNames: [storedName],
+        externalSiteId: price.externalSiteId,
+        volume: price.volume,
+      });
+    });
+
+    const updatedReview = await db.query.reviews.findFirst({
+      where: eq(reviews.id, review.id),
+    });
+    const updatedPrice = await db.query.storePrices.findFirst({
+      where: eq(storePrices.id, price.id),
+    });
+    const alias = await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, aliasName),
+    });
+
+    expect(alias).toMatchObject({
+      bottleId: bottle.id,
+      name: aliasName,
+    });
+    expect(updatedReview).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: null,
+    });
+    expect(updatedPrice).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: null,
     });
   });
 

--- a/apps/server/src/lib/bottleAliases.test.ts
+++ b/apps/server/src/lib/bottleAliases.test.ts
@@ -70,22 +70,63 @@ describe("assignBottleAliasInTransaction", () => {
     });
   });
 
+  test("updates matching reviews with the accepted release when alias stays bottle-level", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const release = await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      edition: "Batch 1",
+    });
+    const review = await fixtures.Review({
+      bottleId: null,
+      releaseId: null,
+      name: release.fullName,
+    });
+
+    await db.transaction(async (tx) => {
+      await assignBottleAliasInTransaction(tx, {
+        bottleId: bottle.id,
+        releaseId: release.id,
+        aliasReleaseId: null,
+        name: release.fullName,
+      });
+    });
+
+    const alias = await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, release.fullName),
+    });
+    const updatedReview = await db.query.reviews.findFirst({
+      where: eq(reviews.id, review.id),
+    });
+
+    expect(alias).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: null,
+    });
+    expect(updatedReview).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: release.id,
+    });
+  });
+
   test("backfills stored reference names that differ from the alias name", async ({
     fixtures,
   }) => {
     const bottle = await fixtures.Bottle();
     const storedName = `${bottle.fullName} 2011 Release`;
     const aliasName = `${storedName} Imported Label`;
-    const review = await fixtures.Review({
-      bottleId: null,
-      releaseId: null,
-      name: storedName,
-    });
     const price = await fixtures.StorePrice({
       bottleId: null,
       releaseId: null,
       name: storedName,
       volume: 750,
+    });
+    const review = await fixtures.Review({
+      bottleId: null,
+      releaseId: null,
+      name: storedName,
+      externalSiteId: price.externalSiteId,
     });
 
     await db.transaction(async (tx) => {
@@ -118,6 +159,61 @@ describe("assignBottleAliasInTransaction", () => {
     });
     expect(updatedPrice).toMatchObject({
       bottleId: bottle.id,
+      releaseId: null,
+    });
+  });
+
+  test("scopes stored reference backfills by external site", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const storedName = `${bottle.fullName} 2011 Release`;
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const otherSite = await fixtures.ExternalSiteOrExisting({
+      type: "astorwines",
+    });
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      releaseId: null,
+      name: storedName,
+      volume: 750,
+      externalSiteId: site.id,
+    });
+    const matchingReview = await fixtures.Review({
+      bottleId: null,
+      releaseId: null,
+      name: storedName,
+      externalSiteId: site.id,
+    });
+    const otherSiteReview = await fixtures.Review({
+      bottleId: null,
+      releaseId: null,
+      name: storedName,
+      externalSiteId: otherSite.id,
+    });
+
+    await db.transaction(async (tx) => {
+      await assignBottleAliasInTransaction(tx, {
+        bottleId: bottle.id,
+        name: storedName,
+        externalSiteId: price.externalSiteId,
+        volume: price.volume,
+      });
+    });
+
+    const updatedMatchingReview = await db.query.reviews.findFirst({
+      where: eq(reviews.id, matchingReview.id),
+    });
+    const updatedOtherSiteReview = await db.query.reviews.findFirst({
+      where: eq(reviews.id, otherSiteReview.id),
+    });
+
+    expect(updatedMatchingReview).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: null,
+    });
+    expect(updatedOtherSiteReview).toMatchObject({
+      bottleId: null,
       releaseId: null,
     });
   });

--- a/apps/server/src/lib/bottleAliases.test.ts
+++ b/apps/server/src/lib/bottleAliases.test.ts
@@ -122,6 +122,53 @@ describe("assignBottleAliasInTransaction", () => {
     });
   });
 
+  test("rejects blank aliases without backfilling references", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const storedName = `${bottle.fullName} 2011 Release`;
+    const review = await fixtures.Review({
+      bottleId: null,
+      releaseId: null,
+      name: storedName,
+    });
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      releaseId: null,
+      name: storedName,
+      volume: 750,
+    });
+
+    await expect(
+      db.transaction(async (tx) =>
+        assignBottleAliasInTransaction(tx, {
+          bottleId: bottle.id,
+          name: "   ",
+        }),
+      ),
+    ).rejects.toThrow("Failed to save alias.");
+
+    const updatedReview = await db.query.reviews.findFirst({
+      where: eq(reviews.id, review.id),
+    });
+    const updatedPrice = await db.query.storePrices.findFirst({
+      where: eq(storePrices.id, price.id),
+    });
+    const alias = await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, "   "),
+    });
+
+    expect(alias).toBeUndefined();
+    expect(updatedReview).toMatchObject({
+      bottleId: null,
+      releaseId: null,
+    });
+    expect(updatedPrice).toMatchObject({
+      bottleId: null,
+      releaseId: null,
+    });
+  });
+
   test("stores assignment provenance when assigning an alias", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/bottleAliases.ts
+++ b/apps/server/src/lib/bottleAliases.ts
@@ -66,7 +66,8 @@ function getAssignmentUpdateValues(options: BottleAliasAssignmentValues) {
 
 /**
  * Assigns a confirmed exact alias inside an existing transaction and records
- * where that assignment came from.
+ * where that assignment came from. `name` is the accepted alias key;
+ * `backfillNames` are legacy or raw stored references that should be repaired.
  */
 export async function assignBottleAliasInTransaction(
   tx: AnyDatabase,
@@ -215,13 +216,18 @@ export async function assignBottleAliasInTransaction(
     .update(reviews)
     .set({
       bottleId,
-      releaseId: nextAliasReleaseId,
+      releaseId: releaseId ?? nextAliasReleaseId,
     })
     .where(
-      or(
-        ...backfillLookupNames.map((value) =>
-          eq(sql`LOWER(${reviews.name})`, value),
+      and(
+        or(
+          ...backfillLookupNames.map((value) =>
+            eq(sql`LOWER(${reviews.name})`, value),
+          ),
         ),
+        externalSiteId !== undefined
+          ? eq(reviews.externalSiteId, externalSiteId)
+          : undefined,
       ),
     );
 

--- a/apps/server/src/lib/bottleAliases.ts
+++ b/apps/server/src/lib/bottleAliases.ts
@@ -90,6 +90,10 @@ export async function assignBottleAliasInTransaction(
     volume?: number;
   } & BottleAliasAssignmentOptions,
 ): Promise<{ alias: BottleAlias; isNew: boolean }> {
+  if (!name.trim()) {
+    throw new FailedToSaveBottleAliasError();
+  }
+
   const assignmentOptions: BottleAliasAssignmentValues = {
     assignmentSource,
     assignedById,

--- a/apps/server/src/lib/bottleAliases.ts
+++ b/apps/server/src/lib/bottleAliases.ts
@@ -11,7 +11,7 @@ import {
 } from "@peated/server/db/schema";
 import { logError } from "@peated/server/lib/log";
 import { pushJob, pushUniqueJob } from "@peated/server/worker/client";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, or, sql } from "drizzle-orm";
 
 export class DuplicateBottleAliasError extends Error {
   constructor(readonly bottleId: number) {
@@ -76,6 +76,7 @@ export async function assignBottleAliasInTransaction(
     aliasReleaseId = releaseId,
     externalSiteId,
     name,
+    backfillNames = [],
     volume,
     assignmentSource,
     assignedById,
@@ -85,6 +86,7 @@ export async function assignBottleAliasInTransaction(
     aliasReleaseId?: number | null;
     externalSiteId?: number;
     name: string;
+    backfillNames?: string[];
     volume?: number;
   } & BottleAliasAssignmentOptions,
 ): Promise<{ alias: BottleAlias; isNew: boolean }> {
@@ -157,6 +159,16 @@ export async function assignBottleAliasInTransaction(
     throw new FailedToSaveBottleAliasError();
   }
 
+  const backfillLookupNames = Array.from(
+    new Set(
+      [name, ...backfillNames].map((value) => value.trim().toLowerCase()),
+    ),
+  ).filter(Boolean);
+  const backfillNameFilter = or(
+    ...backfillLookupNames.map((value) =>
+      eq(sql`LOWER(${storePrices.name})`, value),
+    ),
+  );
   const matchingPrices = await tx
     .update(storePrices)
     .set({
@@ -164,9 +176,13 @@ export async function assignBottleAliasInTransaction(
       releaseId,
     })
     .where(
-      sql`LOWER(${storePrices.name}) = ${name.toLowerCase()}
-        ${externalSiteId ? sql`AND ${storePrices.externalSiteId} = ${externalSiteId}` : sql``}
-        ${volume ? sql`AND ${storePrices.volume} = ${volume}` : sql``}`,
+      and(
+        backfillNameFilter,
+        externalSiteId !== undefined
+          ? eq(storePrices.externalSiteId, externalSiteId)
+          : undefined,
+        volume !== undefined ? eq(storePrices.volume, volume) : undefined,
+      ),
     )
     .returning({
       imageUrl: storePrices.imageUrl,
@@ -197,7 +213,13 @@ export async function assignBottleAliasInTransaction(
       bottleId,
       releaseId: nextAliasReleaseId,
     })
-    .where(eq(sql`LOWER(${reviews.name})`, name.toLowerCase()));
+    .where(
+      or(
+        ...backfillLookupNames.map((value) =>
+          eq(sql`LOWER(${reviews.name})`, value),
+        ),
+      ),
+    );
 
   return {
     alias,
@@ -245,6 +267,7 @@ export async function assignBottleAlias(
     aliasReleaseId?: number | null;
     externalSiteId?: number;
     name: string;
+    backfillNames?: string[];
     volume?: number;
   } & BottleAliasAssignmentOptions,
   contexts?: Record<string, Record<string, any>>,

--- a/apps/server/src/lib/bottleReferenceResolution.test.ts
+++ b/apps/server/src/lib/bottleReferenceResolution.test.ts
@@ -67,7 +67,7 @@ describe("resolveBottleReferenceTarget", () => {
     expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   });
 
-  test("does not use normalized names as fast-path alias matches", async ({
+  test("does not normalize alias lookup names internally", async ({
     fixtures,
   }) => {
     const user = await fixtures.User({ admin: true });

--- a/apps/server/src/lib/normalize.test.ts
+++ b/apps/server/src/lib/normalize.test.ts
@@ -1,6 +1,5 @@
 import {
   normalizeBottle,
-  normalizeBottleAliasKey,
   normalizeVolume,
   stripDuplicateBrandPrefixFromBottleName,
 } from "./normalize";
@@ -179,21 +178,6 @@ describe("normalizeBottle", () => {
     });
     expect(name).toMatchInlineSnapshot(`"Hello World Cask No. 1.285"`);
     expect(statedAge).toBeNull();
-  });
-
-  test("alias key keeps release and source detail for exact matching", async () => {
-    expect(normalizeBottleAliasKey("Ardbeg 10 years old")).toBe(
-      "Ardbeg 10-year-old",
-    );
-    expect(normalizeBottleAliasKey("The Last Drop 42")).toBe(
-      "The Last Drop 42",
-    );
-    expect(
-      normalizeBottleAliasKey("Lagavulin Distillers Edition 2011 Release"),
-    ).toBe("Lagavulin Distillers Edition 2011 Release");
-    expect(
-      normalizeBottleAliasKey("Four Roses OESK Store Pick Cask No. 7"),
-    ).toBe("Four Roses OESK Store Pick Cask No. 7");
   });
 
   test("Traigh Bhan 19-year-old Scotch Batch No. 5", async () => {

--- a/apps/server/src/lib/normalize.test.ts
+++ b/apps/server/src/lib/normalize.test.ts
@@ -1,5 +1,6 @@
 import {
   normalizeBottle,
+  normalizeBottleAliasKey,
   normalizeVolume,
   stripDuplicateBrandPrefixFromBottleName,
 } from "./normalize";
@@ -178,6 +179,21 @@ describe("normalizeBottle", () => {
     });
     expect(name).toMatchInlineSnapshot(`"Hello World Cask No. 1.285"`);
     expect(statedAge).toBeNull();
+  });
+
+  test("alias key keeps release and source detail for exact matching", async () => {
+    expect(normalizeBottleAliasKey("Ardbeg 10 years old")).toBe(
+      "Ardbeg 10-year-old",
+    );
+    expect(normalizeBottleAliasKey("The Last Drop 42")).toBe(
+      "The Last Drop 42",
+    );
+    expect(
+      normalizeBottleAliasKey("Lagavulin Distillers Edition 2011 Release"),
+    ).toBe("Lagavulin Distillers Edition 2011 Release");
+    expect(
+      normalizeBottleAliasKey("Four Roses OESK Store Pick Cask No. 7"),
+    ).toBe("Four Roses OESK Store Pick Cask No. 7");
   });
 
   test("Traigh Bhan 19-year-old Scotch Batch No. 5", async () => {

--- a/apps/server/src/lib/normalize.ts
+++ b/apps/server/src/lib/normalize.ts
@@ -1,6 +1,7 @@
 export {
   normalizeBottle,
   normalizeBottleAge,
+  normalizeBottleAliasKey,
   normalizeBottleBatchNumber,
   normalizeCategory,
   normalizeEntityName,

--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -15,6 +15,7 @@ import {
   searchBottleCandidates,
 } from "@peated/server/lib/bottleReferenceCandidates";
 import type * as CatalogVerificationModule from "@peated/server/lib/catalogVerification";
+import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import {
   applyApprovedStorePriceMatch,
   canClearIgnoredStorePriceAssignment,
@@ -828,6 +829,9 @@ describe("priceMatching", () => {
       where: eq(storePrices.id, price.id),
     });
     const listingAlias = await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, normalizeBottleAliasKey(price.name)),
+    });
+    const rawListingAlias = await db.query.bottleAliases.findFirst({
       where: eq(bottleAliases.name, price.name),
     });
     const observation = await db.query.bottleObservations.findFirst({
@@ -844,6 +848,7 @@ describe("priceMatching", () => {
     });
     expect(updatedPrice?.bottleId).toBe(bottle.id);
     expect(listingAlias?.bottleId).toBe(bottle.id);
+    expect(rawListingAlias).toBeUndefined();
     expect(observation).toMatchObject({
       bottleId: bottle.id,
       releaseId: null,
@@ -2693,7 +2698,7 @@ describe("priceMatching", () => {
       where: eq(storePrices.id, price.id),
     });
     const listingAlias = await db.query.bottleAliases.findFirst({
-      where: eq(bottleAliases.name, price.name),
+      where: eq(bottleAliases.name, normalizeBottleAliasKey(price.name)),
     });
 
     expect(extractFromText).not.toHaveBeenCalled();
@@ -2813,7 +2818,7 @@ describe("priceMatching", () => {
       where: eq(storePrices.id, price.id),
     });
     const listingAlias = await db.query.bottleAliases.findFirst({
-      where: eq(bottleAliases.name, price.name),
+      where: eq(bottleAliases.name, normalizeBottleAliasKey(price.name)),
     });
 
     expect(extractFromText).not.toHaveBeenCalled();
@@ -2949,7 +2954,7 @@ describe("priceMatching", () => {
       where: eq(bottles.id, proposal.suggestedBottleId!),
     });
     const listingAlias = await db.query.bottleAliases.findFirst({
-      where: eq(bottleAliases.name, price.name),
+      where: eq(bottleAliases.name, normalizeBottleAliasKey(price.name)),
     });
     const observation = await db.query.bottleObservations.findFirst({
       where: (bottleObservations, { eq }) =>
@@ -3414,7 +3419,7 @@ describe("priceMatching", () => {
       where: eq(bottles.id, proposal.suggestedBottleId!),
     });
     const listingAlias = await db.query.bottleAliases.findFirst({
-      where: eq(bottleAliases.name, price.name),
+      where: eq(bottleAliases.name, normalizeBottleAliasKey(price.name)),
     });
     const [attempt] = await db
       .select()

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -2258,6 +2258,7 @@ export async function applyApprovedStorePriceMatchProposalInTransaction(
     aliasReleaseId: null,
     externalSiteId: proposal.price.externalSiteId,
     name: aliasKey,
+    backfillNames: [proposal.price.name],
     volume: proposal.price.volume,
     assignmentSource: "source_approved",
     assignedById: reviewedById,

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -65,6 +65,7 @@ import {
   type IncomingBottleDecisionType,
 } from "@peated/server/lib/incomingBottleDecisionLog";
 import { logError } from "@peated/server/lib/log";
+import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import {
   getStorePriceMatchAutomationAssessment,
   shouldVerifyStorePriceMatch,
@@ -2248,14 +2249,15 @@ export async function applyApprovedStorePriceMatchProposalInTransaction(
     }
   }
 
-  // Store listing names stay bottle-level unless an existing canonical release
+  const aliasKey = normalizeBottleAliasKey(proposal.price.name);
+  // Store listing keys stay bottle-level unless an existing canonical release
   // alias already owns the same text, which assignBottleAliasInTransaction preserves.
   const aliasResult = await assignBottleAliasInTransaction(tx, {
     bottleId,
     releaseId,
     aliasReleaseId: null,
     externalSiteId: proposal.price.externalSiteId,
-    name: proposal.price.name,
+    name: aliasKey,
     volume: proposal.price.volume,
     assignmentSource: "source_approved",
     assignedById: reviewedById,

--- a/apps/server/src/orpc/routes/prices/create-batch.test.ts
+++ b/apps/server/src/orpc/routes/prices/create-batch.test.ts
@@ -1,4 +1,7 @@
-import { normalizeBottle } from "@peated/bottle-classifier/normalize";
+import {
+  normalizeBottle,
+  normalizeBottleAliasKey,
+} from "@peated/bottle-classifier/normalize";
 import { db } from "@peated/server/db";
 import { bottleAliases, storePrices } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
@@ -238,7 +241,7 @@ describe("POST /external-sites/:site/prices", () => {
     );
   });
 
-  test("does not trust normalized aliases as exact matches", async ({
+  test("uses identity-preserving alias keys as exact matches", async ({
     fixtures,
   }) => {
     const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
@@ -271,18 +274,56 @@ describe("POST /external-sites/:site/prices", () => {
       .where(eq(storePrices.externalSiteId, site.id));
 
     expect(prices.length).toBe(1);
-    expect(prices[0].bottleId).toBeNull();
+    expect(prices[0].bottleId).toBe(bottle.id);
     expect(prices[0].releaseId).toBeNull();
     expect(prices[0].name).toBe("Ardbeg 10-year-old");
+    expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
+  });
+
+  test("does not use lossy normalized listing names as exact matches", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const bottle = await fixtures.Bottle({
+      name: "Distillers Edition",
+      brandId: (await fixtures.Entity({ name: "Lagavulin" })).id,
+    });
+    expect(bottle.fullName).toBe("Lagavulin Distillers Edition");
+    const user = await fixtures.User({ admin: true });
+
+    await routerClient.prices.createBatch(
+      {
+        site: site.type,
+        prices: [
+          {
+            name: "Lagavulin Distillers Edition 2011 Release",
+            price: 3999,
+            currency: "usd",
+            volume: 750,
+            url: "http://example.com/lossy-normalized-alias",
+          },
+        ],
+      },
+      { context: { user } },
+    );
+
+    const [price] = await db
+      .select()
+      .from(storePrices)
+      .where(eq(storePrices.externalSiteId, site.id));
+
+    expect(price.bottleId).toBeNull();
+    expect(price.releaseId).toBeNull();
+    expect(price.name).toBe(bottle.fullName);
     expect(workerClient.pushUniqueJob).toHaveBeenCalledWith(
       "ResolveStorePriceBottle",
       {
-        priceId: prices[0].id,
+        priceId: price.id,
       },
     );
   });
 
-  test("trusts only the raw source alias that exactly matched", async ({
+  test("writes the same accepted alias key used for lookup", async ({
     fixtures,
   }) => {
     const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
@@ -291,12 +332,12 @@ describe("POST /external-sites/:site/prices", () => {
       brandId: (await fixtures.Entity({ name: "Ardbeg" })).id,
     });
     const rawName = "Ardbeg 10 years old Whisky";
-    const normalizedName = normalizeBottle({ name: rawName }).name;
-    expect(normalizedName).not.toBe(rawName);
+    const aliasKey = normalizeBottleAliasKey(rawName);
+    expect(aliasKey).not.toBe(rawName);
 
     await fixtures.BottleAlias({
       bottleId: bottle.id,
-      name: rawName,
+      name: aliasKey,
     });
     const user = await fixtures.User({ admin: true });
 
@@ -316,17 +357,17 @@ describe("POST /external-sites/:site/prices", () => {
       { context: { user } },
     );
 
-    const rawAlias = await db.query.bottleAliases.findFirst({
-      where: eq(bottleAliases.name, rawName),
+    const alias = await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, aliasKey),
     });
-    expect(rawAlias).toMatchObject({
+    expect(alias).toMatchObject({
       bottleId: bottle.id,
       assignmentSource: "source_approved",
       assignedById: user.id,
     });
     expect(
       await db.query.bottleAliases.findFirst({
-        where: eq(bottleAliases.name, normalizedName),
+        where: eq(bottleAliases.name, rawName),
       }),
     ).toBeUndefined();
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();

--- a/apps/server/src/orpc/routes/prices/create-batch.test.ts
+++ b/apps/server/src/orpc/routes/prices/create-batch.test.ts
@@ -280,6 +280,56 @@ describe("POST /external-sites/:site/prices", () => {
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
   });
 
+  test("falls back to existing raw aliases for legacy exact matches", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const bottle = await fixtures.Bottle({
+      name: "10-year-old",
+      brandId: (await fixtures.Entity({ name: "Ardbeg" })).id,
+    });
+    const rawName = "Ardbeg 10 years old";
+    const aliasKey = normalizeBottleAliasKey(rawName);
+    expect(aliasKey).not.toBe(rawName);
+    await fixtures.BottleAlias({
+      bottleId: bottle.id,
+      name: rawName,
+    });
+    const user = await fixtures.User({ admin: true });
+
+    await routerClient.prices.createBatch(
+      {
+        site: site.type,
+        prices: [
+          {
+            name: rawName,
+            price: 3999,
+            currency: "usd",
+            volume: 750,
+            url: "http://example.com/legacy-raw-alias",
+          },
+        ],
+      },
+      { context: { user } },
+    );
+
+    const [price] = await db
+      .select()
+      .from(storePrices)
+      .where(eq(storePrices.externalSiteId, site.id));
+    const alias = await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, aliasKey),
+    });
+
+    expect(price.bottleId).toBe(bottle.id);
+    expect(alias).toMatchObject({
+      bottleId: bottle.id,
+      assignmentSource: "source_approved",
+      assignedById: user.id,
+    });
+    expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
+  });
+
   test("does not use lossy normalized listing names as exact matches", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/prices/create-batch.test.ts
+++ b/apps/server/src/orpc/routes/prices/create-batch.test.ts
@@ -3,7 +3,7 @@ import {
   normalizeBottleAliasKey,
 } from "@peated/bottle-classifier/normalize";
 import { db } from "@peated/server/db";
-import { bottleAliases, storePrices } from "@peated/server/db/schema";
+import { bottleAliases, reviews, storePrices } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import * as workerClient from "@peated/server/worker/client";
@@ -295,6 +295,11 @@ describe("POST /external-sites/:site/prices", () => {
       bottleId: bottle.id,
       name: rawName,
     });
+    const rawReview = await fixtures.Review({
+      bottleId: null,
+      releaseId: null,
+      name: rawName,
+    });
     const user = await fixtures.User({ admin: true });
 
     await routerClient.prices.createBatch(
@@ -320,8 +325,15 @@ describe("POST /external-sites/:site/prices", () => {
     const alias = await db.query.bottleAliases.findFirst({
       where: eq(bottleAliases.name, aliasKey),
     });
+    const updatedRawReview = await db.query.reviews.findFirst({
+      where: eq(reviews.id, rawReview.id),
+    });
 
     expect(price.bottleId).toBe(bottle.id);
+    expect(updatedRawReview).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: null,
+    });
     expect(alias).toMatchObject({
       bottleId: bottle.id,
       assignmentSource: "source_approved",

--- a/apps/server/src/orpc/routes/prices/create-batch.ts
+++ b/apps/server/src/orpc/routes/prices/create-batch.ts
@@ -9,8 +9,8 @@ import {
   storePriceHistories,
   storePrices,
 } from "@peated/server/db/schema";
+import { assignBottleAliasInTransaction } from "@peated/server/lib/bottleAliases";
 import { findBottleTarget } from "@peated/server/lib/bottleFinder";
-import { upsertBottleAlias } from "@peated/server/lib/db";
 import { chunked } from "@peated/server/lib/scraper";
 import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
@@ -58,6 +58,8 @@ export default procedure
           const [price] = await db.transaction(async (tx) => {
             const { name } = normalizeBottle({ name: sp.name });
             const aliasKey = normalizeBottleAliasKey(sp.name);
+            // New assignments use the deterministic key, but lookup still
+            // accepts legacy raw aliases created before alias keys existed.
             const target =
               (await findBottleTarget(aliasKey, tx)) ??
               (aliasKey !== sp.name
@@ -96,7 +98,13 @@ export default procedure
               .onConflictDoNothing();
 
             if (bottleId) {
-              await upsertBottleAlias(tx, aliasKey, bottleId, releaseId, {
+              await assignBottleAliasInTransaction(tx, {
+                name: aliasKey,
+                backfillNames: [name, sp.name],
+                bottleId,
+                releaseId,
+                externalSiteId: site.id,
+                volume: sp.volume,
                 assignmentSource: "source_approved",
                 assignedById: context.user.id,
               });

--- a/apps/server/src/orpc/routes/prices/create-batch.ts
+++ b/apps/server/src/orpc/routes/prices/create-batch.ts
@@ -58,7 +58,11 @@ export default procedure
           const [price] = await db.transaction(async (tx) => {
             const { name } = normalizeBottle({ name: sp.name });
             const aliasKey = normalizeBottleAliasKey(sp.name);
-            const target = await findBottleTarget(aliasKey, tx);
+            const target =
+              (await findBottleTarget(aliasKey, tx)) ??
+              (aliasKey !== sp.name
+                ? await findBottleTarget(sp.name, tx)
+                : null);
             const bottleId = target?.bottleId ?? null;
             const releaseId = target?.releaseId ?? null;
 

--- a/apps/server/src/orpc/routes/prices/create-batch.ts
+++ b/apps/server/src/orpc/routes/prices/create-batch.ts
@@ -1,4 +1,7 @@
-import { normalizeBottle } from "@peated/bottle-classifier/normalize";
+import {
+  normalizeBottle,
+  normalizeBottleAliasKey,
+} from "@peated/bottle-classifier/normalize";
 import { db } from "@peated/server/db";
 import type { StorePrice } from "@peated/server/db/schema";
 import {
@@ -54,9 +57,8 @@ export default procedure
         prices.map(async (sp) => {
           const [price] = await db.transaction(async (tx) => {
             const { name } = normalizeBottle({ name: sp.name });
-            // Exact alias assignment uses the raw scraped title; the normalized
-            // store_price name is for storage/de-duping, not identity proof.
-            const target = await findBottleTarget(sp.name, tx);
+            const aliasKey = normalizeBottleAliasKey(sp.name);
+            const target = await findBottleTarget(aliasKey, tx);
             const bottleId = target?.bottleId ?? null;
             const releaseId = target?.releaseId ?? null;
 
@@ -90,7 +92,7 @@ export default procedure
               .onConflictDoNothing();
 
             if (bottleId) {
-              await upsertBottleAlias(tx, sp.name, bottleId, releaseId, {
+              await upsertBottleAlias(tx, aliasKey, bottleId, releaseId, {
                 assignmentSource: "source_approved",
                 assignedById: context.user.id,
               });

--- a/apps/server/src/orpc/routes/reviews/create.test.ts
+++ b/apps/server/src/orpc/routes/reviews/create.test.ts
@@ -4,6 +4,7 @@ import {
   incomingBottleDecisionLogs,
   reviews,
 } from "@peated/server/db/schema";
+import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { and, eq } from "drizzle-orm";
@@ -439,6 +440,54 @@ describe("POST /reviews", () => {
       bottleId: bottle.id,
       releaseId: null,
       name: bottle.fullName,
+    });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
+  });
+
+  test("new review falls back to existing raw aliases before classifier", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting();
+    const bottle = await fixtures.Bottle({
+      name: "10-year-old",
+      brandId: (await fixtures.Entity({ name: "Ardbeg" })).id,
+    });
+    const rawName = "Ardbeg 10 years old";
+    const aliasKey = normalizeBottleAliasKey(rawName);
+    expect(aliasKey).not.toBe(rawName);
+    await fixtures.BottleAlias({
+      bottleId: bottle.id,
+      name: rawName,
+    });
+    const adminUser = await fixtures.User({ admin: true });
+
+    const data = await routerClient.reviews.create(
+      {
+        site: site.type,
+        name: rawName,
+        issue: "Default",
+        rating: 89,
+        url: "https://example.com/ardbeg-10-legacy",
+        category: bottle.category,
+      },
+      { context: { user: adminUser } },
+    );
+
+    const review = await db.query.reviews.findFirst({
+      where: (table, { eq }) => eq(table.id, data.id),
+    });
+    const alias = await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, aliasKey),
+    });
+
+    expect(review).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: null,
+      name: bottle.fullName,
+    });
+    expect(alias).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: null,
     });
     expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   });

--- a/apps/server/src/orpc/routes/reviews/create.test.ts
+++ b/apps/server/src/orpc/routes/reviews/create.test.ts
@@ -410,6 +410,72 @@ describe("POST /reviews", () => {
     expect(decisionLog).toBeUndefined();
   });
 
+  test("new review uses identity-preserving alias keys before classifier", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting();
+    const bottle = await fixtures.Bottle({
+      name: "10-year-old",
+      brandId: (await fixtures.Entity({ name: "Ardbeg" })).id,
+    });
+    const adminUser = await fixtures.User({ admin: true });
+
+    const data = await routerClient.reviews.create(
+      {
+        site: site.type,
+        name: "Ardbeg 10 years old",
+        issue: "Default",
+        rating: 89,
+        url: "https://example.com/ardbeg-10",
+        category: bottle.category,
+      },
+      { context: { user: adminUser } },
+    );
+
+    const review = await db.query.reviews.findFirst({
+      where: (table, { eq }) => eq(table.id, data.id),
+    });
+    expect(review).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: null,
+      name: bottle.fullName,
+    });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
+  });
+
+  test("new review does not use lossy normalized names as exact aliases", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting();
+    const bottle = await fixtures.Bottle({
+      name: "Distillers Edition",
+      brandId: (await fixtures.Entity({ name: "Lagavulin" })).id,
+    });
+    const adminUser = await fixtures.User({ admin: true });
+
+    const data = await routerClient.reviews.create(
+      {
+        site: site.type,
+        name: "Lagavulin Distillers Edition 2011 Release",
+        issue: "Default",
+        rating: 89,
+        url: "https://example.com/lagavulin-2011",
+        category: bottle.category,
+      },
+      { context: { user: adminUser } },
+    );
+
+    const review = await db.query.reviews.findFirst({
+      where: (table, { eq }) => eq(table.id, data.id),
+    });
+    expect(review).toMatchObject({
+      bottleId: null,
+      releaseId: null,
+      name: bottle.fullName,
+    });
+    expect(classifyBottleReferenceMock).toHaveBeenCalledTimes(1);
+  });
+
   test("new review can match an existing bottle through the classifier", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/reviews/create.test.ts
+++ b/apps/server/src/orpc/routes/reviews/create.test.ts
@@ -496,11 +496,53 @@ describe("POST /reviews", () => {
     fixtures,
   }) => {
     const site = await fixtures.ExternalSiteOrExisting();
+    const brand = await fixtures.Entity({ name: "Lagavulin" });
     const bottle = await fixtures.Bottle({
       name: "Distillers Edition",
-      brandId: (await fixtures.Entity({ name: "Lagavulin" })).id,
+      brandId: brand.id,
+    });
+    const classifierBottle = await fixtures.Bottle({
+      name: "Distillers Edition 2011 Release",
+      brandId: brand.id,
     });
     const adminUser = await fixtures.User({ admin: true });
+
+    classifyBottleReferenceMock.mockResolvedValue(
+      buildClassification(
+        {
+          action: "match",
+          matchedBottleId: classifierBottle.id,
+          matchedReleaseId: null,
+          candidateBottleIds: [classifierBottle.id],
+        },
+        {
+          candidates: [
+            {
+              bottleId: classifierBottle.id,
+              releaseId: null,
+              fullName: classifierBottle.fullName,
+              bottleFullName: classifierBottle.fullName,
+              alias: classifierBottle.fullName,
+              brand: null,
+              bottler: null,
+              series: null,
+              distillery: [],
+              category: classifierBottle.category,
+              statedAge: classifierBottle.statedAge,
+              edition: null,
+              caskStrength: classifierBottle.caskStrength,
+              singleCask: classifierBottle.singleCask,
+              abv: classifierBottle.abv,
+              vintageYear: classifierBottle.vintageYear,
+              releaseYear: classifierBottle.releaseYear,
+              caskType: classifierBottle.caskType,
+              caskSize: classifierBottle.caskSize,
+              caskFill: classifierBottle.caskFill,
+            },
+          ],
+        },
+      ),
+    );
 
     const data = await routerClient.reviews.create(
       {
@@ -518,11 +560,20 @@ describe("POST /reviews", () => {
       where: (table, { eq }) => eq(table.id, data.id),
     });
     expect(review).toMatchObject({
-      bottleId: null,
+      bottleId: classifierBottle.id,
       releaseId: null,
       name: bottle.fullName,
     });
-    expect(classifyBottleReferenceMock).toHaveBeenCalledTimes(1);
+    const alias = await db.query.bottleAliases.findFirst({
+      where: eq(
+        bottleAliases.name,
+        normalizeBottleAliasKey("Lagavulin Distillers Edition 2011 Release"),
+      ),
+    });
+    expect(alias).toMatchObject({
+      bottleId: classifierBottle.id,
+      releaseId: null,
+    });
   });
 
   test("new review can match an existing bottle through the classifier", async ({

--- a/apps/server/src/orpc/routes/reviews/create.ts
+++ b/apps/server/src/orpc/routes/reviews/create.ts
@@ -58,7 +58,7 @@ export default procedure
         currentBottleId: null,
         currentReleaseId: null,
       },
-      aliasLookupNames: [aliasKey],
+      aliasLookupNames: [aliasKey, rawName],
       extractedIdentity: {
         category: input.category,
       },

--- a/apps/server/src/orpc/routes/reviews/create.ts
+++ b/apps/server/src/orpc/routes/reviews/create.ts
@@ -1,4 +1,7 @@
-import { normalizeBottle } from "@peated/bottle-classifier/normalize";
+import {
+  normalizeBottle,
+  normalizeBottleAliasKey,
+} from "@peated/bottle-classifier/normalize";
 import { db } from "@peated/server/db";
 import { externalSites, reviews } from "@peated/server/db/schema";
 import {
@@ -45,6 +48,7 @@ export default procedure
 
     const rawName = input.name;
     const { name: normalizedName } = normalizeBottle({ name: rawName });
+    const aliasKey = normalizeBottleAliasKey(rawName);
     const resolution = await resolveBottleReferenceTarget({
       reference: {
         externalSiteId: site.id,
@@ -54,9 +58,7 @@ export default procedure
         currentBottleId: null,
         currentReleaseId: null,
       },
-      // Normalized review titles can strip release markers before the
-      // classifier has a chance to review the full reference.
-      aliasLookupNames: [rawName],
+      aliasLookupNames: [aliasKey],
       extractedIdentity: {
         category: input.category,
       },
@@ -137,7 +139,7 @@ export default procedure
       const aliasAssignment = await assignBottleAliasInTransaction(tx, {
         bottleId,
         releaseId,
-        name: reviewName,
+        name: aliasKey,
         ...(resolution.source !== "exact_alias"
           ? {
               assignmentSource: "classifier_approved" as const,

--- a/apps/server/src/orpc/routes/reviews/create.ts
+++ b/apps/server/src/orpc/routes/reviews/create.ts
@@ -140,6 +140,7 @@ export default procedure
         bottleId,
         releaseId,
         name: aliasKey,
+        backfillNames: [reviewName, normalizedName],
         ...(resolution.source !== "exact_alias"
           ? {
               assignmentSource: "classifier_approved" as const,

--- a/apps/server/src/orpc/routes/reviews/create.ts
+++ b/apps/server/src/orpc/routes/reviews/create.ts
@@ -49,6 +49,8 @@ export default procedure
     const rawName = input.name;
     const { name: normalizedName } = normalizeBottle({ name: rawName });
     const aliasKey = normalizeBottleAliasKey(rawName);
+    // New assignments use the deterministic key, while exact lookup also
+    // accepts legacy raw aliases created before alias keys existed.
     const resolution = await resolveBottleReferenceTarget({
       reference: {
         externalSiteId: site.id,
@@ -140,7 +142,8 @@ export default procedure
         bottleId,
         releaseId,
         name: aliasKey,
-        backfillNames: [reviewName, normalizedName],
+        backfillNames: [reviewName, rawName],
+        externalSiteId: site.id,
         ...(resolution.source !== "exact_alias"
           ? {
               assignmentSource: "classifier_approved" as const,

--- a/apps/server/src/worker/jobs/createMissingBottles.test.ts
+++ b/apps/server/src/worker/jobs/createMissingBottles.test.ts
@@ -5,6 +5,7 @@ import {
   reviews,
   storePrices,
 } from "@peated/server/db/schema";
+import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import createMissingBottles from "@peated/server/worker/jobs/createMissingBottles";
 import { and, eq } from "drizzle-orm";
 import { beforeEach, describe, expect, test, vi } from "vitest";
@@ -124,7 +125,7 @@ describe("createMissingBottles", () => {
     expect(bottle?.fullName).toEqual("Springbank Bottle Name");
 
     const alias = await db.query.bottleAliases.findFirst({
-      where: eq(bottleAliases.name, review.name),
+      where: eq(bottleAliases.name, normalizeBottleAliasKey(review.name)),
     });
     expect(alias).toMatchObject({
       bottleId: updatedReview?.bottleId,

--- a/apps/server/src/worker/jobs/createMissingBottles.ts
+++ b/apps/server/src/worker/jobs/createMissingBottles.ts
@@ -10,6 +10,7 @@ import {
   recordIncomingBottleDecisionInTransaction,
   shouldRecordIncomingBottleDecision,
 } from "@peated/server/lib/incomingBottleDecisionLog";
+import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import { getAutomationModeratorUser } from "@peated/server/lib/systemUser";
 import { and, asc, gt, isNull } from "drizzle-orm";
 
@@ -33,6 +34,7 @@ export default async function createMissingBottles() {
 
     for (const review of missingInReviews) {
       cursor = review.id;
+      const aliasKey = normalizeBottleAliasKey(review.name);
 
       const resolution = await resolveBottleReferenceTarget({
         reference: {
@@ -46,7 +48,7 @@ export default async function createMissingBottles() {
         },
         // Normalized fallback aliases can collapse real release detail to the
         // parent before the classifier reviews the full reference title.
-        aliasLookupNames: [review.name],
+        aliasLookupNames: [aliasKey, review.name],
         user: systemUser,
       });
 
@@ -71,7 +73,9 @@ export default async function createMissingBottles() {
         const aliasAssignment = await assignBottleAliasInTransaction(tx, {
           bottleId,
           releaseId: resolution.releaseId,
-          name: review.name,
+          name: aliasKey,
+          backfillNames: [review.name],
+          externalSiteId: review.externalSiteId,
           ...(resolution.source !== "exact_alias"
             ? {
                 assignmentSource: "classifier_approved" as const,

--- a/docs/architecture/bottle-normalization-contract.md
+++ b/docs/architecture/bottle-normalization-contract.md
@@ -106,6 +106,7 @@ safe to remove before review.
 
 Alias lookup and alias writes must use the same accepted key for a workflow.
 That key may be raw source text or an identity-preserving normalized form.
+Code should build that form through `normalizeBottleAliasKey`.
 
 If normalization is lossy or semantic, it is not a safe deterministic alias key.
 Use it for search or classifier evidence instead.

--- a/packages/bottle-classifier/src/normalize.test.ts
+++ b/packages/bottle-classifier/src/normalize.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import {
   normalizeBottle,
   normalizeBottleAge,
+  normalizeBottleAliasKey,
   normalizeBottleBatchNumber,
   normalizeCategory,
   normalizeEntityName,
@@ -96,6 +97,26 @@ describe("normalize", () => {
       releaseYear: 2025,
       caskStrength: true,
     });
+  });
+
+  test("builds alias keys without dropping identity-bearing tokens", () => {
+    expect(normalizeBottleAliasKey("Ardbeg   10 years old")).toBe(
+      "Ardbeg 10-year-old",
+    );
+    expect(normalizeBottleAliasKey("The Last Drop 42")).toBe(
+      "The Last Drop 42",
+    );
+    expect(
+      normalizeBottleAliasKey("Lagavulin Distillers Edition 2011 Release"),
+    ).toBe("Lagavulin Distillers Edition 2011 Release");
+    expect(
+      normalizeBottleAliasKey("Springbank 12 Cask Strength Batch No. 24"),
+    ).toBe("Springbank 12 Cask Strength Batch No. 24");
+    expect(
+      normalizeBottleAliasKey(
+        "Four Roses Single Barrel Barrel Strength OESK Store Pick",
+      ),
+    ).toBe("Four Roses Single Barrel Barrel Strength OESK Store Pick");
   });
 
   test("strips duplicate brand prefixes case-insensitively", () => {

--- a/packages/bottle-classifier/src/normalize.ts
+++ b/packages/bottle-classifier/src/normalize.ts
@@ -161,6 +161,20 @@ export function normalizeBottleBatchNumber(name: string) {
 }
 
 /**
+ * Builds the deterministic key used for exact alias lookup and assignment.
+ * This is narrower than normalizeBottle: it keeps release-year and other
+ * identity-bearing text in the string for classifier/moderator review.
+ */
+export function normalizeBottleAliasKey(name: string): string {
+  name = normalizeString(name);
+  ({ name } = normalizeBottleAge({ name }));
+
+  return name
+    .replaceAll(/^\s*|\s*$/g, "")
+    .replaceAll(/\n\s+|\n+|\s{2,}/gi, " ");
+}
+
+/**
  * Normalizes a bottle name and attached structured traits without making any
  * brand-specific identity inferences.
  */


### PR DESCRIPTION
Add the deterministic alias-key implementation described by the bottle normalization contract.

The new `normalizeBottleAliasKey` path keeps exact alias reuse limited to identity-preserving cleanup such as whitespace and explicit age wording. It intentionally avoids full bottle normalization so release-year, batch, cask, retailer, and other identity-bearing text still fall through to the classifier or resolver instead of becoming accidental deterministic matches.

Price ingestion, review ingestion, and store-price proposal approval now use the same alias key for exact lookup and alias writes. This lets accepted aliases like `Ardbeg 10-year-old` match `Ardbeg 10 years old` without treating lossy normalized names like `Lagavulin Distillers Edition 2011 Release` as proof of the parent bottle.