### PR TITLE
feat(library): Add profile Library filters

### DIFF
--- a/apps/server/src/orpc/routes/collections/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/list.test.ts
@@ -416,4 +416,259 @@ describe("GET /users/:user/collections/:collection/bottles", () => {
     expect(results[0].bottle.id).toBe(bottle.id);
     expect(results[0].release).toBeNull();
   });
+
+  test("can search library bottles by text", async ({ defaults, fixtures }) => {
+    const brand = await fixtures.Entity({ name: "Search Library Brand" });
+    const matchingBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Needle Label",
+    });
+    const otherBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Ordinary Label",
+    });
+    const outsideLibraryBottle = await fixtures.Bottle({
+      brandId: brand.id,
+      name: "Needle Outside",
+    });
+    const libraryCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: libraryCollection.id,
+        bottleId: matchingBottle.id,
+        releaseId: null,
+      },
+      {
+        collectionId: libraryCollection.id,
+        bottleId: otherBottle.id,
+        releaseId: null,
+      },
+    ]);
+
+    const { results } = await routerClient.collections.bottles.list(
+      {
+        user: "me",
+        collection: "library",
+        query: "Needle",
+      },
+      { context: { user: defaults.user } },
+    );
+
+    expect(results.map((r) => r.bottle.id)).toEqual([matchingBottle.id]);
+    expect(results.map((r) => r.bottle.id)).not.toContain(
+      outsideLibraryBottle.id,
+    );
+  });
+
+  test("can filter library bottles by brand", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const matchingBrand = await fixtures.Entity({ name: "Library Brand A" });
+    const otherBrand = await fixtures.Entity({ name: "Library Brand B" });
+    const matchingBottle = await fixtures.Bottle({
+      brandId: matchingBrand.id,
+      name: "Selected",
+    });
+    const otherBottle = await fixtures.Bottle({
+      brandId: otherBrand.id,
+      name: "Filtered Out",
+    });
+    const libraryCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: libraryCollection.id,
+        bottleId: matchingBottle.id,
+        releaseId: null,
+      },
+      {
+        collectionId: libraryCollection.id,
+        bottleId: otherBottle.id,
+        releaseId: null,
+      },
+    ]);
+
+    const { results } = await routerClient.collections.bottles.list(
+      {
+        user: "me",
+        collection: "library",
+        brand: matchingBrand.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    expect(results.map((r) => r.bottle.id)).toEqual([matchingBottle.id]);
+  });
+
+  test("can filter library bottles by distillery", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const matchingDistiller = await fixtures.Entity({
+      name: "Library Distillery A",
+      type: ["distiller"],
+    });
+    const otherDistiller = await fixtures.Entity({
+      name: "Library Distillery B",
+      type: ["distiller"],
+    });
+    const matchingBottle = await fixtures.Bottle({
+      name: "Selected",
+      distillerIds: [matchingDistiller.id],
+    });
+    const otherBottle = await fixtures.Bottle({
+      name: "Filtered Out",
+      distillerIds: [otherDistiller.id],
+    });
+    const libraryCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: libraryCollection.id,
+        bottleId: matchingBottle.id,
+        releaseId: null,
+      },
+      {
+        collectionId: libraryCollection.id,
+        bottleId: otherBottle.id,
+        releaseId: null,
+      },
+    ]);
+
+    const { results } = await routerClient.collections.bottles.list(
+      {
+        user: "me",
+        collection: "library",
+        distiller: matchingDistiller.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    expect(results.map((r) => r.bottle.id)).toEqual([matchingBottle.id]);
+  });
+
+  test("can combine library search brand and distillery filters", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const matchingBrand = await fixtures.Entity({ name: "Combined Brand A" });
+    const otherBrand = await fixtures.Entity({ name: "Combined Brand B" });
+    const matchingDistiller = await fixtures.Entity({
+      name: "Combined Distillery A",
+      type: ["distiller"],
+    });
+    const otherDistiller = await fixtures.Entity({
+      name: "Combined Distillery B",
+      type: ["distiller"],
+    });
+    const matchingBottle = await fixtures.Bottle({
+      brandId: matchingBrand.id,
+      name: "Shared Label Winner",
+      distillerIds: [matchingDistiller.id],
+    });
+    const wrongBrandBottle = await fixtures.Bottle({
+      brandId: otherBrand.id,
+      name: "Shared Label Wrong Brand",
+      distillerIds: [matchingDistiller.id],
+    });
+    const wrongDistillerBottle = await fixtures.Bottle({
+      brandId: matchingBrand.id,
+      name: "Shared Label Wrong Distillery",
+      distillerIds: [otherDistiller.id],
+    });
+    const libraryCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: libraryCollection.id,
+        bottleId: matchingBottle.id,
+        releaseId: null,
+      },
+      {
+        collectionId: libraryCollection.id,
+        bottleId: wrongBrandBottle.id,
+        releaseId: null,
+      },
+      {
+        collectionId: libraryCollection.id,
+        bottleId: wrongDistillerBottle.id,
+        releaseId: null,
+      },
+    ]);
+
+    const { results } = await routerClient.collections.bottles.list(
+      {
+        user: "me",
+        collection: "library",
+        query: "Shared",
+        brand: matchingBrand.id,
+        distiller: matchingDistiller.id,
+      },
+      { context: { user: defaults.user } },
+    );
+
+    expect(results.map((r) => r.bottle.id)).toEqual([matchingBottle.id]);
+  });
+
+  test("rejects library filters for other collection aliases", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const matchingBrand = await fixtures.Entity({ name: "Default Brand A" });
+    const otherBrand = await fixtures.Entity({ name: "Default Brand B" });
+    const matchingDistiller = await fixtures.Entity({
+      name: "Default Distillery A",
+      type: ["distiller"],
+    });
+    const otherDistiller = await fixtures.Entity({
+      name: "Default Distillery B",
+      type: ["distiller"],
+    });
+    const keptBottle = await fixtures.Bottle({
+      brandId: otherBrand.id,
+      name: "Unmatched Default Bottle",
+      distillerIds: [otherDistiller.id],
+    });
+    const defaultCollection = await getDefaultCollection(db, defaults.user.id);
+    if (!defaultCollection) {
+      throw new Error("Default collection not found");
+    }
+
+    await db.insert(collectionBottles).values({
+      collectionId: defaultCollection.id,
+      bottleId: keptBottle.id,
+      releaseId: null,
+    });
+
+    const err = await waitError(() =>
+      routerClient.collections.bottles.list(
+        {
+          user: "me",
+          collection: "default",
+          query: "Missing",
+          brand: matchingBrand.id,
+          distiller: matchingDistiller.id,
+        },
+        { context: { user: defaults.user } },
+      ),
+    );
+
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Collection filters are only supported for Library.]`,
+    );
+  });
 });

--- a/apps/server/src/orpc/routes/collections/bottles/list.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/list.ts
@@ -1,7 +1,9 @@
 import { db } from "@peated/server/db";
 import {
+  bottleAliases,
   bottleReleases,
   bottles,
+  bottlesToDistillers,
   collectionBottles,
 } from "@peated/server/db/schema";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
@@ -15,7 +17,7 @@ import { CollectionBottleSchema, listResponse } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
 import { CollectionBottleSerializer } from "@peated/server/serializers/collectionBottle";
 import type { SQL } from "drizzle-orm";
-import { and, asc, eq, isNull } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 export default procedure
@@ -31,6 +33,9 @@ export default procedure
     z.object({
       collection: z.union([z.enum(reservedCollectionSlugs), z.coerce.number()]),
       user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
+      query: z.coerce.string().default(""),
+      brand: z.coerce.number().nullish(),
+      distiller: z.coerce.number().nullish(),
       bottle: z.coerce.number().optional(),
       release: z.coerce.number().optional(),
       baseOnly: z.coerce.boolean().optional(),
@@ -59,6 +64,14 @@ export default procedure
     const reservedCollection = isReservedCollectionSlug(input.collection)
       ? input.collection
       : null;
+    if (
+      reservedCollection !== "library" &&
+      (input.query || input.brand || input.distiller)
+    ) {
+      throw errors.BAD_REQUEST({
+        message: "Collection filters are only supported for Library.",
+      });
+    }
     const collection = reservedCollection
       ? await getReservedCollection(db, user.id, reservedCollection)
       : await db.query.collections.findFirst({
@@ -90,6 +103,39 @@ export default procedure
     const where: (SQL<unknown> | undefined)[] = [
       eq(collectionBottles.collectionId, collection.id),
     ];
+    if (input.query) {
+      // Match exact aliases alongside the bottle search vector for catalog parity.
+      const exactAliasBottleIds = (
+        await db
+          .selectDistinct({ bottleId: bottleAliases.bottleId })
+          .from(bottleAliases)
+          .where(
+            and(
+              eq(sql`LOWER(${bottleAliases.name})`, input.query.toLowerCase()),
+              isNotNull(bottleAliases.bottleId),
+            ),
+          )
+      )
+        .map((row) => row.bottleId)
+        .filter((bottleId): bottleId is number => bottleId !== null);
+
+      where.push(
+        or(
+          sql`${bottles.searchVector} @@ websearch_to_tsquery ('english', ${input.query})`,
+          exactAliasBottleIds.length
+            ? inArray(bottles.id, exactAliasBottleIds)
+            : undefined,
+        ),
+      );
+    }
+    if (input.brand) {
+      where.push(eq(bottles.brandId, input.brand));
+    }
+    if (input.distiller) {
+      where.push(
+        sql`EXISTS(SELECT FROM ${bottlesToDistillers} WHERE ${bottlesToDistillers.distillerId} = ${input.distiller} AND ${bottlesToDistillers.bottleId} = ${bottles.id})`,
+      );
+    }
     if (input.bottle) {
       where.push(eq(collectionBottles.bottleId, input.bottle));
     }

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -106,6 +106,13 @@ async function handleRpcRequest({ request, response, url }) {
         return true;
       }
       return false;
+    case "entities/details":
+      if (Number(input?.entity) === testBrand.id) {
+        sendRpcResponse(response, testBrand);
+        return true;
+      }
+      sendRpcError(response, "Unexpected entity details payload");
+      return true;
     case "search":
       if (
         !Array.isArray(input?.include) ||
@@ -1346,7 +1353,7 @@ function listCollectionBottles(request, input) {
   const state = getCollectionState(request);
   const collection = getCollection(input);
   const entries = Array.from(state[collection].entries());
-  const results =
+  let results =
     input?.bottle === undefined
       ? entries.map(([, entry]) => ({
           ...entry,
@@ -1358,6 +1365,27 @@ function listCollectionBottles(request, input) {
             ...entry,
             bottle: withCollectionStatus(request, entry.bottle),
           }));
+
+  if (collection === "library" && input?.query) {
+    const query = String(input.query).toLowerCase();
+    results = results.filter((entry) =>
+      entry.bottle.fullName.toLowerCase().includes(query),
+    );
+  }
+
+  if (collection === "library" && input?.brand) {
+    results = results.filter(
+      (entry) => entry.bottle.brand?.id === Number(input.brand),
+    );
+  }
+
+  if (collection === "library" && input?.distiller) {
+    results = results.filter((entry) =>
+      entry.bottle.distillers?.some(
+        (distiller) => distiller.id === Number(input.distiller),
+      ),
+    );
+  }
 
   return {
     results,

--- a/apps/web/e2e/profile-library.spec.ts
+++ b/apps/web/e2e/profile-library.spec.ts
@@ -151,6 +151,80 @@ test.describe("profile library", () => {
     await expectNoHorizontalOverflow(page);
   });
 
+  test("filters Library entries from the profile tab", async ({
+    context,
+    page,
+  }, testInfo) => {
+    const runId = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const bottleId =
+      existingBottle.id +
+      600_000 +
+      (testInfo.project.name.includes("mobile") ? 100_000 : 0) +
+      (Date.now() % 100_000);
+    const savedBottleName = `${existingBottle.brand.name} 16-year-old ${bottleId}`;
+
+    await signIn(context, {
+      accessToken: [
+        testAccessToken,
+        "library-filters",
+        testInfo.project.name,
+        testInfo.workerIndex,
+        testInfo.retry,
+        runId,
+      ].join("-"),
+    });
+
+    await page.goto(`/bottles/${bottleId}`, {
+      waitUntil: "commit",
+    });
+    await page.locator('button[data-collection-action="library"]').click();
+    await expect(
+      page.locator('button[data-collection-action="library"]'),
+    ).toHaveAttribute("aria-pressed", "true");
+
+    await page.goto(`/users/${testUser.username}/library?cursor=2`, {
+      waitUntil: "commit",
+    });
+    await expect(
+      page.getByRole("link", { name: savedBottleName }).first(),
+    ).toBeVisible();
+
+    await page.getByRole("searchbox", { name: "Search library" }).fill("zzzz");
+    await page.getByRole("button", { name: "Search" }).click();
+    await expect(page).toHaveURL(/\/library\?query=zzzz$/);
+    await expect(
+      page.getByText("No library bottles match these filters."),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Clear filters" }).click();
+    await expect(page).toHaveURL(`/users/${testUser.username}/library`);
+    await expect(
+      page.getByRole("link", { name: savedBottleName }).first(),
+    ).toBeVisible();
+
+    await page.goto(`/users/${testUser.username}/library?cursor=2`, {
+      waitUntil: "commit",
+    });
+    await page.getByRole("button", { name: /brand any brand/i }).click();
+    await page.getByPlaceholder("Search brand").fill(existingBottle.brand.name);
+    await expect(
+      page.getByRole("button", { name: existingBottle.brand.name }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: existingBottle.brand.name }).click();
+    await expect(page).toHaveURL(
+      `/users/${testUser.username}/library?brand=${existingBottle.brand.id}`,
+    );
+    await expect(
+      page.getByRole("button", {
+        name: new RegExp(`brand ${existingBottle.brand.name}`, "i"),
+      }),
+    ).toBeVisible();
+    await expect(page.getByPlaceholder("Search brand")).toHaveCount(0);
+    await expect(
+      page.getByRole("link", { name: savedBottleName }).first(),
+    ).toBeVisible();
+  });
+
   test("lets the owner remove a Favorites entry from the profile tab", async ({
     context,
     page,

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryFilters.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryFilters.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import {
+  ChevronDownIcon,
+  MagnifyingGlassIcon,
+  XMarkIcon,
+} from "@heroicons/react/20/solid";
+import BrandIcon from "@peated/web/assets/brand.svg";
+import DistillerIcon from "@peated/web/assets/distiller.svg";
+import Button from "@peated/web/components/button";
+import SelectDialog from "@peated/web/components/selectField/selectDialog";
+import type { Option } from "@peated/web/components/selectField/types";
+import TextInput from "@peated/web/components/textInput";
+import classNames from "@peated/web/lib/classNames";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { useQuery } from "@tanstack/react-query";
+import { usePathname, useSearchParams } from "next/navigation";
+import { type ElementType, type FormEvent, useState } from "react";
+
+type FilterOption = {
+  id: number;
+  name: string;
+};
+
+const FILTER_PARAMS = ["query", "brand", "distiller", "cursor"];
+
+function entityOption(entity?: FilterOption | null) {
+  return entity ? { id: entity.id, name: entity.name } : undefined;
+}
+
+function useLibraryFilters() {
+  const searchParams = useSearchParams();
+
+  const query = searchParams.get("query") ?? "";
+  const brand = searchParams.get("brand");
+  const distiller = searchParams.get("distiller");
+
+  return {
+    query,
+    brandId: brand ? Number(brand) : null,
+    distillerId: distiller ? Number(distiller) : null,
+    hasActiveFilters: Boolean(query || brand || distiller),
+  };
+}
+
+export function LibraryFilters({
+  loading = false,
+  onNavigate,
+}: {
+  loading?: boolean;
+  onNavigate: (href: string) => void;
+}) {
+  const orpc = useORPC();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const { query, brandId, distillerId, hasActiveFilters } = useLibraryFilters();
+
+  const brandQuery = useQuery({
+    ...orpc.entities.details.queryOptions({
+      input: { entity: Number(brandId) },
+    }),
+    enabled: !!brandId,
+  });
+  const distillerQuery = useQuery({
+    ...orpc.entities.details.queryOptions({
+      input: { entity: Number(distillerId) },
+    }),
+    enabled: !!distillerId,
+  });
+
+  const brand = entityOption(brandQuery.data);
+  const distiller = entityOption(distillerQuery.data);
+
+  function pushParams(nextParams: URLSearchParams) {
+    const nextQuery = nextParams.toString();
+    onNavigate(nextQuery ? `${pathname}?${nextQuery}` : pathname);
+  }
+
+  function setFilter(name: string, value?: string | number | null) {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.delete("cursor");
+
+    if (value) {
+      nextParams.set(name, String(value));
+    } else {
+      nextParams.delete(name);
+    }
+
+    pushParams(nextParams);
+  }
+
+  function clearFilters() {
+    const nextParams = new URLSearchParams(searchParams);
+    FILTER_PARAMS.forEach((name) => nextParams.delete(name));
+    pushParams(nextParams);
+  }
+
+  function handleSearch(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    const value = String(data.get("query") ?? "").trim();
+    setFilter("query", value);
+  }
+
+  return (
+    <div
+      className="mb-3 px-3 sm:mb-4 sm:px-0"
+      aria-busy={loading ? "true" : undefined}
+    >
+      <div className="overflow-hidden rounded border border-slate-800 bg-slate-950/70">
+        {loading && (
+          <div
+            className="bg-highlight h-0.5 animate-pulse"
+            aria-hidden="true"
+          />
+        )}
+        <div className="flex flex-col gap-2 p-2 sm:flex-row sm:items-center">
+          <form
+            onSubmit={handleSearch}
+            className="min-w-0 flex-1"
+            role="search"
+          >
+            <div className="flex h-10 items-center gap-2 rounded bg-slate-900 px-3 ring-1 ring-inset ring-slate-800 focus-within:ring-slate-600">
+              <MagnifyingGlassIcon className="text-muted h-5 w-5 shrink-0" />
+              <label className="sr-only" htmlFor="library-query">
+                Search library
+              </label>
+              <TextInput
+                key={query}
+                id="library-query"
+                type="search"
+                name="query"
+                defaultValue={query}
+                placeholder="Search library"
+                className="h-10 min-w-0 flex-1 bg-transparent px-0 py-0"
+              />
+              <Button size="small" type="submit" loading={loading}>
+                Search
+              </Button>
+            </div>
+          </form>
+
+          <div className="grid grid-cols-2 gap-2 sm:flex sm:w-auto sm:shrink-0">
+            <LibraryEntityFilter
+              label="Brand"
+              icon={BrandIcon}
+              placeholder="Any brand"
+              value={brand}
+              loading={brandQuery.isFetching}
+              searchContextType="brand"
+              onChange={(value) => setFilter("brand", value?.id)}
+              onClear={() => setFilter("brand")}
+            />
+            <LibraryEntityFilter
+              label="Distillery"
+              icon={DistillerIcon}
+              placeholder="Any distillery"
+              value={distiller}
+              loading={distillerQuery.isFetching}
+              searchContextType="distiller"
+              onChange={(value) => setFilter("distiller", value?.id)}
+              onClear={() => setFilter("distiller")}
+            />
+          </div>
+
+          {hasActiveFilters && (
+            <Button
+              icon={<XMarkIcon className="h-4 w-4" />}
+              onClick={clearFilters}
+              title="Clear filters"
+              aria-label="Clear filters"
+              loading={loading}
+              className="sm:shrink-0"
+            />
+          )}
+        </div>
+
+        {query && (
+          <div className="flex flex-wrap gap-2 border-t border-slate-800 px-2 py-2">
+            <ActiveFilterChip
+              label={`Search: ${query}`}
+              onClear={() => setFilter("query")}
+            />
+          </div>
+        )}
+      </div>
+      <span className="sr-only" aria-live="polite">
+        {loading ? "Loading library results" : ""}
+      </span>
+    </div>
+  );
+}
+
+function LibraryEntityFilter({
+  label,
+  icon: Icon,
+  placeholder,
+  value,
+  loading,
+  searchContextType,
+  onChange,
+  onClear,
+}: {
+  label: string;
+  icon: ElementType;
+  placeholder: string;
+  value?: FilterOption;
+  loading?: boolean;
+  searchContextType: "brand" | "distiller";
+  onChange: (value?: Option) => void;
+  onClear: () => void;
+}) {
+  const orpc = useORPC();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <div className="relative min-w-0 sm:w-44">
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className={classNames(
+            "flex h-10 w-full min-w-0 items-center gap-2 rounded border px-3 text-left text-sm shadow-sm",
+            value
+              ? "border-highlight/60 bg-slate-900 text-white"
+              : "border-slate-800 bg-slate-900 text-slate-300 hover:border-slate-700 hover:text-white",
+            loading ? "animate-pulse" : "",
+          )}
+          aria-haspopup="dialog"
+          aria-expanded={open}
+        >
+          <Icon className="text-muted h-4 w-4 shrink-0" aria-hidden="true" />
+          <span className="min-w-0 flex-1">
+            <span className="block text-[11px] font-semibold uppercase leading-3 text-slate-500">
+              {label}
+            </span>
+            <span className="block truncate leading-5">
+              {value?.name ?? placeholder}
+            </span>
+          </span>
+          <ChevronDownIcon className="text-muted h-4 w-4 shrink-0" />
+        </button>
+        {value && (
+          <button
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onClear();
+            }}
+            className="absolute right-8 top-1/2 -translate-y-1/2 rounded p-1 text-slate-400 hover:bg-slate-800 hover:text-white"
+            aria-label={`Clear ${label.toLowerCase()} filter`}
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        )}
+      </div>
+      <SelectDialog<Option>
+        open={open}
+        setOpen={setOpen}
+        onSelect={(option) => {
+          onChange(option);
+          setOpen(false);
+        }}
+        selectedValues={value ? [value] : []}
+        searchPlaceholder={`Search ${label.toLowerCase()}`}
+        onQuery={async (query) => {
+          const { results } = await orpc.entities.list.call({
+            query,
+            searchContext: { type: searchContextType },
+          });
+          return results;
+        }}
+        onRenderOption={(item) => (
+          <div className="flex flex-col items-start">
+            <div>{item.name}</div>
+            <div className="text-muted font-normal">
+              {item.shortName || null}
+            </div>
+          </div>
+        )}
+      />
+    </>
+  );
+}
+
+function ActiveFilterChip({
+  label,
+  onClear,
+}: {
+  label: string;
+  onClear: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClear}
+      className="inline-flex h-7 max-w-full items-center gap-1 rounded border border-slate-700 bg-slate-900 px-2 text-xs font-medium text-slate-300 hover:border-slate-600 hover:text-white"
+    >
+      <span className="truncate">{label}</span>
+      <XMarkIcon className="h-4 w-4 shrink-0" />
+    </button>
+  );
+}

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import BottleTable from "@peated/web/components/bottleTable";
+import Button from "@peated/web/components/button";
 import EmptyActivity from "@peated/web/components/emptyActivity";
 import LibraryEntryActions, {
   LibraryEntryImage,
@@ -7,10 +8,13 @@ import LibraryEntryActions, {
 } from "@peated/web/components/libraryEntryActions";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import useAuth from "@peated/web/hooks/useAuth";
+import classNames from "@peated/web/lib/classNames";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { use } from "react";
+import { useRouter } from "next/navigation";
+import { use, useTransition } from "react";
 import { useProfileUserId } from "../../profileContext";
+import { LibraryFilters } from "./libraryFilters";
 
 export default function UserLibrary(props: {
   params: Promise<{ username: string }>;
@@ -24,6 +28,8 @@ export default function UserLibrary(props: {
 
 function UserLibraryTable({ username }: { username: string }) {
   const orpc = useORPC();
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
   const { user } = useAuth();
   const profileUserId = useProfileUserId();
   const queryParams = useApiQueryParams({
@@ -38,26 +44,63 @@ function UserLibraryTable({ username }: { username: string }) {
     }),
   );
   const canEditLibraryImages = user?.id === profileUserId;
+  const libraryHref = `/users/${username}/library`;
+  const hasActiveFilters = Boolean(
+    queryParams.query || queryParams.brand || queryParams.distiller,
+  );
 
-  return bottles.results.length ? (
-    <BottleTable
-      bottleList={bottles.results}
-      rel={bottles.rel}
-      showBottleStats={false}
-      renderCollectionBottleImage={(entry) =>
-        canEditLibraryImages ? (
-          <LibraryEntryImage entry={entry} username={username} />
+  return (
+    <>
+      <LibraryFilters
+        loading={isPending}
+        onNavigate={(href) => {
+          startTransition(() => router.push(href));
+        }}
+      />
+      <div
+        className={classNames(
+          "relative transition-opacity",
+          isPending ? "opacity-60" : "",
+        )}
+        aria-busy={isPending ? "true" : undefined}
+      >
+        {isPending && (
+          <div
+            className="bg-highlight absolute inset-x-0 top-0 z-10 h-px animate-pulse"
+            aria-hidden="true"
+          />
+        )}
+        {bottles.results.length ? (
+          <BottleTable
+            bottleList={bottles.results}
+            rel={bottles.rel}
+            showBottleStats={false}
+            renderCollectionBottleImage={(entry) =>
+              canEditLibraryImages ? (
+                <LibraryEntryImage entry={entry} username={username} />
+              ) : (
+                <LibraryEntryThumbnail entry={entry} />
+              )
+            }
+            renderCollectionBottleActions={
+              canEditLibraryImages
+                ? (entry) => (
+                    <LibraryEntryActions entry={entry} username={username} />
+                  )
+                : undefined
+            }
+          />
+        ) : hasActiveFilters ? (
+          <EmptyActivity>
+            <div className="flex flex-col items-center gap-3">
+              <div>No library bottles match these filters.</div>
+              <Button href={libraryHref}>Clear filters</Button>
+            </div>
+          </EmptyActivity>
         ) : (
-          <LibraryEntryThumbnail entry={entry} />
-        )
-      }
-      renderCollectionBottleActions={
-        canEditLibraryImages
-          ? (entry) => <LibraryEntryActions entry={entry} username={username} />
-          : undefined
-      }
-    />
-  ) : (
-    <EmptyActivity>No library bottles recorded yet.</EmptyActivity>
+          <EmptyActivity>No library bottles recorded yet.</EmptyActivity>
+        )}
+      </div>
+    </>
   );
 }

--- a/apps/web/src/components/button.tsx
+++ b/apps/web/src/components/button.tsx
@@ -20,6 +20,7 @@ type BaseProps = {
   fullHeight?: boolean;
   className?: string;
   title?: string;
+  "aria-label"?: string;
   "aria-pressed"?: boolean | "false" | "true" | "mixed";
   [dataAttribute: `data-${string}`]: string | number | boolean | undefined;
 };

--- a/openspec/changes/improve-library-filtering/.openspec.yaml
+++ b/openspec/changes/improve-library-filtering/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-08

--- a/openspec/changes/improve-library-filtering/design.md
+++ b/openspec/changes/improve-library-filtering/design.md
@@ -1,0 +1,75 @@
+## Context
+
+Library is implemented as a reserved saved collection alias backed by the generic collection tables. The profile Library tab currently calls `collections.bottles.list` with `collection: "library"` and renders results through the shared `BottleTable`.
+
+The general bottle list endpoint already supports text search, brand filtering, and distillery filtering. The Library page cannot use that endpoint directly because the Library view must remain scoped to a specific user's saved collection, keep collection-bottle metadata such as Library entry images, and continue using collection privacy rules.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let viewers search a visible profile's Library by bottle text.
+- Let viewers filter a visible profile's Library by brand and distillery.
+- Keep filtering server-side so pagination and result counts are based on the filtered collection.
+- Keep filters encoded in URL query params.
+- Provide a mobile layout that keeps search visible and makes secondary filters usable without horizontal overflow.
+- Reuse existing collection visibility, serializers, and bottle search/filter semantics where practical.
+
+**Non-Goals:**
+
+- Add arbitrary user-defined collection browsing or management.
+- Add inventory fields, purchase metadata, bottle counts by filter, or cellar management.
+- Add a new persistence table or denormalized search index.
+- Change Favorites behavior unless shared collection list plumbing needs the same input schema.
+- Build facet-only dropdown option endpoints in the first implementation.
+
+## Decisions
+
+### Extend collection bottle listing instead of composing with bottle search
+
+Add optional `query`, `brand`, and `distiller` inputs to `collections.bottles.list`. Apply them inside the existing collection-scoped query.
+
+This keeps the route responsible for profile visibility, reserved collection lookup, collection bottle image serialization, release-aware rows, and pagination. Using `bottles.list` first and then intersecting results with Library entries would make pagination incorrect and would lose collection-bottle row data.
+
+Alternative considered: add a general `collection` filter to `bottles.list`. That could be useful later, but it mixes saved-collection visibility into the global catalog search endpoint and does not return collection-bottle metadata.
+
+### Reuse bottle search semantics
+
+Use the same text-search behavior as the general bottle list where feasible: search the bottle search vector and include exact bottle alias matches. Brand filtering should match `bottles.brandId`; distillery filtering should use `bottlesToDistillers`.
+
+This avoids making Library search feel different from catalog search. If alias matching adds too much query complexity, the implementation can ship with the search vector first, but tests should lock whichever behavior is chosen.
+
+Alternative considered: client-side filtering of the current page. That would be misleading because it only filters the current page of results and breaks pagination.
+
+### Use global async entity selectors first
+
+The brand and distillery dropdowns should use existing entity search patterns rather than a custom static list. The first implementation can search global entities and allow zero-result selections.
+
+Facet-only dropdowns limited to brands or distilleries present in the viewed Library would be better for large libraries, but they require a new metadata endpoint or a new response envelope. Keep that as a later enhancement unless product needs it immediately.
+
+Alternative considered: add `facets` to `collections.bottles.list`. That couples list results and filter metadata and may not fit the current list response shape.
+
+### Responsive filter layout
+
+Desktop should show search, brand, distillery, and clear filters as one horizontal control group above the table.
+
+Mobile should keep the search input visible above the results and show brand/distillery as compact entity-filter controls directly below it. Selected brand and distillery values should live in those controls, while submitted search text can use a removable chip because the input itself can change independently. Filter changes should reset `cursor` so users do not land on an empty later page after narrowing results.
+
+Alternative considered: move brand/distillery into a filter button that opens a bottom sheet or modal. That reduces first-viewport control height, but it made this table-filter interaction feel disconnected and hid two expected refinements behind an extra step.
+
+## Risks / Trade-offs
+
+- Search and distillery filters may add query cost on large collections -> keep conditions collection-scoped and use existing indexed bottle fields where available.
+- Global entity dropdowns can select filters absent from the user's Library -> provide a clear filtered empty state and consider facet metadata later.
+- URL-driven filters can conflict with pagination -> remove or reset `cursor` when filters change.
+- Compact mobile controls can duplicate selected state if chips repeat entity values -> keep selected brand/distillery values in their controls and reserve chips for submitted text search.
+- Release rows inherit bottle brand/distillery filters -> document and test that filters operate on the parent bottle for both base bottle and release Library entries.
+
+## Migration Plan
+
+No database migration is required. Add optional API inputs in a backward-compatible way. Existing Library URLs without filters continue to render the same unfiltered paginated list. Rollback can remove the UI and ignore the new optional API inputs without changing stored data.
+
+## Open Questions
+
+- Should exact alias matching be required for Library search parity with catalog search, or is bottle search-vector matching enough for the first version?
+- Should brand and distillery dropdowns use global entity search initially, or should this change include Library-scoped facet options before implementation?

--- a/openspec/changes/improve-library-filtering/proposal.md
+++ b/openspec/changes/improve-library-filtering/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The profile Library page can list saved bottles, but it becomes hard to use once a user has more than a small set of bottles. Users need fast ways to find a specific bottle and narrow their Library by brand or distillery without leaving the profile Library view.
+
+## What Changes
+
+- Add search support to the Library collection bottle list API.
+- Add brand and distillery filters to the Library collection bottle list API.
+- Add a Library filter bar with a search input, brand dropdown, and distillery dropdown.
+- Preserve filters in the URL so filtered Library views are shareable and browser navigation works.
+- Add responsive mobile behavior: search remains visible, secondary filters move into a compact filter control, active filters are visible, and filtered empty states can be cleared.
+- Keep Library filtering scoped to bottles already saved in the viewed user's Library.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `profile-library`: Profile Library can be searched and filtered by brand and distillery while preserving privacy, pagination, and saved collection semantics.
+
+## Impact
+
+- `collections.bottles.list` oRPC input and query construction need new optional filters.
+- Collection bottle list tests need coverage for search, brand filters, distillery filters, combined filters, pagination reset assumptions, and privacy boundaries.
+- The profile Library page needs a responsive filter UI above the existing bottle table.
+- The web query-param flow needs to pass `query`, `brand`, and `distiller` through to the Library query while preserving `user` and `collection: "library"` overrides.

--- a/openspec/changes/improve-library-filtering/specs/profile-library/spec.md
+++ b/openspec/changes/improve-library-filtering/specs/profile-library/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: Filterable Profile Library
+
+The system SHALL allow visible profile Library pages to be searched and filtered while keeping results scoped to the viewed user's Library collection.
+
+#### Scenario: Search Library by bottle text
+
+- **WHEN** a viewer searches a visible user's Library with a text query
+- **THEN** the system returns only Library entries whose bottle matches the query
+
+#### Scenario: Filter Library by brand
+
+- **WHEN** a viewer filters a visible user's Library by brand
+- **THEN** the system returns only Library entries whose bottle belongs to that brand
+
+#### Scenario: Filter Library by distillery
+
+- **WHEN** a viewer filters a visible user's Library by distillery
+- **THEN** the system returns only Library entries whose bottle is associated with that distillery
+
+#### Scenario: Combine Library filters
+
+- **WHEN** a viewer applies text, brand, and distillery filters together
+- **THEN** the system returns only Library entries that satisfy every active filter
+
+#### Scenario: Filtered results remain Library scoped
+
+- **WHEN** a matching bottle exists in the catalog but is not saved in the viewed user's Library
+- **THEN** the system MUST NOT include that bottle in the filtered Library results
+
+#### Scenario: Filter private Library
+
+- **WHEN** a viewer cannot view a user's private profile
+- **THEN** the system MUST NOT expose filtered or unfiltered Library results for that user
+
+### Requirement: Library Filter URL State
+
+The system SHALL store Library search and filter state in URL query parameters.
+
+#### Scenario: Open filtered Library URL
+
+- **WHEN** a viewer opens a Library URL with search or filter query parameters
+- **THEN** the Library page applies those parameters to the initial result query
+
+#### Scenario: Change Library filter
+
+- **WHEN** a viewer changes the search text, brand filter, or distillery filter
+- **THEN** the Library URL updates to reflect the active filters
+
+#### Scenario: Reset pagination on filter change
+
+- **WHEN** a viewer changes or clears any Library filter while a cursor parameter is present
+- **THEN** the system removes or resets the cursor before querying filtered results
+
+#### Scenario: Clear Library filters
+
+- **WHEN** a viewer clears Library filters
+- **THEN** the Library page removes the filter query parameters and shows the unfiltered Library list
+
+### Requirement: Responsive Library Filter Controls
+
+The system SHALL provide Library filter controls that are usable on both desktop and mobile viewports.
+
+#### Scenario: Desktop filter controls
+
+- **WHEN** a viewer opens the Library page on a desktop-width viewport
+- **THEN** the page displays search, brand, distillery, and clear-filter controls above the Library table
+
+#### Scenario: Mobile search visibility
+
+- **WHEN** a viewer opens the Library page on a mobile-width viewport
+- **THEN** the search control remains visible above the Library results
+
+#### Scenario: Mobile secondary filters
+
+- **WHEN** a viewer opens the Library page on a mobile-width viewport
+- **THEN** the page presents brand and distillery controls as compact controls near search without horizontal overflow
+
+#### Scenario: Mobile active filter visibility
+
+- **WHEN** brand or distillery filters are active on a mobile-width viewport
+- **THEN** the page displays the selected entity values in the filter controls so they can be recognized and cleared
+
+#### Scenario: Filtered empty state
+
+- **WHEN** active Library filters produce no matching entries
+- **THEN** the page displays a filtered empty state with a way to clear the filters

--- a/openspec/changes/improve-library-filtering/tasks.md
+++ b/openspec/changes/improve-library-filtering/tasks.md
@@ -1,0 +1,42 @@
+## 1. Backend Filtering
+
+- [x] 1.1 Add optional `query`, `brand`, and `distiller` inputs to `collections.bottles.list`.
+- [x] 1.2 Apply text search inside the collection-scoped bottle query using the existing bottle search semantics where practical.
+- [x] 1.3 Apply brand filtering through `bottles.brandId`.
+- [x] 1.4 Apply distillery filtering through `bottlesToDistillers`.
+- [x] 1.5 Preserve existing collection alias resolution, profile visibility checks, release rows, ordering, and pagination behavior.
+
+## 2. Backend Tests
+
+- [x] 2.1 Add collection bottle list tests for Library text search.
+- [x] 2.2 Add tests for Library brand filtering.
+- [x] 2.3 Add tests for Library distillery filtering.
+- [x] 2.4 Add tests for combined Library filters.
+- [x] 2.5 Add regression coverage that matching catalog bottles outside the viewed user's Library are excluded.
+- [x] 2.6 Add or preserve coverage that private Library filtering remains blocked by profile visibility.
+
+## 3. Web Filter UI
+
+- [x] 3.1 Add a Library filter bar above the profile Library bottle table.
+- [x] 3.2 Wire the search input to the `query` URL parameter and Library query input.
+- [x] 3.3 Wire the brand dropdown to the `brand` URL parameter and Library query input.
+- [x] 3.4 Wire the distillery dropdown to the `distiller` URL parameter and Library query input.
+- [x] 3.5 Add clear-filter behavior that removes `query`, `brand`, `distiller`, and `cursor`.
+- [x] 3.6 Show the unfiltered empty state only when no filters are active.
+- [x] 3.7 Show a filtered empty state with a clear action when active filters return no Library entries.
+
+## 4. Responsive Behavior
+
+- [x] 4.1 Implement a desktop layout that shows search, brand, distillery, and clear controls in one filter row.
+- [x] 4.2 Implement a mobile layout that keeps search visible and shows brand/distillery as compact controls without horizontal overflow.
+- [x] 4.3 Display active mobile filters through removable search chips or equivalent compact controls.
+- [x] 4.4 Ensure filter changes reset pagination before fetching the next Library result set.
+- [x] 4.5 Verify the Library table and filter controls do not overflow or overlap on mobile widths.
+
+## 5. Verification
+
+- [x] 5.1 Run `pnpm --filter @peated/server test -- src/orpc/routes/collections/bottles/list.test.ts`.
+- [x] 5.2 Run `pnpm --filter @peated/web typecheck`.
+- [x] 5.3 Run targeted lint/format checks for touched files.
+- [x] 5.4 Manually verify desktop Library filtering with local UI.
+- [x] 5.5 Manually verify mobile Library filtering, active filters, and filtered empty state with local UI.


### PR DESCRIPTION
Profile Library pages now support server-side search plus brand and distillery filters while keeping results scoped to saved Library entries. Filter state lives in the URL, pagination resets when filters change, and unsupported filter params on non-Library collection aliases are rejected instead of silently changing generic collection behavior.

The Library tab adds a compact table-style filter toolbar with sidebar-matching brand/distillery icons, pending feedback while route params update, filtered empty states, and a focused Playwright profile Library test covering desktop and mobile filter wiring.
