### PR TITLE
fix(catalog): make migration resumable

### DIFF
--- a/apps/cli/src/commands/catalogMigration.ts
+++ b/apps/cli/src/commands/catalogMigration.ts
@@ -85,7 +85,7 @@ program
 
 program
   .command("apply-catalog-migration")
-  .description("Apply an approved BottleRelease migration in one transaction")
+  .description("Apply or resume an approved BottleRelease migration")
   .argument(
     "<approved-audit>",
     "retained approval-candidate JSON from audit-catalog-migration",
@@ -103,14 +103,31 @@ program
       );
     }
 
-    const result = await applyCatalogMigration({
-      candidate,
-      approval: {
-        approvedBy: process.env.USER?.trim() || "cli-operator",
-        approvedAt: new Date(
-          Math.max(Date.now(), Date.parse(candidate.audit.generatedAt) + 1),
-        ).toISOString(),
+    const result = await applyCatalogMigration(
+      {
+        candidate,
+        approval: {
+          approvedBy: process.env.USER?.trim() || "cli-operator",
+          approvedAt: new Date(
+            Math.max(Date.now(), Date.parse(candidate.audit.generatedAt) + 1),
+          ).toISOString(),
+        },
       },
-    });
+      undefined,
+      undefined,
+      {
+        onProgress(progress) {
+          if (progress.phase === "catalog") {
+            process.stdout.write(
+              `Committed catalog batch: ${progress.committedGroups}/${progress.totalGroups} groups, ${progress.committedParents}/${progress.totalParents} parents, ${progress.committedReleases}/${progress.totalReleases} releases.\n`,
+            );
+          } else {
+            process.stdout.write(
+              `Postflight complete: ${progress.totalGroups} groups, ${progress.totalParents} parents, ${progress.totalReleases} releases.\n`,
+            );
+          }
+        },
+      },
+    );
     process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   });

