### PR TITLE
fix(web): Redirect expired sessions from oRPC 401s

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -443,6 +443,38 @@ test.describe("add bottle flow", () => {
     await expectNoHorizontalOverflow(page);
   });
 
+  test("redirects to login when a scan hits an expired session", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "photo-unauthorized-expired"),
+    });
+
+    await page.goto("/addBottle");
+    await uploadLabel(page);
+
+    await expect(page).toHaveURL(/\/login\?redirectTo=%2FaddBottle$/);
+    await expect(page.getByText("We couldn't read that photo")).toBeHidden();
+  });
+
+  test("keeps local scan errors when a 401 is not an expired session", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "photo-unauthorized-valid"),
+    });
+
+    await page.goto("/addBottle");
+    await uploadLabel(page);
+
+    await expect(page).toHaveURL(/\/addBottle$/);
+    await expect(
+      page.getByText("We couldn't read that photo", { exact: true }),
+    ).toBeVisible();
+  });
+
   test("creates a bottle from a scan with explicit bottle image approval", async ({
     context,
     page,

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -226,6 +226,11 @@ async function handleRpcRequest({ request, response, url }) {
     }
     case "tastings/photoIdentification":
       // E2E access-token suffixes select alternate mock photo-identification scenarios.
+      if (getAccessToken(request).includes("photo-unauthorized")) {
+        sendRpcUnauthorized(response);
+        return true;
+      }
+
       if (getAccessToken(request).includes("photo-create-warning")) {
         sendRpcResponse(
           response,
@@ -386,6 +391,11 @@ async function handleRpcRequest({ request, response, url }) {
       sendRpcResponse(response, buildTasting());
       return true;
     case "users/details":
+      if (getAccessToken(request).includes("photo-unauthorized-expired")) {
+        sendRpcUnauthorized(response);
+        return true;
+      }
+
       if (
         input?.user === "me" ||
         input?.user === testUser.id ||
@@ -1225,4 +1235,22 @@ function sendRpcError(response, message) {
       "Content-Type": "application/json",
     })
     .end(JSON.stringify({ error: { code: "BAD_REQUEST", message } }));
+}
+
+function sendRpcUnauthorized(response) {
+  response
+    .writeHead(401, {
+      ...corsHeaders,
+      "Content-Type": "application/json",
+    })
+    .end(
+      JSON.stringify({
+        json: {
+          defined: true,
+          code: "UNAUTHORIZED",
+          status: 401,
+          message: "Unauthorized.",
+        },
+      }),
+    );
 }

--- a/apps/web/src/app/providers/providers.tsx
+++ b/apps/web/src/app/providers/providers.tsx
@@ -4,13 +4,18 @@ import FlashMessages from "@peated/web/components/flash";
 import { default as config } from "@peated/web/config";
 import { AuthProvider } from "@peated/web/hooks/useAuth";
 import { OnlineStatusProvider } from "@peated/web/hooks/useOnlineStatus";
-import { ensureSessionSynced } from "@peated/web/lib/auth.actions";
+import { getAuthRedirect } from "@peated/web/lib/auth";
+import {
+  ensureSessionSynced,
+  updateSession,
+} from "@peated/web/lib/auth.actions";
 import ORPCProvider from "@peated/web/lib/orpc/provider";
 import { type SessionData } from "@peated/web/lib/session.server";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import { setUser } from "@sentry/nextjs";
 import { ReactQueryStreamedHydration } from "@tanstack/react-query-next-experimental";
-import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useInterval } from "usehooks-ts";
 
 export default function Providers({
@@ -21,6 +26,8 @@ export default function Providers({
   session: SessionData;
 }) {
   const [session, setSession] = useState<SessionData>(initialSession);
+  const unauthorizedHandlingRef = useRef<Promise<boolean> | null>(null);
+  const router = useRouter();
 
   // Sync from server props on navigation
   useEffect(() => {
@@ -37,6 +44,41 @@ export default function Providers({
     }
   }, 60000);
 
+  const handleUnauthorized = useCallback(async () => {
+    if (unauthorizedHandlingRef.current) return unauthorizedHandlingRef.current;
+
+    const handled = (async () => {
+      try {
+        const updated = await updateSession();
+
+        if (updated.user && updated.accessToken) {
+          setSession(updated);
+          return false;
+        }
+      } catch {
+        // Preserve the original 401 handling when session validation itself fails.
+        return false;
+      }
+
+      const currentUrl = new URL(window.location.href);
+      router.push(
+        getAuthRedirect({
+          pathname: currentUrl.pathname,
+          searchParams: currentUrl.search ? currentUrl.searchParams : undefined,
+        }),
+      );
+      return true;
+    })();
+
+    unauthorizedHandlingRef.current = handled;
+
+    try {
+      return await handled;
+    } finally {
+      unauthorizedHandlingRef.current = null;
+    }
+  }, [router]);
+
   setUser(
     session.user
       ? {
@@ -52,6 +94,7 @@ export default function Providers({
       <ORPCProvider
         apiServer={config.API_SERVER}
         accessToken={session.accessToken}
+        onUnauthorized={handleUnauthorized}
       >
         <ReactQueryStreamedHydration>
           <OnlineStatusProvider>

--- a/apps/web/src/components/bottleResolver.tsx
+++ b/apps/web/src/components/bottleResolver.tsx
@@ -9,6 +9,7 @@ import Layout from "@peated/web/components/layout";
 import type { CreateBottlePrefill } from "@peated/web/components/search/createBottleHref";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { isORPCUnauthorizedRedirectError } from "@peated/web/lib/orpc/link";
 import { useMutation } from "@tanstack/react-query";
 import {
   AlertTriangle,
@@ -843,6 +844,8 @@ export default function BottleResolver({
         ),
       });
     } catch (err) {
+      if (isORPCUnauthorizedRedirectError(err)) return;
+
       logError(err);
       setError(
         "We couldn't create that bottle from the photo. Search for the bottle to keep going.",
@@ -866,6 +869,8 @@ export default function BottleResolver({
       });
       setPhotoResult(result);
     } catch (err) {
+      if (isORPCUnauthorizedRedirectError(err)) return;
+
       logError(err, {
         context: "add_tasting_photo_identification",
         rpc: "tastings.photoIdentification",

--- a/apps/web/src/lib/orpc/link.ts
+++ b/apps/web/src/lib/orpc/link.ts
@@ -1,11 +1,26 @@
 import { RPCLink } from "@orpc/client/fetch";
 import { BatchLinkPlugin } from "@orpc/client/plugins";
+import { isORPCClientError } from "@peated/orpc/client/errors";
 import sentryInterceptor from "@peated/orpc/client/interceptors";
+
+class ORPCUnauthorizedRedirectError extends Error {
+  name = "ORPCUnauthorizedRedirectError";
+}
+
+export function isORPCUnauthorizedRedirectError(
+  error: unknown,
+): error is ORPCUnauthorizedRedirectError {
+  return (
+    error instanceof ORPCUnauthorizedRedirectError ||
+    (error instanceof Error && error.name === "ORPCUnauthorizedRedirectError")
+  );
+}
 
 export function getLink({
   apiServer,
   accessToken,
   getAccessToken,
+  onUnauthorized,
   batch,
   userAgent,
   traceContext,
@@ -13,6 +28,7 @@ export function getLink({
   apiServer: string;
   accessToken?: string | null;
   getAccessToken?: () => string | null | undefined;
+  onUnauthorized?: () => boolean | Promise<boolean>;
   batch?: boolean;
   userAgent: string;
   traceContext?: {
@@ -36,7 +52,24 @@ export function getLink({
       };
     },
     url: `${apiServer}/rpc`,
-    interceptors: [sentryInterceptor({ captureInputs: true })],
+    interceptors: [
+      async ({ next, ...options }) => {
+        try {
+          return await next(options);
+        } catch (err) {
+          if (
+            isORPCClientError(err) &&
+            (err.status === 401 || err.name === "UNAUTHORIZED")
+          ) {
+            if (await onUnauthorized?.()) {
+              throw new ORPCUnauthorizedRedirectError();
+            }
+          }
+          throw err;
+        }
+      },
+      sentryInterceptor({ captureInputs: true }),
+    ],
     plugins: [
       new BatchLinkPlugin({
         groups: [

--- a/apps/web/src/lib/orpc/provider.tsx
+++ b/apps/web/src/lib/orpc/provider.tsx
@@ -13,17 +13,21 @@ import { getQueryClient } from "./query";
 export default function ORPCProvider({
   accessToken,
   apiServer,
+  onUnauthorized,
   ...props
-}: { accessToken?: string | null; apiServer: string } & Omit<
-  ComponentProps<typeof ORPCContext.Provider>,
-  "value"
->) {
+}: {
+  accessToken?: string | null;
+  apiServer: string;
+  onUnauthorized?: () => boolean | Promise<boolean>;
+} & Omit<ComponentProps<typeof ORPCContext.Provider>, "value">) {
   const queryClient = getQueryClient(false);
   const traceData = getTraceData();
   const accessTokenRef = useRef(accessToken);
   const previousAccessTokenRef = useRef(accessToken);
+  const onUnauthorizedRef = useRef(onUnauthorized);
 
   accessTokenRef.current = accessToken;
+  onUnauthorizedRef.current = onUnauthorized;
 
   useEffect(() => {
     if (previousAccessTokenRef.current !== accessToken) {
@@ -38,6 +42,7 @@ export default function ORPCProvider({
         apiServer,
         getAccessToken: () => accessTokenRef.current,
         userAgent: "@peated/web (orpc/tanstack-query)",
+        onUnauthorized: () => onUnauthorizedRef.current?.() ?? false,
         traceContext: {
           sentryTrace: traceData["sentry-trace"],
           baggage: traceData.baggage,


### PR DESCRIPTION
Expired-session 401s from oRPC calls now go through the app session refresh flow before protected workflows display local errors. When refresh confirms the session is gone, the app redirects to login with the current path; when refresh succeeds, the original 401 remains available to the caller so local scan errors still render.

The add-bottle e2e mock now covers both cases for photo identification so the regression is pinned to the photo upload flow that exposed it.