### PR TITLE
fix(server): Preserve library images during bottle merge

### DIFF
--- a/apps/server/src/worker/jobs/mergeBottle.test.ts
+++ b/apps/server/src/worker/jobs/mergeBottle.test.ts
@@ -533,4 +533,175 @@ describe("mergeBottle", () => {
     expect(mergedCollectionRows).toHaveLength(1);
     expect(mergedFlightRows).toHaveLength(1);
   });
+
+  it("preserves collection bottle images while merging bottles", async ({
+    fixtures,
+  }) => {
+    const sourceBottle = await fixtures.Bottle({
+      name: "Source Image Bottle",
+      category: "single_malt",
+    });
+    const targetBottle = await fixtures.Bottle({
+      name: "Target Image Bottle",
+      category: "single_malt",
+    });
+    const collection = await fixtures.Collection();
+
+    await db.insert(collectionBottles).values({
+      collectionId: collection.id,
+      bottleId: sourceBottle.id,
+      releaseId: null,
+      imageUrl: "/uploads/collection-bottles/source-entry.webp",
+    });
+
+    await mergeBottle({
+      fromBottleIds: [sourceBottle.id],
+      toBottleId: targetBottle.id,
+    });
+
+    const mergedCollectionRows = await db
+      .select()
+      .from(collectionBottles)
+      .where(
+        and(
+          eq(collectionBottles.collectionId, collection.id),
+          eq(collectionBottles.bottleId, targetBottle.id),
+        ),
+      );
+
+    expect(mergedCollectionRows).toHaveLength(1);
+    expect(mergedCollectionRows[0]?.imageUrl).toBe(
+      "/uploads/collection-bottles/source-entry.webp",
+    );
+  });
+
+  it("reconciles duplicate collection bottle images while merging bottles", async ({
+    fixtures,
+  }) => {
+    const sourceBottle = await fixtures.Bottle({
+      name: "Source Duplicate Image Bottle",
+      category: "single_malt",
+    });
+    const targetBottle = await fixtures.Bottle({
+      name: "Target Duplicate Image Bottle",
+      category: "single_malt",
+    });
+    const fillImageCollection = await fixtures.Collection();
+    const keepImageCollection = await fixtures.Collection();
+
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: fillImageCollection.id,
+        bottleId: sourceBottle.id,
+        releaseId: null,
+        imageUrl: "/uploads/collection-bottles/source-fill.webp",
+      },
+      {
+        collectionId: fillImageCollection.id,
+        bottleId: targetBottle.id,
+        releaseId: null,
+        imageUrl: null,
+      },
+      {
+        collectionId: keepImageCollection.id,
+        bottleId: sourceBottle.id,
+        releaseId: null,
+        imageUrl: "/uploads/collection-bottles/source-keep.webp",
+      },
+      {
+        collectionId: keepImageCollection.id,
+        bottleId: targetBottle.id,
+        releaseId: null,
+        imageUrl: "/uploads/collection-bottles/target-existing.webp",
+      },
+    ]);
+
+    await mergeBottle({
+      fromBottleIds: [sourceBottle.id],
+      toBottleId: targetBottle.id,
+    });
+
+    const fillImageRows = await db
+      .select()
+      .from(collectionBottles)
+      .where(
+        and(
+          eq(collectionBottles.collectionId, fillImageCollection.id),
+          eq(collectionBottles.bottleId, targetBottle.id),
+        ),
+      );
+    const keepImageRows = await db
+      .select()
+      .from(collectionBottles)
+      .where(
+        and(
+          eq(collectionBottles.collectionId, keepImageCollection.id),
+          eq(collectionBottles.bottleId, targetBottle.id),
+        ),
+      );
+
+    expect(fillImageRows).toHaveLength(1);
+    expect(fillImageRows[0]?.imageUrl).toBe(
+      "/uploads/collection-bottles/source-fill.webp",
+    );
+    expect(keepImageRows).toHaveLength(1);
+    expect(keepImageRows[0]?.imageUrl).toBe(
+      "/uploads/collection-bottles/target-existing.webp",
+    );
+  });
+
+  it("dedupes multiple source collection rows while preserving an image", async ({
+    fixtures,
+  }) => {
+    const sourceBottleA = await fixtures.Bottle({
+      name: "Source Multi Image Bottle A",
+      category: "single_malt",
+    });
+    const sourceBottleB = await fixtures.Bottle({
+      name: "Source Multi Image Bottle B",
+      category: "single_malt",
+    });
+    const targetBottle = await fixtures.Bottle({
+      name: "Target Multi Image Bottle",
+      category: "single_malt",
+    });
+    const collection = await fixtures.Collection();
+
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: collection.id,
+        bottleId: sourceBottleA.id,
+        releaseId: null,
+        imageUrl: null,
+        createdAt: new Date("2024-01-01T00:00:00.000Z"),
+      },
+      {
+        collectionId: collection.id,
+        bottleId: sourceBottleB.id,
+        releaseId: null,
+        imageUrl: "/uploads/collection-bottles/source-multi.webp",
+        createdAt: new Date("2024-01-02T00:00:00.000Z"),
+      },
+    ]);
+
+    await mergeBottle({
+      fromBottleIds: [sourceBottleA.id, sourceBottleB.id],
+      toBottleId: targetBottle.id,
+    });
+
+    const mergedCollectionRows = await db
+      .select()
+      .from(collectionBottles)
+      .where(
+        and(
+          eq(collectionBottles.collectionId, collection.id),
+          eq(collectionBottles.bottleId, targetBottle.id),
+        ),
+      );
+
+    expect(mergedCollectionRows).toHaveLength(1);
+    expect(mergedCollectionRows[0]?.imageUrl).toBe(
+      "/uploads/collection-bottles/source-multi.webp",
+    );
+  });
 });

