### PR TITLE
fix(web): show total Library count

### DIFF
--- a/apps/web/src/app/(default)/users/[username]/libraryTabLabel.test.ts
+++ b/apps/web/src/app/(default)/users/[username]/libraryTabLabel.test.ts
@@ -3,11 +3,10 @@ import { formatLibraryTabLabel } from "./libraryTabLabel";
 
 describe("formatLibraryTabLabel", () => {
   test.each([
-    [{ open: 2, sealed: 3 }, "Library (2 open/3 sealed)"],
-    [{ open: 2, sealed: 0 }, "Library (2 open)"],
-    [{ open: 0, sealed: 3 }, "Library (3 sealed)"],
-    [{ open: 0, sealed: 0 }, "Library"],
-  ])("formats status counts", (counts, expected) => {
+    [{ total: 5 }, "Library (5)"],
+    [{ total: 0 }, "Library (0)"],
+    [{ total: 1234 }, "Library (1,234)"],
+  ])("formats the total bottle count", (counts, expected) => {
     expect(formatLibraryTabLabel(counts)).toBe(expected);
   });
 });

--- a/apps/web/src/app/(default)/users/[username]/libraryTabLabel.ts
+++ b/apps/web/src/app/(default)/users/[username]/libraryTabLabel.ts
@@ -1,18 +1,7 @@
-type LibraryStatusCounts = {
-  open: number;
-  sealed: number;
+type LibraryCounts = {
+  total: number;
 };
 
-export function formatLibraryTabLabel({
-  open,
-  sealed,
-}: LibraryStatusCounts): string {
-  const statusCounts = [
-    open > 0 ? `${open.toLocaleString()} open` : null,
-    sealed > 0 ? `${sealed.toLocaleString()} sealed` : null,
-  ].filter((count): count is string => count !== null);
-
-  return statusCounts.length
-    ? `Library (${statusCounts.join("/")})`
-    : "Library";
+export function formatLibraryTabLabel({ total }: LibraryCounts): string {
+  return `Library (${total.toLocaleString()})`;
 }


### PR DESCRIPTION
The profile Library tab now shows the status-independent bottle total (`Library (5)`) instead of splitting the label into open and sealed counts. Empty and localized totals remain explicit (`Library (0)` and `Library (1,234)`), with formatter coverage for each case.
