### PR TITLE
feat(tastings): Add photo identification API

### DIFF
--- a/apps/server/src/lib/photoIdentification.ts
+++ b/apps/server/src/lib/photoIdentification.ts
@@ -1,0 +1,221 @@
+import { createWhiskyLabelExtractor } from "@peated/bottle-classifier";
+import {
+  BottleExtractedDetailsSchema,
+  ImageBottleEvidenceSchema,
+  createIgnoredBottleClassification,
+  type BottleClassificationResult,
+  type BottleExtractedDetails,
+  type ImageBottleEvidence,
+} from "@peated/server/agents/bottleClassifier";
+import config from "@peated/server/config";
+import { absoluteUrl } from "@peated/server/lib/urls";
+import OpenAI from "openai";
+
+const PHOTO_IDENTIFICATION_TIMEOUT_MS = 10_000;
+
+type PhotoIdentificationPendingImage = {
+  id: string;
+  imageUrl: string;
+};
+
+function createOpenAIClient(): OpenAI {
+  return new OpenAI({
+    apiKey: config.OPENAI_API_KEY,
+    baseURL: config.OPENAI_HOST,
+    organization: config.OPENAI_ORGANIZATION,
+    project: config.OPENAI_PROJECT,
+  });
+}
+
+function maybeField<T extends string | number>(
+  value: T | null | undefined,
+  confidence = 0.75,
+) {
+  if (value === null || value === undefined || value === "") {
+    return undefined;
+  }
+
+  return {
+    value,
+    confidence,
+    sourceExtractorIndexes: [0],
+  };
+}
+
+/**
+ * Converts reviewed label extraction output into the image-evidence contract
+ * consumed by the bottle classifier and returned by photo identification.
+ */
+export function buildPhotoEvidenceFromExtractedIdentity({
+  pendingUpload,
+  extractedIdentity,
+}: {
+  pendingUpload: PhotoIdentificationPendingImage;
+  extractedIdentity: BottleExtractedDetails | null;
+}): ImageBottleEvidence {
+  const labelParts = [
+    extractedIdentity?.brand,
+    extractedIdentity?.expression,
+    extractedIdentity?.series,
+    extractedIdentity?.edition,
+    extractedIdentity?.stated_age
+      ? `${extractedIdentity.stated_age} year old`
+      : null,
+    extractedIdentity?.abv ? `${extractedIdentity.abv}% ABV` : null,
+    extractedIdentity?.vintage_year
+      ? `${extractedIdentity.vintage_year} vintage`
+      : null,
+    extractedIdentity?.release_year
+      ? `${extractedIdentity.release_year} release`
+      : null,
+  ].filter(Boolean);
+
+  return ImageBottleEvidenceSchema.parse({
+    sourceImageId: pendingUpload.id,
+    extractors: [
+      {
+        kind: "vision",
+        model: config.OPENAI_MODEL,
+        confidence: extractedIdentity ? 0.75 : 0,
+        textSpans: labelParts.length
+          ? [
+              {
+                text: labelParts.join(" "),
+                confidence: 0.75,
+              },
+            ]
+          : [],
+        observations: extractedIdentity
+          ? ["Read whisky label identity from the uploaded bottle photo."]
+          : ["No reliable bottle identity was read from the uploaded photo."],
+      },
+    ],
+    fieldCandidates: {
+      brand: maybeField(extractedIdentity?.brand),
+      expression: maybeField(extractedIdentity?.expression),
+      statedAge: maybeField(extractedIdentity?.stated_age),
+      abv: maybeField(extractedIdentity?.abv),
+      vintageYear: maybeField(extractedIdentity?.vintage_year),
+      releaseYear: maybeField(extractedIdentity?.release_year),
+      edition: maybeField(extractedIdentity?.edition),
+      caskType: maybeField(extractedIdentity?.cask_type),
+    },
+    photoSuitability: {
+      isSingleBottlePhoto: Boolean(extractedIdentity),
+      labelReadable: Boolean(extractedIdentity),
+      suitableAsTastingImage: true,
+      suitableAsBottleImage: Boolean(extractedIdentity),
+      reason: extractedIdentity
+        ? null
+        : "No reliable label identity was extracted from the photo.",
+    },
+    conflicts: [],
+  });
+}
+
+/**
+ * Runs the server-owned whisky label extraction boundary for a pending image.
+ */
+export async function extractPhotoBottleEvidence({
+  pendingUpload,
+}: {
+  pendingUpload: PhotoIdentificationPendingImage;
+}): Promise<{
+  extractedIdentity: BottleExtractedDetails | null;
+  imageEvidence: ImageBottleEvidence;
+}> {
+  if (!config.OPENAI_API_KEY) {
+    return {
+      extractedIdentity: null,
+      imageEvidence: buildPhotoEvidenceFromExtractedIdentity({
+        pendingUpload,
+        extractedIdentity: null,
+      }),
+    };
+  }
+
+  const extractor = createWhiskyLabelExtractor({
+    client: createOpenAIClient(),
+    model: config.OPENAI_MODEL,
+  });
+  const extractedIdentity = BottleExtractedDetailsSchema.nullable().parse(
+    await extractor.extractFromImage(
+      absoluteUrl(config.API_SERVER, pendingUpload.imageUrl),
+    ),
+  );
+
+  return {
+    extractedIdentity,
+    imageEvidence: buildPhotoEvidenceFromExtractedIdentity({
+      pendingUpload,
+      extractedIdentity,
+    }),
+  };
+}
+
+export function buildPhotoReferenceName(
+  extractedIdentity: BottleExtractedDetails | null,
+) {
+  const parts = [
+    extractedIdentity?.brand,
+    extractedIdentity?.expression,
+    extractedIdentity?.series,
+    extractedIdentity?.edition,
+    extractedIdentity?.stated_age
+      ? `${extractedIdentity.stated_age} year old`
+      : null,
+    extractedIdentity?.vintage_year
+      ? `${extractedIdentity.vintage_year}`
+      : null,
+  ].filter(Boolean);
+
+  return parts.length ? parts.join(" ") : "Bottle photo upload";
+}
+
+/**
+ * Creates the classifier-shaped fallback result used when the photo flow should
+ * preserve the pending image and continue through manual search.
+ */
+export function createManualSearchPhotoClassification({
+  imageEvidence,
+  reason = "Photo identification could not produce a reviewed bottle match.",
+}: {
+  imageEvidence: ImageBottleEvidence;
+  reason?: string;
+}): BottleClassificationResult {
+  return createIgnoredBottleClassification({
+    reason,
+    artifacts: {
+      extractedIdentity: null,
+      imageEvidence,
+      candidates: [],
+      searchEvidence: [],
+      resolvedEntities: [],
+    },
+  });
+}
+
+/**
+ * Bounds the user-visible identification wait while returning a caller-owned
+ * fallback result instead of failing the pending upload.
+ */
+export async function withPhotoIdentificationTimeout<T>(
+  work: Promise<T>,
+  fallback: () => T,
+  timeoutMs = PHOTO_IDENTIFICATION_TIMEOUT_MS,
+): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+
+  try {
+    return await Promise.race([
+      work,
+      new Promise<T>((resolve) => {
+        timeout = setTimeout(() => resolve(fallback()), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timeout) {
+      clearTimeout(timeout);
+    }
+  }
+}

--- a/apps/server/src/orpc/middleware/rateLimit.ts
+++ b/apps/server/src/orpc/middleware/rateLimit.ts
@@ -10,11 +10,17 @@ interface RateLimitOptions {
   keyPrefix?: string; // Optional prefix for the rate limit key
 }
 
-export function createRateLimit(options: RateLimitOptions) {
+/**
+ * Builds reusable rate-limit middleware while preserving any route-specific
+ * context narrowing applied before this middleware runs.
+ */
+export function createRateLimit<TContext extends Context = Context>(
+  options: RateLimitOptions,
+) {
   const { windowMs, maxRequests, keyPrefix = "rl" } = options;
 
   return base
-    .$context<Context>()
+    .$context<TContext>()
     .middleware(async ({ context, next, errors }) => {
       // Use user ID for authenticated users, IP for anonymous
       const identifier = context.user?.id?.toString() || context.ip;

--- a/apps/server/src/orpc/routes/tastings/index.ts
+++ b/apps/server/src/orpc/routes/tastings/index.ts
@@ -6,6 +6,7 @@ import details from "./details";
 import imageDelete from "./image-delete";
 import imageUpdate from "./image-update";
 import list from "./list";
+import photoIdentification from "./photo-identification";
 import update from "./update";
 
 export default base.tag("tastings").router({
@@ -17,4 +18,5 @@ export default base.tag("tastings").router({
   delete: delete_,
   imageUpdate,
   imageDelete,
+  photoIdentification,
 });

--- a/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
@@ -1,0 +1,347 @@
+import { MAX_FILESIZE } from "@peated/server/constants";
+import { db } from "@peated/server/db";
+import {
+  bottleReleases,
+  bottles,
+  pendingUploads,
+  tastings,
+} from "@peated/server/db/schema";
+import type * as photoIdentificationModule from "@peated/server/lib/photoIdentification";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { eq } from "drizzle-orm";
+import { beforeEach, vi } from "vitest";
+
+const classifyBottleReferenceMock = vi.hoisted(() => vi.fn());
+const extractPhotoBottleEvidenceMock = vi.hoisted(() => vi.fn());
+
+vi.mock(
+  "@peated/server/agents/bottleClassifier/classifyBottleReference",
+  () => ({
+    classifyBottleReference: classifyBottleReferenceMock,
+  }),
+);
+
+vi.mock("@peated/server/lib/photoIdentification", async () => {
+  const actual = await vi.importActual<typeof photoIdentificationModule>(
+    "@peated/server/lib/photoIdentification",
+  );
+
+  return {
+    ...actual,
+    extractPhotoBottleEvidence: extractPhotoBottleEvidenceMock,
+  };
+});
+
+function buildImageEvidence(sourceImageId: string) {
+  return {
+    sourceImageId,
+    extractors: [
+      {
+        kind: "vision" as const,
+        model: "test-vision",
+        confidence: 0.9,
+        textSpans: [{ text: "Ardbeg Uigeadail", confidence: 0.9 }],
+        observations: ["Readable Ardbeg Uigeadail front label."],
+      },
+    ],
+    fieldCandidates: {
+      brand: {
+        value: "Ardbeg",
+        confidence: 0.9,
+        sourceExtractorIndexes: [0],
+      },
+      expression: {
+        value: "Uigeadail",
+        confidence: 0.9,
+        sourceExtractorIndexes: [0],
+      },
+    },
+    photoSuitability: {
+      isSingleBottlePhoto: true,
+      labelReadable: true,
+      suitableAsTastingImage: true,
+      suitableAsBottleImage: true,
+    },
+    conflicts: [],
+  };
+}
+
+function buildClassification(decision: Record<string, unknown>) {
+  return {
+    status: "classified" as const,
+    decision: {
+      confidence: 90,
+      rationale: "test fixture",
+      candidateBottleIds: [],
+      ...decision,
+    },
+    artifacts: {
+      extractedIdentity: null,
+      imageEvidence: null,
+      candidates: [],
+      searchEvidence: [],
+      resolvedEntities: [],
+    },
+  };
+}
+
+async function countRows() {
+  const [bottleRows, releaseRows, tastingRows] = await Promise.all([
+    db.select({ id: bottles.id }).from(bottles),
+    db.select({ id: bottleReleases.id }).from(bottleReleases),
+    db.select({ id: tastings.id }).from(tastings),
+  ]);
+
+  return {
+    bottles: bottleRows.length,
+    releases: releaseRows.length,
+    tastings: tastingRows.length,
+  };
+}
+
+describe("POST /tastings/photo-identification", () => {
+  beforeEach(() => {
+    classifyBottleReferenceMock.mockReset();
+    extractPhotoBottleEvidenceMock.mockReset();
+  });
+
+  test("requires authentication", async ({ fixtures }) => {
+    const err = await waitError(
+      routerClient.tastings.photoIdentification({
+        file: await fixtures.SampleSquareImage(),
+        idempotencyKey: "requires-authentication",
+      }),
+    );
+
+    expect(err).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("returns pending image, evidence, classification, and next step", async ({
+    fixtures,
+    defaults,
+  }) => {
+    const before = await countRows();
+    const matchedBottle = await fixtures.Bottle({
+      fullName: "Ardbeg Uigeadail",
+    });
+
+    extractPhotoBottleEvidenceMock.mockImplementation(
+      async ({ pendingUpload }) => ({
+        extractedIdentity: {
+          brand: "Ardbeg",
+          bottler: null,
+          expression: "Uigeadail",
+          series: null,
+          distillery: null,
+          category: "single_malt",
+          stated_age: null,
+          abv: null,
+          release_year: null,
+          vintage_year: null,
+          cask_type: null,
+          cask_size: null,
+          cask_fill: null,
+          cask_strength: null,
+          single_cask: null,
+          edition: null,
+        },
+        imageEvidence: buildImageEvidence(pendingUpload.id),
+      }),
+    );
+    classifyBottleReferenceMock.mockResolvedValue(
+      buildClassification({
+        action: "match",
+        matchedBottleId: matchedBottle.id,
+        matchedReleaseId: null,
+      }),
+    );
+
+    const response = await routerClient.tastings.photoIdentification(
+      {
+        file: await fixtures.SampleSquareImage(),
+        idempotencyKey: "photo-identification-success",
+      },
+      {
+        context: { user: defaults.user },
+      },
+    );
+
+    expect(response.pendingImage.id).toBeDefined();
+    expect(response.pendingImage.imageUrl).toContain(
+      "/uploads/pending-uploads/",
+    );
+    expect(response.imageEvidence.sourceImageId).toBe(response.pendingImage.id);
+    expect(response.classification.status).toBe("classified");
+    expect(response.suggestedNextStep).toBe("confirm_match");
+
+    expect(classifyBottleReferenceMock).toHaveBeenCalledWith({
+      reference: {
+        id: response.pendingImage.id,
+        name: "Ardbeg Uigeadail",
+        url: null,
+        imageUrl: response.pendingImage.imageUrl,
+      },
+      extractedIdentity: expect.objectContaining({
+        brand: "Ardbeg",
+        expression: "Uigeadail",
+      }),
+      imageEvidence: expect.objectContaining({
+        sourceImageId: response.pendingImage.id,
+      }),
+    });
+
+    const after = await countRows();
+    expect(after).toEqual({
+      bottles: before.bottles + 1,
+      releases: before.releases,
+      tastings: before.tastings,
+    });
+  });
+
+  test("reuses pending upload for idempotent retries", async ({
+    fixtures,
+    defaults,
+  }) => {
+    extractPhotoBottleEvidenceMock.mockImplementation(
+      async ({ pendingUpload }) => ({
+        extractedIdentity: null,
+        imageEvidence: buildImageEvidence(pendingUpload.id),
+      }),
+    );
+    classifyBottleReferenceMock.mockResolvedValue(
+      buildClassification({ action: "no_match" }),
+    );
+
+    const first = await routerClient.tastings.photoIdentification(
+      {
+        file: await fixtures.SampleSquareImage(),
+        idempotencyKey: "photo-identification-retry",
+      },
+      {
+        context: { user: defaults.user },
+      },
+    );
+    const second = await routerClient.tastings.photoIdentification(
+      {
+        file: await fixtures.SampleSquareImage(),
+        idempotencyKey: "photo-identification-retry",
+      },
+      {
+        context: { user: defaults.user },
+      },
+    );
+
+    expect(second.pendingImage.id).toBe(first.pendingImage.id);
+
+    const rows = await db
+      .select()
+      .from(pendingUploads)
+      .where(eq(pendingUploads.createdById, defaults.user.id));
+    expect(rows).toHaveLength(1);
+  });
+
+  test("rejects oversized upload before extraction or classification", async ({
+    defaults,
+  }) => {
+    const err = await waitError(
+      routerClient.tastings.photoIdentification(
+        {
+          file: new Blob([new Uint8Array(MAX_FILESIZE + 1)]),
+          idempotencyKey: "photo-identification-oversized",
+        },
+        {
+          context: { user: defaults.user },
+        },
+      ),
+    );
+
+    expect(err).toMatchInlineSnapshot(
+      `[Error: File exceeded maximum upload size of 20.0 MiB.]`,
+    );
+    expect(extractPhotoBottleEvidenceMock).not.toHaveBeenCalled();
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
+  });
+
+  test("falls back to manual search when classifier does not match", async ({
+    fixtures,
+    defaults,
+  }) => {
+    extractPhotoBottleEvidenceMock.mockImplementation(
+      async ({ pendingUpload }) => ({
+        extractedIdentity: null,
+        imageEvidence: buildImageEvidence(pendingUpload.id),
+      }),
+    );
+    classifyBottleReferenceMock.mockResolvedValue(
+      buildClassification({ action: "no_match" }),
+    );
+
+    const response = await routerClient.tastings.photoIdentification(
+      {
+        file: await fixtures.SampleSquareImage(),
+        idempotencyKey: "photo-identification-manual-search",
+      },
+      {
+        context: { user: defaults.user },
+      },
+    );
+
+    expect(response.suggestedNextStep).toBe("manual_search");
+  });
+
+  test("returns pending image with manual search fallback when extraction fails", async ({
+    fixtures,
+    defaults,
+  }) => {
+    extractPhotoBottleEvidenceMock.mockRejectedValue(
+      new Error("vision provider unavailable"),
+    );
+
+    const response = await routerClient.tastings.photoIdentification(
+      {
+        file: await fixtures.SampleSquareImage(),
+        idempotencyKey: "photo-identification-extraction-failure",
+      },
+      {
+        context: { user: defaults.user },
+      },
+    );
+
+    expect(response.pendingImage.id).toBeDefined();
+    expect(response.suggestedNextStep).toBe("manual_search");
+    expect(response.classification).toMatchObject({
+      status: "ignored",
+      reason: "Photo identification could not produce a reviewed bottle match.",
+    });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
+  });
+
+  test("returns pending image with manual search fallback when identification times out", async ({
+    fixtures,
+    defaults,
+  }) => {
+    extractPhotoBottleEvidenceMock.mockImplementation(
+      () => new Promise(() => undefined),
+    );
+
+    const response = await routerClient.tastings.photoIdentification(
+      {
+        file: await fixtures.SampleSquareImage(),
+        idempotencyKey: "photo-identification-timeout",
+      },
+      {
+        context: { user: defaults.user },
+      },
+    );
+
+    expect(response.pendingImage.id).toBeDefined();
+    expect(response.suggestedNextStep).toBe("manual_search");
+    expect(response.classification).toMatchObject({
+      status: "ignored",
+      reason:
+        "Photo identification timed out before a reviewed bottle match was available.",
+    });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
+  }, 15_000);
+});

--- a/apps/server/src/orpc/routes/tastings/photo-identification.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.ts
@@ -1,0 +1,182 @@
+// This route owns the photo lookup boundary for add-tasting. It may create or
+// reuse a pending upload, but it must not create tastings, bottles, releases, or
+// durable classifier trace rows.
+import { classifyBottleReference } from "@peated/server/agents/bottleClassifier/classifyBottleReference";
+import config from "@peated/server/config";
+import { MAX_FILESIZE } from "@peated/server/constants";
+import { logError } from "@peated/server/lib/log";
+import { createPendingImageUpload } from "@peated/server/lib/pendingUploads";
+import {
+  buildPhotoEvidenceFromExtractedIdentity,
+  buildPhotoReferenceName,
+  createManualSearchPhotoClassification,
+  extractPhotoBottleEvidence,
+  withPhotoIdentificationTimeout,
+} from "@peated/server/lib/photoIdentification";
+import { humanizeBytes } from "@peated/server/lib/strings";
+import { compressAndResizeImage } from "@peated/server/lib/uploads";
+import { absoluteUrl } from "@peated/server/lib/urls";
+import { procedure } from "@peated/server/orpc";
+import type { Context } from "@peated/server/orpc/context";
+import {
+  createRateLimit,
+  requireAuth,
+  requireTosAccepted,
+} from "@peated/server/orpc/middleware";
+import {
+  PhotoIdentificationInputSchema,
+  PhotoIdentificationSchema,
+  type PhotoIdentificationSuggestedNextStepEnum,
+} from "@peated/server/schemas";
+import type { z } from "zod";
+
+type AuthenticatedContext = Context & {
+  user: NonNullable<Context["user"]>;
+};
+
+const photoIdentificationRateLimit = createRateLimit<AuthenticatedContext>({
+  windowMs: 60 * 60 * 1000,
+  maxRequests: 30,
+  keyPrefix: "photo-identification",
+});
+
+function getSuggestedNextStep(
+  classification: Awaited<ReturnType<typeof classifyBottleReference>>,
+): z.infer<typeof PhotoIdentificationSuggestedNextStepEnum> {
+  if (classification.status === "ignored") {
+    return "manual_search";
+  }
+
+  switch (classification.decision.action) {
+    case "match":
+      return classification.decision.confidence >= 70
+        ? "confirm_match"
+        : "manual_search";
+    case "create_bottle":
+    case "create_release":
+    case "create_bottle_and_release":
+      return "confirm_create";
+    case "repair_parent_and_create_release":
+    case "repair_bottle":
+      return "needs_review";
+    case "no_match":
+      return "manual_search";
+  }
+}
+
+function buildFallbackIdentificationResult({
+  pendingImage,
+  reason,
+}: {
+  pendingImage: Awaited<ReturnType<typeof createPendingImageUpload>>;
+  reason: string;
+}) {
+  const imageEvidence = buildPhotoEvidenceFromExtractedIdentity({
+    pendingUpload: pendingImage,
+    extractedIdentity: null,
+  });
+
+  return {
+    imageEvidence,
+    classification: createManualSearchPhotoClassification({
+      imageEvidence,
+      reason,
+    }),
+  };
+}
+
+async function identifyPendingImage({
+  pendingImage,
+}: {
+  pendingImage: Awaited<ReturnType<typeof createPendingImageUpload>>;
+}) {
+  const identification = (async () => {
+    const { extractedIdentity, imageEvidence } =
+      await extractPhotoBottleEvidence({
+        pendingUpload: pendingImage,
+      });
+
+    const classification = await classifyBottleReference({
+      reference: {
+        id: pendingImage.id,
+        name: buildPhotoReferenceName(extractedIdentity),
+        url: null,
+        imageUrl: absoluteUrl(config.API_SERVER, pendingImage.imageUrl),
+      },
+      extractedIdentity,
+      imageEvidence,
+    });
+
+    return { imageEvidence, classification };
+  })().catch((err) => {
+    logError(err, {
+      pendingUpload: {
+        id: pendingImage.id,
+        source: "photo_identification",
+      },
+    });
+    throw err;
+  });
+
+  try {
+    return await withPhotoIdentificationTimeout(identification, () =>
+      buildFallbackIdentificationResult({
+        pendingImage,
+        reason:
+          "Photo identification timed out before a reviewed bottle match was available.",
+      }),
+    );
+  } catch {
+    return buildFallbackIdentificationResult({
+      pendingImage,
+      reason: "Photo identification could not produce a reviewed bottle match.",
+    });
+  }
+}
+
+export default procedure
+  .use(requireAuth)
+  .use(requireTosAccepted)
+  .use(photoIdentificationRateLimit)
+  .route({
+    method: "POST",
+    path: "/tastings/photo-identification",
+    summary: "Identify tasting bottle from photo",
+    description:
+      "Upload a temporary bottle photo, extract label evidence, and classify the likely bottle without creating a tasting.",
+    operationId: "identifyTastingBottleFromPhoto",
+  })
+  .input(PhotoIdentificationInputSchema)
+  .output(PhotoIdentificationSchema)
+  .handler(async function ({ input, context, errors }) {
+    const { file, idempotencyKey } = input;
+
+    if (file.size > MAX_FILESIZE) {
+      throw errors.PAYLOAD_TOO_LARGE({
+        message: `File exceeded maximum upload size of ${humanizeBytes(MAX_FILESIZE)}.`,
+      });
+    }
+
+    const pendingImage = await createPendingImageUpload({
+      file,
+      purpose: "photo_tasting_entry",
+      idempotencyKey,
+      createdById: context.user.id,
+      onProcess: (...args) => compressAndResizeImage(...args, 1600, 1600),
+    });
+
+    const { imageEvidence, classification } = await identifyPendingImage({
+      pendingImage,
+    });
+
+    return {
+      pendingImage: {
+        id: pendingImage.id,
+        imageUrl: absoluteUrl(config.API_SERVER, pendingImage.imageUrl),
+        expiresAt: pendingImage.expiresAt.toISOString(),
+      },
+      imageEvidence,
+      classification,
+      suggestedNextStep: getSuggestedNextStep(classification),
+    };
+  });

--- a/apps/server/src/schemas/tastings.ts
+++ b/apps/server/src/schemas/tastings.ts
@@ -1,7 +1,7 @@
 import {
   BottleClassificationResultSchema,
   ImageBottleEvidenceSchema,
-} from "@peated/server/agents/bottleClassifier";
+} from "@peated/bottle-classifier/contract";
 import { z } from "zod";
 import { SIMPLE_RATING_VALUES } from "../constants";
 import { BadgeAwardSchema } from "./badges";

--- a/apps/server/src/schemas/tastings.ts
+++ b/apps/server/src/schemas/tastings.ts
@@ -1,9 +1,14 @@
+import {
+  BottleClassificationResultSchema,
+  ImageBottleEvidenceSchema,
+} from "@peated/server/agents/bottleClassifier";
 import { z } from "zod";
 import { SIMPLE_RATING_VALUES } from "../constants";
 import { BadgeAwardSchema } from "./badges";
 import { BottleReleaseSchema } from "./bottleReleases";
 import { BottleSchema } from "./bottles";
 import { ServingStyleEnum, zDatetime } from "./common";
+import { PendingUploadSchema } from "./pendingUploads";
 import { UserSchema } from "./users";
 
 export const TastingSchema = z.object({
@@ -108,4 +113,32 @@ export const TastingInputSchema = TastingSchema.omit({
     .array(z.number())
     .default([])
     .describe("Array of friend user IDs who were present"),
+});
+
+export const PhotoIdentificationSuggestedNextStepEnum = z.enum([
+  "confirm_match",
+  "confirm_create",
+  "manual_search",
+  "needs_review",
+]);
+
+export const PhotoIdentificationInputSchema = z.object({
+  file: z.instanceof(Blob).describe("Bottle label image to identify"),
+  idempotencyKey: z
+    .string()
+    .trim()
+    .min(1)
+    .max(128)
+    .describe("Client retry key for reusing an existing pending upload"),
+});
+
+export const PhotoIdentificationSchema = z.object({
+  pendingImage: PendingUploadSchema.pick({
+    id: true,
+    imageUrl: true,
+    expiresAt: true,
+  }),
+  imageEvidence: ImageBottleEvidenceSchema,
+  classification: BottleClassificationResultSchema,
+  suggestedNextStep: PhotoIdentificationSuggestedNextStepEnum,
 });


### PR DESCRIPTION
Add the server-side photo identification route for the photo-assisted tasting flow.

The route stores or reuses a processed pending image, builds classifier image evidence, calls the bottle classifier with the extracted identity, and returns a suggested next step without creating tastings, bottles, or releases. Identification failures and timeouts preserve the pending image and fall back to manual search so the user can continue the entry flow.

This also makes the reusable rate-limit middleware preserve narrowed route context, which lets authenticated routes apply route-specific limits after auth. Durable identification trace rows and cancellation across the shared extractor/classifier boundaries are left for follow-up slices.