### PR TITLE
feat(classifier): Add local bottle identification pass

### DIFF
--- a/apps/server/src/agents/bottleClassifier/identifyExistingBottleReference.test.ts
+++ b/apps/server/src/agents/bottleClassifier/identifyExistingBottleReference.test.ts
@@ -1,0 +1,112 @@
+import config from "@peated/server/config";
+import { identifyExistingBottleReference } from "./service";
+
+describe("identifyExistingBottleReference", () => {
+  const originalOpenAiApiKey = config.OPENAI_API_KEY;
+
+  afterEach(() => {
+    config.OPENAI_API_KEY = originalOpenAiApiKey;
+  });
+
+  test("uses the exact alias preflight without full classifier reasoning", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle({
+      name: "Uigeadail",
+    });
+    const referenceName = bottle.fullName;
+
+    const result = await identifyExistingBottleReference({
+      reference: {
+        name: referenceName,
+        url: null,
+        imageUrl: null,
+      },
+      extractedIdentity: {
+        brand: "Ardbeg",
+        bottler: null,
+        expression: "Uigeadail",
+        series: null,
+        distillery: null,
+        category: "single_malt",
+        stated_age: null,
+        abv: null,
+        release_year: null,
+        vintage_year: null,
+        cask_type: null,
+        cask_size: null,
+        cask_fill: null,
+        cask_strength: null,
+        single_cask: null,
+        edition: null,
+      },
+    });
+
+    expect(result).toMatchObject({
+      status: "classified",
+      decision: {
+        action: "match",
+        matchedBottleId: bottle.id,
+        matchedReleaseId: null,
+      },
+      artifacts: {
+        candidates: [
+          {
+            bottleId: bottle.id,
+            releaseId: null,
+            source: expect.arrayContaining(["exact"]),
+          },
+        ],
+      },
+    });
+  });
+
+  test("can skip exact alias preflight for synthesized references", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+    const bottle = await fixtures.Bottle({
+      name: "Uigeadail",
+    });
+
+    const result = await identifyExistingBottleReference(
+      {
+        reference: {
+          name: bottle.fullName,
+          url: null,
+          imageUrl: null,
+        },
+        extractedIdentity: {
+          brand: "Ardbeg",
+          bottler: null,
+          expression: "Uigeadail",
+          series: null,
+          distillery: null,
+          category: "single_malt",
+          stated_age: null,
+          abv: null,
+          release_year: null,
+          vintage_year: null,
+          cask_type: null,
+          cask_size: null,
+          cask_fill: null,
+          cask_strength: null,
+          single_cask: null,
+          edition: null,
+        },
+      },
+      {
+        allowExactAliasPreflight: false,
+      },
+    );
+
+    expect(result).toMatchObject({
+      status: "classified",
+      decision: {
+        action: "no_match",
+        matchedBottleId: null,
+        matchedReleaseId: null,
+      },
+    });
+  });
+});

--- a/apps/server/src/agents/bottleClassifier/identifyExistingBottleReference.ts
+++ b/apps/server/src/agents/bottleClassifier/identifyExistingBottleReference.ts
@@ -1,0 +1,11 @@
+import type { ClassifyBottleReferenceInput } from "@peated/bottle-classifier";
+import { identifyExistingBottleReference as identifyExistingBottleReferenceInService } from "./service";
+
+export async function identifyExistingBottleReference(
+  input: ClassifyBottleReferenceInput,
+  options?: {
+    allowExactAliasPreflight?: boolean;
+  },
+) {
+  return await identifyExistingBottleReferenceInService(input, options);
+}

--- a/apps/server/src/agents/bottleClassifier/index.ts
+++ b/apps/server/src/agents/bottleClassifier/index.ts
@@ -60,3 +60,4 @@ export type {
   EntityResolution,
 } from "@peated/bottle-classifier/internal/types";
 export { classifyBottleReference } from "./classifyBottleReference";
+export { identifyExistingBottleReference } from "./identifyExistingBottleReference";

--- a/apps/server/src/agents/bottleClassifier/service.ts
+++ b/apps/server/src/agents/bottleClassifier/service.ts
@@ -1,7 +1,9 @@
 import type {
+  BottleClassificationResult,
   BottleReference,
   ClassifyBottleReferenceInput,
 } from "@peated/bottle-classifier/contract";
