### PR TITLE
ci: bound web e2e runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -263,6 +263,7 @@ jobs:
   e2e:
     name: "test / web e2e"
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: changes
     if: github.event_name == 'push' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.e2e == 'true' || needs.changes.outputs.repo == 'true'
     steps:

--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -14,6 +14,7 @@ import {
   createdBottleId,
   createdBottleName,
   createdTastingId,
+  destinationBottleGroup,
   exactMatchedBottle,
   exactMatchedBottleId,
   exactSearchBottle,
@@ -152,9 +153,7 @@ test.describe("create bottle", () => {
     await expect(
       page.getByRole("heading", { name: "Add Bottle" }),
     ).toBeVisible();
-    await expect(
-      page.getByText(`${testBrand.name} ${createdBottleName}`),
-    ).toBeVisible();
+    await expect(getBottleIdentityLink(page, createdBottleName)).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Log Tasting" }),
     ).toBeVisible();
@@ -220,9 +219,7 @@ test.describe("create bottle", () => {
     await expect(
       page.getByRole("heading", { name: "Bottle found" }),
     ).toBeVisible();
-    await expect(
-      page.getByText(`${testBrand.name} ${createdBottleName}`),
-    ).toBeVisible();
+    await expect(getBottleIdentityLink(page, createdBottleName)).toBeVisible();
   });
 
   test("adds the created bottle to library from library intent", async ({
@@ -250,9 +247,7 @@ test.describe("create bottle", () => {
     await expect(
       page.getByRole("heading", { name: "Bottle found" }),
     ).toBeVisible();
-    await expect(
-      page.getByText(`${testBrand.name} ${createdBottleName}`),
-    ).toBeVisible();
+    await expect(getBottleIdentityLink(page, createdBottleName)).toBeVisible();
     await expect(
       page.getByRole("button", { name: "In Library" }),
     ).toBeVisible();
@@ -483,7 +478,9 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("heading", { name: "Add Bottle" }),
     ).toBeVisible();
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, destinationBottleGroup.name),
+    ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Add to Library" }),
     ).toBeVisible();
@@ -505,7 +502,9 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("heading", { name: "Added to Library" }),
     ).toBeVisible();
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, destinationBottleGroup.name),
+    ).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
 
@@ -518,11 +517,12 @@ test.describe("add bottle flow", () => {
     });
 
     await page.goto("/search?intent=addBottle&q=Lagavulin");
+    const searchBottleLabel = `${testBrand.name} ${exactSearchBottle.name}`;
     const result = page.locator(".card").filter({
-      has: page.getByRole("link", { name: exactSearchBottle.fullName }),
+      has: page.getByRole("link", { name: searchBottleLabel }),
     });
     const bottleLink = result.getByRole("link", {
-      name: exactSearchBottle.fullName,
+      name: searchBottleLabel,
     });
 
     await expect(bottleLink).toHaveAttribute(
@@ -531,6 +531,7 @@ test.describe("add bottle flow", () => {
     );
     const expectedMetadata = [
       testBrand.name,
+      exactSearchBottle.edition,
       "Single Malt",
       "21 years",
       "55.1% ABV",
@@ -560,7 +561,7 @@ test.describe("add bottle flow", () => {
     expect(addBottleUrl.searchParams.get("intent")).toBe("addBottle");
     expect(addBottleUrl.searchParams.get("release")).toBeNull();
     await expect(
-      page.getByRole("link", { name: exactSearchBottle.fullName }),
+      getBottleIdentityLink(page, exactSearchBottle.name),
     ).toHaveAttribute("href", `/bottles/${exactSearchBottle.id}`);
     await expect(
       page.getByRole("button", { name: "Add to Library" }),
@@ -629,7 +630,9 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("heading", { name: "Added to Library" }),
     ).toBeVisible();
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, destinationBottleGroup.name),
+    ).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
 
@@ -689,7 +692,9 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("heading", { name: "Bottle found" }),
     ).toBeHidden();
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, existingBottle.group.name),
+    ).toBeVisible();
     await expect(
       page.getByText("Matched to existing bottle in Peated"),
     ).toBeVisible();
@@ -723,7 +728,9 @@ test.describe("add bottle flow", () => {
       "src",
       /library\.webp$/,
     );
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, destinationBottleGroup.name),
+    ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Add Another Bottle" }),
     ).toBeVisible();
