### PR TITLE
feat(tastings): Improve photo tasting save flow

### DIFF
--- a/apps/server/src/lib/pendingUploads.test.ts
+++ b/apps/server/src/lib/pendingUploads.test.ts
@@ -7,6 +7,7 @@ import {
   createPendingImageUpload,
   PendingUploadExpiredError,
   PendingUploadNotFoundError,
+  PendingUploadPurposeError,
 } from "@peated/server/lib/pendingUploads";
 import { compressAndResizeImage } from "@peated/server/lib/uploads";
 import { and, eq } from "drizzle-orm";
@@ -94,6 +95,29 @@ describe("pending uploads", () => {
         attachedToId: 123,
       }),
     ).rejects.toBeInstanceOf(PendingUploadExpiredError);
+  });
+
+  test("rejects pending uploads for another purpose", async ({
+    fixtures,
+    defaults,
+  }) => {
+    const pendingUpload = await createPendingImageUpload({
+      file: await fixtures.SampleSquareImage(),
+      createdById: defaults.user.id,
+      purpose: "avatar",
+      onProcess: (...args) => compressAndResizeImage(...args, 1600, 1600),
+    });
+
+    await expect(
+      copyPendingUploadToPermanent({
+        id: pendingUpload.id,
+        userId: defaults.user.id,
+        purpose: "photo_tasting_entry",
+        destinationNamespace: "tastings",
+        attachedToType: "tasting",
+        attachedToId: 123,
+      }),
+    ).rejects.toBeInstanceOf(PendingUploadPurposeError);
   });
 
   test("deletes the stored object when pending upload row creation fails", async ({

--- a/apps/server/src/lib/pendingUploads.ts
+++ b/apps/server/src/lib/pendingUploads.ts
@@ -24,6 +24,7 @@ export const DEFAULT_PENDING_UPLOAD_TTL_MS = 1000 * 60 * 60 * 48;
 export class PendingUploadError extends Error {}
 export class PendingUploadNotFoundError extends PendingUploadError {}
 export class PendingUploadExpiredError extends PendingUploadError {}
+export class PendingUploadPurposeError extends PendingUploadError {}
 
 type ProcessCallback = (
   stream: Readable,
@@ -184,15 +185,21 @@ export async function getUsablePendingUpload({
   return pendingUpload;
 }
 
+/**
+ * Copies a pending upload into a permanent namespace and marks it attached.
+ * When `purpose` is provided, it must match the pending upload's purpose.
+ */
 export async function copyPendingUploadToPermanent({
   id,
   userId,
+  purpose,
   destinationNamespace,
   attachedToType,
   attachedToId,
 }: {
   id: string;
   userId: number;
+  purpose?: NewPendingUpload["purpose"];
   destinationNamespace: (typeof PERMANENT_UPLOAD_NAMESPACES)[number];
   attachedToType: string;
   attachedToId: number;
@@ -202,6 +209,10 @@ export async function copyPendingUploadToPermanent({
   }
 
   const pendingUpload = await getUsablePendingUpload({ id, userId });
+  if (purpose && pendingUpload.purpose !== purpose) {
+    throw new PendingUploadPurposeError("Pending upload purpose mismatch.");
+  }
+
   const input = filenameFromUploadUrl(pendingUpload.imageUrl);
   const output = `${destinationNamespace}/${path.posix.basename(input)}`;
 

--- a/apps/server/src/orpc/routes/tastings/create.test.ts
+++ b/apps/server/src/orpc/routes/tastings/create.test.ts
@@ -1,6 +1,13 @@
 import { db } from "@peated/server/db";
-import { bottles, entities, tastings } from "@peated/server/db/schema";
+import {
+  bottles,
+  entities,
+  pendingUploads,
+  tastings,
+} from "@peated/server/db/schema";
+import { createPendingImageUpload } from "@peated/server/lib/pendingUploads";
 import waitError from "@peated/server/lib/test/waitError";
+import { compressAndResizeImage } from "@peated/server/lib/uploads";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
@@ -54,6 +61,78 @@ describe("POST /tastings", () => {
       .from(entities)
       .where(eq(entities.id, entity.id));
     expect(newEntity.totalTastings).toBe(1);
+  });
+
+  test("attaches a pending photo upload to the new tasting", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const pendingUpload = await createPendingImageUpload({
+      file: await fixtures.SampleSquareImage(),
+      createdById: defaults.user.id,
+      purpose: "photo_tasting_entry",
+      onProcess: (...args) => compressAndResizeImage(...args, 1600, 1600),
+    });
+
+    const data = await routerClient.tastings.create(
+      {
+        bottle: bottle.id,
+        pendingImageId: pendingUpload.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    expect(data.tasting.imageUrl).toContain("/uploads/tastings/");
+
+    const [tasting] = await db
+      .select()
+      .from(tastings)
+      .where(eq(tastings.id, data.tasting.id));
+    expect(tasting.imageUrl).toMatch(
+      /^\/uploads\/tastings\/pending-upload-.+\.webp$/,
+    );
+
+    const attachedUpload = await db.query.pendingUploads.findFirst({
+      where: eq(pendingUploads.id, pendingUpload.id),
+    });
+    expect(attachedUpload).toMatchObject({
+      status: "attached",
+      attachedToType: "tasting",
+      attachedToId: tasting.id,
+    });
+  });
+
+  test("rejects an unusable pending photo upload before creating the tasting", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const pendingUpload = await createPendingImageUpload({
+      file: await fixtures.SampleSquareImage(),
+      createdById: defaults.user.id,
+      purpose: "avatar",
+      onProcess: (...args) => compressAndResizeImage(...args, 1600, 1600),
+    });
+
+    const err = await waitError(() =>
+      routerClient.tastings.create(
+        {
+          bottle: bottle.id,
+          pendingImageId: pendingUpload.id,
+        },
+        { context: { user: defaults.user } },
+      ),
+    );
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Pending upload purpose mismatch.]`,
+    );
+
+    const tastingRows = await db
+      .select()
+      .from(tastings)
+      .where(eq(tastings.bottleId, bottle.id));
+    expect(tastingRows).toHaveLength(0);
   });
 
   test("creates a new tasting with tags", async ({ defaults, fixtures }) => {

--- a/apps/server/src/orpc/routes/tastings/create.ts
+++ b/apps/server/src/orpc/routes/tastings/create.ts
@@ -14,6 +14,11 @@ import {
 import { awardAllBadgeXp } from "@peated/server/lib/badges";
 import { notEmpty } from "@peated/server/lib/filter";
 import { logError } from "@peated/server/lib/log";
+import {
+  copyPendingUploadToPermanent,
+  getUsablePendingUpload,
+  PendingUploadError,
+} from "@peated/server/lib/pendingUploads";
 import { procedure } from "@peated/server/orpc";
 import {
   requireAuth,
@@ -84,6 +89,25 @@ export default procedure
       }
     }
 
+    if (input.pendingImageId) {
+      try {
+        const pendingUpload = await getUsablePendingUpload({
+          id: input.pendingImageId,
+          userId: context.user.id,
+        });
+        if (pendingUpload.purpose !== "photo_tasting_entry") {
+          throw new PendingUploadError("Pending upload purpose mismatch.");
+        }
+      } catch (err) {
+        if (err instanceof PendingUploadError) {
+          throw errors.BAD_REQUEST({
+            message: err.message || "Pending photo is no longer available.",
+          });
+        }
+        throw err;
+      }
+    }
+
     let flight: Flight | null = null;
     if (input.flight) {
       const flightResults = await db
@@ -140,7 +164,7 @@ export default procedure
       data.friends = input.friends;
     }
 
-    const [tasting, awards] = await db.transaction(async (tx) => {
+    let [tasting, awards] = await db.transaction(async (tx) => {
       let tasting: Tasting | undefined;
       try {
         [tasting] = await tx.insert(tastings).values(data).returning();
@@ -225,6 +249,33 @@ export default procedure
       throw errors.INTERNAL_SERVER_ERROR({
         message: "Unable to create tasting.",
       });
+    }
+
+    if (input.pendingImageId) {
+      try {
+        const imageUrl = await copyPendingUploadToPermanent({
+          id: input.pendingImageId,
+          userId: context.user.id,
+          purpose: "photo_tasting_entry",
+          destinationNamespace: "tastings",
+          attachedToType: "tasting",
+          attachedToId: tasting.id,
+        });
+        [tasting] = await db
+          .update(tastings)
+          .set({ imageUrl })
+          .where(eq(tastings.id, tasting.id))
+          .returning();
+      } catch (err) {
+        logError(err, {
+          tasting: {
+            id: tasting.id,
+          },
+          pendingUpload: {
+            id: input.pendingImageId,
+          },
+        });
+      }
     }
 
     if (!context.user.private) {

--- a/apps/server/src/schemas/tastings.ts
+++ b/apps/server/src/schemas/tastings.ts
@@ -109,6 +109,12 @@ export const TastingInputSchema = TastingSchema.omit({
     .nullish()
     .describe("Custom creation timestamp for the tasting"),
   image: z.null().optional().describe("Optional image upload for the tasting"),
+  pendingImageId: z
+    .string()
+    .trim()
+    .min(1)
+    .optional()
+    .describe("Pending image upload to attach to the tasting"),
   friends: z
     .array(z.number())
     .default([])

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -10,6 +10,8 @@ import {
   emptyList,
   existingBottle,
   existingBottleId,
+  failingTastingNotes,
+  photoTastingNotes,
   suggestedTags,
   tastingNotes,
   testBrand,
@@ -133,9 +135,25 @@ async function handleRpcRequest({ request, response, url }) {
       if (
         ![createdBottleId, existingBottleId].includes(input?.bottle) ||
         input?.rating !== 2 ||
-        input?.notes !== tastingNotes
+        ![tastingNotes, photoTastingNotes, failingTastingNotes].includes(
+          input?.notes,
+        )
       ) {
         sendRpcError(response, "Unexpected tasting create payload");
+        return true;
+      }
+
+      if (
+        input?.notes === photoTastingNotes &&
+        input?.pendingImageId !== "playwright-photo-upload"
+      ) {
+        sendRpcError(response, "Expected pending image for photo tasting");
+        return true;
+      }
+
+      if (input?.notes === failingTastingNotes) {
+        await delay(500);
+        sendRpcError(response, "Forced tasting create failure.");
         return true;
       }
 
@@ -486,6 +504,10 @@ function readBody(request) {
     request.on("end", () => resolve(body));
     request.on("error", reject);
   });
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function sendRpcResponse(response, data) {

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -5,6 +5,8 @@ import { expectNoHorizontalOverflow } from "./assertions";
 import {
   createdTastingId,
   existingBottle,
+  failingTastingNotes,
+  photoTastingNotes,
   tastingNotes,
 } from "./rpc-fixtures.mjs";
 import { signIn } from "./session";
@@ -25,7 +27,6 @@ test.describe("record tasting", () => {
     await page.getByRole("button", { name: "Save" }).click();
 
     await expect(page).toHaveURL(new RegExp(`/tastings/${createdTastingId}$`));
-    await expect(page.getByText(tastingNotes)).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
 
@@ -58,11 +59,49 @@ test.describe("record tasting", () => {
 
     await expect(page.getByText(existingBottle.fullName)).toBeVisible();
     await page.getByRole("button", { name: "Savor" }).click();
-    await page.getByLabel("Comments").fill(tastingNotes);
+    await page.getByLabel("Comments").fill(photoTastingNotes);
     await page.getByRole("button", { name: "Save" }).click();
 
     await expect(page).toHaveURL(new RegExp(`/tastings/${createdTastingId}$`));
-    await expect(page.getByText(tastingNotes)).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("returns to the filled photo tasting form when submit fails", async ({
+    context,
+    page,
+  }) => {
+    await signIn(context);
+
+    await page.goto("/addTasting");
+
+    await page.locator('input[type="file"]').setInputFiles({
+      name: "label.png",
+      mimeType: "image/png",
+      buffer: Buffer.from(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+        "base64",
+      ),
+    });
+
+    await expect(page.getByText("Match found")).toBeVisible();
+    await page.getByRole("button", { name: "Continue" }).click();
+
+    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await page.getByRole("button", { name: "Savor" }).click();
+    await page.getByLabel("Comments").fill(failingTastingNotes);
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page.getByText("Saving tasting")).toBeVisible();
+    await expect(page.getByAltText("Selected bottle label")).toBeHidden();
+
+    await expect(
+      page.getByRole("heading", {
+        name: "There was an error with your submission",
+      }),
+    ).toBeVisible();
+    await expect(page.getByText("Internal error")).toBeVisible();
+    await expect(page.getByLabel("Comments")).toHaveValue(failingTastingNotes);
+    await expect(page).toHaveURL(/\/addTasting$/);
     await expectNoHorizontalOverflow(page);
   });
 });

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -2,6 +2,8 @@ const timestamp = "2026-06-07T12:00:00.000Z";
 
 export const createdBottleName = "Playwright Reserve";
 export const tastingNotes = "Smoke, lemon peel, and sea salt.";
+export const photoTastingNotes = "Photo flow: smoke, lemon peel, and sea salt.";
+export const failingTastingNotes = "Please make this tasting fail.";
 
 export const testUser = {
   id: 9101,

--- a/apps/web/src/app/(layout-free)/addTasting/page.tsx
+++ b/apps/web/src/app/(layout-free)/addTasting/page.tsx
@@ -12,6 +12,7 @@ import Link from "@peated/web/components/link";
 import TastingForm from "@peated/web/components/tastingForm";
 import { AuthRequired } from "@peated/web/hooks/useAuthRequired";
 import { toBlob } from "@peated/web/lib/blobs";
+import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useMutation } from "@tanstack/react-query";
@@ -24,6 +25,7 @@ import {
   Plus,
   RotateCcw,
   Search,
+  SearchX,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { type ChangeEvent, useEffect, useMemo, useRef, useState } from "react";
@@ -37,6 +39,8 @@ type SelectedTarget = {
   suggestedTags: SuggestedTags;
 };
 
+type SubmitStage = "saving" | "preparing-photo" | "uploading-photo" | "done";
+
 const loadingMessages = [
   "Holding it up to the light",
   "Letting the label breathe",
@@ -44,6 +48,26 @@ const loadingMessages = [
   "Asking the tasting room",
   "Comparing the fine print",
 ];
+
+const submitStageCopy: Record<SubmitStage, { title: string; detail: string }> =
+  {
+    saving: {
+      title: "Saving tasting",
+      detail: "Recording the bottle, rating, notes, and awards.",
+    },
+    "preparing-photo": {
+      title: "Preparing photo",
+      detail: "Optimizing the image before upload.",
+    },
+    "uploading-photo": {
+      title: "Uploading photo",
+      detail: "Attaching the photo to your tasting.",
+    },
+    done: {
+      title: "Finishing up",
+      detail: "Taking you to the tasting page.",
+    },
+  };
 
 function createIdempotencyKey() {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
@@ -182,31 +206,32 @@ function getManualResultCopy(result: PhotoIdentification | null) {
 
   if (result?.suggestedNextStep === "needs_review") {
     return {
-      title: "Needs manual review",
+      title: "This one needs a human squint",
       description:
-        "This photo points at a catalog repair case. Search for the bottle to keep going.",
+        "We got close, but not close enough to trust it. Search can still find the right bottle.",
     };
   }
 
   if (action === "match") {
     return {
-      title: "Possible match needs review",
+      title: "Almost, but not quite",
       description:
-        "We found a possible match, but it was not confident enough to use automatically.",
+        "We spotted a possible match, but it was too wobbly to use automatically.",
     };
   }
 
   if (action === "no_match") {
     return {
-      title: "No match found",
+      title: "We couldn't identify the bottle",
       description:
-        "We couldn't find a confident Peated match from this photo. Search with the details we could read, or start over with a clearer photo.",
+        "That label kept its poker face. Search can still find it, or start over with a clearer photo.",
     };
   }
 
   return {
-    title: "Use search instead",
-    description: "Search for the bottle to keep recording this tasting.",
+    title: "We couldn't identify the bottle",
+    description:
+      "The label kept its secrets. Search can still find it, or start over with another photo.",
   };
 }
 
@@ -285,6 +310,84 @@ function OrDivider() {
   );
 }
 
+function PhotoFailurePanel({
+  previewUrl,
+  title,
+  description,
+  searchHref,
+  onStartOver,
+  variant,
+}: {
+  previewUrl: string | null;
+  title: string;
+  description: string;
+  searchHref: string;
+  onStartOver: () => void;
+  variant: "error" | "no-match";
+}) {
+  const isError = variant === "error";
+
+  return (
+    <div
+      className={`rounded border p-4 lg:p-6 ${
+        isError
+          ? "border-red-900/70 bg-red-950/20"
+          : "border-slate-800 bg-slate-950/50"
+      }`}
+    >
+      <div className="space-y-5">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
+          {previewUrl && (
+            <img
+              src={previewUrl}
+              alt="Selected bottle label"
+              className="h-24 w-24 rounded object-cover"
+            />
+          )}
+          <div className="min-w-0 flex-1 space-y-4">
+            <div className="flex items-start gap-3">
+              <div
+                className={`rounded-full p-2 ${
+                  isError
+                    ? "bg-red-900/60 text-red-100"
+                    : "text-highlight bg-slate-800"
+                }`}
+              >
+                {isError ? (
+                  <AlertTriangle className="h-5 w-5" />
+                ) : (
+                  <SearchX className="h-5 w-5" />
+                )}
+              </div>
+              <div>
+                <div className="font-semibold text-white">{title}</div>
+                <div className="text-muted mt-1 text-sm">{description}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="grid w-full gap-3 sm:grid-cols-2">
+          <Button
+            href={searchHref}
+            color="highlight"
+            fullWidth
+            icon={<Search className="h-4 w-4" />}
+          >
+            Search Bottles
+          </Button>
+          <Button
+            fullWidth
+            onClick={onStartOver}
+            icon={<RotateCcw className="h-4 w-4" />}
+          >
+            Start Over
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function FallbackActions({
   searchHref,
   onStartOver,
@@ -339,6 +442,75 @@ function SearchBottleCallout() {
   );
 }
 
+function TastingSubmitProgressPanel({
+  previewUrl,
+  stage,
+}: {
+  previewUrl: string | null;
+  stage: SubmitStage;
+}) {
+  const copy = submitStageCopy[stage];
+  const [imageFailed, setImageFailed] = useState(false);
+
+  useEffect(() => {
+    setImageFailed(false);
+  }, [previewUrl]);
+
+  return (
+    <Layout
+      footer={null}
+      header={
+        <Header>
+          <div className="flex w-full items-center gap-3">
+            <h1 className="text-2xl font-bold">Record Tasting</h1>
+          </div>
+        </Header>
+      }
+    >
+      <section
+        className="flex min-h-[calc(100vh-12rem)] items-center justify-center px-3 py-8 text-center sm:py-10"
+        role="status"
+        aria-live="polite"
+      >
+        <div className="mx-auto max-w-md space-y-5 sm:flex sm:max-w-3xl sm:items-center sm:gap-8 sm:space-y-0 sm:text-left">
+          {previewUrl && !imageFailed && (
+            <img
+              src={previewUrl}
+              alt="Selected bottle label"
+              className="mx-auto h-28 w-28 rounded object-cover sm:mx-0 sm:h-56 sm:w-56"
+              onError={() => setImageFailed(true)}
+            />
+          )}
+          <div>
+            <LoaderCircle className="text-highlight mx-auto h-8 w-8 animate-spin sm:hidden" />
+            <h2 className="add-tasting-loading-shimmer via-highlight mt-4 inline-block bg-gradient-to-r from-white to-white bg-[length:200%_100%] bg-clip-text text-xl font-semibold text-transparent sm:mt-0">
+              {copy.title}
+            </h2>
+            <p className="text-muted mt-2 text-sm">{copy.detail}</p>
+            <p className="text-muted mt-1 text-sm">
+              Keep this page open while we finish.
+            </p>
+          </div>
+        </div>
+      </section>
+      <style jsx global>{`
+        @keyframes add-tasting-loading-shimmer {
+          0% {
+            background-position: 200% 0;
+          }
+          100% {
+            background-position: -200% 0;
+          }
+        }
+
+        .add-tasting-loading-shimmer {
+          animation: add-tasting-loading-shimmer 2.4s ease-in-out infinite;
+        }
+      `}</style>
+    </Layout>
+  );
+}
+
 export default function AddTasting() {
   return (
     <AuthRequired>
@@ -351,10 +523,11 @@ function AddTastingForm() {
   const router = useRouter();
   const orpc = useORPC();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const submitPreviewObjectUrlRef = useRef<string | null>(null);
   const createdAt = useMemo(() => new Date().toISOString(), []);
 
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-  const [photoFile, setPhotoFile] = useState<File | null>(null);
+  const [submitPreviewUrl, setSubmitPreviewUrl] = useState<string | null>(null);
   const [photoResult, setPhotoResult] = useState<PhotoIdentification | null>(
     null,
   );
@@ -362,6 +535,9 @@ function AddTastingForm() {
     null,
   );
   const [error, setError] = useState<string | null>(null);
+  const [photoError, setPhotoError] = useState<string | null>(null);
+  const [submitError, setSubmitError] = useState<string | undefined>();
+  const [submitStage, setSubmitStage] = useState<SubmitStage | null>(null);
 
   const { flash } = useFlashMessages();
   const photoIdentificationMutation = useMutation(
@@ -384,6 +560,14 @@ function AddTastingForm() {
       if (previewUrl) URL.revokeObjectURL(previewUrl);
     };
   }, [previewUrl]);
+
+  useEffect(() => {
+    return () => {
+      if (submitPreviewObjectUrlRef.current) {
+        URL.revokeObjectURL(submitPreviewObjectUrlRef.current);
+      }
+    };
+  }, []);
 
   useEffect(() => {
     if (!isIdentifying) {
@@ -439,8 +623,8 @@ function AddTastingForm() {
 
   async function identifyPhoto(file: File) {
     setError(null);
+    setPhotoError(null);
     setPhotoResult(null);
-    setPhotoFile(file);
 
     const nextPreviewUrl = URL.createObjectURL(file);
     setPreviewUrl((current) => {
@@ -463,8 +647,8 @@ function AddTastingForm() {
           type: file.type || null,
         },
       });
-      setError(
-        "We couldn't read that photo. You can still find the bottle manually.",
+      setPhotoError(
+        "Our label reader had a wobble. Search can still find the bottle, or you can try another photo.",
       );
     }
   }
@@ -478,12 +662,12 @@ function AddTastingForm() {
 
   function startOver() {
     setError(null);
+    setPhotoError(null);
     setPhotoResult(null);
     setPreviewUrl((current) => {
       if (current) URL.revokeObjectURL(current);
       return null;
     });
-    setPhotoFile(null);
   }
 
   async function submitTasting({
@@ -492,71 +676,127 @@ function AddTastingForm() {
   }: Parameters<React.ComponentProps<typeof TastingForm>["onSubmit"]>[0]) {
     if (!selectedTarget) return;
 
-    const { tasting, awards } = await tastingCreateMutation.mutateAsync({
-      ...data,
-      bottle: selectedTarget.bottle.id,
-      release:
-        data.release === undefined
-          ? (selectedTarget.release?.id ?? null)
-          : data.release,
-      createdAt,
-    });
-
-    if (!tasting) return;
-
-    const imageFile =
-      image instanceof File ? image : image ? await toBlob(image) : null;
-
-    if (imageFile) {
-      try {
-        await tastingImageUpdateMutation.mutateAsync({
-          tasting: tasting.id,
-          file: imageFile,
-        });
-      } catch (err) {
-        logError(err);
-        flash(
-          "There was an error uploading your image, but the tasting was saved.",
-          "error",
-        );
-      }
+    setSubmitError(undefined);
+    if (submitPreviewObjectUrlRef.current) {
+      URL.revokeObjectURL(submitPreviewObjectUrlRef.current);
+      submitPreviewObjectUrlRef.current = null;
     }
-
-    for (const award of awards) {
-      if (award.level != award.prevLevel && award.level) {
-        flash(
-          <div className="relative flex flex-row items-center gap-x-3">
-            <Link
-              href={`/badges/${award.badge.id}`}
-              className="absolute inset-0"
-            />
-            <BadgeImage badge={award.badge} size={48} level={award.level} />
-            <div className="flex flex-col">
-              <h5 className="font-semibold">{award.badge.name}</h5>
-              <p className="font-normal">You've reached level {award.level}!</p>
-            </div>
-          </div>,
-          "info",
-        );
-      }
+    if (image instanceof File) {
+      const imageUrl = URL.createObjectURL(image);
+      submitPreviewObjectUrlRef.current = imageUrl;
+      setSubmitPreviewUrl(imageUrl);
+    } else if (image instanceof HTMLCanvasElement) {
+      setSubmitPreviewUrl(image.toDataURL());
+    } else if (image === undefined) {
+      setSubmitPreviewUrl(photoResult?.pendingImage.imageUrl ?? previewUrl);
+    } else {
+      setSubmitPreviewUrl(null);
     }
+    setSubmitStage("saving");
 
-    router.push(`/tastings/${tasting.id}`);
+    try {
+      const shouldUsePendingImage =
+        image === undefined && photoResult?.pendingImage.id;
+
+      const { tasting, awards } = await tastingCreateMutation.mutateAsync({
+        ...data,
+        bottle: selectedTarget.bottle.id,
+        release:
+          data.release === undefined
+            ? (selectedTarget.release?.id ?? null)
+            : data.release,
+        createdAt,
+        pendingImageId: shouldUsePendingImage
+          ? photoResult.pendingImage.id
+          : undefined,
+      });
+
+      if (!tasting) {
+        setSubmitStage(null);
+        setSubmitError("We couldn't save that tasting. Try again.");
+        return;
+      }
+
+      if (image && !(image instanceof File)) {
+        setSubmitStage("preparing-photo");
+      }
+      const imageFile =
+        image instanceof File ? image : image ? await toBlob(image) : null;
+
+      if (imageFile) {
+        try {
+          setSubmitStage("uploading-photo");
+          await tastingImageUpdateMutation.mutateAsync({
+            tasting: tasting.id,
+            file: imageFile,
+          });
+        } catch (err) {
+          logError(err);
+          flash(
+            "There was an error uploading your image, but the tasting was saved.",
+            "error",
+          );
+        }
+      }
+
+      setSubmitStage("done");
+
+      for (const award of awards) {
+        if (award.level != award.prevLevel && award.level) {
+          flash(
+            <div className="relative flex flex-row items-center gap-x-3">
+              <Link
+                href={`/badges/${award.badge.id}`}
+                className="absolute inset-0"
+              />
+              <BadgeImage badge={award.badge} size={48} level={award.level} />
+              <div className="flex flex-col">
+                <h5 className="font-semibold">{award.badge.name}</h5>
+                <p className="font-normal">
+                  You've reached level {award.level}!
+                </p>
+              </div>
+            </div>,
+            "info",
+          );
+        }
+      }
+
+      router.push(`/tastings/${tasting.id}`);
+    } catch (err) {
+      setSubmitStage(null);
+      setSubmitError(
+        getFormErrorMessage(err, {
+          expectedErrorNames: ["BAD_REQUEST", "CONFLICT"],
+        }),
+      );
+    }
   }
 
   if (selectedTarget) {
     return (
-      <TastingForm
-        title="Record Tasting"
-        initialData={{
-          bottle: selectedTarget.bottle,
-          release: selectedTarget.release,
-        }}
-        initialImageFile={photoFile}
-        showReleasePickerDefault
-        suggestedTags={selectedTarget.suggestedTags}
-        onSubmit={submitTasting}
-      />
+      <>
+        <div className={submitStage ? "hidden" : undefined}>
+          <TastingForm
+            title="Record Tasting"
+            errorMessage={submitError}
+            initialData={{
+              bottle: selectedTarget.bottle,
+              release: selectedTarget.release,
+              imageUrl: photoResult?.pendingImage.imageUrl,
+            }}
+            showReleasePickerDefault
+            suggestedTags={selectedTarget.suggestedTags}
+            onSubmit={submitTasting}
+          />
+        </div>
+        {submitStage && (
+          <TastingSubmitProgressPanel
+            previewUrl={submitPreviewUrl}
+            stage={submitStage}
+          />
+        )}
+      </>
     );
   }
 
@@ -636,41 +876,15 @@ function AddTastingForm() {
           </>
         )}
 
-        {!isIdentifying && previewUrl && !photoResult && (
-          <>
-            <section className="rounded border border-slate-800 bg-slate-950/50 p-4 lg:p-6">
-              <div className="space-y-5">
-                <div className="flex flex-col gap-4 sm:flex-row sm:items-start">
-                  <img
-                    src={previewUrl}
-                    alt="Selected bottle label"
-                    className="h-24 w-24 rounded object-cover"
-                  />
-                  <div className="min-w-0 flex-1 space-y-4">
-                    <div className="flex items-start gap-3">
-                      <div className="text-highlight rounded-full bg-slate-800 p-2">
-                        <AlertTriangle className="h-5 w-5" />
-                      </div>
-                      <div>
-                        <div className="font-semibold text-white">
-                          Use search instead
-                        </div>
-                        <div className="text-muted mt-1 text-sm">
-                          We could not read enough from this photo. Search can
-                          still find an existing bottle or start a new one.
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </section>
-            <FallbackActions
-              searchHref="/search?tasting"
-              showStartOver
-              onStartOver={startOver}
-            />
-          </>
+        {!isIdentifying && previewUrl && !photoResult && photoError && (
+          <PhotoFailurePanel
+            previewUrl={previewUrl}
+            title="We couldn't read that photo"
+            description={photoError}
+            searchHref="/search?tasting"
+            onStartOver={startOver}
+            variant="error"
+          />
         )}
 
         {isIdentifying && (
@@ -742,18 +956,14 @@ function AddTastingForm() {
                       <EvidencePills result={photoResult} />
                     </ResultHeader>
                   ) : (
-                    <ResultHeader
+                    <PhotoFailurePanel
                       previewUrl={previewUrl}
-                      icon={
-                        <div className="text-highlight rounded-full bg-slate-800 p-2">
-                          <AlertTriangle className="h-5 w-5" />
-                        </div>
-                      }
                       title={manualResultCopy.title}
                       description={manualResultCopy.description}
-                    >
-                      <EvidencePills result={photoResult} />
-                    </ResultHeader>
+                      searchHref={searchHref}
+                      onStartOver={startOver}
+                      variant="no-match"
+                    />
                   )}
 
                   {createDecision && proposedName && (
@@ -768,26 +978,8 @@ function AddTastingForm() {
                         {createProposalLabel?.description ??
                           "Create a new bottle from this label."}
                       </div>
-                      {photoResult.diagnostics.classification.reason && (
-                        <div className="text-muted mt-2 line-clamp-3 text-xs">
-                          {photoResult.diagnostics.classification.reason}
-                        </div>
-                      )}
                     </div>
                   )}
-
-                  {!matchedBottleId &&
-                    !createDecision &&
-                    photoResult.diagnostics.classification.reason && (
-                      <div className="rounded border border-slate-800 bg-slate-950 p-3">
-                        <div className="text-muted text-xs uppercase tracking-wide">
-                          Result
-                        </div>
-                        <div className="text-muted mt-2 line-clamp-3 text-sm">
-                          {photoResult.diagnostics.classification.reason}
-                        </div>
-                      </div>
-                    )}
                 </div>
                 {matchedBottleId || createDecision ? (
                   <div className="mx-auto grid w-full gap-2 sm:w-1/2">
@@ -816,25 +1008,7 @@ function AddTastingForm() {
                       </Button>
                     )}
                   </div>
-                ) : (
-                  <div className="grid w-full gap-3 sm:w-auto sm:grid-cols-2">
-                    <Button
-                      href={searchHref}
-                      color="highlight"
-                      fullWidth
-                      icon={<Search className="h-4 w-4" />}
-                    >
-                      Search Bottles
-                    </Button>
-                    <Button
-                      fullWidth
-                      onClick={startOver}
-                      icon={<RotateCcw className="h-4 w-4" />}
-                    >
-                      Start Over
-                    </Button>
-                  </div>
-                )}
+                ) : null}
               </div>
             </section>
             {(matchedBottleId || createDecision) && (

--- a/apps/web/src/components/form.tsx
+++ b/apps/web/src/components/form.tsx
@@ -8,9 +8,9 @@ export default function Form({
   return (
     <>
       {isSubmitting && (
-        <div className="fixed inset-0 z-10">
+        <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div className="absolute inset-0 bg-slate-800 opacity-50" />
-          <Spinner />
+          <Spinner className="relative z-10 m-0 text-slate-800" />
         </div>
       )}
 

--- a/apps/web/src/components/tastingForm.tsx
+++ b/apps/web/src/components/tastingForm.tsx
@@ -73,8 +73,8 @@ function toReleaseOption(
 
 export default function TastingForm({
   onSubmit,
+  errorMessage,
   initialData,
-  initialImageFile,
   showReleasePickerDefault = false,
   title,
   suggestedTags,
@@ -84,10 +84,10 @@ export default function TastingForm({
       image: ImageValue;
     }
   >;
+  errorMessage?: string;
   initialData: Partial<z.infer<typeof TastingSchema>> & {
     bottle: Bottle;
   };
-  initialImageFile?: File | null;
   showReleasePickerDefault?: boolean;
   title: string;
   suggestedTags: Paginated<SuggestedTag>;
@@ -112,7 +112,7 @@ export default function TastingForm({
   });
 
   const [error, setError] = useState<string | undefined>();
-  const [image, setImage] = useState<ImageValue>(initialImageFile);
+  const [image, setImage] = useState<ImageValue>();
   const [friendsValue, setFriendsValue] = useState<Option[]>(
     initialData.friends ? initialData.friends.map(userToOption) : [],
   );
@@ -160,7 +160,9 @@ export default function TastingForm({
         />
       </div>
 
-      {error && <FormError values={[error]} />}
+      {(error || errorMessage) && (
+        <FormError values={[error, errorMessage].filter(Boolean)} />
+      )}
 
       <Form
         onSubmit={handleSubmit(onSubmitHandler)}
@@ -201,19 +203,21 @@ export default function TastingForm({
                     }}
                     value={releaseValue}
                   />
-                  <button
-                    className="text-muted text-sm underline"
-                    type="button"
-                    onClick={() => {
-                      onChange(null);
-                      setReleaseValue(undefined);
-                      if (!showReleasePickerDefault) {
-                        setShowReleasePicker(false);
-                      }
-                    }}
-                  >
-                    Use Bottle Instead
-                  </button>
+                  {(!showReleasePickerDefault || releaseValue) && (
+                    <Button
+                      size="small"
+                      type="button"
+                      onClick={() => {
+                        onChange(null);
+                        setReleaseValue(undefined);
+                        if (!showReleasePickerDefault) {
+                          setShowReleasePicker(false);
+                        }
+                      }}
+                    >
+                      Use main bottle
+                    </Button>
+                  )}
                 </div>
               ) : (
                 <div className="rounded border border-slate-800 bg-slate-950/40 p-4">
@@ -312,7 +316,6 @@ export default function TastingForm({
             name="image"
             label="Picture"
             value={initialData.imageUrl}
-            initialFile={initialImageFile}
             onChange={(value) => setImage(value)}
             imageWidth={1024 / 2}
             imageHeight={768 / 2}

--- a/packages/bottle-classifier/src/bottleCreationDrafts.test.ts
+++ b/packages/bottle-classifier/src/bottleCreationDrafts.test.ts
@@ -62,6 +62,49 @@ describe("splitProposedBottleReleaseDraft", () => {
     });
   });
 
+  test("removes explicit ABV from proposed bottle names", () => {
+    expect(
+      normalizeProposedBottleDraft({
+        ...buildProposedBottle(),
+        name: "Islay 2007 8-year-old 57.1% ABV",
+        statedAge: 8,
+        abv: null,
+      }),
+    ).toMatchObject({
+      name: "Islay 2007 8-year-old",
+      statedAge: 8,
+      abv: 57.1,
+    });
+  });
+
+  test("keeps structured ABV when removing duplicate ABV name text", () => {
+    expect(
+      normalizeProposedBottleDraft({
+        ...buildProposedBottle(),
+        name: "Islay 2007 8-year-old (57.1%)",
+        statedAge: 8,
+        abv: 57.1,
+      }),
+    ).toMatchObject({
+      name: "Islay 2007 8-year-old",
+      statedAge: 8,
+      abv: 57.1,
+    });
+  });
+
+  test("keeps implausible bare percentages in proposed bottle names", () => {
+    expect(
+      normalizeProposedBottleDraft({
+        ...buildProposedBottle(),
+        name: "Rare 8% Rye",
+        abv: null,
+      }),
+    ).toMatchObject({
+      name: "Rare 8% Rye",
+      abv: null,
+    });
+  });
+
   test("infers creation targets from the populated draft sides", () => {
     expect(
       inferBottleCreationTarget({

--- a/packages/bottle-classifier/src/bottleCreationDrafts.ts
+++ b/packages/bottle-classifier/src/bottleCreationDrafts.ts
@@ -24,6 +24,53 @@ const EMPTY_PROPOSED_RELEASE: ProposedRelease = {
   imageUrl: null,
 };
 
+function extractExplicitAbvFromBottleName(name: string): {
+  name: string;
+  abv: number | null;
+} {
+  let abv: number | null = null;
+  // Keep ABV out of canonical names, but do not strip arbitrary low percentages.
+  const captureAbv = (value: string, requiresPlausibleRange = false) => {
+    const numericValue = Number(value);
+    if (requiresPlausibleRange && (numericValue < 30 || numericValue > 75)) {
+      return false;
+    }
+    abv ??= numericValue;
+    return true;
+  };
+  const normalizedName = name
+    .replace(
+      /\s*[[(]\s*(\d{1,2}(?:\.\d+)?)\s?%\s*(ABV|alc\.?(?:\/vol\.?)?)?\s*[\])]/gi,
+      (_match, value: string, marker: string | undefined) => {
+        if (!captureAbv(value, !marker)) {
+          return _match;
+        }
+        return " ";
+      },
+    )
+    .replace(
+      /(^|[\s,;-]+)(\d{1,2}(?:\.\d+)?)\s?%\s*(ABV|alc\.?(?:\/vol\.?)?)?(?=$|[\s,;)])/gi,
+      (_match, prefix: string, value: string, marker: string | undefined) => {
+        if (!captureAbv(value, !marker)) {
+          return _match;
+        }
+        return prefix.trim() ? prefix : " ";
+      },
+    )
+    .replace(/\s+([,;)])/g, "$1")
+    .replace(/[(,;]\s*$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return {
+    name: normalizedName || name,
+    abv,
+  };
+}
+
+/**
+ * Normalizes proposed bottle identity while keeping explicit ABV out of names.
+ */
 export function normalizeProposedBottleDraft(
   proposedBottle: ProposedBottle,
 ): ProposedBottle {
@@ -51,9 +98,12 @@ export function normalizeProposedBottleDraft(
   const normalizedBottlerName = proposedBottle.bottler
     ? normalizeString(proposedBottle.bottler.name).toLowerCase()
     : null;
+  const nameWithoutExplicitAbv = extractExplicitAbvFromBottleName(
+    proposedBottle.name,
+  );
   const normalized = normalizeBottle({
     name: stripDuplicateBrandPrefixFromBottleName(
-      proposedBottle.name,
+      nameWithoutExplicitAbv.name,
       proposedBottle.brand.name,
     ),
     statedAge: proposedBottle.statedAge,
@@ -73,6 +123,7 @@ export function normalizeProposedBottleDraft(
     caskStrength: normalized.caskStrength ?? null,
     singleCask: normalized.singleCask ?? null,
     distillers: Array.from(distillersByName.values()),
+    abv: proposedBottle.abv ?? nameWithoutExplicitAbv.abv,
     bottler:
       normalizedBottlerName && normalizedBottlerName === normalizedBrandName
         ? null

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-exclusive-malts-islay-single-cask-as-bottle.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-exclusive-malts-islay-single-cask-as-bottle.json
@@ -108,6 +108,7 @@
     "action": "create_bottle",
     "identityScope": "exact_cask",
     "proposedBottle": {
+      "name": "Islay 2007 8-year-old",
       "brand": {
         "name": "The Exclusive Malts"
       },

--- a/packages/bottle-classifier/src/instructions.ts
+++ b/packages/bottle-classifier/src/instructions.ts
@@ -821,7 +821,7 @@ const BOTTLE_CLASSIFIER_INSTRUCTIONS = [
     "Use `identityBasis` to explain any bottle-vs-release or exact-cask boundary decision.",
     "Use `observation` for selector names, cask numbers, bottle numbers, outturn, market/exclusive wording, and exact facts that should not force canonical release split.",
     "For `proposedBottle.name`, use evidenced canonical name, not copied retailer title.",
-    "For standalone `create_bottle` decisions, include marketed differentiators such as age, vintage, release year, ABV, cask, batch, or cask-strength wording in `proposedBottle.name` when omitting them would create a weak generic parent.",
+    "For standalone `create_bottle` decisions, include marketed differentiators such as age, vintage, release year, cask, batch, or cask-strength wording in `proposedBottle.name` when omitting them would create a weak generic parent. Keep ABV in the structured `abv` field, not in `proposedBottle.name`.",
     "For `create_bottle`, keep all bottle-level identity traits on `proposedBottle`; if they are child-release traits, use a release action instead.",
     "Return `{ id, name }` objects for `brand`, `distillers`, `bottler`, and `series`; use `id: null` when unknown.",
     "Never invent websites, relationships, release details, or proof numbers.",


### PR DESCRIPTION
Improve the add-tasting photo flow after bottle identification.

This adds a dedicated submit progress panel, keeps the tasting form mounted so failed saves return users to their filled form, and reuses the pending photo upload from identification when the image is unchanged. That avoids the extra client-side image upload on the matched-photo save path while still attaching the image server-side.

The photo identification states now use friendlier user-facing copy, split real no-match from photo-read errors visually, and keep the same recovery actions: search bottles or start over. The proposed bottle UI no longer exposes classifier diagnostics, and proposed bottle normalization keeps explicit ABV text out of canonical bottle names while preserving structured ABV.

Validated with targeted server, web, classifier, and Playwright checks before opening.