### PR TITLE
feat(classifier): Add alias-safety metadata

### DIFF
--- a/apps/server/src/lib/priceMatchingProposals.test.ts
+++ b/apps/server/src/lib/priceMatchingProposals.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "vitest";
+import { toStorePriceMatchDecision } from "./priceMatchingProposals";
+
+describe("toStorePriceMatchDecision", () => {
+  test("preserves alias scope metadata", () => {
+    const decision = toStorePriceMatchDecision({
+      price: {
+        bottleId: null,
+        releaseId: null,
+      },
+      candidates: [],
+      decision: {
+        action: "match",
+        confidence: 97,
+        rationale: "Exact source page identifies a generic listing title.",
+        candidateBottleIds: [123],
+        identityScope: "product",
+        aliasScope: "none",
+        observation: null,
+        matchedBottleId: 123,
+        matchedReleaseId: null,
+        parentBottleId: null,
+        proposedBottle: null,
+        proposedRelease: null,
+      },
+    });
+
+    expect(decision).toMatchObject({
+      action: "match_existing",
+      suggestedBottleId: 123,
+      aliasScope: "none",
+    });
+  });
+});

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -574,6 +574,7 @@ function maybeBuildExistingBottleRepairDecision({
     ),
     candidateBottleIds: decision.candidateBottleIds,
     identityScope: decision.identityScope,
+    aliasScope: decision.aliasScope ?? "none",
     suggestedBottleId: price.bottleId,
     suggestedReleaseId: null,
     parentBottleId: null,
@@ -583,7 +584,11 @@ function maybeBuildExistingBottleRepairDecision({
   };
 }
 
-function toStorePriceMatchDecision({
+/**
+ * Converts classifier decisions into store-price match decisions while carrying
+ * review metadata needed by later proposal handling.
+ */
+export function toStorePriceMatchDecision({
   price,
   decision,
   candidates,
@@ -606,6 +611,7 @@ function toStorePriceMatchDecision({
       rationale: decision.rationale,
       candidateBottleIds: decision.candidateBottleIds,
       identityScope: decision.identityScope,
+      aliasScope: decision.aliasScope ?? "none",
       suggestedBottleId: decision.matchedBottleId,
       suggestedReleaseId: decision.matchedReleaseId,
       parentBottleId: null,
@@ -622,6 +628,7 @@ function toStorePriceMatchDecision({
       rationale: decision.rationale,
       candidateBottleIds: decision.candidateBottleIds,
       identityScope: decision.identityScope,
+      aliasScope: decision.aliasScope ?? "none",
       suggestedBottleId: decision.matchedBottleId,
       suggestedReleaseId: null,
       parentBottleId: null,
@@ -647,6 +654,7 @@ function toStorePriceMatchDecision({
       rationale: decision.rationale,
       candidateBottleIds: decision.candidateBottleIds,
       identityScope: decision.identityScope,
+      aliasScope: decision.aliasScope ?? "none",
       suggestedBottleId: null,
       suggestedReleaseId: null,
       parentBottleId: null,
@@ -663,6 +671,7 @@ function toStorePriceMatchDecision({
       rationale: decision.rationale,
       candidateBottleIds: decision.candidateBottleIds,
       identityScope: decision.identityScope,
+      aliasScope: decision.aliasScope ?? "none",
       suggestedBottleId: null,
       suggestedReleaseId: null,
       parentBottleId: decision.parentBottleId,
@@ -679,6 +688,7 @@ function toStorePriceMatchDecision({
       rationale: decision.rationale,
       candidateBottleIds: decision.candidateBottleIds,
       identityScope: decision.identityScope,
+      aliasScope: decision.aliasScope ?? "none",
       suggestedBottleId: null,
       suggestedReleaseId: null,
       parentBottleId: null,
@@ -700,6 +710,7 @@ function toStorePriceMatchDecision({
       ),
       candidateBottleIds: decision.candidateBottleIds,
       identityScope: decision.identityScope,
+      aliasScope: decision.aliasScope ?? "none",
       suggestedBottleId: null,
       suggestedReleaseId: null,
       parentBottleId: decision.parentBottleId,
@@ -715,6 +726,7 @@ function toStorePriceMatchDecision({
     rationale: decision.rationale,
     candidateBottleIds: decision.candidateBottleIds,
     identityScope: decision.identityScope,
+    aliasScope: decision.aliasScope ?? "none",
     suggestedBottleId: null,
     suggestedReleaseId: null,
     parentBottleId: null,

--- a/apps/server/src/schemas/priceMatches.test.ts
+++ b/apps/server/src/schemas/priceMatches.test.ts
@@ -99,6 +99,41 @@ describe("StorePriceMatchDecisionSchema", () => {
     );
   });
 
+  test("accepts alias metadata on match decisions", () => {
+    const parsed = StorePriceMatchDecisionSchema.parse({
+      action: "match_existing",
+      confidence: 96,
+      suggestedBottleId: 123,
+      aliasScope: "global_alias",
+    });
+
+    expect(parsed).toMatchObject({
+      aliasScope: "global_alias",
+    });
+  });
+
+  test("rejects unsupported alias scope values", () => {
+    expect(
+      StorePriceMatchDecisionSchema.safeParse({
+        action: "match_existing",
+        confidence: 96,
+        suggestedBottleId: 123,
+        aliasScope: "local_alias",
+      }).success,
+    ).toBe(false);
+
+    expect(
+      StorePriceMatchAgentResponseSchema.safeParse({
+        decision: {
+          action: "match_existing",
+          confidence: 96,
+          suggestedBottleId: 123,
+          aliasScope: "local_alias",
+        },
+      }).success,
+    ).toBe(false);
+  });
+
   test("uses fully required proposedBottle fields for structured outputs", () => {
     const jsonSchema = z.toJSONSchema(
       StorePriceMatchDecisionSchema,

--- a/apps/server/src/schemas/priceMatches.ts
+++ b/apps/server/src/schemas/priceMatches.ts
@@ -16,6 +16,8 @@ import { ExternalSiteSchema } from "./externalSites";
 import { CursorSchema } from "./shared";
 import { StorePriceSchema } from "./stores";
 
+const AliasScopeEnum = z.enum(["global_alias", "none"]);
+
 export const ExtractedBottleDetailsSchema = z.object({
   brand: z.string().nullable().default(null),
   bottler: z.string().nullable().default(null),
@@ -403,6 +405,7 @@ const StorePriceMatchDecisionBaseSchema = z.object({
   rationale: z.string().nullable().default(null),
   candidateBottleIds: z.array(z.number().int()).default([]),
   identityScope: BottleIdentityScopeEnum.default("product"),
+  aliasScope: AliasScopeEnum.optional(),
 });
 
 const StorePriceMatchCreateNewDecisionSchema =

--- a/openspec/changes/add-source-scoped-store-price-identity/.openspec.yaml
+++ b/openspec/changes/add-source-scoped-store-price-identity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-05

--- a/openspec/changes/add-source-scoped-store-price-identity/design.md
+++ b/openspec/changes/add-source-scoped-store-price-identity/design.md
@@ -1,0 +1,179 @@
+## Context
+
+Price matching has two different truths that are currently represented too similarly:
+
+1. This exact store listing or scraped source item belongs to bottle/release X.
+2. This listing name is a reusable canonical Peated identity or global bottle alias.
+
+Those are not equivalent. A retailer can publish a generic display title such as `George Dickel Single Barrel` while the underlying page, internal store listing id, product id, article, image, or SKU identifies one age-specific bottling. The exact listing can be matchable, but the display title must not teach future scrapes that every `George Dickel Single Barrel` listing maps to the same bottle.
+
+Current flow:
+
+- `classifyBottleReference` returns bottle-centric actions and `identityScope = product | exact_cask`.
+- Price matching maps those actions to `match_existing`, `correction`, `create_new`, or `no_match`.
+- Approval calls `applyApprovedStorePriceMatchProposalInTransaction`, assigns the `store_price`, upserts one `bottle_observation`, and calls `assignBottleAliasInTransaction` with the normalized store title.
+- `finalizeBottleAliasAssignment` then pushes alias-change work that can affect future store prices and reviews with the same normalized title.
+
+The classifier already has policy language for weak generic parent avoidance, but it lacks a first-class way to say: "the source item is exact; the name is not globally reusable." That leaves the system with only unsafe choices: broad create, no-match, or a match that can globalize a generic alias.
+
+The primary bug is the alias side effect. Matching one listing can be correct; creating a reusable alias from its generic title can be wrong for every future listing that happens to use the same title. `George Dickel Single Barrel` from two stores, or from the same store at two different times, can refer to different age-specific bottles even when the public title text is unchanged.
+
+Scraper audit findings:
+
+- `StorePriceInputSchema` currently accepts only `name`, `price`, `currency`, `volume`, `url`, and `imageUrl`; scraper source ids have nowhere to go.
+- `scrapePrices` dedupes one run by normalized `name + volume`, which can drop same-title/different-product rows before submission.
+- `store_price` has a unique URL, but ingestion upserts on `(externalSiteId, lower(name), volume)`, which can collapse same-store/same-title/different-bottle listings.
+- Total Wine list pages contain URL ids such as `/p/135113175` and embedded `skuId` values; the current scraper emits only URL.
+- Astor item URLs carry item ids such as `/item/16747`; the current scraper emits only URL.
+- ReserveBar URLs carry grouping ids such as `GROUPING-38632`; the current scraper emits only URL.
+- Wooden Cork list pages include Shopify `data-product-id`, product variant ids, and SKU values; the current scraper emits only URL.
+- Healthy Spirits list pages include Lightspeed `data-pid`, add-to-cart variant ids, and JSON URLs; the current scraper emits only URL.
+- SMWS has structured cask ids, but that path is already a deterministic bottle-creation flow and is less representative of generic store price matching.
+
+The George Dickel case is the negative example. Public evidence shows George Dickel has age-specific single-barrel products, including 9-year and 15-year examples, while the submitted listing title omitted the decisive age. Without exact source-page proof for the submitted SKU, auto-creating a broad `George Dickel Single Barrel` parent would be unsafe.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Make alias safety the hard boundary: generic listing titles must never become reusable aliases.
+- Represent source-specific listing identity separately from reusable canonical product identity.
+- Allow exact source evidence to auto-assign a store price to an existing bottle/release without creating a global alias from a generic title.
+- Keep broad create decisions blocked when evidence supports only a family or sibling set, not a reusable Peated bottle identity.
+- Support future scraper listings by keying source-scoped verification to stable source identifiers, such as internal store listing ids, product ids, canonical URLs, SKUs, or source fingerprints rather than display names alone.
+- Add evals that cover both positive source-specific assignment and negative generic-title broad-create prevention.
+- Keep deterministic code limited to concrete validation, persistence scopes, and impossible-state blockers.
+
+**Non-Goals:**
+
+- Do not auto-create generic parent bottles just because web evidence proves a brand/product family exists.
+- Do not introduce domain allowlists for source truth.
+- Do not make retailer-origin evidence decisive for canonical create traits by itself.
+- Do not solve every dirty legacy bottle repair in this change.
+- Do not make all source-scoped approvals permanent global matching rules.
+
+## Decisions
+
+### Decision: Add alias-safety metadata instead of overloading `identityScope`
+
+Keep `identityScope = product | exact_cask` for bottle-vs-exact-cask modeling, and add a separate field for whether the observed listing title can safely become a reusable global alias:
+
+- `aliasScope = global_alias | none`
+
+Rationale: `identityScope` answers "what kind of Peated identity is this?" It does not answer "can the observed source title become a reusable alias?" A source listing can exactly match a normal product bottle while still having a generic title. The classifier does not need to categorize every reason a title is not alias-safe; `none` is enough for the alias write boundary.
+
+Alternative considered: Add `source_listing` as a third `identityScope`. Rejected because it mixes canonical bottle modeling with evidence scope and would blur exact-cask behavior.
+
+### Decision: Source-scoped approval must not create or update global bottle aliases
+
+When a proposal is approved with `aliasScope = none`, price matching SHALL assign the specific `store_price` and write observation/verification metadata, but MUST skip global `assignBottleAliasInTransaction` for the generic listing title.
+
+Rationale: This is the core safety boundary. The listing can be correct without the title being reusable.
+
+Alternative considered: Create bottle aliases with an `externalSiteId` and rely on current alias logic. Rejected unless the alias lookup path is also source-scoped, because current alias-change jobs can update rows by normalized name and would still risk future generic matches.
+
+Implementation note: if a title is marked generic or source-scoped, no code path should call the existing global alias assignment helper for that title. A future source-scoped lookup mechanism must be separate from `bottle_alias` unless `bottle_alias` itself gains enforceable source scoping across lookup, assignment, and alias-change jobs.
+
+### Decision: Persist source-scoped verification as durable source identity
+
+Use existing `bottle_observation` only if it can support lookup semantics safely. Otherwise add a purpose-built table, likely keyed by:
+
+- `externalSiteId`
+- internal store listing id when a scraper can provide one
+- source product identifier when available
+- canonicalized source URL or URL fingerprint
+- optional listing name fingerprint
+- matched `bottleId` / `releaseId`
+- `aliasScope`, evidence summary/hash, model, confidence, reviewed/verified actor
+
+Rationale: future scraper listings need to verify brand-new rows from stable source identity, not from generic display text. An internal store listing id is often the strongest source-scoped key because it can distinguish two same-title products from the same site. Observations preserve evidence, but they do not currently define reusable source-scoped matching behavior.
+
+Alternative considered: Store all metadata only in `store_price_match_proposal`. Rejected because proposals are per-price and retryable; scraper matching needs durable source identity across future listing rows.
+
+### Decision: Ingestion identity should prefer source keys over title keys
+
+Extend scraper output and `StorePriceInputSchema` with source identity fields such as:
+
+- `sourceProductId`
+- `sourceVariantId`
+- `sourceSku`
+- `sourceFingerprint`
+
+When at least one stable source key is present, ingestion SHALL use that source key plus `externalSiteId` as the primary identity for upsert/dedupe. The existing `(externalSiteId, lower(name), volume)` behavior can remain only as a fallback for sources without stable ids.
+
+Rationale: a classifier flag can prevent alias creation after review, but it cannot recover listings that were already collapsed by name-volume dedupe during scraping or ingestion.
+
+Alternative considered: Keep the DB row keyed by URL only. Rejected as the only solution because URLs can contain tracking params, can be recycled, and some sites expose stronger product/variant ids than URL text.
+
+Implementation note: source keys must be stored and compared as `(externalSiteId, keyType, keyValue)` or a stronger equivalent composite. A SKU, UPC, product id, or variant id must never be treated as a cross-store bottle identity by itself.
+
+### Decision: Classifier decides alias eligibility; code enforces declared scope
+
+The classifier/review policy owns whether the observed listing title is eligible for reusable global alias storage. Deterministic code may:
+
+- validate enum values and required ids
+- block impossible candidate ids
+- cap or block automation when scope and action conflict
+- skip alias writes when `aliasScope = none`
+- require concrete source identifiers for source-scoped reuse
+
+Deterministic code MUST NOT infer source specificity from brand strings, title shape, domain, search rank, "single barrel" wording, vector similarity, or family-page snippets.
+
+Rationale: The user's policy is to trust the agent as much as safely possible, while reserving determinism for 100% concrete rules.
+
+### Decision: Automation gates split create safety from assignment safety
+
+Existing-match or correction assignment can become automation-eligible when:
+
+- the target bottle/release is a known candidate
+- classifier confidence clears the existing-match threshold
+- deterministic blockers are empty
+- exact source evidence exists and `aliasScope = none`
+
+Create-new automation remains stricter:
+
+- `aliasScope` must be `global_alias` or a valid exact-cask bottle identity must be supported by concrete source evidence
+- required canonical traits must be externally validated or otherwise concretely supported
+- generic or underspecified listing identity blocks auto-create
+
+Rationale: assigning one listing is lower blast radius than creating a reusable bottle or alias.
+
+### Decision: Evals encode behavior, not the same bottle-specific tweak
+
+Add evals that use real production-miss provenance when based on production cases, but cover behavior with different examples where possible:
+
+- Generic-label classifier eval: expected output must explicitly mark the listing label as not eligible for global alias storage. The eval should fail if the classifier only returns a match/create decision without the alias-safety metadata.
+- Negative production-miss eval: the George Dickel-style case remains `no_match` or pending create review because broad parent creation is unsafe from generic title plus sibling/family evidence.
+- Positive source-specific eval: a different real listing with a generic display title but source-page/article/SKU evidence that pins an existing bottle. Expected result is existing match with `aliasScope = none` and no-global-alias handling.
+- Alias-safety integration test: approving a source-scoped match assigns only the one store price, does not create or rebind a `bottle_alias` row for the generic label, and does not update future same-name listings from the same or different stores.
+- Scraper reuse test: a later row with the same stable internal listing id or source product id can reuse the source-scoped verification; a later row with only the same generic display title but different source id/URL/SKU cannot.
+
+Rationale: This avoids overfitting to the exact miss while still preserving the observed production artifact, DB outcome, and verified sources required by repo policy.
+
+## Risks / Trade-offs
+
+- Source metadata is incomplete for some scrapers -> Prefer scraper-provided internal listing ids when available; otherwise require fallback to review/no-match when no stable source id, canonical URL, or durable fingerprint exists.
+- Source pages can change under the same URL -> Store evidence hashes/timestamps and allow revalidation or expiration before reuse.
+- New metadata fields may be ignored by older proposal rows -> For new classifier decisions, missing alias-safety metadata must default to no global alias and review-required automation. Legacy/manual approval paths may keep existing behavior only when they are outside the new alias-safety classifier flow.
+- Source-scoped matching could hide bad assignments if overused -> Require high confidence, known candidates, observation evidence, and explicit scope in decision artifacts.
+- More schema surface increases eval churn -> Add schema tests and focused fixtures before changing prompts broadly.
+
+## Migration Plan
+
+1. Extend classifier and server schemas with alias-safety metadata, defaulting legacy decisions to conservative behavior.
+2. Extend scraper output, input schemas, and ingestion persistence to carry stable source ids where available.
+3. Add source-scoped persistence, either through safe `bottle_observation` extensions or a new source identity table.
+4. Update approval flow to skip global alias assignment when `aliasScope = none`.
+5. Update ingestion/matching to consult source-scoped verification only by stable source identity, never by display title alone.
+6. Add eval schema expectations and fixtures before enabling automation gates.
+7. Enable automation only after targeted tests and evals pass.
+
+Rollback strategy: keep the new metadata ignored by automation behind conservative defaults. If source-scoped matching causes issues, disable lookup/automation while preserving observations for review.
+
+## Open Questions
+
+- Which scraper fields are reliably available across sites: internal store listing id, product id, canonical URL, SKU, page hash, image URL, or another stable source key?
+- Should source-scoped verification live in `bottle_observation` facts or a new table with first-class lookup indexes?
+- Should source-scoped assignment be visible in the admin queue as a distinct proposal subtype or only as proposal metadata?
+- How long should source-scoped verification remain reusable before requiring revalidation?
+- Do we need source-scoped aliases for user reviews as well, or only store-price scraper rows?

--- a/openspec/changes/add-source-scoped-store-price-identity/proposal.md
+++ b/openspec/changes/add-source-scoped-store-price-identity/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Store-price matching currently treats an approved listing assignment and a reusable bottle alias as the same kind of truth. That breaks down for scraper listings with generic retailer titles, where a source page can identify one exact item while the displayed name is too broad to reuse for future listings.
+
+This matters now because classifier automation is starting to approve more production misses. We need the classifier and downstream matcher to separate alias eligibility from exact listing assignment without creating unsafe canonical bottles, aliases, or deterministic shortcuts.
+
+The central invariant is alias safety: a generic listing title MUST NOT become a reusable bottle alias, even when the exact listing can be verified and matched.
+
+## What Changes
+
+- Add explicit alias-safety metadata for store-price classification outcomes.
+- Let the classifier say whether the observed listing title is safe as a reusable global alias, without categorizing every reason it is unsafe.
+- Add persistence semantics for source-scoped listing assignments so an exact source item can be matched while forbidding global alias creation from generic listing names.
+- Extend automation policy so source-scoped assignments can be trusted only when the exact source evidence is concrete, while generic creates remain review-only or no-match.
+- Add production-miss and curated eval coverage for generic-title cases, including negative coverage that prevents broad parent creation from family evidence alone.
+- Preserve deterministic policy: code may validate concrete enum values and impossible states, but alias eligibility remains a classifier/review-policy decision.
+
+## Capabilities
+
+### New Capabilities
+
+- `source-scoped-store-price-identity`: Classifier and price-matching behavior for source-specific listing identity, generic listing titles, source-scoped assignments, and alias safety.
+
+### Modified Capabilities
+
+- None. No current OpenSpec capability exists for classifier or store-price matching; this change introduces the capability and references the existing architecture docs as policy.
+
+## Impact
+
+- `packages/bottle-classifier`: decision schema, prompts/instructions, review policy, eval fixture schema, production-miss fixtures, and replay recordings.
+- `apps/server/src/lib/priceMatching*`: proposal mapping, automation assessment, approval application, alias assignment behavior, and observation metadata.
+- `apps/server/src/db/schema`: likely migration for source-scoped listing identity or equivalent durable verification metadata if existing `bottle_observation` cannot safely carry it, including internal store listing ids when scrapers can provide them.
+- `docs/features/store-price-matching.md` and `docs/architecture/bottle-classifier.md`: document the distinction between reusable global aliases and source-specific listing identity.
+- Scraper ingestion paths that create `store_price` rows: future matching should be able to use stable source identifiers, URL/product ids, and source fingerprints without globalizing generic titles.

--- a/openspec/changes/add-source-scoped-store-price-identity/specs/source-scoped-store-price-identity/spec.md
+++ b/openspec/changes/add-source-scoped-store-price-identity/specs/source-scoped-store-price-identity/spec.md
@@ -1,0 +1,148 @@
+## ADDED Requirements
+
+### Requirement: Generic listing titles are never global aliases
+
+The system SHALL NOT create or update a reusable global bottle alias from a listing title marked as not eligible for global alias storage.
+
+#### Scenario: Classifier flags generic label
+
+- **WHEN** a classifier eval fixture uses a listing label that can refer to multiple underlying bottles
+- **THEN** the expected decision SHALL include `aliasScope = none`.
+
+#### Scenario: Exact listing has generic title
+
+- **WHEN** source evidence verifies that one exact listing belongs to a bottle or release but the listing title is generic
+- **THEN** approval SHALL assign the exact listing without creating a reusable bottle alias from that title.
+
+#### Scenario: Future listing reuses same generic title
+
+- **WHEN** a future listing has the same generic title but different or missing source identity
+- **THEN** the system SHALL NOT inherit the prior listing's bottle assignment through global alias matching.
+
+#### Scenario: Same generic title appears at multiple stores
+
+- **WHEN** two stores list the same generic title and the listings refer to different underlying bottles
+- **THEN** approval of one listing SHALL NOT create alias behavior that assigns the other listing.
+
+### Requirement: Classifier declares alias eligibility
+
+The classifier SHALL declare whether the observed listing title is eligible for reusable global alias storage.
+
+#### Scenario: Source page pins a generic title to an existing bottle
+
+- **WHEN** a listing title is generic but source-specific evidence from the listing page, product id, SKU, article, image, or equivalent source artifact pins the exact item to a known local bottle or release
+- **THEN** the classifier SHALL be able to return an existing match while marking the listing title as not eligible for global alias storage.
+
+#### Scenario: Family evidence does not make a generic title reusable
+
+- **WHEN** external evidence proves a brand has sibling or family products but the submitted source does not identify the decisive bottle traits
+- **THEN** the classifier SHALL NOT mark the listing title as eligible for global alias storage or reusable canonical product auto-create.
+
+### Requirement: Source-scoped matches do not create global aliases
+
+The price-matching approval flow SHALL support assigning an exact store listing to a bottle or release without creating or updating a reusable global bottle alias from the listing display name.
+
+#### Scenario: Source-scoped assignment is approved
+
+- **WHEN** an approved match is marked as not eligible for global alias storage
+- **THEN** the system SHALL update the matched `store_price` and evidence record but MUST NOT create a global bottle alias from the normalized listing title.
+
+#### Scenario: Same generic title appears from another source item
+
+- **WHEN** a later listing has the same generic display title but lacks the same stable source identifier, URL, SKU, or source fingerprint
+- **THEN** the system SHALL NOT reuse the previous source-scoped assignment by title alone.
+
+### Requirement: Source-scoped verification is reusable only by stable source identity
+
+The system SHALL persist source-scoped verification in a durable form that can be reused for future scraper listings only when the new row matches stable source identity scoped to the external site and source-key type, such as an internal store listing id, source product id, canonical URL, SKU, or accepted fingerprint, not merely display text.
+
+#### Scenario: New scraper row matches verified source identity
+
+- **WHEN** a brand-new scraper row carries the same verified external site, source-key type, and source-key value as a prior source-scoped verification
+- **THEN** the system SHALL be able to assign the same bottle/release without running generic title alias matching.
+
+#### Scenario: Same source key value appears at another store
+
+- **WHEN** another store has the same SKU, UPC, product id string, or source-key value
+- **THEN** the system SHALL NOT reuse a source-scoped verification unless the external site and key type also match the verified source identity.
+
+#### Scenario: Source identity is insufficient
+
+- **WHEN** a scraper row has only a generic display title and no stable verified source identity
+- **THEN** the system SHALL fall back to normal classifier review and MUST NOT use a source-scoped verification from another source item.
+
+### Requirement: Ingestion preserves stable source ids
+
+Scraper ingestion SHALL preserve stable source product, variant, SKU, URL, or fingerprint identifiers when a scraper can extract them.
+
+#### Scenario: Scraper extracts an internal listing id
+
+- **WHEN** a scraper extracts a stable internal product id, variant id, SKU, grouping id, or equivalent source id
+- **THEN** the submitted store price payload SHALL include that source identity so downstream matching can key source-scoped verification independently of display title.
+
+#### Scenario: Same title has different source ids
+
+- **WHEN** two same-site listings share the same generic display title and volume but expose different stable source ids
+- **THEN** ingestion SHALL preserve them as distinct source items rather than collapsing them by title and volume.
+
+#### Scenario: No source id exists
+
+- **WHEN** a scraper cannot extract a stable source id
+- **THEN** ingestion MAY fall back to canonical URL or, for legacy compatibility only, existing title-volume behavior, but source-scoped reuse SHALL remain unavailable unless a durable source fingerprint exists.
+
+### Requirement: Missing alias-safety metadata is conservative
+
+New classifier decisions SHALL NOT create or update reusable bottle aliases unless the decision explicitly marks the listing label as eligible for global alias storage.
+
+#### Scenario: New decision omits alias scope
+
+- **WHEN** a new classifier decision omits alias-safety metadata
+- **THEN** the system SHALL require review or skip global alias creation rather than assuming the listing title is alias-safe.
+
+#### Scenario: Decision explicitly allows global alias
+
+- **WHEN** a new classifier decision explicitly marks the listing label as eligible for global alias storage
+- **THEN** approval MAY use the existing global alias path if all other match/create requirements pass.
+
+### Requirement: Automation respects source scope
+
+Automation SHALL distinguish low-blast-radius source-scoped assignment from high-blast-radius reusable create or alias behavior.
+
+#### Scenario: Source-scoped existing match can verify
+
+- **WHEN** the classifier returns a high-confidence existing match with exact source-specific evidence, no deterministic blockers, and no global alias eligibility
+- **THEN** automation MAY verify the assignment while preserving source-scoped alias behavior.
+
+#### Scenario: Generic create remains blocked
+
+- **WHEN** the classifier proposes creating a bottle from a generic or underspecified listing identity
+- **THEN** automation SHALL block auto-create even if web evidence supports the broader product family.
+
+### Requirement: Evals cover source specificity and alias safety
+
+Classifier and server tests SHALL cover source-specific identity, generic-title rejection, and source-scoped alias behavior before automation is enabled.
+
+#### Scenario: Generic-label eval controls alias behavior
+
+- **WHEN** a classifier eval covers a generic listing label
+- **THEN** the eval SHALL fail unless the result marks the label as not eligible for global alias storage.
+
+#### Scenario: Positive source-specific eval
+
+- **WHEN** an eval fixture represents a real or curated listing with a generic display title but verified source evidence for an existing bottle/release
+- **THEN** the expected result SHALL encode the existing match and no-global-alias metadata.
+
+#### Scenario: Negative generic-title eval
+
+- **WHEN** an eval fixture represents a production miss where only family or sibling evidence exists and the submitted source omits decisive traits
+- **THEN** the expected result SHALL reject broad reusable creation or require review rather than auto-completing.
+
+#### Scenario: Alias safety integration test
+
+- **WHEN** a source-scoped match is approved
+- **THEN** tests SHALL assert that the matched store price is assigned and that unrelated future listings with the same generic title are not globally reassigned by alias side effects.
+
+#### Scenario: Alias table assertion
+
+- **WHEN** a generic-label match is approved
+- **THEN** tests SHALL assert that no `bottle_alias` row is created or rebound for the generic label.

--- a/openspec/changes/add-source-scoped-store-price-identity/tasks.md
+++ b/openspec/changes/add-source-scoped-store-price-identity/tasks.md
@@ -1,0 +1,56 @@
+## 1. Schema And Classifier Contract
+
+- [x] 1.1 Add classifier/server schema fields for alias scope with conservative defaults for legacy rows.
+- [x] 1.2 Update classifier instructions to require alias-scope decisions without adding deterministic whisky-family shortcuts.
+- [x] 1.3 Update review policy to preserve agent-declared alias scope.
+- [x] 1.4 Extend eval fixture schemas and assertions to encode `aliasScope` expectations.
+
+## 2. Evals First
+
+- [ ] 2.1 Extend eval expectations so fixtures can assert that a listing label is not eligible for global alias storage.
+- [ ] 2.2 Add a generic-label classifier eval that fails unless the classifier marks the label as no-global-alias.
+- [ ] 2.3 Add a negative production-miss eval for the George Dickel-style generic title that must not auto-create a broad parent from family/sibling evidence alone.
+- [ ] 2.4 Add a positive source-specific existing-match eval using a different verified case where source evidence pins a generic listing title to an existing Peated bottle/release and marks it no-global-alias.
+- [ ] 2.5 Add or update replay recordings for any classifier evals that use live web evidence.
+- [ ] 2.6 Run classifier evals and schema tests for the changed fixtures.
+
+## 3. Scraper Source Identity
+
+- [ ] 3.1 Extend `StorePriceInputSchema` and persisted store-price metadata to accept source product id, source variant id, SKU/grouping id, and source fingerprint.
+- [ ] 3.2 Update `scrapePrices` in-run dedupe to prefer stable source ids over `name + volume`.
+- [ ] 3.3 Update price batch ingestion to upsert by `(externalSiteId, sourceKeyType, sourceKeyValue)` when present and use title-volume only as a legacy fallback.
+- [ ] 3.4 Extract source ids in scrapers that expose them: Total Wine `skuId`/URL product id, Astor item id, ReserveBar grouping id, Wooden Cork Shopify product/variant/SKU, and Healthy Spirits Lightspeed `data-pid`/variant id.
+- [ ] 3.5 Add scraper and ingestion tests for same-title/different-source-id preservation.
+
+## 4. Source-Scoped Persistence
+
+- [ ] 4.1 Decide whether `bottle_observation` can safely store reusable source-scoped verification or whether a new indexed table is required.
+- [ ] 4.2 Implement the selected persistence model with source keys for external site, internal store listing id when available, product id or canonical URL, optional SKU/fingerprint, target bottle/release, scope, evidence hash, confidence, and actor.
+- [ ] 4.3 Add migration and database tests for source-scoped lookup and non-reuse by display title alone.
+
+## 5. Approval And Alias Safety
+
+- [ ] 5.1 Update store-price approval flow to skip global bottle alias assignment when alias scope is `none` or the title is classified as generic/underspecified.
+- [ ] 5.2 Preserve exact source evidence and source-scope metadata in observations or the new source identity table.
+- [ ] 5.3 Add integration tests proving source-scoped approval assigns the exact store price, creates no `bottle_alias` row for the generic label, and does not update unrelated future listings with the same generic title.
+- [ ] 5.4 Make new classifier decisions default to no global alias when alias-safety metadata is missing.
+- [ ] 5.5 Ensure current global alias behavior remains unchanged for explicit reusable canonical identity approvals.
+
+## 6. Scraper Reuse
+
+- [ ] 6.1 Update store-price ingestion or resolution to consult source-scoped verification by stable source identity before generic classifier matching.
+- [ ] 6.2 Require review/classifier fallback when stable source identity is missing, changed, or expired.
+- [ ] 6.3 Add tests for same-site/source-key reuse, same-title/different-source non-reuse, same-title/different-store non-reuse, and same source-key value on different stores not reusing verification.
+
+## 7. Automation Gates
+
+- [ ] 7.1 Allow high-confidence source-scoped existing matches or unassigned corrections to auto-verify only when exact source evidence, known candidates, and deterministic blockers align.
+- [ ] 7.2 Keep create-new automation blocked for generic or underspecified listing identity.
+- [ ] 7.3 Add targeted automation tests for source-scoped assignment, generic-create blocking, and legacy-scope defaults.
+
+## 8. Documentation And Validation
+
+- [ ] 8.1 Update `docs/features/store-price-matching.md` with source-scoped listing identity and alias-safety behavior.
+- [ ] 8.2 Update `docs/architecture/bottle-classifier.md` with the classifier alias-safety contract.
+- [ ] 8.3 Run targeted server tests, classifier tests/evals, lint, and typecheck for touched surfaces.
+- [ ] 8.4 Capture any remaining open questions before enabling broad automation.

--- a/packages/bottle-classifier/src/classifier.eval.test.ts
+++ b/packages/bottle-classifier/src/classifier.eval.test.ts
@@ -344,6 +344,15 @@ function evaluateDecisionShape(
   }
 
   if (
+    expected.aliasScope !== undefined &&
+    result.decision.aliasScope !== expected.aliasScope
+  ) {
+    failures.push(
+      `aliasScope expected ${expected.aliasScope} but got ${result.decision.aliasScope}`,
+    );
+  }
+
+  if (
     expected.matchedBottleId !== undefined &&
     result.decision.matchedBottleId !== expected.matchedBottleId
   ) {

--- a/packages/bottle-classifier/src/classifierTypes.test.ts
+++ b/packages/bottle-classifier/src/classifierTypes.test.ts
@@ -70,6 +70,39 @@ describe("BottleClassifierAgentDecisionSchema", () => {
     });
   });
 
+  test("accepts legacy decisions without alias metadata", () => {
+    const decision = BottleClassificationDecisionSchema.parse({
+      action: "no_match",
+      confidence: 40,
+      candidateBottleIds: [],
+    });
+
+    expect(decision.aliasScope).toBeUndefined();
+  });
+
+  test("accepts explicit alias scope values", () => {
+    expect(
+      BottleClassificationDecisionSchema.safeParse({
+        action: "match",
+        confidence: 96,
+        candidateBottleIds: [123],
+        matchedBottleId: 123,
+        aliasScope: "global_alias",
+      }).success,
+    ).toBe(true);
+
+    expect(
+      BottleClassifierAgentDecisionSchema.safeParse({
+        action: "match",
+        confidence: 96,
+        candidateBottleIds: [123],
+        identityScope: "product",
+        aliasScope: "none",
+        matchedBottleId: 123,
+      }).success,
+    ).toBe(true);
+  });
+
   test("parses identity basis and candidate family context", () => {
     const candidate = BottleCandidateSchema.parse({
       kind: "bottle",
@@ -103,6 +136,7 @@ describe("BottleClassifierAgentDecisionSchema", () => {
       rationale: "A second vintage establishes the reusable parent.",
       candidateBottleIds: [100],
       identityScope: "product",
+      aliasScope: "none",
       observation: null,
       identityBasis: {
         bottleTraits: ["brand", "18-year-old"],

--- a/packages/bottle-classifier/src/classifierTypes.ts
+++ b/packages/bottle-classifier/src/classifierTypes.ts
@@ -17,6 +17,8 @@ export const CATEGORY_LIST = [
 
 export const ENTITY_TYPE_LIST = ["brand", "bottler", "distiller"] as const;
 
+export const ALIAS_SCOPES = ["global_alias", "none"] as const;
+
 export const CASK_FILLS = ["1st_fill", "2nd_fill", "refill", "other"] as const;
 
 export const CASK_TYPES = [
@@ -69,6 +71,7 @@ export const CaskTypeEnum = z.enum(CASK_TYPE_IDS);
 export const CaskSizeEnum = z.enum(CASK_SIZE_IDS);
 export const CategoryEnum = z.enum(CATEGORY_LIST);
 export const EntityTypeEnum = z.enum(ENTITY_TYPE_LIST);
+export const AliasScopeEnum = z.enum(ALIAS_SCOPES);
 
 const CURRENT_YEAR = new Date().getFullYear();
 
@@ -498,6 +501,9 @@ const BottleClassifierDecisionBaseSchema = z.object({
   identityScope: BottleIdentityScopeEnum.default("product").describe(
     "`product` for stable bottle-family identity; `exact_cask` only when the exact cask itself is the marketed bottle identity. SMWS codes qualify; generic cask/barrel details do not qualify without reliable evidence that the listed product is an exact single-cask identity.",
   ),
+  aliasScope: AliasScopeEnum.optional().describe(
+    "`global_alias` only when the listing label is safe to store as a reusable bottle alias; `none` when no reusable alias should be created.",
+  ),
   observation: BottleObservationSchema.nullable().default(null),
   identityBasis: BottleIdentityBasisSchema.nullable().optional(),
   confidenceBasis: BottleConfidenceBasisSchema.nullable().optional(),
@@ -656,6 +662,7 @@ export const BottleClassifierAgentDecisionSchema = z.object({
   rationale: z.string().nullable().default(null),
   candidateBottleIds: z.array(z.number().int()).default([]),
   identityScope: BottleIdentityScopeEnum.nullable().default(null),
+  aliasScope: AliasScopeEnum.nullable().default(null),
   observation: BottleObservationSchema.nullable().default(null),
   identityBasis: BottleIdentityBasisSchema.nullable().default(null),
   confidenceBasis: BottleConfidenceBasisSchema.nullable().default(null),
@@ -693,6 +700,7 @@ export type BottleExtractedDetails = z.infer<
 >;
 export type BottleConfidenceBasis = z.infer<typeof BottleConfidenceBasisSchema>;
 export type BottleIdentityBasis = z.infer<typeof BottleIdentityBasisSchema>;
+export type AliasScope = z.infer<typeof AliasScopeEnum>;
 export type BottleEvidenceSourceTier = z.infer<
   typeof BottleEvidenceSourceTierEnum
 >;
@@ -707,15 +715,25 @@ export type BottleCandidateSearchInput = z.infer<
   typeof BottleCandidateSearchInputSchema
 >;
 export type SearchEntitiesArgs = z.infer<typeof SearchEntitiesArgsSchema>;
-export type BottleClassifierAgentDecision = z.infer<
+type BottleClassifierAgentDecisionOutput = z.infer<
   typeof BottleClassifierAgentDecisionSchema
 >;
-export type BottleClassificationDecision = z.infer<
+type BottleClassificationDecisionOutput = z.infer<
   typeof BottleClassificationDecisionSchema
 >;
-export type BottleClassifierAgentDecisionInput = z.input<
-  typeof BottleClassifierAgentDecisionSchema
->;
+export type BottleClassifierAgentDecision = Omit<
+  BottleClassifierAgentDecisionOutput,
+  "aliasScope"
+> & {
+  aliasScope?: AliasScope | null;
+};
+export type BottleClassificationDecision = BottleClassificationDecisionOutput;
+export type BottleClassifierAgentDecisionInput = Omit<
+  z.input<typeof BottleClassifierAgentDecisionSchema>,
+  "aliasScope"
+> & {
+  aliasScope?: AliasScope | null;
+};
 export type BottleObservation = z.infer<typeof BottleObservationSchema>;
 export type EntityResolution = z.infer<typeof EntityResolutionSchema>;
 export type ProposedBottle = z.infer<typeof ProposedBottleSchema>;

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/text-only-listing-strips-retailer-suffix-noise-and-matches-ardbeg-uigeadail.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/text-only-listing-strips-retailer-suffix-noise-and-matches-ardbeg-uigeadail.json
@@ -64,6 +64,7 @@
     "status": "classified",
     "action": "match",
     "identityScope": "product",
+    "aliasScope": "global_alias",
     "matchedBottleId": 630,
     "summary": "Extract the canonical bottle identity from a noisy retailer title and match Ardbeg Uigeadail without needing seeded extraction output."
   }

--- a/packages/bottle-classifier/src/evalFixtureSchemas.ts
+++ b/packages/bottle-classifier/src/evalFixtureSchemas.ts
@@ -1,6 +1,7 @@
 import { readdirSync } from "node:fs";
 import { z } from "zod";
 import {
+  AliasScopeEnum,
   BottleCandidateSchema,
   BottleExtractedDetailsSchema,
   CategoryEnum,
@@ -72,6 +73,7 @@ export const classifierEvalExpectationSchema = z.object({
     ])
     .optional(),
   identityScope: z.enum(["product", "exact_cask"]).optional(),
+  aliasScope: AliasScopeEnum.optional(),
   matchedBottleId: z.number().int().nullable().optional(),
   matchedReleaseId: z.number().int().nullable().optional(),
   parentBottleId: z.number().int().nullable().optional(),

--- a/packages/bottle-classifier/src/instructions.ts
+++ b/packages/bottle-classifier/src/instructions.ts
@@ -731,6 +731,14 @@ const BOTTLE_CLASSIFIER_INSTRUCTIONS = [
     "Judge web results by specificity, independence, and corroboration, not domain familiarity alone.",
   ]),
   "",
+  "Source And Alias Scope:",
+  renderBulletLines([
+    "Always fill `aliasScope`.",
+    "`aliasScope = global_alias` only when the listing title itself is safe as a reusable bottle alias.",
+    "`aliasScope = none` when no reusable global alias should be created; use it for generic, underspecified, source-specific, or otherwise unsafe listing titles.",
+    "Do not infer alias safety from brand prefixes, retailer domain names, title shape, `single barrel` wording, search rank, or sibling family snippets. Use the reviewed evidence in this run.",
+  ]),
+  "",
   "Bottle, Bottling, Exact Cask:",
   renderBulletLines([
     "A parent bottle is the stable marketed product family.",

--- a/packages/bottle-classifier/src/reviewPolicy.test.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.test.ts
@@ -259,6 +259,72 @@ function classifyAgeCreationWithoutSiblingConflict(
 }
 
 describe("finalizeBottleReferenceClassification", () => {
+  test("defaults missing alias metadata to no alias", () => {
+    const result = finalizeBottleReferenceClassification({
+      reference: {
+        name: "Example Private Cask",
+      },
+      decision: {
+        action: "match",
+        confidence: 91,
+        rationale: "The existing candidate matches.",
+        candidateBottleIds: [existingPrivateCask.bottleId],
+        identityScope: "product",
+        observation: null,
+        matchedBottleId: existingPrivateCask.bottleId,
+        matchedReleaseId: null,
+        parentBottleId: null,
+        proposedBottle: null,
+        proposedRelease: null,
+      },
+      artifacts: buildBottleClassificationArtifacts({
+        candidates: [existingPrivateCask],
+      }),
+      options: {
+        enforceCreateWebEvidence: false,
+      },
+    });
+
+    expect(result).toMatchObject({
+      action: "match",
+      aliasScope: "none",
+    });
+  });
+
+  test("preserves alias metadata from the reviewed agent decision", () => {
+    const result = finalizeBottleReferenceClassification({
+      reference: {
+        name: "Example Known Bottle",
+        url: "https://shop.example.test/product/abc123",
+      },
+      decision: {
+        action: "match",
+        confidence: 97,
+        rationale: "The listing title is safe as a reusable alias.",
+        candidateBottleIds: [existingPrivateCask.bottleId],
+        identityScope: "product",
+        aliasScope: "global_alias",
+        observation: null,
+        matchedBottleId: existingPrivateCask.bottleId,
+        matchedReleaseId: null,
+        parentBottleId: null,
+        proposedBottle: null,
+        proposedRelease: null,
+      },
+      artifacts: buildBottleClassificationArtifacts({
+        candidates: [existingPrivateCask],
+      }),
+      options: {
+        enforceCreateWebEvidence: false,
+      },
+    });
+
+    expect(result).toMatchObject({
+      action: "match",
+      aliasScope: "global_alias",
+    });
+  });
+
   test("restores bottle-level age when same-family conflict proves it belongs in the display name", () => {
     const result = classifyShieldaigAgeCreation(
       buildShieldaigAgeCreationDecision("Speyside"),

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -2401,6 +2401,7 @@ function createNoMatchDecision({
     BottleClassifierAgentDecision,
     "confidence" | "rationale" | "identityScope"
   > &
+    Partial<Pick<BottleClassifierAgentDecision, "aliasScope">> &
     Partial<
       Pick<BottleClassifierAgentDecision, "identityBasis" | "confidenceBasis">
     >;
@@ -2409,12 +2410,13 @@ function createNoMatchDecision({
   observation: BottleObservation | null;
   identityScope?: BottleClassificationDecision["identityScope"];
 }): BottleClassificationDecision {
-  return {
+  return BottleClassificationDecisionSchema.parse({
     action: "no_match",
     confidence: decision.confidence,
     rationale,
     candidateBottleIds,
     identityScope: identityScope ?? decision.identityScope ?? "product",
+    aliasScope: decision.aliasScope ?? "none",
     observation,
     identityBasis: decision.identityBasis ?? null,
     confidenceBasis: decision.confidenceBasis ?? null,
@@ -2423,7 +2425,7 @@ function createNoMatchDecision({
     parentBottleId: null,
     proposedBottle: null,
     proposedRelease: null,
-  };
+  });
 }
 
 function rejectInvalidExistingMatch({
@@ -2974,6 +2976,7 @@ function sanitizeClassifierDecision({
         action: "create_bottle",
         confidence: normalizedConfidence,
         identityScope: decision.identityScope ?? "product",
+        aliasScope: decision.aliasScope ?? undefined,
         matchedBottleId: null,
         matchedReleaseId: null,
         parentBottleId: null,
@@ -3846,6 +3849,7 @@ export function finalizeBottleReferenceClassification({
 
   return BottleClassificationDecisionSchema.parse({
     ...finalDecision,
+    aliasScope: finalDecision.aliasScope ?? parsedDecision.aliasScope ?? "none",
     identityBasis: finalDecision.identityBasis ?? parsedDecision.identityBasis,
     confidenceBasis:
       finalDecision.confidenceBasis ?? parsedDecision.confidenceBasis,


### PR DESCRIPTION
Classifier decisions now carry `aliasScope` so price matching can tell whether a listing title is safe to store as a reusable global alias. Missing reviewed metadata defaults to `none`, invalid enum values are rejected by the schemas, and the price-match decision adapter preserves the field for later approval and persistence work.

The OpenSpec change is included with tasks 1.1-1.4 complete. Durable source-key persistence, scraper identifiers, approval alias skipping, and automation gates remain scoped to follow-up tasks.