### PR TITLE
feat(activity): Add library events to main feeds

### DIFF
--- a/apps/server/src/lib/activityFeed.ts
+++ b/apps/server/src/lib/activityFeed.ts
@@ -1,0 +1,327 @@
+import { db } from "@peated/server/db";
+import type {
+  Bottle,
+  BottleRelease,
+  Collection,
+  CollectionBottle,
+  Tasting,
+  User,
+} from "@peated/server/db/schema";
+import {
+  bottleReleases,
+  bottles,
+  collectionBottles,
+} from "@peated/server/db/schema";
+import { getReservedCollection } from "@peated/server/lib/db";
+import { serialize } from "@peated/server/serializers";
+import { CollectionSerializer } from "@peated/server/serializers/collection";
+import { CollectionBottleSerializer } from "@peated/server/serializers/collectionBottle";
+import { TastingSerializer } from "@peated/server/serializers/tasting";
+import { UserSerializer } from "@peated/server/serializers/user";
+import type {
+  ActivityCollectionAddEntry,
+  ActivityEntry,
+} from "@peated/server/types";
+import { and, desc, eq, sql } from "drizzle-orm";
+
+export const COLLECTION_PREVIEW_LIMIT = 4;
+export const SECONDARY_ENTRY_LIMIT_WITH_PRIMARY = 2;
+
+type CollectionBottleWithTarget = CollectionBottle & {
+  bottle: Bottle;
+  release: BottleRelease | null;
+};
+
+type CollectionAddSourceRow = {
+  collectionBottle: CollectionBottle;
+  bottle: Bottle;
+  release: BottleRelease | null;
+};
+
+export type CollectionAddGroup = {
+  collection: Collection;
+  user: User;
+  bucket: Date | string;
+  windowStart: Date;
+  windowEnd: Date;
+  totalItems: number;
+};
+
+export type ActivitySourceWindow = {
+  primaryOffset: number;
+  primaryLimit: number;
+  secondaryOffset: number;
+  secondaryLimit: number;
+};
+
+/** Coerces database date bucket values into UTC activity timestamps. */
+export function coerceActivityDate(value: Date | string) {
+  return value instanceof Date ? value : new Date(`${value}+0000`);
+}
+
+/**
+ * Returns per-source offsets for a logical feed page while keeping secondary
+ * collection groups capped whenever primary tasting activity exists.
+ */
+export function getActivitySourceWindow({
+  cursor,
+  limit,
+  totalPrimary,
+  totalSecondary,
+}: {
+  cursor: number;
+  limit: number;
+  totalPrimary: number;
+  totalSecondary: number;
+}): ActivitySourceWindow {
+  const pageIndex = cursor - 1;
+
+  if (limit === 1) {
+    if (pageIndex < totalPrimary) {
+      return {
+        primaryOffset: pageIndex,
+        primaryLimit: 1,
+        secondaryOffset: 0,
+        secondaryLimit: 0,
+      };
+    }
+
+    return {
+      primaryOffset: totalPrimary,
+      primaryLimit: 0,
+      secondaryOffset: pageIndex - totalPrimary,
+      secondaryLimit: 1,
+    };
+  }
+
+  if (!totalPrimary) {
+    return {
+      primaryOffset: 0,
+      primaryLimit: 0,
+      secondaryOffset: pageIndex * limit,
+      secondaryLimit: limit,
+    };
+  }
+
+  const secondaryPerPage = Math.min(
+    SECONDARY_ENTRY_LIMIT_WITH_PRIMARY,
+    limit - 1,
+  );
+  const primaryPerPageWithSecondary = limit - secondaryPerPage;
+  const pagesWithSecondary = Math.ceil(totalSecondary / secondaryPerPage);
+  const priorPagesWithSecondary = Math.min(pageIndex, pagesWithSecondary);
+  const priorPagesWithoutSecondary = pageIndex - priorPagesWithSecondary;
+  const pageSecondaryOffset =
+    pageIndex < pagesWithSecondary
+      ? pageIndex * secondaryPerPage
+      : totalSecondary;
+  const pageSecondaryLimit =
+    pageIndex < pagesWithSecondary
+      ? Math.min(secondaryPerPage, totalSecondary - pageSecondaryOffset)
+      : 0;
+  const primaryCapacity = limit - pageSecondaryLimit;
+
+  return {
+    primaryOffset:
+      priorPagesWithSecondary * primaryPerPageWithSecondary +
+      priorPagesWithoutSecondary * limit,
+    primaryLimit: primaryCapacity,
+    secondaryOffset: pageSecondaryOffset,
+    secondaryLimit: pageSecondaryLimit,
+  };
+}
+
+/** Interleaves primary tastings with capped secondary collection activity. */
+export function composeActivity({
+  primary,
+  secondary,
+  limit,
+  sourceWindow,
+  totalPrimary,
+  totalSecondary,
+}: {
+  primary: ActivityEntry[];
+  secondary: ActivityEntry[];
+  limit: number;
+  sourceWindow: ActivitySourceWindow;
+  totalPrimary: number;
+  totalSecondary: number;
+}): { results: ActivityEntry[]; hasNext: boolean } {
+  if (limit === 1) {
+    const result = primary.length ? [primary[0]] : secondary.slice(0, 1);
+    return {
+      results: result,
+      hasNext:
+        sourceWindow.primaryOffset + primary.length < totalPrimary ||
+        sourceWindow.secondaryOffset + secondary.length < totalSecondary,
+    };
+  }
+
+  const pageSecondary = secondary.slice(0, sourceWindow.secondaryLimit);
+  const primaryCapacity = limit - pageSecondary.length;
+  const pagePrimary = primary.slice(0, primaryCapacity);
+
+  const result: ActivityEntry[] = [];
+  let secondaryIndex = 0;
+
+  for (const primaryEntry of pagePrimary) {
+    result.push(primaryEntry);
+    if (secondaryIndex < pageSecondary.length) {
+      result.push(pageSecondary[secondaryIndex]);
+      secondaryIndex += 1;
+    }
+  }
+
+  while (result.length < limit && secondaryIndex < pageSecondary.length) {
+    result.push(pageSecondary[secondaryIndex]);
+    secondaryIndex += 1;
+  }
+
+  return {
+    results: result,
+    hasNext:
+      sourceWindow.primaryOffset + pagePrimary.length < totalPrimary ||
+      sourceWindow.secondaryOffset + pageSecondary.length < totalSecondary,
+  };
+}
+
+/** Wraps serialized tastings in the shared activity-entry contract. */
+export async function serializeTastingEntries(
+  tastingRows: Tasting[],
+  currentUser?: User | null,
+) {
+  const serializedTastings = await serialize(
+    TastingSerializer,
+    tastingRows,
+    currentUser,
+  );
+  return tastingRows.map((tasting, index): ActivityEntry => {
+    return {
+      id: `tasting:${tasting.id}`,
+      type: "tasting",
+      priority: "primary",
+      createdAt: tasting.createdAt.toISOString(),
+      tasting: serializedTastings[index],
+    };
+  });
+}
+
+async function getCollectionHref(collection: Collection, user: User) {
+  const [favoritesCollection, libraryCollection] = await Promise.all([
+    getReservedCollection(db, user.id, "default"),
+    getReservedCollection(db, user.id, "library"),
+  ]);
+
+  if (favoritesCollection?.id === collection.id) {
+    return `/users/${user.username}/favorites`;
+  }
+  if (libraryCollection?.id === collection.id) {
+    return `/users/${user.username}/library`;
+  }
+  return null;
+}
+
+async function serializeCollectionForActivity({
+  collection,
+  user,
+  currentUser,
+}: {
+  collection: Collection;
+  user: User;
+  currentUser?: User | null;
+}) {
+  return {
+    ...(await serialize(CollectionSerializer, collection, currentUser)),
+    href: await getCollectionHref(collection, user),
+  };
+}
+
+async function serializeCollectionBottlePreview(
+  rows: CollectionAddSourceRow[],
+  currentUser?: User | null,
+) {
+  return await serialize(
+    CollectionBottleSerializer,
+    rows.map(
+      ({ collectionBottle, bottle, release }): CollectionBottleWithTarget => ({
+        ...collectionBottle,
+        bottle,
+        release,
+      }),
+    ),
+    currentUser,
+  );
+}
+
+/** Serializes grouped collection additions with actor, destination, and previews. */
+export async function serializeCollectionAddEntries({
+  groups,
+  currentUser,
+}: {
+  groups: CollectionAddGroup[];
+  currentUser?: User | null;
+}) {
+  const serializedUsersById = new Map<
+    number,
+    ActivityCollectionAddEntry["createdBy"]
+  >();
+  const serializedCollectionsById = new Map<
+    number,
+    Awaited<ReturnType<typeof serializeCollectionForActivity>>
+  >();
+
+  const entries: ActivityEntry[] = [];
+  for (const group of groups) {
+    let createdBy = serializedUsersById.get(group.user.id);
+    if (!createdBy) {
+      createdBy = await serialize(UserSerializer, group.user, currentUser);
+      serializedUsersById.set(group.user.id, createdBy);
+    }
+
+    let collection = serializedCollectionsById.get(group.collection.id);
+    if (!collection) {
+      collection = await serializeCollectionForActivity({
+        collection: group.collection,
+        user: group.user,
+        currentUser,
+      });
+      serializedCollectionsById.set(group.collection.id, collection);
+    }
+
+    const previewRows = await db
+      .select({
+        collectionBottle: collectionBottles,
+        bottle: bottles,
+        release: bottleReleases,
+      })
+      .from(collectionBottles)
+      .innerJoin(bottles, eq(bottles.id, collectionBottles.bottleId))
+      .leftJoin(
+        bottleReleases,
+        eq(bottleReleases.id, collectionBottles.releaseId),
+      )
+      .where(
+        and(
+          eq(collectionBottles.collectionId, group.collection.id),
+          sql`DATE_TRUNC('day', ${collectionBottles.createdAt}) = ${group.bucket}::timestamp`,
+        ),
+      )
+      .orderBy(desc(collectionBottles.createdAt))
+      .limit(COLLECTION_PREVIEW_LIMIT);
+
+    entries.push({
+      id: `collection_add:${group.user.id}:${group.collection.id}:${group.windowEnd.getTime()}`,
+      type: "collection_add",
+      priority: "secondary",
+      createdAt: group.windowEnd.toISOString(),
+      windowStart: group.windowStart.toISOString(),
+      windowEnd: group.windowEnd.toISOString(),
+      createdBy,
+      collection,
+      items: await serializeCollectionBottlePreview(previewRows, currentUser),
+      totalItems: group.totalItems,
+    });
+  }
+
+  return entries;
+}

