### PR TITLE
fix(web): Remove redundant create proposal copy

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -520,11 +520,6 @@ test.describe("add bottle flow", () => {
       page.getByText(`${testBrand.name} ${createdBottleName}`),
     ).toBeVisible();
     await expect(
-      page.getByText(
-        "This will create the missing bottle or bottling in Peated before continuing.",
-      ),
-    ).toBeVisible();
-    await expect(
       page.getByRole("button", { name: "Add to Library" }),
     ).toBeVisible();
     await expect(

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -333,15 +333,7 @@ function CreateProposalOutcomeActions({
         ? [createButton, libraryButton, tastingButton]
         : [libraryButton, tastingButton, createButton];
 
-  return (
-    <div className="space-y-3">
-      <p className="text-muted text-sm">
-        This will create the missing bottle or bottling in Peated before
-        continuing.
-      </p>
-      <div className="grid gap-3 sm:grid-cols-3">{actionButtons}</div>
-    </div>
-  );
+  return <div className="grid gap-3 sm:grid-cols-3">{actionButtons}</div>;
 }
 
 function OutcomeSelection({

--- a/openspec/changes/defer-add-bottle-creation-until-action/tasks.md
+++ b/openspec/changes/defer-add-bottle-creation-until-action/tasks.md
@@ -8,7 +8,7 @@
 
 - [x] 2.1 Render Add to Library, Log Tasting, and View Bottle for existing resolver targets.
 - [x] 2.2 Render Add to Library, Log Tasting, and Create Bottle for create proposals.
-- [x] 2.3 Add concise supporting copy for create proposals explaining that the selected action will create the missing bottle first.
+- [x] 2.3 Keep create-proposal context in the bottle card subtext so actions do not need duplicate helper copy.
 - [x] 2.4 Remove the create-proposal path that creates a target and then shows a second outcome chooser.
 
 ## 3. Action-Time Commit


### PR DESCRIPTION
Create-proposal actions in Add Bottle no longer render a second helper sentence under the bottle card. The card subtext already explains that this is a new bottle proposal, so the action row can stay focused on Add to Library, Log Tasting, and Create Bottle.

The e2e expectation and OpenSpec task wording are updated to match the leaner UI.
