### PR TITLE
chore(lint): strengthen static analysis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,9 +44,12 @@ jobs:
               - "packages/catalog-verifier/**"
               - "packages/entity-classifier/**"
             repo:
+              - ".oxlintrc.json"
               - "package.json"
               - "pnpm-lock.yaml"
               - "pnpm-workspace.yaml"
+              - "sgconfig.yml"
+              - "tools/ast-grep/**"
               - "turbo.json"
             server:
               - "apps/server/**"
@@ -92,6 +95,30 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Run TFLint
         run: tflint -f compact
+
+  quality:
+    name: "quality / lint and typecheck"
+    runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.repo == 'true' || needs.changes.outputs.server == 'true' || needs.changes.outputs.web == 'true' || needs.changes.outputs.packages == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.18.0
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Run lint
+        run: pnpm lint
+      - name: Run typecheck
+        run: pnpm typecheck
+
   package-build:
     name: "build / packages"
     runs-on: ubuntu-latest
@@ -231,6 +258,7 @@ jobs:
     needs:
       - changes
       - tflint
+      - quality
       - package-build
       - server-build
       - web-build
@@ -248,6 +276,7 @@ jobs:
           failed=0
           for result in \
             "${{ needs.tflint.result }}" \
+            "${{ needs.quality.result }}" \
             "${{ needs['package-build'].result }}" \
             "${{ needs['server-build'].result }}" \
             "${{ needs['web-build'].result }}" \

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,18 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript", "oxc", "react", "nextjs"],
+  "jsPlugins": ["@tanstack/eslint-plugin-query"],
+  "plugins": [
+    "typescript",
+    "oxc",
+    "react",
+    "nextjs",
+    "promise",
+    "jsx-a11y",
+    "vitest"
+  ],
+  "options": {
+    "typeAware": true
+  },
   "settings": {
     "next": {
       "rootDir": ["apps/web/"]
@@ -10,7 +22,53 @@
     "nextjs/no-img-element": "off",
     "no-unused-expressions": "off",
     "no-unused-vars": "off",
-    "react/exhaustive-deps": "off",
+    "preserve-caught-error": "error",
+    "promise/no-multiple-resolved": "error",
+    "typescript/await-thenable": "error",
+    "typescript/no-floating-promises": ["error", { "ignoreVoid": true }],
+    "typescript/no-misused-promises": ["error", { "checksVoidReturn": false }],
+    "typescript/switch-exhaustiveness-check": "warn",
+    "react/exhaustive-deps": "error",
+    "react/react-compiler": "warn",
+    "jsx-a11y/no-autofocus": "off",
+    "jsx-a11y/no-redundant-roles": "off",
+    "jsx-a11y/prefer-tag-over-role": "off",
+    "jsx-a11y/img-redundant-alt": "off",
+    "jsx-a11y/alt-text": "error",
+    "jsx-a11y/anchor-has-content": "error",
+    "jsx-a11y/anchor-is-valid": "error",
+    "jsx-a11y/click-events-have-key-events": "error",
+    "jsx-a11y/control-has-associated-label": "error",
+    "jsx-a11y/html-has-lang": "error",
+    "jsx-a11y/lang": "error",
+    "jsx-a11y/no-static-element-interactions": "error",
+    "vitest/require-mock-type-parameters": "off",
+    "vitest/require-to-throw-message": "off",
+    "vitest/no-conditional-expect": "off",
+    // This rule does not recognize Vitest 4's custom messages or deferred
+    // assertions that are awaited after advancing fake timers.
+    "vitest/valid-expect": "off",
+    "vitest/valid-title": "error",
+    "vitest/expect-expect": [
+      "error",
+      {
+        "assertFunctionNames": [
+          "expect",
+          "expectCommittedMerge",
+          "expectGrounded",
+          "expectTypeOf"
+        ]
+      }
+    ],
+    "vitest/no-commented-out-tests": "error",
+    "@tanstack/query/exhaustive-deps": "error",
+    "@tanstack/query/no-rest-destructuring": "warn",
+    "@tanstack/query/stable-query-client": "error",
+    "@tanstack/query/no-unstable-deps": "error",
+    "@tanstack/query/infinite-query-property-order": "error",
+    "@tanstack/query/no-void-query-fn": "error",
+    "@tanstack/query/mutation-property-order": "error",
+    "@tanstack/query/prefer-query-options": "error",
     "typescript/consistent-type-imports": "error"
   },
   "ignorePatterns": [

--- a/apps/cli/src/commands/users.ts
+++ b/apps/cli/src/commands/users.ts
@@ -60,7 +60,7 @@ subcommand
         .where(eq(sql`LOWER(${users.email})`, email.toLowerCase()))
         .returning();
       if (!existingUser) {
-        throw new Error(`Unknown user: ${email}.`);
+        throw new Error(`Unknown user: ${email}.`, { cause: err });
       }
       user = existingUser;
     }

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,14 +1,13 @@
 {
   "extends": "@peated/tsconfig/base.json",
   "compilerOptions": {
-    "baseUrl": "./",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
     "paths": {
       "@peated/bottle-classifier": [
         "../../packages/bottle-classifier/src/index.ts"
       ],
       "@peated/bottle-classifier/*": ["../../packages/bottle-classifier/src/*"],
-      "@peated/cli/*": ["src/*"],
+      "@peated/cli/*": ["./src/*"],
       "@peated/server/*": ["../../apps/server/src/*"]
     }
   },

--- a/apps/server/src/lib/api.ts
+++ b/apps/server/src/lib/api.ts
@@ -21,7 +21,7 @@ import { follows, users } from "../db/schema";
 export async function getUserFromId(
   db: AnyDatabase,
   userId: string | number | "me",
-  currentUser?: User | null | undefined,
+  currentUser?: User | null,
 ): Promise<User | null> {
   if (userId === "me") {
     return currentUser || null;

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -43,6 +43,7 @@ export function verifyPayload(
       }
       if (!decoded || typeof decoded === "string") {
         rej("invalid token");
+        return;
       }
       res(decoded);
     });
@@ -198,7 +199,9 @@ export async function verifyChallenge(
   try {
     payload = (await verifyPayload(signedChallenge)) as any;
   } catch (err) {
-    throw new Error("Challenge signature is invalid or has expired");
+    throw new Error("Challenge signature is invalid or has expired", {
+      cause: err,
+    });
   }
 
   if (!payload?.challenge || !payload?.createdAt) {

--- a/apps/server/src/lib/badges/integration.test.ts
+++ b/apps/server/src/lib/badges/integration.test.ts
@@ -9,8 +9,8 @@ import { asc } from "drizzle-orm";
 import { awardAllBadgeXp } from ".";
 import { createTastingForBadge, getPersistedBadgeTasting } from "./testHelpers";
 
-describe("badge integration test", () => {
-  test("test first tasting example", async ({ fixtures }) => {
+describe("badge integration", () => {
+  test("first tasting example", async ({ fixtures }) => {
     const country = await fixtures.Country();
     const region = await fixtures.Region({ countryId: country.id });
 
@@ -63,7 +63,7 @@ describe("badge integration test", () => {
     `);
   });
 
-  test("test 50 states example", async ({ fixtures }) => {
+  test("50 states example", async ({ fixtures }) => {
     const user = await fixtures.User();
 
     const countrySc = await fixtures.Country({ name: "Scotland" });

--- a/apps/server/src/lib/batchQueue.ts
+++ b/apps/server/src/lib/batchQueue.ts
@@ -27,8 +27,7 @@ export default class BatchQueue<T> {
 
   private async checkBatchSize(): Promise<void> {
     while (this.queue.length >= this.batchSize && !this.processingBatch) {
-      this.processBatch();
-      await this.checkBatchSize(); // Check again in case more items were added
+      await this.processBatch();
     }
   }
 

--- a/apps/server/src/lib/bottleFinder.test.ts
+++ b/apps/server/src/lib/bottleFinder.test.ts
@@ -13,12 +13,6 @@ describe("findBottleId", () => {
     expect(result).toMatchInlineSnapshot(`1`);
   });
 
-  // test("matches fullName as prefix", async ({ fixtures }) => {
-  //   const bottle = await fixtures.Bottle();
-  //   const result = await findBottleId(bottle.fullName + " Single Grain");
-  //   expect(result).toBe(bottle.id);
-  // });
-
   test("will not wrongly match a suffix", async ({ fixtures }) => {
     const brand = await fixtures.Entity({ name: "The Macallan" });
     const bottle = await fixtures.Bottle({

--- a/apps/server/src/lib/cron.ts
+++ b/apps/server/src/lib/cron.ts
@@ -11,8 +11,8 @@ export function scheduledJob(
   cb: () => Promise<void>,
 ) {
   const task = new AsyncTask(jobName, async () => {
-    Sentry.withIsolationScope(async (scope) => {
-      Sentry.startNewTrace(async () => {
+    await Sentry.withIsolationScope(async (scope) => {
+      await Sentry.startNewTrace(async () => {
         const jobId = cuid2.createId();
 
         scope.setContext("monitor", {

--- a/apps/server/src/lib/openai.ts
+++ b/apps/server/src/lib/openai.ts
@@ -32,7 +32,7 @@ export async function getStructuredResponse<Schema extends ZodSchema<any>>(
   pipelineName: string,
   prompt: string | Message[],
   schema: Schema,
-  fullSchema?: undefined | null,
+  fullSchema?: null,
   model?: string,
   logContext?: Record<string, Record<string, any>>,
 ): Promise<z.infer<Schema> | null>;

--- a/apps/server/src/lib/passkey.ts
+++ b/apps/server/src/lib/passkey.ts
@@ -128,9 +128,10 @@ export async function verifyPasskeyRegistration(
     if (err instanceof z.ZodError) {
       throw new Error(
         `Invalid client data JSON: ${err.issues.map((issue) => issue.message).join(", ")}`,
+        { cause: err },
       );
     }
-    throw new Error("Invalid client data JSON format");
+    throw new Error("Invalid client data JSON format", { cause: err });
   }
 
   const challenge = clientDataJSON.challenge;
@@ -138,8 +139,10 @@ export async function verifyPasskeyRegistration(
   // Verify the signed challenge to prevent tampering and replay attacks
   try {
     await verifyChallenge(signedChallenge, challenge);
-  } catch (err: any) {
-    throw new Error(err.message || "Invalid challenge");
+  } catch (err: unknown) {
+    throw new Error(err instanceof Error ? err.message : "Invalid challenge", {
+      cause: err,
+    });
   }
 
   // Verify the WebAuthn registration response

--- a/apps/server/src/lib/scraper.ts
+++ b/apps/server/src/lib/scraper.ts
@@ -32,9 +32,7 @@ const BottleConflictDataSchema = z.object({
   bottle: z.number().int().positive(),
 });
 
-if (!existsSync(CACHE)) {
-  mkdirSync(CACHE);
-}
+mkdirSync(CACHE, { recursive: true });
 
 export class PageNotFound extends Error {}
 

--- a/apps/server/src/orpc/client.ts
+++ b/apps/server/src/orpc/client.ts
@@ -6,7 +6,7 @@ import { type Router } from "@peated/server/orpc/router";
 
 export function createClient(
   apiServer: string,
-  accessToken?: string | null | undefined,
+  accessToken?: string | null,
 ): RouterClient<Router> {
   const link = new RPCLink({
     url: `${apiServer}/rpc`,

--- a/apps/server/src/orpc/errors.ts
+++ b/apps/server/src/orpc/errors.ts
@@ -8,11 +8,7 @@ export class ConflictError extends ORPCError<
 > {
   public existingRow: ConflictMatch;
 
-  constructor(
-    row: ConflictMatch,
-    err: Error | undefined = undefined,
-    message: string | undefined = undefined,
-  ) {
+  constructor(row: ConflictMatch, err?: Error, message?: string) {
     super("CONFLICT", {
       message: message ?? `Conflicting object already exists (ID=${row.id}).`,
       cause: err,

--- a/apps/server/src/orpc/routes/email/resend-verification.test.ts
+++ b/apps/server/src/orpc/routes/email/resend-verification.test.ts
@@ -6,9 +6,11 @@ describe("POST /email/resend-verification", () => {
   test("initiates email", async ({ fixtures }) => {
     const user = await fixtures.User({ verified: false });
 
-    await routerClient.email.resendVerification(undefined, {
-      context: { user },
-    });
+    await expect(
+      routerClient.email.resendVerification(undefined, {
+        context: { user },
+      }),
+    ).resolves.toEqual({});
   });
 
   test("already verified", async ({ fixtures }) => {

--- a/apps/server/src/orpc/routes/friends/create.ts
+++ b/apps/server/src/orpc/routes/friends/create.ts
@@ -123,7 +123,7 @@ export default procedure
       if (!myFollow) return;
 
       if (myFollow.status === "pending")
-        createNotification(tx, {
+        await createNotification(tx, {
           fromUserId: myFollow.fromUserId,
           type: "friend_request",
           objectId: myFollow.id,

--- a/apps/server/src/orpc/routes/friends/delete.ts
+++ b/apps/server/src/orpc/routes/friends/delete.ts
@@ -74,7 +74,7 @@ export default procedure
         );
 
       if (follow)
-        deleteNotification(tx, {
+        await deleteNotification(tx, {
           type: "friend_request",
           objectId: follow.id,
           userId: follow.toUserId,

--- a/apps/server/src/orpc/routes/prices/list.test.ts
+++ b/apps/server/src/orpc/routes/prices/list.test.ts
@@ -161,20 +161,6 @@ describe("GET /prices", () => {
     expect(result.results[0].id).toBe(price1.id);
   });
 
-  // TODO: We cant reliably test this as the params are type-safe and its throwing a
-  // validation error rather than a 404.
-  // test("throws NOT_FOUND for non-existent site", async ({ fixtures }) => {
-  //   const admin = await fixtures.User({ admin: true });
-
-  //   const err = await waitError(
-  //     routerClient.prices.list(
-  //       { site: "nonexistent" as any },
-  //       { context: { user: admin } },
-  //     ),
-  //   );
-  //   expect(err).toMatchInlineSnapshot(`[Error: Site not found.]`);
-  // });
-
   test("requires admin permission", async ({ fixtures }) => {
     const user = await fixtures.User({ admin: false });
 

--- a/apps/server/src/orpc/routes/root.ts
+++ b/apps/server/src/orpc/routes/root.ts
@@ -8,6 +8,10 @@ export default procedure
     path: "/",
     summary: "API root",
     description: "Get basic API information including version",
+    spec: (spec) => ({
+      ...spec,
+      operationId: "getRoot",
+    }),
   })
   .output(
     z.object({

--- a/apps/server/src/orpc/routes/toasts/create.ts
+++ b/apps/server/src/orpc/routes/toasts/create.ts
@@ -60,7 +60,7 @@ export default procedure
           .set({ toasts: sql`${tastings.toasts} + 1` })
           .where(eq(tastings.id, targetTasting.id));
 
-        createNotification(tx, {
+        await createNotification(tx, {
           fromUserId: toast.createdById,
           type: "toast",
           objectId: toast.id,

--- a/apps/server/src/worker/client.ts
+++ b/apps/server/src/worker/client.ts
@@ -117,10 +117,7 @@ export async function getConnection() {
   return connection;
 }
 
-export async function gracefulShutdown(
-  signal?: string | undefined,
-  worker?: Worker | undefined,
-) {
+export async function gracefulShutdown(signal?: string, worker?: Worker) {
   scheduler.stop();
   if (connection) connection.disconnect();
   connection = null;
@@ -183,6 +180,6 @@ export async function runWorker() {
 
   process.on("SIGTERM", () => termProcess("SIGTERM"));
 
-  worker.run();
+  void worker.run();
   logInfo("Worker running", {});
 }

--- a/apps/server/src/worker/jobs/scrapeSMWS.ts
+++ b/apps/server/src/worker/jobs/scrapeSMWS.ts
@@ -9,7 +9,7 @@ import {
   type BottleInputSchema,
   type StorePriceInputSchema,
 } from "@peated/server/schemas";
-import { type z } from "zod";
+import { z } from "zod";
 import { logScrapeWarning } from "./scrapeLogging";
 
 const SITE = "smws";
@@ -45,21 +45,23 @@ export default async function scrapeSMWS() {
   // }
 }
 
-type SMWSPayload = {
-  items: {
-    name: string;
-    age: number | null;
-    abv: number | null;
-    cask_no: string;
-    cask_type: string;
-    categories: string[];
-    price: number;
-    url: string;
-    release_date: string; // seems to be iso
-    distilleddate: string; // needs parsed
-    image: string;
-  }[];
-};
+const SMWSPayloadSchema = z.object({
+  items: z.array(
+    z.object({
+      name: z.string(),
+      age: z.number().nullable(),
+      abv: z.union([z.string(), z.number()]).nullable(),
+      cask_no: z.string(),
+      cask_type: z.string(),
+      categories: z.array(z.string()),
+      price: z.number(),
+      url: z.string(),
+      release_date: z.string().nullable(),
+      distilleddate: z.string(),
+      image: z.string(),
+    }),
+  ),
+});
 
 export async function scrapeBottles(
   url: string,
@@ -70,7 +72,7 @@ export async function scrapeBottles(
   ) => Promise<void>,
 ) {
   const body = await getUrl(url);
-  const data = JSON.parse(body) as SMWSPayload;
+  const data = SMWSPayloadSchema.parse(JSON.parse(body));
 
   await chunked(data.items, 10, async (items) => {
     await Promise.all(

--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -869,7 +869,7 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("button", { name: "Log Tasting" }),
     ).toBeVisible();
-    await expect(createRequests).toHaveLength(0);
+    expect(createRequests).toHaveLength(0);
 
     const requestPromise = waitForPhotoIdentificationCreate(page);
     await page.getByRole("button", { name: "Create Bottle" }).click();

--- a/apps/web/image-types.d.ts
+++ b/apps/web/image-types.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="next/image-types/global" />

--- a/apps/web/src/app/(admin)/admin/(default)/queue/bottleSelector.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/bottleSelector.tsx
@@ -83,7 +83,7 @@ export default function BottleSelector({
     if (!open) return;
 
     setQuery(name ?? "");
-    onSearch(name ?? "");
+    void onSearch(name ?? "");
   }, [name, onSearch, open]);
 
   const invalidatePendingRequests = () => {
@@ -141,7 +141,7 @@ export default function BottleSelector({
               setResults([]);
               setError(null);
               setSuccessfulQuery(null);
-              onSearch(value);
+              void onSearch(value);
             }}
             closeIcon={<XMarkIcon className="h-8 w-8" />}
             placeholder="Search for a bottle"

--- a/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
@@ -20,7 +20,7 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { usePathname, useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import BottleSelector from "./bottleSelector";
 import QueueItemCard, { type QueueItem } from "./queueItemCard";
 
@@ -138,11 +138,11 @@ export default function Page() {
     activeRetryRun?.status === "pending" ||
     activeRetryRun?.status === "running";
 
-  async function refreshQueueList(): Promise<void> {
+  const refreshQueueList = useCallback(async (): Promise<void> => {
     await queryClient.invalidateQueries({
       queryKey: listQueryOptions.queryKey,
     });
-  }
+  }, [listQueryOptions.queryKey, queryClient]);
 
   useEffect(() => {
     if (!activeRetryRun || retryRunIsActive) {
@@ -150,7 +150,7 @@ export default function Page() {
     }
 
     void refreshQueueList();
-  }, [activeRetryRun?.status, retryRunIsActive]);
+  }, [activeRetryRun, refreshQueueList, retryRunIsActive]);
 
   async function handleRetryAll(): Promise<void> {
     if (

--- a/apps/web/src/app/(admin)/admin/(default)/queue/queueItemCard.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/queueItemCard.tsx
@@ -602,7 +602,7 @@ function BottleIdentitySection({
   placeholder,
 }: {
   label: string;
-  bottle: QueueItem["currentBottle"] | QueueItem["suggestedBottle"];
+  bottle: QueueItem["currentBottle"];
   placeholder: string;
 }) {
   return (

--- a/apps/web/src/app/(default)/(activity)/priceChanges.tsx
+++ b/apps/web/src/app/(default)/(activity)/priceChanges.tsx
@@ -63,6 +63,12 @@ export default function PriceChanges() {
     <div>
       {data.results.length ? (
         <table className="my-2 min-w-full text-sm">
+          <thead className="sr-only">
+            <tr>
+              <th scope="col">Bottle</th>
+              <th scope="col">Price change</th>
+            </tr>
+          </thead>
           <colgroup>
             <col className="min-w-full sm:w-5/6" />
             <col className="sm:w-1/6" />
@@ -81,7 +87,10 @@ export default function PriceChanges() {
                       isLibrary={price.isLibrary}
                     />
                   </td>
-                  <td className="py-2 pl-3 pr-4 text-right sm:table-cell sm:pr-3">
+                  <td
+                    aria-label="Price change"
+                    className="py-2 pl-3 pr-4 text-right sm:table-cell sm:pr-3"
+                  >
                     <div className="text-muted flex flex-col items-end text-xs">
                       <span>
                         <Price value={price.price} currency={price.currency} />

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/activity/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/activity/page.tsx
@@ -7,7 +7,7 @@ import ActivityList, {
 } from "@peated/web/components/activityList";
 import EmptyActivity from "@peated/web/components/emptyActivity";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { useSuspenseQuery } from "@tanstack/react-query";
+import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 
 export const fetchCache = "default-no-store";
 
@@ -18,31 +18,33 @@ export default function UserActivityPage(props: {
 }) {
   const { username } = use(props.params);
   const orpc = useORPC();
-  const { data: activity } = useSuspenseQuery({
-    queryKey: ["profile-activity", username, "favorites-hidden"],
-    queryFn: async () => {
-      const results = [];
-      let cursor: number | undefined;
-      let fetchedPageCount = 0;
+  const { data: activity } = useSuspenseQuery(
+    queryOptions({
+      queryKey: ["profile-activity", username, "favorites-hidden"],
+      queryFn: async () => {
+        const results = [];
+        let cursor: number | undefined;
+        let fetchedPageCount = 0;
 
-      do {
-        const page = await orpc.users.activity.list.call({
-          user: username,
-          limit: 10,
-          cursor,
-        });
-        fetchedPageCount += 1;
-        results.push(...filterFavoriteActivity(page.results));
-        cursor = page.rel?.nextCursor ?? undefined;
-      } while (
-        results.length < 10 &&
-        cursor &&
-        fetchedPageCount < MAX_ACTIVITY_PAGES
-      );
+        do {
+          const page = await orpc.users.activity.list.call({
+            user: username,
+            limit: 10,
+            cursor,
+          });
+          fetchedPageCount += 1;
+          results.push(...filterFavoriteActivity(page.results));
+          cursor = page.rel?.nextCursor ?? undefined;
+        } while (
+          results.length < 10 &&
+          cursor &&
+          fetchedPageCount < MAX_ACTIVITY_PAGES
+        );
 
-      return results.slice(0, 10);
-    },
-  });
+        return results.slice(0, 10);
+      },
+    }),
+  );
 
   return activity.length ? (
     <ActivityList values={activity} />

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
@@ -88,7 +88,7 @@ function MergeBottleForm({ bottleId }: { bottleId: string }) {
   const bottleMergeMutation = useMutation({
     ...orpc.bottles.merge.mutationOptions(),
     onSuccess: (newBottle) => {
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: orpc.bottles.details.key({
           input: { bottle: newBottle.id },
         }),

--- a/apps/web/src/app/(layout-free)/entities/[entityId]/merge/page.tsx
+++ b/apps/web/src/app/(layout-free)/entities/[entityId]/merge/page.tsx
@@ -53,7 +53,7 @@ function EntityMergeForm({ entityId }: { entityId: string }) {
   const entityMergeMutation = useMutation({
     ...orpc.entities.merge.mutationOptions(),
     onSuccess: (newEntity) => {
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: orpc.entities.details.key({
           input: { entity: newEntity.id },
         }),

--- a/apps/web/src/app/(layout-free)/verify/page.tsx
+++ b/apps/web/src/app/(layout-free)/verify/page.tsx
@@ -21,7 +21,7 @@ export default function Verify() {
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
 
-  const emailVerifyMutation = useMutation(
+  const { mutate: verifyEmail } = useMutation(
     orpc.email.verify.mutationOptions({
       onSuccess: async () => {
         setSuccess(true);
@@ -40,7 +40,7 @@ export default function Verify() {
       setLoading(false);
       return;
     }
-    emailVerifyMutation.mutate(
+    verifyEmail(
       { token },
       {
         onError: (err: any) => {
@@ -57,7 +57,7 @@ export default function Verify() {
         },
       },
     );
-  }, [token]);
+  }, [token, verifyEmail]);
 
   return (
     <LayoutSplash>

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -20,7 +20,7 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <html>
+    <html lang="en">
       <body>
         {/* `NextError` is the default Next.js error page component. Its type
         definition requires a `statusCode` prop. However, since the App Router

--- a/apps/web/src/app/providers/providers.tsx
+++ b/apps/web/src/app/providers/providers.tsx
@@ -32,7 +32,7 @@ export default function Providers({
   // Sync from server props on navigation
   useEffect(() => {
     setSession(initialSession);
-  }, [initialSession.accessToken, initialSession.ts]);
+  }, [initialSession]);
 
   // Periodic session refresh
   useInterval(async () => {

--- a/apps/web/src/components/activityFeed.tsx
+++ b/apps/web/src/components/activityFeed.tsx
@@ -15,12 +15,15 @@ import { useEventListener } from "usehooks-ts";
 
 export default function ActivityFeed({
   activityList,
-  filter = "global",
+  filter,
 }: {
   activityList: Outputs["activity"]["list"];
   filter: "global" | "friends" | "local";
 }) {
   const orpc = useORPC();
+  // TanStack's helper currently widens queryFn to skipToken, which is not
+  // accepted by the suspense hook's narrower type.
+  /* oxlint-disable @tanstack/query/prefer-query-options */
   const {
     data: { pages },
     error,
@@ -62,6 +65,7 @@ export default function ActivityFeed({
     getNextPageParam: (lastPage) => lastPage.rel?.nextCursor,
     getPreviousPageParam: (firstPage) => firstPage.rel?.prevCursor,
   });
+  /* oxlint-enable @tanstack/query/prefer-query-options */
 
   const onScroll = () => {
     if (!hasNextPage) return;
@@ -69,7 +73,7 @@ export default function ActivityFeed({
     const scrollHeight = document.documentElement.scrollHeight;
     const clientHeight = document.documentElement.clientHeight;
     if (scrollTop + clientHeight >= scrollHeight - 100) {
-      fetchNextPage();
+      void fetchNextPage();
     }
   };
 

--- a/apps/web/src/components/admin/badgeConfigForms/ageCheckConfigForm.tsx
+++ b/apps/web/src/components/admin/badgeConfigForms/ageCheckConfigForm.tsx
@@ -28,7 +28,7 @@ export default function AgeCheckConfigForm({
   useEffect(() => {
     const subscription = watch((value, { name, type }) => onChange(value));
     return () => subscription.unsubscribe();
-  }, [watch]);
+  }, [onChange, watch]);
 
   return (
     <>

--- a/apps/web/src/components/admin/badgeConfigForms/bottleCheckConfigForm.tsx
+++ b/apps/web/src/components/admin/badgeConfigForms/bottleCheckConfigForm.tsx
@@ -30,7 +30,7 @@ export default function BottleCheckConfigForm({
   useEffect(() => {
     const subscription = watch((value, { name, type }) => onChange(value));
     return () => subscription.unsubscribe();
-  }, [watch]);
+  }, [onChange, watch]);
 
   // TODO:
   const [bottleValue, setBottleValue] = useState<BottleOption[] | undefined>(

--- a/apps/web/src/components/admin/badgeConfigForms/categoryCheckConfigForm.tsx
+++ b/apps/web/src/components/admin/badgeConfigForms/categoryCheckConfigForm.tsx
@@ -36,7 +36,7 @@ export default function CategoryCheckConfigForm({
   useEffect(() => {
     const subscription = watch((value, { name, type }) => onChange(value));
     return () => subscription.unsubscribe();
-  }, [watch]);
+  }, [onChange, watch]);
 
   return (
     <>

--- a/apps/web/src/components/admin/badgeConfigForms/entityCheckConfigForm.tsx
+++ b/apps/web/src/components/admin/badgeConfigForms/entityCheckConfigForm.tsx
@@ -37,7 +37,7 @@ export default function EntityCheckConfigForm({
   useEffect(() => {
     const subscription = watch((value, { name, type }) => onChange(value));
     return () => subscription.unsubscribe();
-  }, [watch]);
+  }, [onChange, watch]);
 
   // TODO:
   const [entityValue, setEntityValue] = useState<Option | undefined>(

--- a/apps/web/src/components/admin/badgeConfigForms/regionCheckConfigForm.tsx
+++ b/apps/web/src/components/admin/badgeConfigForms/regionCheckConfigForm.tsx
@@ -31,7 +31,7 @@ export default function RegionCheckConfigForm({
   useEffect(() => {
     const subscription = watch((value, { name, type }) => onChange(value));
     return () => subscription.unsubscribe();
-  }, [watch]);
+  }, [onChange, watch]);
 
   // TODO:
   const [countryValue, setCountryValue] = useState<Option | undefined>(

--- a/apps/web/src/components/admin/storePriceTable.tsx
+++ b/apps/web/src/components/admin/storePriceTable.tsx
@@ -21,7 +21,11 @@ export default function StorePriceTable({
         </colgroup>
         <thead className="text-muted hidden border-b border-slate-800 text-sm font-semibold sm:table-header-group">
           <tr>
-            <th scope="col" className="px-3 py-2.5 text-left" />
+            <th
+              scope="col"
+              aria-label="Image"
+              className="px-3 py-2.5 text-left"
+            />
             <th scope="col" className="px-3 py-2.5 text-left">
               Name
             </th>
@@ -39,7 +43,11 @@ export default function StorePriceTable({
               <tr key={price.id} className="border-b border-slate-800 text-sm">
                 <td>
                   {price.imageUrl && (
-                    <img src={price.imageUrl} className="max-h-16 max-w-full" />
+                    <img
+                      src={price.imageUrl}
+                      alt={price.name}
+                      className="max-h-16 max-w-full"
+                    />
                   )}
                 </td>
                 <td className="max-w-0 px-3 py-3">

--- a/apps/web/src/components/bottleOverview.tsx
+++ b/apps/web/src/components/bottleOverview.tsx
@@ -187,6 +187,7 @@ export default function BottleOverview({
               <div className="flex w-full justify-center rounded border border-slate-900 bg-white p-3 opacity-80">
                 <img
                   src={bottle.imageUrl}
+                  alt=""
                   className="block max-w-full rounded"
                   aria-hidden="true"
                 />

--- a/apps/web/src/components/bottleReviews.tsx
+++ b/apps/web/src/components/bottleReviews.tsx
@@ -37,7 +37,11 @@ export default function BottleReviews({ bottleId }: { bottleId: number }) {
               key={r.id}
               className="relative col-span-3 grid grid-cols-subgrid items-center gap-x-2 gap-y-2 p-2 hover:bg-slate-800"
             >
-              <a href={r.url} className="absolute inset-0" />
+              <a
+                href={r.url}
+                aria-label={`Read ${r.site.name} review`}
+                className="absolute inset-0"
+              />
               <span className="flex items-center gap-x-2">{r.site.name}</span>
               <span className="flex items-center justify-end gap-x-2">
                 <RatingIcon rating={r.rating} />

--- a/apps/web/src/components/colorField.tsx
+++ b/apps/web/src/components/colorField.tsx
@@ -72,6 +72,7 @@ export default forwardRef<HTMLInputElement, Props>(
             return (
               <button
                 key={num}
+                aria-label={`Color ${num}`}
                 className={classNames(
                   "pointer h-8 flex-1",
                   num === value ? "h-12 px-2" : "",

--- a/apps/web/src/components/entityField.tsx
+++ b/apps/web/src/components/entityField.tsx
@@ -98,7 +98,7 @@ function CreateForm({
         onSubmit={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          handleSubmit(onSubmit)(e);
+          void handleSubmit(onSubmit)(e);
         }}
         isSubmitting={isSubmitting}
       >

--- a/apps/web/src/components/formField.tsx
+++ b/apps/web/src/components/formField.tsx
@@ -1,5 +1,5 @@
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
-import type { MouseEvent, ReactNode } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import classNames from "../lib/classNames";
 import FormLabel from "./formLabel";
 import HelpText from "./helpText";
@@ -16,7 +16,6 @@ type Props = React.ComponentPropsWithoutRef<"div"> & {
   };
   className?: string;
   labelAction?: () => void;
-  onClick?: (e: MouseEvent<HTMLDivElement>) => void;
 };
 
 export default function FormField({
@@ -30,16 +29,32 @@ export default function FormField({
   error,
   labelAction,
   onClick,
+  ...props
 }: Props) {
+  const interactionProps = onClick
+    ? {
+        role: "button",
+        tabIndex: 0,
+        onClick,
+        onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            event.currentTarget.click();
+          }
+        },
+      }
+    : {};
+
   return (
     <div
+      {...props}
+      {...interactionProps}
       className={classNames(
         `relative block px-4 py-4 text-white focus-within:z-10`,
         className,
         onClick ? "cursor-pointer" : "",
         error ? "border border-red-500" : "",
       )}
-      onClick={onClick}
     >
       {error?.message && (
         <div className="-mx-3 -mt-2.5 mb-2.5 bg-red-600 px-3 py-2.5 sm:-mx-5 sm:-mt-4 sm:mb-4 sm:px-5">

--- a/apps/web/src/components/formField.tsx
+++ b/apps/web/src/components/formField.tsx
@@ -1,5 +1,5 @@
 import { ChevronRightIcon } from "@heroicons/react/20/solid";
-import type { KeyboardEvent, ReactNode } from "react";
+import type { ReactNode } from "react";
 import classNames from "../lib/classNames";
 import FormLabel from "./formLabel";
 import HelpText from "./helpText";
@@ -28,31 +28,27 @@ export default function FormField({
   htmlFor,
   error,
   labelAction,
-  onClick,
   ...props
 }: Props) {
-  const interactionProps = onClick
-    ? {
-        role: "button",
-        tabIndex: 0,
-        onClick,
-        onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
-          if (event.key === "Enter" || event.key === " ") {
-            event.preventDefault();
-            event.currentTarget.click();
-          }
-        },
-      }
-    : {};
+  const labelClassName = classNames(
+    "flex w-full flex-auto items-center text-left",
+    labelAction ? "cursor-pointer" : "cursor-default",
+  );
+  const labelContent = (
+    <>
+      {label}
+      {labelAction && (
+        <ChevronRightIcon className="ml-1 inline-block h-5 font-bold" />
+      )}
+    </>
+  );
 
   return (
     <div
       {...props}
-      {...interactionProps}
       className={classNames(
         `relative block px-4 py-4 text-white focus-within:z-10`,
         className,
-        onClick ? "cursor-pointer" : "",
         error ? "border border-red-500" : "",
       )}
     >
@@ -62,19 +58,27 @@ export default function FormField({
         </div>
       )}
 
-      {label && (
+      {label && labelAction ? (
+        <FormLabel
+          as="button"
+          type="button"
+          onClick={labelAction}
+          required={required}
+          labelNote={labelNote}
+          className={labelClassName}
+        >
+          {labelContent}
+        </FormLabel>
+      ) : label ? (
         <FormLabel
           htmlFor={htmlFor}
           required={required}
           labelNote={labelNote}
-          className="flex flex-auto cursor-pointer items-center"
+          className={labelClassName}
         >
-          {label}
-          {labelAction && (
-            <ChevronRightIcon className="ml-1 inline-block h-5 font-bold" />
-          )}
+          {labelContent}
         </FormLabel>
-      )}
+      ) : null}
       {children}
       {helpText && <HelpText>{helpText}</HelpText>}
     </div>

--- a/apps/web/src/components/imageField.tsx
+++ b/apps/web/src/components/imageField.tsx
@@ -112,7 +112,7 @@ export default forwardRef<HTMLInputElement, Props>(
     useEffect(() => {
       if (!initialFile) return;
 
-      (async () => {
+      void (async () => {
         const imageSrc = await fileToDataUrl(initialFile);
         setImageSrc(imageSrc);
         onSave(await fileDataToCanvas(initialFile));
@@ -122,7 +122,7 @@ export default forwardRef<HTMLInputElement, Props>(
     const updateImageSrc = () => {
       const file = Array.from(fileRef.current?.files || []).find(() => true);
       if (file) {
-        (async () => {
+        void (async () => {
           const imageSrc = await fileToDataUrl(file);
           setImageSrc(imageSrc);
           if (noEditor) onSave(await fileDataToCanvas(file));

--- a/apps/web/src/components/imageField.tsx
+++ b/apps/web/src/components/imageField.tsx
@@ -147,9 +147,6 @@ export default forwardRef<HTMLInputElement, Props>(
         // in order for the 'drop' event to register.
         // See: https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/Drag_operations#droptargets
         // https://stackoverflow.com/questions/8006715/drag-drop-files-into-standard-html-file-input
-        onClick={(e) => {
-          fileRef.current?.click();
-        }}
         onDragOver={(e) => {
           e.preventDefault();
         }}
@@ -190,10 +187,14 @@ export default forwardRef<HTMLInputElement, Props>(
                 }}
               />
             ) : (
-              <div className="flex w-full flex-col items-center justify-center p-4 text-sm group-hover:bg-slate-700">
+              <button
+                type="button"
+                className="flex w-full flex-col items-center justify-center p-4 text-sm text-white group-hover:bg-slate-700"
+                onClick={() => fileRef.current?.click()}
+              >
                 <PhotoIcon className="h-12 w-12" />
                 Tap to upload an Image
-              </div>
+              </button>
             )}
             {(imageSrc || finalImage) && (
               <div
@@ -202,7 +203,12 @@ export default forwardRef<HTMLInputElement, Props>(
                   maxHeight: imageHeight,
                 }}
               >
-                <Button color="highlight">Change Image</Button>
+                <Button
+                  color="highlight"
+                  onClick={() => fileRef.current?.click()}
+                >
+                  Change Image
+                </Button>
                 <Button
                   color="danger"
                   onClick={(e) => {
@@ -220,6 +226,7 @@ export default forwardRef<HTMLInputElement, Props>(
             )}
           </div>
           <input
+            id={`f-${name}`}
             type="file"
             name={name}
             accept="image/*"

--- a/apps/web/src/components/imageModal.tsx
+++ b/apps/web/src/components/imageModal.tsx
@@ -39,15 +39,15 @@ export function ImageModal({
           {title && <DialogTitle className="sr-only">{title}</DialogTitle>}
           <img src={image} alt={alt} className="max-h-full max-w-full" />
           {action && (
-            <div
-              className="absolute bottom-4 left-1/2 flex -translate-x-1/2 justify-center sm:bottom-6"
-              onClick={(event) => event.stopPropagation()}
-            >
+            <div className="absolute bottom-4 left-1/2 flex -translate-x-1/2 justify-center sm:bottom-6">
               <Button
                 size="small"
                 icon={action.icon}
                 disabled={action.disabled}
-                onClick={action.onClick}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  action.onClick();
+                }}
               >
                 {action.label}
               </Button>

--- a/apps/web/src/components/join.test.tsx
+++ b/apps/web/src/components/join.test.tsx
@@ -5,7 +5,14 @@ import Join from "./join";
 
 describe("Join", () => {
   it("keeps punctuation joins inside a single inline flex item", () => {
-    const links = [<a key="x">X</a>, <a key="y">Y</a>];
+    const links = [
+      <a key="x" href="/x">
+        X
+      </a>,
+      <a key="y" href="/y">
+        Y
+      </a>,
+    ];
 
     const html = renderToStaticMarkup(
       <div className="flex gap-x-1">
@@ -14,7 +21,7 @@ describe("Join", () => {
     );
 
     expect(html).toBe(
-      '<div class="flex gap-x-1"><span><a>X</a>, <a>Y</a></span></div>',
+      '<div class="flex gap-x-1"><span><a href="/x">X</a>, <a href="/y">Y</a></span></div>',
     );
   });
 });

--- a/apps/web/src/components/legend.tsx
+++ b/apps/web/src/components/legend.tsx
@@ -20,6 +20,7 @@ export default function Legend({
       <div className="flex-grow text-lg">{title}</div>
       {isCollapsed !== undefined && onCollapse && (
         <button
+          aria-label={isCollapsed ? "Expand section" : "Collapse section"}
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();

--- a/apps/web/src/components/notifications/entry.tsx
+++ b/apps/web/src/components/notifications/entry.tsx
@@ -6,6 +6,7 @@ import { BottleLabel } from "@peated/web/components/bottleIdentity";
 import Link from "@peated/web/components/link";
 import classNames from "@peated/web/lib/classNames";
 import { useRouter } from "next/navigation";
+import type { KeyboardEvent } from "react";
 import UserAvatar from "../userAvatar";
 import FriendRequestEntry from "./friendRequestEntry";
 
@@ -20,21 +21,33 @@ export default function NotificationEntry({
 }) {
   const router = useRouter();
   const link = getLink({ notification });
+  const openNotification = () => {
+    if (!link) return;
+    onMarkRead();
+    router.push(link);
+  };
+  const interactionProps = link
+    ? {
+        role: "link",
+        tabIndex: 0,
+        onClick: openNotification,
+        onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
+          if (event.key === "Enter" || event.key === " ") {
+            event.preventDefault();
+            openNotification();
+          }
+        },
+      }
+    : {};
+
   return (
     <div
+      {...interactionProps}
       className={classNames(
         "bg-slate-950 p-3",
         notification.read ? "text-muted" : "text-white",
         link ? "group cursor-pointer rounded hover:bg-slate-700" : "",
       )}
-      onClick={
-        link
-          ? () => {
-              onMarkRead();
-              router.push(link);
-            }
-          : undefined
-      }
     >
       <div className="flex flex-auto items-start">
         <div className="flex-shrink-0 self-center">

--- a/apps/web/src/components/passkeyManager.tsx
+++ b/apps/web/src/components/passkeyManager.tsx
@@ -70,7 +70,7 @@ export default function PasskeyManager() {
       });
 
       // Refresh passkeys list
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: orpc.auth.passkey.list.key({ input: undefined }),
       });
     } catch (err: any) {
@@ -93,7 +93,7 @@ export default function PasskeyManager() {
 
     try {
       await deletePasskeyMutation.mutateAsync({ passkeyId });
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: orpc.auth.passkey.list.key({ input: undefined }),
       });
     } catch (err: any) {
@@ -112,7 +112,7 @@ export default function PasskeyManager() {
         passkeyId,
         nickname: editingName.trim() || undefined,
       });
-      queryClient.invalidateQueries({
+      void queryClient.invalidateQueries({
         queryKey: orpc.auth.passkey.list.key({ input: undefined }),
       });
       setEditingId(null);
@@ -160,7 +160,7 @@ export default function PasskeyManager() {
                       onChange={(e) => setEditingName(e.target.value)}
                       onKeyDown={(e) => {
                         if (e.key === "Enter") {
-                          handleSavePasskey(passkey.id);
+                          void handleSavePasskey(passkey.id);
                         } else if (e.key === "Escape") {
                           handleCancelEdit();
                         }

--- a/apps/web/src/components/passwordResetChangeForm.tsx
+++ b/apps/web/src/components/passwordResetChangeForm.tsx
@@ -91,7 +91,7 @@ export default function PasswordResetChangeForm({ token }: { token: string }) {
       formData.append("passkeyResponse", JSON.stringify(response));
       formData.append("signedChallenge", signedChallenge);
 
-      await passkeyFormAction(formData);
+      passkeyFormAction(formData);
     } catch (err: any) {
       logError(err, { context: "passkey_recovery" });
 

--- a/apps/web/src/components/pendingTosAlert.tsx
+++ b/apps/web/src/components/pendingTosAlert.tsx
@@ -10,7 +10,7 @@ export default function PendingTosAlert() {
   const [state, acceptAction] = useActionState(acceptTosForm, undefined);
 
   useEffect(() => {
-    if (state?.ok) updateSession();
+    if (state?.ok) void updateSession();
   }, [state?.ok]);
 
   return (

--- a/apps/web/src/components/pendingVerificationAlert.tsx
+++ b/apps/web/src/components/pendingVerificationAlert.tsx
@@ -20,9 +20,9 @@ export default function PendingVerificationAlert() {
   useEffect(() => {
     if (state?.alreadyVerified) {
       flash("Oops, looks like you already verified your account.", "success");
-      updateSession();
+      void updateSession();
     }
-  }, [state?.alreadyVerified]);
+  }, [flash, state?.alreadyVerified]);
 
   return (
     <Alert type="default" noMargin>

--- a/apps/web/src/components/queryBoundary.tsx
+++ b/apps/web/src/components/queryBoundary.tsx
@@ -40,7 +40,7 @@ const ErrorView = ({ error, resetErrorBoundary }: any) => {
       <div>
         {error ? error.message || error.toString() : "Internal server error"}
       </div>
-      <button title="Retry" onClick={resetErrorBoundary} />
+      <button aria-label="Retry" title="Retry" onClick={resetErrorBoundary} />
     </EmptyActivity>
   );
 };

--- a/apps/web/src/components/search/bottleResult.tsx
+++ b/apps/web/src/components/search/bottleResult.tsx
@@ -55,7 +55,7 @@ export function getBottleResultHref({
 
 export default function BottleResultRow({
   result: { ref: bottle },
-  directToTasting = false,
+  directToTasting,
   addBottleIntent,
   pendingImage,
 }: {

--- a/apps/web/src/components/search/panel.tsx
+++ b/apps/web/src/components/search/panel.tsx
@@ -105,7 +105,7 @@ export default function SearchPanel({
       setState("ready");
       setInitialState("ready");
     },
-    [addBottleIntent, directToTasting, searchType, user],
+    [addBottleIntent, directToTasting, orpc.search, searchType, user],
   );
 
   // TODO: handle errors
@@ -115,7 +115,7 @@ export default function SearchPanel({
     const curValue = initialValue ?? value ?? "";
     setQuery(curValue);
     if (onQueryChange) onQueryChange(curValue);
-    onQuery(curValue);
+    void onQuery(curValue);
   }, [initialValue, value, onQuery, onQueryChange]);
 
   return (
@@ -132,7 +132,7 @@ export default function SearchPanel({
             onChange={(value) => {
               setQuery(value);
               if (onQueryChange) onQueryChange(value);
-              onQuery(value);
+              void onQuery(value);
             }}
             onSubmit={(value) => {
               const params = new URLSearchParams({ q: value });

--- a/apps/web/src/components/search/result.tsx
+++ b/apps/web/src/components/search/result.tsx
@@ -10,7 +10,7 @@ export type Result = BottleResult | UserResult | EntityResult;
 
 export default function ResultRow({
   result,
-  directToTasting = false,
+  directToTasting,
   addBottleIntent,
   pendingImage,
 }: {

--- a/apps/web/src/components/searchHeaderForm.tsx
+++ b/apps/web/src/components/searchHeaderForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import useAutofocus from "../hooks/useAutofocus";
 import Spinner from "./spinner";
 
@@ -26,23 +26,22 @@ export default function SearchHeaderForm({
   children?: ReactNode;
 }) {
   const [value, setValue] = useState(props.value ?? "");
+  const previousPropValue = useRef(props.value);
+  const latestValue = useRef(value);
 
   const ref = useAutofocus<HTMLInputElement>(() => {
     return autoFocus || !onFocus;
   });
 
   useEffect(() => {
-    if (props.value !== value) {
-      const newValue = props.value ?? "";
-      setValue(newValue);
-      if (onChange) onChange(newValue);
-    }
-  }, [props.value]);
+    if (props.value === previousPropValue.current) return;
 
-  // we store the onChange event here as setState is async
-  // and if you type a value and quickly hit enter (to submit)
-  // it will not capture the last character
-  let _lastValue = value;
+    previousPropValue.current = props.value;
+    const newValue = props.value ?? "";
+    latestValue.current = newValue;
+    setValue(newValue);
+    onChange?.(newValue);
+  }, [onChange, props.value]);
 
   return (
     <form
@@ -52,8 +51,8 @@ export default function SearchHeaderForm({
       onSubmit={(e) => {
         e.stopPropagation();
 
-        if (onSubmit) onSubmit(_lastValue);
-        else if (onChange) onChange(_lastValue);
+        if (onSubmit) onSubmit(latestValue.current);
+        else if (onChange) onChange(latestValue.current);
       }}
     >
       <input
@@ -66,7 +65,7 @@ export default function SearchHeaderForm({
         placeholder={placeholder}
         onFocus={onFocus}
         onChange={(e) => {
-          _lastValue = e.target.value;
+          latestValue.current = e.target.value;
           setValue(e.target.value);
           if (onChange) onChange(e.target.value);
         }}

--- a/apps/web/src/components/searchHeaderForm.tsx
+++ b/apps/web/src/components/searchHeaderForm.tsx
@@ -26,6 +26,7 @@ export default function SearchHeaderForm({
   children?: ReactNode;
 }) {
   const [value, setValue] = useState(props.value ?? "");
+  const hasMounted = useRef(false);
   const previousPropValue = useRef(props.value);
   const latestValue = useRef(value);
 
@@ -34,6 +35,11 @@ export default function SearchHeaderForm({
   });
 
   useEffect(() => {
+    if (!hasMounted.current) {
+      hasMounted.current = true;
+      if (props.value === undefined) onChange?.("");
+      return;
+    }
     if (props.value === previousPropValue.current) return;
 
     previousPropValue.current = props.value;

--- a/apps/web/src/components/selectField/index.tsx
+++ b/apps/web/src/components/selectField/index.tsx
@@ -136,6 +136,8 @@ export default function SelectField<T extends Option>({
   else if (!suggestedOptions)
     suggestedOptions = options.slice(0, targetOptions);
 
+  const canOpenDialog = !noDialog && !readOnly && !disabled;
+
   const toggleOption = (option: T) => {
     setPreviousValues(filterDupes([option], previousValues));
     if (value.find((i) => i.id == option.id && i.name == option.name)) {
@@ -182,15 +184,10 @@ export default function SelectField<T extends Option>({
       className={className}
       error={error}
       labelAction={
-        !noDialog && !readOnly && !disabled
+        canOpenDialog
           ? () => {
               setDialogOpen(true);
             }
-          : undefined
-      }
-      onClick={
-        !noDialog && !readOnly && !disabled
-          ? () => setDialogOpen(true)
           : undefined
       }
     >
@@ -213,9 +210,19 @@ export default function SelectField<T extends Option>({
             {onRenderChip ? onRenderChip(option) : option.name}
           </Chip>
         ))}
-        {visibleValues.length === 0 && placeholder && (
-          <div className="text-muted sm:leading-6">{placeholder}</div>
-        )}
+        {visibleValues.length === 0 &&
+          placeholder &&
+          (canOpenDialog ? (
+            <button
+              type="button"
+              className="text-muted text-left sm:leading-6"
+              onClick={() => setDialogOpen(true)}
+            >
+              {placeholder}
+            </button>
+          ) : (
+            <div className="text-muted sm:leading-6">{placeholder}</div>
+          ))}
         {visibleValues.length > 0 &&
           value.length < targetOptions &&
           (!options.length || visibleValues.length != options.length) &&

--- a/apps/web/src/components/selectField/index.tsx
+++ b/apps/web/src/components/selectField/index.tsx
@@ -115,6 +115,9 @@ export default function SelectField<T extends Option>({
     targetOptions = options.length;
   }
 
+  // The field accepts object arrays that callers commonly recreate; retain
+  // deep comparison so controlled values do not produce a callback loop.
+  /* oxlint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     const newValue = Array.isArray(props.value)
       ? props.value
@@ -123,6 +126,7 @@ export default function SelectField<T extends Option>({
         : [];
     setValue(newValue);
   }, [JSON.stringify(props.value)]);
+  /* oxlint-enable react-hooks/exhaustive-deps */
 
   const [value, setValue] = useState<T[]>(initialValue);
   const [previousValues, setPreviousValues] = useState<T[]>(value);
@@ -147,6 +151,7 @@ export default function SelectField<T extends Option>({
     return true;
   };
 
+  /* oxlint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     if (!onChange) return;
     if (multiple) {
@@ -155,6 +160,7 @@ export default function SelectField<T extends Option>({
       (onChange as (value: T) => void)(value[0]);
     }
   }, [JSON.stringify(value)]);
+  /* oxlint-enable react-hooks/exhaustive-deps */
 
   const visibleValues = rememberValues
     ? filterDupes(value, previousValues)

--- a/apps/web/src/components/selectField/selectDialog.tsx
+++ b/apps/web/src/components/selectField/selectDialog.tsx
@@ -4,7 +4,7 @@ import config from "@peated/web/config";
 import classNames from "@peated/web/lib/classNames";
 import { motion } from "framer-motion";
 import type { ReactNode } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useDebounceCallback } from "usehooks-ts";
 import LayoutModal from "../layoutModal";
 import ListItem from "../listItem";
@@ -25,7 +25,7 @@ export default function SelectDialog<T extends Option>({
   open,
   setOpen,
   onSelect,
-  selectedValues = [],
+  selectedValues,
   searchPlaceholder,
   emptyListItem,
   canCreate = false,
@@ -33,7 +33,7 @@ export default function SelectDialog<T extends Option>({
   multiple = false,
   onQuery,
   onResults,
-  options = [],
+  options,
   onRenderOption,
 }: {
   open: boolean;
@@ -50,11 +50,18 @@ export default function SelectDialog<T extends Option>({
   options?: T[];
   onRenderOption?: OnRenderOption<T>;
 }) {
+  const resolvedOptions = useMemo(() => options ?? [], [options]);
+  const resolvedSelectedValues = useMemo(
+    () => selectedValues ?? [],
+    [selectedValues],
+  );
   const [query, setQuery] = useState("");
-  const [optionList, setOptionList] = useState<T[]>([...selectedValues]);
+  const [optionList, setOptionList] = useState<T[]>([
+    ...resolvedSelectedValues,
+  ]);
   const [results, setResults] = useState<T[]>([]);
   const [previousValues, setPreviousValues] = useState<T[]>([
-    ...selectedValues,
+    ...resolvedSelectedValues,
   ]);
   const [isLoading, setLoading] = useState(false);
   const [initialState, setInitialState] = useState<"loading" | "ready">(
@@ -66,8 +73,8 @@ export default function SelectDialog<T extends Option>({
     async (query = "") => {
       setLoading(true);
       const results = onQuery
-        ? await onQuery(query, options)
-        : options.filter(
+        ? await onQuery(query, resolvedOptions)
+        : resolvedOptions.filter(
             (o) => o.name.toLowerCase().indexOf(query.toLowerCase()) !== -1,
           );
       if (results === undefined) throw new Error("Invalid results returned");
@@ -76,7 +83,7 @@ export default function SelectDialog<T extends Option>({
       setLoading(false);
       setInitialState("ready");
     },
-    [onQuery, onResults],
+    [onQuery, onResults, resolvedOptions],
   );
 
   const onSearch = useDebounceCallback(unsafe_onSearch);
@@ -87,12 +94,8 @@ export default function SelectDialog<T extends Option>({
   };
 
   useEffect(() => {
-    setOptionList(filterDupes(selectedValues, results, previousValues));
-  }, [
-    JSON.stringify(selectedValues),
-    JSON.stringify(results),
-    JSON.stringify(previousValues),
-  ]);
+    setOptionList(filterDupes(resolvedSelectedValues, results, previousValues));
+  }, [resolvedSelectedValues, results, previousValues]);
 
   const listItemClasses = `px-3 group relative border-b border-slate-800 bg-slate-950 hover:bg-slate-900`;
 
@@ -106,7 +109,7 @@ export default function SelectDialog<T extends Option>({
               onClose={() => setOpen(false)}
               onChange={(value) => {
                 setLoading(true);
-                onSearch(value);
+                void onSearch(value);
               }}
               onDone={multiple ? () => setOpen(false) : undefined}
               closeIcon={<XMarkIcon className="h-8 w-8" />}
@@ -133,7 +136,7 @@ export default function SelectDialog<T extends Option>({
                       <CheckIcon
                         className={classNames(
                           "-ml-2 h-10 w-10 flex-none rounded p-2",
-                          selectedValues.find(
+                          resolvedSelectedValues.find(
                             (i) => i.id == option.id && i.name == option.name,
                           )
                             ? "bg-highlight text-black"
@@ -145,7 +148,7 @@ export default function SelectDialog<T extends Option>({
                         <div className="font-semibold text-white">
                           <button
                             onClick={() => {
-                              selectOption(option);
+                              void selectOption(option);
                             }}
                           >
                             <span className="absolute inset-x-0 -top-px bottom-0" />
@@ -225,7 +228,9 @@ export default function SelectDialog<T extends Option>({
           setOpen={setCreateOpen}
           render={createForm}
           onSubmit={(newOption) => {
-            selectOption(onResults ? onResults([newOption])[0] : newOption);
+            void selectOption(
+              onResults ? onResults([newOption])[0] : newOption,
+            );
           }}
         />
       )}

--- a/apps/web/src/components/seriesField.tsx
+++ b/apps/web/src/components/seriesField.tsx
@@ -95,7 +95,7 @@ function CreateForm({
         onSubmit={(e) => {
           e.preventDefault();
           e.stopPropagation();
-          handleSubmit(onSubmit)(e);
+          void handleSubmit(onSubmit)(e);
         }}
         isSubmitting={isSubmitting}
       >

--- a/apps/web/src/components/sidePanel.tsx
+++ b/apps/web/src/components/sidePanel.tsx
@@ -60,7 +60,7 @@ export function SidePanelHeader({
 
 export default function SidePanel({
   onClose,
-  open = false,
+  open,
   children,
   ...props
 }: {

--- a/apps/web/src/components/tableSkeleton.tsx
+++ b/apps/web/src/components/tableSkeleton.tsx
@@ -32,6 +32,7 @@ export default function TableSkeleton({
               <th
                 key={index}
                 scope="col"
+                aria-label="Loading"
                 className={classNames(
                   "px-3 py-2.5",
                   index !== 0 ? "hidden sm:table-cell" : "",

--- a/apps/web/src/components/tastingListItem.tsx
+++ b/apps/web/src/components/tastingListItem.tsx
@@ -35,9 +35,13 @@ const tastingActionClassName =
   "inline-flex h-9 items-center justify-center gap-x-1.5 rounded px-2 text-sm font-medium text-muted transition-colors hover:bg-slate-800 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-peated disabled:cursor-default disabled:opacity-60";
 
 function ImageWithSkeleton({
+  alt,
   src,
   ...props
-}: Omit<ComponentPropsWithoutRef<"img">, "src"> & { src: string }) {
+}: Omit<ComponentPropsWithoutRef<"img">, "alt" | "src"> & {
+  alt: string;
+  src: string;
+}) {
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
@@ -51,7 +55,7 @@ function ImageWithSkeleton({
 
   if (!loaded) return <ImageSkeleton />;
 
-  return <img src={src} {...props} />;
+  return <img src={src} alt={alt} {...props} />;
 }
 
 function ImageSkeleton() {

--- a/apps/web/src/components/tooltip.tsx
+++ b/apps/web/src/components/tooltip.tsx
@@ -34,6 +34,14 @@ export default function Tooltip({
       onClick={() => {
         setVisible(!visible);
       }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          setVisible(!visible);
+        }
+      }}
+      role="button"
+      tabIndex={0}
       style={style}
     >
       {children}

--- a/apps/web/src/hooks/useAuth.tsx
+++ b/apps/web/src/hooks/useAuth.tsx
@@ -20,7 +20,7 @@ const AuthContext = createContext<Auth>({
 });
 
 export const AuthProvider = ({
-  user = null,
+  user,
   children,
 }: {
   user: User | null;

--- a/apps/web/src/lib/auth.actions.ts
+++ b/apps/web/src/lib/auth.actions.ts
@@ -167,11 +167,9 @@ type GenericResult = {
 };
 
 export async function resendVerificationForm(
-  prevState?:
-    | (GenericResult & {
-        alreadyVerified?: boolean;
-      })
-    | undefined,
+  prevState?: GenericResult & {
+    alreadyVerified?: boolean;
+  },
   formData?: FormData,
 ) {
   "use server";

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@peated/tsconfig/base.json",
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "compilerOptions": {
-    "baseUrl": ".",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
     "lib": ["esnext", "dom", "dom.iterable"],
     "jsx": "preserve",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "user": "dotenv -e .env.local -- pnpm --filter='./apps/cli' cli users",
     "start": "dotenv -e .env.local -- turbo start",
     "typecheck": "turbo typecheck",
-    "lint": "github-actionlint && oxlint .",
+    "lint": "github-actionlint && oxlint . && pnpm ast-grep:lint",
+    "ast-grep:lint": "ast-grep scan",
+    "ast-grep:test": "ast-grep test --skip-snapshot-tests",
     "test": "turbo test",
     "test:all": "turbo test && pnpm --dir apps/web test:e2e",
     "test:web": "pnpm --dir apps/web test",
@@ -57,9 +59,12 @@
     "typescript": "catalog:"
   },
   "devDependencies": {
+    "@ast-grep/cli": "0.45.0",
+    "@tanstack/eslint-plugin-query": "5.101.4",
     "github-actionlint": "1.7.12",
     "lint-staged": "^14.0.1",
     "oxlint": "^1.72.0",
+    "oxlint-tsgolint": "7.0.2001",
     "prettier": "catalog:",
     "prettier-plugin-organize-imports": "^3.2.4",
     "prettier-plugin-tailwindcss": "catalog:"
@@ -69,6 +74,7 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
+      "@ast-grep/cli",
       "bcrypt"
     ]
   },

--- a/packages/bottle-classifier/src/bottleClassificationEvidence.ts
+++ b/packages/bottle-classifier/src/bottleClassificationEvidence.ts
@@ -80,10 +80,7 @@ export function extractedIdentityLooksLikePlainAgeStatementReference(
 // The legacy `spirit` bucket means the category is unknown, not that the
 // bottle is positively identified as a generic spirit family.
 function normalizeComparableCategory(
-  value:
-    | BottleCandidate["category"]
-    | BottleExtractedDetails["category"]
-    | null,
+  value: BottleCandidate["category"] | null,
 ) {
   return value === "spirit" ? null : value;
 }

--- a/packages/bottle-classifier/src/priceMatchingEvidence.ts
+++ b/packages/bottle-classifier/src/priceMatchingEvidence.ts
@@ -483,10 +483,7 @@ function getCategoryKeywords(value: string): string[] {
 // The legacy `spirit` bucket is a fallback for missing whisky category data,
 // so it should not count as either supportive identity evidence or a conflict.
 function normalizeComparableCategory(
-  value:
-    | BottleCandidate["category"]
-    | BottleExtractedDetails["category"]
-    | null,
+  value: BottleCandidate["category"] | null,
 ) {
   return value === "spirit" ? null : value;
 }

--- a/packages/bottle-classifier/tsconfig.json
+++ b/packages/bottle-classifier/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@peated/tsconfig/internal.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
+    "rootDir": "src",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
     "lib": ["ESNext", "DOM"]
   },

--- a/packages/design/tsconfig.json
+++ b/packages/design/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@peated/tsconfig/internal.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
+    "rootDir": "src",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json"
   },
   "include": ["src"],

--- a/packages/email/tsconfig.json
+++ b/packages/email/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "extends": "@peated/tsconfig/internal.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
+    "rootDir": "src",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
     "paths": {
-      "@peated/email": ["src/*"]
+      "@peated/email": ["./src/*"]
     }
   },
   "include": ["src"],

--- a/packages/entity-classifier/tsconfig.json
+++ b/packages/entity-classifier/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@peated/tsconfig/internal.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
+    "rootDir": "src",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
     "lib": ["ESNext", "DOM"]
   },

--- a/packages/orpc/tsconfig.json
+++ b/packages/orpc/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "extends": "@peated/tsconfig/internal.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "outDir": "dist",
+    "rootDir": "src",
     "tsBuildInfoFile": "node_modules/.cache/tsbuildinfo.json",
     "lib": ["ESNext", "DOM"]
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,12 @@ importers:
         specifier: 'catalog:'
         version: 5.9.3
     devDependencies:
+      '@ast-grep/cli':
+        specifier: 0.45.0
+        version: 0.45.0
+      '@tanstack/eslint-plugin-query':
+        specifier: 5.101.4
+        version: 5.101.4(eslint@10.8.0(jiti@1.21.7))(typescript@5.9.3)
       github-actionlint:
         specifier: 1.7.12
         version: 1.7.12
@@ -149,7 +155,10 @@ importers:
         version: 14.0.1
       oxlint:
         specifier: ^1.72.0
-        version: 1.72.0
+        version: 1.72.0(oxlint-tsgolint@7.0.2001)
+      oxlint-tsgolint:
+        specifier: 7.0.2001
+        version: 7.0.2001
       prettier:
         specifier: 'catalog:'
         version: 3.8.1
@@ -828,6 +837,53 @@ packages:
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@ast-grep/cli-darwin-arm64@0.45.0':
+    resolution: {integrity: sha512-/GqKTawC6/g9k+NDr0u3PvJ0LJkmY5NH4GfvwrgmB8HjRVOoUXWQx5vVzZoEVrAcTogfNWEMs4I5Gdh+glQvPw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ast-grep/cli-darwin-x64@0.45.0':
+    resolution: {integrity: sha512-SvcLPpOX2HaPepwuuSzTRdnrlcaVprQGdwuoW00+KWRjGZJj5z0WGIY84wjfTYhzUxaN5+z4GlCwLGgn0ojMzw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/cli-linux-arm64-gnu@0.45.0':
+    resolution: {integrity: sha512-N0vVTmASn/YR76BoY1zrIltLJ+PJ/zOv2aszX51Wym1ZA6P75tUPctofXh6KzEpESMdx2DcIDyDWVRi672SaQQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@ast-grep/cli-linux-x64-gnu@0.45.0':
+    resolution: {integrity: sha512-rAMZJzAiBuXMViuJgdPeMZXI9HnqwMCh3ybIoj8dfWBPsAywKgU8vyH4kd/R5fFr/oB4lKVhTJ2/mEBsOQTHaQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@ast-grep/cli-win32-arm64-msvc@0.45.0':
+    resolution: {integrity: sha512-9RMvGHSE7uMGzlrQ296caPUkF5jX3KcWewyUJLqpxtEQVwZUkJ7R2/rSxBhjZeg7dp1+keIgt/vH/7FyIO5Wwg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ast-grep/cli-win32-ia32-msvc@0.45.0':
+    resolution: {integrity: sha512-jkQtIpWYJcorhfoRh99cMyeK+edAaysF2z2MR3bRdCDE8EcNfWfqGuWDcLInXwFWFX739dQ6rq9ev3e9o+owXA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/cli-win32-x64-msvc@0.45.0':
+    resolution: {integrity: sha512-2okmFrV/NP1qBATV21+pFIFiUlh5QbKNzTjCTyuaOhCzt0TwYao/RF5b2VUfsvBMtLqYj4rz69GvcPikznskfg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ast-grep/cli@0.45.0':
+    resolution: {integrity: sha512-OQ4pcktMtg1hcQat/iCpX9r8HJ7mU/2SZVoGHA9id2gEfosvDw5m5RINQXsSRZXQW8bl45FW6FhdK0O2FiKjsw==}
+    engines: {node: '>= 12.0.0'}
+    hasBin: true
 
   '@babel/code-frame@7.24.7':
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
@@ -2204,6 +2260,36 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@eslint-community/eslint-utils@4.10.1':
+    resolution: {integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint/config-array@0.23.5':
+    resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/config-helpers@0.7.0':
+    resolution: {integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/core@1.2.1':
+    resolution: {integrity: sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/object-schema@3.0.5':
+    resolution: {integrity: sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@eslint/plugin-kit@0.7.2':
+    resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   '@faker-js/faker@8.4.1':
     resolution: {integrity: sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0, npm: '>=6.14.13'}
@@ -2289,6 +2375,26 @@ packages:
     resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
     peerDependencies:
       react-hook-form: ^7.55.0
+
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanwhocodes/module-importer@1.0.1':
+    resolution: {integrity: sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==}
+    engines: {node: '>=12.22'}
+
+  '@humanwhocodes/retry@0.4.3':
+    resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
+    engines: {node: '>=18.18'}
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3170,6 +3276,36 @@ packages:
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
+    resolution: {integrity: sha512-CUJEdbSZ54+Xy9OXqOhWLTKZKV0BBiV7C2i/ygyVmXtkUNXx5YCzN8DpSSshTAKktoL7S+tnQ/ftFG/i7X896w==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
+    resolution: {integrity: sha512-pXfBb5BqONCcgrXQNUZWXgiYmRSWJzd97S8i41VVOh6ut0tyo+cJ5FKFpczDHxiVNfj/3e7c9B4MtztNdpIVCw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
+    resolution: {integrity: sha512-roP7zujb/QDPzDwEKsFFpzNHHy91/Y7oX9vQXk78ekyZtcQj1QXDIMH33gjDdHBfRl4K9pZ36xhRgrP4Zr+R8A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
+    resolution: {integrity: sha512-UDezNqdECVmngu2TPnjaS1YoAmcTaBoI5lV9vk3VahBxoi+I5r9k3iJTT7qZoYWOXTD/7T7bNcwRgrocR6BscQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
+    resolution: {integrity: sha512-uJZhqB6pdXLuN+AD1F5082byyQti/NPmJA77GtcFlmT2HzRelqbNls3SaIqxpjdFgvSBF9g0yOKGBkGFg7kX8Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
+    resolution: {integrity: sha512-FkDRm8hx9OwzGQqyWG1tO5QrTLRApff9DzSgpz9QZau37BR8d1VYKOxMLGf6shPZntJFoTwIIJYT68VndYDCog==}
+    cpu: [x64]
+    os: [win32]
 
   '@oxlint/binding-android-arm-eabi@1.72.0':
     resolution: {integrity: sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA==}
@@ -4605,6 +4741,15 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
+  '@tanstack/eslint-plugin-query@5.101.4':
+    resolution: {integrity: sha512-jqAZJWXGd5PthJYH9wmC2O5Ry5xAN2/7zxi9qcANQ+Xix8V5JkqNRjZ8Fh+rYzqzVYGiHqbrHekt+uh38OZVpw==}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ^5.4.0 || ^6.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   '@tanstack/query-core@5.90.20':
     resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
 
@@ -4748,6 +4893,9 @@ packages:
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
+  '@types/esrecurse@4.3.1':
+    resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -4842,6 +4990,43 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@typescript-eslint/project-service@8.65.0':
+    resolution: {integrity: sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.65.0':
+    resolution: {integrity: sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.65.0':
+    resolution: {integrity: sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.65.0':
+    resolution: {integrity: sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.65.0':
+    resolution: {integrity: sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.65.0':
+    resolution: {integrity: sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.65.0':
+    resolution: {integrity: sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -5039,6 +5224,11 @@ packages:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
       acorn: ^8
+
+  acorn-jsx@5.3.2:
+    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
@@ -5296,6 +5486,10 @@ packages:
   brace-expansion@5.0.4:
     resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
     engines: {node: 18 || 20 || >=22}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5863,6 +6057,9 @@ packages:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
 
+  deep-is@0.1.4:
+    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
@@ -6229,6 +6426,36 @@ packages:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
 
+  eslint-scope@9.1.2:
+    resolution: {integrity: sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint-visitor-keys@3.4.3:
+    resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  eslint@10.8.0:
+    resolution: {integrity: sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    hasBin: true
+    peerDependencies:
+      jiti: '*'
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
+  espree@11.2.0:
+    resolution: {integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  esquery@1.7.0:
+    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
+    engines: {node: '>=0.10'}
+
   esrecurse@4.3.0:
     resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
     engines: {node: '>=4.0'}
@@ -6316,6 +6543,9 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
+  fast-levenshtein@2.0.6:
+    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
@@ -6345,6 +6575,10 @@ packages:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
 
+  file-entry-cache@8.0.0:
+    resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
+    engines: {node: '>=16.0.0'}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -6364,6 +6598,13 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  flat-cache@4.0.1:
+    resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
+    engines: {node: '>=16'}
+
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
@@ -6837,6 +7078,10 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  imurmurhash@0.1.4:
+    resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
+    engines: {node: '>=0.8.19'}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -7171,6 +7416,9 @@ packages:
   json-bigint@1.0.0:
     resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
 
+  json-buffer@3.0.1:
+    resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
+
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
@@ -7182,6 +7430,9 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-stable-stringify-without-jsonify@1.0.1:
+    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -7206,6 +7457,9 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  keyv@4.5.4:
+    resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
   kind-of@3.2.2:
     resolution: {integrity: sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==}
     engines: {node: '>=0.10.0'}
@@ -7215,6 +7469,10 @@ packages:
 
   leaflet@1.9.4:
     resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
+
+  levn@0.4.1:
+    resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
+    engines: {node: '>= 0.8.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -7548,6 +7806,10 @@ packages:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
 
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -7642,6 +7904,9 @@ packages:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  natural-compare@1.4.0:
+    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -7808,6 +8073,10 @@ packages:
   openapi-types@12.1.3:
     resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
 
+  optionator@0.9.4:
+    resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
+    engines: {node: '>= 0.8.0'}
+
   ora@8.2.0:
     resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
     engines: {node: '>=18'}
@@ -7818,6 +8087,10 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  oxlint-tsgolint@7.0.2001:
+    resolution: {integrity: sha512-KjK/XLcXr1DSyonKhsuFqJRiuKqcyG9j3LJ8nkOsrLzGvodBPqzHOKauy10asLMDI0sUpvb+1sxlzff3udZvfg==}
+    hasBin: true
 
   oxlint@1.72.0:
     resolution: {integrity: sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA==}
@@ -8142,6 +8415,10 @@ packages:
     peerDependenciesMeta:
       rxjs:
         optional: true
+
+  prelude-ls@1.2.1:
+    resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
+    engines: {node: '>= 0.8.0'}
 
   prettier-plugin-organize-imports@3.2.4:
     resolution: {integrity: sha512-6m8WBhIp0dfwu0SkgfOxJqh+HpdyfqSSLfKKRZSFbDuEQXDDndb8fTpRWkUrX/uBenkex3MgnVk0J3b3Y5byog==}
@@ -9265,6 +9542,12 @@ packages:
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
+
   ts-debounce@4.0.0:
     resolution: {integrity: sha512-+1iDGY6NmOGidq7i7xZGA4cm8DAa6fqdYcvO5Z6yBevH++Bdo9Qt/mN0TzHUgcCcKv1gmh9+W5dHqz8pMWbCbg==}
 
@@ -9306,6 +9589,10 @@ packages:
   turbo@2.9.14:
     resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
     hasBin: true
+
+  type-check@0.4.0:
+    resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
+    engines: {node: '>= 0.8.0'}
 
   type-fest@0.7.1:
     resolution: {integrity: sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg==}
@@ -9819,6 +10106,10 @@ packages:
   wkx@0.5.0:
     resolution: {integrity: sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==}
 
+  word-wrap@1.2.5:
+    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
+    engines: {node: '>=0.10.0'}
+
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -9938,6 +10229,39 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
       lru-cache: 10.4.3
     optional: true
+
+  '@ast-grep/cli-darwin-arm64@0.45.0':
+    optional: true
+
+  '@ast-grep/cli-darwin-x64@0.45.0':
+    optional: true
+
+  '@ast-grep/cli-linux-arm64-gnu@0.45.0':
+    optional: true
+
+  '@ast-grep/cli-linux-x64-gnu@0.45.0':
+    optional: true
+
+  '@ast-grep/cli-win32-arm64-msvc@0.45.0':
+    optional: true
+
+  '@ast-grep/cli-win32-ia32-msvc@0.45.0':
+    optional: true
+
+  '@ast-grep/cli-win32-x64-msvc@0.45.0':
+    optional: true
+
+  '@ast-grep/cli@0.45.0':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@ast-grep/cli-darwin-arm64': 0.45.0
+      '@ast-grep/cli-darwin-x64': 0.45.0
+      '@ast-grep/cli-linux-arm64-gnu': 0.45.0
+      '@ast-grep/cli-linux-x64-gnu': 0.45.0
+      '@ast-grep/cli-win32-arm64-msvc': 0.45.0
+      '@ast-grep/cli-win32-ia32-msvc': 0.45.0
+      '@ast-grep/cli-win32-x64-msvc': 0.45.0
 
   '@babel/code-frame@7.24.7':
     dependencies:
@@ -11434,6 +11758,36 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0(jiti@1.21.7))':
+    dependencies:
+      eslint: 10.8.0(jiti@1.21.7)
+      eslint-visitor-keys: 3.4.3
+
+  '@eslint-community/regexpp@4.12.2': {}
+
+  '@eslint/config-array@0.23.5':
+    dependencies:
+      '@eslint/object-schema': 3.0.5
+      debug: 4.4.3
+      minimatch: 10.2.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@eslint/config-helpers@0.7.0':
+    dependencies:
+      '@eslint/core': 1.2.1
+
+  '@eslint/core@1.2.1':
+    dependencies:
+      '@types/json-schema': 7.0.15
+
+  '@eslint/object-schema@3.0.5': {}
+
+  '@eslint/plugin-kit@0.7.2':
+    dependencies:
+      '@eslint/core': 1.2.1
+      levn: 0.4.1
+
   '@faker-js/faker@8.4.1': {}
 
   '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)':
@@ -11563,6 +11917,22 @@ snapshots:
     dependencies:
       '@standard-schema/utils': 0.3.0
       react-hook-form: 7.78.0(react@19.2.7)
+
+  '@humanfs/core@0.19.2':
+    dependencies:
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
+      '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
+
+  '@humanwhocodes/module-importer@1.0.1': {}
+
+  '@humanwhocodes/retry@0.4.3': {}
 
   '@img/colour@1.1.0':
     optional: true
@@ -12636,6 +13006,24 @@ snapshots:
       - ws
 
   '@oxc-project/types@0.124.0': {}
+
+  '@oxlint-tsgolint/darwin-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/darwin-x64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/linux-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/linux-x64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/win32-arm64@7.0.2001':
+    optional: true
+
+  '@oxlint-tsgolint/win32-x64@7.0.2001':
+    optional: true
 
   '@oxlint/binding-android-arm-eabi@1.72.0':
     optional: true
@@ -13949,6 +14337,15 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.19(ts-node@10.9.2(@types/node@24.13.2)(typescript@5.9.3))
 
+  '@tanstack/eslint-plugin-query@5.101.4(eslint@10.8.0(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/utils': 8.65.0(eslint@10.8.0(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 10.8.0(jiti@1.21.7)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@tanstack/query-core@5.90.20': {}
 
   '@tanstack/react-query-next-experimental@5.91.0(@tanstack/react-query@5.90.21(react@19.2.7))(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
@@ -14087,6 +14484,8 @@ snapshots:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
+  '@types/esrecurse@4.3.1': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
@@ -14192,6 +14591,57 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 24.13.2
+
+  '@typescript-eslint/project-service@8.65.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.65.0
+      debug: 4.4.3
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.65.0':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
+
+  '@typescript-eslint/tsconfig-utils@8.65.0(typescript@5.9.3)':
+    dependencies:
+      typescript: 5.9.3
+
+  '@typescript-eslint/types@8.65.0': {}
+
+  '@typescript-eslint/typescript-estree@8.65.0(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.65.0(typescript@5.9.3)
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/visitor-keys': 8.65.0
+      debug: 4.4.3
+      minimatch: 10.2.4
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.65.0(eslint@10.8.0(jiti@1.21.7))(typescript@5.9.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@1.21.7))
+      '@typescript-eslint/scope-manager': 8.65.0
+      '@typescript-eslint/types': 8.65.0
+      '@typescript-eslint/typescript-estree': 8.65.0(typescript@5.9.3)
+      eslint: 10.8.0(jiti@1.21.7)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.65.0':
+    dependencies:
+      '@typescript-eslint/types': 8.65.0
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -14499,6 +14949,10 @@ snapshots:
     dependencies:
       acorn: 8.17.0
 
+  acorn-jsx@5.3.2(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn-walk@8.3.5:
     dependencies:
       acorn: 8.17.0
@@ -14777,6 +15231,10 @@ snapshots:
       balanced-match: 1.0.2
 
   brace-expansion@5.0.4:
+    dependencies:
+      balanced-match: 4.0.4
+
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -15363,6 +15821,8 @@ snapshots:
 
   deep-eql@5.0.2: {}
 
+  deep-is@0.1.4: {}
+
   deepmerge@4.3.1: {}
 
   define-data-property@1.1.4:
@@ -15395,8 +15855,7 @@ snapshots:
 
   detect-libc@2.0.3: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -15779,6 +16238,64 @@ snapshots:
       esrecurse: 4.3.0
       estraverse: 4.3.0
 
+  eslint-scope@9.1.2:
+    dependencies:
+      '@types/esrecurse': 4.3.1
+      '@types/estree': 1.0.9
+      esrecurse: 4.3.0
+      estraverse: 5.3.0
+
+  eslint-visitor-keys@3.4.3: {}
+
+  eslint-visitor-keys@5.0.1: {}
+
+  eslint@10.8.0(jiti@1.21.7):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@1.21.7))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5
+      '@eslint/config-helpers': 0.7.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.6
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 1.21.7
+    transitivePeerDependencies:
+      - supports-color
+
+  espree@11.2.0:
+    dependencies:
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
+      eslint-visitor-keys: 5.0.1
+
+  esquery@1.7.0:
+    dependencies:
+      estraverse: 5.3.0
+
   esrecurse@4.3.0:
     dependencies:
       estraverse: 5.3.0
@@ -15892,6 +16409,8 @@ snapshots:
 
   fast-json-stable-stringify@2.1.0: {}
 
+  fast-levenshtein@2.0.6: {}
+
   fast-uri@3.0.6: {}
 
   fast-xml-builder@1.1.0:
@@ -15918,6 +16437,10 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  file-entry-cache@8.0.0:
+    dependencies:
+      flat-cache: 4.0.1
 
   fill-range@7.1.1:
     dependencies:
@@ -15946,6 +16469,13 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  flat-cache@4.0.1:
+    dependencies:
+      flatted: 3.4.4
+      keyv: 4.5.4
+
+  flatted@3.4.4: {}
 
   follow-redirects@1.16.0: {}
 
@@ -16593,6 +17123,8 @@ snapshots:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
 
+  imurmurhash@0.1.4: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -16952,6 +17484,8 @@ snapshots:
     dependencies:
       bignumber.js: 9.3.1
 
+  json-buffer@3.0.1: {}
+
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -16959,6 +17493,8 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
 
@@ -17102,6 +17638,10 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  keyv@4.5.4:
+    dependencies:
+      json-buffer: 3.0.1
+
   kind-of@3.2.2:
     dependencies:
       is-buffer: 1.1.6
@@ -17109,6 +17649,11 @@ snapshots:
   leac@0.6.0: {}
 
   leaflet@1.9.4: {}
+
+  levn@0.4.1:
+    dependencies:
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -17409,6 +17954,10 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.4
 
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
@@ -17493,6 +18042,8 @@ snapshots:
 
   nanoid@3.3.8: {}
 
+  natural-compare@1.4.0: {}
+
   negotiator@1.0.0:
     optional: true
 
@@ -17547,7 +18098,7 @@ snapshots:
 
   node-gyp-build-optional-packages@5.2.2:
     dependencies:
-      detect-libc: 2.0.3
+      detect-libc: 2.1.2
     optional: true
 
   node-releases@2.0.18: {}
@@ -17668,6 +18219,15 @@ snapshots:
 
   openapi-types@12.1.3: {}
 
+  optionator@0.9.4:
+    dependencies:
+      deep-is: 0.1.4
+      fast-levenshtein: 2.0.6
+      levn: 0.4.1
+      prelude-ls: 1.2.1
+      type-check: 0.4.0
+      word-wrap: 1.2.5
+
   ora@8.2.0:
     dependencies:
       chalk: 5.6.2
@@ -17688,7 +18248,16 @@ snapshots:
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
 
-  oxlint@1.72.0:
+  oxlint-tsgolint@7.0.2001:
+    optionalDependencies:
+      '@oxlint-tsgolint/darwin-arm64': 7.0.2001
+      '@oxlint-tsgolint/darwin-x64': 7.0.2001
+      '@oxlint-tsgolint/linux-arm64': 7.0.2001
+      '@oxlint-tsgolint/linux-x64': 7.0.2001
+      '@oxlint-tsgolint/win32-arm64': 7.0.2001
+      '@oxlint-tsgolint/win32-x64': 7.0.2001
+
+  oxlint@1.72.0(oxlint-tsgolint@7.0.2001):
     optionalDependencies:
       '@oxlint/binding-android-arm-eabi': 1.72.0
       '@oxlint/binding-android-arm64': 1.72.0
@@ -17709,6 +18278,7 @@ snapshots:
       '@oxlint/binding-win32-arm64-msvc': 1.72.0
       '@oxlint/binding-win32-ia32-msvc': 1.72.0
       '@oxlint/binding-win32-x64-msvc': 1.72.0
+      oxlint-tsgolint: 7.0.2001
 
   p-defer@1.0.0: {}
 
@@ -18005,6 +18575,8 @@ snapshots:
       '@posthog/core': 1.39.6
     optionalDependencies:
       rxjs: 7.8.1
+
+  prelude-ls@1.2.1: {}
 
   prettier-plugin-organize-imports@3.2.4(prettier@3.8.1)(typescript@5.9.3):
     dependencies:
@@ -19354,6 +19926,10 @@ snapshots:
 
   trough@2.2.0: {}
 
+  ts-api-utils@2.5.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   ts-debounce@4.0.0: {}
 
   ts-interface-checker@0.1.13: {}
@@ -19421,6 +19997,10 @@ snapshots:
       '@turbo/linux-arm64': 2.9.14
       '@turbo/windows-64': 2.9.14
       '@turbo/windows-arm64': 2.9.14
+
+  type-check@0.4.0:
+    dependencies:
+      prelude-ls: 1.2.1
 
   type-fest@0.7.1: {}
 
@@ -19986,6 +20566,8 @@ snapshots:
   wkx@0.5.0:
     dependencies:
       '@types/node': 24.13.2
+
+  word-wrap@1.2.5: {}
 
   wrap-ansi@6.2.0:
     dependencies:

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,4 @@
+ruleDirs:
+  - tools/ast-grep/rules
+testConfigs:
+  - testDir: tools/ast-grep/tests

--- a/tools/ast-grep/rules/no-unvalidated-json-parse-cast.yml
+++ b/tools/ast-grep/rules/no-unvalidated-json-parse-cast.yml
@@ -1,0 +1,16 @@
+id: no-unvalidated-json-parse-cast
+language: TypeScript
+severity: error
+message: Validate parsed JSON at the runtime boundary instead of asserting its type.
+note: Parse unknown JSON with a schema (for example, Zod) before using it as typed data.
+files:
+  - apps/**/src/**/*.ts
+  - packages/**/src/**/*.ts
+ignores:
+  - apps/**/src/**/*.test.ts
+  - packages/**/src/**/*.test.ts
+rule:
+  all:
+    - pattern: JSON.parse($VALUE) as $TYPE
+    - not:
+        pattern: JSON.parse($VALUE) as unknown

--- a/tools/ast-grep/rules/orpc-handler-requires-output.yml
+++ b/tools/ast-grep/rules/orpc-handler-requires-output.yml
@@ -1,0 +1,13 @@
+id: orpc-handler-requires-output
+language: TypeScript
+severity: error
+message: Every oRPC handler must declare an output schema.
+files:
+  - apps/server/src/orpc/routes/**/*.ts
+rule:
+  all:
+    - pattern: $PROCEDURE.handler($HANDLER)
+    - not:
+        has:
+          pattern: $CHAIN.output($SCHEMA)
+          stopBy: end

--- a/tools/ast-grep/rules/orpc-route-requires-operation-id.yml
+++ b/tools/ast-grep/rules/orpc-route-requires-operation-id.yml
@@ -1,0 +1,15 @@
+id: orpc-route-requires-operation-id
+language: TypeScript
+severity: error
+message: Every oRPC route must declare a stable OpenAPI operationId.
+files:
+  - apps/server/src/orpc/routes/**/*.ts
+rule:
+  all:
+    - pattern: $PROCEDURE.route($CONFIG)
+    - not:
+        has:
+          pattern:
+            context: "{ operationId: $ID }"
+            selector: pair
+          stopBy: end

--- a/tools/ast-grep/tests/no-unvalidated-json-parse-cast-test.yml
+++ b/tools/ast-grep/tests/no-unvalidated-json-parse-cast-test.yml
@@ -1,0 +1,7 @@
+id: no-unvalidated-json-parse-cast
+valid:
+  - const data = PayloadSchema.parse(JSON.parse(body));
+  - "const data: unknown = JSON.parse(body);"
+invalid:
+  - const data = JSON.parse(body) as Payload;
+  - "const data = JSON.parse(body) as { items: Item[] };"

--- a/tools/ast-grep/tests/orpc-handler-requires-output-test.yml
+++ b/tools/ast-grep/tests/orpc-handler-requires-output-test.yml
@@ -1,0 +1,5 @@
+id: orpc-handler-requires-output
+valid:
+  - procedure.output(ItemSchema).handler(async () => item)
+invalid:
+  - procedure.handler(async () => item)

--- a/tools/ast-grep/tests/orpc-route-requires-operation-id-test.yml
+++ b/tools/ast-grep/tests/orpc-route-requires-operation-id-test.yml
@@ -1,0 +1,14 @@
+id: orpc-route-requires-operation-id
+valid:
+  - |
+    procedure.route({
+      method: "GET",
+      path: "/items",
+      spec: (spec) => ({ ...spec, operationId: "listItems" }),
+    })
+invalid:
+  - |
+    procedure.route({
+      method: "GET",
+      path: "/items",
+    })


### PR DESCRIPTION
Oxlint is now a type-aware required CI gate with TanStack Query, promise, React dependency, accessibility, Vitest, and React Compiler checks. Project-level ast-grep rules additionally enforce runtime validation for parsed JSON and stable oRPC output schemas and operation IDs. The wider code diff resolves the concrete issues exposed by that enforcement, including unawaited database work, unstable query options and effects, missing error causes, unsafe SMWS payload assertions, and inaccessible interactive elements.

Review should start with the lint/CI configuration and ast-grep rules, then treat the application edits as compliance fixes. React Compiler and selected type-aware diagnostics intentionally remain warnings as a visible backlog; the high-signal rules fail CI. Local lint, all package typechecks, ast-grep rule tests, web tests, CLI tests, and targeted server tests pass. The aggregate run encountered PostgreSQL connection termination, and all six implicated server files passed together on a clean rerun.
