### PR TITLE
fix(library): Shorten bottling names

### DIFF
--- a/apps/web/e2e/profile-library.spec.ts
+++ b/apps/web/e2e/profile-library.spec.ts
@@ -5,6 +5,8 @@ import {
   displayImageBottleId,
   displayImageUrl,
   existingBottle,
+  existingRelease,
+  existingReleaseId,
   testAccessToken,
   testUser,
 } from "./rpc-fixtures.mjs";
@@ -106,7 +108,7 @@ test.describe("profile library", () => {
     ).toBeVisible();
     await expect(
       savedBottleRow.getByRole("img", { name: "In Library" }),
-    ).toBeVisible();
+    ).toHaveCount(0);
     await expect(
       savedBottleRow.getByRole("img", { name: "Favorite" }),
     ).toHaveCount(0);
@@ -149,6 +151,45 @@ test.describe("profile library", () => {
       0,
     );
     await expectNoHorizontalOverflow(page);
+  });
+
+  test("renders concise bottling names in Library", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: [
+        testAccessToken,
+        "library-release-name",
+        testInfo.project.name,
+        testInfo.workerIndex,
+        testInfo.retry,
+      ].join("-"),
+    });
+
+    await page.goto(
+      `/addBottle?bottle=${existingBottle.id}&release=${existingReleaseId}&intent=library`,
+    );
+    await page.getByRole("button", { name: "Add to Library" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Added to Library" }),
+    ).toBeVisible();
+
+    await page.goto(`/users/${testUser.username}/library`, {
+      waitUntil: "commit",
+    });
+
+    const conciseName = `${existingBottle.fullName} - ${existingRelease.edition} (${existingRelease.releaseYear})`;
+    const bottlingLink = page.getByRole("link", { name: conciseName });
+
+    await expect(bottlingLink).toBeVisible();
+    await expect(bottlingLink).toHaveAttribute(
+      "title",
+      existingRelease.fullName,
+    );
+    await expect(
+      page.getByRole("link", { name: existingRelease.fullName, exact: true }),
+    ).toHaveCount(0);
   });
 
   test("filters Library entries from the profile tab", async ({

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
@@ -78,6 +78,8 @@ function UserLibraryTable({ username }: { username: string }) {
           <BottleTable
             bottleList={bottles.results}
             rel={bottles.rel}
+            conciseBottlingNames
+            hideLibraryStatus
             showBottleStats={false}
             renderCollectionBottleImage={(entry) =>
               canEditLibrary ? (

--- a/apps/web/src/components/bottleStatusIcons.tsx
+++ b/apps/web/src/components/bottleStatusIcons.tsx
@@ -8,11 +8,13 @@ import type { Bottle } from "@peated/server/types";
 type BottleStatusIconsProps = {
   bottle: Pick<Bottle, "isFavorite" | "isLibrary" | "hasTasted">;
   className?: string;
+  hideLibrary?: boolean;
 };
 
 export default function BottleStatusIcons({
   bottle,
   className = "h-4 w-4",
+  hideLibrary = false,
 }: BottleStatusIconsProps) {
   return (
     <>
@@ -27,7 +29,7 @@ export default function BottleStatusIcons({
           <StarIcon className={className} aria-hidden="true" />
         </span>
       )}
-      {bottle.isLibrary && (
+      {bottle.isLibrary && !hideLibrary && (
         <span
           role="img"
           aria-label="In Library"

--- a/apps/web/src/components/bottleTable.tsx
+++ b/apps/web/src/components/bottleTable.tsx
@@ -10,7 +10,10 @@ import type {
 import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
 import type { ComponentProps, ReactNode } from "react";
-import { getBottleBottlingPath } from "../lib/bottlings";
+import {
+  formatBottleBottlingName,
+  getBottleBottlingPath,
+} from "../lib/bottlings";
 import classNames from "../lib/classNames";
 import BottleLink from "./bottleLink";
 import SimpleRatingIndicator from "./simpleRatingIndicator";
@@ -34,6 +37,8 @@ export default function BottleTable({
   renderCollectionBottleImage,
   renderCollectionBottleMeta,
   renderCollectionBottleActions,
+  conciseBottlingNames = false,
+  hideLibraryStatus = false,
   showBottleStats = true,
   ...props
 }: Omit<ComponentProps<typeof Table>, "items" | "rel" | "columns"> & {
@@ -42,6 +47,8 @@ export default function BottleTable({
   renderCollectionBottleImage?: (item: CollectionBottle) => ReactNode;
   renderCollectionBottleMeta?: (item: CollectionBottle) => ReactNode;
   renderCollectionBottleActions?: (item: CollectionBottle) => ReactNode;
+  conciseBottlingNames?: boolean;
+  hideLibraryStatus?: boolean;
   showBottleStats?: boolean;
 }) {
   const rows: BottleRow[] = bottleList.map((item) =>
@@ -104,8 +111,11 @@ export default function BottleTable({
                           item.release.id,
                         )}
                         className="font-medium hover:underline"
+                        title={item.release.fullName}
                       >
-                        {item.release.fullName}
+                        {conciseBottlingNames
+                          ? formatBottleBottlingName(item.bottle, item.release)
+                          : item.release.fullName}
                       </Link>
                     ) : (
                       <BottleLink
@@ -116,7 +126,10 @@ export default function BottleTable({
                         {item.bottle.name}
                       </BottleLink>
                     )}
-                    <BottleStatusIcons bottle={item.bottle} />
+                    <BottleStatusIcons
+                      bottle={item.bottle}
+                      hideLibrary={hideLibraryStatus}
+                    />
                     {collectionMeta}
                     {!item.release && item.bottle.singleCask && (
                       <SingleCaskChip />

--- a/apps/web/src/lib/bottlings.test.ts
+++ b/apps/web/src/lib/bottlings.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+
+import { formatBottleBottlingName } from "./bottlings";
+
+describe("formatBottleBottlingName", () => {
+  it("uses concise bottling fields instead of canonical trait suffixes", () => {
+    expect(
+      formatBottleBottlingName(
+        { fullName: "A.D. Rattray Glenrothes" },
+        {
+          edition: "Individual Cask Release",
+          releaseYear: 2021,
+          vintageYear: 1997,
+          fullName:
+            "A.D. Rattray Glenrothes - Individual Cask Release - 23-year-old - 2021 Release - 1997 Vintage - Single Cask - Cask Strength",
+        },
+      ),
+    ).toBe(
+      "A.D. Rattray Glenrothes - Individual Cask Release (2021) (1997 Vintage)",
+    );
+  });
+
+  it("removes canonical trait suffixes when no concise fields exist", () => {
+    expect(
+      formatBottleBottlingName(
+        { fullName: "Laphroaig Single Cask Selection" },
+        {
+          edition: null,
+          releaseYear: null,
+          vintageYear: null,
+          fullName:
+            "Laphroaig Single Cask Selection - Fortunato's Folly - 54.1% ABV - Single Cask - Cask Strength",
+        },
+      ),
+    ).toBe("Laphroaig Single Cask Selection - Fortunato's Folly - 54.1% ABV");
+  });
+});

--- a/apps/web/src/lib/bottlings.ts
+++ b/apps/web/src/lib/bottlings.ts
@@ -5,6 +5,12 @@ type BottlingSummary = Pick<
   "edition" | "releaseYear" | "vintageYear" | "fullName"
 >;
 
+type BottleSummary = {
+  fullName: string;
+};
+
+const CANONICAL_TRAIT_SUFFIX = /(?: - (?:Single Cask|Cask Strength))+$/;
+
 export function getBottleBottlingsPath(bottleId: number | string) {
   return `/bottles/${bottleId}/bottlings`;
 }
@@ -45,6 +51,18 @@ export function formatBottlingName(
   }
 
   return bottling.fullName;
+}
+
+/** Builds a list-friendly full name without canonical classification suffixes. */
+export function formatBottleBottlingName(
+  bottle: BottleSummary,
+  bottling: BottlingSummary,
+) {
+  const bottlingName = formatBottlingName(bottling);
+
+  return bottlingName === bottling.fullName
+    ? bottling.fullName.replace(CANONICAL_TRAIT_SUFFIX, "")
+    : `${bottle.fullName} - ${bottlingName}`;
 }
 
 export function formatBottlingCountLabel(numReleases: number) {


### PR DESCRIPTION
Library rows now use concise bottling labels instead of the full canonical release name, preventing classification suffixes such as Single Cask and Cask Strength from overwhelming the bottle identity. The canonical name remains available as hover context.

The library page also suppresses its redundant In Library status icon without changing status icons or release naming on other bottle lists. Profile-library coverage verifies the concise title and icon behavior on desktop and mobile.