### PR TITLE
fix(web): refine library presentation

### DIFF
--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -21,7 +21,6 @@ import {
   createdTastingId,
   destinationBottleGroup,
   destinationBottleGroupId,
-  emptyLibraryStats,
   emptyList,
   exactMatchedBottle,
   exactMatchedBottleId,
@@ -34,6 +33,7 @@ import {
   flightBottleFixture,
   flightBottleFixtureId,
   groupedBottleDetails,
+  libraryInsightsStats,
   missingBottleId,
   photoTastingNotes,
   priceChangeList,
@@ -760,11 +760,10 @@ async function handleRpcRequest({ request, response, url }) {
         sendRpcResponse(response, testUser);
         return true;
       }
-
       sendRpcError(response, "Unexpected user details payload");
       return true;
     case "users/libraryStats":
-      sendRpcResponse(response, emptyLibraryStats);
+      sendRpcResponse(response, libraryInsightsStats);
       return true;
     case "users/badgeList":
       sendRpcResponse(response, emptyList);

--- a/apps/web/e2e/profile-library.spec.ts
+++ b/apps/web/e2e/profile-library.spec.ts
@@ -17,6 +17,53 @@ import {
 import { signIn } from "./session";
 
 test.describe("profile library", () => {
+  test("stretches the age profile to match the distillery card", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: [
+        testAccessToken,
+        "library-insights",
+        testInfo.project.name,
+      ].join("-"),
+    });
+
+    await page.goto(`/users/${testUser.username}/library`, {
+      waitUntil: "commit",
+    });
+
+    const ageCard = page
+      .getByRole("heading", { name: "Age profile" })
+      .locator("xpath=../..");
+    const distilleryCard = page
+      .getByRole("heading", { name: "Top distilleries" })
+      .locator("xpath=../..");
+    const ageChart = ageCard.locator("[data-age-profile-chart]");
+
+    await expect(ageCard).toBeVisible();
+    await expect(distilleryCard).toBeVisible();
+    await expect(ageChart).toBeVisible();
+
+    if (!testInfo.project.name.includes("mobile")) {
+      const [ageCardBox, distilleryCardBox, ageChartBox] = await Promise.all([
+        ageCard.boundingBox(),
+        distilleryCard.boundingBox(),
+        ageChart.boundingBox(),
+      ]);
+
+      expect(ageCardBox).not.toBeNull();
+      expect(distilleryCardBox).not.toBeNull();
+      expect(ageChartBox).not.toBeNull();
+      expect(
+        Math.abs(ageCardBox!.height - distilleryCardBox!.height),
+      ).toBeLessThan(2);
+      expect(ageChartBox!.height).toBeGreaterThan(140);
+    }
+
+    await expectNoHorizontalOverflow(page);
+  });
+
   test("renders a Bottle-owned image on the detail page", async ({
     context,
     page,
@@ -124,6 +171,15 @@ test.describe("profile library", () => {
     await expect(
       page.getByText("No library bottles recorded yet."),
     ).toHaveCount(0);
+
+    const statusButton = savedBottleRow.locator(
+      'button[data-status="unset"]:visible',
+    );
+    await statusButton.click();
+    await page.getByRole("menuitem", { name: "Sealed" }).click();
+    await expect(
+      savedBottleRow.locator('button[data-status="sealed"]:visible'),
+    ).toBeVisible();
 
     await page.goto("/library", {
       waitUntil: "commit",

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -32,20 +32,26 @@ export const testUser = {
   },
 };
 
-export const emptyLibraryStats = {
-  total: 0,
-  distillers: [],
+export const libraryInsightsStats = {
+  total: 76,
+  distillers: [
+    { id: 101, name: "Laphroaig", count: 8 },
+    { id: 102, name: "Caol Ila", count: 4 },
+    { id: 103, name: "Highland Park", count: 3 },
+    { id: 104, name: "Woodinville Whiskey Co.", count: 3 },
+    { id: 105, name: "Ardbeg", count: 2 },
+  ],
   age: {
-    knownCount: 0,
-    median: null,
-    oldest: null,
+    knownCount: 54,
+    median: 15.5,
+    oldest: 52,
     buckets: [
-      { id: "under10", label: "Under 10", count: 0 },
-      { id: "from10To12", label: "10–12", count: 0 },
-      { id: "from13To17", label: "13–17", count: 0 },
-      { id: "from18To24", label: "18–24", count: 0 },
-      { id: "atLeast25", label: "25+", count: 0 },
-      { id: "unstated", label: "Unstated", count: 0 },
+      { id: "under10", label: "Under 10", count: 13 },
+      { id: "from10To12", label: "10–12", count: 6 },
+      { id: "from13To17", label: "13–17", count: 11 },
+      { id: "from18To24", label: "18–24", count: 12 },
+      { id: "atLeast25", label: "25+", count: 12 },
+      { id: "unstated", label: "Unstated", count: 22 },
     ],
   },
   categories: [],

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
@@ -40,6 +40,8 @@ describe("LibraryInsightsContent", () => {
     expect(html).toContain("Median 12 yr");
     expect(html).toContain("Under 10: 1 bottle");
     expect(html).toContain("Age stated for 3 of 4 bottles");
+    expect(html).toContain("data-age-profile-chart");
+    expect(html).toContain("min-h-28 flex-1");
     expect(html).not.toContain("Library types");
   });
 

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
@@ -81,7 +81,7 @@ function InsightCard({
   children: ReactNode;
 }) {
   return (
-    <section className="rounded border border-slate-800 bg-slate-950/70 p-3">
+    <section className="flex h-full flex-col rounded border border-slate-800 bg-slate-950/70 p-3">
       <div className="mb-3 flex min-h-8 items-start justify-between gap-3">
         <h2 className="text-sm font-semibold text-white">{title}</h2>
         {detail ? (
@@ -117,7 +117,11 @@ function AgeDistribution({ stats }: { stats: LibraryStats }) {
 
   return (
     <InsightCard title="Age profile" detail={detail}>
-      <div className="grid h-28 grid-cols-6 gap-1" aria-hidden="true">
+      <div
+        className="grid min-h-28 flex-1 grid-cols-6 gap-1"
+        data-age-profile-chart
+        aria-hidden="true"
+      >
         {stats.age.buckets.map((bucket) => (
           <div key={bucket.id} className="flex min-w-0 flex-col items-center">
             <span className="text-muted mb-1 h-4 text-[10px] tabular-nums">

--- a/apps/web/src/components/bottleIdentity.test.tsx
+++ b/apps/web/src/components/bottleIdentity.test.tsx
@@ -1,7 +1,10 @@
 import type { Bottle } from "@peated/server/types";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
-import BottleIdentity, { getRelativeBottleIdentity } from "./bottleIdentity";
+import BottleIdentity, {
+  getAbsoluteBottleTitle,
+  getRelativeBottleIdentity,
+} from "./bottleIdentity";
 
 function makeBottle(overrides: Partial<Bottle> = {}): Bottle {
   return {
@@ -73,6 +76,70 @@ describe("BottleIdentity", () => {
     expect(html).not.toContain(">12 years<");
     expect(html).not.toContain(">Cask strength</span>");
     expect(html).toContain('title="Springbank 12 Cask Strength Batch 24"');
+  });
+
+  it("moves canonical metadata out of ungrouped Library headlines", () => {
+    const bottle = makeBottle({
+      name: "Whiskyland - Chapter Thirty Three - 52-year-old - 2026 Release - 1973 Vintage - 53.2% ABV",
+      fullName:
+        "Decadent Drinks Whiskyland - Chapter Thirty Three - 52-year-old - 2026 Release - 1973 Vintage - 53.2% ABV",
+      group: undefined,
+      edition: "Chapter Thirty Three",
+      statedAge: 52,
+      releaseYear: 2026,
+      vintageYear: 1973,
+      abv: 53.2,
+      caskStrength: false,
+    });
+    const html = renderToStaticMarkup(
+      <BottleIdentity bottle={bottle} mode="absolute" />,
+    );
+
+    expect(getAbsoluteBottleTitle(bottle)).toBe(
+      "Whiskyland - Chapter Thirty Three",
+    );
+    expect(html).toContain(">Whiskyland - Chapter Thirty Three</a>");
+    expect(html).toContain(">52 years</span>");
+    expect(html).toContain(">2026 release</span>");
+    expect(html).toContain(">1973 vintage</span>");
+    expect(html).toContain(">53.2% ABV</span>");
+  });
+
+  it("strips canonical cask traits while preserving the product and edition", () => {
+    expect(
+      getAbsoluteBottleTitle(
+        makeBottle({
+          name: "Glenrothes - Individual Cask Release - 23-year-old - 2021 Release - 1997 Vintage - Single Cask - Cask Strength",
+          group: undefined,
+          edition: "Individual Cask Release",
+          statedAge: 23,
+          releaseYear: 2021,
+          vintageYear: 1997,
+          abv: null,
+          singleCask: true,
+          caskStrength: true,
+        }),
+      ),
+    ).toBe("Glenrothes - Individual Cask Release");
+  });
+
+  it("keeps metadata-only names as the absolute headline", () => {
+    const bottle = makeBottle({
+      name: "21-year-old",
+      group: undefined,
+      edition: null,
+      statedAge: 21,
+      releaseYear: null,
+      abv: null,
+      caskStrength: false,
+    });
+    const html = renderToStaticMarkup(
+      <BottleIdentity bottle={bottle} mode="absolute" />,
+    );
+
+    expect(getAbsoluteBottleTitle(bottle)).toBe("21-year-old");
+    expect(html).toContain(">21-year-old</a>");
+    expect(html).not.toContain(">21 years</span>");
   });
 
   it("uses every modeled exact branch before falling back to the name", () => {

--- a/apps/web/src/components/bottleIdentity.tsx
+++ b/apps/web/src/components/bottleIdentity.tsx
@@ -1,3 +1,4 @@
+import { toTitleCase } from "@peated/server/lib/strings";
 import type { Bottle } from "@peated/server/types";
 import Link from "@peated/web/components/link";
 import type { ReactNode } from "react";
@@ -33,6 +34,51 @@ type RelativeIdentity = {
 
 function formatAbv(abv: number) {
   return `${abv.toFixed(1)}% ABV`;
+}
+
+function getCanonicalMetadataSegments(bottle: BottleIdentitySource) {
+  return new Set(
+    [
+      bottle.statedAge !== null ? `${bottle.statedAge}-year-old` : undefined,
+      bottle.releaseYear !== null ? `${bottle.releaseYear} Release` : undefined,
+      bottle.vintageYear !== null ? `${bottle.vintageYear} Vintage` : undefined,
+      bottle.abv !== null ? formatAbv(bottle.abv) : undefined,
+      bottle.singleCask ? "Single Cask" : undefined,
+      bottle.caskStrength ? "Cask Strength" : undefined,
+      bottle.caskType ? `${toTitleCase(bottle.caskType)} Cask` : undefined,
+      bottle.caskSize ? toTitleCase(bottle.caskSize) : undefined,
+      bottle.caskFill
+        ? bottle.caskFill === "other"
+          ? "Other Fill"
+          : toTitleCase(bottle.caskFill)
+        : undefined,
+    ]
+      .filter((value): value is string => value !== undefined)
+      .map((value) => value.toLocaleLowerCase()),
+  );
+}
+
+/**
+ * Removes only canonical trailing metadata from an ungrouped Bottle name.
+ * A metadata-only name remains intact so identities such as "21-year-old"
+ * still have a useful headline.
+ */
+export function getAbsoluteBottleTitle(bottle: BottleIdentitySource) {
+  if (bottle.group) return bottle.group.name;
+
+  const metadataSegments = getCanonicalMetadataSegments(bottle);
+  const titleSegments = bottle.name.split(" - ");
+
+  while (
+    titleSegments.length &&
+    metadataSegments.has(
+      titleSegments[titleSegments.length - 1]!.toLocaleLowerCase(),
+    )
+  ) {
+    titleSegments.pop();
+  }
+
+  return titleSegments.length ? titleSegments.join(" - ") : bottle.name;
 }
 
 function getEditionMetadataDuplicates(
@@ -197,7 +243,7 @@ export default function BottleIdentity({
   const relativeIdentity = getRelativeBottleIdentity(bottle);
   const isAbsolute = mode === "absolute";
   const title = isAbsolute
-    ? (bottle.group?.name ?? bottle.name)
+    ? getAbsoluteBottleTitle(bottle)
     : relativeIdentity.label;
   const leadingContent =
     isAbsolute && bottle.group && !relativeIdentity.fallback

--- a/apps/web/src/components/libraryEntryActions.test.ts
+++ b/apps/web/src/components/libraryEntryActions.test.ts
@@ -1,8 +1,11 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import { QueryClient, type QueryKey } from "@tanstack/react-query";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
 import {
+  LibraryEntryStatusMenu,
   removeCollectionBottleFromListCaches,
   replaceCollectionBottleInListCaches,
 } from "./libraryEntryActions";
@@ -215,5 +218,26 @@ describe("Library entry list caches", () => {
     expect(updatedFirstList?.rel).toBe(firstList.rel);
     expect(updatedFilteredList?.rel).toBe(filteredList.rel);
     expect(queryClient.getQueryData(unrelatedQueryKey)).toBe(unrelatedData);
+  });
+});
+
+describe("Library entry status menu", () => {
+  it("renders the current status as a compact semantic control", () => {
+    const html = renderToStaticMarkup(
+      createElement(LibraryEntryStatusMenu, {
+        value: "sealed",
+        disabled: false,
+        onChange: () => {},
+      }),
+    );
+
+    expect(html).toContain("Sealed");
+    expect(html).toContain('data-status="sealed"');
+    expect(html).toContain("rounded-full");
+    expect(html).toContain("border-emerald");
+    expect(html).toContain("bg-emerald");
+    expect(html).toContain(
+      'aria-label="Change bottle status, current status Sealed"',
+    );
   });
 });

--- a/apps/web/src/components/libraryEntryActions.tsx
+++ b/apps/web/src/components/libraryEntryActions.tsx
@@ -344,7 +344,7 @@ export function LibraryEntryStatus({ entry }: { entry: CollectionBottle }) {
   return <CollectionBottleStatusLabel status={entry.status} />;
 }
 
-function LibraryEntryStatusMenu({
+export function LibraryEntryStatusMenu({
   value,
   disabled,
   onChange,
@@ -361,8 +361,14 @@ function LibraryEntryStatusMenu({
       <MenuButton
         type="button"
         disabled={disabled}
+        data-status={value ?? "unset"}
         aria-label={`Change bottle status, current status ${label}`}
-        className="text-muted inline-flex h-7 items-center gap-1 text-xs font-medium transition-colors hover:text-white disabled:cursor-auto disabled:opacity-70"
+        className={classNames(
+          "focus-visible:outline-peated inline-flex h-7 min-w-20 items-center justify-between gap-1.5 rounded-full border px-2.5 text-xs font-semibold shadow-sm transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-auto disabled:opacity-70",
+          currentMeta
+            ? currentMeta.labelClassName
+            : "border-slate-700 bg-slate-900 text-slate-300 hover:border-slate-600 hover:text-white",
+        )}
       >
         {label}
         <ChevronDownIcon className="h-3.5 w-3.5" aria-hidden="true" />


### PR DESCRIPTION
Library rows now keep ungrouped bottle headlines concise instead of dumping canonical full names into the title. The fallback removes only canonical trailing metadata such as age, vintage, release year, strength, and cask details, preserving actual product names and metadata-only titles such as `21-year-old`.

Editable library status controls now use compact semantic pills for sealed, open, empty, and unset bottles, making the current state easier to scan without looking like a generic select field.

The age-profile plot also fills the available insight-card height so it aligns with the top-distiller chart. Regression coverage includes the reported long-name and age-distribution cases, semantic status styling, and desktop/mobile browser checks for equal-height cards and horizontal overflow.

Validated with the web Vitest suite (122 tests), web typecheck, targeted lint, and the full desktop/mobile profile-library Playwright spec (10 tests).
