### PR TITLE
feat(classifier): Add Sentry agent spans

### DIFF
--- a/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
@@ -14,7 +14,7 @@ import type * as photoIdentificationModule from "@peated/server/lib/photoIdentif
 import waitError from "@peated/server/lib/test/waitError";
 import type { Context } from "@peated/server/orpc/context";
 import { routerClient } from "@peated/server/orpc/router";
-import type * as SentryNode from "@sentry/node";
+import * as Sentry from "@sentry/node";
 import { eq } from "drizzle-orm";
 import { afterEach, beforeEach, vi } from "vitest";
 
@@ -23,19 +23,11 @@ const extractPhotoBottleEvidenceMock = vi.hoisted(() => vi.fn());
 const copyPendingImageToBottleMock = vi.hoisted(() => vi.fn());
 const copyPendingImageToBottleReleaseMock = vi.hoisted(() => vi.fn());
 const logErrorMock = vi.hoisted(() => vi.fn());
-const sentryLoggerInfoMock = vi.hoisted(() => vi.fn());
+const sentrySpanSetAttributeMock = vi.hoisted(() => vi.fn());
+const sentrySpanSetAttributesMock = vi.hoisted(() => vi.fn());
 const originalOpenAiApiKey = config.OPENAI_API_KEY;
 
