### PR TITLE
feat(library): Open saved photos in image viewer

### DIFF
--- a/apps/web/e2e/profile-library.spec.ts
+++ b/apps/web/e2e/profile-library.spec.ts
@@ -194,13 +194,30 @@ test.describe("profile library", () => {
       savedBottleRow.getByText("Only for this Library entry."),
     ).toHaveCount(0);
 
-    await uploadLibraryImage(page, savedBottleRow);
+    const addImageButton = savedBottleRow.getByRole("button", {
+      name: `Add image for ${savedBottleName}`,
+    });
+    await expect(addImageButton).toBeVisible();
+    await uploadLibraryImage(page, addImageButton);
 
     await expect(
       savedBottleRow.getByRole("img", {
         name: `Photo of ${savedBottleName}`,
       }),
     ).toHaveAttribute("src", /library-replaced-\d+\.webp$/);
+
+    const viewImageButton = savedBottleRow.getByRole("button", {
+      name: `View image for ${savedBottleName}`,
+    });
+    await expect(viewImageButton).toBeVisible();
+    await viewImageButton.click();
+    await expect(
+      page.getByRole("heading", { name: `Photo of ${savedBottleName}` }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Replace Photo" }),
+    ).toBeVisible();
+    await page.keyboard.press("Escape");
 
     await signIn(context, {
       accessToken,
@@ -246,10 +263,9 @@ test.describe("profile library", () => {
   });
 });
 
-async function uploadLibraryImage(page: Page, row: Locator) {
+async function uploadLibraryImage(page: Page, trigger: Locator) {
   const fileChooserPromise = page.waitForEvent("filechooser");
-  await row.getByRole("button", { name: "Bottle options" }).click();
-  await page.getByRole("menuitem", { name: "Edit Image" }).click();
+  await trigger.click();
   const fileChooser = await fileChooserPromise;
   await fileChooser.setFiles({
     name: "library-label.png",

--- a/apps/web/src/components/imageModal.tsx
+++ b/apps/web/src/components/imageModal.tsx
@@ -1,15 +1,31 @@
 "use client";
 
-import { Dialog, DialogPanel } from "@headlessui/react";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
+import type { ReactNode } from "react";
+import Button from "./button";
 
+/**
+ * Shared full-screen image viewer with an optional single contextual action.
+ */
 export function ImageModal({
+  action,
+  alt = "",
   image,
   open,
   setOpen,
+  title,
 }: {
+  action?: {
+    disabled?: boolean;
+    icon?: ReactNode;
+    label: string;
+    onClick: () => void;
+  };
+  alt?: string;
   image: string;
   open: boolean;
   setOpen: (value: boolean) => void;
+  title?: string;
 }) {
   return (
     <Dialog open={open} as="div" className="dialog" onClose={setOpen}>
@@ -20,7 +36,23 @@ export function ImageModal({
             setOpen(false);
           }}
         >
-          <img src={image} className="max-h-full max-w-full" />
+          {title && <DialogTitle className="sr-only">{title}</DialogTitle>}
+          <img src={image} alt={alt} className="max-h-full max-w-full" />
+          {action && (
+            <div
+              className="absolute bottom-4 left-1/2 flex -translate-x-1/2 justify-center sm:bottom-6"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <Button
+                size="small"
+                icon={action.icon}
+                disabled={action.disabled}
+                onClick={action.onClick}
+              >
+                {action.label}
+              </Button>
+            </div>
+          )}
         </DialogPanel>
       </div>
     </Dialog>

--- a/apps/web/src/components/libraryEntryActions.tsx
+++ b/apps/web/src/components/libraryEntryActions.tsx
@@ -4,6 +4,7 @@ import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import { EllipsisVerticalIcon } from "@heroicons/react/20/solid";
 import type { CollectionBottle, PagingRel } from "@peated/server/types";
 import Button from "@peated/web/components/button";
+import { ImageModal } from "@peated/web/components/imageModal";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
@@ -158,12 +159,28 @@ function useLibraryEntryMutations({
 }
 
 export function LibraryEntryThumbnail({ entry }: { entry: CollectionBottle }) {
+  const [imageOpen, setImageOpen] = useState(false);
+
   return entry.imageUrl ? (
-    <div className="h-12 w-12 shrink-0 overflow-hidden rounded border border-slate-800 bg-slate-900">
-      <img
-        src={entry.imageUrl}
+    <div className="h-12 w-12 shrink-0">
+      <button
+        type="button"
+        className="h-12 w-12 overflow-hidden rounded border border-slate-800 bg-slate-900"
+        aria-label={`View image for ${entry.bottle.fullName}`}
+        onClick={() => setImageOpen(true)}
+      >
+        <img
+          src={entry.imageUrl}
+          alt={`Photo of ${entry.bottle.fullName}`}
+          className="h-full w-full object-cover"
+        />
+      </button>
+      <ImageModal
+        image={entry.imageUrl}
         alt={`Photo of ${entry.bottle.fullName}`}
-        className="h-full w-full object-cover"
+        title={`Photo of ${entry.bottle.fullName}`}
+        open={imageOpen}
+        setOpen={setImageOpen}
       />
     </div>
   ) : null;
@@ -181,26 +198,53 @@ export function LibraryEntryImage({
       entry,
       username,
     });
+  const [imageOpen, setImageOpen] = useState(false);
+  const imageAlt = `Photo of ${entry.bottle.fullName}`;
 
   return (
     <div className="min-w-0 shrink-0">
       <button
         type="button"
         className="flex h-12 w-12 items-center justify-center overflow-hidden rounded border border-slate-800 bg-slate-900 disabled:opacity-60"
-        aria-label={`Edit image for ${entry.bottle.fullName}`}
+        aria-label={
+          entry.imageUrl
+            ? `View image for ${entry.bottle.fullName}`
+            : `Add image for ${entry.bottle.fullName}`
+        }
         disabled={isBusy}
-        onClick={() => fileInputRef.current?.click()}
+        onClick={() => {
+          if (entry.imageUrl) {
+            setImageOpen(true);
+          } else {
+            fileInputRef.current?.click();
+          }
+        }}
       >
         {entry.imageUrl ? (
           <img
             src={entry.imageUrl}
-            alt={`Photo of ${entry.bottle.fullName}`}
+            alt={imageAlt}
             className="h-full w-full object-cover"
           />
         ) : (
           <ImagePlus className="text-muted h-6 w-6" aria-hidden="true" />
         )}
       </button>
+      {entry.imageUrl && (
+        <ImageModal
+          image={entry.imageUrl}
+          alt={imageAlt}
+          title={imageAlt}
+          open={imageOpen}
+          setOpen={setImageOpen}
+          action={{
+            label: "Replace Photo",
+            icon: <ImagePlus className="h-4 w-4" />,
+            disabled: isBusy,
+            onClick: () => fileInputRef.current?.click(),
+          }}
+        />
+      )}
       {error && (
         <div className="mt-1 text-xs font-medium text-red-300" role="alert">
           {error}
@@ -214,7 +258,10 @@ export function LibraryEntryImage({
         aria-label={`Edit image for ${entry.bottle.fullName}`}
         onChange={(event) => {
           const file = event.currentTarget.files?.[0];
-          if (file) void replaceImage(file);
+          if (file) {
+            setImageOpen(false);
+            void replaceImage(file);
+          }
         }}
       />
     </div>


### PR DESCRIPTION
Library rows now treat the thumbnail click according to image state: empty placeholders still open upload directly, while saved photos open the shared image viewer. Owned Library entries get a focused Replace Photo action inside that viewer, and read-only profile Library thumbnails can use the same viewer without edit controls.

The profile Library Playwright flow now covers the empty-photo upload state, the saved-photo viewer state, and the Replace Photo action across desktop and mobile projects.
