### PR TITLE
feat(entities): Add entity alias management

### DIFF
--- a/apps/server/src/lib/db.ts
+++ b/apps/server/src/lib/db.ts
@@ -78,6 +78,16 @@ export function coerceToUpsert({
   return rv;
 }
 
+export class DuplicateEntityAliasError extends Error {
+  constructor(
+    readonly entityId: number,
+    readonly aliasName: string,
+  ) {
+    super(`Duplicate entity alias found (${entityId}) for "${aliasName}".`);
+    this.name = "DuplicateEntityAliasError";
+  }
+}
+
 function getEntityAliasNames({
   name,
   shortName,
@@ -243,9 +253,7 @@ export async function upsertEntityAliases({
       continue;
     }
 
-    throw new Error(
-      `Duplicate entity alias found (${existingAlias.entityId}) for "${aliasName}".`,
-    );
+    throw new DuplicateEntityAliasError(existingAlias.entityId, aliasName);
   }
 
   if (!previousEntity) {

--- a/apps/server/src/orpc/routes/entities/aliases/create.test.ts
+++ b/apps/server/src/orpc/routes/entities/aliases/create.test.ts
@@ -1,0 +1,157 @@
+import { db } from "@peated/server/db";
+import { changes, entityAliases } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { desc, eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+describe("POST /entities/:entity/aliases", () => {
+  test("creates entity alias", async ({ fixtures }) => {
+    const user = await fixtures.User({ mod: true });
+    const entity = await fixtures.Entity({ name: "Wolfburn" });
+
+    const data = await routerClient.entities.aliases.create(
+      {
+        entity: entity.id,
+        name: "Wolfburn Distillery",
+      },
+      { context: { user } },
+    );
+
+    expect(data).toMatchObject({
+      name: "Wolfburn Distillery",
+      isCanonical: false,
+    });
+
+    const [alias] = await db
+      .select()
+      .from(entityAliases)
+      .where(eq(entityAliases.name, "Wolfburn Distillery"));
+    expect(alias?.entityId).toBe(entity.id);
+
+    const [change] = await db
+      .select()
+      .from(changes)
+      .where(eq(changes.objectId, entity.id))
+      .orderBy(desc(changes.id))
+      .limit(1);
+    expect(change).toMatchObject({
+      objectType: "entity",
+      type: "update",
+      data: {
+        alias: "Wolfburn Distillery",
+      },
+    });
+  });
+
+  test("is idempotent when alias already belongs to entity", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const entity = await fixtures.Entity();
+    const alias = await fixtures.EntityAlias({
+      entityId: entity.id,
+      name: "Existing Alias",
+    });
+
+    const data = await routerClient.entities.aliases.create(
+      {
+        entity: entity.id,
+        name: "Existing Alias",
+      },
+      { context: { user } },
+    );
+
+    expect(data).toMatchObject({
+      name: alias.name,
+      isCanonical: false,
+    });
+  });
+
+  test("claims an unbound alias", async ({ fixtures }) => {
+    const user = await fixtures.User({ mod: true });
+    const entity = await fixtures.Entity();
+    await fixtures.EntityAlias({
+      entityId: null,
+      name: "Unbound Alias",
+    });
+
+    await routerClient.entities.aliases.create(
+      {
+        entity: entity.id,
+        name: "Unbound Alias",
+      },
+      { context: { user } },
+    );
+
+    const [alias] = await db
+      .select()
+      .from(entityAliases)
+      .where(eq(entityAliases.name, "Unbound Alias"));
+    expect(alias?.entityId).toBe(entity.id);
+  });
+
+  test("requires authentication", async () => {
+    const err = await waitError(() =>
+      routerClient.entities.aliases.create({
+        entity: 1,
+        name: "Test Alias",
+      }),
+    );
+    expect(err).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("requires mod privileges", async ({ fixtures }) => {
+    const user = await fixtures.User();
+    const entity = await fixtures.Entity();
+
+    const err = await waitError(() =>
+      routerClient.entities.aliases.create(
+        {
+          entity: entity.id,
+          name: "Test Alias",
+        },
+        { context: { user } },
+      ),
+    );
+    expect(err).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("rejects alias owned by another entity", async ({ fixtures }) => {
+    const user = await fixtures.User({ mod: true });
+    const entity = await fixtures.Entity();
+    const otherEntity = await fixtures.Entity();
+    await fixtures.EntityAlias({
+      entityId: otherEntity.id,
+      name: "Conflicting Alias",
+    });
+
+    const err = await waitError(() =>
+      routerClient.entities.aliases.create(
+        {
+          entity: entity.id,
+          name: "Conflicting Alias",
+        },
+        { context: { user } },
+      ),
+    );
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Alias already belongs to another entity (${otherEntity.id}).]`,
+    );
+  });
+
+  test("returns 404 for missing entity", async ({ fixtures }) => {
+    const user = await fixtures.User({ mod: true });
+
+    const err = await waitError(() =>
+      routerClient.entities.aliases.create(
+        {
+          entity: 123456789,
+          name: "Test Alias",
+        },
+        { context: { user } },
+      ),
+    );
+    expect(err).toMatchInlineSnapshot(`[Error: Entity not found.]`);
+  });
+});

--- a/apps/server/src/orpc/routes/entities/aliases/create.ts
+++ b/apps/server/src/orpc/routes/entities/aliases/create.ts
@@ -1,0 +1,134 @@
+import { normalizeEntityName } from "@peated/bottle-classifier/normalize";
+import { db } from "@peated/server/db";
+import type { EntityAlias } from "@peated/server/db/schema";
+import { changes, entities, entityAliases } from "@peated/server/db/schema";
+import { logError } from "@peated/server/lib/log";
+import { procedure } from "@peated/server/orpc";
+import { requireMod } from "@peated/server/orpc/middleware";
+import { pushUniqueJob } from "@peated/server/worker/client";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { z } from "zod";
+
+const OutputSchema = z.object({
+  name: z.string(),
+  isCanonical: z.boolean(),
+  createdAt: z.string(),
+});
+
+export default procedure
+  .use(requireMod)
+  .route({
+    method: "POST",
+    path: "/entities/{entity}/aliases",
+    summary: "Create entity alias",
+    description:
+      "Add an alias to an entity. Requires moderator privileges and refuses aliases already owned by another entity.",
+    operationId: "createEntityAlias",
+  })
+  .input(
+    z.object({
+      entity: z.coerce.number(),
+      name: z.string().trim().min(1),
+    }),
+  )
+  .output(OutputSchema)
+  .handler(async function ({ input, context, errors }) {
+    const aliasName = normalizeEntityName(input.name).trim();
+    if (!aliasName) {
+      throw errors.BAD_REQUEST({
+        message: "Alias name is required.",
+      });
+    }
+
+    const [entity] = await db
+      .select()
+      .from(entities)
+      .where(eq(entities.id, input.entity));
+
+    if (!entity) {
+      throw errors.NOT_FOUND({
+        message: "Entity not found.",
+      });
+    }
+
+    const lowerAliasName = aliasName.toLowerCase();
+
+    const alias = await db.transaction(async (tx) => {
+      const existingAlias = await tx.query.entityAliases.findFirst({
+        where: eq(sql`LOWER(${entityAliases.name})`, lowerAliasName),
+      });
+
+      if (existingAlias?.entityId === entity.id) {
+        return existingAlias;
+      }
+
+      if (existingAlias?.entityId) {
+        throw errors.CONFLICT({
+          message: `Alias already belongs to another entity (${existingAlias.entityId}).`,
+        });
+      }
+
+      let nextAlias: EntityAlias | undefined;
+      if (existingAlias) {
+        [nextAlias] = await tx
+          .update(entityAliases)
+          .set({
+            name: aliasName,
+            entityId: entity.id,
+          })
+          .where(
+            and(
+              eq(sql`LOWER(${entityAliases.name})`, lowerAliasName),
+              isNull(entityAliases.entityId),
+            ),
+          )
+          .returning();
+      } else {
+        [nextAlias] = await tx
+          .insert(entityAliases)
+          .values({
+            name: aliasName,
+            entityId: entity.id,
+          })
+          .onConflictDoNothing()
+          .returning();
+      }
+
+      if (!nextAlias) {
+        throw errors.CONFLICT({
+          message: "Alias already exists.",
+        });
+      }
+
+      await tx.insert(changes).values({
+        objectType: "entity",
+        objectId: entity.id,
+        displayName: entity.name,
+        createdById: context.user.id,
+        type: "update",
+        data: {
+          alias: aliasName,
+        },
+      });
+
+      return nextAlias;
+    });
+
+    try {
+      await pushUniqueJob("IndexEntitySearchVectors", {
+        entityId: entity.id,
+      });
+    } catch (err) {
+      logError(err, {
+        entity: {
+          id: entity.id,
+        },
+      });
+    }
+
+    return {
+      name: alias.name,
+      isCanonical: alias.name.toLowerCase() === entity.name.toLowerCase(),
+      createdAt: alias.createdAt.toISOString(),
+    };
+  });

--- a/apps/server/src/orpc/routes/entities/aliases/index.ts
+++ b/apps/server/src/orpc/routes/entities/aliases/index.ts
@@ -1,7 +1,9 @@
+import create from "./create";
 import delete_ from "./delete";
 import list from "./list";
 
 export default {
+  create,
   list,
   delete: delete_,
 };

--- a/apps/server/src/orpc/routes/entities/create.ts
+++ b/apps/server/src/orpc/routes/entities/create.ts
@@ -9,7 +9,10 @@ import {
   regions,
 } from "@peated/server/db/schema";
 import { queueEntityCreationVerification } from "@peated/server/lib/catalogVerification";
-import { upsertEntityAliases } from "@peated/server/lib/db";
+import {
+  DuplicateEntityAliasError,
+  upsertEntityAliases,
+} from "@peated/server/lib/db";
 import { logError } from "@peated/server/lib/log";
 import { buildEntitySearchVector } from "@peated/server/lib/search";
 import { procedure } from "@peated/server/orpc";
@@ -114,25 +117,34 @@ export default procedure
         return null;
       }
 
-      await Promise.all([
-        upsertEntityAliases({
+      try {
+        await upsertEntityAliases({
           db: tx,
           entity,
-        }),
-        tx.insert(changes).values({
-          objectType: "entity",
-          objectId: entity.id,
-          displayName: entity.name,
-          type: "add",
-          createdAt: entity.createdAt,
-          createdById: user.id,
-          data: {
-            ...data,
-            catalogVerification:
-              buildCatalogVerificationCreationMetadata("manual_entry"),
-          },
-        }),
-      ]);
+        });
+      } catch (err) {
+        if (err instanceof DuplicateEntityAliasError) {
+          throw errors.CONFLICT({
+            message: err.message,
+            cause: err,
+          });
+        }
+        throw err;
+      }
+
+      await tx.insert(changes).values({
+        objectType: "entity",
+        objectId: entity.id,
+        displayName: entity.name,
+        type: "add",
+        createdAt: entity.createdAt,
+        createdById: user.id,
+        data: {
+          ...data,
+          catalogVerification:
+            buildCatalogVerificationCreationMetadata("manual_entry"),
+        },
+      });
 
       return {
         entity,

--- a/apps/server/src/orpc/routes/entities/update.test.ts
+++ b/apps/server/src/orpc/routes/entities/update.test.ts
@@ -396,6 +396,47 @@ describe("PATCH /entities/:entity", () => {
     expect(preservedShortNameAlias?.entityId).toEqual(entity.id);
   });
 
+  test("rejects a rename that would claim another entity alias", async ({
+    fixtures,
+  }) => {
+    const entity = await fixtures.Entity({
+      name: "Original Distillery",
+    });
+    const aliasOwner = await fixtures.Entity({
+      name: "Alias Owner",
+    });
+    await fixtures.EntityAlias({
+      entityId: aliasOwner.id,
+      name: "Mars Shinshu",
+    });
+
+    const modUser = await fixtures.User({ mod: true });
+    const err = await waitError(
+      routerClient.entities.update(
+        {
+          entity: entity.id,
+          name: "Mars Shinshu",
+        },
+        { context: { user: modUser } },
+      ),
+    );
+
+    expect(err.message).toBe(
+      `Duplicate entity alias found (${aliasOwner.id}) for "Mars Shinshu".`,
+    );
+
+    const [unchangedEntity] = await db
+      .select()
+      .from(entities)
+      .where(eq(entities.id, entity.id));
+    expect(unchangedEntity.name).toBe("Original Distillery");
+
+    const conflictingAlias = await db.query.entityAliases.findFirst({
+      where: eq(entityAliases.name, "Mars Shinshu"),
+    });
+    expect(conflictingAlias?.entityId).toBe(aliasOwner.id);
+  });
+
   test("changing short name retires the old entity alias", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/entities/update.ts
+++ b/apps/server/src/orpc/routes/entities/update.ts
@@ -9,7 +9,10 @@ import {
   entities,
   regions,
 } from "@peated/server/db/schema";
-import { upsertEntityAliases } from "@peated/server/lib/db";
+import {
+  DuplicateEntityAliasError,
+  upsertEntityAliases,
+} from "@peated/server/lib/db";
 import { arraysEqual } from "@peated/server/lib/equals";
 import { logError } from "@peated/server/lib/log";
 import { procedure } from "@peated/server/orpc";
@@ -182,11 +185,21 @@ export default procedure
       if (!newEntity) return;
 
       if (data.name || data.shortName !== undefined) {
-        await upsertEntityAliases({
-          db: tx,
-          entity: newEntity,
-          previousEntity: entity,
-        });
+        try {
+          await upsertEntityAliases({
+            db: tx,
+            entity: newEntity,
+            previousEntity: entity,
+          });
+        } catch (err) {
+          if (err instanceof DuplicateEntityAliasError) {
+            throw errors.CONFLICT({
+              message: err.message,
+              cause: err,
+            });
+          }
+          throw err;
+        }
       }
 
       if (data.name || data.shortName !== undefined) {

--- a/apps/web/src/app/(default)/entities/[entityId]/aliases/page.tsx
+++ b/apps/web/src/app/(default)/entities/[entityId]/aliases/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
+import Button from "@peated/web/components/button";
 import Chip from "@peated/web/components/chip";
 import ConfirmationButton from "@peated/web/components/confirmationButton";
 import Table from "@peated/web/components/table";
+import TextField from "@peated/web/components/textField";
 import TimeSince from "@peated/web/components/timeSince";
 import useAuth from "@peated/web/hooks/useAuth";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { useState, type FormEvent } from "react";
 
 export default function EntityAliases({
   params: { entityId },
@@ -15,53 +22,110 @@ export default function EntityAliases({
 }) {
   const { user } = useAuth();
   const orpc = useORPC();
-  const { data: aliasList } = useSuspenseQuery(
-    orpc.entities.aliases.list.queryOptions({
-      input: { entity: Number(entityId) },
-    }),
+  const queryClient = useQueryClient();
+  const aliasesQueryOptions = orpc.entities.aliases.list.queryOptions({
+    input: { entity: Number(entityId) },
+  });
+  const { data: aliasList } = useSuspenseQuery(aliasesQueryOptions);
+  const [aliasName, setAliasName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const createAliasMutation = useMutation(
+    orpc.entities.aliases.create.mutationOptions(),
   );
 
   const deleteAliasMutation = useMutation(
     orpc.entities.aliases.delete.mutationOptions(),
   );
 
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    try {
+      await createAliasMutation.mutateAsync({
+        entity: Number(entityId),
+        name: aliasName,
+      });
+      setAliasName("");
+      await queryClient.invalidateQueries({
+        queryKey: aliasesQueryOptions.queryKey,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to add alias.");
+    }
+  };
+
   return (
-    <Table
-      items={aliasList.results}
-      columns={[
-        {
-          name: "name",
-          value: (item) => (
-            <>
-              <div>{item.name}</div>
-              {item.isCanonical && (
-                <Chip as="div" size="small" color="highlight">
-                  Canonical
-                </Chip>
-              )}
-            </>
-          ),
-        },
-        {
-          name: "created",
-          value: (item) => <TimeSince date={item.createdAt} />,
-        },
-        {
-          hidden: !user?.mod,
-          name: "delete",
-          title: "",
-          value: (item) =>
-            !item.isCanonical && (
-              <ConfirmationButton
-                onContinue={() =>
-                  deleteAliasMutation.mutate({ name: item.name })
-                }
-              >
-                Delete
-              </ConfirmationButton>
+    <>
+      {user?.mod && (
+        <form
+          className="mb-6 flex flex-col gap-3 border border-slate-800 sm:flex-row sm:items-start"
+          onSubmit={onSubmit}
+        >
+          <TextField
+            name="alias"
+            label="Alias"
+            value={aliasName}
+            onChange={(event) =>
+              setAliasName((event.target as HTMLInputElement).value)
+            }
+            error={error ? { message: error } : undefined}
+            className="flex-1"
+          />
+          <Button
+            type="submit"
+            color="primary"
+            disabled={!aliasName.trim() || createAliasMutation.isPending}
+            loading={createAliasMutation.isPending}
+            className="m-4 sm:mt-9"
+          >
+            Add Alias
+          </Button>
+        </form>
+      )}
+      <Table
+        items={aliasList.results}
+        columns={[
+          {
+            name: "name",
+            value: (item) => (
+              <>
+                <div>{item.name}</div>
+                {item.isCanonical && (
+                  <Chip as="div" size="small" color="highlight">
+                    Canonical
+                  </Chip>
+                )}
+              </>
             ),
-        },
-      ]}
-    />
+          },
+          {
+            name: "created",
+            value: (item) => <TimeSince date={item.createdAt} />,
+          },
+          {
+            hidden: !user?.mod,
+            name: "delete",
+            title: "",
+            value: (item) =>
+              !item.isCanonical && (
+                <ConfirmationButton
+                  onContinue={async () => {
+                    await deleteAliasMutation.mutateAsync({
+                      name: item.name,
+                    });
+                    await queryClient.invalidateQueries({
+                      queryKey: aliasesQueryOptions.queryKey,
+                    });
+                  }}
+                >
+                  Delete
+                </ConfirmationButton>
+              ),
+          },
+        ]}
+      />
+    </>
   );
 }

--- a/packages/bottle-classifier/src/smws.test.ts
+++ b/packages/bottle-classifier/src/smws.test.ts
@@ -50,6 +50,36 @@ describe("smws", () => {
       name: "RW6.5 Sauna Smoke",
       selector: "Sauna Smoke",
     });
+    expect(parseReferenceName("SMWS 162.1 Island intrigue")).toMatchObject({
+      category: "single_malt",
+      code: "162.1",
+      distiller: "Isle of Raasay Distillery",
+    });
+    expect(parseReferenceName("SMWS 164.1 Welsh rarity")).toMatchObject({
+      category: "single_malt",
+      code: "164.1",
+      distiller: "Penderyn Distillery",
+    });
+    expect(parseReferenceName("SMWS 165.1 Northern peat")).toMatchObject({
+      category: "single_malt",
+      code: "165.1",
+      distiller: "Wolfburn",
+    });
+    expect(parseReferenceName("SMWS 166.1 Island smoke")).toMatchObject({
+      category: "single_malt",
+      code: "166.1",
+      distiller: "Torabhaig",
+    });
+    expect(parseReferenceName("SMWS 167.1 Riverside dram")).toMatchObject({
+      category: "single_malt",
+      code: "167.1",
+      distiller: "The Clydeside Distillery",
+    });
+    expect(parseReferenceName("SMWS 168.1 KinGlassie preview")).toMatchObject({
+      category: "single_malt",
+      code: "168.1",
+      distiller: "InchDairnie Distillery",
+    });
     expect(parseReferenceName("RW6.5 Sauna Smoke")).toBeNull();
     expect(parseReferenceName("SMWS single cask 54.2% ABV")).toBeNull();
   });

--- a/packages/bottle-classifier/src/smws.ts
+++ b/packages/bottle-classifier/src/smws.ts
@@ -184,11 +184,16 @@ export const SMWS_DISTILLERY_CODES: Record<string, string> = {
   156: "Glasgow Distillery",
   157: "Armorik",
   158: "Yuza",
-  159: "Komagatake",
-  160: "Tsunuki",
-  161: "Mc'nean Distillery",
-  162: "",
+  159: "Mars Shinshu",
+  160: "Mars Tsunuki",
+  161: "Nc'nean Distillery",
+  162: "Isle of Raasay Distillery",
   163: "Isle of Harris Distillery",
+  164: "Penderyn Distillery", // double distilled
+  165: "Wolfburn", // peated
+  166: "Torabhaig",
+  167: "The Clydeside Distillery",
+  168: "InchDairnie Distillery", // KinGlassie
 
   // Single Grain
   G1: "North British",


### PR DESCRIPTION
Add moderator-facing entity alias creation from the entity aliases page, backed by a new entity alias create route. This lets moderators attach alternate names without needing direct database edits, while preserving existing alias ownership rules and safely claiming aliases that were previously unbound.

The route records entity alias changes, handles duplicate-alias conflicts consistently with entity create/update, and keeps search reindexing best-effort after the database write so a queue outage does not fail the user action.

This also updates the SMWS distillery mapping through code 168, including the Wolfburn canonical short name and coverage for the newly added codes.