### PR TITLE
fix(web): clarify incorrect bottle match action

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -506,9 +506,7 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("link", { name: "View Bottle" }),
     ).toHaveAttribute("href", `/bottles/${existingBottle.id}`);
-    await expect(
-      page.getByRole("link", { name: "Add Similar" }),
-    ).toHaveAttribute("href", `/bottles/${existingBottle.id}/addRelease`);
+    await expect(page.getByRole("link", { name: "Add Similar" })).toBeHidden();
     await expect(
       page.getByRole("link", { name: "Search Bottles" }),
     ).toHaveAttribute("href", "/search?intent=addBottle");
@@ -722,7 +720,13 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("button", { name: "Log Tasting" }),
     ).toBeVisible();
-    await expect(page.getByRole("link", { name: "Add Similar" })).toBeVisible();
+    await expect(page.getByRole("link", { name: "Add Similar" })).toBeHidden();
+    await expect(
+      page.getByRole("heading", { name: "Not the right bottle?" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Create New Bottle" }),
+    ).toBeVisible();
     await expect(
       page.getByRole("link", { name: "View Bottle" }),
     ).toHaveAttribute("href", `/bottles/${existingBottle.id}`);
@@ -1347,7 +1351,7 @@ test.describe("add bottle flow", () => {
       page.getByRole("button", { name: "Add to Library" }),
     ).toBeVisible();
     const createBottleLink = page.getByRole("link", {
-      name: "Create Bottle",
+      name: "Create New Bottle",
     });
     await expect(createBottleLink).toBeVisible();
 

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -30,10 +30,7 @@ import TastingForm, {
 } from "@peated/web/components/tastingForm";
 import useAuth from "@peated/web/hooks/useAuth";
 import { AuthRequired } from "@peated/web/hooks/useAuthRequired";
-import {
-  getAddSimilarBottlePath,
-  getPendingImageFromParams,
-} from "@peated/web/lib/addBottle";
+import { getPendingImageFromParams } from "@peated/web/lib/addBottle";
 import { toBlob } from "@peated/web/lib/blobs";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { logError } from "@peated/web/lib/log";
@@ -180,7 +177,7 @@ function CollectionBottlePanel({ entry }: { entry: CollectionBottle }) {
 function LoadingBottlePanel() {
   return (
     <Layout footer={null} header={<FlowHeader>{null}</FlowHeader>}>
-      <div className="mx-auto mt-5 max-w-3xl">
+      <div className="mx-auto mt-5 max-w-3xl px-4 lg:px-0">
         <Spinner />
       </div>
     </Layout>
@@ -202,7 +199,7 @@ function BottleLoadErrorPanel({
 }) {
   return (
     <Layout footer={null} header={<FlowHeader>{null}</FlowHeader>}>
-      <div className="mx-auto mt-5 max-w-3xl space-y-5">
+      <div className="mx-auto mt-5 max-w-3xl space-y-5 px-4 lg:px-0">
         <FormError values={[message]} />
         <div className="grid gap-3 sm:grid-cols-2">
           <Button
@@ -319,31 +316,12 @@ function MatchedOutcomeActions({
       View Bottle
     </OutcomeButton>
   );
-  const addSimilarBottleButton = (
-    <OutcomeButton
-      key="similar-bottle"
-      href={getAddSimilarBottlePath(bottle.id)}
-      icon={<Plus className="h-4 w-4" />}
-    >
-      Add Similar
-    </OutcomeButton>
-  );
   const actionButtons =
     intent === "tasting"
-      ? [
-          tastingButton,
-          libraryButton,
-          viewButton,
-          addSimilarBottleButton,
-        ].filter(Boolean)
-      : [
-          libraryButton,
-          tastingButton,
-          viewButton,
-          addSimilarBottleButton,
-        ].filter(Boolean);
+      ? [tastingButton, libraryButton, viewButton]
+      : [libraryButton, tastingButton, viewButton];
 
-  return <div className="grid gap-3 sm:grid-cols-4">{actionButtons}</div>;
+  return <div className="grid gap-3 sm:grid-cols-3">{actionButtons}</div>;
 }
 
 function CreateProposalOutcomeActions({
@@ -462,33 +440,14 @@ function OutcomeSelection({
       View Bottle
     </OutcomeButton>
   );
-  const addSimilarBottleButton = wasCreated ? null : (
-    <OutcomeButton
-      key="similar-bottle"
-      href={getAddSimilarBottlePath(selection.bottle.id)}
-      icon={<Plus className="h-4 w-4" />}
-    >
-      Add Similar
-    </OutcomeButton>
-  );
   const actionButtons =
     intent === "tasting"
-      ? [
-          tastingButton,
-          libraryButton,
-          viewButton,
-          addSimilarBottleButton,
-        ].filter(Boolean)
-      : [
-          libraryButton,
-          tastingButton,
-          viewButton,
-          addSimilarBottleButton,
-        ].filter(Boolean);
+      ? [tastingButton, libraryButton, viewButton]
+      : [libraryButton, tastingButton, viewButton];
 
   return (
     <Layout footer={null} header={<FlowHeader>{null}</FlowHeader>}>
-      <div className="mx-auto mt-5 max-w-3xl space-y-5">
+      <div className="mx-auto mt-5 max-w-3xl space-y-5 px-4 lg:px-0">
         <BottlePanel
           bottle={selection.bottle}
           previewUrl={selection.previewUrl}
@@ -512,11 +471,7 @@ function OutcomeSelection({
               <h2 className="font-semibold text-white">{title}</h2>
               <p className="text-muted mt-1 text-sm">{description}</p>
             </div>
-            <div
-              className={`grid gap-3 ${wasCreated ? "sm:grid-cols-3" : "sm:grid-cols-4"}`}
-            >
-              {actionButtons}
-            </div>
+            <div className="grid gap-3 sm:grid-cols-3">{actionButtons}</div>
           </div>
         </section>
         <div className="grid gap-3 sm:grid-cols-2">
@@ -565,7 +520,7 @@ function AddedToLibrary({
 }) {
   return (
     <Layout footer={null} header={<FlowHeader>{null}</FlowHeader>}>
-      <div className="mx-auto mt-5 max-w-3xl space-y-5">
+      <div className="mx-auto mt-5 max-w-3xl space-y-5 px-4 lg:px-0">
         <section className="rounded border border-slate-800 bg-slate-950/50 p-4 lg:p-6">
           <div className="space-y-5">
             <div className="flex items-start gap-3">

--- a/apps/web/src/components/bottleResolver/index.tsx
+++ b/apps/web/src/components/bottleResolver/index.tsx
@@ -443,7 +443,7 @@ export default function BottleResolver({
         onChange={onFileChange}
       />
 
-      <div className="mx-auto mt-5 max-w-3xl space-y-5">
+      <div className="mx-auto mt-5 max-w-3xl space-y-5 px-4 lg:px-0">
         {!previewUrl && !photoResult && !isIdentifying && (
           <PhotoUploadState
             searchHref={defaultSearchHref}
@@ -518,6 +518,15 @@ export default function BottleResolver({
                 searchHref={searchHref}
                 searchLabel={searchActionLabel}
                 createBottleHref={matchedBottle ? createBottleHref : null}
+                createBottleLabel={
+                  matchedBottle ? "Create New Bottle" : undefined
+                }
+                title={matchedBottle ? "Not the right bottle?" : undefined}
+                description={
+                  matchedBottle
+                    ? "Search for the correct bottle or create a new one using the details from this label."
+                    : undefined
+                }
                 showStartOver
                 onStartOver={startOver}
               />

--- a/apps/web/src/components/bottleResolver/panels.test.tsx
+++ b/apps/web/src/components/bottleResolver/panels.test.tsx
@@ -1,0 +1,24 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { FallbackActions } from "./panels";
+
+describe("FallbackActions", () => {
+  it("presents an explicit create path when a matched bottle is incorrect", () => {
+    const html = renderToStaticMarkup(
+      <FallbackActions
+        searchHref="/search"
+        searchLabel="Search Bottles"
+        createBottleHref="/bottles/new?pendingImageId=scan"
+        createBottleLabel="Create New Bottle"
+        title="Not the right bottle?"
+        description="Create a new one using the details from this label."
+      />,
+    );
+
+    expect(html).toContain("Not the right bottle?");
+    expect(html).toContain("Create New Bottle");
+    expect(html).toContain("/bottles/new?pendingImageId=scan");
+    expect(html).not.toContain("Add Similar");
+  });
+});

--- a/apps/web/src/components/bottleResolver/panels.tsx
+++ b/apps/web/src/components/bottleResolver/panels.tsx
@@ -376,6 +376,8 @@ export function FallbackActions({
   searchLabel,
   createBottleHref,
   createBottleLabel = "Create Bottle",
+  title,
+  description,
   onStartOver,
   showStartOver = false,
 }: {
@@ -383,6 +385,8 @@ export function FallbackActions({
   searchLabel: string;
   createBottleHref?: string | null;
   createBottleLabel?: string;
+  title?: string;
+  description?: string;
   onStartOver?: () => void;
   showStartOver?: boolean;
 }) {
@@ -390,8 +394,17 @@ export function FallbackActions({
     (createBottleHref ? 1 : 0) + (showStartOver && onStartOver ? 1 : 0) + 1;
 
   return (
-    <div className="space-y-3">
-      <OrDivider />
+    <div className="space-y-3 px-4 lg:px-6">
+      {title ? (
+        <div>
+          <h2 className="font-semibold text-white">{title}</h2>
+          {description ? (
+            <p className="text-muted mt-1 text-sm">{description}</p>
+          ) : null}
+        </div>
+      ) : (
+        <OrDivider />
+      )}
       <div
         className={`mx-auto grid w-full gap-3 ${
           columnCount >= 3 ? "sm:grid-cols-3" : "sm:w-1/2 sm:grid-cols-2"

--- a/docs/features/bottle-entry-workflow.md
+++ b/docs/features/bottle-entry-workflow.md
@@ -41,6 +41,10 @@ identity remains unresolved.
 
 - Add Bottle accepts shared and exact fields in one submission and always
   creates a Bottle, never a child release record.
+- When photo identification matches an existing Bottle, the result presents an
+  explicit “Not the right bottle?” recovery path. Manual creation uses the
+  scanned label details and pending photo rather than cloning the matched
+  Bottle.
 - “Add a similar bottle” uses the selected Bottle and its group's shared label
   only to prefill the same independent form. Submission does not carry source
   Bottle or group authority and starts in a new singleton group.


### PR DESCRIPTION
Matched bottle results now separate actions for the proposed match from recovery when the match is wrong. The Add Bottle flow removes the ambiguous “Add Similar” action and presents “Not the right bottle?” with search and “Create New Bottle”; manual creation keeps the scanned label details and pending photo. “Add a similar bottle” remains available from bottle detail pages as a template-oriented action.

The resolver and subsequent Add Bottle states now use consistent mobile gutters, and the recovery controls align with the matched card’s content at desktop widths. Focused web coverage passes (176 tests), and the matched-scan flow was verified in Chromium at 1440×900 and 390×844 with no horizontal overflow.
