### PR TITLE
feat(web): Move profile details under activity

### DIFF
--- a/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
@@ -3,8 +3,12 @@ import { use } from "react";
 
 import EmptyActivity from "@peated/web/components/emptyActivity";
 import TastingList from "@peated/web/components/tastingList";
+import UserFlavorDistributionChart from "@peated/web/components/userFlavorDistributionChart";
+import UserLocationChart from "@peated/web/components/userLocationChart";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { useProfileUserId } from "../profileContext";
+import { UserBadgeList } from "../userBadgeList";
 
 export const fetchCache = "default-no-store";
 
@@ -14,6 +18,7 @@ export default function UserProfilePage(props: {
   const params = use(props.params);
 
   const { username } = params;
+  const userId = useProfileUserId();
 
   const orpc = useORPC();
   const { data: tastings } = useSuspenseQuery(
@@ -22,9 +27,21 @@ export default function UserProfilePage(props: {
     }),
   );
 
-  if (!tastings.results.length) {
-    return <EmptyActivity />;
-  }
+  return (
+    <div>
+      {tastings.results.length ? (
+        <TastingList values={tastings.results} />
+      ) : (
+        <EmptyActivity />
+      )}
 
-  return <TastingList values={tastings.results} />;
+      <div className="mt-8 space-y-6 px-3 lg:px-0">
+        <UserBadgeList userId={userId} />
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <UserLocationChart userId={userId} />
+          <UserFlavorDistributionChart userId={userId} />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/app/(default)/users/[username]/layout.tsx
+++ b/apps/web/src/app/(default)/users/[username]/layout.tsx
@@ -4,8 +4,6 @@ import EmptyActivity from "@peated/web/components/emptyActivity";
 import Link from "@peated/web/components/link";
 import Tabs, { TabItem } from "@peated/web/components/tabs";
 import UserAvatar from "@peated/web/components/userAvatar";
-import UserFlavorDistributionChart from "@peated/web/components/userFlavorDistributionChart";
-import UserLocationChart from "@peated/web/components/userLocationChart";
 import { getCurrentUser } from "@peated/web/lib/auth.server";
 import { createServerClient } from "@peated/web/lib/orpc/client.server";
 import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
@@ -14,7 +12,7 @@ import type { ProfilePage, WithContext } from "schema-dts";
 import FriendButton from "./friendButton";
 import LogoutButton from "./logoutButton";
 import ModActions from "./modActions";
-import { UserBadgeList } from "./userBadgeList";
+import { ProfileProvider } from "./profileContext";
 
 export const fetchCache = "default-no-store";
 
@@ -154,14 +152,7 @@ export default async function Layout(props: {
       {isPrivate ? (
         <EmptyActivity>This users profile is private.</EmptyActivity>
       ) : (
-        <>
-          <div className="mb-4 px-3 lg:mb-8 lg:px-0">
-            <UserBadgeList userId={user.id} />
-          </div>
-          <div className="grid-cols mb-4 hidden grid-cols-1 gap-4 px-3 lg:grid lg:grid-cols-2 lg:px-0">
-            <UserLocationChart userId={user.id} />
-            <UserFlavorDistributionChart userId={user.id} />
-          </div>
+        <ProfileProvider userId={user.id}>
           <div className="hidden lg:block">
             <Tabs fullWidth border>
               <TabItem as={Link} href={`/users/${user.username}`} controlled>
@@ -186,7 +177,7 @@ export default async function Layout(props: {
             </Tabs>
           </div>
           {children}
-        </>
+        </ProfileProvider>
       )}
     </>
   );

--- a/apps/web/src/app/(default)/users/[username]/profileContext.tsx
+++ b/apps/web/src/app/(default)/users/[username]/profileContext.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { createContext, useContext, type ReactNode } from "react";
+
+const ProfileUserIdContext = createContext<number | null>(null);
+
+/** Provides the current profile id to nested profile tab routes. */
+export function ProfileProvider({
+  userId,
+  children,
+}: {
+  userId: number;
+  children: ReactNode;
+}) {
+  return (
+    <ProfileUserIdContext.Provider value={userId}>
+      {children}
+    </ProfileUserIdContext.Provider>
+  );
+}
+
+/** Returns the profile id loaded by the parent profile layout. */
+export function useProfileUserId() {
+  const userId = useContext(ProfileUserIdContext);
+  if (!userId) {
+    throw new Error("useProfileUserId must be used within ProfileProvider");
+  }
+  return userId;
+}

--- a/apps/web/src/app/(default)/users/[username]/userBadgeList.tsx
+++ b/apps/web/src/app/(default)/users/[username]/userBadgeList.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import BadgeImage from "@peated/web/components/badgeImage";
+import { DistributionChartLegend } from "@peated/web/components/distributionChart";
 import Link from "@peated/web/components/link";
 import classNames from "@peated/web/lib/classNames";
 import { useORPC } from "@peated/web/lib/orpc/context";
@@ -16,10 +17,11 @@ export function UserBadgeList({ userId }: { userId: number }) {
     }),
   );
 
-  if (!awardList.results) return null;
+  if (!awardList.results.length) return null;
 
   return (
-    <div className="flex justify-center lg:justify-start">
+    <div>
+      <DistributionChartLegend>Achievements</DistributionChartLegend>
       <ul className="scrollbar-none flex gap-2 overflow-x-scroll lg:flex-wrap lg:overflow-x-auto">
         {awardList.results.map((award) => {
           return (


### PR DESCRIPTION
Profile activity now owns the secondary profile details that were previously rendered above the tabs. Achievements, Top Regions, and Top Flavors appear below the Activity feed, while Favorites and Library start directly with their own content.

A route-local profile context passes only the loaded profile id into tab routes so the moved sections can reuse the parent profile lookup without exposing the full user object to every child route.