### PR TITLE
fix(web): prevent tasting image upload hangs

### DIFF
--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -761,6 +761,17 @@ async function handleRpcRequest({ request, response, url }) {
       );
       return true;
     case "tastings/imageUpdate":
+      if (getAccessToken(request).includes("tasting-image-failure")) {
+        sendRpcError(response, "Forced tasting image upload failure.");
+        return true;
+      }
+      if (
+        input?.tasting !== createdTastingId ||
+        input.__mockHasUploadFile !== true
+      ) {
+        sendRpcError(response, "Unexpected tasting image update payload.");
+        return true;
+      }
       sendRpcResponse(response, {
         imageUrl: "http://127.0.0.1:4999/uploads/tasting.webp",
       });

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -13,6 +13,11 @@ import {
 } from "./rpc-fixtures.mjs";
 import { signIn } from "./session";
 
+const testImage = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64",
+);
+
 test.describe("log tasting", () => {
   test("preserves query params when redirecting legacy bottle tasting links", async ({
     context,
@@ -64,9 +69,14 @@ test.describe("log tasting", () => {
     await expect(page.getByTitle(existingBottle.fullName)).toBeVisible();
     await page.getByRole("button", { name: "Savor" }).click();
     await page.getByLabel("Comments").fill(tastingNotes);
+    await uploadTastingImage(page);
     const createRequestPromise = waitForTastingCreate(page);
+    const imageRequestPromise = page.waitForRequest((request) =>
+      request.url().includes("/rpc/tastings/imageUpdate"),
+    );
     await page.getByRole("button", { name: "Save" }).click();
     const createInput = getRpcInput(await createRequestPromise);
+    await imageRequestPromise;
 
     expect(createInput.bottle).toBe(existingBottle.id);
     expect(createInput).not.toHaveProperty("target");
@@ -74,6 +84,30 @@ test.describe("log tasting", () => {
 
     await expect(page).toHaveURL(new RegExp(`/tastings/${createdTastingId}$`));
     await expectNoHorizontalOverflow(page);
+  });
+
+  test("finishes saving when tasting image upload fails", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: `${testAccessToken}-tasting-image-failure-${testInfo.project.name}`,
+    });
+
+    await page.goto(`/bottles/${existingBottle.id}/addTasting`);
+    await page.getByRole("button", { name: "Log Tasting" }).click();
+    await page.getByRole("button", { name: "Savor" }).click();
+    await page.getByLabel("Comments").fill(tastingNotes);
+    await uploadTastingImage(page);
+
+    await page.getByRole("button", { name: "Save" }).click();
+
+    await expect(
+      page.getByText(
+        "There was an error uploading your image, but the tasting was saved.",
+      ),
+    ).toBeVisible();
+    await expect(page).toHaveURL(new RegExp(`/tastings/${createdTastingId}$`));
   });
 
   test("logs a tasting from a matched bottle photo", async ({
@@ -177,16 +211,24 @@ async function uploadLabel(page: Page) {
     await page.locator('input[type="file"]').setInputFiles({
       name: `label-${attempt}.png`,
       mimeType: "image/png",
-      buffer: Buffer.from(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
-        "base64",
-      ),
+      buffer: testImage,
     });
 
     if (await requestPromise) return;
   }
 
   throw new Error("Photo identification request was not sent.");
+}
+
+async function uploadTastingImage(page: Page) {
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "tasting.png",
+    mimeType: "image/png",
+    buffer: testImage,
+  });
+  await expect(page.getByRole("heading", { name: "Crop Image" })).toBeVisible();
+  await page.getByRole("dialog").getByRole("button", { name: "Save" }).click();
+  await expect(page.getByAltText("uploaded image")).toBeVisible();
 }
 
 function waitForTastingCreate(page: Page) {

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -38,6 +38,7 @@ import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import type { TastingTagSuggestion } from "@peated/web/lib/tastingForm";
+import { uploadTastingImageAfterSave } from "@peated/web/lib/tastingImageUpload";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   AlertTriangle,
@@ -943,17 +944,23 @@ function AddBottleFlowContent() {
       throw new Error("Tasting was not returned after save.");
     }
 
-    const imageFile =
-      image instanceof File ? image : image ? await toBlob(image) : null;
-
-    if (imageFile) {
+    if (image) {
       try {
-        await tastingImageUpdateMutation.mutateAsync({
-          tasting: tasting.id,
-          file: imageFile,
+        await uploadTastingImageAfterSave({
+          prepare: async () =>
+            image instanceof File ? image : await toBlob(image),
+          upload: async (imageFile) => {
+            await tastingImageUpdateMutation.mutateAsync({
+              tasting: tasting.id,
+              file: imageFile,
+            });
+          },
         });
       } catch (err) {
-        logError(err);
+        logError(err, {
+          context: "tasting_image_upload_after_create",
+          extra: { tastingId: tasting.id },
+        });
         flash(
           "There was an error uploading your image, but the tasting was saved.",
           "error",

--- a/apps/web/src/lib/blobs.test.ts
+++ b/apps/web/src/lib/blobs.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { constructorMock, toBlobMock } = vi.hoisted(() => ({
+  constructorMock: vi.fn(),
+  toBlobMock: vi.fn(),
+}));
+
+vi.mock("pica", () => ({
+  default: class PicaMock {
+    constructor(options: unknown) {
+      constructorMock(options);
+    }
+
+    toBlob = toBlobMock;
+  },
+}));
+
+import { toBlob } from "./blobs";
+
+beforeEach(() => {
+  toBlobMock.mockResolvedValue(new Blob(["image"]));
+});
+
+describe("toBlob", () => {
+  it("keeps Pica image processing off its generated web worker", async () => {
+    const canvas = { width: 600, height: 600 } as HTMLCanvasElement;
+
+    await toBlob(canvas);
+
+    expect(constructorMock).toHaveBeenCalledWith({
+      features: ["js", "wasm"],
+    });
+    expect(toBlobMock).toHaveBeenCalledWith(canvas, "image/webp", 0.9);
+  });
+});

--- a/apps/web/src/lib/blobs.ts
+++ b/apps/web/src/lib/blobs.ts
@@ -5,7 +5,9 @@ const IMAGE_BLOB_QUALITY = 0.9;
 const MAX_IMAGE_EDGE = 1600;
 
 export const toBlob = async (canvas: HTMLCanvasElement): Promise<Blob> => {
-  const p = new pica();
+  // Pica's generated worker can throw before posting a response on Mobile
+  // Safari, leaving its resize promise pending indefinitely.
+  const p = new pica({ features: ["js", "wasm"] });
   const scale = Math.min(
     MAX_IMAGE_EDGE / canvas.width,
     MAX_IMAGE_EDGE / canvas.height,

--- a/apps/web/src/lib/tastingImageUpload.test.ts
+++ b/apps/web/src/lib/tastingImageUpload.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { uploadTastingImageAfterSave } from "./tastingImageUpload";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("uploadTastingImageAfterSave", () => {
+  it("uploads the prepared image", async () => {
+    const file = new Blob(["image"]);
+    const upload = vi.fn().mockResolvedValue(undefined);
+
+    await uploadTastingImageAfterSave({
+      prepare: async () => file,
+      upload,
+    });
+
+    expect(upload).toHaveBeenCalledWith(file);
+  });
+
+  it("reports image preparation failures", async () => {
+    const error = new Error("Could not convert canvas");
+
+    await expect(
+      uploadTastingImageAfterSave({
+        prepare: async () => {
+          throw error;
+        },
+        upload: vi.fn(),
+      }),
+    ).rejects.toBe(error);
+  });
+
+  it("times out an image upload that never settles", async () => {
+    vi.useFakeTimers();
+    const result = uploadTastingImageAfterSave({
+      prepare: async () => new Blob(["image"]),
+      upload: async () => await new Promise(() => {}),
+      timeoutMs: 100,
+    });
+    const expectation = expect(result).rejects.toThrow(
+      "Tasting image upload timed out.",
+    );
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expectation;
+  });
+
+  it("identifies image preparation timeouts", async () => {
+    vi.useFakeTimers();
+    const result = uploadTastingImageAfterSave({
+      prepare: async () => await new Promise(() => {}),
+      upload: vi.fn(),
+      timeoutMs: 100,
+    });
+    const expectation = expect(result).rejects.toThrow(
+      "Tasting image preparation timed out.",
+    );
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    await expectation;
+  });
+});

--- a/apps/web/src/lib/tastingImageUpload.ts
+++ b/apps/web/src/lib/tastingImageUpload.ts
@@ -1,0 +1,32 @@
+const TASTING_IMAGE_UPLOAD_TIMEOUT_MS = 90_000;
+
+export async function uploadTastingImageAfterSave({
+  prepare,
+  upload,
+  timeoutMs = TASTING_IMAGE_UPLOAD_TIMEOUT_MS,
+}: {
+  prepare: () => Promise<Blob>;
+  upload: (file: Blob) => Promise<unknown>;
+  timeoutMs?: number;
+}): Promise<void> {
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  let stage: "preparation" | "upload" = "preparation";
+
+  try {
+    await Promise.race([
+      (async () => {
+        const file = await prepare();
+        stage = "upload";
+        await upload(file);
+      })(),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Tasting image ${stage} timed out.`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}


### PR DESCRIPTION
Creating a tasting with a manually uploaded image now completes even when client-side image preparation or the upload request stalls. Pica resizing stays enabled through its JS/WASM backends but no longer uses its generated Web Worker, and post-save image handling has a 90-second stage-aware deadline. Failures retain the saved tasting, show the existing partial-success warning, navigate away from the submitting overlay, and include the tasting ID in Sentry context.

Mobile Safari was crashing Pica’s blob worker after `tastings/create` succeeded but before `tastings/imageUpdate` started. Pica did not propagate that worker error, leaving its resize promise pending indefinitely. Regression coverage exercises the non-worker image configuration, preparation and upload timeouts, multipart upload success, and desktop/mobile recovery when the image API fails.
