### PR TITLE
fix(api): Reuse GCS client for uploads

### DIFF
--- a/apps/server/src/app.test.ts
+++ b/apps/server/src/app.test.ts
@@ -1,0 +1,22 @@
+import config from "@peated/server/config";
+import { mkdir, writeFile } from "fs/promises";
+import { join } from "path";
+import { describe, expect, test } from "vitest";
+import { app } from "./app";
+
+describe("GET /uploads/:filename", () => {
+  test("serves uploaded image files with image headers", async () => {
+    const filename = "test-upload.webp";
+    const imageBytes = Buffer.from("RIFF\x00\x00\x00\x00WEBP");
+
+    await mkdir(config.UPLOAD_PATH, { recursive: true });
+    await writeFile(join(config.UPLOAD_PATH, filename), imageBytes);
+
+    const response = await app.request(`/uploads/${filename}`);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toBe("image/webp");
+    expect(response.headers.get("cache-control")).toBe("public, max-age=86400");
+    expect(Buffer.from(await response.arrayBuffer())).toEqual(imageBytes);
+  });
+});

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -1,4 +1,3 @@
-import { Storage } from "@google-cloud/storage";
 import { getConnInfo } from "@hono/node-server/conninfo";
 import { OpenAPIGenerator } from "@orpc/openapi";
 import { OpenAPIHandler } from "@orpc/openapi/fetch";
@@ -26,12 +25,14 @@ import { cors } from "hono/cors";
 import { logger } from "hono/logger";
 import { secureHeaders } from "hono/secure-headers";
 import { contentType } from "mime-types";
+import { Readable } from "node:stream";
 import { setTimeout } from "node:timers/promises";
 import { format } from "path";
 import type { ZodIssue } from "zod";
 import { ZodError } from "zod";
 import config from "./config";
 import { getUserFromHeader } from "./lib/auth";
+import { getStorage } from "./lib/gcs";
 import { logError } from "./lib/log";
 import router from "./orpc/router";
 import {
@@ -206,17 +207,14 @@ export const app = new Hono()
   .get("/uploads/:filename", async (c) => {
     const filename = c.req.param("filename");
 
-    let stream;
+    let stream: Readable;
     if (process.env.USE_GCS_STORAGE) {
       const bucketName = process.env.GCS_BUCKET_NAME as string;
       const bucketPath = process.env.GCS_BUCKET_PATH
         ? `${process.env.GCS_BUCKET_PATH}/`
         : "";
 
-      const cloudStorage = new Storage({
-        credentials: config.GCP_CREDENTIALS,
-      });
-      const file = cloudStorage
+      const file = getStorage()
         .bucket(bucketName)
         .file(`${bucketPath}${filename}`);
 
@@ -242,9 +240,7 @@ export const app = new Hono()
       contentType(filename) || "application/octet-stream",
     );
 
-    // Return the stream
-    // TODO: fix this
-    return c.body(stream as any);
+    return c.body(Readable.toWeb(stream) as ReadableStream<Uint8Array>);
   })
   .get("/", async (c) => {
     return c.html(`

--- a/apps/server/src/lib/gcs.ts
+++ b/apps/server/src/lib/gcs.ts
@@ -1,0 +1,12 @@
+import { Storage } from "@google-cloud/storage";
+import config from "../config";
+
+let storage: Storage | null = null;
+
+export function getStorage() {
+  storage ??= new Storage({
+    credentials: config.GCP_CREDENTIALS,
+  });
+
+  return storage;
+}

--- a/apps/server/src/lib/uploads.ts
+++ b/apps/server/src/lib/uploads.ts
@@ -1,4 +1,3 @@
-import { Storage } from "@google-cloud/storage";
 import { createId } from "@paralleldrive/cuid2";
 import { createWriteStream } from "node:fs";
 import sharp from "sharp";
@@ -7,6 +6,7 @@ import { startSpan } from "@sentry/node";
 import type { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import config from "../config";
+import { getStorage } from "./gcs";
 
 export const compressAndResizeImage = (
   stream: Readable,
@@ -83,10 +83,7 @@ export async function copyFile({
           bucketName,
         });
 
-        const cloudStorage = new Storage({
-          credentials: config.GCP_CREDENTIALS,
-        });
-
+        const cloudStorage = getStorage();
         const dest = cloudStorage
           .bucket(bucketName)
           .file(`${bucketPath}${output}`);
@@ -157,10 +154,6 @@ export const storeFile = async ({
           ? `${config.GCS_BUCKET_PATH}/`
           : "";
 
-        const cloudStorage = new Storage({
-          credentials: config.GCP_CREDENTIALS,
-        });
-
         await startSpan(
           {
             op: "gcs.file",
@@ -170,7 +163,7 @@ export const storeFile = async ({
             span?.setAttributes({
               bucketName,
             });
-            const file = cloudStorage
+            const file = getStorage()
               .bucket(bucketName)
               .file(`${bucketPath}${newFilename}`);
 


### PR DESCRIPTION
Reuse one Google Cloud Storage client for upload reads and writes instead of constructing a fresh client for each request. This reduces token churn in the image storage path, which was implicated while investigating production uploads returning HTML 503 responses that Chrome surfaced as ORB-blocked images.

The upload serving route now passes a proper Web stream to Hono instead of casting the Node stream, and the new route test covers serving uploaded image bytes with the expected image headers.

Validation run locally:
- pnpm test
- pnpm --filter @peated/server test -- src/app.test.ts src/orpc/routes/bottles/image-update.test.ts src/orpc/routes/badges/image-update.test.ts src/orpc/routes/tastings/image-update.test.ts src/orpc/routes/users/avatar-update.test.ts