### PR TITLE
build: Update Docker runtime to Node 24

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,9 @@
 # production
 **/build
 **/dist
+**/.next
+**/.turbo
+**/.playwright
 
 # misc
 **/.DS_Store

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -80,7 +80,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.14.0"
+          node-version: "24.18.0"
           cache: "pnpm"
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
+          node-version: 24.18.0
       - name: Run docker images
         run: docker compose up -d
       - name: Get pnpm store directory
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22.14.0
+          node-version: 24.18.0
       - name: Get pnpm store directory
         shell: bash
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Package Manager
 
-- Use `pnpm@10.3.0` with Node `22.14.x`
+- Use `pnpm@10.3.0` with Node `24.18.0`
 - Core commands: `pnpm install`, `pnpm dev`, `pnpm dev:server`, `pnpm dev:web`, `pnpm test`, `pnpm lint`, `pnpm typecheck`, `pnpm format`
 
 ## File-Scoped Commands

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,47 +1,52 @@
-FROM node:22-slim as base
+FROM node:24.18.0-slim AS base
 # set for base and all layer that inherit from it
 ENV NODE_ENV="production" \
+    DEBIAN_FRONTEND="noninteractive" \
     PNPM_HOME="/pnpm" \
     PATH="$PNPM_HOME:$PATH"
