### PR TITLE
feat: enable Bottle Checks review by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,9 +30,9 @@ OPENAI_API_KEY=
 # BRAVE_API_KEY=
 # Optional: combined OpenAI + Brave web-search budget per eval case.
 # BOTTLE_CLASSIFIER_EVAL_MAX_SEARCH_QUERIES=3
-# Bottle-check operation rollout controls. All are disabled by default.
-# BOTTLE_CHECK_SHADOW_GENERATION=1
-# BOTTLE_CHECK_MODERATOR_VISIBILITY=1
+# Bottle-check review is enabled by default; catalog execution is disabled.
+# BOTTLE_CHECK_SHADOW_GENERATION=0
+# BOTTLE_CHECK_MODERATOR_VISIBILITY=0
 # BOTTLE_CHECK_EXECUTION=1
 UPLOAD_PATH=
 USE_GCS_STORAGE=

--- a/apps/server/src/config.test.ts
+++ b/apps/server/src/config.test.ts
@@ -1,25 +1,35 @@
 import config, { resolveBottleCheckFeatureFlags } from "./config";
 
-const disabledFlags = {
-  BOTTLE_CHECK_SHADOW_GENERATION: false,
-  BOTTLE_CHECK_MODERATOR_VISIBILITY: false,
+const reviewOnlyFlags = {
+  BOTTLE_CHECK_SHADOW_GENERATION: true,
+  BOTTLE_CHECK_MODERATOR_VISIBILITY: true,
   BOTTLE_CHECK_EXECUTION: false,
 };
 
 describe("Bottle check feature flags", () => {
-  test("are disabled by default in public server config", () => {
-    expect(config).toMatchObject(disabledFlags);
-    expect(resolveBottleCheckFeatureFlags({})).toEqual(disabledFlags);
+  test("default to review-only in public server config", () => {
+    expect(config).toMatchObject(reviewOnlyFlags);
+    expect(resolveBottleCheckFeatureFlags({})).toEqual(reviewOnlyFlags);
+  });
+
+  test("treats empty values as unset", () => {
+    expect(
+      resolveBottleCheckFeatureFlags({
+        BOTTLE_CHECK_SHADOW_GENERATION: "",
+        BOTTLE_CHECK_MODERATOR_VISIBILITY: "",
+        BOTTLE_CHECK_EXECUTION: "",
+      }),
+    ).toEqual(reviewOnlyFlags);
   });
 
   test.each([
-    "BOTTLE_CHECK_SHADOW_GENERATION",
-    "BOTTLE_CHECK_MODERATOR_VISIBILITY",
-    "BOTTLE_CHECK_EXECUTION",
-  ] as const)("%s can be enabled independently", (name) => {
-    expect(resolveBottleCheckFeatureFlags({ [name]: "1" })).toEqual({
-      ...disabledFlags,
-      [name]: true,
+    ["BOTTLE_CHECK_SHADOW_GENERATION", "0", false],
+    ["BOTTLE_CHECK_MODERATOR_VISIBILITY", "false", false],
+    ["BOTTLE_CHECK_EXECUTION", "1", true],
+  ] as const)("%s can override its default", (name, value, expected) => {
+    expect(resolveBottleCheckFeatureFlags({ [name]: value })).toEqual({
+      ...reviewOnlyFlags,
+      [name]: expected,
     });
   });
 

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -3,11 +3,12 @@ import { tmpdir } from "node:os";
 
 type Environment = Readonly<Record<string, string | undefined>>;
 
-function parseDisabledByDefaultFlag(
+function parseFeatureFlag(
   name: string,
   value: string | undefined,
+  defaultValue: boolean,
 ): boolean {
-  if (value === undefined || value === "") return false;
+  if (value === undefined || value === "") return defaultValue;
 
   switch (value.trim().toLowerCase()) {
     case "1":
@@ -23,17 +24,20 @@ function parseDisabledByDefaultFlag(
 
 export function resolveBottleCheckFeatureFlags(environment: Environment) {
   return {
-    BOTTLE_CHECK_SHADOW_GENERATION: parseDisabledByDefaultFlag(
+    BOTTLE_CHECK_SHADOW_GENERATION: parseFeatureFlag(
       "BOTTLE_CHECK_SHADOW_GENERATION",
       environment.BOTTLE_CHECK_SHADOW_GENERATION,
+      true,
     ),
-    BOTTLE_CHECK_MODERATOR_VISIBILITY: parseDisabledByDefaultFlag(
+    BOTTLE_CHECK_MODERATOR_VISIBILITY: parseFeatureFlag(
       "BOTTLE_CHECK_MODERATOR_VISIBILITY",
       environment.BOTTLE_CHECK_MODERATOR_VISIBILITY,
+      true,
     ),
-    BOTTLE_CHECK_EXECUTION: parseDisabledByDefaultFlag(
+    BOTTLE_CHECK_EXECUTION: parseFeatureFlag(
       "BOTTLE_CHECK_EXECUTION",
       environment.BOTTLE_CHECK_EXECUTION,
+      false,
     ),
   };
 }

--- a/apps/server/src/orpc/routes/root.test.ts
+++ b/apps/server/src/orpc/routes/root.test.ts
@@ -3,9 +3,14 @@ import { routerClient } from "@peated/server/orpc/router";
 import { describe, expect, test } from "vitest";
 
 describe("GET /", () => {
-  test("returns version info", async () => {
+  test("returns version info and review-only Bottle Check capabilities", async () => {
     const result = await routerClient.root();
     expect(result.version).toBeDefined();
+    expect(result.capabilities).toEqual({
+      bottleAudits: true,
+      bottleCheckExecution: false,
+      bottleChecks: true,
+    });
   });
 
   test("reports Bottle Check capabilities from the server flags", async () => {

--- a/apps/server/src/worker/jobs/verifyBottleCreation.test.ts
+++ b/apps/server/src/worker/jobs/verifyBottleCreation.test.ts
@@ -32,6 +32,7 @@ describe("verifyBottleCreation", () => {
   test("records flagged findings for suspicious manually created bottles", async ({
     fixtures,
   }) => {
+    config.BOTTLE_CHECK_SHADOW_GENERATION = false;
     const currentBrand = await fixtures.Entity({
       name: "Canadian",
       type: ["brand", "distiller"],

--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -67,7 +67,7 @@ intent:
 - `resolve_reference` identifies a Bottle from a listing or other external
   reference. Its existing structured decision remains the authoritative result.
 - `audit_bottle` reviews an existing Bottle from a moderator request or a
-  sampled post-user-creation job. Its result is a narrative summary, proposed
+  post-user-creation job. Its result is a narrative summary, proposed
   operations, and findings; it has no redundant structured conclusion.
 
 A proposed operation is an agent suggestion with a typed input, rationale, and
@@ -108,9 +108,12 @@ immutable.
 
 Generation, moderator visibility, and execution are controlled separately by
 `BOTTLE_CHECK_SHADOW_GENERATION`, `BOTTLE_CHECK_MODERATOR_VISIBILITY`, and
-`BOTTLE_CHECK_EXECUTION`. All three default off. Post-user-creation audits run
-after the Bottle save commits and never delay or roll back that save. These
-flags do not alter the four proposal tools exposed when a full check runs.
+`BOTTLE_CHECK_EXECUTION`. Generation and moderator visibility default on;
+execution defaults off. Post-user-creation audits run after the Bottle save
+commits and never delay or roll back that save. The job audits 100% of eligible
+`manual_entry` Bottles. `price_match_automation` Bottles use a deterministic
+sample that defaults to 10%. These flags do not alter the four proposal tools
+exposed when a full check runs.
 
 ### BottleGroup Findings
 

--- a/openspec/changes/add-bottle-check-operations/design.md
+++ b/openspec/changes/add-bottle-check-operations/design.md
@@ -195,11 +195,12 @@ clean audit records no work; proposed changes enter moderator review; findings
 remain visible without changing the Bottle.
 
 For Bottles, this agent check replaces the job's existing heuristic
-passed/flagged finding calculation. The job keeps its sampling, uniqueness, and
-queue boundary, but it does not write a second verification result beside the
-check. Existing deterministic Brand-repair candidate discovery may seed
-read-only candidate context; it is not a parallel conclusion or operation
-generator.
+passed/flagged finding calculation. The job selects 100% of eligible
+`manual_entry` Bottles and a deterministic `price_match_automation` sample that
+defaults to 10%. It keeps its uniqueness and queue boundary, but it does not
+write a second verification result beside the check. Existing deterministic
+Brand-repair candidate discovery may seed read-only candidate context; it is
+not a parallel conclusion or operation generator.
 
 This post-create audit is a correlated follow-up Bottle check using the same
 classifier capability, not independent verification. Its result can surface
@@ -786,10 +787,11 @@ runs.
 5. Extract and test the canonical Entity update service, then enable Entity
    operations.
 6. Enable `audit_bottle` for individual moderator-triggered runs.
-7. Extend `VerifyBottleCreation` with idempotent post-create checks for a
-   bounded end-user Bottle sample.
-8. Expand source kinds and audit sampling only after review precision is
-   acceptable.
+7. Extend `VerifyBottleCreation` with idempotent post-create checks for 100% of
+   eligible `manual_entry` Bottles and a deterministic `price_match_automation`
+   sample that defaults to 10%.
+8. Expand source kinds or change the automation sample only after review
+   precision is acceptable.
 9. Use reviewed `bottle_group` findings to scope a separate BottleGroup-repair
    proposal around the smallest operations demonstrated by real cases.
 

--- a/openspec/changes/add-bottle-check-operations/specs/bottle-operation-review/spec.md
+++ b/openspec/changes/add-bottle-check-operations/specs/bottle-operation-review/spec.md
@@ -237,16 +237,24 @@ approval, regardless of source or confidence.
 
 ### Requirement: Newly added Bottles may receive background audits
 
-The add-Bottle workflow SHALL support optionally enqueueing one idempotent
-`audit_bottle` check through the existing `VerifyBottleCreation` job after the
-authoritative Bottle save commits.
+With shadow generation enabled, the existing `VerifyBottleCreation` job SHALL
+run one idempotent `audit_bottle` check for 100% of eligible `manual_entry`
+Bottles. `price_match_automation` Bottles SHALL use a deterministic sample that
+defaults to 10%. The check SHALL run after the authoritative Bottle save
+commits.
 
 #### Scenario: User-created Bottle commits
 
-- **WHEN** post-create audit sampling selects the Bottle
+- **WHEN** an eligible `manual_entry` Bottle commits
 - **THEN** the save response SHALL complete without waiting for the audit
 - **AND** `VerifyBottleCreation` SHALL run the check against the committed
   Bottle using the existing Bottle-creation event and origin for retry safety
+
+#### Scenario: Automated price-match Bottle commits
+
+- **WHEN** deterministic sampling selects a `price_match_automation` Bottle
+- **THEN** `VerifyBottleCreation` SHALL run the same post-create check
+- **AND** the sample rate SHALL default to 10%
 
 #### Scenario: Post-create audit proposes changes
 
@@ -259,7 +267,8 @@ authoritative Bottle save commits.
 - **WHEN** Bottle post-create verification uses the new check
 - **THEN** it SHALL replace the previous Bottle-specific heuristic
   passed/flagged finding calculation
-- **AND** sampling and unique-job behavior SHALL remain
+- **AND** 100% coverage of eligible `manual_entry` Bottles, deterministic
+  `price_match_automation` sampling, and unique-job behavior SHALL remain
 - **AND** it SHALL NOT create a second actionable verification result or queue
 
 ### Requirement: Bottle operations use canonical services

--- a/openspec/changes/add-bottle-check-operations/tasks.md
+++ b/openspec/changes/add-bottle-check-operations/tasks.md
@@ -150,15 +150,16 @@
 
 ## 6. Rollout and Documentation
 
-- [x] 6.1 Add shadow-generation, moderator-visibility, and execution flags,
-      disabled by default.
+- [x] 6.1 Add shadow-generation, moderator-visibility, and execution flags;
+      default generation and visibility on while keeping execution off.
 - [x] 6.2 Enable shadow check generation for individual full reference retries
       and moderator-triggered Bottle audits.
 - [x] 6.3 Extend the existing `VerifyBottleCreation` job with an idempotent
-      sampled post-create Bottle check that runs only after the end-user save
-      commits, replaces the previous Bottle-specific heuristic conclusion, creates
-      no duplicate actionable result, and never auto-applies supplemental
-      operations.
+      post-create Bottle check for 100% of eligible `manual_entry` Bottles and a
+      deterministic `price_match_automation` sample that defaults to 10%. Run
+      it only after the save commits, replace the previous Bottle-specific
+      heuristic conclusion, create no duplicate actionable result, and never
+      auto-apply supplemental operations.
 - [x] 6.4 Preserve automatic primary classification only in the existing
       end-user add-Bottle workflow and its established review policy.
 - [ ] 6.5 Measure intent accuracy, schema validity, diagnostic exact reference


### PR DESCRIPTION
Bottle Check generation and moderator visibility now default on when their environment variables are unset, so production-style deployments collect post-creation audits and expose the moderator review UI without additional rollout configuration. Catalog execution remains off by default and explicit true/false overrides continue to work.

This audits 100% of eligible manual-entry Bottles and retains the existing deterministic 10% default sample for price-automation Bottles. The environment example documents opt-outs for generation and visibility plus the separate execution opt-in; no routes, migrations, sampling logic, or catalog mutation behavior changed.