--- a/apps/server/src/lib/catalogMigrationApply.test.ts
+++ b/apps/server/src/lib/catalogMigrationApply.test.ts
@@ -39,6 +39,134 @@ async function approvedInput(): Promise<CatalogMigrationApplyInput> {
 }
 
 describe("applyCatalogMigration", () => {
+  test("commits complete batches, reports progress, and resumes after interruption", async ({
+    fixtures,
+  }) => {
+    const parents = await Promise.all([
+      fixtures.LegacyBottle({ name: "Resume Family One" }),
+      fixtures.LegacyBottle({ name: "Resume Family Two" }),
+      fixtures.LegacyBottle({ name: "Resume Family Three" }),
+    ]);
+    const releases = await Promise.all(
+      parents.map((parent, index) =>
+        fixtures.BottleRelease({
+          bottleId: parent.id,
+          name: `${parent.name} Release`,
+          fullName: `${parent.fullName} Release`,
+          edition: `Resume ${index + 1}`,
+        }),
+      ),
+    );
+    const releaseTastings = await Promise.all(
+      releases.map((release, index) =>
+        fixtures.Tasting({
+          bottleId: release.bottleId,
+          releaseId: release.id,
+          notes: `resume tasting ${index + 1}`,
+          tags: [],
+          createdAt: new Date(`2025-01-0${index + 1}T00:00:00.000Z`),
+        }),
+      ),
+    );
+    const input = await approvedInput();
+
+    await expect(
+      applyCatalogMigration(input, db, undefined, {
+        batchSize: 1,
+        onProgress() {
+          throw new Error("intentional interruption");
+        },
+      }),
+    ).rejects.toThrow("intentional interruption");
+
+    const checkpointedParents = await db
+      .select({ id: bottles.id, groupId: bottles.groupId })
+      .from(bottles)
+      .where(
+        inArray(
+          bottles.id,
+          parents.map(({ id }) => id),
+        ),
+      )
+      .orderBy(asc(bottles.id));
+    expect(
+      checkpointedParents.filter(({ groupId }) => groupId !== null),
+    ).toEqual([expect.objectContaining({ id: parents[0]?.id })]);
+    expect(await db.select().from(bottleGroups)).toHaveLength(1);
+    const checkpointedMappings = await db
+      .select()
+      .from(bottleReleasePromotions);
+    expect(checkpointedMappings).toHaveLength(1);
+    expect(checkpointedMappings[0]?.releaseId).toBe(releases[0]?.id);
+    expect(
+      await db.query.tastings.findFirst({
+        where: eq(tastings.id, releaseTastings[0]!.id),
+      }),
+    ).toMatchObject({
+      bottleId: checkpointedMappings[0]?.promotedBottleId,
+      releaseId: releases[0]?.id,
+    });
+
+    const progress: Array<{
+      phase: string;
+      committedGroups: number;
+      totalGroups: number;
+    }> = [];
+    const result = await applyCatalogMigration(input, db, undefined, {
+      batchSize: 1,
+      onProgress(event) {
+        progress.push(event);
+      },
+    });
+
+    expect(result.status).toBe("applied");
+    expect(result.counts).toMatchObject({
+      parents: 2,
+      groups: 2,
+      parentBottlesAssigned: 2,
+      releases: 2,
+      consumers: {
+        bySlot: { tasting: 2 },
+        total: 2,
+      },
+    });
+    expect(progress).toEqual([
+      expect.objectContaining({
+        phase: "catalog",
+        committedGroups: 2,
+        totalGroups: 3,
+        committedReleases: 2,
+      }),
+      expect.objectContaining({
+        phase: "catalog",
+        committedGroups: 3,
+        totalGroups: 3,
+        committedReleases: 3,
+      }),
+      expect.objectContaining({
+        phase: "postflight",
+        committedGroups: 3,
+        totalGroups: 3,
+      }),
+    ]);
+    expect(await db.select().from(bottleGroups)).toHaveLength(3);
+    expect(
+      await db
+        .select({ groupId: bottles.groupId })
+        .from(bottles)
+        .where(
+          inArray(
+            bottles.id,
+            parents.map(({ id }) => id),
+          ),
+        ),
+    ).toEqual([
+      { groupId: expect.any(Number) },
+      { groupId: expect.any(Number) },
+      { groupId: expect.any(Number) },
+    ]);
+  });
+
   test("claims unresolved canonical aliases for retained and promoted Bottles", async ({
     fixtures,
   }) => {
@@ -538,6 +666,7 @@ describe("applyCatalogMigration", () => {
     });
     expect(promotedOne?.createdAt).toEqual(releaseCreatedAt);
     expect(promotedOne?.updatedAt).toEqual(releaseUpdatedAt);
+    expect(promotedOne?.searchVector).toEqual(oneRelease.searchVector);
     const fallbackMapping = mappings.find(
       ({ releaseId }) => releaseId === multiReleases[0]?.id,
     );

--- a/apps/server/src/lib/catalogMigrationApply.ts
+++ b/apps/server/src/lib/catalogMigrationApply.ts
@@ -1,9 +1,9 @@
 /**
- * Owns the one-shot legacy BottleRelease migration. The complete catalog is
- * planned under a fixed table lock set, then committed or rolled back as one
- * transaction without invoking runtime queues or target compatibility.
+ * Owns the resumable legacy BottleRelease migration. Complete family
+ * components are committed in bounded transactions without invoking runtime
+ * queues or target compatibility.
  */
-import { and, asc, eq, isNull, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
 import { db, type AnyConnection, type AnyTransaction } from "../db";
 import {
   bottleAliases,
@@ -130,6 +130,23 @@ type AppliedFamily = {
 
 type CoreCounts = Omit<CatalogMigrationApplyResult["counts"], "consumers">;
 
+export type CatalogMigrationProgress = Readonly<{
+  phase: "catalog" | "postflight";
+  committedGroups: number;
+  totalGroups: number;
+  committedParents: number;
+  totalParents: number;
+  committedReleases: number;
+  totalReleases: number;
+}>;
+
+export type CatalogMigrationApplyOptions = Readonly<{
+  batchSize?: number;
+  onProgress?: (progress: CatalogMigrationProgress) => void | Promise<void>;
+}>;
+
+const DEFAULT_CATALOG_MIGRATION_BATCH_SIZE = 250;
+
 const ZERO_CORE_COUNTS: CoreCounts = {
   parents: 0,
   groups: 0,
@@ -146,6 +163,31 @@ const ZERO_CORE_COUNTS: CoreCounts = {
   bottleStatsRecomputed: 0,
   groupStatsRecomputed: 0,
 };
+
+function emptyApplyCounts(): CatalogMigrationApplyResult["counts"] {
+  return {
+    ...ZERO_CORE_COUNTS,
+    consumers: {
+      bySlot: { ...EMPTY_CONSUMER_RESULT.bySlot },
+      total: 0,
+    },
+  };
+}
+
+function addApplyCounts(
+  total: CatalogMigrationApplyResult["counts"],
+  addition: CatalogMigrationApplyResult["counts"],
+): void {
+  for (const key of Object.keys(ZERO_CORE_COUNTS) as Array<keyof CoreCounts>) {
+    total[key] += addition[key];
+  }
+  for (const slot of Object.keys(total.consumers.bySlot) as Array<
+    keyof CatalogMigrationConsumerResult["bySlot"]
+  >) {
+    total.consumers.bySlot[slot] += addition.consumers.bySlot[slot];
+  }
+  total.consumers.total += addition.consumers.total;
+}
 
 function sameRevision(
   left: CatalogMigrationRevisionEvidence,
@@ -367,7 +409,6 @@ function materializedBottle(
       : parent.suggestedTags,
     avgRating: release.avgRating,
     totalTastings: release.totalTastings,
-    searchVector: release.searchVector,
     createdAt: release.createdAt,
     updatedAt: release.updatedAt,
     createdByActorId: release.createdByActorId,
@@ -398,7 +439,6 @@ const MATERIALIZED_BOTTLE_FIELDS = [
   "imageUrl",
   "tastingNotes",
   "suggestedTags",
-  "searchVector",
   "createdAt",
   "updatedAt",
   "createdByActorId",
@@ -435,6 +475,11 @@ function canonicalNames(name: string): string[] {
 async function buildFamilyPlans(
   tx: AnyTransaction,
   state: MigrationState,
+  {
+    collisionBottles = state.bottles,
+  }: {
+    collisionBottles?: Bottle[];
+  } = {},
 ): Promise<FamilyPlan[]> {
   const parentById = new Map(
     state.bottles.map((bottle) => [bottle.id, bottle]),
@@ -498,7 +543,7 @@ async function buildFamilyPlans(
   }
 
   const bottleByCanonicalName = new Map<string, Bottle[]>();
-  for (const bottle of state.bottles) {
+  for (const bottle of collisionBottles) {
     const key = claimKey(bottle.fullName);
     const matchingBottles = bottleByCanonicalName.get(key) ?? [];
     matchingBottles.push(bottle);
@@ -546,6 +591,20 @@ async function buildFamilyPlans(
     if (firstParentId === undefined) continue;
     for (const duplicateParentId of duplicateParentIds) {
       unionParentGroups(firstParentId, duplicateParentId);
+    }
+  }
+  const parentIdsByCheckpointGroup = new Map<number, number[]>();
+  for (const parent of state.bottles) {
+    if (parent.groupId === null) continue;
+    const parentIds = parentIdsByCheckpointGroup.get(parent.groupId) ?? [];
+    parentIds.push(parent.id);
+    parentIdsByCheckpointGroup.set(parent.groupId, parentIds);
+  }
+  for (const parentIds of parentIdsByCheckpointGroup.values()) {
+    const [firstParentId, ...groupedParentIds] = parentIds;
+    if (firstParentId === undefined) continue;
+    for (const groupedParentId of groupedParentIds) {
+      unionParentGroups(firstParentId, groupedParentId);
     }
   }
   for (const alias of aliases) {
@@ -676,6 +735,7 @@ async function buildFamilyPlans(
   };
 
   for (const parent of state.bottles) {
+    if (parent.groupId !== null) continue;
     claimCanonicalIdentity({
       fullName: parent.fullName,
       bottleId: parent.id,
@@ -787,6 +847,13 @@ async function insertGroup(
           releaseId: release.id,
           reason: "promoted_bottle_insert_missing",
         });
+      }
+      if (release.searchVector !== null) {
+        await tx.execute(
+          sql`UPDATE ${bottles}
+              SET search_vector = ${release.searchVector}::tsvector
+              WHERE id = ${bottle.id}`,
+        );
       }
       if (plan.ownedRows.distillerIds.length) {
         await tx.insert(bottlesToDistillers).values(
@@ -947,10 +1014,17 @@ function emptyOwnedRows(): ParentOwnedRows {
 
 async function loadBottleOwnedRowsByBottleId(
   tx: AnyTransaction,
+  bottleIds?: readonly number[],
 ): Promise<Map<number, ParentOwnedRows>> {
+  const scopedBottleIds = bottleIds ? [...bottleIds] : undefined;
   const distillers = await tx
     .select()
     .from(bottlesToDistillers)
+    .where(
+      scopedBottleIds
+        ? inArray(bottlesToDistillers.bottleId, scopedBottleIds)
+        : undefined,
+    )
     .orderBy(
       asc(bottlesToDistillers.bottleId),
       asc(bottlesToDistillers.distillerId),
@@ -958,10 +1032,20 @@ async function loadBottleOwnedRowsByBottleId(
   const tags = await tx
     .select()
     .from(bottleTags)
+    .where(
+      scopedBottleIds
+        ? inArray(bottleTags.bottleId, scopedBottleIds)
+        : undefined,
+    )
     .orderBy(asc(bottleTags.bottleId), asc(bottleTags.tag));
   const flavorProfiles = await tx
     .select()
     .from(bottleFlavorProfiles)
+    .where(
+      scopedBottleIds
+        ? inArray(bottleFlavorProfiles.bottleId, scopedBottleIds)
+        : undefined,
+    )
     .orderBy(
       asc(bottleFlavorProfiles.bottleId),
       asc(bottleFlavorProfiles.flavorProfile),
@@ -1036,29 +1120,56 @@ type AppliedFamilyPostflightState = {
 
 async function loadAppliedFamilyPostflightState(
   tx: AnyTransaction,
+  applied: readonly AppliedFamily[],
 ): Promise<AppliedFamilyPostflightState> {
+  const bottleIds = [
+    ...new Set(
+      applied.flatMap((family) => [
+        family.plan.parent.id,
+        ...family.promoted.map(({ bottle }) => bottle.id),
+      ]),
+    ),
+  ];
+  const groupIds = [...new Set(applied.map(({ groupId }) => groupId))];
+  const releaseIds = [
+    ...new Set(
+      applied.flatMap((family) =>
+        family.promoted.map(({ release }) => release.id),
+      ),
+    ),
+  ];
   const bottleRows = await tx
     .select({ bottle: bottles })
     .from(bottles)
     .leftJoin(bottleTombstones, eq(bottleTombstones.bottleId, bottles.id))
-    .where(isNull(bottleTombstones.bottleId))
+    .where(
+      and(isNull(bottleTombstones.bottleId), inArray(bottles.id, bottleIds)),
+    )
     .orderBy(asc(bottles.id));
   const groups = await tx
     .select()
     .from(bottleGroups)
+    .where(inArray(bottleGroups.id, groupIds))
     .orderBy(asc(bottleGroups.id));
-  const mappings = await tx
-    .select()
-    .from(bottleReleasePromotions)
-    .orderBy(asc(bottleReleasePromotions.releaseId));
+  const mappings = releaseIds.length
+    ? await tx
+        .select()
+        .from(bottleReleasePromotions)
+        .where(inArray(bottleReleasePromotions.releaseId, releaseIds))
+        .orderBy(asc(bottleReleasePromotions.releaseId))
+    : [];
   const groupDistillers = await tx
     .select()
     .from(bottleGroupDistillers)
+    .where(inArray(bottleGroupDistillers.groupId, groupIds))
     .orderBy(
       asc(bottleGroupDistillers.groupId),
       asc(bottleGroupDistillers.distillerId),
     );
-  const ownedRowsByBottleId = await loadBottleOwnedRowsByBottleId(tx);
+  const ownedRowsByBottleId = await loadBottleOwnedRowsByBottleId(
+    tx,
+    bottleIds,
+  );
   const aliases = await tx
     .select({
       name: bottleAliases.name,
@@ -1092,7 +1203,8 @@ async function assertAppliedFamilies(
   tx: AnyTransaction,
   applied: AppliedFamily[],
 ): Promise<void> {
-  const state = await loadAppliedFamilyPostflightState(tx);
+  if (!applied.length) return;
+  const state = await loadAppliedFamilyPostflightState(tx, applied);
   for (const family of applied) {
     const parent = state.bottleById.get(family.plan.parent.id);
     const group = state.groupById.get(family.groupId);
@@ -1150,160 +1262,105 @@ async function assertAppliedFamilies(
   }
 }
 
-async function loadCompletedFamilies(
-  tx: AnyTransaction,
-  state: MigrationState,
-): Promise<AppliedFamily[]> {
-  if (state.mappings.length !== state.releases.length) {
-    throw new CatalogMigrationApplyError("partial_state", {
-      releaseCount: state.releases.length,
-      mappingCount: state.mappings.length,
-    });
-  }
+function parentMigrationState(state: MigrationState): MigrationState {
   const promotedIds = new Set(
     state.mappings.flatMap(({ promotedBottleId }) =>
       promotedBottleId === null ? [] : [promotedBottleId],
     ),
   );
-  const parentState: MigrationState = {
+  return {
     ...state,
     bottles: state.bottles.filter(({ id }) => !promotedIds.has(id)),
   };
-  const plans = await buildFamilyPlansForCompletedState(tx, parentState);
+}
+
+function partitionFamilyPlans(
+  state: MigrationState,
+  plans: FamilyPlan[],
+): {
+  pendingGroups: FamilyPlan[][];
+  completedFamilies: AppliedFamily[];
+} {
   const mappingByReleaseId = new Map(
     state.mappings.map((mapping) => [mapping.releaseId, mapping]),
   );
   const bottleById = new Map(
     state.bottles.map((bottle) => [bottle.id, bottle]),
   );
-  const plansByGroupId = new Map<number, FamilyPlan[]>();
+  const plansByGroupKey = new Map<string, FamilyPlan[]>();
   for (const plan of plans) {
-    if (plan.parent.groupId === null) continue;
-    const groupPlans = plansByGroupId.get(plan.parent.groupId) ?? [];
+    const groupPlans = plansByGroupKey.get(plan.groupKey) ?? [];
     groupPlans.push(plan);
-    plansByGroupId.set(plan.parent.groupId, groupPlans);
+    plansByGroupKey.set(plan.groupKey, groupPlans);
   }
-  return plans.map((plan) => {
-    if (plan.parent.groupId === null) {
+
+  const pendingGroups: FamilyPlan[][] = [];
+  const completedFamilies: AppliedFamily[] = [];
+  for (const groupPlans of plansByGroupKey.values()) {
+    const assignedGroupIds = new Set(
+      groupPlans.flatMap(({ parent }) =>
+        parent.groupId === null ? [] : [parent.groupId],
+      ),
+    );
+    const releases = groupPlans.flatMap((plan) => plan.releases);
+    const mappedReleaseCount = releases.filter((release) =>
+      mappingByReleaseId.has(release.id),
+    ).length;
+    if (assignedGroupIds.size === 0 && mappedReleaseCount === 0) {
+      pendingGroups.push(groupPlans);
+      continue;
+    }
+    if (
+      assignedGroupIds.size !== 1 ||
+      groupPlans.some(({ parent }) => parent.groupId === null) ||
+      mappedReleaseCount !== releases.length
+    ) {
       throw new CatalogMigrationApplyError("partial_state", {
-        parentId: plan.parent.id,
-        reason: "parent_group_missing",
+        parentIds: groupPlans.map(({ parent }) => parent.id),
+        assignedGroupIds: [...assignedGroupIds],
+        releaseCount: releases.length,
+        mappedReleaseCount,
+        reason: "incomplete_group_checkpoint",
       });
     }
-    const groupPlans = plansByGroupId.get(plan.parent.groupId) ?? [plan];
+    const groupId = [...assignedGroupIds][0]!;
     const representativeParentId = Math.min(
       ...groupPlans.map(({ parent }) => parent.id),
     );
-    return {
-      plan,
-      groupId: plan.parent.groupId,
-      representativeParentId,
-      groupTotalBottles: groupPlans.reduce(
-        (total, groupPlan) => total + groupPlan.releases.length + 1,
-        0,
-      ),
-      groupDistillerIds: [
-        ...new Set(
-          groupPlans.flatMap(({ ownedRows }) => ownedRows.distillerIds),
-        ),
-      ].sort((left, right) => left - right),
-      promoted: plan.releases.map((release) => {
-        const mapping = mappingByReleaseId.get(release.id);
-        const bottle =
-          mapping?.promotedBottleId === null ||
-          mapping?.promotedBottleId === undefined
-            ? undefined
-            : bottleById.get(mapping.promotedBottleId);
-        if (!mapping || !bottle || bottle.groupId !== plan.parent.groupId) {
-          throw new CatalogMigrationApplyError("partial_state", {
-            parentId: plan.parent.id,
-            releaseId: release.id,
-            reason: "promotion_missing",
-          });
-        }
-        return { release, bottle };
-      }),
-    };
-  });
-}
-
-async function buildFamilyPlansForCompletedState(
-  tx: AnyTransaction,
-  state: MigrationState,
-): Promise<FamilyPlan[]> {
-  const releasesByParentId = new Map<number, BottleRelease[]>();
-  for (const release of state.releases) {
-    const familyReleases = releasesByParentId.get(release.bottleId) ?? [];
-    familyReleases.push(release);
-    releasesByParentId.set(release.bottleId, familyReleases);
-  }
-  const parentIds = new Set(state.bottles.map(({ id }) => id));
-  const ownedRowsByBottleId = await loadBottleOwnedRowsByBottleId(tx);
-  const parentCountByGroupId = new Map<number, number>();
-  for (const parent of state.bottles) {
-    if (parent.groupId !== null) {
-      parentCountByGroupId.set(
-        parent.groupId,
-        (parentCountByGroupId.get(parent.groupId) ?? 0) + 1,
-      );
-    }
-  }
-  const plans: FamilyPlan[] = [];
-  for (const parent of state.bottles) {
-    plans.push({
-      parent,
-      releases: releasesByParentId.get(parent.id) ?? [],
-      ownedRows: ownedRowsByBottleId.get(parent.id) ?? emptyOwnedRows(),
-      groupKey: claimKey(parent.fullName),
-      sharedParentIdentity:
-        parent.groupId !== null &&
-        (parentCountByGroupId.get(parent.groupId) ?? 0) > 1,
-    });
-  }
-  if (state.releases.some((release) => !parentIds.has(release.bottleId))) {
-    throw new CatalogMigrationApplyError("partial_state", {
-      reason: "release_parent_missing",
-    });
-  }
-  return plans;
-}
-
-async function classifyState(
-  tx: AnyTransaction,
-  state: MigrationState,
-): Promise<
-  | { status: "pending" }
-  | { status: "already_complete"; families: AppliedFamily[] }
-> {
-  if (
-    !state.bottles.length &&
-    !state.releases.length &&
-    !state.mappings.length
-  ) {
-    return { status: "already_complete", families: [] };
-  }
-  if (!state.mappings.length) {
-    const assignedParents = state.bottles.filter(
-      ({ groupId }) => groupId !== null,
+    const groupTotalBottles = groupPlans.reduce(
+      (total, groupPlan) => total + groupPlan.releases.length + 1,
+      0,
     );
-    if (!assignedParents.length) return { status: "pending" };
-    if (
-      !state.releases.length &&
-      assignedParents.length === state.bottles.length
-    ) {
-      const families = await loadCompletedFamilies(tx, state);
-      return { status: "already_complete", families };
+    const groupDistillerIds = [
+      ...new Set(groupPlans.flatMap(({ ownedRows }) => ownedRows.distillerIds)),
+    ].sort((left, right) => left - right);
+    for (const plan of groupPlans) {
+      completedFamilies.push({
+        plan,
+        groupId,
+        representativeParentId,
+        groupTotalBottles,
+        groupDistillerIds,
+        promoted: plan.releases.map((release) => {
+          const mapping = mappingByReleaseId.get(release.id);
+          const bottle =
+            mapping?.promotedBottleId === null ||
+            mapping?.promotedBottleId === undefined
+              ? undefined
+              : bottleById.get(mapping.promotedBottleId);
+          if (!mapping || !bottle || bottle.groupId !== groupId) {
+            throw new CatalogMigrationApplyError("partial_state", {
+              parentId: plan.parent.id,
+              releaseId: release.id,
+              reason: "invalid_promotion_checkpoint",
+            });
+          }
+          return { release, bottle };
+        }),
+      });
     }
-    throw new CatalogMigrationApplyError("partial_state", {
-      assignedParentIds: assignedParents.map(({ id }) => id),
-      mappingCount: 0,
-      releaseCount: state.releases.length,
-    });
   }
-  return {
-    status: "already_complete",
-    families: await loadCompletedFamilies(tx, state),
-  };
+  return { pendingGroups, completedFamilies };
 }
 
 function countsFor(
@@ -1387,14 +1444,37 @@ function assertPostflightAudit(
   }
 }
 
+function assertResumableBaseline(
+  candidate: CatalogMigrationApprovalCandidate,
+  state: MigrationState,
+  parentState: MigrationState,
+): void {
+  if (
+    parentState.bottles.length !== candidate.audit.legacyCatalog.totalParents ||
+    state.releases.length !== candidate.audit.legacyCatalog.totalReleases ||
+    state.mappings.length > state.releases.length
+  ) {
+    throw new CatalogMigrationApplyError("partial_state", {
+      expectedParentCount: candidate.audit.legacyCatalog.totalParents,
+      actualParentCount: parentState.bottles.length,
+      expectedReleaseCount: candidate.audit.legacyCatalog.totalReleases,
+      actualReleaseCount: state.releases.length,
+      mappingCount: state.mappings.length,
+      reason: "baseline_count_mismatch",
+    });
+  }
+}
+
 /**
- * Applies the approved catalog migration exactly once. A complete second call
- * validates the committed graph and returns `already_complete` with zero writes.
+ * Applies the approved catalog migration in bounded, component-complete
+ * transactions. Group assignments and promotion mappings are durable
+ * checkpoints; reruns skip committed components and continue safely.
  */
 export async function applyCatalogMigration(
   input: unknown,
   database: AnyConnection = db,
   migrationsFolder?: string,
+  options: CatalogMigrationApplyOptions = {},
 ): Promise<CatalogMigrationApplyResult> {
   const parsed = CatalogMigrationApplyInputSchema.parse(input);
   if (
@@ -1409,9 +1489,112 @@ export async function applyCatalogMigration(
   await assertWritablePrimaryPreflight(database);
 
   const startedAt = new Date();
+  const batchSize = options.batchSize ?? DEFAULT_CATALOG_MIGRATION_BATCH_SIZE;
+  if (!Number.isSafeInteger(batchSize) || batchSize <= 0) {
+    throw new CatalogMigrationApplyError("approval_invalid", {
+      batchSize,
+      reason: "invalid_batch_size",
+    });
+  }
+  const counts = emptyApplyCounts();
+  let appliedAny = false;
+
+  for (;;) {
+    const batch = await database.transaction(async (tx) => {
+      await tx.execute(sql`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`);
+      await lockMigrationTables(tx);
+      const databaseEvidence = await loadCatalogMigrationDatabaseEvidence(tx);
+      const revision = await loadCatalogMigrationRevisionEvidenceInTransaction(
+        parsed.candidate.revision.gitRevision,
+        tx,
+        migrationsFolder,
+        databaseEvidence,
+      );
+      assertApprovedPreflight(parsed.candidate, revision);
+
+      const state = await loadMigrationState(tx);
+      const parentState = parentMigrationState(state);
+      assertResumableBaseline(parsed.candidate, state, parentState);
+      const plans = await buildFamilyPlans(tx, parentState, {
+        collisionBottles: state.bottles,
+      });
+      const { pendingGroups, completedFamilies } = partitionFamilyPlans(
+        state,
+        plans,
+      );
+      const completedGroupCount = new Set(
+        completedFamilies.map(({ groupId }) => groupId),
+      ).size;
+      const totalGroups = completedGroupCount + pendingGroups.length;
+      if (!completedFamilies.length) {
+        await assertAuditUnchanged(tx, parsed.candidate, revision);
+        await preflightLegacyConsumersInTransaction(tx);
+      }
+      if (!pendingGroups.length) {
+        return {
+          kind: "catalog_complete" as const,
+          revision,
+          totalGroups,
+          totalParents: plans.length,
+          totalReleases: state.releases.length,
+        };
+      }
+
+      const selectedGroups = pendingGroups.slice(0, batchSize);
+      const selectedPlans = selectedGroups.flat();
+      const applied: AppliedFamily[] = [];
+      for (const groupPlans of selectedGroups) {
+        applied.push(...(await insertGroup(tx, groupPlans)));
+      }
+      const releaseIds = selectedPlans.flatMap((plan) =>
+        plan.releases.map(({ id }) => id),
+      );
+      const consumers = releaseIds.length
+        ? await repointLegacyConsumersInTransaction(
+            tx,
+            await preflightLegacyConsumersInTransaction(tx, releaseIds),
+            releaseIds,
+          )
+        : emptyApplyCounts().consumers;
+      const aliases = await reserveCanonicalAliases(tx, applied);
+      const appliedStatsFamilies = statsFamilies(applied);
+      const stats = await recomputeCatalogMigrationStatsInTransaction(
+        tx,
+        appliedStatsFamilies,
+      );
+      await assertAppliedFamilies(tx, applied);
+      if (releaseIds.length) {
+        await assertLegacyConsumersPromotedInTransaction(tx, releaseIds);
+      }
+
+      return {
+        kind: "batch_committed" as const,
+        revision,
+        counts: countsFor(selectedPlans, aliases, consumers, stats),
+        progress: {
+          phase: "catalog" as const,
+          committedGroups: completedGroupCount + selectedGroups.length,
+          totalGroups,
+          committedParents: completedFamilies.length + applied.length,
+          totalParents: plans.length,
+          committedReleases:
+            completedFamilies.reduce(
+              (total, family) => total + family.promoted.length,
+              0,
+            ) + releaseIds.length,
+          totalReleases: state.releases.length,
+        },
+      };
+    });
+
+    if (batch.kind === "catalog_complete") break;
+    appliedAny = true;
+    addApplyCounts(counts, batch.counts);
+    await options.onProgress?.(batch.progress);
+  }
+
   const transactionResult = await database.transaction(async (tx) => {
     await tx.execute(sql`SET TRANSACTION ISOLATION LEVEL SERIALIZABLE`);
-    // Preserve the authoritative snapshot: no SELECT may precede these locks.
     await lockMigrationTables(tx);
     const databaseEvidence = await loadCatalogMigrationDatabaseEvidence(tx);
     const revision = await loadCatalogMigrationRevisionEvidenceInTransaction(
@@ -1423,72 +1606,34 @@ export async function applyCatalogMigration(
     assertApprovedPreflight(parsed.candidate, revision);
 
     const state = await loadMigrationState(tx);
-    const classification = await classifyState(tx, state);
-    if (classification.status === "already_complete") {
-      const completedStatsFamilies = statsFamilies(classification.families);
-      await assertAppliedFamilies(tx, classification.families);
-      await assertLegacyConsumersPromotedInTransaction(tx);
-      await assertCatalogMigrationStatsInTransaction(
-        tx,
-        completedStatsFamilies,
-      );
-      const postflightAudit = await collectCatalogMigrationAudit(
-        tx,
-        revision.databaseEvidence,
-      );
-      assertPostflightAudit(postflightAudit, {
-        parentCount: classification.families.length,
-        releaseCount: state.releases.length,
+    const parentState = parentMigrationState(state);
+    assertResumableBaseline(parsed.candidate, state, parentState);
+    const plans = await buildFamilyPlans(tx, parentState, {
+      collisionBottles: state.bottles,
+    });
+    const { pendingGroups, completedFamilies } = partitionFamilyPlans(
+      state,
+      plans,
+    );
+    if (pendingGroups.length) {
+      throw new CatalogMigrationApplyError("partial_state", {
+        pendingGroupCount: pendingGroups.length,
+        reason: "catalog_checkpoint_regressed",
       });
-      return {
-        status: "already_complete" as const,
-        revision,
-        counts: {
-          ...ZERO_CORE_COUNTS,
-          consumers: EMPTY_CONSUMER_RESULT,
-        },
-        postflightAudit,
-      };
     }
-
-    await assertAuditUnchanged(tx, parsed.candidate, revision);
-    const plans = await buildFamilyPlans(tx, state);
-    const consumerPreflight = await preflightLegacyConsumersInTransaction(tx);
-    const plansByGroupKey = new Map<string, FamilyPlan[]>();
-    for (const plan of plans) {
-      const groupPlans = plansByGroupKey.get(plan.groupKey) ?? [];
-      groupPlans.push(plan);
-      plansByGroupKey.set(plan.groupKey, groupPlans);
-    }
-    const applied: AppliedFamily[] = [];
-    for (const groupPlans of plansByGroupKey.values()) {
-      applied.push(...(await insertGroup(tx, groupPlans)));
-    }
-
-    const consumers = await repointLegacyConsumersInTransaction(
-      tx,
-      consumerPreflight,
-    );
-    const aliases = await reserveCanonicalAliases(tx, applied);
-    const appliedStatsFamilies = statsFamilies(applied);
-    const stats = await recomputeCatalogMigrationStatsInTransaction(
-      tx,
-      appliedStatsFamilies,
-    );
-    await assertAppliedFamilies(tx, applied);
+    const completedStatsFamilies = statsFamilies(completedFamilies);
+    await assertAppliedFamilies(tx, completedFamilies);
     await assertLegacyConsumersPromotedInTransaction(tx);
-
-    const finalState = await loadMigrationState(tx);
+    await assertCatalogMigrationStatsInTransaction(tx, completedStatsFamilies);
     if (
-      finalState.bottles.length !==
-        state.bottles.length + state.releases.length ||
-      finalState.mappings.length !== state.releases.length
+      state.bottles.length !== plans.length + state.releases.length ||
+      state.mappings.length !== state.releases.length
     ) {
       throw new CatalogMigrationApplyError("postflight_failed", {
-        initialBottleCount: state.bottles.length,
-        finalBottleCount: finalState.bottles.length,
+        parentCount: plans.length,
+        bottleCount: state.bottles.length,
         releaseCount: state.releases.length,
-        mappingCount: finalState.mappings.length,
+        mappingCount: state.mappings.length,
       });
     }
     const postflightAudit = await collectCatalogMigrationAudit(
@@ -1499,24 +1644,32 @@ export async function applyCatalogMigration(
       parentCount: plans.length,
       releaseCount: state.releases.length,
     });
+    return { revision, postflightAudit, plans, completedFamilies };
+  });
 
-    return {
-      status: "applied" as const,
-      revision,
-      counts: countsFor(plans, aliases, consumers, stats),
-      postflightAudit,
-    };
+  await options.onProgress?.({
+    phase: "postflight",
+    committedGroups: new Set(
+      transactionResult.completedFamilies.map(({ groupId }) => groupId),
+    ).size,
+    totalGroups: new Set(
+      transactionResult.completedFamilies.map(({ groupId }) => groupId),
+    ).size,
+    committedParents: transactionResult.plans.length,
+    totalParents: transactionResult.plans.length,
+    committedReleases: parsed.candidate.audit.legacyCatalog.totalReleases,
+    totalReleases: parsed.candidate.audit.legacyCatalog.totalReleases,
   });
 
   return CatalogMigrationApplyResultSchema.parse({
     schemaVersion: CATALOG_MIGRATION_APPLY_SCHEMA_VERSION,
-    status: transactionResult.status,
+    status: appliedAny ? "applied" : "already_complete",
     approvedAuditGeneratedAt: parsed.candidate.audit.generatedAt,
     revision: transactionResult.revision,
     approval: parsed.approval,
     startedAt: startedAt.toISOString(),
     completedAt: new Date().toISOString(),
-    counts: transactionResult.counts,
+    counts,
     postflightAudit: transactionResult.postflightAudit,
   });
 }

--- a/apps/server/src/lib/catalogMigrationConsumers.ts
+++ b/apps/server/src/lib/catalogMigrationConsumers.ts
@@ -192,7 +192,22 @@ function firstRow<T>(rows: T[], label: string): T {
   return row;
 }
 
-function referencesSql(): string {
+function sqlIdList(releaseIds: readonly number[] | undefined): string | null {
+  if (releaseIds === undefined) return null;
+  if (
+    !releaseIds.length ||
+    releaseIds.some((id) => !Number.isSafeInteger(id) || id <= 0)
+  ) {
+    throw new CatalogMigrationConsumerError("postflight_failed", null, null, {
+      reason: "invalid_release_scope",
+      releaseIds,
+    });
+  }
+  return [...new Set(releaseIds)].join(",");
+}
+
+function referencesSql(releaseIds?: readonly number[]): string {
+  const scopedIds = sqlIdList(releaseIds);
   return CONSUMER_SLOT_DEFINITIONS.map(
     ({ slot, table, bottleColumn, releaseColumn, rowId }) => `
       SELECT
@@ -202,6 +217,7 @@ function referencesSql(): string {
         ${releaseColumn} AS release_id
       FROM ${table}
       WHERE ${releaseColumn} IS NOT NULL
+        ${scopedIds === null ? "" : `AND ${releaseColumn} IN (${scopedIds})`}
     `,
   ).join("\nUNION ALL\n");
 }
@@ -217,10 +233,11 @@ function emptyResult(): CatalogMigrationConsumerResult {
 
 async function loadConsumerCounts(
   tx: AnyTransaction,
+  releaseIds?: readonly number[],
 ): Promise<CatalogMigrationConsumerResult> {
   const result = await tx.execute<ConsumerCountRow>(
     sql.raw(`
-    WITH refs AS (${referencesSql()})
+    WITH refs AS (${referencesSql(releaseIds)})
     SELECT slot, COUNT(*)::int AS count
     FROM refs
     GROUP BY slot
@@ -234,12 +251,23 @@ async function loadConsumerCounts(
   return counts;
 }
 
-async function assertNoMembershipConflicts(tx: AnyTransaction): Promise<void> {
+async function assertNoMembershipConflicts(
+  tx: AnyTransaction,
+  releaseIds?: readonly number[],
+): Promise<void> {
+  const scopedIds = sqlIdList(releaseIds);
+  const releaseScope = (qualifier = "") =>
+    scopedIds === null ? "" : `AND ${qualifier}release_id IN (${scopedIds})`;
+  const bottleScope =
+    scopedIds === null
+      ? ""
+      : "AND bottle_id IN (SELECT promoted_bottle_id FROM complete_promotion)";
   const result = await tx.execute<MembershipConflictRow>(
     sql.raw(`
     WITH complete_promotion AS (
       SELECT release_id, promoted_bottle_id
       FROM bottle_release_promotion
+      WHERE TRUE ${releaseScope()}
     ),
     tasting_final AS (
       SELECT
@@ -249,7 +277,7 @@ async function assertNoMembershipConflicts(tx: AnyTransaction): Promise<void> {
         t.created_at
       FROM tasting t
       LEFT JOIN complete_promotion p ON p.release_id = t.release_id
-      WHERE t.release_id IS NOT NULL
+      WHERE t.release_id IS NOT NULL ${releaseScope("t.")}
       UNION ALL
       SELECT
         id::text,
@@ -257,7 +285,7 @@ async function assertNoMembershipConflicts(tx: AnyTransaction): Promise<void> {
         created_by_id,
         created_at
       FROM tasting
-      WHERE release_id IS NULL AND bottle_id IS NOT NULL
+      WHERE release_id IS NULL AND bottle_id IS NOT NULL ${bottleScope}
     ),
     collection_final AS (
       SELECT
@@ -266,11 +294,11 @@ async function assertNoMembershipConflicts(tx: AnyTransaction): Promise<void> {
         COALESCE(p.promoted_bottle_id, -c.release_id) AS final_bottle_id
       FROM collection_bottle c
       LEFT JOIN complete_promotion p ON p.release_id = c.release_id
-      WHERE c.release_id IS NOT NULL
+      WHERE c.release_id IS NOT NULL ${releaseScope("c.")}
       UNION ALL
       SELECT id::text, collection_id, bottle_id
       FROM collection_bottle
-      WHERE release_id IS NULL AND bottle_id IS NOT NULL
+      WHERE release_id IS NULL AND bottle_id IS NOT NULL ${bottleScope}
     ),
     flight_final AS (
       SELECT
@@ -279,14 +307,14 @@ async function assertNoMembershipConflicts(tx: AnyTransaction): Promise<void> {
         COALESCE(p.promoted_bottle_id, -f.release_id) AS final_bottle_id
       FROM flight_bottle f
       LEFT JOIN complete_promotion p ON p.release_id = f.release_id
-      WHERE f.release_id IS NOT NULL
+      WHERE f.release_id IS NOT NULL ${releaseScope("f.")}
       UNION ALL
       SELECT
         CONCAT(flight_id, ':', bottle_id, ':null'),
         flight_id,
         bottle_id
       FROM flight_bottle
-      WHERE release_id IS NULL AND bottle_id IS NOT NULL
+      WHERE release_id IS NULL AND bottle_id IS NOT NULL ${bottleScope}
     ),
     conflicts AS (
       SELECT
@@ -339,10 +367,13 @@ async function assertNoMembershipConflicts(tx: AnyTransaction): Promise<void> {
   }
 }
 
-async function assertLegacyPairs(tx: AnyTransaction): Promise<void> {
+async function assertLegacyPairs(
+  tx: AnyTransaction,
+  releaseIds?: readonly number[],
+): Promise<void> {
   const result = await tx.execute<InvalidPairRow>(
     sql.raw(`
-    WITH refs AS (${referencesSql()})
+    WITH refs AS (${referencesSql(releaseIds)})
     SELECT
       refs.slot,
       refs.row_id AS "rowId",
@@ -377,7 +408,11 @@ async function assertLegacyPairs(tx: AnyTransaction): Promise<void> {
   }
 }
 
-async function assertPromotionGraph(tx: AnyTransaction): Promise<void> {
+async function assertPromotionGraph(
+  tx: AnyTransaction,
+  releaseIds?: readonly number[],
+): Promise<void> {
+  const scopedIds = sqlIdList(releaseIds);
   const result = await tx.execute<InvalidPromotionRow>(
     sql.raw(`
     SELECT
@@ -410,15 +445,18 @@ async function assertPromotionGraph(tx: AnyTransaction): Promise<void> {
       ON parent_tombstone.bottle_id = parent.id
     LEFT JOIN bottle_tombstone promoted_tombstone
       ON promoted_tombstone.bottle_id = promoted.id
-    WHERE promotion.release_id IS NULL
-       OR promotion.promoted_bottle_id = release.bottle_id
-       OR parent.id IS NULL
-       OR parent.group_id IS NULL
-       OR parent_tombstone.bottle_id IS NOT NULL
-       OR promoted.id IS NULL
-       OR promoted.group_id IS NULL
-       OR promoted_tombstone.bottle_id IS NOT NULL
-       OR parent.group_id IS DISTINCT FROM promoted.group_id
+    WHERE (
+      promotion.release_id IS NULL
+      OR promotion.promoted_bottle_id = release.bottle_id
+      OR parent.id IS NULL
+      OR parent.group_id IS NULL
+      OR parent_tombstone.bottle_id IS NOT NULL
+      OR promoted.id IS NULL
+      OR promoted.group_id IS NULL
+      OR promoted_tombstone.bottle_id IS NOT NULL
+      OR parent.group_id IS DISTINCT FROM promoted.group_id
+    )
+    ${scopedIds === null ? "" : `AND release.id IN (${scopedIds})`}
     ORDER BY release.id
     LIMIT 1
   `),
@@ -484,8 +522,10 @@ function assertSameCounts(
 async function applySlot(
   tx: AnyTransaction,
   definition: ConsumerSlotDefinition,
+  releaseIds?: readonly number[],
 ): Promise<number> {
   const { table, bottleColumn, releaseColumn } = definition;
+  const scopedIds = sqlIdList(releaseIds);
   const result = await tx.execute<{ count: number }>(
     sql.raw(`
     WITH updated AS (
@@ -496,6 +536,7 @@ async function applySlot(
         ON promotion.release_id = release.id
       WHERE consumer.${releaseColumn} = release.id
         AND consumer.${bottleColumn} IS DISTINCT FROM promotion.promoted_bottle_id
+        ${scopedIds === null ? "" : `AND release.id IN (${scopedIds})`}
       RETURNING 1
     )
     SELECT COUNT(*)::int AS count
@@ -507,10 +548,11 @@ async function applySlot(
 
 async function assertPromotedPairs(
   tx: AnyTransaction,
+  releaseIds?: readonly number[],
 ): Promise<CatalogMigrationConsumerResult> {
   const result = await tx.execute<InvalidPairRow>(
     sql.raw(`
-    WITH refs AS (${referencesSql()})
+    WITH refs AS (${referencesSql(releaseIds)})
     SELECT
       refs.slot,
       refs.row_id AS "rowId",
@@ -546,7 +588,7 @@ async function assertPromotedPairs(
       },
     );
   }
-  return await loadConsumerCounts(tx);
+  return await loadConsumerCounts(tx, releaseIds);
 }
 
 /**
@@ -555,10 +597,11 @@ async function assertPromotedPairs(
  */
 export async function preflightLegacyConsumersInTransaction(
   tx: AnyTransaction,
+  releaseIds?: readonly number[],
 ): Promise<CatalogMigrationConsumerPreflight> {
-  const counts = await loadConsumerCounts(tx);
-  await assertNoMembershipConflicts(tx);
-  await assertLegacyPairs(tx);
+  const counts = await loadConsumerCounts(tx, releaseIds);
+  await assertNoMembershipConflicts(tx, releaseIds);
+  await assertLegacyPairs(tx, releaseIds);
   return Object.freeze({
     bySlot: Object.freeze({ ...counts.bySlot }),
     total: counts.total,
@@ -574,20 +617,21 @@ export async function preflightLegacyConsumersInTransaction(
 export async function repointLegacyConsumersInTransaction(
   tx: AnyTransaction,
   preflight: CatalogMigrationConsumerPreflight,
+  releaseIds?: readonly number[],
 ): Promise<CatalogMigrationConsumerResult> {
-  await assertPromotionGraph(tx);
-  const before = await loadConsumerCounts(tx);
+  await assertPromotionGraph(tx, releaseIds);
+  const before = await loadConsumerCounts(tx, releaseIds);
   assertSameCounts(preflight.bySlot, before.bySlot, "mutation_count_mismatch");
-  await assertLegacyPairs(tx);
-  await assertNoMembershipConflicts(tx);
+  await assertLegacyPairs(tx, releaseIds);
+  await assertNoMembershipConflicts(tx, releaseIds);
 
   const bySlot = emptyResult().bySlot;
   for (const definition of CONSUMER_SLOT_DEFINITIONS) {
-    bySlot[definition.slot] = await applySlot(tx, definition);
+    bySlot[definition.slot] = await applySlot(tx, definition, releaseIds);
   }
   assertSameCounts(preflight.bySlot, bySlot, "mutation_count_mismatch");
 
-  const after = await assertPromotedPairs(tx);
+  const after = await assertPromotedPairs(tx, releaseIds);
   assertSameCounts(preflight.bySlot, after.bySlot, "postflight_failed");
   return { bySlot, total: preflight.total };
 }
@@ -598,8 +642,9 @@ export async function repointLegacyConsumersInTransaction(
  */
 export async function assertLegacyConsumersPromotedInTransaction(
   tx: AnyTransaction,
+  releaseIds?: readonly number[],
 ): Promise<CatalogMigrationConsumerResult> {
-  await assertPromotionGraph(tx);
-  await assertNoMembershipConflicts(tx);
-  return await assertPromotedPairs(tx);
+  await assertPromotionGraph(tx, releaseIds);
+  await assertNoMembershipConflicts(tx, releaseIds);
+  return await assertPromotedPairs(tx, releaseIds);
 }

--- a/openspec/changes/flatten-bottlings-into-bottles/design.md
+++ b/openspec/changes/flatten-bottlings-into-bottles/design.md
@@ -21,7 +21,7 @@ every consumer use one direct Bottle foreign key.
 - Keep BottleGroup as relationship, shared identity-edit intent,
   representative selection, and aggregation scope.
 - Keep grouping outside ordinary user creation and activity workflows.
-- Migrate all data in one retained-audit-gated, fail-fast transaction.
+- Migrate all data in retained-audit-gated, resumable, bounded transactions.
 - Preserve legacy URLs and release ids through durable mappings.
 - Remove the unreleased CatalogTarget implementation rather than maintain two
   identity systems.
@@ -214,31 +214,28 @@ metadata. Evidence generation fails closed unless its database role can execute
 `pg_control_system()` and `pg_is_in_recovery()`; apply may use a different
 writer role but must attest to the same primary cluster and database.
 
-### One fail-fast transaction
+### Resumable bounded transactions
 
-The migration executes once inside one database transaction:
+The migration executes deterministic BottleGroup components in bounded batches:
 
-1. acquire affected tables in a fixed documented order;
-2. rerun collision and integrity preflight under the transaction;
-3. create or validate one BottleGroup per legacy parent;
-4. keep each parent Bottle and assign it to its group;
-5. promote every BottleRelease to a complete Bottle;
-6. create durable release-to-Bottle mappings;
-7. repoint every release-specific consumer Bottle reference to the promoted
-   Bottle while retaining `releaseId` as historical migration evidence until
-   separately approved cleanup;
-8. leave every parent-only Bottle reference on the parent;
-9. materialize aliases, observations, proposals, and attempts with the same
-   direct-Bottle rule;
-10. assert mapping completeness, valid Bottle foreign keys, group membership,
-    uniqueness, counts, and no remaining supported release-specific runtime
-    reference;
-11. commit or roll back everything.
+1. acquire affected tables in a fixed documented order for one bounded batch;
+2. on the first batch, rerun the retained collision and integrity preflight;
+3. create whole BottleGroups, assign every linked legacy parent, and promote
+   every release for those groups;
+4. repoint only those releases' consumers, reserve their aliases, and recompute
+   their Bottle and group statistics;
+5. validate the batch and commit;
+6. emit committed group, parent, and release progress;
+7. on rerun, infer completed components from group assignments and durable
+   promotion mappings, reject half-written components, and skip complete ones;
+8. after all batches commit, run one full postflight validation and audit.
 
-No checkpoint state machine, per-family partial commit, shadow target parity, or
-generic target reconciliation remains. Table locks intentionally queue writes
-for the bounded transaction. Activation must ensure old application and worker
-processes cannot write legacy-only release references after commit.
+Group assignment plus the durable release-to-Bottle mapping form the checkpoint;
+no separate checkpoint table or external state machine is required. A failed
+batch rolls back without discarding earlier complete batches. Table locks
+intentionally queue writes only for each bounded transaction. Activation must
+ensure old application and worker processes cannot write legacy-only release
+references during the migration.
 
 ### Postflight and cleanup
 
@@ -267,8 +264,8 @@ Destructive cleanup requires:
 2. Remove CatalogTarget schema and regenerate the unreleased additive migration.
 3. Replace target loaders, schemas, serializers, and domain services with
    direct Bottle ownership.
-4. Replace the resumable target backfill with one fail-fast direct-Bottle
-   migration transaction and retained pre/post audit.
+4. Replace the target backfill with resumable component-complete direct-Bottle
+   migration batches and retained pre/post audit.
 5. Cut server consumers, routes, workers, statistics, badges, analytics, and
    integrations to Bottle ids.
 6. Cut web workflows and generated clients to Bottle-only selection and
@@ -284,9 +281,9 @@ working, and receive focused verification before commit.
 
 - **A parent-only row may describe a specific but unknown release.** Keeping it
   on the general Bottle preserves recorded knowledge without inventing detail.
-- **A one-shot transaction can block writes.** Use the retained production
-  audit to establish bounded size, lock tables in a fixed order, run during the
-  low-traffic migration window, and fail before mutation on ambiguity.
+- **Migration batches can block writes.** Bound each transaction by complete
+  identity components, print progress after commit, retain resumable
+  checkpoints, and run during the low-traffic migration window.
 - **An old process can write a release reference after migration.** Coordinate
   application/worker activation so legacy writers are stopped or rejected
   before transaction commit.

--- a/openspec/changes/flatten-bottlings-into-bottles/proposal.md
+++ b/openspec/changes/flatten-bottlings-into-bottles/proposal.md
@@ -29,9 +29,10 @@ catalog integrations should never need a second polymorphic target identity.
   only; exact editorial presentation remains on Bottle.
 - Collapse Add Bottle and Add Bottling into one Bottle form with all concrete
   identity fields.
-- Migrate legacy releases and consumer references in one audited, fail-fast
-  transaction after a retained production preflight. Preserve old URLs and API
-  references through durable release-to-Bottle mappings and redirects.
+- Migrate legacy releases and consumer references in audited, resumable,
+  component-complete batches after a retained production preflight. Preserve
+  old URLs and API references through durable release-to-Bottle mappings and
+  redirects.
 - **BREAKING**: retire `BottleRelease`, nested bottling APIs, `releaseId`, and
   the unreleased `CatalogTarget` system after validation and backup approval.
 - Supersede `add-target-aware-catalog-creation`, which would deepen the paired
@@ -65,5 +66,5 @@ None.
   adapters, and nested bottling redirects.
 - Add/edit Bottle forms, Bottle pages, related-release pages, search, Library,
   tasting, price, review, and flight workflows.
-- A retained production preflight, one fail-fast data transaction, postflight
-  validation, and separately approved destructive cleanup.
+- A retained production preflight, resumable bounded data transactions,
+  postflight validation, and separately approved destructive cleanup.

--- a/openspec/changes/flatten-bottlings-into-bottles/specs/direct-bottle-identity/spec.md
+++ b/openspec/changes/flatten-bottlings-into-bottles/specs/direct-bottle-identity/spec.md
@@ -100,8 +100,8 @@ Bottle identity atomically with the consumer mutation.
 
 ### Requirement: Legacy migration is fail-fast and auditable
 
-The system SHALL provide a retained read-only preflight and one all-or-nothing
-database transaction for the initial legacy data migration.
+The system SHALL provide a retained read-only preflight and resumable,
+component-complete database transactions for the initial legacy data migration.
 
 #### Scenario: Run production preflight
 
@@ -114,17 +114,18 @@ database transaction for the initial legacy data migration.
 #### Scenario: Apply the migration
 
 - **WHEN** an approved migration begins
-- **THEN** it locks affected tables in a fixed order
-- **AND** creates or validates groups, promoted Bottles, mappings, aliases, and
-  direct Bottle references in one database transaction
-- **AND** validates all invariants before commit
+- **THEN** each bounded batch locks affected tables in a fixed order
+- **AND** creates or validates whole groups, promoted Bottles, mappings,
+  aliases, scoped direct Bottle references, and statistics atomically
+- **AND** emits progress only after the batch commits
 
 #### Scenario: Migration fails
 
-- **WHEN** any collision, invalid pair, concurrent drift, or final assertion
+- **WHEN** any collision, invalid pair, concurrent drift, or batch assertion
   fails
-- **THEN** the complete transaction rolls back
-- **AND** no partial family or consumer migration remains
+- **THEN** the current batch rolls back
+- **AND** prior committed group checkpoints remain valid
+- **AND** a rerun skips committed groups and resumes unfinished work
 
 #### Scenario: Migration succeeds
 

--- a/openspec/changes/flatten-bottlings-into-bottles/tasks.md
+++ b/openspec/changes/flatten-bottlings-into-bottles/tasks.md
@@ -70,8 +70,8 @@ and map to an explicit removal task.
 
 ## 4. One-Shot Legacy Migration
 
-- [x] 4.1 Replace target/checkpoint migration writers with one transaction
-      owner and one retained read-only pre/post audit boundary.
+- [x] 4.1 Replace target/checkpoint migration writers with one migration owner
+      and one retained read-only pre/post audit boundary.
 - [x] 4.2 Lock affected tables in a documented fixed order and rerun collision
       and integrity preflight before the first mutation.
 - [x] 4.3 Assign every legacy parent Bottle to one migration-created group and
@@ -177,6 +177,9 @@ and map to an explicit removal task.
       Bottle canonicalization instead of treating them as collisions.
 - [x] 7.18 Group legacy parents connected by assigned exact aliases while
       preserving both Bottle identities and the existing alias assignment.
+- [x] 7.19 Preserve legacy tsvector values without re-tokenizing them and make
+      catalog migration batches transactionally complete, resumable from durable
+      graph checkpoints, and observable after each commit.
 
 ## 8. Production Migration And Later Destructive Cleanup
 


### PR DESCRIPTION
The production catalog migration now preserves legacy `tsvector` values without re-tokenizing them, commits complete BottleGroup components in bounded batches, and prints committed group, parent, and release progress. If the process exits after a commit, rerunning the same apply command recognizes durable group assignments and release-promotion mappings and continues with unfinished components.

The previous materialization path passed a serialized `tsvector` through the custom column encoder, changing the value and failing postflight after the entire long-running transaction. Batch validation is now scoped to only the component being committed; completed batches receive only cheap checkpoint-shape classification on resume, followed by one full postflight after all batches finish. Regression coverage simulates an interruption after the first committed batch and verifies that its promoted consumer reference remains durable while the next invocation completes the remaining work.
