### PR TITLE
fix(worker): Reconcile missing price match proposals

### DIFF
--- a/apps/server/src/worker/client.ts
+++ b/apps/server/src/worker/client.ts
@@ -128,6 +128,13 @@ export async function runWorker() {
   // dont run the scraper in dev
   if (config.ENV === "production") {
     scheduledJob("*/5 * * * *", "schedule-scrapers", scheduleScrapers);
+    scheduledJob(
+      "17 * * * *",
+      "reconcile-store-price-match-proposals",
+      async () => {
+        await runJob("ReconcileStorePriceMatchProposals");
+      },
+    );
     scheduledJob("0 * * * *", "cleanup-pending-uploads", async () => {
       await runJob("CleanupPendingUploads");
     });

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -23,6 +23,7 @@ import onBottleReleaseChange from "./onBottleReleaseChange";
 import onEntityChange from "./onEntityChange";
 import processNotification from "./processNotification";
 import processStorePriceMatchRetryRun from "./processStorePriceMatchRetryRun";
+import reconcileStorePriceMatchProposals from "./reconcileStorePriceMatchProposals";
 import resolveStorePriceBottle from "./resolveStorePriceBottle";
 import scrapeAstorWines from "./scrapeAstorWines";
 import scrapeHealthySpirits from "./scrapeHealthySpirits";
@@ -65,6 +66,10 @@ registry.add("OnBottleReleaseChange", onBottleReleaseChange);
 registry.add("OnEntityChange", onEntityChange);
 registry.add("ProcessNotification", processNotification);
 registry.add("ProcessStorePriceMatchRetryRun", processStorePriceMatchRetryRun);
+registry.add(
+  "ReconcileStorePriceMatchProposals",
+  reconcileStorePriceMatchProposals,
+);
 registry.add("ResolveStorePriceBottle", resolveStorePriceBottle);
 registry.add("ScrapeAstorWines", scrapeAstorWines);
 registry.add("ScrapeHealthySpirits", scrapeHealthySpirits);

--- a/apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.test.ts
+++ b/apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.test.ts
@@ -1,0 +1,127 @@
+import { db } from "@peated/server/db";
+import {
+  storePriceMatchProposals,
+  storePrices,
+} from "@peated/server/db/schema";
+import * as workerClient from "@peated/server/worker/client";
+import "@peated/server/worker/jobs";
+import reconcileStorePriceMatchProposals from "@peated/server/worker/jobs/reconcileStorePriceMatchProposals";
+import registry from "@peated/server/worker/registry";
+import { eq, sql } from "drizzle-orm";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@peated/server/worker/client", () => ({
+  pushJob: vi.fn(),
+}));
+
+async function agePrice(priceId: number, minutes: number) {
+  await db
+    .update(storePrices)
+    .set({
+      updatedAt: sql`NOW() - make_interval(mins => ${minutes})`,
+    })
+    .where(eq(storePrices.id, priceId));
+}
+
+describe("reconcileStorePriceMatchProposals", () => {
+  beforeEach(() => {
+    vi.mocked(workerClient.pushJob).mockReset();
+  });
+
+  test("queues resolver jobs for unmatched store prices without proposals", async ({
+    fixtures,
+  }) => {
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      name: "Unmatched Store Listing",
+    });
+    await agePrice(price.id, 60);
+
+    const result = await reconcileStorePriceMatchProposals();
+
+    expect(result).toEqual({ queuedCount: 1 });
+    expect(workerClient.pushJob).toHaveBeenCalledWith(
+      "ResolveStorePriceBottle",
+      {
+        priceId: price.id,
+      },
+    );
+  });
+
+  test("skips prices that already have proposals", async ({ fixtures }) => {
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      name: "Already Proposed Listing",
+    });
+    await agePrice(price.id, 60);
+
+    await db.insert(storePriceMatchProposals).values({
+      priceId: price.id,
+      proposalType: "create_new",
+      status: "pending_review",
+    });
+
+    const result = await reconcileStorePriceMatchProposals();
+
+    expect(result).toEqual({ queuedCount: 0 });
+    expect(workerClient.pushJob).not.toHaveBeenCalled();
+  });
+
+  test("skips matched and hidden prices", async ({ fixtures }) => {
+    const bottle = await fixtures.Bottle();
+    const matchedPrice = await fixtures.StorePrice({
+      bottleId: bottle.id,
+      name: "Matched Store Listing",
+    });
+    const hiddenPrice = await fixtures.StorePrice({
+      bottleId: null,
+      hidden: true,
+      name: "Hidden Store Listing",
+    });
+    await agePrice(matchedPrice.id, 60);
+    await agePrice(hiddenPrice.id, 60);
+
+    const result = await reconcileStorePriceMatchProposals();
+
+    expect(result).toEqual({ queuedCount: 0 });
+    expect(workerClient.pushJob).not.toHaveBeenCalled();
+  });
+
+  test("honors the minimum age guard", async ({ fixtures }) => {
+    const freshPrice = await fixtures.StorePrice({
+      bottleId: null,
+      name: "Fresh Store Listing",
+    });
+    const oldPrice = await fixtures.StorePrice({
+      bottleId: null,
+      name: "Old Store Listing",
+    });
+    await agePrice(freshPrice.id, 5);
+    await agePrice(oldPrice.id, 60);
+
+    const result = await reconcileStorePriceMatchProposals({
+      minAgeMinutes: 30,
+    });
+
+    expect(result).toEqual({ queuedCount: 1 });
+    expect(workerClient.pushJob).toHaveBeenCalledTimes(1);
+    expect(workerClient.pushJob).toHaveBeenCalledWith(
+      "ResolveStorePriceBottle",
+      {
+        priceId: oldPrice.id,
+      },
+    );
+    expect(workerClient.pushJob).not.toHaveBeenCalledWith(
+      "ResolveStorePriceBottle",
+      {
+        priceId: freshPrice.id,
+      },
+    );
+  });
+
+  test("is registered as a worker job", () => {
+    expect(registry.get("ReconcileStorePriceMatchProposals")).toBeTypeOf(
+      "function",
+    );
+  });
+});

