### PR TITLE
fix(worker): Preserve Sentry user attribution in jobs

### DIFF
--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -30,6 +30,7 @@ import path from "path";
 import type { ZodIssue } from "zod";
 import { ZodError } from "zod";
 import config from "./config";
+import { userToActorContext, withActorContext } from "./lib/actorContext";
 import { getUserFromHeader } from "./lib/auth";
 import { getStorage } from "./lib/gcs";
 import { httpLogger, logError, logInfo, logWarn } from "./lib/log";
@@ -335,37 +336,39 @@ export const app = new Hono()
         })
       : setUser(null);
 
-    // Enforce ToS acceptance for authenticated users except reserved auth paths
-    if (user && !user.termsAcceptedAt) {
-      const path = new URL(c.req.url).pathname;
-      const allowed = path.startsWith("/v1/auth/");
-      if (!allowed) {
-        return c.json(
-          {
-            message: "Terms acceptance required.",
-            error: "Forbidden",
-            statusCode: 403,
-          },
-          403,
-        );
+    return await withActorContext(userToActorContext(user), async () => {
+      // Enforce ToS acceptance for authenticated users except reserved auth paths
+      if (user && !user.termsAcceptedAt) {
+        const path = new URL(c.req.url).pathname;
+        const allowed = path.startsWith("/v1/auth/");
+        if (!allowed) {
+          return c.json(
+            {
+              message: "Terms acceptance required.",
+              error: "Forbidden",
+              statusCode: 403,
+            },
+            403,
+          );
+        }
       }
-    }
 
-    const connInfo = getConnInfo(c);
-    const { matched, response } = await openapiHandler.handle(c.req.raw, {
-      prefix: "/v1",
-      context: {
-        user,
-        ip: getClientIp(c.req.raw, connInfo),
-        userAgent: c.req.header("user-agent"),
-      },
+      const connInfo = getConnInfo(c);
+      const { matched, response } = await openapiHandler.handle(c.req.raw, {
+        prefix: "/v1",
+        context: {
+          user,
+          ip: getClientIp(c.req.raw, connInfo),
+          userAgent: c.req.header("user-agent"),
+        },
+      });
+
+      if (matched) {
+        return c.newResponse(response.body, response);
+      }
+
+      await next();
     });
-
-    if (matched) {
-      return c.newResponse(response.body, response);
-    }
-
-    await next();
   })
   .use("/rpc/*", async (c, next) => {
     const user = await getUserFromHeader(c.req.header("authorization"));
@@ -378,37 +381,39 @@ export const app = new Hono()
         })
       : setUser(null);
 
-    // Enforce ToS acceptance for authenticated users except reserved auth paths
-    if (user && !user.termsAcceptedAt) {
-      const path = new URL(c.req.url).pathname;
-      const allowed = path.startsWith("/rpc/auth/");
-      if (!allowed) {
-        return c.json(
-          {
-            message: "Terms acceptance required.",
-            error: "Forbidden",
-            statusCode: 403,
-          },
-          403,
-        );
+    return await withActorContext(userToActorContext(user), async () => {
+      // Enforce ToS acceptance for authenticated users except reserved auth paths
+      if (user && !user.termsAcceptedAt) {
+        const path = new URL(c.req.url).pathname;
+        const allowed = path.startsWith("/rpc/auth/");
+        if (!allowed) {
+          return c.json(
+            {
+              message: "Terms acceptance required.",
+              error: "Forbidden",
+              statusCode: 403,
+            },
+            403,
+          );
+        }
       }
-    }
 
-    const connInfo = getConnInfo(c);
-    const { matched, response } = await rpcHandler.handle(c.req.raw, {
-      prefix: "/rpc",
-      context: {
-        user,
-        ip: getClientIp(c.req.raw, connInfo),
-        userAgent: c.req.header("user-agent"),
-      },
+      const connInfo = getConnInfo(c);
+      const { matched, response } = await rpcHandler.handle(c.req.raw, {
+        prefix: "/rpc",
+        context: {
+          user,
+          ip: getClientIp(c.req.raw, connInfo),
+          userAgent: c.req.header("user-agent"),
+        },
+      });
+
+      if (matched) {
+        return c.newResponse(response.body, response);
+      }
+
+      await next();
     });
-
-    if (matched) {
-      return c.newResponse(response.body, response);
-    }
-
-    await next();
   });
 
 export type AppType = typeof app;

--- a/apps/server/src/lib/actorContext.ts
+++ b/apps/server/src/lib/actorContext.ts
@@ -1,0 +1,37 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type ActorContext = {
+  type: "user";
+  userId: number;
+  username?: string;
+};
+
+const actorContextStorage = new AsyncLocalStorage<ActorContext | undefined>();
+
+/** Convert an authenticated Peated user into the app-owned actor shape. */
+export function userToActorContext(
+  user: { id: number; username?: string | null } | null | undefined,
+): ActorContext | undefined {
+  if (!user) {
+    return undefined;
+  }
+
+  return {
+    type: "user",
+    userId: user.id,
+    ...(user.username ? { username: user.username } : {}),
+  };
+}
+
+/** Run code with app-owned actor context available to nested dispatches. */
+export function withActorContext<T>(
+  actor: ActorContext | undefined,
+  callback: () => Promise<T>,
+): Promise<T> {
+  return actorContextStorage.run(actor, callback);
+}
+
+/** Read the current app-owned actor context. */
+export function getCurrentActorContext(): ActorContext | undefined {
+  return actorContextStorage.getStore();
+}

--- a/apps/server/src/lib/openaiClient.test.ts
+++ b/apps/server/src/lib/openaiClient.test.ts
@@ -1,0 +1,24 @@
+import * as Sentry from "@sentry/node";
+import { describe, expect, test } from "vitest";
+import { withSentryConversation } from "./openaiClient";
+
+describe("withSentryConversation", () => {
+  test("preserves Sentry user attribution in the conversation scope", async () => {
+    await Sentry.withIsolationScope(async (scope) => {
+      scope.setUser({
+        id: "123",
+        username: "dcramer",
+      });
+
+      await withSentryConversation("bottle_details:11868", async () => {
+        expect(Sentry.getIsolationScope().getUser()).toEqual({
+          id: "123",
+          username: "dcramer",
+        });
+        expect(Sentry.getIsolationScope().getScopeData().conversationId).toBe(
+          "bottle_details:11868",
+        );
+      });
+    });
+  });
+});

--- a/apps/server/src/lib/openaiClient.ts
+++ b/apps/server/src/lib/openaiClient.ts
@@ -17,12 +17,13 @@ export function createOpenAIClient(): OpenAI {
   });
 }
 