--- a/apps/server/src/worker/jobs/mergeBottle.ts
+++ b/apps/server/src/worker/jobs/mergeBottle.ts
@@ -20,7 +20,7 @@ import { upsertBottleAlias } from "@peated/server/lib/db";
 import { formatReleaseName } from "@peated/server/lib/format";
 import { logError, logInfo } from "@peated/server/lib/log";
 import { pushUniqueJob } from "@peated/server/worker/client";
-import { eq, inArray, or, sql } from "drizzle-orm";
+import { asc, eq, inArray, or, sql } from "drizzle-orm";
 
 // TODO: this should happen async
 export default async function mergeBottle({
@@ -68,7 +68,8 @@ export default async function mergeBottle({
       tx
         .select()
         .from(collectionBottles)
-        .where(inArray(collectionBottles.bottleId, fromBottleIds)),
+        .where(inArray(collectionBottles.bottleId, fromBottleIds))
+        .orderBy(asc(collectionBottles.createdAt), asc(collectionBottles.id)),
       tx
         .select()
         .from(flightBottles)
@@ -124,17 +125,45 @@ export default async function mergeBottle({
     }
 
     if (sourceCollectionRows.length > 0) {
+      // Collapse source rows before upsert; existing target images win unless blank.
+      const mergedSourceCollectionRows = Array.from(
+        sourceCollectionRows
+          .reduce((rows, row) => {
+            const key = `${row.collectionId}:${row.releaseId ?? "null"}`;
+            const existingRow = rows.get(key);
+            if (!existingRow) {
+              rows.set(key, row);
+            } else if (!existingRow.imageUrl && row.imageUrl) {
+              rows.set(key, { ...existingRow, imageUrl: row.imageUrl });
+            }
+            return rows;
+          }, new Map<string, (typeof sourceCollectionRows)[number]>())
+          .values(),
+      );
+
       await tx
         .insert(collectionBottles)
         .values(
-          sourceCollectionRows.map((row) => ({
+          mergedSourceCollectionRows.map((row) => ({
             collectionId: row.collectionId,
             bottleId: toBottleId,
             releaseId: row.releaseId,
+            imageUrl: row.imageUrl,
             createdAt: row.createdAt,
           })),
         )
-        .onConflictDoNothing();
+        .onConflictDoUpdate({
+          target: [
+            collectionBottles.collectionId,
+            collectionBottles.bottleId,
+            collectionBottles.releaseId,
+          ],
+          set: {
+            imageUrl: sql<
+              string | null
+            >`COALESCE(${collectionBottles.imageUrl}, excluded.image_url)`,
+          },
+        });
     }
 
     if (sourceFlightRows.length > 0) {


### PR DESCRIPTION
Bottle merges now carry collection entry image metadata when source bottle collection rows are recreated for the target bottle. If the target collection row already has an image, it stays unchanged; if it is blank, a source image backfills it.

The merge path also collapses duplicate source collection rows before the upsert so multi-source merges cannot trip PostgreSQL's repeated conflict-update error. Regression coverage covers source-only image preservation, target/source reconciliation, and multi-source duplicate rows.