### PR TITLE
fix(web): restore tasting bottle visuals

### DIFF
--- a/apps/web/src/app/(default)/tastings/page.tsx
+++ b/apps/web/src/app/(default)/tastings/page.tsx
@@ -2,12 +2,10 @@
 
 import type { Inputs } from "@peated/server/orpc/router";
 import Glyph from "@peated/web/assets/glyph.svg";
+import BottleTable from "@peated/web/components/bottleTable";
 import EmbeddedLogin from "@peated/web/components/embeddedLogin";
 import EmptyActivity from "@peated/web/components/emptyActivity";
 import SimpleHeader from "@peated/web/components/simpleHeader";
-import SimpleRatingIndicator from "@peated/web/components/simpleRatingIndicator";
-import Table from "@peated/web/components/table";
-import TastingBottleIdentity from "@peated/web/components/tastingBottleIdentity";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import useAuth from "@peated/web/hooks/useAuth";
 import { useORPC } from "@peated/web/lib/orpc/context";
@@ -58,44 +56,9 @@ function TastingList() {
       <SimpleHeader>Tastings</SimpleHeader>
 
       {data.results.length > 0 ? (
-        <Table
-          items={data.results}
-          primaryKey={(tasting) => String(tasting.id)}
+        <BottleTable
+          bottleList={data.results.map((tasting) => tasting.bottle)}
           rel={data.rel}
-          columns={[
-            {
-              name: "name",
-              title: "Bottle",
-              className: "min-w-full sm:w-1/2",
-              value: (tasting) => (
-                <TastingBottleIdentity
-                  bottle={tasting.bottle}
-                  variant="inline"
-                />
-              ),
-            },
-            {
-              name: "tastings",
-              value: (tasting) => tasting.bottle.totalTastings.toLocaleString(),
-              className: "sm:w-24",
-            },
-            {
-              name: "rating",
-              value: (tasting) => (
-                <SimpleRatingIndicator avgRating={tasting.bottle.avgRating} />
-              ),
-              className: "sm:w-20",
-              align: "center",
-            },
-            {
-              name: "age",
-              value: (tasting) => {
-                const age = tasting.bottle.statedAge;
-                return age ? `${age} years` : null;
-              },
-              className: "sm:w-24",
-            },
-          ]}
         />
       ) : (
         <EmptyActivity href="/addBottle?intent=tasting">

--- a/apps/web/src/components/tastingBottleIdentity.test.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.test.tsx
@@ -8,25 +8,26 @@ import TastingBottleIdentity, {
 const bottle = {
   id: 42,
   fullName: "Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42",
-  name: "21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42",
   brand: {
     name: "Lagavulin",
     shortName: null,
   },
+  group: {
+    name: "21",
+  },
+  edition: "2025 Release",
   category: "single_malt",
   statedAge: 21,
-  abv: 55.1,
   vintageYear: 2004,
   releaseYear: 2025,
   singleCask: true,
-  caskStrength: true,
-  caskFill: "1st_fill",
-  caskType: "oloroso",
-  caskSize: "hogshead",
+  distillers: [{ id: 7, name: "Lagavulin Distillery" }],
+  isLibrary: true,
+  hasTasted: true,
 } satisfies TastingBottleIdentitySource;
 
 describe("TastingBottleIdentity", () => {
-  it("renders structured identity and exact fields in a panel", () => {
+  it("renders the legacy highlighted bottle card in a panel", () => {
     const html = renderToStaticMarkup(
       <TastingBottleIdentity bottle={bottle} />,
     );
@@ -36,14 +37,15 @@ describe("TastingBottleIdentity", () => {
     expect(html).toContain(
       'title="Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42"',
     );
-    expect(text).toContain(bottle.fullName);
-    expect(text).toContain("Single Malt·21 years·55.1% ABV");
-    expect(text).toContain("2004 vintage·2025 release");
-    expect(text).toContain("Single cask·Cask strength");
-    expect(text).toContain("1st Fill Oloroso Hogshead cask");
+    expect(text).toContain("Lagavulin 21");
+    expect(text).toContain("2025 Release (2025) (2004 Vintage)");
+    expect(text).toContain("·Lagavulin Distillery");
+    expect(text).toContain("Single Malt");
+    expect(text).toContain("Aged 21 years");
+    expect(html).toContain("bg-highlight p-4 text-black lg:p-5");
   });
 
-  it("renders the clean name and status chip in the legacy card layout", () => {
+  it("renders the complete legacy inline bottle card", () => {
     const html = renderToStaticMarkup(
       <TastingBottleIdentity bottle={bottle} variant="inline" />,
     );
@@ -54,9 +56,31 @@ describe("TastingBottleIdentity", () => {
     );
     expect(html).not.toContain("border-slate-800");
     expect(html).not.toContain("bg-slate-950");
-    expect(text).toContain(bottle.fullName);
+    expect(text).toContain("Lagavulin 21");
+    expect(text).toContain("2025 Release (2025) (2004 Vintage)");
+    expect(text).toContain("·Lagavulin Distillery");
+    expect(text).toContain("Single Malt");
+    expect(text).toContain("Aged 21 years");
     expect(text).toContain("Single Cask");
-    expect(text).toContain("2025 Release");
-    expect(text).toContain("55.1% ABV");
+    expect(text).not.toContain("55.1% ABV");
+    expect(html).toContain('data-bottle-status="library"');
+    expect(html).toContain('data-bottle-status="tasted"');
   });
+
+  it.each(["inline", "panel"] as const)(
+    "falls back to the exact Bottle name in the %s variant",
+    (variant) => {
+      const html = renderToStaticMarkup(
+        <TastingBottleIdentity
+          bottle={{ ...bottle, group: undefined }}
+          variant={variant}
+        />,
+      );
+
+      expect(html).toContain('href="/bottles/42"');
+      expect(html).toContain(
+        "Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42",
+      );
+    },
+  );
 });

--- a/apps/web/src/components/tastingBottleIdentity.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.tsx
@@ -1,17 +1,44 @@
+import { formatCategoryName } from "@peated/server/lib/format";
 import type { Bottle } from "@peated/server/types";
-import BottleExactMetadata, {
-  type BottleExactMetadataSource,
-} from "@peated/web/components/bottleExactMetadata";
+import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
+import classNames from "../lib/classNames";
+import Join from "./join";
 import SingleCaskChip from "./singleCaskChip";
 
 export type TastingBottleIdentitySource = Pick<
   Bottle,
-  "id" | "fullName" | "name" | "singleCask"
-> &
-  BottleExactMetadataSource & {
-    brand: Pick<Bottle["brand"], "name" | "shortName">;
-  };
+  | "id"
+  | "fullName"
+  | "edition"
+  | "releaseYear"
+  | "vintageYear"
+  | "singleCask"
+  | "category"
+  | "statedAge"
+  | "isLibrary"
+  | "hasTasted"
+> & {
+  brand: Pick<Bottle["brand"], "name" | "shortName">;
+  distillers: Pick<Bottle["distillers"][number], "id" | "name">[];
+  group?: Pick<NonNullable<Bottle["group"]>, "name">;
+};
+
+function getExactBottleLabel(
+  bottle: TastingBottleIdentitySource,
+  displayName: string,
+) {
+  if (bottle.edition) {
+    return `${bottle.edition}${bottle.releaseYear ? ` (${bottle.releaseYear})` : ""}${bottle.vintageYear ? ` (${bottle.vintageYear} Vintage)` : ""}`;
+  }
+  if (bottle.releaseYear) return `${bottle.releaseYear} Bottling`;
+  if (bottle.vintageYear) return `${bottle.vintageYear} Vintage`;
+
+  const prefix = `${displayName} - `;
+  return bottle.fullName.startsWith(prefix)
+    ? bottle.fullName.slice(prefix.length)
+    : null;
+}
 
 export default function TastingBottleIdentity({
   bottle,
@@ -20,40 +47,78 @@ export default function TastingBottleIdentity({
   bottle: TastingBottleIdentitySource;
   variant?: "inline" | "panel";
 }) {
-  const displayName = `${bottle.brand.shortName || bottle.brand.name} ${bottle.name}`;
-
-  if (variant === "inline") {
-    return (
-      <div className="flex items-center space-x-2 overflow-hidden sm:space-x-3 sm:rounded">
-        <div className="flex-1 overflow-hidden">
-          <div className="flex w-full items-center gap-x-1 font-bold">
-            <div className="space-x-1">
-              <h4 className="inline font-bold" title={bottle.fullName}>
-                <Link
-                  href={`/bottles/${bottle.id}`}
-                  className="hover:underline"
-                >
-                  {displayName}
-                </Link>
-              </h4>
-              {bottle.singleCask && <SingleCaskChip />}
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
+  const displayName = bottle.group
+    ? `${bottle.brand.shortName || bottle.brand.name} ${bottle.group.name}`
+    : bottle.fullName;
+  const exactBottleLabel = getExactBottleLabel(bottle, displayName);
 
   return (
-    <div className="rounded border border-slate-800 bg-slate-950 p-4 lg:p-5">
-      <Link
-        href={`/bottles/${bottle.id}`}
-        title={bottle.fullName}
-        className="font-semibold hover:underline"
+    <div
+      className={classNames(
+        "flex items-center space-x-2 overflow-hidden sm:space-x-3 sm:rounded",
+        variant === "panel" ? "bg-highlight p-4 text-black lg:p-5" : "",
+      )}
+    >
+      <div className="flex-1 overflow-hidden">
+        <div className="flex w-full items-center gap-x-1 font-bold">
+          <div className="space-x-1">
+            <h4 className="inline font-bold" title={bottle.fullName}>
+              <Link href={`/bottles/${bottle.id}`} className="hover:underline">
+                {displayName}
+              </Link>
+            </h4>
+            <BottleStatusIcons bottle={bottle} className="inline h-4 w-4" />
+            {!exactBottleLabel && bottle.singleCask && <SingleCaskChip />}
+          </div>
+        </div>
+        <div
+          className={classNames(
+            "flex flex-row gap-x-1 text-sm",
+            variant === "inline" ? "text-muted" : "",
+          )}
+        >
+          {exactBottleLabel ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <span>{exactBottleLabel}</span>
+              {bottle.singleCask && <SingleCaskChip />}
+            </div>
+          ) : null}
+          {!!(exactBottleLabel && bottle.distillers.length) && (
+            <div>&middot;</div>
+          )}
+          {bottle.distillers.length ? (
+            <Join divider=", ">
+              {bottle.distillers.map((distiller) => (
+                <Link
+                  key={distiller.id}
+                  href={`/entities/${distiller.id}`}
+                  className="hover:underline"
+                >
+                  {distiller.name}
+                </Link>
+              ))}
+            </Join>
+          ) : null}
+        </div>
+      </div>
+      <div
+        className={classNames(
+          variant === "inline" ? "text-muted" : "",
+          "hidden w-[200px] flex-col items-end justify-center whitespace-nowrap text-sm sm:flex",
+        )}
       >
-        {displayName}
-      </Link>
-      <BottleExactMetadata bottle={bottle} />
+        <div className="max-w-full truncate">
+          {bottle.category ? (
+            <Link
+              href={`/bottles?category=${bottle.category}`}
+              className="hover:underline"
+            >
+              {formatCategoryName(bottle.category)}
+            </Link>
+          ) : null}
+        </div>
+        <div>{bottle.statedAge ? `Aged ${bottle.statedAge} years` : null}</div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/tastingForm.tsx
+++ b/apps/web/src/components/tastingForm.tsx
@@ -140,7 +140,7 @@ export default function TastingForm(
       onSave={handleSubmit(onSubmitHandler)}
       saveDisabled={isSubmitting}
     >
-      <div className="lg:mb-8 lg:p-0">
+      <div className="-mt-4 lg:-mt-8 lg:mb-8 lg:p-0">
         <TastingBottleIdentity bottle={props.initialData.bottle} />
       </div>
 

--- a/apps/web/src/components/tastingListItem.tsx
+++ b/apps/web/src/components/tastingListItem.tsx
@@ -102,8 +102,8 @@ export default function TastingListItem({
   const canToast = !hasToasted && !isTaster && user;
 
   return (
-    <li className="-mt-1 flex flex-col gap-y-2 overflow-hidden border border-slate-800 bg-gradient-to-r from-slate-950 to-slate-900">
-      <div className="flex items-center space-x-4 px-3 pt-3 lg:px-5 lg:pt-4">
+    <li className="-mt-1 flex flex-col gap-y-4 overflow-hidden border border-slate-800 bg-gradient-to-r from-slate-950 to-slate-900">
+      <div className="flex items-center space-x-4 px-3 pt-3 lg:px-5 lg:pt-5">
         <UserAvatar size={32} user={tasting.createdBy} />
         <div className="flex-auto space-y-1 font-semibold">
           <Link
@@ -146,7 +146,7 @@ export default function TastingListItem({
       )}
 
       {!!tasting.notes && (
-        <div className="prose prose-invert prose-p:my-0 max-w-none px-3 text-sm sm:px-5">
+        <div className="prose prose-invert -my-1 max-w-none px-3 text-sm sm:px-5">
           <Markdown content={tasting.notes} noLinks />
         </div>
       )}
@@ -156,7 +156,7 @@ export default function TastingListItem({
         tasting.rating ||
         tasting.tags.length > 0) && (
         <div className="text-muted px-3 text-sm sm:px-5">
-          <DefinitionList className="grid-cols mb-0 grid grid-cols-2 sm:grid-cols-2 [&>div>dd]:mb-0">
+          <DefinitionList className="grid-cols grid grid-cols-2 sm:grid-cols-2">
             {tasting.rating && (
               <div>
                 <DefinitionList.Term>Rating</DefinitionList.Term>
@@ -229,7 +229,7 @@ export default function TastingListItem({
         </ul>
       )}
 
-      <aside className="flex items-center space-x-3 px-3 pb-3 lg:px-5">
+      <aside className="flex items-center space-x-3 px-3 pb-3 lg:px-5 lg:pb-5">
         <Button
           icon={
             <HandThumbUpIcon className="-ml-0.5 h-5 w-5" aria-hidden="true" />


### PR DESCRIPTION
Restores the pre-flattening tasting bottle presentation across activity cards, the highlighted bottle on the tasting form, and the tastings table while preserving the direct Bottle and group-aware label behavior introduced in #498. The flattening follow-up had replaced the established visual composition with a metadata panel and custom table, changing spacing, hierarchy, status indicators, and responsive behavior.

The implementation reinstates the previous visual components and spacing without reverting the new identity semantics. Desktop and mobile captures were compared against a checkout from before the bottle-group merge; the activity card produced zero differing pixels, and the tasting-form banner matches the former dimensions, padding, color, and responsive layout. The web component suite passes 108 tests alongside the web typecheck and targeted lint.
