### PR TITLE
fix(web): standardize bottle identity labels

### DIFF
--- a/apps/server/src/serializers/flight.ts
+++ b/apps/server/src/serializers/flight.ts
@@ -52,6 +52,8 @@ export const FlightDetailsSerializer = serializer({
       BottleSerializer,
       bottleRows,
       currentUser,
+      [],
+      { includeGroupSummary: true },
     );
     const bottleById = new Map(
       serializedBottles.map((bottle) => [bottle.id, bottle]),

--- a/apps/server/src/serializers/notification.ts
+++ b/apps/server/src/serializers/notification.ts
@@ -140,6 +140,8 @@ export const NotificationSerializer = serializer({
       BottleSerializer,
       bottleList,
       currentUser,
+      [],
+      { includeGroupSummary: true },
     );
     const bottlesById = new Map(
       serializedBottleList.map((bottle, index) => [

--- a/apps/server/src/serializers/storePrice.ts
+++ b/apps/server/src/serializers/storePrice.ts
@@ -198,6 +198,8 @@ export const PriceChangeSerializer = serializer({
       BottleSerializer,
       bottleList,
       currentUser,
+      [],
+      { includeGroupSummary: true },
     );
     const bottlesById = new Map(
       serializedBottles.map((bottle) => [bottle.id, bottle]),

--- a/apps/web/src/app/(default)/(activity)/newBottles.tsx
+++ b/apps/web/src/app/(default)/(activity)/newBottles.tsx
@@ -1,10 +1,7 @@
 "use client";
 
-import { formatCategoryName } from "@peated/server/lib/format";
-import BottleLink from "@peated/web/components/bottleLink";
+import BottleIdentity from "@peated/web/components/bottleIdentity";
 import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
-import Link from "@peated/web/components/link";
-import { getBottleDisplayName } from "@peated/web/lib/bottleDisplayName";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
@@ -53,25 +50,12 @@ export default function NewBottles() {
             return (
               <tr key={bottle.id} className="border-b border-slate-800">
                 <td className="max-w-0 py-2 pl-4 pr-4 text-sm sm:pl-3">
-                  <div className="flex items-center space-x-1">
-                    <BottleLink
-                      bottle={bottle}
-                      className="font-medium hover:underline"
-                    >
-                      {getBottleDisplayName(bottle)}
-                    </BottleLink>
-                    <BottleStatusIcons bottle={bottle} />
-                  </div>
-                  <div className="text-muted flex gap-x-1 text-sm">
-                    {bottle.category && (
-                      <Link
-                        href={`/bottles/?category=${bottle.category}`}
-                        className="hover:underline"
-                      >
-                        {formatCategoryName(bottle.category)}
-                      </Link>
-                    )}
-                  </div>
+                  <BottleIdentity
+                    bottle={bottle}
+                    mode="absolute"
+                    metadataVariant="summary"
+                    trailingContent={<BottleStatusIcons bottle={bottle} />}
+                  />
                 </td>
               </tr>
             );

--- a/apps/web/src/app/(default)/(activity)/priceChanges.test.tsx
+++ b/apps/web/src/app/(default)/(activity)/priceChanges.test.tsx
@@ -3,23 +3,54 @@ import { describe, expect, it } from "vitest";
 
 import { PriceChangeIdentity } from "./priceChanges";
 
+function bottleIdentity({
+  id,
+  fullName,
+  category,
+}: {
+  id: number;
+  fullName: string;
+  category: "single_malt" | null;
+}) {
+  return {
+    id,
+    fullName,
+    name: fullName.replace(/^Springbank /, ""),
+    brand: { name: "Springbank", shortName: null },
+    group: { name: "12 Cask Strength", statedAge: 12 },
+    category,
+    edition: null,
+    statedAge: 12,
+    abv: null,
+    vintageYear: null,
+    releaseYear: null,
+    singleCask: false,
+    caskStrength: true,
+    caskFill: null,
+    caskType: null,
+    caskSize: null,
+  };
+}
+
 describe("PriceChangeIdentity", () => {
   it("links price changes to their independently complete Bottle", () => {
     const html = renderToStaticMarkup(
       <PriceChangeIdentity
-        bottle={{
+        bottle={bottleIdentity({
           id: 19,
           fullName: "Springbank 12 Cask Strength Batch 24",
           category: "single_malt",
-        }}
+        })}
         hasTasted={false}
         isLibrary
       />,
     );
+    const text = html.replace(/<[^>]*>/g, "");
 
     expect(html).toContain('href="/bottles/19"');
-    expect(html).toContain("Springbank 12 Cask Strength Batch 24");
-    expect(html).toContain("Single Malt");
+    expect(text).toContain("Springbank");
+    expect(text).toContain("12 Cask Strength");
+    expect(text).not.toContain("Springbank 12 Cask Strength Batch 24");
     expect(html).toContain('aria-label="In Library"');
     expect(html).not.toContain('aria-label="Tasted"');
   });
@@ -27,11 +58,11 @@ describe("PriceChangeIdentity", () => {
   it("renders tasted state without release-family presentation", () => {
     const html = renderToStaticMarkup(
       <PriceChangeIdentity
-        bottle={{
+        bottle={bottleIdentity({
           id: 99,
           fullName: "Springbank 12 Cask Strength",
           category: null,
-        }}
+        })}
         hasTasted
         isLibrary={false}
       />,

--- a/apps/web/src/app/(default)/(activity)/priceChanges.tsx
+++ b/apps/web/src/app/(default)/(activity)/priceChanges.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { formatCategoryName } from "@peated/server/lib/format";
-import type { Bottle } from "@peated/server/types";
 import { type Currency } from "@peated/server/types";
+import BottleIdentity, {
+  type BottleIdentitySource,
+} from "@peated/web/components/bottleIdentity";
 import { BottleStatusIndicators } from "@peated/web/components/bottleStatusIcons";
-import Link from "@peated/web/components/link";
 import Price from "@peated/web/components/price";
 import classNames from "@peated/web/lib/classNames";
 import { useORPC } from "@peated/web/lib/orpc/context";
@@ -37,32 +37,19 @@ export function PriceChangeIdentity({
   hasTasted,
   isLibrary,
 }: {
-  bottle: Pick<Bottle, "id" | "fullName" | "category">;
+  bottle: BottleIdentitySource;
   hasTasted: boolean;
   isLibrary: boolean;
 }) {
   return (
-    <>
-      <div className="flex items-center space-x-1">
-        <Link
-          href={`/bottles/${bottle.id}`}
-          className="truncate hover:underline"
-        >
-          {bottle.fullName}
-        </Link>
+    <BottleIdentity
+      bottle={bottle}
+      mode="absolute"
+      metadataVariant="summary"
+      trailingContent={
         <BottleStatusIndicators hasTasted={hasTasted} isLibrary={isLibrary} />
-      </div>
-      {!!bottle.category && (
-        <div className="text-muted text-sm">
-          <Link
-            href={`/bottles/?category=${bottle.category}`}
-            className="hover:underline"
-          >
-            {formatCategoryName(bottle.category)}
-          </Link>
-        </div>
-      )}
-    </>
+      }
+    />
   );
 }
 

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -3,6 +3,7 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import type { Bottle } from "@peated/server/types";
 import BadgeImage from "@peated/web/components/badgeImage";
+import BottleIdentity from "@peated/web/components/bottleIdentity";
 import BottleResolver, {
   type BottleResolverAction,
   type BottleResolverCreateProposalActionsProps,
@@ -143,14 +144,12 @@ function BottlePanel({
             className="h-24 w-24 shrink-0 rounded object-cover"
           />
         )}
-        <div className="min-w-0 flex-1">
-          <Link
-            href={getViewBottleHref(bottle)}
-            className="font-semibold text-white hover:underline"
-          >
-            {bottle.fullName}
-          </Link>
-        </div>
+        <BottleIdentity
+          bottle={bottle}
+          href={getViewBottleHref(bottle)}
+          className="min-w-0 flex-1"
+          linkClassName="font-semibold text-white hover:underline"
+        />
       </div>
     </section>
   );
@@ -167,14 +166,12 @@ function CollectionBottlePanel({ entry }: { entry: CollectionBottle }) {
             className="h-24 w-24 shrink-0 rounded object-cover"
           />
         )}
-        <div className="min-w-0 flex-1">
-          <Link
-            href={getViewBottleHref(entry.bottle)}
-            className="font-semibold text-white hover:underline"
-          >
-            {entry.bottle.fullName}
-          </Link>
-        </div>
+        <BottleIdentity
+          bottle={entry.bottle}
+          href={getViewBottleHref(entry.bottle)}
+          className="min-w-0 flex-1"
+          linkClassName="font-semibold text-white hover:underline"
+        />
       </div>
     </section>
   );

--- a/apps/web/src/components/activityList.tsx
+++ b/apps/web/src/components/activityList.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
+import BottleIdentity from "@peated/web/components/bottleIdentity";
 import Link from "@peated/web/components/link";
-import { getBottleDisplayName } from "@peated/web/lib/bottleDisplayName";
 import { AnimatePresence } from "framer-motion";
 import { useState } from "react";
 import TastingListItem from "./tastingListItem";
@@ -44,18 +43,6 @@ function CollectionLink({ activity }: { activity: CollectionAddActivity }) {
   );
 }
 
-function getCollectionItemHref(item: CollectionAddItem) {
-  return `/bottles/${item.bottle.id}`;
-}
-
-function getCollectionItemDisplayName(item: CollectionAddItem) {
-  return getBottleDisplayName(item.bottle);
-}
-
-function getCollectionItemDetail(item: CollectionAddItem) {
-  return item.bottle.category ? formatCategoryName(item.bottle.category) : null;
-}
-
 function CollectionItemImage({ item }: { item: CollectionAddItem }) {
   const imageUrl = item.imageUrl ?? item.bottle.imageUrl;
 
@@ -76,24 +63,15 @@ function CollectionItemImage({ item }: { item: CollectionAddItem }) {
 }
 
 function CollectionPreviewItem({ item }: { item: CollectionAddItem }) {
-  const detail = getCollectionItemDetail(item);
-  const href = getCollectionItemHref(item);
-  const displayName = getCollectionItemDisplayName(item);
-
   return (
     <li className="flex min-w-0 items-center gap-x-3 px-3 py-2">
       <CollectionItemImage item={item} />
-      <div className="min-w-0 flex-1">
-        <Link
-          href={href}
-          className="block truncate text-sm font-semibold text-white hover:underline"
-          title={item.bottle.fullName}
-        >
-          {displayName}
-        </Link>
-        {detail ? (
-          <div className="text-muted truncate text-xs">{detail}</div>
-        ) : null}
+      <div className="min-w-0 flex-1 text-sm">
+        <BottleIdentity
+          bottle={item.bottle}
+          mode="absolute"
+          metadataVariant="summary"
+        />
       </div>
     </li>
   );

--- a/apps/web/src/components/bottleExactMetadata.test.tsx
+++ b/apps/web/src/components/bottleExactMetadata.test.tsx
@@ -7,6 +7,7 @@ import BottleExactMetadata, {
 
 const exactBottle = {
   category: "single_malt",
+  edition: "2025 Release",
   statedAge: 21,
   abv: 55.1,
   vintageYear: 2004,
@@ -27,7 +28,7 @@ describe("BottleExactMetadata", () => {
 
     expect(html).toContain("flex-wrap");
     expect(text).toBe(
-      "Lagavulin·Single Malt·21 years·55.1% ABV·2004 vintage·2025 release·Single cask·Cask strength·1st Fill Oloroso Hogshead cask",
+      "Lagavulin·2025 Release·Single Malt·21 years·55.1% ABV·2004 vintage·Single cask·Cask strength·1st Fill Oloroso Hogshead cask",
     );
     expect(html.match(/class="inline-flex whitespace-nowrap"/g)).toHaveLength(
       9,
@@ -66,6 +67,7 @@ describe("BottleExactMetadata", () => {
       <BottleExactMetadata
         bottle={{
           category: null,
+          edition: null,
           statedAge: null,
           abv: null,
           vintageYear: null,
@@ -109,6 +111,7 @@ describe("BottleExactMetadata", () => {
       <BottleExactMetadata
         bottle={{
           ...exactBottle,
+          edition: null,
           statedAge: 4,
           vintageYear: null,
           releaseYear: null,

--- a/apps/web/src/components/bottleExactMetadata.tsx
+++ b/apps/web/src/components/bottleExactMetadata.tsx
@@ -42,6 +42,10 @@ export function getBottleExactMetadata(
 ): MetadataItem[] {
   const metadata: MetadataItem[] = [];
 
+  if (bottle.edition) {
+    metadata.push({ key: "edition", content: bottle.edition });
+  }
+
   if (bottle.category) {
     metadata.push({
       key: "category",
@@ -81,7 +85,25 @@ export function getBottleExactMetadata(
     metadata.push({ key: "cask-details", content: `${caskDetails} cask` });
   }
 
-  return metadata;
+  const seenLabels = new Set<string>();
+  return metadata.filter(({ content }) => {
+    if (typeof content !== "string") return true;
+
+    const label = content.trim().toLowerCase();
+    if (seenLabels.has(label)) return false;
+
+    seenLabels.add(label);
+    return true;
+  });
+}
+
+export function hasBottleExactMetadata(
+  bottle: BottleExactMetadataSource,
+  exclude: readonly BottleExactMetadataKey[] = [],
+) {
+  return getBottleExactMetadata(bottle).some(
+    ({ key }) => !exclude.includes(key),
+  );
 }
 
 function getBottleReleaseSummary(
@@ -136,7 +158,7 @@ export default function BottleExactMetadata({
 }: {
   bottle: BottleExactMetadataSource;
   className?: string;
-  exclude?: BottleExactMetadataKey[];
+  exclude?: readonly BottleExactMetadataKey[];
   leadingContent?: ReactNode;
   variant?: "full" | "summary";
 }) {

--- a/apps/web/src/components/bottleHeader.test.tsx
+++ b/apps/web/src/components/bottleHeader.test.tsx
@@ -1,0 +1,47 @@
+import type { Bottle } from "@peated/server/types";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import BottleHeader from "./bottleHeader";
+
+vi.mock("@peated/web/assets/bottle.svg", () => ({ default: "svg" }));
+
+describe("BottleHeader", () => {
+  it("separates the shared label from exact Bottle metadata", () => {
+    const bottle = {
+      id: 42,
+      fullName: "Lagavulin 21 - Distillers Edition - 2025 Release - 55.1% ABV",
+      name: "21 - Distillers Edition - 2025 Release - 55.1% ABV",
+      group: {
+        name: "21",
+      },
+      brand: {
+        id: 7,
+        name: "Lagavulin Distillery",
+        shortName: "Lagavulin",
+      },
+      distillers: [],
+      edition: "Distillers Edition",
+      category: "single_malt",
+      statedAge: 21,
+      abv: 55.1,
+      vintageYear: null,
+      releaseYear: 2025,
+      singleCask: null,
+      caskStrength: true,
+      caskFill: null,
+      caskType: null,
+      caskSize: null,
+    } as unknown as Bottle;
+
+    const html = renderToStaticMarkup(<BottleHeader bottle={bottle} />);
+    const text = html.replace(/<[^>]*>/g, "");
+
+    expect(text).toContain("Lagavulin21");
+    expect(text).not.toContain(bottle.fullName);
+    expect(text).toContain(
+      "Distillers Edition·Single Malt·21 years·55.1% ABV·2025 release·Cask strength",
+    );
+    expect(html).toContain(`title="${bottle.fullName}"`);
+  });
+});

--- a/apps/web/src/components/bottleHeader.test.tsx
+++ b/apps/web/src/components/bottleHeader.test.tsx
@@ -44,4 +44,32 @@ describe("BottleHeader", () => {
     );
     expect(html).toContain(`title="${bottle.fullName}"`);
   });
+
+  it("does not repeat an edition already expressed by the title", () => {
+    const bottle = {
+      id: 42,
+      fullName: "Lagavulin Distillers Edition - 2025 Release",
+      name: "Distillers Edition - 2025 Release",
+      group: { name: "Distillers Edition" },
+      brand: { id: 7, name: "Lagavulin", shortName: null },
+      distillers: [],
+      edition: "Distillers Edition",
+      category: "single_malt",
+      statedAge: null,
+      abv: null,
+      vintageYear: null,
+      releaseYear: 2025,
+      singleCask: null,
+      caskStrength: null,
+      caskFill: null,
+      caskType: null,
+      caskSize: null,
+    } as unknown as Bottle;
+
+    const html = renderToStaticMarkup(<BottleHeader bottle={bottle} />);
+    const text = html.replace(/<[^>]*>/g, "");
+
+    expect(text.match(/Distillers Edition/g)).toHaveLength(1);
+    expect(text).toContain("2025 release");
+  });
 });

--- a/apps/web/src/components/bottleHeader.tsx
+++ b/apps/web/src/components/bottleHeader.tsx
@@ -1,7 +1,10 @@
-import { formatCategoryName } from "@peated/server/lib/format";
 import type { Bottle } from "@peated/server/types";
 import BottleIcon from "@peated/web/assets/bottle.svg";
+import BottleExactMetadata, {
+  hasBottleExactMetadata,
+} from "@peated/web/components/bottleExactMetadata";
 import Link from "@peated/web/components/link";
+import { getBottleLabel } from "@peated/web/lib/bottleLabel";
 import BottleMetadata from "./bottleMetadata";
 import PageHeader from "./pageHeader";
 import SingleCaskChip from "./singleCaskChip";
@@ -15,6 +18,9 @@ export default function BottleHeader({
   href?: string;
   compact?: boolean;
 }) {
+  const label = getBottleLabel(bottle);
+  const metadataExclude = bottle.singleCask ? (["single-cask"] as const) : [];
+
   return (
     <PageHeader
       icon={BottleIcon}
@@ -22,18 +28,25 @@ export default function BottleHeader({
       title={
         <div className="flex flex-wrap items-center gap-2">
           {href ? (
-            <Link href={href} className="hover:underline">
-              {bottle.fullName}
+            <Link
+              href={href}
+              title={bottle.fullName}
+              className="hover:underline"
+            >
+              {label}
             </Link>
           ) : (
-            <div className="flex flex-wrap items-center gap-2">
+            <div
+              title={bottle.fullName}
+              className="flex flex-wrap items-center gap-2"
+            >
               <Link
                 href={`/entities/${bottle.brand.id}`}
                 className="hover:underline"
               >
                 {bottle.brand.shortName || bottle.brand.name}
               </Link>
-              {bottle.name}
+              {bottle.group?.name || bottle.name}
             </div>
           )}
           {bottle.singleCask && <SingleCaskChip />}
@@ -46,25 +59,9 @@ export default function BottleHeader({
         />
       }
       metadata={
-        (bottle.category || bottle.statedAge) && (
-          <div className="text-muted flex w-full min-w-[150px] flex-col items-center justify-center gap-x-1 lg:w-auto lg:items-end">
-            <div>
-              {bottle.category && (
-                <Link
-                  href={`/bottles?category=${encodeURIComponent(
-                    bottle.category,
-                  )}`}
-                  className="hover:underline"
-                >
-                  {formatCategoryName(bottle.category)}
-                </Link>
-              )}
-            </div>
-            <div>
-              {bottle.statedAge ? `Aged ${bottle.statedAge} years` : null}
-            </div>
-          </div>
-        )
+        hasBottleExactMetadata(bottle, metadataExclude) ? (
+          <BottleExactMetadata bottle={bottle} exclude={metadataExclude} />
+        ) : null
       }
     />
   );

--- a/apps/web/src/components/bottleHeader.tsx
+++ b/apps/web/src/components/bottleHeader.tsx
@@ -1,6 +1,7 @@
 import type { Bottle } from "@peated/server/types";
 import BottleIcon from "@peated/web/assets/bottle.svg";
 import BottleExactMetadata, {
+  type BottleExactMetadataKey,
   hasBottleExactMetadata,
 } from "@peated/web/components/bottleExactMetadata";
 import Link from "@peated/web/components/link";
@@ -19,7 +20,18 @@ export default function BottleHeader({
   compact?: boolean;
 }) {
   const label = getBottleLabel(bottle);
-  const metadataExclude = bottle.singleCask ? (["single-cask"] as const) : [];
+  const expressionName = bottle.group?.name || bottle.name;
+  const metadataExclude: BottleExactMetadataKey[] = [];
+
+  if (bottle.singleCask) metadataExclude.push("single-cask");
+  if (
+    bottle.edition &&
+    expressionName
+      .toLocaleLowerCase()
+      .includes(bottle.edition.toLocaleLowerCase())
+  ) {
+    metadataExclude.push("edition");
+  }
 
   return (
     <PageHeader
@@ -46,7 +58,7 @@ export default function BottleHeader({
               >
                 {bottle.brand.shortName || bottle.brand.name}
               </Link>
-              {bottle.group?.name || bottle.name}
+              {expressionName}
             </div>
           )}
           {bottle.singleCask && <SingleCaskChip />}

--- a/apps/web/src/components/bottleIdentity.tsx
+++ b/apps/web/src/components/bottleIdentity.tsx
@@ -1,18 +1,18 @@
 import { toTitleCase } from "@peated/server/lib/strings";
 import type { Bottle } from "@peated/server/types";
 import Link from "@peated/web/components/link";
-import type { ReactNode } from "react";
+import { getBottleLabel } from "@peated/web/lib/bottleLabel";
+import classNames from "@peated/web/lib/classNames";
+import type { MouseEventHandler, ReactNode } from "react";
 import BottleExactMetadata, {
   type BottleExactMetadataKey,
 } from "./bottleExactMetadata";
 
-type BottleIdentitySource = Pick<
+export type BottleIdentitySource = Pick<
   Bottle,
   | "id"
   | "fullName"
   | "name"
-  | "group"
-  | "brand"
   | "edition"
   | "category"
   | "statedAge"
@@ -24,7 +24,24 @@ type BottleIdentitySource = Pick<
   | "caskFill"
   | "caskType"
   | "caskSize"
->;
+> & {
+  brand: Pick<Bottle["brand"], "name" | "shortName">;
+  group?: Pick<NonNullable<Bottle["group"]>, "name" | "statedAge">;
+};
+
+export function BottleLabel({
+  bottle,
+  className,
+}: {
+  bottle: Pick<BottleIdentitySource, "fullName" | "name" | "brand" | "group">;
+  className?: string;
+}) {
+  return (
+    <span title={bottle.fullName} className={className}>
+      {getBottleLabel(bottle)}
+    </span>
+  );
+}
 
 type RelativeIdentity = {
   label: string;
@@ -87,7 +104,7 @@ function getEditionMetadataDuplicates(
   const edition = bottle.edition?.toLocaleLowerCase();
   if (!edition) return [];
 
-  const duplicates: BottleExactMetadataKey[] = [];
+  const duplicates: BottleExactMetadataKey[] = ["edition"];
   if (
     bottle.vintageYear !== null &&
     edition.includes(String(bottle.vintageYear)) &&
@@ -213,18 +230,23 @@ function BottleIdentityLink({
   children,
   className,
   current,
+  onClick,
+  href,
 }: {
   bottle: BottleIdentitySource;
   children: ReactNode;
   className?: string;
   current?: boolean;
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
+  href?: string;
 }) {
   return (
     <Link
-      href={`/bottles/${bottle.id}`}
+      href={href ?? `/bottles/${bottle.id}`}
       title={bottle.fullName}
       aria-current={current ? "page" : undefined}
       className={className}
+      onClick={onClick}
     >
       {children}
     </Link>
@@ -233,14 +255,24 @@ function BottleIdentityLink({
 
 export default function BottleIdentity({
   bottle,
-  mode,
+  mode = "absolute",
   current = false,
   metadataVariant = "full",
+  onClick,
+  trailingContent,
+  href,
+  className,
+  linkClassName,
 }: {
   bottle: BottleIdentitySource;
-  mode: "absolute" | "relative";
+  mode?: "absolute" | "relative";
   current?: boolean;
   metadataVariant?: "full" | "summary";
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
+  trailingContent?: ReactNode;
+  href?: string;
+  className?: string;
+  linkClassName?: string;
 }) {
   const relativeIdentity = getRelativeBottleIdentity(bottle);
   const isAbsolute = mode === "absolute";
@@ -258,7 +290,7 @@ export default function BottleIdentity({
     : [];
 
   return (
-    <div className="min-w-0">
+    <div className={classNames("min-w-0", className)}>
       {isAbsolute ? (
         <div className="text-muted truncate text-xs font-medium uppercase tracking-wide">
           {bottle.brand.name}
@@ -268,10 +300,16 @@ export default function BottleIdentity({
         <BottleIdentityLink
           bottle={bottle}
           current={current}
-          className="break-words font-semibold hover:underline"
+          onClick={onClick}
+          href={href}
+          className={classNames(
+            "break-words font-semibold hover:underline",
+            linkClassName,
+          )}
         >
           {title}
         </BottleIdentityLink>
+        {trailingContent}
         {current ? (
           <span
             className="h-2 w-2 shrink-0 rounded-full bg-orange-400"

--- a/apps/web/src/components/bottleResolver/states.tsx
+++ b/apps/web/src/components/bottleResolver/states.tsx
@@ -1,4 +1,5 @@
 import type { Bottle } from "@peated/server/types";
+import BottleIdentity from "@peated/web/components/bottleIdentity";
 import Button from "@peated/web/components/button";
 import Link from "@peated/web/components/link";
 import { Camera, Check, Plus, Search } from "lucide-react";
@@ -239,12 +240,10 @@ export function PhotoMatchCreateState({
             fallbackIcon={<Check className="text-highlight h-6 w-6" />}
           >
             <div className="space-y-2">
-              <Link
-                href={`/bottles/${matchedBottle.id}`}
-                className="font-semibold text-white hover:underline"
-              >
-                {matchedBottle.fullName}
-              </Link>
+              <BottleIdentity
+                bottle={matchedBottle}
+                linkClassName="font-semibold text-white hover:underline"
+              />
               <EvidencePills result={result} compact />
             </div>
           </PhotoResultCard>

--- a/apps/web/src/components/flightBottleIdentity.tsx
+++ b/apps/web/src/components/flightBottleIdentity.tsx
@@ -3,9 +3,9 @@
 import type { Bottle } from "@peated/server/types";
 import { getAddBottleHref } from "@peated/web/lib/addBottle";
 import { useState } from "react";
+import BottleIdentity from "./bottleIdentity";
 import BottlePanel from "./bottlePanel";
 import { ClientOnly } from "./clientOnly";
-import Link from "./link";
 
 export default function FlightBottleIdentity({
   bottle,
@@ -18,16 +18,15 @@ export default function FlightBottleIdentity({
 
   return (
     <>
-      <Link
-        href={`/bottles/${bottle.id}`}
-        className="font-semibold hover:underline"
+      <BottleIdentity
+        bottle={bottle}
+        mode="absolute"
+        metadataVariant="summary"
         onClick={(event) => {
           event.preventDefault();
           setOpen(true);
         }}
-      >
-        {bottle.fullName}
-      </Link>
+      />
       {open && (
         <ClientOnly>
           {() => (

--- a/apps/web/src/components/notifications/entry.tsx
+++ b/apps/web/src/components/notifications/entry.tsx
@@ -2,6 +2,7 @@
 
 import { XMarkIcon } from "@heroicons/react/20/solid";
 import type { Notification } from "@peated/server/types";
+import { BottleLabel } from "@peated/web/components/bottleIdentity";
 import Link from "@peated/web/components/link";
 import classNames from "@peated/web/lib/classNames";
 import { useRouter } from "next/navigation";
@@ -113,7 +114,7 @@ export const getStatusMessage = ({
               href={`/tastings/${notification.ref.id}`}
               className="font-semibold"
             >
-              {notification.ref.bottle.fullName}
+              <BottleLabel bottle={notification.ref.bottle} />
             </Link>
           ) : (
             "unknown tasting"
@@ -129,7 +130,7 @@ export const getStatusMessage = ({
               href={`/tastings/${notification.ref.id}`}
               className="font-semibold"
             >
-              {notification.ref.bottle.fullName}
+              <BottleLabel bottle={notification.ref.bottle} />
             </Link>
           ) : (
             "an unknown tasting"

--- a/apps/web/src/components/search/bottleResult.test.tsx
+++ b/apps/web/src/components/search/bottleResult.test.tsx
@@ -113,8 +113,9 @@ describe("BottleResultRow", () => {
     expect(html).toContain('href="/bottles/42/releases"');
     expect(html).toContain("relative z-10");
     expect(text).toContain("3 related releases");
-    expect(text).toContain(exactBottle.fullName);
-    expect(text).toContain("Lagavulin·Single Malt·16 years");
+    expect(text).toContain(group.fullName);
+    expect(text).not.toContain(exactBottle.fullName);
+    expect(text).toContain("Lagavulin·Distillers Edition·Single Malt·16 years");
     expect(text).toContain("16 years·43.0% ABV");
     expect(text).toContain("2008 vintage·2024 release");
     expect(text).toContain("Single cask·Cask strength");

--- a/apps/web/src/components/search/bottleResult.tsx
+++ b/apps/web/src/components/search/bottleResult.tsx
@@ -1,6 +1,7 @@
 import type { Bottle } from "@peated/server/types";
 import BottleIcon from "@peated/web/assets/bottle.svg";
 import BottleExactMetadata from "@peated/web/components/bottleExactMetadata";
+import { BottleLabel } from "@peated/web/components/bottleIdentity";
 import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
 import {
@@ -81,7 +82,7 @@ export default function BottleResultRow({
             })}
           >
             <span className="absolute inset-x-0 -top-px bottom-0" />
-            <span>{bottle.fullName}</span>
+            <BottleLabel bottle={bottle} />
           </Link>
           <BottleStatusIcons bottle={bottle} />
         </div>

--- a/apps/web/src/lib/bottleLabel.ts
+++ b/apps/web/src/lib/bottleLabel.ts
@@ -1,0 +1,17 @@
+type BottleLabelSource = {
+  name: string;
+  brand: {
+    name: string;
+    shortName?: string | null;
+  };
+  group?: {
+    name: string;
+  };
+};
+
+export function getBottleLabel(bottle: BottleLabelSource) {
+  const brandName = bottle.brand.shortName || bottle.brand.name;
+  const expressionName = bottle.group?.name || bottle.name;
+
+  return `${brandName} ${expressionName}`;
+}


### PR DESCRIPTION
Bottle names across detail headers, search, activity feeds, new-bottle and price-change lists, flights, notifications, photo matching, and bottle-entry flows now use the shared bottle-identity presentation. The renderer shows the brand and stable expression name as the primary label, moves release-specific fields into structured metadata, retains the canonical full name as a tooltip, and avoids repeating metadata already represented by the title or status indicators.

The shared identity component now supports compact summaries, custom destinations, click handling, and trailing status content without forcing callers to rebuild bottle labels. Nested flight, notification, and price-change payloads include bottle-group summaries so those surfaces can select stable expression names. Exact-record selectors, merge workflows, admin tools, sharing metadata, and structured metadata continue using canonical full names where disambiguation or indexing requires them.

Desktop and mobile browser checks covered the pathological duplicated-release bottle, search results, bottle lists, and activity surfaces. All 136 web tests and both package typechecks pass; backend route tests remain blocked before serializer execution by the existing local test-schema mismatch where `bottle_alias.release_id` is absent.
