### PR TITLE
fix(web): clarify bottle distillery attribution

### DIFF
--- a/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/page.tsx
+++ b/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/page.tsx
@@ -54,7 +54,10 @@ export default function Page(props: { params: Promise<{ flightId: string }> }) {
                           />
                         </div>
                         <div className="text-muted flex flex-row items-start space-x-1 truncate">
-                          <Distillers distillers={bottle.distillers} />
+                          <Distillers
+                            distillers={bottle.distillers}
+                            isBlend={bottle.category === "blend"}
+                          />
                         </div>
                         {bottle.description}
                       </td>

--- a/apps/web/src/components/bottleHeader.test.tsx
+++ b/apps/web/src/components/bottleHeader.test.tsx
@@ -107,7 +107,34 @@ describe("BottleHeader", () => {
     expect(text).not.toContain("Distilled at");
   });
 
-  it("retains distinct distiller attribution", () => {
+  it("uses production wording for a non-blend distiller", () => {
+    const bottle = {
+      id: 42,
+      fullName: "Compass Box Orchard House",
+      name: "Orchard House",
+      group: { name: "Orchard House" },
+      brand: { id: 7, name: "Compass Box", shortName: null },
+      distillers: [{ id: 8, name: "Clynelish" }],
+      edition: null,
+      category: "single_malt",
+      statedAge: null,
+      abv: 46,
+      vintageYear: null,
+      releaseYear: null,
+      singleCask: false,
+      caskStrength: false,
+      caskFill: null,
+      caskType: null,
+      caskSize: null,
+    } as unknown as Bottle;
+
+    const html = renderToStaticMarkup(<BottleHeader bottle={bottle} />);
+    const text = html.replace(/<[^>]*>/g, "");
+
+    expect(text).toContain("Distilled atClynelish");
+  });
+
+  it("uses provenance wording for a blend with one known distillery", () => {
     const bottle = {
       id: 42,
       fullName: "Compass Box Orchard House",
@@ -131,7 +158,46 @@ describe("BottleHeader", () => {
     const html = renderToStaticMarkup(<BottleHeader bottle={bottle} />);
     const text = html.replace(/<[^>]*>/g, "");
 
-    expect(text).toContain("Distilled atClynelish");
+    expect(text).toContain("DistilleryClynelish");
+    expect(text).not.toContain("Distilled at");
+  });
+
+  it("shows every distiller name in the multi-distiller tooltip", () => {
+    const bottle = {
+      id: 42,
+      fullName: "Compass Box Seven Distilleries",
+      name: "Seven Distilleries",
+      group: { name: "Seven Distilleries" },
+      brand: { id: 7, name: "Compass Box", shortName: null },
+      distillers: [
+        { id: 1, name: "Aberlour" },
+        { id: 2, name: "Clynelish" },
+        { id: 3, name: "Dailuaine" },
+        { id: 4, name: "Glen Elgin" },
+        { id: 5, name: "Linkwood" },
+        { id: 6, name: "Mortlach" },
+        { id: 7, name: "Teaninich" },
+      ],
+      edition: null,
+      category: "blend",
+      statedAge: null,
+      abv: 46,
+      vintageYear: null,
+      releaseYear: null,
+      singleCask: false,
+      caskStrength: false,
+      caskFill: null,
+      caskType: null,
+      caskSize: null,
+    } as unknown as Bottle;
+
+    const html = renderToStaticMarkup(<BottleHeader bottle={bottle} />);
+    const text = html.replace(/<[^>]*>/g, "");
+
+    expect(text).toContain("7 distilleries");
+    for (const distillery of bottle.distillers) {
+      expect(text).toContain(distillery.name);
+    }
   });
 
   it("does not add a chip when Single Cask is already in the title", () => {

--- a/apps/web/src/components/bottleHeader.tsx
+++ b/apps/web/src/components/bottleHeader.tsx
@@ -88,7 +88,10 @@ export default function BottleHeader({
             />
             {distinctDistillers.length ? (
               <div className="text-muted mt-1 text-sm">
-                <Distillers distillers={distinctDistillers} />
+                <Distillers
+                  distillers={distinctDistillers}
+                  isBlend={bottle.category === "blend"}
+                />
               </div>
             ) : null}
           </div>

--- a/apps/web/src/components/bottleMetadata.tsx
+++ b/apps/web/src/components/bottleMetadata.tsx
@@ -61,14 +61,42 @@ export const Brand = ({ data: { brand } }: Props) => {
   );
 };
 
-export const Distillers = ({ distillers }: { distillers?: Distiller[] }) => {
+export const Distillers = ({
+  distillers,
+  isBlend = false,
+}: {
+  distillers?: Distiller[];
+  isBlend?: boolean;
+}) => {
   if (!distillers?.length) return null;
 
   if (distillers.length > 1) {
     return (
-      <Tooltip title={distillers.map((d) => d.name).join(", ")} origin="center">
+      <Tooltip
+        title={
+          <div>
+            <div className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+              {isBlend ? "Distilleries" : "Distillers"}
+            </div>
+            <ul className="grid grid-cols-2 gap-x-4 gap-y-1.5">
+              {distillers.map((distiller) => (
+                <li key={distiller.id}>
+                  <Link
+                    href={`/entities/${distiller.id}`}
+                    className="block text-slate-200 hover:text-white hover:underline"
+                  >
+                    {distiller.name}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        }
+        contentClassName="w-72 max-w-[calc(100vw-2rem)] rounded-lg border border-slate-700 bg-slate-900 p-3 text-left text-sm shadow-xl"
+        origin="center"
+      >
         <span className="underline decoration-dotted">
-          {distillers.length} distillers
+          {distillers.length} {isBlend ? "distilleries" : "distillers"}
         </span>
       </Tooltip>
     );
@@ -77,7 +105,7 @@ export const Distillers = ({ distillers }: { distillers?: Distiller[] }) => {
   const d = distillers[0];
   return (
     <div className="space-x-1">
-      <span>Distilled at</span>
+      <span>{isBlend ? "Distillery" : "Distilled at"}</span>
       <Link
         key={d.id}
         href={`/entities/${d.id}`}

--- a/apps/web/src/components/pageHeader.test.tsx
+++ b/apps/web/src/components/pageHeader.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import PageHeader from "./pageHeader";
+
+describe("PageHeader", () => {
+  it("allows title extras such as tooltips to overflow the title wrapper", () => {
+    const html = renderToStaticMarkup(
+      <PageHeader title="Bottle name" titleExtra={<span>Tooltip</span>} />,
+    );
+
+    expect(html).toContain(
+      'class="flex min-w-0 flex-auto flex-col items-center justify-center lg:w-auto lg:items-start"',
+    );
+    expect(html).toContain(
+      'class="max-w-full truncate text-center font-semibold lg:mx-0 lg:text-left text-2xl"',
+    );
+  });
+});

--- a/apps/web/src/components/pageHeader.tsx
+++ b/apps/web/src/components/pageHeader.tsx
@@ -29,7 +29,7 @@ export default function PageHeader({
         </div>
       )}
 
-      <div className="flex flex-auto flex-col items-center justify-center truncate lg:w-auto lg:items-start">
+      <div className="flex min-w-0 flex-auto flex-col items-center justify-center lg:w-auto lg:items-start">
         <h1
           className={classNames(
             "max-w-full truncate text-center font-semibold lg:mx-0 lg:text-left",

--- a/apps/web/src/components/tooltip.test.tsx
+++ b/apps/web/src/components/tooltip.test.tsx
@@ -1,0 +1,28 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import Tooltip from "./tooltip";
+
+describe("Tooltip", () => {
+  it("centers a centered tooltip over its trigger", () => {
+    const html = renderToStaticMarkup(
+      <Tooltip title="Tooltip content" origin="center">
+        <span>Trigger</span>
+      </Tooltip>,
+    );
+
+    expect(html).toContain("z-10");
+    expect(html).toContain("left-1/2 -translate-x-1/2");
+  });
+
+  it("allows a caller to style the tooltip panel", () => {
+    const html = renderToStaticMarkup(
+      <Tooltip title="Tooltip content" contentClassName="w-72 rounded-lg">
+        <span>Trigger</span>
+      </Tooltip>,
+    );
+
+    expect(html).toContain("w-72 rounded-lg");
+    expect(html).not.toContain("w-48 max-w-48");
+  });
+});

--- a/apps/web/src/components/tooltip.tsx
+++ b/apps/web/src/components/tooltip.tsx
@@ -9,6 +9,7 @@ type Props = {
   title: ReactNode;
   children?: ReactNode;
   className?: string;
+  contentClassName?: string;
   origin?: "left" | "right" | "center";
   style?: Record<string, any>;
 };
@@ -18,6 +19,7 @@ export default function Tooltip({
   children,
   origin = "right",
   className,
+  contentClassName,
   style,
 }: Props) {
   const ref = useRef<HTMLSpanElement>(null);
@@ -39,10 +41,12 @@ export default function Tooltip({
       {children}
       <span
         className={classNames(
-          "absolute top-6 w-48 max-w-48 scale-0 items-center justify-center rounded bg-slate-700 p-2 text-center text-xs text-slate-400 transition-all group-hover:scale-100 group-focus:scale-100 group-active:scale-100",
+          "absolute top-6 z-10 scale-0 transition-all group-hover:scale-100 group-focus:scale-100 group-active:scale-100",
+          contentClassName ||
+            "w-48 max-w-48 rounded bg-slate-700 p-2 text-center text-xs text-slate-400",
           origin === "right" ? "right-0" : "",
           origin === "left" ? "left-0" : "",
-          // origin === "center" ? "-right-1/2" : "",
+          origin === "center" ? "left-1/2 -translate-x-1/2" : "",
           visible ? "scale-100" : "",
         )}
         ref={ref}


### PR DESCRIPTION
Blend bottle headers now label one known source as `Distillery` and summarize multiple sources as `N distilleries`; hovering or focusing the summary opens a readable, linked two-column list. Non-blends retain `Distilled at` and `N distillers`, and the flight overlay uses the same semantics.

This also fixes the page-header overflow that clipped tooltip content and corrects centered tooltip positioning while preserving bottle-title truncation. Component tests cover the wording, complete tooltip contents, overflow behavior, and positioning; web typecheck, 10 targeted Vitest tests, Prettier, oxlint, and desktop/mobile browser QA passed.
