### PR TITLE
fix(web): Preserve created bottling library target

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -184,6 +184,42 @@ test.describe("create bottle", () => {
     ).toBeVisible();
   });
 
+  test("adds the created bottling to library from a bottle-and-release proposal", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "proposal-release-library"),
+      user: {
+        ...testUser,
+        mod: true,
+      },
+    });
+
+    await page.goto("/bottles/new?proposal=9901&returnAction=library");
+
+    await expect(
+      page.getByRole("heading", { name: "Create Bottle" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Bottle")).toHaveValue(createdBottleName);
+
+    const libraryRequestPromise = waitForCollectionBottleCreate(page);
+    await page.getByRole("button", { name: "Create Bottle" }).click();
+    const libraryInput = getRpcInput(await libraryRequestPromise);
+
+    expect(libraryInput.bottle).toBe(createdBottleId);
+    expect(libraryInput.release).toBe(createdReleaseId);
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/addBottle\\?bottle=${createdBottleId}&release=${createdReleaseId}&intent=library$`,
+      ),
+    );
+    await expect(page.getByText("First Fill Oloroso")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "In Library" }),
+    ).toBeVisible();
+  });
+
   test("shows validation when saving without a brand", async ({
     context,
     page,
@@ -663,6 +699,39 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("heading", { name: "Bottle created" }),
     ).toBeHidden();
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("creates a scan release proposal as part of Add to Library", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(
+        testInfo,
+        "photo-create-release-default-image-library",
+      ),
+    });
+
+    await page.goto("/addBottle");
+    await uploadLabel(page);
+
+    const requestPromise = waitForPhotoIdentificationCreate(page);
+    const libraryRequestPromise = waitForCollectionBottleCreate(page);
+    await page.getByRole("button", { name: "Add to Library" }).click();
+    const input = getRpcInput(await requestPromise);
+    const libraryInput = getRpcInput(await libraryRequestPromise);
+
+    expect(input.createToken).toBe(
+      "playwright-create-token:create_bottle_and_release:suitable",
+    );
+    expect(libraryInput.bottle).toBe(createdBottleId);
+    expect(libraryInput.release).toBe(createdReleaseId);
+    expect(libraryInput.pendingImageId).toBe("playwright-photo-upload");
+    await expect(
+      page.getByRole("heading", { name: "Added to Library" }),
+    ).toBeVisible();
+    await expect(page.getByText("First Fill Oloroso")).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
 

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -141,6 +141,39 @@ async function handleRpcRequest({ request, response, url }) {
       sendRpcResponse(response, bottle);
       return true;
     }
+    case "prices/matchQueue/details":
+      if (input?.proposal !== 9901) {
+        sendRpcError(
+          response,
+          "Unexpected price match proposal details payload",
+        );
+        return true;
+      }
+
+      sendRpcResponse(response, buildBottleAndReleaseProposal());
+      return true;
+    case "prices/matchQueue/createBottle": {
+      const expectedBrand =
+        input?.bottle?.brand === testBrand.id ||
+        (input?.bottle?.brand &&
+          typeof input.bottle.brand === "object" &&
+          input.bottle.brand.name === testBrand.name);
+      if (
+        input?.proposal !== 9901 ||
+        input?.bottle?.name !== createdBottleName ||
+        !expectedBrand ||
+        input?.release?.edition !== "First Fill Oloroso"
+      ) {
+        sendRpcError(response, "Unexpected price match create bottle payload");
+        return true;
+      }
+
+      sendRpcResponse(response, {
+        bottle: buildBottleForId(createdBottleId),
+        release: buildCreatedRelease(),
+      });
+      return true;
+    }
     case "bottles/details": {
       if (input?.bottle === createdBottleId) {
         sendRpcResponse(
@@ -986,6 +1019,98 @@ function buildCreatedRelease() {
     edition: "First Fill Oloroso",
     releaseYear: 2026,
   });
+}
+
+function buildBottleAndReleaseProposal() {
+  return {
+    id: 9901,
+    status: "pending_review",
+    proposalType: "create_new",
+    confidence: null,
+    modelConfidence: 90,
+    automationScore: 90,
+    automationEligible: false,
+    automationBlockers: [],
+    decisiveMatchAttributes: [],
+    plainAgeBottleAutoVerifyEligible: false,
+    differentiatingAttributes: [],
+    webEvidenceChecks: [],
+    currentBottleId: null,
+    currentReleaseId: null,
+    suggestedBottleId: null,
+    suggestedReleaseId: null,
+    parentBottleId: null,
+    creationTarget: "bottle_and_release",
+    candidateBottles: [],
+    extractedLabel: null,
+    proposedBottle: {
+      name: createdBottleName,
+      series: null,
+      category: "single_malt",
+      edition: null,
+      statedAge: null,
+      caskStrength: null,
+      singleCask: null,
+      abv: null,
+      vintageYear: null,
+      releaseYear: null,
+      caskType: null,
+      caskSize: null,
+      caskFill: null,
+      brand: { id: testBrand.id, name: testBrand.name },
+      distillers: [{ id: testBrand.id, name: testBrand.name }],
+      bottler: null,
+    },
+    proposedRelease: {
+      edition: "First Fill Oloroso",
+      statedAge: null,
+      abv: null,
+      caskStrength: null,
+      singleCask: null,
+      vintageYear: null,
+      releaseYear: 2026,
+      caskType: null,
+      caskSize: null,
+      caskFill: null,
+      description: null,
+      tastingNotes: null,
+    },
+    searchEvidence: [],
+    rationale: null,
+    model: "playwright",
+    error: null,
+    lastEvaluatedAt: null,
+    reviewedAt: null,
+    isProcessing: false,
+    processingQueuedAt: null,
+    processingExpiresAt: null,
+    createdAt: "2026-06-07T12:00:00.000Z",
+    updatedAt: "2026-06-07T12:00:00.000Z",
+    price: {
+      id: 9902,
+      name: `${testBrand.name} ${createdBottleName}`,
+      price: 99,
+      currency: "usd",
+      imageUrl: null,
+      url: "https://example.test/bottle",
+      volume: 750,
+      updatedAt: "2026-06-07T12:00:00.000Z",
+      isValid: true,
+      site: {
+        id: 9903,
+        name: "Playwright Store",
+        type: "woodencork",
+        lastRunAt: null,
+        nextRunAt: null,
+        runEvery: null,
+      },
+    },
+    currentBottle: null,
+    currentRelease: null,
+    suggestedBottle: null,
+    suggestedRelease: null,
+    parentBottle: null,
+  };
 }
 
 /**

--- a/apps/web/src/app/(layout-free)/bottles/new/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/new/page.tsx
@@ -10,7 +10,10 @@ import useAuth from "@peated/web/hooks/useAuth";
 import { VerifiedRequired } from "@peated/web/hooks/useAuthRequired";
 import { getAddBottleHref } from "@peated/web/lib/addBottle";
 import { toBlob } from "@peated/web/lib/blobs";
-import { getNewBottleBottlingPath } from "@peated/web/lib/bottlings";
+import {
+  getBottleBottlingPath,
+  getNewBottleBottlingPath,
+} from "@peated/web/lib/bottlings";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useMutation, useQuery } from "@tanstack/react-query";
@@ -229,6 +232,7 @@ function CreateBottleForm() {
             })
           : await bottleCreateMutation.mutateAsync(data);
         const createdBottle = "bottle" in created ? created.bottle : created;
+        const createdRelease = "release" in created ? created.release : null;
 
         if (image) {
           const blob = await toBlob(image);
@@ -249,20 +253,35 @@ function CreateBottleForm() {
         if (returnAction === "library") {
           await libraryCreateMutation.mutateAsync({
             bottle: createdBottle.id,
+            release: createdRelease?.id ?? null,
             user: "me",
             collection: "library",
           });
           router.replace(
-            getAddBottleHref({ bottleId: createdBottle.id, intent: "library" }),
+            getAddBottleHref({
+              bottleId: createdBottle.id,
+              releaseId: createdRelease?.id ?? null,
+              intent: "library",
+            }),
           );
         } else if (returnAction === "view") {
-          router.replace(`/bottles/${createdBottle.id}`);
+          router.replace(
+            createdRelease
+              ? getBottleBottlingPath(createdBottle.id, createdRelease.id)
+              : `/bottles/${createdBottle.id}`,
+          );
         } else if (returnAction === "addBottle") {
-          router.replace(getAddBottleHref({ bottleId: createdBottle.id }));
+          router.replace(
+            getAddBottleHref({
+              bottleId: createdBottle.id,
+              releaseId: createdRelease?.id ?? null,
+            }),
+          );
         } else if (returnAction === "tasting") {
           router.replace(
             getAddBottleHref({
               bottleId: createdBottle.id,
+              releaseId: createdRelease?.id ?? null,
               intent: "tasting",
             }),
           );
@@ -272,6 +291,7 @@ function CreateBottleForm() {
           router.replace(
             getAddBottleHref({
               bottleId: createdBottle.id,
+              releaseId: createdRelease?.id ?? null,
               intent: "tasting",
             }),
           );


### PR DESCRIPTION
When bottle creation returns both a parent bottle and a child bottling, the Add Bottle flow now keeps the bottling ID through Library saves and follow-up Add Bottle, Tasting, and View redirects. This prevents a newly created bottling from being saved as only the base bottle and then incorrectly appearing already handled.

The regression coverage exercises both creation paths that can produce a bottle plus bottling: moderator bottle-and-release proposals and scan-created release proposals. The Add Bottle E2E spec passes across desktop and mobile, and the web build/typecheck pass.