### PR TITLE
fix(catalog): group alias-linked migration parents

### DIFF
--- a/apps/server/src/lib/catalogMigrationApply.test.ts
+++ b/apps/server/src/lib/catalogMigrationApply.test.ts
@@ -170,6 +170,54 @@ describe("applyCatalogMigration", () => {
     expect(await db.select().from(bottleGroups)).toHaveLength(1);
   });
 
+  test("groups legacy parents connected by an assigned exact alias", async ({
+    fixtures,
+  }) => {
+    const aliasOwner = await fixtures.LegacyBottle({
+      name: "Canonical Alias Owner",
+    });
+    const matchingParent = await fixtures.LegacyBottle({
+      name: "Canonical Alias Match",
+    });
+    await db
+      .delete(bottleAliases)
+      .where(eq(bottleAliases.bottleId, matchingParent.id));
+    await fixtures.BottleAlias({
+      bottleId: aliasOwner.id,
+      releaseId: null,
+      name: matchingParent.fullName,
+      assignedByActorId: aliasOwner.createdByActorId,
+    });
+    const input = await approvedInput();
+
+    expect(input.candidate.audit.blockingIssueCount).toBe(0);
+
+    const result = await applyCatalogMigration(input);
+    const parents = await db
+      .select({ id: bottles.id, groupId: bottles.groupId })
+      .from(bottles)
+      .where(inArray(bottles.id, [aliasOwner.id, matchingParent.id]))
+      .orderBy(asc(bottles.id));
+    const alias = await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, matchingParent.fullName),
+    });
+
+    expect(result.status).toBe("applied");
+    expect(result.counts).toMatchObject({
+      parents: 2,
+      groups: 1,
+      parentBottlesAssigned: 2,
+      groupStatsRecomputed: 1,
+    });
+    expect(parents[0]?.groupId).not.toBeNull();
+    expect(parents[1]?.groupId).toBe(parents[0]?.groupId);
+    expect(alias).toMatchObject({
+      bottleId: aliasOwner.id,
+      releaseId: null,
+    });
+    expect(await db.select().from(bottleTombstones)).toEqual([]);
+  });
+
   test("reassigns a same-family canonical alias to its promoted Bottle", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/catalogMigrationApply.ts
+++ b/apps/server/src/lib/catalogMigrationApply.ts
@@ -507,8 +507,67 @@ async function buildFamilyPlans(
   const aliasByName = new Map(
     aliases.map((alias) => [claimKey(alias.name), alias]),
   );
+  const groupParentByParentId = new Map(
+    state.bottles.map((parent) => [parent.id, parent.id]),
+  );
+  const findGroupParent = (parentId: number): number => {
+    const groupParentId = groupParentByParentId.get(parentId);
+    if (groupParentId === undefined) return parentId;
+    if (groupParentId === parentId) return groupParentId;
+    const rootParentId = findGroupParent(groupParentId);
+    groupParentByParentId.set(parentId, rootParentId);
+    return rootParentId;
+  };
+  const unionParentGroups = (leftParentId: number, rightParentId: number) => {
+    const leftRoot = findGroupParent(leftParentId);
+    const rightRoot = findGroupParent(rightParentId);
+    if (leftRoot === rightRoot) return;
+    const [representativeId, joinedId] = [leftRoot, rightRoot].sort(
+      (left, right) => left - right,
+    );
+    groupParentByParentId.set(joinedId, representativeId);
+  };
+  const parentIdsByLiteralName = new Map<string, number[]>();
+  const parentIdsByCanonicalName = new Map<string, number[]>();
+  for (const parent of state.bottles) {
+    const literalKey = claimKey(parent.fullName);
+    const literalParentIds = parentIdsByLiteralName.get(literalKey) ?? [];
+    literalParentIds.push(parent.id);
+    parentIdsByLiteralName.set(literalKey, literalParentIds);
+    for (const name of canonicalNames(parent.fullName)) {
+      const key = claimKey(name);
+      const canonicalParentIds = parentIdsByCanonicalName.get(key) ?? [];
+      canonicalParentIds.push(parent.id);
+      parentIdsByCanonicalName.set(key, canonicalParentIds);
+    }
+  }
+  for (const parentIds of parentIdsByLiteralName.values()) {
+    const [firstParentId, ...duplicateParentIds] = parentIds;
+    if (firstParentId === undefined) continue;
+    for (const duplicateParentId of duplicateParentIds) {
+      unionParentGroups(firstParentId, duplicateParentId);
+    }
+  }
+  for (const alias of aliases) {
+    if (
+      alias.ignored === true ||
+      alias.releaseId !== null ||
+      alias.bottleId === null ||
+      !parentById.has(alias.bottleId)
+    ) {
+      continue;
+    }
+    for (const matchingParentId of parentIdsByCanonicalName.get(
+      claimKey(alias.name),
+    ) ?? []) {
+      unionParentGroups(alias.bottleId, matchingParentId);
+    }
+  }
   const groupKeyByParentId = new Map(
-    state.bottles.map((parent) => [parent.id, claimKey(parent.fullName)]),
+    state.bottles.map((parent) => [
+      parent.id,
+      `parent:${findGroupParent(parent.id)}`,
+    ]),
   );
   const parentCountByGroupKey = new Map<string, number>();
   for (const groupKey of groupKeyByParentId.values()) {

--- a/openspec/changes/flatten-bottlings-into-bottles/design.md
+++ b/openspec/changes/flatten-bottlings-into-bottles/design.md
@@ -98,12 +98,13 @@ For a legacy family:
 - the release-to-Bottle mapping remains durable for redirects and old API
   translation.
 
-Legacy parents with the same case-insensitive complete canonical name share one
+Legacy parents with the same case-insensitive complete canonical name, or whose
+canonical name is an active exact alias of another legacy parent, share one
 migration-created BottleGroup. The oldest Bottle id is the deterministic
-representative, every duplicate parent remains an active Bottle, and each
-parent's promoted releases join that shared group. Because an exact alias can
-have only one Bottle owner, the migration does not create or reassign ambiguous
-parent canonical aliases for these shared-name members.
+representative, every linked parent remains an active Bottle, and each parent's
+promoted releases join that shared group. Because an exact alias can have only
+one Bottle owner, the migration preserves the existing assignment and does not
+create or reassign ambiguous parent canonical aliases for these members.
 
 The parent is not synthetic migration debris and is not automatically deleted.
 A later explicit Bottle merge may retire it only if product review establishes

--- a/openspec/changes/flatten-bottlings-into-bottles/tasks.md
+++ b/openspec/changes/flatten-bottlings-into-bottles/tasks.md
@@ -175,6 +175,8 @@ and map to an explicit removal task.
       merging Bottle identities or creating ambiguous canonical aliases.
 - [x] 7.17 Claim unresolved exact aliases during retained-parent and promoted
       Bottle canonicalization instead of treating them as collisions.
+- [x] 7.18 Group legacy parents connected by assigned exact aliases while
+      preserving both Bottle identities and the existing alias assignment.
 
 ## 8. Production Migration And Later Destructive Cleanup
 


### PR DESCRIPTION
The catalog migration now uses active parent-owned exact aliases as deterministic
BottleGroup evidence. When one legacy parent's canonical name is already an
alias of another legacy parent, both Bottle IDs and their consumer references
remain intact, their releases are promoted into one shared group, and the
existing alias assignment is preserved.

Production exposed `Amrut Fusion X` as Bottle `38003` while that exact name was
already assigned as an alias to Bottle `413`. The previous planner treated this
established identity relationship as a collision. Assigned release aliases,
ignored aliases, and promoted-release identity collisions remain fail-fast.
Database-backed coverage verifies shared grouping without a merge or alias
retarget; the 27-test focused migration suite, server/CLI typechecks, lint, and
strict OpenSpec validation pass.