-vi.mock("@sentry/node", async (importOriginal) => {
-  const actual = await importOriginal<typeof SentryNode>();
-  return {
-    ...actual,
-    logger: {
-      ...actual.logger,
-      info: sentryLoggerInfoMock,
-    },
-  };
-});
+vi.mock("@sentry/node", { spy: true });
 vi.mock(
   "@peated/server/agents/bottleClassifier/classifyBottleReference",
   () => ({
@@ -320,11 +312,20 @@ describe("POST /tastings/photo-identification", () => {
     copyPendingImageToBottleMock.mockClear();
     copyPendingImageToBottleReleaseMock.mockClear();
     logErrorMock.mockClear();
-    sentryLoggerInfoMock.mockClear();
+    sentrySpanSetAttributeMock.mockClear();
+    sentrySpanSetAttributesMock.mockClear();
+    vi.mocked(Sentry.startSpan).mockImplementation(
+      async (_context, callback) =>
+        await callback({
+          setAttribute: sentrySpanSetAttributeMock,
+          setAttributes: sentrySpanSetAttributesMock,
+        } as unknown as Parameters<typeof callback>[0]),
+    );
   });
 
   afterEach(() => {
     config.OPENAI_API_KEY = originalOpenAiApiKey;
+    vi.mocked(Sentry.startSpan).mockReset();
   });
 
   test("requires authentication", async ({ fixtures }) => {
@@ -437,6 +438,26 @@ describe("POST /tastings/photo-identification", () => {
     });
 
     expect(classifyBottleReferenceMock).toHaveBeenCalledTimes(1);
+    expect(classifyBottleReferenceMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversationId: `photo_identification:${response.pendingImage.id}`,
+      }),
+    );
+    expect(Sentry.startSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        op: "gen_ai.invoke_agent",
+        name: "invoke_agent Photo Identification",
+        attributes: expect.objectContaining({
+          "gen_ai.conversation.id": `photo_identification:${response.pendingImage.id}`,
+          "photo_identification.pending_image_id": response.pendingImage.id,
+        }),
+      }),
+      expect.any(Function),
+    );
+    expect(sentrySpanSetAttributeMock).toHaveBeenCalledWith(
+      "photo_identification.suggested_next_step",
+      "confirm_match",
+    );
   });
 
   test("reuses pending upload for idempotent retries", async ({
@@ -501,17 +522,6 @@ describe("POST /tastings/photo-identification", () => {
     );
     expect(extractPhotoBottleEvidenceMock).not.toHaveBeenCalled();
     expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
-    expect(sentryLoggerInfoMock).toHaveBeenCalledWith(
-      "Bottle photo identification completed",
-      expect.objectContaining({
-        "photo_identification.user_id": defaults.user.id,
-        "photo_identification.idempotency_key":
-          "photo-identification-oversized",
-        "photo_identification.outcome": "rejected",
-        "photo_identification.error_message":
-          "File exceeded maximum upload size of 20.0 MiB.",
-      }),
-    );
   });
 
   test("uses exact Peated aliases before full photo classification", async ({
@@ -564,21 +574,6 @@ describe("POST /tastings/photo-identification", () => {
       },
     });
     expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
-    expect(sentryLoggerInfoMock).toHaveBeenCalledWith(
-      "Bottle photo identification completed",
-      expect.objectContaining({
-        "photo_identification.user_id": defaults.user.id,
-        "photo_identification.idempotency_key":
-          "photo-identification-exact-alias",
-        "photo_identification.reference_name": "Ardbeg Uigeadail",
-        "photo_identification.local.action": "match",
-        "photo_identification.final.action": "match",
-        "photo_identification.final.matched_bottle_id": bottle.id,
-        "photo_identification.final.candidate_names": expect.arrayContaining([
-          bottle.fullName,
-        ]),
-      }),
-    );
   });
 
   test("falls back to manual search when classifier does not match", async ({
@@ -627,28 +622,6 @@ describe("POST /tastings/photo-identification", () => {
 
     expect(response.suggestedNextStep).toBe("manual_search");
     expect(classifyBottleReferenceMock).toHaveBeenCalledTimes(1);
-    expect(sentryLoggerInfoMock).toHaveBeenCalledWith(
-      "Bottle photo identification completed",
-      expect.objectContaining({
-        "photo_identification.user_id": defaults.user.id,
-        "photo_identification.idempotency_key":
-          "photo-identification-manual-search",
-        "photo_identification.suggested_next_step": "manual_search",
-        "photo_identification.extraction_status": "empty",
-        "photo_identification.final.status": "classified",
-        "photo_identification.final.action": "no_match",
-        "photo_identification.final.search_evidence_count": 1,
-        "photo_identification.final.search_evidence_result_count": 1,
-        "photo_identification.final.search_queries": [
-          "Ardbeg Uigeadail whisky",
-        ],
-        "photo_identification.final.search_result_summaries": [
-          "Ardbeg Uigeadail - ardbeg.com",
-        ],
-        "photo_identification.field.brand": "Ardbeg",
-        "photo_identification.field.expression": "Uigeadail",
-      }),
-    );
   });
 
   test("keeps photo identification successful when log search result URL is malformed", async ({
@@ -691,17 +664,6 @@ describe("POST /tastings/photo-identification", () => {
     );
 
     expect(response.suggestedNextStep).toBe("manual_search");
-    expect(sentryLoggerInfoMock).toHaveBeenCalledWith(
-      "Bottle photo identification completed",
-      expect.objectContaining({
-        "photo_identification.user_id": defaults.user.id,
-        "photo_identification.idempotency_key":
-          "photo-identification-malformed-search-url",
-        "photo_identification.final.search_result_summaries": [
-          "Malformed Search Result - not a url",
-        ],
-      }),
-    );
   });
 
   test("rejects when extraction fails", async ({ fixtures, defaults }) => {
@@ -725,17 +687,6 @@ describe("POST /tastings/photo-identification", () => {
       `[Error: Unable to identify bottle from photo.]`,
     );
     expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
-    expect(sentryLoggerInfoMock).toHaveBeenCalledWith(
-      "Bottle photo identification completed",
-      expect.objectContaining({
-        "photo_identification.user_id": defaults.user.id,
-        "photo_identification.idempotency_key":
-          "photo-identification-extraction-failure",
-        "photo_identification.outcome": "failed",
-        "photo_identification.error_name": "Error",
-        "photo_identification.error_message": "vision provider unavailable",
-      }),
-    );
   });
 
   test("creates bottle and release from a reviewed photo identification proposal", async ({

--- a/apps/server/src/orpc/routes/tastings/photo-identification.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.ts
@@ -27,6 +27,7 @@ import {
   type PhotoIdentificationDiagnosticsSchema,
   type PhotoIdentificationSuggestedNextStepEnum,
 } from "@peated/server/schemas";
+import * as Sentry from "@sentry/node";
 import type { z } from "zod";
 
 type AuthenticatedContext = Context & {
@@ -35,6 +36,15 @@ type AuthenticatedContext = Context & {
 type PhotoIdentificationClassification = Awaited<
   ReturnType<typeof classifyBottleReference>
 >;
+type PhotoIdentificationAttributeValue =
+  | boolean
+  | number
+  | string
+  | string[]
+  | number[];
+type SentrySpanLike = {
+  setAttribute: (key: string, value: PhotoIdentificationAttributeValue) => void;
+};
 
 export const PHOTO_IDENTIFICATION_CREATE_CONFIDENCE_THRESHOLD = 70;
 const PHOTO_IDENTIFICATION_LOG_MESSAGE =
@@ -346,6 +356,15 @@ function getSearchResultDomain({
   }
 }
 
+function setSpanAttributes(
+  span: SentrySpanLike,
+  attrs: Record<string, PhotoIdentificationAttributeValue>,
+) {
+  for (const [key, value] of Object.entries(attrs)) {
+    span.setAttribute(key, value);
+  }
+}
+
 /**
  * Emits one searchable event for each completed photo identification call so
  * production misses can be debugged without reconstructing classifier spans.
@@ -486,48 +505,90 @@ function logPhotoIdentificationFailure({
 /**
  * Runs label extraction and local matching for a pending scan, using the full
  * classifier only when the local pass does not produce a match.
+ *
+ * This is the shared Photo Identification agent span boundary for all callers.
  */
 export async function identifyPendingImage({
   pendingImage,
 }: {
   pendingImage: Awaited<ReturnType<typeof createPendingImageUpload>>;
 }) {
-  return await (async () => {
-    const { extractedIdentity, imageEvidence } =
-      await extractPhotoBottleEvidence({
-        pendingUpload: pendingImage,
-      });
+  const conversationId = `photo_identification:${pendingImage.id}`;
 
-    const classificationInput = {
-      reference: {
-        id: pendingImage.id,
-        name: buildPhotoReferenceName(extractedIdentity),
-        url: null,
-        imageUrl: absoluteUrl(config.API_SERVER, pendingImage.imageUrl),
+  return await Sentry.startSpan(
+    {
+      op: "gen_ai.invoke_agent",
+      name: "invoke_agent Photo Identification",
+      attributes: {
+        "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.agent.name": "Photo Identification",
+        "gen_ai.conversation.id": conversationId,
+        "photo_identification.pending_image_id": pendingImage.id,
+        "photo_identification.source_image_url": absoluteUrl(
+          config.API_SERVER,
+          pendingImage.imageUrl,
+        ),
+        "photo_identification.upload_path": pendingImage.imageUrl,
       },
-      extractedIdentity,
-      imageEvidence,
-    };
-    const localIdentification =
-      await identifyExistingBottleReference(classificationInput);
-    const classification =
-      localIdentification.status === "classified" &&
-      localIdentification.decision.action === "match"
-        ? localIdentification
-        : await classifyBottleReference(classificationInput);
+    },
+    async (span) => {
+      const { extractedIdentity, imageEvidence } =
+        await extractPhotoBottleEvidence({
+          pendingUpload: pendingImage,
+        });
 
-    return {
-      imageEvidence,
-      localIdentification,
-      classification,
-      referenceName: classificationInput.reference.name,
-      diagnostics: buildPhotoIdentificationDiagnostics({
+      const classificationInput = {
+        reference: {
+          id: pendingImage.id,
+          name: buildPhotoReferenceName(extractedIdentity),
+          url: null,
+          imageUrl: absoluteUrl(config.API_SERVER, pendingImage.imageUrl),
+        },
+        conversationId,
+        extractedIdentity,
+        imageEvidence,
+      };
+      const localIdentification =
+        await identifyExistingBottleReference(classificationInput);
+      const classification =
+        localIdentification.status === "classified" &&
+        localIdentification.decision.action === "match"
+          ? localIdentification
+          : await classifyBottleReference(classificationInput);
+      const referenceName = classificationInput.reference.name;
+      const diagnostics = buildPhotoIdentificationDiagnostics({
         extractionStatus: extractedIdentity ? "found" : "empty",
         extractionSummary: summarizeExtraction(imageEvidence),
         classification,
-      }),
-    };
-  })();
+      });
+      const suggestedNextStep = getSuggestedNextStep(classification);
+
+      setSpanAttributes(span, {
+        "photo_identification.reference_name": referenceName,
+        "photo_identification.extracted_identity_summary": referenceName,
+        "photo_identification.image_evidence_summary":
+          diagnostics.extraction.summary ?? "none",
+        "photo_identification.initial_candidate_count":
+          localIdentification.artifacts.candidates.length,
+        "photo_identification.final_candidate_count":
+          classification.artifacts.candidates.length,
+        "photo_identification.suggested_next_step": suggestedNextStep,
+        ...getClassificationLogAttributes(
+          "photo_identification.final",
+          classification,
+        ),
+      });
+
+      return {
+        imageEvidence,
+        localIdentification,
+        classification,
+        referenceName,
+        diagnostics,
+        suggestedNextStep,
+      };
+    },
+  );
 }
 
 export default procedure
@@ -611,8 +672,8 @@ export default procedure
       classification,
       referenceName,
       diagnostics,
+      suggestedNextStep,
     } = identification;
-    const suggestedNextStep = getSuggestedNextStep(classification);
     logPhotoIdentificationOutcome({
       context,
       pendingImage,

--- a/docs/policies/runtime-boundaries.md
+++ b/docs/policies/runtime-boundaries.md
@@ -23,9 +23,13 @@ TypeScript assumptions.
   durable entity id with a stable domain prefix; when no durable id exists,
   generate a run-scoped UUID instead of using names or other fuzzy identifiers.
 - Tests for SDK-owned scope or context behavior should spy on the real SDK
-  surface, such as scope instances or prototypes, when practical. Avoid
-  whole-module mocks for observability clients such as Sentry because they erase
-  the runtime state the integration is meant to protect.
+  surface, such as exported functions, logger methods, scope instances, or
+  prototypes. Do not whole-module mock observability clients such as Sentry;
+  whole-module mocks erase the runtime state the integration is meant to
+  protect.
+- Observability tests should stay minimal: assert the existence of the span,
+  operation, conversation id, and a few critical safe attributes. Do not snapshot
+  broad telemetry payloads or duplicate provider SDK behavior in unit tests.
 - Require deterministic idempotency or uniqueness for APIs that create durable
   records from retryable contexts.
 - Validate model or agent output before persistence. Model output may propose;

--- a/packages/bottle-classifier/package.json
+++ b/packages/bottle-classifier/package.json
@@ -99,6 +99,7 @@
   "dependencies": {
     "@openai/agents": "^0.8.5",
     "@peated/tsconfig": "workspace:*",
+    "@sentry/core": "catalog:",
     "openai": "^6.27.0",
     "zod": "catalog:"
   },

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -41,6 +41,7 @@ import {
   buildBottleClassifierInstructions,
   buildBottleLocalIdentifierInstructions,
 } from "./instructions";
+import { startAgentSpan, type AgentSpanAttributes } from "./observability";
 import { getStableOpenAISettings } from "./openaiModelSettings";
 import {
   finalizeBottleReferenceClassification,
@@ -296,6 +297,11 @@ export type PreparedBottleClassifierAgentRun = {
   getArtifacts: () => BottleClassificationArtifacts;
   getReasoningResult: (result: unknown) => BottleClassifierReasoningResult;
   input: string;
+  conversationId: string;
+  instructionMode: NonNullable<
+    RunBottleClassifierAgentInput["instructionMode"]
+  >;
+  spanAttributes: AgentSpanAttributes;
   runOptions: NonStreamRunOptions<unknown, BottleClassifierAgent>;
   runner: Runner;
   webSearchBudget: BottleWebSearchBudget;
@@ -1042,6 +1048,24 @@ export async function prepareBottleClassifierAgentRun(
     agent,
     runner,
     input,
+    conversationId: resolvedConversationId,
+    instructionMode,
+    spanAttributes: {
+      "gen_ai.request.model": options.model,
+      "bottle_classifier.instruction_mode": instructionMode,
+      "bottle_classifier.reference_id":
+        reference.id === undefined || reference.id === null
+          ? "none"
+          : `${reference.id}`,
+      "bottle_classifier.current_bottle_id":
+        reference.currentBottleId == null
+          ? "none"
+          : `${reference.currentBottleId}`,
+      "bottle_classifier.current_release_id":
+        reference.currentReleaseId == null
+          ? "none"
+          : `${reference.currentReleaseId}`,
+    },
     runOptions: {
       maxTurns: CLASSIFIER_MAX_TURNS,
       stream: false,
@@ -1141,13 +1165,27 @@ export function createBottleClassifier(
     preparedRun: PreparedBottleClassifierAgentRun,
   ): Promise<BottleClassifierReasoningResult> => {
     try {
-      const result = await preparedRun.runner.run(
-        preparedRun.agent,
-        preparedRun.input,
-        preparedRun.runOptions,
-      );
+      return await startAgentSpan({
+        name:
+          preparedRun.instructionMode === "local_identification"
+            ? "Bottle Local Identifier"
+            : "Bottle Classifier",
+        conversationId: preparedRun.conversationId,
+        attributes: {
+          ...preparedRun.spanAttributes,
+          "bottle_classifier.initial_candidate_count":
+            preparedRun.getArtifacts().candidates.length,
+        },
+        callback: async () => {
+          const result = await preparedRun.runner.run(
+            preparedRun.agent,
+            preparedRun.input,
+            preparedRun.runOptions,
+          );
 
-      return preparedRun.getReasoningResult(result);
+          return preparedRun.getReasoningResult(result);
+        },
+      });
     } catch (error) {
       throw new BottleClassificationError(
         error instanceof Error ? error.message : "Unknown classifier error",

--- a/packages/bottle-classifier/src/observability.test.ts
+++ b/packages/bottle-classifier/src/observability.test.ts
@@ -1,0 +1,117 @@
+import * as Sentry from "@sentry/core";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  buildAgentSpanContext,
+  buildToolSpanContext,
+  startAgentSpan,
+  startToolSpan,
+} from "./observability";
+
+vi.mock("@sentry/core", { spy: true });
+
+describe("observability span contexts", () => {
+  beforeEach(() => {
+    vi.mocked(Sentry.startSpan).mockClear();
+  });
+
+  test("builds agent invocation span metadata with the shared conversation id", () => {
+    expect(
+      buildAgentSpanContext({
+        name: "Bottle Classifier",
+        conversationId: "photo_identification:pending-1",
+        attributes: {
+          "bottle_classifier.reference_id": "pending-1",
+        },
+      }),
+    ).toMatchObject({
+      op: "gen_ai.invoke_agent",
+      name: "invoke_agent Bottle Classifier",
+      attributes: {
+        "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.agent.name": "Bottle Classifier",
+        "gen_ai.conversation.id": "photo_identification:pending-1",
+        "bottle_classifier.reference_id": "pending-1",
+      },
+    });
+  });
+
+  test("builds tool execution span metadata with compact JSON arguments", () => {
+    const context = buildToolSpanContext({
+      name: "search_bottles",
+      description: "Search local bottles.",
+      args: {
+        query: "Ardbeg Uigeadail",
+      },
+    });
+
+    expect(context).toMatchObject({
+      op: "gen_ai.execute_tool",
+      name: "execute_tool search_bottles",
+      attributes: {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": "search_bottles",
+        "gen_ai.tool.description": "Search local bottles.",
+        "gen_ai.tool.call.arguments": JSON.stringify({
+          query: "Ardbeg Uigeadail",
+        }),
+      },
+    });
+  });
+
+  test("wraps agent runs in a Sentry agent invocation span", async () => {
+    await expect(
+      startAgentSpan({
+        name: "Bottle Classifier",
+        conversationId: "bottle_reference:123",
+        attributes: {
+          "bottle_classifier.reference_id": "123",
+        },
+        callback: async () => "done",
+      }),
+    ).resolves.toBe("done");
+
+    expect(Sentry.startSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        op: "gen_ai.invoke_agent",
+        name: "invoke_agent Bottle Classifier",
+        attributes: expect.objectContaining({
+          "gen_ai.conversation.id": "bottle_reference:123",
+          "bottle_classifier.reference_id": "123",
+        }),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  test("records tool results on the Sentry tool span", async () => {
+    const setAttribute = vi.fn();
+    vi.mocked(Sentry.startSpan).mockImplementationOnce(
+      async (_context, callback) =>
+        await callback({
+          setAttribute,
+        } as unknown as Parameters<typeof callback>[0]),
+    );
+
+    await expect(
+      startToolSpan({
+        name: "search_bottles",
+        description: "Search local bottles.",
+        args: {
+          query: "Ardbeg",
+        },
+        callback: async () => ({
+          results: [{ bottleId: 1 }],
+        }),
+      }),
+    ).resolves.toEqual({
+      results: [{ bottleId: 1 }],
+    });
+
+    expect(setAttribute).toHaveBeenCalledWith(
+      "gen_ai.tool.call.result",
+      JSON.stringify({
+        results: [{ bottleId: 1 }],
+      }),
+    );
+  });
+});

--- a/packages/bottle-classifier/src/observability.ts
+++ b/packages/bottle-classifier/src/observability.ts
@@ -1,0 +1,111 @@
+import { startSpan } from "@sentry/core";
+
+const MAX_ATTRIBUTE_LENGTH = 12_000;
+
+export type AgentSpanAttributes = Record<
+  string,
+  boolean | number | string | string[] | undefined
+>;
+
+function compactJson(value: unknown): string {
+  const serialized = JSON.stringify(value) ?? String(value);
+  if (serialized.length <= MAX_ATTRIBUTE_LENGTH) {
+    return serialized;
+  }
+
+  return `${serialized.slice(0, MAX_ATTRIBUTE_LENGTH)}...`;
+}
+
+/**
+ * Builds `gen_ai.invoke_agent` metadata with the caller-owned conversation id.
+ */
+export function buildAgentSpanContext({
+  name,
+  conversationId,
+  attributes = {},
+}: {
+  name: string;
+  conversationId: string;
+  attributes?: AgentSpanAttributes;
+}) {
+  return {
+    op: "gen_ai.invoke_agent",
+    name: `invoke_agent ${name}`,
+    attributes: {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": name,
+      "gen_ai.conversation.id": conversationId,
+      ...attributes,
+    },
+  };
+}
+
+/**
+ * Builds `gen_ai.execute_tool` metadata with compact JSON tool arguments.
+ */
+export function buildToolSpanContext({
+  name,
+  description,
+  args,
+}: {
+  name: string;
+  description: string;
+  args: unknown;
+}) {
+  return {
+    op: "gen_ai.execute_tool",
+    name: `execute_tool ${name}`,
+    attributes: {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": name,
+      "gen_ai.tool.description": description,
+      "gen_ai.tool.call.arguments": compactJson(args),
+    },
+  };
+}
+
+/**
+ * Wraps a classifier agent run in Sentry's `gen_ai.invoke_agent` span while
+ * preserving the caller-owned conversation id.
+ */
+export async function startAgentSpan<T>({
+  name,
+  conversationId,
+  attributes = {},
+  callback,
+}: {
+  name: string;
+  conversationId: string;
+  attributes?: AgentSpanAttributes;
+  callback: () => Promise<T>;
+}): Promise<T> {
+  return await startSpan(
+    buildAgentSpanContext({ name, conversationId, attributes }),
+    callback,
+  );
+}
+
+/**
+ * Wraps tool execution in `gen_ai.execute_tool` and records compact JSON
+ * arguments/results so spans stay useful without carrying oversized payloads.
+ */
+export async function startToolSpan<T>({
+  name,
+  description,
+  args,
+  callback,
+}: {
+  name: string;
+  description: string;
+  args: unknown;
+  callback: () => Promise<T>;
+}): Promise<T> {
+  return await startSpan(
+    buildToolSpanContext({ name, description, args }),
+    async (span) => {
+      const result = await callback();
+      span.setAttribute("gen_ai.tool.call.result", compactJson(result));
+      return result;
+    },
+  );
+}

--- a/packages/bottle-classifier/src/tools/firecrawlWebSearch.ts
+++ b/packages/bottle-classifier/src/tools/firecrawlWebSearch.ts
@@ -1,6 +1,7 @@
 import { tool } from "@openai/agents";
 import { z } from "zod";
 import type { BottleSearchEvidence } from "../classifierTypes";
+import { startToolSpan } from "../observability";
 import {
   BottleWebSearchArgsSchema,
   buildBottleSearchEvidence,
@@ -10,6 +11,8 @@ import {
 
 const FIRECRAWL_API_URL = "https://api.firecrawl.dev";
 const FIRECRAWL_SEARCH_TIMEOUT_MS = 30000;
+const FIRECRAWL_WEB_SEARCH_TOOL_DESCRIPTION =
+  "Search web pages and return readable page excerpts for decisive bottle or release evidence. Use focused queries when local search is insufficient, especially when exact ABV, cask, vintage, or bottle/release scope matters.";
 
 const FirecrawlSearchResultSchema = z
   .object({
@@ -93,25 +96,31 @@ export function createFirecrawlWebSearchTool({
 }) {
   return tool({
     name: "firecrawl_web_search",
-    description:
-      "Search web pages and return readable page excerpts for decisive bottle or release evidence. Use focused queries when local search is insufficient, especially when exact ABV, cask, vintage, or bottle/release scope matters.",
+    description: FIRECRAWL_WEB_SEARCH_TOOL_DESCRIPTION,
     parameters: BottleWebSearchArgsSchema,
     execute: async (args) => {
-      if (!budget.tryConsume()) {
-        return budget.getExhaustedError();
-      }
+      return await startToolSpan({
+        name: "firecrawl_web_search",
+        description: FIRECRAWL_WEB_SEARCH_TOOL_DESCRIPTION,
+        args,
+        callback: async () => {
+          if (!budget.tryConsume()) {
+            return budget.getExhaustedError();
+          }
 
-      const evidence = await runFirecrawlWebSearch({
-        apiKey,
-        apiUrl,
-        query: args.query,
+          const evidence = await runFirecrawlWebSearch({
+            apiKey,
+            apiUrl,
+            query: args.query,
+          });
+
+          if (!("error" in evidence) && evidence.results.length > 0) {
+            onEvidence?.(evidence);
+          }
+
+          return evidence;
+        },
       });
-
-      if (!("error" in evidence) && evidence.results.length > 0) {
-        onEvidence?.(evidence);
-      }
-
-      return evidence;
     },
   });
 }

--- a/packages/bottle-classifier/src/tools/openaiWebSearch.ts
+++ b/packages/bottle-classifier/src/tools/openaiWebSearch.ts
@@ -8,6 +8,7 @@ import {
   BottleSearchEvidenceSchema,
   type BottleSearchEvidence,
 } from "../classifierTypes";
+import { startToolSpan } from "../observability";
 import { getStableOpenAISettings } from "../openaiModelSettings";
 import {
   BottleWebSearchArgsSchema,
@@ -22,6 +23,8 @@ import {
 const OPENAI_WEB_SEARCH_RESPONSE_INCLUDES: ResponseIncludable[] = [
   "web_search_call.action.sources",
 ];
+const OPENAI_WEB_SEARCH_TOOL_DESCRIPTION =
+  "Search live web evidence for decisive bottle or release traits after local search is insufficient. Keep queries narrow and judge results by source content, independence, specificity, and corroboration.";
 
 export function extractOpenAISearchEvidence(
   query: string,
@@ -163,16 +166,21 @@ export function createOpenAIWebSearchTool({
 }) {
   return tool({
     name: "openai_web_search",
-    description:
-      "Search live web evidence for decisive bottle or release traits after local search is insufficient. Keep queries narrow and judge results by source content, independence, specificity, and corroboration.",
+    description: OPENAI_WEB_SEARCH_TOOL_DESCRIPTION,
     parameters: BottleWebSearchArgsSchema,
     execute: async (args) => {
-      return await runBottleWebEvidenceSearch({
-        client,
-        model,
-        budget,
-        query: args.query,
-        onEvidence,
+      return await startToolSpan({
+        name: "openai_web_search",
+        description: OPENAI_WEB_SEARCH_TOOL_DESCRIPTION,
+        args,
+        callback: async () =>
+          await runBottleWebEvidenceSearch({
+            client,
+            model,
+            budget,
+            query: args.query,
+            onEvidence,
+          }),
       });
     },
   });

--- a/packages/bottle-classifier/src/tools/searchBottles.ts
+++ b/packages/bottle-classifier/src/tools/searchBottles.ts
@@ -6,10 +6,13 @@ import {
   type BottleCandidate,
   type BottleCandidateSearchInput,
 } from "../classifierTypes";
+import { startToolSpan } from "../observability";
 
 const SearchBottlesResultSchema = z.object({
   results: z.array(BottleCandidateSchema),
 });
+const SEARCH_BOTTLES_TOOL_DESCRIPTION =
+  "Search local Peated bottle and release candidates. Use before web search when local matches are missing or conflicting, and again after web evidence reveals a canonical trait that could recover a better local candidate.";
 
 export type SearchBottlesResult = z.infer<typeof SearchBottlesResultSchema>;
 
@@ -24,8 +27,7 @@ export function createSearchBottlesTool({
 }) {
   return tool({
     name: "search_bottles",
-    description:
-      "Search local Peated bottle and release candidates. Use before web search when local matches are missing or conflicting, and again after web evidence reveals a canonical trait that could recover a better local candidate.",
+    description: SEARCH_BOTTLES_TOOL_DESCRIPTION,
     parameters: BottleCandidateSearchInputSchema.extend({
       query: BottleCandidateSearchInputSchema.shape.query.describe(
         "Bottle search text. Exclude volume, pack-size, gift-set, and price noise.",
@@ -85,10 +87,17 @@ export function createSearchBottlesTool({
       ),
     }),
     execute: async (args) => {
-      const results = await searchBottles(args);
-      onResults?.(results);
-      return SearchBottlesResultSchema.parse({
-        results,
+      return await startToolSpan({
+        name: "search_bottles",
+        description: SEARCH_BOTTLES_TOOL_DESCRIPTION,
+        args,
+        callback: async () => {
+          const results = await searchBottles(args);
+          onResults?.(results);
+          return SearchBottlesResultSchema.parse({
+            results,
+          });
+        },
       });
     },
   });

--- a/packages/bottle-classifier/src/tools/searchEntities.ts
+++ b/packages/bottle-classifier/src/tools/searchEntities.ts
@@ -6,9 +6,12 @@ import {
   type EntityResolution,
   type SearchEntitiesArgs,
 } from "../classifierTypes";
+import { startToolSpan } from "../observability";
 
 export const EntitySearchResultSchema = EntityResolutionSchema;
 export type EntitySearchResult = EntityResolution;
+const SEARCH_ENTITIES_TOOL_DESCRIPTION =
+  "Search local Peated brand, distillery, and bottler entities. Use when producer identity is blocking a match or create decision. Do not use for bottles.";
 
 export function createSearchEntitiesTool(
   {
@@ -23,17 +26,23 @@ export function createSearchEntitiesTool(
 ) {
   return tool({
     name: "search_entities",
-    description:
-      "Search local Peated brand, distillery, and bottler entities. Use when producer identity is blocking a match or create decision. Do not use for bottles.",
+    description: SEARCH_ENTITIES_TOOL_DESCRIPTION,
     parameters: SearchEntitiesArgsSchema,
     execute: async (args) => {
-      const results = await searchEntities(args);
-      const parsedResults = SearchEntitiesResultSchema.parse({
-        results,
-      });
+      return await startToolSpan({
+        name: "search_entities",
+        description: SEARCH_ENTITIES_TOOL_DESCRIPTION,
+        args,
+        callback: async () => {
+          const results = await searchEntities(args);
+          const parsedResults = SearchEntitiesResultSchema.parse({
+            results,
+          });
 
-      onResults?.(parsedResults.results);
-      return parsedResults;
+          onResults?.(parsedResults.results);
+          return parsedResults;
+        },
+      });
     },
   });
 }

--- a/packages/entity-classifier/package.json
+++ b/packages/entity-classifier/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@openai/agents": "^0.6.0",
     "@peated/tsconfig": "workspace:*",
+    "@sentry/core": "catalog:",
     "openai": "^6.27.0",
     "zod": "catalog:"
   },

--- a/packages/entity-classifier/src/classifierRuntime.ts
+++ b/packages/entity-classifier/src/classifierRuntime.ts
@@ -19,6 +19,7 @@ import {
 } from "./contract";
 import { EntityClassificationError } from "./error";
 import { buildEntityClassifierInstructions } from "./instructions";
+import { startAgentSpan } from "./observability";
 import { getDeterministicOpenAISettings } from "./openaiModelSettings";
 import { finalizeEntityClassification } from "./reviewPolicy";
 import { createOpenAIWebSearchTool, createSearchEntitiesTool } from "./tools";
@@ -150,21 +151,33 @@ export function createEntityClassifier(
       outputType: EntityClassificationDecisionSchema,
       tools,
     });
+    const conversationId = `entity:${reference.entity.id}`;
     const runner = new Runner({
       modelProvider: new OpenAIProvider({
         openAIClient: options.client,
         useResponses: true,
       }),
       workflowName: "Entity Classifier",
-      groupId: `entity:${reference.entity.id}`,
+      groupId: conversationId,
       traceMetadata: {
+        "gen_ai.conversation.id": conversationId,
         entity_id: `${reference.entity.id}`,
       },
     });
 
     try {
-      const result = await runner.run(agent, buildAgentInput(reference), {
-        maxTurns: ENTITY_CLASSIFIER_MAX_TURNS,
+      const result = await startAgentSpan({
+        name: "Entity Classifier",
+        conversationId,
+        attributes: {
+          "gen_ai.request.model": options.model,
+          "entity_classifier.entity_id": `${reference.entity.id}`,
+          "entity_classifier.entity_name": reference.entity.name,
+        },
+        callback: async () =>
+          await runner.run(agent, buildAgentInput(reference), {
+            maxTurns: ENTITY_CLASSIFIER_MAX_TURNS,
+          }),
       });
       if (!result.finalOutput) {
         throw new Error("Agent returned empty output");

--- a/packages/entity-classifier/src/observability.test.ts
+++ b/packages/entity-classifier/src/observability.test.ts
@@ -1,0 +1,117 @@
+import * as Sentry from "@sentry/core";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import {
+  buildAgentSpanContext,
+  buildToolSpanContext,
+  startAgentSpan,
+  startToolSpan,
+} from "./observability";
+
+vi.mock("@sentry/core", { spy: true });
+
+describe("observability span contexts", () => {
+  beforeEach(() => {
+    vi.mocked(Sentry.startSpan).mockClear();
+  });
+
+  test("builds agent invocation span metadata with the shared conversation id", () => {
+    expect(
+      buildAgentSpanContext({
+        name: "Entity Classifier",
+        conversationId: "entity:42",
+        attributes: {
+          "entity_classifier.entity_id": "42",
+        },
+      }),
+    ).toMatchObject({
+      op: "gen_ai.invoke_agent",
+      name: "invoke_agent Entity Classifier",
+      attributes: {
+        "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.agent.name": "Entity Classifier",
+        "gen_ai.conversation.id": "entity:42",
+        "entity_classifier.entity_id": "42",
+      },
+    });
+  });
+
+  test("builds tool execution span metadata with compact JSON arguments", () => {
+    const context = buildToolSpanContext({
+      name: "search_entities",
+      description: "Search local entities.",
+      args: {
+        query: "Ardbeg",
+      },
+    });
+
+    expect(context).toMatchObject({
+      op: "gen_ai.execute_tool",
+      name: "execute_tool search_entities",
+      attributes: {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.tool.name": "search_entities",
+        "gen_ai.tool.description": "Search local entities.",
+        "gen_ai.tool.call.arguments": JSON.stringify({
+          query: "Ardbeg",
+        }),
+      },
+    });
+  });
+
+  test("wraps agent runs in a Sentry agent invocation span", async () => {
+    await expect(
+      startAgentSpan({
+        name: "Entity Classifier",
+        conversationId: "entity:42",
+        attributes: {
+          "entity_classifier.entity_id": "42",
+        },
+        callback: async () => "done",
+      }),
+    ).resolves.toBe("done");
+
+    expect(Sentry.startSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        op: "gen_ai.invoke_agent",
+        name: "invoke_agent Entity Classifier",
+        attributes: expect.objectContaining({
+          "gen_ai.conversation.id": "entity:42",
+          "entity_classifier.entity_id": "42",
+        }),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  test("records tool results on the Sentry tool span", async () => {
+    const setAttribute = vi.fn();
+    vi.mocked(Sentry.startSpan).mockImplementationOnce(
+      async (_context, callback) =>
+        await callback({
+          setAttribute,
+        } as unknown as Parameters<typeof callback>[0]),
+    );
+
+    await expect(
+      startToolSpan({
+        name: "search_entities",
+        description: "Search local entities.",
+        args: {
+          query: "Ardbeg",
+        },
+        callback: async () => ({
+          results: [{ entityId: 1 }],
+        }),
+      }),
+    ).resolves.toEqual({
+      results: [{ entityId: 1 }],
+    });
+
+    expect(setAttribute).toHaveBeenCalledWith(
+      "gen_ai.tool.call.result",
+      JSON.stringify({
+        results: [{ entityId: 1 }],
+      }),
+    );
+  });
+});

--- a/packages/entity-classifier/src/observability.ts
+++ b/packages/entity-classifier/src/observability.ts
@@ -1,0 +1,111 @@
+import { startSpan } from "@sentry/core";
+
+const MAX_ATTRIBUTE_LENGTH = 12_000;
+
+export type AgentSpanAttributes = Record<
+  string,
+  boolean | number | string | string[] | undefined
+>;
+
+function compactJson(value: unknown): string {
+  const serialized = JSON.stringify(value) ?? String(value);
+  if (serialized.length <= MAX_ATTRIBUTE_LENGTH) {
+    return serialized;
+  }
+
+  return `${serialized.slice(0, MAX_ATTRIBUTE_LENGTH)}...`;
+}
+
+/**
+ * Builds `gen_ai.invoke_agent` metadata with the caller-owned conversation id.
+ */
+export function buildAgentSpanContext({
+  name,
+  conversationId,
+  attributes = {},
+}: {
+  name: string;
+  conversationId: string;
+  attributes?: AgentSpanAttributes;
+}) {
+  return {
+    op: "gen_ai.invoke_agent",
+    name: `invoke_agent ${name}`,
+    attributes: {
+      "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.agent.name": name,
+      "gen_ai.conversation.id": conversationId,
+      ...attributes,
+    },
+  };
+}
+
+/**
+ * Builds `gen_ai.execute_tool` metadata with compact JSON tool arguments.
+ */
+export function buildToolSpanContext({
+  name,
+  description,
+  args,
+}: {
+  name: string;
+  description: string;
+  args: unknown;
+}) {
+  return {
+    op: "gen_ai.execute_tool",
+    name: `execute_tool ${name}`,
+    attributes: {
+      "gen_ai.operation.name": "execute_tool",
+      "gen_ai.tool.name": name,
+      "gen_ai.tool.description": description,
+      "gen_ai.tool.call.arguments": compactJson(args),
+    },
+  };
+}
+
+/**
+ * Wraps a classifier agent run in Sentry's `gen_ai.invoke_agent` span while
+ * preserving the caller-owned conversation id.
+ */
+export async function startAgentSpan<T>({
+  name,
+  conversationId,
+  attributes = {},
+  callback,
+}: {
+  name: string;
+  conversationId: string;
+  attributes?: AgentSpanAttributes;
+  callback: () => Promise<T>;
+}): Promise<T> {
+  return await startSpan(
+    buildAgentSpanContext({ name, conversationId, attributes }),
+    callback,
+  );
+}
+
+/**
+ * Wraps tool execution in `gen_ai.execute_tool` and records compact JSON
+ * arguments/results so spans stay useful without carrying oversized payloads.
+ */
+export async function startToolSpan<T>({
+  name,
+  description,
+  args,
+  callback,
+}: {
+  name: string;
+  description: string;
+  args: unknown;
+  callback: () => Promise<T>;
+}): Promise<T> {
+  return await startSpan(
+    buildToolSpanContext({ name, description, args }),
+    async (span) => {
+      const result = await callback();
+      span.setAttribute("gen_ai.tool.call.result", compactJson(result));
+      return result;
+    },
+  );
+}

--- a/packages/entity-classifier/src/tools/openaiWebSearch.ts
+++ b/packages/entity-classifier/src/tools/openaiWebSearch.ts
@@ -6,6 +6,7 @@ import {
   EntityClassificationSearchEvidenceSchema,
   type EntityClassificationSearchEvidence,
 } from "../classifierTypes";
+import { startToolSpan } from "../observability";
 import { getDeterministicOpenAISettings } from "../openaiModelSettings";
 
 const WebSearchArgsSchema = z
@@ -13,6 +14,8 @@ const WebSearchArgsSchema = z
     query: z.string().trim().min(1),
   })
   .strict();
+const OPENAI_WEB_SEARCH_TOOL_DESCRIPTION =
+  "Search the live web for official producer naming, website, location, and branding evidence. Prefer official sources and use this only when local entity evidence is still ambiguous.";
 
 function getResultDomain(url: string): string {
   try {
@@ -149,37 +152,43 @@ export function createOpenAIWebSearchTool({
 
   return tool({
     name: "openai_web_search",
-    description:
-      "Search the live web for official producer naming, website, location, and branding evidence. Prefer official sources and use this only when local entity evidence is still ambiguous.",
+    description: OPENAI_WEB_SEARCH_TOOL_DESCRIPTION,
     parameters: WebSearchArgsSchema,
     execute: async (args) => {
-      if (remainingQueries <= 0) {
-        return {
-          error: "Web search budget exhausted.",
-        };
-      }
+      return await startToolSpan({
+        name: "openai_web_search",
+        description: OPENAI_WEB_SEARCH_TOOL_DESCRIPTION,
+        args,
+        callback: async () => {
+          if (remainingQueries <= 0) {
+            return {
+              error: "Web search budget exhausted.",
+            };
+          }
 
-      remainingQueries -= 1;
-      const parsedArgs = WebSearchArgsSchema.parse(args);
+          remainingQueries -= 1;
+          const parsedArgs = WebSearchArgsSchema.parse(args);
 
-      try {
-        const response = await client.responses.create(
-          buildOpenAIWebSearchRequest({
-            model,
-            query: parsedArgs.query,
-          }),
-        );
-        const evidence = extractSearchEvidence(parsedArgs.query, response);
-        onEvidence?.(evidence);
-        return evidence;
-      } catch (error) {
-        return {
-          error:
-            error instanceof Error
-              ? `OpenAI web search failed: ${error.message}`
-              : "OpenAI web search failed",
-        };
-      }
+          try {
+            const response = await client.responses.create(
+              buildOpenAIWebSearchRequest({
+                model,
+                query: parsedArgs.query,
+              }),
+            );
+            const evidence = extractSearchEvidence(parsedArgs.query, response);
+            onEvidence?.(evidence);
+            return evidence;
+          } catch (error) {
+            return {
+              error:
+                error instanceof Error
+                  ? `OpenAI web search failed: ${error.message}`
+                  : "OpenAI web search failed",
+            };
+          }
+        },
+      });
     },
   });
 }

--- a/packages/entity-classifier/src/tools/searchEntities.ts
+++ b/packages/entity-classifier/src/tools/searchEntities.ts
@@ -5,8 +5,11 @@ import {
   type EntityResolution,
   type SearchEntitiesArgs,
 } from "../classifierTypes";
+import { startToolSpan } from "../observability";
 
 const SearchEntitiesResultSchema = EntityResolutionSchema.array();
+const SEARCH_ENTITIES_TOOL_DESCRIPTION =
+  "Search the local entity database for likely sibling brands, distilleries, or bottlers. Use this before web search when you need to confirm whether a better existing producer row already exists locally.";
 
 export function createSearchEntitiesTool({
   onResults,
@@ -17,16 +20,22 @@ export function createSearchEntitiesTool({
 }) {
   return tool({
     name: "search_entities",
-    description:
-      "Search the local entity database for likely sibling brands, distilleries, or bottlers. Use this before web search when you need to confirm whether a better existing producer row already exists locally.",
+    description: SEARCH_ENTITIES_TOOL_DESCRIPTION,
     parameters: SearchEntitiesArgsSchema,
     execute: async (args) => {
-      const parsedArgs = SearchEntitiesArgsSchema.parse(args);
-      const results = SearchEntitiesResultSchema.parse(
-        await searchEntities(parsedArgs),
-      );
-      onResults?.(results);
-      return { results };
+      return await startToolSpan({
+        name: "search_entities",
+        description: SEARCH_ENTITIES_TOOL_DESCRIPTION,
+        args,
+        callback: async () => {
+          const parsedArgs = SearchEntitiesArgsSchema.parse(args);
+          const results = SearchEntitiesResultSchema.parse(
+            await searchEntities(parsedArgs),
+          );
+          onResults?.(results);
+          return { results };
+        },
+      });
     },
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,10 +414,10 @@ importers:
         version: 6.0.3
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@24.13.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+        version: 8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   apps/web:
     dependencies:
@@ -617,6 +617,9 @@ importers:
       '@peated/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@sentry/core':
+        specifier: 'catalog:'
+        version: 10.53.0
       openai:
         specifier: ^6.27.0
         version: 6.27.0(ws@8.18.3)(zod@4.3.6)
@@ -725,6 +728,9 @@ importers:
       '@peated/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@sentry/core':
+        specifier: 'catalog:'
+        version: 10.53.0
       openai:
         specifier: ^6.27.0
         version: 6.27.0(ws@8.18.3)(zod@4.3.6)
@@ -14234,14 +14240,6 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@25.9.1)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.13.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 8.0.8(@types/node@24.13.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-
   '@vitest/mocker@4.1.4(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.4
@@ -19649,22 +19647,6 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vite@8.0.8(@types/node@24.13.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.10
-      rolldown: 1.0.0-rc.15
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 24.13.2
-      esbuild: 0.19.12
-      fsevents: 2.3.3
-      jiti: 1.21.7
-      terser: 5.48.0
-      tsx: 4.21.0
-      yaml: 2.9.0
-
   vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -19731,36 +19713,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@24.13.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/runner': 4.1.4
-      '@vitest/snapshot': 4.1.4
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@24.13.2)(esbuild@0.19.12)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 24.13.2
-      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
-      jsdom: 25.0.1
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
Classifier and photo-identification runs now emit Sentry AI Agent Monitoring spans around the agent workflow and each classifier tool call. The photo workflow owns one shared `photo_identification:<pendingUpload.id>` conversation id, so extraction, local matching, full classification, and create-from-photo all group under the same workflow trace.

The classifier packages use a small `@sentry/core` helper for `gen_ai.invoke_agent` and `gen_ai.execute_tool` metadata, while the route tests avoid whole-module Sentry mocks and only assert the requested tracing contract.

Fixes #437