### PR TITLE
feat(tastings): Add photo-first tasting flow

### DIFF
--- a/apps/server/src/lib/bottleReferenceResolution.ts
+++ b/apps/server/src/lib/bottleReferenceResolution.ts
@@ -120,7 +120,7 @@ async function getExistingRelease(releaseId: number): Promise<BottleRelease> {
   return release;
 }
 
-async function applyClassifierCreateDecision({
+export async function applyClassifierCreateDecision({
   decision,
   user,
 }: {

--- a/apps/server/src/lib/pendingUploads.ts
+++ b/apps/server/src/lib/pendingUploads.ts
@@ -157,7 +157,7 @@ export async function createPendingImageUpload({
   return pendingUpload;
 }
 
-async function getUsablePendingUpload({
+export async function getUsablePendingUpload({
   id,
   userId,
   now = new Date(),

--- a/apps/server/src/lib/photoIdentification.test.ts
+++ b/apps/server/src/lib/photoIdentification.test.ts
@@ -1,0 +1,27 @@
+import {
+  createPendingImageUpload,
+  PENDING_UPLOAD_NAMESPACE,
+} from "@peated/server/lib/pendingUploads";
+import { getPhotoExtractionImageInput } from "@peated/server/lib/photoIdentification";
+import { compressAndResizeImage } from "@peated/server/lib/uploads";
+
+describe("photo identification", () => {
+  test("uses a data URL for local pending image extraction", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const pendingUpload = await createPendingImageUpload({
+      file: await fixtures.SampleSquareImage(),
+      createdById: defaults.user.id,
+      purpose: "photo_tasting_entry",
+      onProcess: (...args) => compressAndResizeImage(...args, 1600, 1600),
+    });
+
+    const imageInput = await getPhotoExtractionImageInput({ pendingUpload });
+
+    expect(pendingUpload.imageUrl).toContain(
+      `/uploads/${PENDING_UPLOAD_NAMESPACE}/`,
+    );
+    expect(imageInput).toMatch(/^data:image\/webp;base64,/);
+  });
+});

--- a/apps/server/src/lib/photoIdentification.ts
+++ b/apps/server/src/lib/photoIdentification.ts
@@ -8,15 +8,32 @@ import {
   type ImageBottleEvidence,
 } from "@peated/server/agents/bottleClassifier";
 import config from "@peated/server/config";
-import { absoluteUrl } from "@peated/server/lib/urls";
+import { readFile } from "@peated/server/lib/uploads";
 import OpenAI from "openai";
 
-const PHOTO_IDENTIFICATION_TIMEOUT_MS = 10_000;
+const PHOTO_IDENTIFICATION_TIMEOUT_MS = 60_000;
 
 type PhotoIdentificationPendingImage = {
   id: string;
   imageUrl: string;
 };
+
+function filenameFromUploadUrl(imageUrl: string): string {
+  if (!imageUrl.startsWith("/uploads/")) {
+    throw new Error("Pending image URL is not an upload URL.");
+  }
+  return imageUrl.slice("/uploads/".length);
+}
+
+export async function getPhotoExtractionImageInput({
+  pendingUpload,
+}: {
+  pendingUpload: PhotoIdentificationPendingImage;
+}) {
+  const filename = filenameFromUploadUrl(pendingUpload.imageUrl);
+  const image = await readFile({ filename });
+  return `data:image/webp;base64,${image.toString("base64")}`;
+}
 
 function createOpenAIClient(): OpenAI {
   return new OpenAI({
@@ -140,7 +157,7 @@ export async function extractPhotoBottleEvidence({
   });
   const extractedIdentity = BottleExtractedDetailsSchema.nullable().parse(
     await extractor.extractFromImage(
-      absoluteUrl(config.API_SERVER, pendingUpload.imageUrl),
+      await getPhotoExtractionImageInput({ pendingUpload }),
     ),
   );
 

--- a/apps/server/src/lib/uploads.ts
+++ b/apps/server/src/lib/uploads.ts
@@ -1,6 +1,11 @@
 import { createId } from "@paralleldrive/cuid2";
 import { createWriteStream } from "node:fs";
-import { copyFile as copyLocalFile, mkdir, unlink } from "node:fs/promises";
+import {
+  copyFile as copyLocalFile,
+  mkdir,
+  readFile as readLocalFile,
+  unlink,
+} from "node:fs/promises";
 import path from "node:path";
 import sharp from "sharp";
 
@@ -137,6 +142,39 @@ export async function deleteFile({
           }
         }
       }
+    },
+  );
+}
+
+export async function readFile({
+  filename,
+}: {
+  filename: string;
+}): Promise<Buffer> {
+  return await startSpan(
+    {
+      op: "peated.read-file",
+      name: filename,
+    },
+    async (span) => {
+      span?.setAttributes({
+        filename,
+      });
+
+      if (process.env.USE_GCS_STORAGE) {
+        const bucketName = config.GCS_BUCKET_NAME as string;
+        const bucketPath = config.GCS_BUCKET_PATH
+          ? `${config.GCS_BUCKET_PATH}/`
+          : "";
+
+        const [contents] = await getStorage()
+          .bucket(bucketName)
+          .file(`${bucketPath}${filename}`)
+          .download();
+        return contents;
+      }
+
+      return await readLocalFile(path.join(config.UPLOAD_PATH, filename));
     },
   );
 }

--- a/apps/server/src/orpc/routes/tastings/index.ts
+++ b/apps/server/src/orpc/routes/tastings/index.ts
@@ -7,6 +7,7 @@ import imageDelete from "./image-delete";
 import imageUpdate from "./image-update";
 import list from "./list";
 import photoIdentification from "./photo-identification";
+import photoIdentificationCreate from "./photo-identification-create";
 import update from "./update";
 
 export default base.tag("tastings").router({
@@ -19,4 +20,5 @@ export default base.tag("tastings").router({
   imageUpdate,
   imageDelete,
   photoIdentification,
+  photoIdentificationCreate,
 });

--- a/apps/server/src/orpc/routes/tastings/photo-identification-create.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification-create.ts
@@ -1,0 +1,113 @@
+import { call } from "@orpc/server";
+import { applyClassifierCreateDecision } from "@peated/server/lib/bottleReferenceResolution";
+import {
+  PendingUploadError,
+  getUsablePendingUpload,
+} from "@peated/server/lib/pendingUploads";
+import { procedure } from "@peated/server/orpc";
+import type { Context } from "@peated/server/orpc/context";
+import {
+  requireAuth,
+  requireTosAccepted,
+  requireVerified,
+} from "@peated/server/orpc/middleware";
+import { BottleReleaseSchema, BottleSchema } from "@peated/server/schemas";
+import { z } from "zod";
+import bottleReleasesDetails from "../bottleReleases/details";
+import bottlesDetails from "../bottles/details";
+import { identifyPendingImage } from "./photo-identification";
+
+type AuthenticatedContext = Context & {
+  user: NonNullable<Context["user"]>;
+};
+
+export default procedure
+  .use(requireAuth)
+  .use(requireVerified)
+  .use(requireTosAccepted)
+  .route({
+    method: "POST",
+    path: "/tastings/photo-identification-create",
+    summary: "Create bottle target from photo identification",
+    description:
+      "Create the bottle or release target from a reviewed photo identification result before recording a tasting.",
+    operationId: "createTastingBottleTargetFromPhotoIdentification",
+  })
+  .input(
+    z.object({
+      pendingImageId: z.string().trim().min(1),
+    }),
+  )
+  .output(
+    z.object({
+      bottle: BottleSchema,
+      release: BottleReleaseSchema.nullable(),
+    }),
+  )
+  .handler(async function ({ input, context, errors }) {
+    const user = context.user;
+    if (!user) {
+      throw errors.UNAUTHORIZED();
+    }
+
+    let pendingImage;
+    try {
+      pendingImage = await getUsablePendingUpload({
+        id: input.pendingImageId,
+        userId: user.id,
+      });
+    } catch (err) {
+      if (err instanceof PendingUploadError) {
+        throw errors.BAD_REQUEST({
+          message: err.message || "Pending photo is no longer available.",
+        });
+      }
+      throw err;
+    }
+    const { classification } = await identifyPendingImage({ pendingImage });
+
+    if (classification.status !== "classified") {
+      throw errors.BAD_REQUEST({
+        message: "Photo identification result is not a create proposal.",
+      });
+    }
+
+    const decision = classification.decision;
+    if (
+      decision.action !== "create_bottle" &&
+      decision.action !== "create_release" &&
+      decision.action !== "create_bottle_and_release"
+    ) {
+      throw errors.BAD_REQUEST({
+        message: "Photo identification result is not a create proposal.",
+      });
+    }
+
+    const authenticatedContext: AuthenticatedContext = {
+      ...context,
+      user,
+    };
+
+    const result = await applyClassifierCreateDecision({
+      decision,
+      user,
+    });
+
+    const bottle = await call(
+      bottlesDetails,
+      { bottle: result.bottleId },
+      { context: authenticatedContext },
+    );
+    const release = result.releaseId
+      ? await call(
+          bottleReleasesDetails,
+          { release: result.releaseId },
+          { context: authenticatedContext },
+        )
+      : null;
+
+    return {
+      bottle,
+      release,
+    };
+  });

--- a/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
@@ -1,3 +1,4 @@
+import { BottleClassificationResultSchema } from "@peated/server/agents/bottleClassifier/contract";
 import { MAX_FILESIZE } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import {
@@ -30,6 +31,8 @@ vi.mock("@peated/server/lib/photoIdentification", async () => {
   return {
     ...actual,
     extractPhotoBottleEvidence: extractPhotoBottleEvidenceMock,
+    withPhotoIdentificationTimeout: <T>(work: Promise<T>, fallback: () => T) =>
+      actual.withPhotoIdentificationTimeout(work, fallback, 10),
   };
 });
 
@@ -68,7 +71,7 @@ function buildImageEvidence(sourceImageId: string) {
 }
 
 function buildClassification(decision: Record<string, unknown>) {
-  return {
+  return BottleClassificationResultSchema.parse({
     status: "classified" as const,
     decision: {
       confidence: 90,
@@ -83,7 +86,7 @@ function buildClassification(decision: Record<string, unknown>) {
       searchEvidence: [],
       resolvedEntities: [],
     },
-  };
+  });
 }
 
 async function countRows() {
@@ -344,4 +347,107 @@ describe("POST /tastings/photo-identification", () => {
     });
     expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   }, 15_000);
+
+  test("creates bottle and release from a reviewed photo identification proposal", async ({
+    defaults,
+    fixtures,
+  }) => {
+    extractPhotoBottleEvidenceMock.mockImplementation(
+      async ({ pendingUpload }) => ({
+        extractedIdentity: {
+          brand: "Pōkeno Photo Test",
+          expression: "Totara Cask",
+          series: "Exploration Series",
+          distillery: "Pōkeno Photo Test",
+          bottler: null,
+          category: "single_malt",
+          stated_age: null,
+          abv: 43,
+          vintage_year: null,
+          release_year: null,
+          cask_type: null,
+          cask_size: null,
+          cask_fill: null,
+          cask_strength: null,
+          single_cask: null,
+          edition: "Exploration Series No. 1",
+        },
+        imageEvidence: buildImageEvidence(pendingUpload.id),
+      }),
+    );
+    classifyBottleReferenceMock.mockResolvedValue(
+      buildClassification({
+        action: "create_bottle_and_release",
+        confidence: 91,
+        rationale: "Reliable web evidence supports the product identity.",
+        proposedBottle: {
+          name: "Totara Cask",
+          series: {
+            id: null,
+            name: "Exploration Series",
+          },
+          category: "single_malt",
+          edition: null,
+          statedAge: null,
+          caskStrength: null,
+          singleCask: null,
+          abv: null,
+          vintageYear: null,
+          releaseYear: null,
+          caskType: null,
+          caskSize: null,
+          caskFill: null,
+          brand: {
+            id: null,
+            name: "Pōkeno Photo Test",
+          },
+          distillers: [
+            {
+              id: null,
+              name: "Pōkeno Photo Test",
+            },
+          ],
+          bottler: null,
+        },
+        proposedRelease: {
+          edition: "Exploration Series No. 1",
+          statedAge: null,
+          abv: 43,
+          caskStrength: null,
+          singleCask: null,
+          vintageYear: null,
+          releaseYear: null,
+          caskType: null,
+          caskSize: null,
+          caskFill: null,
+        },
+      }),
+    );
+
+    const identification = await routerClient.tastings.photoIdentification(
+      {
+        file: await fixtures.SampleSquareImage(),
+        idempotencyKey: "photo-identification-create",
+      },
+      {
+        context: { user: defaults.user },
+      },
+    );
+
+    const response = await routerClient.tastings.photoIdentificationCreate(
+      {
+        pendingImageId: identification.pendingImage.id,
+      },
+      {
+        context: { user: defaults.user },
+      },
+    );
+
+    expect(response.bottle.fullName).toBe("Pōkeno Photo Test Totara Cask");
+    expect(response.release).toMatchObject({
+      bottleId: response.bottle.id,
+      edition: "Exploration Series No. 1",
+      abv: 43,
+    });
+  });
 });

--- a/apps/server/src/orpc/routes/tastings/photo-identification.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.ts
@@ -26,6 +26,7 @@ import {
 import {
   PhotoIdentificationInputSchema,
   PhotoIdentificationSchema,
+  type PhotoIdentificationDiagnosticsSchema,
   type PhotoIdentificationSuggestedNextStepEnum,
 } from "@peated/server/schemas";
 import type { z } from "zod";
@@ -67,25 +68,95 @@ function getSuggestedNextStep(
 function buildFallbackIdentificationResult({
   pendingImage,
   reason,
+  extractionStatus,
 }: {
   pendingImage: Awaited<ReturnType<typeof createPendingImageUpload>>;
   reason: string;
+  extractionStatus: z.infer<
+    typeof PhotoIdentificationDiagnosticsSchema
+  >["extraction"]["status"];
 }) {
   const imageEvidence = buildPhotoEvidenceFromExtractedIdentity({
     pendingUpload: pendingImage,
     extractedIdentity: null,
   });
+  const classification = createManualSearchPhotoClassification({
+    imageEvidence,
+    reason,
+  });
 
   return {
     imageEvidence,
-    classification: createManualSearchPhotoClassification({
-      imageEvidence,
-      reason,
+    classification,
+    diagnostics: buildPhotoIdentificationDiagnostics({
+      extractionStatus,
+      extractionSummary: reason,
+      classification,
     }),
   };
 }
 
-async function identifyPendingImage({
+function summarizeExtraction(
+  imageEvidence: z.infer<typeof PhotoIdentificationSchema>["imageEvidence"],
+) {
+  const text = imageEvidence.extractors
+    .flatMap((extractor) => extractor.textSpans.map((span) => span.text))
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+
+  return text || null;
+}
+
+function buildPhotoIdentificationDiagnostics({
+  extractionStatus,
+  extractionSummary,
+  classification,
+}: {
+  extractionStatus: z.infer<
+    typeof PhotoIdentificationDiagnosticsSchema
+  >["extraction"]["status"];
+  extractionSummary: string | null;
+  classification: Awaited<ReturnType<typeof classifyBottleReference>>;
+}): z.infer<typeof PhotoIdentificationDiagnosticsSchema> {
+  const artifacts = classification.artifacts;
+
+  if (classification.status === "ignored") {
+    return {
+      extraction: {
+        status: extractionStatus,
+        summary: extractionSummary,
+      },
+      candidates: {
+        count: artifacts.candidates.length,
+      },
+      classification: {
+        status: "ignored",
+        action: null,
+        confidence: null,
+        reason: classification.reason,
+      },
+    };
+  }
+
+  return {
+    extraction: {
+      status: extractionStatus,
+      summary: extractionSummary,
+    },
+    candidates: {
+      count: artifacts.candidates.length,
+    },
+    classification: {
+      status: "classified",
+      action: classification.decision.action,
+      confidence: classification.decision.confidence,
+      reason: classification.decision.rationale,
+    },
+  };
+}
+
+export async function identifyPendingImage({
   pendingImage,
 }: {
   pendingImage: Awaited<ReturnType<typeof createPendingImageUpload>>;
@@ -107,7 +178,15 @@ async function identifyPendingImage({
       imageEvidence,
     });
 
-    return { imageEvidence, classification };
+    return {
+      imageEvidence,
+      classification,
+      diagnostics: buildPhotoIdentificationDiagnostics({
+        extractionStatus: extractedIdentity ? "found" : "empty",
+        extractionSummary: summarizeExtraction(imageEvidence),
+        classification,
+      }),
+    };
   })().catch((err) => {
     logError(err, {
       pendingUpload: {
@@ -124,12 +203,14 @@ async function identifyPendingImage({
         pendingImage,
         reason:
           "Photo identification timed out before a reviewed bottle match was available.",
+        extractionStatus: "timed_out",
       }),
     );
   } catch {
     return buildFallbackIdentificationResult({
       pendingImage,
       reason: "Photo identification could not produce a reviewed bottle match.",
+      extractionStatus: "failed",
     });
   }
 }
@@ -165,9 +246,11 @@ export default procedure
       onProcess: (...args) => compressAndResizeImage(...args, 1600, 1600),
     });
 
-    const { imageEvidence, classification } = await identifyPendingImage({
-      pendingImage,
-    });
+    const { imageEvidence, classification, diagnostics } =
+      await identifyPendingImage({
+        pendingImage,
+      });
+    const suggestedNextStep = getSuggestedNextStep(classification);
 
     return {
       pendingImage: {
@@ -177,6 +260,7 @@ export default procedure
       },
       imageEvidence,
       classification,
-      suggestedNextStep: getSuggestedNextStep(classification),
+      suggestedNextStep,
+      diagnostics,
     };
   });

--- a/apps/server/src/schemas/tastings.ts
+++ b/apps/server/src/schemas/tastings.ts
@@ -132,6 +132,22 @@ export const PhotoIdentificationInputSchema = z.object({
     .describe("Client retry key for reusing an existing pending upload"),
 });
 
+export const PhotoIdentificationDiagnosticsSchema = z.object({
+  extraction: z.object({
+    status: z.enum(["found", "empty", "failed", "timed_out"]),
+    summary: z.string().nullable().default(null),
+  }),
+  candidates: z.object({
+    count: z.number().int().min(0),
+  }),
+  classification: z.object({
+    status: z.enum(["ignored", "classified"]),
+    action: z.string().nullable().default(null),
+    confidence: z.number().nullable().default(null),
+    reason: z.string().nullable().default(null),
+  }),
+});
+
 export const PhotoIdentificationSchema = z.object({
   pendingImage: PendingUploadSchema.pick({
     id: true,
@@ -141,4 +157,5 @@ export const PhotoIdentificationSchema = z.object({
   imageEvidence: ImageBottleEvidenceSchema,
   classification: BottleClassificationResultSchema,
   suggestedNextStep: PhotoIdentificationSuggestedNextStepEnum,
+  diagnostics: PhotoIdentificationDiagnosticsSchema,
 });

--- a/apps/web/src/app/(default)/entities/[entityId]/(tabs)/tastings/page.tsx
+++ b/apps/web/src/app/(default)/entities/[entityId]/(tabs)/tastings/page.tsx
@@ -25,7 +25,7 @@ export default function EntityTastings({
       {tastingList.results.length ? (
         <TastingList values={tastingList.results} />
       ) : (
-        <EmptyActivity href={`/search?tasting`}>
+        <EmptyActivity href="/addTasting">
           <span className="mt-2 block font-semibold ">
             Are you enjoying a dram?
           </span>

--- a/apps/web/src/app/(default)/tastings/page.tsx
+++ b/apps/web/src/app/(default)/tastings/page.tsx
@@ -61,7 +61,7 @@ function TastingList() {
           rel={data.rel}
         />
       ) : (
-        <EmptyActivity href="/search?tasting">
+        <EmptyActivity href="/addTasting">
           <Glyph className="h-16 w-16" />
 
           <div className="mt-4 font-semibold">What are you drinking?</div>

--- a/apps/web/src/app/(layout-free)/addTasting/layout.tsx
+++ b/apps/web/src/app/(layout-free)/addTasting/layout.tsx
@@ -1,0 +1,7 @@
+import { type Metadata } from "next";
+
+export { default } from "@peated/web/components/defaultLayout";
+
+export const metadata: Metadata = {
+  title: "Record Tasting",
+};

--- a/apps/web/src/app/(layout-free)/addTasting/loading.tsx
+++ b/apps/web/src/app/(layout-free)/addTasting/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@peated/web/components/defaultLoading";

--- a/apps/web/src/app/(layout-free)/addTasting/page.tsx
+++ b/apps/web/src/app/(layout-free)/addTasting/page.tsx
@@ -1,0 +1,758 @@
+"use client";
+
+import type { Outputs } from "@peated/server/orpc/router";
+import type { Bottle, BottleRelease } from "@peated/server/types";
+import BadgeImage from "@peated/web/components/badgeImage";
+import Button from "@peated/web/components/button";
+import { useFlashMessages } from "@peated/web/components/flash";
+import FormError from "@peated/web/components/formError";
+import Header from "@peated/web/components/header";
+import Layout from "@peated/web/components/layout";
+import Link from "@peated/web/components/link";
+import TastingForm from "@peated/web/components/tastingForm";
+import useAuthRequired from "@peated/web/hooks/useAuthRequired";
+import { toBlob } from "@peated/web/lib/blobs";
+import { logError } from "@peated/web/lib/log";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { useMutation } from "@tanstack/react-query";
+import {
+  AlertTriangle,
+  Camera,
+  Check,
+  ChevronLeft,
+  LoaderCircle,
+  Plus,
+  RotateCcw,
+  Search,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
+
+type PhotoIdentification = Outputs["tastings"]["photoIdentification"];
+type SuggestedTags = Outputs["bottles"]["suggestedTags"];
+
+type SelectedTarget = {
+  bottle: Bottle;
+  release: BottleRelease | null;
+  suggestedTags: SuggestedTags;
+};
+
+const loadingMessages = [
+  "Holding it up to the light",
+  "Letting the label breathe",
+  "Checking the dusty shelf",
+  "Asking the tasting room",
+  "Comparing the fine print",
+];
+
+function createIdempotencyKey() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function getFieldValue(
+  result: PhotoIdentification | null,
+  field: keyof PhotoIdentification["imageEvidence"]["fieldCandidates"],
+) {
+  const value = result?.imageEvidence.fieldCandidates[field]?.value;
+  if (value === undefined || value === null) return null;
+  if (field === "statedAge") return `${value} years`;
+  if (field === "abv") return `${value}% ABV`;
+  return String(value);
+}
+
+function getSearchSeed(result: PhotoIdentification | null) {
+  const brand = getFieldValue(result, "brand");
+  const expression = getFieldValue(result, "expression");
+  return [brand, expression].filter(Boolean).join(" ");
+}
+
+function getSearchHref(query = "") {
+  return `/search?tasting${query ? `&q=${encodeURIComponent(query)}` : ""}`;
+}
+
+function getMatchedBottleId(result: PhotoIdentification | null) {
+  if (
+    result?.suggestedNextStep === "confirm_match" &&
+    result.classification.status === "classified" &&
+    result.classification.decision.action === "match"
+  ) {
+    return result.classification.decision.matchedBottleId;
+  }
+  return null;
+}
+
+function getMatchedReleaseId(result: PhotoIdentification | null) {
+  if (
+    result?.classification.status === "classified" &&
+    result.classification.decision.action === "match"
+  ) {
+    return result.classification.decision.matchedReleaseId;
+  }
+  return null;
+}
+
+function getCreateDecision(result: PhotoIdentification | null) {
+  if (
+    result?.suggestedNextStep !== "confirm_create" ||
+    result.classification.status !== "classified"
+  ) {
+    return null;
+  }
+
+  switch (result.classification.decision.action) {
+    case "create_bottle":
+    case "create_release":
+    case "create_bottle_and_release":
+      return result.classification.decision;
+    default:
+      return null;
+  }
+}
+
+function getProposedName(result: PhotoIdentification | null) {
+  const decision = getCreateDecision(result);
+  if (!decision) return null;
+
+  if (decision.action === "create_release") {
+    return decision.proposedRelease.edition ?? "New release";
+  }
+
+  if (decision.action === "create_bottle_and_release") {
+    return [
+      decision.proposedBottle.brand.name,
+      decision.proposedBottle.name,
+      decision.proposedRelease.edition,
+    ]
+      .filter(Boolean)
+      .join(" ");
+  }
+
+  return [decision.proposedBottle.brand.name, decision.proposedBottle.name]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function getParentBottleName(result: PhotoIdentification | null) {
+  const decision = getCreateDecision(result);
+  if (!decision || decision.action !== "create_release") return null;
+
+  const parent = result?.classification.artifacts.candidates.find(
+    (candidate) =>
+      candidate.bottleId === decision.parentBottleId &&
+      (candidate.releaseId === null || candidate.releaseId === undefined),
+  );
+  return parent?.bottleFullName || parent?.fullName || null;
+}
+
+function getCreateProposalLabel(result: PhotoIdentification | null) {
+  const decision = getCreateDecision(result);
+  if (!decision) return null;
+  const parentBottleName = getParentBottleName(result);
+
+  if (decision.action === "create_release") {
+    return {
+      title: "Bottle found",
+      description: parentBottleName
+        ? `Create a new bottling for ${parentBottleName}.`
+        : "Create a new bottling for this bottle.",
+    };
+  }
+
+  if (decision.action === "create_bottle_and_release") {
+    return {
+      title: "Bottle found",
+      description: "Create the bottle and its specific bottling.",
+    };
+  }
+
+  return {
+    title: "Bottle found",
+    description: "Create a new bottle from this label.",
+  };
+}
+
+function EvidencePills({ result }: { result: PhotoIdentification | null }) {
+  const fields = [
+    ["Brand", getFieldValue(result, "brand")],
+    ["Expression", getFieldValue(result, "expression")],
+    ["Age", getFieldValue(result, "statedAge")],
+    ["ABV", getFieldValue(result, "abv")],
+    ["Edition", getFieldValue(result, "edition")],
+    ["Vintage", getFieldValue(result, "vintageYear")],
+  ].filter(([, value]) => value);
+
+  if (!fields.length) return null;
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {fields.map(([label, value]) => (
+        <div
+          key={label}
+          className="rounded border border-slate-800 bg-slate-950 px-3 py-2 text-sm"
+        >
+          <span className="text-muted">{label}</span>{" "}
+          <span className="font-medium text-white">{value}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function OrDivider() {
+  return (
+    <div className="flex items-center gap-3">
+      <div className="h-px flex-1 bg-slate-800" />
+      <div className="text-muted text-xs font-semibold uppercase tracking-wide">
+        Or
+      </div>
+      <div className="h-px flex-1 bg-slate-800" />
+    </div>
+  );
+}
+
+function FallbackActions({
+  searchHref,
+  onStartOver,
+  showStartOver = false,
+}: {
+  searchHref: string;
+  onStartOver?: () => void;
+  showStartOver?: boolean;
+}) {
+  return (
+    <div className="space-y-3">
+      <OrDivider />
+      <div className="mx-auto grid w-full gap-3 sm:w-1/2 sm:grid-cols-2">
+        <Button
+          href={searchHref}
+          fullWidth
+          icon={<Search className="h-4 w-4" />}
+        >
+          Search Bottles
+        </Button>
+        {showStartOver && onStartOver && (
+          <Button
+            fullWidth
+            onClick={onStartOver}
+            icon={<RotateCcw className="h-4 w-4" />}
+          >
+            Start Over
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SearchBottleCallout() {
+  return (
+    <section className="mx-3 rounded border border-slate-800 bg-slate-950/50 p-4 sm:mx-0">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <div className="font-semibold text-white">Prefer to search?</div>
+          <div className="text-muted mt-1 text-sm">
+            Find an existing bottle or start a new one manually.
+          </div>
+        </div>
+        <div className="shrink-0">
+          <Button href="/search?tasting" icon={<Search className="h-4 w-4" />}>
+            Search Bottles
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default function AddTasting() {
+  useAuthRequired();
+
+  const router = useRouter();
+  const orpc = useORPC();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const createdAt = useMemo(() => new Date().toISOString(), []);
+
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [photoResult, setPhotoResult] = useState<PhotoIdentification | null>(
+    null,
+  );
+  const [selectedTarget, setSelectedTarget] = useState<SelectedTarget | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+
+  const { flash } = useFlashMessages();
+  const photoIdentificationMutation = useMutation(
+    orpc.tastings.photoIdentification.mutationOptions(),
+  );
+  const tastingCreateMutation = useMutation(
+    orpc.tastings.create.mutationOptions(),
+  );
+  const tastingImageUpdateMutation = useMutation(
+    orpc.tastings.imageUpdate.mutationOptions(),
+  );
+  const photoIdentificationCreateMutation = useMutation(
+    orpc.tastings.photoIdentificationCreate.mutationOptions(),
+  );
+  const isIdentifying = photoIdentificationMutation.isPending;
+  const [loadingMessageIndex, setLoadingMessageIndex] = useState(0);
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  useEffect(() => {
+    if (!isIdentifying) {
+      setLoadingMessageIndex(0);
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      setLoadingMessageIndex((index) => (index + 1) % loadingMessages.length);
+    }, 2700);
+
+    return () => window.clearInterval(timer);
+  }, [isIdentifying]);
+
+  async function loadTarget(bottleId: number, releaseId: number | null = null) {
+    const [bottle, suggestedTags, release] = await Promise.all([
+      orpc.bottles.details.call({ bottle: bottleId }),
+      orpc.bottles.suggestedTags.call({ bottle: bottleId }),
+      releaseId
+        ? orpc.bottleReleases.details.call({ release: releaseId })
+        : Promise.resolve(null),
+    ]);
+    setSelectedTarget({ bottle, release, suggestedTags });
+  }
+
+  async function acceptCreateProposal(result: PhotoIdentification) {
+    if (
+      result.classification.status !== "classified" ||
+      !getCreateDecision(result)
+    ) {
+      return;
+    }
+
+    try {
+      const created = await photoIdentificationCreateMutation.mutateAsync({
+        pendingImageId: result.pendingImage.id,
+      });
+      const suggestedTags = await orpc.bottles.suggestedTags.call({
+        bottle: created.bottle.id,
+      });
+      setSelectedTarget({
+        bottle: created.bottle,
+        release: created.release,
+        suggestedTags,
+      });
+    } catch (err) {
+      logError(err);
+      setError(
+        "We couldn't create that bottle from the photo. Search for the bottle to keep going.",
+      );
+    }
+  }
+
+  async function identifyPhoto(file: File) {
+    setError(null);
+    setPhotoResult(null);
+    setPhotoFile(file);
+
+    const nextPreviewUrl = URL.createObjectURL(file);
+    setPreviewUrl((current) => {
+      if (current) URL.revokeObjectURL(current);
+      return nextPreviewUrl;
+    });
+
+    try {
+      const result = await photoIdentificationMutation.mutateAsync({
+        file,
+        idempotencyKey: createIdempotencyKey(),
+      });
+      setPhotoResult(result);
+    } catch (err) {
+      logError(err);
+      setError(
+        "We couldn't read that photo. You can still find the bottle manually.",
+      );
+    }
+  }
+
+  function onFileChange(event: ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    void identifyPhoto(file);
+    event.target.value = "";
+  }
+
+  function startOver() {
+    setError(null);
+    setPhotoResult(null);
+    setPreviewUrl((current) => {
+      if (current) URL.revokeObjectURL(current);
+      return null;
+    });
+    setPhotoFile(null);
+  }
+
+  async function submitTasting({
+    image,
+    ...data
+  }: Parameters<React.ComponentProps<typeof TastingForm>["onSubmit"]>[0]) {
+    if (!selectedTarget) return;
+
+    const { tasting, awards } = await tastingCreateMutation.mutateAsync({
+      ...data,
+      bottle: selectedTarget.bottle.id,
+      release:
+        data.release === undefined
+          ? (selectedTarget.release?.id ?? null)
+          : data.release,
+      createdAt,
+    });
+
+    if (!tasting) return;
+
+    const imageFile =
+      image instanceof File ? image : image ? await toBlob(image) : null;
+
+    if (imageFile) {
+      try {
+        await tastingImageUpdateMutation.mutateAsync({
+          tasting: tasting.id,
+          file: imageFile,
+        });
+      } catch (err) {
+        logError(err);
+        flash(
+          "There was an error uploading your image, but the tasting was saved.",
+          "error",
+        );
+      }
+    }
+
+    for (const award of awards) {
+      if (award.level != award.prevLevel && award.level) {
+        flash(
+          <div className="relative flex flex-row items-center gap-x-3">
+            <Link
+              href={`/badges/${award.badge.id}`}
+              className="absolute inset-0"
+            />
+            <BadgeImage badge={award.badge} size={48} level={award.level} />
+            <div className="flex flex-col">
+              <h5 className="font-semibold">{award.badge.name}</h5>
+              <p className="font-normal">You've reached level {award.level}!</p>
+            </div>
+          </div>,
+          "info",
+        );
+      }
+    }
+
+    router.push(`/tastings/${tasting.id}`);
+  }
+
+  if (selectedTarget) {
+    return (
+      <TastingForm
+        title="Record Tasting"
+        initialData={{
+          bottle: selectedTarget.bottle,
+          release: selectedTarget.release,
+        }}
+        initialImageFile={photoFile}
+        showReleasePickerDefault
+        suggestedTags={selectedTarget.suggestedTags}
+        onSubmit={submitTasting}
+      />
+    );
+  }
+
+  const matchedBottleId = getMatchedBottleId(photoResult);
+  const matchedReleaseId = getMatchedReleaseId(photoResult);
+  const createDecision = getCreateDecision(photoResult);
+  const proposedName = getProposedName(photoResult);
+  const createProposalLabel = getCreateProposalLabel(photoResult);
+  const searchSeed = getSearchSeed(photoResult);
+  const searchHref = getSearchHref(searchSeed);
+
+  return (
+    <Layout
+      footer={null}
+      header={
+        <Header>
+          <div className="flex w-full items-center gap-3">
+            <button
+              type="button"
+              aria-label="Back"
+              className="text-muted group flex justify-center"
+              onClick={() => router.back()}
+            >
+              <div className="-my-1 rounded bg-slate-800 p-1 group-hover:bg-slate-700 group-hover:text-white">
+                <ChevronLeft className="h-8 w-8" />
+              </div>
+            </button>
+            <h1 className="text-2xl font-bold">Record Tasting</h1>
+          </div>
+        </Header>
+      }
+    >
+      <input
+        ref={fileInputRef}
+        className="hidden"
+        type="file"
+        accept="image/*"
+        capture="environment"
+        onChange={onFileChange}
+      />
+
+      <div className="mx-auto mt-5 max-w-3xl space-y-5">
+        {!previewUrl && !photoResult && !isIdentifying && (
+          <>
+            <section className="px-3 sm:px-0">
+              <div className="space-y-5">
+                <div className="text-center">
+                  <div className="text-muted text-sm">
+                    Start with a bottle photo
+                  </div>
+                  <h2 className="mt-1 text-2xl font-semibold text-white">
+                    Capture the label, then confirm the match.
+                  </h2>
+                </div>
+
+                <button
+                  type="button"
+                  className="flex min-h-72 w-full flex-col items-center justify-center gap-4 rounded border border-slate-800 bg-black p-6 text-center transition hover:border-slate-700 hover:bg-slate-950"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <div className="rounded-full border border-slate-700 bg-slate-950 p-5">
+                    <Camera className="text-highlight h-10 w-10" />
+                  </div>
+                  <div>
+                    <div className="text-lg font-semibold text-white">
+                      Take or upload a photo
+                    </div>
+                    <div className="text-muted mt-1 text-sm">
+                      Use a clear bottle label for the fastest match.
+                    </div>
+                  </div>
+                </button>
+              </div>
+            </section>
+            <SearchBottleCallout />
+          </>
+        )}
+
+        {!isIdentifying && previewUrl && !photoResult && (
+          <>
+            <section className="rounded border border-slate-800 bg-slate-950/50 p-4 lg:p-6">
+              <div className="space-y-5">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+                  <img
+                    src={previewUrl}
+                    alt="Selected bottle label"
+                    className="h-24 w-24 rounded object-cover"
+                  />
+                  <div className="min-w-0 flex-1 space-y-4">
+                    <div className="flex items-start gap-3">
+                      <div className="text-highlight rounded-full bg-slate-800 p-2">
+                        <AlertTriangle className="h-5 w-5" />
+                      </div>
+                      <div>
+                        <div className="font-semibold text-white">
+                          Use search instead
+                        </div>
+                        <div className="text-muted mt-1 text-sm">
+                          We could not read enough from this photo. Search can
+                          still find an existing bottle or start a new one.
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+            <FallbackActions
+              searchHref="/search?tasting"
+              showStartOver
+              onStartOver={startOver}
+            />
+          </>
+        )}
+
+        {isIdentifying && (
+          <section className="flex min-h-[calc(100vh-12rem)] items-center justify-center px-3 py-8 text-center">
+            <div className="mx-auto max-w-md space-y-5">
+              {previewUrl && (
+                <img
+                  src={previewUrl}
+                  alt="Selected bottle label"
+                  className="mx-auto h-28 w-28 rounded object-cover"
+                />
+              )}
+              <div>
+                <LoaderCircle className="text-highlight mx-auto h-8 w-8 animate-spin" />
+                <h2 className="mt-4 text-xl font-semibold text-white">
+                  {loadingMessages[loadingMessageIndex]}
+                </h2>
+                <p className="text-muted mt-2 text-sm">
+                  Reading the label and checking Peated for a match.
+                </p>
+                <p className="text-muted mt-1 text-sm">
+                  This can take up to 30 seconds.
+                </p>
+                <div className="mt-5">
+                  <Button
+                    href="/search?tasting"
+                    icon={<Search className="h-4 w-4" />}
+                  >
+                    Search Bottles
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </section>
+        )}
+
+        {!isIdentifying && photoResult && (
+          <>
+            <section className="rounded border border-slate-800 bg-slate-950/50 p-4 lg:p-6">
+              <div className="space-y-5">
+                <div className="space-y-4">
+                  {matchedBottleId ? (
+                    <div className="flex items-start gap-3">
+                      {previewUrl && (
+                        <img
+                          src={previewUrl}
+                          alt=""
+                          className="h-8 w-8 rounded object-cover"
+                        />
+                      )}
+                      <div className="bg-highlight rounded-full p-2 text-black">
+                        <Check className="h-5 w-5" />
+                      </div>
+                      <div>
+                        <div className="font-semibold text-white">
+                          Match found
+                        </div>
+                        <div className="text-muted mt-1 text-sm">
+                          We'll use the existing bottle for this tasting.
+                        </div>
+                      </div>
+                    </div>
+                  ) : createDecision ? (
+                    <div className="flex items-start gap-3">
+                      {previewUrl && (
+                        <img
+                          src={previewUrl}
+                          alt=""
+                          className="h-8 w-8 rounded object-cover"
+                        />
+                      )}
+                      <div className="bg-highlight rounded-full p-2 text-black">
+                        <Plus className="h-5 w-5" />
+                      </div>
+                      <div>
+                        <div className="font-semibold text-white">
+                          {createProposalLabel?.title ?? "New bottle found"}
+                        </div>
+                        <div className="text-muted mt-1 text-sm">
+                          {createProposalLabel?.description ??
+                            "We'll create this bottle before recording your tasting."}
+                        </div>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="flex items-start gap-3">
+                      {previewUrl && (
+                        <img
+                          src={previewUrl}
+                          alt=""
+                          className="h-8 w-8 rounded object-cover"
+                        />
+                      )}
+                      <div className="text-highlight rounded-full bg-slate-800 p-2">
+                        <AlertTriangle className="h-5 w-5" />
+                      </div>
+                      <div>
+                        <div className="font-semibold text-white">
+                          Needs manual review
+                        </div>
+                        <div className="text-muted mt-1 text-sm">
+                          We kept the photo. Search for the bottle to keep
+                          going.
+                        </div>
+                      </div>
+                    </div>
+                  )}
+
+                  <EvidencePills result={photoResult} />
+
+                  {createDecision && proposedName && (
+                    <div className="rounded border border-slate-800 bg-slate-950 p-3">
+                      <div className="text-muted text-xs uppercase tracking-wide">
+                        Proposed
+                      </div>
+                      <div className="mt-1 font-semibold text-white">
+                        {proposedName}
+                      </div>
+                      <div className="text-muted mt-2 text-sm">
+                        {createProposalLabel?.description ??
+                          "Create a new bottle from this label."}
+                      </div>
+                      {photoResult.diagnostics.classification.reason && (
+                        <div className="text-muted mt-2 line-clamp-3 text-xs">
+                          {photoResult.diagnostics.classification.reason}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+                <div className="mx-auto grid w-full gap-2 sm:w-1/2">
+                  {matchedBottleId && (
+                    <Button
+                      color="highlight"
+                      fullWidth
+                      onClick={() =>
+                        void loadTarget(matchedBottleId, matchedReleaseId)
+                      }
+                    >
+                      Continue
+                    </Button>
+                  )}
+                  {createDecision && (
+                    <Button
+                      color="highlight"
+                      fullWidth
+                      icon={<Plus className="h-4 w-4" />}
+                      onClick={() => void acceptCreateProposal(photoResult)}
+                      disabled={photoIdentificationCreateMutation.isPending}
+                    >
+                      {photoIdentificationCreateMutation.isPending
+                        ? "Creating..."
+                        : "Continue"}
+                    </Button>
+                  )}
+                </div>
+              </div>
+            </section>
+            <FallbackActions
+              searchHref={searchHref}
+              showStartOver
+              onStartOver={startOver}
+            />
+          </>
+        )}
+
+        {error && <FormError values={[error]} />}
+      </div>
+    </Layout>
+  );
+}

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/addTasting/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/addTasting/page.tsx
@@ -94,7 +94,7 @@ export default function AddTasting({
             try {
               await tastingImageUpdateMutation.mutateAsync({
                 tasting: tasting.id,
-                file: await toBlob(image),
+                file: image instanceof File ? image : await toBlob(image),
               });
             } catch (err) {
               logError(err);

--- a/apps/web/src/app/(layout-free)/tastings/[tastingId]/edit/page.tsx
+++ b/apps/web/src/app/(layout-free)/tastings/[tastingId]/edit/page.tsx
@@ -58,7 +58,7 @@ export default function Page({
           try {
             await tastingImageUpdateMutation.mutateAsync({
               tasting: tasting.id,
-              file: await toBlob(image),
+              file: image instanceof File ? image : await toBlob(image),
             });
           } catch (err) {
             logError(err);

--- a/apps/web/src/components/activityFeed.tsx
+++ b/apps/web/src/components/activityFeed.tsx
@@ -84,7 +84,7 @@ export default function ActivityFeed({
           </Fragment>
         ))
       ) : (
-        <EmptyActivity href="/search?tasting">
+        <EmptyActivity href="/addTasting">
           <Glyph className="h-16 w-16" />
 
           <div className="mt-4 font-semibold">What are you drinking?</div>

--- a/apps/web/src/components/appFooter.tsx
+++ b/apps/web/src/components/appFooter.tsx
@@ -15,7 +15,7 @@ export default function AppFooter() {
       </NavLink>
 
       <NavLink
-        href="/search?tasting"
+        href="/addTasting"
         className="focus:ring-highlight text-muted relative -mt-5 flex max-w-xs items-center rounded border-t border-t-slate-700 bg-slate-950 text-sm hover:bg-slate-700 focus:outline-none focus:ring"
       >
         <PeatedGlyph className="m-5 h-9 w-9" />

--- a/apps/web/src/components/imageField.tsx
+++ b/apps/web/src/components/imageField.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { forwardRef, useEffect, useRef, useState } from "react";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
 
 import { PhotoIcon } from "@heroicons/react/20/solid";
 import setRef from "../lib/setRef";
@@ -27,6 +27,7 @@ type Props = Omit<
   imageWidth?: number;
   imageHeight?: number;
   noEditor?: boolean;
+  initialFile?: File | null;
 };
 
 const fileToDataUrl = (file: File): Promise<string> => {
@@ -81,6 +82,7 @@ export default forwardRef<HTMLInputElement, Props>(
       imageWidth = 600,
       imageHeight = 600,
       noEditor,
+      initialFile,
     },
     ref,
   ) => {
@@ -89,13 +91,33 @@ export default forwardRef<HTMLInputElement, Props>(
     const [_isHover, setHover] = useState(false);
     const [imageSrc, setImageSrc] = useState<string | null>();
     const [finalImage, setFinalImage] = useState<HTMLCanvasElement | null>();
+    const onChangeRef = useRef(onChange);
 
     const [editorOpen, setEditorOpen] = useState(false);
+
+    useEffect(() => {
+      onChangeRef.current = onChange;
+    }, [onChange]);
+
+    const onSave = useCallback((image: HTMLCanvasElement | null) => {
+      setFinalImage(image);
+      onChangeRef.current(image);
+    }, []);
 
     useEffect(() => {
       setImageSrc(value || "");
       setFinalImage(null);
     }, [value]);
+
+    useEffect(() => {
+      if (!initialFile) return;
+
+      (async () => {
+        const imageSrc = await fileToDataUrl(initialFile);
+        setImageSrc(imageSrc);
+        onSave(await fileDataToCanvas(initialFile));
+      })();
+    }, [initialFile, onSave]);
 
     const updateImageSrc = () => {
       const file = Array.from(fileRef.current?.files || []).find(() => true);
@@ -111,11 +133,6 @@ export default forwardRef<HTMLInputElement, Props>(
         setImageSrc("");
         onSave(null);
       }
-    };
-
-    const onSave = (image: HTMLCanvasElement | null) => {
-      setFinalImage(image);
-      if (onChange) onChange(image);
     };
 
     return (

--- a/apps/web/src/components/sidebar.tsx
+++ b/apps/web/src/components/sidebar.tsx
@@ -32,7 +32,7 @@ export default function Sidebar() {
           <nav className="flex flex-1 flex-col">
             <ul role="list" className="flex flex-1 flex-col gap-y-7">
               <li>
-                <Button href="/search?tasting" fullWidth color="highlight">
+                <Button href="/addTasting" fullWidth color="highlight">
                   Record a Tasting
                 </Button>
               </li>

--- a/apps/web/src/components/tastingForm.tsx
+++ b/apps/web/src/components/tastingForm.tsx
@@ -37,6 +37,7 @@ import NoResultsFoundEntry from "./selectField/noResultsFoundEntry";
 import ServingStyleIcon from "./servingStyleIcon";
 
 type FormSchemaType = z.infer<typeof TastingInputSchema>;
+type ImageValue = HTMLCanvasElement | File | null | undefined;
 
 function formatServingStyle(style: ServingStyle) {
   return toTitleCase(style);
@@ -73,17 +74,21 @@ function toReleaseOption(
 export default function TastingForm({
   onSubmit,
   initialData,
+  initialImageFile,
+  showReleasePickerDefault = false,
   title,
   suggestedTags,
 }: {
   onSubmit: SubmitHandler<
     Omit<FormSchemaType, "image"> & {
-      image: HTMLCanvasElement | null | undefined;
+      image: ImageValue;
     }
   >;
   initialData: Partial<z.infer<typeof TastingSchema>> & {
     bottle: Bottle;
   };
+  initialImageFile?: File | null;
+  showReleasePickerDefault?: boolean;
   title: string;
   suggestedTags: Paginated<SuggestedTag>;
 }) {
@@ -107,14 +112,12 @@ export default function TastingForm({
   });
 
   const [error, setError] = useState<string | undefined>();
-  const [image, setImage] = useState<HTMLCanvasElement | null | undefined>(
-    null,
-  );
+  const [image, setImage] = useState<ImageValue>(initialImageFile);
   const [friendsValue, setFriendsValue] = useState<Option[]>(
     initialData.friends ? initialData.friends.map(userToOption) : [],
   );
   const [showReleasePicker, setShowReleasePicker] = useState(
-    Boolean(initialData.release),
+    showReleasePickerDefault || Boolean(initialData.release),
   );
   const [releaseValue, setReleaseValue] = useState<ReleaseOption | undefined>(
     toReleaseOption(initialData.release),
@@ -167,7 +170,7 @@ export default function TastingForm({
           <Controller
             name="release"
             control={control}
-            render={({ field: { onChange, value, ref, ...field } }) =>
+            render={({ field: { onChange, ref, ...field } }) =>
               showReleasePicker ? (
                 <div className="space-y-3">
                   <SelectField<ReleaseOption>
@@ -204,7 +207,9 @@ export default function TastingForm({
                     onClick={() => {
                       onChange(null);
                       setReleaseValue(undefined);
-                      setShowReleasePicker(false);
+                      if (!showReleasePickerDefault) {
+                        setShowReleasePicker(false);
+                      }
                     }}
                   >
                     Use Bottle Instead
@@ -307,6 +312,7 @@ export default function TastingForm({
             name="image"
             label="Picture"
             value={initialData.imageUrl}
+            initialFile={initialImageFile}
             onChange={(value) => setImage(value)}
             imageWidth={1024 / 2}
             imageHeight={768 / 2}

--- a/docs/features/photo-tasting-entry.md
+++ b/docs/features/photo-tasting-entry.md
@@ -4,12 +4,21 @@
 
 Draft for product and implementation iteration.
 
+Initial rollout should be a new standalone record-tasting experience, not a
+replacement for the existing bottle-scoped tasting flow. Build and vet the new
+photo-first flow at `/addTasting` while keeping the current
+`/bottles/[bottleId]/addTasting` path unchanged.
+
 ## Goal
 
 Let a user record a tasting by taking or uploading a bottle photo instead of
 starting with text search. The photo-assisted path should identify the bottle,
 let the user confirm or correct the match, and then create the same tasting
-record the existing search path creates.
+record the existing search path creates. Like the existing search-based bottle
+picker, the photo path must be able to land on either an existing bottle/release
+or a new bottle/release proposal. Ideally, a clear label photo should drive the
+new-bottle path automatically enough that the user reviews fields instead of
+starting from scratch.
 
 The uploaded photo may also become the tasting image. If the flow creates a new
 bottle or release, or finds an existing bottle or release without an image, the
@@ -49,26 +58,43 @@ measure each phase separately before optimizing prompts or models.
 
 ## Product Flow
 
-The add-tasting flow has two entry paths:
+The new record-tasting flow has two entry paths:
 
-1. Search for a bottle by text.
-2. Add a bottle photo.
+1. Take or upload a bottle photo.
+2. Find a bottle manually, using the existing `/search?tasting` path.
 
-The photo path should converge back to the same confirmed tasting form:
+The first screen should make photo capture the primary action while keeping
+manual bottle search immediately available. This is a new experience for
+choosing a bottle before the tasting form, not a modal or minor enhancement
+inside the existing bottle detail page flow.
+
+The photo path should identify what bottle target the tasting belongs to before
+the user reaches the tasting form. That target may be an existing bottle/release
+or a reviewed new bottle/release proposal:
 
 1. User uploads or takes a photo.
 2. Server stores a pending processed image.
 3. Server extracts label evidence from the image.
 4. Server classifies the bottle reference using the existing bottle classifier.
 5. UI shows the photo, extracted evidence, and suggested bottle/release outcome.
-6. User confirms the suggestion, searches manually, or chooses another candidate.
-7. User records tasting notes, rating, tags, serving style, flight, and friends.
-8. Server creates the tasting and attaches the pending image if selected.
-9. Server may promote the image to a bottle or release image under deterministic
-   policy.
+6. User confirms an existing match, opens full bottle search, chooses another
+   candidate, or reviews the proposed new bottle/release fields.
+7. Server creates any approved new bottle/release before tasting save when the
+   confirmed photo-identification result is a creation proposal.
+8. User records tasting notes, rating, tags, serving style, flight, and friends.
+9. Server creates the tasting and attaches the pending image if selected.
+10. Server may promote the image to a bottle or release image under deterministic
+    policy.
 
-Low-confidence photo identification should fall back to seeded manual search
+Low-confidence photo identification should fall back to seeded full search
 rather than forcing a create or match decision.
+
+Manual search from this page should reuse the existing `/search?tasting`
+experience instead of embedding a narrower local search. That route already
+handles selecting existing bottles and starting the add-bottle path when no
+match exists. The user should be able to finish a tasting without taking a
+photo. A failed photo lookup should keep a local preview visible on `/addTasting`
+with actions to start over or open full bottle search.
 
 ## User Experience
 
@@ -77,11 +103,16 @@ not like a separate moderation workflow.
 
 ### Entry Point
 
-On add tasting, show the existing bottle search as the primary path with a
-camera/upload action nearby:
+Expose the new experience at `/addTasting` and route general record-tasting
+entry points there. Keep existing bottle-scoped deep links that already know the
+target bottle or bottling on `/bottles/[bottleId]/addTasting`.
 
-- Search field for bottle lookup.
-- Camera/upload button for photo lookup.
+On the new page, show a photo-first choice with manual search as the explicit
+fallback:
+
+- A large camera/upload target for photo lookup as the primary action.
+- A secondary search callout that opens `/search?tasting` for users who want to
+  find or add a bottle manually.
 - Recent or suggested bottles can remain below the search path if they already
   exist in the current UI.
 
@@ -93,12 +124,10 @@ The camera action should work well on mobile and desktop:
 ### Identification Progress
 
 After a photo is selected, show the image immediately and keep the user on the
-same task. The progress state should name the current phase without exposing
-implementation details:
-
-1. Preparing photo.
-2. Reading label.
-3. Looking for matching bottles.
+same task. The progress state should feel like a centered loading screen with
+the selected image as a thumbnail, a spinner, and short whisky-themed loading
+messages. Avoid numbered step indicators or implementation-specific phase
+names.
 
 If identification takes longer than expected, keep the uploaded photo visible
 and let the user switch to manual search without losing the pending image.
@@ -117,10 +146,9 @@ When identification succeeds, show a compact confirmation view:
 - confidence or review state in plain language
 - extracted key facts, such as brand, expression, age, vintage, ABV, and edition
 - a clear primary action to continue with the proposed bottle
-- secondary actions to search manually, choose another result, or retake/upload a
-  different photo
+- secondary actions to search bottles or start over
 
-The UI should distinguish these outcomes:
+The UI should distinguish these photo-identification outcomes:
 
 - matched existing bottle/release
 - proposed new bottle
@@ -128,19 +156,22 @@ The UI should distinguish these outcomes:
 - uncertain result requiring manual search
 
 When the result proposes creation, the UI should show the proposed canonical
-name and important fields before the user continues. The user should not need to
-understand classifier internals, but they should be able to spot obvious errors
-such as the wrong age statement or brand.
+name and important fields before the user continues. A strong photo result
+should prefill as much of the new bottle/release proposal as possible, including
+brand, series, expression, category, age, ABV, vintage, release year, edition,
+and cask details when visible. The user should not need to understand classifier
+internals, but they should be able to spot obvious errors such as the wrong age
+statement or brand.
 
 ### Low Confidence And Multiple Candidates
 
 If the classifier is uncertain, show seeded search results instead of a hard
 failure:
 
-- keep the extracted search text in the search box
-- show likely bottle/release candidates
-- make manual search the primary next step
-- preserve the uploaded photo so it can still attach to the tasting
+- seed `/search?tasting` with extracted search text when available
+- make full bottle search the primary next step
+- keep the uploaded photo visible on the result screen until the user starts
+  over or leaves for full search
 
 If the photo appears to contain multiple bottles, do not auto-select a result.
 Ask the user to choose from candidates or retake the photo.
@@ -152,23 +183,34 @@ bottle and tasting fields intact. The UI should explain that the photo expired
 and offer to re-upload before save.
 
 If the identification request fails, keep the local preview while the page is
-open and switch to manual search. The user should not have to restart the
-tasting entry flow.
+open and offer full bottle search plus start over. The user should not have to
+restart the tasting entry flow just to try another photo.
 
 ### Tasting Form
 
-After the user confirms or manually selects a bottle, continue to the normal
-tasting form with the bottle/release fixed at the top. The photo should remain
-visible as a pending tasting image.
+After the user confirms, manually selects, or approves creation of a
+bottle/release, continue to the normal tasting form with the resolved
+bottle/release fixed at the top. The uploaded photo should appear in the normal
+tasting picture field as the default selected image, as if the user had already
+chosen it in that field.
 
-The form should include image choices:
+Be careful implementing this default image behavior. The photo picker should not
+be a second, independent attachment system that can drift from the form state.
+Prefer representing the pending upload as the initial value for the existing
+picture control, while preserving the user's ability to replace it, remove it,
+or save without a picture. Saving the tasting should attach the image only if the
+picture field still references the pending upload at submit time.
 
-- attach this photo to my tasting
-- use as bottle image if the bottle has no image
+If policy allows using the same photo as a bottle or release image, expose that
+as a separate secondary choice from the tasting picture field. Hide or disable
+the promotion option when policy says promotion is not allowed, such as when the
+existing bottle already has an image or the photo is unsuitable as a canonical
+bottle image.
 
-The bottle-image option should be hidden or disabled when policy says promotion
-is not allowed, such as when the existing bottle already has an image or the
-photo is unsuitable as a canonical bottle image.
+For the first standalone version, the form may reuse the existing tasting form
+component if it can support a bottle chosen inside the page. Avoid changing the
+legacy bottle-scoped form contract unless the change is backwards-compatible for
+the existing route.
 
 ### Save Result
 
@@ -327,6 +369,7 @@ Output:
     | "confirm_create"
     | "manual_search"
     | "needs_review";
+  diagnostics: PhotoIdentificationDiagnostics;
 }
 ```
 
@@ -340,9 +383,17 @@ identification state instead of creating duplicate pending objects.
 The route should have a bounded timeout. On timeout, return the pending image and
 manual-search seed data if available rather than failing the whole entry flow.
 
-### Create Tasting With Pending Image
+### Create Tasting With Selected Picture
 
-Extend the existing tasting create input with:
+For the first standalone version, keep tasting creation on the existing tasting
+create route. When the user confirms a photo result, the client should seed the
+normal tasting `Picture` field with the uploaded local file. If the user leaves
+that field selected, the client uploads it through the existing tasting image
+update route after the tasting is created. If the user removes or replaces the
+picture field value, submit that current field state instead.
+
+This means the first version should not extend tasting create with pending-image
+fields:
 
 ```ts
 {
@@ -353,20 +404,22 @@ Extend the existing tasting create input with:
 }
 ```
 
-The route should:
+Those fields remain a future option if the flow needs server-side pending-image
+reuse after leaving `/addTasting`. The current route should:
 
-- validate ownership of `pendingImageId`
 - create the tasting through the existing deterministic path
-- copy the pending image into the tasting namespace when selected
+- upload the selected picture through the existing image update path when
+  selected
 - promote the image to a bottle or release only after the tasting and any
   required bottle/release creation are durable
 - return partial-success information if image copy or promotion fails after the
   tasting is created
 - avoid re-running image identification during final tasting save
 
-`photoIdentificationId` links the user-confirmed choice back to the extraction
-and classifier trace for audit, eval sampling, and future debugging. It should
-not be required for manual search flows that only reuse a pending image.
+Future `photoIdentificationId` support may link the user-confirmed choice back
+to the extraction and classifier trace for audit, eval sampling, and debugging.
+It should not be required for manual search flows that only reuse a local
+picture field value.
 
 ## Image Evidence Contract
 
@@ -743,8 +796,8 @@ Scope:
 - show immediate local preview
 - show identification progress states
 - show confirmation state for match, create proposal, or manual-search fallback
-- preserve pending image while user searches manually
-- add attach/promote controls in the tasting form
+- seed the uploaded photo into the normal tasting picture field
+- allow the user to remove or replace that picture field value
 - show partial-success save messaging
 
 UI verification:
@@ -754,7 +807,7 @@ UI verification:
 - slow identification with manual fallback
 - low-confidence result
 - successful existing-bottle match
-- image attach disabled because pending image expired
+- uploaded photo appears in the tasting picture field by default
 - text does not overflow compact mobile controls
 
 Browser verification should use the local UI verification playbook when auth or

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-pokeno-exploration-series-totara-cask.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-pokeno-exploration-series-totara-cask.json
@@ -1,0 +1,143 @@
+{
+  "id": "image-backed-photo-matches-pokeno-exploration-series-totara-cask",
+  "name": "image-backed photo: matches Pokeno Exploration Series No. 1 Totara Cask from label evidence",
+  "input": {
+    "reference": {
+      "name": "Bottle photo upload",
+      "url": "https://api.peated.com/uploads/tastings-tcpwlgq69tkvom09zlx0e1gy.webp",
+      "imageUrl": "https://api.peated.com/uploads/tastings-tcpwlgq69tkvom09zlx0e1gy.webp"
+    },
+    "extractedIdentity": {
+      "brand": "Pōkeno",
+      "bottler": null,
+      "expression": "Exploration Series No. 1 Totara Cask",
+      "series": "Exploration Series",
+      "distillery": ["Pōkeno"],
+      "category": "single_malt",
+      "stated_age": null,
+      "abv": 40,
+      "release_year": null,
+      "vintage_year": null,
+      "cask_type": "totara",
+      "cask_size": null,
+      "cask_fill": null,
+      "cask_strength": null,
+      "single_cask": null,
+      "edition": null
+    },
+    "initialCandidates": [
+      {
+        "kind": "bottle",
+        "releaseId": null,
+        "alias": null,
+        "bottleFullName": "Pōkeno Exploration Series No. 1 Totara Cask",
+        "brand": "Pōkeno",
+        "bottler": null,
+        "series": "Exploration Series",
+        "distillery": ["Pōkeno"],
+        "category": "single_malt",
+        "statedAge": null,
+        "edition": null,
+        "caskStrength": null,
+        "singleCask": null,
+        "abv": null,
+        "vintageYear": null,
+        "releaseYear": null,
+        "caskType": null,
+        "caskSize": null,
+        "caskFill": null,
+        "score": 0.98,
+        "source": ["exact"],
+        "bottleId": 44263,
+        "fullName": "Pōkeno Exploration Series No. 1 Totara Cask"
+      }
+    ]
+  },
+  "searchResponses": [
+    {
+      "when": ["pokeno", "totara"],
+      "results": [
+        {
+          "kind": "bottle",
+          "releaseId": null,
+          "alias": null,
+          "bottleFullName": "Pōkeno Exploration Series No. 1 Totara Cask",
+          "brand": "Pōkeno",
+          "bottler": null,
+          "series": "Exploration Series",
+          "distillery": ["Pōkeno"],
+          "category": "single_malt",
+          "statedAge": null,
+          "edition": null,
+          "caskStrength": null,
+          "singleCask": null,
+          "abv": null,
+          "vintageYear": null,
+          "releaseYear": null,
+          "caskType": null,
+          "caskSize": null,
+          "caskFill": null,
+          "score": 0.98,
+          "source": ["exact"],
+          "bottleId": 44263,
+          "fullName": "Pōkeno Exploration Series No. 1 Totara Cask"
+        }
+      ]
+    },
+    {
+      "when": ["pokeno", "exploration", "totara"],
+      "results": [
+        {
+          "kind": "bottle",
+          "releaseId": null,
+          "alias": null,
+          "bottleFullName": "Pōkeno Exploration Series No. 1 Totara Cask",
+          "brand": "Pōkeno",
+          "bottler": null,
+          "series": "Exploration Series",
+          "distillery": ["Pōkeno"],
+          "category": "single_malt",
+          "statedAge": null,
+          "edition": null,
+          "caskStrength": null,
+          "singleCask": null,
+          "abv": null,
+          "vintageYear": null,
+          "releaseYear": null,
+          "caskType": null,
+          "caskSize": null,
+          "caskFill": null,
+          "score": 0.98,
+          "source": ["exact"],
+          "bottleId": 44263,
+          "fullName": "Pōkeno Exploration Series No. 1 Totara Cask"
+        }
+      ]
+    }
+  ],
+  "provenance": {
+    "source": "production_miss",
+    "verifiedSourceUrls": [
+      "https://pokenowhisky.com/product/pokeno-totara-cask/",
+      "https://pokenowhisky.com/blogs/pokeno-whiskys-exploration-series-features-totara-cask-finish-single-malt/"
+    ],
+    "dbOutcome": {
+      "bottleId": 44263,
+      "releaseId": null,
+      "createsBottle": false,
+      "createsRelease": false,
+      "summary": "Assign the photo tasting to existing Peated bottle 44263, Pōkeno Exploration Series No. 1 Totara Cask, with releaseId null. Do not create a new Pōkeno bottle or release for this photo."
+    },
+    "notes": "Added from a failed /addTasting photo-identification attempt using the preserved uploaded image. The label visibly shows Pōkeno Aotearoa New Zealand Single Malt Whisky, Exploration Series No. 01, Totara Cask, 700ml, 40% ABV. The official Pokeno product page and blog verify Totara Cask as part of the Exploration Series."
+  },
+  "expected": {
+    "status": "classified",
+    "action": "match",
+    "identityScope": "product",
+    "matchedBottleId": 44263,
+    "matchedReleaseId": null,
+    "confidenceBand": "auto_verification",
+    "verifyEligible": true,
+    "summary": "Use the uploaded bottle photo label evidence to match the existing Pōkeno Exploration Series No. 1 Totara Cask bottle. This is an existing-bottle tasting flow case, not a new-bottle creation case."
+  }
+}

--- a/skills/peated-qa/SKILL.md
+++ b/skills/peated-qa/SKILL.md
@@ -19,12 +19,18 @@ Use after Peated code changes need manual behavior checks. This is not a test/li
 
 ## Start Local Runtime
 
-| Need         | Command                                         | URL                     |
-| ------------ | ----------------------------------------------- | ----------------------- |
-| API only     | `pnpm dev:server:api`                           | `http://localhost:4300` |
-| API + worker | `docker compose up -d redis`; `pnpm dev:server` | `http://localhost:4300` |
-| Web          | `pnpm dev:web`                                  | `http://localhost:3200` |
-| CLI          | `pnpm cli <cmd>`                                | loads `.env.local`      |
+For normal web UI QA, prefer the root `pnpm dev` command. It starts the web
+app, API, worker, package watchers, and shared `.env.local` setup together,
+which matches the expected local development runtime. Use the narrower commands
+below only when intentionally isolating one surface.
+
+| Need         | Command                                         | URL                                                        |
+| ------------ | ----------------------------------------------- | ---------------------------------------------------------- |
+| Full app     | `pnpm dev`                                      | web: `http://localhost:3200`, API: `http://localhost:4300` |
+| API only     | `pnpm dev:server:api`                           | `http://localhost:4300`                                    |
+| API + worker | `docker compose up -d redis`; `pnpm dev:server` | `http://localhost:4300`                                    |
+| Web          | `pnpm dev:web`                                  | `http://localhost:3200`                                    |
+| CLI          | `pnpm cli <cmd>`                                | loads `.env.local`                                         |
 
 Fallback paired ports when `3200` is busy:
 


### PR DESCRIPTION
Add a standalone photo-first tasting flow at `/addTasting`. The route starts with an upload-first experience, keeps full bottle search available as the fallback path, shows a focused loading/result flow while photo identification runs, and continues into the existing tasting form with the uploaded image already selected in the Picture field.

General record-tasting entry points now route to this flow, while known bottle/bottling deep links continue to use the existing scoped add-tasting form. The server side now reads pending upload bytes for photo extraction, returns diagnostics for the flow, and uses a server-owned create endpoint that recomputes identification from the pending image instead of trusting client-supplied classifier output.

This also adds the Pōkeno Totara Cask photo miss as a classifier eval fixture and updates the photo tasting spec/QA notes for the new workflow.

Review areas worth focusing on: the `photoIdentificationCreate` duplicate-safe create path, the `TastingForm`/`ImageField` initial image behavior, and the mobile layout of the new `/addTasting` route.