### PR TITLE
feat(profile): reorganize profile overview and insights

### DIFF
--- a/apps/server/src/orpc/routes/users/age-stats.test.ts
+++ b/apps/server/src/orpc/routes/users/age-stats.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "vitest";
+
+import { buildAgeStats } from "./age-stats";
+
+describe("buildAgeStats", () => {
+  test("handles more ages than can be passed as function arguments", () => {
+    const ages = Array.from({ length: 200_000 }, (_, index) => index);
+
+    const stats = buildAgeStats(ages, 0);
+
+    expect(stats.knownCount).toBe(200_000);
+    expect(stats.median).toBe(99_999.5);
+    expect(stats.oldest).toBe(199_999);
+  });
+});

--- a/apps/server/src/orpc/routes/users/age-stats.ts
+++ b/apps/server/src/orpc/routes/users/age-stats.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+export const AgeStatsSchema = z.object({
+  knownCount: z.number(),
+  median: z.number().nullable(),
+  oldest: z.number().nullable(),
+  buckets: z.array(
+    z.object({
+      id: z.enum([
+        "under10",
+        "from10To12",
+        "from13To17",
+        "from18To24",
+        "atLeast25",
+        "unstated",
+      ]),
+      label: z.string(),
+      count: z.number(),
+    }),
+  ),
+});
+
+export type AgeStats = z.infer<typeof AgeStatsSchema>;
+
+function median(values: number[]): number | null {
+  if (values.length === 0) return null;
+
+  const sorted = values.toSorted((left, right) => left - right);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1]! + sorted[middle]!) / 2
+    : sorted[middle]!;
+}
+
+export function buildAgeStats(ages: number[], unstatedCount: number): AgeStats {
+  return {
+    knownCount: ages.length,
+    median: median(ages),
+    oldest: ages.length ? Math.max(...ages) : null,
+    buckets: [
+      {
+        id: "under10",
+        label: "Under 10",
+        count: ages.filter((age) => age < 10).length,
+      },
+      {
+        id: "from10To12",
+        label: "10–12",
+        count: ages.filter((age) => age >= 10 && age <= 12).length,
+      },
+      {
+        id: "from13To17",
+        label: "13–17",
+        count: ages.filter((age) => age >= 13 && age <= 17).length,
+      },
+      {
+        id: "from18To24",
+        label: "18–24",
+        count: ages.filter((age) => age >= 18 && age <= 24).length,
+      },
+      {
+        id: "atLeast25",
+        label: "25+",
+        count: ages.filter((age) => age >= 25).length,
+      },
+      {
+        id: "unstated",
+        label: "Unstated",
+        count: unstatedCount,
+      },
+    ],
+  };
+}

