### PR TITLE
feat(profile): Add activity feed

### DIFF
--- a/apps/server/src/orpc/routes/users/activity/index.ts
+++ b/apps/server/src/orpc/routes/users/activity/index.ts
@@ -1,0 +1,6 @@
+import { base } from "@peated/server/orpc";
+import list from "./list";
+
+export default base.tag("users").router({
+  list,
+});

--- a/apps/server/src/orpc/routes/users/activity/list.test.ts
+++ b/apps/server/src/orpc/routes/users/activity/list.test.ts
@@ -1,0 +1,434 @@
+import { db } from "@peated/server/db";
+import { collectionBottles } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+describe("GET /users/:user/activity", () => {
+  test("returns tastings as primary activity", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const tasting = await fixtures.Tasting({
+      createdById: defaults.user.id,
+      createdAt: new Date("2026-01-03T12:00:00Z"),
+    });
+
+    const result = await routerClient.users.activity.list({
+      user: defaults.user.username,
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      id: `tasting:${tasting.id}`,
+      type: "tasting",
+      priority: "primary",
+      createdAt: "2026-01-03T12:00:00.000Z",
+      tasting: {
+        id: tasting.id,
+      },
+    });
+  });
+
+  test("fills pages with tastings when no secondary activity exists", async ({
+    defaults,
+    fixtures,
+  }) => {
+    for (let i = 0; i < 12; i++) {
+      await fixtures.Tasting({
+        createdById: defaults.user.id,
+        createdAt: new Date(`2026-01-03T${String(i).padStart(2, "0")}:00:00Z`),
+      });
+    }
+
+    const firstPage = await routerClient.users.activity.list({
+      user: defaults.user.username,
+      limit: 10,
+    });
+    const secondPage = await routerClient.users.activity.list({
+      user: defaults.user.username,
+      cursor: firstPage.rel.nextCursor ?? 2,
+      limit: 10,
+    });
+
+    expect(firstPage.results).toHaveLength(10);
+    expect(firstPage.results.every((entry) => entry.type === "tasting")).toBe(
+      true,
+    );
+    expect(firstPage.rel.nextCursor).toBe(2);
+    expect(secondPage.results).toHaveLength(2);
+    expect(secondPage.rel.nextCursor).toBeNull();
+  });
+
+  test("groups additions to the same collection", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const collection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+    const bottles = await Promise.all([
+      fixtures.Bottle(),
+      fixtures.Bottle(),
+      fixtures.Bottle(),
+      fixtures.Bottle(),
+      fixtures.Bottle(),
+      fixtures.Bottle(),
+    ]);
+
+    await db.insert(collectionBottles).values(
+      bottles.map((bottle, index) => ({
+        collectionId: collection.id,
+        bottleId: bottle.id,
+        createdAt: new Date(`2026-01-03T1${index}:00:00Z`),
+      })),
+    );
+
+    const result = await routerClient.users.activity.list({
+      user: defaults.user.username,
+    });
+
+    expect(result.results).toHaveLength(1);
+    const [entry] = result.results;
+    expect(entry).toMatchObject({
+      type: "collection_add",
+      priority: "secondary",
+      createdAt: "2026-01-03T15:00:00.000Z",
+      windowStart: "2026-01-03T10:00:00.000Z",
+      windowEnd: "2026-01-03T15:00:00.000Z",
+      collection: {
+        id: collection.id,
+        name: "Library",
+        href: `/users/${defaults.user.username}/library`,
+      },
+      totalItems: 6,
+    });
+    expect(entry.type === "collection_add" ? entry.items : []).toHaveLength(4);
+  });
+
+  test("keeps collection additions in separate time windows", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const collection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+    const [firstBottle, secondBottle] = await Promise.all([
+      fixtures.Bottle(),
+      fixtures.Bottle(),
+    ]);
+
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: collection.id,
+        bottleId: firstBottle.id,
+        createdAt: new Date("2026-01-03T12:00:00Z"),
+      },
+      {
+        collectionId: collection.id,
+        bottleId: secondBottle.id,
+        createdAt: new Date("2026-01-04T12:00:00Z"),
+      },
+    ]);
+
+    const result = await routerClient.users.activity.list({
+      user: defaults.user.username,
+    });
+
+    const collectionEntries = result.results.filter(
+      (entry) => entry.type === "collection_add",
+    );
+    expect(collectionEntries).toHaveLength(2);
+    expect(
+      collectionEntries.map((entry) => ({
+        createdAt: entry.createdAt,
+        totalItems: entry.totalItems,
+        windowStart: entry.windowStart,
+        windowEnd: entry.windowEnd,
+      })),
+    ).toEqual([
+      {
+        createdAt: "2026-01-04T12:00:00.000Z",
+        totalItems: 1,
+        windowStart: "2026-01-04T12:00:00.000Z",
+        windowEnd: "2026-01-04T12:00:00.000Z",
+      },
+      {
+        createdAt: "2026-01-03T12:00:00.000Z",
+        totalItems: 1,
+        windowStart: "2026-01-03T12:00:00.000Z",
+        windowEnd: "2026-01-03T12:00:00.000Z",
+      },
+    ]);
+  });
+
+  test("keeps additions to different collections separate", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const [library, favorites] = await Promise.all([
+      fixtures.Collection({
+        name: "Library",
+        createdById: defaults.user.id,
+      }),
+      fixtures.Collection({
+        name: "Default",
+        createdById: defaults.user.id,
+      }),
+    ]);
+    const [libraryBottle, favoriteBottle] = await Promise.all([
+      fixtures.Bottle(),
+      fixtures.Bottle(),
+    ]);
+
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: library.id,
+        bottleId: libraryBottle.id,
+        createdAt: new Date("2026-01-03T12:00:00Z"),
+      },
+      {
+        collectionId: favorites.id,
+        bottleId: favoriteBottle.id,
+        createdAt: new Date("2026-01-03T12:00:00Z"),
+      },
+    ]);
+
+    const result = await routerClient.users.activity.list({
+      user: defaults.user.username,
+    });
+
+    const collectionEntries = result.results.filter(
+      (entry) => entry.type === "collection_add",
+    );
+    expect(collectionEntries).toHaveLength(2);
+    expect(
+      collectionEntries.map((entry) => entry.collection.name).sort(),
+    ).toEqual(["Default", "Library"]);
+  });
+
+  test("links legacy default collection activity to favorites", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const collection = await fixtures.Collection({
+      name: "Personal Favorites",
+      createdById: defaults.user.id,
+    });
+    const bottle = await fixtures.Bottle();
+
+    await db.insert(collectionBottles).values({
+      collectionId: collection.id,
+      bottleId: bottle.id,
+      createdAt: new Date("2026-01-03T12:00:00Z"),
+    });
+
+    const result = await routerClient.users.activity.list({
+      user: defaults.user.username,
+    });
+
+    expect(result.results[0]).toMatchObject({
+      type: "collection_add",
+      collection: {
+        id: collection.id,
+        name: "Personal Favorites",
+        href: `/users/${defaults.user.username}/favorites`,
+      },
+    });
+  });
+
+  test("does not count duplicate collection add attempts", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+
+    await routerClient.collections.bottles.create(
+      {
+        user: "me",
+        collection: "library",
+        bottle: bottle.id,
+      },
+      { context: { user: defaults.user } },
+    );
+    await routerClient.collections.bottles.create(
+      {
+        user: "me",
+        collection: "library",
+        bottle: bottle.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    const result = await routerClient.users.activity.list({
+      user: defaults.user.username,
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      type: "collection_add",
+      totalItems: 1,
+    });
+  });
+
+  test("caps secondary entries when primary activity exists", async ({
+    defaults,
+    fixtures,
+  }) => {
+    for (let i = 0; i < 3; i++) {
+      await fixtures.Tasting({
+        createdById: defaults.user.id,
+        createdAt: new Date(`2026-01-03T1${i}:30:00Z`),
+      });
+    }
+
+    for (let i = 0; i < 4; i++) {
+      const collection = await fixtures.Collection({
+        name: `Shelf ${i}`,
+        createdById: defaults.user.id,
+      });
+      const bottle = await fixtures.Bottle();
+      await db.insert(collectionBottles).values({
+        collectionId: collection.id,
+        bottleId: bottle.id,
+        createdAt: new Date(`2026-01-03T1${i}:00:00Z`),
+      });
+    }
+
+    const result = await routerClient.users.activity.list({
+      user: defaults.user.username,
+      limit: 10,
+    });
+
+    expect(
+      result.results.filter((entry) => entry.type === "tasting"),
+    ).toHaveLength(3);
+    expect(
+      result.results.filter((entry) => entry.type === "collection_add"),
+    ).toHaveLength(2);
+  });
+
+  test("paginates remaining secondary entries when primary activity exists", async ({
+    defaults,
+    fixtures,
+  }) => {
+    await fixtures.Tasting({
+      createdById: defaults.user.id,
+      createdAt: new Date("2026-01-03T12:30:00Z"),
+    });
+
+    for (let i = 0; i < 4; i++) {
+      const collection = await fixtures.Collection({
+        name: `Shelf ${i}`,
+        createdById: defaults.user.id,
+      });
+      const bottle = await fixtures.Bottle();
+      await db.insert(collectionBottles).values({
+        collectionId: collection.id,
+        bottleId: bottle.id,
+        createdAt: new Date(`2026-01-03T1${i}:00:00Z`),
+      });
+    }
+
+    const firstPage = await routerClient.users.activity.list({
+      user: defaults.user.username,
+      limit: 3,
+    });
+    const secondPage = await routerClient.users.activity.list({
+      user: defaults.user.username,
+      cursor: firstPage.rel.nextCursor ?? 2,
+      limit: 3,
+    });
+
+    expect(
+      firstPage.results.filter((entry) => entry.type === "tasting"),
+    ).toHaveLength(1);
+    expect(
+      firstPage.results.filter((entry) => entry.type === "collection_add"),
+    ).toHaveLength(2);
+    expect(firstPage.rel.nextCursor).toBe(2);
+    expect(secondPage.results).toHaveLength(2);
+    expect(
+      secondPage.results.every((entry) => entry.type === "collection_add"),
+    ).toBe(true);
+    expect(secondPage.rel.nextCursor).toBeNull();
+  });
+
+  test("paginates mixed activity with limit one", async ({
+    defaults,
+    fixtures,
+  }) => {
+    await fixtures.Tasting({
+      createdById: defaults.user.id,
+      createdAt: new Date("2026-01-03T12:30:00Z"),
+    });
+    const collection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+    const bottle = await fixtures.Bottle();
+    await db.insert(collectionBottles).values({
+      collectionId: collection.id,
+      bottleId: bottle.id,
+      createdAt: new Date("2026-01-03T12:00:00Z"),
+    });
+
+    const firstPage = await routerClient.users.activity.list({
+      user: defaults.user.username,
+      limit: 1,
+    });
+    const secondPage = await routerClient.users.activity.list({
+      user: defaults.user.username,
+      cursor: firstPage.rel.nextCursor ?? 2,
+      limit: 1,
+    });
+
+    expect(firstPage.results).toHaveLength(1);
+    expect(firstPage.results[0].type).toBe("tasting");
+    expect(firstPage.rel.nextCursor).toBe(2);
+    expect(secondPage.results).toHaveLength(1);
+    expect(secondPage.results[0].type).toBe("collection_add");
+    expect(secondPage.rel.nextCursor).toBeNull();
+  });
+
+  test("shows grouped collection activity when no tastings exist", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const collection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+    const bottle = await fixtures.Bottle();
+    await db.insert(collectionBottles).values({
+      collectionId: collection.id,
+      bottleId: bottle.id,
+      createdAt: new Date("2026-01-03T12:00:00Z"),
+    });
+
+    const result = await routerClient.users.activity.list({
+      user: defaults.user.username,
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      type: "collection_add",
+      priority: "secondary",
+    });
+  });
+
+  test("preserves private profile visibility", async ({ fixtures }) => {
+    const privateUser = await fixtures.User({ private: true });
+    await fixtures.Tasting({ createdById: privateUser.id });
+
+    const err = await waitError(() =>
+      routerClient.users.activity.list({
+        user: privateUser.username,
+      }),
+    );
+
+    expect(err).toMatchInlineSnapshot(`[Error: User's profile is private.]`);
+  });
+});

