### PR TITLE
fix(server): Normalize Postgres SSL cert URL params

### DIFF
--- a/apps/server/src/db/connection.test.ts
+++ b/apps/server/src/db/connection.test.ts
@@ -1,0 +1,35 @@
+import { normalizePostgresConnectionString } from "./connection";
+
+describe("normalizePostgresConnectionString", () => {
+  test("removes system sslcert sentinel values", () => {
+    const result = new URL(
+      normalizePostgresConnectionString(
+        "postgres://user:pass@example.com:5432/peated?sslmode=verify-full&sslcert=system",
+      ),
+    );
+
+    expect(result.searchParams.get("sslmode")).toBe("verify-full");
+    expect(result.searchParams.has("sslcert")).toBe(false);
+  });
+
+  test("keeps explicit certificate paths", () => {
+    const result = new URL(
+      normalizePostgresConnectionString(
+        "postgres://user:pass@example.com:5432/peated?sslmode=verify-full&sslcert=%2Fetc%2Fclient.crt",
+      ),
+    );
+
+    expect(result.searchParams.get("sslcert")).toBe("/etc/client.crt");
+  });
+
+  test("defaults system certificate URLs to verified TLS", () => {
+    const result = new URL(
+      normalizePostgresConnectionString(
+        "postgres://user:pass@example.com:5432/peated?sslrootcert=system",
+      ),
+    );
+
+    expect(result.searchParams.get("sslmode")).toBe("verify-full");
+    expect(result.searchParams.has("sslrootcert")).toBe(false);
+  });
+});

--- a/apps/server/src/db/connection.ts
+++ b/apps/server/src/db/connection.ts
@@ -1,0 +1,42 @@
+import type { PoolConfig } from "pg";
+
+const SYSTEM_SSL_CERT_PARAMS = ["sslcert", "sslrootcert"] as const;
+
+export function normalizePostgresConnectionString(connectionString: string) {
+  const url = new URL(connectionString);
+  let removedSystemCertParam = false;
+
+  for (const param of SYSTEM_SSL_CERT_PARAMS) {
+    if (url.searchParams.get(param) === "system") {
+      url.searchParams.delete(param);
+      removedSystemCertParam = true;
+    }
+  }
+
+  if (
+    removedSystemCertParam &&
+    !url.searchParams.has("ssl") &&
+    !url.searchParams.has("sslmode")
+  ) {
+    url.searchParams.set("sslmode", "verify-full");
+  }
+
+  return url.toString();
+}
+
+export function getPostgresConnectionConfig(): PoolConfig {
+  if (process.env.INSTANCE_UNIX_SOCKET) {
+    return {
+      host: process.env.INSTANCE_UNIX_SOCKET,
+      user: process.env.DATABASE_USER,
+      password: process.env.DATABASE_PASSWORD,
+      database: process.env.DATABASE_NAME,
+    };
+  }
+
+  return {
+    connectionString: process.env.DATABASE_URL
+      ? normalizePostgresConnectionString(process.env.DATABASE_URL)
+      : undefined,
+  };
+}

--- a/apps/server/src/db/index.ts
+++ b/apps/server/src/db/index.ts
@@ -3,6 +3,7 @@ import type { NodePgQueryResultHKT } from "drizzle-orm/node-postgres";
 import { drizzle } from "drizzle-orm/node-postgres";
 import type { PgTransaction } from "drizzle-orm/pg-core";
 import config from "../config";
+import { getPostgresConnectionConfig } from "./connection";
 import * as schema from "./schema";
 
 // I love to ESM.
@@ -25,19 +26,8 @@ BigInt.prototype.toJSON = function (): string {
 };
 
 function createPool(): NodePgPool {
-  const connectionConfig = process.env.INSTANCE_UNIX_SOCKET
-    ? {
-        host: process.env.INSTANCE_UNIX_SOCKET,
-        user: process.env.DATABASE_USER,
-        password: process.env.DATABASE_PASSWORD,
-        database: process.env.DATABASE_NAME,
-      }
-    : {
-        connectionString: process.env.DATABASE_URL,
-      };
-
   return new Pool({
-    ...connectionConfig,
+    ...getPostgresConnectionConfig(),
     // Vitest can re-evaluate modules across suites. Reusing one low-concurrency
     // pool in test mode avoids exhausting local Postgres clients.
     ...(config.ENV === "test"

--- a/apps/server/src/test/global-setup.ts
+++ b/apps/server/src/test/global-setup.ts
@@ -1,5 +1,6 @@
 import { drizzle } from "drizzle-orm/node-postgres";
 import pg, { Client } from "pg";
+import { normalizePostgresConnectionString } from "../db/connection";
 import { migrate } from "../db/migrate";
 import * as schema from "../db/schema";
 
@@ -59,7 +60,9 @@ async function setupDatabase(): Promise<void> {
 export default async function globalSetup(): Promise<() => Promise<void>> {
   const migrationPool = new pg.Pool({
     application_name: TEST_DB_APPLICATION_NAME,
-    connectionString: process.env.DATABASE_URL,
+    connectionString: process.env.DATABASE_URL
+      ? normalizePostgresConnectionString(process.env.DATABASE_URL)
+      : undefined,
   });
   const migrationDb = drizzle(migrationPool, {
     schema,


### PR DESCRIPTION
Normalize Postgres connection URLs before passing them to node-postgres.

PlanetScale-style URLs may include `sslcert=system` or `sslrootcert=system` to indicate system certificate trust. node-postgres interprets those params as local certificate file paths, so it tries to open a file named `system` and fails with ENOENT before TLS starts.

This strips only the provider-specific `system` sentinel values, preserves explicit certificate file paths, and defaults those system-certificate URLs to `sslmode=verify-full` when no TLS mode is already present. The runtime pool and test migration pool now share the same normalization path.

Validated with the focused connection-string test, server typecheck, lint-staged hooks, and a direct node-postgres reproduction showing the raw URL fails with `ENOENT system` while the normalized URL initializes TLS config.