--- a/apps/server/src/orpc/routes/users/age-stats.ts
+++ b/apps/server/src/orpc/routes/users/age-stats.ts
@@ -36,7 +36,9 @@ export function buildAgeStats(ages: number[], unstatedCount: number): AgeStats {
   return {
     knownCount: ages.length,
     median: median(ages),
-    oldest: ages.length ? Math.max(...ages) : null,
+    oldest: ages.length
+      ? ages.reduce((oldest, age) => Math.max(oldest, age))
+      : null,
     buckets: [
       {
         id: "under10",

--- a/apps/server/src/orpc/routes/users/index.ts
+++ b/apps/server/src/orpc/routes/users/index.ts
@@ -8,6 +8,7 @@ import libraryStats from "./library-stats";
 import list from "./list";
 import regionList from "./region-list";
 import tagList from "./tag-list";
+import tastingStats from "./tasting-stats";
 import update from "./update";
 
 export default base.tag("users").router({
@@ -21,4 +22,5 @@ export default base.tag("users").router({
   libraryStats,
   regionList,
   tagList,
+  tastingStats,
 });

--- a/apps/server/src/orpc/routes/users/library-stats.ts
+++ b/apps/server/src/orpc/routes/users/library-stats.ts
@@ -12,6 +12,7 @@ import { procedure } from "@peated/server/orpc";
 import { CategoryEnum } from "@peated/server/schemas";
 import { and, eq, gt, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
+import { AgeStatsSchema, buildAgeStats } from "./age-stats";
 import {
   readJoinedUserBottle,
   type UserBottleRead,
@@ -19,19 +20,6 @@ import {
 } from "./tasting-bottle-scan";
 
 const LIBRARY_STATS_BATCH_SIZE = 200;
-
-const AgeBucketSchema = z.object({
-  id: z.enum([
-    "under10",
-    "from10To12",
-    "from13To17",
-    "from18To24",
-    "atLeast25",
-    "unstated",
-  ]),
-  label: z.string(),
-  count: z.number(),
-});
 
 const LibraryStatsSchema = z.object({
   total: z.number(),
@@ -42,12 +30,7 @@ const LibraryStatsSchema = z.object({
       count: z.number(),
     }),
   ),
-  age: z.object({
-    knownCount: z.number(),
-    median: z.number().nullable(),
-    oldest: z.number().nullable(),
-    buckets: z.array(AgeBucketSchema),
-  }),
+  age: AgeStatsSchema,
   categories: z.array(
     z.object({
       category: CategoryEnum,
@@ -61,7 +44,6 @@ type LibraryStats = z.infer<typeof LibraryStatsSchema>;
 type LibraryStatsAccumulator = {
   total: number;
   ages: number[];
-  oldestAge: number | null;
   categoryCounts: Map<Category, number>;
   distillerCounts: Map<number, number>;
   unstatedAgeCount: number;
@@ -95,7 +77,6 @@ function createLibraryStatsAccumulator(): LibraryStatsAccumulator {
   return {
     total: 0,
     ages: [],
-    oldestAge: null,
     categoryCounts: new Map(),
     distillerCounts: new Map(),
     unstatedAgeCount: 0,
@@ -118,10 +99,6 @@ function accumulateLibraryStats(
       accumulator.unstatedAgeCount += 1;
     } else {
       accumulator.ages.push(bottle.statedAge);
-      accumulator.oldestAge =
-        accumulator.oldestAge === null
-          ? bottle.statedAge
-          : Math.max(accumulator.oldestAge, bottle.statedAge);
     }
     if (bottle.category !== null) {
       incrementCount(accumulator.categoryCounts, bottle.category);
@@ -130,16 +107,6 @@ function accumulateLibraryStats(
       incrementCount(accumulator.distillerCounts, distillerId);
     }
   }
-}
-
-function median(values: number[]): number | null {
-  if (values.length === 0) return null;
-
-  const sorted = values.toSorted((left, right) => left - right);
-  const middle = Math.floor(sorted.length / 2);
-  return sorted.length % 2 === 0
-    ? (sorted[middle - 1]! + sorted[middle]!) / 2
-    : sorted[middle]!;
 }
 
 async function finalizeLibraryStats(
@@ -185,46 +152,7 @@ async function finalizeLibraryStats(
   return {
     total: accumulator.total,
     distillers,
-    age: {
-      knownCount: accumulator.ages.length,
-      median: median(accumulator.ages),
-      oldest: accumulator.oldestAge,
-      buckets: [
-        {
-          id: "under10",
-          label: "Under 10",
-          count: accumulator.ages.filter((age) => age < 10).length,
-        },
-        {
-          id: "from10To12",
-          label: "10–12",
-          count: accumulator.ages.filter((age) => age >= 10 && age <= 12)
-            .length,
-        },
-        {
-          id: "from13To17",
-          label: "13–17",
-          count: accumulator.ages.filter((age) => age >= 13 && age <= 17)
-            .length,
-        },
-        {
-          id: "from18To24",
-          label: "18–24",
-          count: accumulator.ages.filter((age) => age >= 18 && age <= 24)
-            .length,
-        },
-        {
-          id: "atLeast25",
-          label: "25+",
-          count: accumulator.ages.filter((age) => age >= 25).length,
-        },
-        {
-          id: "unstated",
-          label: "Unstated",
-          count: accumulator.unstatedAgeCount,
-        },
-      ],
-    },
+    age: buildAgeStats(accumulator.ages, accumulator.unstatedAgeCount),
     categories,
   };
 }

--- a/apps/server/src/orpc/routes/users/tasting-stats.test.ts
+++ b/apps/server/src/orpc/routes/users/tasting-stats.test.ts
@@ -1,0 +1,72 @@
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+describe("GET /users/:user/tasting-stats", () => {
+  test("summarizes the ages of tasted bottles", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const ages = [8, 12, 18, 25, null];
+
+    for (const statedAge of ages) {
+      const bottle = await fixtures.Bottle({ statedAge });
+      await fixtures.Tasting({
+        bottleId: bottle.id,
+        createdById: defaults.user.id,
+      });
+    }
+
+    const otherBottle = await fixtures.Bottle({ statedAge: 50 });
+    await fixtures.Tasting({ bottleId: otherBottle.id });
+
+    const data = await routerClient.users.tastingStats(
+      { user: defaults.user.id },
+      { context: { user: defaults.user } },
+    );
+
+    expect(data).toEqual({
+      total: 5,
+      age: {
+        knownCount: 4,
+        median: 15,
+        oldest: 25,
+        buckets: [
+          { id: "under10", label: "Under 10", count: 1 },
+          { id: "from10To12", label: "10–12", count: 1 },
+          { id: "from13To17", label: "13–17", count: 0 },
+          { id: "from18To24", label: "18–24", count: 1 },
+          { id: "atLeast25", label: "25+", count: 1 },
+          { id: "unstated", label: "Unstated", count: 1 },
+        ],
+      },
+    });
+  });
+
+  test("returns empty insights when the user has no tastings", async ({
+    defaults,
+  }) => {
+    const data = await routerClient.users.tastingStats(
+      { user: defaults.user.id },
+      { context: { user: defaults.user } },
+    );
+
+    expect(data.total).toBe(0);
+    expect(data.age).toMatchObject({
+      knownCount: 0,
+      median: null,
+      oldest: null,
+    });
+    expect(data.age.buckets.every((bucket) => bucket.count === 0)).toBe(true);
+  });
+
+  test("does not expose a private profile", async ({ fixtures }) => {
+    const user = await fixtures.User({ private: true });
+
+    const error = await waitError(() =>
+      routerClient.users.tastingStats({ user: user.id }),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: User's profile is private.]`);
+  });
+});

--- a/apps/server/src/orpc/routes/users/tasting-stats.ts
+++ b/apps/server/src/orpc/routes/users/tasting-stats.ts
@@ -1,0 +1,70 @@
+import { db } from "@peated/server/db";
+import { getUserFromId, profileVisible } from "@peated/server/lib/api";
+import { procedure } from "@peated/server/orpc";
+import { z } from "zod";
+import { AgeStatsSchema, buildAgeStats } from "./age-stats";
+import {
+  scanUserTastingBottles,
+  UserBottleReadIntegrityError,
+} from "./tasting-bottle-scan";
+
+const TastingStatsSchema = z.object({
+  total: z.number(),
+  age: AgeStatsSchema,
+});
+
+export default procedure
+  .route({
+    method: "GET",
+    path: "/users/{user}/tasting-stats",
+    summary: "Get user tasting statistics",
+    description: "Retrieve age insights for bottles tasted by a visible user",
+    operationId: "getUserTastingStats",
+  })
+  .input(
+    z.object({
+      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
+    }),
+  )
+  .output(TastingStatsSchema)
+  .handler(async function ({ input, context, errors }) {
+    const user = await getUserFromId(db, input.user, context.user);
+    if (!user) {
+      throw errors.NOT_FOUND({
+        message: "User not found.",
+      });
+    }
+
+    if (!(await profileVisible(db, user, context.user))) {
+      throw errors.BAD_REQUEST({
+        message: "User's profile is private.",
+      });
+    }
+
+    const ages: number[] = [];
+    let total = 0;
+    let unstatedCount = 0;
+
+    try {
+      for await (const rows of scanUserTastingBottles(user.id)) {
+        total += rows.length;
+        for (const { bottle } of rows) {
+          if (bottle?.statedAge === null || !bottle) {
+            unstatedCount += 1;
+          } else {
+            ages.push(bottle.statedAge);
+          }
+        }
+      }
+    } catch (error) {
+      if (error instanceof UserBottleReadIntegrityError) {
+        throw errors.CONFLICT({ message: error.message, cause: error });
+      }
+      throw error;
+    }
+
+    return {
+      total,
+      age: buildAgeStats(ages, unstatedCount),
+    };
+  });

--- a/apps/web/e2e/activity-feed.spec.ts
+++ b/apps/web/e2e/activity-feed.spec.ts
@@ -26,7 +26,9 @@ test.describe("activity feed", () => {
   test("fills profile activity after hiding a Favorites-only page", async ({
     page,
   }) => {
-    await page.goto(`/users/${testUser.username}`, { waitUntil: "commit" });
+    await page.goto(`/users/${testUser.username}/activity`, {
+      waitUntil: "commit",
+    });
 
     await expect(page.getByText(tastingNotes)).toBeVisible();
     await expect(page.getByText("Personal Favorites")).toHaveCount(0);

--- a/apps/web/e2e/profile-library.spec.ts
+++ b/apps/web/e2e/profile-library.spec.ts
@@ -17,7 +17,7 @@ import {
 import { signIn } from "./session";
 
 test.describe("profile library", () => {
-  test("stretches the age profile to match the distillery card", async ({
+  test("stretches bottle ages to match the distillery card", async ({
     context,
     page,
   }, testInfo) => {
@@ -29,12 +29,12 @@ test.describe("profile library", () => {
       ].join("-"),
     });
 
-    await page.goto(`/users/${testUser.username}/library`, {
+    await page.goto(`/users/${testUser.username}`, {
       waitUntil: "commit",
     });
 
     const ageCard = page
-      .getByRole("heading", { name: "Age profile" })
+      .getByRole("heading", { name: "Bottle ages" })
       .locator("xpath=../..");
     const distilleryCard = page
       .getByRole("heading", { name: "Top distilleries" })

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/activity/loading.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/activity/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@peated/web/components/defaultLoading";

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/activity/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/activity/page.tsx
@@ -11,6 +11,8 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 
 export const fetchCache = "default-no-store";
 
+const MAX_ACTIVITY_PAGES = 10;
+
 export default function UserActivityPage(props: {
   params: Promise<{ username: string }>;
 }) {
@@ -21,6 +23,7 @@ export default function UserActivityPage(props: {
     queryFn: async () => {
       const results = [];
       let cursor: number | undefined;
+      let fetchedPageCount = 0;
 
       do {
         const page = await orpc.users.activity.list.call({
@@ -28,9 +31,14 @@ export default function UserActivityPage(props: {
           limit: 10,
           cursor,
         });
+        fetchedPageCount += 1;
         results.push(...filterFavoriteActivity(page.results));
         cursor = page.rel?.nextCursor ?? undefined;
-      } while (results.length < 10 && cursor);
+      } while (
+        results.length < 10 &&
+        cursor &&
+        fetchedPageCount < MAX_ACTIVITY_PAGES
+      );
 
       return results.slice(0, 10);
     },

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/activity/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/activity/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { use } from "react";
+
+import ActivityList, {
+  filterFavoriteActivity,
+} from "@peated/web/components/activityList";
+import EmptyActivity from "@peated/web/components/emptyActivity";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+export const fetchCache = "default-no-store";
+
+export default function UserActivityPage(props: {
+  params: Promise<{ username: string }>;
+}) {
+  const { username } = use(props.params);
+  const orpc = useORPC();
+  const { data: activity } = useSuspenseQuery({
+    queryKey: ["profile-activity", username, "favorites-hidden"],
+    queryFn: async () => {
+      const results = [];
+      let cursor: number | undefined;
+
+      do {
+        const page = await orpc.users.activity.list.call({
+          user: username,
+          limit: 10,
+          cursor,
+        });
+        results.push(...filterFavoriteActivity(page.results));
+        cursor = page.rel?.nextCursor ?? undefined;
+      } while (results.length < 10 && cursor);
+
+      return results.slice(0, 10);
+    },
+  });
+
+  return activity.length ? (
+    <ActivityList values={activity} />
+  ) : (
+    <EmptyActivity />
+  );
+}

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
@@ -36,7 +36,7 @@ describe("LibraryInsightsContent", () => {
     expect(html).toContain("Top distilleries");
     expect(html).toContain("Example Distillery");
     expect(html).toContain("Example Distillery: 3 bottles");
-    expect(html).toContain("Age profile");
+    expect(html).toContain("Bottle ages");
     expect(html).toContain("Median 12 yr");
     expect(html).toContain("Under 10: 1 bottle");
     expect(html).toContain("Age stated for 3 of 4 bottles");

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
@@ -40,8 +40,6 @@ describe("LibraryInsightsContent", () => {
     expect(html).toContain("Median 12 yr");
     expect(html).toContain("Under 10: 1 bottle");
     expect(html).toContain("Age stated for 3 of 4 bottles");
-    expect(html).toContain("data-age-profile-chart");
-    expect(html).toContain("min-h-28 flex-1");
     expect(html).not.toContain("Library types");
   });
 

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
@@ -40,6 +40,8 @@ describe("LibraryInsightsContent", () => {
     expect(html).toContain("Median 12 yr");
     expect(html).toContain("Under 10: 1 bottle");
     expect(html).toContain("Age stated for 3 of 4 bottles");
+    expect(html).toContain("data-age-profile-chart");
+    expect(html).toContain("min-h-28 flex-1");
     expect(html).not.toContain("Library types");
   });
 

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
@@ -2,6 +2,7 @@
 
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
+import AgeInsightCard from "@peated/web/components/ageInsightCard";
 import {
   InsightCard,
   InsightCardSkeleton,
@@ -15,77 +16,6 @@ import { useEffect } from "react";
 type LibraryStats = Outputs["users"]["libraryStats"];
 
 const MINIMUM_AGE_SAMPLE = 3;
-
-function formatBottleCount(count: number) {
-  return `${count.toLocaleString()} ${count === 1 ? "bottle" : "bottles"}`;
-}
-
-function formatAge(age: number) {
-  return Number.isInteger(age) ? age.toLocaleString() : age.toFixed(1);
-}
-
-function AgeDistribution({ stats }: { stats: LibraryStats }) {
-  const largestCount = Math.max(
-    ...stats.age.buckets.map((bucket) => bucket.count),
-    1,
-  );
-  const detail = [
-    stats.age.median !== null
-      ? `Median ${formatAge(stats.age.median)} yr`
-      : null,
-    stats.age.oldest !== null
-      ? `Oldest ${formatAge(stats.age.oldest)} yr`
-      : null,
-  ]
-    .filter((value): value is string => value !== null)
-    .join(" · ");
-
-  return (
-    <InsightCard title="Age profile" detail={detail}>
-      <div
-        className="grid min-h-28 flex-1 grid-cols-6 gap-1"
-        data-age-profile-chart
-        aria-hidden="true"
-      >
-        {stats.age.buckets.map((bucket) => (
-          <div key={bucket.id} className="flex min-w-0 flex-col items-center">
-            <span className="text-muted mb-1 h-4 text-[10px] tabular-nums">
-              {bucket.count ? bucket.count.toLocaleString() : ""}
-            </span>
-            <div className="flex min-h-0 w-full flex-1 items-end justify-center">
-              <div
-                className={
-                  bucket.id === "unstated"
-                    ? "w-3/5 rounded-t bg-slate-600"
-                    : "bg-highlight w-3/5 rounded-t"
-                }
-                style={{
-                  height: bucket.count
-                    ? `${Math.max(10, (bucket.count / largestCount) * 100)}%`
-                    : 0,
-                }}
-              />
-            </div>
-            <span className="mt-1 min-h-7 text-center text-[10px] leading-3 text-slate-400">
-              {bucket.label}
-            </span>
-          </div>
-        ))}
-      </div>
-      <ul className="sr-only">
-        {stats.age.buckets.map((bucket) => (
-          <li key={bucket.id}>
-            {bucket.label}: {formatBottleCount(bucket.count)}
-          </li>
-        ))}
-      </ul>
-      <p className="text-muted mt-1 text-[11px]">
-        Age stated for {stats.age.knownCount.toLocaleString()} of{" "}
-        {stats.total.toLocaleString()} bottles
-      </p>
-    </InsightCard>
-  );
-}
 
 function CategoryDistribution({ stats }: { stats: LibraryStats }) {
   return (
@@ -135,7 +65,14 @@ export function LibraryInsightsContent({
           />
         </InsightCard>
       ) : null}
-      {showAge ? <AgeDistribution stats={stats} /> : null}
+      {showAge ? (
+        <AgeInsightCard
+          age={stats.age}
+          title="Bottle ages"
+          total={stats.total}
+          unit="bottle"
+        />
+      ) : null}
       {showCategories ? <CategoryDistribution stats={stats} /> : null}
     </div>
   );

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
@@ -50,7 +50,7 @@ export function LibraryInsightsContent({
 
   return (
     <div
-      className={`mb-4 grid grid-cols-1 gap-3 px-3 sm:px-0 ${cardCount > 1 ? "lg:grid-cols-2" : ""}`}
+      className={`mb-4 grid grid-cols-1 gap-3 ${cardCount > 1 ? "lg:grid-cols-2" : ""}`}
     >
       {showDistillers ? (
         <InsightCard title="Top distilleries">
@@ -80,7 +80,7 @@ export function LibraryInsightsContent({
 
 function LibraryInsightsSkeleton() {
   return (
-    <div className="mb-4 grid grid-cols-1 gap-3 px-3 sm:px-0 lg:grid-cols-2">
+    <div className="mb-4 grid grid-cols-1 gap-3 lg:grid-cols-2">
       <InsightCardSkeleton />
       <InsightCardSkeleton />
     </div>

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
@@ -2,97 +2,22 @@
 
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
-import Link from "@peated/web/components/link";
+import {
+  InsightCard,
+  InsightCardSkeleton,
+  RankedInsightBars,
+} from "@peated/web/components/insightCard";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, type ReactNode } from "react";
+import { useEffect } from "react";
 
 type LibraryStats = Outputs["users"]["libraryStats"];
-type RankedItem = {
-  id: string | number;
-  label: string;
-  count: number;
-  href?: string;
-};
 
 const MINIMUM_AGE_SAMPLE = 3;
 
 function formatBottleCount(count: number) {
   return `${count.toLocaleString()} ${count === 1 ? "bottle" : "bottles"}`;
-}
-
-function RankedBars({ items }: { items: RankedItem[] }) {
-  const largestCount = Math.max(...items.map((item) => item.count), 1);
-
-  return (
-    <ol className="space-y-2">
-      {items.map((item) => {
-        const content = (
-          <>
-            <div className="mb-1 flex items-center justify-between gap-3 text-xs">
-              <span className="truncate font-medium text-slate-200">
-                {item.label}
-              </span>
-              <span className="text-muted shrink-0 tabular-nums">
-                {item.count.toLocaleString()}
-              </span>
-            </div>
-            <div className="h-1.5 overflow-hidden rounded-full bg-slate-800">
-              <div
-                className="bg-highlight h-full rounded-full"
-                style={{ width: `${(item.count / largestCount) * 100}%` }}
-              />
-            </div>
-          </>
-        );
-
-        return (
-          <li key={item.id}>
-            {item.href ? (
-              <Link
-                href={item.href}
-                className="focus-visible:ring-highlight group block rounded focus-visible:outline-none focus-visible:ring-2"
-                aria-label={`${item.label}: ${formatBottleCount(item.count)}`}
-              >
-                {content}
-              </Link>
-            ) : (
-              <div
-                aria-label={`${item.label}: ${formatBottleCount(item.count)}`}
-              >
-                {content}
-              </div>
-            )}
-          </li>
-        );
-      })}
-    </ol>
-  );
-}
-
-function InsightCard({
-  title,
-  detail,
-  children,
-}: {
-  title: string;
-  detail?: string;
-  children: ReactNode;
-}) {
-  return (
-    <section className="flex h-full flex-col rounded border border-slate-800 bg-slate-950/70 p-3">
-      <div className="mb-3 flex min-h-8 items-start justify-between gap-3">
-        <h2 className="text-sm font-semibold text-white">{title}</h2>
-        {detail ? (
-          <span className="text-muted text-right text-[11px] leading-4">
-            {detail}
-          </span>
-        ) : null}
-      </div>
-      {children}
-    </section>
-  );
 }
 
 function formatAge(age: number) {
@@ -165,7 +90,8 @@ function AgeDistribution({ stats }: { stats: LibraryStats }) {
 function CategoryDistribution({ stats }: { stats: LibraryStats }) {
   return (
     <InsightCard title="Library types" detail="Age data is limited">
-      <RankedBars
+      <RankedInsightBars
+        unit="bottle"
         items={stats.categories.map((item) => ({
           id: item.category,
           label: formatCategoryName(item.category),
@@ -198,7 +124,8 @@ export function LibraryInsightsContent({
     >
       {showDistillers ? (
         <InsightCard title="Top distilleries">
-          <RankedBars
+          <RankedInsightBars
+            unit="bottle"
             items={stats.distillers.map((distiller) => ({
               id: distiller.id,
               label: distiller.name,
@@ -217,8 +144,8 @@ export function LibraryInsightsContent({
 function LibraryInsightsSkeleton() {
   return (
     <div className="mb-4 grid grid-cols-1 gap-3 px-3 sm:px-0 lg:grid-cols-2">
-      <div className="h-44 animate-pulse rounded bg-slate-900" />
-      <div className="h-44 animate-pulse rounded bg-slate-900" />
+      <InsightCardSkeleton />
+      <InsightCardSkeleton />
     </div>
   );
 }

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
@@ -4,7 +4,6 @@ import Button from "@peated/web/components/button";
 import EmptyActivity from "@peated/web/components/emptyActivity";
 import LibraryEntryActions, {
   LibraryEntryImage,
-  LibraryEntryStatus,
   LibraryEntryThumbnail,
 } from "@peated/web/components/libraryEntryActions";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
@@ -88,9 +87,6 @@ function UserLibraryTable({ username }: { username: string }) {
               ) : (
                 <LibraryEntryThumbnail entry={entry} />
               )
-            }
-            renderCollectionBottleMeta={(entry) =>
-              canEditLibrary ? null : <LibraryEntryStatus entry={entry} />
             }
             renderCollectionBottleActions={
               canEditLibrary

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
@@ -16,7 +16,6 @@ import { useRouter } from "next/navigation";
 import { use, useTransition } from "react";
 import { useProfileUserId } from "../../profileContext";
 import { LibraryFilters } from "./libraryFilters";
-import LibraryInsights from "./libraryInsights";
 
 export default function UserLibrary(props: {
   params: Promise<{ username: string }>;
@@ -56,7 +55,6 @@ function UserLibraryTable({ username }: { username: string }) {
 
   return (
     <>
-      <LibraryInsights username={username} />
       <LibraryFilters
         loading={isPending}
         onNavigate={(href) => {

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
@@ -29,6 +29,9 @@ export default function UserProfilePage(props: {
           <h2 id="library-heading" className="text-lg font-semibold text-white">
             Library
           </h2>
+          <p className="text-muted mt-1 text-sm">
+            A snapshot of the bottles currently in their library.
+          </p>
         </div>
         <LibraryInsights username={username} />
       </section>

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
@@ -18,9 +18,7 @@ export default function UserProfilePage(props: {
 
   return (
     <div className="space-y-8 px-3 py-2 lg:px-0">
-      <section>
-        <UserBadgeList userId={userId} />
-      </section>
+      <UserBadgeList userId={userId} />
 
       <UserTastingInsights userId={userId} />
 

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
@@ -1,8 +1,7 @@
 "use client";
 import { use } from "react";
 
-import UserFlavorDistributionChart from "@peated/web/components/userFlavorDistributionChart";
-import UserLocationChart from "@peated/web/components/userLocationChart";
+import UserTastingInsights from "@peated/web/components/userTastingInsights";
 import { useProfileUserId } from "../profileContext";
 import { UserBadgeList } from "../userBadgeList";
 import LibraryInsights from "./library/libraryInsights";
@@ -23,20 +22,7 @@ export default function UserProfilePage(props: {
         <UserBadgeList userId={userId} />
       </section>
 
-      <section aria-labelledby="tastings-heading">
-        <div className="mb-3">
-          <h2
-            id="tastings-heading"
-            className="text-lg font-semibold text-white"
-          >
-            Tastings
-          </h2>
-        </div>
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
-          <UserLocationChart userId={userId} />
-          <UserFlavorDistributionChart userId={userId} />
-        </div>
-      </section>
+      <UserTastingInsights userId={userId} />
 
       <section aria-labelledby="library-heading">
         <div className="mb-3">

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
@@ -23,18 +23,14 @@ export default function UserProfilePage(props: {
         <UserBadgeList userId={userId} />
       </section>
 
-      <section aria-labelledby="tasting-profile-heading">
-        <div className="mb-4">
+      <section aria-labelledby="tastings-heading">
+        <div className="mb-3">
           <h2
-            id="tasting-profile-heading"
+            id="tastings-heading"
             className="text-lg font-semibold text-white"
           >
-            Tasting profile
+            Tastings
           </h2>
-          <p className="text-muted mt-1 text-sm">
-            The regions and flavors that show up most often in {username}
-            &apos;s tastings.
-          </p>
         </div>
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <UserLocationChart userId={userId} />
@@ -42,17 +38,11 @@ export default function UserProfilePage(props: {
         </div>
       </section>
 
-      <section aria-labelledby="library-profile-heading">
-        <div className="mb-4">
-          <h2
-            id="library-profile-heading"
-            className="text-lg font-semibold text-white"
-          >
-            Library profile
+      <section aria-labelledby="library-heading">
+        <div className="mb-3">
+          <h2 id="library-heading" className="text-lg font-semibold text-white">
+            Library
           </h2>
-          <p className="text-muted mt-1 text-sm">
-            A snapshot of the bottles {username} has collected.
-          </p>
         </div>
         <LibraryInsights username={username} />
       </section>

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/page.tsx
@@ -1,16 +1,11 @@
 "use client";
 import { use } from "react";
 
-import ActivityList, {
-  filterFavoriteActivity,
-} from "@peated/web/components/activityList";
-import EmptyActivity from "@peated/web/components/emptyActivity";
 import UserFlavorDistributionChart from "@peated/web/components/userFlavorDistributionChart";
 import UserLocationChart from "@peated/web/components/userLocationChart";
-import { useORPC } from "@peated/web/lib/orpc/context";
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { useProfileUserId } from "../profileContext";
 import { UserBadgeList } from "../userBadgeList";
+import LibraryInsights from "./library/libraryInsights";
 
 export const fetchCache = "default-no-store";
 
@@ -22,44 +17,45 @@ export default function UserProfilePage(props: {
   const { username } = params;
   const userId = useProfileUserId();
 
-  const orpc = useORPC();
-  const { data: activity } = useSuspenseQuery({
-    queryKey: ["profile-activity", username, "favorites-hidden"],
-    queryFn: async () => {
-      const results = [];
-      let cursor: number | undefined;
-
-      do {
-        const page = await orpc.users.activity.list.call({
-          user: username,
-          limit: 10,
-          cursor,
-        });
-        results.push(...filterFavoriteActivity(page.results));
-        cursor = page.rel?.nextCursor ?? undefined;
-      } while (results.length < 10 && cursor);
-
-      return results.slice(0, 10);
-    },
-  });
-
   return (
-    <div>
-      <div className="mt-1 space-y-6 px-3 lg:px-0">
+    <div className="space-y-8 px-3 py-2 lg:px-0">
+      <section>
         <UserBadgeList userId={userId} />
+      </section>
+
+      <section aria-labelledby="tasting-profile-heading">
+        <div className="mb-4">
+          <h2
+            id="tasting-profile-heading"
+            className="text-lg font-semibold text-white"
+          >
+            Tasting profile
+          </h2>
+          <p className="text-muted mt-1 text-sm">
+            The regions and flavors that show up most often in {username}
+            &apos;s tastings.
+          </p>
+        </div>
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           <UserLocationChart userId={userId} />
           <UserFlavorDistributionChart userId={userId} />
         </div>
-      </div>
+      </section>
 
-      <div className="mt-8">
-        {activity.length ? (
-          <ActivityList values={activity} />
-        ) : (
-          <EmptyActivity />
-        )}
-      </div>
+      <section aria-labelledby="library-profile-heading">
+        <div className="mb-4">
+          <h2
+            id="library-profile-heading"
+            className="text-lg font-semibold text-white"
+          >
+            Library profile
+          </h2>
+          <p className="text-muted mt-1 text-sm">
+            A snapshot of the bottles {username} has collected.
+          </p>
+        </div>
+        <LibraryInsights username={username} />
+      </section>
     </div>
   );
 }

--- a/apps/web/src/app/(default)/users/[username]/layout.tsx
+++ b/apps/web/src/app/(default)/users/[username]/layout.tsx
@@ -10,7 +10,6 @@ import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
 import { type ReactNode } from "react";
 import type { ProfilePage, WithContext } from "schema-dts";
 import FriendButton from "./friendButton";
-import { formatLibraryTabLabel } from "./libraryTabLabel";
 import LogoutButton from "./logoutButton";
 import ModActions from "./modActions";
 import { ProfileProvider } from "./profileContext";
@@ -153,21 +152,26 @@ export default async function Layout(props: {
         <EmptyActivity>This users profile is private.</EmptyActivity>
       ) : (
         <ProfileProvider userId={user.id}>
-          <div className="hidden lg:block">
-            <Tabs border>
-              <TabItem as={Link} href={`/users/${user.username}`} controlled>
-                Activity
-              </TabItem>
-              <TabItem
-                as={Link}
-                href={`/users/${user.username}/library`}
-                controlled
-                desktopOnly
-              >
-                {formatLibraryTabLabel(user.stats.library)}
-              </TabItem>
-            </Tabs>
-          </div>
+          <Tabs border aria-label={`${user.username}'s profile`}>
+            <TabItem as={Link} href={`/users/${user.username}`} controlled>
+              Profile
+            </TabItem>
+            <TabItem
+              as={Link}
+              href={`/users/${user.username}/activity`}
+              controlled
+            >
+              Activity
+            </TabItem>
+            <TabItem
+              as={Link}
+              href={`/users/${user.username}/library`}
+              controlled
+              count={user.stats.library.total}
+            >
+              Library
+            </TabItem>
+          </Tabs>
           {children}
         </ProfileProvider>
       )}

--- a/apps/web/src/app/(default)/users/[username]/layout.tsx
+++ b/apps/web/src/app/(default)/users/[username]/layout.tsx
@@ -167,9 +167,8 @@ export default async function Layout(props: {
               as={Link}
               href={`/users/${user.username}/library`}
               controlled
-              count={user.stats.library.total}
             >
-              Library
+              Library ({user.stats.library.total.toLocaleString()})
             </TabItem>
           </Tabs>
           {children}

--- a/apps/web/src/app/(default)/users/[username]/layout.tsx
+++ b/apps/web/src/app/(default)/users/[username]/layout.tsx
@@ -16,6 +16,42 @@ import { ProfileProvider } from "./profileContext";
 
 export const fetchCache = "default-no-store";
 
+function ProfileStat({
+  href,
+  label,
+  value,
+}: {
+  href?: string;
+  label: string;
+  value: number;
+}) {
+  const content = (
+    <>
+      <span className="group-hover:text-highlight order-1 text-xl font-bold tracking-wide text-white transition-colors">
+        {value.toLocaleString()}
+      </span>
+      <span className="text-muted order-2 mt-0.5 min-h-8 text-xs leading-4 sm:text-sm">
+        {label}
+      </span>
+    </>
+  );
+
+  return (
+    <li className="px-2 text-center sm:px-4">
+      {href ? (
+        <Link
+          href={href}
+          className="group flex flex-col rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400"
+        >
+          {content}
+        </Link>
+      ) : (
+        <div className="flex flex-col">{content}</div>
+      )}
+    </li>
+  );
+}
+
 export async function generateMetadata(props: {
   params: Promise<{ username: string }>;
 }) {
@@ -85,9 +121,9 @@ export default async function Layout(props: {
           <UserAvatar user={user} size={132} />
         </div>
         <div className="flex w-full flex-col justify-center gap-y-3 px-4 lg:w-auto lg:flex-auto lg:gap-y-1 lg:px-0">
-          <h3 className="self-center text-3xl font-semibold leading-normal text-white lg:self-start">
+          <h1 className="self-center text-3xl font-semibold leading-normal text-white lg:self-start">
             {user.username}
-          </h3>
+          </h1>
           <div className="text-muted flex flex-col items-center gap-x-2 gap-y-2 self-center lg:flex-row lg:self-start">
             <div>
               {user.admin ? (
@@ -101,32 +137,23 @@ export default async function Layout(props: {
               ) : null}
             </div>
           </div>
-          <div className="flex justify-center lg:justify-start">
-            <div className="mr-4 pr-3 text-center">
-              <span className="block text-xl font-bold uppercase tracking-wide text-white">
-                {user.stats.tastings.toLocaleString()}
-              </span>
-              <span className="text-muted text-sm">Tastings</span>
-            </div>
-            <div className="px-3 text-center">
-              <span className="block text-xl font-bold uppercase tracking-wide text-white">
-                {user.stats.bottles.toLocaleString()}
-              </span>
-              <span className="text-muted text-sm">Bottles</span>
-            </div>
-            <div className="px-3 text-center">
-              <span className="block text-xl font-bold uppercase tracking-wide text-white">
-                {user.stats.library.total.toLocaleString()}
-              </span>
-              <span className="text-muted text-sm">Library bottles</span>
-            </div>
-            <div className="mb-4 pl-3 text-center">
-              <span className="block text-xl font-bold uppercase tracking-wide text-white">
-                {user.stats.contributions.toLocaleString()}
-              </span>
-              <span className="text-muted text-sm">Contributions</span>
-            </div>
-          </div>
+          <ul className="mx-auto grid w-full max-w-lg grid-cols-4 divide-x divide-slate-800 lg:mx-0">
+            <ProfileStat
+              href={`/users/${user.username}/activity`}
+              label="Tastings"
+              value={user.stats.tastings}
+            />
+            <ProfileStat label="Unique bottles" value={user.stats.bottles} />
+            <ProfileStat
+              href={`/users/${user.username}/library`}
+              label="In library"
+              value={user.stats.library.total}
+            />
+            <ProfileStat
+              label="Contributions"
+              value={user.stats.contributions}
+            />
+          </ul>
         </div>
         <div className="flex w-full flex-col items-center justify-center lg:w-auto lg:items-end">
           {currentUser && (

--- a/apps/web/src/app/(default)/users/[username]/layout.tsx
+++ b/apps/web/src/app/(default)/users/[username]/layout.tsx
@@ -81,12 +81,12 @@ export default async function Layout(props: {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <div className="mb-4 flex min-w-full flex-wrap gap-y-4 lg:mb-8 lg:flex-nowrap">
+      <div className="mb-3 flex min-w-full flex-wrap gap-y-4 lg:flex-nowrap lg:gap-x-6">
         <div className="flex w-full justify-center lg:w-auto lg:justify-start">
-          <UserAvatar user={user} size={150} />
+          <UserAvatar user={user} size={132} />
         </div>
-        <div className="flex w-full flex-col justify-center gap-y-4 px-4 lg:w-auto lg:flex-auto lg:gap-y-2">
-          <h3 className="self-center text-4xl font-semibold leading-normal text-white lg:self-start">
+        <div className="flex w-full flex-col justify-center gap-y-3 px-4 lg:w-auto lg:flex-auto lg:gap-y-1 lg:px-0">
+          <h3 className="self-center text-3xl font-semibold leading-normal text-white lg:self-start">
             {user.username}
           </h3>
           <div className="text-muted flex flex-col items-center gap-x-2 gap-y-2 self-center lg:flex-row lg:self-start">
@@ -109,13 +109,13 @@ export default async function Layout(props: {
               </span>
               <span className="text-muted text-sm">Tastings</span>
             </div>
-            <div className="mb-4 px-3 text-center">
+            <div className="px-3 text-center">
               <span className="block text-xl font-bold uppercase tracking-wide text-white">
                 {user.stats.bottles.toLocaleString()}
               </span>
               <span className="text-muted text-sm">Bottles</span>
             </div>
-            <div className="mb-4 px-3 text-center">
+            <div className="px-3 text-center">
               <span className="block text-xl font-bold uppercase tracking-wide text-white">
                 {user.stats.library.total.toLocaleString()}
               </span>
@@ -154,7 +154,7 @@ export default async function Layout(props: {
       ) : (
         <ProfileProvider userId={user.id}>
           <div className="hidden lg:block">
-            <Tabs fullWidth border>
+            <Tabs border>
               <TabItem as={Link} href={`/users/${user.username}`} controlled>
                 Activity
               </TabItem>

--- a/apps/web/src/app/(default)/users/[username]/userBadgeList.tsx
+++ b/apps/web/src/app/(default)/users/[username]/userBadgeList.tsx
@@ -1,11 +1,78 @@
 "use client";
 
+import type { Outputs } from "@peated/server/orpc/router";
 import BadgeImage from "@peated/web/components/badgeImage";
-import { DistributionChartLegend } from "@peated/web/components/distributionChart";
 import Link from "@peated/web/components/link";
 import classNames from "@peated/web/lib/classNames";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
+import { useState } from "react";
+
+type BadgeAward = Outputs["users"]["badgeList"]["results"][number];
+
+const INITIAL_BADGE_COUNT = 8;
+
+export function UserBadgeAwards({ awards }: { awards: BadgeAward[] }) {
+  const [showAll, setShowAll] = useState(false);
+  const earnedAwards = awards.filter((award) => award.level > 0);
+
+  if (!earnedAwards.length) return null;
+
+  const visibleAwards = showAll
+    ? earnedAwards
+    : earnedAwards.slice(0, INITIAL_BADGE_COUNT);
+  const hiddenCount = earnedAwards.length - INITIAL_BADGE_COUNT;
+
+  return (
+    <section aria-labelledby="achievements-heading">
+      <div className="mb-3 flex items-start justify-between gap-4">
+        <div>
+          <h2
+            id="achievements-heading"
+            className="text-lg font-semibold text-white"
+          >
+            Achievements
+          </h2>
+          <p className="text-muted mt-1 text-sm">
+            Milestones earned through their tastings.
+          </p>
+        </div>
+        {hiddenCount > 0 ? (
+          <button
+            type="button"
+            className={classNames(
+              "text-muted hover:text-highlight mt-1 shrink-0 text-sm",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400",
+            )}
+            onClick={() => setShowAll((value) => !value)}
+            aria-expanded={showAll}
+          >
+            {showAll ? "Show fewer" : `Show all ${earnedAwards.length}`}
+          </button>
+        ) : null}
+      </div>
+      <ul className="scrollbar-none grid auto-cols-[6.5rem] grid-flow-col gap-2 overflow-x-auto pb-1 lg:grid-flow-row lg:grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] lg:overflow-visible">
+        {visibleAwards.map((award) => (
+          <li key={award.id}>
+            <Link
+              href={`/badges/${award.badge.id}`}
+              className="group flex h-full flex-col items-center rounded border border-slate-800 bg-slate-950/50 p-2 text-center transition hover:border-slate-700 hover:bg-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400"
+              aria-label={`${award.badge.name}, level ${award.level.toLocaleString()}`}
+            >
+              <BadgeImage badge={award.badge} level={award.level} />
+              <span className="mt-2 line-clamp-2 min-h-8 text-xs leading-4 text-slate-200">
+                {award.badge.name}
+              </span>
+              <span className="text-muted mt-1 text-[11px]">
+                Level {award.level}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
 
 export function UserBadgeList({ userId }: { userId: number }) {
   const orpc = useORPC();
@@ -17,43 +84,5 @@ export function UserBadgeList({ userId }: { userId: number }) {
     }),
   );
 
-  if (!awardList.results.length) return null;
-
-  return (
-    <div>
-      <DistributionChartLegend>Achievements</DistributionChartLegend>
-      <ul className="scrollbar-none flex gap-2 overflow-x-scroll lg:flex-wrap lg:overflow-x-auto">
-        {awardList.results.map((award) => {
-          return (
-            <li
-              key={award.id}
-              title={award.badge.name}
-              className={classNames(
-                "group relative flex flex-shrink-0 flex-col items-center gap-y-1 rounded p-1 text-sm hover:bg-slate-800",
-                award.level === 0 ? "grayscale" : "",
-              )}
-            >
-              <Link
-                href={`/badges/${award.badge.id}`}
-                className="absolute inset-0"
-                aria-label={`${award.badge.name}, ${
-                  award.level > 0
-                    ? `level ${award.level.toLocaleString()}`
-                    : "discovered"
-                }`}
-              />
-              <BadgeImage badge={award.badge} level={award.level} />
-              <div className="text-muted text-xs">
-                {award.level > 0 ? (
-                  <>Level {award.level}</>
-                ) : (
-                  <em>Discovered</em>
-                )}
-              </div>
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
+  return <UserBadgeAwards awards={awardList.results} />;
 }

--- a/apps/web/src/app/(default)/users/[username]/userBadgeList.tsx
+++ b/apps/web/src/app/(default)/users/[username]/userBadgeList.tsx
@@ -36,6 +36,11 @@ export function UserBadgeList({ userId }: { userId: number }) {
               <Link
                 href={`/badges/${award.badge.id}`}
                 className="absolute inset-0"
+                aria-label={`${award.badge.name}, ${
+                  award.level > 0
+                    ? `level ${award.level.toLocaleString()}`
+                    : "discovered"
+                }`}
               />
               <BadgeImage badge={award.badge} level={award.level} />
               <div className="text-muted text-xs">

--- a/apps/web/src/app/(default)/users/[username]/userBadgeList.tsx
+++ b/apps/web/src/app/(default)/users/[username]/userBadgeList.tsx
@@ -4,9 +4,11 @@ import type { Outputs } from "@peated/server/orpc/router";
 import BadgeImage from "@peated/web/components/badgeImage";
 import Link from "@peated/web/components/link";
 import classNames from "@peated/web/lib/classNames";
+import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { useState } from "react";
+import { Suspense, useState } from "react";
+import { ErrorBoundary } from "react-error-boundary";
 
 type BadgeAward = Outputs["users"]["badgeList"]["results"][number];
 
@@ -74,7 +76,7 @@ export function UserBadgeAwards({ awards }: { awards: BadgeAward[] }) {
   );
 }
 
-export function UserBadgeList({ userId }: { userId: number }) {
+function UserBadgeListContent({ userId }: { userId: number }) {
   const orpc = useORPC();
   const { data: awardList } = useSuspenseQuery(
     orpc.users.badgeList.queryOptions({
@@ -85,4 +87,59 @@ export function UserBadgeList({ userId }: { userId: number }) {
   );
 
   return <UserBadgeAwards awards={awardList.results} />;
+}
+
+function UserBadgeListSkeleton() {
+  return (
+    <section aria-labelledby="achievements-loading-heading">
+      <div className="mb-3">
+        <h2
+          id="achievements-loading-heading"
+          className="text-lg font-semibold text-white"
+        >
+          Achievements
+        </h2>
+        <p className="text-muted mt-1 text-sm">
+          Milestones earned through their tastings.
+        </p>
+      </div>
+      <div className="scrollbar-none grid auto-cols-[6.5rem] grid-flow-col gap-2 overflow-x-auto pb-1 lg:grid-flow-row lg:grid-cols-[repeat(auto-fill,minmax(6.5rem,1fr))] lg:overflow-visible">
+        {Array.from({ length: INITIAL_BADGE_COUNT }, (_, index) => (
+          <div
+            key={index}
+            className="h-36 animate-pulse rounded bg-slate-900"
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function UserBadgeListError() {
+  return (
+    <section aria-labelledby="achievements-error-heading">
+      <h2
+        id="achievements-error-heading"
+        className="mb-3 text-lg font-semibold text-white"
+      >
+        Achievements
+      </h2>
+      <div className="text-muted rounded border border-slate-800 bg-slate-950/70 p-4 text-sm">
+        Achievements could not be loaded.
+      </div>
+    </section>
+  );
+}
+
+export function UserBadgeList({ userId }: { userId: number }) {
+  return (
+    <ErrorBoundary
+      fallback={<UserBadgeListError />}
+      onError={(error) => logError(error, { context: "profile_achievements" })}
+    >
+      <Suspense fallback={<UserBadgeListSkeleton />}>
+        <UserBadgeListContent userId={userId} />
+      </Suspense>
+    </ErrorBoundary>
+  );
 }

--- a/apps/web/src/components/ageInsightCard.tsx
+++ b/apps/web/src/components/ageInsightCard.tsx
@@ -1,0 +1,77 @@
+import type { Outputs } from "@peated/server/orpc/router";
+import { InsightCard } from "@peated/web/components/insightCard";
+
+type AgeStats = Outputs["users"]["libraryStats"]["age"];
+
+function formatCount(count: number, unit: string) {
+  return `${count.toLocaleString()} ${unit}${count === 1 ? "" : "s"}`;
+}
+
+function formatAge(age: number) {
+  return Number.isInteger(age) ? age.toLocaleString() : age.toFixed(1);
+}
+
+export default function AgeInsightCard({
+  age,
+  title,
+  total,
+  unit,
+}: {
+  age: AgeStats;
+  title: string;
+  total: number;
+  unit: string;
+}) {
+  const largestCount = Math.max(
+    ...age.buckets.map((bucket) => bucket.count),
+    1,
+  );
+  const detail = [
+    age.median !== null ? `Median ${formatAge(age.median)} yr` : null,
+    age.oldest !== null ? `Oldest ${formatAge(age.oldest)} yr` : null,
+  ]
+    .filter((value): value is string => value !== null)
+    .join(" · ");
+
+  return (
+    <InsightCard title={title} detail={detail}>
+      <div className="grid h-28 grid-cols-6 gap-1" aria-hidden="true">
+        {age.buckets.map((bucket) => (
+          <div key={bucket.id} className="flex min-w-0 flex-col items-center">
+            <span className="text-muted mb-1 h-4 text-[10px] tabular-nums">
+              {bucket.count ? bucket.count.toLocaleString() : ""}
+            </span>
+            <div className="flex min-h-0 w-full flex-1 items-end justify-center">
+              <div
+                className={
+                  bucket.id === "unstated"
+                    ? "w-3/5 rounded-t bg-slate-600"
+                    : "bg-highlight w-3/5 rounded-t"
+                }
+                style={{
+                  height: bucket.count
+                    ? `${Math.max(10, (bucket.count / largestCount) * 100)}%`
+                    : 0,
+                }}
+              />
+            </div>
+            <span className="mt-1 min-h-7 text-center text-[10px] leading-3 text-slate-400">
+              {bucket.label}
+            </span>
+          </div>
+        ))}
+      </div>
+      <ul className="sr-only">
+        {age.buckets.map((bucket) => (
+          <li key={bucket.id}>
+            {bucket.label}: {formatCount(bucket.count, unit)}
+          </li>
+        ))}
+      </ul>
+      <p className="text-muted mt-1 text-[11px]">
+        Age stated for {age.knownCount.toLocaleString()} of{" "}
+        {formatCount(total, unit)}
+      </p>
+    </InsightCard>
+  );
+}

--- a/apps/web/src/components/ageInsightCard.tsx
+++ b/apps/web/src/components/ageInsightCard.tsx
@@ -35,7 +35,11 @@ export default function AgeInsightCard({
 
   return (
     <InsightCard title={title} detail={detail}>
-      <div className="grid h-28 grid-cols-6 gap-1" aria-hidden="true">
+      <div
+        className="grid min-h-28 flex-1 grid-cols-6 gap-1"
+        data-age-profile-chart
+        aria-hidden="true"
+      >
         {age.buckets.map((bucket) => (
           <div key={bucket.id} className="flex min-w-0 flex-col items-center">
             <span className="text-muted mb-1 h-4 text-[10px] tabular-nums">

--- a/apps/web/src/components/badgeImage.tsx
+++ b/apps/web/src/components/badgeImage.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { type Badge } from "@peated/server/types";
 import classNames from "../lib/classNames";
 
@@ -36,17 +38,31 @@ export default function BadgeImage({
   if (!badge.imageUrl)
     return <PlaceholderBadgeImage size={size} isMaxLevel={isMaxLevel} />;
   return (
-    <img
-      src={badge.imageUrl}
-      alt={badge.name}
-      className={classNames(
-        "rounded",
-        isMaxLevel ? "ring-highlight ring-1 ring-inset" : "",
-      )}
+    <span
+      className="relative inline-block shrink-0"
       style={{
         width: size,
         height: size,
       }}
-    />
+    >
+      <span className="absolute inset-0">
+        <PlaceholderBadgeImage size={size} isMaxLevel={isMaxLevel} />
+      </span>
+      <img
+        src={badge.imageUrl}
+        alt=""
+        className={classNames(
+          "relative rounded",
+          isMaxLevel ? "ring-highlight ring-1 ring-inset" : "",
+        )}
+        style={{
+          width: size,
+          height: size,
+        }}
+        onError={(event) => {
+          event.currentTarget.hidden = true;
+        }}
+      />
+    </span>
   );
 }

--- a/apps/web/src/components/insightCard.tsx
+++ b/apps/web/src/components/insightCard.tsx
@@ -82,7 +82,7 @@ export function InsightCard({
   return (
     <section
       className={classNames(
-        "rounded border border-slate-800 bg-slate-950/70 p-3",
+        "flex h-full flex-col rounded border border-slate-800 bg-slate-950/70 p-3",
         className,
       )}
     >

--- a/apps/web/src/components/insightCard.tsx
+++ b/apps/web/src/components/insightCard.tsx
@@ -1,0 +1,111 @@
+import Link from "@peated/web/components/link";
+import classNames from "@peated/web/lib/classNames";
+import type { ReactNode } from "react";
+
+export type RankedInsightItem = {
+  id: string | number;
+  label: string;
+  count: number;
+  href?: string;
+};
+
+function formatCount(count: number, unit: string) {
+  return `${count.toLocaleString()} ${unit}${count === 1 ? "" : "s"}`;
+}
+
+export function RankedInsightBars({
+  items,
+  unit,
+}: {
+  items: RankedInsightItem[];
+  unit: string;
+}) {
+  const largestCount = Math.max(...items.map((item) => item.count), 1);
+
+  return (
+    <ol className="space-y-2">
+      {items.map((item) => {
+        const content = (
+          <>
+            <div className="mb-1 flex items-center justify-between gap-3 text-xs">
+              <span className="truncate font-medium text-slate-200">
+                {item.label}
+              </span>
+              <span className="text-muted shrink-0 tabular-nums">
+                {item.count.toLocaleString()}
+              </span>
+            </div>
+            <div className="h-1.5 overflow-hidden rounded-full bg-slate-800">
+              <div
+                className="bg-highlight h-full rounded-full"
+                style={{ width: `${(item.count / largestCount) * 100}%` }}
+              />
+            </div>
+          </>
+        );
+
+        return (
+          <li key={item.id}>
+            {item.href ? (
+              <Link
+                href={item.href}
+                className="focus-visible:ring-highlight group block rounded focus-visible:outline-none focus-visible:ring-2"
+                aria-label={`${item.label}: ${formatCount(item.count, unit)}`}
+              >
+                {content}
+              </Link>
+            ) : (
+              <div
+                aria-label={`${item.label}: ${formatCount(item.count, unit)}`}
+              >
+                {content}
+              </div>
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+export function InsightCard({
+  title,
+  detail,
+  className,
+  children,
+}: {
+  title: string;
+  detail?: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <section
+      className={classNames(
+        "rounded border border-slate-800 bg-slate-950/70 p-3",
+        className,
+      )}
+    >
+      <div className="mb-3 flex min-h-8 items-start justify-between gap-3">
+        <h3 className="text-sm font-semibold text-white">{title}</h3>
+        {detail ? (
+          <span className="text-muted text-right text-[11px] leading-4">
+            {detail}
+          </span>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+export function InsightCardSkeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={classNames(
+        "h-44 animate-pulse rounded bg-slate-900",
+        className,
+      )}
+    />
+  );
+}

--- a/apps/web/src/components/userTastingInsights.tsx
+++ b/apps/web/src/components/userTastingInsights.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { formatFlavorProfile } from "@peated/server/lib/format";
+import {
+  InsightCard,
+  InsightCardSkeleton,
+  RankedInsightBars,
+} from "@peated/web/components/insightCard";
+import { logError } from "@peated/web/lib/log";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { useSuspenseQueries } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { ErrorBoundary } from "react-error-boundary";
+
+function UserTastingInsightsContent({ userId }: { userId: number }) {
+  const orpc = useORPC();
+  const [regionsQuery, flavorsQuery] = useSuspenseQueries({
+    queries: [
+      orpc.users.regionList.queryOptions({
+        input: { user: userId },
+      }),
+      orpc.users.flavorList.queryOptions({
+        input: { user: userId },
+      }),
+    ],
+  });
+
+  const regions = regionsQuery.data.results;
+  const flavors = flavorsQuery.data.results;
+
+  if (!regions.length && !flavors.length) return null;
+
+  return (
+    <section aria-labelledby="tastings-heading">
+      <h2
+        id="tastings-heading"
+        className="mb-3 text-lg font-semibold text-white"
+      >
+        Tastings
+      </h2>
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        {regions.length ? (
+          <InsightCard title="Top regions" className="only:lg:col-span-2">
+            <RankedInsightBars
+              unit="tasting"
+              items={regions.map((item) => ({
+                id: item.region
+                  ? `${item.country.slug}/${item.region.slug}`
+                  : item.country.slug,
+                label: item.region?.name ?? item.country.name,
+                count: item.count,
+                href: `/locations/${item.country.slug}${
+                  item.region ? `/regions/${item.region.slug}` : ""
+                }`,
+              }))}
+            />
+          </InsightCard>
+        ) : null}
+        {flavors.length ? (
+          <InsightCard title="Top flavors" className="only:lg:col-span-2">
+            <RankedInsightBars
+              unit="tasting"
+              items={flavors.map((item) => ({
+                id: item.flavorProfile,
+                label: formatFlavorProfile(item.flavorProfile),
+                count: item.count,
+                href: `/bottles?flavorProfile=${encodeURIComponent(
+                  item.flavorProfile,
+                )}`,
+              }))}
+            />
+          </InsightCard>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function UserTastingInsightsSkeleton() {
+  return (
+    <section aria-labelledby="tastings-loading-heading">
+      <h2
+        id="tastings-loading-heading"
+        className="mb-3 text-lg font-semibold text-white"
+      >
+        Tastings
+      </h2>
+      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        <InsightCardSkeleton />
+        <InsightCardSkeleton />
+      </div>
+    </section>
+  );
+}
+
+function UserTastingInsightsError() {
+  return (
+    <section aria-labelledby="tastings-error-heading">
+      <h2
+        id="tastings-error-heading"
+        className="mb-3 text-lg font-semibold text-white"
+      >
+        Tastings
+      </h2>
+      <div className="text-muted rounded border border-slate-800 bg-slate-950/70 p-4 text-sm">
+        Tasting insights could not be loaded.
+      </div>
+    </section>
+  );
+}
+
+export default function UserTastingInsights({ userId }: { userId: number }) {
+  return (
+    <ErrorBoundary
+      fallback={<UserTastingInsightsError />}
+      onError={(error) => logError(error, { context: "tasting_insights" })}
+    >
+      <Suspense fallback={<UserTastingInsightsSkeleton />}>
+        <UserTastingInsightsContent userId={userId} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}

--- a/apps/web/src/components/userTastingInsights.tsx
+++ b/apps/web/src/components/userTastingInsights.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { formatFlavorProfile } from "@peated/server/lib/format";
+import AgeInsightCard from "@peated/web/components/ageInsightCard";
 import {
   InsightCard,
   InsightCardSkeleton,
   RankedInsightBars,
 } from "@peated/web/components/insightCard";
+import classNames from "@peated/web/lib/classNames";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQueries } from "@tanstack/react-query";
@@ -14,7 +16,7 @@ import { ErrorBoundary } from "react-error-boundary";
 
 function UserTastingInsightsContent({ userId }: { userId: number }) {
   const orpc = useORPC();
-  const [regionsQuery, flavorsQuery] = useSuspenseQueries({
+  const [regionsQuery, flavorsQuery, statsQuery] = useSuspenseQueries({
     queries: [
       orpc.users.regionList.queryOptions({
         input: { user: userId },
@@ -22,13 +24,20 @@ function UserTastingInsightsContent({ userId }: { userId: number }) {
       orpc.users.flavorList.queryOptions({
         input: { user: userId },
       }),
+      orpc.users.tastingStats.queryOptions({
+        input: { user: userId },
+      }),
     ],
   });
 
   const regions = regionsQuery.data.results;
   const flavors = flavorsQuery.data.results;
+  const stats = statsQuery.data;
+  const showAge = stats.age.knownCount >= 3;
+  const cardCount =
+    Number(regions.length > 0) + Number(flavors.length > 0) + Number(showAge);
 
-  if (!regions.length && !flavors.length) return null;
+  if (!cardCount) return null;
 
   return (
     <section aria-labelledby="tastings-heading">
@@ -38,9 +47,18 @@ function UserTastingInsightsContent({ userId }: { userId: number }) {
       >
         Tastings
       </h2>
-      <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+      <p className="text-muted -mt-2 mb-3 text-sm">
+        Patterns across the bottles they’ve tasted.
+      </p>
+      <div
+        className={classNames(
+          "grid grid-cols-1 gap-3",
+          cardCount === 2 && "lg:grid-cols-2",
+          cardCount >= 3 && "lg:grid-cols-3",
+        )}
+      >
         {regions.length ? (
-          <InsightCard title="Top regions" className="only:lg:col-span-2">
+          <InsightCard title="Top regions">
             <RankedInsightBars
               unit="tasting"
               items={regions.map((item) => ({
@@ -57,7 +75,7 @@ function UserTastingInsightsContent({ userId }: { userId: number }) {
           </InsightCard>
         ) : null}
         {flavors.length ? (
-          <InsightCard title="Top flavors" className="only:lg:col-span-2">
+          <InsightCard title="Top flavors">
             <RankedInsightBars
               unit="tasting"
               items={flavors.map((item) => ({
@@ -70,6 +88,14 @@ function UserTastingInsightsContent({ userId }: { userId: number }) {
               }))}
             />
           </InsightCard>
+        ) : null}
+        {showAge ? (
+          <AgeInsightCard
+            age={stats.age}
+            title="Ages tasted"
+            total={stats.total}
+            unit="tasting"
+          />
         ) : null}
       </div>
     </section>


### PR DESCRIPTION
Profiles now separate the overview, Activity, and Library into dedicated tabs. The overview presents earned achievements plus tasting and Library insights with clearer summary metrics, while Activity and Library remain focused lists.

This adds shared age-distribution primitives and a public tasting-stats endpoint, hides sparse or empty insights, limits achievements to earned badges with graceful image fallbacks, and improves profile navigation semantics and mobile layout. Reviewers should focus on the profile information hierarchy and the distinction between ages tasted and bottle ages.