@@ -739,7 +746,9 @@ test.describe("add bottle flow", () => {
 
     await page.goto("/addBottle");
     await uploadLabel(page);
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, existingBottle.group.name),
+    ).toBeVisible();
     await expect(
       page.getByText("Matched to existing bottle in Peated"),
     ).toBeVisible();
@@ -765,7 +774,9 @@ test.describe("add bottle flow", () => {
 
     await page.goto("/addBottle");
     await uploadLabel(page);
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, existingBottle.group.name),
+    ).toBeVisible();
     const savePhotoButton = page.getByRole("button", { name: "Save Photo" });
     await expect(savePhotoButton).toBeVisible();
     await expect(savePhotoButton).toBeEnabled();
@@ -1023,9 +1034,7 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("heading", { name: "Added to Library" }),
     ).toBeVisible();
-    await expect(
-      page.getByText(`${testBrand.name} ${createdBottleName}`),
-    ).toBeVisible();
+    await expect(getBottleIdentityLink(page, createdBottleName)).toBeVisible();
     await expect(
       page.getByRole("heading", { name: "Bottle created" }),
     ).toBeHidden();
@@ -1124,7 +1133,9 @@ test.describe("add bottle flow", () => {
     );
     await expect(page).toHaveURL(new RegExp(`/bottles/${existingBottle.id}$`));
     await expect(
-      page.getByRole("heading", { name: existingBottle.fullName }),
+      page.getByRole("heading", {
+        name: `${testBrand.name} ${destinationBottleGroup.name}`,
+      }),
     ).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
@@ -1150,7 +1161,9 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("heading", { name: "Added to Library" }),
     ).toBeVisible();
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, destinationBottleGroup.name),
+    ).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
 
