### PR TITLE
fix(server): Prevent duplicate SMWS bottle creates

### DIFF
--- a/apps/server/src/lib/bottleReferenceCandidates.ts
+++ b/apps/server/src/lib/bottleReferenceCandidates.ts
@@ -8,6 +8,7 @@ import {
   normalizeBottleBatchNumber,
   normalizeString,
 } from "@peated/bottle-classifier/normalize";
+import { parseReferenceName as parseSmwsReferenceName } from "@peated/bottle-classifier/smws";
 import config from "@peated/server/config";
 import { CATEGORY_LIST } from "@peated/server/constants";
 import { db } from "@peated/server/db";
@@ -244,6 +245,34 @@ function buildRawSearchName(input: BottleCandidateSearchInput) {
     .trim();
 }
 
+function getSmwsExtractedLabelCode(
+  extractedLabel: BottleReferenceIdentity | null,
+): string | null {
+  if (!extractedLabel) {
+    return null;
+  }
+
+  const identityAnchors = [extractedLabel.brand, extractedLabel.bottler].filter(
+    Boolean,
+  );
+  const codeFields = [extractedLabel.edition, extractedLabel.expression].filter(
+    Boolean,
+  );
+
+  for (const identityAnchor of identityAnchors) {
+    for (const codeField of codeFields) {
+      const code = parseSmwsReferenceName(
+        `${identityAnchor} ${codeField}`,
+      )?.code;
+      if (code) {
+        return code;
+      }
+    }
+  }
+
+  return null;
+}
+
 function getBottleCandidateKey(
   candidate: Pick<BottleCandidate, "bottleId" | "releaseId" | "kind">,
 ) {
@@ -435,6 +464,10 @@ function normalizeComparableText(value: string | null | undefined) {
 
 function escapeRegExp(value: string) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function getExactCaskCodeSqlPattern(code: string) {
+  return `(^|[^A-Z0-9])${escapeRegExp(code)}([^A-Z0-9]|$)`;
 }
 
 function getParentSearchSignals({
@@ -1545,11 +1578,24 @@ async function getBrandCandidates(
   if (!brandName) {
     return [];
   }
-  const expression = extractedLabel.expression || normalizedName;
+  const smwsCode = getSmwsExtractedLabelCode(extractedLabel);
+  const expression = smwsCode ?? extractedLabel.expression ?? normalizedName;
   const comparableExpression = normalizeComparableText(expression);
   const comparableExpressionClause = comparableExpression
     ? sql`OR LOWER(REPLACE(${bottles.fullName}, ${"'"}, '')) LIKE ${`%${comparableExpression}%`}`
     : sql``;
+  const smwsCodePattern = smwsCode
+    ? getExactCaskCodeSqlPattern(smwsCode)
+    : null;
+  const expressionClause = smwsCodePattern
+    ? sql`(
+        ${bottles.name} ~* ${smwsCodePattern}
+        OR ${bottles.fullName} ~* ${smwsCodePattern}
+      )`
+    : sql`(
+        LOWER(${bottles.fullName}) LIKE LOWER(${`%${expression}%`})
+        ${comparableExpressionClause}
+      )`;
 
   const result = await db.execute<{
     bottleId: number;
@@ -1586,10 +1632,7 @@ async function getBrandCandidates(
       LOWER(${entities.name}) = LOWER(${brandName})
       OR LOWER(COALESCE(${entities.shortName}, '')) = LOWER(${brandName})
     )
-      AND (
-        LOWER(${bottles.fullName}) LIKE LOWER(${`%${expression}%`})
-        ${comparableExpressionClause}
-      )
+      AND ${expressionClause}
     ORDER BY ${bottles.fullName} ASC
     LIMIT ${BRAND_CANDIDATE_LIMIT}
   `);

--- a/apps/server/src/lib/bottleReferenceResolution.test.ts
+++ b/apps/server/src/lib/bottleReferenceResolution.test.ts
@@ -1,3 +1,5 @@
+import { db } from "@peated/server/db";
+import { bottles } from "@peated/server/db/schema";
 import { resolveBottleReferenceTarget } from "@peated/server/lib/bottleReferenceResolution";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -26,6 +28,35 @@ function buildClassification(decision: Record<string, unknown>) {
       resolvedEntities: [],
     },
   };
+}
+
+function buildSmwsProposedBottle() {
+  return {
+    name: "35.331",
+    series: null,
+    category: "single_malt",
+    edition: null,
+    statedAge: null,
+    caskStrength: null,
+    singleCask: true,
+    abv: null,
+    vintageYear: null,
+    releaseYear: null,
+    brand: {
+      id: null,
+      name: "SMWS",
+    },
+    distillers: [],
+    bottler: {
+      id: null,
+      name: "SMWS",
+    },
+  };
+}
+
+async function countBottles() {
+  const rows = await db.select({ id: bottles.id }).from(bottles);
+  return rows.length;
 }
 
 describe("resolveBottleReferenceTarget", () => {
@@ -194,5 +225,149 @@ describe("resolveBottleReferenceTarget", () => {
       createdBottle: false,
       createdRelease: false,
     });
+  });
+
+  test("reuses existing SMWS bottles by code when a classifier create omits the subtitle", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ admin: true });
+    const brand = await fixtures.Entity({
+      type: ["brand", "bottler"],
+      name: "SMWS Guard Society",
+      shortName: "SMWS",
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "35.331 Ultra hoggie",
+      singleCask: true,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "35.3310 False lead",
+      singleCask: true,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "135.331 False lead",
+      singleCask: true,
+    });
+
+    const bottleCount = await countBottles();
+
+    classifyBottleReferenceMock.mockResolvedValue(
+      buildClassification({
+        action: "create_bottle",
+        confidence: 100,
+        identityScope: "exact_cask",
+        observation: {
+          caskNumber: "35.331",
+        },
+        matchedBottleId: null,
+        matchedReleaseId: null,
+        parentBottleId: null,
+        proposedBottle: buildSmwsProposedBottle(),
+        proposedRelease: null,
+      }),
+    );
+
+    const result = await resolveBottleReferenceTarget({
+      reference: {
+        name: "SMWS 35.331",
+        url: null,
+        imageUrl: null,
+        currentBottleId: null,
+        currentReleaseId: null,
+      },
+      aliasLookupNames: [],
+      user,
+    });
+
+    expect(result).toMatchObject({
+      bottleId: bottle.id,
+      releaseId: null,
+      source: "classifier_create_bottle",
+      createdBottle: false,
+      createdRelease: false,
+    });
+
+    expect(await countBottles()).toBe(bottleCount);
+  });
+
+  test("reuses existing SMWS bottles by code for combined classifier create decisions", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ admin: true });
+    const brand = await fixtures.Entity({
+      type: ["brand", "bottler"],
+      name: "SMWS Combined Guard Society",
+      shortName: "SMWS",
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "35.331 Ultra hoggie",
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "35.3310 False lead",
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "135.331 False lead",
+    });
+
+    const bottleCount = await countBottles();
+
+    classifyBottleReferenceMock.mockResolvedValue(
+      buildClassification({
+        action: "create_bottle_and_release",
+        confidence: 100,
+        identityScope: "exact_cask",
+        observation: {
+          caskNumber: "35.331",
+        },
+        matchedBottleId: null,
+        matchedReleaseId: null,
+        parentBottleId: null,
+        proposedBottle: buildSmwsProposedBottle(),
+        proposedRelease: {
+          edition: "Ultra hoggie",
+          statedAge: null,
+          abv: null,
+          caskStrength: null,
+          singleCask: null,
+          vintageYear: null,
+          releaseYear: null,
+          description: null,
+          tastingNotes: null,
+          imageUrl: null,
+        },
+      }),
+    );
+
+    const result = await resolveBottleReferenceTarget({
+      reference: {
+        name: "SMWS 35.331",
+        url: null,
+        imageUrl: null,
+        currentBottleId: null,
+        currentReleaseId: null,
+      },
+      aliasLookupNames: [],
+      user,
+    });
+
+    expect(result).toMatchObject({
+      bottleId: bottle.id,
+      source: "classifier_create_bottle_and_release",
+      createdBottle: false,
+      createdRelease: true,
+    });
+    expect(await countBottles()).toBe(bottleCount);
   });
 });

--- a/apps/server/src/lib/createBottle.ts
+++ b/apps/server/src/lib/createBottle.ts
@@ -1,3 +1,4 @@
+import { parseReferenceName as parseSmwsReferenceName } from "@peated/bottle-classifier/smws";
 import { type CatalogVerificationCreationSource } from "@peated/catalog-verifier";
 import { db, type AnyTransaction } from "@peated/server/db";
 import type { Bottle, Entity, NewBottle, User } from "@peated/server/db/schema";
@@ -7,6 +8,7 @@ import {
   bottleSeries,
   bottlesToDistillers,
   changes,
+  entities,
 } from "@peated/server/db/schema";
 import { processSeries } from "@peated/server/lib/bottleHelpers";
 import {
@@ -29,6 +31,7 @@ import { BottleSerializer } from "@peated/server/serializers/bottle";
 import type { BottlePreviewResult } from "@peated/server/types";
 import { pushJob } from "@peated/server/worker/client";
 import { and, eq, isNull, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import type { z } from "zod";
 
 export class BottleCreateBadRequestError extends Error {
@@ -52,6 +55,11 @@ export type CreateBottleResult = {
   seriesCreated: boolean;
 };
 
+type SmwsEntityName = {
+  name: string;
+  shortName?: string | null;
+};
+
 async function getExistingBottleIdForAlias(
   tx: AnyTransaction,
   aliasName: string,
@@ -65,6 +73,166 @@ async function getExistingBottleIdForAlias(
     .limit(1);
 
   return result?.bottleId ?? null;
+}
+
+function getSmwsCodeFromValues(values: Array<string | null | undefined>) {
+  for (const value of values) {
+    const code = parseSmwsReferenceName(value)?.code;
+    if (code) {
+      return code;
+    }
+  }
+
+  return null;
+}
+
+function valuesHaveSmwsCode(
+  values: Array<string | null | undefined>,
+  code: string,
+) {
+  return values.some((value) => parseSmwsReferenceName(value)?.code === code);
+}
+
+function entityNameVariants(
+  entity: SmwsEntityName | null,
+  name: string | null,
+) {
+  if (!entity || !name) {
+    return [];
+  }
+
+  return [
+    entity.shortName ? `${entity.shortName} ${name}` : null,
+    `${entity.name} ${name}`,
+  ];
+}
+
+function getSmwsCodeForBottleCreate({
+  name,
+  fullName,
+  brand,
+  bottler,
+}: {
+  name: string;
+  fullName: string;
+  brand: SmwsEntityName;
+  bottler: SmwsEntityName | null;
+}) {
+  return getSmwsCodeFromValues([
+    fullName,
+    ...entityNameVariants(brand, name),
+    ...entityNameVariants(bottler, name),
+  ]);
+}
+
+function rowHasSmwsCode(
+  row: {
+    aliasName: string | null;
+    bottleName: string;
+    fullName: string;
+    brandName: string | null;
+    brandShortName: string | null;
+    bottlerName: string | null;
+    bottlerShortName: string | null;
+  },
+  code: string,
+) {
+  const brand = { name: row.brandName ?? "", shortName: row.brandShortName };
+  const bottler = {
+    name: row.bottlerName ?? "",
+    shortName: row.bottlerShortName,
+  };
+
+  return valuesHaveSmwsCode(
+    [
+      row.aliasName,
+      row.fullName,
+      ...entityNameVariants(brand, row.bottleName),
+      ...entityNameVariants(brand, row.aliasName),
+      ...entityNameVariants(bottler, row.bottleName),
+      ...entityNameVariants(bottler, row.aliasName),
+    ],
+    code,
+  );
+}
+
+async function findExistingSmwsBottleIdForCreate(
+  tx: AnyTransaction,
+  {
+    name,
+    fullName,
+    brand,
+    bottler,
+  }: {
+    name: string;
+    fullName: string;
+    brand: SmwsEntityName;
+    bottler: SmwsEntityName | null;
+  },
+): Promise<number | null> {
+  const code = getSmwsCodeForBottleCreate({
+    name,
+    fullName,
+    brand,
+    bottler,
+  });
+  if (!code) {
+    return null;
+  }
+
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtext(${`smws:${code}`}))`,
+  );
+
+  const brandEntity = alias(entities, "smws_create_brand");
+  const bottlerEntity = alias(entities, "smws_create_bottler");
+  const codeSearch = `%${code}%`;
+  const smwsSearch = "%SMWS%";
+  const societySearch = "%Scotch Malt Whisky Society%";
+
+  const rows = await tx
+    .select({
+      bottleId: bottles.id,
+      bottleName: bottles.name,
+      fullName: bottles.fullName,
+      aliasName: bottleAliases.name,
+      brandName: brandEntity.name,
+      brandShortName: brandEntity.shortName,
+      bottlerName: bottlerEntity.name,
+      bottlerShortName: bottlerEntity.shortName,
+    })
+    .from(bottles)
+    .innerJoin(brandEntity, eq(brandEntity.id, bottles.brandId))
+    .leftJoin(bottlerEntity, eq(bottlerEntity.id, bottles.bottlerId))
+    .leftJoin(
+      bottleAliases,
+      and(
+        eq(bottleAliases.bottleId, bottles.id),
+        sql`${bottleAliases.ignored} IS DISTINCT FROM true`,
+      ),
+    )
+    .where(
+      and(
+        sql`(
+          ${bottles.name} ILIKE ${codeSearch}
+          OR ${bottles.fullName} ILIKE ${codeSearch}
+          OR ${bottleAliases.name} ILIKE ${codeSearch}
+        )`,
+        sql`(
+          LOWER(${brandEntity.name}) IN ('smws', 'the scotch malt whisky society', 'scotch malt whisky society')
+          OR LOWER(COALESCE(${brandEntity.shortName}, '')) = 'smws'
+          OR LOWER(COALESCE(${bottlerEntity.name}, '')) IN ('smws', 'the scotch malt whisky society', 'scotch malt whisky society')
+          OR LOWER(COALESCE(${bottlerEntity.shortName}, '')) = 'smws'
+          OR ${bottles.fullName} ILIKE ${smwsSearch}
+          OR ${bottles.fullName} ILIKE ${societySearch}
+          OR ${bottleAliases.name} ILIKE ${smwsSearch}
+          OR ${bottleAliases.name} ILIKE ${societySearch}
+        )`,
+      ),
+    )
+    .orderBy(bottles.id);
+
+  return rows.find((row) => rowHasSmwsCode(row, code))?.bottleId ?? null;
 }
 
 export async function createBottleInTransaction(
@@ -97,6 +265,19 @@ export async function createBottleInTransaction(
   const newAliases: string[] = [];
   const newEntityIds: Set<number> = new Set();
   let seriesCreated = false;
+
+  const existingSmwsBottleId = await findExistingSmwsBottleIdForCreate(tx, {
+    name: bottleData.name,
+    fullName: formatBottleName({
+      ...bottleData,
+      name: `${bottleData.brand.shortName || bottleData.brand.name} ${bottleData.name}`,
+    }),
+    brand: bottleData.brand,
+    bottler: bottleData.bottler ?? null,
+  });
+  if (existingSmwsBottleId) {
+    throw new BottleAlreadyExistsError(existingSmwsBottleId);
+  }
 
   const brandUpsert = await upsertEntity({
     db: tx,

--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -19,6 +19,7 @@ import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import {
   applyApprovedStorePriceMatch,
   canClearIgnoredStorePriceAssignment,
+  createBottleFromStorePriceMatchProposal,
   ignoreStorePriceMatchProposal,
   resolveStorePriceMatchProposal,
 } from "@peated/server/lib/priceMatching";
@@ -146,6 +147,11 @@ function buildMockBottleReferenceClassification(
     },
     ...restOverrides,
   } as any;
+}
+
+async function countBottles() {
+  const rows = await db.select({ id: bottles.id }).from(bottles);
+  return rows.length;
 }
 
 function normalizeMockBottleClassifierDecision(decision: Record<string, any>) {
@@ -354,6 +360,207 @@ describe("priceMatching", () => {
         }),
       ]),
     );
+  });
+
+  test("finds existing SMWS bottles by code when the source omits the subtitle", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    const brand = await fixtures.Entity({
+      type: ["brand", "bottler"],
+      name: "SMWS Candidate Society",
+      shortName: "SMWS",
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "35.331 Ultra hoggie",
+      singleCask: true,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "35.3310 False lead",
+      singleCask: true,
+    });
+    for (let index = 1; index <= 6; index += 1) {
+      await fixtures.Bottle({
+        brandId: brand.id,
+        bottlerId: brand.id,
+        name: `135.331 False lead ${index}`,
+        singleCask: true,
+      });
+    }
+
+    const candidates = await searchBottleCandidates({
+      query: "SMWS 35.331",
+      brand: "SMWS",
+      expression: null,
+      series: null,
+      distillery: [],
+      category: "single_malt",
+      stated_age: null,
+      abv: null,
+      cask_type: null,
+      cask_strength: null,
+      single_cask: true,
+      edition: "35.331",
+      vintage_year: null,
+      release_year: null,
+      currentBottleId: null,
+      limit: 15,
+    });
+
+    expect(candidates).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          bottleId: bottle.id,
+          fullName: "SMWS 35.331 Ultra hoggie",
+          source: expect.arrayContaining(["brand"]),
+        }),
+      ]),
+    );
+  });
+
+  test("create_new proposal approval reuses existing SMWS bottles by code", async ({
+    fixtures,
+  }) => {
+    config.OPENAI_API_KEY = undefined;
+
+    const reviewer = await fixtures.User();
+    const brand = await fixtures.Entity({
+      type: ["brand", "bottler"],
+      name: "SMWS Price Guard Society",
+      shortName: "SMWS",
+    });
+    const bottle = await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "35.331 Ultra hoggie",
+      singleCask: true,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "35.3310 False lead",
+      singleCask: true,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "135.331 False lead",
+      singleCask: true,
+    });
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      externalSiteId: site.id,
+      name: "SMWS 35.331",
+      imageUrl: null,
+    });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "create_new",
+        creationTarget: "bottle",
+        extractedLabel: {
+          brand: "SMWS",
+          bottler: "SMWS",
+          expression: null,
+          series: null,
+          distillery: [],
+          category: "single_malt",
+          stated_age: null,
+          abv: null,
+          release_year: null,
+          vintage_year: null,
+          cask_type: null,
+          cask_size: null,
+          cask_fill: null,
+          cask_strength: null,
+          single_cask: true,
+          edition: "35.331",
+        },
+        proposedBottle: {
+          name: "35.331",
+          series: null,
+          category: "single_malt",
+          edition: null,
+          statedAge: null,
+          caskStrength: null,
+          singleCask: true,
+          abv: null,
+          vintageYear: null,
+          releaseYear: null,
+          caskType: null,
+          caskSize: null,
+          caskFill: null,
+          brand: {
+            id: brand.id,
+            name: "SMWS",
+          },
+          distillers: [],
+          bottler: {
+            id: brand.id,
+            name: "SMWS",
+          },
+        },
+        proposedRelease: null,
+      })
+      .returning();
+    const bottleCount = await countBottles();
+
+    const result = await createBottleFromStorePriceMatchProposal({
+      proposalId: proposal.id,
+      input: {
+        name: "35.331",
+        series: null,
+        category: "single_malt",
+        edition: null,
+        statedAge: null,
+        caskStrength: null,
+        singleCask: true,
+        abv: null,
+        vintageYear: null,
+        releaseYear: null,
+        caskType: null,
+        caskSize: null,
+        caskFill: null,
+        brand: brand.id,
+        distillers: [],
+        bottler: brand.id,
+        description: null,
+        descriptionSrc: null,
+        imageUrl: null,
+        flavorProfile: null,
+      },
+      user: reviewer,
+    });
+
+    const updatedProposal = await db.query.storePriceMatchProposals.findFirst({
+      where: eq(storePriceMatchProposals.id, proposal.id),
+    });
+    const decisionLog = await db.query.incomingBottleDecisionLogs.findFirst({
+      where: and(
+        eq(incomingBottleDecisionLogs.sourceKind, "store_price"),
+        eq(incomingBottleDecisionLogs.sourceId, price.id),
+      ),
+    });
+
+    expect(result.bottle.id).toBe(bottle.id);
+    expect(await countBottles()).toBe(bottleCount);
+    expect(updatedProposal).toMatchObject({
+      status: "approved",
+      suggestedBottleId: bottle.id,
+    });
+    expect(decisionLog).toMatchObject({
+      decision: "create_bottle",
+      bottleId: bottle.id,
+      createdBottle: false,
+    });
   });
 
   test("prefers a literal exact alias over apostrophe-normalized fallback matches", async ({

--- a/apps/server/src/orpc/routes/bottles/create.test.ts
+++ b/apps/server/src/orpc/routes/bottles/create.test.ts
@@ -561,6 +561,49 @@ describe("POST /bottles", () => {
     expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   });
 
+  test("rejects duplicate SMWS bottle codes without requiring the subtitle", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({
+      type: ["brand", "bottler"],
+      name: "SMWS Manual Guard Society",
+      shortName: "SMWS",
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "35.331 Ultra hoggie",
+      singleCask: true,
+    });
+    await fixtures.Bottle({
+      brandId: brand.id,
+      bottlerId: brand.id,
+      name: "35.3310 False lead",
+      singleCask: true,
+    });
+    const bottleCount = (await db.select({ id: bottles.id }).from(bottles))
+      .length;
+
+    const err = await waitError(
+      routerClient.bottles.create(
+        {
+          name: "35.331",
+          brand: brand.id,
+          bottler: brand.id,
+          singleCask: true,
+        },
+        { context: { user: defaults.user } },
+      ),
+    );
+
+    expect(err).toMatchInlineSnapshot(`[Error: Bottle already exists.]`);
+    expect((await db.select({ id: bottles.id }).from(bottles)).length).toBe(
+      bottleCount,
+    );
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
+  });
+
   test("updates statedAge bottle w/ age signal", async ({
     defaults,
     fixtures,


### PR DESCRIPTION
SMWS bottle creation now reuses an existing bottle when the proposed name has the same exact cask code, even if the subtitle is missing or changed. The guard runs in shared bottle creation before create side effects, so manual bottle entry, classifier/photo creation, combined bottle/release creation, and store-price create proposals all get the same conflict behavior.

Candidate retrieval also treats SMWS codes as bounded exact codes, so near matches like `135.331` or `35.3310` cannot crowd out `35.331` before candidates are shown. Regression coverage exercises the classifier, store-price proposal, and manual create paths with overlapping-code fixtures.