### PR TITLE
ref(web): simplify manual Bottle entry

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -58,7 +58,7 @@ test.describe("create bottle", () => {
     expect(currentUrl.pathname).toBe("/bottles/new");
     expect(currentUrl.searchParams.get("name")).toBe(createdBottleName);
     await expect(
-      page.getByRole("heading", { name: "Create Bottle" }),
+      page.getByRole("heading", { name: "Add Bottle" }),
     ).toBeVisible();
   });
 
@@ -81,15 +81,19 @@ test.describe("create bottle", () => {
     );
 
     await expect(
-      page.getByRole("heading", { name: "Create Bottle" }),
+      page.getByRole("heading", { name: "Add Bottle" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("textbox", { name: "Bottle", exact: true }),
+      page.getByRole("textbox", { name: "Bottle Name", exact: true }),
     ).toHaveValue(createdBottleName);
-    await expect(page.getByLabel("Edition / Label")).toBeVisible();
-    await expect(page.getByLabel("ABV")).toBeVisible();
+    const moreDetails = page.getByRole("button", { name: /More Details/ });
+    await expect(moreDetails).toHaveAttribute("aria-expanded", "false");
+    await moreDetails.click();
+    await expect(moreDetails).toHaveAttribute("aria-expanded", "true");
+    await expect(page.getByLabel("Edition or Batch")).toBeVisible();
+    await expect(page.getByLabel("Alcohol (ABV)")).toBeVisible();
     await expect(page.getByLabel("Release Year")).toBeVisible();
-    await expect(page.getByLabel("Vintage Year")).toBeVisible();
+    await expect(page.getByLabel("Distillation Year")).toBeVisible();
     await expect(page.getByText("Single Cask", { exact: true })).toBeVisible();
     await expect(
       page.getByText("Cask Strength", { exact: true }),
@@ -105,10 +109,10 @@ test.describe("create bottle", () => {
     await page.getByRole("button", { name: testBrand.name }).click();
     await expect(page.getByPlaceholder("Search")).toBeHidden();
 
-    await page.getByLabel("Edition / Label").fill("Founder's Cask");
-    await page.getByLabel("ABV").fill("58.7");
+    await page.getByLabel("Edition or Batch").fill("Founder's Cask");
+    await page.getByLabel("Alcohol (ABV)").fill("58.7");
     await page.getByLabel("Release Year").fill("2025");
-    await page.getByLabel("Vintage Year").fill("2009");
+    await page.getByLabel("Distillation Year").fill("2009");
     await toggleBottleBoolean(page, "Single Cask");
     await toggleBottleBoolean(page, "Cask Strength");
     await selectSimpleBottleField(page, "Cask Fill", "1st Fill");
@@ -116,7 +120,7 @@ test.describe("create bottle", () => {
     await selectSimpleBottleField(page, "Cask Size", "Hogshead");
 
     const createRequestPromise = waitForBottleCreate(page);
-    await page.getByRole("button", { name: "Create Bottle" }).click();
+    await page.getByRole("button", { name: "Add Bottle" }).click();
     const createInput = getRpcInput(await createRequestPromise);
 
     expect(createRequests).toHaveLength(1);
@@ -298,14 +302,14 @@ test.describe("create bottle", () => {
     await page.goto("/bottles/new?proposal=9901&returnAction=library");
 
     await expect(
-      page.getByRole("heading", { name: "Create Bottle" }),
+      page.getByRole("heading", { name: "Add Bottle" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("textbox", { name: "Bottle", exact: true }),
+      page.getByRole("textbox", { name: "Bottle Name", exact: true }),
     ).toHaveValue(createdBottleName);
 
     const libraryRequestPromise = waitForCollectionBottleCreate(page);
-    await page.getByRole("button", { name: "Create Bottle" }).click();
+    await page.getByRole("button", { name: "Add Bottle" }).click();
     const libraryInput = getRpcInput(await libraryRequestPromise);
 
     expect(libraryInput.bottle).toBe(createdBottleId);
@@ -342,7 +346,7 @@ test.describe("create bottle", () => {
     const imageUpdateRequestPromise = page.waitForRequest((request) =>
       request.url().includes("/rpc/bottles/imageUpdate"),
     );
-    await page.getByRole("button", { name: "Create Bottle" }).click();
+    await page.getByRole("button", { name: "Add Bottle" }).click();
     await imageUpdateRequestPromise;
 
     await expect(page).toHaveURL(/\/addBottle\?/);
@@ -368,7 +372,7 @@ test.describe("create bottle", () => {
     await page
       .locator('input[type="file"][name="image"]')
       .setInputFiles(buildImageFile("replacement-label.png"));
-    await page.getByRole("button", { name: "Create Bottle" }).click();
+    await page.getByRole("button", { name: "Add Bottle" }).click();
 
     await expect(page).toHaveURL(
       new RegExp(`/addBottle\\?bottle=${createdBottleId}&intent=addBottle$`),
@@ -397,18 +401,18 @@ test.describe("create bottle", () => {
     await page.goto(`/bottles/${existingBottleId}/addRelease`);
 
     await expect(
-      page.getByRole("heading", { name: "Add a similar bottle" }),
+      page.getByRole("heading", { name: "Add a Similar Bottle" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("textbox", { name: "Bottle", exact: true }),
+      page.getByRole("textbox", { name: "Bottle Name", exact: true }),
     ).toHaveValue(addAnotherReleaseSourceBottle.group.name);
-    await expect(page.getByLabel("Stated Age")).toHaveValue(
+    await expect(page.getByLabel("Age Statement")).toHaveValue(
       String(addAnotherReleaseSourceBottle.statedAge),
     );
-    await expect(page.getByLabel("Edition / Label")).toHaveValue(
+    await expect(page.getByLabel("Edition or Batch")).toHaveValue(
       addAnotherReleaseSourceBottle.edition,
     );
-    await expect(page.getByLabel("ABV")).toHaveValue(
+    await expect(page.getByLabel("Alcohol (ABV)")).toHaveValue(
       String(addAnotherReleaseSourceBottle.abv),
     );
     await expect(page.getByLabel("Release Year")).toHaveValue(
@@ -418,7 +422,7 @@ test.describe("create bottle", () => {
     await expect(page.getByLabel("Source Bottle")).toHaveCount(0);
 
     const createRequestPromise = waitForBottleCreate(page);
-    await page.getByRole("button", { name: "Create Bottle" }).click();
+    await page.getByRole("button", { name: "Add Bottle" }).click();
     const createInput = getRpcInput(await createRequestPromise);
 
     expect(createRequests).toHaveLength(1);
@@ -452,9 +456,9 @@ test.describe("create bottle", () => {
     await page.goto(`/bottles/new?name=${encodeURIComponent("Hogback")}`);
 
     await expect(
-      page.getByRole("heading", { name: "Create Bottle" }),
+      page.getByRole("heading", { name: "Add Bottle" }),
     ).toBeVisible();
-    await page.getByRole("button", { name: "Create Bottle" }).click();
+    await page.getByRole("button", { name: "Add Bottle" }).click();
 
     await expect(page.getByText("Brand is required.")).toBeVisible();
     await page.getByText("e.g. Laphroaig").click();
@@ -1350,15 +1354,15 @@ test.describe("add bottle flow", () => {
 
     await page.getByRole("link", { name: "Create Bottle" }).click();
     await expect(
-      page.getByRole("heading", { name: "Create Bottle" }),
+      page.getByRole("heading", { name: "Add Bottle" }),
     ).toBeVisible();
     await expect(
-      page.getByRole("textbox", { name: "Bottle", exact: true }),
+      page.getByRole("textbox", { name: "Bottle Name", exact: true }),
     ).toHaveValue(createdBottleName);
     await expect(
       page.getByRole("button", { name: testBrand.name }).first(),
     ).toBeVisible();
-    await page.getByRole("button", { name: "Create Bottle" }).click();
+    await page.getByRole("button", { name: "Add Bottle" }).click();
 
     await expect(page).toHaveURL(/\/addBottle\?/);
     const createdUrl = new URL(page.url());
@@ -1411,7 +1415,7 @@ test.describe("add bottle flow", () => {
     );
     await page.getByRole("button", { name: "Remove Image" }).click();
     await expect(page.getByAltText("uploaded image")).toBeHidden();
-    await page.getByRole("button", { name: "Create Bottle" }).click();
+    await page.getByRole("button", { name: "Add Bottle" }).click();
 
     await expect(page).toHaveURL(/\/addBottle\?/);
     const createdUrl = new URL(page.url());
@@ -1525,11 +1529,9 @@ async function expectFooterBelowAction(action: Locator, footer: Locator) {
 }
 
 async function submitCreateBottle(page: Page) {
+  await expect(page.getByRole("heading", { name: "Add Bottle" })).toBeVisible();
   await expect(
-    page.getByRole("heading", { name: "Create Bottle" }),
-  ).toBeVisible();
-  await expect(
-    page.getByRole("textbox", { name: "Bottle", exact: true }),
+    page.getByRole("textbox", { name: "Bottle Name", exact: true }),
   ).toHaveValue(createdBottleName);
 
   await page.getByText("e.g. Laphroaig").click();
@@ -1537,5 +1539,5 @@ async function submitCreateBottle(page: Page) {
   await page.getByRole("button", { name: testBrand.name }).click();
   await expect(page.getByPlaceholder("Search")).toBeHidden();
 
-  await page.getByRole("button", { name: "Create Bottle" }).click();
+  await page.getByRole("button", { name: "Add Bottle" }).click();
 }

--- a/apps/web/e2e/unified-bottle-workflows.spec.ts
+++ b/apps/web/e2e/unified-bottle-workflows.spec.ts
@@ -108,18 +108,18 @@ test.describe("unified Bottle workflows", () => {
     );
 
     await expect(
-      page.getByRole("heading", { name: "Add a similar bottle" }),
+      page.getByRole("heading", { name: "Add a Similar Bottle" }),
     ).toBeVisible();
-    await expect(page.getByLabel("Bottle", { exact: true })).toHaveValue(
+    await expect(page.getByLabel("Bottle Name", { exact: true })).toHaveValue(
       createdBottleName,
     );
     await expect(
       page.getByText(testBrand.name, { exact: true }).first(),
     ).toBeVisible();
-    await expect(page.getByLabel("Stated Age")).toHaveValue(
+    await expect(page.getByLabel("Age Statement")).toHaveValue(
       String(anotherReleaseSourceBottle.statedAge),
     );
-    await expect(page.getByLabel("Edition / Label")).toHaveValue(
+    await expect(page.getByLabel("Edition or Batch")).toHaveValue(
       "First Fill Oloroso",
     );
     await expect(page.getByLabel("Release Year")).toHaveValue("2026");
@@ -128,7 +128,7 @@ test.describe("unified Bottle workflows", () => {
     const createRequestPromise = page.waitForRequest((request) =>
       request.url().includes("/rpc/prices/matchQueue/createBottle"),
     );
-    await page.getByRole("button", { name: "Create Bottle" }).click();
+    await page.getByRole("button", { name: "Add Bottle" }).click();
     const input = getRpcInput(await createRequestPromise);
 
     expect(Object.keys(input).sort()).toEqual([
@@ -158,7 +158,7 @@ test.describe("unified Bottle workflows", () => {
     await expect(page).toHaveURL(new RegExp(`${returnTo}$`));
   });
 
-  test("renders shared and exact Bottle edit ownership", async ({
+  test("keeps exact age ownership behind the unified Bottle form", async ({
     context,
     page,
   }, testInfo) => {
@@ -172,35 +172,25 @@ test.describe("unified Bottle workflows", () => {
     await expect(
       page.getByRole("heading", { name: "Edit Bottle" }),
     ).toBeVisible();
-    await expect(page.getByLabel("Bottle", { exact: true })).toHaveValue(
+    await expect(page.getByLabel("Bottle Name", { exact: true })).toHaveValue(
       unifiedBottleEditContext.shared.name,
     );
-    await expect(page.getByLabel("Shared Stated Age")).toHaveValue(
-      String(unifiedBottleEditContext.shared.statedAge),
-    );
-    await expect(page.getByLabel("Bottle-specific Stated Age")).toHaveValue(
+    await expect(page.getByLabel("Age Statement")).toHaveValue(
       String(unifiedBottleEditContext.exact.statedAge),
     );
-    const showsPreviewMetadata = (page.viewportSize()?.width ?? 0) >= 640;
-    const initialPreviewAge = page.getByText(
-      `Aged ${unifiedBottleEditContext.exact.statedAge} years`,
-      { exact: true },
+    await expect(page.getByLabel("Shared Stated Age")).toHaveCount(0);
+    await expect(page.getByLabel("Bottle-specific Stated Age")).toHaveCount(0);
+    const preview = page.getByRole("region", { name: "Bottle preview" });
+    await expect(preview).toContainText(
+      `${unifiedBottleEditContext.exact.statedAge} years`,
     );
-    await expect(initialPreviewAge).toHaveText(
-      `Aged ${unifiedBottleEditContext.exact.statedAge} years`,
-    );
-    if (showsPreviewMetadata) {
-      await expect(initialPreviewAge).toBeVisible();
-    } else {
-      await expect(initialPreviewAge).toBeHidden();
-    }
-    await expect(page.getByLabel("Edition / Label")).toHaveValue(
+    await expect(page.getByLabel("Edition or Batch")).toHaveValue(
       unifiedBottleEditContext.exact.edition,
     );
-    await expect(page.getByLabel("ABV")).toHaveValue(
+    await expect(page.getByLabel("Alcohol (ABV)")).toHaveValue(
       String(unifiedBottleEditContext.exact.abv),
     );
-    await expect(page.getByLabel("Vintage Year")).toHaveValue(
+    await expect(page.getByLabel("Distillation Year")).toHaveValue(
       String(unifiedBottleEditContext.exact.vintageYear),
     );
     await expect(page.getByLabel("Release Year")).toHaveValue(
@@ -208,42 +198,31 @@ test.describe("unified Bottle workflows", () => {
     );
     await expect(
       page.getByRole("group", { name: "Release family details" }),
-    ).toContainText(
-      "Changes here update all 3 Bottles in this release family.",
-    );
+    ).toHaveCount(0);
     await expect(
       page.getByRole("group", { name: "Exact Bottle details" }),
-    ).toBeVisible();
-    const preview = page.getByRole("region", { name: "Bottle preview" });
+    ).toHaveCount(0);
     await expect(preview).toContainText("Cask 42");
     await expect(preview).toContainText("55.1% ABV");
-    await expect(preview).toContainText("2023 Release");
-    await expect(preview).toContainText("2004 Vintage");
+    await expect(preview).toContainText("2023 release");
+    await expect(preview).toContainText("2004 vintage");
     await expect(page.getByText("Edit Bottling", { exact: true })).toHaveCount(
       0,
     );
 
-    await page.getByLabel("Edition / Label").fill("Cask 43");
+    await page.getByLabel("Edition or Batch").fill("Cask 43");
     await expect(preview).toContainText("Cask 43");
     await expect(preview).not.toContainText("Cask 42");
-    await page.getByLabel("Shared Stated Age").fill("19");
-    await page.getByLabel("Bottle-specific Stated Age").fill("22");
-    const updatedPreviewAge = page.getByText("Aged 22 years", { exact: true });
-    await expect(updatedPreviewAge).toHaveText("Aged 22 years");
-    if (showsPreviewMetadata) {
-      await expect(updatedPreviewAge).toBeVisible();
-    } else {
-      await expect(updatedPreviewAge).toBeHidden();
-    }
+    await page.getByLabel("Age Statement").fill("22");
+    await expect(preview).toContainText("22 years");
 
     const updateRequestPromise = page.waitForRequest((request) =>
       request.url().includes("/rpc/bottles/update"),
     );
-    await page.getByRole("button", { name: "Save" }).click();
+    await page.getByRole("button", { name: "Save Changes" }).click();
     const updateInput = getRpcInput(await updateRequestPromise);
     expect(updateInput).toEqual({
       bottle: existingBottleId,
-      shared: { statedAge: 19 },
       exact: { edition: "Cask 43", statedAge: 22 },
     });
     await expectNoHorizontalOverflow(page);

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/addRelease/layout.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/addRelease/layout.tsx
@@ -3,5 +3,5 @@ import { type Metadata } from "next";
 export { default } from "@peated/web/components/defaultLayout";
 
 export const metadata: Metadata = {
-  title: "Add a similar bottle",
+  title: "Add a Similar Bottle",
 };

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/addRelease/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/addRelease/page.tsx
@@ -61,7 +61,7 @@ function AddSimilarBottleForm({ bottleId }: { bottleId: string }) {
 
   if (proposalId && proposalQuery.isLoading) return <Spinner />;
   if (!sourceBottle.group) {
-    throw new Error("Adding a similar Bottle requires a BottleGroup summary.");
+    throw new Error("Adding a similar Bottle requires source Bottle details.");
   }
 
   const initialData = {
@@ -75,8 +75,8 @@ function AddSimilarBottleForm({ bottleId }: { bottleId: string }) {
 
   return (
     <BottleForm
-      title="Add a similar bottle"
-      saveLabel="Create Bottle"
+      title="Add a Similar Bottle"
+      saveLabel="Add Bottle"
       returnTo={returnTo}
       initialData={initialData}
       onSubmit={async ({ image, ...data }) => {

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/buildConcreteBottleUpdateInput.test.ts
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/buildConcreteBottleUpdateInput.test.ts
@@ -12,7 +12,6 @@ function formValue(
   return {
     name: "Springbank 12 Cask Strength",
     statedAge: 12,
-    exactStatedAge: null,
     series: null,
     category: "single_malt",
     brand: 1,
@@ -43,7 +42,7 @@ function submitMeta(
 }
 
 describe("buildConcreteBottleUpdateInput", () => {
-  test("omits both scopes when neither stated-age control is dirty", () => {
+  test("omits both scopes when the age field is not dirty", () => {
     expect(
       buildConcreteBottleUpdateInput(
         formValue({ statedAge: 18 }),
@@ -58,20 +57,22 @@ describe("buildConcreteBottleUpdateInput", () => {
     ).toEqual({ exact: { edition: "Batch 24", abv: 57.2 } });
   });
 
-  test("routes the Bottle-specific age to the exact patch", () => {
+  test("routes an exact-owned age without exposing a second form field", () => {
     expect(
       buildConcreteBottleUpdateInput(
-        formValue({ exactStatedAge: 15 }),
-        submitMeta("exactStatedAge"),
+        formValue({ statedAge: 15 }),
+        submitMeta("statedAge"),
+        { statedAgeScope: "exact" },
       ),
     ).toEqual({ exact: { statedAge: 15 } });
   });
 
-  test("clears the Bottle-specific override without changing shared age", () => {
+  test("clears an exact-owned age without changing shared values", () => {
     expect(
       buildConcreteBottleUpdateInput(
-        formValue({ statedAge: 12, exactStatedAge: null }),
-        submitMeta("exactStatedAge"),
+        formValue({ statedAge: null }),
+        submitMeta("statedAge"),
+        { statedAgeScope: "exact" },
       ),
     ).toEqual({ exact: { statedAge: null } });
   });
@@ -97,7 +98,6 @@ describe("buildConcreteBottleUpdateInput", () => {
           bottler: 7,
           flavorProfile: "deep_rich_dried_fruit",
           singleCask: true,
-          exactStatedAge: 15,
           vintageYear: 2012,
           caskSize: "hogshead",
           caskType: "oloroso",
@@ -113,7 +113,6 @@ describe("buildConcreteBottleUpdateInput", () => {
           "bottler",
           "flavorProfile",
           "edition",
-          "exactStatedAge",
           "abv",
           "singleCask",
           "caskStrength",
@@ -139,7 +138,6 @@ describe("buildConcreteBottleUpdateInput", () => {
       },
       exact: {
         edition: "Batch 24",
-        statedAge: 15,
         abv: 57.2,
         singleCask: true,
         caskStrength: true,

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/buildConcreteBottleUpdateInput.ts
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/buildConcreteBottleUpdateInput.ts
@@ -9,18 +9,29 @@ type ExactPatch = NonNullable<ConcreteBottleUpdateInput["exact"]>;
 
 /**
  * Partitions only dirty fields rendered by the live form into sparse
- * shared/exact patches. The two stated-age controls preserve their distinct
- * shared and Bottle-specific ownership; non-rendered tasting notes stay untouched.
+ * shared/exact patches. The edit context keeps stated-age ownership internal
+ * while the form presents one effective value.
  */
 export function buildConcreteBottleUpdateInput(
   value: BottleFormSubmitValue,
   { dirtyFields }: BottleFormSubmitMeta,
+  {
+    statedAgeScope = "shared",
+  }: {
+    statedAgeScope?: "shared" | "exact";
+  } = {},
 ): ConcreteBottleUpdateInput {
   const shared: SharedPatch = {};
   const exact: ExactPatch = {};
 
   if (dirtyFields.has("name")) shared.name = value.name;
-  if (dirtyFields.has("statedAge")) shared.statedAge = value.statedAge;
+  if (dirtyFields.has("statedAge")) {
+    if (statedAgeScope === "exact") {
+      exact.statedAge = value.statedAge;
+    } else {
+      shared.statedAge = value.statedAge;
+    }
+  }
   if (dirtyFields.has("series")) shared.series = value.series;
   if (dirtyFields.has("category")) shared.category = value.category;
   if (dirtyFields.has("brand")) shared.brand = value.brand;
@@ -31,9 +42,6 @@ export function buildConcreteBottleUpdateInput(
   }
 
   if (dirtyFields.has("edition")) exact.edition = value.edition;
-  if (dirtyFields.has("exactStatedAge")) {
-    exact.statedAge = value.exactStatedAge ?? null;
-  }
   if (dirtyFields.has("abv")) exact.abv = value.abv;
   if (dirtyFields.has("singleCask")) exact.singleCask = value.singleCask;
   if (dirtyFields.has("caskStrength")) {

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
@@ -45,7 +45,10 @@ function BottleEditForm({ bottleId }: { bottleId: string }) {
         const { image } = value;
         await bottleUpdateMutation.mutateAsync({
           bottle: context.bottleId,
-          ...buildConcreteBottleUpdateInput(value, meta),
+          ...buildConcreteBottleUpdateInput(value, meta, {
+            statedAgeScope:
+              context.exact.statedAge === null ? "shared" : "exact",
+          }),
         });
 
         if (image) {
@@ -71,11 +74,10 @@ function BottleEditForm({ bottleId }: { bottleId: string }) {
       initialData={{
         ...context.shared,
         ...context.exact,
-        statedAge: context.shared.statedAge,
+        statedAge: context.exact.statedAge ?? context.shared.statedAge,
       }}
-      exactStatedAge={context.exact.statedAge}
-      sharedIdentityBottleCount={context.totalBottles}
       title="Edit Bottle"
+      saveLabel="Save Changes"
     />
   );
 }

--- a/apps/web/src/app/(layout-free)/bottles/new/layout.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/new/layout.tsx
@@ -2,9 +2,9 @@ import { type Metadata } from "next";
 
 export { default } from "@peated/web/components/defaultLayout";
 
-// Create Bottle is a focused form workflow, matching other layout-free bottle
+// Manual Bottle entry is a focused form workflow, matching other layout-free Bottle
 // edit/add-release routes instead of the browse list sidebar.
 export const metadata: Metadata = {
-  title: "Create Bottle",
+  title: "Add Bottle",
   alternates: { canonical: "https://peated.com/bottles/new" },
 };

--- a/apps/web/src/app/(layout-free)/bottles/new/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/new/page.tsx
@@ -274,8 +274,8 @@ function CreateBottleForm() {
         }
       }}
       initialData={initialData}
-      title="Create Bottle"
-      saveLabel="Create Bottle"
+      title="Add Bottle"
+      saveLabel="Add Bottle"
       returnTo={returnTo}
     />
   );

--- a/apps/web/src/components/bottleExactMetadata.tsx
+++ b/apps/web/src/components/bottleExactMetadata.tsx
@@ -1,6 +1,7 @@
 import { formatCategoryName } from "@peated/server/lib/format";
 import { toTitleCase } from "@peated/server/lib/strings";
 import type { ConcreteBottleV1 } from "@peated/server/schemas";
+import classNames from "@peated/web/lib/classNames";
 import type { ReactNode } from "react";
 
 export type BottleExactMetadataSource = Pick<
@@ -81,10 +82,12 @@ export function getBottleExactMetadata(
 
 export default function BottleExactMetadata({
   bottle,
+  className,
   exclude = [],
   leadingContent,
 }: {
   bottle: BottleExactMetadataSource;
+  className?: string;
   exclude?: BottleExactMetadataKey[];
   leadingContent?: ReactNode;
 }) {
@@ -99,7 +102,12 @@ export default function BottleExactMetadata({
   if (!items.length) return null;
 
   return (
-    <div className="text-muted mt-1 flex flex-wrap text-sm leading-5">
+    <div
+      className={classNames(
+        "text-muted mt-1 flex flex-wrap text-sm leading-5",
+        className,
+      )}
+    >
       {items.map(({ key, content }, index) => (
         <span key={key} className="inline-flex whitespace-nowrap">
           {index ? <span className="mx-1.5">&middot;</span> : null}

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -20,7 +20,6 @@ import {
 } from "@peated/server/lib/format";
 import { toTitleCase } from "@peated/server/lib/strings";
 import type { Entity, FlavorProfile } from "@peated/server/types";
-import Collapsable from "@peated/web/components/collapsable";
 import EntityField from "@peated/web/components/entityField";
 import Fieldset from "@peated/web/components/fieldset";
 import FormError from "@peated/web/components/formError";
@@ -464,242 +463,233 @@ export default function BottleForm({
             )}
           </button>
 
-          <Collapsable open={moreDetailsOpen}>
-            <div
-              id="more-bottle-details"
-              aria-hidden={!moreDetailsOpen}
-              inert={!moreDetailsOpen ? true : undefined}
-            >
-              <TextField
-                {...register("edition")}
-                error={errors.edition}
-                type="text"
-                label="Edition or Batch"
-                helpText="An edition, batch, or label shown on the bottle."
-                placeholder="e.g. Batch 24"
-              />
+          <div id="more-bottle-details" hidden={!moreDetailsOpen}>
+            <TextField
+              {...register("edition")}
+              error={errors.edition}
+              type="text"
+              label="Edition or Batch"
+              helpText="An edition, batch, or label shown on the bottle."
+              placeholder="e.g. Batch 24"
+            />
 
-              <Controller
-                name="series"
-                control={control}
-                render={({ field: { onChange, value, ref, ...field } }) => (
-                  <SeriesField
-                    {...field}
-                    error={errors.series}
-                    label="Series"
-                    helpText="The series this bottle belongs to, if any."
-                    placeholder="e.g. A Midwinter Night's Dram"
-                    brand={brandValue?.id ? Number(brandValue.id) : 0}
-                    disabled={!brandValue}
-                    canCreate
-                    onChange={(value) => {
-                      onChange(value?.id ?? value ?? null);
-                      setSeriesValue(value);
-                    }}
-                    value={seriesValue}
-                  />
-                )}
-              />
-
-              <TextField
-                {...register("releaseYear", {
-                  setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
-                })}
-                error={errors.releaseYear}
-                type="number"
-                label="Release Year"
-                placeholder="e.g. 2024"
-                helpText="The year this bottle was released."
-              />
-
-              <TextField
-                {...register("vintageYear", {
-                  setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
-                })}
-                error={errors.vintageYear}
-                type="number"
-                label="Distillation Year"
-                placeholder="e.g. 1986"
-                helpText="The year the spirit was distilled."
-              />
-
-              <BooleanField
-                control={control}
-                label="Single Cask"
-                helpText="Shown as a single-cask bottling on the label."
-                name="singleCask"
-              />
-
-              <BooleanField
-                control={control}
-                label="Cask Strength"
-                helpText="Shown as cask strength on the label."
-                name="caskStrength"
-              />
-
-              <Controller
-                name="caskFill"
-                control={control}
-                render={({ field: { onChange, value, ref, ...field } }) => (
-                  <SelectField
-                    {...field}
-                    error={errors.caskFill}
-                    label="Cask Fill"
-                    placeholder="e.g. 1st Fill"
-                    simple
-                    options={caskFillList}
-                    onChange={(value) => onChange(value?.id)}
-                    value={
-                      value
-                        ? caskFillList.find((item) => item.id === value)
-                        : undefined
-                    }
-                  />
-                )}
-              />
-
-              <Controller
-                name="caskType"
-                control={control}
-                render={({ field: { onChange, value, ref, ...field } }) => (
-                  <SelectField
-                    {...field}
-                    error={errors.caskType}
-                    label="Cask Type"
-                    placeholder="e.g. Bourbon"
-                    simple
-                    options={caskTypeList}
-                    onChange={(value) => onChange(value?.id)}
-                    value={
-                      value
-                        ? caskTypeList.find((item) => item.id === value)
-                        : undefined
-                    }
-                  />
-                )}
-              />
-
-              <Controller
-                name="caskSize"
-                control={control}
-                render={({ field: { onChange, value, ref, ...field } }) => (
-                  <SelectField
-                    {...field}
-                    error={errors.caskSize}
-                    label="Cask Size"
-                    placeholder="e.g. Hogshead"
-                    simple
-                    options={caskSizeList}
-                    onChange={(value) => onChange(value?.id)}
-                    value={
-                      value
-                        ? caskSizeList.find((item) => item.id === value)
-                        : undefined
-                    }
-                  />
-                )}
-              />
-
-              <Controller
-                name="flavorProfile"
-                control={control}
-                render={({ field: { onChange, value, ref, ...field } }) => (
-                  <SelectField
-                    {...field}
-                    error={errors.flavorProfile}
-                    placeholder="The flavor profile of the spirit."
-                    suggestedOptions={[]}
-                    label="Flavor Profile"
-                    onRenderOption={(option) => {
-                      const classes = classesForProfile(
-                        option.id as FlavorProfile,
-                      );
-                      return (
-                        <div className="flex flex-col items-start justify-start gap-y-2 text-left">
-                          <h4
-                            className={`${classes.bg} ${classes.bgHover} rounded px-2 py-1`}
-                          >
-                            {option.name}
-                          </h4>
-                          <div className="text-muted text-sm font-normal">
-                            {notesForProfile(option.id as FlavorProfile)}
-                          </div>
-                        </div>
-                      );
-                    }}
-                    options={flavorProfileList}
-                    onChange={(value) => onChange(value?.id)}
-                    value={
-                      value
-                        ? {
-                            id: value,
-                            name: formatFlavorProfile(value),
-                          }
-                        : undefined
-                    }
-                  />
-                )}
-              />
-
-              {canUseBottleLookup && (
-                <div className="flex justify-end px-4 py-4">
-                  <Button
-                    color="primary"
-                    onClick={async () => {
-                      const result =
-                        await generateDataMutation.mutateAsync(getValues());
-
-                      if (!result) return;
-                      const currentValues = getValues();
-                      if (result.description && !currentValues.description) {
-                        setValue("description", result.description, {
-                          shouldDirty: true,
-                        });
-                        setValue("descriptionSrc", "generated", {
-                          shouldDirty: true,
-                        });
-                      }
-
-                      if (
-                        result.flavorProfile &&
-                        !currentValues.flavorProfile
-                      ) {
-                        setValue(
-                          "flavorProfile",
-                          result.flavorProfile as FlavorProfile,
-                          { shouldDirty: true },
-                        );
-                      }
-                    }}
-                    disabled={generateDataMutation.isPending}
-                    icon={<BoltIcon className="-ml-0.5 h-4 w-4" />}
-                  >
-                    Suggest Description &amp; Flavor [Beta]
-                  </Button>
-                </div>
+            <Controller
+              name="series"
+              control={control}
+              render={({ field: { onChange, value, ref, ...field } }) => (
+                <SeriesField
+                  {...field}
+                  error={errors.series}
+                  label="Series"
+                  helpText="The series this bottle belongs to, if any."
+                  placeholder="e.g. A Midwinter Night's Dram"
+                  brand={brandValue?.id ? Number(brandValue.id) : 0}
+                  disabled={!brandValue}
+                  canCreate
+                  onChange={(value) => {
+                    onChange(value?.id ?? value ?? null);
+                    setSeriesValue(value);
+                  }}
+                  value={seriesValue}
+                />
               )}
+            />
 
-              <ImageField
-                name="image"
-                label="Catalog Image"
-                value={imageUrl}
-                onChange={(value) => setImage(value)}
-                noEditor
-              />
+            <TextField
+              {...register("releaseYear", {
+                setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
+              })}
+              error={errors.releaseYear}
+              type="number"
+              label="Release Year"
+              placeholder="e.g. 2024"
+              helpText="The year this bottle was released."
+            />
 
-              <TextAreaField
-                {...register("description", {
-                  setValueAs: (v) => (v === "" || !v ? null : v),
-                  onChange: () => {
-                    setValue("descriptionSrc", "user", { shouldDirty: true });
-                  },
-                })}
-                error={errors.description}
-                label="Description"
-                rows={8}
-              />
-            </div>
-          </Collapsable>
+            <TextField
+              {...register("vintageYear", {
+                setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
+              })}
+              error={errors.vintageYear}
+              type="number"
+              label="Distillation Year"
+              placeholder="e.g. 1986"
+              helpText="The year the spirit was distilled."
+            />
+
+            <BooleanField
+              control={control}
+              label="Single Cask"
+              helpText="Shown as a single-cask bottling on the label."
+              name="singleCask"
+            />
+
+            <BooleanField
+              control={control}
+              label="Cask Strength"
+              helpText="Shown as cask strength on the label."
+              name="caskStrength"
+            />
+
+            <Controller
+              name="caskFill"
+              control={control}
+              render={({ field: { onChange, value, ref, ...field } }) => (
+                <SelectField
+                  {...field}
+                  error={errors.caskFill}
+                  label="Cask Fill"
+                  placeholder="e.g. 1st Fill"
+                  simple
+                  options={caskFillList}
+                  onChange={(value) => onChange(value?.id)}
+                  value={
+                    value
+                      ? caskFillList.find((item) => item.id === value)
+                      : undefined
+                  }
+                />
+              )}
+            />
+
+            <Controller
+              name="caskType"
+              control={control}
+              render={({ field: { onChange, value, ref, ...field } }) => (
+                <SelectField
+                  {...field}
+                  error={errors.caskType}
+                  label="Cask Type"
+                  placeholder="e.g. Bourbon"
+                  simple
+                  options={caskTypeList}
+                  onChange={(value) => onChange(value?.id)}
+                  value={
+                    value
+                      ? caskTypeList.find((item) => item.id === value)
+                      : undefined
+                  }
+                />
+              )}
+            />
+
+            <Controller
+              name="caskSize"
+              control={control}
+              render={({ field: { onChange, value, ref, ...field } }) => (
+                <SelectField
+                  {...field}
+                  error={errors.caskSize}
+                  label="Cask Size"
+                  placeholder="e.g. Hogshead"
+                  simple
+                  options={caskSizeList}
+                  onChange={(value) => onChange(value?.id)}
+                  value={
+                    value
+                      ? caskSizeList.find((item) => item.id === value)
+                      : undefined
+                  }
+                />
+              )}
+            />
+
+            <Controller
+              name="flavorProfile"
+              control={control}
+              render={({ field: { onChange, value, ref, ...field } }) => (
+                <SelectField
+                  {...field}
+                  error={errors.flavorProfile}
+                  placeholder="The flavor profile of the spirit."
+                  suggestedOptions={[]}
+                  label="Flavor Profile"
+                  onRenderOption={(option) => {
+                    const classes = classesForProfile(
+                      option.id as FlavorProfile,
+                    );
+                    return (
+                      <div className="flex flex-col items-start justify-start gap-y-2 text-left">
+                        <h4
+                          className={`${classes.bg} ${classes.bgHover} rounded px-2 py-1`}
+                        >
+                          {option.name}
+                        </h4>
+                        <div className="text-muted text-sm font-normal">
+                          {notesForProfile(option.id as FlavorProfile)}
+                        </div>
+                      </div>
+                    );
+                  }}
+                  options={flavorProfileList}
+                  onChange={(value) => onChange(value?.id)}
+                  value={
+                    value
+                      ? {
+                          id: value,
+                          name: formatFlavorProfile(value),
+                        }
+                      : undefined
+                  }
+                />
+              )}
+            />
+
+            {canUseBottleLookup && (
+              <div className="flex justify-end px-4 py-4">
+                <Button
+                  color="primary"
+                  onClick={async () => {
+                    const result =
+                      await generateDataMutation.mutateAsync(getValues());
+
+                    if (!result) return;
+                    const currentValues = getValues();
+                    if (result.description && !currentValues.description) {
+                      setValue("description", result.description, {
+                        shouldDirty: true,
+                      });
+                      setValue("descriptionSrc", "generated", {
+                        shouldDirty: true,
+                      });
+                    }
+
+                    if (result.flavorProfile && !currentValues.flavorProfile) {
+                      setValue(
+                        "flavorProfile",
+                        result.flavorProfile as FlavorProfile,
+                        { shouldDirty: true },
+                      );
+                    }
+                  }}
+                  disabled={generateDataMutation.isPending}
+                  icon={<BoltIcon className="-ml-0.5 h-4 w-4" />}
+                >
+                  Suggest Description &amp; Flavor [Beta]
+                </Button>
+              </div>
+            )}
+
+            <ImageField
+              name="image"
+              label="Catalog Image"
+              value={imageUrl}
+              onChange={(value) => setImage(value)}
+              noEditor
+            />
+
+            <TextAreaField
+              {...register("description", {
+                setValueAs: (v) => (v === "" || !v ? null : v),
+                onChange: () => {
+                  setValue("descriptionSrc", "user", { shouldDirty: true });
+                },
+              })}
+              error={errors.description}
+              label="Description"
+              rows={8}
+            />
+          </div>
         </Fieldset>
       </Form>
     </FormScreen>

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { BoltIcon } from "@heroicons/react/20/solid";
+import {
+  BoltIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@heroicons/react/20/solid";
 import {
   CASK_FILLS,
   CASK_SIZES,
@@ -8,10 +12,7 @@ import {
   CATEGORY_LIST,
   FLAVOR_PROFILES,
 } from "@peated/server/constants";
-import {
-  ConcreteBottleUpdateInputSchema,
-  IndependentConcreteBottleCreateRouteInputSchema,
-} from "@peated/server/lib/concreteBottleSchemas";
+import { IndependentConcreteBottleCreateRouteInputSchema } from "@peated/server/lib/concreteBottleSchemas";
 import {
   formatCategoryName,
   formatFlavorProfile,
@@ -19,6 +20,7 @@ import {
 } from "@peated/server/lib/format";
 import { toTitleCase } from "@peated/server/lib/strings";
 import type { Entity, FlavorProfile } from "@peated/server/types";
+import Collapsable from "@peated/web/components/collapsable";
 import EntityField from "@peated/web/components/entityField";
 import Fieldset from "@peated/web/components/fieldset";
 import FormError from "@peated/web/components/formError";
@@ -29,7 +31,6 @@ import type { Option } from "@peated/web/components/selectField";
 import SelectField from "@peated/web/components/selectField";
 import SeriesField from "@peated/web/components/seriesField";
 import TextField from "@peated/web/components/textField";
-import config from "@peated/web/config";
 import useAuth from "@peated/web/hooks/useAuth";
 import {
   getFormErrorMessage,
@@ -41,7 +42,7 @@ import { useORPC } from "@peated/web/lib/orpc/context";
 import { zodResolver } from "@peated/web/lib/zodResolver";
 import { useMutation } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import type { SubmitHandler } from "react-hook-form";
 import { Controller, useForm } from "react-hook-form";
 import type { z } from "zod";
@@ -79,12 +80,8 @@ const caskTypeList = CASK_TYPES.map(({ id }) => ({
 type CreateFormSchemaType = z.infer<
   typeof IndependentConcreteBottleCreateRouteInputSchema
 >;
-const BottleFormSchema =
-  IndependentConcreteBottleCreateRouteInputSchema.safeExtend({
-    exactStatedAge:
-      ConcreteBottleUpdateInputSchema.shape.exact.unwrap().shape.statedAge,
-  });
-type FormSchemaType = z.infer<typeof BottleFormSchema>;
+const BottleFormSchema = IndependentConcreteBottleCreateRouteInputSchema;
+type FormSchemaType = CreateFormSchemaType;
 type ChoiceLike = {
   id?: number | null;
   name?: string | null;
@@ -112,6 +109,32 @@ export type BottleFormSubmitMeta = {
   dirtyFields: ReadonlySet<BottleFormFieldName>;
 };
 
+const moreDetailFields = [
+  "edition",
+  "releaseYear",
+  "vintageYear",
+  "series",
+  "singleCask",
+  "caskStrength",
+  "caskFill",
+  "caskType",
+  "caskSize",
+  "flavorProfile",
+  "description",
+] as const satisfies ReadonlyArray<BottleFormFieldName>;
+
+function hasMoreDetails(initialData: BottleFormInitialData) {
+  return (
+    Boolean(initialData.imageUrl) ||
+    moreDetailFields.some((field) => {
+      const value = initialData[field];
+      return (
+        value !== null && value !== undefined && value !== "" && value !== false
+      );
+    })
+  );
+}
+
 const toEntityChoiceValue = (
   value: number | Entity | ChoiceLike | null | undefined,
 ): FormSchemaType["brand"] | FormSchemaType["bottler"] =>
@@ -137,8 +160,6 @@ export default function BottleForm({
   title,
   returnTo,
   saveLabel,
-  sharedIdentityBottleCount,
-  exactStatedAge,
 }: {
   onSubmit: (
     value: BottleFormSubmitValue,
@@ -148,8 +169,6 @@ export default function BottleForm({
   title: string;
   returnTo?: string | null;
   saveLabel?: string;
-  sharedIdentityBottleCount?: number;
-  exactStatedAge?: number | null;
 }) {
   const { imageUrl, ...initialFormData } = initialData;
   const {
@@ -168,11 +187,13 @@ export default function BottleForm({
       brand: toEntityChoiceValue(initialData.brand) ?? undefined,
       distillers: toDistillerChoiceValues(initialData.distillers),
       series: toSeriesChoiceValue(initialData.series),
-      ...(exactStatedAge !== undefined ? { exactStatedAge } : {}),
     },
   });
 
   const [error, setError] = useState<string | undefined>();
+  const [moreDetailsOpen, setMoreDetailsOpen] = useState(() =>
+    hasMoreDetails(initialData),
+  );
   const [image, setImage] = useState<HTMLCanvasElement | null | undefined>(
     undefined,
   );
@@ -180,6 +201,12 @@ export default function BottleForm({
   const orpc = useORPC();
   const { user } = useAuth();
   const canUseBottleLookup = !!(user?.mod || user?.admin);
+
+  useEffect(() => {
+    if (moreDetailFields.some((field) => errors[field])) {
+      setMoreDetailsOpen(true);
+    }
+  }, [errors]);
 
   const generateDataMutation = useMutation(
     orpc.ai.bottleLookup.mutationOptions(),
@@ -220,9 +247,7 @@ export default function BottleForm({
   const previewData = {
     name: watch("name"),
     category: watch("category"),
-    sharedStatedAge: watch("statedAge"),
-    exactStatedAge:
-      exactStatedAge !== undefined ? watch("exactStatedAge") : null,
+    statedAge: watch("statedAge"),
     edition: watch("edition"),
     releaseYear: watch("releaseYear"),
     vintageYear: watch("vintageYear"),
@@ -242,10 +267,7 @@ export default function BottleForm({
       previewData.brand ||
       previewData.distillers.length,
     ) ||
-    (previewData.sharedStatedAge !== null &&
-      previewData.sharedStatedAge !== undefined) ||
-    (previewData.exactStatedAge !== null &&
-      previewData.exactStatedAge !== undefined);
+    (previewData.statedAge !== null && previewData.statedAge !== undefined);
 
   return (
     <FormScreen
@@ -258,30 +280,8 @@ export default function BottleForm({
       <div className="border-slate-700 p-4 lg:mb-8 lg:border">
         <div className="prose prose-invert text-muted max-w-full text-sm leading-6">
           <p>
-            It can be tricky to find the right information, so if you&apos;re
-            struggling, just try to fill in the components that you're confident
-            about. The brand will almost always have multiple bottles (e.g.{" "}
-            <em>Hibiki</em>), and the bottle name, if nothing else, you can use
-            the full bottle label.
-          </p>
-          {sharedIdentityBottleCount !== undefined ? (
-            <p>
-              {sharedIdentityBottleCount === 1
-                ? "This release family has 1 Bottle, so shared edits update only this Bottle's identity."
-                : `Shared edits update all ${sharedIdentityBottleCount.toLocaleString()} Bottle identities in this release family.`}{" "}
-              Exact Bottle details below affect only this Bottle.
-            </p>
-          ) : (
-            <p>
-              Enter the shared expression details and any exact release details
-              shown on this Bottle.
-            </p>
-          )}
-          <p>
-            Have any suggestions for making it easier to enter correct data?{" "}
-            <a href={config.GITHUB_REPO}>Open an Issue on GitHub</a> or{" "}
-            <a href={config.DISCORD_LINK}>drop a note on Discord</a> if you have
-            feedback. We'll update the bottle preview as you enter information.
+            Add what you can confirm from the label. Brand and bottle name are
+            required; anything else can be left blank.
           </p>
         </div>
       </div>
@@ -299,16 +299,6 @@ export default function BottleForm({
         isSubmitting={isSubmitting}
       >
         <Fieldset>
-          <legend className="text-highlight px-1 pt-4 text-lg font-bold">
-            Release family details
-          </legend>
-          <p className="text-muted pb-2 text-sm leading-6">
-            {sharedIdentityBottleCount === undefined
-              ? "These details describe the expression shared by related releases."
-              : sharedIdentityBottleCount === 1
-                ? "Changes here update this Bottle's shared release-family identity."
-                : `Changes here update all ${sharedIdentityBottleCount.toLocaleString()} Bottles in this release family.`}
-          </p>
           <Controller
             name="brand"
             control={control}
@@ -339,84 +329,10 @@ export default function BottleForm({
             {...register("name")}
             error={errors.name}
             type="text"
-            label="Bottle"
+            label="Bottle Name"
             required
-            helpText={
-              <div className="flex flex-col gap-y-2">
-                <p>
-                  The name of the expression. We'll do our best to clean this up
-                  for you, but generally speaking there's a few things to think
-                  about:
-                </p>
-                <ul className="ml-6 flex list-disc flex-col gap-y-1">
-                  <li>
-                    The unique expression name is the focus. For example,{" "}
-                    <strong>do not</strong> include the series if applicable,
-                    like <em>A Midwinter NIght's Dram</em>.
-                  </li>
-                  <li>
-                    Edition names should not be included. For example,{" "}
-                    <strong>do not include</strong> <em>2010 Spring Release</em>
-                    .
-                  </li>
-                  <li>
-                    Flavor text should be avoided whenever possible. For
-                    example, <strong>Do not include</strong>{" "}
-                    <em>Scotch Malt Whisky</em>.
-                  </li>
-                  <li>
-                    If there is no other identifying series information use core
-                    data. For example, <em>10-year-old Single Malt</em>...
-                  </li>
-                  <li>
-                    However, if the expression is clearly identifying,{" "}
-                    <em>do not include</em> the stated age or the spirit type.
-                  </li>
-                </ul>
-              </div>
-            }
+            helpText="Enter the name without repeating the brand. Add edition, batch, and year information under More Details."
             placeholder="e.g. 12-year-old"
-          />
-
-          <Controller
-            name="series"
-            control={control}
-            render={({ field: { onChange, value, ref, ...field } }) => (
-              <SeriesField
-                {...field}
-                error={errors.series}
-                label="Series"
-                helpText="The series this bottle belongs to (if any)."
-                placeholder="e.g. A Midwinter Night's Dram"
-                brand={brandValue?.id ? Number(brandValue.id) : 0}
-                disabled={!brandValue}
-                canCreate
-                onChange={(value) => {
-                  onChange(value?.id ?? value ?? null);
-                  setSeriesValue(value);
-                }}
-                value={seriesValue}
-              />
-            )}
-          />
-          <TextField
-            {...register("statedAge", {
-              setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
-            })}
-            error={errors.statedAge}
-            type="number"
-            label={
-              sharedIdentityBottleCount === undefined
-                ? "Stated Age"
-                : "Shared Stated Age"
-            }
-            placeholder="e.g. 12"
-            helpText={
-              sharedIdentityBottleCount === undefined
-                ? "The number of years the spirit was aged, as stated on the bottle."
-                : "The stated age shared by every Bottle in this group unless a Bottle-specific override is set below."
-            }
-            suffixLabel="years"
           />
 
           <Controller
@@ -426,7 +342,7 @@ export default function BottleForm({
               <SelectField
                 {...field}
                 error={errors.category}
-                label="Category"
+                label="Type"
                 placeholder="e.g. Single Malt"
                 helpText="The kind of spirit."
                 simple
@@ -444,6 +360,33 @@ export default function BottleForm({
             )}
           />
 
+          <TextField
+            {...register("statedAge", {
+              setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
+            })}
+            error={errors.statedAge}
+            type="number"
+            label="Age Statement"
+            placeholder="e.g. 12"
+            helpText="The age shown on the bottle's label."
+            suffixLabel="years"
+          />
+
+          <TextField
+            {...register("abv", {
+              setValueAs: (v) => (v === "" || !v ? null : parseFloat(v)),
+            })}
+            error={errors.abv}
+            type="number"
+            label="Alcohol (ABV)"
+            placeholder="e.g. 40.5"
+            helpText="The alcohol percentage shown on the label."
+            suffixLabel="%"
+            step="0.1"
+            min="0"
+            max="100"
+          />
+
           <Controller
             name="distillers"
             control={control}
@@ -456,9 +399,9 @@ export default function BottleForm({
                   brand: brandValue?.id ? Number(brandValue.id) : null,
                   bottleName: watch("name"),
                 }}
-                label="Distiller"
+                label="Distilled By"
                 placeholder="e.g. Angel's Envy, Suntory Whisky"
-                helpText="The distilleries which produce the spirit(s) for this bottle."
+                helpText="The distilleries that produced the spirit."
                 createDialogHelpText="The distiller is the group that makes the spirit."
                 suggestedOptions={brandValue ? [brandValue] : []}
                 onChange={(value) => {
@@ -479,8 +422,8 @@ export default function BottleForm({
               <EntityField
                 {...field}
                 error={errors.bottler}
-                label="Bottler"
-                helpText="The company bottling the spirit."
+                label="Bottled By"
+                helpText="Use this when the bottler is different from the brand."
                 placeholder="e.g. The Scotch Malt Whisky Society"
                 suggestedOptions={brandValue ? [brandValue] : []}
                 searchContext={{
@@ -497,258 +440,266 @@ export default function BottleForm({
               />
             )}
           />
+        </Fieldset>
 
-          <Controller
-            name="flavorProfile"
-            control={control}
-            render={({ field: { onChange, value, ref, ...field } }) => (
-              <SelectField
-                {...field}
-                error={errors.flavorProfile}
-                placeholder="The flavor profile of the spirit."
-                suggestedOptions={[]}
-                label="Flavor Profile"
-                onRenderOption={(option) => {
-                  const classes = classesForProfile(option.id as FlavorProfile);
-                  return (
-                    <div className="flex flex-col items-start justify-start gap-y-2 text-left">
-                      <h4
-                        className={`${classes.bg} ${classes.bgHover} rounded px-2 py-1`}
-                      >
-                        {option.name}
-                      </h4>
-                      <div className="text-muted text-sm font-normal">
-                        {notesForProfile(option.id as FlavorProfile)}
-                      </div>
-                    </div>
-                  );
-                }}
-                options={flavorProfileList}
-                onChange={(value) => onChange(value?.id)}
-                value={
-                  value
-                    ? {
-                        id: value,
-                        name: formatFlavorProfile(value),
+        <Fieldset>
+          <button
+            type="button"
+            className="flex w-full items-center justify-between px-4 py-4 text-left"
+            aria-controls="more-bottle-details"
+            aria-expanded={moreDetailsOpen}
+            onClick={() => setMoreDetailsOpen((open) => !open)}
+          >
+            <span>
+              <span className="block text-lg font-medium">More Details</span>
+              <span className="text-muted mt-1 block text-sm font-normal">
+                Edition, batch, year, cask information, and other optional
+                details.
+              </span>
+            </span>
+            {moreDetailsOpen ? (
+              <ChevronUpIcon className="text-muted h-5 w-5 shrink-0" />
+            ) : (
+              <ChevronDownIcon className="text-muted h-5 w-5 shrink-0" />
+            )}
+          </button>
+
+          <Collapsable open={moreDetailsOpen}>
+            <div
+              id="more-bottle-details"
+              aria-hidden={!moreDetailsOpen}
+              inert={!moreDetailsOpen ? true : undefined}
+            >
+              <TextField
+                {...register("edition")}
+                error={errors.edition}
+                type="text"
+                label="Edition or Batch"
+                helpText="An edition, batch, or label shown on the bottle."
+                placeholder="e.g. Batch 24"
+              />
+
+              <Controller
+                name="series"
+                control={control}
+                render={({ field: { onChange, value, ref, ...field } }) => (
+                  <SeriesField
+                    {...field}
+                    error={errors.series}
+                    label="Series"
+                    helpText="The series this bottle belongs to, if any."
+                    placeholder="e.g. A Midwinter Night's Dram"
+                    brand={brandValue?.id ? Number(brandValue.id) : 0}
+                    disabled={!brandValue}
+                    canCreate
+                    onChange={(value) => {
+                      onChange(value?.id ?? value ?? null);
+                      setSeriesValue(value);
+                    }}
+                    value={seriesValue}
+                  />
+                )}
+              />
+
+              <TextField
+                {...register("releaseYear", {
+                  setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
+                })}
+                error={errors.releaseYear}
+                type="number"
+                label="Release Year"
+                placeholder="e.g. 2024"
+                helpText="The year this bottle was released."
+              />
+
+              <TextField
+                {...register("vintageYear", {
+                  setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
+                })}
+                error={errors.vintageYear}
+                type="number"
+                label="Distillation Year"
+                placeholder="e.g. 1986"
+                helpText="The year the spirit was distilled."
+              />
+
+              <BooleanField
+                control={control}
+                label="Single Cask"
+                helpText="Shown as a single-cask bottling on the label."
+                name="singleCask"
+              />
+
+              <BooleanField
+                control={control}
+                label="Cask Strength"
+                helpText="Shown as cask strength on the label."
+                name="caskStrength"
+              />
+
+              <Controller
+                name="caskFill"
+                control={control}
+                render={({ field: { onChange, value, ref, ...field } }) => (
+                  <SelectField
+                    {...field}
+                    error={errors.caskFill}
+                    label="Cask Fill"
+                    placeholder="e.g. 1st Fill"
+                    simple
+                    options={caskFillList}
+                    onChange={(value) => onChange(value?.id)}
+                    value={
+                      value
+                        ? caskFillList.find((item) => item.id === value)
+                        : undefined
+                    }
+                  />
+                )}
+              />
+
+              <Controller
+                name="caskType"
+                control={control}
+                render={({ field: { onChange, value, ref, ...field } }) => (
+                  <SelectField
+                    {...field}
+                    error={errors.caskType}
+                    label="Cask Type"
+                    placeholder="e.g. Bourbon"
+                    simple
+                    options={caskTypeList}
+                    onChange={(value) => onChange(value?.id)}
+                    value={
+                      value
+                        ? caskTypeList.find((item) => item.id === value)
+                        : undefined
+                    }
+                  />
+                )}
+              />
+
+              <Controller
+                name="caskSize"
+                control={control}
+                render={({ field: { onChange, value, ref, ...field } }) => (
+                  <SelectField
+                    {...field}
+                    error={errors.caskSize}
+                    label="Cask Size"
+                    placeholder="e.g. Hogshead"
+                    simple
+                    options={caskSizeList}
+                    onChange={(value) => onChange(value?.id)}
+                    value={
+                      value
+                        ? caskSizeList.find((item) => item.id === value)
+                        : undefined
+                    }
+                  />
+                )}
+              />
+
+              <Controller
+                name="flavorProfile"
+                control={control}
+                render={({ field: { onChange, value, ref, ...field } }) => (
+                  <SelectField
+                    {...field}
+                    error={errors.flavorProfile}
+                    placeholder="The flavor profile of the spirit."
+                    suggestedOptions={[]}
+                    label="Flavor Profile"
+                    onRenderOption={(option) => {
+                      const classes = classesForProfile(
+                        option.id as FlavorProfile,
+                      );
+                      return (
+                        <div className="flex flex-col items-start justify-start gap-y-2 text-left">
+                          <h4
+                            className={`${classes.bg} ${classes.bgHover} rounded px-2 py-1`}
+                          >
+                            {option.name}
+                          </h4>
+                          <div className="text-muted text-sm font-normal">
+                            {notesForProfile(option.id as FlavorProfile)}
+                          </div>
+                        </div>
+                      );
+                    }}
+                    options={flavorProfileList}
+                    onChange={(value) => onChange(value?.id)}
+                    value={
+                      value
+                        ? {
+                            id: value,
+                            name: formatFlavorProfile(value),
+                          }
+                        : undefined
+                    }
+                  />
+                )}
+              />
+
+              {canUseBottleLookup && (
+                <div className="flex justify-end px-4 py-4">
+                  <Button
+                    color="primary"
+                    onClick={async () => {
+                      const result =
+                        await generateDataMutation.mutateAsync(getValues());
+
+                      if (!result) return;
+                      const currentValues = getValues();
+                      if (result.description && !currentValues.description) {
+                        setValue("description", result.description, {
+                          shouldDirty: true,
+                        });
+                        setValue("descriptionSrc", "generated", {
+                          shouldDirty: true,
+                        });
                       }
-                    : undefined
-                }
-              />
-            )}
-          />
-        </Fieldset>
 
-        <Fieldset>
-          <legend className="text-highlight px-1 pt-4 text-lg font-bold">
-            Exact Bottle details
-          </legend>
-          <div className="text-muted pb-2 text-sm leading-6">
-            <p>
-              These details belong only to this exact Bottle.
-              {sharedIdentityBottleCount !== undefined && (
-                <>
-                  {" "}
-                  {sharedIdentityBottleCount === 1
-                    ? "This release family has 1 Bottle; shared edits above update its identity."
-                    : `Shared edits above update all ${sharedIdentityBottleCount.toLocaleString()} Bottle identities in this release family.`}
-                </>
+                      if (
+                        result.flavorProfile &&
+                        !currentValues.flavorProfile
+                      ) {
+                        setValue(
+                          "flavorProfile",
+                          result.flavorProfile as FlavorProfile,
+                          { shouldDirty: true },
+                        );
+                      }
+                    }}
+                    disabled={generateDataMutation.isPending}
+                    icon={<BoltIcon className="-ml-0.5 h-4 w-4" />}
+                  >
+                    Suggest Description &amp; Flavor [Beta]
+                  </Button>
+                </div>
               )}
-            </p>
-          </div>
 
-          <TextField
-            {...register("edition")}
-            error={errors.edition}
-            type="text"
-            label="Edition / Label"
-            helpText="Optional edition, batch, or label for this exact Bottle."
-            placeholder="e.g. Batch 24, 1990 Release"
-          />
-
-          {exactStatedAge !== undefined && (
-            <TextField
-              {...register("exactStatedAge", {
-                setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
-              })}
-              error={errors.exactStatedAge}
-              type="number"
-              label="Bottle-specific Stated Age"
-              helpText={`Optional override for this exact Bottle. Leave blank to inherit the shared stated age${watch("statedAge") == null ? "." : ` of ${watch("statedAge")} years.`}`}
-              placeholder="Inherit shared age"
-              suffixLabel="years"
-            />
-          )}
-
-          <TextField
-            {...register("abv", {
-              setValueAs: (v) => (v === "" || !v ? null : parseFloat(v)),
-            })}
-            error={errors.abv}
-            type="number"
-            label="ABV"
-            placeholder="e.g. 40.5"
-            helpText="Alcohol by volume for this exact Bottle."
-            suffixLabel="%"
-            step="0.1"
-            min="0"
-            max="100"
-          />
-
-          <TextField
-            {...register("releaseYear", {
-              setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
-            })}
-            error={errors.releaseYear}
-            type="number"
-            label="Release Year"
-            placeholder="e.g. 1990"
-            helpText="The year this exact Bottle was released."
-          />
-
-          <TextField
-            {...register("vintageYear", {
-              setValueAs: (v) => (v === "" || !v ? null : parseInt(v, 10)),
-            })}
-            error={errors.vintageYear}
-            type="number"
-            label="Vintage Year"
-            placeholder="e.g. 1986"
-            helpText="The distillation vintage for this exact Bottle."
-          />
-
-          <BooleanField
-            control={control}
-            label="Single Cask"
-            helpText="Whether the bottle itself is explicitly a single-cask release."
-            name="singleCask"
-          />
-
-          <BooleanField
-            control={control}
-            label="Cask Strength"
-            helpText="Whether the bottle itself is explicitly bottled at cask strength."
-            name="caskStrength"
-          />
-
-          <Controller
-            name="caskFill"
-            control={control}
-            render={({ field: { onChange, value, ref, ...field } }) => (
-              <SelectField
-                {...field}
-                error={errors.caskFill}
-                label="Cask Fill"
-                placeholder="e.g. 1st Fill"
-                simple
-                options={caskFillList}
-                onChange={(value) => onChange(value?.id)}
-                value={
-                  value
-                    ? caskFillList.find((item) => item.id === value)
-                    : undefined
-                }
+              <ImageField
+                name="image"
+                label="Catalog Image"
+                value={imageUrl}
+                onChange={(value) => setImage(value)}
+                noEditor
               />
-            )}
-          />
 
-          <Controller
-            name="caskType"
-            control={control}
-            render={({ field: { onChange, value, ref, ...field } }) => (
-              <SelectField
-                {...field}
-                error={errors.caskType}
-                label="Cask Type"
-                placeholder="e.g. Bourbon"
-                simple
-                options={caskTypeList}
-                onChange={(value) => onChange(value?.id)}
-                value={
-                  value
-                    ? caskTypeList.find((item) => item.id === value)
-                    : undefined
-                }
+              <TextAreaField
+                {...register("description", {
+                  setValueAs: (v) => (v === "" || !v ? null : v),
+                  onChange: () => {
+                    setValue("descriptionSrc", "user", { shouldDirty: true });
+                  },
+                })}
+                error={errors.description}
+                label="Description"
+                rows={8}
               />
-            )}
-          />
-
-          <Controller
-            name="caskSize"
-            control={control}
-            render={({ field: { onChange, value, ref, ...field } }) => (
-              <SelectField
-                {...field}
-                error={errors.caskSize}
-                label="Cask Size"
-                placeholder="e.g. Hogshead"
-                simple
-                options={caskSizeList}
-                onChange={(value) => onChange(value?.id)}
-                value={
-                  value
-                    ? caskSizeList.find((item) => item.id === value)
-                    : undefined
-                }
-              />
-            )}
-          />
-        </Fieldset>
-
-        <Fieldset>
-          <div className="flex items-center justify-between gap-4">
-            <div className="font-medium">Additional Details</div>
-            {canUseBottleLookup && (
-              <Button
-                color="primary"
-                onClick={async () => {
-                  const result =
-                    await generateDataMutation.mutateAsync(getValues());
-
-                  if (!result) return;
-                  const currentValues = getValues();
-                  if (result.description && !currentValues.description) {
-                    setValue("description", result.description, {
-                      shouldDirty: true,
-                    });
-                    setValue("descriptionSrc", "generated", {
-                      shouldDirty: true,
-                    });
-                  }
-
-                  if (result.flavorProfile && !currentValues.flavorProfile)
-                    setValue(
-                      "flavorProfile",
-                      result.flavorProfile as FlavorProfile,
-                      { shouldDirty: true },
-                    );
-                }}
-                disabled={generateDataMutation.isPending}
-                icon={<BoltIcon className="-ml-0.5 h-4 w-4" />}
-              >
-                Suggest description &amp; family flavor [Beta]
-              </Button>
-            )}
-          </div>
-
-          <ImageField
-            name="image"
-            label="Image"
-            value={imageUrl}
-            onChange={(value) => setImage(value)}
-            noEditor
-          />
-
-          <TextAreaField
-            {...register("description", {
-              setValueAs: (v) => (v === "" || !v ? null : v),
-              onChange: () => {
-                setValue("descriptionSrc", "user", { shouldDirty: true });
-              },
-            })}
-            error={errors.description}
-            label="Description"
-            rows={8}
-          />
+            </div>
+          </Collapsable>
         </Fieldset>
       </Form>
     </FormScreen>

--- a/apps/web/src/components/previewBottleCard.test.tsx
+++ b/apps/web/src/components/previewBottleCard.test.tsx
@@ -3,16 +3,15 @@ import { describe, expect, it } from "vitest";
 import { PreviewBottleCard } from "./previewBottleCard";
 
 describe("PreviewBottleCard", () => {
-  it("materializes the complete exact Bottle identity", () => {
+  it("renders a concise identity with release details as metadata", () => {
     const html = renderToStaticMarkup(
       <PreviewBottleCard
         data={{
-          name: "12-year-old Cask Strength",
+          name: "12-year-old",
           brand: { id: 1, name: "Springbank" },
           distillers: [{ id: 2, name: "J & A Mitchell" }],
           category: "single_malt",
-          sharedStatedAge: 12,
-          exactStatedAge: null,
+          statedAge: 12,
           edition: "Batch 24",
           releaseYear: 2025,
           vintageYear: 2013,
@@ -27,16 +26,21 @@ describe("PreviewBottleCard", () => {
     );
 
     expect(html).toContain('aria-label="Bottle preview"');
-    expect(html).toContain("Springbank 12-year-old Cask Strength");
+    expect(html).toContain("Springbank");
+    expect(html).toContain("12-year-old");
     expect(html).toContain("Batch 24");
+    expect(html).toContain("12 years");
     expect(html).toContain("2025");
     expect(html).toContain("2013");
-    expect(html).toContain("57.2%");
+    expect(html).toContain("57.2% ABV");
     expect(html).toContain("Single Cask");
-    expect(html).toContain("Cask Strength");
-    expect(html).toContain("Oloroso Cask");
-    expect(html).toContain("Hogshead");
-    expect(html).toContain("1st Fill");
-    expect(html).toContain("Aged 12 years");
+    expect(html).toContain("Cask strength");
+    expect(html).toContain("1st Fill Oloroso Hogshead cask");
+    expect(html).toContain("uppercase");
+    expect(html).toContain("bg-highlight");
+    expect(html).toContain("text-black/70");
+    expect(html).not.toContain("Single Malt");
+    expect(html).not.toContain("Distilled at");
+    expect(html).not.toContain("border-slate-800");
   });
 });

--- a/apps/web/src/components/previewBottleCard.tsx
+++ b/apps/web/src/components/previewBottleCard.tsx
@@ -1,11 +1,8 @@
-import {
-  materializeConcreteBottleIdentity,
-  type ConcreteBottleExactIdentity,
-} from "@peated/server/lib/concreteBottleIdentity";
-import { formatCategoryName } from "@peated/server/lib/format";
-import type { ReactNode } from "react";
-import Join from "./join";
+import BottleExactMetadata, {
+  type BottleExactMetadataSource,
+} from "./bottleExactMetadata";
 import type { Option } from "./selectField";
+import SingleCaskChip from "./singleCaskChip";
 
 type EntityOption = Option & {
   shortName?: string;
@@ -15,38 +12,8 @@ type BottleFormData = {
   name: string;
   brand?: EntityOption | null | undefined;
   distillers?: EntityOption[] | null | undefined;
-  sharedStatedAge?: number | null | undefined;
-  exactStatedAge?: number | null | undefined;
-  category?: string | null | undefined;
-} & Omit<ConcreteBottleExactIdentity, "statedAge">;
-
-function BottleScaffold({
-  name,
-  category,
-  distillers,
-  statedAge,
-}: {
-  name: ReactNode;
-  category: ReactNode;
-  distillers: ReactNode;
-  statedAge: ReactNode;
-}) {
-  return (
-    <section
-      aria-label="Bottle preview"
-      className="bg-highlight flex items-center space-x-2 overflow-hidden p-4 text-black sm:space-x-3 sm:rounded lg:p-5"
-    >
-      <div className="flex-1 overflow-hidden">
-        <div className="flex w-full items-center gap-x-1 font-bold">{name}</div>
-        <div className="flex flex-row gap-x-1 text-sm">{distillers}</div>
-      </div>
-      <div className="hidden w-[200px] flex-col items-end justify-center whitespace-nowrap text-sm sm:flex">
-        <div className="max-w-full truncate">{category}</div>
-        <div>{statedAge}</div>
-      </div>
-    </section>
-  );
-}
+  edition?: string | null | undefined;
+} & Partial<BottleExactMetadataSource>;
 
 export const PreviewBottleCard = ({
   data,
@@ -54,43 +21,41 @@ export const PreviewBottleCard = ({
   data: Partial<BottleFormData>;
 }) => {
   const { brand } = data;
-  const stableName = data.name ?? "";
-  const stableFullName =
-    `${brand ? `${brand.shortName || brand.name} ` : ""}${stableName}`.trim();
-  const identity = materializeConcreteBottleIdentity({
-    stable: {
-      name: stableName,
-      fullName: stableFullName,
-      statedAge: data.sharedStatedAge ?? null,
-    },
-    exact: {
-      edition: data.edition ?? null,
-      statedAge: data.exactStatedAge ?? null,
-      releaseYear: data.releaseYear ?? null,
-      vintageYear: data.vintageYear ?? null,
-      abv: data.abv ?? null,
-      singleCask: data.singleCask ?? null,
-      caskStrength: data.caskStrength ?? null,
-      caskType: data.caskType ?? null,
-      caskSize: data.caskSize ?? null,
-      caskFill: data.caskFill ?? null,
-    },
-  });
 
   return (
-    <BottleScaffold
-      name={identity.fullName}
-      category={data.category ? formatCategoryName(data.category) : null}
-      distillers={
-        data.distillers?.length ? (
-          <Join divider=", ">
-            {data.distillers.map((d) => (
-              <span key={d.id}>{d.name}</span>
-            ))}
-          </Join>
-        ) : null
-      }
-      statedAge={identity.statedAge ? `Aged ${identity.statedAge} years` : null}
-    />
+    <section
+      aria-label="Bottle preview"
+      className="bg-highlight min-w-0 p-4 text-black sm:rounded lg:p-5"
+    >
+      {brand && (
+        <div className="truncate text-xs font-medium uppercase tracking-wide text-black/60">
+          {brand.shortName || brand.name}
+        </div>
+      )}
+      {data.name && (
+        <div className="flex min-w-0 flex-wrap items-center gap-x-2">
+          <div className="break-words font-semibold">{data.name}</div>
+          {data.singleCask ? (
+            <SingleCaskChip className="!border-black/20 !bg-black/10 !text-black hover:!bg-black/10" />
+          ) : null}
+        </div>
+      )}
+      <BottleExactMetadata
+        className="!text-black/70"
+        bottle={{
+          category: null,
+          statedAge: data.statedAge ?? null,
+          abv: data.abv ?? null,
+          vintageYear: data.vintageYear ?? null,
+          releaseYear: data.releaseYear ?? null,
+          singleCask: false,
+          caskStrength: data.caskStrength ?? null,
+          caskFill: data.caskFill ?? null,
+          caskType: data.caskType ?? null,
+          caskSize: data.caskSize ?? null,
+        }}
+        leadingContent={data.edition || undefined}
+      />
+    </section>
   );
 };


### PR DESCRIPTION
Manual Bottle creation and editing now present one Bottle-oriented form: the core label facts stay up front, while edition, release year, cask information, description, and other release-specific fields live under an automatically expanding **More Details** section. The routes consistently use “Add Bottle” terminology, and internal BottleGroup/shared-versus-exact ownership language is no longer exposed to users.

The edit path still preserves existing age ownership behind the scenes: the single **Age Statement** field updates the shared or Bottle-specific value according to the loaded Bottle context. The yellow preview card remains, but its contents now use a clearer brand/name/status hierarchy with exact release metadata kept secondary. This affects manual create, edit, and Add Similar flows; the automated photo flow is unchanged.

Focused form and update-partition coverage passes alongside web typecheck and lint.
