### PR TITLE
feat(library): Add collection insights

### DIFF
--- a/apps/server/src/orpc/routes/users/details.test.ts
+++ b/apps/server/src/orpc/routes/users/details.test.ts
@@ -1,3 +1,5 @@
+import { db } from "@peated/server/db";
+import { collectionBottles } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
@@ -69,6 +71,67 @@ describe("GET /users/:user", () => {
     );
 
     expect(data.stats.contributions).toBe(1);
+  });
+
+  test("counts non-empty Library bottles by status", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const library = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+    const otherCollection = await fixtures.Collection({
+      name: "Other Collection",
+      createdById: defaults.user.id,
+    });
+    const [openBottle, sealedBottle, emptyBottle, unsetBottle, otherBottle] =
+      await Promise.all([
+        fixtures.Bottle(),
+        fixtures.Bottle(),
+        fixtures.Bottle(),
+        fixtures.Bottle(),
+        fixtures.Bottle(),
+      ]);
+
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: library.id,
+        bottleId: openBottle.id,
+        status: "open",
+      },
+      {
+        collectionId: library.id,
+        bottleId: sealedBottle.id,
+        status: "sealed",
+      },
+      {
+        collectionId: library.id,
+        bottleId: emptyBottle.id,
+        status: "empty",
+      },
+      {
+        collectionId: library.id,
+        bottleId: unsetBottle.id,
+        status: null,
+      },
+      {
+        collectionId: otherCollection.id,
+        bottleId: otherBottle.id,
+        status: "open",
+      },
+    ]);
+
+    const data = await routerClient.users.details(
+      { user: defaults.user.id },
+      { context: { user: defaults.user } },
+    );
+
+    expect(data.stats.library).toEqual({
+      total: 3,
+      open: 1,
+      sealed: 1,
+    });
   });
 
   test("errors on invalid username", async () => {

--- a/apps/server/src/orpc/routes/users/details.test.ts
+++ b/apps/server/src/orpc/routes/users/details.test.ts
@@ -17,6 +17,24 @@ describe("GET /users/:user", () => {
     expect(data.friendStatus).toBe("none");
   });
 
+  test("returns zero Library stats without collection entries", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const user = await fixtures.User();
+
+    const data = await routerClient.users.details(
+      { user: user.id },
+      { context: { user: defaults.user } },
+    );
+
+    expect(data.stats.library).toEqual({
+      total: 0,
+      open: 0,
+      sealed: 0,
+    });
+  });
+
   test("get user:me", async ({ defaults }) => {
     const data = await routerClient.users.details(
       { user: "me" },

--- a/apps/server/src/orpc/routes/users/details.ts
+++ b/apps/server/src/orpc/routes/users/details.ts
@@ -6,6 +6,7 @@ import {
   tastings,
 } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
+import { RESERVED_COLLECTIONS } from "@peated/server/lib/db";
 import { procedure } from "@peated/server/orpc";
 import { UserSchema, detailsResponse } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
@@ -35,6 +36,11 @@ export default procedure
           tastings: z.number(),
           bottles: z.number(),
           collected: z.number(),
+          library: z.object({
+            total: z.number(),
+            open: z.number(),
+            sealed: z.number(),
+          }),
           contributions: z.number(),
         }),
       }),
@@ -61,9 +67,19 @@ export default procedure
       .where(eq(tastings.createdById, user.id))
       .limit(1);
 