-RUN corepack enable
-RUN apt update -y && apt install -y libc-dev fftw-dev gcc g++ make libc6 ca-certificates
+RUN corepack enable && corepack prepare pnpm@10.3.0 --activate
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        fftw-dev \
+        g++ \
+        gcc \
+        libc-dev \
+        libc6 \
+        make \
+    && rm -rf /var/lib/apt/lists/*
 
-FROM base as base-env
+FROM base AS base-env
 WORKDIR /app
-# these are used for sourcemap publishing, and to prevent cache busting
-# on docker layers - they SHOULD NOT CHANGE between targets
+
+COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml .
+COPY apps/cli/package.json ./apps/cli/package.json
+COPY apps/web/package.json ./apps/web/package.json
+COPY apps/server/package.json ./apps/server/package.json
+# given packages are mostly universally shared code, this simplifies our logic
+COPY packages ./packages
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store NODE_ENV=development SKIP_INSTALL_SIMPLE_GIT_HOOKS=1 pnpm install --frozen-lockfile
+COPY . .
+# We run this again as Docker seems to wipe our node_modules, but they're cached
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store NODE_ENV=development SKIP_INSTALL_SIMPLE_GIT_HOOKS=1 pnpm install --frozen-lockfile
+
+# needs bound before build
 ARG SENTRY_DSN
 ARG API_SERVER
 ARG URL_PREFIX
 ARG GOOGLE_CLIENT_ID
 ARG FATHOM_SITE_ID
-ENV SENTRY_DSN=$SENTRY_DSN \
-    API_SERVER=$API_SERVER \
-    URL_PREFIX=$URL_PREFIX \
-    GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID \
-    FATHOM_SITE_ID=$FATHOM_SITE_ID
-
-ADD .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml .
-ADD apps/cli/package.json ./apps/cli/package.json
-ADD apps/web/package.json ./apps/web/package.json
-ADD apps/server/package.json ./apps/server/package.json
-# given packages are mostly universally shared code, this simplifies our logic
-ADD packages .
-
-# ensure latest corepack otherwise we could hit cert issues
-RUN npm i -g corepack@latest
-
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store NODE_ENV=development pnpm install --frozen-lockfile
-ADD . .
-# We run this again as Docker seems to wipe our node_modules, but they're cached
-RUN --mount=type=cache,id=pnpm,target=/pnpm/store NODE_ENV=development pnpm install --frozen-lockfile
-
-# needs bound before build
 ARG VERSION
 ARG SENTRY_PROJECT
 ARG SENTRY_ORG
 ARG SENTRY_AUTH_TOKEN
-ENV VERSION=$VERSION \
+ENV SENTRY_DSN=$SENTRY_DSN \
+    API_SERVER=$API_SERVER \
+    URL_PREFIX=$URL_PREFIX \
+    GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID \
+    FATHOM_SITE_ID=$FATHOM_SITE_ID \
+    VERSION=$VERSION \
     SENTRY_RELEASE=$VERSION \
     SENTRY_ORG=$SENTRY_ORG \
     SENTRY_PROJECT=$SENTRY_PROJECT \
@@ -62,9 +67,6 @@ EXPOSE 4000
 
 WORKDIR /app
 
-ARG VERSION
-ENV VERSION $VERSION
-
 # override the command
-# e.g. pnpm start:worker
+# e.g. pnpm --filter @peated/server start:worker
 CMD ["exit", "1"]

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "prettier-plugin-tailwindcss": "catalog:"
   },
   "engines": {
-    "node": ">=22.14.0 <23.0.0"
+    "node": ">=24.18.0 <25.0.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [
@@ -75,7 +75,7 @@
   },
   "packageManager": "pnpm@10.3.0",
   "volta": {
-    "node": "22.14.0",
+    "node": "24.18.0",
     "pnpm": "10.3.0"
   },
   "simple-git-hooks": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,8 +37,8 @@ catalogs:
       specifier: ^5.91.0
       version: 5.91.0
     '@types/node':
-      specifier: ^22.19.17
-      version: 22.19.17
+      specifier: ^24.13.2
+      version: 24.13.2
     '@types/pg':
       specifier: ^8.18.0
       version: 8.18.0
@@ -179,7 +179,7 @@ importers:
         version: 5.0.2
       '@types/node':
         specifier: 'catalog:'
-        version: 22.19.17
+        version: 24.13.2
       '@types/pg':
         specifier: 'catalog:'
         version: 8.18.0
@@ -302,7 +302,7 @@ importers:
         version: 4.7.4
       '@types/node':
         specifier: 'catalog:'
-        version: 22.19.17
+        version: 24.13.2
       '@types/nodemailer':
         specifier: ^7.0.11
         version: 7.0.11
@@ -368,7 +368,7 @@ importers:
         version: 9.0.3
       jsx-email:
         specifier: 'catalog:'
-        version: 1.12.1(@jsx-email/app-preview@1.2.6(@types/node@22.19.17)(@types/react-dom@18.3.0)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))(@types/node@22.19.17)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0)
+        version: 1.12.1(@jsx-email/app-preview@1.2.6(@types/node@24.13.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0)(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)))(@types/node@24.13.2)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0)
       mime-types:
         specifier: ^3.0.2
         version: 3.0.2
@@ -420,10 +420,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)
+        version: 8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
 
   apps/web:
     dependencies:
@@ -555,7 +555,7 @@ importers:
         version: 2.4.0
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))
+        version: 1.0.7(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)))
       ts-debounce:
         specifier: ^4.0.0
         version: 4.0.0
@@ -577,16 +577,16 @@ importers:
         version: 8.1.0(typescript@5.9.3)
       '@tailwindcss/forms':
         specifier: 'catalog:'
-        version: 0.5.11(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))
+        version: 0.5.11(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)))
       '@tailwindcss/typography':
         specifier: 'catalog:'
-        version: 0.5.19(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))
+        version: 0.5.19(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)))
       '@types/leaflet':
         specifier: ^1.9.12
         version: 1.9.12
       '@types/node':
         specifier: 'catalog:'
-        version: 22.19.17
+        version: 24.13.2
       '@types/pica':
         specifier: ^9.0.4
         version: 9.0.4
@@ -610,16 +610,16 @@ importers:
         version: 8.5.9
       tailwind-scrollbar:
         specifier: ^3.1.0
-        version: 3.1.0(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))
+        version: 3.1.0(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)))
       tailwindcss:
         specifier: 'catalog:'
-        version: 3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+        version: 3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
 
   packages/bottle-classifier:
     dependencies:
@@ -638,7 +638,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 22.19.17
+        version: 24.13.2
       '@vitest-evals/harness-openai-agents':
         specifier: 0.14.0
         version: 0.14.0(@openai/agents@0.8.5(ws@8.18.3)(zod@4.3.6))(vitest-evals@0.14.0(tinyrainbow@2.0.0)(vitest@4.1.4)(zod@4.3.6))
@@ -650,10 +650,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)
+        version: 8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
       vitest-evals:
         specifier: 0.14.0
         version: 0.14.0(tinyrainbow@2.0.0)(vitest@4.1.4)(zod@4.3.6)
@@ -678,13 +678,13 @@ importers:
         version: link:../tsconfig
       '@tailwindcss/forms':
         specifier: 'catalog:'
-        version: 0.5.11(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))
+        version: 0.5.11(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)))
       '@tailwindcss/typography':
         specifier: 'catalog:'
-        version: 0.5.19(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))
+        version: 0.5.19(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)))
       '@types/node':
         specifier: 'catalog:'
-        version: 22.19.17
+        version: 24.13.2
       eslint:
         specifier: 'catalog:'
         version: 8.57.1
@@ -696,10 +696,10 @@ importers:
         version: 0.5.14(prettier-plugin-organize-imports@3.2.4(prettier@3.8.1)(typescript@5.9.3))(prettier@3.8.1)
       tailwind-scrollbar:
         specifier: ^3.1.0
-        version: 3.1.0(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))
+        version: 3.1.0(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)))
       tailwindcss:
         specifier: 'catalog:'
-        version: 3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+        version: 3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -746,16 +746,16 @@ importers:
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
-        version: 22.19.17
+        version: 24.13.2
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)
+        version: 8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
 
   packages/orpc:
     dependencies:
@@ -4390,11 +4390,8 @@ packages:
   '@types/mysql@2.15.27':
     resolution: {integrity: sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA==}
 
-  '@types/node@22.19.17':
-    resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
-
-  '@types/node@25.6.0':
-    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
 
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
@@ -9228,11 +9225,8 @@ packages:
   uncrypto@0.1.3:
     resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
-
-  undici-types@7.19.2:
-    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
@@ -11604,7 +11598,7 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
     optional: true
 
-  '@jsx-email/app-preview@1.2.6(@types/node@22.19.17)(@types/react-dom@18.3.0)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))':
+  '@jsx-email/app-preview@1.2.6(@types/node@24.13.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0)(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))':
     dependencies:
       '@radix-ui/colors': 3.0.0
       '@radix-ui/react-collapsible': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.3.1))(react@18.3.1)
@@ -11613,7 +11607,7 @@ snapshots:
       '@radix-ui/react-select': 2.2.6(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot': 1.0.2(@types/react@18.3.3)(react@18.3.1)
       '@radix-ui/react-toggle-group': 1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.2.0(react@18.3.1))(react@18.3.1)
-      '@vitejs/plugin-react': 4.7.0(vite@4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0))
+      '@vitejs/plugin-react': 4.7.0(vite@4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0))
       classnames: 2.3.2
       framer-motion: 10.16.16(react-dom@18.2.0(react@18.3.1))(react@18.3.1)
       react: 18.3.1
@@ -11621,10 +11615,10 @@ snapshots:
       react-router-dom: 6.20.1(react-dom@18.2.0(react@18.3.1))(react@18.3.1)
       shikiji: 0.8.7
       superstruct: 1.0.4
-      tailwindcss: 3.4.0(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      tailwindcss: 3.4.0(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
       titleize: 4.0.0
-      vite: 4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0)
-      vite-plugin-node-polyfills: 0.16.0(rollup@4.62.2)(vite@4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0))
+      vite: 4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0)
+      vite-plugin-node-polyfills: 0.16.0(rollup@4.62.2)(vite@4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0))
     transitivePeerDependencies:
       - '@types/node'
       - '@types/react'
@@ -13546,15 +13540,15 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
 
-  '@tailwindcss/forms@0.5.11(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))':
+  '@tailwindcss/forms@0.5.11(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
 
-  '@tailwindcss/typography@0.5.19(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))':
+  '@tailwindcss/typography@0.5.19(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)))':
     dependencies:
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
 
   '@tanstack/query-core@5.90.20': {}
 
@@ -13639,7 +13633,7 @@ snapshots:
 
   '@types/bcrypt@5.0.2':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
 
   '@types/caseless@0.12.5': {}
 
@@ -13650,7 +13644,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.13.2
 
   '@types/d3-array@3.2.1': {}
 
@@ -13713,7 +13707,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
 
   '@types/leaflet@1.9.12':
     dependencies:
@@ -13735,15 +13729,11 @@ snapshots:
 
   '@types/mysql@2.15.27':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.13.2
 
-  '@types/node@22.19.17':
+  '@types/node@24.13.2':
     dependencies:
-      undici-types: 6.21.0
-
-  '@types/node@25.6.0':
-    dependencies:
-      undici-types: 7.19.2
+      undici-types: 7.18.2
 
   '@types/node@25.9.1':
     dependencies:
@@ -13751,7 +13741,7 @@ snapshots:
 
   '@types/nodemailer@7.0.11':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
 
   '@types/pg-pool@2.0.7':
     dependencies:
@@ -13759,13 +13749,13 @@ snapshots:
 
   '@types/pg@8.15.6':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.13.2
       pg-protocol: 1.13.0
       pg-types: 2.2.0
 
   '@types/pg@8.18.0':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
       pg-protocol: 1.7.1
       pg-types: 2.2.0
 
@@ -13789,7 +13779,7 @@ snapshots:
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 25.6.0
+      '@types/node': 24.13.2
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
 
@@ -13797,7 +13787,7 @@ snapshots:
 
   '@types/tedious@4.0.14':
     dependencies:
-      '@types/node': 25.9.1
+      '@types/node': 24.13.2
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -13807,7 +13797,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.6.0
+      '@types/node': 24.13.2
 
   '@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
@@ -13946,14 +13936,14 @@ snapshots:
     dependencies:
       '@unocss/core': 0.58.9
 
-  '@vitejs/plugin-react@4.3.4(vite@4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0))':
+  '@vitejs/plugin-react@4.3.4(vite@4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0))':
     dependencies:
       '@babel/core': 7.26.8
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.8)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.8)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0)
+      vite: 4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -13968,7 +13958,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0))':
+  '@vitejs/plugin-react@4.7.0(vite@4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -13976,7 +13966,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0)
+      vite: 4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -14017,7 +14007,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -14044,13 +14034,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@25.9.1)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))':
+  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)
+      vite: 8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -17091,10 +17081,10 @@ snapshots:
       object.assign: 4.1.7
       object.values: 1.2.1
 
-  jsx-email@1.12.1(@jsx-email/app-preview@1.2.6(@types/node@22.19.17)(@types/react-dom@18.3.0)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))(@types/node@22.19.17)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0):
+  jsx-email@1.12.1(@jsx-email/app-preview@1.2.6(@types/node@24.13.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0)(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)))(@types/node@24.13.2)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0):
     dependencies:
       '@dot/log': 0.1.5
-      '@jsx-email/app-preview': 1.2.6(@types/node@22.19.17)(@types/react-dom@18.3.0)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      '@jsx-email/app-preview': 1.2.6(@types/node@24.13.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(lightningcss@1.32.0)(react@18.3.1)(rollup@4.62.2)(terser@5.48.0)(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
       '@jsx-email/doiuse-email': 1.0.4
       '@jsx-email/minify-preset': 1.0.1
       '@radix-ui/react-slot': 1.0.2(@types/react@18.3.3)(react@18.3.1)
@@ -17105,7 +17095,7 @@ snapshots:
       '@unocss/preset-wind': 0.58.9
       '@unocss/transformer-compile-class': 0.58.9
       '@unocss/transformer-variant-group': 0.58.9
-      '@vitejs/plugin-react': 4.3.4(vite@4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0))
+      '@vitejs/plugin-react': 4.3.4(vite@4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0))
       autoprefixer: 10.4.27(postcss@8.5.2)
       chalk: 4.1.2
       classnames: 2.5.1
@@ -17134,8 +17124,8 @@ snapshots:
       superstruct: 1.0.4
       titleize: 4.0.0
       unist-util-visit: 5.0.0
-      vite: 4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0)
-      vite-plugin-node-polyfills: 0.16.0(rollup@4.62.2)(vite@4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0))
+      vite: 4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0)
+      vite-plugin-node-polyfills: 0.16.0(rollup@4.62.2)(vite@4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0))
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@types/node'
@@ -18061,13 +18051,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.9
 
-  postcss-load-config@4.0.2(postcss@8.5.15)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.15)(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.5.15
-      ts-node: 10.9.2(@types/node@22.19.17)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@24.13.2)(typescript@5.9.3)
 
   postcss-load-config@4.0.2(postcss@8.5.15)(ts-node@10.9.2(@types/node@25.9.1)(typescript@5.9.3)):
     dependencies:
@@ -18077,13 +18067,13 @@ snapshots:
       postcss: 8.5.15
       ts-node: 10.9.2(@types/node@25.9.1)(typescript@5.9.3)
 
-  postcss-load-config@4.0.2(postcss@8.5.9)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
+  postcss-load-config@4.0.2(postcss@8.5.9)(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.4.5
     optionalDependencies:
       postcss: 8.5.9
-      ts-node: 10.9.2(@types/node@22.19.17)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@24.13.2)(typescript@5.9.3)
 
   postcss-nested@6.2.0(postcss@8.5.15):
     dependencies:
@@ -19249,15 +19239,15 @@ snapshots:
 
   tailwind-merge@2.4.0: {}
 
-  tailwind-scrollbar@3.1.0(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))):
+  tailwind-scrollbar@3.1.0(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))):
     dependencies:
-      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))):
     dependencies:
-      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
 
-  tailwindcss@3.4.0(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
+  tailwindcss@3.4.0(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -19276,7 +19266,7 @@ snapshots:
       postcss: 8.5.15
       postcss-import: 15.1.0(postcss@8.5.15)
       postcss-js: 4.1.0(postcss@8.5.15)
-      postcss-load-config: 4.0.2(postcss@8.5.15)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.5.15)(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
       postcss-nested: 6.2.0(postcss@8.5.15)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.12
@@ -19311,7 +19301,7 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  tailwindcss@3.4.19(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
+  tailwindcss@3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -19330,7 +19320,7 @@ snapshots:
       postcss: 8.5.9
       postcss-import: 15.1.0(postcss@8.5.9)
       postcss-js: 4.1.0(postcss@8.5.9)
-      postcss-load-config: 4.0.2(postcss@8.5.9)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      postcss-load-config: 4.0.2(postcss@8.5.9)(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
       postcss-nested: 6.2.0(postcss@8.5.9)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.11
@@ -19471,14 +19461,14 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
       acorn: 8.16.0
       acorn-walk: 8.3.5
       arg: 4.1.3
@@ -19618,9 +19608,7 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
-  undici-types@6.21.0: {}
-
-  undici-types@7.19.2: {}
+  undici-types@7.18.2: {}
 
   undici-types@7.24.6: {}
 
@@ -19809,13 +19797,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-node-polyfills@0.16.0(rollup@4.62.2)(vite@4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0)):
+  vite-plugin-node-polyfills@0.16.0(rollup@4.62.2)(vite@4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.62.2)
       buffer-polyfill: buffer@6.0.3
       node-stdlib-browser: 1.3.1
       process: 0.11.10
-      vite: 4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0)
+      vite: 4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0)
     transitivePeerDependencies:
       - rollup
 
@@ -19829,13 +19817,13 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  vite@4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(terser@5.48.0):
+  vite@4.5.14(@types/node@24.13.2)(lightningcss@1.32.0)(terser@5.48.0):
     dependencies:
       esbuild: 0.18.20
       postcss: 8.5.2
       rollup: 3.29.5
     optionalDependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
       fsevents: 2.3.3
       lightningcss: 1.32.0
       terser: 5.48.0
@@ -19868,7 +19856,7 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.4.5
 
-  vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5):
+  vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -19876,7 +19864,7 @@ snapshots:
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
       esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 1.21.7
@@ -19889,7 +19877,7 @@ snapshots:
       '@vitest-evals/core': 0.14.0
       '@vitest-evals/report-ui': 0.14.0
       tinyrainbow: 2.0.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
     optionalDependencies:
       zod: 4.3.6
 
@@ -19935,10 +19923,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)):
+  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
+      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -19955,11 +19943,11 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)
+      vite: 8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.4.5)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
       '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
       jsdom: 25.0.1
     transitivePeerDependencies:
@@ -20117,7 +20105,7 @@ snapshots:
 
   wkx@0.5.0:
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 24.13.2
 
   word-wrap@1.2.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,7 +26,7 @@ catalog:
 
   tsx: ^4.21.0
   typescript: ^5.9.3
-  "@types/node": ^22.19.17
+  "@types/node": ^24.13.2
   "@types/pg": ^8.18.0
   vite: ^8.0.8
   vitest: "~4.1.4"


### PR DESCRIPTION
Update the Docker image and repo runtime metadata to Node 24.18.0 LTS, keeping Docker, Volta, CI, and AGENTS.md aligned on the same patch release. This also moves the Node ambient type catalog to the Node 24 line.

While touching the Dockerfile, clean up the install layers: use pinned Corepack pnpm activation, switch ADDs to COPYs, copy workspace packages into the correct ./packages path, skip simple-git-hooks during Docker installs, and keep build-time release/Sentry environment variables available immediately before pnpm build:docker.

The Docker context now ignores generated Next, Turbo, and Playwright output. This avoids sending local build artifacts like apps/web/.next to remote builders. The Render deploy issue came from passing quotes as part of the pnpm filter argument; use the package-name form instead, for example pnpm --filter @peated/server start:api.