### PR TITLE
fix(web): Keep bottle metadata commas inline

### DIFF
--- a/apps/web/src/components/join.test.tsx
+++ b/apps/web/src/components/join.test.tsx
@@ -1,0 +1,20 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import Join from "./join";
+
+describe("Join", () => {
+  it("keeps punctuation joins inside a single inline flex item", () => {
+    const links = [<a key="x">X</a>, <a key="y">Y</a>];
+
+    const html = renderToStaticMarkup(
+      <div className="flex gap-x-1">
+        <Join divider=", ">{links}</Join>
+      </div>,
+    );
+
+    expect(html).toBe(
+      '<div class="flex gap-x-1"><span><a>X</a>, <a>Y</a></span></div>',
+    );
+  });
+});

--- a/apps/web/src/components/join.tsx
+++ b/apps/web/src/components/join.tsx
@@ -9,7 +9,7 @@ export default function Join({
   divider: ReactNode;
 }) {
   return (
-    <>
+    <span>
       {children.map((child, index) => {
         return (
           <Fragment key={index}>
@@ -18,6 +18,6 @@ export default function Join({
           </Fragment>
         );
       })}
-    </>
+    </span>
   );
 }


### PR DESCRIPTION
Bottle metadata that renders multiple linked values now keeps comma dividers inside the same inline element as the names. The shared Join component previously returned adjacent flex children, so parent gap spacing could visually separate punctuation from multi-distillery bottle links.

The regression test renders Join inside a flex row with gap spacing to lock in the expected inline comma markup.