### PR TITLE
ref(price-matching): Require explicit actors for writes

### DIFF
--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -5,11 +5,13 @@ import {
   bottleReleases,
   bottles,
   bottlesToDistillers,
+  changes,
   incomingBottleDecisionLogs,
   storePriceMatchAttempts,
   storePriceMatchProposals,
   storePrices,
 } from "@peated/server/db/schema";
+import { getPeatedSystemActor, getUserActor } from "@peated/server/lib/actors";
 import {
   findBottleReferenceCandidates,
   searchBottleCandidates,
@@ -538,7 +540,7 @@ describe("priceMatching", () => {
         flavorProfile: null,
       },
       user: reviewer,
-      actorType: "user",
+      actor: await getUserActor(reviewer),
     });
 
     const updatedProposal = await db.query.storePriceMatchProposals.findFirst({
@@ -1168,6 +1170,7 @@ describe("priceMatching", () => {
       sourceKind: "store_price",
       sourceId: price.id,
       proposalId: proposal.id,
+      actorId: (await getPeatedSystemActor()).id,
       decision: "match_existing",
       bottleId: bottle.id,
       releaseId: null,
@@ -3098,7 +3101,6 @@ describe("priceMatching", () => {
     const listingAlias = await db.query.bottleAliases.findFirst({
       where: eq(bottleAliases.name, normalizeBottleAliasKey(price.name)),
     });
-
     expect(extractFromText).not.toHaveBeenCalled();
     expect(classifyBottleReference).toHaveBeenCalledOnce();
     expect(proposal).toMatchObject({
@@ -3809,6 +3811,7 @@ describe("priceMatching", () => {
       }),
     );
 
+    const systemActor = await getPeatedSystemActor();
     const proposal = await resolveStorePriceMatchProposal(price.id);
     const updatedPrice = await db.query.storePrices.findFirst({
       where: eq(storePrices.id, price.id),
@@ -3818,6 +3821,13 @@ describe("priceMatching", () => {
     });
     const listingAlias = await db.query.bottleAliases.findFirst({
       where: eq(bottleAliases.name, normalizeBottleAliasKey(price.name)),
+    });
+    const creationChange = await db.query.changes.findFirst({
+      where: and(
+        eq(changes.objectType, "bottle"),
+        eq(changes.objectId, proposal.suggestedBottleId!),
+        eq(changes.type, "add"),
+      ),
     });
     const [attempt] = await db
       .select()
@@ -3835,8 +3845,11 @@ describe("priceMatching", () => {
     expect(createdBottle).toMatchObject({
       name: "Web Reserve",
       fullName: "Auto Brand Web Reserve",
+      createdByActorId: systemActor.id,
     });
     expect(listingAlias?.bottleId).toBe(proposal.suggestedBottleId);
+    expect(listingAlias?.assignedByActorId).toBe(systemActor.id);
+    expect(creationChange?.actorId).toBe(systemActor.id);
     expect(attempt).toMatchObject({
       automationEligible: true,
       finalStatus: "approved",
@@ -3853,6 +3866,7 @@ describe("priceMatching", () => {
       sourceKind: "store_price",
       sourceId: price.id,
       proposalId: proposal.id,
+      actorId: systemActor.id,
       decision: "create_bottle",
       bottleId: proposal.suggestedBottleId,
       releaseId: null,
@@ -5111,6 +5125,7 @@ describe("priceMatching", () => {
     await ignoreStorePriceMatchProposal({
       proposalId: proposal.id,
       reviewedById: reviewer.id,
+      actor: await getUserActor(reviewer),
     });
 
     const [reviewedAttempt] = await db
@@ -5121,6 +5136,42 @@ describe("priceMatching", () => {
     expect(reviewedAttempt).toMatchObject({
       finalStatus: "ignored",
       reviewedById: reviewer.id,
+    });
+  });
+
+  test("rejects ignoring a proposal with an actor from another user", async ({
+    fixtures,
+  }) => {
+    const reviewer = await fixtures.User();
+    const otherUser = await fixtures.User();
+    const price = await fixtures.StorePrice({
+      name: "Ignore Mismatch Candidate",
+    });
+
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "no_match",
+      })
+      .returning();
+
+    await expect(
+      ignoreStorePriceMatchProposal({
+        proposalId: proposal.id,
+        reviewedById: reviewer.id,
+        actor: await getUserActor(otherUser),
+      }),
+    ).rejects.toThrow(`does not match user ${reviewer.id}`);
+
+    const updatedProposal = await db.query.storePriceMatchProposals.findFirst({
+      where: eq(storePriceMatchProposals.id, proposal.id),
+    });
+
+    expect(updatedProposal).toMatchObject({
+      status: "pending_review",
+      reviewedById: null,
     });
   });
 
@@ -5868,7 +5919,7 @@ describe("priceMatching", () => {
       proposalId: reviewableProposal.id,
       bottleId: bottle.id,
       reviewedById: user.id,
-      actorType: "user",
+      actor: await getUserActor(user),
     });
 
     const updatedReviewableProposal =
@@ -5986,7 +6037,7 @@ describe("priceMatching", () => {
       bottleId: bottle.id,
       releaseId: release.id,
       reviewedById: reviewer.id,
-      actorType: "user",
+      actor: await getUserActor(reviewer),
     });
 
     const observation = await db.query.bottleObservations.findFirst({

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -17,6 +17,7 @@ import {
 import config from "@peated/server/config";
 import { db, type AnyDatabase, type AnyTransaction } from "@peated/server/db";
 import {
+  actors,
   bottleObservations,
   bottleReleases,
   bottleSeries,
@@ -31,11 +32,7 @@ import {
   type StorePriceMatchProposal,
   type User,
 } from "@peated/server/db/schema";
-import {
-  getPeatedSystemActorForDatabase,
-  getUserActorByIdForDatabase,
-  getUserActorForDatabase,
-} from "@peated/server/lib/actors";
+import { getPeatedSystemActor } from "@peated/server/lib/actors";
 import {
   assignBottleAliasInTransaction,
   finalizeBottleAliasAssignment,
@@ -116,7 +113,39 @@ type StorePriceMatchDecision = z.infer<typeof StorePriceMatchDecisionSchema>;
 type StorePriceMatchProposalForReview = StorePriceMatchProposal & {
   price: StorePrice;
 };
-type IncomingBottleDecisionActorType = IncomingBottleDecisionActor["type"];
+
+async function getPriceMatchWriteActorForDatabase(
+  tx: AnyDatabase,
+  actor: IncomingBottleDecisionActor,
+  {
+    userId,
+    allowSystemActor = false,
+  }: {
+    userId: number;
+    allowSystemActor?: boolean;
+  },
+): Promise<IncomingBottleDecisionActor> {
+  const storedActor = await tx.query.actors.findFirst({
+    where: eq(actors.id, actor.id),
+  });
+
+  if (!storedActor || storedActor.type !== actor.type) {
+    throw new Error(`Invalid price match actor ${actor.id}.`);
+  }
+
+  if (storedActor.type === "system") {
+    if (!allowSystemActor) {
+      throw new Error(`System actor ${actor.id} is not allowed here.`);
+    }
+    return storedActor;
+  }
+
+  if (storedActor.userId !== userId) {
+    throw new Error(`User actor ${actor.id} does not match user ${userId}.`);
+  }
+
+  return storedActor;
+}
 
 function withStoreCaskBottleDefaults(
   proposedBottle: BottleClassificationDecision["proposedBottle"],
@@ -1058,13 +1087,18 @@ async function applyBottleRepairDraftInTransaction(
     bottleId,
     proposedBottle,
     user,
+    actor,
   }: {
     bottleId: number;
     proposedBottle: ProposedBottle;
     user: User;
+    actor: IncomingBottleDecisionActor;
   },
 ) {
-  const actorId = (await getUserActorForDatabase(tx, user)).id;
+  const writeActor = await getPriceMatchWriteActorForDatabase(tx, actor, {
+    userId: user.id,
+  });
+  const actorId = writeActor.id;
   const bottle = await getBottleForStorePriceRepairInTransaction(tx, bottleId);
   const currentDistillers = bottle.bottlesToDistillers.map(
     (row) => row.distiller,
@@ -1676,8 +1710,7 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
     releaseInput,
     user,
     creationSource,
-    actorType,
-    actor: actorInput,
+    actor,
     expectedProcessingToken,
   }: {
     proposalId: number;
@@ -1685,8 +1718,7 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
     releaseInput?: z.infer<typeof BottleReleaseInputSchema>;
     user: User;
     creationSource: CatalogVerificationCreationSource;
-    actorType: IncomingBottleDecisionActorType;
-    actor?: IncomingBottleDecisionActor;
+    actor: IncomingBottleDecisionActor;
     expectedProcessingToken?: string;
   },
 ) {
@@ -1708,11 +1740,10 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
     );
   }
 
-  const actor =
-    actorInput ??
-    (actorType === "system"
-      ? await getPeatedSystemActorForDatabase(tx)
-      : await getUserActorForDatabase(tx, user));
+  const writeActor = await getPriceMatchWriteActorForDatabase(tx, actor, {
+    userId: user.id,
+    allowSystemActor: creationSource === "price_match_automation",
+  });
 
   let createResult: Awaited<
     ReturnType<typeof createBottleInTransaction>
@@ -1736,7 +1767,7 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
     try {
       createResult = await createBottleInTransaction(tx, {
         creationSource,
-        createdByActorId: actor.id,
+        createdByActorId: writeActor.id,
         input,
         context: {
           user,
@@ -1771,7 +1802,7 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
     try {
       createReleaseResult = await createBottleReleaseInTransaction(tx, {
         bottleId: releaseBottleId,
-        createdByActorId: actor.id,
+        createdByActorId: writeActor.id,
         input: releaseInput,
         user,
       });
@@ -1808,8 +1839,9 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
       bottleId: resolvedBottleId,
       releaseId: resolvedReleaseId,
       reviewedById: user.id,
+      allowSystemActor: creationSource === "price_match_automation",
       decisionLog: {
-        actor,
+        actor: writeActor,
         decision: getIncomingBottleDecisionFromCreationTarget(creationTarget),
         createdBottle: !!createResult,
         createdRelease: !!createReleaseResult,
@@ -1838,7 +1870,7 @@ export async function createBottleFromStorePriceMatchProposal({
   releaseInput,
   user,
   creationSource = "price_match_review",
-  actorType,
+  actor,
   expectedProcessingToken,
 }: {
   proposalId: number;
@@ -1846,7 +1878,7 @@ export async function createBottleFromStorePriceMatchProposal({
   releaseInput?: z.infer<typeof BottleReleaseInputSchema>;
   user: User;
   creationSource?: CatalogVerificationCreationSource;
-  actorType: IncomingBottleDecisionActorType;
+  actor: IncomingBottleDecisionActor;
   expectedProcessingToken?: string;
 }) {
   const result = await db.transaction(async (tx) =>
@@ -1856,7 +1888,7 @@ export async function createBottleFromStorePriceMatchProposal({
       releaseInput,
       user,
       creationSource,
-      actorType,
+      actor,
       expectedProcessingToken,
     }),
   );
@@ -2100,7 +2132,8 @@ export async function resolveStorePriceMatchProposal(
           bottleId: proposal.suggestedBottleId,
           releaseId: proposal.suggestedReleaseId ?? null,
           reviewedById: automationUser.id,
-          actorType: "system",
+          actor: await getPeatedSystemActor(),
+          allowSystemActor: true,
           expectedProcessingToken: processingToken,
         });
 
@@ -2119,7 +2152,7 @@ export async function resolveStorePriceMatchProposal(
         ...createInputs,
         user: automationUser,
         creationSource: "price_match_automation",
-        actorType: "system",
+        actor: await getPeatedSystemActor(),
         expectedProcessingToken: processingToken,
       });
 
@@ -2352,16 +2385,16 @@ export async function applyApprovedStorePriceMatchProposalInTransaction(
     bottleId,
     releaseId = null,
     reviewedById,
-    decisionLog = {
-      decision: "match_existing",
-    },
+    allowSystemActor = false,
+    decisionLog,
   }: {
     proposal: StorePriceMatchProposalForReview;
     bottleId: number;
     releaseId?: number | null;
     reviewedById: number;
-    decisionLog?: {
-      actor?: IncomingBottleDecisionActor;
+    allowSystemActor?: boolean;
+    decisionLog: {
+      actor: IncomingBottleDecisionActor;
       decision: IncomingBottleDecisionType;
       createdBottle?: boolean;
       createdRelease?: boolean;
@@ -2369,6 +2402,15 @@ export async function applyApprovedStorePriceMatchProposalInTransaction(
     };
   },
 ) {
+  const actor = await getPriceMatchWriteActorForDatabase(
+    tx,
+    decisionLog.actor,
+    {
+      userId: reviewedById,
+      allowSystemActor,
+    },
+  );
+
   if (releaseId !== null) {
     const release = await tx.query.bottleReleases.findFirst({
       where: eq(bottleReleases.id, releaseId),
@@ -2380,9 +2422,6 @@ export async function applyApprovedStorePriceMatchProposalInTransaction(
       );
     }
   }
-
-  const actor =
-    decisionLog.actor ?? (await getUserActorByIdForDatabase(tx, reviewedById));
 
   const aliasKey = normalizeBottleAliasKey(proposal.price.name);
   // Store listing keys stay bottle-level unless an existing canonical release
@@ -2460,14 +2499,16 @@ export async function applyApprovedStorePriceMatchInTransaction(
     bottleId,
     releaseId,
     reviewedById,
-    actorType,
+    actor,
+    allowSystemActor = false,
     expectedProcessingToken,
   }: {
     proposalId: number;
     bottleId: number;
     releaseId?: number | null;
     reviewedById: number;
-    actorType: IncomingBottleDecisionActorType;
+    actor: IncomingBottleDecisionActor;
+    allowSystemActor?: boolean;
     expectedProcessingToken?: string;
   },
 ) {
@@ -2476,16 +2517,12 @@ export async function applyApprovedStorePriceMatchInTransaction(
     expectedProcessingToken,
   });
 
-  const actor =
-    actorType === "system"
-      ? await getPeatedSystemActorForDatabase(tx)
-      : await getUserActorByIdForDatabase(tx, reviewedById);
-
   return await applyApprovedStorePriceMatchProposalInTransaction(tx, {
     proposal,
     bottleId,
     releaseId,
     reviewedById,
+    allowSystemActor,
     decisionLog: {
       actor,
       decision: "match_existing",
@@ -2498,14 +2535,16 @@ export async function applyApprovedStorePriceMatch({
   bottleId,
   releaseId,
   reviewedById,
-  actorType,
+  actor,
+  allowSystemActor = false,
   expectedProcessingToken,
 }: {
   proposalId: number;
   bottleId: number;
   releaseId?: number | null;
   reviewedById: number;
-  actorType: IncomingBottleDecisionActorType;
+  actor: IncomingBottleDecisionActor;
+  allowSystemActor?: boolean;
   expectedProcessingToken?: string;
 }) {
   const aliasResult = await db.transaction(async (tx) =>
@@ -2514,7 +2553,8 @@ export async function applyApprovedStorePriceMatch({
       bottleId,
       releaseId,
       reviewedById,
-      actorType,
+      actor,
+      allowSystemActor,
       expectedProcessingToken,
     }),
   );
@@ -2535,10 +2575,12 @@ export async function applyApprovedStorePriceMatch({
 export async function applyStorePriceBottleRepairFromProposal({
   proposalId,
   user,
+  actor,
   expectedProcessingToken,
 }: {
   proposalId: number;
   user: User;
+  actor: IncomingBottleDecisionActor;
   expectedProcessingToken?: string;
 }) {
   const { repairResult, aliasResult } = await db.transaction(async (tx) => {
@@ -2555,6 +2597,7 @@ export async function applyStorePriceBottleRepairFromProposal({
       bottleId: proposal.currentBottleId!,
       proposedBottle,
       user,
+      actor,
     });
     const approvedAliasResult =
       await applyApprovedStorePriceMatchProposalInTransaction(tx, {
@@ -2562,6 +2605,10 @@ export async function applyStorePriceBottleRepairFromProposal({
         bottleId: repairedBottle.bottle.id,
         releaseId: null,
         reviewedById: user.id,
+        decisionLog: {
+          actor,
+          decision: "match_existing",
+        },
       });
 
     return {
@@ -2583,13 +2630,19 @@ export async function applyStorePriceBottleRepairFromProposal({
 export async function ignoreStorePriceMatchProposal({
   proposalId,
   reviewedById,
+  actor,
 }: {
   proposalId: number;
   reviewedById: number;
+  actor: IncomingBottleDecisionActor;
 }) {
   await db.transaction(async (tx) => {
     await getStorePriceMatchProposalForReviewInTransaction(tx, {
       proposalId,
+    });
+
+    await getPriceMatchWriteActorForDatabase(tx, actor, {
+      userId: reviewedById,
     });
 
     await tx

--- a/apps/server/src/orpc/routes/prices/matchQueue/apply-bottle-repair.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/apply-bottle-repair.ts
@@ -1,3 +1,4 @@
+import { getUserActor } from "@peated/server/lib/actors";
 import {
   DuplicateBottleAliasError,
   FailedToSaveBottleAliasError,
@@ -39,6 +40,7 @@ export default procedure
       const bottle = await applyStorePriceBottleRepairFromProposal({
         proposalId: input.proposal,
         user: context.user,
+        actor: await getUserActor(context.user),
       });
 
       return await serialize(BottleSerializer, bottle, context.user);

--- a/apps/server/src/orpc/routes/prices/matchQueue/create-bottle.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/create-bottle.ts
@@ -1,3 +1,4 @@
+import { getUserActor } from "@peated/server/lib/actors";
 import {
   DuplicateBottleAliasError,
   FailedToSaveBottleAliasError,
@@ -70,7 +71,7 @@ export default procedure
         input: input.bottle,
         releaseInput: input.release,
         user: context.user,
-        actorType: "user",
+        actor: await getUserActor(context.user),
       });
 
       return {

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -6,17 +6,20 @@ import {
   bottleSeries,
   bottles,
   bottlesToDistillers,
+  changes,
+  incomingBottleDecisionLogs,
   reviews,
   storePriceMatchProposals,
   storePriceMatchRetryRunItems,
   storePriceMatchRetryRuns,
   storePrices,
 } from "@peated/server/db/schema";
+import { getUserActor } from "@peated/server/lib/actors";
 import type * as catalogVerificationModule from "@peated/server/lib/catalogVerification";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import * as workerClient from "@peated/server/worker/client";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const queueBottleCreationVerificationMock = vi.hoisted(() => vi.fn());
@@ -711,6 +714,15 @@ describe("price match queue", () => {
     expect(updatedSourceSeries?.numReleases).toEqual(0);
     expect(updatedTargetSeries?.numReleases).toEqual(1);
 
+    const repairChange = await db.query.changes.findFirst({
+      where: and(
+        eq(changes.objectType, "bottle"),
+        eq(changes.objectId, currentBottle.id),
+        eq(changes.type, "update"),
+      ),
+    });
+    expect(repairChange?.actorId).toBe((await getUserActor(user)).id);
+
     const observation = await db.query.bottleObservations.findFirst({
       where: (bottleObservations, { eq }) =>
         eq(bottleObservations.sourceKey, `store_price:${price.id}`),
@@ -1209,8 +1221,18 @@ describe("price match queue", () => {
     const updatedBottle = await db.query.bottles.findFirst({
       where: (table, { eq }) => eq(table.id, bottle.id),
     });
+    const decisionLog = await db.query.incomingBottleDecisionLogs.findFirst({
+      where: and(
+        eq(incomingBottleDecisionLogs.sourceKind, "store_price"),
+        eq(incomingBottleDecisionLogs.sourceId, price.id),
+      ),
+    });
+
+    const userActor = await getUserActor(user);
 
     expect(alias?.bottleId).toBe(bottle.id);
+    expect(alias?.assignedByActorId).toBe(userActor.id);
+    expect(decisionLog?.actorId).toBe(userActor.id);
     expect(updatedPrice?.bottleId).toBe(bottle.id);
     expect(updatedSiblingPrice?.bottleId).toBeNull();
     expect(updatedReview?.bottleId).toBe(bottle.id);
@@ -1285,8 +1307,17 @@ describe("price match queue", () => {
     const listingAlias = await db.query.bottleAliases.findFirst({
       where: eq(bottleAliases.name, "Queue Create Candidate"),
     });
+    const decisionLog = await db.query.incomingBottleDecisionLogs.findFirst({
+      where: and(
+        eq(incomingBottleDecisionLogs.sourceKind, "store_price"),
+        eq(incomingBottleDecisionLogs.sourceId, price.id),
+      ),
+    });
+
+    const userActor = await getUserActor(user);
 
     expect(result.bottle.fullName).toBe("Queue Brand Single Cask");
+    expect(decisionLog?.actorId).toBe(userActor.id);
     expect(updatedPrice?.bottleId).toBe(result.bottle.id);
     expect(updatedProposal).toMatchObject({
       status: "approved",
@@ -1295,6 +1326,7 @@ describe("price match queue", () => {
       reviewedById: user.id,
     });
     expect(listingAlias?.bottleId).toBe(result.bottle.id);
+    expect(listingAlias?.assignedByActorId).toBe(userActor.id);
     expect(queueBottleCreationVerificationMock).toHaveBeenCalledWith({
       bottleId: result.bottle.id,
       creationSource: "price_match_review",

--- a/apps/server/src/orpc/routes/prices/matchQueue/resolve.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/resolve.ts
@@ -1,3 +1,4 @@
+import { getUserActor } from "@peated/server/lib/actors";
 import {
   DuplicateBottleAliasError,
   FailedToSaveBottleAliasError,
@@ -50,7 +51,7 @@ export default procedure
           bottleId: input.bottle!,
           releaseId: input.release ?? null,
           reviewedById: context.user.id,
-          actorType: "user",
+          actor: await getUserActor(context.user),
         });
         return {};
       }
@@ -58,6 +59,7 @@ export default procedure
       await ignoreStorePriceMatchProposal({
         proposalId: input.proposal,
         reviewedById: context.user.id,
+        actor: await getUserActor(context.user),
       });
       return {};
     } catch (err) {


### PR DESCRIPTION
Price-match moderation writes now require callers to pass the actor being attributed instead of selecting one from an actorType flag. Route handlers resolve the moderator actor at the boundary, automation opts into the system actor explicitly, and the helper reloads actors before writing so mismatches fail before mutation.

The integration coverage now checks user and system actor attribution across approve, create, repair, and ignore paths.