--- a/apps/server/src/orpc/routes/users/activity/list.ts
+++ b/apps/server/src/orpc/routes/users/activity/list.ts
@@ -1,0 +1,462 @@
+import { db } from "@peated/server/db";
+import type {
+  Bottle,
+  BottleRelease,
+  Collection,
+  CollectionBottle,
+  Tasting,
+  User,
+} from "@peated/server/db/schema";
+import {
+  bottleReleases,
+  bottles,
+  collectionBottles,
+  collections,
+  tastings,
+} from "@peated/server/db/schema";
+import { getUserFromId, profileVisible } from "@peated/server/lib/api";
+import { getReservedCollection } from "@peated/server/lib/db";
+import { procedure } from "@peated/server/orpc";
+import {
+  ProfileActivityEntrySchema,
+  listResponse,
+} from "@peated/server/schemas";
+import { serialize } from "@peated/server/serializers";
+import { CollectionSerializer } from "@peated/server/serializers/collection";
+import { CollectionBottleSerializer } from "@peated/server/serializers/collectionBottle";
+import { TastingSerializer } from "@peated/server/serializers/tasting";
+import { UserSerializer } from "@peated/server/serializers/user";
+import type { ProfileActivityEntry } from "@peated/server/types";
+import { and, desc, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+
+// Profile activity is assembled at read time from authoritative tasting and
+// collection tables. Tastings are primary activity; collection additions are
+// grouped secondary activity and capped so they do not dominate the feed.
+const COLLECTION_PREVIEW_LIMIT = 4;
+const SECONDARY_ENTRY_LIMIT_WITH_PRIMARY = 2;
+
+type CollectionBottleWithTarget = CollectionBottle & {
+  bottle: Bottle;
+  release: BottleRelease | null;
+};
+
+type CollectionAddSourceRow = {
+  collectionBottle: CollectionBottle;
+  bottle: Bottle;
+  release: BottleRelease | null;
+};
+
+type CollectionAddGroup = {
+  collection: Collection;
+  bucket: Date | string;
+  windowStart: Date;
+  windowEnd: Date;
+  totalItems: number;
+};
+
+type CollectionAddGroupRow = {
+  collection: Collection;
+  bucket: Date | string;
+  windowStart: Date | string;
+  windowEnd: Date | string;
+  totalItems: string;
+};
+
+type ActivitySourceWindow = {
+  primaryOffset: number;
+  primaryLimit: number;
+  secondaryOffset: number;
+  secondaryLimit: number;
+};
+
+function coerceDate(value: Date | string) {
+  return value instanceof Date ? value : new Date(`${value}+0000`);
+}
+
+/**
+ * Returns per-source offsets for a logical feed page while keeping secondary
+ * collection groups capped whenever primary tasting activity exists.
+ */
+function getActivitySourceWindow({
+  cursor,
+  limit,
+  totalPrimary,
+  totalSecondary,
+}: {
+  cursor: number;
+  limit: number;
+  totalPrimary: number;
+  totalSecondary: number;
+}): ActivitySourceWindow {
+  const pageIndex = cursor - 1;
+
+  if (limit === 1) {
+    if (pageIndex < totalPrimary) {
+      return {
+        primaryOffset: pageIndex,
+        primaryLimit: 1,
+        secondaryOffset: 0,
+        secondaryLimit: 0,
+      };
+    }
+
+    return {
+      primaryOffset: totalPrimary,
+      primaryLimit: 0,
+      secondaryOffset: pageIndex - totalPrimary,
+      secondaryLimit: 1,
+    };
+  }
+
+  if (!totalPrimary) {
+    return {
+      primaryOffset: 0,
+      primaryLimit: 0,
+      secondaryOffset: pageIndex * limit,
+      secondaryLimit: limit,
+    };
+  }
+
+  const secondaryPerPage = Math.min(
+    SECONDARY_ENTRY_LIMIT_WITH_PRIMARY,
+    limit - 1,
+  );
+  const primaryPerPageWithSecondary = limit - secondaryPerPage;
+  const pagesWithSecondary = Math.ceil(totalSecondary / secondaryPerPage);
+  const priorPagesWithSecondary = Math.min(pageIndex, pagesWithSecondary);
+  const priorPagesWithoutSecondary = pageIndex - priorPagesWithSecondary;
+  const pageSecondaryOffset =
+    pageIndex < pagesWithSecondary
+      ? pageIndex * secondaryPerPage
+      : totalSecondary;
+  const pageSecondaryLimit =
+    pageIndex < pagesWithSecondary
+      ? Math.min(secondaryPerPage, totalSecondary - pageSecondaryOffset)
+      : 0;
+  const primaryCapacity = limit - pageSecondaryLimit;
+
+  return {
+    primaryOffset:
+      priorPagesWithSecondary * primaryPerPageWithSecondary +
+      priorPagesWithoutSecondary * limit,
+    primaryLimit: primaryCapacity,
+    secondaryOffset: pageSecondaryOffset,
+    secondaryLimit: pageSecondaryLimit,
+  };
+}
+
+async function getCollectionHref(collection: Collection, user: User) {
+  const [favoritesCollection, libraryCollection] = await Promise.all([
+    getReservedCollection(db, user.id, "default"),
+    getReservedCollection(db, user.id, "library"),
+  ]);
+
+  if (favoritesCollection?.id === collection.id) {
+    return `/users/${user.username}/favorites`;
+  }
+  if (libraryCollection?.id === collection.id) {
+    return `/users/${user.username}/library`;
+  }
+  return null;
+}
+
+function composeProfileActivity({
+  primary,
+  secondary,
+  limit,
+  sourceWindow,
+  totalPrimary,
+  totalSecondary,
+}: {
+  primary: ProfileActivityEntry[];
+  secondary: ProfileActivityEntry[];
+  limit: number;
+  sourceWindow: ActivitySourceWindow;
+  totalPrimary: number;
+  totalSecondary: number;
+}): { results: ProfileActivityEntry[]; hasNext: boolean } {
+  if (limit === 1) {
+    const result = primary.length ? [primary[0]] : secondary.slice(0, 1);
+    return {
+      results: result,
+      hasNext:
+        sourceWindow.primaryOffset + primary.length < totalPrimary ||
+        sourceWindow.secondaryOffset + secondary.length < totalSecondary,
+    };
+  }
+
+  const pageSecondary = secondary.slice(0, sourceWindow.secondaryLimit);
+  const primaryCapacity = limit - pageSecondary.length;
+  const pagePrimary = primary.slice(0, primaryCapacity);
+
+  const result: ProfileActivityEntry[] = [];
+  let secondaryIndex = 0;
+
+  for (const primaryEntry of pagePrimary) {
+    result.push(primaryEntry);
+    if (secondaryIndex < pageSecondary.length) {
+      result.push(pageSecondary[secondaryIndex]);
+      secondaryIndex += 1;
+    }
+  }
+
+  while (result.length < limit && secondaryIndex < pageSecondary.length) {
+    result.push(pageSecondary[secondaryIndex]);
+    secondaryIndex += 1;
+  }
+
+  return {
+    results: result,
+    hasNext:
+      sourceWindow.primaryOffset + pagePrimary.length < totalPrimary ||
+      sourceWindow.secondaryOffset + pageSecondary.length < totalSecondary,
+  };
+}
+
+async function serializeTastingEntries(
+  tastingRows: Tasting[],
+  currentUser?: User | null,
+) {
+  const serializedTastings = await serialize(
+    TastingSerializer,
+    tastingRows,
+    currentUser,
+  );
+  return tastingRows.map((tasting, index): ProfileActivityEntry => {
+    return {
+      id: `tasting:${tasting.id}`,
+      type: "tasting",
+      priority: "primary",
+      createdAt: tasting.createdAt.toISOString(),
+      tasting: serializedTastings[index],
+    };
+  });
+}
+
+async function serializeCollectionForActivity({
+  collection,
+  user,
+  currentUser,
+}: {
+  collection: Collection;
+  user: User;
+  currentUser?: User | null;
+}) {
+  return {
+    ...(await serialize(CollectionSerializer, collection, currentUser)),
+    href: await getCollectionHref(collection, user),
+  };
+}
+
+async function serializeCollectionBottlePreview(
+  rows: CollectionAddSourceRow[],
+  currentUser?: User | null,
+) {
+  return await serialize(
+    CollectionBottleSerializer,
+    rows.map(
+      ({ collectionBottle, bottle, release }): CollectionBottleWithTarget => ({
+        ...collectionBottle,
+        bottle,
+        release,
+      }),
+    ),
+    currentUser,
+  );
+}
+
+async function serializeCollectionAddEntries({
+  groups,
+  user,
+  currentUser,
+}: {
+  groups: CollectionAddGroup[];
+  user: User;
+  currentUser?: User | null;
+}) {
+  const createdBy = await serialize(UserSerializer, user, currentUser);
+  const serializedCollectionsById = new Map<
+    number,
+    Awaited<ReturnType<typeof serializeCollectionForActivity>>
+  >();
+
+  const entries: ProfileActivityEntry[] = [];
+  for (const group of groups) {
+    let collection = serializedCollectionsById.get(group.collection.id);
+    if (!collection) {
+      collection = await serializeCollectionForActivity({
+        collection: group.collection,
+        user,
+        currentUser,
+      });
+      serializedCollectionsById.set(group.collection.id, collection);
+    }
+
+    const previewRows = await db
+      .select({
+        collectionBottle: collectionBottles,
+        bottle: bottles,
+        release: bottleReleases,
+      })
+      .from(collectionBottles)
+      .innerJoin(bottles, eq(bottles.id, collectionBottles.bottleId))
+      .leftJoin(
+        bottleReleases,
+        eq(bottleReleases.id, collectionBottles.releaseId),
+      )
+      .where(
+        and(
+          eq(collectionBottles.collectionId, group.collection.id),
+          sql`DATE_TRUNC('day', ${collectionBottles.createdAt}) = ${group.bucket}::timestamp`,
+        ),
+      )
+      .orderBy(desc(collectionBottles.createdAt))
+      .limit(COLLECTION_PREVIEW_LIMIT);
+
+    entries.push({
+      id: `collection_add:${group.collection.id}:${group.windowEnd.getTime()}`,
+      type: "collection_add",
+      priority: "secondary",
+      createdAt: group.windowEnd.toISOString(),
+      windowStart: group.windowStart.toISOString(),
+      windowEnd: group.windowEnd.toISOString(),
+      createdBy,
+      collection,
+      items: await serializeCollectionBottlePreview(previewRows, currentUser),
+      totalItems: group.totalItems,
+    });
+  }
+
+  return entries;
+}
+
+export default procedure
+  .route({
+    method: "GET",
+    path: "/users/{user}/activity",
+    summary: "List profile activity",
+    description:
+      "Retrieve a user's profile activity feed with tastings and grouped collection additions",
+    operationId: "listUserActivity",
+  })
+  .input(
+    z.object({
+      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
+      cursor: z.coerce.number().gte(1).default(1),
+      limit: z.coerce.number().gte(1).lte(100).default(10),
+    }),
+  )
+  .output(listResponse(ProfileActivityEntrySchema))
+  .handler(async function ({ input, context, errors }) {
+    const user = await getUserFromId(db, input.user, context.user);
+    if (!user) {
+      if (input.user === "me") {
+        throw errors.UNAUTHORIZED();
+      }
+      throw errors.NOT_FOUND({
+        message: "User not found.",
+      });
+    }
+
+    if (!(await profileVisible(db, user, context.user))) {
+      throw errors.BAD_REQUEST({
+        message: "User's profile is private.",
+      });
+    }
+
+    const collectionBucket = sql<Date>`DATE_TRUNC('day', ${collectionBottles.createdAt})`;
+    const collectionGroupCreatedAt = sql<Date>`MAX(${collectionBottles.createdAt})`;
+    const [primaryCountRows, secondaryCountResult] = await Promise.all([
+      db
+        .select({
+          count: sql<string>`COUNT(${tastings.id})`,
+        })
+        .from(tastings)
+        .where(eq(tastings.createdById, user.id)),
+      db.execute<{ count: string }>(sql`
+        SELECT COUNT(*) as count
+        FROM (
+          SELECT 1
+          FROM ${collectionBottles}
+          INNER JOIN ${collections}
+            ON ${collections.id} = ${collectionBottles.collectionId}
+            AND ${collections.createdById} = ${user.id}
+          GROUP BY ${collections.id}, DATE_TRUNC('day', ${collectionBottles.createdAt})
+        ) activity_groups
+      `),
+    ]);
+    const totalPrimary = Number(primaryCountRows[0]?.count ?? 0);
+    const totalSecondary = Number(secondaryCountResult.rows[0]?.count ?? 0);
+    const sourceWindow = getActivitySourceWindow({
+      cursor: input.cursor,
+      limit: input.limit,
+      totalPrimary,
+      totalSecondary,
+    });
+
+    const [tastingRows, collectionGroupRows] = await Promise.all([
+      db
+        .select()
+        .from(tastings)
+        .where(eq(tastings.createdById, user.id))
+        .orderBy(desc(tastings.createdAt))
+        .limit(sourceWindow.primaryLimit)
+        .offset(sourceWindow.primaryOffset),
+      db
+        .select({
+          collection: collections,
+          bucket: collectionBucket,
+          windowStart: sql<Date>`MIN(${collectionBottles.createdAt})`,
+          windowEnd: sql<Date>`MAX(${collectionBottles.createdAt})`,
+          totalItems: sql<string>`COUNT(${collectionBottles.id})`,
+        })
+        .from(collectionBottles)
+        .innerJoin(
+          collections,
+          and(
+            eq(collections.id, collectionBottles.collectionId),
+            eq(collections.createdById, user.id),
+          ),
+        )
+        .groupBy(collections.id, collectionBucket)
+        .orderBy(desc(collectionGroupCreatedAt))
+        .limit(sourceWindow.secondaryLimit)
+        .offset(sourceWindow.secondaryOffset),
+    ]);
+
+    const primaryEntries = await serializeTastingEntries(
+      tastingRows,
+      context.user,
+    );
+    const secondaryEntries = await serializeCollectionAddEntries({
+      groups: collectionGroupRows.map(
+        (row: CollectionAddGroupRow): CollectionAddGroup => ({
+          collection: row.collection,
+          bucket: row.bucket,
+          windowStart: coerceDate(row.windowStart),
+          windowEnd: coerceDate(row.windowEnd),
+          totalItems: Number(row.totalItems),
+        }),
+      ),
+      user,
+      currentUser: context.user,
+    });
+
+    const activity = composeProfileActivity({
+      primary: primaryEntries,
+      secondary: secondaryEntries,
+      limit: input.limit,
+      sourceWindow,
+      totalPrimary,
+      totalSecondary,
+    });
+
+    return {
+      results: activity.results,
+      rel: {
+        nextCursor: activity.hasNext ? input.cursor + 1 : null,
+        prevCursor: input.cursor > 1 ? input.cursor - 1 : null,
+      },
+    };
+  });

--- a/apps/server/src/orpc/routes/users/index.ts
+++ b/apps/server/src/orpc/routes/users/index.ts
@@ -1,4 +1,5 @@
 import { base } from "@peated/server/orpc";
+import activity from "./activity";
 import avatarUpdate from "./avatar-update";
 import badgeList from "./badge-list";
 import details from "./details";
@@ -9,6 +10,7 @@ import tagList from "./tag-list";
 import update from "./update";
 
 export default base.tag("users").router({
+  activity,
   details,
   list,
   update,

--- a/apps/server/src/schemas/index.ts
+++ b/apps/server/src/schemas/index.ts
@@ -19,6 +19,7 @@ export * from "./magicLink";
 export * from "./notifications";
 export * from "./pendingUploads";
 export * from "./priceMatches";
+export * from "./profileActivity";
 export * from "./regions";
 export * from "./reviews";
 export * from "./shared";

--- a/apps/server/src/schemas/profileActivity.ts
+++ b/apps/server/src/schemas/profileActivity.ts
@@ -1,0 +1,62 @@
+import { z } from "zod";
+import { CollectionBottleSchema, CollectionSchema } from "./collections";
+import { TastingSchema } from "./tastings";
+import { UserSchema } from "./users";
+
+export const ProfileTastingActivitySchema = z.object({
+  id: z.string().describe("Stable activity entry identifier"),
+  type: z.literal("tasting"),
+  priority: z.literal("primary"),
+  createdAt: z
+    .string()
+    .datetime()
+    .readonly()
+    .describe("Timestamp used to order this activity entry"),
+  tasting: TastingSchema.describe("Tasting represented by this activity entry"),
+});
+
+export const ProfileCollectionActivityCollectionSchema =
+  CollectionSchema.extend({
+    href: z
+      .string()
+      .nullable()
+      .describe("Profile collection route when the destination is linkable"),
+  });
+
+export const ProfileCollectionAddActivitySchema = z.object({
+  id: z.string().describe("Stable activity entry identifier"),
+  type: z.literal("collection_add"),
+  priority: z.literal("secondary"),
+  createdAt: z
+    .string()
+    .datetime()
+    .readonly()
+    .describe("Timestamp used to order this activity entry"),
+  windowStart: z
+    .string()
+    .datetime()
+    .readonly()
+    .describe("Earliest collection addition represented by this entry"),
+  windowEnd: z
+    .string()
+    .datetime()
+    .readonly()
+    .describe("Latest collection addition represented by this entry"),
+  createdBy: UserSchema.readonly().describe("User who added the items"),
+  collection: ProfileCollectionActivityCollectionSchema.describe(
+    "Destination collection for the grouped additions",
+  ),
+  items: z
+    .array(CollectionBottleSchema)
+    .describe("Preview collection items represented by this entry"),
+  totalItems: z
+    .number()
+    .int()
+    .gte(1)
+    .describe("Total collection items represented by this entry"),
+});
+
+export const ProfileActivityEntrySchema = z.discriminatedUnion("type", [
+  ProfileTastingActivitySchema,
+  ProfileCollectionAddActivitySchema,
+]);

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -33,6 +33,9 @@ import type {
   NotificationSchema,
   ObjectTypeEnum,
   PointSchema,
+  ProfileActivityEntrySchema,
+  ProfileCollectionAddActivitySchema,
+  ProfileTastingActivitySchema,
   RegionSchema,
   ReviewSchema,
   ServingStyleEnum,
@@ -61,6 +64,13 @@ export type ObjectType = z.infer<typeof ObjectTypeEnum>;
 export type FollowStatus = z.infer<typeof FollowStatusEnum>;
 export type FriendStatus = z.infer<typeof FriendStatusEnum>;
 export type Point = z.infer<typeof PointSchema>;
+export type ProfileActivityEntry = z.infer<typeof ProfileActivityEntrySchema>;
+export type ProfileCollectionAddActivity = z.infer<
+  typeof ProfileCollectionAddActivitySchema
+>;
+export type ProfileTastingActivity = z.infer<
+  typeof ProfileTastingActivitySchema
+>;
 
 export type Badge = z.infer<typeof BadgeSchema>;
 export type BadgeAward = z.infer<typeof BadgeAwardSchema>;

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
@@ -2,7 +2,7 @@
 import { use } from "react";
 
 import EmptyActivity from "@peated/web/components/emptyActivity";
-import TastingList from "@peated/web/components/tastingList";
+import ProfileActivityList from "@peated/web/components/profileActivityList";
 import UserFlavorDistributionChart from "@peated/web/components/userFlavorDistributionChart";
 import UserLocationChart from "@peated/web/components/userLocationChart";
 import { useORPC } from "@peated/web/lib/orpc/context";
@@ -21,26 +21,28 @@ export default function UserProfilePage(props: {
   const userId = useProfileUserId();
 
   const orpc = useORPC();
-  const { data: tastings } = useSuspenseQuery(
-    orpc.tastings.list.queryOptions({
+  const { data: activity } = useSuspenseQuery(
+    orpc.users.activity.list.queryOptions({
       input: { user: username, limit: 10 },
     }),
   );
 
   return (
     <div>
-      {tastings.results.length ? (
-        <TastingList values={tastings.results} />
-      ) : (
-        <EmptyActivity />
-      )}
-
-      <div className="mt-8 space-y-6 px-3 lg:px-0">
+      <div className="mt-1 space-y-6 px-3 lg:px-0">
         <UserBadgeList userId={userId} />
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <UserLocationChart userId={userId} />
           <UserFlavorDistributionChart userId={userId} />
         </div>
+      </div>
+
+      <div className="mt-8">
+        {activity.results.length ? (
+          <ProfileActivityList values={activity.results} />
+        ) : (
+          <EmptyActivity />
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/(default)/users/[username]/layout.tsx
+++ b/apps/web/src/app/(default)/users/[username]/layout.tsx
@@ -60,9 +60,8 @@ export default async function Layout(props: {
 
   const isPrivate =
     user.private &&
-    currentUser &&
-    user.id !== currentUser.id &&
-    user.friendStatus !== "friends";
+    (!currentUser ||
+      (user.id !== currentUser.id && user.friendStatus !== "friends"));
 
   const jsonLd: WithContext<ProfilePage> = {
     "@context": "https://schema.org",

--- a/apps/web/src/components/profileActivityList.tsx
+++ b/apps/web/src/components/profileActivityList.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import { formatCategoryName } from "@peated/server/lib/format";
+import type { Outputs } from "@peated/server/orpc/router";
+import Link from "@peated/web/components/link";
+import {
+  formatBottlingName,
+  getBottleBottlingPath,
+} from "@peated/web/lib/bottlings";
+import { AnimatePresence } from "framer-motion";
+import { useState } from "react";
+import TastingListItem from "./tastingListItem";
+import TimeSince from "./timeSince";
+import UserAvatar from "./userAvatar";
+
+type ProfileActivityListResult = Outputs["users"]["activity"]["list"];
+type ProfileActivityEntry = ProfileActivityListResult["results"][number];
+type ProfileCollectionAddActivity = Extract<
+  ProfileActivityEntry,
+  { type: "collection_add" }
+>;
+type ProfileCollectionAddItem = ProfileCollectionAddActivity["items"][number];
+
+function formatBottleCount(count: number) {
+  return `${count.toLocaleString()} bottle${count === 1 ? "" : "s"}`;
+}
+
+function getCollectionLabel(activity: ProfileCollectionAddActivity) {
+  if (activity.collection.href?.endsWith("/favorites")) {
+    return "Favorites";
+  }
+  return activity.collection.name;
+}
+
+function CollectionLink({
+  activity,
+}: {
+  activity: ProfileCollectionAddActivity;
+}) {
+  const label = getCollectionLabel(activity);
+
+  if (!activity.collection.href) {
+    return <span className="font-semibold text-white">{label}</span>;
+  }
+
+  return (
+    <Link
+      href={activity.collection.href}
+      className="font-semibold text-white hover:underline"
+    >
+      {label}
+    </Link>
+  );
+}
+
+function getCollectionItemHref(item: ProfileCollectionAddItem) {
+  if (item.release) {
+    return getBottleBottlingPath(item.bottle.id, item.release.id);
+  }
+  return `/bottles/${item.bottle.id}`;
+}
+
+function getCollectionItemTitle(item: ProfileCollectionAddItem) {
+  return item.release?.fullName ?? item.bottle.fullName;
+}
+
+function getCollectionItemDetail(item: ProfileCollectionAddItem) {
+  if (item.release) {
+    const bottlingName = formatBottlingName(item.release);
+    return bottlingName && bottlingName !== item.release.fullName
+      ? bottlingName
+      : item.bottle.fullName;
+  }
+
+  return item.bottle.category ? formatCategoryName(item.bottle.category) : null;
+}
+
+function CollectionItemImage({ item }: { item: ProfileCollectionAddItem }) {
+  const imageUrl =
+    item.imageUrl ??
+    item.release?.imageUrl ??
+    item.bottle.displayImageUrl ??
+    item.bottle.imageUrl;
+
+  if (!imageUrl) {
+    return null;
+  }
+
+  return (
+    <div className="h-10 w-10 shrink-0 overflow-hidden rounded border border-slate-800 bg-slate-900">
+      <img
+        src={imageUrl}
+        alt=""
+        className="h-full w-full object-cover"
+        aria-hidden="true"
+      />
+    </div>
+  );
+}
+
+function CollectionPreviewItem({ item }: { item: ProfileCollectionAddItem }) {
+  const detail = getCollectionItemDetail(item);
+
+  return (
+    <li className="flex min-w-0 items-center gap-x-3 px-3 py-2">
+      <CollectionItemImage item={item} />
+      <div className="min-w-0 flex-1">
+        <Link
+          href={getCollectionItemHref(item)}
+          className="block truncate text-sm font-semibold text-white hover:underline"
+          title={getCollectionItemTitle(item)}
+        >
+          {getCollectionItemTitle(item)}
+        </Link>
+        {detail ? (
+          <div className="text-muted truncate text-xs">{detail}</div>
+        ) : null}
+      </div>
+    </li>
+  );
+}
+
+function CollectionAddActivityItem({
+  activity,
+}: {
+  activity: ProfileCollectionAddActivity;
+}) {
+  const remainingCount = activity.totalItems - activity.items.length;
+
+  return (
+    <li className="-mt-1 overflow-hidden border border-slate-800 bg-slate-950/80">
+      <div className="flex items-start gap-x-3 px-3 py-3 lg:px-5">
+        <UserAvatar size={32} user={activity.createdBy} />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 flex-col gap-y-1 sm:flex-row sm:items-start sm:justify-between sm:gap-x-4">
+            <div className="min-w-0 break-words text-sm leading-6">
+              <Link
+                href={`/users/${activity.createdBy.username}`}
+                className="font-semibold text-white hover:underline"
+              >
+                {activity.createdBy.username}
+              </Link>{" "}
+              <span className="text-muted">
+                added {formatBottleCount(activity.totalItems)} to{" "}
+              </span>
+              <CollectionLink activity={activity} />
+            </div>
+            <TimeSince
+              className="font-muted shrink-0 text-xs sm:text-sm"
+              date={activity.createdAt}
+            />
+          </div>
+
+          {activity.items.length > 0 ? (
+            <ul className="mt-3 divide-y divide-slate-800 overflow-hidden rounded border border-slate-800/80 bg-slate-950">
+              {activity.items.map((item) => (
+                <CollectionPreviewItem key={item.id} item={item} />
+              ))}
+              {remainingCount > 0 ? (
+                <li className="text-muted px-3 py-2 text-xs font-semibold">
+                  +{remainingCount.toLocaleString()} more
+                </li>
+              ) : null}
+            </ul>
+          ) : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export default function ProfileActivityList({
+  values,
+}: {
+  values: ProfileActivityListResult["results"];
+}) {
+  const [deletedTastingIds, setDeletedTastingIds] = useState<number[]>([]);
+
+  return (
+    <ul className="mt-1">
+      <AnimatePresence>
+        {values.map((activity) => {
+          switch (activity.type) {
+            case "tasting":
+              if (deletedTastingIds.includes(activity.tasting.id)) {
+                return null;
+              }
+              return (
+                <TastingListItem
+                  key={activity.id}
+                  tasting={activity.tasting}
+                  onDelete={(tasting) => {
+                    setDeletedTastingIds((ids) => [...ids, tasting.id]);
+                  }}
+                />
+              );
+            case "collection_add":
+              return (
+                <CollectionAddActivityItem
+                  key={activity.id}
+                  activity={activity}
+                />
+              );
+          }
+        })}
+      </AnimatePresence>
+    </ul>
+  );
+}

--- a/openspec/changes/add-profile-activity-feed/.openspec.yaml
+++ b/openspec/changes/add-profile-activity-feed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/add-profile-activity-feed/design.md
+++ b/openspec/changes/add-profile-activity-feed/design.md
@@ -1,0 +1,85 @@
+## Context
+
+Profile Activity currently renders the first page of `tastings.list({ user })`, so activity is effectively tasting-only. Collection additions already write `collection_bottle` rows with `created_at` timestamps, but the existing collection bottle list route orders by bottle name for collection browsing and is not suitable as an activity source.
+
+The new profile feed needs a union activity model: tastings remain primary entries, while collection additions become low-priority secondary entries. The feed should make Library/Favorites additions visible without turning bulk Library imports into a wall of low-value feed items.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a profile activity API that returns a discriminated union of profile activity entries.
+- Keep tastings as primary activity entries with existing rendering and behavior.
+- Add grouped collection-add entries as secondary activity.
+- Apply secondary-entry grouping and throttling on the backend so clients receive a feed that is already composed for profile display.
+- Preserve current profile privacy behavior.
+- Link secondary entries to the destination collection when a stable web route exists and link preview items to bottle or release pages.
+
+**Non-Goals:**
+
+- Replace global, friends, or local activity feeds in this change.
+- Add comments, toasts, notifications, or actions to collection-add entries.
+- Add arbitrary custom collection management or custom collection detail pages.
+- Add a durable generic `activity` table unless implementation proves read-time composition is insufficient.
+- Backfill historical synthetic activity beyond existing `collection_bottle.created_at` rows available to query.
+
+## Decisions
+
+### Add a profile activity route instead of expanding `tastings.list`
+
+Introduce a user-scoped profile activity route, for example `users.activity.list`, that resolves the target user, applies profile visibility rules, and returns activity entries. The response uses a discriminated union such as `type: "tasting"` and `type: "collection_add"` with a shared `createdAt` field.
+
+Alternative considered: add collection-add rows into `tastings.list`. That would overload a tasting-specific API and force tasting consumers to handle non-tasting rows.
+
+### Compose activity at read time for v1
+
+Build profile activity from existing source tables:
+
+- `tastings` for primary tasting activity.
+- `collection_bottle` joined to `collection` for secondary collection-add activity.
+
+This avoids a new durable activity table while the product rules are still settling. The route should fetch enough recent source rows to group secondary entries and still return the requested page size after throttling.
+
+Alternative considered: write activity rows during collection bottle creation. That gives stronger batch semantics, but adds a new persistence model before we know whether profile-only activity needs it.
+
+### Treat collection-add entries as secondary activity
+
+Collection-add rows must be grouped before feed composition. Group by target user, collection, and a bounded time window. A default 24-hour window is a reasonable first pass for profile activity because bulk Library imports often happen as one session and are lower-priority than tastings.
+
+After grouping, compose the feed so secondary entries are visible but capped. Initial policy:
+
+- Return at most one secondary entry between primary tasting entries.
+- Return no more than two secondary entries in the first page of ten entries when primary entries exist.
+- If a profile has no primary entries, collection-add groups can fill the profile Activity tab instead of showing an empty state.
+- Each collection-add entry previews a small fixed number of items, such as three or four, and includes `totalItems` for the hidden count.
+
+Alternative considered: strict reverse-chronological merge of all groups. That is simpler, but a user importing many bottles could push tastings off the first page.
+
+### Keep collection-add rendering compact
+
+Collection-add entries should render as compact feed rows/cards rather than full tasting cards. A single item can show one bottle context row; multiple items should render a concise preview list with a `+N more` affordance. The card should visually share the profile feed style but avoid large imagery and action buttons.
+
+Alternative considered: reuse `BottleCard` for every item in a grouped entry. That is useful for one item but too heavy for multi-item groups.
+
+### Use current collection routes as link targets for reserved collections
+
+For reserved profile collections, link `Library` to `/users/:username/library` and `Favorites` to `/users/:username/favorites`. Custom numeric collections can appear in the API response but should not get a collection link until the web app has a stable custom collection route.
+
+Alternative considered: add custom collection detail routes in this change. That is a separate product surface and not required for profile activity visibility.
+
+## Risks / Trade-offs
+
+- Read-time grouping can be more complex than a stored activity table -> keep the route profile-scoped and add focused tests around grouping and pagination before broadening it.
+- Offset pagination can split or duplicate grouped secondary entries -> use a timestamp-oriented cursor or over-fetch enough rows to make page boundaries stable.
+- Secondary throttling may hide some collection activity -> include `totalItems` and destination links so the visible summary still represents the action.
+- Collection-add timestamps come from individual row creation, not an explicit batch action -> group by bounded time window and collection to approximate user intent.
+- Custom collection entries may lack a stable web link -> provide bottle/release links and reserved collection links for v1.
+
+## Migration Plan
+
+No schema migration is required for the initial read-time composition approach. Add backend schemas/routes, update the profile Activity tab to consume the new route, and leave global/friends/local activity on the existing tasting feed. Rollback can restore the profile tab to `tastings.list({ user })` without changing collection data.
+
+## Open Questions
+
+- Should the secondary grouping window start at 24 hours, or should it be shorter for Favorites than Library?
+- Should custom collection-add activity be included before custom collection web routes exist, or should v1 limit secondary entries to reserved Favorites and Library?

--- a/openspec/changes/add-profile-activity-feed/proposal.md
+++ b/openspec/changes/add-profile-activity-feed/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+User profiles currently show only tasting activity, so adding bottles to Library or Favorites is invisible even though those actions are meaningful profile signals. Collection-add activity should appear in the profile feed, but as low-priority grouped entries so bulk Library updates do not overwhelm tastings.
+
+## What Changes
+
+- Add a profile activity feed API that returns a union of activity entry types instead of only tastings.
+- Include tasting entries as primary activity and collection-add entries as secondary activity.
+- Aggregate collection-add activity by user, destination collection, and time window before it reaches the client.
+- Throttle secondary collection-add entries so they fill feed gaps without pushing too many primary tasting entries down.
+- Render profile activity with distinct components for primary tasting cards and compact collection-add summaries.
+- Link collection-add entries to the destination collection when a web route exists, and link previewed bottles or releases to their catalog pages.
+- Preserve existing tasting rendering and existing profile privacy behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `profile-activity-feed`: Profile activity feed API, activity union schema, secondary collection-add grouping policy, and profile feed rendering behavior.
+
+### Modified Capabilities
+
+## Impact
+
+- Backend oRPC routes: add or extend a user profile activity route with a discriminated activity response.
+- Backend schemas and serializers: add activity entry schemas and collection-add summary serialization.
+- Backend queries: combine user tastings with recent `collection_bottle` rows joined through the owning collection, ordered by activity time and grouped for secondary entries.
+- Web profile route: replace direct `tastings.list({ user })` usage on the Activity tab with the profile activity feed.
+- Web components: add a polymorphic profile activity list and compact collection-add item component while reusing existing tasting item rendering.
+- Tests: cover activity union response shape, privacy behavior, collection-add grouping/throttling, and existing tasting rendering compatibility.

--- a/openspec/changes/add-profile-activity-feed/specs/profile-activity-feed/spec.md
+++ b/openspec/changes/add-profile-activity-feed/specs/profile-activity-feed/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Profile activity returns a union feed
+
+The system SHALL provide a profile activity feed API that returns a discriminated union of activity entries for a target user.
+
+#### Scenario: Tasting activity appears as a primary entry
+
+- **WHEN** a visible profile has a recent tasting
+- **THEN** the profile activity feed includes a `tasting` entry marked as primary activity with the serialized tasting payload and activity timestamp
+
+#### Scenario: Collection-add activity appears as a secondary entry
+
+- **WHEN** a visible profile has recent bottles added to a supported collection
+- **THEN** the profile activity feed includes a `collection_add` entry marked as secondary activity with the destination collection, preview items, total item count, and activity timestamp
+
+### Requirement: Profile visibility is preserved
+
+The system MUST apply the same profile visibility rules to profile activity that existing profile collection and tasting views apply.
+
+#### Scenario: Private profile is not visible
+
+- **WHEN** a viewer cannot access a user's private profile
+- **THEN** the profile activity feed request is rejected or hidden consistently with the existing private profile behavior
+
+#### Scenario: Visible profile returns activity
+
+- **WHEN** a viewer can access a user's profile
+- **THEN** the profile activity feed may include that user's visible tasting and collection-add activity entries
+
+### Requirement: Collection additions are grouped
+
+The system SHALL aggregate collection-add activity by target user, destination collection, and a bounded time window before returning profile activity entries.
+
+#### Scenario: Multiple additions to one collection are grouped
+
+- **WHEN** a user adds multiple bottles or releases to the same supported collection within the grouping window
+- **THEN** the profile activity feed returns one `collection_add` entry for that collection with preview items and `totalItems` equal to the number of grouped additions
+
+#### Scenario: Additions to different collections are separate
+
+- **WHEN** a user adds bottles to different supported collections
+- **THEN** the profile activity feed returns separate `collection_add` entries for each destination collection
+
+#### Scenario: Existing duplicate add attempts do not create new activity
+
+- **WHEN** a user attempts to add a bottle or release that already exists in the destination collection
+- **THEN** the duplicate attempt does not increase the grouped activity item count
+
+### Requirement: Secondary activity is throttled
+
+The system SHALL compose profile activity so secondary collection-add entries do not overwhelm primary tasting entries.
+
+#### Scenario: Primary entries are prioritized
+
+- **WHEN** a profile has both tasting entries and many collection-add groups
+- **THEN** the first page of the profile activity feed prioritizes tasting entries and includes only a capped number of secondary collection-add entries
+
+#### Scenario: Secondary entries fill an otherwise empty profile
+
+- **WHEN** a profile has collection-add activity but no tasting activity
+- **THEN** the profile activity feed shows grouped collection-add entries instead of an empty activity state
+
+### Requirement: Collection-add entries are linkable and compact
+
+The system SHALL render collection-add profile activity as compact entries with linkable destination and item context.
+
+#### Scenario: Reserved collection entry links to collection tab
+
+- **WHEN** a collection-add activity entry targets Library or Favorites
+- **THEN** the rendered entry links the destination collection to the user's corresponding profile collection tab
+
+#### Scenario: Preview item links to catalog page
+
+- **WHEN** a collection-add activity entry previews a bottle or release
+- **THEN** each previewed item links to its bottle or release detail page
+
+#### Scenario: Multi-item entry shows hidden count
+
+- **WHEN** a collection-add activity entry contains more items than the preview limit
+- **THEN** the rendered entry displays the preview items and a remaining item count
+
+### Requirement: Existing tasting rendering remains compatible
+
+The system MUST continue rendering tasting activity normally after the profile Activity tab switches to the union feed.
+
+#### Scenario: Existing tasting card behavior is preserved
+
+- **WHEN** the profile activity feed includes a `tasting` entry
+- **THEN** the web UI renders it with the existing tasting list item behavior and supported interactions

--- a/openspec/changes/add-profile-activity-feed/tasks.md
+++ b/openspec/changes/add-profile-activity-feed/tasks.md
@@ -1,0 +1,39 @@
+## 1. Backend Activity Contract
+
+- [x] 1.1 Add profile activity entry schemas for `tasting` and `collection_add` discriminated union responses.
+- [x] 1.2 Add collection-add summary serialization that includes destination collection, preview collection bottle items, total item count, and activity timestamps.
+- [x] 1.3 Add an oRPC profile activity list route under the user/profile route surface with target user resolution and existing profile visibility checks.
+- [x] 1.4 Wire the new route into the server router with a stable operation id and generated client types.
+
+## 2. Backend Feed Composition
+
+- [x] 2.1 Query recent user tastings as primary activity source rows ordered by creation time.
+- [x] 2.2 Query recent `collection_bottle` rows joined to `collection`, bottle, and release records as secondary activity source rows ordered by creation time.
+- [x] 2.3 Group collection-add source rows by user, collection, and bounded time window while excluding duplicate add attempts that did not create rows.
+- [x] 2.4 Compose primary and secondary rows into one paginated profile feed with secondary entries capped so they do not overwhelm primary tasting entries.
+- [x] 2.5 Return collection links for reserved Favorites and Library destinations and item links through serialized bottle/release data.
+
+## 3. Backend Tests
+
+- [x] 3.1 Add route tests proving tasting activity appears as primary profile activity.
+- [x] 3.2 Add route tests proving multiple additions to the same collection are grouped into one secondary entry with preview items and total count.
+- [x] 3.3 Add route tests proving additions to different collections produce separate secondary entries.
+- [x] 3.4 Add route tests proving secondary entries are capped when a profile also has primary tasting activity.
+- [x] 3.5 Add route tests proving collection-add entries fill an otherwise empty visible profile.
+- [x] 3.6 Add route tests proving private profile visibility behavior matches existing profile routes.
+
+## 4. Web Profile Activity UI
+
+- [x] 4.1 Add a polymorphic profile activity list component that dispatches by activity entry type.
+- [x] 4.2 Reuse existing tasting list item rendering for `tasting` activity entries.
+- [x] 4.3 Add a compact collection-add activity item with destination collection link, preview item links, and `+N more` count.
+- [x] 4.4 Replace the profile Activity tab query from `tastings.list({ user })` to the new profile activity feed.
+- [x] 4.5 Preserve existing profile stats, badge list, and charts below the activity list.
+- [x] 4.6 Keep the empty state correct when a profile has neither tasting nor collection-add activity.
+
+## 5. Verification
+
+- [x] 5.1 Run targeted backend profile activity route tests.
+- [x] 5.2 Run targeted web lint/typecheck for changed profile activity files.
+- [x] 5.3 Manually verify a profile with tastings and collection additions renders a mixed feed at desktop and mobile widths.
+- [x] 5.4 Manually verify a profile with only collection additions shows grouped secondary activity instead of an empty activity state.


### PR DESCRIPTION
Profiles now load a unified activity feed instead of a tasting-only list. The new `users.activity.list` API returns primary tasting entries alongside grouped secondary collection-add entries, with Library/Favorites links and preview item links so saved bottles can appear without turning bulk collection updates into a wall of feed rows.

Collection additions are grouped by collection and day bucket and capped when tasting activity is present. The route keeps existing profile visibility rules, including private-profile handling, and the Activity tab reuses the existing tasting row while rendering collection additions as compact feed entries.

The OpenSpec change is included with the implementation. Browser QA covered mixed feeds, collection-only feeds, and anonymous private profiles at desktop and mobile widths.
