### PR TITLE
fix(catalog): claim unassigned migration aliases

### DIFF
--- a/apps/server/src/lib/catalogMigrationApply.test.ts
+++ b/apps/server/src/lib/catalogMigrationApply.test.ts
@@ -39,6 +39,67 @@ async function approvedInput(): Promise<CatalogMigrationApplyInput> {
 }
 
 describe("applyCatalogMigration", () => {
+  test("claims unresolved canonical aliases for retained and promoted Bottles", async ({
+    fixtures,
+  }) => {
+    const parent = await fixtures.LegacyBottle({
+      name: "Unresolved Alias Family",
+    });
+    const release = await fixtures.BottleRelease({
+      bottleId: parent.id,
+      fullName: `${parent.fullName} 2026`,
+      name: `${parent.name} 2026`,
+    });
+    await db.delete(bottleAliases).where(eq(bottleAliases.bottleId, parent.id));
+    await Promise.all([
+      fixtures.BottleAlias({
+        bottleId: null,
+        releaseId: null,
+        name: parent.fullName,
+        assignedByActorId: parent.createdByActorId,
+      }),
+      fixtures.BottleAlias({
+        bottleId: null,
+        releaseId: null,
+        name: release.fullName,
+        assignedByActorId: release.createdByActorId,
+      }),
+    ]);
+    const input = await approvedInput();
+
+    expect(input.candidate.audit.blockingIssueCount).toBe(0);
+
+    const result = await applyCatalogMigration(input);
+    const mapping = await db.query.bottleReleasePromotions.findFirst({
+      where: eq(bottleReleasePromotions.releaseId, release.id),
+    });
+    const aliases = await db
+      .select({
+        name: bottleAliases.name,
+        bottleId: bottleAliases.bottleId,
+        releaseId: bottleAliases.releaseId,
+        assignmentSource: bottleAliases.assignmentSource,
+      })
+      .from(bottleAliases)
+      .where(inArray(bottleAliases.name, [parent.fullName, release.fullName]))
+      .orderBy(asc(bottleAliases.name));
+
+    expect(result.status).toBe("applied");
+    expect(mapping?.promotedBottleId).not.toBeNull();
+    expect(aliases).toEqual(
+      [
+        { name: parent.fullName, bottleId: parent.id },
+        { name: release.fullName, bottleId: mapping?.promotedBottleId },
+      ]
+        .sort((left, right) => left.name.localeCompare(right.name))
+        .map((alias) => ({
+          ...alias,
+          releaseId: null,
+          assignmentSource: "canonical",
+        })),
+    );
+  });
+
   test("groups literal duplicate legacy parents without merging their Bottle identities", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/catalogMigrationApply.ts
+++ b/apps/server/src/lib/catalogMigrationApply.ts
@@ -592,15 +592,17 @@ async function buildFamilyPlans(
         alias.releaseId === null && alias.bottleId !== null
           ? groupKeyByParentId.get(alias.bottleId)
           : undefined;
+      const unassigned = alias.bottleId === null && alias.releaseId === null;
       const owned =
-        releaseId === null
+        unassigned ||
+        (releaseId === null
           ? alias.releaseId === null &&
             (alias.bottleId === parentId ||
               ((parentCountByGroupKey.get(groupKey) ?? 0) > 1 &&
                 aliasParentGroupKey === groupKey))
           : (alias.releaseId === releaseId &&
               (alias.bottleId === parentId || alias.bottleId === null)) ||
-            (alias.releaseId === null && alias.bottleId === parentId);
+            (alias.releaseId === null && alias.bottleId === parentId));
       if (!owned || alias.ignored === true) {
         throw new CatalogMigrationApplyError("alias_collision", {
           name,

--- a/openspec/changes/flatten-bottlings-into-bottles/design.md
+++ b/openspec/changes/flatten-bottlings-into-bottles/design.md
@@ -147,7 +147,9 @@ affected source and destination groups without retargeting consumer rows.
 
 Exact aliases point directly to Bottle. A general expression alias may point to
 the retained general Bottle. Alias propagation reuses that Bottle id for prices
-and reviews.
+and reviews. During the one-shot migration, a non-ignored alias with neither a
+Bottle nor BottleRelease owner is unresolved rather than conflicting; an exact
+canonical claim assigns it to the retained or promoted Bottle transactionally.
 
 Prices, observations, proposals, attempts, classifier decisions, photo flows,
 activity notifications, badges, analytics, cache keys, and queue payloads all

--- a/openspec/changes/flatten-bottlings-into-bottles/tasks.md
+++ b/openspec/changes/flatten-bottlings-into-bottles/tasks.md
@@ -173,6 +173,8 @@ and map to an explicit removal task.
       self-contained.
 - [x] 7.16 Group literal same-name legacy parents deterministically without
       merging Bottle identities or creating ambiguous canonical aliases.
+- [x] 7.17 Claim unresolved exact aliases during retained-parent and promoted
+      Bottle canonicalization instead of treating them as collisions.
 
 ## 8. Production Migration And Later Destructive Cleanup
 


### PR DESCRIPTION
The catalog migration now treats a non-ignored alias with no Bottle or
BottleRelease owner as unresolved evidence, allowing the canonical retained or
promoted Bottle to claim it transactionally. Assigned aliases, ignored aliases,
and aliases owned by competing Bottles remain fail-fast collisions.

Production exposed an unresolved alias for `Säntis Malt Edition Himmelberg`
that passed the retained audit but was rejected by the locked planner. The
reservation layer already safely supports adopting these rows; this aligns the
planner with that behavior. Database-backed coverage exercises both a retained
parent and a promoted release, and the focused migration suite, server/CLI
typechecks, lint, and strict OpenSpec validation pass.
