### PR TITLE
feat(search): Add first-class bottling results

### DIFF
--- a/apps/server/migrations/0193_slow_risque.sql
+++ b/apps/server/migrations/0193_slow_risque.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "bottle_release_search_idx" ON "bottle_release" USING gin ("search_vector");

--- a/apps/server/migrations/meta/0193_snapshot.json
+++ b/apps/server/migrations/meta/0193_snapshot.json
@@ -1,0 +1,6881 @@
+{
+  "id": "6e708f71-1e37-438c-8059-887c220f6839",
+  "prevId": "35e533ba-c15b-474b-9310-da4f160904d4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.actor": {
+      "name": "actor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "actor_type_key_unq": {
+          "name": "actor_type_key_unq",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "actor_user_idx": {
+          "name": "actor_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actor_user_id_user_id_fk": {
+          "name": "actor_user_id_user_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badge_award_tracked_object": {
+      "name": "badge_award_tracked_object",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "award_id": {
+          "name": "award_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "badge_award_object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "badge_award_tracked_object_unq": {
+          "name": "badge_award_tracked_object_unq",
+          "columns": [
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "badge_award_tracked_object_award_id_badge_award_id_fk": {
+          "name": "badge_award_tracked_object_award_id_badge_award_id_fk",
+          "tableFrom": "badge_award_tracked_object",
+          "tableTo": "badge_award",
+          "columnsFrom": [
+            "award_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badge_award": {
+      "name": "badge_award",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp": {
+          "name": "xp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level": {
+          "name": "level",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "badge_award_unq": {
+          "name": "badge_award_unq",
+          "columns": [
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "badge_award_badge_id_badges_id_fk": {
+          "name": "badge_award_badge_id_badges_id_fk",
+          "tableFrom": "badge_award",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "badge_award_user_id_user_id_fk": {
+          "name": "badge_award_user_id_user_id_fk",
+          "tableFrom": "badge_award",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_level": {
+          "name": "max_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "tracker": {
+          "name": "tracker",
+          "type": "badge_award_object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bottle'"
+        },
+        "formula": {
+          "name": "formula",
+          "type": "badge_formula",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "checks": {
+          "name": "checks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "badge_name_unq": {
+          "name": "badge_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_alias": {
+      "name": "bottle_alias",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(3072)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored": {
+          "name": "ignored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "bottle_alias_assignment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy'"
+        },
+        "assigned_by_actor_id": {
+          "name": "assigned_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bottle_alias_name_idx": {
+          "name": "bottle_alias_name_idx",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_alias_bottle_idx": {
+          "name": "bottle_alias_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_alias_release_idx": {
+          "name": "bottle_alias_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_alias_assigned_by_actor_idx": {
+          "name": "bottle_alias_assigned_by_actor_idx",
+          "columns": [
+            {
+              "expression": "assigned_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_alias_bottle_id_bottle_id_fk": {
+          "name": "bottle_alias_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_alias",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_alias_release_id_bottle_release_id_fk": {
+          "name": "bottle_alias_release_id_bottle_release_id_fk",
+          "tableFrom": "bottle_alias",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_alias_assigned_by_actor_id_actor_id_fk": {
+          "name": "bottle_alias_assigned_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_alias",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "assigned_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_flavor_profile": {
+      "name": "bottle_flavor_profile",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_flavor_profile_bottle_id_bottle_id_fk": {
+          "name": "bottle_flavor_profile_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_flavor_profile",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_flavor_profile_bottle_id_flavor_profile_pk": {
+          "name": "bottle_flavor_profile_bottle_id_flavor_profile_pk",
+          "columns": [
+            "bottle_id",
+            "flavor_profile"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_observation": {
+      "name": "bottle_observation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_identity": {
+          "name": "parsed_identity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facts": {
+          "name": "facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bottle_observation_source_idx": {
+          "name": "bottle_observation_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_bottle_idx": {
+          "name": "bottle_observation_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_release_idx": {
+          "name": "bottle_observation_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_external_site_idx": {
+          "name": "bottle_observation_external_site_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_observation_bottle_id_bottle_id_fk": {
+          "name": "bottle_observation_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_observation_release_id_bottle_release_id_fk": {
+          "name": "bottle_observation_release_id_bottle_release_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_observation_external_site_id_external_site_id_fk": {
+          "name": "bottle_observation_external_site_id_external_site_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_observation_created_by_id_user_id_fk": {
+          "name": "bottle_observation_created_by_id_user_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_release": {
+      "name": "bottle_release",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vintage_year": {
+          "name": "vintage_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abv": {
+          "name": "abv",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "single_cask": {
+          "name": "single_cask",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_strength": {
+          "name": "cask_strength",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_age": {
+          "name": "stated_age",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_size": {
+          "name": "cask_size",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_type": {
+          "name": "cask_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_fill": {
+          "name": "cask_fill",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasting_notes": {
+          "name": "tasting_notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_tags": {
+          "name": "suggested_tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_release_bottle_idx": {
+          "name": "bottle_release_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_release_created_by_actor_idx": {
+          "name": "bottle_release_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_release_search_idx": {
+          "name": "bottle_release_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bottle_release_full_name_idx": {
+          "name": "bottle_release_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_release_bottle_id_bottle_id_fk": {
+          "name": "bottle_release_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_release",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_release_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_release_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_release",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bottle_release_stated_age_check": {
+          "name": "bottle_release_stated_age_check",
+          "value": "\"bottle_release\".\"stated_age\" IS NULL OR (\"bottle_release\".\"stated_age\" >= 0 AND \"bottle_release\".\"stated_age\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bottle_series": {
+      "name": "bottle_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_releases": {
+          "name": "num_releases",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_series_full_name_key": {
+          "name": "bottle_series_full_name_key",
+          "columns": [
+            {
+              "expression": "LOWER(\"full_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_series_search_idx": {
+          "name": "bottle_series_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bottle_series_brand_idx": {
+          "name": "bottle_series_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_series_created_by_actor_idx": {
+          "name": "bottle_series_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_series_brand_id_entity_id_fk": {
+          "name": "bottle_series_brand_id_entity_id_fk",
+          "tableFrom": "bottle_series",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_series_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_series_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_series",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_tag": {
+      "name": "bottle_tag",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_tag_bottle_id_bottle_id_fk": {
+          "name": "bottle_tag_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_tag",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_tag_bottle_id_tag_pk": {
+          "name": "bottle_tag_bottle_id_tag_pk",
+          "columns": [
+            "bottle_id",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_tombstone": {
+      "name": "bottle_tombstone",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_bottle_id": {
+          "name": "new_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle": {
+      "name": "bottle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stated_age": {
+          "name": "stated_age",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottler_id": {
+          "name": "bottler_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abv": {
+          "name": "abv",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "single_cask": {
+          "name": "single_cask",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_strength": {
+          "name": "cask_strength",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vintage_year": {
+          "name": "vintage_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_size": {
+          "name": "cask_size",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_type": {
+          "name": "cask_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_fill": {
+          "name": "cask_fill",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasting_notes": {
+          "name": "tasting_notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_tags": {
+          "name": "suggested_tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_stats": {
+          "name": "rating_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pass\":0,\"sip\":0,\"savor\":0,\"total\":0,\"avg\":null,\"percentage\":{\"pass\":0,\"sip\":0,\"savor\":0}}'::jsonb"
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_releases": {
+          "name": "num_releases",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_search_idx": {
+          "name": "bottle_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bottle_brand_idx": {
+          "name": "bottle_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_bottler_idx": {
+          "name": "bottle_bottler_idx",
+          "columns": [
+            {
+              "expression": "bottler_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_created_by_actor_idx": {
+          "name": "bottle_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_category_idx": {
+          "name": "bottle_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_flavor_profile_idx": {
+          "name": "bottle_flavor_profile_idx",
+          "columns": [
+            {
+              "expression": "flavor_profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_series_id_bottle_series_id_fk": {
+          "name": "bottle_series_id_bottle_series_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "bottle_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_brand_id_entity_id_fk": {
+          "name": "bottle_brand_id_entity_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_bottler_id_entity_id_fk": {
+          "name": "bottle_bottler_id_entity_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "bottler_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bottle_stated_age_check": {
+          "name": "bottle_stated_age_check",
+          "value": "\"bottle\".\"stated_age\" IS NULL OR (\"bottle\".\"stated_age\" >= 0 AND \"bottle\".\"stated_age\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bottle_distiller": {
+      "name": "bottle_distiller",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distiller_id": {
+          "name": "distiller_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_distiller_bottle_id_bottle_id_fk": {
+          "name": "bottle_distiller_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_distiller",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_distiller_distiller_id_entity_id_fk": {
+          "name": "bottle_distiller_distiller_id_entity_id_fk",
+          "tableFrom": "bottle_distiller",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "distiller_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_distiller_bottle_id_distiller_id_pk": {
+          "name": "bottle_distiller_bottle_id_distiller_id_pk",
+          "columns": [
+            "bottle_id",
+            "distiller_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change": {
+      "name": "change",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'add'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "change_actor_idx": {
+          "name": "change_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_actor_id_actor_id_fk": {
+          "name": "change_actor_id_actor_id_fk",
+          "tableFrom": "change",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection_bottle": {
+      "name": "collection_bottle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "collection_bottle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_bottle_bottle_idx": {
+          "name": "collection_bottle_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_bottle_release_idx": {
+          "name": "collection_bottle_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_bottle_collection_id_collection_id_fk": {
+          "name": "collection_bottle_collection_id_collection_id_fk",
+          "tableFrom": "collection_bottle",
+          "tableTo": "collection",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collection_bottle_bottle_id_bottle_id_fk": {
+          "name": "collection_bottle_bottle_id_bottle_id_fk",
+          "tableFrom": "collection_bottle",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collection_bottle_release_id_bottle_release_id_fk": {
+          "name": "collection_bottle_release_id_bottle_release_id_fk",
+          "tableFrom": "collection_bottle",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collection_bottle_collection_id_bottle_id_release_id_unique": {
+          "name": "collection_bottle_collection_id_bottle_id_release_id_unique",
+          "nullsNotDistinct": true,
+          "columns": [
+            "collection_id",
+            "bottle_id",
+            "release_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection": {
+      "name": "collection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "collection_name_unq": {
+          "name": "collection_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\"), \"created_by_id\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_created_by_idx": {
+          "name": "collection_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_created_by_id_user_id_fk": {
+          "name": "collection_created_by_id_user_id_fk",
+          "tableFrom": "collection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "comment_unq": {
+          "name": "comment_unq",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_tasting_id_tasting_id_fk": {
+          "name": "comments_tasting_id_tasting_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_created_by_id_user_id_fk": {
+          "name": "comments_created_by_id_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alpha2": {
+          "name": "alpha2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_distillers": {
+          "name": "total_distillers",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "country_name_unq": {
+          "name": "country_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "country_slug_unq": {
+          "name": "country_slug_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity": {
+      "name": "entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "entity_type[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year_established": {
+          "name": "year_established",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_name_unq": {
+          "name": "entity_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_search_idx": {
+          "name": "entity_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "entity_country_by_idx": {
+          "name": "entity_country_by_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_region_idx": {
+          "name": "entity_region_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_created_by_actor_idx": {
+          "name": "entity_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_country_id_country_id_fk": {
+          "name": "entity_country_id_country_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_region_id_region_id_fk": {
+          "name": "entity_region_id_region_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_created_by_actor_id_actor_id_fk": {
+          "name": "entity_created_by_actor_id_actor_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_parent_fk": {
+          "name": "entity_parent_fk",
+          "tableFrom": "entity",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_alias": {
+      "name": "entity_alias",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entity_alias_entity_idx": {
+          "name": "entity_alias_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_alias_name_idx": {
+          "name": "entity_alias_name_idx",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_alias_entity_id_entity_id_fk": {
+          "name": "entity_alias_entity_id_entity_id_fk",
+          "tableFrom": "entity_alias",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_tombstone": {
+      "name": "entity_tombstone",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_entity_id": {
+          "name": "new_entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event": {
+      "name": "event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repeats": {
+          "name": "repeats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_name_unq": {
+          "name": "event_name_unq",
+          "columns": [
+            {
+              "expression": "date_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_country_id": {
+          "name": "event_country_id",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_country_id_country_id_fk": {
+          "name": "event_country_id_country_id_fk",
+          "tableFrom": "event",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_site_config": {
+      "name": "external_site_config",
+      "schema": "",
+      "columns": {
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "external_site_config_external_site_id_external_site_id_fk": {
+          "name": "external_site_config_external_site_id_external_site_id_fk",
+          "tableFrom": "external_site_config",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "external_site_config_external_site_id_key_pk": {
+          "name": "external_site_config_external_site_id_key_pk",
+          "columns": [
+            "external_site_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_site": {
+      "name": "external_site",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "external_site_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_every": {
+          "name": "run_every",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_site_type": {
+          "name": "external_site_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight_bottle": {
+      "name": "flight_bottle",
+      "schema": "",
+      "columns": {
+        "flight_id": {
+          "name": "flight_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "flight_bottle_flight_id_flight_id_fk": {
+          "name": "flight_bottle_flight_id_flight_id_fk",
+          "tableFrom": "flight_bottle",
+          "tableTo": "flight",
+          "columnsFrom": [
+            "flight_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "flight_bottle_bottle_id_bottle_id_fk": {
+          "name": "flight_bottle_bottle_id_bottle_id_fk",
+          "tableFrom": "flight_bottle",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "flight_bottle_release_id_bottle_release_id_fk": {
+          "name": "flight_bottle_release_id_bottle_release_id_fk",
+          "tableFrom": "flight_bottle",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flight_bottle_flight_id_bottle_id_release_id_unique": {
+          "name": "flight_bottle_flight_id_bottle_id_release_id_unique",
+          "nullsNotDistinct": true,
+          "columns": [
+            "flight_id",
+            "bottle_id",
+            "release_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight": {
+      "name": "flight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "flight_public_id": {
+          "name": "flight_public_id",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flight_created_by_id_user_id_fk": {
+          "name": "flight_created_by_id_user_id_fk",
+          "tableFrom": "flight",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follow": {
+      "name": "follow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "follow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_unq": {
+          "name": "follow_unq",
+          "columns": [
+            {
+              "expression": "from_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_to_user_idx": {
+          "name": "follow_to_user_idx",
+          "columns": [
+            {
+              "expression": "to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_from_user_id_user_id_fk": {
+          "name": "follow_from_user_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "follow_to_user_id_user_id_fk": {
+          "name": "follow_to_user_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity": {
+      "name": "identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "identity_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "identity_unq": {
+          "name": "identity_unq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_user_idx": {
+          "name": "identity_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_user_id_user_id_fk": {
+          "name": "identity_user_id_user_id_fk",
+          "tableFrom": "identity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incoming_bottle_decision_log": {
+      "name": "incoming_bottle_decision_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "incoming_bottle_decision_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "incoming_bottle_decision_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_bottle": {
+          "name": "created_bottle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_release": {
+          "name": "created_release",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incoming_bottle_decision_source_unq": {
+          "name": "incoming_bottle_decision_source_unq",
+          "columns": [
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_created_idx": {
+          "name": "incoming_bottle_decision_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_external_site_idx": {
+          "name": "incoming_bottle_decision_external_site_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_bottle_idx": {
+          "name": "incoming_bottle_decision_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_release_idx": {
+          "name": "incoming_bottle_decision_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_actor_ref_idx": {
+          "name": "incoming_bottle_decision_actor_ref_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incoming_bottle_decision_log_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "incoming_bottle_decision_log_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_external_site_id_external_site_id_fk": {
+          "name": "incoming_bottle_decision_log_external_site_id_external_site_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_actor_id_actor_id_fk": {
+          "name": "incoming_bottle_decision_log_actor_id_actor_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_bottle_id_bottle_id_fk": {
+          "name": "incoming_bottle_decision_log_bottle_id_bottle_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_release_id_bottle_release_id_fk": {
+          "name": "incoming_bottle_decision_log_release_id_bottle_release_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "notifications_unq": {
+          "name": "notifications_unq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_from_user_id_user_id_fk": {
+          "name": "notifications_from_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_credential_id_unq": {
+          "name": "passkey_credential_id_unq",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_user_idx": {
+          "name": "passkey_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_upload": {
+      "name": "pending_upload",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "pendingUploadKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "pendingUploadPurpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pendingUploadStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_to_type": {
+          "name": "attached_to_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_to_id": {
+          "name": "attached_to_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_deleted_at": {
+          "name": "object_deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_upload_created_by_idx": {
+          "name": "pending_upload_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_upload_status_expires_at_idx": {
+          "name": "pending_upload_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_upload_created_by_id_user_id_fk": {
+          "name": "pending_upload_created_by_id_user_id_fk",
+          "tableFrom": "pending_upload",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_upload_idempotency_key": {
+          "name": "pending_upload_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "created_by_id",
+            "purpose",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.region": {
+      "name": "region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_distillers": {
+          "name": "total_distillers",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "region_name_unq": {
+          "name": "region_name_unq",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "region_slug_unq": {
+          "name": "region_slug_unq",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "region_country_idx": {
+          "name": "region_country_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "region_country_id_country_id_fk": {
+          "name": "region_country_id_country_id_fk",
+          "tableFrom": "region",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.legacy_release_repair_review": {
+      "name": "legacy_release_repair_review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "legacy_bottle_id": {
+          "name": "legacy_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_parent_full_name": {
+          "name": "proposed_parent_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_bottle_fingerprint": {
+          "name": "legacy_bottle_fingerprint",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_candidates_fingerprint": {
+          "name": "parent_candidates_fingerprint",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_edition": {
+          "name": "release_edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "legacy_release_repair_review_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_parent_bottle_id": {
+          "name": "reviewed_parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_version": {
+          "name": "review_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legacy_release_repair_review_bottle_idx": {
+          "name": "legacy_release_repair_review_bottle_idx",
+          "columns": [
+            {
+              "expression": "legacy_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_release_repair_review_parent_idx": {
+          "name": "legacy_release_repair_review_parent_idx",
+          "columns": [
+            {
+              "expression": "reviewed_parent_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_release_repair_review_resolution_idx": {
+          "name": "legacy_release_repair_review_resolution_idx",
+          "columns": [
+            {
+              "expression": "resolution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "legacy_release_repair_review_legacy_bottle_id_bottle_id_fk": {
+          "name": "legacy_release_repair_review_legacy_bottle_id_bottle_id_fk",
+          "tableFrom": "legacy_release_repair_review",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "legacy_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "legacy_release_repair_review_reviewed_parent_bottle_id_bottle_id_fk": {
+          "name": "legacy_release_repair_review_reviewed_parent_bottle_id_bottle_id_fk",
+          "tableFrom": "legacy_release_repair_review",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "reviewed_parent_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue": {
+          "name": "issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_unq_name": {
+          "name": "review_unq_name",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_bottle_idx": {
+          "name": "review_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_release_idx": {
+          "name": "review_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_external_site_id_external_site_id_fk": {
+          "name": "review_external_site_id_external_site_id_fk",
+          "tableFrom": "review",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_bottle_id_bottle_id_fk": {
+          "name": "review_bottle_id_bottle_id_fk",
+          "tableFrom": "review",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_release_id_bottle_release_id_fk": {
+          "name": "review_release_id_bottle_release_id_fk",
+          "tableFrom": "review",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_url_unique": {
+          "name": "review_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_history": {
+      "name": "store_price_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_history_unq": {
+          "name": "store_price_history_unq",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "volume",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_history_price_id_store_price_id_fk": {
+          "name": "store_price_history_price_id_store_price_id_fk",
+          "tableFrom": "store_price_history",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_attempt": {
+      "name": "store_price_match_attempt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "store_price_match_proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_status": {
+          "name": "initial_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_status": {
+          "name": "final_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bottle_id": {
+          "name": "current_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_release_id": {
+          "name": "current_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_bottle_id": {
+          "name": "suggested_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_release_id": {
+          "name": "suggested_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_bottle_id": {
+          "name": "parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_target": {
+          "name": "creation_target",
+          "type": "store_price_match_creation_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_eligible": {
+          "name": "automation_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "automation_score": {
+          "name": "automation_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_attempt_price_idx": {
+          "name": "store_price_match_attempt_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_proposal_idx": {
+          "name": "store_price_match_attempt_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_created_idx": {
+          "name": "store_price_match_attempt_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_final_status_idx": {
+          "name": "store_price_match_attempt_final_status_idx",
+          "columns": [
+            {
+              "expression": "final_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_attempt_price_id_store_price_id_fk": {
+          "name": "store_price_match_attempt_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "store_price_match_attempt_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_current_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_current_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "current_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_current_release_id_bottle_release_id_fk": {
+          "name": "store_price_match_attempt_current_release_id_bottle_release_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "current_release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_suggested_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_suggested_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "suggested_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_suggested_release_id_bottle_release_id_fk": {
+          "name": "store_price_match_attempt_suggested_release_id_bottle_release_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "suggested_release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_parent_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_parent_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "parent_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_reviewed_by_id_user_id_fk": {
+          "name": "store_price_match_attempt_reviewed_by_id_user_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_proposal": {
+      "name": "store_price_match_proposal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "store_price_match_proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bottle_id": {
+          "name": "current_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_release_id": {
+          "name": "current_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_bottle_id": {
+          "name": "suggested_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_release_id": {
+          "name": "suggested_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_bottle_id": {
+          "name": "parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_target": {
+          "name": "creation_target",
+          "type": "store_price_match_creation_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_scope": {
+          "name": "alias_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_bottles": {
+          "name": "candidate_bottles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "extracted_label": {
+          "name": "extracted_label",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_bottle": {
+          "name": "proposed_bottle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_release": {
+          "name": "proposed_release",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_evidence": {
+          "name": "search_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "automation_assessment": {
+          "name": "automation_assessment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entered_queue_at": {
+          "name": "entered_queue_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_token": {
+          "name": "processing_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_queued_at": {
+          "name": "processing_queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_expires_at": {
+          "name": "processing_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_proposal_price_idx": {
+          "name": "store_price_match_proposal_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_status_idx": {
+          "name": "store_price_match_proposal_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_type_idx": {
+          "name": "store_price_match_proposal_type_idx",
+          "columns": [
+            {
+              "expression": "proposal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_current_bottle_idx": {
+          "name": "store_price_match_proposal_current_bottle_idx",
+          "columns": [
+            {
+              "expression": "current_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_current_release_idx": {
+          "name": "store_price_match_proposal_current_release_idx",
+          "columns": [
+            {
+              "expression": "current_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_processing_expires_idx": {
+          "name": "store_price_match_proposal_processing_expires_idx",
+          "columns": [
+            {
+              "expression": "processing_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_entered_queue_idx": {
+          "name": "store_price_match_proposal_entered_queue_idx",
+          "columns": [
+            {
+              "expression": "entered_queue_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_suggested_bottle_idx": {
+          "name": "store_price_match_proposal_suggested_bottle_idx",
+          "columns": [
+            {
+              "expression": "suggested_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_suggested_release_idx": {
+          "name": "store_price_match_proposal_suggested_release_idx",
+          "columns": [
+            {
+              "expression": "suggested_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_parent_bottle_idx": {
+          "name": "store_price_match_proposal_parent_bottle_idx",
+          "columns": [
+            {
+              "expression": "parent_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_reviewed_by_idx": {
+          "name": "store_price_match_proposal_reviewed_by_idx",
+          "columns": [
+            {
+              "expression": "reviewed_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_proposal_price_id_store_price_id_fk": {
+          "name": "store_price_match_proposal_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_current_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_current_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "current_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_current_release_id_bottle_release_id_fk": {
+          "name": "store_price_match_proposal_current_release_id_bottle_release_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "current_release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_suggested_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_suggested_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "suggested_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_suggested_release_id_bottle_release_id_fk": {
+          "name": "store_price_match_proposal_suggested_release_id_bottle_release_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "suggested_release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_parent_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_parent_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "parent_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_reviewed_by_id_user_id_fk": {
+          "name": "store_price_match_proposal_reviewed_by_id_user_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_retry_run_item": {
+      "name": "store_price_match_retry_run_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_retry_run_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_retry_run_item_unq": {
+          "name": "store_price_match_retry_run_item_unq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_run_status_idx": {
+          "name": "store_price_match_retry_run_item_run_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_proposal_idx": {
+          "name": "store_price_match_retry_run_item_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_price_idx": {
+          "name": "store_price_match_retry_run_item_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_retry_run_item_run_id_store_price_match_retry_run_id_fk": {
+          "name": "store_price_match_retry_run_item_run_id_store_price_match_retry_run_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price_match_retry_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_retry_run_item_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "store_price_match_retry_run_item_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_retry_run_item_price_id_store_price_id_fk": {
+          "name": "store_price_match_retry_run_item_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_retry_run": {
+      "name": "store_price_match_retry_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "store_price_match_retry_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "store_price_match_retry_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_web'"
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_retry_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "matched_count": {
+          "name": "matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_count": {
+          "name": "processed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_count": {
+          "name": "resolved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviewable_count": {
+          "name": "reviewable_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errored_count": {
+          "name": "errored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_retry_run_status_idx": {
+          "name": "store_price_match_retry_run_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_created_by_idx": {
+          "name": "store_price_match_retry_run_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_created_at_idx": {
+          "name": "store_price_match_retry_run_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_retry_run_created_by_id_user_id_fk": {
+          "name": "store_price_match_retry_run_created_by_id_user_id_fk",
+          "tableFrom": "store_price_match_retry_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price": {
+      "name": "store_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_unq_name": {
+          "name": "store_price_unq_name",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "volume",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_bottle_idx": {
+          "name": "store_price_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_release_idx": {
+          "name": "store_price_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_external_site_id_external_site_id_fk": {
+          "name": "store_price_external_site_id_external_site_id_fk",
+          "tableFrom": "store_price",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_bottle_id_bottle_id_fk": {
+          "name": "store_price_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_release_id_bottle_release_id_fk": {
+          "name": "store_price_release_id_bottle_release_id_fk",
+          "tableFrom": "store_price",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "store_price_url_unique": {
+          "name": "store_price_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag": {
+      "name": "tag",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "synonyms": {
+          "name": "synonyms",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "tag_category": {
+          "name": "tag_category",
+          "type": "tag_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasting_badge_award": {
+      "name": "tasting_badge_award",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "award_id": {
+          "name": "award_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasting_badge_award_key": {
+          "name": "tasting_badge_award_key",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_badge_award_award_id": {
+          "name": "tasting_badge_award_award_id",
+          "columns": [
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasting_badge_award_tasting_id_tasting_id_fk": {
+          "name": "tasting_badge_award_tasting_id_tasting_id_fk",
+          "tableFrom": "tasting_badge_award",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasting_badge_award_award_id_badge_award_id_fk": {
+          "name": "tasting_badge_award_award_id_badge_award_id_fk",
+          "tableFrom": "tasting_badge_award",
+          "tableTo": "badge_award",
+          "columnsFrom": [
+            "award_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasting": {
+      "name": "tasting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "color": {
+          "name": "color",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_legacy": {
+          "name": "rating_legacy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_style": {
+          "name": "serving_style",
+          "type": "servingStyle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "friends": {
+          "name": "friends",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::bigint[]"
+        },
+        "flight_id": {
+          "name": "flight_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "toasts": {
+          "name": "toasts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tasting_bottle_idx": {
+          "name": "tasting_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_release_idx": {
+          "name": "tasting_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_flight_idx": {
+          "name": "tasting_flight_idx",
+          "columns": [
+            {
+              "expression": "flight_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_created_by_idx": {
+          "name": "tasting_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasting_bottle_id_bottle_id_fk": {
+          "name": "tasting_bottle_id_bottle_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasting_release_id_bottle_release_id_fk": {
+          "name": "tasting_release_id_bottle_release_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "bottle_release",
+          "columnsFrom": [
+            "release_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasting_flight_id_flight_id_fk": {
+          "name": "tasting_flight_id_flight_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "flight",
+          "columnsFrom": [
+            "flight_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasting_created_by_id_user_id_fk": {
+          "name": "tasting_created_by_id_user_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tasting_unq": {
+          "name": "tasting_unq",
+          "nullsNotDistinct": true,
+          "columns": [
+            "bottle_id",
+            "release_id",
+            "created_by_id",
+            "created_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.toasts": {
+      "name": "toasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "toast_unq": {
+          "name": "toast_unq",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "toasts_tasting_id_tasting_id_fk": {
+          "name": "toasts_tasting_id_tasting_id_fk",
+          "tableFrom": "toasts",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "toasts_created_by_id_user_id_fk": {
+          "name": "toasts_created_by_id_user_id_fk",
+          "tableFrom": "toasts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "admin": {
+          "name": "admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mod": {
+          "name": "mod",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_comments": {
+          "name": "notify_comments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_unq": {
+          "name": "user_email_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_username_unq": {
+          "name": "user_username_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "system",
+        "user"
+      ]
+    },
+    "public.badge_award_object_type": {
+      "name": "badge_award_object_type",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "entity",
+        "country",
+        "region"
+      ]
+    },
+    "public.badge_formula": {
+      "name": "badge_formula",
+      "schema": "public",
+      "values": [
+        "default",
+        "linear",
+        "fibonacci"
+      ]
+    },
+    "public.bottle_alias_assignment_source": {
+      "name": "bottle_alias_assignment_source",
+      "schema": "public",
+      "values": [
+        "legacy",
+        "canonical",
+        "source_approved",
+        "classifier_approved",
+        "human_approved"
+      ]
+    },
+    "public.type": {
+      "name": "type",
+      "schema": "public",
+      "values": [
+        "add",
+        "update",
+        "delete"
+      ]
+    },
+    "public.collection_bottle_status": {
+      "name": "collection_bottle_status",
+      "schema": "public",
+      "values": [
+        "sealed",
+        "open",
+        "empty"
+      ]
+    },
+    "public.entity_type": {
+      "name": "entity_type",
+      "schema": "public",
+      "values": [
+        "brand",
+        "distiller",
+        "bottler"
+      ]
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "public",
+      "values": [
+        "blend",
+        "bourbon",
+        "rye",
+        "single_grain",
+        "single_malt",
+        "single_pot_still",
+        "spirit"
+      ]
+    },
+    "public.content_source": {
+      "name": "content_source",
+      "schema": "public",
+      "values": [
+        "generated",
+        "user"
+      ]
+    },
+    "public.flavor_profile": {
+      "name": "flavor_profile",
+      "schema": "public",
+      "values": [
+        "young_spritely",
+        "sweet_fruit_mellow",
+        "spicy_sweet",
+        "spicy_dry",
+        "deep_rich_dried_fruit",
+        "old_dignified",
+        "light_delicate",
+        "juicy_oak_vanilla",
+        "oily_coastal",
+        "lightly_peated",
+        "peated",
+        "heavily_peated"
+      ]
+    },
+    "public.legacy_release_repair_review_resolution": {
+      "name": "legacy_release_repair_review_resolution",
+      "schema": "public",
+      "values": [
+        "allow_create_parent",
+        "blocked",
+        "reuse_existing_parent"
+      ]
+    },
+    "public.object_type": {
+      "name": "object_type",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "bottle_release",
+        "bottle_series",
+        "comment",
+        "entity",
+        "tasting",
+        "toast",
+        "follow"
+      ]
+    },
+    "public.tag_category": {
+      "name": "tag_category",
+      "schema": "public",
+      "values": [
+        "cereal",
+        "fruity",
+        "floral",
+        "peaty",
+        "feinty",
+        "sulphury",
+        "woody",
+        "winey"
+      ]
+    },
+    "public.external_site_type": {
+      "name": "external_site_type",
+      "schema": "public",
+      "values": [
+        "astorwines",
+        "healthyspirits",
+        "reservebar",
+        "smws",
+        "smwsa",
+        "totalwine",
+        "woodencork",
+        "whiskyadvocate"
+      ]
+    },
+    "public.follow_status": {
+      "name": "follow_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "pending",
+        "following"
+      ]
+    },
+    "public.identity_provider": {
+      "name": "identity_provider",
+      "schema": "public",
+      "values": [
+        "google",
+        "passkey"
+      ]
+    },
+    "public.incoming_bottle_decision_source_kind": {
+      "name": "incoming_bottle_decision_source_kind",
+      "schema": "public",
+      "values": [
+        "review",
+        "store_price"
+      ]
+    },
+    "public.incoming_bottle_decision_type": {
+      "name": "incoming_bottle_decision_type",
+      "schema": "public",
+      "values": [
+        "match_existing",
+        "create_bottle",
+        "create_release",
+        "create_bottle_and_release"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "comment",
+        "toast",
+        "friend_request"
+      ]
+    },
+    "public.pendingUploadKind": {
+      "name": "pendingUploadKind",
+      "schema": "public",
+      "values": [
+        "image"
+      ]
+    },
+    "public.pendingUploadPurpose": {
+      "name": "pendingUploadPurpose",
+      "schema": "public",
+      "values": [
+        "photo_tasting_entry",
+        "tasting_image",
+        "bottle_image",
+        "bottle_release_image",
+        "badge_image",
+        "avatar"
+      ]
+    },
+    "public.pendingUploadStatus": {
+      "name": "pendingUploadStatus",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attached",
+        "expired"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "usd",
+        "gbp",
+        "eur"
+      ]
+    },
+    "public.store_price_match_creation_target": {
+      "name": "store_price_match_creation_target",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "release",
+        "bottle_and_release"
+      ]
+    },
+    "public.store_price_match_proposal_status": {
+      "name": "store_price_match_proposal_status",
+      "schema": "public",
+      "values": [
+        "verified",
+        "pending_review",
+        "approved",
+        "ignored",
+        "errored"
+      ]
+    },
+    "public.store_price_match_proposal_type": {
+      "name": "store_price_match_proposal_type",
+      "schema": "public",
+      "values": [
+        "match_existing",
+        "create_new",
+        "correction",
+        "no_match"
+      ]
+    },
+    "public.store_price_match_retry_run_item_status": {
+      "name": "store_price_match_retry_run_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.store_price_match_retry_run_kind": {
+      "name": "store_price_match_retry_run_kind",
+      "schema": "public",
+      "values": [
+        "create_new",
+        "match_existing",
+        "correction",
+        "errored"
+      ]
+    },
+    "public.store_price_match_retry_run_mode": {
+      "name": "store_price_match_retry_run_mode",
+      "schema": "public",
+      "values": [
+        "no_web",
+        "full"
+      ]
+    },
+    "public.store_price_match_retry_run_status": {
+      "name": "store_price_match_retry_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.servingStyle": {
+      "name": "servingStyle",
+      "schema": "public",
+      "values": [
+        "neat",
+        "rocks",
+        "splash"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/migrations/meta/_journal.json
+++ b/apps/server/migrations/meta/_journal.json
@@ -1352,6 +1352,13 @@
       "when": 1783536986980,
       "tag": "0192_tranquil_carnage",
       "breakpoints": false
+    },
+    {
+      "idx": 193,
+      "version": "7",
+      "when": 1784047760659,
+      "tag": "0193_slow_risque",
+      "breakpoints": false
     }
   ]
 }

--- a/apps/server/src/db/schema/bottles.ts
+++ b/apps/server/src/db/schema/bottles.ts
@@ -356,6 +356,7 @@ export const bottleReleases = pgTable(
   (table) => [
     index("bottle_release_bottle_idx").on(table.bottleId),
     index("bottle_release_created_by_actor_idx").on(table.createdByActorId),
+    index("bottle_release_search_idx").using("gin", table.searchVector),
     uniqueIndex("bottle_release_full_name_idx").on(table.fullName),
     check(
       "bottle_release_stated_age_check",

--- a/apps/server/src/orpc/routes/search.test.ts
+++ b/apps/server/src/orpc/routes/search.test.ts
@@ -1,3 +1,4 @@
+import { TSVector } from "@peated/server/db/columns";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { describe, expect, test } from "vitest";
@@ -66,8 +67,10 @@ describe("GET /search", () => {
     });
 
     expect(results.length).toBe(1);
-    expect(results[0].type).toBe("entity");
-    expect(results[0].ref.id).toBe(entity.id);
+    expect(results[0]).toMatchObject({
+      type: "entity",
+      ref: { id: entity.id },
+    });
   });
 
   test("respects the limit parameter", async ({ fixtures }) => {
@@ -105,8 +108,122 @@ describe("GET /search", () => {
       limit: 10,
     });
 
-    expect(results[0].type).toBe("bottle");
-    expect(results[0].ref.id).toBe(exactMatch.id);
+    expect(results[0]).toMatchObject({
+      type: "bottle",
+      ref: { id: exactMatch.id },
+    });
+  });
+
+  test("returns exact bottlings as first-class search results", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle({ name: "Cairdeas" });
+    const bottling = await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      name: "Cairdeas Warehouse 1",
+      edition: "Warehouse 1",
+      releaseYear: 2022,
+      abv: 52.2,
+      searchVector: [new TSVector("Warehouse 1 2022")],
+    });
+
+    const { results } = await routerClient.search({
+      query: "Warehouse 1 2022",
+      include: ["bottlings"],
+      limit: 10,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      type: "bottling",
+      ref: { id: bottling.id, bottleId: bottle.id },
+      bottle: { id: bottle.id },
+    });
+  });
+
+  test("preserves the bottling target for exact release aliases", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle({ name: "Annual Malt" });
+    const bottling = await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      name: "Annual Malt 2022 Edition",
+      edition: "2022 Edition",
+      releaseYear: 2022,
+    });
+    const aliasName = "Unique Annual Malt Twenty Two";
+    await fixtures.BottleAlias({
+      bottleId: bottle.id,
+      releaseId: bottling.id,
+      name: aliasName,
+      ignored: null,
+    });
+
+    const { results } = await routerClient.search({
+      query: aliasName,
+      include: ["bottles", "bottlings"],
+      limit: 10,
+    });
+
+    expect(results[0]).toMatchObject({
+      type: "bottling",
+      ref: { id: bottling.id, bottleId: bottle.id },
+      bottle: { id: bottle.id },
+    });
+  });
+
+  test("keeps exact release aliases ahead of text matches before limiting", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle({ name: "Limit Test Malt" });
+    const exactBottling = await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      name: "Limit Test Malt Exact Edition",
+      edition: "Exact Edition",
+    });
+    const aliasName = "Limit Test Release Alias";
+    await fixtures.BottleAlias({
+      bottleId: bottle.id,
+      releaseId: exactBottling.id,
+      name: aliasName,
+    });
+    await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      name: "Limit Test Malt Popular Edition",
+      edition: "Popular Edition",
+      totalTastings: 100,
+      searchVector: [new TSVector(aliasName)],
+    });
+
+    const { results } = await routerClient.search({
+      query: aliasName,
+      include: ["bottlings"],
+      limit: 1,
+    });
+
+    expect(results).toMatchObject([
+      {
+        type: "bottling",
+        ref: { id: exactBottling.id },
+      },
+    ]);
+  });
+
+  test("does not return bottlings unless requested", async ({ fixtures }) => {
+    const bottle = await fixtures.Bottle({ name: "Search Scope Malt" });
+    const bottling = await fixtures.BottleRelease({
+      bottleId: bottle.id,
+      name: "Search Scope Malt Batch 7",
+      edition: "Batch 7",
+    });
+
+    const { results } = await routerClient.search({
+      query: bottling.fullName,
+      include: ["bottles"],
+      limit: 10,
+    });
+
+    expect(results.every((result) => result.type !== "bottling")).toBe(true);
   });
 
   test("returns empty results with no query", async () => {

--- a/apps/server/src/orpc/routes/search.ts
+++ b/apps/server/src/orpc/routes/search.ts
@@ -1,68 +1,95 @@
+import { db } from "@peated/server/db";
+import {
+  bottleAliases,
+  bottleReleases,
+  bottles,
+} from "@peated/server/db/schema";
 import { procedure } from "@peated/server/orpc";
 import { routerClient } from "@peated/server/orpc/router";
-import { BottleSchema, EntitySchema, UserSchema } from "@peated/server/schemas";
-import type { Bottle, Entity, User } from "@peated/server/types";
+import {
+  BottleReleaseSchema,
+  BottleSchema,
+  EntitySchema,
+  UserSchema,
+} from "@peated/server/schemas";
+import { serialize } from "@peated/server/serializers";
+import { BottleSerializer } from "@peated/server/serializers/bottle";
+import { BottleReleaseSerializer } from "@peated/server/serializers/bottleRelease";
+import { and, desc, eq, inArray, isNotNull, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
-export type BottleResult = {
-  type: "bottle";
-  ref: Bottle;
+const SearchResultSchema = z.union([
+  z.object({
+    type: z.literal("bottle"),
+    ref: BottleSchema,
+  }),
+  z.object({
+    type: z.literal("bottling"),
+    ref: BottleReleaseSchema,
+    bottle: BottleSchema,
+  }),
+  z.object({
+    type: z.literal("entity"),
+    ref: EntitySchema,
+  }),
+  z.object({
+    type: z.literal("user"),
+    ref: UserSchema,
+  }),
+]);
+
+type Result = z.infer<typeof SearchResultSchema>;
+
+type RankedResult = Result & {
+  exactAliasMatch?: boolean;
 };
 
-export type EntityResult = {
-  type: "entity";
-  ref: Entity;
-};
+const INCLUDE_LIST = ["bottles", "bottlings", "entities", "users"] as const;
 
-export type UserResult = {
-  type: "user";
-  ref: User;
-};
-
-export type Result = BottleResult | UserResult | EntityResult;
-
-const INCLUDE_LIST = ["bottles", "entities", "users"] as const;
-
-function sortResults(query: string, unsortedResults: Result[]) {
-  const exactMatches: number[] = [];
+/** Promotes exact targets while preserving each source's rank among ties. */
+function sortResults(query: string, unsortedResults: RankedResult[]) {
   const lowerQuery = query.toLowerCase();
-  unsortedResults.forEach((value, index) => {
+
+  const isExactMatch = (value: RankedResult) => {
+    if (value.exactAliasMatch) return true;
     if (value.type === "entity") {
-      if (
+      return (
         value.ref.name.toLowerCase() === lowerQuery ||
         value.ref.shortName?.toLowerCase() === lowerQuery
-      ) {
-        exactMatches.push(index);
-      }
-    } else if (value.type === "user") {
-      if (value.ref.username.toLowerCase() === lowerQuery) {
-        exactMatches.push(index);
-      }
-    } else {
-      if (
+      );
+    }
+    if (value.type === "user") {
+      return value.ref.username.toLowerCase() === lowerQuery;
+    }
+    if (value.type === "bottling") {
+      return (
         value.ref.fullName.toLowerCase() === lowerQuery ||
         value.ref.name.toLowerCase() === lowerQuery
-      ) {
-        exactMatches.push(index);
-      }
+      );
     }
-  });
+    return (
+      value.ref.fullName.toLowerCase() === lowerQuery ||
+      value.ref.name.toLowerCase() === lowerQuery
+    );
+  };
 
-  const results = [...unsortedResults];
-  exactMatches.forEach((resultIndex, index) => {
-    const item = results.splice(resultIndex, 1);
-    results.unshift(...item);
-  });
-  return results;
+  return unsortedResults
+    .map((result, index) => ({ result, index, exact: isExactMatch(result) }))
+    .sort((left, right) => {
+      if (left.exact !== right.exact) return left.exact ? -1 : 1;
+      return left.index - right.index;
+    })
+    .map(({ result }) => result);
 }
 
+/** Aggregates global search while preserving exact bottle-release identity. */
 export default procedure
   .route({
     method: "GET",
     path: "/search",
     summary: "Global search",
     description:
-      "Search across bottles, entities, and users with configurable result types and limits",
+      "Search across bottles, bottlings, entities, and users with configurable result types and limits",
     spec: (spec) => ({
       ...spec,
       operationId: "search",
@@ -78,27 +105,12 @@ export default procedure
   .output(
     z.object({
       query: z.string(),
-      results: z.array(
-        z.union([
-          z.object({
-            type: z.literal("bottle"),
-            ref: BottleSchema,
-          }),
-          z.object({
-            type: z.literal("entity"),
-            ref: EntitySchema,
-          }),
-          z.object({
-            type: z.literal("user"),
-            ref: UserSchema,
-          }),
-        ]),
-      ),
+      results: z.array(SearchResultSchema),
     }),
   )
   .handler(async function ({ input, context, errors }) {
     const { query, include, limit } = input;
-    const promises = [];
+    const promises: Promise<RankedResult[]>[] = [];
 
     if (include.includes("bottles")) {
       promises.push(
@@ -116,6 +128,90 @@ export default procedure
             data.results.map((b: any) => ({ type: "bottle", ref: b })),
           )
           .catch(() => []),
+      );
+    }
+
+    if (include.includes("bottlings") && query) {
+      promises.push(
+        (async () => {
+          // Accepted release aliases carry an exact target that FTS cannot infer.
+          const exactAliasReleaseIds = (
+            await db
+              .selectDistinct({ releaseId: bottleAliases.releaseId })
+              .from(bottleAliases)
+              .where(
+                and(
+                  eq(sql`LOWER(${bottleAliases.name})`, query.toLowerCase()),
+                  sql`${bottleAliases.ignored} IS DISTINCT FROM TRUE`,
+                  isNotNull(bottleAliases.releaseId),
+                ),
+              )
+          )
+            .map((row) => row.releaseId)
+            .filter((releaseId): releaseId is number => releaseId !== null);
+          const exactAliasOrder = exactAliasReleaseIds.length
+            ? [
+                desc(
+                  sql<number>`CASE WHEN ${inArray(
+                    bottleReleases.id,
+                    exactAliasReleaseIds,
+                  )} THEN 1 ELSE 0 END`,
+                ),
+              ]
+            : [];
+
+          const releaseList = await db
+            .select()
+            .from(bottleReleases)
+            .where(
+              or(
+                sql`${bottleReleases.searchVector} @@ websearch_to_tsquery ('english', ${query})`,
+                exactAliasReleaseIds.length
+                  ? inArray(bottleReleases.id, exactAliasReleaseIds)
+                  : undefined,
+              ),
+            )
+            .orderBy(
+              ...exactAliasOrder,
+              desc(
+                sql`ts_rank(${bottleReleases.searchVector}, websearch_to_tsquery('english', ${query}))`,
+              ),
+              desc(bottleReleases.totalTastings),
+            )
+            .limit(limit);
+
+          if (!releaseList.length) return [];
+
+          const bottleIds = [
+            ...new Set(releaseList.map((row) => row.bottleId)),
+          ];
+          const bottleList = await db
+            .select()
+            .from(bottles)
+            .where(inArray(bottles.id, bottleIds));
+          const [serializedBottles, serializedBottlings] = await Promise.all([
+            serialize(BottleSerializer, bottleList, context.user ?? undefined),
+            serialize(
+              BottleReleaseSerializer,
+              releaseList,
+              context.user ?? undefined,
+            ),
+          ]);
+          const bottlesById = new Map(
+            serializedBottles.map((bottle) => [bottle.id, bottle]),
+          );
+          const exactAliasReleaseIdSet = new Set(exactAliasReleaseIds);
+
+          return serializedBottlings.map((bottling) => {
+            const bottle = bottlesById.get(bottling.bottleId)!;
+            return {
+              type: "bottling" as const,
+              ref: bottling,
+              bottle,
+              exactAliasMatch: exactAliasReleaseIdSet.has(bottling.id),
+            };
+          });
+        })().catch(() => []),
       );
     }
 
@@ -161,11 +257,14 @@ export default procedure
 
     const sortedResults = sortResults(
       query,
-      results.reduce((prev: any[], cur: any[]) => [...prev, ...cur], []),
+      results.reduce<RankedResult[]>((prev, cur) => [...prev, ...cur], []),
     );
 
     return {
       query,
-      results: sortedResults.slice(0, limit),
+      results: sortedResults.slice(0, limit).map((result) => {
+        const { exactAliasMatch: _exactAliasMatch, ...publicResult } = result;
+        return publicResult;
+      }),
     };
   });

--- a/apps/web/src/components/search/bottlingResult.tsx
+++ b/apps/web/src/components/search/bottlingResult.tsx
@@ -1,0 +1,116 @@
+import { formatCategoryName } from "@peated/server/lib/format";
+import type { Bottle, BottleRelease } from "@peated/server/types";
+import BottleIcon from "@peated/web/assets/bottle.svg";
+import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
+import Link from "@peated/web/components/link";
+import {
+  getAddBottleHref,
+  type PendingImageRouteState,
+} from "@peated/web/lib/addBottle";
+import {
+  formatBottleBottlingName,
+  getBottleBottlingPath,
+} from "@peated/web/lib/bottlings";
+import Join from "../join";
+import type { AddBottleRouteIntent } from "./bottleResult";
+
+export type BottlingResult = {
+  type: "bottling";
+  ref: BottleRelease;
+  bottle: Bottle;
+};
+
+export function getBottlingResultHref({
+  bottleId,
+  bottlingId,
+  directToTasting = false,
+  addBottleIntent,
+  pendingImage,
+}: {
+  bottleId: number;
+  bottlingId: number;
+  directToTasting?: boolean;
+  addBottleIntent?: AddBottleRouteIntent;
+  pendingImage?: PendingImageRouteState | null;
+}) {
+  if (addBottleIntent) {
+    return getAddBottleHref({
+      bottleId,
+      releaseId: bottlingId,
+      intent: addBottleIntent,
+      pendingImageId: pendingImage?.id,
+      pendingImageUrl: pendingImage?.imageUrl,
+    });
+  }
+
+  if (directToTasting) {
+    return getAddBottleHref({
+      bottleId,
+      releaseId: bottlingId,
+      intent: "tasting",
+    });
+  }
+
+  return getBottleBottlingPath(bottleId, bottlingId);
+}
+
+export default function BottlingResultRow({
+  result: { ref: bottling, bottle },
+  directToTasting = false,
+  addBottleIntent,
+  pendingImage,
+}: {
+  result: BottlingResult;
+  directToTasting: boolean;
+  addBottleIntent?: AddBottleRouteIntent;
+  pendingImage?: PendingImageRouteState | null;
+}) {
+  return (
+    <>
+      <BottleIcon className="m-2 hidden h-10 w-auto sm:block" />
+
+      <div className="min-w-0 flex-auto">
+        <div className="flex items-center space-x-1 font-semibold leading-6">
+          <Link
+            href={getBottlingResultHref({
+              bottleId: bottle.id,
+              bottlingId: bottling.id,
+              directToTasting,
+              addBottleIntent,
+              pendingImage,
+            })}
+          >
+            <span className="absolute inset-x-0 -top-px bottom-0" />
+            <span>{formatBottleBottlingName(bottle, bottling)}</span>
+          </Link>
+          <BottleStatusIcons
+            bottle={{ isLibrary: false, hasTasted: bottling.hasTasted }}
+            hideLibrary
+          />
+        </div>
+        <div className="text-muted mt-1 flex gap-x-1 truncate text-sm leading-5">
+          <span>Bottling of {bottle.fullName}</span>
+          {bottle.distillers.length ? (
+            <>
+              <span>&middot;</span>
+              <Join divider=", ">
+                {bottle.distillers.map((distiller) => (
+                  <span key={distiller.id}>{distiller.name}</span>
+                ))}
+              </Join>
+            </>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="hidden items-end gap-x-4 sm:flex sm:flex-col">
+        <div className="text-muted leading-6">
+          {bottle.category && formatCategoryName(bottle.category)}
+        </div>
+        <div className="text-muted mt-1 text-sm leading-5">
+          {bottling.abv !== null ? `${bottling.abv.toFixed(1)}% ABV` : null}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/web/src/components/search/panel.tsx
+++ b/apps/web/src/components/search/panel.tsx
@@ -80,9 +80,11 @@ export default function SearchPanel({
 
       const isUserQuery = query.indexOf("@") !== -1 && user;
 
-      const include: ("bottles" | "entities" | "users")[] = [];
-      if (directToTasting || addBottleIntent || !isUserQuery)
+      const include: ("bottles" | "bottlings" | "entities" | "users")[] = [];
+      if (directToTasting || addBottleIntent || !isUserQuery) {
         include.push("bottles");
+        include.push("bottlings");
+      }
       if (
         !directToTasting &&
         !addBottleIntent &&

--- a/apps/web/src/components/search/result.tsx
+++ b/apps/web/src/components/search/result.tsx
@@ -1,12 +1,14 @@
 import type { PendingImageRouteState } from "@peated/web/lib/addBottle";
 import type { AddBottleRouteIntent, BottleResult } from "./bottleResult";
 import BottleResultRow from "./bottleResult";
+import type { BottlingResult } from "./bottlingResult";
+import BottlingResultRow from "./bottlingResult";
 import type { EntityResult } from "./entityResult";
 import EntityResultRow from "./entityResult";
 import type { UserResult } from "./userResult";
 import UserResultRow from "./userResult";
 
-export type Result = BottleResult | UserResult | EntityResult;
+export type Result = BottleResult | BottlingResult | UserResult | EntityResult;
 
 export default function ResultRow({
   result,
@@ -23,6 +25,15 @@ export default function ResultRow({
     case "bottle":
       return (
         <BottleResultRow
+          result={result}
+          directToTasting={directToTasting}
+          addBottleIntent={addBottleIntent}
+          pendingImage={pendingImage}
+        />
+      );
+    case "bottling":
+      return (
+        <BottlingResultRow
           result={result}
           directToTasting={directToTasting}
           addBottleIntent={addBottleIntent}

--- a/apps/web/src/components/search/searchResults.test.ts
+++ b/apps/web/src/components/search/searchResults.test.ts
@@ -1,7 +1,14 @@
-import { describe, expect, it } from "vitest";
+import type { Bottle, BottleRelease } from "@peated/server/types";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
 
 import { getBottleResultHref } from "./bottleResult";
+import { getBottlingResultHref } from "./bottlingResult";
 import { getCreateBottleHref } from "./createBottleHref";
+import ResultRow from "./result";
+
+vi.mock("@peated/web/assets/bottle.svg", () => ({ default: () => null }));
 
 describe("search result create bottle links", () => {
   it("targets the Create Bottle route for missing bottles", () => {
@@ -93,5 +100,68 @@ describe("search result create bottle links", () => {
         directToTasting: true,
       }),
     ).toBe("/addBottle?bottle=123&intent=tasting");
+  });
+
+  it("links exact bottling results to the bottling page", () => {
+    expect(
+      getBottlingResultHref({
+        bottleId: 123,
+        bottlingId: 456,
+      }),
+    ).toBe("/bottles/123/bottlings/456");
+  });
+
+  it("preserves exact bottlings through Add Bottle intents", () => {
+    expect(
+      getBottlingResultHref({
+        bottleId: 123,
+        bottlingId: 456,
+        addBottleIntent: "library",
+      }),
+    ).toBe("/addBottle?bottle=123&release=456&intent=library");
+  });
+
+  it("preserves exact bottlings through tasting shortcuts", () => {
+    expect(
+      getBottlingResultHref({
+        bottleId: 123,
+        bottlingId: 456,
+        directToTasting: true,
+      }),
+    ).toBe("/addBottle?bottle=123&release=456&intent=tasting");
+  });
+
+  it("renders exact bottlings as distinct release links", () => {
+    const bottle = {
+      id: 123,
+      fullName: "Laphroaig Cairdeas",
+      category: "single_malt",
+      distillers: [],
+    } as unknown as Bottle;
+    const bottling = {
+      id: 456,
+      bottleId: bottle.id,
+      fullName: "Laphroaig Cairdeas Warehouse 1",
+      name: "Cairdeas Warehouse 1",
+      edition: "Warehouse 1",
+      releaseYear: 2022,
+      vintageYear: null,
+      abv: 52.2,
+      hasTasted: false,
+    } as BottleRelease;
+
+    const html = renderToStaticMarkup(
+      createElement(ResultRow, {
+        result: { type: "bottling", ref: bottling, bottle },
+        directToTasting: false,
+        addBottleIntent: "library",
+      }),
+    );
+
+    expect(html).toContain("Laphroaig Cairdeas - Warehouse 1 (2022)");
+    expect(html).toContain("Bottling of Laphroaig Cairdeas");
+    expect(html).toContain(
+      'href="/addBottle?bottle=123&amp;release=456&amp;intent=library"',
+    );
   });
 });


### PR DESCRIPTION
Global search now returns bottle releases as `bottling` results alongside parent bottles. Exact accepted release aliases keep their release target and are promoted before result limits, while the search UI labels bottlings with parent context and carries both IDs into detail, library, and tasting routes.

The new result shape keeps the release as the primary reference and provides its parent separately:

```ts
{ type: "bottling"; ref: BottleRelease; bottle: Bottle }
```

A generated GIN index supports release full-text search. This is the search and discovery slice of #481; contextual creation and catalog restructuring remain separate work.

Refs #481