### PR TITLE
feat(classifier): Set agent conversation IDs

### DIFF
--- a/apps/server/src/agents/bottleClassifier/service.ts
+++ b/apps/server/src/agents/bottleClassifier/service.ts
@@ -26,6 +26,7 @@ import {
   withSentryConversation,
 } from "@peated/server/lib/openaiClient";
 import { absoluteUrl } from "@peated/server/lib/urls";
+import { randomUUID } from "node:crypto";
 
 let bottleClassifier: ReturnType<typeof createBottleClassifier> | null = null;
 
@@ -148,6 +149,31 @@ function normalizeReferenceForClassifier(
   };
 }
 
+function buildReferenceConversationId(
+  prefix: string,
+  reference: BottleReference,
+  conversationId?: string,
+) {
+  const explicitConversationId = conversationId?.trim();
+  if (explicitConversationId) {
+    return explicitConversationId;
+  }
+
+  const id =
+    reference.id === undefined || reference.id === null || reference.id === ""
+      ? randomUUID()
+      : reference.id;
+
+  return `${prefix}:${id}`;
+}
+
+async function withReferenceConversation<T>(
+  conversationId: string,
+  callback: () => Promise<T>,
+) {
+  return await withSentryConversation(conversationId, callback);
+}
+
 export function getBottleClassifier() {
   if (bottleClassifier) {
     return bottleClassifier;
@@ -190,15 +216,17 @@ export async function classifyBottleReference(
   input: ClassifyBottleReferenceInput,
 ) {
   const reference = normalizeReferenceForClassifier(input.reference);
-  const conversationId =
-    reference.id === undefined || reference.id === null
-      ? `bottle_classifier:${reference.name}`
-      : `bottle_reference:${reference.id}`;
+  const conversationId = buildReferenceConversationId(
+    "bottle_reference",
+    reference,
+    input.conversationId,
+  );
 
-  return await withSentryConversation(conversationId, async () => {
+  return await withReferenceConversation(conversationId, async () => {
     return await getBottleClassifier().classifyBottleReference({
       ...input,
       reference,
+      conversationId,
     });
   });
 }
@@ -311,17 +339,19 @@ export async function identifyExistingBottleReference(
   } = {},
 ) {
   const reference = normalizeReferenceForClassifier(input.reference);
+  const conversationId = buildReferenceConversationId(
+    "bottle_identifier",
+    reference,
+    input.conversationId,
+  );
   const normalizedInput = {
     ...input,
+    conversationId,
     extractedIdentity: withoutExtractedCaskFields(input.extractedIdentity),
     reference,
   };
-  const conversationId =
-    reference.id === undefined || reference.id === null
-      ? `bottle_identifier:${reference.name}`
-      : `bottle_identifier:${reference.id}`;
 
-  return await withSentryConversation(conversationId, async () => {
+  return await withReferenceConversation(conversationId, async () => {
     if (options.allowExactAliasPreflight !== false) {
       const exactAliasClassification = await identifyExactAliasReference({
         input: normalizedInput,
@@ -345,15 +375,21 @@ export async function runBottleClassifierAgent(
   input: RunBottleClassifierAgentInput,
 ) {
   const reference = normalizeReferenceForClassifier(input.reference);
-  const conversationId =
-    reference.id === undefined || reference.id === null
-      ? `bottle_classifier:${reference.name}`
-      : `bottle_reference:${reference.id}`;
+  const conversationPrefix =
+    input.instructionMode === "local_identification"
+      ? "bottle_identifier"
+      : "bottle_reference";
+  const conversationId = buildReferenceConversationId(
+    conversationPrefix,
+    reference,
+    input.conversationId,
+  );
 
-  return await withSentryConversation(conversationId, async () => {
+  return await withReferenceConversation(conversationId, async () => {
     return await getBottleClassifier().runBottleClassifierAgent({
       ...input,
       reference,
+      conversationId,
     });
   });
 }

--- a/docs/policies/runtime-boundaries.md
+++ b/docs/policies/runtime-boundaries.md
@@ -19,6 +19,13 @@ TypeScript assumptions.
 - Keep platform clients and SDK details inside the layer that owns them. Expose
   narrow capability functions such as `queue`, `store`, `dispatch`, or `verify`
   rather than raw clients.
+- AI agent runs should always own an observability conversation id. Prefer a
+  durable entity id with a stable domain prefix; when no durable id exists,
+  generate a run-scoped UUID instead of using names or other fuzzy identifiers.
+- Tests for SDK-owned scope or context behavior should spy on the real SDK
+  surface, such as scope instances or prototypes, when practical. Avoid
+  whole-module mocks for observability clients such as Sentry because they erase
+  the runtime state the integration is meant to protect.
 - Require deterministic idempotency or uniqueness for APIs that create durable
   records from retryable contexts.
 - Validate model or agent output before persistence. Model output may propose;

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -4,6 +4,7 @@ import {
   Runner,
   type NonStreamRunOptions,
 } from "@openai/agents";
+import { randomUUID } from "node:crypto";
 import type OpenAI from "openai";
 import { normalizePotentialProofLikeDecision } from "./abv";
 import {
@@ -85,6 +86,7 @@ type BottleClassifierReasoningRun = {
 
 export type RunBottleClassifierAgentInput = {
   reference: BottleReference;
+  conversationId?: string;
   extractedIdentity?: BottleExtractedDetails | null;
   imageEvidence?: ImageBottleEvidence | null;
   initialCandidates?: BottleCandidate[];
@@ -298,6 +300,28 @@ export type PreparedBottleClassifierAgentRun = {
   runner: Runner;
   webSearchBudget: BottleWebSearchBudget;
 };
+
+function buildClassifierConversationId(
+  reference: BottleReference,
+  instructionMode: RunBottleClassifierAgentInput["instructionMode"],
+  conversationId?: string,
+) {
+  const explicitConversationId = conversationId?.trim();
+  if (explicitConversationId) {
+    return explicitConversationId;
+  }
+
+  const prefix =
+    instructionMode === "local_identification"
+      ? "bottle_identifier"
+      : "bottle_reference";
+  const id =
+    reference.id === undefined || reference.id === null || reference.id === ""
+      ? randomUUID()
+      : reference.id;
+
+  return `${prefix}:${id}`;
+}
 
 function mergeSearchEvidence(
   searchEvidence: BottleClassificationArtifacts["searchEvidence"],
@@ -839,6 +863,7 @@ export async function prepareBottleClassifierAgentRun(
     investigationHint = null,
     webSearchBudget: inputWebSearchBudget,
     instructionMode = "classification",
+    conversationId,
   }: RunBottleClassifierAgentInput,
 ): Promise<PreparedBottleClassifierAgentRun> {
   const dataSource = getBottleClassifierDataSource(options);
@@ -966,17 +991,20 @@ export async function prepareBottleClassifierAgentRun(
     outputType: BottleClassifierAgentDecisionSchema,
     tools,
   });
+  const resolvedConversationId = buildClassifierConversationId(
+    reference,
+    instructionMode,
+    conversationId,
+  );
   const runner = new Runner({
     modelProvider: new OpenAIProvider({
       openAIClient: options.client,
       useResponses: true,
     }),
     workflowName: "Bottle Classifier",
-    groupId:
-      reference.id === undefined || reference.id === null
-        ? undefined
-        : `bottle_reference:${reference.id}`,
+    groupId: resolvedConversationId,
     traceMetadata: {
+      "gen_ai.conversation.id": resolvedConversationId,
       source_id:
         reference.id === undefined || reference.id === null
           ? "none"
@@ -1142,10 +1170,18 @@ export function createBottleClassifier(
     investigationHint = null,
     webSearchBudget,
     instructionMode = "classification",
+    conversationId,
   }: RunBottleClassifierAgentInput): Promise<BottleClassifierReasoningRun> => {
+    const resolvedConversationId = buildClassifierConversationId(
+      reference,
+      instructionMode,
+      conversationId,
+    );
+
     if (options.overrides?.runBottleClassifierAgent) {
       const reasoning = await options.overrides.runBottleClassifierAgent({
         reference,
+        conversationId: resolvedConversationId,
         extractedIdentity,
         imageEvidence,
         initialCandidates,
@@ -1178,6 +1214,7 @@ export function createBottleClassifier(
 
     const preparedRun = await prepareBottleClassifierAgentRun(options, {
       reference,
+      conversationId: resolvedConversationId,
       initialCandidates,
       extractedIdentity,
       imageEvidence,
@@ -1206,6 +1243,11 @@ export function createBottleClassifier(
     input: ClassifyBottleReferenceInput,
   ): Promise<BottleClassificationResult> => {
     const parsedInput = ClassifyBottleReferenceInputSchema.parse(input);
+    const conversationId = buildClassifierConversationId(
+      parsedInput.reference,
+      "classification",
+      parsedInput.conversationId,
+    );
     let artifacts = buildBottleClassificationArtifacts({});
 
     try {
@@ -1293,6 +1335,7 @@ export function createBottleClassifier(
 
       const reasoningRun = await runBottleClassifierAgentWithBudget({
         reference: parsedInput.reference,
+        conversationId,
         extractedIdentity: artifacts.extractedIdentity,
         imageEvidence: artifacts.imageEvidence,
         initialCandidates: artifacts.candidates,
@@ -1337,6 +1380,7 @@ export function createBottleClassifier(
         ) {
           const retryReasoningRun = await runBottleClassifierAgentWithBudget({
             reference: parsedInput.reference,
+            conversationId,
             extractedIdentity: investigationArtifacts.extractedIdentity,
             imageEvidence: investigationArtifacts.imageEvidence,
             initialCandidates: investigationArtifacts.candidates,
@@ -1382,6 +1426,11 @@ export function createBottleClassifier(
     input: ClassifyBottleReferenceInput,
   ): Promise<BottleClassificationResult> => {
     const parsedInput = ClassifyBottleReferenceInputSchema.parse(input);
+    const conversationId = buildClassifierConversationId(
+      parsedInput.reference,
+      "local_identification",
+      parsedInput.conversationId,
+    );
     let artifacts = buildBottleClassificationArtifacts({});
 
     try {
@@ -1480,6 +1529,7 @@ export function createBottleClassifier(
 
       const reasoningRun = await runBottleClassifierAgentWithBudget({
         reference: parsedInput.reference,
+        conversationId,
         extractedIdentity: artifacts.extractedIdentity,
         imageEvidence: artifacts.imageEvidence,
         initialCandidates: artifacts.candidates,

--- a/packages/bottle-classifier/src/contract.ts
+++ b/packages/bottle-classifier/src/contract.ts
@@ -113,6 +113,7 @@ export const CandidateExpansionModeSchema = z.enum(["open", "initial_only"]);
 export const ClassifyBottleReferenceInputSchema = z
   .object({
     reference: BottleReferenceSchema,
+    conversationId: z.string().trim().min(1).optional(),
     extractedIdentity: BottleExtractedDetailsSchema.nullable().optional(),
     imageEvidence: ImageBottleEvidenceSchema.nullable().optional(),
     initialCandidates: z.array(BottleCandidateSchema).optional(),
@@ -150,6 +151,7 @@ export type CandidateExpansionMode = z.infer<
 >;
 export type ClassifyBottleReferenceInput = {
   reference: BottleReference;
+  conversationId?: string;
   extractedIdentity?: null | z.infer<typeof BottleExtractedDetailsSchema>;
   imageEvidence?: null | z.infer<typeof ImageBottleEvidenceSchema>;
   initialCandidates?: z.infer<typeof BottleCandidateSchema>[];


### PR DESCRIPTION
Bottle classifier and local-identification agent runs now carry a conversation id through Sentry isolation and OpenAI Runner trace metadata. Runs backed by Peated references keep stable `bottle_reference:<id>` or `bottle_identifier:<id>` ids, while id-less runs generate a UUID with the same prefix so they can still be tracked without relying on bottle names.

The runtime-boundaries policy now records that agent runs should always own a conversation id and that SDK scope/context tests should use real SDK surfaces when they need coverage.