### PR TITLE
fix(web): disable spelling assistance in search inputs

### DIFF
--- a/apps/web/src/app/(admin)/admin/(default)/brand-repairs/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/brand-repairs/page.tsx
@@ -370,7 +370,7 @@ export default function Page() {
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
             <div className="min-w-0 flex-1">
               <TextInput
-                type="text"
+                type="search"
                 name="query"
                 defaultValue={currentQuery}
                 placeholder="Search bottle, alias, or brand names"

--- a/apps/web/src/app/(admin)/admin/(default)/entity-audits/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/entity-audits/page.tsx
@@ -252,7 +252,7 @@ export default function Page() {
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
             <div className="min-w-0 flex-1">
               <TextInput
-                type="text"
+                type="search"
                 name="query"
                 defaultValue={currentQuery}
                 placeholder="Search entity, alias, or target brand names"

--- a/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
@@ -347,7 +347,7 @@ export default function Page() {
           <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
             <div className="min-w-0 flex-1">
               <TextInput
-                type="text"
+                type="search"
                 name="query"
                 defaultValue={currentQuery}
                 placeholder="Search incoming listings"

--- a/apps/web/src/app/(default)/friends/page.tsx
+++ b/apps/web/src/app/(default)/friends/page.tsx
@@ -68,8 +68,11 @@ function FriendsPage() {
                 @
               </span>
               <input
+                autoCapitalize="none"
+                autoCorrect="off"
                 id="friend-search"
                 name="q"
+                spellCheck={false}
                 type="search"
                 placeholder="username"
                 className="min-w-0 flex-1 border-0 bg-transparent px-1.5 text-sm text-white outline-none placeholder:text-slate-500 focus:ring-0"

--- a/apps/web/src/components/searchBar.tsx
+++ b/apps/web/src/components/searchBar.tsx
@@ -12,7 +12,7 @@ export default function SearchBar({ name = "query" }: { name?: string }) {
         <MagnifyingGlassIcon className="text-muted h-5 w-5 " />
         <div className="flex-grow">
           <TextInput
-            type="text"
+            type="search"
             name={name}
             defaultValue={searchParams.get(name) ?? ""}
           />

--- a/apps/web/src/components/searchHeaderForm.tsx
+++ b/apps/web/src/components/searchHeaderForm.tsx
@@ -58,7 +58,10 @@ export default function SearchHeaderForm({
     >
       <input
         autoFocus={autoFocus || !onFocus}
+        autoCapitalize="none"
+        autoCorrect="off"
         name={name}
+        spellCheck={false}
         value={value}
         placeholder={placeholder}
         onFocus={onFocus}

--- a/apps/web/src/components/searchInputHints.test.tsx
+++ b/apps/web/src/components/searchInputHints.test.tsx
@@ -1,0 +1,22 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import SearchHeaderForm from "./searchHeaderForm";
+import TextInput from "./textInput";
+
+describe("search input hints", () => {
+  it("disables spelling assistance in search headers", () => {
+    const html = renderToStaticMarkup(<SearchHeaderForm />);
+
+    expect(html).toContain('autoCapitalize="none"');
+    expect(html).toContain('autoCorrect="off"');
+    expect(html).toContain('spellCheck="false"');
+  });
+
+  it("disables spelling assistance on shared search inputs", () => {
+    const html = renderToStaticMarkup(<TextInput type="search" />);
+
+    expect(html).toContain('autoCapitalize="none"');
+    expect(html).toContain('autoCorrect="off"');
+    expect(html).toContain('spellCheck="false"');
+  });
+});

--- a/apps/web/src/components/textInput.tsx
+++ b/apps/web/src/components/textInput.tsx
@@ -10,6 +10,14 @@ export default forwardRef<HTMLInputElement, Props>(function TextInput(
   ref,
 ) {
   const { disabled, readOnly } = props;
+  const searchProps =
+    props.type === "search"
+      ? {
+          autoCapitalize: "none",
+          autoCorrect: "off",
+          spellCheck: false,
+        }
+      : {};
   const baseStyles = classNames(
     "rounded px-4 py-2 sm:leading-6 border-0 focus:ring-0",
     disabled || readOnly ? "bg-slate-900 text-slate-300" : "",
@@ -27,6 +35,7 @@ export default forwardRef<HTMLInputElement, Props>(function TextInput(
             className,
           )}
           ref={ref}
+          {...searchProps}
           {...props}
         />
         <span className="flex select-none items-center text-slate-300 sm:text-sm">
@@ -45,6 +54,7 @@ export default forwardRef<HTMLInputElement, Props>(function TextInput(
         className || "",
       )}
       ref={ref}
+      {...searchProps}
       {...props}
     />
   );


### PR DESCRIPTION
Search fields now disable browser spellcheck, autocorrect, and automatic capitalization, preventing brand and distillery names from being rewritten during lookup. The behavior is centralized in the shared entity-picker and search inputs, with standalone search surfaces moved to `type="search"` and covered by render-level regression tests.
