### PR TITLE
fix(web): Preserve profile collection query params

### DIFF
--- a/apps/web/src/app/(default)/users/[username]/(tabs)/favorites/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/favorites/page.tsx
@@ -4,6 +4,7 @@ import { use } from "react";
 import BottleTable from "@peated/web/components/bottleTable";
 import EmptyActivity from "@peated/web/components/emptyActivity";
 import FavoriteEntryActions from "@peated/web/components/favoriteEntryActions";
+import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import useAuth from "@peated/web/hooks/useAuth";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -23,12 +24,15 @@ function UserFavoritesTable({ username }: { username: string }) {
   const orpc = useORPC();
   const { user } = useAuth();
   const profileUserId = useProfileUserId();
+  const queryParams = useApiQueryParams({
+    overrides: {
+      user: username,
+      collection: "default",
+    },
+  });
   const { data: bottles } = useSuspenseQuery(
     orpc.collections.bottles.list.queryOptions({
-      input: {
-        user: username,
-        collection: "default",
-      },
+      input: queryParams,
     }),
   );
   const canEditFavorites = user?.id === profileUserId;

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
@@ -5,6 +5,7 @@ import LibraryEntryActions, {
   LibraryEntryImage,
   LibraryEntryThumbnail,
 } from "@peated/web/components/libraryEntryActions";
+import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import useAuth from "@peated/web/hooks/useAuth";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -25,12 +26,15 @@ function UserLibraryTable({ username }: { username: string }) {
   const orpc = useORPC();
   const { user } = useAuth();
   const profileUserId = useProfileUserId();
+  const queryParams = useApiQueryParams({
+    overrides: {
+      user: username,
+      collection: "library",
+    },
+  });
   const { data: bottles } = useSuspenseQuery(
     orpc.collections.bottles.list.queryOptions({
-      input: {
-        user: username,
-        collection: "library",
-      },
+      input: queryParams,
     }),
   );
   const canEditLibraryImages = user?.id === profileUserId;


### PR DESCRIPTION
Profile library and favorites pagination now send the current URL query params into the collection list request. The route still fixes the profile user and collection as explicit overrides, so cursor pagination works and future filters can pass through without allowing the URL to change which profile collection is queried.