+/** Run an AI conversation scope without clearing inherited Sentry attribution. */
 export async function withSentryConversation<T>(
   conversationId: string,
   callback: () => Promise<T>,
 ): Promise<T> {
-  return await Sentry.withIsolationScope(async () => {
-    Sentry.setConversationId(conversationId);
+  return await Sentry.withIsolationScope(async (scope) => {
+    scope.setConversationId(conversationId);
     return await callback();
   });
 }

--- a/apps/server/src/worker/README.md
+++ b/apps/server/src/worker/README.md
@@ -63,9 +63,9 @@ Without this step, TypeScript will not allow you to queue the job.
 ### Queue a Job
 
 ```typescript
-import { addJob } from "@peated/server/worker/client";
+import { pushJob } from "@peated/server/worker/client";
 
-await addJob("MyNewJob", { param1: "value" });
+await pushJob("MyNewJob", { param1: "value" });
 ```
 
 ### Run Immediately (Testing)
@@ -93,7 +93,7 @@ scheduledJob("0 3 * * *", "cleanup-job", async () => {
 ```typescript
 type JobFunction = (
   args?: any, // Job parameters
-  context?: JobContext, // Trace context for Sentry
+  context?: JobContext, // Trace and app-owned actor context
 ) => Promise<unknown>;
 ```
 
@@ -101,5 +101,7 @@ type JobFunction = (
 
 - **Automatic Sentry instrumentation**: All jobs are wrapped with error tracking
 - **Trace propagation**: Supports distributed tracing via context
+- **Actor propagation**: Carries authenticated user attribution into queued
+  worker context and applies it to Sentry user/attributes in the worker
 - **Logging**: Automatic success/failure logging with duration
 - **Type safety**: TypeScript ensures job names are valid

--- a/apps/server/src/worker/client.ts
+++ b/apps/server/src/worker/client.ts
@@ -8,6 +8,11 @@ import config from "../config";
 import { logError, logInfo } from "../lib/log";
 import "./jobs";
 import scheduleScrapers from "./jobs/scheduleScrapers";
+import {
+  buildJobContext,
+  buildQueuedJobData,
+  parseQueuedJobData,
+} from "./payload";
 import registry from "./registry";
 import { type JobName } from "./types";
 
@@ -33,7 +38,7 @@ export async function runJob<T>(jobName: JobName, args?: Record<string, any>) {
 
   const jobFn = registry.get(jobName);
   if (!jobFn) throw new Error(`Unknown job: ${jobName}`);
-  return await jobFn(args, { traceContext: activeContext });
+  return await jobFn(args, buildJobContext(activeContext));
 }
 
 export async function pushUniqueJob(
@@ -78,10 +83,7 @@ export async function pushJob(
       try {
         await defaultQueue.add(
           jobName,
-          {
-            args,
-            context: { traceContext: activeContext },
-          },
+          buildQueuedJobData(args, activeContext),
           opts,
         );
       } catch (e) {
@@ -146,7 +148,7 @@ export async function runWorker() {
     defaultQueue.name,
     async (job) => {
       const jobFn = registry.get(job.name);
-      const { args, context } = job.data;
+      const { args, context } = parseQueuedJobData(job.data);
       return await jobFn(args, context);
     },
     { connection, autorun: false },

--- a/apps/server/src/worker/context.test.ts
+++ b/apps/server/src/worker/context.test.ts
@@ -1,0 +1,148 @@
+import * as Sentry from "@sentry/node";
+import { describe, expect, test } from "vitest";
+import {
+  getCurrentActorContext,
+  userToActorContext,
+  withActorContext,
+} from "../lib/actorContext";
+import { applyJobActorContextToSentry } from "./context";
+import { buildQueuedJobData, parseQueuedJobData } from "./payload";
+import { parseJobContext } from "./types";
+
+describe("worker context", () => {
+  test("serializes Peated users as queue actor context", () => {
+    expect(userToActorContext({ id: 123, username: "dcramer" })).toEqual({
+      type: "user",
+      userId: 123,
+      username: "dcramer",
+    });
+  });
+
+  test("ignores missing users", () => {
+    expect(userToActorContext(null)).toBe(undefined);
+    expect(userToActorContext(undefined)).toBe(undefined);
+  });
+
+  test("stores queue context outside Sentry", async () => {
+    await withActorContext(
+      {
+        type: "user",
+        userId: 321,
+        username: "stored",
+      },
+      async () => {
+        expect(getCurrentActorContext()).toEqual({
+          type: "user",
+          userId: 321,
+          username: "stored",
+        });
+        expect(Sentry.getIsolationScope().getUser()?.id).toBeUndefined();
+      },
+    );
+  });
+
+  test("builds queued job data with current actor context", async () => {
+    await withActorContext(
+      {
+        type: "user",
+        userId: 123,
+        username: "dcramer",
+      },
+      async () => {
+        expect(
+          buildQueuedJobData(
+            { bottleId: 11868 },
+            { "sentry-trace": "trace", baggage: "sampled" },
+          ),
+        ).toEqual({
+          args: { bottleId: 11868 },
+          context: {
+            traceContext: { "sentry-trace": "trace", baggage: "sampled" },
+            actor: {
+              type: "user",
+              userId: 123,
+              username: "dcramer",
+            },
+          },
+        });
+      },
+    );
+  });
+
+  test("restores user actor context onto a Sentry isolation scope", async () => {
+    await Sentry.withIsolationScope(async (scope) => {
+      applyJobActorContextToSentry(scope, {
+        type: "user",
+        userId: 456,
+        username: "peated",
+      });
+
+      expect(scope.getUser()).toEqual({
+        id: "456",
+        username: "peated",
+      });
+      expect(scope.getScopeData().attributes).toEqual({
+        "actor.type": "user",
+        "actor.user_id": 456,
+        "actor.username": "peated",
+      });
+    });
+  });
+
+  test("parses queued actor context from worker payloads", () => {
+    expect(
+      parseJobContext({
+        traceContext: { "sentry-trace": "trace", baggage: "sampled" },
+        actor: {
+          type: "user",
+          userId: 789,
+          username: "queued",
+        },
+      }),
+    ).toEqual({
+      traceContext: { "sentry-trace": "trace", baggage: "sampled" },
+      actor: {
+        type: "user",
+        userId: 789,
+        username: "queued",
+      },
+    });
+  });
+
+  test("parses queued job data envelopes", () => {
+    expect(
+      parseQueuedJobData({
+        args: { bottleId: 11868 },
+        context: {
+          traceContext: { "sentry-trace": "trace", baggage: "sampled" },
+          actor: {
+            type: "user",
+            userId: 789,
+            username: "queued",
+          },
+        },
+      }),
+    ).toEqual({
+      args: { bottleId: 11868 },
+      context: {
+        traceContext: { "sentry-trace": "trace", baggage: "sampled" },
+        actor: {
+          type: "user",
+          userId: 789,
+          username: "queued",
+        },
+      },
+    });
+  });
+
+  test("drops malformed queued actor context", () => {
+    expect(
+      parseJobContext({
+        actor: {
+          type: "user",
+          userId: "not-a-number",
+        },
+      }),
+    ).toEqual({});
+  });
+});

--- a/apps/server/src/worker/context.ts
+++ b/apps/server/src/worker/context.ts
@@ -1,0 +1,26 @@
+import type { Scope } from "@sentry/core";
+import type { JobActorContext } from "./types";
+
+/** Apply queued actor attribution to Sentry without using Sentry as storage. */
+export function applyJobActorContextToSentry(
+  scope: Scope,
+  actor: JobActorContext | undefined,
+) {
+  if (!actor) {
+    scope.setUser(null);
+    scope.removeAttribute("actor.type");
+    scope.removeAttribute("actor.user_id");
+    scope.removeAttribute("actor.username");
+    return;
+  }
+
+  scope.setUser({
+    id: String(actor.userId),
+    ...(actor.username ? { username: actor.username } : {}),
+  });
+  scope.setAttributes({
+    "actor.type": actor.type,
+    "actor.user_id": actor.userId,
+    ...(actor.username ? { "actor.username": actor.username } : {}),
+  });
+}

--- a/apps/server/src/worker/payload.ts
+++ b/apps/server/src/worker/payload.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { getCurrentActorContext } from "../lib/actorContext";
+import { parseJobContext, type JobContext } from "./types";
+
+const QueuedJobDataSchema = z
+  .object({
+    args: z.unknown().optional(),
+    context: z.unknown().optional(),
+  })
+  .strict();
+
+export type QueuedJobData = {
+  args?: unknown;
+  context: JobContext;
+};
+
+/** Build app-owned job context for direct and queued job dispatches. */
+export function buildJobContext(
+  traceContext: JobContext["traceContext"] = {},
+): JobContext {
+  return {
+    traceContext,
+    actor: getCurrentActorContext(),
+  };
+}
+
+/** Build the serialized payload handed to the queue. */
+export function buildQueuedJobData(
+  args?: unknown,
+  traceContext: JobContext["traceContext"] = {},
+): QueuedJobData {
+  return {
+    args,
+    context: buildJobContext(traceContext),
+  };
+}
+
+/** Parse queued job data, dropping malformed context while preserving job args. */
+export function parseQueuedJobData(input: unknown): QueuedJobData {
+  const result = QueuedJobDataSchema.safeParse(input);
+  if (!result.success) {
+    return {
+      context: {},
+    };
+  }
+
+  return {
+    args: result.data.args,
+    context: parseJobContext(result.data.context),
+  };
+}

--- a/apps/server/src/worker/registry.ts
+++ b/apps/server/src/worker/registry.ts
@@ -1,6 +1,8 @@
 import cuid2 from "@paralleldrive/cuid2";
+import { withActorContext } from "@peated/server/lib/actorContext";
 import { logError, logInfo } from "@peated/server/lib/log";
 import * as Sentry from "@sentry/node";
+import { applyJobActorContextToSentry } from "./context";
 import { type JobFunction } from "./types";
 
 // instrument a job with Sentry
@@ -19,61 +21,67 @@ function instrumentedJob<T>(jobName: string, jobFn: JobFunction) {
         baggage: traceContext?.baggage,
       },
       async () => {
-        return Sentry.withScope(async function (scope) {
-          scope.setContext("job", {
-            name: jobName,
-            id: jobId,
+        return withActorContext(context.actor, async () => {
+          return Sentry.withIsolationScope(async (isolationScope) => {
+            applyJobActorContextToSentry(isolationScope, context.actor);
+
+            return Sentry.withScope(async function (scope) {
+              scope.setContext("job", {
+                name: jobName,
+                id: jobId,
+              });
+              scope.setTransactionName(jobName);
+
+              // this is sentry's wrapper
+              return await Sentry.startSpan(
+                {
+                  op: "consume default",
+                  name: `bullmq.${jobName.toLowerCase()}`,
+                },
+                async (span) => {
+                  span.setAttribute("messaging.operation.type", "process");
+                  span.setAttribute("messaging.operation.name", "consume");
+                  // TODO: THIS IS WRONG - it should set from the worker itself but idk that
+                  // we have that data
+                  span.setAttribute("messaging.destination.name", "default");
+                  span.setAttribute("messaging.message.id", jobId);
+                  span.setAttribute("messaging.system", "bullmq");
+
+                  logInfo("Running job {jobName} {jobId}", {
+                    extra: {
+                      jobName,
+                      jobId,
+                    },
+                  });
+                  const start = new Date().getTime();
+                  let success = false;
+                  try {
+                    await jobFn(params, context);
+                    success = true;
+                    span.setStatus({
+                      code: 1, // OK
+                    });
+                  } catch (e) {
+                    logError(e);
+                    span.setStatus({
+                      code: 2, // ERROR
+                    });
+                  }
+
+                  const duration = new Date().getTime() - start;
+
+                  logInfo("Job {status} {jobName} {jobId}", {
+                    extra: {
+                      status: success ? "succeeded" : "failed",
+                      jobName,
+                      jobId,
+                      durationMs: duration,
+                    },
+                  });
+                },
+              );
+            });
           });
-          scope.setTransactionName(jobName);
-
-          // this is sentry's wrapper
-          return await Sentry.startSpan(
-            {
-              op: "consume default",
-              name: `bullmq.${jobName.toLowerCase()}`,
-            },
-            async (span) => {
-              span.setAttribute("messaging.operation.type", "process");
-              span.setAttribute("messaging.operation.name", "consume");
-              // TODO: THIS IS WRONG - it should set from the worker itself but idk that
-              // we have that data
-              span.setAttribute("messaging.destination.name", "default");
-              span.setAttribute("messaging.message.id", jobId);
-              span.setAttribute("messaging.system", "bullmq");
-
-              logInfo("Running job {jobName} {jobId}", {
-                extra: {
-                  jobName,
-                  jobId,
-                },
-              });
-              const start = new Date().getTime();
-              let success = false;
-              try {
-                await jobFn(params, context);
-                success = true;
-                span.setStatus({
-                  code: 1, // OK
-                });
-              } catch (e) {
-                logError(e);
-                span.setStatus({
-                  code: 2, // ERROR
-                });
-              }
-
-              const duration = new Date().getTime() - start;
-
-              logInfo("Job {status} {jobName} {jobId}", {
-                extra: {
-                  status: success ? "succeeded" : "failed",
-                  jobName,
-                  jobId,
-                  durationMs: duration,
-                },
-              });
-            },
-          );
         });
       },
     );

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 // TODO: how can we automate registration here without importing the job code?
 export type JobName =
   | "CapturePriceImage"
@@ -41,12 +43,34 @@ export type JobName =
   | "VerifyBottleCreation"
   | "VerifyEntityCreation";
 
-type TraceContext = {
-  "sentry-trace"?: string;
-  baggage?: any;
-};
+const TraceContextSchema = z
+  .object({
+    "sentry-trace": z.string().optional(),
+    baggage: z.string().optional(),
+  })
+  .passthrough();
 
-type JobContext = { traceContext?: TraceContext };
+const JobActorContextSchema = z.object({
+  type: z.literal("user"),
+  userId: z.number().int().positive(),
+  username: z.string().optional(),
+});
+
+const JobContextSchema = z
+  .object({
+    traceContext: TraceContextSchema.optional(),
+    actor: JobActorContextSchema.optional(),
+  })
+  .strict();
+
+export type JobActorContext = z.infer<typeof JobActorContextSchema>;
+export type JobContext = z.infer<typeof JobContextSchema>;
+
+/** Parse queued job context, dropping malformed trace or actor attribution. */
+export function parseJobContext(input: unknown): JobContext {
+  const result = JobContextSchema.safeParse(input);
+  return result.success ? result.data : {};
+}
 
 export type JobFunction = (
   args?: any,

--- a/docs/development/backend-testing.md
+++ b/docs/development/backend-testing.md
@@ -7,7 +7,8 @@ Backend tests in this repo are integration-first. Test behavior over real wiring
 - Prefer integration tests over isolated unit tests.
 - Verify observable behavior, not implementation details.
 - Do not add fluff unit tests that mock internal collaborators, route layers, database access, serializers, or random call chains that do not need separate verification.
-- Only mock true external boundaries or unavoidable side effects, such as email delivery, worker dispatch, passkey verification, third-party HTTP, or AI providers.
+- Only mock true external boundaries or unavoidable side effects, such as email delivery, passkey verification, third-party HTTP, or AI providers.
+- First-party services should not be mocked when their contract is the behavior under test. Exercise the real owned boundary, use an existing fixture, or extract a small deterministic helper for payload construction.
 - Small deterministic helpers may be tested directly when there is no useful integration surface and the test does not require unnecessary mocking. These cases should be uncommon.
 
 ## What Integration Means Here
@@ -93,12 +94,17 @@ If a helper test starts building fake collaborators or asserting internal call s
 Mocking is allowed only at boundaries that are expensive, unsafe, or inappropriate to invoke in tests:
 
 - outbound email;
-- worker queue dispatch;
+- worker queue dispatch when the enqueue itself is incidental to the behavior under test;
 - passkey or auth provider verification;
 - third-party HTTP services;
 - AI providers or other hosted external systems.
 
 Do not mock internal business logic purely to make a backend test look unit-sized.
+
+When queue serialization or worker context propagation is the behavior under
+test, do not whole-module mock `worker/client`. Assert against a real queue
+fixture if one exists, or against the deterministic first-party payload builder
+used by the enqueue path.
 
 Do not mock or suppress logging. Leave the logging facade and console methods
 wired so emitted logs remain available during test runs. Tests should verify the


### PR DESCRIPTION
Queued worker runs now carry authenticated Sentry user attribution alongside trace context, parse the serialized context at the BullMQ boundary, and restore it on worker isolation scopes. AI conversation scopes preserve that user while setting conversation IDs, so conversations like bottle_details:11868 remain attributable.

Malformed or stale job context falls back to an empty context instead of failing the job, and the queued attribution payload is limited to user id and username.