### PR TITLE
fix(tastings): Bound photo identification response

### DIFF
--- a/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
@@ -70,7 +70,10 @@ function buildImageEvidence(sourceImageId: string) {
   };
 }
 
-function buildClassification(decision: Record<string, unknown>) {
+function buildClassification(
+  decision: Record<string, unknown>,
+  artifacts: Record<string, unknown> = {},
+) {
   return BottleClassificationResultSchema.parse({
     status: "classified" as const,
     decision: {
@@ -85,6 +88,7 @@ function buildClassification(decision: Record<string, unknown>) {
       candidates: [],
       searchEvidence: [],
       resolvedEntities: [],
+      ...artifacts,
     },
   });
 }
@@ -153,11 +157,33 @@ describe("POST /tastings/photo-identification", () => {
       }),
     );
     classifyBottleReferenceMock.mockResolvedValue(
-      buildClassification({
-        action: "match",
-        matchedBottleId: matchedBottle.id,
-        matchedReleaseId: null,
-      }),
+      buildClassification(
+        {
+          action: "match",
+          matchedBottleId: matchedBottle.id,
+          matchedReleaseId: null,
+        },
+        {
+          candidates: [
+            {
+              kind: "bottle",
+              bottleId: matchedBottle.id,
+              releaseId: null,
+              fullName: "Ardbeg Uigeadail",
+              bottleFullName: "Ardbeg Uigeadail",
+              brand: "Ardbeg",
+              score: 0.98,
+              source: ["exact"],
+            },
+          ],
+          searchEvidence: [
+            {
+              query: "Ardbeg Uigeadail",
+              results: [],
+            },
+          ],
+        },
+      ),
     );
 
     const response = await routerClient.tastings.photoIdentification(
@@ -177,6 +203,33 @@ describe("POST /tastings/photo-identification", () => {
     expect(response.imageEvidence.sourceImageId).toBe(response.pendingImage.id);
     expect(response.classification.status).toBe("classified");
     expect(response.suggestedNextStep).toBe("confirm_match");
+    expect(response.classification).toMatchObject({
+      decision: {
+        action: "match",
+        matchedBottleId: matchedBottle.id,
+        matchedReleaseId: null,
+      },
+      artifacts: {
+        candidates: [
+          {
+            bottleId: matchedBottle.id,
+            releaseId: null,
+            bottleFullName: "Ardbeg Uigeadail",
+            fullName: "Ardbeg Uigeadail",
+          },
+        ],
+      },
+    });
+    expect(response.classification.artifacts).toEqual({
+      candidates: [
+        {
+          bottleId: matchedBottle.id,
+          releaseId: null,
+          bottleFullName: "Ardbeg Uigeadail",
+          fullName: "Ardbeg Uigeadail",
+        },
+      ],
+    });
 
     expect(classifyBottleReferenceMock).toHaveBeenCalledWith({
       reference: {

--- a/apps/server/src/orpc/routes/tastings/photo-identification.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.ts
@@ -108,6 +108,103 @@ function summarizeExtraction(
   return text || null;
 }
 
+/**
+ * Strips server-owned classifier internals from the browser response while
+ * preserving the fields the photo tasting flow needs to continue.
+ */
+function serializePhotoIdentificationClassification(
+  classification: Awaited<ReturnType<typeof classifyBottleReference>>,
+): z.infer<typeof PhotoIdentificationSchema>["classification"] {
+  const artifacts = {
+    candidates: classification.artifacts.candidates.map((candidate) => ({
+      bottleId: candidate.bottleId,
+      releaseId: candidate.releaseId,
+      bottleFullName: candidate.bottleFullName,
+      fullName: candidate.fullName,
+    })),
+  };
+
+  if (classification.status === "ignored") {
+    return {
+      status: "ignored",
+      reason: classification.reason,
+      artifacts,
+    };
+  }
+
+  const { decision } = classification;
+  type SerializedDecision = Extract<
+    z.infer<typeof PhotoIdentificationSchema>["classification"],
+    { status: "classified" }
+  >["decision"];
+  let serializedDecision: SerializedDecision;
+
+  switch (decision.action) {
+    case "match":
+      serializedDecision = {
+        action: "match",
+        matchedBottleId: decision.matchedBottleId,
+        matchedReleaseId: decision.matchedReleaseId,
+      };
+      break;
+    case "create_bottle":
+      serializedDecision = {
+        action: "create_bottle",
+        proposedBottle: {
+          name: decision.proposedBottle.name,
+          brand: {
+            name: decision.proposedBottle.brand.name,
+          },
+        },
+      };
+      break;
+    case "create_release":
+      serializedDecision = {
+        action: "create_release",
+        parentBottleId: decision.parentBottleId,
+        proposedRelease: {
+          edition: decision.proposedRelease.edition,
+        },
+      };
+      break;
+    case "create_bottle_and_release":
+      serializedDecision = {
+        action: "create_bottle_and_release",
+        proposedBottle: {
+          name: decision.proposedBottle.name,
+          brand: {
+            name: decision.proposedBottle.brand.name,
+          },
+        },
+        proposedRelease: {
+          edition: decision.proposedRelease.edition,
+        },
+      };
+      break;
+    case "repair_parent_and_create_release":
+      serializedDecision = {
+        action: "repair_parent_and_create_release",
+      };
+      break;
+    case "repair_bottle":
+      serializedDecision = {
+        action: "repair_bottle",
+      };
+      break;
+    case "no_match":
+      serializedDecision = {
+        action: "no_match",
+      };
+      break;
+  }
+
+  return {
+    status: "classified",
+    decision: serializedDecision,
+    artifacts,
+  };
+}
+
 function buildPhotoIdentificationDiagnostics({
   extractionStatus,
   extractionSummary,
@@ -259,7 +356,8 @@ export default procedure
         expiresAt: pendingImage.expiresAt.toISOString(),
       },
       imageEvidence,
-      classification,
+      classification:
+        serializePhotoIdentificationClassification(classification),
       suggestedNextStep,
       diagnostics,
     };

--- a/apps/server/src/schemas/tastings.ts
+++ b/apps/server/src/schemas/tastings.ts
@@ -1,5 +1,7 @@
-import { ImageBottleEvidenceSchema } from "@peated/bottle-classifier/contract";
-import { BottleCandidateSchema } from "@peated/server/agents/bottleClassifier";
+import {
+  BottleCandidateSchema,
+  ImageBottleEvidenceSchema,
+} from "@peated/bottle-classifier/contract";
 import { z } from "zod";
 import { SIMPLE_RATING_VALUES } from "../constants";
 import { BadgeAwardSchema } from "./badges";

--- a/apps/server/src/schemas/tastings.ts
+++ b/apps/server/src/schemas/tastings.ts
@@ -1,7 +1,5 @@
-import {
-  BottleClassificationResultSchema,
-  ImageBottleEvidenceSchema,
-} from "@peated/bottle-classifier/contract";
+import { ImageBottleEvidenceSchema } from "@peated/bottle-classifier/contract";
+import { BottleCandidateSchema } from "@peated/server/agents/bottleClassifier";
 import { z } from "zod";
 import { SIMPLE_RATING_VALUES } from "../constants";
 import { BadgeAwardSchema } from "./badges";
@@ -148,6 +146,78 @@ export const PhotoIdentificationDiagnosticsSchema = z.object({
   }),
 });
 
+const PhotoIdentificationCandidateSchema = BottleCandidateSchema.pick({
+  bottleId: true,
+  releaseId: true,
+  bottleFullName: true,
+  fullName: true,
+});
+
+const PhotoIdentificationProposedBottleSchema = z.object({
+  name: z.string().trim().min(1),
+  brand: z.object({
+    name: z.string().trim().min(1),
+  }),
+});
+
+const PhotoIdentificationProposedReleaseSchema = z.object({
+  edition: z.string().nullable(),
+});
+
+export const PhotoIdentificationDecisionSchema = z.discriminatedUnion(
+  "action",
+  [
+    z.object({
+      action: z.literal("match"),
+      matchedBottleId: z.number().int(),
+      matchedReleaseId: z.number().int().nullable(),
+    }),
+    z.object({
+      action: z.literal("create_bottle"),
+      proposedBottle: PhotoIdentificationProposedBottleSchema,
+    }),
+    z.object({
+      action: z.literal("create_release"),
+      parentBottleId: z.number().int(),
+      proposedRelease: PhotoIdentificationProposedReleaseSchema,
+    }),
+    z.object({
+      action: z.literal("create_bottle_and_release"),
+      proposedBottle: PhotoIdentificationProposedBottleSchema,
+      proposedRelease: PhotoIdentificationProposedReleaseSchema,
+    }),
+    z.object({
+      action: z.literal("repair_parent_and_create_release"),
+    }),
+    z.object({
+      action: z.literal("repair_bottle"),
+    }),
+    z.object({
+      action: z.literal("no_match"),
+    }),
+  ],
+);
+
+export const PhotoIdentificationClassificationSchema = z.discriminatedUnion(
+  "status",
+  [
+    z.object({
+      status: z.literal("ignored"),
+      reason: z.string().min(1),
+      artifacts: z.object({
+        candidates: z.array(PhotoIdentificationCandidateSchema),
+      }),
+    }),
+    z.object({
+      status: z.literal("classified"),
+      decision: PhotoIdentificationDecisionSchema,
+      artifacts: z.object({
+        candidates: z.array(PhotoIdentificationCandidateSchema),
+      }),
+    }),
+  ],
+);
+
 export const PhotoIdentificationSchema = z.object({
   pendingImage: PendingUploadSchema.pick({
     id: true,
@@ -155,7 +225,7 @@ export const PhotoIdentificationSchema = z.object({
     expiresAt: true,
   }),
   imageEvidence: ImageBottleEvidenceSchema,
-  classification: BottleClassificationResultSchema,
+  classification: PhotoIdentificationClassificationSchema,
   suggestedNextStep: PhotoIdentificationSuggestedNextStepEnum,
   diagnostics: PhotoIdentificationDiagnosticsSchema,
 });

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -164,6 +164,97 @@ async function handleRpcRequest({ request, response, url }) {
       });
       return true;
     }
+    case "tastings/photoIdentification":
+      sendRpcResponse(response, {
+        pendingImage: {
+          id: "playwright-photo-upload",
+          imageUrl: "http://127.0.0.1:4999/uploads/playwright-photo.webp",
+          expiresAt: "2026-06-07T13:00:00.000Z",
+        },
+        imageEvidence: {
+          sourceImageId: "playwright-photo-upload",
+          sourceImageHash: "playwright-photo-hash",
+          extractors: [
+            {
+              kind: "vision",
+              model: "playwright",
+              confidence: 0.95,
+              textSpans: [
+                {
+                  text: "Lagavulin 16",
+                  confidence: 0.95,
+                },
+              ],
+              observations: ["Single bottle label is readable."],
+            },
+          ],
+          fieldCandidates: {
+            brand: {
+              value: testBrand.name,
+              confidence: 0.98,
+              sourceExtractorIndexes: [0],
+            },
+            expression: {
+              value: existingBottle.name,
+              confidence: 0.94,
+              sourceExtractorIndexes: [0],
+            },
+            statedAge: {
+              value: 16,
+              confidence: 0.94,
+              sourceExtractorIndexes: [0],
+            },
+          },
+          photoSuitability: {
+            isSingleBottlePhoto: true,
+            labelReadable: true,
+            suitableAsTastingImage: true,
+            suitableAsBottleImage: true,
+            reason: null,
+          },
+          conflicts: [],
+        },
+        classification: {
+          status: "classified",
+          decision: {
+            action: "match",
+            matchedBottleId: existingBottleId,
+            matchedReleaseId: null,
+          },
+          artifacts: {
+            candidates: [
+              {
+                bottleId: existingBottleId,
+                releaseId: null,
+                bottleFullName: existingBottle.fullName,
+                fullName: existingBottle.fullName,
+              },
+            ],
+          },
+        },
+        suggestedNextStep: "confirm_match",
+        diagnostics: {
+          extraction: {
+            status: "found",
+            summary: "Lagavulin 16",
+          },
+          candidates: {
+            count: 1,
+          },
+          classification: {
+            status: "classified",
+            action: "match",
+            confidence: 95,
+            reason: "Matched the fixture bottle.",
+          },
+        },
+      });
+      return true;
+    case "tastings/imageUpdate":
+      sendRpcResponse(response, {
+        imageUrl: "http://127.0.0.1:4999/uploads/tasting.webp",
+      });
+      return true;
     case "tastings/details":
       if (input?.tasting !== createdTastingId) {
         sendRpcError(response, "Unexpected tasting details payload");
@@ -368,6 +459,15 @@ async function readRpcInput(request, url) {
 
   if (request.method === "GET" || request.method === "HEAD") {
     return undefined;
+  }
+
+  const contentType = request.headers["content-type"] ?? "";
+  if (
+    typeof contentType === "string" &&
+    !contentType.includes("application/json")
+  ) {
+    request.resume();
+    return {};
   }
 
   const body = await readBody(request);

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { Buffer } from "node:buffer";
 
 import { expectNoHorizontalOverflow } from "./assertions";
 import {
@@ -19,6 +20,43 @@ test.describe("record tasting", () => {
     ).toBeVisible();
     await expect(page.getByText(existingBottle.fullName)).toBeVisible();
 
+    await page.getByRole("button", { name: "Savor" }).click();
+    await page.getByLabel("Comments").fill(tastingNotes);
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/tastings/${createdTastingId}$`));
+    await expect(page.getByText(tastingNotes)).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("records a tasting from a matched bottle photo", async ({
+    context,
+    page,
+  }) => {
+    await signIn(context);
+
+    await page.goto("/addTasting");
+
+    await expect(
+      page.getByRole("heading", { name: "Record Tasting" }),
+    ).toBeVisible();
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "label.png",
+      mimeType: "image/png",
+      buffer: Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+        "base64",
+      ),
+    });
+
+    await expect(page.getByText("Match found")).toBeVisible();
+    await expect(page.getByText("Lagavulin")).toBeVisible();
+    await expect(page.getByText("16 years")).toBeVisible();
+
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
     await page.getByRole("button", { name: "Savor" }).click();
     await page.getByLabel("Comments").fill(tastingNotes);
     await page.getByRole("button", { name: "Save" }).click();

--- a/docs/features/photo-tasting-entry.md
+++ b/docs/features/photo-tasting-entry.md
@@ -356,6 +356,50 @@ Input:
 Output:
 
 ```ts
+type PhotoIdentificationCandidate = {
+  bottleId: number;
+  releaseId?: number | null;
+  bottleFullName?: string | null;
+  fullName: string;
+};
+
+type PhotoIdentificationDecision =
+  | {
+      action: "match";
+      matchedBottleId: number;
+      matchedReleaseId: number | null;
+    }
+  | {
+      action: "create_bottle";
+      proposedBottle: {
+        name: string;
+        brand: { name: string };
+      };
+    }
+  | {
+      action: "create_release";
+      parentBottleId: number;
+      proposedRelease: {
+        edition: string | null;
+      };
+    }
+  | {
+      action: "create_bottle_and_release";
+      proposedBottle: {
+        name: string;
+        brand: { name: string };
+      };
+      proposedRelease: {
+        edition: string | null;
+      };
+    }
+  | {
+      action:
+        | "repair_parent_and_create_release"
+        | "repair_bottle"
+        | "no_match";
+    };
+
 {
   pendingImage: {
     id: string;
@@ -363,7 +407,21 @@ Output:
     expiresAt: string;
   };
   imageEvidence: ImageBottleEvidence;
-  classification: BottleClassifierResult;
+  classification:
+    | {
+        status: "ignored";
+        reason: string;
+        artifacts: {
+          candidates: PhotoIdentificationCandidate[];
+        };
+      }
+    | {
+        status: "classified";
+        decision: PhotoIdentificationDecision;
+        artifacts: {
+          candidates: PhotoIdentificationCandidate[];
+        };
+      };
   suggestedNextStep:
     | "confirm_match"
     | "confirm_create"
@@ -374,7 +432,9 @@ Output:
 ```
 
 This route intentionally has no permanent side effects beyond creating the
-pending upload record and traceable extraction/classification artifacts.
+pending upload record. The public response should return bounded
+photo-identification data; full classifier artifacts remain server-owned
+diagnostics instead of browser payload.
 
 The route should support idempotency for client retries. If the same user retries
 with the same `idempotencyKey`, return the existing pending upload and current

--- a/packages/bottle-classifier/src/contract.ts
+++ b/packages/bottle-classifier/src/contract.ts
@@ -8,6 +8,7 @@ import {
 } from "./classifierTypes";
 import { ImageBottleEvidenceSchema } from "./imageEvidence";
 
+export { BottleCandidateSchema } from "./classifierTypes";
 export {
   ImageBottleEvidenceConflictSchema,
   ImageBottleEvidenceSchema,


### PR DESCRIPTION
Bound the `/tastings/photo-identification` response to the fields the add-tasting browser flow needs instead of returning the full classifier artifact graph.

The production failure showed the backend returning 200 after a long photo-identification request while the browser reported `Failed to fetch`. Keeping the response as a route-owned projection reduces the payload crossing that browser/API boundary without changing accepted image inputs or classifier behavior.

This also updates the photo tasting feature API notes and adds route coverage for non-empty candidates to ensure classifier-only fields stay server-owned.

Fixes PEATED-37G