### PR TITLE
feat(web): Defer add bottle creation until action

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -12,9 +12,12 @@ import { expectNoHorizontalOverflow } from "./assertions";
 import {
   createdBottleId,
   createdBottleName,
+  createdReleaseId,
+  createdTastingId,
   existingBottle,
   existingRelease,
   existingReleaseId,
+  photoTastingNotes,
   testAccessToken,
   testBrand,
   testUser,
@@ -492,7 +495,7 @@ test.describe("add bottle flow", () => {
     ).toBeVisible();
   });
 
-  test("creates a bottle from a scan with the photo as the default image", async ({
+  test("defers scan bottle creation until Create Bottle is clicked", async ({
     context,
     page,
   }, testInfo) => {
@@ -503,8 +506,31 @@ test.describe("add bottle flow", () => {
       ),
     });
 
+    const createRequests: Request[] = [];
+    page.on("request", (request) => {
+      if (request.url().includes("/rpc/tastings/photoIdentificationCreate")) {
+        createRequests.push(request);
+      }
+    });
+
     await page.goto("/addBottle");
     await uploadLabel(page);
+
+    await expect(
+      page.getByText(`${testBrand.name} ${createdBottleName}`),
+    ).toBeVisible();
+    await expect(
+      page.getByText(
+        "This will create the missing bottle or bottling in Peated before continuing.",
+      ),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Add to Library" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Log Tasting" }),
+    ).toBeVisible();
+    await expect(createRequests).toHaveLength(0);
 
     const requestPromise = waitForPhotoIdentificationCreate(page);
     await page.getByRole("button", { name: "Create Bottle" }).click();
@@ -514,19 +540,16 @@ test.describe("add bottle flow", () => {
       "playwright-create-token:create_bottle:suitable",
     );
     expect(input).not.toHaveProperty("catalogImageApproval");
+    await expect(page).toHaveURL(new RegExp(`/bottles/${createdBottleId}$`));
     await expect(
-      page.getByText(`${testBrand.name} ${createdBottleName}`),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("heading", { name: "Bottle created" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Add to Library" }),
+      page.getByRole("heading", {
+        name: `${testBrand.name} ${createdBottleName}`,
+      }),
     ).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
 
-  test("creates a release from a scan with the photo as the default release image", async ({
+  test("creates a release from a scan when Create Bottle is clicked", async ({
     context,
     page,
   }, testInfo) => {
@@ -548,15 +571,11 @@ test.describe("add bottle flow", () => {
       "playwright-create-token:create_bottle_and_release:suitable",
     );
     expect(input).not.toHaveProperty("catalogImageApproval");
+    await expect(page).toHaveURL(
+      new RegExp(`/bottles/${createdBottleId}/bottlings/${createdReleaseId}$`),
+    );
     await expect(
       page.getByText(`${testBrand.name} ${createdBottleName}`),
-    ).toBeVisible();
-    await expect(page.getByText("First Fill Oloroso")).toBeVisible();
-    await expect(
-      page.getByRole("heading", { name: "Bottle created" }),
-    ).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Add to Library" }),
     ).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
@@ -580,8 +599,11 @@ test.describe("add bottle flow", () => {
       "playwright-create-token:create_bottle:unsuitable",
     );
     expect(input).not.toHaveProperty("catalogImageApproval");
+    await expect(page).toHaveURL(new RegExp(`/bottles/${createdBottleId}$`));
     await expect(
-      page.getByText(`${testBrand.name} ${createdBottleName}`),
+      page.getByRole("heading", {
+        name: `${testBrand.name} ${createdBottleName}`,
+      }),
     ).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
@@ -604,12 +626,161 @@ test.describe("add bottle flow", () => {
         "The bottle was created, but the public image was not saved.",
       ),
     ).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/bottles/${createdBottleId}$`));
+    await expect(
+      page.getByRole("heading", {
+        name: `${testBrand.name} ${createdBottleName}`,
+      }),
+    ).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("creates a scan proposal as part of Add to Library", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(
+        testInfo,
+        "photo-create-bottle-default-image-library",
+      ),
+    });
+
+    await page.goto("/addBottle");
+    await uploadLabel(page);
+
+    const requestPromise = waitForPhotoIdentificationCreate(page);
+    const libraryRequestPromise = waitForCollectionBottleCreate(page);
+    await page.getByRole("button", { name: "Add to Library" }).click();
+    const input = getRpcInput(await requestPromise);
+    const libraryInput = getRpcInput(await libraryRequestPromise);
+
+    expect(input.createToken).toBe(
+      "playwright-create-token:create_bottle:suitable",
+    );
+    expect(libraryInput.pendingImageId).toBe("playwright-photo-upload");
+    await expect(
+      page.getByRole("heading", { name: "Added to Library" }),
+    ).toBeVisible();
     await expect(
       page.getByText(`${testBrand.name} ${createdBottleName}`),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Add to Library" }),
+      page.getByRole("heading", { name: "Bottle created" }),
+    ).toBeHidden();
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("creates a scan proposal as part of Log Tasting", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(
+        testInfo,
+        "photo-create-bottle-default-image-tasting",
+      ),
+    });
+
+    await page.goto("/addBottle?intent=tasting");
+    await uploadLabel(page);
+
+    const requestPromise = waitForPhotoIdentificationCreate(page);
+    await page.getByRole("button", { name: "Log Tasting" }).click();
+    const input = getRpcInput(await requestPromise);
+
+    expect(input.createToken).toBe(
+      "playwright-create-token:create_bottle:suitable",
+    );
+    await expect(
+      page.getByRole("heading", { name: "Log Tasting" }),
     ).toBeVisible();
+    await expect(
+      page.getByText(`${testBrand.name} ${createdBottleName}`),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Savor" }).click();
+    await page.getByLabel("Comments").fill(photoTastingNotes);
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(page).toHaveURL(new RegExp(`/tastings/${createdTastingId}$`));
+    await expect(
+      page.getByRole("heading", { name: "Bottle created" }),
+    ).toBeHidden();
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("routes to an existing bottle when action-time create reuses a target", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "photo-create-existing-view"),
+    });
+
+    await page.goto("/addBottle");
+    await uploadLabel(page);
+
+    const requestPromise = waitForPhotoIdentificationCreate(page);
+    await page.getByRole("button", { name: "Create Bottle" }).click();
+    const input = getRpcInput(await requestPromise);
+
+    expect(input.createToken).toBe(
+      "playwright-create-token:create_bottle:suitable",
+    );
+    await expect(page).toHaveURL(new RegExp(`/bottles/${existingBottle.id}$`));
+    await expect(
+      page.getByRole("heading", { name: existingBottle.fullName }),
+    ).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("adds an existing reused create proposal to Library", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "photo-create-existing-library"),
+    });
+
+    await page.goto("/addBottle");
+    await uploadLabel(page);
+
+    const requestPromise = waitForPhotoIdentificationCreate(page);
+    await page.getByRole("button", { name: "Add to Library" }).click();
+    const input = getRpcInput(await requestPromise);
+
+    expect(input.createToken).toBe(
+      "playwright-create-token:create_bottle:suitable",
+    );
+    await expect(
+      page.getByRole("heading", { name: "Added to Library" }),
+    ).toBeVisible();
+    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("opens Log Tasting for an existing reused create proposal", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "photo-create-existing-tasting"),
+    });
+
+    await page.goto("/addBottle?intent=tasting");
+    await uploadLabel(page);
+
+    const requestPromise = waitForPhotoIdentificationCreate(page);
+    await page.getByRole("button", { name: "Log Tasting" }).click();
+    const input = getRpcInput(await requestPromise);
+
+    expect(input.createToken).toBe(
+      "playwright-create-token:create_bottle:suitable",
+    );
+    await expect(
+      page.getByRole("heading", { name: "Log Tasting" }),
+    ).toBeVisible();
+    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
 
@@ -774,7 +945,13 @@ function uniqueAccessToken(testInfo: TestInfo, suffix: string) {
 }
 
 async function uploadLabel(page: Page) {
-  await page.locator('input[type="file"]').setInputFiles({
+  await expect(
+    page.getByRole("button", { name: /Take or upload a photo/ }),
+  ).toBeVisible();
+  const fileChooserPromise = page.waitForEvent("filechooser");
+  await page.getByRole("button", { name: /Take or upload a photo/ }).click();
+  const fileChooser = await fileChooserPromise;
+  await fileChooser.setFiles({
     name: "label.png",
     mimeType: "image/png",
     buffer: Buffer.from(
@@ -787,6 +964,12 @@ async function uploadLabel(page: Page) {
 function waitForPhotoIdentificationCreate(page: Page) {
   return page.waitForRequest((request) =>
     request.url().includes("/rpc/tastings/photoIdentificationCreate"),
+  );
+}
+
+function waitForCollectionBottleCreate(page: Page) {
+  return page.waitForRequest((request) =>
+    request.url().includes("/rpc/collections/bottles/create"),
   );
 }
 

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -36,6 +36,11 @@ const corsHeaders = {
   Vary: "Origin",
 };
 
+const mockUploadImage = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64",
+);
+
 const collectionStateByToken = new Map();
 const pendingUploadStateByToken = new Map();
 let collectionBottleId = 1;
@@ -53,6 +58,17 @@ const server = http.createServer(async (request, response) => {
   }
 
   const url = new URL(request.url ?? "/", `http://${host}:${port}`);
+  if (url.pathname.startsWith("/uploads/")) {
+    response
+      .writeHead(200, {
+        ...corsHeaders,
+        "Cache-Control": "no-store",
+        "Content-Type": "image/png",
+      })
+      .end(mockUploadImage);
+    return;
+  }
+
   if (url.pathname.startsWith("/rpc")) {
     const handled = await handleRpcRequest({ request, response, url });
     if (!handled) {
@@ -158,12 +174,22 @@ async function handleRpcRequest({ request, response, url }) {
       return true;
     }
     case "bottleReleases/details": {
-      if (input?.release !== existingReleaseId) {
+      if (input?.release === existingReleaseId) {
+        sendRpcResponse(response, existingRelease);
+        return true;
+      }
+
+      if (input?.release === createdReleaseId) {
+        sendRpcResponse(response, buildCreatedRelease());
+        return true;
+      }
+
+      if (typeof input?.release !== "number") {
         sendRpcError(response, "Unexpected bottle release details payload");
         return true;
       }
 
-      sendRpcResponse(response, existingRelease);
+      sendRpcError(response, "Unexpected bottle release details payload");
       return true;
     }
     case "bottles/suggestedTags":
@@ -236,6 +262,15 @@ async function handleRpcRequest({ request, response, url }) {
         sendRpcResponse(
           response,
           buildCreateProposalPhotoIdentification({ action: "create_bottle" }),
+        );
+        return true;
+      }
+
+      if (getAccessToken(request).includes("photo-create-existing")) {
+        sendRpcResponse(
+          response,
+          buildCreateProposalPhotoIdentification({ action: "create_bottle" }),
+          "77777777777777777777777777777777",
         );
         return true;
       }
@@ -589,8 +624,11 @@ function mutateCollectionBottle(request, input, action) {
   if (
     input?.release !== undefined &&
     input.release !== null &&
-    (input.release !== existingReleaseId ||
-      input.bottle !== existingRelease.bottleId)
+    !(
+      (input.release === existingReleaseId &&
+        input.bottle === existingRelease.bottleId) ||
+      (input.release === createdReleaseId && input.bottle === createdBottleId)
+    )
   ) {
     throw new Error("Unexpected collection release payload");
   }
@@ -620,7 +658,12 @@ function mutateCollectionBottle(request, input, action) {
           input.bottle === existingBottleId
             ? existingBottle
             : buildBottleForId(input.bottle),
-        release: input.release === existingReleaseId ? existingRelease : null,
+        release:
+          input.release === existingReleaseId
+            ? existingRelease
+            : input.release === createdReleaseId
+              ? buildCreatedRelease()
+              : null,
         imageUrl: input.pendingImageId
           ? "http://127.0.0.1:4999/uploads/library.webp"
           : null,
@@ -880,6 +923,13 @@ function createPhotoIdentificationTarget(request, input) {
     };
   }
 
+  if (token.includes("photo-create-existing")) {
+    return {
+      bottle: existingBottle,
+      release: null,
+    };
+  }
+
   if (token.includes("photo-create-unsuitable")) {
     return {
       bottle,
@@ -890,14 +940,7 @@ function createPhotoIdentificationTarget(request, input) {
   if (token.includes("photo-create-release-default-image")) {
     return {
       bottle,
-      release: buildBottleRelease({
-        id: createdReleaseId,
-        bottleId: createdBottleId,
-        fullName: `${bottle.fullName} First Fill Oloroso`,
-        name: "First Fill Oloroso",
-        edition: "First Fill Oloroso",
-        releaseYear: 2026,
-      }),
+      release: buildCreatedRelease(),
     };
   }
 
@@ -923,12 +966,26 @@ function getExpectedPhotoCreateToken(request) {
 
   if (
     token.includes("photo-create-bottle-default-image") ||
-    token.includes("photo-create-warning")
+    token.includes("photo-create-warning") ||
+    token.includes("photo-create-existing")
   ) {
     return "playwright-create-token:create_bottle:suitable";
   }
 
   return null;
+}
+
+function buildCreatedRelease() {
+  const bottle = buildBottleForId(createdBottleId);
+
+  return buildBottleRelease({
+    id: createdReleaseId,
+    bottleId: createdBottleId,
+    fullName: `${bottle.fullName} First Fill Oloroso`,
+    name: "First Fill Oloroso",
+    edition: "First Fill Oloroso",
+    releaseYear: 2026,
+  });
 }
 
 /**

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -4,6 +4,8 @@ import type { Outputs } from "@peated/server/orpc/router";
 import BadgeImage from "@peated/web/components/badgeImage";
 import BottleCard from "@peated/web/components/bottleCard";
 import BottleResolver, {
+  type BottleResolverAction,
+  type BottleResolverCreateProposalActionsProps,
   type BottleResolverMatchedActionsProps,
   type BottleResolverTarget,
 } from "@peated/web/components/bottleResolver";
@@ -280,6 +282,66 @@ function MatchedOutcomeActions({
       : [libraryButton, tastingButton, viewButton];
 
   return <div className="grid gap-3 sm:grid-cols-3">{actionButtons}</div>;
+}
+
+function CreateProposalOutcomeActions({
+  createPending,
+  resolvingAction,
+  intent,
+  onResolve,
+}: BottleResolverCreateProposalActionsProps & { intent: AddBottleIntent }) {
+  const creating = createPending || Boolean(resolvingAction);
+  const libraryButton = (
+    <OutcomeButton
+      key="library"
+      onClick={() => onResolve("library")}
+      icon={<BookOpen className="h-4 w-4" />}
+      emphasized
+      disabled={creating}
+      loading={resolvingAction === "library"}
+    >
+      Add to Library
+    </OutcomeButton>
+  );
+  const tastingButton = (
+    <OutcomeButton
+      key="tasting"
+      onClick={() => onResolve("tasting")}
+      icon={<Wine className="h-4 w-4" />}
+      emphasized
+      disabled={creating}
+      loading={resolvingAction === "tasting"}
+    >
+      Log Tasting
+    </OutcomeButton>
+  );
+  const createButton = (
+    <OutcomeButton
+      key="create"
+      onClick={() => onResolve("create")}
+      icon={<Plus className="h-4 w-4" />}
+      disabled={creating}
+      loading={resolvingAction === "create"}
+    >
+      Create Bottle
+    </OutcomeButton>
+  );
+  const actionButtons =
+    intent === "tasting"
+      ? [tastingButton, libraryButton, createButton]
+      : intent === "view"
+        ? [createButton, libraryButton, tastingButton]
+        : [libraryButton, tastingButton, createButton];
+
+  return (
+    <div className="space-y-3">
+      <p className="text-muted text-sm">
+        This will create the missing bottle or bottling in Peated before
+        continuing.
+      </p>
+      <div className="grid gap-3 sm:grid-cols-3">{actionButtons}</div>
+    </div>
+  );
 }
 
 function OutcomeSelection({
@@ -628,7 +690,7 @@ function AddBottleFlowContent() {
 
   async function handleResolvedTarget(
     target: BottleResolverTarget,
-    action?: "library" | "tasting",
+    action?: BottleResolverAction,
   ) {
     setLibraryError(undefined);
     setAddedEntry(null);
@@ -636,10 +698,17 @@ function AddBottleFlowContent() {
     setTastingDraft(null);
     setTastingLoadError(undefined);
 
+    if (action) {
+      target.warnings?.forEach((warning) => flash(warning, "error"));
+    }
+
     if (action === "library") {
       await addToLibrary(target, { showOutcomeWhileSaving: false });
     } else if (action === "tasting") {
       await startLogTasting(target);
+    } else if (action === "create") {
+      router.push(getViewBottleHref(target));
+      revokeBlobPreviewUrl(target);
     } else {
       setSelectedTarget(target);
     }
@@ -827,6 +896,9 @@ function AddBottleFlowContent() {
       searchActionLabel="Search Bottles"
       renderMatchedResultActions={(props) => (
         <MatchedOutcomeActions {...props} intent={intent} />
+      )}
+      renderCreateProposalActions={(props) => (
+        <CreateProposalOutcomeActions {...props} intent={intent} />
       )}
       onResolve={handleResolvedTarget}
     />

--- a/apps/web/src/components/bottleResolver/index.tsx
+++ b/apps/web/src/components/bottleResolver/index.tsx
@@ -43,12 +43,15 @@ import {
   PhotoUploadState,
 } from "./states";
 import type {
+  BottleResolverAction,
   BottleResolverMatchedAction,
   BottleResolverProps,
   BottleResolverTarget,
 } from "./types";
 
 export type {
+  BottleResolverAction,
+  BottleResolverCreateProposalActionsProps,
   BottleResolverMatchedAction,
   BottleResolverMatchedActionsProps,
   BottleResolverProps,
@@ -69,6 +72,7 @@ export default function BottleResolver({
   createBottleHrefForResult,
   title,
   renderMatchedResultActions,
+  renderCreateProposalActions,
   createProposalActionLabel = "Continue",
   searchActionLabel = "Search Bottles",
 }: BottleResolverProps) {
@@ -91,7 +95,7 @@ export default function BottleResolver({
     useState<PhotoFailureTrace | null>(null);
   const [loadingMessageIndex, setLoadingMessageIndex] = useState(0);
   const [resolvingAction, setResolvingAction] =
-    useState<BottleResolverMatchedAction | null>(null);
+    useState<BottleResolverAction | null>(null);
   const [matchedBottleStatus, setMatchedBottleStatus] = useState<{
     bottleId: number;
     releaseId: number | null;
@@ -159,7 +163,7 @@ export default function BottleResolver({
 
   async function resolveTarget(
     target: Omit<BottleResolverTarget, "pendingImage" | "previewUrl">,
-    action?: BottleResolverMatchedAction,
+    action?: BottleResolverAction,
   ) {
     const currentPreviewUrl = previewUrl;
     const photoTrace =
@@ -221,7 +225,10 @@ export default function BottleResolver({
     }
   }
 
-  async function acceptCreateProposal(result: PhotoIdentification) {
+  async function acceptCreateProposal(
+    result: PhotoIdentification,
+    action: BottleResolverAction,
+  ) {
     if (
       result.classification.status !== "classified" ||
       !getCreateDecision(result)
@@ -229,6 +236,8 @@ export default function BottleResolver({
       return;
     }
 
+    setError(null);
+    setResolvingAction(action);
     try {
       if (!result.createToken) {
         setError(
@@ -242,17 +251,20 @@ export default function BottleResolver({
       };
       const created =
         await photoIdentificationCreateMutation.mutateAsync(payload);
-      await resolveTarget({
-        bottle: created.bottle,
-        release: created.release,
-        hasExactLibraryEntry: false,
-        resultSource: "created",
-        warnings: (created.warnings ?? []).map(
-          (warning) =>
-            warning.message ||
-            "The bottle was created, but the public image was not saved.",
-        ),
-      });
+      await resolveTarget(
+        {
+          bottle: created.bottle,
+          release: created.release,
+          hasExactLibraryEntry: false,
+          resultSource: "created",
+          warnings: (created.warnings ?? []).map(
+            (warning) =>
+              warning.message ||
+              "The bottle was created, but the public image was not saved.",
+          ),
+        },
+        action,
+      );
     } catch (err) {
       if (isORPCUnauthorizedRedirectError(err)) return;
 
@@ -260,6 +272,8 @@ export default function BottleResolver({
       setError(
         "We couldn't create that bottle from the photo. Search for the bottle to keep going.",
       );
+    } finally {
+      setResolvingAction(null);
     }
   }
 
@@ -479,6 +493,7 @@ export default function BottleResolver({
                 matchedBottleId={matchedBottleId}
                 matchedReleaseId={matchedReleaseId}
                 renderMatchedResultActions={renderMatchedResultActions}
+                renderCreateProposalActions={renderCreateProposalActions}
                 createProposalLabel={createProposalLabel}
                 hasCreateDecision={Boolean(createDecision)}
                 proposedName={proposedName}
@@ -492,8 +507,8 @@ export default function BottleResolver({
                 onLoadTarget={(bottleId, releaseId, action) => {
                   void loadTarget(bottleId, releaseId, action);
                 }}
-                onAcceptCreateProposal={(result) => {
-                  void acceptCreateProposal(result);
+                onAcceptCreateProposal={(result, action) => {
+                  void acceptCreateProposal(result, action);
                 }}
               />
             ) : (

--- a/apps/web/src/components/bottleResolver/states.tsx
+++ b/apps/web/src/components/bottleResolver/states.tsx
@@ -14,6 +14,8 @@ import {
   SearchBottleCallout,
 } from "./panels";
 import type {
+  BottleResolverAction,
+  BottleResolverCreateProposalActionsProps,
   BottleResolverMatchedAction,
   BottleResolverMatchedActionsProps,
 } from "./types";
@@ -186,6 +188,7 @@ export function PhotoMatchCreateState({
   matchedBottleId,
   matchedReleaseId,
   renderMatchedResultActions,
+  renderCreateProposalActions,
   createProposalLabel,
   hasCreateDecision,
   proposedName,
@@ -204,12 +207,15 @@ export function PhotoMatchCreateState({
   renderMatchedResultActions?: (
     props: BottleResolverMatchedActionsProps,
   ) => ReactNode;
+  renderCreateProposalActions?: (
+    props: BottleResolverCreateProposalActionsProps,
+  ) => ReactNode;
   createProposalLabel: { title: string; description: string } | null;
   hasCreateDecision: boolean;
   proposedName: string | null;
   createPending: boolean;
   createActionLabel: string;
-  resolvingAction: BottleResolverMatchedAction | null;
+  resolvingAction: BottleResolverAction | null;
   hasExactLibraryEntry: boolean;
   loadingExactLibraryStatus: boolean;
   onLoadTarget: (
@@ -217,7 +223,10 @@ export function PhotoMatchCreateState({
     releaseId: number | null,
     action?: BottleResolverMatchedAction,
   ) => void;
-  onAcceptCreateProposal: (result: PhotoIdentification) => void;
+  onAcceptCreateProposal: (
+    result: PhotoIdentification,
+    action: BottleResolverAction,
+  ) => void;
 }) {
   const matchedCandidate = getMatchedCandidate(result);
 
@@ -244,7 +253,8 @@ export function PhotoMatchCreateState({
               releaseId: matchedReleaseId,
               hasExactLibraryEntry,
               loadingExactLibraryStatus,
-              resolvingAction,
+              resolvingAction:
+                resolvingAction === "create" ? null : resolvingAction,
               onResolve: (action) => {
                 onLoadTarget(matchedBottleId, matchedReleaseId, action);
               },
@@ -282,19 +292,33 @@ export function PhotoMatchCreateState({
         >
           <EvidencePills result={result} compact />
         </PhotoResultCard>
-        <div className="mx-auto grid w-full gap-2 sm:w-1/2">
-          {hasCreateDecision && (
-            <Button
-              color="highlight"
-              fullWidth
-              icon={<Plus className="h-4 w-4" />}
-              onClick={() => onAcceptCreateProposal(result)}
-              disabled={createPending}
-            >
-              {createPending ? "Creating..." : createActionLabel}
-            </Button>
-          )}
-        </div>
+        {hasCreateDecision && (
+          <div
+            className={
+              renderCreateProposalActions
+                ? "space-y-3"
+                : "mx-auto grid w-full gap-2 sm:w-1/2"
+            }
+          >
+            {renderCreateProposalActions ? (
+              renderCreateProposalActions({
+                createPending,
+                resolvingAction,
+                onResolve: (action) => onAcceptCreateProposal(result, action),
+              })
+            ) : (
+              <Button
+                color="highlight"
+                fullWidth
+                icon={<Plus className="h-4 w-4" />}
+                onClick={() => onAcceptCreateProposal(result, "create")}
+                disabled={createPending}
+              >
+                {createPending ? "Creating..." : createActionLabel}
+              </Button>
+            )}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/apps/web/src/components/bottleResolver/types.ts
+++ b/apps/web/src/components/bottleResolver/types.ts
@@ -19,7 +19,11 @@ export type BottleResolverTarget = {
   warnings?: string[];
 };
 
-export type BottleResolverMatchedAction = "library" | "tasting";
+export type BottleResolverAction = "library" | "tasting" | "create";
+export type BottleResolverMatchedAction = Exclude<
+  BottleResolverAction,
+  "create"
+>;
 
 export type BottleResolverMatchedActionsProps = {
   bottleId: number;
@@ -30,10 +34,16 @@ export type BottleResolverMatchedActionsProps = {
   onResolve: (action: BottleResolverMatchedAction) => void;
 };
 
+export type BottleResolverCreateProposalActionsProps = {
+  createPending: boolean;
+  resolvingAction: BottleResolverAction | null;
+  onResolve: (action: BottleResolverAction) => void;
+};
+
 export type BottleResolverProps = {
   onResolve: (
     target: BottleResolverTarget,
-    action?: BottleResolverMatchedAction,
+    action?: BottleResolverAction,
   ) => Promise<void> | void;
   searchHrefForQuery: (query?: string) => string;
   createBottleHrefForResult?: (
@@ -43,6 +53,9 @@ export type BottleResolverProps = {
   title: string;
   renderMatchedResultActions?: (
     props: BottleResolverMatchedActionsProps,
+  ) => ReactNode;
+  renderCreateProposalActions?: (
+    props: BottleResolverCreateProposalActionsProps,
   ) => ReactNode;
   createProposalActionLabel?: string;
   searchActionLabel?: string;

--- a/openspec/changes/add-bottle-flow/design.md
+++ b/openspec/changes/add-bottle-flow/design.md
@@ -45,7 +45,7 @@ Extract the scan/search/review logic from `/addTasting` into a reusable Bottle R
 - `intent=tasting`: Log Tasting is primary.
 - no intent or `intent=choose`: show all applicable outcomes.
 
-Existing bottle matches show Add to Library, Log Tasting, and View Bottle. Missing or uncertain bottles show Search Again, Start Over, and Create Bottle when user creation is available.
+Existing bottle matches show Add to Library, Log Tasting, and View Bottle. Clear missing-target create proposals show Add to Library, Log Tasting, and Create Bottle; unresolved or ambiguous bottles show Search Again, Start Over, and Create Bottle when user creation is available.
 
 For scan-backed results, the classifier should preserve release and bottling traits visible on the label, including edition, batch, barrel/cask number, stated age, ABV, and expression name. If the exact identity exists in Peated, the resolver should confirm the match. If it does not exist and the identity is otherwise clear, the resolver should confirm a create proposal. Search Again should mean "the system could not identify the bottle/release," not "the target row is missing enrichment."
 

--- a/openspec/changes/add-bottle-flow/specs/add-bottle-flow/spec.md
+++ b/openspec/changes/add-bottle-flow/specs/add-bottle-flow/spec.md
@@ -37,7 +37,9 @@ The system SHALL resolve scan, search, and manual creation paths into a bottle t
 #### Scenario: Create proposal resolved
 
 - **WHEN** photo identification proposes creating a bottle or release
-- **THEN** the system shows proposed bottle or release fields before the user can create the target
+- **THEN** the system shows proposed bottle or release fields
+- **AND** the system offers Add to Library, Log Tasting, and Create Bottle actions
+- **AND** each selected action creates or reuses the proposed target before continuing
 
 #### Scenario: Scan resolves source identity before catalog action
 

--- a/openspec/changes/defer-add-bottle-creation-until-action/.openspec.yaml
+++ b/openspec/changes/defer-add-bottle-creation-until-action/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-07

--- a/openspec/changes/defer-add-bottle-creation-until-action/design.md
+++ b/openspec/changes/defer-add-bottle-creation-until-action/design.md
@@ -1,0 +1,114 @@
+## Context
+
+The Add Bottle flow already separates existing-match actions from create
+proposal handling. Existing matches can Add to Library or Log Tasting directly.
+Create proposals currently create the target first, then return to a chooser
+state. That is backwards for the intended interaction: the resolver should
+preview the proposed target, then creation should happen only as part of the
+user's chosen terminal action.
+
+The photo identification create endpoint already creates or reuses classifier
+create decisions and returns a concrete bottle/release target. The server-side
+create helpers already convert deterministic duplicate creation into existing
+target ids. The change should therefore move the client-side commit point
+without introducing fuzzy matching or a new manual-entry branch.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep create proposals non-persistent while they are being previewed.
+- Render action choices for create proposals: Add to Library, Log Tasting, and
+  Create Bottle.
+- Keep existing matches on Add to Library, Log Tasting, and View Bottle.
+- Create or reuse the proposed target only after the selected terminal action.
+- Continue the selected action against a reused existing target when the create
+  path discovers a duplicate.
+- Avoid showing a second outcome chooser after creation.
+
+**Non-Goals:**
+
+- Add or change manual catalog entry from the Add Bottle resolver.
+- Add fuzzy client-side duplicate matching.
+- Change classifier identity policy or review policy.
+- Change collection image semantics beyond preserving existing pending-image
+  behavior through the selected action.
+- Rename Log Tasting copy.
+
+## Decisions
+
+### Create proposals become resolver targets with pending commit
+
+Represent a missing target in the resolver as a proposed target that carries the
+existing photo-identification create token and display data. Do not call the
+create endpoint when rendering that proposal.
+
+Alternative considered: create immediately and hide the resulting chooser. That
+still persists abandoned proposals and does not satisfy the product invariant.
+
+### Terminal actions own creation
+
+Add a shared action path for resolver outcomes:
+
+- Existing target + Add to Library: add the existing target.
+- Existing target + Log Tasting: load tasting metadata and open the form.
+- Existing target + View Bottle: navigate to the existing target.
+- Create proposal + Add to Library: create or reuse the target, then add it to
+  Library.
+- Create proposal + Log Tasting: create or reuse the target, then open the Log
+  Tasting form.
+- Create proposal + Create Bottle: create or reuse the target, then navigate to
+  the target detail page.
+
+This keeps the user action as the single commit point and avoids a second
+choice screen.
+
+### Reuse existing server create semantics
+
+Use the current photo identification create route for classifier-backed create
+proposals. The underlying create helpers already return existing bottle/release
+targets for deterministic duplicate cases. The client should treat the returned
+target the same whether it was newly created or reused.
+
+If future non-photo create proposals are added, they should follow the same
+contract: action-time create returns a concrete target or a deterministic
+existing target, then the selected action continues.
+
+### Keep label differences minimal
+
+The action row differs only where the catalog target existence changes the
+third action:
+
+- Existing target: `View Bottle`
+- Missing target: `Create Bottle`
+
+Add to Library and Log Tasting stay visible for both states. Supporting copy can
+explain that the missing-target actions will create the bottle first, but the
+button labels should remain focused on the user's selected outcome.
+
+## Risks / Trade-offs
+
+- Creation succeeds but the follow-up Library add fails -> Keep the resolved
+  target in state and show the follow-up error so the user can retry without
+  creating again.
+- Creation succeeds but loading tasting metadata fails -> Keep the resolved
+  target in state and show the tasting load error so the user can retry.
+- Pending scan image is reused across create and Library/Tasting actions ->
+  Preserve existing pending-image ids through action-time create and pass them
+  to the same follow-up APIs used today.
+- Create proposal token expires before action click -> Surface the existing
+  invalid proposal error and offer search/start-over fallback.
+- Users may miss that Add to Library or Log Tasting will create a missing
+  target -> Use concise subtext near the action row, not an extra blocking
+  step.
+
+## Migration Plan
+
+1. Update resolver state/types so create proposals can render action buttons
+   without calling creation.
+2. Move photo create endpoint calls into the selected action handler.
+3. Route the returned or reused target into the existing Add to Library, Log
+   Tasting, or View/Create continuation.
+4. Remove the post-create chooser path for create proposals.
+5. Add targeted tests and UI verification for existing target, missing target,
+   duplicate reuse, and abandoned proposal flows.

--- a/openspec/changes/defer-add-bottle-creation-until-action/proposal.md
+++ b/openspec/changes/defer-add-bottle-creation-until-action/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+The Add Bottle flow currently treats a missing catalog target as a separate
+"create first, choose action second" step. This adds friction and obscures the
+real user intent: add the bottle to Library, log a tasting, or create/view the
+catalog bottle.
+
+## What Changes
+
+- Defer catalog bottle or release creation until the user clicks a terminal
+  action.
+- Keep create proposals as preview-only resolver results until that terminal
+  action is chosen.
+- Show the same action set for existing matches and create proposals, except
+  the third action is `View Bottle` for existing targets and `Create Bottle` for
+  missing targets.
+- Make `Add to Library` and `Log Tasting` implicitly create the proposed target
+  before continuing when Peated does not already have it.
+- If action-time creation discovers that the target already exists, continue the
+  selected action against the existing target instead of creating a duplicate.
+- Preserve the current no-manual-entry behavior for this flow; manual catalog
+  entry remains out of scope for this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `add-bottle-flow`: Deferred create-proposal commit behavior for the Add Bottle
+  resolver and its Library, Log Tasting, and Create/View actions.
+
+### Modified Capabilities
+
+## Impact
+
+- Web Add Bottle resolver states and action rendering for create proposals.
+- Web Add Bottle action handling for Library, Log Tasting, and Create/View.
+- Existing create-proposal API usage from photo identification.
+- Duplicate/conflict handling when a proposed target is created at action time.
+- Targeted tests and local UI checks for existing-match and missing-target
+  branches.

--- a/openspec/changes/defer-add-bottle-creation-until-action/specs/add-bottle-flow/spec.md
+++ b/openspec/changes/defer-add-bottle-creation-until-action/specs/add-bottle-flow/spec.md
@@ -1,0 +1,96 @@
+## ADDED Requirements
+
+### Requirement: Create proposals are preview-only before terminal action
+
+The system SHALL keep missing-target create proposals as non-persistent Add
+Bottle resolver results until the user chooses a terminal action.
+
+#### Scenario: Create proposal displayed without persistence
+
+- **WHEN** photo identification or catalog resolution determines that Peated
+  does not have the identified bottle or release yet
+- **THEN** the Add Bottle resolver displays the proposed target without creating
+  a catalog bottle or release
+- **AND** no catalog creation request is sent before the user chooses Add to
+  Library, Log Tasting, or Create Bottle
+
+#### Scenario: Create proposal abandoned
+
+- **WHEN** the Add Bottle resolver displays a create proposal
+- **AND** the user starts over, searches again, navigates away, or dismisses the
+  flow before choosing a terminal action
+- **THEN** the system does not create a catalog bottle or release for that
+  proposal
+
+### Requirement: Create proposal actions
+
+The system SHALL render action-specific terminal choices for missing-target
+create proposals instead of requiring a separate create-then-choose step.
+
+#### Scenario: Existing target actions
+
+- **WHEN** the Add Bottle resolver identifies an existing bottle or release
+- **THEN** the system shows Add to Library, Log Tasting, and View Bottle actions
+- **AND** View Bottle routes to the existing bottle or release without issuing a
+  catalog creation request
+
+#### Scenario: Missing target actions
+
+- **WHEN** the Add Bottle resolver identifies a missing bottle or release as a
+  create proposal
+- **THEN** the system shows Add to Library, Log Tasting, and Create Bottle
+  actions
+- **AND** the system does not show a generic Create Bottle confirmation that
+  leads to a second outcome chooser
+
+#### Scenario: Create Bottle action
+
+- **WHEN** the user chooses Create Bottle for a create proposal
+- **THEN** the system creates the proposed catalog bottle or release
+- **AND** the system routes to the created bottle or release detail page
+
+#### Scenario: Add to Library action for missing target
+
+- **WHEN** the user chooses Add to Library for a create proposal
+- **THEN** the system creates the proposed catalog bottle or release
+- **AND** the system saves that exact target to the user's Library
+- **AND** the system shows the Added to Library terminal state without showing a
+  second outcome chooser
+
+#### Scenario: Log Tasting action for missing target
+
+- **WHEN** the user chooses Log Tasting for a create proposal
+- **THEN** the system creates the proposed catalog bottle or release
+- **AND** the system opens the Log Tasting form for that exact target without
+  showing a second outcome chooser
+
+### Requirement: Action-time existing target reuse
+
+The system SHALL treat action-time duplicate discovery as an existing target and
+continue the user's selected action without creating a duplicate catalog entry.
+
+#### Scenario: Duplicate discovered during Create Bottle
+
+- **WHEN** the user chooses Create Bottle for a create proposal
+- **AND** the catalog creation request determines that the proposed target
+  already exists
+- **THEN** the system routes to the existing bottle or release detail page
+- **AND** the system does not create a duplicate catalog bottle or release
+
+#### Scenario: Duplicate discovered during Add to Library
+
+- **WHEN** the user chooses Add to Library for a create proposal
+- **AND** the catalog creation request determines that the proposed target
+  already exists
+- **THEN** the system saves the existing exact target to the user's Library
+- **AND** the system shows the Added to Library terminal state for that existing
+  target
+- **AND** the system does not create a duplicate catalog bottle or release
+
+#### Scenario: Duplicate discovered during Log Tasting
+
+- **WHEN** the user chooses Log Tasting for a create proposal
+- **AND** the catalog creation request determines that the proposed target
+  already exists
+- **THEN** the system opens the Log Tasting form for the existing exact target
+- **AND** the system does not create a duplicate catalog bottle or release

--- a/openspec/changes/defer-add-bottle-creation-until-action/tasks.md
+++ b/openspec/changes/defer-add-bottle-creation-until-action/tasks.md
@@ -1,0 +1,36 @@
+## 1. Resolver Proposal State
+
+- [x] 1.1 Update Bottle Resolver types so create proposals can be represented as pending resolver outcomes without calling creation.
+- [x] 1.2 Preserve create-token, pending-image, preview-url, trace, proposed-name, and warning metadata on pending create proposals.
+- [x] 1.3 Ensure start-over, search-again, dismissal, and navigation-away paths do not call the create endpoint.
+
+## 2. Action Rendering
+
+- [x] 2.1 Render Add to Library, Log Tasting, and View Bottle for existing resolver targets.
+- [x] 2.2 Render Add to Library, Log Tasting, and Create Bottle for create proposals.
+- [x] 2.3 Add concise supporting copy for create proposals explaining that the selected action will create the missing bottle first.
+- [x] 2.4 Remove the create-proposal path that creates a target and then shows a second outcome chooser.
+
+## 3. Action-Time Commit
+
+- [x] 3.1 Add a shared action handler that accepts an existing target or pending create proposal plus the selected action.
+- [x] 3.2 For Create Bottle, create or reuse the proposed target and route to the resulting bottle or release page.
+- [x] 3.3 For Add to Library, create or reuse the proposed target, then save that exact target to Library using the existing Library add path.
+- [x] 3.4 For Log Tasting, create or reuse the proposed target, then open the Log Tasting form using the existing tasting draft path.
+- [x] 3.5 Preserve pending scan image reuse for Library and Log Tasting follow-up actions.
+- [x] 3.6 If creation succeeds but the follow-up action fails, keep the resolved target in state and surface a retryable error without creating again.
+
+## 4. Existing Target Reuse
+
+- [x] 4.1 Treat server create responses that reuse an existing bottle or release the same as newly created targets.
+- [x] 4.2 Verify Add to Library continues against an existing reused target without duplicate catalog creation.
+- [x] 4.3 Verify Log Tasting continues against an existing reused target without duplicate catalog creation.
+- [x] 4.4 Verify Create Bottle routes to the existing target when action-time creation discovers one.
+
+## 5. Verification
+
+- [x] 5.1 Add focused tests or component-level checks proving create proposals do not call creation before a terminal action.
+- [x] 5.2 Add focused tests or component-level checks for create proposal Add to Library, Log Tasting, and Create Bottle continuations.
+- [x] 5.3 Add or update tests for existing target Add to Library, Log Tasting, and View Bottle actions to guard against regressions.
+- [x] 5.4 Run targeted web typecheck/lint for the touched Add Bottle resolver files.
+- [x] 5.5 Use local UI verification at desktop and mobile widths for existing-match and missing-target create-proposal flows.


### PR DESCRIPTION
Add Bottle scan create proposals now stay pending until the user chooses Add to Library, Log Tasting, or Create Bottle. Existing matches still expose Add to Library, Log Tasting, and View Bottle; create proposals create or reuse the target at action time before continuing.

The OpenSpec change captures the deferred-create contract, and the e2e coverage exercises no-create-before-action, action-time existing reuse, and pending scan image reuse for Library and tasting continuations.