--- a/apps/server/src/orpc/routes/activity/index.ts
+++ b/apps/server/src/orpc/routes/activity/index.ts
@@ -1,0 +1,6 @@
+import { base } from "@peated/server/orpc";
+import list from "./list";
+
+export default base.tag("activity").router({
+  list,
+});

--- a/apps/server/src/orpc/routes/activity/list.test.ts
+++ b/apps/server/src/orpc/routes/activity/list.test.ts
@@ -1,0 +1,294 @@
+import { db } from "@peated/server/db";
+import { collectionBottles } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+describe("GET /activity", () => {
+  test("returns tastings and grouped collection additions", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User();
+    const tasting = await fixtures.Tasting({
+      createdById: user.id,
+      createdAt: new Date("2026-01-03T12:30:00Z"),
+    });
+    const collection = await fixtures.Collection({
+      name: "Library",
+      createdById: user.id,
+    });
+    const [firstBottle, secondBottle] = await Promise.all([
+      fixtures.Bottle(),
+      fixtures.Bottle(),
+    ]);
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: collection.id,
+        bottleId: firstBottle.id,
+        createdAt: new Date("2026-01-03T12:00:00Z"),
+      },
+      {
+        collectionId: collection.id,
+        bottleId: secondBottle.id,
+        createdAt: new Date("2026-01-03T12:10:00Z"),
+      },
+    ]);
+
+    const result = await routerClient.activity.list({
+      filter: "global",
+      limit: 10,
+    });
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toMatchObject({
+      id: `tasting:${tasting.id}`,
+      type: "tasting",
+      priority: "primary",
+      tasting: {
+        id: tasting.id,
+      },
+    });
+    expect(result.results[1]).toMatchObject({
+      type: "collection_add",
+      priority: "secondary",
+      createdBy: {
+        id: user.id,
+      },
+      collection: {
+        id: collection.id,
+        href: `/users/${user.username}/library`,
+      },
+      totalItems: 2,
+    });
+  });
+
+  test("hides private users from anonymous global activity", async ({
+    fixtures,
+  }) => {
+    const publicUser = await fixtures.User();
+    const privateUser = await fixtures.User({ private: true });
+    const visibleTasting = await fixtures.Tasting({
+      createdById: publicUser.id,
+      createdAt: new Date("2026-01-03T12:30:00Z"),
+    });
+    await fixtures.Tasting({
+      createdById: privateUser.id,
+      createdAt: new Date("2026-01-03T12:40:00Z"),
+    });
+    const privateCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: privateUser.id,
+    });
+    await db.insert(collectionBottles).values({
+      collectionId: privateCollection.id,
+      bottleId: (await fixtures.Bottle()).id,
+      createdAt: new Date("2026-01-03T12:45:00Z"),
+    });
+
+    const result = await routerClient.activity.list({
+      filter: "global",
+      limit: 10,
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      type: "tasting",
+      tasting: {
+        id: visibleTasting.id,
+      },
+    });
+  });
+
+  test("shows followed private users in authenticated global activity", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const friend = await fixtures.User({ private: true });
+    await fixtures.Follow({
+      fromUserId: defaults.user.id,
+      toUserId: friend.id,
+      status: "following",
+    });
+    const tasting = await fixtures.Tasting({
+      createdById: friend.id,
+      createdAt: new Date("2026-01-03T12:30:00Z"),
+    });
+    const collection = await fixtures.Collection({
+      name: "Library",
+      createdById: friend.id,
+    });
+    await db.insert(collectionBottles).values({
+      collectionId: collection.id,
+      bottleId: (await fixtures.Bottle()).id,
+      createdAt: new Date("2026-01-03T12:00:00Z"),
+    });
+
+    const result = await routerClient.activity.list(
+      {
+        filter: "global",
+        limit: 10,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    expect(result.results.map((entry) => entry.type)).toEqual([
+      "tasting",
+      "collection_add",
+    ]);
+    expect(result.results[0]).toMatchObject({
+      type: "tasting",
+      tasting: {
+        id: tasting.id,
+      },
+    });
+    expect(result.results[1]).toMatchObject({
+      type: "collection_add",
+      createdBy: {
+        id: friend.id,
+      },
+    });
+  });
+
+  test("requires authentication for friends activity", async () => {
+    const err = await waitError(() =>
+      routerClient.activity.list({
+        filter: "friends",
+      }),
+    );
+
+    expect(err).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("friends activity includes followed users only", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const friend = await fixtures.User();
+    const stranger = await fixtures.User();
+    await fixtures.Follow({
+      fromUserId: defaults.user.id,
+      toUserId: friend.id,
+      status: "following",
+    });
+    const friendTasting = await fixtures.Tasting({
+      createdById: friend.id,
+      createdAt: new Date("2026-01-03T12:30:00Z"),
+    });
+    await fixtures.Tasting({
+      createdById: stranger.id,
+      createdAt: new Date("2026-01-03T12:40:00Z"),
+    });
+    const friendCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: friend.id,
+    });
+    const strangerCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: stranger.id,
+    });
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: friendCollection.id,
+        bottleId: (await fixtures.Bottle()).id,
+        createdAt: new Date("2026-01-03T12:00:00Z"),
+      },
+      {
+        collectionId: strangerCollection.id,
+        bottleId: (await fixtures.Bottle()).id,
+        createdAt: new Date("2026-01-03T12:10:00Z"),
+      },
+    ]);
+
+    const result = await routerClient.activity.list(
+      {
+        filter: "friends",
+        limit: 10,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toMatchObject({
+      type: "tasting",
+      tasting: {
+        id: friendTasting.id,
+      },
+    });
+    expect(result.results[1]).toMatchObject({
+      type: "collection_add",
+      createdBy: {
+        id: friend.id,
+      },
+    });
+  });
+
+  test("groups collection-only activity", async ({ fixtures }) => {
+    const user = await fixtures.User();
+    const collection = await fixtures.Collection({
+      name: "Library",
+      createdById: user.id,
+    });
+    const bottles = await Promise.all([
+      fixtures.Bottle(),
+      fixtures.Bottle(),
+      fixtures.Bottle(),
+    ]);
+    await db.insert(collectionBottles).values(
+      bottles.map((bottle, index) => ({
+        collectionId: collection.id,
+        bottleId: bottle.id,
+        createdAt: new Date(`2026-01-03T1${index}:00:00Z`),
+      })),
+    );
+
+    const result = await routerClient.activity.list({
+      filter: "global",
+      limit: 10,
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({
+      type: "collection_add",
+      totalItems: 3,
+    });
+    expect(
+      result.results[0].type === "collection_add"
+        ? result.results[0].items
+        : [],
+    ).toHaveLength(3);
+  });
+
+  test("caps secondary entries when tasting activity exists", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User();
+    await fixtures.Tasting({
+      createdById: user.id,
+      createdAt: new Date("2026-01-03T12:30:00Z"),
+    });
+
+    for (let i = 0; i < 4; i++) {
+      const collection = await fixtures.Collection({
+        name: `Shelf ${i}`,
+        createdById: user.id,
+      });
+      await db.insert(collectionBottles).values({
+        collectionId: collection.id,
+        bottleId: (await fixtures.Bottle()).id,
+        createdAt: new Date(`2026-01-03T1${i}:00:00Z`),
+      });
+    }
+
+    const result = await routerClient.activity.list({
+      filter: "global",
+      limit: 10,
+    });
+
+    expect(
+      result.results.filter((entry) => entry.type === "tasting"),
+    ).toHaveLength(1);
+    expect(
+      result.results.filter((entry) => entry.type === "collection_add"),
+    ).toHaveLength(2);
+  });
+});

