### PR TITLE
fix(web): restore compact tasting display

### DIFF
--- a/apps/server/src/orpc/routes/tastings/list.test.ts
+++ b/apps/server/src/orpc/routes/tastings/list.test.ts
@@ -15,6 +15,9 @@ describe("GET /tastings", () => {
     expect(results.find(({ id }) => id === tasting.id)?.bottle.id).toBe(
       bottle.id,
     );
+    expect(results.find(({ id }) => id === tasting.id)?.bottle.group?.id).toBe(
+      bottle.groupId,
+    );
     expect(results[0]).not.toHaveProperty("target");
     expect(results[0]).not.toHaveProperty("release");
   });

--- a/apps/server/src/orpc/routes/tastings/photo-identification-create.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification-create.ts
@@ -281,7 +281,9 @@ export default procedure
       });
     }
     return {
-      bottle: await serialize(BottleSerializer, bottle, user),
+      bottle: await serialize(BottleSerializer, bottle, user, [], {
+        includeGroupSummary: true,
+      }),
       ...(warning ? { warnings: [warning] } : {}),
     };
   });

--- a/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
@@ -375,7 +375,10 @@ describe("POST /tastings/photo-identification", () => {
     expect(response.classification).toMatchObject({
       decision: {
         action: "match",
-        matchedBottle: { id: matchedBottleId },
+        matchedBottle: {
+          id: matchedBottleId,
+          group: { id: matchedBottle.groupId },
+        },
       },
       artifacts: {
         candidates: [
@@ -900,6 +903,7 @@ describe("POST /tastings/photo-identification", () => {
     const bottle = await db.query.bottles.findFirst({
       where: eq(bottles.id, response.bottle.id),
     });
+    expect(response.bottle.group?.id).toBe(bottle?.groupId);
     expect(bottle?.imageUrl).toMatch(
       new RegExp(
         `^/uploads/bottles/bottle-${response.bottle.id}-pending-upload-.+\\.webp$`,

--- a/apps/server/src/orpc/routes/tastings/photo-identification.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.ts
@@ -180,7 +180,13 @@ async function serializePhotoIdentificationClassification(
 
       serializedDecision = {
         action: "match",
-        matchedBottle: await serialize(BottleSerializer, matchedBottle),
+        matchedBottle: await serialize(
+          BottleSerializer,
+          matchedBottle,
+          undefined,
+          [],
+          { includeGroupSummary: true },
+        ),
       };
       break;
     }

--- a/apps/server/src/serializers/tasting.ts
+++ b/apps/server/src/serializers/tasting.ts
@@ -43,6 +43,8 @@ export const TastingSerializer = serializer({
       BottleSerializer,
       bottleList,
       currentUser,
+      [],
+      { includeGroupSummary: true },
     );
     const serializedBottleById = new Map(
       bottleList.map((bottle, index) => [bottle.id, serializedBottles[index]!]),

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -11,6 +11,7 @@ import {
   bottleImageUrl,
   buildActivity,
   buildBottle,
+  buildBottleGroup,
   buildCollectionBottle,
   buildFavoriteActivity,
   buildTasting,
@@ -1299,11 +1300,15 @@ function isExactBottlePhotoScenario(request) {
 }
 
 function buildCreatedBottle({ includeExactBottleDetails = false } = {}) {
-  const bottle = buildBottle({
+  const bottleWithoutGroup = buildBottle({
     id: createdBottleId,
     name: createdBottleName,
     brand: testBrand,
   });
+  const bottle = {
+    ...bottleWithoutGroup,
+    group: buildBottleGroup({ bottle: bottleWithoutGroup }),
+  };
   if (!includeExactBottleDetails) return bottle;
 
   return {

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -61,7 +61,7 @@ test.describe("log tasting", () => {
     await expect(
       page.getByRole("heading", { name: "Log Tasting" }),
     ).toBeVisible();
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(page.getByTitle(existingBottle.fullName)).toBeVisible();
     await page.getByRole("button", { name: "Savor" }).click();
     await page.getByLabel("Comments").fill(tastingNotes);
     const createRequestPromise = waitForTastingCreate(page);

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -144,7 +144,11 @@ export function buildBottle({
   };
 }
 
-export const existingBottle = buildBottle();
+const existingBottleWithoutGroup = buildBottle();
+export const existingBottle = {
+  ...existingBottleWithoutGroup,
+  group: buildBottleGroup({ bottle: existingBottleWithoutGroup }),
+};
 
 export const exactMergeOtherBottle = {
   ...buildBottle({
@@ -322,7 +326,7 @@ export const legacyPromotedBottle = {
  * @param {BottleGroupFixtureOptions} [options]
  * @returns {BottleGroupV1}
  */
-function buildBottleGroup({
+export function buildBottleGroup({
   id,
   fullName,
   name,

--- a/apps/web/src/app/(default)/tastings/page.tsx
+++ b/apps/web/src/app/(default)/tastings/page.tsx
@@ -68,7 +68,10 @@ function TastingList() {
               title: "Bottle",
               className: "min-w-full sm:w-1/2",
               value: (tasting) => (
-                <TastingBottleIdentity bottle={tasting.bottle} compact />
+                <TastingBottleIdentity
+                  bottle={tasting.bottle}
+                  variant="inline"
+                />
               ),
             },
             {

--- a/apps/web/src/components/tastingBottleIdentity.test.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.test.tsx
@@ -7,7 +7,14 @@ import TastingBottleIdentity, {
 
 const bottle = {
   id: 42,
-  fullName: "Lagavulin 21 Cask 42",
+  fullName: "Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42",
+  brand: {
+    name: "Lagavulin",
+    shortName: null,
+  },
+  group: {
+    name: "21",
+  },
   category: "single_malt",
   statedAge: 21,
   abv: 55.1,
@@ -21,17 +28,45 @@ const bottle = {
 } satisfies TastingBottleIdentitySource;
 
 describe("TastingBottleIdentity", () => {
-  it("links the hydrated Bottle and renders its distinguishing fields", () => {
+  it("renders structured identity and exact fields in a panel", () => {
     const html = renderToStaticMarkup(
       <TastingBottleIdentity bottle={bottle} />,
     );
     const text = html.replace(/<[^>]*>/g, "");
 
     expect(html).toContain('href="/bottles/42"');
-    expect(text).toContain("Lagavulin 21 Cask 42");
+    expect(html).toContain(
+      'title="Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42"',
+    );
+    expect(text).toContain("Lagavulin 21");
     expect(text).toContain("Single Malt·21 years·55.1% ABV");
     expect(text).toContain("2004 vintage·2025 release");
     expect(text).toContain("Single cask·Cask strength");
     expect(text).toContain("1st Fill Oloroso Hogshead cask");
+  });
+
+  it("renders the clean name and status chip in the legacy card layout", () => {
+    const html = renderToStaticMarkup(
+      <TastingBottleIdentity bottle={bottle} variant="inline" />,
+    );
+    const text = html.replace(/<[^>]*>/g, "");
+
+    expect(html).toContain(
+      'class="flex items-center space-x-2 overflow-hidden sm:space-x-3 sm:rounded"',
+    );
+    expect(html).not.toContain("border-slate-800");
+    expect(html).not.toContain("bg-slate-950");
+    expect(text).toContain("Lagavulin 21");
+    expect(text).toContain("Single Cask");
+    expect(text).not.toContain("2025 Release");
+    expect(text).not.toContain("55.1% ABV");
+  });
+
+  it("requires the tasting API display identity", () => {
+    expect(() =>
+      renderToStaticMarkup(
+        <TastingBottleIdentity bottle={{ ...bottle, group: undefined }} />,
+      ),
+    ).toThrowError("Tasting bottle is missing its display identity.");
   });
 });

--- a/apps/web/src/components/tastingBottleIdentity.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.tsx
@@ -3,36 +3,62 @@ import BottleExactMetadata, {
   type BottleExactMetadataSource,
 } from "@peated/web/components/bottleExactMetadata";
 import Link from "@peated/web/components/link";
+import SingleCaskChip from "./singleCaskChip";
 
-export type TastingBottleIdentitySource = Pick<Bottle, "id" | "fullName"> &
-  BottleExactMetadataSource;
+export type TastingBottleIdentitySource = Pick<
+  Bottle,
+  "id" | "fullName" | "singleCask"
+> &
+  BottleExactMetadataSource & {
+    brand: Pick<Bottle["brand"], "name" | "shortName">;
+    group?: Pick<NonNullable<Bottle["group"]>, "name">;
+  };
 
 export default function TastingBottleIdentity({
   bottle,
-  compact = false,
+  variant = "panel",
 }: {
   bottle: TastingBottleIdentitySource;
-  compact?: boolean;
+  variant?: "inline" | "panel";
 }) {
-  const content = (
-    <>
-      <Link
-        href={`/bottles/${bottle.id}`}
-        className="font-semibold hover:underline"
-      >
-        {bottle.fullName}
-      </Link>
-      <BottleExactMetadata bottle={bottle} />
-    </>
-  );
+  if (!bottle.group) {
+    throw new Error("Tasting bottle is missing its display identity.");
+  }
 
-  if (compact) {
-    return <div className="min-w-0">{content}</div>;
+  const displayName = `${bottle.brand.shortName || bottle.brand.name} ${bottle.group.name}`;
+
+  if (variant === "inline") {
+    return (
+      <div className="flex items-center space-x-2 overflow-hidden sm:space-x-3 sm:rounded">
+        <div className="flex-1 overflow-hidden">
+          <div className="flex w-full items-center gap-x-1 font-bold">
+            <div className="space-x-1">
+              <h4 className="inline font-bold" title={bottle.fullName}>
+                <Link
+                  href={`/bottles/${bottle.id}`}
+                  className="hover:underline"
+                >
+                  {displayName}
+                </Link>
+              </h4>
+              {bottle.singleCask && <SingleCaskChip />}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
   }
 
   return (
     <div className="rounded border border-slate-800 bg-slate-950 p-4 lg:p-5">
-      {content}
+      <Link
+        href={`/bottles/${bottle.id}`}
+        title={bottle.fullName}
+        className="font-semibold hover:underline"
+      >
+        {displayName}
+      </Link>
+      <BottleExactMetadata bottle={bottle} />
     </div>
   );
 }

--- a/apps/web/src/components/tastingListItem.tsx
+++ b/apps/web/src/components/tastingListItem.tsx
@@ -102,8 +102,8 @@ export default function TastingListItem({
   const canToast = !hasToasted && !isTaster && user;
 
   return (
-    <li className="-mt-1 flex flex-col gap-y-4 overflow-hidden border border-slate-800 bg-gradient-to-r from-slate-950 to-slate-900">
-      <div className="flex items-center space-x-4 px-3 pt-3 lg:px-5 lg:pt-5">
+    <li className="-mt-1 flex flex-col gap-y-2 overflow-hidden border border-slate-800 bg-gradient-to-r from-slate-950 to-slate-900">
+      <div className="flex items-center space-x-4 px-3 pt-3 lg:px-5 lg:pt-4">
         <UserAvatar size={32} user={tasting.createdBy} />
         <div className="flex-auto space-y-1 font-semibold">
           <Link
@@ -125,7 +125,7 @@ export default function TastingListItem({
 
       {!noBottle && (
         <div className="px-3 sm:px-5">
-          <TastingBottleIdentity bottle={tasting.bottle} />
+          <TastingBottleIdentity bottle={tasting.bottle} variant="inline" />
         </div>
       )}
 
@@ -146,7 +146,7 @@ export default function TastingListItem({
       )}
 
       {!!tasting.notes && (
-        <div className="prose prose-invert -my-1 max-w-none px-3 text-sm sm:px-5">
+        <div className="prose prose-invert prose-p:my-0 max-w-none px-3 text-sm sm:px-5">
           <Markdown content={tasting.notes} noLinks />
         </div>
       )}
@@ -156,7 +156,7 @@ export default function TastingListItem({
         tasting.rating ||
         tasting.tags.length > 0) && (
         <div className="text-muted px-3 text-sm sm:px-5">
-          <DefinitionList className="grid-cols grid grid-cols-2 sm:grid-cols-2">
+          <DefinitionList className="grid-cols mb-0 grid grid-cols-2 sm:grid-cols-2 [&>div>dd]:mb-0">
             {tasting.rating && (
               <div>
                 <DefinitionList.Term>Rating</DefinitionList.Term>
@@ -229,7 +229,7 @@ export default function TastingListItem({
         </ul>
       )}
 
-      <aside className="flex items-center space-x-3 px-3 pb-3 lg:px-5 lg:pb-5">
+      <aside className="flex items-center space-x-3 px-3 pb-3 lg:px-5">
         <Button
           icon={
             <HandThumbUpIcon className="-ml-0.5 h-5 w-5" aria-hidden="true" />


### PR DESCRIPTION
Tasting cards and tasting table rows now present the shared bottle identity as the brand plus BottleGroup name, with a single compact Single Cask chip when applicable. Exact `fullName` data remains available for titles and detail-oriented contexts without exposing every release attribute in the feed.

The catalog flattening changed tastings from the previous inline bottle row to a padded exact-identity panel, while several tasting and photo-identification responses did not include the BottleGroup summary needed for the simpler label. This hydrates that summary across tasting feeds and photo-based tasting entry, restores an unboxed inline identity, and removes stacked Markdown and definition-list margins so cards retain a compact vertical rhythm. The affected tasting, activity-feed, and photo-entry workflows pass on both desktop and mobile Playwright projects.