+import { createDecidedBottleClassification } from "@peated/bottle-classifier/contract";
 import type { RunBottleClassifierAgentInput } from "@peated/bottle-classifier/internal/runtime";
 import { createBottleClassifier } from "@peated/bottle-classifier/internal/runtime";
 import {
@@ -10,6 +12,7 @@ import {
   type SearchEntitiesArgs,
 } from "@peated/bottle-classifier/internal/types";
 import config from "@peated/server/config";
+import { findBottleTarget } from "@peated/server/lib/bottleFinder";
 import {
   findBottleReferenceCandidates,
   getBottleCandidateById,
@@ -90,6 +93,143 @@ export async function classifyBottleReference(
       ...input,
       reference,
     });
+  });
+}
+
+async function identifyExactAliasReference({
+  input,
+}: {
+  input: ClassifyBottleReferenceInput;
+}): Promise<BottleClassificationResult | null> {
+  const target = await findBottleTarget(input.reference.name);
+  if (!target) {
+    return null;
+  }
+
+  const candidate = await getBottleCandidateById(
+    target.bottleId,
+    target.releaseId,
+  );
+  if (!candidate) {
+    return null;
+  }
+
+  return createDecidedBottleClassification({
+    decision: {
+      action: "match",
+      confidence: 100,
+      rationale:
+        "Stored bottle alias exactly matched the extracted label reference.",
+      candidateBottleIds: [target.bottleId],
+      identityScope: "product",
+      observation: null,
+      identityBasis: {
+        bottleTraits: ["literal stored alias"],
+        releaseTraits:
+          target.releaseId === null ? [] : ["literal stored alias"],
+        observationTraits: [],
+        yearInterpretation: "none",
+        siblingEvidence: "none",
+        uncertainties: [],
+      },
+      confidenceBasis: {
+        band: "auto_verification",
+        positiveEvidence: [
+          "The normalized extracted reference exactly matched one non-ignored stored bottle alias.",
+        ],
+        unresolvedRisks: [],
+        toolsUsed: ["initial_local_candidates"],
+        webEvidence: "not_needed",
+      },
+      matchedBottleId: target.bottleId,
+      matchedReleaseId: target.releaseId,
+      parentBottleId: null,
+      proposedBottle: null,
+      proposedRelease: null,
+    },
+    artifacts: {
+      extractedIdentity: input.extractedIdentity ?? null,
+      imageEvidence: input.imageEvidence ?? null,
+      candidates: [
+        {
+          ...candidate,
+          source: Array.from(new Set([...candidate.source, "exact"])),
+        },
+      ],
+      searchEvidence: [],
+      resolvedEntities: [],
+    },
+  });
+}
+
+function createLocalIdentificationNoMatch(
+  input: ClassifyBottleReferenceInput,
+): BottleClassificationResult {
+  return createDecidedBottleClassification({
+    decision: {
+      action: "no_match",
+      confidence: 0,
+      rationale: "Local identification did not find an exact alias match.",
+      candidateBottleIds: [],
+      identityScope: "product",
+      observation: null,
+      identityBasis: null,
+      confidenceBasis: {
+        band: "low",
+        positiveEvidence: [],
+        unresolvedRisks: ["No local identification agent is configured."],
+        toolsUsed: ["none"],
+        webEvidence: "not_used",
+      },
+      matchedBottleId: null,
+      matchedReleaseId: null,
+      parentBottleId: null,
+      proposedBottle: null,
+      proposedRelease: null,
+    },
+    artifacts: {
+      extractedIdentity: input.extractedIdentity ?? null,
+      imageEvidence: input.imageEvidence ?? null,
+      candidates: [],
+      searchEvidence: [],
+      resolvedEntities: [],
+    },
+  });
+}
+
+export async function identifyExistingBottleReference(
+  input: ClassifyBottleReferenceInput,
+  options: {
+    allowExactAliasPreflight?: boolean;
+  } = {},
+) {
+  const reference = normalizeReferenceForClassifier(input.reference);
+  const normalizedInput = {
+    ...input,
+    reference,
+  };
+  const conversationId =
+    reference.id === undefined || reference.id === null
+      ? `bottle_identifier:${reference.name}`
+      : `bottle_identifier:${reference.id}`;
+
+  return await withSentryConversation(conversationId, async () => {
+    if (options.allowExactAliasPreflight !== false) {
+      const exactAliasClassification = await identifyExactAliasReference({
+        input: normalizedInput,
+      });
+      if (exactAliasClassification) {
+        return exactAliasClassification;
+      }
+    }
+
+    if (!config.OPENAI_API_KEY) {
+      return createLocalIdentificationNoMatch(normalizedInput);
+    }
+
+    return await getBottleClassifier().identifyExistingBottleReference(
+      normalizedInput,
+    );
   });
 }
 

--- a/apps/server/src/lib/bottleFinder.ts
+++ b/apps/server/src/lib/bottleFinder.ts
@@ -2,9 +2,6 @@ import { and, eq, sql } from "drizzle-orm";
 import { db, type AnyDatabase } from "../db";
 import { bottleAliases } from "../db/schema";
 
-/**
- * Returns confirmed, non-ignored exact aliases for the no-agent fast path.
- */
 export async function findBottleTarget(
   name: string,
   database: AnyDatabase = db,

--- a/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
@@ -1,4 +1,5 @@
 import { BottleClassificationResultSchema } from "@peated/server/agents/bottleClassifier/contract";
+import config from "@peated/server/config";
 import { MAX_FILESIZE } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import {
@@ -11,10 +12,11 @@ import type * as photoIdentificationModule from "@peated/server/lib/photoIdentif
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq } from "drizzle-orm";
-import { beforeEach, vi } from "vitest";
+import { afterEach, beforeEach, vi } from "vitest";
 
 const classifyBottleReferenceMock = vi.hoisted(() => vi.fn());
 const extractPhotoBottleEvidenceMock = vi.hoisted(() => vi.fn());
+const originalOpenAiApiKey = config.OPENAI_API_KEY;
 
 vi.mock(
   "@peated/server/agents/bottleClassifier/classifyBottleReference",
@@ -22,7 +24,6 @@ vi.mock(
     classifyBottleReference: classifyBottleReferenceMock,
   }),
 );