-    const [{ collectedBottles }] = await db
+    const [
+      {
+        collectedBottles,
+        totalLibraryBottles,
+        openLibraryBottles,
+        sealedLibraryBottles,
+      },
+    ] = await db
       .select({
         collectedBottles: sql<string>`COUNT(DISTINCT ${collectionBottles.bottleId})`,
+        totalLibraryBottles: sql<string>`COUNT(${collectionBottles.id}) FILTER (WHERE LOWER(${collections.name}) = ${RESERVED_COLLECTIONS.library.name.toLowerCase()} AND ${collectionBottles.status} IS DISTINCT FROM 'empty')`,
+        openLibraryBottles: sql<string>`COUNT(${collectionBottles.id}) FILTER (WHERE LOWER(${collections.name}) = ${RESERVED_COLLECTIONS.library.name.toLowerCase()} AND ${collectionBottles.status} = 'open')`,
+        sealedLibraryBottles: sql<string>`COUNT(${collectionBottles.id}) FILTER (WHERE LOWER(${collections.name}) = ${RESERVED_COLLECTIONS.library.name.toLowerCase()} AND ${collectionBottles.status} = 'sealed')`,
       })
       .from(collections)
       .innerJoin(
@@ -94,6 +110,11 @@ export default procedure
         tastings: Number(totalTastings),
         bottles: Number(totalBottles),
         collected: Number(collectedBottles),
+        library: {
+          total: Number(totalLibraryBottles),
+          open: Number(openLibraryBottles),
+          sealed: Number(sealedLibraryBottles),
+        },
         contributions: Number(totalContributions),
       },
     };

--- a/apps/server/src/orpc/routes/users/index.ts
+++ b/apps/server/src/orpc/routes/users/index.ts
@@ -4,6 +4,7 @@ import avatarUpdate from "./avatar-update";
 import badgeList from "./badge-list";
 import details from "./details";
 import flavorList from "./flavor-list";
+import libraryStats from "./library-stats";
 import list from "./list";
 import regionList from "./region-list";
 import tagList from "./tag-list";
@@ -17,6 +18,7 @@ export default base.tag("users").router({
   avatarUpdate,
   badgeList,
   flavorList,
+  libraryStats,
   regionList,
   tagList,
 });

