### PR TITLE
fix(auth): Surface magic link email delivery failures

### DIFF
--- a/apps/server/src/lib/email.test.ts
+++ b/apps/server/src/lib/email.test.ts
@@ -3,7 +3,7 @@ import type { Transporter } from "nodemailer";
 import { createTransport } from "nodemailer";
 import type Mail from "nodemailer/lib/mailer";
 import type SMTPTransport from "nodemailer/lib/smtp-transport";
-import { notifyComment } from "./email";
+import { notifyComment, sendMagicLinkEmail } from "./email";
 
 let transport: Transporter<SMTPTransport.SentMessageInfo>;
 let outbox: Mail.Options[];
@@ -49,6 +49,7 @@ const createEmailTestHarness = () => {
 
 beforeEach(async () => {
   config.API_SERVER = "http://localhost";
+  config.SMTP_HOST = "localhost";
   config.SMTP_FROM = "example@example.com";
 
   const harness = createEmailTestHarness();
@@ -121,5 +122,29 @@ describe("notifyComment", () => {
     const msg = outbox[0];
     expect(msg.to).toBe(author.email);
     expect(msg.subject).toBe("New Comment on Tasting");
+  });
+});
+
+describe("sendMagicLinkEmail", () => {
+  test("requires SendGrid SMTP credentials", async ({ fixtures }) => {
+    const user = await fixtures.User({ active: true });
+    const originalHost = config.SMTP_HOST;
+    const originalUser = config.SMTP_USER;
+    const originalPass = config.SMTP_PASS;
+
+    config.SMTP_HOST = "smtp.sendgrid.net";
+    config.SMTP_USER = undefined;
+    config.SMTP_PASS = undefined;
+
+    try {
+      await expect(sendMagicLinkEmail({ user, transport })).rejects.toThrow(
+        "SMTP credentials are not configured",
+      );
+      expect(outbox.length).toBe(0);
+    } finally {
+      config.SMTP_HOST = originalHost;
+      config.SMTP_USER = originalUser;
+      config.SMTP_PASS = originalPass;
+    }
   });
 });

--- a/apps/server/src/lib/email.ts
+++ b/apps/server/src/lib/email.ts
@@ -35,18 +35,33 @@ type CommentWithRelations = Comment & {
 };
 
 const hasEmailSupport = () => {
-  if (!config.URL_PREFIX) {
-    logError("URL_PREFIX is not configured");
-    return false;
-  }
+  const error = getEmailSupportError({ requireSmtpCredentials: false });
+  if (error) logError(error);
 
-  if (!config.SMTP_FROM) {
-    logError("SMTP_FROM is not configured");
-    return false;
-  }
-
-  return true;
+  return !error;
 };
+
+function getEmailSupportError({
+  requireSmtpCredentials,
+}: {
+  requireSmtpCredentials: boolean;
+}) {
+  if (!config.URL_PREFIX) return "URL_PREFIX is not configured";
+  if (!config.SMTP_FROM) return "SMTP_FROM is not configured";
+  if (
+    requireSmtpCredentials &&
+    config.SMTP_HOST === "smtp.sendgrid.net" &&
+    (!config.SMTP_USER || !config.SMTP_PASS)
+  ) {
+    return "SMTP credentials are not configured";
+  }
+  return null;
+}
+
+function assertEmailSupport() {
+  const error = getEmailSupportError({ requireSmtpCredentials: true });
+  if (error) throw new Error(error);
+}
 
 const createMailTransport = () => {
   const user = config.SMTP_USER;
@@ -233,8 +248,7 @@ export async function sendMagicLinkEmail({
   user: User;
   transport?: Transporter<SMTPTransport.SentMessageInfo>;
 }) {
-  // TODO: error out
-  if (!hasEmailSupport()) return;
+  assertEmailSupport();
 
   if (!transport) {
     if (!mailTransport) mailTransport = createMailTransport();

--- a/apps/server/src/orpc/routes/auth/login.ts
+++ b/apps/server/src/orpc/routes/auth/login.ts
@@ -98,7 +98,7 @@ export default procedure
 
       // Log unexpected errors with minimal context
       logError(error as Error, {
-        context: {
+        extra: {
           name: "auth/login",
         },
       });

--- a/apps/server/src/orpc/routes/auth/magic-link/create.test.ts
+++ b/apps/server/src/orpc/routes/auth/magic-link/create.test.ts
@@ -27,6 +27,28 @@ describe("POST /auth/magic-link", () => {
     expect(sendMagicLinkEmail).toHaveBeenCalledWith({ user });
   });
 
+  test("throws error when magic link email delivery fails", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ active: true });
+    vi.mocked(sendMagicLinkEmail).mockRejectedValueOnce(
+      new Error("SMTP credentials are not configured"),
+    );
+
+    const error = await waitError(
+      routerClient.auth.magicLink.create(
+        {
+          email: user.email,
+        },
+        { context: { ip: "127.0.0.1" } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(
+      `[Error: Unable to send magic link email.]`,
+    );
+  });
+
   test("throws error when user is not found", async ({ fixtures }) => {
     const error = await waitError(
       routerClient.auth.magicLink.create(

--- a/apps/server/src/orpc/routes/auth/magic-link/create.ts
+++ b/apps/server/src/orpc/routes/auth/magic-link/create.ts
@@ -48,7 +48,7 @@ export default procedure
       await sendMagicLinkEmail({ user });
     } catch (error) {
       logError(error, {
-        context: {
+        extra: {
           name: "auth/magic-link/create",
           userId: user.id,
         },

--- a/apps/server/src/orpc/routes/auth/magic-link/create.ts
+++ b/apps/server/src/orpc/routes/auth/magic-link/create.ts
@@ -1,6 +1,7 @@
 import { db } from "@peated/server/db";
 import { users } from "@peated/server/db/schema";
 import { sendMagicLinkEmail } from "@peated/server/lib/email";
+import { logError } from "@peated/server/lib/log";
 import { procedure } from "@peated/server/orpc";
 import { authRateLimit } from "@peated/server/orpc/middleware";
 import { eq, sql } from "drizzle-orm";
@@ -43,7 +44,19 @@ export default procedure
       });
     }
 
-    await sendMagicLinkEmail({ user });
+    try {
+      await sendMagicLinkEmail({ user });
+    } catch (error) {
+      logError(error, {
+        context: {
+          name: "auth/magic-link/create",
+          userId: user.id,
+        },
+      });
+      throw errors.INTERNAL_SERVER_ERROR({
+        message: "Unable to send magic link email.",
+      });
+    }
 
     return {};
   });

--- a/apps/server/src/orpc/routes/auth/recovery/challenge.ts
+++ b/apps/server/src/orpc/routes/auth/recovery/challenge.ts
@@ -117,7 +117,7 @@ export default procedure
       }
 
       logError(error as Error, {
-        context: {
+        extra: {
           name: "auth/recovery/challenge",
         },
       });

--- a/apps/server/src/orpc/routes/auth/recovery/confirm-passkey.ts
+++ b/apps/server/src/orpc/routes/auth/recovery/confirm-passkey.ts
@@ -182,7 +182,7 @@ export default procedure
       }
 
       logError(error as Error, {
-        context: {
+        extra: {
           name: "auth/recovery/confirm-passkey",
         },
       });

--- a/apps/server/src/orpc/routes/auth/recovery/create.ts
+++ b/apps/server/src/orpc/routes/auth/recovery/create.ts
@@ -54,7 +54,7 @@ export default procedure
       }
 
       logError(error as Error, {
-        context: {
+        extra: {
           name: "auth/recovery/create",
           email: input.email,
         },


### PR DESCRIPTION
Magic link login now treats SendGrid credential gaps as a required email delivery failure instead of silently no-oping or surfacing an opaque client-side internal error.

Capture delivery failures with route and user context, and return a controlled form error while preserving best-effort behavior for unrelated email paths.

Fixes PEATED-49A