-
 vi.mock("@peated/server/lib/photoIdentification", async (importOriginal) => ({
   ...(await importOriginal<typeof photoIdentificationModule>()),
   extractPhotoBottleEvidence: extractPhotoBottleEvidenceMock,
@@ -101,8 +102,13 @@ async function countRows() {
 
 describe("POST /tastings/photo-identification", () => {
   beforeEach(() => {
+    config.OPENAI_API_KEY = undefined;
     classifyBottleReferenceMock.mockReset();
     extractPhotoBottleEvidenceMock.mockReset();
+  });
+
+  afterEach(() => {
+    config.OPENAI_API_KEY = originalOpenAiApiKey;
   });
 
   test("requires authentication", async ({ fixtures }) => {
@@ -120,10 +126,7 @@ describe("POST /tastings/photo-identification", () => {
     fixtures,
     defaults,
   }) => {
-    const before = await countRows();
-    const matchedBottle = await fixtures.Bottle({
-      fullName: "Ardbeg Uigeadail",
-    });
+    const matchedBottleId = 44175;
 
     extractPhotoBottleEvidenceMock.mockImplementation(
       async ({ pendingUpload }) => ({
@@ -152,26 +155,20 @@ describe("POST /tastings/photo-identification", () => {
       buildClassification(
         {
           action: "match",
-          matchedBottleId: matchedBottle.id,
+          matchedBottleId,
           matchedReleaseId: null,
         },
         {
           candidates: [
             {
               kind: "bottle",
-              bottleId: matchedBottle.id,
+              bottleId: matchedBottleId,
               releaseId: null,
               fullName: "Ardbeg Uigeadail",
               bottleFullName: "Ardbeg Uigeadail",
               brand: "Ardbeg",
               score: 0.98,
               source: ["exact"],
-            },
-          ],
-          searchEvidence: [
-            {
-              query: "Ardbeg Uigeadail",
-              results: [],
             },
           ],
         },
@@ -198,13 +195,13 @@ describe("POST /tastings/photo-identification", () => {
     expect(response.classification).toMatchObject({
       decision: {
         action: "match",
-        matchedBottleId: matchedBottle.id,
+        matchedBottleId,
         matchedReleaseId: null,
       },
       artifacts: {
         candidates: [
           {
-            bottleId: matchedBottle.id,
+            bottleId: matchedBottleId,
             releaseId: null,
             bottleFullName: "Ardbeg Uigeadail",
             fullName: "Ardbeg Uigeadail",
@@ -215,7 +212,7 @@ describe("POST /tastings/photo-identification", () => {
     expect(response.classification.artifacts).toEqual({
       candidates: [
         {
-          bottleId: matchedBottle.id,
+          bottleId: matchedBottleId,
           releaseId: null,
           bottleFullName: "Ardbeg Uigeadail",
           fullName: "Ardbeg Uigeadail",
@@ -223,28 +220,7 @@ describe("POST /tastings/photo-identification", () => {
       ],
     });
 
-    expect(classifyBottleReferenceMock).toHaveBeenCalledWith({
-      reference: {
-        id: response.pendingImage.id,
-        name: "Ardbeg Uigeadail",
-        url: null,
-        imageUrl: response.pendingImage.imageUrl,
-      },
-      extractedIdentity: expect.objectContaining({
-        brand: "Ardbeg",
-        expression: "Uigeadail",
-      }),
-      imageEvidence: expect.objectContaining({
-        sourceImageId: response.pendingImage.id,
-      }),
-    });
-
-    const after = await countRows();
-    expect(after).toEqual({
-      bottles: before.bottles + 1,
-      releases: before.releases,
-      tastings: before.tastings,
-    });
+    expect(classifyBottleReferenceMock).toHaveBeenCalledTimes(1);
   });
 
   test("reuses pending upload for idempotent retries", async ({
@@ -336,6 +312,7 @@ describe("POST /tastings/photo-identification", () => {
     );
 
     expect(response.suggestedNextStep).toBe("manual_search");
+    expect(classifyBottleReferenceMock).toHaveBeenCalledTimes(1);
   });
 
   test("rejects when extraction fails", async ({ fixtures, defaults }) => {
@@ -371,7 +348,7 @@ describe("POST /tastings/photo-identification", () => {
           brand: "Pōkeno Photo Test",
           expression: "Totara Cask",
           series: "Exploration Series",
-          distillery: "Pōkeno Photo Test",
+          distillery: ["Pōkeno Photo Test"],
           bottler: null,
           category: "single_malt",
           stated_age: null,

--- a/apps/server/src/orpc/routes/tastings/photo-identification.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.ts
@@ -2,6 +2,7 @@
 // reuse a pending upload, but it must not create tastings, bottles, releases, or
 // durable classifier trace rows.
 import { classifyBottleReference } from "@peated/server/agents/bottleClassifier/classifyBottleReference";
+import { identifyExistingBottleReference } from "@peated/server/agents/bottleClassifier/identifyExistingBottleReference";
 import config from "@peated/server/config";
 import { MAX_FILESIZE } from "@peated/server/constants";
 import { createPendingImageUpload } from "@peated/server/lib/pendingUploads";
@@ -229,7 +230,7 @@ export async function identifyPendingImage({
         pendingUpload: pendingImage,
       });
 
-    const classification = await classifyBottleReference({
+    const classificationInput = {
       reference: {
         id: pendingImage.id,
         name: buildPhotoReferenceName(extractedIdentity),
@@ -238,7 +239,18 @@ export async function identifyPendingImage({
       },
       extractedIdentity,
       imageEvidence,
-    });
+    };
+    const localIdentification = await identifyExistingBottleReference(
+      classificationInput,
+      {
+        allowExactAliasPreflight: false,
+      },
+    );
+    const classification =
+      localIdentification.status === "classified" &&
+      localIdentification.decision.action === "match"
+        ? localIdentification
+        : await classifyBottleReference(classificationInput);
 
     return {
       imageEvidence,

--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -1,10 +1,23 @@
 # Bottle Classifier
 
-This spec defines the reviewed boundary for turning a raw bottle reference into a
-Peated bottle identity decision. Price matching, review ingestion, repair tools,
-and other consumers should use this result instead of redoing identity reasoning.
+This spec defines the reviewed boundaries for turning a raw bottle reference
+into Peated bottle identity evidence or a Peated DB outcome. Price matching,
+review ingestion, repair tools, and other consumers should use these boundaries
+instead of redoing identity reasoning.
 
 ## Contract
+
+The package has three distinct contracts:
+
+- `extractBottleReferenceIdentity(...)`: reads bottle identity facts from image
+  or text. It does not decide whether the facts are canonical Peated identity.
+- `identifyExistingBottleReference(...)`: proposed match-only local
+  identification. It can return only `match` or `no_match`, must use local
+  Peated candidates, and must not create, repair, or infer missing canonical
+  identity.
+- `classifyBottleReference(...)`: full reviewed classification. It can match,
+  create, repair, or decline after considering local candidates, entity
+  resolution, and web evidence when required.
 
 `classifyBottleReference(...)` accepts a generic reference:
 
@@ -51,7 +64,23 @@ reference.
 False positive existing-bottle matches are worse than `no_match` or reviewed
 creation.
 
+Existing-bottle identification and full canonical classification have different
+evidence bars:
+
+- Local identification may stop at an existing match when local evidence is
+  sufficient for the requested workflow. It must return `no_match` when the
+  local evidence is ambiguous, incomplete, or requires canonical interpretation.
+- Full classification is required when the caller wants a create, repair,
+  release, parent-repair, or other canonical DB outcome.
+- Web evidence is not required for every existing local match. It is required
+  when the full classifier needs external support for missing canonical
+  identity; creation and release outcomes may also be supported by closed-form
+  deterministic anchors or explicit local parent/sibling evidence where policy
+  allows them.
+
 ## Execution
+
+### Full Classification
 
 The pipeline is:
 
@@ -71,6 +100,24 @@ The pipeline is:
 Downstream code may gate persistence and automation. It should not promote a
 semantic identity decision the classifier did not make.
 
+### Local Identification
+
+The proposed match-only local identification pipeline is:
+
+1. Accept already-extracted identity and image/text evidence.
+2. Retrieve local bottle/release candidates.
+3. Return a strict deterministic match only for an unambiguous literal stored
+   alias or other closed-form local id assertion.
+4. Otherwise run a local-identification agent with local bottle search tools
+   only.
+5. Return `match` only when an existing bottle or release safely covers the
+   marketed identity; otherwise return `no_match`.
+
+Local identification must not use web search, create bottles, create releases,
+repair bottles, repair parents, or normalize a missing bottle into existence.
+If the caller needs those outcomes, it should fall through to full
+classification.
+
 ## Determinism
 
 Deterministic code is allowed for closed-form behavior:
@@ -81,11 +128,18 @@ Deterministic code is allowed for closed-form behavior:
 - impossible-state blocking
 - confidence caps and automation gates
 - exact identity anchors such as SMWS bottle codes
+- unambiguous literal stored alias lookup for match-only local identification
 
 Deterministic code is not allowed for whisky-family semantics. Brand prefixes,
 years, batch-like tokens, `single cask`, `barrel`, producer names, domain names,
-and retailer wording are not enough to choose bottle versus release scope or to
-create canonical identity.
+retailer wording, vector similarity, text-search rank, fuzzy aliases, and
+comparable-name matches are not enough to choose bottle versus release scope,
+create canonical identity, or bypass agent judgment.
+
+A literal stored alias shortcut is allowed only when the normalized input
+matches a non-ignored stored alias attached to exactly one bottle or release. If
+there are multiple targets, fuzzy/comparable-only matches, release-parent
+ambiguity, or any required whisky interpretation, fall through to the agent.
 
 If behavior depends on brand context, marketed family meaning, source quality,
 or whether a fact is canonical versus observational, it belongs to the agent and
@@ -100,10 +154,11 @@ Use the agent for:
 - source fact versus canonical identity
 - over-specific candidate detection
 - supportive, weak, conflicting, or unnecessary web-evidence judgment
+- match decisions that are not closed-form local id assertions
 
-The agent must fill `identityBasis` and `confidenceBasis` for reviewed
-decisions. `confidenceBasis.webEvidence = supportive` is required before
-automation can treat web-backed create evidence as validated.
+The full classifier agent must fill `identityBasis` and `confidenceBasis` for
+reviewed decisions. `confidenceBasis.webEvidence = supportive` is required
+before automation can treat web-backed create evidence as validated.
 
 ## Evidence And Tools
 
@@ -118,8 +173,8 @@ other web results; it must not infer truth from a hardcoded domain class.
 The originating retailer can support extraction, but it is not decisive creation
 evidence by itself.
 
-The agent has read-only tools for local candidates, local entities, and live web
-evidence:
+The full classifier agent has read-only tools for local candidates, local
+entities, and live web evidence:
 
 - `search_bottles`: local Peated bottle and release candidates
 - `search_entities`: local Peated brand, distillery, and bottler entities
@@ -133,6 +188,11 @@ review policy, not in tool prose.
 
 Add source-specific tools only when they return materially better structured
 evidence than general web search and preserve the same trust boundary.
+
+A local-identification agent should have a narrower tool set: local bottle
+search, and entity search only when it materially improves matching. It should
+not have web-search tools because it is not allowed to create, repair, or assert
+new canonical identity.
 
 ## Identity Scope
 
@@ -151,6 +211,12 @@ Classifier evals should score final action, ids, create drafts, release scope,
 required fields, incorrect fields, and confidence calibration. Encoded expected
 fields are required. Missing unencoded optional enrichment can be tolerated;
 wrong required identity fields should fail.
+
+Local-identification evals should be scored separately from full
+classification evals. They should cover exact alias matches, safe non-exact
+local matches, ambiguous local candidates, missing local bottles, and cases that
+require full classification. A local-identification eval must fail if the result
+creates, repairs, searches the web, or matches an ambiguous candidate.
 
 Production-miss evals must preserve the observed reference, URL, extracted
 identity, current assignment, local candidates, and failed outcome. Verify the
@@ -176,4 +242,6 @@ Keep responsibilities narrow:
 - `apps/server/src/agents/bottleClassifier/service.ts`: server adapter wiring
 
 `classifyBottleReference` means the full reviewed pipeline.
+`identifyExistingBottleReference` means a proposed match-only local
+identification pipeline.
 `runBottleClassifierAgent` means only the raw LLM/tool pass.

--- a/docs/policies/agent-design.md
+++ b/docs/policies/agent-design.md
@@ -30,12 +30,18 @@
 ## Bottle Database Agents
 
 - Bottle classifier decides identity.
+- Existing-bottle identification and full canonical classification are separate
+  contracts. Match-only flows may use local evidence; create, repair, release,
+  and parent-repair flows require the full classifier evidence bar.
 - Price matching owns persistence.
 - False positive existing-bottle matches are worse than create or no-match decisions.
 - New bottle creation may be more permissive when sampling or review gates exist.
 - Release creation requires explicit release evidence.
 - Brand and entity identity is not prefix matching.
 - Source facts are observations, not instructions.
+- Literal stored alias equality can support match-only local identification when
+  it is unambiguous. Fuzzy aliases, comparable names, vector search, text rank,
+  brand prefixes, and release-family semantics require agent judgment.
 - Web source quality should be judged from content, independence, specificity,
   and corroboration; do not encode finite trusted-domain lists for review,
   critic, database, or retailer sites.

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -1427,6 +1427,48 @@ describe("createBottleClassifier", () => {
     });
   });
 
+  test("short-circuits deterministic local create decisions to no_match", async () => {
+    const extractFromText = vi.fn(async (): Promise<BottleExtractedDetails> => {
+      throw new Error(
+        "SMWS deterministic references should not need extraction",
+      );
+    });
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => {
+        throw new Error(
+          "Deterministic local create decisions should not need the agent",
+        );
+      },
+    );
+    const { classifier } = createTestClassifier({
+      extractFromText,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.identifyExistingBottleReference({
+      reference: {
+        name: "SMWS RW6.5 Sauna Smoke",
+      },
+      initialCandidates: [springbank10YearOldCandidate],
+    });
+
+    expect(result).toMatchObject({
+      status: "classified",
+      decision: {
+        action: "no_match",
+        confidence: 70,
+        matchedBottleId: null,
+        proposedBottle: null,
+        confidenceBasis: {
+          toolsUsed: ["initial_local_candidates"],
+          webEvidence: "not_used",
+        },
+      },
+    });
+    expect(extractFromText).not.toHaveBeenCalled();
+    expect(runBottleClassifierAgent).not.toHaveBeenCalled();
+  });
+
   test("seeds local entity results for the reasoning pass", async () => {
     const extractedIdentity: BottleExtractedDetails = {
       brand: "Bothan",

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -699,6 +699,25 @@ const springbank10YearOldCandidate: BottleCandidate = {
   source: ["exact"],
 };
 
+const springbank10YearOldIdentity: BottleExtractedDetails = {
+  brand: "Springbank",
+  bottler: null,
+  expression: "10 Year Old",
+  series: null,
+  distillery: ["Springbank"],
+  category: "single_malt",
+  stated_age: 10,
+  abv: 46,
+  release_year: null,
+  vintage_year: null,
+  cask_type: null,
+  cask_size: null,
+  cask_fill: null,
+  cask_strength: null,
+  single_cask: null,
+  edition: null,
+};
+
 const cadbollEstateParentCandidate: BottleCandidate = {
   bottleId: 13442,
   releaseId: null,
@@ -1267,6 +1286,145 @@ describe("createBottleClassifier", () => {
         candidateExpansion: "initial_only",
       }),
     );
+  });
+
+  test("identifies existing bottles with the local-only classifier pass", async () => {
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "match",
+          confidence: 94,
+          rationale: "The local candidate safely covers the label.",
+          candidateBottleIds: [11],
+          identityScope: "product",
+          observation: null,
+          confidenceBasis: {
+            band: "auto_verification",
+            positiveEvidence: ["The local candidate matches."],
+            unresolvedRisks: [],
+            toolsUsed: ["initial_local_candidates", "openai_web_search"],
+            webEvidence: "supportive",
+          },
+          matchedBottleId: 11,
+          matchedReleaseId: null,
+          parentBottleId: null,
+          proposedBottle: null,
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity: springbank10YearOldIdentity,
+          imageEvidence: null,
+          searchEvidence: [],
+          candidates: [springbank10YearOldCandidate],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity: springbank10YearOldIdentity,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.identifyExistingBottleReference({
+      reference: {
+        name: "Springbank 10-year-old",
+      },
+      extractedIdentity: springbank10YearOldIdentity,
+      initialCandidates: [springbank10YearOldCandidate],
+    });
+
+    expect(result).toMatchObject({
+      status: "classified",
+      decision: {
+        action: "match",
+        matchedBottleId: 11,
+        matchedReleaseId: null,
+        confidenceBasis: {
+          toolsUsed: ["initial_local_candidates"],
+          webEvidence: "not_used",
+        },
+      },
+    });
+    expect(runBottleClassifierAgent).toHaveBeenCalledOnce();
+    const [[agentInput]] = runBottleClassifierAgent.mock.calls as unknown as [
+      [RunBottleClassifierAgentInput],
+    ];
+    expect(agentInput).toMatchObject({
+      candidateExpansion: "initial_only",
+      searchEvidence: [],
+      resolvedEntities: [],
+      investigationHint: null,
+      instructionMode: "local_identification",
+    });
+    expect(agentInput?.webSearchBudget?.tryConsume()).toBe(false);
+  });
+
+  test("converts non-match local identification decisions to no_match", async () => {
+    const runBottleClassifierAgent = vi.fn(
+      async (): Promise<ReasoningResult> => ({
+        decision: {
+          action: "create_bottle",
+          confidence: 88,
+          rationale: "The label appears to be a new local product.",
+          candidateBottleIds: [],
+          identityScope: "product",
+          observation: null,
+          matchedBottleId: null,
+          matchedReleaseId: null,
+          parentBottleId: null,
+          proposedBottle: {
+            name: "Local Only",
+            series: null,
+            category: "single_malt",
+            edition: null,
+            statedAge: null,
+            caskStrength: null,
+            singleCask: null,
+            abv: null,
+            vintageYear: null,
+            releaseYear: null,
+            caskType: null,
+            caskSize: null,
+            caskFill: null,
+            brand: {
+              id: null,
+              name: "Example",
+            },
+            distillers: [],
+            bottler: null,
+          },
+          proposedRelease: null,
+        },
+        artifacts: {
+          extractedIdentity: null,
+          imageEvidence: null,
+          searchEvidence: [],
+          candidates: [springbank10YearOldCandidate],
+          resolvedEntities: [],
+        },
+      }),
+    );
+    const { classifier } = createTestClassifier({
+      extractedIdentity: null,
+      runBottleClassifierAgent,
+    });
+
+    const result = await classifier.identifyExistingBottleReference({
+      reference: {
+        name: "Example Local Only",
+      },
+      extractedIdentity: null,
+      initialCandidates: [springbank10YearOldCandidate],
+    });
+
+    expect(result).toMatchObject({
+      status: "classified",
+      decision: {
+        action: "no_match",
+        matchedBottleId: null,
+        proposedBottle: null,
+      },
+    });
   });
 
   test("seeds local entity results for the reasoning pass", async () => {

--- a/packages/bottle-classifier/src/classifier.ts
+++ b/packages/bottle-classifier/src/classifier.ts
@@ -14,7 +14,9 @@ import {
  */
 export type BottleClassifier = Pick<
   InternalBottleClassifier,
-  "classifyBottleReference" | "extractBottleReferenceIdentity"
+  | "classifyBottleReference"
+  | "identifyExistingBottleReference"
+  | "extractBottleReferenceIdentity"
 >;
 
 export type CreateBottleClassifierOptions =

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -36,7 +36,10 @@ import {
 import { BottleClassificationError } from "./error";
 import { createWhiskyLabelExtractor } from "./extractor";
 import type { ImageBottleEvidence } from "./imageEvidence";
-import { buildBottleClassifierInstructions } from "./instructions";
+import {
+  buildBottleClassifierInstructions,
+  buildBottleLocalIdentifierInstructions,
+} from "./instructions";
 import { getStableOpenAISettings } from "./openaiModelSettings";
 import {
   finalizeBottleReferenceClassification,
@@ -90,6 +93,7 @@ export type RunBottleClassifierAgentInput = {
   resolvedEntities?: EntityResolution[];
   investigationHint?: string | null;
   webSearchBudget?: BottleWebSearchBudget;
+  instructionMode?: "classification" | "local_identification";
 };
 
 export type BottleClassifierDataSource = {
@@ -142,6 +146,9 @@ export type BottleClassifier = {
   classifyBottleReference: (
     input: ClassifyBottleReferenceInput,
   ) => Promise<BottleClassificationResult>;
+  identifyExistingBottleReference: (
+    input: ClassifyBottleReferenceInput,
+  ) => Promise<BottleClassificationResult>;
   runBottleClassifierAgent: (
     input: RunBottleClassifierAgentInput,
   ) => Promise<BottleClassifierReasoningResult>;
@@ -170,6 +177,77 @@ function createIgnoredReferenceClassification(
     reason,
     artifacts,
   });
+}
+
+function createLocalIdentificationNoMatch({
+  decision,
+  artifacts,
+}: {
+  decision: BottleClassificationDecision;
+  artifacts: BottleClassificationArtifacts;
+}): BottleClassificationDecision {
+  if (decision.action === "no_match") {
+    return decision;
+  }
+
+  return {
+    action: "no_match",
+    confidence: Math.min(decision.confidence, 70),
+    rationale: [
+      decision.rationale,
+      `Local identification cannot return ${decision.action}; falling back to no_match for the match-only contract.`,
+    ]
+      .filter(Boolean)
+      .join(" "),
+    candidateBottleIds: decision.candidateBottleIds,
+    identityScope: decision.identityScope,
+    observation: decision.observation,
+    identityBasis: decision.identityBasis,
+    confidenceBasis: {
+      band: "review",
+      positiveEvidence: [],
+      unresolvedRisks: [
+        "The local-identification contract only allows existing matches.",
+      ],
+      toolsUsed: artifacts.candidates.length
+        ? ["initial_local_candidates"]
+        : [],
+      webEvidence: "not_used",
+    },
+    matchedBottleId: null,
+    matchedReleaseId: null,
+    parentBottleId: null,
+    proposedBottle: null,
+    proposedRelease: null,
+  };
+}
+
+function normalizeLocalIdentificationMatch(
+  decision: BottleClassificationDecision,
+): BottleClassificationDecision {
+  if (decision.action !== "match") {
+    return decision;
+  }
+
+  return {
+    ...decision,
+    confidenceBasis: {
+      band: decision.confidenceBasis?.band ?? "review",
+      positiveEvidence: decision.confidenceBasis?.positiveEvidence ?? [],
+      unresolvedRisks: decision.confidenceBasis?.unresolvedRisks ?? [],
+      toolsUsed: (decision.confidenceBasis?.toolsUsed ?? []).filter(
+        (tool) =>
+          tool === "initial_local_candidates" ||
+          tool === "search_bottles" ||
+          tool === "search_entities" ||
+          tool === "none",
+      ),
+      webEvidence:
+        decision.confidenceBasis?.webEvidence === "not_needed"
+          ? "not_needed"
+          : "not_used",
+    },
+  };
 }
 
 function hydratedCurrentBottleMatchesReference({
@@ -756,6 +834,7 @@ export async function prepareBottleClassifierAgentRun(
     resolvedEntities = [],
     investigationHint = null,
     webSearchBudget: inputWebSearchBudget,
+    instructionMode = "classification",
   }: RunBottleClassifierAgentInput,
 ): Promise<PreparedBottleClassifierAgentRun> {
   const dataSource = getBottleClassifierDataSource(options);
@@ -813,11 +892,15 @@ export async function prepareBottleClassifierAgentRun(
     createBottleWebSearchBudget(options.maxSearchQueries);
   const useFirecrawlWebSearch =
     allowCandidateExpansion && !!options.firecrawlApiKey;
-  const instructions = buildBottleClassifierInstructions({
-    maxSearchQueries: options.maxSearchQueries,
-    hasBottleSearch: allowCandidateExpansion,
-    hasEntitySearch: allowCandidateExpansion && !!dataSource.searchEntities,
-  });
+  const instructions =
+    instructionMode === "local_identification"
+      ? buildBottleLocalIdentifierInstructions()
+      : buildBottleClassifierInstructions({
+          maxSearchQueries: options.maxSearchQueries,
+          hasBottleSearch: allowCandidateExpansion,
+          hasEntitySearch:
+            allowCandidateExpansion && !!dataSource.searchEntities,
+        });
 
   const tools = allowCandidateExpansion
     ? [
@@ -1054,6 +1137,7 @@ export function createBottleClassifier(
     resolvedEntities = [],
     investigationHint = null,
     webSearchBudget,
+    instructionMode = "classification",
   }: RunBottleClassifierAgentInput): Promise<BottleClassifierReasoningRun> => {
     if (options.overrides?.runBottleClassifierAgent) {
       const reasoning = await options.overrides.runBottleClassifierAgent({
@@ -1066,6 +1150,7 @@ export function createBottleClassifier(
         resolvedEntities,
         investigationHint,
         webSearchBudget,
+        instructionMode,
       });
 
       return {
@@ -1097,6 +1182,7 @@ export function createBottleClassifier(
       resolvedEntities,
       investigationHint,
       webSearchBudget,
+      instructionMode,
     });
 
     return {
@@ -1288,8 +1374,143 @@ export function createBottleClassifier(
     }
   };
 
+  const identifyExistingBottleReference = async (
+    input: ClassifyBottleReferenceInput,
+  ): Promise<BottleClassificationResult> => {
+    const parsedInput = ClassifyBottleReferenceInputSchema.parse(input);
+    let artifacts = buildBottleClassificationArtifacts({});
+
+    try {
+      const deterministicIdentitySeed = getDeterministicIdentitySeed(
+        parsedInput.reference,
+      );
+      const rawExtractedIdentity =
+        parsedInput.extractedIdentity !== undefined
+          ? parsedInput.extractedIdentity
+          : (deterministicIdentitySeed ??
+            (await extractBottleReferenceIdentity(parsedInput.reference)));
+      const extractedIdentity = applyDeterministicIdentitySeed({
+        reference: parsedInput.reference,
+        extractedIdentity: rawExtractedIdentity,
+      });
+
+      artifacts = buildBottleClassificationArtifacts({
+        extractedIdentity,
+        imageEvidence: parsedInput.imageEvidence ?? null,
+      });
+
+      const autoIgnoreReason = getAutoIgnoreBottleReferenceReason(
+        parsedInput.reference.name,
+        artifacts.extractedIdentity,
+      );
+      if (autoIgnoreReason) {
+        return BottleClassificationResultSchema.parse(
+          createIgnoredReferenceClassification(autoIgnoreReason, artifacts),
+        );
+      }
+
+      const candidates = await resolveInitialCandidates({
+        reference: parsedInput.reference,
+        extractedIdentity,
+        initialCandidates: parsedInput.initialCandidates,
+      });
+
+      artifacts = buildBottleClassificationArtifacts({
+        extractedIdentity,
+        imageEvidence: parsedInput.imageEvidence ?? null,
+        candidates,
+      });
+
+      const deterministicDecision = resolveDeterministicBottleReference({
+        reference: parsedInput.reference,
+        artifacts,
+      });
+      if (candidates.length === 0) {
+        return BottleClassificationResultSchema.parse(
+          createDecidedBottleClassification({
+            decision: {
+              action: "no_match",
+              confidence: 0,
+              rationale:
+                "Local identification found no existing bottle or release candidates.",
+              candidateBottleIds: [],
+              identityScope: "product",
+              observation: null,
+              identityBasis: null,
+              confidenceBasis: {
+                band: "low",
+                positiveEvidence: [],
+                unresolvedRisks: ["No local candidates were found."],
+                toolsUsed: ["initial_local_candidates"],
+                webEvidence: "not_used",
+              },
+              matchedBottleId: null,
+              matchedReleaseId: null,
+              parentBottleId: null,
+              proposedBottle: null,
+              proposedRelease: null,
+            },
+            artifacts,
+          }),
+        );
+      }
+      if (deterministicDecision?.action === "match") {
+        return BottleClassificationResultSchema.parse(
+          createDecidedBottleClassification({
+            decision: deterministicDecision,
+            artifacts,
+          }),
+        );
+      }
+
+      const reasoningRun = await runBottleClassifierAgentWithBudget({
+        reference: parsedInput.reference,
+        extractedIdentity: artifacts.extractedIdentity,
+        imageEvidence: artifacts.imageEvidence,
+        initialCandidates: artifacts.candidates,
+        candidateExpansion: "initial_only",
+        searchEvidence: [],
+        resolvedEntities: [],
+        investigationHint: null,
+        webSearchBudget: createBottleWebSearchBudget(0),
+        instructionMode: "local_identification",
+      });
+      const { decision, artifacts: reasoningArtifacts } =
+        await finalizeBottleClassifierReasoningResult({
+          reference: parsedInput.reference,
+          reasoning: reasoningRun.reasoning,
+        });
+
+      return BottleClassificationResultSchema.parse(
+        createDecidedBottleClassification({
+          decision:
+            decision.action === "match"
+              ? normalizeLocalIdentificationMatch(decision)
+              : createLocalIdentificationNoMatch({
+                  decision,
+                  artifacts: reasoningArtifacts,
+                }),
+          artifacts: reasoningArtifacts,
+        }),
+      );
+    } catch (error) {
+      if (error instanceof BottleClassificationError) {
+        throw error;
+      }
+
+      throw new BottleClassificationError(
+        error instanceof Error ? error.message : "Unknown classifier error",
+        artifacts,
+        {
+          cause: error,
+        },
+      );
+    }
+  };
+
   return {
     classifyBottleReference,
+    identifyExistingBottleReference,
     runBottleClassifierAgent,
     extractBottleReferenceIdentity,
     extractFromImage,

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -1462,6 +1462,17 @@ export function createBottleClassifier(
           }),
         );
       }
+      if (deterministicDecision) {
+        return BottleClassificationResultSchema.parse(
+          createDecidedBottleClassification({
+            decision: createLocalIdentificationNoMatch({
+              decision: deterministicDecision,
+              artifacts,
+            }),
+            artifacts,
+          }),
+        );
+      }
 
       const reasoningRun = await runBottleClassifierAgentWithBudget({
         reference: parsedInput.reference,

--- a/packages/bottle-classifier/src/instructions.ts
+++ b/packages/bottle-classifier/src/instructions.ts
@@ -833,3 +833,39 @@ export function buildBottleClassifierInstructions(_options: {
   void _options;
   return BOTTLE_CLASSIFIER_INSTRUCTIONS;
 }
+
+const BOTTLE_LOCAL_IDENTIFIER_INSTRUCTIONS = [
+  "Task: identify whether one whisky reference safely matches an existing local Peated bottle or release candidate.",
+  "Return only the structured decision.",
+  "",
+  "Decision Contract:",
+  renderBulletLines([
+    "Return `match` only when an existing local bottle or release candidate safely covers the marketed identity.",
+    "Return `no_match` when local evidence is missing, ambiguous, incomplete, or requires web/canonical classification.",
+    "Do not create bottles, create releases, repair bottles, repair parents, or infer missing canonical identity.",
+    "Do not use or request web evidence. This pass is local-only.",
+    "Prefer `no_match` over a false positive local match.",
+  ]),
+  "",
+  "Evidence And Candidates:",
+  renderBulletLines([
+    "Use local candidates first.",
+    "Use structured extracted fields first, then names/aliases when structured data is sparse.",
+    "Candidates can be bottle or release targets. Use `kind` and `releaseId`.",
+    "`familyContext` is evidence about sibling bottles and child releases; it is not a deterministic rule.",
+    "Ignore generic words, package text, condition text, retailer SEO, volume, and gift packaging.",
+  ]),
+  "",
+  "Output:",
+  renderBulletLines([
+    "`match`: safe existing candidate id.",
+    "`no_match`: no safe local existing match. The caller may run full classification.",
+    "Always fill `identityBasis` and `confidenceBasis` from local evidence only.",
+    "Set `confidenceBasis.webEvidence = not_used` or `not_needed`; never use `supportive`.",
+    "List only local tools actually used in `confidenceBasis.toolsUsed`.",
+  ]),
+].join("\n");
+
+export function buildBottleLocalIdentifierInstructions() {
+  return BOTTLE_LOCAL_IDENTIFIER_INSTRUCTIONS;
+}


### PR DESCRIPTION
Add a match-only local bottle identification path for photo add-tasting before the full classifier fallback.

The full classifier still owns create, repair, release inference, and web-backed canonical evidence. Local identification uses stable local-only instructions, initial candidates only, zero web-search budget, and clamps non-match outputs back to no_match.

The server wrapper keeps literal exact-alias lookup for callers with literal references, while the photo route disables that shortcut because its reference name is synthesized from extracted label fields. That keeps the faster path from adding invalid determinism where agent validation is still required.

Validation run before commit:
- pnpm --filter @peated/bottle-classifier test -- src/classifier.test.ts
- pnpm --filter @peated/bottle-classifier typecheck
- pnpm --filter @peated/server test -- src/agents/bottleClassifier/identifyExistingBottleReference.test.ts src/lib/bottleFinder.test.ts
- pnpm --filter @peated/server test -- src/orpc/routes/tastings/photo-identification.test.ts
- pnpm --filter @peated/server typecheck
- pnpm exec oxlint ... --fix
- pnpm exec prettier --check ...
- git diff --check