--- a/apps/server/src/orpc/routes/users/library-stats.test.ts
+++ b/apps/server/src/orpc/routes/users/library-stats.test.ts
@@ -1,0 +1,161 @@
+import { db } from "@peated/server/db";
+import {
+  bottlesToDistillers,
+  collectionBottles,
+} from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+describe("GET /users/:user/library/stats", () => {
+  test("returns empty insights when the Library does not exist", async ({
+    defaults,
+  }) => {
+    const data = await routerClient.users.libraryStats(
+      { user: defaults.user.id },
+      { context: { user: defaults.user } },
+    );
+
+    expect(data).toMatchObject({
+      total: 0,
+      distillers: [],
+      age: {
+        knownCount: 0,
+        median: null,
+        oldest: null,
+      },
+      categories: [],
+    });
+    expect(data.age.buckets.every((bucket) => bucket.count === 0)).toBe(true);
+  });
+
+  test("summarizes non-empty Library entries", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const library = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+    const otherCollection = await fixtures.Collection({
+      name: "Other Collection",
+      createdById: defaults.user.id,
+    });
+    const distillerA = await fixtures.Entity({ name: "Alpha Distillery" });
+    const distillerB = await fixtures.Entity({ name: "Beta Distillery" });
+    const youngBottle = await fixtures.Bottle({
+      category: "single_malt",
+      statedAge: 8,
+    });
+    const releaseBottle = await fixtures.Bottle({
+      category: "bourbon",
+      statedAge: 12,
+    });
+    const release = await fixtures.BottleRelease({
+      bottleId: releaseBottle.id,
+      statedAge: 18,
+    });
+    const oldBottle = await fixtures.Bottle({
+      category: "single_malt",
+      statedAge: 25,
+    });
+    const unstatedBottle = await fixtures.Bottle({
+      category: "rye",
+      statedAge: null,
+    });
+    const emptyBottle = await fixtures.Bottle({
+      category: "single_malt",
+      statedAge: 50,
+    });
+    const otherBottle = await fixtures.Bottle({
+      category: "single_malt",
+      statedAge: 40,
+    });
+
+    await db.insert(bottlesToDistillers).values([
+      { bottleId: youngBottle.id, distillerId: distillerA.id },
+      { bottleId: releaseBottle.id, distillerId: distillerA.id },
+      { bottleId: oldBottle.id, distillerId: distillerB.id },
+      { bottleId: emptyBottle.id, distillerId: distillerB.id },
+      { bottleId: otherBottle.id, distillerId: distillerB.id },
+    ]);
+    await db.insert(collectionBottles).values([
+      {
+        collectionId: library.id,
+        bottleId: youngBottle.id,
+        status: "open",
+      },
+      {
+        collectionId: library.id,
+        bottleId: releaseBottle.id,
+        releaseId: release.id,
+        status: "sealed",
+      },
+      {
+        collectionId: library.id,
+        bottleId: oldBottle.id,
+        status: null,
+      },
+      {
+        collectionId: library.id,
+        bottleId: unstatedBottle.id,
+        status: "open",
+      },
+      {
+        collectionId: library.id,
+        bottleId: emptyBottle.id,
+        status: "empty",
+      },
+      {
+        collectionId: otherCollection.id,
+        bottleId: otherBottle.id,
+        status: "sealed",
+      },
+    ]);
+
+    const data = await routerClient.users.libraryStats(
+      { user: defaults.user.id },
+      { context: { user: defaults.user } },
+    );
+
+    expect(data.total).toBe(4);
+    expect(data.distillers).toEqual([
+      { id: distillerA.id, name: distillerA.name, count: 2 },
+      { id: distillerB.id, name: distillerB.name, count: 1 },
+    ]);
+    expect(data.age).toEqual({
+      knownCount: 3,
+      median: 18,
+      oldest: 25,
+      buckets: [
+        { id: "under10", label: "Under 10", count: 1 },
+        { id: "from10To12", label: "10–12", count: 0 },
+        { id: "from13To17", label: "13–17", count: 0 },
+        { id: "from18To24", label: "18–24", count: 1 },
+        { id: "atLeast25", label: "25+", count: 1 },
+        { id: "unstated", label: "Unstated", count: 1 },
+      ],
+    });
+    expect(data.categories).toEqual([
+      { category: "single_malt", count: 2 },
+      { category: "bourbon", count: 1 },
+      { category: "rye", count: 1 },
+    ]);
+  });
+
+  test("rejects private Library insights for other users", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const privateUser = await fixtures.User({ private: true });
+
+    const error = await waitError(() =>
+      routerClient.users.libraryStats(
+        { user: privateUser.id },
+        { context: { user: defaults.user } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: User's profile is private.]`);
+  });
+});

--- a/apps/server/src/orpc/routes/users/library-stats.ts
+++ b/apps/server/src/orpc/routes/users/library-stats.ts
@@ -1,0 +1,217 @@
+import { db } from "@peated/server/db";
+import {
+  bottleReleases,
+  bottles,
+  bottlesToDistillers,
+  collectionBottles,
+  entities,
+} from "@peated/server/db/schema";
+import { getUserFromId, profileVisible } from "@peated/server/lib/api";
+import { getReservedCollection } from "@peated/server/lib/db";
+import { procedure } from "@peated/server/orpc";
+import { CategoryEnum } from "@peated/server/schemas";
+import { and, asc, desc, eq, isNotNull, sql } from "drizzle-orm";
+import { z } from "zod";
+
+const AgeBucketSchema = z.object({
+  id: z.enum([
+    "under10",
+    "from10To12",
+    "from13To17",
+    "from18To24",
+    "atLeast25",
+    "unstated",
+  ]),
+  label: z.string(),
+  count: z.number(),
+});
+
+const emptyStats = {
+  total: 0,
+  distillers: [],
+  age: {
+    knownCount: 0,
+    median: null,
+    oldest: null,
+    buckets: [
+      { id: "under10" as const, label: "Under 10", count: 0 },
+      { id: "from10To12" as const, label: "10–12", count: 0 },
+      { id: "from13To17" as const, label: "13–17", count: 0 },
+      { id: "from18To24" as const, label: "18–24", count: 0 },
+      { id: "atLeast25" as const, label: "25+", count: 0 },
+      { id: "unstated" as const, label: "Unstated", count: 0 },
+    ],
+  },
+  categories: [],
+};
+
+export default procedure
+  .route({
+    method: "GET",
+    path: "/users/{user}/library/stats",
+    summary: "Get user Library statistics",
+    description:
+      "Retrieve distillery, age, and category insights for non-empty bottles in a visible user's Library",
+    operationId: "getUserLibraryStats",
+  })
+  .input(
+    z.object({
+      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
+    }),
+  )
+  .output(
+    z.object({
+      total: z.number(),
+      distillers: z.array(
+        z.object({
+          id: z.number(),
+          name: z.string(),
+          count: z.number(),
+        }),
+      ),
+      age: z.object({
+        knownCount: z.number(),
+        median: z.number().nullable(),
+        oldest: z.number().nullable(),
+        buckets: z.array(AgeBucketSchema),
+      }),
+      categories: z.array(
+        z.object({
+          category: CategoryEnum,
+          count: z.number(),
+        }),
+      ),
+    }),
+  )
+  .handler(async function ({ input, context, errors }) {
+    const user = await getUserFromId(db, input.user, context.user);
+    if (!user) {
+      throw errors.NOT_FOUND({
+        message: "User not found.",
+      });
+    }
+
+    if (!(await profileVisible(db, user, context.user))) {
+      throw errors.BAD_REQUEST({
+        message: "User's profile is private.",
+      });
+    }
+
+    const library = await getReservedCollection(db, user.id, "library");
+    if (!library) {
+      return emptyStats;
+    }
+
+    const nonEmptyLibraryEntry = and(
+      eq(collectionBottles.collectionId, library.id),
+      sql`${collectionBottles.status} IS DISTINCT FROM 'empty'`,
+    );
+    const statedAge = sql<number>`COALESCE(${bottleReleases.statedAge}, ${bottles.statedAge})`;
+
+    const [ageRows, distillerRows, categoryRows] = await Promise.all([
+      db
+        .select({
+          total: sql<string>`COUNT(${collectionBottles.id})`,
+          knownCount: sql<string>`COUNT(${statedAge})`,
+          median: sql<
+            string | null
+          >`PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY ${statedAge}) FILTER (WHERE ${statedAge} IS NOT NULL)`,
+          oldest: sql<number | null>`MAX(${statedAge})`,
+          under10: sql<string>`COUNT(*) FILTER (WHERE ${statedAge} < 10)`,
+          from10To12: sql<string>`COUNT(*) FILTER (WHERE ${statedAge} BETWEEN 10 AND 12)`,
+          from13To17: sql<string>`COUNT(*) FILTER (WHERE ${statedAge} BETWEEN 13 AND 17)`,
+          from18To24: sql<string>`COUNT(*) FILTER (WHERE ${statedAge} BETWEEN 18 AND 24)`,
+          atLeast25: sql<string>`COUNT(*) FILTER (WHERE ${statedAge} >= 25)`,
+          unstated: sql<string>`COUNT(*) FILTER (WHERE ${statedAge} IS NULL)`,
+        })
+        .from(collectionBottles)
+        .innerJoin(bottles, eq(bottles.id, collectionBottles.bottleId))
+        .leftJoin(
+          bottleReleases,
+          eq(bottleReleases.id, collectionBottles.releaseId),
+        )
+        .where(nonEmptyLibraryEntry),
+      db
+        .select({
+          id: entities.id,
+          name: entities.name,
+          count: sql<string>`COUNT(${collectionBottles.id})`,
+        })
+        .from(collectionBottles)
+        .innerJoin(
+          bottlesToDistillers,
+          eq(bottlesToDistillers.bottleId, collectionBottles.bottleId),
+        )
+        .innerJoin(entities, eq(entities.id, bottlesToDistillers.distillerId))
+        .where(nonEmptyLibraryEntry)
+        .groupBy(entities.id, entities.name)
+        .orderBy(desc(sql`COUNT(${collectionBottles.id})`), asc(entities.name))
+        .limit(5),
+      db
+        .select({
+          category: bottles.category,
+          count: sql<string>`COUNT(${collectionBottles.id})`,
+        })
+        .from(collectionBottles)
+        .innerJoin(bottles, eq(bottles.id, collectionBottles.bottleId))
+        .where(and(nonEmptyLibraryEntry, isNotNull(bottles.category)))
+        .groupBy(bottles.category)
+        .orderBy(
+          desc(sql`COUNT(${collectionBottles.id})`),
+          asc(bottles.category),
+        )
+        .limit(5),
+    ]);
+
+    const age = ageRows[0];
+    if (!age) {
+      return emptyStats;
+    }
+
+    return {
+      total: Number(age.total),
+      distillers: distillerRows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        count: Number(row.count),
+      })),
+      age: {
+        knownCount: Number(age.knownCount),
+        median: age.median === null ? null : Number(age.median),
+        oldest: age.oldest === null ? null : Number(age.oldest),
+        buckets: [
+          { id: "under10", label: "Under 10", count: Number(age.under10) },
+          {
+            id: "from10To12",
+            label: "10–12",
+            count: Number(age.from10To12),
+          },
+          {
+            id: "from13To17",
+            label: "13–17",
+            count: Number(age.from13To17),
+          },
+          {
+            id: "from18To24",
+            label: "18–24",
+            count: Number(age.from18To24),
+          },
+          {
+            id: "atLeast25",
+            label: "25+",
+            count: Number(age.atLeast25),
+          },
+          {
+            id: "unstated",
+            label: "Unstated",
+            count: Number(age.unstated),
+          },
+        ],
+      },
+      categories: categoryRows.flatMap((row) =>
+        row.category
+          ? [{ category: row.category, count: Number(row.count) }]
+          : [],
+      ),
+    };
+  });

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -13,6 +13,7 @@ import {
   createdTastingId,
   displayImageBottleId,
   displayImageUrl,
+  emptyLibraryStats,
   emptyList,
   existingBottle,
   existingBottleId,
@@ -531,6 +532,9 @@ async function handleRpcRequest({ request, response, url }) {
       }
 
       sendRpcError(response, "Unexpected user details payload");
+      return true;
+    case "users/libraryStats":
+      sendRpcResponse(response, emptyLibraryStats);
       return true;
     case "users/badgeList":
       sendRpcResponse(response, emptyList);

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -21,8 +21,32 @@ export const testUser = {
     tastings: 0,
     bottles: 0,
     collected: 0,
+    library: {
+      total: 0,
+      open: 0,
+      sealed: 0,
+    },
     contributions: 0,
   },
+};
+
+export const emptyLibraryStats = {
+  total: 0,
+  distillers: [],
+  age: {
+    knownCount: 0,
+    median: null,
+    oldest: null,
+    buckets: [
+      { id: "under10", label: "Under 10", count: 0 },
+      { id: "from10To12", label: "10–12", count: 0 },
+      { id: "from13To17", label: "13–17", count: 0 },
+      { id: "from18To24", label: "18–24", count: 0 },
+      { id: "atLeast25", label: "25+", count: 0 },
+      { id: "unstated", label: "Unstated", count: 0 },
+    ],
+  },
+  categories: [],
 };
 
 export const testAccessToken = "peated-playwright-access-token";

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
@@ -1,0 +1,74 @@
+import type { Outputs } from "@peated/server/orpc/router";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { LibraryInsightsContent } from "./libraryInsights";
+
+type LibraryStats = Outputs["users"]["libraryStats"];
+
+function makeStats(overrides: Partial<LibraryStats> = {}): LibraryStats {
+  return {
+    total: 4,
+    distillers: [{ id: 1, name: "Example Distillery", count: 3 }],
+    age: {
+      knownCount: 3,
+      median: 12,
+      oldest: 25,
+      buckets: [
+        { id: "under10", label: "Under 10", count: 1 },
+        { id: "from10To12", label: "10–12", count: 1 },
+        { id: "from13To17", label: "13–17", count: 0 },
+        { id: "from18To24", label: "18–24", count: 0 },
+        { id: "atLeast25", label: "25+", count: 1 },
+        { id: "unstated", label: "Unstated", count: 1 },
+      ],
+    },
+    categories: [{ category: "single_malt", count: 3 }],
+    ...overrides,
+  };
+}
+
+describe("LibraryInsightsContent", () => {
+  test("shows distilleries and age distribution with enough age data", () => {
+    const html = renderToStaticMarkup(
+      <LibraryInsightsContent stats={makeStats()} username="collector" />,
+    );
+
+    expect(html).toContain("Top distilleries");
+    expect(html).toContain("Example Distillery");
+    expect(html).toContain("Example Distillery: 3 bottles");
+    expect(html).toContain("Age profile");
+    expect(html).toContain("Median 12 yr");
+    expect(html).toContain("Under 10: 1 bottle");
+    expect(html).toContain("Age stated for 3 of 4 bottles");
+    expect(html).not.toContain("Library types");
+  });
+
+  test("falls back to category mix when age data is limited", () => {
+    const stats = makeStats({
+      age: {
+        ...makeStats().age,
+        knownCount: 2,
+      },
+    });
+    const html = renderToStaticMarkup(
+      <LibraryInsightsContent stats={stats} username="collector" />,
+    );
+
+    expect(html).toContain("Library types");
+    expect(html).toContain("Single Malt");
+    expect(html).toContain("Single Malt: 3 bottles");
+    expect(html).toContain("Age data is limited");
+    expect(html).not.toContain("Age profile");
+  });
+
+  test("renders nothing for an empty Library", () => {
+    const html = renderToStaticMarkup(
+      <LibraryInsightsContent
+        stats={makeStats({ total: 0 })}
+        username="collector"
+      />,
+    );
+
+    expect(html).toBe("");
+  });
+});

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { formatCategoryName } from "@peated/server/lib/format";
+import type { Outputs } from "@peated/server/orpc/router";
+import Link from "@peated/web/components/link";
+import { logError } from "@peated/web/lib/log";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, type ReactNode } from "react";
+
+type LibraryStats = Outputs["users"]["libraryStats"];
+type RankedItem = {
+  id: string | number;
+  label: string;
+  count: number;
+  href?: string;
+};
+
+const MINIMUM_AGE_SAMPLE = 3;
+
+function formatBottleCount(count: number) {
+  return `${count.toLocaleString()} ${count === 1 ? "bottle" : "bottles"}`;
+}
+
+function RankedBars({ items }: { items: RankedItem[] }) {
+  const largestCount = Math.max(...items.map((item) => item.count), 1);
+
+  return (
+    <ol className="space-y-2">
+      {items.map((item) => {
+        const content = (
+          <>
+            <div className="mb-1 flex items-center justify-between gap-3 text-xs">
+              <span className="truncate font-medium text-slate-200">
+                {item.label}
+              </span>
+              <span className="text-muted shrink-0 tabular-nums">
+                {item.count.toLocaleString()}
+              </span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-slate-800">
+              <div
+                className="bg-highlight h-full rounded-full"
+                style={{ width: `${(item.count / largestCount) * 100}%` }}
+              />
+            </div>
+          </>
+        );
+
+        return (
+          <li key={item.id}>
+            {item.href ? (
+              <Link
+                href={item.href}
+                className="focus-visible:ring-highlight group block rounded focus-visible:outline-none focus-visible:ring-2"
+                aria-label={`${item.label}: ${formatBottleCount(item.count)}`}
+              >
+                {content}
+              </Link>
+            ) : (
+              <div
+                aria-label={`${item.label}: ${formatBottleCount(item.count)}`}
+              >
+                {content}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function InsightCard({
+  title,
+  detail,
+  children,
+}: {
+  title: string;
+  detail?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded border border-slate-800 bg-slate-950/70 p-3">
+      <div className="mb-3 flex min-h-8 items-start justify-between gap-3">
+        <h2 className="text-sm font-semibold text-white">{title}</h2>
+        {detail ? (
+          <span className="text-muted text-right text-[11px] leading-4">
+            {detail}
+          </span>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function formatAge(age: number) {
+  return Number.isInteger(age) ? age.toLocaleString() : age.toFixed(1);
+}
+
+function AgeDistribution({ stats }: { stats: LibraryStats }) {
+  const largestCount = Math.max(
+    ...stats.age.buckets.map((bucket) => bucket.count),
+    1,
+  );
+  const detail = [
+    stats.age.median !== null
+      ? `Median ${formatAge(stats.age.median)} yr`
+      : null,
+    stats.age.oldest !== null
+      ? `Oldest ${formatAge(stats.age.oldest)} yr`
+      : null,
+  ]
+    .filter((value): value is string => value !== null)
+    .join(" · ");
+
+  return (
+    <InsightCard title="Age profile" detail={detail}>
+      <div className="grid h-28 grid-cols-6 gap-1" aria-hidden="true">
+        {stats.age.buckets.map((bucket) => (
+          <div key={bucket.id} className="flex min-w-0 flex-col items-center">
+            <span className="text-muted mb-1 h-4 text-[10px] tabular-nums">
+              {bucket.count ? bucket.count.toLocaleString() : ""}
+            </span>
+            <div className="flex min-h-0 w-full flex-1 items-end justify-center">
+              <div
+                className={
+                  bucket.id === "unstated"
+                    ? "w-3/5 rounded-t bg-slate-600"
+                    : "bg-highlight w-3/5 rounded-t"
+                }
+                style={{
+                  height: bucket.count
+                    ? `${Math.max(10, (bucket.count / largestCount) * 100)}%`
+                    : 0,
+                }}
+              />
+            </div>
+            <span className="mt-1 min-h-7 text-center text-[10px] leading-3 text-slate-400">
+              {bucket.label}
+            </span>
+          </div>
+        ))}
+      </div>
+      <ul className="sr-only">
+        {stats.age.buckets.map((bucket) => (
+          <li key={bucket.id}>
+            {bucket.label}: {formatBottleCount(bucket.count)}
+          </li>
+        ))}
+      </ul>
+      <p className="text-muted mt-1 text-[11px]">
+        Age stated for {stats.age.knownCount.toLocaleString()} of{" "}
+        {stats.total.toLocaleString()} bottles
+      </p>
+    </InsightCard>
+  );
+}
+
+function CategoryDistribution({ stats }: { stats: LibraryStats }) {
+  return (
+    <InsightCard title="Library types" detail="Age data is limited">
+      <RankedBars
+        items={stats.categories.map((item) => ({
+          id: item.category,
+          label: formatCategoryName(item.category),
+          count: item.count,
+        }))}
+      />
+    </InsightCard>
+  );
+}
+
+export function LibraryInsightsContent({
+  stats,
+  username,
+}: {
+  stats: LibraryStats;
+  username: string;
+}) {
+  if (!stats.total) return null;
+
+  const showAge = stats.age.knownCount >= MINIMUM_AGE_SAMPLE;
+  const showCategories = !showAge && stats.categories.length > 0;
+  const showDistillers = stats.distillers.length > 0;
+  const cardCount = Number(showDistillers) + Number(showAge || showCategories);
+
+  if (!cardCount) return null;
+
+  return (
+    <div
+      className={`mb-4 grid grid-cols-1 gap-3 px-3 sm:px-0 ${cardCount > 1 ? "lg:grid-cols-2" : ""}`}
+    >
+      {showDistillers ? (
+        <InsightCard title="Top distilleries">
+          <RankedBars
+            items={stats.distillers.map((distiller) => ({
+              id: distiller.id,
+              label: distiller.name,
+              count: distiller.count,
+              href: `/users/${username}/library?distiller=${distiller.id}`,
+            }))}
+          />
+        </InsightCard>
+      ) : null}
+      {showAge ? <AgeDistribution stats={stats} /> : null}
+      {showCategories ? <CategoryDistribution stats={stats} /> : null}
+    </div>
+  );
+}
+
+function LibraryInsightsSkeleton() {
+  return (
+    <div className="mb-4 grid grid-cols-1 gap-3 px-3 sm:px-0 lg:grid-cols-2">
+      <div className="h-44 animate-pulse rounded bg-slate-900" />
+      <div className="h-44 animate-pulse rounded bg-slate-900" />
+    </div>
+  );
+}
+
+export default function LibraryInsights({ username }: { username: string }) {
+  const orpc = useORPC();
+  const statsQuery = useQuery(
+    orpc.users.libraryStats.queryOptions({
+      input: { user: username },
+    }),
+  );
+
+  useEffect(() => {
+    if (statsQuery.error) {
+      logError(statsQuery.error, { context: "library_insights" });
+    }
+  }, [statsQuery.error]);
+
+  if (statsQuery.isLoading) return <LibraryInsightsSkeleton />;
+  if (!statsQuery.data || statsQuery.isError) return null;
+
+  return <LibraryInsightsContent stats={statsQuery.data} username={username} />;
+}

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
@@ -16,6 +16,7 @@ import { useRouter } from "next/navigation";
 import { use, useTransition } from "react";
 import { useProfileUserId } from "../../profileContext";
 import { LibraryFilters } from "./libraryFilters";
+import LibraryInsights from "./libraryInsights";
 
 export default function UserLibrary(props: {
   params: Promise<{ username: string }>;
@@ -55,6 +56,7 @@ function UserLibraryTable({ username }: { username: string }) {
 
   return (
     <>
+      <LibraryInsights username={username} />
       <LibraryFilters
         loading={isPending}
         onNavigate={(href) => {

--- a/apps/web/src/app/(default)/users/[username]/layout.tsx
+++ b/apps/web/src/app/(default)/users/[username]/layout.tsx
@@ -10,6 +10,7 @@ import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
 import { type ReactNode } from "react";
 import type { ProfilePage, WithContext } from "schema-dts";
 import FriendButton from "./friendButton";
+import { formatLibraryTabLabel } from "./libraryTabLabel";
 import LogoutButton from "./logoutButton";
 import ModActions from "./modActions";
 import { ProfileProvider } from "./profileContext";
@@ -116,9 +117,9 @@ export default async function Layout(props: {
             </div>
             <div className="mb-4 px-3 text-center">
               <span className="block text-xl font-bold uppercase tracking-wide text-white">
-                {user.stats.collected.toLocaleString()}
+                {user.stats.library.total.toLocaleString()}
               </span>
-              <span className="text-muted text-sm">Collected</span>
+              <span className="text-muted text-sm">Library bottles</span>
             </div>
             <div className="mb-4 pl-3 text-center">
               <span className="block text-xl font-bold uppercase tracking-wide text-white">
@@ -163,7 +164,7 @@ export default async function Layout(props: {
                 controlled
                 desktopOnly
               >
-                Library
+                {formatLibraryTabLabel(user.stats.library)}
               </TabItem>
             </Tabs>
           </div>

--- a/apps/web/src/app/(default)/users/[username]/libraryTabLabel.test.ts
+++ b/apps/web/src/app/(default)/users/[username]/libraryTabLabel.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "vitest";
+import { formatLibraryTabLabel } from "./libraryTabLabel";
+
+describe("formatLibraryTabLabel", () => {
+  test.each([
+    [{ open: 2, sealed: 3 }, "Library (2 open/3 sealed)"],
+    [{ open: 2, sealed: 0 }, "Library (2 open)"],
+    [{ open: 0, sealed: 3 }, "Library (3 sealed)"],
+    [{ open: 0, sealed: 0 }, "Library"],
+  ])("formats status counts", (counts, expected) => {
+    expect(formatLibraryTabLabel(counts)).toBe(expected);
+  });
+});

--- a/apps/web/src/app/(default)/users/[username]/libraryTabLabel.ts
+++ b/apps/web/src/app/(default)/users/[username]/libraryTabLabel.ts
@@ -1,0 +1,18 @@
+type LibraryStatusCounts = {
+  open: number;
+  sealed: number;
+};
+
+export function formatLibraryTabLabel({
+  open,
+  sealed,
+}: LibraryStatusCounts): string {
+  const statusCounts = [
+    open > 0 ? `${open.toLocaleString()} open` : null,
+    sealed > 0 ? `${sealed.toLocaleString()} sealed` : null,
+  ].filter((count): count is string => count !== null);
+
+  return statusCounts.length
+    ? `Library (${statusCounts.join("/")})`
+    : "Library";
+}


### PR DESCRIPTION
Library profiles now show non-empty bottle totals and open/sealed counts, with the tab summarizing the statuses that exist.

The Library page adds compact top-distillery and age-distribution insights above the filters. Distillery bars reuse the existing filter, release-specific ages take precedence over parent ages, and sparse age data falls back to category mix. Empty bottles remain visible in the Library but are excluded from every insight.