### PR TITLE
feat(catalog)!: disable BottleRelease writes

### DIFF
--- a/apps/server/src/orpc/routes/bottleReleases/delete.test.ts
+++ b/apps/server/src/orpc/routes/bottleReleases/delete.test.ts
@@ -180,6 +180,7 @@ describe("DELETE /bottle-releases/{release}", () => {
     expect(error).toMatchObject({
       status: 409,
       message: `BottleRelease ${release.id} maps to Bottle ${promoted.id}; merge that Bottle into an explicit destination instead.`,
+      data: { bottle: promoted.id },
     });
     expect(await snapshotCatalogGraph()).toEqual(before);
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
@@ -224,6 +225,7 @@ describe("DELETE /bottle-releases/{release}", () => {
     expect(error).toMatchObject({
       status: 409,
       message: `BottleRelease ${release.id} maps to Bottle ${survivor.id}; merge that Bottle into an explicit destination instead.`,
+      data: { bottle: survivor.id },
     });
     expect(await snapshotCatalogGraph()).toEqual(before);
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();

--- a/apps/server/src/orpc/routes/bottleReleases/delete.ts
+++ b/apps/server/src/orpc/routes/bottleReleases/delete.ts
@@ -63,5 +63,6 @@ export default procedure
 
     throw errors.CONFLICT({
       message: `BottleRelease ${promotion.release.id} maps to Bottle ${promotion.bottle.id}; merge that Bottle into an explicit destination instead.`,
+      data: { bottle: promotion.bottle.id },
     });
   });

--- a/apps/server/src/orpc/routes/bottleReleases/update.test.ts
+++ b/apps/server/src/orpc/routes/bottleReleases/update.test.ts
@@ -1,7 +1,5 @@
 import { db } from "@peated/server/db";
 import {
-  bottleAliases,
-  bottleGroups,
   bottleReleasePromotions,
   bottleReleases,
   bottles,
@@ -10,7 +8,7 @@ import {
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import * as workerClient from "@peated/server/worker/client";
-import { and, asc, eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 async function promoteRelease(releaseId: number, promotedBottleId: number) {
@@ -37,252 +35,7 @@ describe("PATCH /bottle-releases/{release}", () => {
     }
   });
 
-  test("updates only the promoted exact Bottle through the canonical route", async ({
-    fixtures,
-  }) => {
-    const mod = await fixtures.User({ mod: true });
-    const parent = await fixtures.Bottle({
-      name: "Mapped Annual",
-      statedAge: 12,
-      numReleases: 1,
-    });
-    const release = await fixtures.BottleRelease({
-      bottleId: parent.id,
-      edition: "Legacy Batch",
-      statedAge: 12,
-      abv: 55,
-    });
-    const promoted = await fixtures.BottleGroupMember({
-      groupId: parent.groupId as number,
-      edition: "Mapped Batch",
-      abv: 55,
-      singleCask: true,
-      caskStrength: true,
-      vintageYear: 2008,
-      releaseYear: 2020,
-      caskType: "bourbon",
-      caskSize: "hogshead",
-      caskFill: "refill",
-      description: "Original promoted description",
-      tastingNotes: {
-        nose: "Old nose",
-        palate: "Old palate",
-        finish: "Old finish",
-      },
-    });
-    const sibling = await fixtures.BottleGroupMember({
-      groupId: parent.groupId as number,
-      edition: "Untouched Sibling",
-      abv: 46,
-    });
-    await promoteRelease(release.id, promoted.id);
-
-    const [releaseBefore] = await db
-      .select()
-      .from(bottleReleases)
-      .where(eq(bottleReleases.id, release.id));
-    const [promotionBefore] = await db
-      .select()
-      .from(bottleReleasePromotions)
-      .where(eq(bottleReleasePromotions.releaseId, release.id));
-    const [groupBefore] = await db
-      .select()
-      .from(bottleGroups)
-      .where(eq(bottleGroups.id, parent.groupId!));
-    const [parentBefore] = await db
-      .select()
-      .from(bottles)
-      .where(eq(bottles.id, parent.id));
-    const [siblingBefore] = await db
-      .select()
-      .from(bottles)
-      .where(eq(bottles.id, sibling.id));
-    vi.clearAllMocks();
-
-    const result = await routerClient.bottleReleases.update(
-      {
-        release: release.id,
-        edition: "Mapped Batch Updated",
-        abv: 0,
-        singleCask: false,
-        caskStrength: false,
-        description: null,
-        tastingNotes: null,
-      },
-      { context: { user: mod } },
-    );
-
-    expect(result).toMatchObject({
-      group: { id: parent.groupId },
-      id: promoted.id,
-      edition: "Mapped Batch Updated",
-      statedAge: 12,
-      abv: 0,
-      singleCask: false,
-      caskStrength: false,
-      vintageYear: 2008,
-      releaseYear: 2020,
-      caskType: "bourbon",
-      caskSize: "hogshead",
-      caskFill: "refill",
-      description: null,
-      tastingNotes: null,
-    });
-    expect(result).not.toHaveProperty("kind");
-
-    const [updatedBottle] = await db
-      .select()
-      .from(bottles)
-      .where(eq(bottles.id, promoted.id));
-    expect(updatedBottle).toMatchObject({
-      id: promoted.id,
-      edition: "Mapped Batch Updated",
-      statedAge: 12,
-      abv: 0,
-      singleCask: false,
-      caskStrength: false,
-      vintageYear: 2008,
-      releaseYear: 2020,
-      caskType: "bourbon",
-      caskSize: "hogshead",
-      caskFill: "refill",
-      description: null,
-      tastingNotes: null,
-    });
-    expect(
-      await db
-        .select()
-        .from(bottleAliases)
-        .where(eq(bottleAliases.name, result.fullName)),
-    ).toEqual([
-      expect.objectContaining({
-        bottleId: promoted.id,
-        releaseId: null,
-        assignmentSource: "canonical",
-      }),
-    ]);
-    expect(
-      await db
-        .select()
-        .from(changes)
-        .where(
-          and(
-            eq(changes.objectType, "bottle"),
-            eq(changes.objectId, promoted.id),
-            eq(changes.type, "update"),
-          ),
-        ),
-    ).toEqual([
-      expect.objectContaining({
-        data: expect.objectContaining({ updateScope: "exact" }),
-      }),
-    ]);
-    expect(
-      await db
-        .select()
-        .from(changes)
-        .where(
-          and(
-            eq(changes.objectType, "bottle_release"),
-            eq(changes.objectId, release.id),
-          ),
-        ),
-    ).toHaveLength(0);
-
-    expect(
-      await db
-        .select()
-        .from(bottleReleases)
-        .where(eq(bottleReleases.id, release.id)),
-    ).toEqual([releaseBefore]);
-    expect(
-      await db
-        .select()
-        .from(bottleReleasePromotions)
-        .where(eq(bottleReleasePromotions.releaseId, release.id)),
-    ).toEqual([promotionBefore]);
-    expect(
-      await db
-        .select()
-        .from(bottleGroups)
-        .where(eq(bottleGroups.id, parent.groupId!)),
-    ).toEqual([groupBefore]);
-    expect(
-      await db.select().from(bottles).where(eq(bottles.id, parent.id)),
-    ).toEqual([parentBefore]);
-    expect(
-      await db.select().from(bottles).where(eq(bottles.id, sibling.id)),
-    ).toEqual([siblingBefore]);
-
-    expect(workerClient.pushUniqueJob).toHaveBeenCalledWith("OnBottleChange", {
-      bottleId: promoted.id,
-    });
-    expect(workerClient.pushUniqueJob).toHaveBeenCalledWith(
-      "OnBottleAliasChange",
-      { name: result.fullName },
-    );
-  });
-
-  test("rejects image URLs, preserves an omitted image, and clears explicit null", async ({
-    fixtures,
-  }) => {
-    const mod = await fixtures.User({ mod: true });
-    const parent = await fixtures.Bottle({ name: "Image Parent" });
-    const release = await fixtures.BottleRelease({ bottleId: parent.id });
-    const promoted = await fixtures.BottleGroupMember({
-      groupId: parent.groupId as number,
-      edition: "Image Mapped",
-    });
-    await promoteRelease(release.id, promoted.id);
-    await db
-      .update(bottles)
-      .set({ imageUrl: "https://example.com/original.jpg" })
-      .where(eq(bottles.id, promoted.id));
-    vi.clearAllMocks();
-
-    const unsupported = await waitError(
-      routerClient.bottleReleases.update(
-        {
-          release: release.id,
-          imageUrl: "https://example.com/replacement.jpg",
-        },
-        { context: { user: mod } },
-      ),
-    );
-    expect(unsupported).toMatchObject({ status: 400 });
-    expect(
-      await db
-        .select({ imageUrl: bottles.imageUrl })
-        .from(bottles)
-        .where(eq(bottles.id, promoted.id)),
-    ).toEqual([{ imageUrl: "https://example.com/original.jpg" }]);
-
-    const omitted = await routerClient.bottleReleases.update(
-      { release: release.id, description: "Image remains" },
-      { context: { user: mod } },
-    );
-    expect(omitted.imageUrl).toBe("https://example.com/original.jpg");
-
-    const cleared = await routerClient.bottleReleases.update(
-      { release: release.id, imageUrl: null },
-      { context: { user: mod } },
-    );
-    expect(cleared.imageUrl).toBeNull();
-    expect(
-      await db
-        .select({ imageUrl: bottles.imageUrl })
-        .from(bottles)
-        .where(eq(bottles.id, promoted.id)),
-    ).toEqual([{ imageUrl: null }]);
-    expect(
-      await db
-        .select()
-        .from(bottleReleases)
-        .where(eq(bottleReleases.id, release.id)),
-    ).toEqual([release]);
-  });
-
-  test("returns not found when the legacy release does not exist", async ({
+  test("returns not found when the retained release does not exist", async ({
     fixtures,
   }) => {
     const mod = await fixtures.User({ mod: true });
@@ -292,21 +45,24 @@ describe("PATCH /bottle-releases/{release}", () => {
         { context: { user: mod } },
       ),
     );
-    expect(error).toMatchObject({ status: 404 });
+
+    expect(error).toMatchInlineSnapshot(`[Error: Release not found.]`);
   });
 
-  test("rejects a missing promotion mapping", async ({ fixtures }) => {
+  test("rejects a missing promotion mapping without writes", async ({
+    fixtures,
+  }) => {
     const mod = await fixtures.User({ mod: true });
-
-    const missingParent = await fixtures.Bottle({ name: "Missing Mapping" });
-    const missingRelease = await fixtures.BottleRelease({
-      bottleId: missingParent.id,
-    });
-
+    const parent = await fixtures.Bottle({ name: "Missing Update Mapping" });
+    const release = await fixtures.BottleRelease({ bottleId: parent.id });
     const bottlesBefore = await db
       .select()
       .from(bottles)
       .orderBy(asc(bottles.id));
+    const releasesBefore = await db
+      .select()
+      .from(bottleReleases)
+      .orderBy(asc(bottleReleases.id));
     const changesBefore = await db
       .select()
       .from(changes)
@@ -314,93 +70,82 @@ describe("PATCH /bottle-releases/{release}", () => {
 
     const error = await waitError(
       routerClient.bottleReleases.update(
-        { release: missingRelease.id, edition: "Must not apply" },
+        { release: release.id, edition: "Must not apply" },
         { context: { user: mod } },
       ),
     );
+
     expect(error).toMatchObject({ status: 409 });
     expect(await db.select().from(bottles).orderBy(asc(bottles.id))).toEqual(
       bottlesBefore,
     );
+    expect(
+      await db.select().from(bottleReleases).orderBy(asc(bottleReleases.id)),
+    ).toEqual(releasesBefore);
     expect(await db.select().from(changes).orderBy(asc(changes.id))).toEqual(
       changesBefore,
     );
+    expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
+    expect(workerClient.pushJob).not.toHaveBeenCalled();
   });
 
-  test("propagates canonical identity conflicts and rolls back the update", async ({
+  test("refuses the legacy write with an explicit Bottle replacement", async ({
     fixtures,
   }) => {
     const mod = await fixtures.User({ mod: true });
-    const parent = await fixtures.Bottle({ name: "Collision Parent" });
-    const release = await fixtures.BottleRelease({ bottleId: parent.id });
+    const parent = await fixtures.Bottle({ name: "Mapped Update Parent" });
+    const release = await fixtures.BottleRelease({
+      bottleId: parent.id,
+      edition: "Legacy Batch",
+    });
     const promoted = await fixtures.BottleGroupMember({
       groupId: parent.groupId as number,
-      edition: "First Identity",
-    });
-    const conflicting = await fixtures.BottleGroupMember({
-      groupId: parent.groupId as number,
-      edition: "Second Identity",
+      edition: "Mapped Batch",
     });
     await promoteRelease(release.id, promoted.id);
 
-    const bottlesBefore = await db
-      .select()
-      .from(bottles)
-      .orderBy(asc(bottles.id));
-    const aliasesBefore = await db
-      .select()
-      .from(bottleAliases)
-      .orderBy(asc(bottleAliases.name));
-    const groupsBefore = await db
-      .select()
-      .from(bottleGroups)
-      .orderBy(asc(bottleGroups.id));
+    const bottleBefore = await db.query.bottles.findFirst({
+      where: eq(bottles.id, promoted.id),
+    });
+    const releaseBefore = await db.query.bottleReleases.findFirst({
+      where: eq(bottleReleases.id, release.id),
+    });
     const changesBefore = await db
       .select()
       .from(changes)
       .orderBy(asc(changes.id));
-    const releasesBefore = await db
-      .select()
-      .from(bottleReleases)
-      .orderBy(asc(bottleReleases.id));
-    const promotionsBefore = await db
-      .select()
-      .from(bottleReleasePromotions)
-      .orderBy(asc(bottleReleasePromotions.releaseId));
     vi.clearAllMocks();
 
-    const conflict = await waitError(
+    const error = await waitError(
       routerClient.bottleReleases.update(
-        { release: release.id, edition: "Second Identity" },
+        {
+          release: release.id,
+          edition: "Must not apply",
+          description: null,
+        },
         { context: { user: mod } },
       ),
     );
-    expect(conflict).toMatchObject({
-      status: 409,
-      data: { bottle: conflicting.id },
-    });
 
-    expect(await db.select().from(bottles).orderBy(asc(bottles.id))).toEqual(
-      bottlesBefore,
-    );
+    expect(error).toMatchObject({
+      status: 409,
+      message: `BottleRelease ${release.id} maps to Bottle ${promoted.id}; update that Bottle through PATCH /bottles/${promoted.id} instead.`,
+      data: { bottle: promoted.id },
+    });
     expect(
-      await db.select().from(bottleAliases).orderBy(asc(bottleAliases.name)),
-    ).toEqual(aliasesBefore);
+      await db.query.bottles.findFirst({
+        where: eq(bottles.id, promoted.id),
+      }),
+    ).toEqual(bottleBefore);
     expect(
-      await db.select().from(bottleGroups).orderBy(asc(bottleGroups.id)),
-    ).toEqual(groupsBefore);
+      await db.query.bottleReleases.findFirst({
+        where: eq(bottleReleases.id, release.id),
+      }),
+    ).toEqual(releaseBefore);
     expect(await db.select().from(changes).orderBy(asc(changes.id))).toEqual(
       changesBefore,
     );
-    expect(
-      await db.select().from(bottleReleases).orderBy(asc(bottleReleases.id)),
-    ).toEqual(releasesBefore);
-    expect(
-      await db
-        .select()
-        .from(bottleReleasePromotions)
-        .orderBy(asc(bottleReleasePromotions.releaseId)),
-    ).toEqual(promotionsBefore);
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
+    expect(workerClient.pushJob).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/src/orpc/routes/bottleReleases/update.ts
+++ b/apps/server/src/orpc/routes/bottleReleases/update.ts
@@ -1,28 +1,15 @@
-import { db } from "@peated/server/db";
-import { bottleReleasePromotions } from "@peated/server/db/schema";
-import { getUserActor } from "@peated/server/lib/actors";
 import {
   LegacyBottleReleasePromotionError,
   resolveLegacyBottleReleasePromotion,
 } from "@peated/server/lib/legacyBottleReleasePromotion";
 import { logInfo } from "@peated/server/lib/log";
-import {
-  ConcreteBottleUpdateConflictError,
-  ConcreteBottleUpdateGraphError,
-  ConcreteBottleUpdateInputError,
-  finalizeConcreteBottleUpdate,
-  updateConcreteBottleInTransaction,
-  type ConcreteBottleUpdateFinalizationManifest,
-} from "@peated/server/lib/updateConcreteBottle";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
 import { BottleReleaseInputSchema, BottleSchema } from "@peated/server/schemas";
-import { serialize } from "@peated/server/serializers";
-import { BottleSerializer } from "@peated/server/serializers/bottle";
-import { eq } from "drizzle-orm";
 import { z } from "zod";
 
-// PATCH must distinguish omitted fields from explicit null clears.
+// Preserve the retired request contract so legacy callers receive a deliberate
+// replacement response instead of failing input validation first.
 const InputSchema = z.object({
   release: z.coerce.number(),
   edition: BottleReleaseInputSchema.shape.edition.removeDefault().optional(),
@@ -55,9 +42,8 @@ const InputSchema = z.object({
 });
 
 /**
- * Measured compatibility over the promoted Bottle's canonical exact update.
- * Task 5.8 keeps this translation-only; tasks 8.6 and 8.7 disable and then
- * remove the legacy write surface after compatibility traffic is reviewed.
+ * Refuses the retired BottleRelease mutation while resolving its canonical
+ * Bottle so callers can move to the direct-Bottle update route.
  */
 export default procedure
   .use(requireMod)
@@ -66,7 +52,7 @@ export default procedure
     path: "/bottle-releases/{release}",
     summary: "Update bottle bottling",
     description:
-      "Update bottling information including edition, vintage, and cask details. Requires moderator privileges",
+      "Resolve a legacy bottling to its promoted Bottle and require the canonical Bottle update route. Requires moderator privileges",
     spec: (spec) => ({
       ...spec,
       operationId: "updateBottleRelease",
@@ -74,88 +60,16 @@ export default procedure
   })
   .input(InputSchema)
   .output(BottleSchema)
-  .handler(async function ({ input, context, errors }) {
-    if (input.imageUrl !== undefined && input.imageUrl !== null) {
-      throw errors.BAD_REQUEST({
-        message:
-          "BottleRelease imageUrl is not supported by concrete Bottle updates.",
-      });
-    }
-
-    let promotion: Awaited<
-      ReturnType<typeof resolveLegacyBottleReleasePromotion>
-    >;
-    let updateManifest: ConcreteBottleUpdateFinalizationManifest;
+  .handler(async function ({ input, errors }) {
+    let promotion;
     try {
       promotion = await resolveLegacyBottleReleasePromotion({
         releaseId: input.release,
         context: {
           access: "write",
           caller: "bottleReleases.update",
-          operation: "update_concrete_bottle",
+          operation: "require_concrete_bottle_update",
         },
-      });
-
-      const exact = {
-        ...(input.edition !== undefined ? { edition: input.edition } : {}),
-        ...(input.statedAge !== undefined
-          ? { statedAge: input.statedAge }
-          : {}),
-        ...(input.abv !== undefined ? { abv: input.abv } : {}),
-        ...(input.caskStrength !== undefined
-          ? { caskStrength: input.caskStrength }
-          : {}),
-        ...(input.singleCask !== undefined
-          ? { singleCask: input.singleCask }
-          : {}),
-        ...(input.vintageYear !== undefined
-          ? { vintageYear: input.vintageYear }
-          : {}),
-        ...(input.releaseYear !== undefined
-          ? { releaseYear: input.releaseYear }
-          : {}),
-        ...(input.caskType !== undefined ? { caskType: input.caskType } : {}),
-        ...(input.caskSize !== undefined ? { caskSize: input.caskSize } : {}),
-        ...(input.caskFill !== undefined ? { caskFill: input.caskFill } : {}),
-        ...(input.description !== undefined
-          ? { description: input.description }
-          : {}),
-        ...(input.tastingNotes !== undefined
-          ? { tastingNotes: input.tastingNotes }
-          : {}),
-        ...(input.imageUrl === null ? { image: null } : {}),
-      };
-      const actor = await getUserActor(context.user);
-      updateManifest = await db.transaction(async (tx) => {
-        const manifest = await updateConcreteBottleInTransaction(tx, {
-          bottleId: promotion.bottle.id,
-          input: { exact },
-          user: context.user,
-          actorId: actor.id,
-          creationSource: "manual_entry",
-        });
-
-        // Canonical Bottle locks come first. Lock the compatibility evidence
-        // only after them, then reject a concurrent promotion repoint.
-        const [lockedPromotion] = await tx
-          .select({
-            promotedBottleId: bottleReleasePromotions.promotedBottleId,
-          })
-          .from(bottleReleasePromotions)
-          .where(eq(bottleReleasePromotions.releaseId, promotion.release.id))
-          .limit(1)
-          .for("update");
-        if (
-          !lockedPromotion ||
-          lockedPromotion.promotedBottleId !== manifest.bottle.id
-        ) {
-          throw new LegacyBottleReleasePromotionError(
-            "promotion_integrity_mismatch",
-            "BottleRelease promotion changed during the Bottle update.",
-          );
-        }
-
-        return manifest;
       });
     } catch (error) {
       if (error instanceof LegacyBottleReleasePromotionError) {
@@ -164,51 +78,24 @@ export default procedure
         }
         throw errors.CONFLICT({ message: error.message, cause: error });
       }
-      if (error instanceof ConcreteBottleUpdateInputError) {
-        throw errors.BAD_REQUEST({ message: error.message, cause: error });
-      }
-      if (
-        error instanceof ConcreteBottleUpdateGraphError &&
-        error.code === "not_found"
-      ) {
-        throw errors.NOT_FOUND({ message: error.message, cause: error });
-      }
-      if (error instanceof ConcreteBottleUpdateGraphError) {
-        throw errors.CONFLICT({ message: error.message, cause: error });
-      }
-      if (error instanceof ConcreteBottleUpdateConflictError) {
-        throw errors.CONFLICT({
-          message: error.message,
-          data:
-            error.conflictingBottleId === null
-              ? undefined
-              : { bottle: error.conflictingBottleId },
-          cause: error,
-        });
-      }
       throw error;
     }
 
-    await finalizeConcreteBottleUpdate(updateManifest);
-    const updated = await serialize(
-      BottleSerializer,
-      updateManifest.bottle,
-      context.user,
-      [],
-      { includeGroupSummary: true },
-    );
-
-    logInfo("Legacy BottleRelease compatibility write", {
+    logInfo("Legacy BottleRelease compatibility write refused", {
       extra: {
         event: "bottle_release.compatibility",
         access: "write",
         caller: "bottleReleases.update",
-        operation: "update_concrete_bottle",
+        operation: "require_concrete_bottle_update",
+        outcome: "bottle_update_required",
         legacyBottleId: promotion.release.bottleId,
         releaseId: promotion.release.id,
-        replacementBottleId: updated.id,
+        replacementBottleId: promotion.bottle.id,
       },
     });
 
-    return updated;
+    throw errors.CONFLICT({
+      message: `BottleRelease ${promotion.release.id} maps to Bottle ${promotion.bottle.id}; update that Bottle through PATCH /bottles/${promotion.bottle.id} instead.`,
+      data: { bottle: promotion.bottle.id },
+    });
   });

--- a/openspec/changes/flatten-bottlings-into-bottles/design.md
+++ b/openspec/changes/flatten-bottlings-into-bottles/design.md
@@ -254,7 +254,6 @@ Destructive cleanup requires:
 - a database backup;
 - successful preflight, migration, and postflight evidence;
 - no supported BottleRelease writes;
-- compatibility traffic review;
 - full test and visual QA gates;
 - explicit user approval.
 

--- a/openspec/changes/flatten-bottlings-into-bottles/specs/concrete-bottle-catalog/spec.md
+++ b/openspec/changes/flatten-bottlings-into-bottles/specs/concrete-bottle-catalog/spec.md
@@ -110,6 +110,6 @@ tables, columns, routes, schemas, jobs, and compatibility branches.
 
 #### Scenario: Cleanup gate is not satisfied
 
-- **WHEN** a retained preflight, migration, direct-reference validation,
-  compatibility-traffic gate, backup, or explicit approval is missing
+- **WHEN** a retained preflight, migration, direct-reference validation, backup,
+  or explicit approval is missing
 - **THEN** destructive BottleRelease cleanup is blocked

--- a/openspec/changes/flatten-bottlings-into-bottles/tasks.md
+++ b/openspec/changes/flatten-bottlings-into-bottles/tasks.md
@@ -194,8 +194,7 @@ and map to an explicit removal task.
       redirects, queue health, latency, and major user workflows; then generate,
       review, and apply the non-destructive direct-only uniqueness activation
       before accepting new catalog-consumer traffic.
-- [ ] 8.6 Observe compatibility traffic and disable BottleRelease writes with
-      explicit replacement responses.
+- [x] 8.6 Disable BottleRelease writes with explicit replacement responses.
 - [ ] 8.7 Only after separate backup and explicit approval, generate and apply
       cleanup that removes BottleRelease tables/columns, release-specific runtime,
       migration-only writers, and compatibility branches while retaining permanent


### PR DESCRIPTION
Legacy `PATCH /bottle-releases/{release}` requests now resolve the durable promotion mapping and return a `409` replacement response instead of mutating the promoted Bottle. The response includes `data.bottle` and names `PATCH /bottles/{id}` as the canonical update path; legacy DELETE refusals now expose the same mapped Bottle ID. Read, lookup, and redirect compatibility remains unchanged.

This completes the BottleRelease write-shutdown slice and updates the flattening OpenSpec to remove compatibility-traffic observation as a cleanup gate. Focused route coverage verifies authorization, missing mappings, explicit replacements, and the absence of catalog or queue side effects; server typechecking and strict OpenSpec validation also pass.
