### PR TITLE
fix(web): render tasting Bottle identity directly

### DIFF
--- a/apps/web/src/components/tastingBottleIdentity.test.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.test.tsx
@@ -8,12 +8,10 @@ import TastingBottleIdentity, {
 const bottle = {
   id: 42,
   fullName: "Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42",
+  name: "21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42",
   brand: {
     name: "Lagavulin",
     shortName: null,
-  },
-  group: {
-    name: "21",
   },
   category: "single_malt",
   statedAge: 21,
@@ -38,7 +36,7 @@ describe("TastingBottleIdentity", () => {
     expect(html).toContain(
       'title="Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42"',
     );
-    expect(text).toContain("Lagavulin 21");
+    expect(text).toContain(bottle.fullName);
     expect(text).toContain("Single Malt·21 years·55.1% ABV");
     expect(text).toContain("2004 vintage·2025 release");
     expect(text).toContain("Single cask·Cask strength");
@@ -56,26 +54,9 @@ describe("TastingBottleIdentity", () => {
     );
     expect(html).not.toContain("border-slate-800");
     expect(html).not.toContain("bg-slate-950");
-    expect(text).toContain("Lagavulin 21");
+    expect(text).toContain(bottle.fullName);
     expect(text).toContain("Single Cask");
-    expect(text).not.toContain("2025 Release");
-    expect(text).not.toContain("55.1% ABV");
+    expect(text).toContain("2025 Release");
+    expect(text).toContain("55.1% ABV");
   });
-
-  it.each(["inline", "panel"] as const)(
-    "falls back to the exact Bottle name in the %s variant",
-    (variant) => {
-      const html = renderToStaticMarkup(
-        <TastingBottleIdentity
-          bottle={{ ...bottle, group: undefined }}
-          variant={variant}
-        />,
-      );
-
-      expect(html).toContain('href="/bottles/42"');
-      expect(html).toContain(
-        "Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42",
-      );
-    },
-  );
 });

--- a/apps/web/src/components/tastingBottleIdentity.test.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.test.tsx
@@ -62,11 +62,20 @@ describe("TastingBottleIdentity", () => {
     expect(text).not.toContain("55.1% ABV");
   });
 
-  it("requires the tasting API display identity", () => {
-    expect(() =>
-      renderToStaticMarkup(
-        <TastingBottleIdentity bottle={{ ...bottle, group: undefined }} />,
-      ),
-    ).toThrowError("Tasting bottle is missing its display identity.");
-  });
+  it.each(["inline", "panel"] as const)(
+    "falls back to the exact Bottle name in the %s variant",
+    (variant) => {
+      const html = renderToStaticMarkup(
+        <TastingBottleIdentity
+          bottle={{ ...bottle, group: undefined }}
+          variant={variant}
+        />,
+      );
+
+      expect(html).toContain('href="/bottles/42"');
+      expect(html).toContain(
+        "Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42",
+      );
+    },
+  );
 });

--- a/apps/web/src/components/tastingBottleIdentity.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.tsx
@@ -7,11 +7,10 @@ import SingleCaskChip from "./singleCaskChip";
 
 export type TastingBottleIdentitySource = Pick<
   Bottle,
-  "id" | "fullName" | "singleCask"
+  "id" | "fullName" | "name" | "singleCask"
 > &
   BottleExactMetadataSource & {
     brand: Pick<Bottle["brand"], "name" | "shortName">;
-    group?: Pick<NonNullable<Bottle["group"]>, "name">;
   };
 
 export default function TastingBottleIdentity({
@@ -21,9 +20,7 @@ export default function TastingBottleIdentity({
   bottle: TastingBottleIdentitySource;
   variant?: "inline" | "panel";
 }) {
-  const displayName = bottle.group
-    ? `${bottle.brand.shortName || bottle.brand.name} ${bottle.group.name}`
-    : bottle.fullName;
+  const displayName = `${bottle.brand.shortName || bottle.brand.name} ${bottle.name}`;
 
   if (variant === "inline") {
     return (

--- a/apps/web/src/components/tastingBottleIdentity.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.tsx
@@ -21,11 +21,9 @@ export default function TastingBottleIdentity({
   bottle: TastingBottleIdentitySource;
   variant?: "inline" | "panel";
 }) {
-  if (!bottle.group) {
-    throw new Error("Tasting bottle is missing its display identity.");
-  }
-
-  const displayName = `${bottle.brand.shortName || bottle.brand.name} ${bottle.group.name}`;
+  const displayName = bottle.group
+    ? `${bottle.brand.shortName || bottle.brand.name} ${bottle.group.name}`
+    : bottle.fullName;
 
   if (variant === "inline") {
     return (


### PR DESCRIPTION
Tasting identity now renders from the selected Bottle's own `brand + name` and
no longer depends on an expanded BottleGroup summary. The canonical `fullName`
remains available as the title, and panel rendering retains the Bottle's exact
metadata.

BottleGroup is relationship context rather than display authority for a
tasting's direct Bottle reference. Removing that dependency also prevents stale
or mixed-version payloads without `bottle.group` from crashing server rendering.
Both inline and panel rendering are covered, and the complete web Vitest suite,
web typecheck, and lint pass.