--- a/apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.test.ts
+++ b/apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.test.ts
@@ -3,6 +3,7 @@ import {
   storePriceMatchProposals,
   storePrices,
 } from "@peated/server/db/schema";
+import * as log from "@peated/server/lib/log";
 import * as workerClient from "@peated/server/worker/client";
 import "@peated/server/worker/jobs";
 import reconcileStorePriceMatchProposals from "@peated/server/worker/jobs/reconcileStorePriceMatchProposals";
@@ -12,6 +13,10 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 vi.mock("@peated/server/worker/client", () => ({
   pushJob: vi.fn(),
+}));
+
+vi.mock("@peated/server/lib/log", () => ({
+  logError: vi.fn(),
 }));
 
 async function agePrice(priceId: number, minutes: number) {
@@ -117,6 +122,50 @@ describe("reconcileStorePriceMatchProposals", () => {
         priceId: freshPrice.id,
       },
     );
+  });
+
+  test("continues queueing prices after a dispatch failure", async ({
+    fixtures,
+  }) => {
+    const newerPrice = await fixtures.StorePrice({
+      bottleId: null,
+      name: "Newer Unmatched Store Listing",
+    });
+    const olderPrice = await fixtures.StorePrice({
+      bottleId: null,
+      name: "Older Unmatched Store Listing",
+    });
+    await agePrice(newerPrice.id, 60);
+    await agePrice(olderPrice.id, 120);
+
+    const error = new Error("queue unavailable");
+    vi.mocked(workerClient.pushJob)
+      .mockRejectedValueOnce(error)
+      .mockResolvedValueOnce(undefined);
+
+    const result = await reconcileStorePriceMatchProposals();
+
+    expect(result).toEqual({ queuedCount: 1 });
+    expect(workerClient.pushJob).toHaveBeenCalledTimes(2);
+    expect(workerClient.pushJob).toHaveBeenNthCalledWith(
+      1,
+      "ResolveStorePriceBottle",
+      {
+        priceId: newerPrice.id,
+      },
+    );
+    expect(workerClient.pushJob).toHaveBeenNthCalledWith(
+      2,
+      "ResolveStorePriceBottle",
+      {
+        priceId: olderPrice.id,
+      },
+    );
+    expect(log.logError).toHaveBeenCalledWith(error, {
+      price: {
+        id: newerPrice.id,
+      },
+    });
   });
 
   test("is registered as a worker job", () => {

--- a/apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.ts
+++ b/apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.ts
@@ -47,6 +47,8 @@ export default async function reconcileStorePriceMatchProposals({
     .orderBy(desc(storePrices.updatedAt), desc(storePrices.id))
     .limit(limit);
 
+  let queuedCount = 0;
+
   for (const price of prices) {
     // Bypass unique enqueue here: stale unique BullMQ ids are one reason these
     // legacy rows can be missing proposals in the first place.
@@ -54,23 +56,23 @@ export default async function reconcileStorePriceMatchProposals({
       await pushJob("ResolveStorePriceBottle", {
         priceId: price.id,
       });
+      queuedCount += 1;
     } catch (error) {
       logError(error, {
         price: {
           id: price.id,
         },
       });
-      throw error;
     }
   }
 
-  if (prices.length > 0) {
+  if (queuedCount > 0) {
     console.log(
-      `Queued ${prices.length} unmatched store price${prices.length === 1 ? "" : "s"} without match proposals`,
+      `Queued ${queuedCount} unmatched store price${queuedCount === 1 ? "" : "s"} without match proposals`,
     );
   }
 
   return {
-    queuedCount: prices.length,
+    queuedCount,
   };
 }

--- a/apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.ts
+++ b/apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.ts
@@ -1,0 +1,76 @@
+import { db } from "@peated/server/db";
+import {
+  storePriceMatchProposals,
+  storePrices,
+} from "@peated/server/db/schema";
+import { logError } from "@peated/server/lib/log";
+import { pushJob } from "@peated/server/worker/client";
+import { desc, eq, sql } from "drizzle-orm";
+
+type ReconcileStorePriceMatchProposalsArgs = {
+  limit?: number;
+  minAgeMinutes?: number;
+};
+
+function clampInteger(value: number, min: number, max: number) {
+  return Math.min(Math.max(Math.trunc(value), min), max);
+}
+
+/**
+ * Reconciles legacy unmatched store prices that never produced match proposals.
+ *
+ * The matcher still owns proposal creation; this job only redispatches eligible
+ * visible rows and relies on the proposal table to bound durable duplicates.
+ */
+export default async function reconcileStorePriceMatchProposals({
+  limit: inputLimit = 500,
+  minAgeMinutes: inputMinAgeMinutes = 30,
+}: ReconcileStorePriceMatchProposalsArgs = {}) {
+  const limit = clampInteger(inputLimit, 1, 1000);
+  const minAgeMinutes = clampInteger(inputMinAgeMinutes, 0, 60 * 24 * 30);
+
+  const prices = await db
+    .select({
+      id: storePrices.id,
+    })
+    .from(storePrices)
+    .leftJoin(
+      storePriceMatchProposals,
+      eq(storePriceMatchProposals.priceId, storePrices.id),
+    )
+    .where(
+      sql`${storePrices.hidden} = false
+        AND ${storePrices.bottleId} IS NULL
+        AND ${storePriceMatchProposals.id} IS NULL
+        AND ${storePrices.updatedAt} <= NOW() - make_interval(mins => ${minAgeMinutes})`,
+    )
+    .orderBy(desc(storePrices.updatedAt), desc(storePrices.id))
+    .limit(limit);
+
+  for (const price of prices) {
+    // Bypass unique enqueue here: stale unique BullMQ ids are one reason these
+    // legacy rows can be missing proposals in the first place.
+    try {
+      await pushJob("ResolveStorePriceBottle", {
+        priceId: price.id,
+      });
+    } catch (error) {
+      logError(error, {
+        price: {
+          id: price.id,
+        },
+      });
+      throw error;
+    }
+  }
+
+  if (prices.length > 0) {
+    console.log(
+      `Queued ${prices.length} unmatched store price${prices.length === 1 ? "" : "s"} without match proposals`,
+    );
+  }
+
+  return {
+    queuedCount: prices.length,
+  };
+}

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -23,6 +23,7 @@ export type JobName =
   | "OnEntityChange"
   | "ProcessStorePriceMatchRetryRun"
   | "ProcessNotification"
+  | "ReconcileStorePriceMatchProposals"
   | "ResolveStorePriceBottle"
   | "ScrapeAstorWines"
   | "ScrapeHealthySpirits"


### PR DESCRIPTION
Add a scheduled worker reconciliation job for unmatched store prices that do not have price match proposals.

Some older or missed scraper rows can remain visible with no bottle assignment while never appearing in the incoming listings queue, because the queue is driven by `store_price_match_proposal` rows rather than `store_price.bottle_id IS NULL`. The new hourly job finds visible unmatched prices with no proposal and redispatches them through the existing `ResolveStorePriceBottle` resolver so proposal creation stays owned by the price matcher.

The repair deliberately uses normal queue dispatch instead of the unique enqueue helper, because stale unique BullMQ job IDs are one possible reason these legacy rows never produced proposals. The durable proposal uniqueness constraint and the no-proposal selector keep persistent duplicate work bounded.

Garfield review passed. Validation run locally:

`pnpm --filter @peated/server test -- src/worker/jobs/reconcileStorePriceMatchProposals.test.ts`
`pnpm exec eslint apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.ts apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.test.ts apps/server/src/worker/client.ts apps/server/src/worker/jobs/index.ts apps/server/src/worker/types.ts --fix`
`pnpm --filter @peated/server typecheck`