### PR TITLE
fix(web): standardize concise bottle identity rendering

### DIFF
--- a/apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/releases/releaseFamilyView.test.tsx
+++ b/apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/releases/releaseFamilyView.test.tsx
@@ -148,7 +148,7 @@ describe("ReleaseFamilyView", () => {
     expect(html).toContain("2004 vintage");
     expect(html).toContain("2025 release");
     expect(html).toContain("Single cask");
-    expect(html).toContain("Cask strength");
+    expect(html).not.toContain("Cask strength");
     expect(html).toContain("1st Fill Oloroso Hogshead cask");
     expect(html).toContain("1 rating");
     expect(html).not.toContain("1 tasting");

--- a/apps/web/src/app/(default)/bottles/[bottleId]/bottleFullHeader.tsx
+++ b/apps/web/src/app/(default)/bottles/[bottleId]/bottleFullHeader.tsx
@@ -19,7 +19,7 @@ export default function BottleFullHeader({
     <div className="w-full p-3 lg:py-0">
       <BottleHeader bottle={bottle} />
 
-      <div className="my-8 flex flex-col justify-center gap-2 sm:flex-row lg:justify-start">
+      <div className="mb-5 mt-4 flex flex-col justify-center gap-2 sm:flex-row lg:justify-start">
         <div className="flex flex-grow justify-center gap-4 gap-x-2 lg:justify-start">
           <Suspense
             fallback={

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/page.tsx
@@ -78,7 +78,6 @@ function UserLibraryTable({ username }: { username: string }) {
             bottleList={bottles.results}
             rel={bottles.rel}
             hideLibraryStatus
-            identityMode="absolute"
             showRatingSummary
             showBottleStats={false}
             compactIdentity

--- a/apps/web/src/components/bottleHeader.test.tsx
+++ b/apps/web/src/components/bottleHeader.test.tsx
@@ -40,8 +40,9 @@ describe("BottleHeader", () => {
     expect(text).toContain("Lagavulin21");
     expect(text).not.toContain(bottle.fullName);
     expect(text).toContain(
-      "Distillers Edition·Single Malt·21 years·55.1% ABV·2025 release·Cask strength",
+      "Distillers Edition·Single Malt·21 years·55.1% ABV·2025 release",
     );
+    expect(text).not.toContain("Cask strength");
     expect(html).toContain(`title="${bottle.fullName}"`);
   });
 
@@ -71,5 +72,93 @@ describe("BottleHeader", () => {
 
     expect(text.match(/Distillers Edition/g)).toHaveLength(1);
     expect(text).toContain("2025 release");
+  });
+
+  it("keeps repeated identity fields out of a single-cask header", () => {
+    const bottle = {
+      id: 42,
+      fullName: "Pōkeno Double Bourbon Cask 3-year-old",
+      name: "Double Bourbon Cask 3-year-old",
+      group: { name: "Double Bourbon Cask 3-year-old" },
+      brand: { id: 7, name: "Pōkeno", shortName: null },
+      distillers: [{ id: 7, name: "Pōkeno" }],
+      edition: null,
+      category: "single_malt",
+      statedAge: 3,
+      abv: 56,
+      vintageYear: null,
+      releaseYear: null,
+      singleCask: true,
+      caskStrength: true,
+      caskFill: null,
+      caskType: "bourbon",
+      caskSize: null,
+    } as unknown as Bottle;
+
+    const html = renderToStaticMarkup(<BottleHeader bottle={bottle} />);
+    const text = html.replace(/<[^>]*>/g, "");
+
+    expect(text.match(/Pōkeno/g)).toHaveLength(1);
+    expect(text.match(/Single Cask/g)).toHaveLength(1);
+    expect(text).not.toContain("3 years");
+    expect(text).not.toContain("Bourbon cask");
+    expect(text).toContain("Single Malt·56.0% ABV");
+    expect(text).not.toContain("Cask strength");
+    expect(text).not.toContain("Distilled at");
+  });
+
+  it("retains distinct distiller attribution", () => {
+    const bottle = {
+      id: 42,
+      fullName: "Compass Box Orchard House",
+      name: "Orchard House",
+      group: { name: "Orchard House" },
+      brand: { id: 7, name: "Compass Box", shortName: null },
+      distillers: [{ id: 8, name: "Clynelish" }],
+      edition: null,
+      category: "blend",
+      statedAge: null,
+      abv: 46,
+      vintageYear: null,
+      releaseYear: null,
+      singleCask: false,
+      caskStrength: false,
+      caskFill: null,
+      caskType: null,
+      caskSize: null,
+    } as unknown as Bottle;
+
+    const html = renderToStaticMarkup(<BottleHeader bottle={bottle} />);
+    const text = html.replace(/<[^>]*>/g, "");
+
+    expect(text).toContain("Distilled atClynelish");
+  });
+
+  it("does not add a chip when Single Cask is already in the title", () => {
+    const bottle = {
+      id: 42,
+      fullName: "Pōkeno Single Cask 4-year-old",
+      name: "Single Cask 4-year-old",
+      group: { name: "Single Cask 4-year-old" },
+      brand: { id: 7, name: "Pōkeno", shortName: null },
+      distillers: [],
+      edition: null,
+      category: null,
+      statedAge: 4,
+      abv: null,
+      vintageYear: null,
+      releaseYear: null,
+      singleCask: true,
+      caskStrength: false,
+      caskFill: null,
+      caskType: null,
+      caskSize: null,
+    } as unknown as Bottle;
+
+    const html = renderToStaticMarkup(<BottleHeader bottle={bottle} />);
+    const text = html.replace(/<[^>]*>/g, "");
+
+    expect(text.match(/Single Cask/g)).toHaveLength(1);
+    expect(html).not.toContain('title="Single cask"');
   });
 });

--- a/apps/web/src/components/bottleHeader.tsx
+++ b/apps/web/src/components/bottleHeader.tsx
@@ -1,12 +1,16 @@
 import type { Bottle } from "@peated/server/types";
 import BottleIcon from "@peated/web/assets/bottle.svg";
 import BottleExactMetadata, {
-  type BottleExactMetadataKey,
   hasBottleExactMetadata,
 } from "@peated/web/components/bottleExactMetadata";
+import {
+  getAbsoluteBottleLabel,
+  getAbsoluteBottleTitle,
+  getBottleMetadataExclusions,
+  getDistinctBottleDistillers,
+} from "@peated/web/components/bottleIdentity";
 import Link from "@peated/web/components/link";
-import { getBottleLabel } from "@peated/web/lib/bottleLabel";
-import BottleMetadata from "./bottleMetadata";
+import { Distillers } from "./bottleMetadata";
 import PageHeader from "./pageHeader";
 import SingleCaskChip from "./singleCaskChip";
 
@@ -19,19 +23,27 @@ export default function BottleHeader({
   href?: string;
   compact?: boolean;
 }) {
-  const label = getBottleLabel(bottle);
-  const expressionName = bottle.group?.name || bottle.name;
-  const metadataExclude: BottleExactMetadataKey[] = [];
+  const label = getAbsoluteBottleLabel(bottle);
+  const expressionName = getAbsoluteBottleTitle(bottle);
+  const metadataExclude = getBottleMetadataExclusions(bottle, expressionName);
+  const distinctDistillers = getDistinctBottleDistillers(bottle);
+  const showSingleCaskChip =
+    bottle.singleCask && !metadataExclude.has("single-cask");
 
-  if (bottle.singleCask) metadataExclude.push("single-cask");
+  if (showSingleCaskChip) metadataExclude.add("single-cask");
   if (
     bottle.edition &&
     expressionName
       .toLocaleLowerCase()
       .includes(bottle.edition.toLocaleLowerCase())
   ) {
-    metadataExclude.push("edition");
+    metadataExclude.add("edition");
   }
+  const metadataKeys = [...metadataExclude];
+  const hasIdentityDetails =
+    showSingleCaskChip ||
+    hasBottleExactMetadata(bottle, metadataKeys) ||
+    distinctDistillers.length > 0;
 
   return (
     <PageHeader
@@ -61,18 +73,25 @@ export default function BottleHeader({
               {expressionName}
             </div>
           )}
-          {bottle.singleCask && <SingleCaskChip />}
         </div>
       }
       titleExtra={
-        <BottleMetadata
-          data={bottle}
-          className="text-muted w-full truncate text-center lg:text-left"
-        />
-      }
-      metadata={
-        hasBottleExactMetadata(bottle, metadataExclude) ? (
-          <BottleExactMetadata bottle={bottle} exclude={metadataExclude} />
+        hasIdentityDetails ? (
+          <div className="flex max-w-full flex-col items-center lg:items-start">
+            <BottleExactMetadata
+              bottle={bottle}
+              exclude={metadataKeys}
+              leadingContent={
+                showSingleCaskChip ? <SingleCaskChip /> : undefined
+              }
+              className="justify-center lg:justify-start"
+            />
+            {distinctDistillers.length ? (
+              <div className="text-muted mt-1 text-sm">
+                <Distillers distillers={distinctDistillers} />
+              </div>
+            ) : null}
+          </div>
         ) : null
       }
     />

--- a/apps/web/src/components/bottleIdentity.test.tsx
+++ b/apps/web/src/components/bottleIdentity.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 import BottleIdentity, {
   getAbsoluteBottleTitle,
+  getMetadataExpressedByTitle,
   getRelativeBottleIdentity,
 } from "./bottleIdentity";
 
@@ -42,7 +43,7 @@ describe("BottleIdentity", () => {
     expect(html).toContain("Batch 24");
     expect(html).toContain("57.2% ABV");
     expect(html).toContain("2023 release");
-    expect(html).toContain("Cask strength");
+    expect(html).not.toContain(">Cask strength</span>");
     expect(html).toContain('aria-current="page"');
     expect(html).toContain('title="Currently viewing"');
     expect(html).toContain("bg-orange-400");
@@ -76,6 +77,29 @@ describe("BottleIdentity", () => {
     expect(html).not.toContain(">12 years<");
     expect(html).not.toContain(">Cask strength</span>");
     expect(html).toContain('title="Springbank 12 Cask Strength Batch 24"');
+  });
+
+  it("does not use exact age as a subtitle when the family title includes it", () => {
+    const html = renderToStaticMarkup(
+      <BottleIdentity
+        bottle={makeBottle({
+          group: {
+            ...makeBottle().group!,
+            name: "Single Cask 4-year-old",
+            fullName: "Springbank Single Cask 4-year-old",
+            statedAge: null,
+          },
+          edition: null,
+          statedAge: 4,
+          singleCask: true,
+        })}
+        mode="absolute"
+      />,
+    );
+
+    expect(html).toContain("Single Cask 4-year-old");
+    expect(html).not.toContain(">4 years<");
+    expect(html).not.toContain(">Single cask<");
   });
 
   it("moves canonical metadata out of ungrouped Library headlines", () => {
@@ -121,6 +145,21 @@ describe("BottleIdentity", () => {
         }),
       ),
     ).toBe("Glenrothes - Individual Cask Release");
+  });
+
+  it("keeps cask details when a title only expresses part of the cask", () => {
+    const bottle = makeBottle({
+      caskFill: "1st_fill",
+      caskType: "bourbon",
+      caskSize: "hogshead",
+    });
+
+    expect(getMetadataExpressedByTitle(bottle, "Bourbon Cask")).not.toContain(
+      "cask-details",
+    );
+    expect(
+      getMetadataExpressedByTitle(bottle, "1st Fill Bourbon Hogshead Cask"),
+    ).toContain("cask-details");
   });
 
   it("keeps metadata-only names as the absolute headline", () => {

--- a/apps/web/src/components/bottleIdentity.tsx
+++ b/apps/web/src/components/bottleIdentity.tsx
@@ -1,7 +1,6 @@
 import { toTitleCase } from "@peated/server/lib/strings";
 import type { Bottle } from "@peated/server/types";
 import Link from "@peated/web/components/link";
-import { getBottleLabel } from "@peated/web/lib/bottleLabel";
 import classNames from "@peated/web/lib/classNames";
 import type { MouseEventHandler, ReactNode } from "react";
 import BottleExactMetadata, {
@@ -33,12 +32,12 @@ export function BottleLabel({
   bottle,
   className,
 }: {
-  bottle: Pick<BottleIdentitySource, "fullName" | "name" | "brand" | "group">;
+  bottle: BottleIdentitySource;
   className?: string;
 }) {
   return (
     <span title={bottle.fullName} className={className}>
-      {getBottleLabel(bottle)}
+      {getAbsoluteBottleLabel(bottle)}
     </span>
   );
 }
@@ -87,7 +86,7 @@ export function getAbsoluteBottleTitle(bottle: BottleIdentitySource) {
   const titleSegments = bottle.name.split(" - ");
 
   while (
-    titleSegments.length &&
+    titleSegments.length > 1 &&
     metadataSegments.has(
       titleSegments[titleSegments.length - 1]!.toLocaleLowerCase(),
     )
@@ -96,6 +95,29 @@ export function getAbsoluteBottleTitle(bottle: BottleIdentitySource) {
   }
 
   return titleSegments.length ? titleSegments.join(" - ") : bottle.name;
+}
+
+export function getAbsoluteBottleLabel(bottle: BottleIdentitySource) {
+  const brandName = bottle.brand.shortName || bottle.brand.name;
+  return `${brandName} ${getAbsoluteBottleTitle(bottle)}`;
+}
+
+export function getDistinctBottleDistillers({
+  brand,
+  distillers,
+}: {
+  brand: Pick<Bottle["brand"], "name" | "shortName">;
+  distillers: Pick<Bottle["distillers"][number], "id" | "name">[];
+}) {
+  const brandNames = new Set(
+    [brand.name, brand.shortName]
+      .filter((name): name is string => Boolean(name))
+      .map((name) => name.toLocaleLowerCase()),
+  );
+
+  return distillers.filter(
+    (distiller) => !brandNames.has(distiller.name.toLocaleLowerCase()),
+  );
 }
 
 function getEditionMetadataDuplicates(
@@ -135,12 +157,31 @@ function getEditionMetadataDuplicates(
   return duplicates;
 }
 
-function getMetadataExpressedByTitle(
-  bottle: BottleIdentitySource,
+export function getMetadataExpressedByTitle(
+  bottle: Pick<
+    BottleIdentitySource,
+    | "edition"
+    | "statedAge"
+    | "abv"
+    | "vintageYear"
+    | "releaseYear"
+    | "singleCask"
+    | "caskStrength"
+    | "caskFill"
+    | "caskType"
+    | "caskSize"
+  >,
   title: string,
 ): BottleExactMetadataKey[] {
   const normalizedTitle = title.toLocaleLowerCase();
   const duplicates: BottleExactMetadataKey[] = [];
+
+  if (
+    bottle.edition &&
+    normalizedTitle.includes(bottle.edition.toLocaleLowerCase())
+  ) {
+    duplicates.push("edition");
+  }
 
   if (
     bottle.statedAge !== null &&
@@ -176,7 +217,33 @@ function getMetadataExpressedByTitle(
   if (bottle.caskStrength && normalizedTitle.includes("cask strength")) {
     duplicates.push("cask-strength");
   }
+  const caskDetails = [
+    bottle.caskFill,
+    bottle.caskType,
+    bottle.caskSize,
+  ].filter((value): value is NonNullable<typeof value> => value !== null);
+  if (
+    caskDetails.length > 0 &&
+    caskDetails.every((value) =>
+      normalizedTitle.includes(toTitleCase(value).toLocaleLowerCase()),
+    )
+  ) {
+    duplicates.push("cask-details");
+  }
   return duplicates;
+}
+
+export function getBottleMetadataExclusions(
+  bottle: Parameters<typeof getMetadataExpressedByTitle>[0],
+  displayedIdentity: string,
+) {
+  const exclusions = new Set(
+    getMetadataExpressedByTitle(bottle, displayedIdentity),
+  );
+
+  if (bottle.abv !== null) exclusions.add("cask-strength");
+
+  return exclusions;
 }
 
 /**
@@ -216,11 +283,11 @@ export function getRelativeBottleIdentity(
   if (bottle.singleCask) {
     return { label: "Single cask", excludeMetadata: ["single-cask"] };
   }
-  if (bottle.caskStrength) {
-    return { label: "Cask strength", excludeMetadata: ["cask-strength"] };
-  }
   if (bottle.abv !== null) {
     return { label: formatAbv(bottle.abv), excludeMetadata: ["abv"] };
+  }
+  if (bottle.caskStrength) {
+    return { label: "Cask strength", excludeMetadata: ["cask-strength"] };
   }
   return { label: bottle.name, excludeMetadata: [], fallback: true };
 }
@@ -263,6 +330,7 @@ export default function BottleIdentity({
   href,
   className,
   linkClassName,
+  showBrand = true,
 }: {
   bottle: BottleIdentitySource;
   mode?: "absolute" | "relative";
@@ -273,27 +341,34 @@ export default function BottleIdentity({
   href?: string;
   className?: string;
   linkClassName?: string;
+  showBrand?: boolean;
 }) {
   const relativeIdentity = getRelativeBottleIdentity(bottle);
   const isAbsolute = mode === "absolute";
   const title = isAbsolute
     ? getAbsoluteBottleTitle(bottle)
     : relativeIdentity.label;
+  const titleMetadata = getBottleMetadataExclusions(bottle, title);
   const leadingContent =
-    isAbsolute && bottle.group && !relativeIdentity.fallback
+    isAbsolute &&
+    bottle.group &&
+    !relativeIdentity.fallback &&
+    !relativeIdentity.excludeMetadata.some((key) => titleMetadata.has(key))
       ? relativeIdentity.label
       : undefined;
   const displayedLeadingContent =
     metadataVariant === "summary" ? undefined : leadingContent;
-  const titleMetadata = isAbsolute
-    ? getMetadataExpressedByTitle(bottle, title)
-    : [];
+  const metadataExclude = titleMetadata;
+  if (!isAbsolute || displayedLeadingContent) {
+    relativeIdentity.excludeMetadata.forEach((key) => metadataExclude.add(key));
+  }
+  metadataExclude.add("category");
 
   return (
     <div className={classNames("min-w-0", className)}>
-      {isAbsolute ? (
+      {isAbsolute && showBrand ? (
         <div className="text-muted truncate text-xs font-medium uppercase tracking-wide">
-          {bottle.brand.name}
+          {bottle.brand.shortName || bottle.brand.name}
         </div>
       ) : null}
       <div className="flex min-w-0 flex-wrap items-center gap-x-2">
@@ -321,13 +396,7 @@ export default function BottleIdentity({
       <BottleExactMetadata
         bottle={bottle}
         variant={metadataVariant}
-        exclude={[
-          "category",
-          ...titleMetadata,
-          ...(!isAbsolute || displayedLeadingContent
-            ? relativeIdentity.excludeMetadata
-            : []),
-        ]}
+        exclude={[...metadataExclude]}
         leadingContent={displayedLeadingContent}
       />
     </div>

--- a/apps/web/src/components/bottleTable.tsx
+++ b/apps/web/src/components/bottleTable.tsx
@@ -8,10 +8,8 @@ import BottleStatusIcons, {
 import Link from "@peated/web/components/link";
 import type { ComponentProps, ReactNode } from "react";
 import BottleIdentity from "./bottleIdentity";
-import BottleLink from "./bottleLink";
 import BottleRatingSummary from "./bottleRatingSummary";
 import SimpleRatingIndicator from "./simpleRatingIndicator";
-import SingleCaskChip from "./singleCaskChip";
 import Table from "./table";
 
 type BottleRow = {
@@ -33,7 +31,6 @@ export default function BottleTable({
   hideLibraryStatus = false,
   showBottleStats = true,
   showRatingSummary = false,
-  identityMode = "legacy",
   compactIdentity = false,
   ...props
 }: Omit<ComponentProps<typeof Table>, "items" | "rel" | "columns"> & {
@@ -45,7 +42,6 @@ export default function BottleTable({
   hideLibraryStatus?: boolean;
   showBottleStats?: boolean;
   showRatingSummary?: boolean;
-  identityMode?: "legacy" | "absolute";
   compactIdentity?: boolean;
 }) {
   const rows: BottleRow[] = bottleList.map((item) =>
@@ -85,9 +81,8 @@ export default function BottleTable({
               !compactIdentity &&
               categoryName &&
               String(bottle.category) !== "other" &&
-              (identityMode === "legacy" ||
-                categoryName.toLocaleLowerCase() !==
-                  identityTitle.toLocaleLowerCase());
+              categoryName.toLocaleLowerCase() !==
+                identityTitle.toLocaleLowerCase();
             const collectionImage =
               item.collectionBottle &&
               renderCollectionBottleImage?.(item.collectionBottle);
@@ -121,43 +116,20 @@ export default function BottleTable({
               <div className="flex min-w-0 items-start gap-3">
                 {collectionImage}
                 <div className="flex min-w-0 flex-1 flex-col justify-center">
-                  {identityMode === "absolute" ? (
-                    <BottleIdentity
-                      bottle={bottle}
-                      mode="absolute"
-                      metadataVariant={compactIdentity ? "summary" : "full"}
-                    />
-                  ) : (
-                    <div className="flex min-w-0 flex-wrap items-center gap-x-1">
-                      <BottleLink
-                        bottle={bottle}
-                        className="font-medium hover:underline"
-                      >
-                        {bottle.fullName}
-                      </BottleLink>
-                    </div>
-                  )}
-                  {identityMode === "absolute" ? (
-                    <div className="text-muted mt-1 flex min-w-0 flex-wrap items-center gap-x-1 text-sm">
-                      {statusIndicators}
-                      {collectionMeta}
-                      {collectionMeta && categoryLink ? (
-                        <span aria-hidden="true">&middot;</span>
-                      ) : null}
-                      {categoryLink}
-                    </div>
-                  ) : (
-                    <>
-                      <div className="mt-1 flex min-w-0 flex-wrap items-center gap-x-1">
-                        {statusIndicators}
-                        {collectionMeta}
-                        {bottle.singleCask ? <SingleCaskChip /> : null}
-                      </div>
-                      <div className="text-muted flex flex-col gap-y-1 text-sm">
-                        {categoryLink}
-                      </div>
-                    </>
-                  )}
+                  <BottleIdentity
+                    bottle={bottle}
+                    mode="absolute"
+                    metadataVariant={compactIdentity ? "summary" : "full"}
+                    showBrand={!props.groupBy}
+                  />
+                  <div className="text-muted mt-1 flex min-w-0 flex-wrap items-center gap-x-1 text-sm">
+                    {statusIndicators}
+                    {collectionMeta}
+                    {collectionMeta && categoryLink ? (
+                      <span aria-hidden="true">&middot;</span>
+                    ) : null}
+                    {categoryLink}
+                  </div>
                 </div>
                 {showRatingSummary ? (
                   <BottleRatingSummary

--- a/apps/web/src/components/bottleTable.tsx
+++ b/apps/web/src/components/bottleTable.tsx
@@ -7,7 +7,7 @@ import BottleStatusIcons, {
 } from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
 import type { ComponentProps, ReactNode } from "react";
-import BottleIdentity from "./bottleIdentity";
+import BottleIdentity, { getAbsoluteBottleTitle } from "./bottleIdentity";
 import BottleRatingSummary from "./bottleRatingSummary";
 import SimpleRatingIndicator from "./simpleRatingIndicator";
 import Table from "./table";
@@ -76,7 +76,7 @@ export default function BottleTable({
             const categoryName = bottle.category
               ? formatCategoryName(bottle.category)
               : null;
-            const identityTitle = bottle.group?.name ?? bottle.name;
+            const identityTitle = getAbsoluteBottleTitle(bottle);
             const showCategory =
               !compactIdentity &&
               categoryName &&

--- a/apps/web/src/components/previewBottleCard.test.tsx
+++ b/apps/web/src/components/previewBottleCard.test.tsx
@@ -29,12 +29,12 @@ describe("PreviewBottleCard", () => {
     expect(html).toContain("Springbank");
     expect(html).toContain("12-year-old");
     expect(html).toContain("Batch 24");
-    expect(html).toContain("12 years");
+    expect(html).not.toContain("12 years");
     expect(html).toContain("2025");
     expect(html).toContain("2013");
     expect(html).toContain("57.2% ABV");
     expect(html).toContain("Single Cask");
-    expect(html).toContain("Cask strength");
+    expect(html).not.toContain("Cask strength");
     expect(html).toContain("1st Fill Oloroso Hogshead cask");
     expect(html).toContain("uppercase");
     expect(html).toContain("bg-highlight");

--- a/apps/web/src/components/previewBottleCard.tsx
+++ b/apps/web/src/components/previewBottleCard.tsx
@@ -1,6 +1,7 @@
 import BottleExactMetadata, {
   type BottleExactMetadataSource,
 } from "./bottleExactMetadata";
+import { getBottleMetadataExclusions } from "./bottleIdentity";
 import type { Option } from "./selectField";
 import SingleCaskChip from "./singleCaskChip";
 
@@ -21,6 +22,32 @@ export const PreviewBottleCard = ({
   data: Partial<BottleFormData>;
 }) => {
   const { brand } = data;
+  const exactBottle = {
+    category: null,
+    edition: data.edition ?? null,
+    statedAge: data.statedAge ?? null,
+    abv: data.abv ?? null,
+    vintageYear: data.vintageYear ?? null,
+    releaseYear: data.releaseYear ?? null,
+    singleCask: data.singleCask ?? null,
+    caskStrength: data.caskStrength ?? null,
+    caskFill: data.caskFill ?? null,
+    caskType: data.caskType ?? null,
+    caskSize: data.caskSize ?? null,
+  };
+  const editionInTitle = Boolean(
+    data.edition &&
+    data.name?.toLocaleLowerCase().includes(data.edition.toLocaleLowerCase()),
+  );
+  const leadingEdition = editionInTitle ? undefined : data.edition || undefined;
+  const metadataExclude = getBottleMetadataExclusions(
+    exactBottle,
+    [data.name, leadingEdition].filter(Boolean).join(" "),
+  );
+  const showSingleCaskChip =
+    data.singleCask && !metadataExclude.has("single-cask");
+
+  if (showSingleCaskChip) metadataExclude.add("single-cask");
 
   return (
     <section
@@ -35,26 +62,16 @@ export const PreviewBottleCard = ({
       {data.name && (
         <div className="flex min-w-0 flex-wrap items-center gap-x-2">
           <div className="break-words font-semibold">{data.name}</div>
-          {data.singleCask ? (
+          {showSingleCaskChip ? (
             <SingleCaskChip className="!border-black/20 !bg-black/10 !text-black hover:!bg-black/10" />
           ) : null}
         </div>
       )}
       <BottleExactMetadata
         className="!text-black/70"
-        bottle={{
-          category: null,
-          statedAge: data.statedAge ?? null,
-          abv: data.abv ?? null,
-          vintageYear: data.vintageYear ?? null,
-          releaseYear: data.releaseYear ?? null,
-          singleCask: false,
-          caskStrength: data.caskStrength ?? null,
-          caskFill: data.caskFill ?? null,
-          caskType: data.caskType ?? null,
-          caskSize: data.caskSize ?? null,
-        }}
-        leadingContent={data.edition || undefined}
+        bottle={exactBottle}
+        exclude={[...metadataExclude]}
+        leadingContent={leadingEdition}
       />
     </section>
   );

--- a/apps/web/src/components/search/bottleResult.test.tsx
+++ b/apps/web/src/components/search/bottleResult.test.tsx
@@ -115,12 +115,14 @@ describe("BottleResultRow", () => {
     expect(text).toContain("3 related releases");
     expect(text).toContain(group.fullName);
     expect(text).not.toContain(exactBottle.fullName);
-    expect(text).toContain("Lagavulin·Distillers Edition·Single Malt·16 years");
-    expect(text).toContain("16 years·43.0% ABV");
+    expect(text).toContain("Distillers Edition·Single Malt·43.0% ABV");
+    expect(text).not.toContain("16 years");
     expect(text).toContain("2008 vintage·2024 release");
-    expect(text).toContain("Single cask·Cask strength");
+    expect(text).toContain("Single cask");
+    expect(text).not.toContain("Cask strength");
     expect(text).toContain("1st Fill Oloroso Hogshead cask");
     expect(text.match(/Distillers Edition/g)).toHaveLength(1);
+    expect(text.match(/Lagavulin/g)).toHaveLength(1);
     expect(html).toContain(
       '<span class="inline-flex whitespace-nowrap"><span class="mx-1.5">·</span>Single Malt</span>',
     );

--- a/apps/web/src/components/search/bottleResult.tsx
+++ b/apps/web/src/components/search/bottleResult.tsx
@@ -1,7 +1,12 @@
 import type { Bottle } from "@peated/server/types";
 import BottleIcon from "@peated/web/assets/bottle.svg";
 import BottleExactMetadata from "@peated/web/components/bottleExactMetadata";
-import { BottleLabel } from "@peated/web/components/bottleIdentity";
+import {
+  BottleLabel,
+  getAbsoluteBottleTitle,
+  getBottleMetadataExclusions,
+  getDistinctBottleDistillers,
+} from "@peated/web/components/bottleIdentity";
 import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
 import {
@@ -59,13 +64,18 @@ export default function BottleResultRow({
   addBottleIntent?: AddBottleRouteIntent;
   pendingImage?: PendingImageRouteState | null;
 }) {
-  const distillerMetadata = bottle.distillers.length ? (
+  const distillers = getDistinctBottleDistillers(bottle);
+  const distillerMetadata = distillers.length ? (
     <Join divider=", ">
-      {bottle.distillers.map((distiller) => (
+      {distillers.map((distiller) => (
         <span key={distiller.id}>{distiller.name}</span>
       ))}
     </Join>
   ) : undefined;
+  const metadataExclude = getBottleMetadataExclusions(
+    bottle,
+    getAbsoluteBottleTitle(bottle),
+  );
 
   return (
     <>
@@ -89,6 +99,7 @@ export default function BottleResultRow({
         <BottleExactMetadata
           bottle={bottle}
           leadingContent={distillerMetadata}
+          exclude={[...metadataExclude]}
         />
         {bottle.group && bottle.group.totalBottles > 1 ? (
           <div className="mt-1 text-xs">

--- a/apps/web/src/components/tastingBottleIdentity.test.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.test.tsx
@@ -7,20 +7,28 @@ import TastingBottleIdentity, {
 
 const bottle = {
   id: 42,
-  fullName: "Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42",
+  fullName:
+    "Lagavulin 21-year-old - 2025 Release - 55.1% ABV - Single Cask - Cask Strength",
+  name: "21-year-old - 2025 Release - 55.1% ABV - Single Cask - Cask Strength",
   brand: {
     name: "Lagavulin",
     shortName: null,
   },
   group: {
-    name: "21",
+    name: "21-year-old",
+    statedAge: 21,
   },
   edition: "2025 Release",
   category: "single_malt",
   statedAge: 21,
+  abv: 55.1,
   vintageYear: 2004,
   releaseYear: 2025,
   singleCask: true,
+  caskStrength: true,
+  caskFill: null,
+  caskType: null,
+  caskSize: null,
   distillers: [{ id: 7, name: "Lagavulin Distillery" }],
   isLibrary: true,
   hasTasted: true,
@@ -35,13 +43,15 @@ describe("TastingBottleIdentity", () => {
 
     expect(html).toContain('href="/bottles/42"');
     expect(html).toContain(
-      'title="Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42"',
+      'title="Lagavulin 21-year-old - 2025 Release - 55.1% ABV - Single Cask - Cask Strength"',
     );
-    expect(text).toContain("Lagavulin 21");
-    expect(text).toContain("2025 Release (2025) (2004 Vintage)");
+    expect(text).toContain("Lagavulin 21-year-old");
+    expect(text).toContain("2025 Release");
+    expect(text.match(/2025 Release/g)).toHaveLength(1);
+    expect(text).not.toContain("2004 Vintage");
     expect(text).toContain("·Lagavulin Distillery");
     expect(text).toContain("Single Malt");
-    expect(text).toContain("Aged 21 years");
+    expect(text).not.toContain("Aged 21 years");
     expect(html).toContain("bg-highlight");
     expect(html).toContain("p-4");
     expect(html).toContain("text-black");
@@ -59,8 +69,8 @@ describe("TastingBottleIdentity", () => {
     );
     expect(html).not.toContain("border-slate-800");
     expect(html).not.toContain("bg-slate-950");
-    expect(text).toContain("Lagavulin 21");
-    expect(text).not.toContain("Lagavulin 21 - 2025 Release");
+    expect(text).toContain("Lagavulin 21-year-old");
+    expect(text).not.toContain("Lagavulin 21-year-old - 2025 Release");
     expect(text).not.toContain("2025 Release");
     expect(text).not.toContain("Lagavulin Distillery");
     expect(text).not.toContain("Single Malt");
@@ -76,7 +86,7 @@ describe("TastingBottleIdentity", () => {
       <TastingBottleIdentity
         bottle={{
           ...bottle,
-          group: { name: "Single Cask 21" },
+          group: { name: "Single Cask 21", statedAge: 21 },
         }}
         variant="inline"
       />,
@@ -88,7 +98,7 @@ describe("TastingBottleIdentity", () => {
   });
 
   it.each(["inline", "panel"] as const)(
-    "falls back to the exact Bottle name in the %s variant",
+    "falls back to a concise absolute Bottle name in the %s variant",
     (variant) => {
       const html = renderToStaticMarkup(
         <TastingBottleIdentity
@@ -98,8 +108,9 @@ describe("TastingBottleIdentity", () => {
       );
 
       expect(html).toContain('href="/bottles/42"');
-      expect(html).toContain(
-        "Lagavulin 21 - 2025 Release - 55.1% ABV - Single Cask - Cask 42",
+      expect(html).toContain("Lagavulin 21-year-old");
+      expect(html).not.toContain(
+        ">Lagavulin 21-year-old - 2025 Release - 55.1% ABV - Single Cask - Cask Strength<",
       );
     },
   );

--- a/apps/web/src/components/tastingBottleIdentity.tsx
+++ b/apps/web/src/components/tastingBottleIdentity.tsx
@@ -1,43 +1,21 @@
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Bottle } from "@peated/server/types";
+import {
+  type BottleIdentitySource,
+  getAbsoluteBottleLabel,
+  getBottleMetadataExclusions,
+  getDistinctBottleDistillers,
+  getRelativeBottleIdentity,
+} from "@peated/web/components/bottleIdentity";
 import BottleStatusIcons from "@peated/web/components/bottleStatusIcons";
 import Link from "@peated/web/components/link";
 import Join from "./join";
 import SingleCaskChip from "./singleCaskChip";
 
-export type TastingBottleIdentitySource = Pick<
-  Bottle,
-  | "id"
-  | "fullName"
-  | "edition"
-  | "releaseYear"
-  | "vintageYear"
-  | "singleCask"
-  | "category"
-  | "statedAge"
-  | "isLibrary"
-  | "hasTasted"
-> & {
-  brand: Pick<Bottle["brand"], "name" | "shortName">;
-  distillers: Pick<Bottle["distillers"][number], "id" | "name">[];
-  group?: Pick<NonNullable<Bottle["group"]>, "name">;
-};
-
-function getExactBottleLabel(
-  bottle: TastingBottleIdentitySource,
-  displayName: string,
-) {
-  if (bottle.edition) {
-    return `${bottle.edition}${bottle.releaseYear ? ` (${bottle.releaseYear})` : ""}${bottle.vintageYear ? ` (${bottle.vintageYear} Vintage)` : ""}`;
-  }
-  if (bottle.releaseYear) return `${bottle.releaseYear} Bottling`;
-  if (bottle.vintageYear) return `${bottle.vintageYear} Vintage`;
-
-  const prefix = `${displayName} - `;
-  return bottle.fullName.startsWith(prefix)
-    ? bottle.fullName.slice(prefix.length)
-    : null;
-}
+export type TastingBottleIdentitySource = BottleIdentitySource &
+  Pick<Bottle, "isLibrary" | "hasTasted"> & {
+    distillers: Pick<Bottle["distillers"][number], "id" | "name">[];
+  };
 
 export default function TastingBottleIdentity({
   bottle,
@@ -46,13 +24,20 @@ export default function TastingBottleIdentity({
   bottle: TastingBottleIdentitySource;
   variant?: "inline" | "panel";
 }) {
-  const displayName = bottle.group
-    ? `${bottle.brand.shortName || bottle.brand.name} ${bottle.group.name}`
-    : bottle.fullName;
-  const exactBottleLabel = getExactBottleLabel(bottle, displayName);
-  const showSingleCaskChip =
-    bottle.singleCask &&
-    !/\bsingle[\s-]+cask\b/i.test(`${displayName} ${exactBottleLabel ?? ""}`);
+  const displayName = getAbsoluteBottleLabel(bottle);
+  const relativeIdentity = getRelativeBottleIdentity(bottle);
+  const exactBottleLabel =
+    bottle.group && !relativeIdentity.fallback ? relativeIdentity.label : null;
+  const distinctDistillers = getDistinctBottleDistillers(bottle);
+  const inlineSingleCaskChip =
+    bottle.singleCask && !/\bsingle[\s-]+cask\b/i.test(displayName);
+  const panelSingleCaskChip =
+    inlineSingleCaskChip &&
+    !/\bsingle[\s-]+cask\b/i.test(exactBottleLabel ?? "");
+  const metadataExclude = getBottleMetadataExclusions(
+    bottle,
+    `${displayName} ${exactBottleLabel ?? ""}`,
+  );
 
   if (variant === "inline") {
     return (
@@ -69,7 +54,7 @@ export default function TastingBottleIdentity({
                 </Link>
               </h4>
               <BottleStatusIcons bottle={bottle} className="inline h-4 w-4" />
-              {showSingleCaskChip && <SingleCaskChip />}
+              {inlineSingleCaskChip && <SingleCaskChip />}
             </div>
           </div>
         </div>
@@ -88,22 +73,22 @@ export default function TastingBottleIdentity({
               </Link>
             </h4>
             <BottleStatusIcons bottle={bottle} className="inline h-4 w-4" />
-            {!exactBottleLabel && showSingleCaskChip && <SingleCaskChip />}
+            {!exactBottleLabel && panelSingleCaskChip && <SingleCaskChip />}
           </div>
         </div>
         <div className="flex flex-row gap-x-1 text-sm">
           {exactBottleLabel ? (
             <div className="flex flex-wrap items-center gap-2">
               <span>{exactBottleLabel}</span>
-              {showSingleCaskChip && <SingleCaskChip />}
+              {panelSingleCaskChip && <SingleCaskChip />}
             </div>
           ) : null}
-          {!!(exactBottleLabel && bottle.distillers.length) && (
+          {!!(exactBottleLabel && distinctDistillers.length) && (
             <div>&middot;</div>
           )}
-          {bottle.distillers.length ? (
+          {distinctDistillers.length ? (
             <Join divider=", ">
-              {bottle.distillers.map((distiller) => (
+              {distinctDistillers.map((distiller) => (
                 <Link
                   key={distiller.id}
                   href={`/entities/${distiller.id}`}
@@ -127,7 +112,11 @@ export default function TastingBottleIdentity({
             </Link>
           ) : null}
         </div>
-        <div>{bottle.statedAge ? `Aged ${bottle.statedAge} years` : null}</div>
+        <div>
+          {bottle.statedAge && !metadataExclude.has("age")
+            ? `Aged ${bottle.statedAge} years`
+            : null}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Bottle identities now use the same concise title and metadata rules across the detail header, catalog tables, global search, activity and newest-bottle cards, release families, tasting cards, and bottle-form previews. Repeated brand/distiller, age, release, cask, and single-cask details are removed, and “Cask strength” is omitted when the ABV already communicates it. Full canonical names remain available for tooltips, SEO, selectors, and administrative workflows.

Previously, each surface assembled bottle labels independently, which allowed canonical metadata to leak into headlines or render twice. The shared identity helpers now decide the displayed title and metadata exclusions while preserving genuinely distinguishing release and cask details. The affected pages were visually checked at desktop and mobile widths, and the web suite passes with 142 tests plus typecheck and lint.
