### PR TITLE
fix(web): polish bottle identity and profile layout

### DIFF
--- a/apps/server/src/orpc/routes/activity/list.test.ts
+++ b/apps/server/src/orpc/routes/activity/list.test.ts
@@ -86,6 +86,9 @@ describe("GET /activity", () => {
     expect(collectionItems.map((item) => item.bottle.id)).toEqual(
       expect.arrayContaining([firstBottle.id, secondBottle.id, thirdBottle.id]),
     );
+    expect(collectionItems.every((item) => item.bottle.group?.fullName)).toBe(
+      true,
+    );
   });
 
   test("hides private users from anonymous global activity", async ({

--- a/apps/server/src/orpc/routes/collections/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/list.test.ts
@@ -92,6 +92,36 @@ describe("GET /users/:user/collections/:collection/bottles", () => {
     ]);
   });
 
+  test("returns legacy ungrouped Bottles from Library", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const bottle = await fixtures.LegacyBottle({
+      name: "Legacy Library Bottle",
+    });
+    const collection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+      totalBottles: 1,
+    });
+    await db.insert(collectionBottles).values({
+      collectionId: collection.id,
+      bottleId: bottle.id,
+    });
+
+    const response = await routerClient.collections.bottles.list(
+      { user: "me", collection: "library" },
+      { context: { user: defaults.user } },
+    );
+
+    expect(response.results).toHaveLength(1);
+    expect(response.results[0]?.bottle).toMatchObject({
+      id: bottle.id,
+      fullName: bottle.fullName,
+    });
+    expect(response.results[0]?.bottle).not.toHaveProperty("group");
+  });
+
   test("rejects the removed target filter", async ({ defaults, fixtures }) => {
     type Input = Parameters<typeof routerClient.collections.bottles.list>[0];
 

--- a/apps/server/src/orpc/routes/collections/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/list.test.ts
@@ -55,6 +55,9 @@ describe("GET /users/:user/collections/:collection/bottles", () => {
     expect(response.results[0]?.bottle).toMatchObject({
       id: first.id,
       fullName: first.fullName,
+      group: {
+        id: first.groupId,
+      },
     });
     expect(response.results[0]).not.toHaveProperty("target");
   });

--- a/apps/server/src/orpc/routes/flights/create.test.ts
+++ b/apps/server/src/orpc/routes/flights/create.test.ts
@@ -99,9 +99,10 @@ describe("POST /flights", () => {
     fixtures,
   }) => {
     const user = await fixtures.User();
+    const brand = await fixtures.Entity({ name: "Flight Ordering Brand" });
     const laterBottle = await fixtures.Bottle({
+      brandId: brand.id,
       name: "Zulu release",
-      fullName: "Zulu release",
     });
     if (laterBottle.groupId === null) {
       throw new Error("Bottle group fixture not found");
@@ -113,7 +114,7 @@ describe("POST /flights", () => {
         brandId: laterBottle.brandId,
         createdByActorId: laterBottle.createdByActorId,
         name: "Alpha release",
-        fullName: "Alpha release",
+        fullName: `${brand.name} Alpha release`,
       })
       .returning();
     if (!firstBottle) throw new Error("Same-group Bottle fixture not found");

--- a/apps/server/src/serializers/bottle.test.ts
+++ b/apps/server/src/serializers/bottle.test.ts
@@ -313,18 +313,12 @@ describe("BottleSerializer", () => {
     expect(result).not.toHaveProperty("numReleases");
   });
 
-  it("omits group enrichment for legacy ungrouped Bottles", async ({
+  it("serializes independently without a group unless enrichment is requested", async ({
     fixtures,
   }) => {
     const bottle = await fixtures.LegacyBottle({ name: "Missing Group" });
 
-    const [result] = await serialize(
-      BottleSerializer,
-      [bottle],
-      undefined,
-      [],
-      { includeGroupSummary: true },
-    );
+    const [result] = await serialize(BottleSerializer, [bottle]);
 
     expect(result).toMatchObject({
       id: bottle.id,
@@ -333,22 +327,11 @@ describe("BottleSerializer", () => {
     });
     expect(BottleSchema.safeParse(result).success).toBe(true);
     expect(result).not.toHaveProperty("group");
-  });
-
-  it("rejects group enrichment when a referenced group is missing", async ({
-    fixtures,
-  }) => {
-    const bottle = await fixtures.LegacyBottle({ name: "Missing Group" });
-    const missingGroupId = 999_999;
 
     await expect(
-      serialize(
-        BottleSerializer,
-        [{ ...bottle, groupId: missingGroupId }],
-        undefined,
-        [],
-        { includeGroupSummary: true },
-      ),
+      serialize(BottleSerializer, [bottle], undefined, [], {
+        includeGroupSummary: true,
+      }),
     ).rejects.toThrow(
       `Bottle ${bottle.id} does not belong to an active BottleGroup.`,
     );

--- a/apps/server/src/serializers/bottle.test.ts
+++ b/apps/server/src/serializers/bottle.test.ts
@@ -313,12 +313,18 @@ describe("BottleSerializer", () => {
     expect(result).not.toHaveProperty("numReleases");
   });
 
-  it("serializes independently without a group unless enrichment is requested", async ({
+  it("omits group enrichment for legacy ungrouped Bottles", async ({
     fixtures,
   }) => {
     const bottle = await fixtures.LegacyBottle({ name: "Missing Group" });
 
-    const [result] = await serialize(BottleSerializer, [bottle]);
+    const [result] = await serialize(
+      BottleSerializer,
+      [bottle],
+      undefined,
+      [],
+      { includeGroupSummary: true },
+    );
 
     expect(result).toMatchObject({
       id: bottle.id,
@@ -327,11 +333,22 @@ describe("BottleSerializer", () => {
     });
     expect(BottleSchema.safeParse(result).success).toBe(true);
     expect(result).not.toHaveProperty("group");
+  });
+
+  it("rejects group enrichment when a referenced group is missing", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.LegacyBottle({ name: "Missing Group" });
+    const missingGroupId = 999_999;
 
     await expect(
-      serialize(BottleSerializer, [bottle], undefined, [], {
-        includeGroupSummary: true,
-      }),
+      serialize(
+        BottleSerializer,
+        [{ ...bottle, groupId: missingGroupId }],
+        undefined,
+        [],
+        { includeGroupSummary: true },
+      ),
     ).rejects.toThrow(
       `Bottle ${bottle.id} does not belong to an active BottleGroup.`,
     );

--- a/apps/server/src/serializers/bottle.ts
+++ b/apps/server/src/serializers/bottle.ts
@@ -88,8 +88,10 @@ export const BottleSerializer = serializer({
       );
 
       for (const item of itemList) {
-        const group =
-          item.groupId === null ? undefined : groupById.get(item.groupId);
+        if (item.groupId === null) {
+          continue;
+        }
+        const group = groupById.get(item.groupId);
         if (!group) {
           throw new Error(
             `Bottle ${item.id} does not belong to an active BottleGroup.`,

--- a/apps/server/src/serializers/bottle.ts
+++ b/apps/server/src/serializers/bottle.ts
@@ -88,10 +88,8 @@ export const BottleSerializer = serializer({
       );
 
       for (const item of itemList) {
-        if (item.groupId === null) {
-          continue;
-        }
-        const group = groupById.get(item.groupId);
+        const group =
+          item.groupId === null ? undefined : groupById.get(item.groupId);
         if (!group) {
           throw new Error(
             `Bottle ${item.id} does not belong to an active BottleGroup.`,

--- a/apps/server/src/serializers/collectionBottle.ts
+++ b/apps/server/src/serializers/collectionBottle.ts
@@ -34,6 +34,8 @@ export const CollectionBottleSerializer = serializer({
       BottleSerializer,
       bottleRows,
       currentUser,
+      [],
+      { includeGroupSummary: true },
     );
     const bottleById = new Map(
       serializedBottles.map((bottle) => [bottle.id, bottle]),

--- a/apps/server/src/serializers/collectionBottle.ts
+++ b/apps/server/src/serializers/collectionBottle.ts
@@ -30,13 +30,21 @@ export const CollectionBottleSerializer = serializer({
       .select()
       .from(bottles)
       .where(inArray(bottles.id, bottleIds));
-    const serializedBottles = await serialize(
-      BottleSerializer,
-      bottleRows,
-      currentUser,
-      [],
-      { includeGroupSummary: true },
-    );
+    const [groupedBottles, legacyBottles] = await Promise.all([
+      serialize(
+        BottleSerializer,
+        bottleRows.filter(({ groupId }) => groupId !== null),
+        currentUser,
+        [],
+        { includeGroupSummary: true },
+      ),
+      serialize(
+        BottleSerializer,
+        bottleRows.filter(({ groupId }) => groupId === null),
+        currentUser,
+      ),
+    ]);
+    const serializedBottles = [...groupedBottles, ...legacyBottles];
     const bottleById = new Map(
       serializedBottles.map((bottle) => [bottle.id, bottle]),
     );

--- a/apps/web/e2e/activity-feed.spec.ts
+++ b/apps/web/e2e/activity-feed.spec.ts
@@ -1,14 +1,21 @@
 import { expect, test } from "@playwright/test";
 
 import { expectNoHorizontalOverflow } from "./assertions";
-import { existingBottle, tastingNotes, testUser } from "./rpc-fixtures.mjs";
+import { homeBottle, tastingNotes, testUser } from "./rpc-fixtures.mjs";
 
 test.describe("activity feed", () => {
   test("renders tasting and Library addition activity", async ({ page }) => {
     await page.goto("/", { waitUntil: "commit" });
 
+    const tastingActivity = page
+      .locator("li")
+      .filter({ hasText: tastingNotes })
+      .first();
     await expect(
-      page.getByRole("link", { name: existingBottle.fullName }).first(),
+      tastingActivity.getByRole("link", {
+        name: homeBottle.group.fullName,
+        exact: true,
+      }),
     ).toBeVisible();
     await expect(page.getByText(tastingNotes)).toBeVisible();
     const collectionAddRow = page.locator("li").filter({

--- a/apps/web/e2e/home-feed.spec.ts
+++ b/apps/web/e2e/home-feed.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "@playwright/test";
+
+import { expectNoHorizontalOverflow } from "./assertions";
+import { homeAwards, homeBottle, tastingNotes } from "./rpc-fixtures.mjs";
+
+test("home feed favors recognizable bottle names over exact release names", async ({
+  page,
+}, testInfo) => {
+  await page.goto("/", { waitUntil: "commit" });
+
+  await expect(page.getByText(homeBottle.group.fullName).first()).toBeVisible();
+  await expect(
+    page.getByText(homeBottle.fullName, { exact: true }),
+  ).toHaveCount(0);
+  await expect(page.getByTitle(homeBottle.fullName).first()).toBeVisible();
+  await expect(page.getByText(tastingNotes)).toBeVisible();
+  await expect(page.getByText("Single Cask", { exact: true })).toHaveCount(0);
+
+  const tastingCard = page
+    .locator("li")
+    .filter({ hasText: tastingNotes })
+    .first();
+  const [bottleNameBox, notesBox, ratingBox] = await Promise.all([
+    tastingCard
+      .getByRole("link", { name: homeBottle.group.fullName })
+      .boundingBox(),
+    tastingCard.getByText(tastingNotes, { exact: true }).boundingBox(),
+    tastingCard.getByText("Rating", { exact: true }).boundingBox(),
+  ]);
+  expect(bottleNameBox).not.toBeNull();
+  expect(notesBox).not.toBeNull();
+  expect(ratingBox).not.toBeNull();
+  expect(
+    notesBox!.y - (bottleNameBox!.y + bottleNameBox!.height),
+  ).toBeLessThanOrEqual(12);
+  expect(ratingBox!.y - (notesBox!.y + notesBox!.height)).toBeLessThanOrEqual(
+    12,
+  );
+
+  const awardRows = homeAwards.map((award) =>
+    page.getByTitle(award.badge.name, { exact: true }),
+  );
+  await expect(awardRows[0]).toBeVisible();
+  await expect(awardRows[1]).toBeVisible();
+  const [firstAwardBox, secondAwardBox] = await Promise.all(
+    awardRows.map((row) => row.boundingBox()),
+  );
+  expect(firstAwardBox).not.toBeNull();
+  expect(secondAwardBox).not.toBeNull();
+  expect(
+    secondAwardBox!.y - (firstAwardBox!.y + firstAwardBox!.height),
+  ).toBeLessThanOrEqual(1);
+
+  await expectNoHorizontalOverflow(page);
+  if (process.env.PEATED_VISUAL_DIR) {
+    await page.screenshot({
+      path: `${process.env.PEATED_VISUAL_DIR}/peated-home-page-${testInfo.project.name}.png`,
+      fullPage: false,
+    });
+    await page.locator("ul.mt-1").screenshot({
+      path: `${process.env.PEATED_VISUAL_DIR}/peated-home-${testInfo.project.name}.png`,
+    });
+  }
+});

--- a/apps/web/e2e/library-row.spec.ts
+++ b/apps/web/e2e/library-row.spec.ts
@@ -44,7 +44,9 @@ test("library shows only useful release details on one line", async ({
   await expect(
     row.getByRole("link", { name: homeBottle.group.name, exact: true }),
   ).toBeVisible();
-  await expect(row.getByText(homeBottle.brand.name, { exact: true })).toBeVisible();
+  await expect(
+    row.getByText(homeBottle.brand.name, { exact: true }),
+  ).toBeVisible();
 
   const metadata = row.locator(".text-muted.mt-1.block.truncate");
   await expect(metadata).toBeVisible();

--- a/apps/web/e2e/library-row.spec.ts
+++ b/apps/web/e2e/library-row.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from "@playwright/test";
+
+import { expectNoHorizontalOverflow } from "./assertions";
+import {
+  destinationBottleGroup,
+  existingBottle,
+  homeBottle,
+  testAccessToken,
+  testUser,
+} from "./rpc-fixtures.mjs";
+import { signIn } from "./session";
+
+test("library shows only useful release details on one line", async ({
+  context,
+  page,
+}, testInfo) => {
+  await signIn(context, {
+    accessToken: `${testAccessToken}-visual-library-${testInfo.project.name}`,
+  });
+
+  await page.goto(`/bottles/${homeBottle.id}`, { waitUntil: "commit" });
+  const homeLibraryButton = page.locator(
+    'button[data-collection-action="library"]',
+  );
+  await homeLibraryButton.click();
+  await expect(homeLibraryButton).toHaveAttribute("aria-pressed", "true");
+
+  await page.goto(`/bottles/${existingBottle.id}`, { waitUntil: "commit" });
+  const existingLibraryButton = page.locator(
+    'button[data-collection-action="library"]',
+  );
+  await existingLibraryButton.click();
+  await expect(existingLibraryButton).toHaveAttribute("aria-pressed", "true");
+
+  await page.goto(`/users/${testUser.username}/library`, {
+    waitUntil: "commit",
+  });
+
+  const row = page
+    .getByTitle(homeBottle.fullName, { exact: true })
+    .first()
+    .locator("xpath=ancestor::tr");
+  await expect(row).toBeVisible();
+  await expect(
+    row.getByRole("link", { name: homeBottle.group.name, exact: true }),
+  ).toBeVisible();
+  await expect(row.getByText(homeBottle.brand.name, { exact: true })).toBeVisible();
+
+  const metadata = row.locator(".text-muted.mt-1.block.truncate");
+  await expect(metadata).toBeVisible();
+  await expect(metadata).toHaveCSS("white-space", "nowrap");
+  await expect(metadata).toHaveText("Pedro Ximenez cask·55.8% ABV");
+  await expect(row.getByText("Single Malt", { exact: true })).toHaveCount(0);
+
+  const nameOnlyRow = page
+    .getByRole("link", { name: destinationBottleGroup.name, exact: true })
+    .first()
+    .locator("xpath=ancestor::tr");
+  await expect(nameOnlyRow).toBeVisible();
+  await expect(
+    nameOnlyRow.getByRole("link", {
+      name: destinationBottleGroup.name,
+      exact: true,
+    }),
+  ).toBeVisible();
+  await expect(
+    nameOnlyRow.locator(".text-muted.mt-1.block.truncate"),
+  ).toHaveCount(0);
+  await expect(
+    nameOnlyRow.getByText("Single Malt", { exact: true }),
+  ).toHaveCount(0);
+
+  await expectNoHorizontalOverflow(page);
+  if (process.env.PEATED_VISUAL_DIR) {
+    await page.addStyleTag({
+      content: "body { padding-bottom: 300px !important; }",
+    });
+    const table = page.locator("table");
+    await table.evaluate((element) => {
+      element.scrollIntoView({ block: "center" });
+    });
+    await table.screenshot({
+      path: `${process.env.PEATED_VISUAL_DIR}/peated-library-${testInfo.project.name}.png`,
+    });
+  }
+});

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -35,6 +35,7 @@ import {
   flightBottleFixtureId,
   groupedBottleDetails,
   libraryInsightsStats,
+  homeBottle,
   missingBottleId,
   moderatorUser,
   photoTastingNotes,
@@ -1780,6 +1781,7 @@ function withCollectionStatus(request, bottle) {
 }
 
 function getMockBottle(request, bottleId) {
+  if (bottleId === homeBottle.id) return homeBottle;
   if (bottleId === existingBottleId) {
     if (getAccessToken(request).includes("add-another-release")) {
       return addAnotherReleaseSourceBottle;

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -34,8 +34,8 @@ import {
   flightBottleFixture,
   flightBottleFixtureId,
   groupedBottleDetails,
-  libraryInsightsStats,
   homeBottle,
+  libraryInsightsStats,
   missingBottleId,
   moderatorUser,
   photoTastingNotes,
@@ -483,6 +483,17 @@ async function handleRpcRequest({ request, response, url }) {
       if (getAccessToken(request).includes("exact-bottle-merge")) {
         sendRpcResponse(response, {
           results: [existingBottle, exactMergeOtherBottle],
+          rel: { nextCursor: null, prevCursor: null },
+        });
+        return true;
+      }
+      if (
+        !getAccessToken(request).includes("flight-bottles") &&
+        input?.limit === 10 &&
+        input?.sort === "-created"
+      ) {
+        sendRpcResponse(response, {
+          results: [homeBottle, existingBottle],
           rel: { nextCursor: null, prevCursor: null },
         });
         return true;

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -2,6 +2,7 @@ import http from "node:http";
 
 import {
   addAnotherReleaseSourceBottle,
+  adminUser,
   anotherReleaseSourceBottle,
   bottleGroup,
   bottleGroupId,
@@ -35,6 +36,7 @@ import {
   groupedBottleDetails,
   libraryInsightsStats,
   missingBottleId,
+  moderatorUser,
   photoTastingNotes,
   priceChangeList,
   priceSite,
@@ -771,6 +773,19 @@ async function handleRpcRequest({ request, response, url }) {
         sendRpcResponse(response, testUser);
         return true;
       }
+      if (input?.user === adminUser.id || input?.user === adminUser.username) {
+        sendRpcResponse(response, adminUser);
+        return true;
+      }
+
+      if (
+        input?.user === moderatorUser.id ||
+        input?.user === moderatorUser.username
+      ) {
+        sendRpcResponse(response, moderatorUser);
+        return true;
+      }
+
       sendRpcError(response, "Unexpected user details payload");
       return true;
     case "users/libraryStats":

--- a/apps/web/e2e/profile-header.spec.ts
+++ b/apps/web/e2e/profile-header.spec.ts
@@ -27,7 +27,9 @@ for (const { label, slug, user } of roleProfiles) {
     await expect(role).toBeVisible();
     await expect(page.getByText("225", { exact: true })).toBeVisible();
     await expect(
-      page.getByRole("main").getByText("Tastings", { exact: true }),
+      page.getByRole("link", {
+        name: `${user.stats.tastings.toLocaleString()} Tastings`,
+      }),
     ).toBeVisible();
 
     const [usernameBox, roleBox] = await Promise.all([
@@ -41,7 +43,7 @@ for (const { label, slug, user } of roleProfiles) {
     );
     expect(
       roleBox!.y - (usernameBox!.y + usernameBox!.height),
-    ).toBeLessThanOrEqual(4);
+    ).toBeLessThanOrEqual(8);
 
     if (testInfo.project.name.includes("mobile")) {
       expect(

--- a/apps/web/e2e/profile-header.spec.ts
+++ b/apps/web/e2e/profile-header.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+import { expectNoHorizontalOverflow } from "./assertions";
+import { adminUser, moderatorUser, testAccessToken } from "./rpc-fixtures.mjs";
+import { signIn } from "./session";
+
+const roleProfiles = [
+  { label: "Admin", slug: "admin", user: adminUser },
+  { label: "Moderator", slug: "moderator", user: moderatorUser },
+] as const;
+
+for (const { label, slug, user } of roleProfiles) {
+  test(`keeps the ${label} role beneath the profile name`, async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: `${testAccessToken}-${slug}-profile-${testInfo.project.name}`,
+      user,
+    });
+
+    await page.goto(`/users/${user.username}`, { waitUntil: "commit" });
+
+    const username = page.getByRole("heading", { name: user.username });
+    const role = page.getByText(label, { exact: true });
+    await expect(username).toBeVisible();
+    await expect(role).toBeVisible();
+    await expect(page.getByText("225", { exact: true })).toBeVisible();
+    await expect(
+      page.getByRole("main").getByText("Tastings", { exact: true }),
+    ).toBeVisible();
+
+    const [usernameBox, roleBox] = await Promise.all([
+      username.boundingBox(),
+      role.boundingBox(),
+    ]);
+    expect(usernameBox).not.toBeNull();
+    expect(roleBox).not.toBeNull();
+    expect(roleBox!.y).toBeGreaterThanOrEqual(
+      usernameBox!.y + usernameBox!.height,
+    );
+    expect(
+      roleBox!.y - (usernameBox!.y + usernameBox!.height),
+    ).toBeLessThanOrEqual(4);
+
+    if (testInfo.project.name.includes("mobile")) {
+      expect(
+        Math.abs(
+          usernameBox!.x +
+            usernameBox!.width / 2 -
+            (roleBox!.x + roleBox!.width / 2),
+        ),
+      ).toBeLessThanOrEqual(2);
+    } else {
+      expect(Math.abs(usernameBox!.x - roleBox!.x)).toBeLessThanOrEqual(2);
+    }
+
+    await expectNoHorizontalOverflow(page);
+
+    if (process.env.PEATED_VISUAL_DIR) {
+      await page.screenshot({
+        path: `${process.env.PEATED_VISUAL_DIR}/peated-profile-${slug}-${testInfo.project.name}.png`,
+        fullPage: false,
+      });
+    }
+  });
+}

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -629,6 +629,7 @@ export function buildCollection({
  *   notes?: string,
  *   rating?: number,
  *   tags?: string[],
+ *   awards?: import("@peated/server/types").BadgeAward[],
  * }} [options]
  */
 export function buildTasting({
@@ -637,6 +638,7 @@ export function buildTasting({
   notes = tastingNotes,
   rating = 2,
   tags = /** @type {string[]} */ ([]),
+  awards = /** @type {import("@peated/server/types").BadgeAward[]} */ ([]),
 } = {}) {
   return {
     id,
@@ -648,7 +650,7 @@ export function buildTasting({
     color: null,
     servingStyle: null,
     friends: [],
-    awards: [],
+    awards,
     comments: 0,
     toasts: 0,
     hasToasted: false,
@@ -657,14 +659,42 @@ export function buildTasting({
   };
 }
 
+export const homeAwards = [
+  {
+    id: 51_001,
+    xp: 1,
+    level: 0,
+    badge: {
+      id: 52_001,
+      name: "Luck of the Irish",
+      maxLevel: 25,
+      imageUrl: null,
+    },
+    createdAt: timestamp,
+  },
+  {
+    id: 51_002,
+    xp: 1,
+    level: 0,
+    badge: {
+      id: 52_002,
+      name: "Pot Still Pioneer",
+      maxLevel: 25,
+      imageUrl: null,
+    },
+    createdAt: timestamp,
+  },
+];
+
 export function buildActivity({
   tasting = buildTasting({
-    bottle: {
-      ...existingBottle,
-      isFavorite: true,
-    },
+    bottle: homeBottle,
+    awards: homeAwards,
   }),
-  collectionBottle = buildCollectionBottle({ id: 9701 }),
+  collectionBottle = buildCollectionBottle({
+    id: 9701,
+    bottle: /** @type {CollectionBottle["bottle"]} */ (homeBottle),
+  }),
 } = {}) {
   return {
     results: [

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -342,6 +342,30 @@ export function buildBottleGroup({
   };
 }
 
+/** @type {ConcreteFixtureBottle} */
+const homeBottleWithoutGroup = {
+  ...buildBottle({
+    id: 50_000,
+    name: "Single Cask 4-year-old - 55.8% ABV - Pedro Ximenez Cask",
+  }),
+  fullName: "Lagavulin Single Cask 4-year-old - 55.8% ABV - Pedro Ximenez Cask",
+  statedAge: 4,
+  abv: 55.8,
+  singleCask: true,
+  caskStrength: true,
+  caskType: "pedro_ximenez",
+  imageUrl: "http://127.0.0.1:4999/uploads/home-bottle.png",
+};
+
+export const homeBottle = {
+  ...homeBottleWithoutGroup,
+  group: buildBottleGroup({
+    bottle: homeBottleWithoutGroup,
+    fullName: "Lagavulin Single Cask 4-year-old",
+    name: "Single Cask 4-year-old",
+  }),
+};
+
 export const bottleGroupId = 50_001;
 export const destinationBottleGroupId = 50_002;
 

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -32,6 +32,34 @@ export const testUser = {
   },
 };
 
+export const adminUser = {
+  ...testUser,
+  id: 9102,
+  username: "admin-review",
+  email: "admin-review@example.com",
+  admin: true,
+  stats: {
+    ...testUser.stats,
+    tastings: 225,
+    bottles: 206,
+    library: {
+      total: 78,
+      open: 12,
+      sealed: 66,
+    },
+    contributions: 70,
+  },
+};
+
+export const moderatorUser = {
+  ...adminUser,
+  id: 9103,
+  username: "moderator-review",
+  email: "moderator-review@example.com",
+  admin: false,
+  mod: true,
+};
+
 export const libraryInsightsStats = {
   total: 76,
   distillers: [

--- a/apps/web/src/app/(default)/(activity)/newBottles.tsx
+++ b/apps/web/src/app/(default)/(activity)/newBottles.tsx
@@ -4,6 +4,7 @@ import { formatCategoryName } from "@peated/server/lib/format";
 import BottleLink from "@peated/web/components/bottleLink";
 import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
+import { getBottleDisplayName } from "@peated/web/lib/bottleDisplayName";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
@@ -57,7 +58,7 @@ export default function NewBottles() {
                       bottle={bottle}
                       className="font-medium hover:underline"
                     >
-                      {`${bottle.brand.shortName || bottle.brand.name} ${bottle.name}`}
+                      {getBottleDisplayName(bottle)}
                     </BottleLink>
                     <BottleStatusIcons bottle={bottle} />
                   </div>

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
@@ -81,6 +81,7 @@ function UserLibraryTable({ username }: { username: string }) {
             identityMode="absolute"
             showRatingSummary
             showBottleStats={false}
+            compactIdentity
             renderCollectionBottleImage={(entry) =>
               canEditLibrary ? (
                 <LibraryEntryImage entry={entry} username={username} />

--- a/apps/web/src/app/(default)/users/[username]/layout.tsx
+++ b/apps/web/src/app/(default)/users/[username]/layout.tsx
@@ -122,16 +122,16 @@ export default async function Layout(props: {
         </div>
         <div className="contents lg:flex lg:w-auto lg:flex-auto lg:flex-col lg:justify-center lg:gap-y-2 lg:px-4">
           <div className="min-w-0 self-center lg:self-start">
-            <h1 className="break-words text-2xl font-semibold leading-tight text-white lg:text-4xl lg:leading-normal">
+            <h1 className="break-words text-center text-2xl font-semibold leading-tight text-white lg:text-left lg:text-4xl lg:leading-normal">
               {user.username}
             </h1>
-            <div className="text-muted mt-2 flex items-center gap-x-2 lg:mt-0">
+            <div className="text-muted mt-2 flex items-center justify-center gap-x-2 lg:mt-0 lg:justify-start">
               {user.admin ? (
-                <Chip size="small" color="highlight">
+                <Chip as="span" size="small" color="highlight">
                   Admin
                 </Chip>
               ) : user.mod ? (
-                <Chip size="small" color="highlight">
+                <Chip as="span" size="small" color="highlight">
                   Moderator
                 </Chip>
               ) : null}

--- a/apps/web/src/components/activityList.tsx
+++ b/apps/web/src/components/activityList.tsx
@@ -3,6 +3,7 @@
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
 import Link from "@peated/web/components/link";
+import { getBottleDisplayName } from "@peated/web/lib/bottleDisplayName";
 import { AnimatePresence } from "framer-motion";
 import { useState } from "react";
 import TastingListItem from "./tastingListItem";
@@ -47,8 +48,8 @@ function getCollectionItemHref(item: CollectionAddItem) {
   return `/bottles/${item.bottle.id}`;
 }
 
-function getCollectionItemTitle(item: CollectionAddItem) {
-  return item.bottle.fullName;
+function getCollectionItemDisplayName(item: CollectionAddItem) {
+  return getBottleDisplayName(item.bottle);
 }
 
 function getCollectionItemDetail(item: CollectionAddItem) {
@@ -77,7 +78,7 @@ function CollectionItemImage({ item }: { item: CollectionAddItem }) {
 function CollectionPreviewItem({ item }: { item: CollectionAddItem }) {
   const detail = getCollectionItemDetail(item);
   const href = getCollectionItemHref(item);
-  const title = getCollectionItemTitle(item);
+  const displayName = getCollectionItemDisplayName(item);
 
   return (
     <li className="flex min-w-0 items-center gap-x-3 px-3 py-2">
@@ -85,10 +86,10 @@ function CollectionPreviewItem({ item }: { item: CollectionAddItem }) {
       <div className="min-w-0 flex-1">
         <Link
           href={href}
-          className="line-clamp-2 text-sm font-semibold text-white hover:underline sm:line-clamp-1"
-          title={title}
+          className="block truncate text-sm font-semibold text-white hover:underline"
+          title={item.bottle.fullName}
         >
-          {title}
+          {displayName}
         </Link>
         {detail ? (
           <div className="text-muted truncate text-xs">{detail}</div>

--- a/apps/web/src/components/bottleExactMetadata.test.tsx
+++ b/apps/web/src/components/bottleExactMetadata.test.tsx
@@ -25,6 +25,7 @@ describe("BottleExactMetadata", () => {
     );
     const text = html.replace(/<[^>]*>/g, "");
 
+    expect(html).toContain("flex-wrap");
     expect(text).toBe(
       "Lagavulin·Single Malt·21 years·55.1% ABV·2004 vintage·2025 release·Single cask·Cask strength·1st Fill Oloroso Hogshead cask",
     );
@@ -49,6 +50,56 @@ describe("BottleExactMetadata", () => {
           caskSize: null,
         }}
       />,
+    );
+
+    expect(html).toBe("");
+  });
+
+  it("summarizes only the highest-value release identifiers", () => {
+    const html = renderToStaticMarkup(
+      <BottleExactMetadata
+        bottle={{
+          ...exactBottle,
+          edition: "Batch 24",
+          group: { statedAge: 21 },
+        }}
+        variant="summary"
+      />,
+    );
+    const text = html.replace(/<[^>]*>/g, "");
+
+    expect(html).toContain("block truncate");
+    expect(html).not.toContain("flex-wrap");
+    expect(text).toBe("Batch 24·2004 vintage·2025 release");
+    expect(text).not.toContain("21 years");
+    expect(text).not.toContain("Single cask");
+    expect(text).not.toContain("Cask strength");
+    expect(text).not.toContain("Single Malt");
+  });
+
+  it("uses cask and ABV when they are the useful differentiators", () => {
+    const html = renderToStaticMarkup(
+      <BottleExactMetadata
+        bottle={{
+          ...exactBottle,
+          statedAge: 4,
+          vintageYear: null,
+          releaseYear: null,
+          caskType: "pedro_ximenez",
+          caskSize: null,
+          group: { statedAge: 4 },
+        }}
+        variant="summary"
+      />,
+    );
+    const text = html.replace(/<[^>]*>/g, "");
+
+    expect(text).toBe("Pedro Ximenez cask·55.1% ABV");
+  });
+
+  it("omits a release summary when the full Bottle name is already shown", () => {
+    const html = renderToStaticMarkup(
+      <BottleExactMetadata bottle={exactBottle} variant="summary" />,
     );
 
     expect(html).toBe("");

--- a/apps/web/src/components/bottleExactMetadata.test.tsx
+++ b/apps/web/src/components/bottleExactMetadata.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import BottleExactMetadata, {
   type BottleExactMetadataSource,
@@ -32,6 +32,33 @@ describe("BottleExactMetadata", () => {
     expect(html.match(/class="inline-flex whitespace-nowrap"/g)).toHaveLength(
       9,
     );
+  });
+
+  it("renders leading content alongside an edition without duplicate keys", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    try {
+      const html = renderToStaticMarkup(
+        <BottleExactMetadata
+          bottle={{
+            ...exactBottle,
+            edition: "Distillers Edition",
+            group: { statedAge: exactBottle.statedAge },
+          }}
+          leadingContent="Lagavulin"
+          variant="summary"
+        />,
+      );
+      const text = html.replace(/<[^>]*>/g, "");
+
+      expect(text).toContain("Lagavulin");
+      expect(text).toContain("Distillers Edition");
+      expect(consoleError).not.toHaveBeenCalled();
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 
   it("omits absent optional metadata without empty separators", () => {

--- a/apps/web/src/components/bottleExactMetadata.tsx
+++ b/apps/web/src/components/bottleExactMetadata.tsx
@@ -1,6 +1,6 @@
 import { formatCategoryName } from "@peated/server/lib/format";
 import { toTitleCase } from "@peated/server/lib/strings";
-import type { ConcreteBottleV1 } from "@peated/server/schemas";
+import type { BottleGroupV1, ConcreteBottleV1 } from "@peated/server/schemas";
 import classNames from "@peated/web/lib/classNames";
 import type { ReactNode } from "react";
 
@@ -16,10 +16,14 @@ export type BottleExactMetadataSource = Pick<
   | "caskFill"
   | "caskType"
   | "caskSize"
->;
+> & {
+  edition?: ConcreteBottleV1["edition"];
+  group?: Partial<Pick<BottleGroupV1, "statedAge">>;
+};
 
 export type BottleExactMetadataKey =
   | "category"
+  | "edition"
   | "age"
   | "abv"
   | "vintage"
@@ -80,31 +84,79 @@ export function getBottleExactMetadata(
   return metadata;
 }
 
+function getBottleReleaseSummary(
+  bottle: BottleExactMetadataSource,
+): MetadataItem[] {
+  if (!bottle.group) return [];
+
+  const metadata: MetadataItem[] = [];
+
+  if (bottle.edition) {
+    metadata.push({ key: "edition", content: bottle.edition });
+  }
+  if (
+    bottle.statedAge !== null &&
+    bottle.statedAge !== bottle.group.statedAge
+  ) {
+    metadata.push({ key: "age", content: `${bottle.statedAge} years` });
+  }
+  if (bottle.vintageYear !== null) {
+    metadata.push({
+      key: "vintage",
+      content: `${bottle.vintageYear} vintage`,
+    });
+  }
+  if (bottle.releaseYear !== null) {
+    metadata.push({
+      key: "release",
+      content: `${bottle.releaseYear} release`,
+    });
+  }
+
+  const caskDetails = [bottle.caskType, bottle.caskSize]
+    .filter((value): value is NonNullable<typeof value> => value !== null)
+    .map(toTitleCase)
+    .join(" ");
+  if (caskDetails) {
+    metadata.push({ key: "cask-details", content: `${caskDetails} cask` });
+  }
+  if (bottle.abv !== null) {
+    metadata.push({ key: "abv", content: `${bottle.abv.toFixed(1)}% ABV` });
+  }
+
+  return metadata.slice(0, 3);
+}
+
 export default function BottleExactMetadata({
   bottle,
   className,
   exclude = [],
   leadingContent,
+  variant = "full",
 }: {
   bottle: BottleExactMetadataSource;
   className?: string;
   exclude?: BottleExactMetadataKey[];
   leadingContent?: ReactNode;
+  variant?: "full" | "summary";
 }) {
   const excluded = new Set(exclude);
-  const metadata = getBottleExactMetadata(bottle).filter(
-    ({ key }) => !excluded.has(key),
-  );
-  const items: { key: string; content: ReactNode }[] =
+  const metadata = (
+    variant === "summary"
+      ? getBottleReleaseSummary(bottle)
+      : getBottleExactMetadata(bottle)
+  ).filter(({ key }) => !excluded.has(key));
+  const items: MetadataItem[] =
     leadingContent !== undefined
-      ? [{ key: "leading", content: leadingContent }, ...metadata]
+      ? [{ key: "edition", content: leadingContent }, ...metadata]
       : metadata;
   if (!items.length) return null;
 
   return (
     <div
       className={classNames(
-        "text-muted mt-1 flex flex-wrap text-sm leading-5",
+        "text-muted mt-1 text-sm leading-5",
+        variant === "summary" ? "block truncate" : "flex flex-wrap",
         className,
       )}
     >

--- a/apps/web/src/components/bottleExactMetadata.tsx
+++ b/apps/web/src/components/bottleExactMetadata.tsx
@@ -146,9 +146,9 @@ export default function BottleExactMetadata({
       ? getBottleReleaseSummary(bottle)
       : getBottleExactMetadata(bottle)
   ).filter(({ key }) => !excluded.has(key));
-  const items: MetadataItem[] =
+  const items: Array<MetadataItem | { key: "leading"; content: ReactNode }> =
     leadingContent !== undefined
-      ? [{ key: "edition", content: leadingContent }, ...metadata]
+      ? [{ key: "leading", content: leadingContent }, ...metadata]
       : metadata;
   if (!items.length) return null;
 

--- a/apps/web/src/components/bottleIdentity.tsx
+++ b/apps/web/src/components/bottleIdentity.tsx
@@ -235,10 +235,12 @@ export default function BottleIdentity({
   bottle,
   mode,
   current = false,
+  metadataVariant = "full",
 }: {
   bottle: BottleIdentitySource;
   mode: "absolute" | "relative";
   current?: boolean;
+  metadataVariant?: "full" | "summary";
 }) {
   const relativeIdentity = getRelativeBottleIdentity(bottle);
   const isAbsolute = mode === "absolute";
@@ -249,6 +251,8 @@ export default function BottleIdentity({
     isAbsolute && bottle.group && !relativeIdentity.fallback
       ? relativeIdentity.label
       : undefined;
+  const displayedLeadingContent =
+    metadataVariant === "summary" ? undefined : leadingContent;
   const titleMetadata = isAbsolute
     ? getMetadataExpressedByTitle(bottle, title)
     : [];
@@ -278,14 +282,15 @@ export default function BottleIdentity({
       </div>
       <BottleExactMetadata
         bottle={bottle}
+        variant={metadataVariant}
         exclude={[
           "category",
           ...titleMetadata,
-          ...(!isAbsolute || leadingContent
+          ...(!isAbsolute || displayedLeadingContent
             ? relativeIdentity.excludeMetadata
             : []),
         ]}
-        leadingContent={leadingContent}
+        leadingContent={displayedLeadingContent}
       />
     </div>
   );

--- a/apps/web/src/components/bottleTable.tsx
+++ b/apps/web/src/components/bottleTable.tsx
@@ -34,6 +34,7 @@ export default function BottleTable({
   showBottleStats = true,
   showRatingSummary = false,
   identityMode = "legacy",
+  compactIdentity = false,
   ...props
 }: Omit<ComponentProps<typeof Table>, "items" | "rel" | "columns"> & {
   bottleList: (Bottle | CollectionBottle)[];
@@ -45,6 +46,7 @@ export default function BottleTable({
   showBottleStats?: boolean;
   showRatingSummary?: boolean;
   identityMode?: "legacy" | "absolute";
+  compactIdentity?: boolean;
 }) {
   const rows: BottleRow[] = bottleList.map((item) =>
     "bottle" in item
@@ -72,6 +74,7 @@ export default function BottleTable({
             : showBottleStats
               ? "min-w-full sm:w-1/2"
               : "w-full",
+          cellClassName: compactIdentity ? "max-w-0" : undefined,
           value: (item) => {
             const { bottle } = item;
             const categoryName = bottle.category
@@ -118,7 +121,11 @@ export default function BottleTable({
                 {collectionImage}
                 <div className="flex min-w-0 flex-1 flex-col justify-center">
                   {identityMode === "absolute" ? (
-                    <BottleIdentity bottle={bottle} mode="absolute" />
+                    <BottleIdentity
+                      bottle={bottle}
+                      mode="absolute"
+                      metadataVariant={compactIdentity ? "summary" : "full"}
+                    />
                   ) : (
                     <div className="flex min-w-0 flex-wrap items-center gap-x-1">
                       <BottleLink

--- a/apps/web/src/components/bottleTable.tsx
+++ b/apps/web/src/components/bottleTable.tsx
@@ -82,6 +82,7 @@ export default function BottleTable({
               : null;
             const identityTitle = bottle.group?.name ?? bottle.name;
             const showCategory =
+              !compactIdentity &&
               categoryName &&
               String(bottle.category) !== "other" &&
               (identityMode === "legacy" ||

--- a/apps/web/src/components/table.tsx
+++ b/apps/web/src/components/table.tsx
@@ -17,6 +17,7 @@ export type Column<T extends Record<string, any>> = {
   align?: "left" | "right" | "center" | "default";
   title?: string;
   className?: string;
+  cellClassName?: string;
   value?: (item: T) => ReactElement | string | null | false;
   hidden?: boolean;
 };
@@ -161,6 +162,7 @@ export default function Table<
                       key={col.name}
                       className={classNames(
                         "group relative items-center gap-x-2 p-3",
+                        col.cellClassName,
                         colN !== 0 ? "hidden sm:table-cell" : "table-cell",
                         colAlign === "left"
                           ? "text-left"

--- a/apps/web/src/components/tastingBottleIdentity.test.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.test.tsx
@@ -42,7 +42,10 @@ describe("TastingBottleIdentity", () => {
     expect(text).toContain("·Lagavulin Distillery");
     expect(text).toContain("Single Malt");
     expect(text).toContain("Aged 21 years");
-    expect(html).toContain("bg-highlight p-4 text-black lg:p-5");
+    expect(html).toContain("bg-highlight");
+    expect(html).toContain("p-4");
+    expect(html).toContain("text-black");
+    expect(html).toContain("lg:p-5");
   });
 
   it("renders the complete legacy inline bottle card", () => {
@@ -57,14 +60,31 @@ describe("TastingBottleIdentity", () => {
     expect(html).not.toContain("border-slate-800");
     expect(html).not.toContain("bg-slate-950");
     expect(text).toContain("Lagavulin 21");
-    expect(text).toContain("2025 Release (2025) (2004 Vintage)");
-    expect(text).toContain("·Lagavulin Distillery");
-    expect(text).toContain("Single Malt");
-    expect(text).toContain("Aged 21 years");
+    expect(text).not.toContain("Lagavulin 21 - 2025 Release");
+    expect(text).not.toContain("2025 Release");
+    expect(text).not.toContain("Lagavulin Distillery");
+    expect(text).not.toContain("Single Malt");
+    expect(text).not.toContain("Aged 21 years");
     expect(text).toContain("Single Cask");
     expect(text).not.toContain("55.1% ABV");
     expect(html).toContain('data-bottle-status="library"');
     expect(html).toContain('data-bottle-status="tasted"');
+  });
+
+  it("does not repeat Single Cask when the clean name already includes it", () => {
+    const html = renderToStaticMarkup(
+      <TastingBottleIdentity
+        bottle={{
+          ...bottle,
+          group: { name: "Single Cask 21" },
+        }}
+        variant="inline"
+      />,
+    );
+    const text = html.replace(/<[^>]*>/g, "");
+
+    expect(text.match(/Single Cask/g)).toHaveLength(1);
+    expect(html).not.toContain('title="Single cask"');
   });
 
   it.each(["inline", "panel"] as const)(

--- a/apps/web/src/components/tastingBottleIdentity.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.tsx
@@ -2,7 +2,6 @@ import { formatCategoryName } from "@peated/server/lib/format";
 import type { Bottle } from "@peated/server/types";
 import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
-import classNames from "../lib/classNames";
 import Join from "./join";
 import SingleCaskChip from "./singleCaskChip";
 
@@ -51,14 +50,35 @@ export default function TastingBottleIdentity({
     ? `${bottle.brand.shortName || bottle.brand.name} ${bottle.group.name}`
     : bottle.fullName;
   const exactBottleLabel = getExactBottleLabel(bottle, displayName);
+  const showSingleCaskChip =
+    bottle.singleCask &&
+    !/\bsingle[\s-]+cask\b/i.test(`${displayName} ${exactBottleLabel ?? ""}`);
+
+  if (variant === "inline") {
+    return (
+      <div className="flex items-center space-x-2 overflow-hidden sm:space-x-3 sm:rounded">
+        <div className="flex-1 overflow-hidden">
+          <div className="flex w-full items-center gap-x-1 font-bold">
+            <div className="space-x-1">
+              <h4 className="inline font-bold" title={bottle.fullName}>
+                <Link
+                  href={`/bottles/${bottle.id}`}
+                  className="hover:underline"
+                >
+                  {displayName}
+                </Link>
+              </h4>
+              <BottleStatusIcons bottle={bottle} className="inline h-4 w-4" />
+              {showSingleCaskChip && <SingleCaskChip />}
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div
-      className={classNames(
-        "flex items-center space-x-2 overflow-hidden sm:space-x-3 sm:rounded",
-        variant === "panel" ? "bg-highlight p-4 text-black lg:p-5" : "",
-      )}
-    >
+    <div className="bg-highlight flex items-center space-x-2 overflow-hidden p-4 text-black sm:space-x-3 sm:rounded lg:p-5">
       <div className="flex-1 overflow-hidden">
         <div className="flex w-full items-center gap-x-1 font-bold">
           <div className="space-x-1">
@@ -68,19 +88,14 @@ export default function TastingBottleIdentity({
               </Link>
             </h4>
             <BottleStatusIcons bottle={bottle} className="inline h-4 w-4" />
-            {!exactBottleLabel && bottle.singleCask && <SingleCaskChip />}
+            {!exactBottleLabel && showSingleCaskChip && <SingleCaskChip />}
           </div>
         </div>
-        <div
-          className={classNames(
-            "flex flex-row gap-x-1 text-sm",
-            variant === "inline" ? "text-muted" : "",
-          )}
-        >
+        <div className="flex flex-row gap-x-1 text-sm">
           {exactBottleLabel ? (
             <div className="flex flex-wrap items-center gap-2">
               <span>{exactBottleLabel}</span>
-              {bottle.singleCask && <SingleCaskChip />}
+              {showSingleCaskChip && <SingleCaskChip />}
             </div>
           ) : null}
           {!!(exactBottleLabel && bottle.distillers.length) && (
@@ -101,12 +116,7 @@ export default function TastingBottleIdentity({
           ) : null}
         </div>
       </div>
-      <div
-        className={classNames(
-          variant === "inline" ? "text-muted" : "",
-          "hidden w-[200px] flex-col items-end justify-center whitespace-nowrap text-sm sm:flex",
-        )}
-      >
+      <div className="hidden w-[200px] flex-col items-end justify-center whitespace-nowrap text-sm sm:flex">
         <div className="max-w-full truncate">
           {bottle.category ? (
             <Link

--- a/apps/web/src/components/tastingListItem.tsx
+++ b/apps/web/src/components/tastingListItem.tsx
@@ -150,7 +150,7 @@ export default function TastingListItem({
       )}
 
       {!!tasting.notes && (
-        <div className="prose prose-invert -my-1 max-w-none px-3 text-sm sm:px-5">
+        <div className="prose prose-invert prose-p:my-0 -my-2 max-w-none px-3 text-sm sm:px-5">
           <Markdown content={tasting.notes} noLinks />
         </div>
       )}
@@ -210,13 +210,13 @@ export default function TastingListItem({
       )}
 
       {!!tasting.awards.length && (
-        <ul className="flex flex-col gap-y-2 sm:px-3">
+        <ul className="flex flex-col sm:px-3">
           {tasting.awards.map((award) => {
             return (
               <li
                 key={award.id}
                 title={award.badge.name}
-                className="group relative flex items-center gap-x-1 rounded px-2 py-2 text-sm"
+                className="group relative flex items-center gap-x-1 rounded px-2 py-1 text-sm"
               >
                 <Link
                   href={`/badges/${award.badge.id}`}

--- a/apps/web/src/lib/bottleDisplayName.test.ts
+++ b/apps/web/src/lib/bottleDisplayName.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getBottleDisplayName } from "./bottleDisplayName";
+
+describe("getBottleDisplayName", () => {
+  it("uses the stable expression when a group summary is available", () => {
+    expect(
+      getBottleDisplayName({
+        fullName:
+          "Pōkeno Single Cask 4-year-old - 55.8% ABV - Pedro Ximenez Cask",
+        group: {
+          fullName: "Pōkeno Single Cask 4-year-old",
+        },
+      }),
+    ).toBe("Pōkeno Single Cask 4-year-old");
+  });
+
+  it("falls back to the exact name without a group summary", () => {
+    expect(
+      getBottleDisplayName({
+        fullName: "Pōkeno Single Cask 4-year-old",
+      }),
+    ).toBe("Pōkeno Single Cask 4-year-old");
+  });
+});

--- a/apps/web/src/lib/bottleDisplayName.ts
+++ b/apps/web/src/lib/bottleDisplayName.ts
@@ -1,0 +1,9 @@
+import type { Bottle } from "@peated/server/types";
+
+type BottleDisplayNameSource = Pick<Bottle, "fullName"> & {
+  group?: Pick<NonNullable<Bottle["group"]>, "fullName">;
+};
+
+export function getBottleDisplayName(bottle: BottleDisplayNameSource) {
+  return bottle.group?.fullName ?? bottle.fullName;
+}


### PR DESCRIPTION
Home, tasting, and Library surfaces now favor concise Bottle group names while preserving exact release names in metadata and hover titles. Library rows keep a curated set of release details on one line, tasting notes and achievement rows use tighter spacing, and redundant Single Cask badges are suppressed.

Profile role badges once again sit beneath the username—centered on mobile and left-aligned on desktop—without invalid list markup. Collection activity responses now include Bottle group summaries so clients can render compact identity consistently.

Responsive Playwright coverage exercises the profile, Library, and home feed at desktop and mobile widths, including wrapping, overflow, and spacing assertions. Component and route coverage verify display-name fallbacks and serialized group data; web/server typechecks and the targeted UI tests pass.
