### PR TITLE
fix(tastings): Surface photo identification failures

### DIFF
--- a/apps/server/src/lib/photoIdentification.ts
+++ b/apps/server/src/lib/photoIdentification.ts
@@ -2,8 +2,6 @@ import { createWhiskyLabelExtractor } from "@peated/bottle-classifier";
 import {
   BottleExtractedDetailsSchema,
   ImageBottleEvidenceSchema,
-  createIgnoredBottleClassification,
-  type BottleClassificationResult,
   type BottleExtractedDetails,
   type ImageBottleEvidence,
 } from "@peated/server/agents/bottleClassifier";
@@ -13,8 +11,6 @@ import {
   withSentryConversation,
 } from "@peated/server/lib/openaiClient";
 import { readFile } from "@peated/server/lib/uploads";
-
-const PHOTO_IDENTIFICATION_TIMEOUT_MS = 60_000;
 
 type PhotoIdentificationPendingImage = {
   id: string;
@@ -186,52 +182,4 @@ export function buildPhotoReferenceName(
   ].filter(Boolean);
 
   return parts.length ? parts.join(" ") : "Bottle photo upload";
-}
-
-/**
- * Creates the classifier-shaped fallback result used when the photo flow should
- * preserve the pending image and continue through manual search.
- */
-export function createManualSearchPhotoClassification({
-  imageEvidence,
-  reason = "Photo identification could not produce a reviewed bottle match.",
-}: {
-  imageEvidence: ImageBottleEvidence;
-  reason?: string;
-}): BottleClassificationResult {
-  return createIgnoredBottleClassification({
-    reason,
-    artifacts: {
-      extractedIdentity: null,
-      imageEvidence,
-      candidates: [],
-      searchEvidence: [],
-      resolvedEntities: [],
-    },
-  });
-}
-
-/**
- * Bounds the user-visible identification wait while returning a caller-owned
- * fallback result instead of failing the pending upload.
- */
-export async function withPhotoIdentificationTimeout<T>(
-  work: Promise<T>,
-  fallback: () => T,
-  timeoutMs = PHOTO_IDENTIFICATION_TIMEOUT_MS,
-): Promise<T> {
-  let timeout: NodeJS.Timeout | undefined;
-
-  try {
-    return await Promise.race([
-      work,
-      new Promise<T>((resolve) => {
-        timeout = setTimeout(() => resolve(fallback()), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout);
-    }
-  }
 }

--- a/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
@@ -23,18 +23,10 @@ vi.mock(
   }),
 );
 
-vi.mock("@peated/server/lib/photoIdentification", async () => {
-  const actual = await vi.importActual<typeof photoIdentificationModule>(
-    "@peated/server/lib/photoIdentification",
-  );
-
-  return {
-    ...actual,
-    extractPhotoBottleEvidence: extractPhotoBottleEvidenceMock,
-    withPhotoIdentificationTimeout: <T>(work: Promise<T>, fallback: () => T) =>
-      actual.withPhotoIdentificationTimeout(work, fallback, 10),
-  };
-});
+vi.mock("@peated/server/lib/photoIdentification", async (importOriginal) => ({
+  ...(await importOriginal<typeof photoIdentificationModule>()),
+  extractPhotoBottleEvidence: extractPhotoBottleEvidenceMock,
+}));
 
 function buildImageEvidence(sourceImageId: string) {
   return {
@@ -346,60 +338,28 @@ describe("POST /tastings/photo-identification", () => {
     expect(response.suggestedNextStep).toBe("manual_search");
   });
 
-  test("returns pending image with manual search fallback when extraction fails", async ({
-    fixtures,
-    defaults,
-  }) => {
+  test("rejects when extraction fails", async ({ fixtures, defaults }) => {
     extractPhotoBottleEvidenceMock.mockRejectedValue(
       new Error("vision provider unavailable"),
     );
 
-    const response = await routerClient.tastings.photoIdentification(
-      {
-        file: await fixtures.SampleSquareImage(),
-        idempotencyKey: "photo-identification-extraction-failure",
-      },
-      {
-        context: { user: defaults.user },
-      },
+    const err = await waitError(
+      routerClient.tastings.photoIdentification(
+        {
+          file: await fixtures.SampleSquareImage(),
+          idempotencyKey: "photo-identification-extraction-failure",
+        },
+        {
+          context: { user: defaults.user },
+        },
+      ),
     );
 
-    expect(response.pendingImage.id).toBeDefined();
-    expect(response.suggestedNextStep).toBe("manual_search");
-    expect(response.classification).toMatchObject({
-      status: "ignored",
-      reason: "Photo identification could not produce a reviewed bottle match.",
-    });
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Unable to identify bottle from photo.]`,
+    );
     expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   });
-
-  test("returns pending image with manual search fallback when identification times out", async ({
-    fixtures,
-    defaults,
-  }) => {
-    extractPhotoBottleEvidenceMock.mockImplementation(
-      () => new Promise(() => undefined),
-    );
-
-    const response = await routerClient.tastings.photoIdentification(
-      {
-        file: await fixtures.SampleSquareImage(),
-        idempotencyKey: "photo-identification-timeout",
-      },
-      {
-        context: { user: defaults.user },
-      },
-    );
-
-    expect(response.pendingImage.id).toBeDefined();
-    expect(response.suggestedNextStep).toBe("manual_search");
-    expect(response.classification).toMatchObject({
-      status: "ignored",
-      reason:
-        "Photo identification timed out before a reviewed bottle match was available.",
-    });
-    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
-  }, 15_000);
 
   test("creates bottle and release from a reviewed photo identification proposal", async ({
     defaults,

--- a/apps/server/src/orpc/routes/tastings/photo-identification.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.ts
@@ -4,14 +4,10 @@
 import { classifyBottleReference } from "@peated/server/agents/bottleClassifier/classifyBottleReference";
 import config from "@peated/server/config";
 import { MAX_FILESIZE } from "@peated/server/constants";
-import { logError } from "@peated/server/lib/log";
 import { createPendingImageUpload } from "@peated/server/lib/pendingUploads";
 import {
-  buildPhotoEvidenceFromExtractedIdentity,
   buildPhotoReferenceName,
-  createManualSearchPhotoClassification,
   extractPhotoBottleEvidence,
-  withPhotoIdentificationTimeout,
 } from "@peated/server/lib/photoIdentification";
 import { humanizeBytes } from "@peated/server/lib/strings";
 import { compressAndResizeImage } from "@peated/server/lib/uploads";
@@ -63,37 +59,6 @@ function getSuggestedNextStep(
     case "no_match":
       return "manual_search";
   }
-}
-
-function buildFallbackIdentificationResult({
-  pendingImage,
-  reason,
-  extractionStatus,
-}: {
-  pendingImage: Awaited<ReturnType<typeof createPendingImageUpload>>;
-  reason: string;
-  extractionStatus: z.infer<
-    typeof PhotoIdentificationDiagnosticsSchema
-  >["extraction"]["status"];
-}) {
-  const imageEvidence = buildPhotoEvidenceFromExtractedIdentity({
-    pendingUpload: pendingImage,
-    extractedIdentity: null,
-  });
-  const classification = createManualSearchPhotoClassification({
-    imageEvidence,
-    reason,
-  });
-
-  return {
-    imageEvidence,
-    classification,
-    diagnostics: buildPhotoIdentificationDiagnostics({
-      extractionStatus,
-      extractionSummary: reason,
-      classification,
-    }),
-  };
 }
 
 function summarizeExtraction(
@@ -258,7 +223,7 @@ export async function identifyPendingImage({
 }: {
   pendingImage: Awaited<ReturnType<typeof createPendingImageUpload>>;
 }) {
-  const identification = (async () => {
+  return await (async () => {
     const { extractedIdentity, imageEvidence } =
       await extractPhotoBottleEvidence({
         pendingUpload: pendingImage,
@@ -284,32 +249,7 @@ export async function identifyPendingImage({
         classification,
       }),
     };
-  })().catch((err) => {
-    logError(err, {
-      pendingUpload: {
-        id: pendingImage.id,
-        source: "photo_identification",
-      },
-    });
-    throw err;
-  });
-
-  try {
-    return await withPhotoIdentificationTimeout(identification, () =>
-      buildFallbackIdentificationResult({
-        pendingImage,
-        reason:
-          "Photo identification timed out before a reviewed bottle match was available.",
-        extractionStatus: "timed_out",
-      }),
-    );
-  } catch {
-    return buildFallbackIdentificationResult({
-      pendingImage,
-      reason: "Photo identification could not produce a reviewed bottle match.",
-      extractionStatus: "failed",
-    });
-  }
+  })();
 }
 
 export default procedure
@@ -343,10 +283,19 @@ export default procedure
       onProcess: (...args) => compressAndResizeImage(...args, 1600, 1600),
     });
 
-    const { imageEvidence, classification, diagnostics } =
-      await identifyPendingImage({
+    let identification: Awaited<ReturnType<typeof identifyPendingImage>>;
+    try {
+      identification = await identifyPendingImage({
         pendingImage,
       });
+    } catch (err) {
+      throw errors.INTERNAL_SERVER_ERROR({
+        message: "Unable to identify bottle from photo.",
+        cause: err,
+      });
+    }
+
+    const { imageEvidence, classification, diagnostics } = identification;
     const suggestedNextStep = getSuggestedNextStep(classification);
 
     return {

--- a/apps/server/src/schemas/tastings.ts
+++ b/apps/server/src/schemas/tastings.ts
@@ -134,7 +134,7 @@ export const PhotoIdentificationInputSchema = z.object({
 
 export const PhotoIdentificationDiagnosticsSchema = z.object({
   extraction: z.object({
-    status: z.enum(["found", "empty", "failed", "timed_out"]),
+    status: z.enum(["found", "empty"]),
     summary: z.string().nullable().default(null),
   }),
   candidates: z.object({

--- a/apps/web/src/app/(layout-free)/addTasting/page.tsx
+++ b/apps/web/src/app/(layout-free)/addTasting/page.tsx
@@ -419,7 +419,14 @@ function AddTastingForm() {
       });
       setPhotoResult(result);
     } catch (err) {
-      logError(err);
+      logError(err, {
+        context: "add_tasting_photo_identification",
+        rpc: "tastings.photoIdentification",
+        file: {
+          size: file.size,
+          type: file.type || null,
+        },
+      });
       setError(
         "We couldn't read that photo. You can still find the bottle manually.",
       );

--- a/docs/features/photo-tasting-entry.md
+++ b/docs/features/photo-tasting-entry.md
@@ -440,8 +440,9 @@ The route should support idempotency for client retries. If the same user retrie
 with the same `idempotencyKey`, return the existing pending upload and current
 identification state instead of creating duplicate pending objects.
 
-The route should have a bounded timeout. On timeout, return the pending image and
-manual-search seed data if available rather than failing the whole entry flow.
+If extraction or classification fails or times out, the route should fail the
+photo-identification request. The client keeps the local preview visible and
+lets the user continue by manually searching for the bottle.
 
 ### Create Tasting With Selected Picture
 
@@ -803,15 +804,15 @@ Scope:
 - call the bottle classifier with extracted identity and image evidence
 - return pending image, evidence summary, classification, and suggested next step
 - support idempotency keys
-- enforce file size, processed image size, timeout, and rate limits
+- enforce file size, processed image size, and rate limits
 
 API integration tests:
 
 - valid photo-identification request returns pending image and classifier result
 - idempotent retry returns the same pending image/result state
 - oversized upload fails before model calls
-- timeout returns pending image and manual-search fallback when possible
-- rate-limited request falls back cleanly
+- extraction or classifier failure rejects the photo-identification request
+- rate-limited request fails cleanly
 - route does not create bottles, releases, or tastings
 
 Classifier calls in route tests should use a test adapter/fake at the server


### PR DESCRIPTION
Remove the server-side timeout/manual-search fallback from add-tasting photo identification. Extraction or classification failures now fail the RPC request with the canonical internal error shape, after the raw error is logged server-side.

The add-tasting client keeps the existing manual fallback message and now includes feature-specific Sentry context plus non-sensitive file metadata for failed photo-identification requests.

Also updates the photo tasting feature doc and diagnostics schema so they no longer advertise timeout/failure diagnostic states that are not returned.