@@ -1312,7 +1325,9 @@ test.describe("add bottle flow", () => {
     await page.goto("/addBottle");
     await uploadLabel(page);
 
-    await expect(page.getByText(exactMatchedBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, exactMatchedBottle.group.name),
+    ).toBeVisible();
     await expect(
       page.getByText("Matched to existing bottle in Peated"),
     ).toBeVisible();
@@ -1382,9 +1397,7 @@ test.describe("add bottle flow", () => {
       "src",
       pendingScanImageUrl,
     );
-    await expect(
-      page.getByText(`${testBrand.name} ${createdBottleName}`),
-    ).toBeVisible();
+    await expect(getBottleIdentityLink(page, createdBottleName)).toBeVisible();
 
     const libraryRequestPromise = waitForCollectionBottleCreate(page);
     await page.getByRole("button", { name: "Add to Library" }).click();
@@ -1442,6 +1455,10 @@ function uniqueAccessToken(testInfo: TestInfo, suffix: string) {
     `w${testInfo.workerIndex}`,
     `r${testInfo.retry}`,
   ].join("-");
+}
+
+function getBottleIdentityLink(page: Page, name: string) {
+  return page.getByRole("main").getByRole("link", { name, exact: true });
 }
 
 async function toggleBottleBoolean(page: Page, label: string) {

--- a/apps/web/e2e/bottle-group-workflows.spec.ts
+++ b/apps/web/e2e/bottle-group-workflows.spec.ts
@@ -18,7 +18,7 @@ test.describe("Bottle releases", () => {
     await expect(
       page.getByRole("heading", {
         level: 1,
-        name: bottleGroupRepresentative.fullName,
+        name: `${bottleGroup.fullName} Single Cask`,
       }),
     ).toBeVisible();
     await expect(
@@ -61,7 +61,7 @@ test.describe("Bottle releases", () => {
     await expect(
       page.getByRole("heading", {
         level: 1,
-        name: bottleGroupMember.fullName,
+        name: bottleGroup.fullName,
       }),
     ).toBeVisible();
     await expect(

--- a/apps/web/e2e/bottle-page-redirects.spec.ts
+++ b/apps/web/e2e/bottle-page-redirects.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import {
+  destinationBottleGroup,
   exactMatchedBottleId,
   existingBottleId,
   missingBottleId,
@@ -13,7 +14,7 @@ test.describe("Bottle page redirects", () => {
   test("renders an active Bottle without redirecting", async ({ page }) => {
     await page.goto(`/bottles/${existingBottleId}`);
     await expect(
-      page.getByRole("heading", { name: "Lagavulin 16-year-old" }),
+      page.getByRole("heading", { name: destinationBottleGroup.fullName }),
     ).toBeVisible();
   });
 

--- a/apps/web/e2e/bottle-prices.spec.ts
+++ b/apps/web/e2e/bottle-prices.spec.ts
@@ -34,7 +34,7 @@ test.describe("Bottle prices", () => {
     });
     await prices
       .getByRole("link", {
-        name: priceChangeFirstBottle.fullName,
+        name: priceChangeFirstBottle.group.name,
         exact: true,
       })
       .click();

--- a/apps/web/e2e/flight-bottles.spec.ts
+++ b/apps/web/e2e/flight-bottles.spec.ts
@@ -24,7 +24,7 @@ test.describe("Flight bottles", () => {
     for (const bottle of [existingBottle, exactSearchBottle]) {
       const bottleRow = page.getByRole("row").filter({
         has: page.getByRole("link", {
-          name: bottle.fullName,
+          name: bottle.name,
           exact: true,
         }),
       });
@@ -73,13 +73,13 @@ test.describe("Flight bottles", () => {
     );
     await expect(
       page.getByRole("link", {
-        name: existingBottle.fullName,
+        name: existingBottle.name,
         exact: true,
       }),
     ).toBeVisible();
     await expect(
       page.getByRole("link", {
-        name: exactSearchBottle.fullName,
+        name: exactSearchBottle.name,
         exact: true,
       }),
     ).toBeVisible();

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -4,6 +4,7 @@ import { Buffer } from "node:buffer";
 import { expectNoHorizontalOverflow } from "./assertions";
 import {
   createdTastingId,
+  destinationBottleGroup,
   existingBottle,
   failingTastingNotes,
   photoTastingNotes,
@@ -29,7 +30,9 @@ test.describe("log tasting", () => {
     await expect(
       page.getByRole("heading", { name: "Add Bottle" }),
     ).toBeVisible();
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, destinationBottleGroup.name),
+    ).toBeVisible();
     await expect(
       page
         .locator("main section")
@@ -103,7 +106,9 @@ test.describe("log tasting", () => {
 
     await uploadLabel(page);
 
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, existingBottle.group.name),
+    ).toBeVisible();
     await expect(
       page.getByText("Matched to existing bottle in Peated"),
     ).toBeVisible();
@@ -115,7 +120,7 @@ test.describe("log tasting", () => {
     await expect(
       page
         .locator("main section")
-        .filter({ hasText: existingBottle.fullName })
+        .filter({ hasText: "Matched to existing bottle in Peated" })
         .getByRole("button", { name: "Log Tasting" }),
     ).toBeVisible();
 
@@ -124,7 +129,12 @@ test.describe("log tasting", () => {
     await expect(
       page.getByRole("heading", { name: "Log Tasting" }),
     ).toBeVisible();
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        level: 4,
+        name: existingBottle.fullName,
+      }),
+    ).toBeVisible();
     await page.getByRole("button", { name: "Savor" }).click();
     await page.getByLabel("Comments").fill(photoTastingNotes);
     await page.getByRole("button", { name: "Save" }).click();
@@ -149,10 +159,17 @@ test.describe("log tasting", () => {
 
     await uploadLabel(page);
 
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      getBottleIdentityLink(page, existingBottle.group.name),
+    ).toBeVisible();
     await page.getByRole("button", { name: "Log Tasting" }).click();
 
-    await expect(page.getByText(existingBottle.fullName)).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        level: 4,
+        name: existingBottle.fullName,
+      }),
+    ).toBeVisible();
     await page.getByRole("button", { name: "Savor" }).click();
     await page.getByLabel("Comments").fill(failingTastingNotes);
     await page.getByRole("button", { name: "Save" }).click();
@@ -169,6 +186,10 @@ test.describe("log tasting", () => {
     await expectNoHorizontalOverflow(page);
   });
 });
+
+function getBottleIdentityLink(page: Page, name: string) {
+  return page.getByRole("main").getByRole("link", { name, exact: true });
+}
 
 async function uploadLabel(page: Page) {
   await expect(

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
   testDir: "./e2e",
   outputDir: ".playwright/test-results",
   timeout: 60_000,
+  globalTimeout: process.env.CI ? 12 * 60_000 : undefined,
+  maxFailures: process.env.CI ? 5 : 0,
   fullyParallel: true,
   workers: 2,
   forbidOnly: !!process.env.CI,


### PR DESCRIPTION
CI now stops web E2E runs after five failures or twelve minutes, while GitHub Actions enforces a fifteen-minute hard job ceiling. Local Playwright runs retain their existing unlimited suite duration and failure count.

This prevents broad regressions or stuck Playwright teardown from consuming the default multi-hour Actions limit. Healthy runs still have roughly twice their normal six-minute execution budget before the suite-level cutoff.
