### PR TITLE
fix(web): Preserve add bottle scan images

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -24,6 +24,9 @@ import {
 } from "./rpc-fixtures.mjs";
 import { signIn } from "./session";
 
+const pendingScanImageUrl =
+  "http://127.0.0.1:4999/uploads/playwright-photo.webp";
+
 test.describe("create bottle", () => {
   test("renders the Add Bottle resolver at the plain route", async ({
     context,
@@ -270,6 +273,9 @@ test.describe("add bottle flow", () => {
       page.getByRole("link", { name: "View Bottle" }),
     ).toHaveAttribute("href", `/bottles/${existingBottle.id}`);
     await expect(
+      page.getByRole("link", { name: "Add Bottling" }),
+    ).toHaveAttribute("href", `/bottles/${existingBottle.id}/bottlings/new`);
+    await expect(
       page.getByRole("link", { name: "Search Bottles" }),
     ).toHaveAttribute("href", "/search?intent=addBottle");
 
@@ -367,6 +373,49 @@ test.describe("add bottle flow", () => {
     ).toBeVisible();
   });
 
+  test("preserves scanned photos through Add Bottle search fallback", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "scan-search-library"),
+    });
+
+    await page.goto(
+      `/search?intent=addBottle&q=Lagavulin&pendingImageId=playwright-photo-upload&pendingImageUrl=${encodeURIComponent(pendingScanImageUrl)}`,
+    );
+    await page.getByRole("link", { name: existingBottle.fullName }).click();
+
+    await expect(page).toHaveURL(/\/addBottle\?/);
+    const addBottleUrl = new URL(page.url());
+    expect(addBottleUrl.searchParams.get("pendingImageId")).toBe(
+      "playwright-photo-upload",
+    );
+    expect(addBottleUrl.searchParams.get("pendingImageUrl")).toBe(
+      pendingScanImageUrl,
+    );
+    await expect(page.getByAltText("Selected bottle label")).toHaveAttribute(
+      "src",
+      pendingScanImageUrl,
+    );
+    await expect(
+      page.getByRole("link", { name: "Search Bottles" }),
+    ).toHaveAttribute(
+      "href",
+      `/search?intent=addBottle&pendingImageId=playwright-photo-upload&pendingImageUrl=${encodeURIComponent(pendingScanImageUrl)}`,
+    );
+
+    const libraryRequestPromise = waitForCollectionBottleCreate(page);
+    await page.getByRole("button", { name: "Add to Library" }).click();
+    const libraryInput = getRpcInput(await libraryRequestPromise);
+
+    expect(libraryInput.pendingImageId).toBe("playwright-photo-upload");
+    await expect(
+      page.getByRole("heading", { name: "Added to Library" }),
+    ).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+  });
+
   test("adds a searched bottle to Library from the Add Bottle resolver", async ({
     context,
     page,
@@ -458,6 +507,9 @@ test.describe("add bottle flow", () => {
       page.getByRole("button", { name: "Log Tasting" }),
     ).toBeVisible();
     await expect(
+      page.getByRole("link", { name: "Add Bottling" }),
+    ).toBeVisible();
+    await expect(
       page.getByRole("link", { name: "View Bottle" }),
     ).toHaveAttribute("href", `/bottles/${existingBottle.id}`);
     await expectFooterBelowAction(
@@ -496,6 +548,42 @@ test.describe("add bottle flow", () => {
     const inLibraryButton = page.getByRole("button", { name: "In Library" });
     await expect(inLibraryButton).toBeVisible();
     await expect(inLibraryButton).toBeDisabled();
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("saves a scanned photo onto an existing Library entry without an image", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "scan-library-fill-image"),
+    });
+
+    await page.goto(`/addBottle?bottle=${existingBottle.id}`);
+    await page.getByRole("button", { name: "Add to Library" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Added to Library" }),
+    ).toBeVisible();
+
+    await page.goto("/addBottle");
+    await uploadLabel(page);
+    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    const savePhotoButton = page.getByRole("button", { name: "Save Photo" });
+    await expect(savePhotoButton).toBeVisible();
+    await expect(savePhotoButton).toBeEnabled();
+
+    const libraryRequestPromise = waitForCollectionBottleCreate(page);
+    await savePhotoButton.click();
+    const libraryInput = getRpcInput(await libraryRequestPromise);
+
+    expect(libraryInput.pendingImageId).toBe("playwright-photo-upload");
+    await expect(
+      page.getByRole("heading", { name: "Added to Library" }),
+    ).toBeVisible();
+    await expect(page.getByAltText("Selected bottle label")).toHaveAttribute(
+      "src",
+      /library\.webp$/,
+    );
     await expectNoHorizontalOverflow(page);
   });
 
@@ -925,6 +1013,12 @@ test.describe("add bottle flow", () => {
     const createUrl = new URL(href!, page.url());
     expect(createUrl.pathname).toBe("/bottles/new");
     expect(createUrl.searchParams.get("returnAction")).toBe("addBottle");
+    expect(createUrl.searchParams.get("pendingImageId")).toBe(
+      "playwright-photo-upload",
+    );
+    expect(createUrl.searchParams.get("pendingImageUrl")).toBe(
+      pendingScanImageUrl,
+    );
     expect(createUrl.searchParams.get("brandName")).toBe(testBrand.name);
     expect(createUrl.searchParams.get("name")).toBe(createdBottleName);
     await expectNoHorizontalOverflow(page);
@@ -985,16 +1079,73 @@ test.describe("add bottle flow", () => {
     ).toBeVisible();
     await page.getByRole("button", { name: "Create Bottle" }).click();
 
-    await expect(page).toHaveURL(
-      new RegExp(`/addBottle\\?bottle=${createdBottleId}&intent=addBottle$`),
+    await expect(page).toHaveURL(/\/addBottle\?/);
+    const createdUrl = new URL(page.url());
+    expect(createdUrl.pathname).toBe("/addBottle");
+    expect(createdUrl.searchParams.get("bottle")).toBe(String(createdBottleId));
+    expect(createdUrl.searchParams.get("intent")).toBe("addBottle");
+    expect(createdUrl.searchParams.get("pendingImageId")).toBe(
+      "playwright-photo-upload",
+    );
+    expect(createdUrl.searchParams.get("pendingImageUrl")).toBe(
+      pendingScanImageUrl,
     );
     await expect(
       page.getByRole("heading", { name: "Bottle found" }),
     ).toBeVisible();
+    await expect(page.getByAltText("Selected bottle label")).toHaveAttribute(
+      "src",
+      pendingScanImageUrl,
+    );
     await expect(
       page.getByText(`${testBrand.name} ${createdBottleName}`),
     ).toBeVisible();
+
+    const libraryRequestPromise = waitForCollectionBottleCreate(page);
+    await page.getByRole("button", { name: "Add to Library" }).click();
+    const libraryInput = getRpcInput(await libraryRequestPromise);
+
+    expect(libraryInput.pendingImageId).toBe("playwright-photo-upload");
+    await expect(
+      page.getByRole("heading", { name: "Added to Library" }),
+    ).toBeVisible();
     await expectNoHorizontalOverflow(page);
+  });
+
+  test("clears a pending scan when the manual create image is removed", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: uniqueAccessToken(testInfo, "photo-no-match-remove-image"),
+    });
+
+    await page.goto("/addBottle");
+    await uploadLabel(page);
+    await page.getByRole("link", { name: "Create Bottle" }).click();
+
+    await expect(page.getByAltText("uploaded image")).toHaveAttribute(
+      "src",
+      pendingScanImageUrl,
+    );
+    await page.getByRole("button", { name: "Remove Image" }).click();
+    await expect(page.getByAltText("uploaded image")).toBeHidden();
+    await page.getByRole("button", { name: "Create Bottle" }).click();
+
+    await expect(page).toHaveURL(/\/addBottle\?/);
+    const createdUrl = new URL(page.url());
+    expect(createdUrl.searchParams.get("pendingImageId")).toBeNull();
+    expect(createdUrl.searchParams.get("pendingImageUrl")).toBeNull();
+    await expect(page.getByAltText("Selected bottle label")).toBeHidden();
+
+    const libraryRequestPromise = waitForCollectionBottleCreate(page);
+    await page.getByRole("button", { name: "Add to Library" }).click();
+    const libraryInput = getRpcInput(await libraryRequestPromise);
+
+    expect(libraryInput).not.toHaveProperty("pendingImageId");
+    await expect(
+      page.getByRole("heading", { name: "Added to Library" }),
+    ).toBeVisible();
   });
 });
 

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -8,6 +8,7 @@ import BottleResolver, {
   type BottleResolverCreateProposalActionsProps,
   type BottleResolverMatchedActionsProps,
   type BottleResolverTarget,
+  type PendingImageRef,
 } from "@peated/web/components/bottleResolver";
 import { PhotoIdentificationTraceFootnote } from "@peated/web/components/bottleResolver/panels";
 import Button from "@peated/web/components/button";
@@ -21,8 +22,12 @@ import { getCreateBottleHref } from "@peated/web/components/search/createBottleH
 import Spinner from "@peated/web/components/spinner";
 import TastingForm from "@peated/web/components/tastingForm";
 import { AuthRequired } from "@peated/web/hooks/useAuthRequired";
+import { getPendingImageFromParams } from "@peated/web/lib/addBottle";
 import { toBlob } from "@peated/web/lib/blobs";
-import { getBottleBottlingPath } from "@peated/web/lib/bottlings";
+import {
+  getBottleBottlingPath,
+  getNewBottleBottlingPath,
+} from "@peated/web/lib/bottlings";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
@@ -74,11 +79,19 @@ function parseId(value: string | null) {
   return Number.isInteger(id) && id > 0 ? id : null;
 }
 
-function getSearchHref(query = "", intent: AddBottleIntent = "choose") {
+function getSearchHref(
+  query = "",
+  intent: AddBottleIntent = "choose",
+  pendingImage?: PendingImageRef | null,
+) {
   const params = new URLSearchParams({
     intent: intent === "choose" ? "addBottle" : intent,
   });
   if (query) params.set("q", query);
+  if (pendingImage?.id) params.set("pendingImageId", pendingImage.id);
+  if (pendingImage?.imageUrl) {
+    params.set("pendingImageUrl", pendingImage.imageUrl);
+  }
   return `/search?${params.toString()}`;
 }
 
@@ -95,6 +108,21 @@ function getViewBottleHref(
   target: Pick<BottleResolverTarget, "bottle" | "release">,
 ) {
   return getViewBottleHrefByIds(target.bottle.id, target.release?.id ?? null);
+}
+
+function canSaveTargetToLibrary(target: BottleResolverTarget) {
+  return (
+    !target.hasExactLibraryEntry ||
+    Boolean(target.pendingImage && target.exactLibraryEntryImageUrl === null)
+  );
+}
+
+function getLibraryActionLabel(target: {
+  hasExactLibraryEntry: boolean;
+  canSaveLibraryPhoto?: boolean;
+}) {
+  if (!target.hasExactLibraryEntry) return "Add to Library";
+  return target.canSaveLibraryPhoto ? "Save Photo" : "In Library";
 }
 
 function FlowHeader({ children }: { children: ReactNode }) {
@@ -234,11 +262,16 @@ function MatchedOutcomeActions({
   bottleId,
   releaseId,
   hasExactLibraryEntry,
+  exactLibraryEntryImageUrl,
+  pendingImage,
   loadingExactLibraryStatus,
   resolvingAction,
   intent,
   onResolve,
 }: BottleResolverMatchedActionsProps & { intent: AddBottleIntent }) {
+  const canSaveLibraryPhoto = Boolean(
+    pendingImage && hasExactLibraryEntry && exactLibraryEntryImageUrl === null,
+  );
   const libraryButton = (
     <OutcomeButton
       key="library"
@@ -248,11 +281,11 @@ function MatchedOutcomeActions({
       disabled={
         Boolean(resolvingAction) ||
         loadingExactLibraryStatus ||
-        hasExactLibraryEntry
+        (hasExactLibraryEntry && !canSaveLibraryPhoto)
       }
       loading={resolvingAction === "library" || loadingExactLibraryStatus}
     >
-      {hasExactLibraryEntry ? "In Library" : "Add to Library"}
+      {getLibraryActionLabel({ hasExactLibraryEntry, canSaveLibraryPhoto })}
     </OutcomeButton>
   );
   const tastingButton = (
@@ -276,12 +309,26 @@ function MatchedOutcomeActions({
       View Bottle
     </OutcomeButton>
   );
+  const addBottlingButton =
+    releaseId === null ? (
+      <OutcomeButton
+        key="bottling"
+        href={getNewBottleBottlingPath(bottleId)}
+        icon={<Plus className="h-4 w-4" />}
+      >
+        Add Bottling
+      </OutcomeButton>
+    ) : null;
   const actionButtons =
     intent === "tasting"
-      ? [tastingButton, libraryButton, viewButton]
-      : [libraryButton, tastingButton, viewButton];
+      ? [tastingButton, libraryButton, viewButton, addBottlingButton].filter(
+          Boolean,
+        )
+      : [libraryButton, tastingButton, viewButton, addBottlingButton].filter(
+          Boolean,
+        );
 
-  return <div className="grid gap-3 sm:grid-cols-3">{actionButtons}</div>;
+  return <div className="grid gap-3 sm:grid-cols-4">{actionButtons}</div>;
 }
 
 function CreateProposalOutcomeActions({
@@ -367,11 +414,16 @@ function OutcomeSelection({
       icon={<BookOpen className="h-4 w-4" />}
       emphasized
       disabled={
-        target.hasExactLibraryEntry || addingToLibrary || loggingTasting
+        !canSaveTargetToLibrary(target) || addingToLibrary || loggingTasting
       }
       loading={addingToLibrary}
     >
-      {target.hasExactLibraryEntry ? "In Library" : "Add to Library"}
+      {getLibraryActionLabel({
+        hasExactLibraryEntry: target.hasExactLibraryEntry,
+        canSaveLibraryPhoto: Boolean(
+          target.pendingImage && target.exactLibraryEntryImageUrl === null,
+        ),
+      })}
     </OutcomeButton>
   );
   const tastingButton = (
@@ -395,10 +447,23 @@ function OutcomeSelection({
       View Bottle
     </OutcomeButton>
   );
+  const addBottlingButton = !target.release ? (
+    <OutcomeButton
+      key="bottling"
+      href={getNewBottleBottlingPath(target.bottle.id)}
+      icon={<Plus className="h-4 w-4" />}
+    >
+      Add Bottling
+    </OutcomeButton>
+  ) : null;
   const actionButtons =
     intent === "tasting"
-      ? [tastingButton, libraryButton, viewButton]
-      : [libraryButton, tastingButton, viewButton];
+      ? [tastingButton, libraryButton, viewButton, addBottlingButton].filter(
+          Boolean,
+        )
+      : [libraryButton, tastingButton, viewButton, addBottlingButton].filter(
+          Boolean,
+        );
 
   return (
     <Layout footer={null} header={<FlowHeader>{null}</FlowHeader>}>
@@ -423,12 +488,12 @@ function OutcomeSelection({
               <h2 className="font-semibold text-white">{title}</h2>
               <p className="text-muted mt-1 text-sm">{description}</p>
             </div>
-            <div className="grid gap-3 sm:grid-cols-3">{actionButtons}</div>
+            <div className="grid gap-3 sm:grid-cols-4">{actionButtons}</div>
           </div>
         </section>
         <div className="grid gap-3 sm:grid-cols-2">
           <Button
-            href={getSearchHref("", intent)}
+            href={getSearchHref("", intent, target.pendingImage)}
             fullWidth
             icon={<Search className="h-4 w-4" />}
           >
@@ -525,10 +590,14 @@ function AddBottleFlowContent() {
     searchParams.get("release") ?? searchParams.get("bottling"),
   );
   const requestedFlightId = searchParams.get("flight") || null;
+  const requestedPendingImage = useMemo(
+    () => getPendingImageFromParams(new URLSearchParams(searchParams)),
+    [searchParams],
+  );
   const requestedTargetKey = useMemo(() => {
     if (!requestedBottleId) return null;
-    return `${requestedBottleId}:${requestedReleaseId ?? "base"}`;
-  }, [requestedBottleId, requestedReleaseId]);
+    return `${requestedBottleId}:${requestedReleaseId ?? "base"}:${requestedPendingImage?.id ?? "no-image"}`;
+  }, [requestedBottleId, requestedPendingImage?.id, requestedReleaseId]);
 
   const [loadedTargetKey, setLoadedTargetKey] = useState<string | null>(null);
   const [loadingTarget, setLoadingTarget] = useState(false);
@@ -599,6 +668,7 @@ function AddBottleFlowContent() {
         ]);
 
         if (cancelled) return;
+        const exactLibraryEntry = collectionStatus.results[0] ?? null;
         if (release && release.bottleId !== bottle.id) {
           setSelectedTarget(null);
           setLoadedTargetKey(null);
@@ -610,9 +680,10 @@ function AddBottleFlowContent() {
         setSelectedTarget({
           bottle,
           release,
-          hasExactLibraryEntry: collectionStatus.results.length > 0,
-          pendingImage: null,
-          previewUrl: null,
+          hasExactLibraryEntry: Boolean(exactLibraryEntry),
+          exactLibraryEntryImageUrl: exactLibraryEntry?.imageUrl ?? null,
+          pendingImage: requestedPendingImage,
+          previewUrl: requestedPendingImage?.imageUrl || null,
         });
         setLoadedTargetKey(requestedTargetKey);
       } catch (err) {
@@ -639,6 +710,7 @@ function AddBottleFlowContent() {
     loadedTargetKey,
     orpc,
     requestedBottleId,
+    requestedPendingImage,
     requestedReleaseId,
     requestedTargetKey,
   ]);
@@ -721,7 +793,7 @@ function AddBottleFlowContent() {
     }
     setLibraryError(undefined);
     setTastingDraft(null);
-    if (target.hasExactLibraryEntry) return;
+    if (!canSaveTargetToLibrary(target)) return;
 
     try {
       const entry = await libraryCreateMutation.mutateAsync({
@@ -873,15 +945,19 @@ function AddBottleFlowContent() {
   return (
     <BottleResolver
       title="Add Bottle"
-      searchHrefForQuery={(query) => getSearchHref(query, intent)}
+      searchHrefForQuery={(query, pendingImage) =>
+        getSearchHref(query, intent, pendingImage)
+      }
       createBottleHrefForResult={(
         query: string,
         prefill?: CreateBottlePrefill,
+        pendingImage?: PendingImageRef | null,
       ) =>
         getCreateBottleHref({
           query,
           returnAction: getCreateReturnAction(intent),
           prefill,
+          pendingImage,
         })
       }
       createProposalActionLabel="Create Bottle"

--- a/apps/web/src/app/(layout-free)/bottles/new/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/new/page.tsx
@@ -76,6 +76,8 @@ function CreateBottleForm() {
     searchParams.get("returnAction") || searchParams.get("intent"),
   );
   const proposalId = searchParams.get("proposal");
+  const pendingImageId = searchParams.get("pendingImageId")?.trim() || null;
+  const pendingImageUrl = searchParams.get("pendingImageUrl") || null;
 
   const distiller = searchParams.get("distiller") || null;
   const brand = searchParams.get("brand") || null;
@@ -112,6 +114,7 @@ function CreateBottleForm() {
 
   const [initialData, setInitialData] = useState<BottleFormInitialData>({
     name,
+    ...(pendingImageUrl ? { imageUrl: pendingImageUrl } : {}),
     ...(brandName ? { brand: brandName } : {}),
     ...(statedAge !== null ? { statedAge } : {}),
     ...(abv !== null ? { abv } : {}),
@@ -233,6 +236,9 @@ function CreateBottleForm() {
           : await bottleCreateMutation.mutateAsync(data);
         const createdBottle = "bottle" in created ? created.bottle : created;
         const createdRelease = "release" in created ? created.release : null;
+        const nextPendingImageId = image === undefined ? pendingImageId : null;
+        const nextPendingImageUrl =
+          image === undefined ? pendingImageUrl : null;
 
         if (image) {
           const blob = await toBlob(image);
@@ -256,11 +262,14 @@ function CreateBottleForm() {
             release: createdRelease?.id ?? null,
             user: "me",
             collection: "library",
+            pendingImageId: nextPendingImageId ?? undefined,
           });
           router.replace(
             getAddBottleHref({
               bottleId: createdBottle.id,
               releaseId: createdRelease?.id ?? null,
+              pendingImageId: nextPendingImageId,
+              pendingImageUrl: nextPendingImageUrl,
               intent: "library",
             }),
           );
@@ -275,6 +284,8 @@ function CreateBottleForm() {
             getAddBottleHref({
               bottleId: createdBottle.id,
               releaseId: createdRelease?.id ?? null,
+              pendingImageId: nextPendingImageId,
+              pendingImageUrl: nextPendingImageUrl,
             }),
           );
         } else if (returnAction === "tasting") {
@@ -282,6 +293,8 @@ function CreateBottleForm() {
             getAddBottleHref({
               bottleId: createdBottle.id,
               releaseId: createdRelease?.id ?? null,
+              pendingImageId: nextPendingImageId,
+              pendingImageUrl: nextPendingImageUrl,
               intent: "tasting",
             }),
           );

--- a/apps/web/src/components/bottleResolver/index.tsx
+++ b/apps/web/src/components/bottleResolver/index.tsx
@@ -56,6 +56,7 @@ export type {
   BottleResolverMatchedActionsProps,
   BottleResolverProps,
   BottleResolverTarget,
+  PendingImageRef,
 } from "./types";
 
 const loadingMessages = [
@@ -100,6 +101,7 @@ export default function BottleResolver({
     bottleId: number;
     releaseId: number | null;
     hasExactLibraryEntry: boolean;
+    imageUrl: string | null;
     loading: boolean;
   } | null>(null);
 
@@ -209,11 +211,13 @@ export default function BottleResolver({
           baseOnly: releaseId == null,
         }),
       ]);
+      const exactLibraryEntry = collectionStatus.results[0] ?? null;
       await resolveTarget(
         {
           bottle,
           release,
-          hasExactLibraryEntry: collectionStatus.results.length > 0,
+          hasExactLibraryEntry: Boolean(exactLibraryEntry),
+          exactLibraryEntryImageUrl: exactLibraryEntry?.imageUrl ?? null,
         },
         action,
       );
@@ -354,13 +358,14 @@ export default function BottleResolver({
   const createProposalLabel = getCreateProposalLabel(photoResult);
   const defaultSearchHref = searchHrefForQuery();
   const searchSeed = getSearchSeed(photoResult);
-  const searchHref = searchHrefForQuery(searchSeed);
+  const searchHref = searchHrefForQuery(searchSeed, photoResult?.pendingImage);
   const createBottlePrefill = getCreateBottlePrefill(photoResult);
   const createBottleHref =
     photoResult && createBottleHrefForResult
       ? createBottleHrefForResult(
           getCreateNameSeed(photoResult),
           createBottlePrefill,
+          photoResult.pendingImage,
         )
       : null;
   const manualResultCopy = getManualResultCopy(photoResult);
@@ -388,6 +393,7 @@ export default function BottleResolver({
       bottleId: statusBottleId,
       releaseId: statusReleaseId,
       hasExactLibraryEntry: false,
+      imageUrl: null,
       loading: true,
     });
 
@@ -400,11 +406,13 @@ export default function BottleResolver({
           release: statusReleaseId ?? undefined,
           baseOnly: statusReleaseId == null,
         });
+        const exactLibraryEntry = collectionStatus.results[0] ?? null;
         if (cancelled) return;
         setMatchedBottleStatus({
           bottleId: statusBottleId,
           releaseId: statusReleaseId,
-          hasExactLibraryEntry: collectionStatus.results.length > 0,
+          hasExactLibraryEntry: Boolean(exactLibraryEntry),
+          imageUrl: exactLibraryEntry?.imageUrl ?? null,
           loading: false,
         });
       } catch (err) {
@@ -414,6 +422,7 @@ export default function BottleResolver({
           bottleId: statusBottleId,
           releaseId: statusReleaseId,
           hasExactLibraryEntry: false,
+          imageUrl: null,
           loading: false,
         });
       }
@@ -501,6 +510,8 @@ export default function BottleResolver({
                 createActionLabel={createProposalActionLabel}
                 resolvingAction={resolvingAction}
                 hasExactLibraryEntry={matchedBottleHasExactLibraryEntry}
+                exactLibraryEntryImageUrl={matchedBottleStatus?.imageUrl}
+                pendingImage={photoResult.pendingImage}
                 loadingExactLibraryStatus={
                   matchedBottleExactLibraryStatusLoading
                 }

--- a/apps/web/src/components/bottleResolver/states.tsx
+++ b/apps/web/src/components/bottleResolver/states.tsx
@@ -196,6 +196,8 @@ export function PhotoMatchCreateState({
   createActionLabel,
   resolvingAction,
   hasExactLibraryEntry,
+  exactLibraryEntryImageUrl,
+  pendingImage,
   loadingExactLibraryStatus,
   onLoadTarget,
   onAcceptCreateProposal,
@@ -217,6 +219,8 @@ export function PhotoMatchCreateState({
   createActionLabel: string;
   resolvingAction: BottleResolverAction | null;
   hasExactLibraryEntry: boolean;
+  exactLibraryEntryImageUrl?: string | null;
+  pendingImage: PhotoIdentification["pendingImage"] | null;
   loadingExactLibraryStatus: boolean;
   onLoadTarget: (
     bottleId: number,
@@ -252,6 +256,8 @@ export function PhotoMatchCreateState({
               bottleId: matchedBottleId,
               releaseId: matchedReleaseId,
               hasExactLibraryEntry,
+              exactLibraryEntryImageUrl,
+              pendingImage,
               loadingExactLibraryStatus,
               resolvingAction:
                 resolvingAction === "create" ? null : resolvingAction,

--- a/apps/web/src/components/bottleResolver/types.ts
+++ b/apps/web/src/components/bottleResolver/types.ts
@@ -4,11 +4,17 @@ import type { ReactNode } from "react";
 
 import type { PhotoIdentification } from "./helpers";
 
+export type PendingImageRef = Pick<
+  PhotoIdentification["pendingImage"],
+  "id" | "imageUrl"
+>;
+
 export type BottleResolverTarget = {
   bottle: Bottle;
   release: BottleRelease | null;
   hasExactLibraryEntry: boolean;
-  pendingImage: PhotoIdentification["pendingImage"] | null;
+  exactLibraryEntryImageUrl?: string | null;
+  pendingImage: PendingImageRef | null;
   /** Blob preview ownership transfers to the resolver caller only after onResolve succeeds. */
   previewUrl: string | null;
   resultSource?: "created" | "found";
@@ -29,6 +35,8 @@ export type BottleResolverMatchedActionsProps = {
   bottleId: number;
   releaseId: number | null;
   hasExactLibraryEntry: boolean;
+  exactLibraryEntryImageUrl?: string | null;
+  pendingImage: PendingImageRef | null;
   loadingExactLibraryStatus: boolean;
   resolvingAction: BottleResolverMatchedAction | null;
   onResolve: (action: BottleResolverMatchedAction) => void;
@@ -45,10 +53,14 @@ export type BottleResolverProps = {
     target: BottleResolverTarget,
     action?: BottleResolverAction,
   ) => Promise<void> | void;
-  searchHrefForQuery: (query?: string) => string;
+  searchHrefForQuery: (
+    query?: string,
+    pendingImage?: PendingImageRef | null,
+  ) => string;
   createBottleHrefForResult?: (
     query: string,
     prefill?: CreateBottlePrefill,
+    pendingImage?: PendingImageRef | null,
   ) => string;
   title: string;
   renderMatchedResultActions?: (

--- a/apps/web/src/components/search/bottleResult.tsx
+++ b/apps/web/src/components/search/bottleResult.tsx
@@ -6,6 +6,7 @@ import Link from "@peated/web/components/link";
 import {
   getAddBottleHref,
   type AddBottleRouteIntent,
+  type PendingImageRouteState,
 } from "@peated/web/lib/addBottle";
 import { formatBottlingCountLabel } from "@peated/web/lib/bottlings";
 import { type ReactNode } from "react";
@@ -24,13 +25,20 @@ export function getBottleResultHref({
   bottleId,
   directToTasting = false,
   addBottleIntent,
+  pendingImage,
 }: {
   bottleId: number;
   directToTasting?: boolean;
   addBottleIntent?: AddBottleRouteIntent;
+  pendingImage?: PendingImageRouteState | null;
 }) {
   if (addBottleIntent) {
-    return getAddBottleHref({ bottleId, intent: addBottleIntent });
+    return getAddBottleHref({
+      bottleId,
+      intent: addBottleIntent,
+      pendingImageId: pendingImage?.id,
+      pendingImageUrl: pendingImage?.imageUrl,
+    });
   }
 
   if (directToTasting) {
@@ -44,10 +52,12 @@ export default function BottleResultRow({
   result: { ref: bottle },
   directToTasting = false,
   addBottleIntent,
+  pendingImage,
 }: {
   result: BottleResult;
   directToTasting: boolean;
   addBottleIntent?: AddBottleRouteIntent;
+  pendingImage?: PendingImageRouteState | null;
 }) {
   const metadata: ReactNode[] = [];
   if (bottle.distillers.length)
@@ -72,6 +82,7 @@ export default function BottleResultRow({
               bottleId: bottle.id,
               directToTasting,
               addBottleIntent,
+              pendingImage,
             })}
           >
             <span className="absolute inset-x-0 -top-px bottom-0" />

--- a/apps/web/src/components/search/createBottleHref.ts
+++ b/apps/web/src/components/search/createBottleHref.ts
@@ -1,4 +1,5 @@
 import { toTitleCase } from "@peated/server/lib/strings";
+import type { PendingImageRouteState } from "@peated/web/lib/addBottle";
 
 export type CreateBottleReturnAction =
   | "addBottle"
@@ -23,10 +24,12 @@ export function getCreateBottleHref({
   query,
   returnAction,
   prefill,
+  pendingImage,
 }: {
   query: string;
   returnAction?: CreateBottleReturnAction;
   prefill?: CreateBottlePrefill;
+  pendingImage?: PendingImageRouteState | null;
 }) {
   const params = new URLSearchParams({
     name: toTitleCase(query),
@@ -48,6 +51,10 @@ export function getCreateBottleHref({
   }
   if (prefill?.releaseYear !== null && prefill?.releaseYear !== undefined) {
     params.set("releaseYear", String(prefill.releaseYear));
+  }
+  if (pendingImage?.id) params.set("pendingImageId", pendingImage.id);
+  if (pendingImage?.imageUrl) {
+    params.set("pendingImageUrl", pendingImage.imageUrl);
   }
   return `/bottles/new?${params.toString()}`;
 }

--- a/apps/web/src/components/search/panel.tsx
+++ b/apps/web/src/components/search/panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import useAuth from "@peated/web/hooks/useAuth";
+import { getPendingImageFromParams } from "@peated/web/lib/addBottle";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
@@ -53,6 +54,7 @@ export default function SearchPanel({
   const qs = useSearchParams();
   const intent = qs.get("intent");
   const addBottleIntent = getAddBottleIntent(intent);
+  const pendingImage = getPendingImageFromParams(qs);
   // The empty ?tasting flag is the legacy direct shortcut; intent=tasting keeps the Add Bottle resolver.
   const directToTasting = qs.has("tasting");
   const createBottleReturnAction =
@@ -135,6 +137,11 @@ export default function SearchPanel({
               if (addBottleIntent) {
                 params.set("intent", addBottleIntent);
               }
+              if (pendingImage?.id)
+                params.set("pendingImageId", pendingImage.id);
+              if (pendingImage?.imageUrl) {
+                params.set("pendingImageUrl", pendingImage.imageUrl);
+              }
               router.replace(`${location.pathname}?${params.toString()}`);
             }}
             loading={state === "loading"}
@@ -153,6 +160,7 @@ export default function SearchPanel({
           directToTasting={directToTasting}
           addBottleIntent={addBottleIntent}
           createBottleReturnAction={createBottleReturnAction}
+          pendingImage={pendingImage}
         />
       )}
     </Layout>

--- a/apps/web/src/components/search/result.tsx
+++ b/apps/web/src/components/search/result.tsx
@@ -1,3 +1,4 @@
+import type { PendingImageRouteState } from "@peated/web/lib/addBottle";
 import type { AddBottleRouteIntent, BottleResult } from "./bottleResult";
 import BottleResultRow from "./bottleResult";
 import type { EntityResult } from "./entityResult";
@@ -11,10 +12,12 @@ export default function ResultRow({
   result,
   directToTasting = false,
   addBottleIntent,
+  pendingImage,
 }: {
   result: Result;
   directToTasting: boolean;
   addBottleIntent?: AddBottleRouteIntent;
+  pendingImage?: PendingImageRouteState | null;
 }) {
   switch (result.type) {
     case "bottle":
@@ -23,6 +26,7 @@ export default function ResultRow({
           result={result}
           directToTasting={directToTasting}
           addBottleIntent={addBottleIntent}
+          pendingImage={pendingImage}
         />
       );
     case "entity":

--- a/apps/web/src/components/search/searchResults.test.ts
+++ b/apps/web/src/components/search/searchResults.test.ts
@@ -47,6 +47,21 @@ describe("search result create bottle links", () => {
     );
   });
 
+  it("preserves pending scan images for reviewed bottle creation", () => {
+    expect(
+      getCreateBottleHref({
+        query: "playwright reserve",
+        returnAction: "addBottle",
+        pendingImage: {
+          id: "pending-photo",
+          imageUrl: "http://127.0.0.1:4999/uploads/pending.webp",
+        },
+      }),
+    ).toBe(
+      "/bottles/new?name=Playwright+Reserve&returnAction=addBottle&pendingImageId=pending-photo&pendingImageUrl=http%3A%2F%2F127.0.0.1%3A4999%2Fuploads%2Fpending.webp",
+    );
+  });
+
   it("routes Add Bottle intent bottle rows through the Add Bottle flow", () => {
     expect(
       getBottleResultHref({
@@ -54,6 +69,21 @@ describe("search result create bottle links", () => {
         addBottleIntent: "addBottle",
       }),
     ).toBe("/addBottle?bottle=123&intent=addBottle");
+  });
+
+  it("preserves pending scan images for Add Bottle search results", () => {
+    expect(
+      getBottleResultHref({
+        bottleId: 123,
+        addBottleIntent: "addBottle",
+        pendingImage: {
+          id: "pending-photo",
+          imageUrl: "http://127.0.0.1:4999/uploads/pending.webp",
+        },
+      }),
+    ).toBe(
+      "/addBottle?bottle=123&pendingImageId=pending-photo&pendingImageUrl=http%3A%2F%2F127.0.0.1%3A4999%2Fuploads%2Fpending.webp&intent=addBottle",
+    );
   });
 
   it("routes tasting search shortcuts through the Add Bottle flow", () => {

--- a/apps/web/src/components/search/searchResults.tsx
+++ b/apps/web/src/components/search/searchResults.tsx
@@ -2,6 +2,7 @@ import { PlusIcon } from "@heroicons/react/20/solid";
 import { toTitleCase } from "@peated/server/lib/strings";
 import type { Outputs } from "@peated/server/orpc/router";
 import Link from "@peated/web/components/link";
+import type { PendingImageRouteState } from "@peated/web/lib/addBottle";
 import ListItem from "../listItem";
 import type { AddBottleRouteIntent } from "./bottleResult";
 import {
@@ -17,6 +18,7 @@ export default function SearchResults({
   directToTasting = false,
   addBottleIntent,
   createBottleReturnAction,
+  pendingImage,
 }: {
   query: string;
   results: Outputs["search"]["results"];
@@ -24,6 +26,7 @@ export default function SearchResults({
   directToTasting?: boolean;
   addBottleIntent?: AddBottleRouteIntent;
   createBottleReturnAction?: CreateBottleReturnAction;
+  pendingImage?: PendingImageRouteState | null;
 }) {
   return (
     <ul
@@ -40,6 +43,7 @@ export default function SearchResults({
                 href={getCreateBottleHref({
                   query,
                   returnAction: createBottleReturnAction,
+                  pendingImage,
                 })}
               >
                 <span className="absolute inset-x-0 -top-px bottom-0" />
@@ -68,6 +72,7 @@ export default function SearchResults({
               result={result}
               directToTasting={directToTasting}
               addBottleIntent={addBottleIntent}
+              pendingImage={pendingImage}
             />
           </ListItem>
         );

--- a/apps/web/src/lib/addBottle.ts
+++ b/apps/web/src/lib/addBottle.ts
@@ -5,15 +5,36 @@ export type AddBottleRouteIntent =
   | "tasting"
   | "view";
 
+export type PendingImageRouteState = {
+  id: string;
+  imageUrl?: string | null;
+};
+
+export function getPendingImageFromParams(
+  searchParams: Pick<URLSearchParams, "get">,
+) {
+  const id = searchParams.get("pendingImageId")?.trim();
+  if (!id) return null;
+
+  return {
+    id,
+    imageUrl: searchParams.get("pendingImageUrl") || "",
+  };
+}
+
 export function getAddBottleHref({
   bottleId,
   releaseId,
   flightId,
+  pendingImageId,
+  pendingImageUrl,
   intent = "addBottle",
 }: {
   bottleId?: number | string | null;
   releaseId?: number | string | null;
   flightId?: string | null;
+  pendingImageId?: string | null;
+  pendingImageUrl?: string | null;
   intent?: AddBottleRouteIntent;
 }) {
   const params = new URLSearchParams();
@@ -21,6 +42,8 @@ export function getAddBottleHref({
   if (bottleId) params.set("bottle", String(bottleId));
   if (releaseId) params.set("release", String(releaseId));
   if (flightId) params.set("flight", flightId);
+  if (pendingImageId) params.set("pendingImageId", pendingImageId);
+  if (pendingImageUrl) params.set("pendingImageUrl", pendingImageUrl);
   params.set("intent", intent);
 
   return `/addBottle?${params.toString()}`;


### PR DESCRIPTION
Pending scan images now stay attached as route state through Add Bottle search fallback, direct target loading, and manual catalog creation returns. That keeps the scanned photo visible on the Add Bottle form and lets existing Library entries without an image save the pending photo through the new Save Photo path.

Base-bottle Add Bottle outcomes now also expose Add Bottling so the manual bottling path is discoverable from both resolved and scan-matched base bottles. The rebase preserves the new created-release return handling from main, so manual creation can return with both release IDs and pending scan image state. Verified with `pnpm --filter @peated/web typecheck`, `pnpm --dir apps/web test -- src/components/search/searchResults.test.ts`, and `pnpm --dir apps/web test:e2e -- add-bottle.spec.ts` (70 passed).