--- a/apps/server/src/orpc/routes/activity/list.ts
+++ b/apps/server/src/orpc/routes/activity/list.ts
@@ -2,7 +2,9 @@ import { db } from "@peated/server/db";
 import {
   collectionBottles,
   collections,
+  follows,
   tastings,
+  users,
 } from "@peated/server/db/schema";
 import {
   coerceActivityDate,
@@ -12,66 +14,102 @@ import {
   serializeTastingEntries,
   type CollectionAddGroup,
 } from "@peated/server/lib/activityFeed";
-import { getUserFromId, profileVisible } from "@peated/server/lib/api";
 import { procedure } from "@peated/server/orpc";
-import {
-  ProfileActivityEntrySchema,
-  listResponse,
-} from "@peated/server/schemas";
-import { and, desc, eq, sql } from "drizzle-orm";
+import { ActivityEntrySchema, listResponse } from "@peated/server/schemas";
+import type { SQL } from "drizzle-orm";
+import { and, desc, eq, or, sql } from "drizzle-orm";
 import { z } from "zod";
+
+// Main activity is read-time composition over authoritative source tables. The
+// route owns visibility filtering; shared helpers own entry shaping/throttling.
+// The local filter intentionally mirrors the existing global feed until product
+// semantics define what local activity should mean.
+type ActivityFilter = "global" | "friends" | "local";
 
 type CollectionAddGroupRow = {
   collection: typeof collections.$inferSelect;
+  user: typeof users.$inferSelect;
   bucket: Date | string;
   windowStart: Date | string;
   windowEnd: Date | string;
   totalItems: string;
 };
 
+function visibleActivityUserCondition({
+  filter,
+  currentUserId,
+}: {
+  filter: ActivityFilter;
+  currentUserId?: number;
+}) {
+  if (filter === "friends" && currentUserId) {
+    return sql`${users.id} IN (
+      SELECT ${follows.toUserId}
+      FROM ${follows}
+      WHERE ${follows.fromUserId} = ${currentUserId}
+        AND ${follows.status} = 'following'
+    )`;
+  }
+
+  const visibleUsers: SQL<unknown>[] = [eq(users.private, false)];
+  if (currentUserId) {
+    visibleUsers.push(
+      eq(users.id, currentUserId),
+      sql`${users.id} IN (
+        SELECT ${follows.toUserId}
+        FROM ${follows}
+        WHERE ${follows.fromUserId} = ${currentUserId}
+          AND ${follows.status} = 'following'
+      )`,
+    );
+  }
+
+  return or(...visibleUsers);
+}
+
 export default procedure
   .route({
     method: "GET",
-    path: "/users/{user}/activity",
-    summary: "List profile activity",
+    path: "/activity",
+    summary: "List activity",
     description:
-      "Retrieve a user's profile activity feed with tastings and grouped collection additions",
-    operationId: "listUserActivity",
+      "Retrieve mixed activity with tastings and grouped collection additions",
+    operationId: "listActivity",
   })
   .input(
-    z.object({
-      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
-      cursor: z.coerce.number().gte(1).default(1),
-      limit: z.coerce.number().gte(1).lte(100).default(10),
-    }),
+    z
+      .object({
+        filter: z.enum(["global", "friends", "local"]).default("global"),
+        cursor: z.coerce.number().gte(1).default(1),
+        limit: z.coerce.number().gte(1).lte(100).default(10),
+      })
+      .default({
+        filter: "global",
+        cursor: 1,
+        limit: 10,
+      }),
   )
-  .output(listResponse(ProfileActivityEntrySchema))
+  .output(listResponse(ActivityEntrySchema))
   .handler(async function ({ input, context, errors }) {
-    const user = await getUserFromId(db, input.user, context.user);
-    if (!user) {
-      if (input.user === "me") {
-        throw errors.UNAUTHORIZED();
-      }
-      throw errors.NOT_FOUND({
-        message: "User not found.",
-      });
+    if (input.filter === "friends" && !context.user) {
+      throw errors.UNAUTHORIZED();
     }
 
-    if (!(await profileVisible(db, user, context.user))) {
-      throw errors.BAD_REQUEST({
-        message: "User's profile is private.",
-      });
-    }
-
+    const userCondition = visibleActivityUserCondition({
+      filter: input.filter,
+      currentUserId: context.user?.id,
+    });
     const collectionBucket = sql<Date>`DATE_TRUNC('day', ${collectionBottles.createdAt})`;
     const collectionGroupCreatedAt = sql<Date>`MAX(${collectionBottles.createdAt})`;
+
     const [primaryCountRows, secondaryCountResult] = await Promise.all([
       db
         .select({
           count: sql<string>`COUNT(${tastings.id})`,
         })
         .from(tastings)
-        .where(eq(tastings.createdById, user.id)),
+        .innerJoin(users, eq(users.id, tastings.createdById))
+        .where(userCondition),
       db.execute<{ count: string }>(sql`
         SELECT COUNT(*) as count
         FROM (
@@ -79,8 +117,10 @@ export default procedure
           FROM ${collectionBottles}
           INNER JOIN ${collections}
             ON ${collections.id} = ${collectionBottles.collectionId}
-            AND ${collections.createdById} = ${user.id}
-          GROUP BY ${collections.id}, DATE_TRUNC('day', ${collectionBottles.createdAt})
+          INNER JOIN ${users}
+            ON ${users.id} = ${collections.createdById}
+          WHERE ${userCondition}
+          GROUP BY ${users.id}, ${collections.id}, DATE_TRUNC('day', ${collectionBottles.createdAt})
         ) activity_groups
       `),
     ]);
@@ -95,15 +135,17 @@ export default procedure
 
     const [tastingRows, collectionGroupRows] = await Promise.all([
       db
-        .select()
+        .select({ tasting: tastings })
         .from(tastings)
-        .where(eq(tastings.createdById, user.id))
+        .innerJoin(users, eq(users.id, tastings.createdById))
+        .where(userCondition)
         .orderBy(desc(tastings.createdAt))
         .limit(sourceWindow.primaryLimit)
         .offset(sourceWindow.primaryOffset),
       db
         .select({
           collection: collections,
+          user: users,
           bucket: collectionBucket,
           windowStart: sql<Date>`MIN(${collectionBottles.createdAt})`,
           windowEnd: sql<Date>`MAX(${collectionBottles.createdAt})`,
@@ -112,26 +154,25 @@ export default procedure
         .from(collectionBottles)
         .innerJoin(
           collections,
-          and(
-            eq(collections.id, collectionBottles.collectionId),
-            eq(collections.createdById, user.id),
-          ),
+          eq(collections.id, collectionBottles.collectionId),
         )
-        .groupBy(collections.id, collectionBucket)
+        .innerJoin(users, eq(users.id, collections.createdById))
+        .where(and(userCondition))
+        .groupBy(users.id, collections.id, collectionBucket)
         .orderBy(desc(collectionGroupCreatedAt))
         .limit(sourceWindow.secondaryLimit)
         .offset(sourceWindow.secondaryOffset),
     ]);
 
     const primaryEntries = await serializeTastingEntries(
-      tastingRows,
+      tastingRows.map((row) => row.tasting),
       context.user,
     );
     const secondaryEntries = await serializeCollectionAddEntries({
       groups: collectionGroupRows.map(
         (row: CollectionAddGroupRow): CollectionAddGroup => ({
           collection: row.collection,
-          user,
+          user: row.user,
           bucket: row.bucket,
           windowStart: coerceActivityDate(row.windowStart),
           windowEnd: coerceActivityDate(row.windowEnd),

--- a/apps/server/src/orpc/routes/index.ts
+++ b/apps/server/src/orpc/routes/index.ts
@@ -1,3 +1,4 @@
+import activity from "./activity";
 import admin from "./admin";
 import ai from "./ai";
 import auth from "./auth";
@@ -32,6 +33,7 @@ import users from "./users";
 import version from "./version";
 
 export interface Router {
+  activity: typeof activity;
   admin: typeof admin;
   ai: typeof ai;
   auth: typeof auth;
@@ -67,6 +69,7 @@ export interface Router {
 }
 
 export default {
+  activity,
   admin,
   ai,
   auth,

--- a/apps/server/src/schemas/profileActivity.ts
+++ b/apps/server/src/schemas/profileActivity.ts
@@ -3,7 +3,7 @@ import { CollectionBottleSchema, CollectionSchema } from "./collections";
 import { TastingSchema } from "./tastings";
 import { UserSchema } from "./users";
 
-export const ProfileTastingActivitySchema = z.object({
+export const ActivityTastingEntrySchema = z.object({
   id: z.string().describe("Stable activity entry identifier"),
   type: z.literal("tasting"),
   priority: z.literal("primary"),
@@ -15,15 +15,14 @@ export const ProfileTastingActivitySchema = z.object({
   tasting: TastingSchema.describe("Tasting represented by this activity entry"),
 });
 
-export const ProfileCollectionActivityCollectionSchema =
-  CollectionSchema.extend({
-    href: z
-      .string()
-      .nullable()
-      .describe("Profile collection route when the destination is linkable"),
-  });
+export const ActivityCollectionSchema = CollectionSchema.extend({
+  href: z
+    .string()
+    .nullable()
+    .describe("Activity collection route when the destination is linkable"),
+});
 
-export const ProfileCollectionAddActivitySchema = z.object({
+export const ActivityCollectionAddEntrySchema = z.object({
   id: z.string().describe("Stable activity entry identifier"),
   type: z.literal("collection_add"),
   priority: z.literal("secondary"),
@@ -43,7 +42,7 @@ export const ProfileCollectionAddActivitySchema = z.object({
     .readonly()
     .describe("Latest collection addition represented by this entry"),
   createdBy: UserSchema.readonly().describe("User who added the items"),
-  collection: ProfileCollectionActivityCollectionSchema.describe(
+  collection: ActivityCollectionSchema.describe(
     "Destination collection for the grouped additions",
   ),
   items: z
@@ -56,7 +55,14 @@ export const ProfileCollectionAddActivitySchema = z.object({
     .describe("Total collection items represented by this entry"),
 });
 
-export const ProfileActivityEntrySchema = z.discriminatedUnion("type", [
-  ProfileTastingActivitySchema,
-  ProfileCollectionAddActivitySchema,
+export const ActivityEntrySchema = z.discriminatedUnion("type", [
+  ActivityTastingEntrySchema,
+  ActivityCollectionAddEntrySchema,
 ]);
+
+export const ProfileTastingActivitySchema = ActivityTastingEntrySchema;
+export const ProfileCollectionActivityCollectionSchema =
+  ActivityCollectionSchema;
+export const ProfileCollectionAddActivitySchema =
+  ActivityCollectionAddEntrySchema;
+export const ProfileActivityEntrySchema = ActivityEntrySchema;

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -1,5 +1,7 @@
 import type { z } from "zod";
 import type {
+  ActivityCollectionAddEntrySchema,
+  ActivityEntrySchema,
   BadgeAwardSchema,
   BadgeCheckSchema,
   BadgeCheckTypeEnum,
@@ -64,6 +66,10 @@ export type ObjectType = z.infer<typeof ObjectTypeEnum>;
 export type FollowStatus = z.infer<typeof FollowStatusEnum>;
 export type FriendStatus = z.infer<typeof FriendStatusEnum>;
 export type Point = z.infer<typeof PointSchema>;
+export type ActivityEntry = z.infer<typeof ActivityEntrySchema>;
+export type ActivityCollectionAddEntry = z.infer<
+  typeof ActivityCollectionAddEntrySchema
+>;
 export type ProfileActivityEntry = z.infer<typeof ProfileActivityEntrySchema>;
 export type ProfileCollectionAddActivity = z.infer<
   typeof ProfileCollectionAddActivitySchema

--- a/apps/web/e2e/activity-feed.spec.ts
+++ b/apps/web/e2e/activity-feed.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+import { expectNoHorizontalOverflow } from "./assertions";
+import { existingBottle, tastingNotes, testUser } from "./rpc-fixtures.mjs";
+
+test.describe("activity feed", () => {
+  test("renders tasting and Library addition activity", async ({ page }) => {
+    await page.goto("/", { waitUntil: "commit" });
+
+    await expect(
+      page.getByRole("link", { name: existingBottle.fullName }).first(),
+    ).toBeVisible();
+    await expect(page.getByText(tastingNotes)).toBeVisible();
+    const collectionAddRow = page.locator("li").filter({
+      hasText: `${testUser.username} added 1 bottle to Library`,
+    });
+    await expect(collectionAddRow).toBeVisible();
+    await expect(
+      collectionAddRow.getByRole("link", { name: "Library" }),
+    ).toHaveAttribute("href", `/users/${testUser.username}/library`);
+    await expectNoHorizontalOverflow(page);
+  });
+});

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -1,6 +1,7 @@
 import http from "node:http";
 
 import {
+  buildActivity,
   buildBottle,
   buildBottleRelease,
   buildCollectionBottle,
@@ -93,6 +94,9 @@ async function handleRpcRequest({ request, response, url }) {
   const input = await readRpcInput(request, url);
 
   switch (path) {
+    case "activity/list":
+      sendRpcResponse(response, buildActivity());
+      return true;
     case "entities/list":
       if (input?.query === testBrand.name) {
         sendRpcResponse(response, {

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -174,6 +174,20 @@ export function buildCollectionBottle({
   };
 }
 
+export function buildCollection({
+  id = 9601,
+  name = "Library",
+  href = `/users/${testUser.username}/library`,
+} = {}) {
+  return {
+    id,
+    name,
+    totalBottles: 1,
+    createdAt: timestamp,
+    href,
+  };
+}
+
 export function buildTasting({
   id = createdTastingId,
   bottle = existingBottle,
@@ -198,6 +212,39 @@ export function buildTasting({
     hasToasted: false,
     createdAt: timestamp,
     createdBy: testUser,
+  };
+}
+
+export function buildActivity({
+  tasting = buildTasting(),
+  collectionBottle = buildCollectionBottle({ id: 9701 }),
+} = {}) {
+  return {
+    results: [
+      {
+        id: `tasting:${tasting.id}`,
+        type: "tasting",
+        priority: "primary",
+        createdAt: tasting.createdAt,
+        tasting,
+      },
+      {
+        id: "collection_add:9101:9601:1780833600000",
+        type: "collection_add",
+        priority: "secondary",
+        createdAt: timestamp,
+        windowStart: timestamp,
+        windowEnd: timestamp,
+        createdBy: testUser,
+        collection: buildCollection(),
+        items: [collectionBottle],
+        totalItems: 1,
+      },
+    ],
+    rel: {
+      nextCursor: null,
+      prevCursor: null,
+    },
   };
 }
 

--- a/apps/web/src/app/(default)/(activity)/activity/friends/page.tsx
+++ b/apps/web/src/app/(default)/(activity)/activity/friends/page.tsx
@@ -18,8 +18,8 @@ export default function Page() {
 function FriendsActivityPage() {
   const filter = "friends";
   const orpc = useORPC();
-  const { data: tastingList } = useSuspenseQuery(
-    orpc.tastings.list.queryOptions({
+  const { data: activityList } = useSuspenseQuery(
+    orpc.activity.list.queryOptions({
       input: {
         filter,
         limit: 10,
@@ -27,5 +27,5 @@ function FriendsActivityPage() {
     }),
   );
 
-  return <ActivityFeed tastingList={tastingList} filter={filter} />;
+  return <ActivityFeed activityList={activityList} filter={filter} />;
 }

--- a/apps/web/src/app/(default)/(activity)/activity/local/page.tsx
+++ b/apps/web/src/app/(default)/(activity)/activity/local/page.tsx
@@ -9,8 +9,8 @@ export const fetchCache = "default-no-store";
 export default function Page() {
   const filter = "local";
   const orpc = useORPC();
-  const { data: tastingList } = useSuspenseQuery(
-    orpc.tastings.list.queryOptions({
+  const { data: activityList } = useSuspenseQuery(
+    orpc.activity.list.queryOptions({
       input: {
         filter,
         limit: 10,
@@ -18,5 +18,5 @@ export default function Page() {
     }),
   );
 
-  return <ActivityFeed tastingList={tastingList} filter={filter} />;
+  return <ActivityFeed activityList={activityList} filter={filter} />;
 }

--- a/apps/web/src/app/(default)/(activity)/page.tsx
+++ b/apps/web/src/app/(default)/(activity)/page.tsx
@@ -9,9 +9,9 @@ export const fetchCache = "default-no-store";
 export default function Page() {
   const filter = "global";
   const orpc = useORPC();
-  const { data: tastingList } = useSuspenseQuery(
-    orpc.tastings.list.queryOptions({ input: { limit: 10, filter } }),
+  const { data: activityList } = useSuspenseQuery(
+    orpc.activity.list.queryOptions({ input: { limit: 10, filter } }),
   );
 
-  return <ActivityFeed tastingList={tastingList} filter={filter} />;
+  return <ActivityFeed activityList={activityList} filter={filter} />;
 }

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { use } from "react";
 
+import ActivityList from "@peated/web/components/activityList";
 import EmptyActivity from "@peated/web/components/emptyActivity";
-import ProfileActivityList from "@peated/web/components/profileActivityList";
 import UserFlavorDistributionChart from "@peated/web/components/userFlavorDistributionChart";
 import UserLocationChart from "@peated/web/components/userLocationChart";
 import { useORPC } from "@peated/web/lib/orpc/context";
@@ -39,7 +39,7 @@ export default function UserProfilePage(props: {
 
       <div className="mt-8">
         {activity.results.length ? (
-          <ProfileActivityList values={activity.results} />
+          <ActivityList values={activity.results} />
         ) : (
           <EmptyActivity />
         )}

--- a/apps/web/src/components/activityFeed.tsx
+++ b/apps/web/src/components/activityFeed.tsx
@@ -2,20 +2,20 @@
 
 import type { Outputs } from "@peated/server/orpc/router";
 import Glyph from "@peated/web/assets/glyph.svg";
+import ActivityList from "@peated/web/components/activityList";
 import Alert from "@peated/web/components/alert";
 import EmptyActivity from "@peated/web/components/emptyActivity";
 import Spinner from "@peated/web/components/spinner";
-import TastingList from "@peated/web/components/tastingList";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseInfiniteQuery } from "@tanstack/react-query";
 import { Fragment } from "react";
 import { useEventListener } from "usehooks-ts";
 
 export default function ActivityFeed({
-  tastingList,
+  activityList,
   filter = "global",
 }: {
-  tastingList: Outputs["tastings"]["list"];
+  activityList: Outputs["activity"]["list"];
   filter: "global" | "friends" | "local";
 }) {
   const orpc = useORPC();
@@ -27,14 +27,14 @@ export default function ActivityFeed({
     isFetching,
     isFetchingNextPage,
   } = useSuspenseInfiniteQuery({
-    queryKey: orpc.tastings.list.key({
+    queryKey: orpc.activity.list.key({
       input: {
         filter,
         limit: 10,
       },
     }),
     queryFn: async ({ pageParam }) => {
-      return await orpc.tastings.list.call({
+      return await orpc.activity.list.call({
         filter,
         limit: 10,
         cursor: pageParam,
@@ -44,7 +44,7 @@ export default function ActivityFeed({
     staleTime: Infinity,
     initialData: () => {
       return {
-        pages: [tastingList],
+        pages: [activityList],
         pageParams: [undefined],
       };
     },
@@ -80,7 +80,7 @@ export default function ActivityFeed({
       {pages.length > 1 || pages[0].results.length ? (
         pages.map((group, i) => (
           <Fragment key={i}>
-            <TastingList values={group.results} />
+            <ActivityList values={group.results} />
           </Fragment>
         ))
       ) : (

--- a/apps/web/src/components/activityList.tsx
+++ b/apps/web/src/components/activityList.tsx
@@ -13,30 +13,23 @@ import TastingListItem from "./tastingListItem";
 import TimeSince from "./timeSince";
 import UserAvatar from "./userAvatar";
 
-type ProfileActivityListResult = Outputs["users"]["activity"]["list"];
-type ProfileActivityEntry = ProfileActivityListResult["results"][number];
-type ProfileCollectionAddActivity = Extract<
-  ProfileActivityEntry,
-  { type: "collection_add" }
->;
-type ProfileCollectionAddItem = ProfileCollectionAddActivity["items"][number];
+type ActivityListResult = Outputs["activity"]["list"];
+type ActivityEntry = ActivityListResult["results"][number];
+type CollectionAddActivity = Extract<ActivityEntry, { type: "collection_add" }>;
+type CollectionAddItem = CollectionAddActivity["items"][number];
 
 function formatBottleCount(count: number) {
   return `${count.toLocaleString()} bottle${count === 1 ? "" : "s"}`;
 }
 
-function getCollectionLabel(activity: ProfileCollectionAddActivity) {
+function getCollectionLabel(activity: CollectionAddActivity) {
   if (activity.collection.href?.endsWith("/favorites")) {
     return "Favorites";
   }
   return activity.collection.name;
 }
 
-function CollectionLink({
-  activity,
-}: {
-  activity: ProfileCollectionAddActivity;
-}) {
+function CollectionLink({ activity }: { activity: CollectionAddActivity }) {
   const label = getCollectionLabel(activity);
 
   if (!activity.collection.href) {
@@ -53,18 +46,18 @@ function CollectionLink({
   );
 }
 
-function getCollectionItemHref(item: ProfileCollectionAddItem) {
+function getCollectionItemHref(item: CollectionAddItem) {
   if (item.release) {
     return getBottleBottlingPath(item.bottle.id, item.release.id);
   }
   return `/bottles/${item.bottle.id}`;
 }
 
-function getCollectionItemTitle(item: ProfileCollectionAddItem) {
+function getCollectionItemTitle(item: CollectionAddItem) {
   return item.release?.fullName ?? item.bottle.fullName;
 }
 
-function getCollectionItemDetail(item: ProfileCollectionAddItem) {
+function getCollectionItemDetail(item: CollectionAddItem) {
   if (item.release) {
     const bottlingName = formatBottlingName(item.release);
     return bottlingName && bottlingName !== item.release.fullName
@@ -75,7 +68,7 @@ function getCollectionItemDetail(item: ProfileCollectionAddItem) {
   return item.bottle.category ? formatCategoryName(item.bottle.category) : null;
 }
 
-function CollectionItemImage({ item }: { item: ProfileCollectionAddItem }) {
+function CollectionItemImage({ item }: { item: CollectionAddItem }) {
   const imageUrl =
     item.imageUrl ??
     item.release?.imageUrl ??
@@ -98,7 +91,7 @@ function CollectionItemImage({ item }: { item: ProfileCollectionAddItem }) {
   );
 }
 
-function CollectionPreviewItem({ item }: { item: ProfileCollectionAddItem }) {
+function CollectionPreviewItem({ item }: { item: CollectionAddItem }) {
   const detail = getCollectionItemDetail(item);
 
   return (
@@ -123,7 +116,7 @@ function CollectionPreviewItem({ item }: { item: ProfileCollectionAddItem }) {
 function CollectionAddActivityItem({
   activity,
 }: {
-  activity: ProfileCollectionAddActivity;
+  activity: CollectionAddActivity;
 }) {
   const remainingCount = activity.totalItems - activity.items.length;
 
@@ -169,10 +162,10 @@ function CollectionAddActivityItem({
   );
 }
 
-export default function ProfileActivityList({
+export default function ActivityList({
   values,
 }: {
-  values: ProfileActivityListResult["results"];
+  values: ActivityListResult["results"];
 }) {
   const [deletedTastingIds, setDeletedTastingIds] = useState<number[]>([]);
 

--- a/openspec/changes/add-main-activity-feed-library-events/.openspec.yaml
+++ b/openspec/changes/add-main-activity-feed-library-events/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/add-main-activity-feed-library-events/design.md
+++ b/openspec/changes/add-main-activity-feed-library-events/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The profile activity feed already composes tastings and grouped collection additions at read time. Main activity pages still call `tastings.list({ filter })`, so they cannot surface Library or Favorites additions. The new endpoint needs the existing main feed filters while preserving the profile feed's secondary-activity policy.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide a top-level main activity feed API for global, friends, and local pages.
+- Reuse the existing activity entry contract so profile and main UI can share rendering.
+- Centralize activity composition logic so grouping, preview serialization, and throttling do not diverge.
+- Mirror the existing tasting feed visibility behavior for all activity sources.
+- Keep collection-add entries compact and secondary to tastings.
+
+**Non-Goals:**
+
+- Define new semantics for the local feed; this change preserves the current tasting-filter behavior.
+- Add a durable activity table or write-time activity events.
+- Add new activity types beyond tastings and collection additions.
+- Add custom collection detail pages.
+- Change collection privacy or profile visibility rules.
+
+## Decisions
+
+### Add a top-level `activity.list` route
+
+The main feed gets a dedicated `GET /activity` route instead of expanding `tastings.list`. `tastings.list` remains a tasting-specific API, while `activity.list` owns the mixed feed contract and can grow to future activity types.
+
+Alternative considered: return collection additions from `tastings.list`. That would make every tasting-list consumer defensive against non-tasting rows and blur API ownership.
+
+### Extract shared read-time composition helpers
+
+Profile and main feeds should call shared helpers for entry serialization, collection-add grouping, reserved collection links, and secondary throttling. Route files should own source selection and visibility filters; shared helpers should own activity entry assembly.
+
+Alternative considered: copy the profile route logic into a main route. That would be fast initially but would make future changes to grouping or preview behavior error-prone.
+
+### Filter source rows by visible owners
+
+Main feed visibility should match current `tastings.list` behavior:
+
+- `friends` requires an authenticated viewer and includes followed users.
+- `global` hides private users from anonymous viewers and from non-followers, while showing the viewer and followed users when authenticated.
+- `local` keeps the current behavior, which is effectively the global filtering path until a product-specific local rule exists.
+
+Collection-add source rows use the collection owner as the actor for these visibility rules.
+
+### Keep offset-style page cursors for parity
+
+The existing feed APIs use numeric page cursors. The new route can reuse the profile composition window logic and return numeric next/previous cursors, accepting the same limitations as the current profile feed.
+
+Alternative considered: introduce timestamp cursors. That is more robust for changing timelines, but it would add a pagination model only for this route without solving existing profile-feed parity.
+
+## Risks / Trade-offs
+
+- Read-time grouping queries can grow complex -> keep filtering and composition helpers small, named, and covered by route integration tests.
+- Main feeds can include many users, making collection-add grouping heavier than profile grouping -> query only grouped buckets for the current page window and fetch previews per returned group.
+- `local` remains underspecified -> preserve existing behavior now and leave a separate change for true local semantics.
+- Shared activity schema currently has profile-oriented names -> add generic aliases where useful without breaking existing profile route consumers.
+
+## Migration Plan
+
+No database migration is required. Add the route and shared helper, switch web activity pages to the new route, and leave profile activity on the same response contract. Rollback can restore the web pages to `tastings.list` and remove the top-level route without data changes.
+
+## Open Questions
+
+- Should local activity eventually filter by viewer location, tasting location, or bottle availability region?
+- Should custom collection additions remain visible on main feeds before custom collection pages exist, or should the route limit collection-add entries to reserved Library and Favorites?

--- a/openspec/changes/add-main-activity-feed-library-events/proposal.md
+++ b/openspec/changes/add-main-activity-feed-library-events/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+The main activity feeds currently show only tastings, while profile activity now surfaces grouped Library and Favorites additions. Main feeds should represent the same meaningful collection activity without turning bulk library imports into noisy timelines.
+
+## What Changes
+
+- Add a main activity feed API that returns a discriminated union of tasting and grouped collection-add entries.
+- Reuse the profile feed's compact collection-add presentation for global, friends, and local activity pages.
+- Apply the same visibility semantics as the existing tasting feed when selecting users for each main feed filter.
+- Keep collection-add activity secondary and capped so tastings remain the dominant feed signal when present.
+- Preserve the current local feed behavior unless and until a separate local-specific product rule is defined.
+
+## Capabilities
+
+### New Capabilities
+
+- `main-activity-feed`: Main activity feed API, visibility-filtered activity composition, and web rendering for mixed tasting and collection-add entries.
+
+### Modified Capabilities
+
+## Impact
+
+- Backend oRPC routes: add a top-level activity list route and wire it into the router.
+- Backend activity composition: extract shared profile/main feed helpers so collection-add grouping and throttling are maintained in one place.
+- Backend schemas: expose a generic activity entry schema compatible with the existing profile activity response shape.
+- Web activity pages: switch global, friends, and local pages from `tastings.list` to the new mixed activity feed.
+- Web components: make the mixed activity list reusable across profile and main feed surfaces.
+- Tests: add integration coverage for visibility filters, grouped collection-add entries, secondary throttling, and anonymous/private behavior.

--- a/openspec/changes/add-main-activity-feed-library-events/specs/main-activity-feed/spec.md
+++ b/openspec/changes/add-main-activity-feed-library-events/specs/main-activity-feed/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Main activity returns a mixed feed
+
+The system SHALL provide a main activity feed API that returns a discriminated union of activity entries for global, friends, and local feed pages.
+
+#### Scenario: Tasting entries remain primary activity
+
+- **WHEN** a visible user has recent tasting activity matching the requested feed filter
+- **THEN** the main activity feed includes `tasting` entries marked as primary activity with serialized tasting payloads
+
+#### Scenario: Collection-add entries appear as secondary activity
+
+- **WHEN** a visible user has recent additions to a supported collection matching the requested feed filter
+- **THEN** the main activity feed includes `collection_add` entries marked as secondary activity with actor, collection, preview items, total item count, and activity timestamps
+
+### Requirement: Main activity applies feed visibility filters
+
+The system MUST apply the same user visibility and friend-filter rules to main activity source rows that the existing tasting feed applies.
+
+#### Scenario: Anonymous global feed hides private users
+
+- **WHEN** an anonymous viewer requests the global activity feed
+- **THEN** the feed excludes tasting and collection-add activity owned by private users
+
+#### Scenario: Authenticated global feed includes visible private users
+
+- **WHEN** an authenticated viewer requests the global activity feed
+- **THEN** the feed may include activity from the viewer and followed private users while excluding private users the viewer cannot see
+
+#### Scenario: Friends feed requires authentication
+
+- **WHEN** an anonymous viewer requests the friends activity feed
+- **THEN** the request is rejected as unauthorized
+
+#### Scenario: Friends feed includes followed users
+
+- **WHEN** an authenticated viewer requests the friends activity feed
+- **THEN** the feed includes tasting and collection-add activity owned by followed users and excludes non-followed users
+
+### Requirement: Main collection additions are grouped
+
+The system SHALL aggregate main-feed collection-add activity by actor, destination collection, and bounded time window before returning activity entries.
+
+#### Scenario: Multiple additions to one collection are grouped
+
+- **WHEN** a visible user adds multiple bottles or releases to the same supported collection within the grouping window
+- **THEN** the main activity feed returns one `collection_add` entry for that actor and collection with preview items and `totalItems` equal to the grouped additions
+
+#### Scenario: Additions from different actors are separate
+
+- **WHEN** different visible users add bottles to collections within the same time window
+- **THEN** the main activity feed returns separate `collection_add` entries per actor and destination collection
+
+### Requirement: Secondary activity is throttled on main feeds
+
+The system SHALL compose main activity so secondary collection-add entries do not overwhelm primary tasting entries.
+
+#### Scenario: Primary entries are prioritized
+
+- **WHEN** the main feed has both tasting entries and many collection-add groups
+- **THEN** the returned page prioritizes tasting entries and includes only a capped number of secondary collection-add entries
+
+#### Scenario: Secondary entries fill collection-only feeds
+
+- **WHEN** the main feed has collection-add activity but no tasting activity
+- **THEN** the feed shows grouped collection-add entries instead of an empty activity state
+
+### Requirement: Main activity renders collection-add entries
+
+The web app MUST render main activity entries using the same mixed activity presentation as profile activity.
+
+#### Scenario: Main activity page shows grouped collection addition
+
+- **WHEN** the main activity API returns a `collection_add` entry
+- **THEN** the web feed renders a compact collection-add row with actor link, destination collection link when available, preview item links, and remaining item count
+
+#### Scenario: Main activity page preserves tasting behavior
+
+- **WHEN** the main activity API returns a `tasting` entry
+- **THEN** the web feed renders it with the existing tasting list item behavior and supported interactions

--- a/openspec/changes/add-main-activity-feed-library-events/tasks.md
+++ b/openspec/changes/add-main-activity-feed-library-events/tasks.md
@@ -1,0 +1,32 @@
+## 1. Backend Contract
+
+- [x] 1.1 Add generic activity schema/type exports compatible with the existing profile activity entry shape.
+- [x] 1.2 Add a top-level `activity` oRPC router with a `list` route for `global`, `friends`, and `local` filters.
+- [x] 1.3 Wire the activity router into the root server router.
+
+## 2. Backend Composition
+
+- [x] 2.1 Extract shared activity composition helpers from the profile activity route.
+- [x] 2.2 Update the profile activity route to use the shared helper without changing its response contract.
+- [x] 2.3 Implement main feed source filtering for tastings and collection additions using existing visibility semantics.
+- [x] 2.4 Implement main feed collection-add grouping by actor, collection, and day bucket with preview serialization.
+
+## 3. Backend Tests
+
+- [x] 3.1 Add main activity route tests for mixed tasting and collection-add responses.
+- [x] 3.2 Add route tests for anonymous/private visibility and authenticated global visibility.
+- [x] 3.3 Add route tests for friends feed authentication and followed-user filtering.
+- [x] 3.4 Add route tests for grouped collection-only activity and secondary throttling.
+
+## 4. Web Activity UI
+
+- [x] 4.1 Rename or generalize the profile activity list component so main and profile feeds share mixed activity rendering.
+- [x] 4.2 Switch global, friends, and local activity pages to query the new activity list route.
+- [x] 4.3 Update infinite scrolling in the main `ActivityFeed` component to use the mixed activity route and response type.
+- [x] 4.4 Preserve the current main feed empty and error states.
+
+## 5. Verification
+
+- [x] 5.1 Run targeted backend activity route tests.
+- [x] 5.2 Run server and web typechecks for touched packages.
+- [x] 5.3 Run file-scoped lint/format for changed TypeScript files.


### PR DESCRIPTION
Main activity feeds now use a mixed activity API that combines tastings with grouped Library and Favorites additions. The same compact collection-add rendering used on profile activity is shared with the global, friends, and local feed pages, while tastings remain the primary feed signal.

The backend composition logic now lives in a shared activity helper so profile and main feeds keep the same grouping, preview, and secondary-throttling behavior. The local feed intentionally preserves the existing global-like filtering until a separate product rule defines true local activity semantics.

Playwright mocks now include an activity-list response, with a focused desktop/mobile activity-feed spec covering the mixed tasting plus Library addition row.