### PR TITLE
feat(profile): add Overview insights

### DIFF
--- a/apps/server/src/orpc/routes/users/library-stats.test.ts
+++ b/apps/server/src/orpc/routes/users/library-stats.test.ts
@@ -22,6 +22,8 @@ describe("GET /users/:user/library/stats", () => {
 
     expect(data).toMatchObject({
       total: 0,
+      status: { open: 0, sealed: 0, unspecified: 0 },
+      brands: [],
       distillers: [],
       age: {
         knownCount: 0,
@@ -47,19 +49,29 @@ describe("GET /users/:user/library/stats", () => {
     });
     const distillerA = await fixtures.Entity({ name: "Alpha Distillery" });
     const distillerB = await fixtures.Entity({ name: "Beta Distillery" });
+    const brandA = await fixtures.Entity({ name: "Alpha Brand" });
+    const brandB = await fixtures.Entity({ name: "Beta Brand" });
     const youngBottle = await fixtures.Bottle({
+      brandId: brandA.id,
+      name: "Young Release",
       category: "single_malt",
       statedAge: 8,
     });
     const twelveYearBottle = await fixtures.Bottle({
+      brandId: brandA.id,
+      name: "Twelve Year Release",
       category: "bourbon",
       statedAge: 12,
     });
     const oldBottle = await fixtures.Bottle({
+      brandId: brandA.id,
+      name: "Old Release",
       category: "single_malt",
       statedAge: 25,
     });
     const unstatedBottle = await fixtures.Bottle({
+      brandId: brandB.id,
+      name: "Unstated Release",
       category: "rye",
       statedAge: null,
     });
@@ -118,6 +130,11 @@ describe("GET /users/:user/library/stats", () => {
     );
 
     expect(data.total).toBe(4);
+    expect(data.status).toEqual({ open: 2, sealed: 1, unspecified: 1 });
+    expect(data.brands).toEqual([
+      { id: brandA.id, name: brandA.name, count: 3 },
+      { id: brandB.id, name: brandB.name, count: 1 },
+    ]);
     expect(data.distillers).toEqual([
       { id: distillerA.id, name: distillerA.name, count: 2 },
       { id: distillerB.id, name: distillerB.name, count: 1 },
@@ -333,8 +350,9 @@ describe("GET /users/:user/library/stats", () => {
       { context: { user: defaults.user } },
     );
 
-    expect(data).toEqual({
+    expect(data).toMatchObject({
       total: 201,
+      status: { open: 198, sealed: 3, unspecified: 0 },
       distillers: [
         { id: distillerA.id, name: distillerA.name, count: 2 },
         { id: distillerB.id, name: distillerB.name, count: 1 },

--- a/apps/server/src/orpc/routes/users/library-stats.ts
+++ b/apps/server/src/orpc/routes/users/library-stats.ts
@@ -23,6 +23,18 @@ const LIBRARY_STATS_BATCH_SIZE = 200;
 
 const LibraryStatsSchema = z.object({
   total: z.number(),
+  status: z.object({
+    open: z.number(),
+    sealed: z.number(),
+    unspecified: z.number(),
+  }),
+  brands: z.array(
+    z.object({
+      id: z.number(),
+      name: z.string(),
+      count: z.number(),
+    }),
+  ),
   distillers: z.array(
     z.object({
       id: z.number(),
@@ -45,13 +57,24 @@ type LibraryStatsAccumulator = {
   total: number;
   ages: number[];
   categoryCounts: Map<Category, number>;
+  brandCounts: Map<number, number>;
   distillerCounts: Map<number, number>;
+  status: {
+    open: number;
+    sealed: number;
+    unspecified: number;
+  };
   unstatedAgeCount: number;
 };
-type LibraryBottleRead = UserBottleRead & { distillerIds: number[] };
+type LibraryBottleRead = UserBottleRead & {
+  distillerIds: number[];
+  status: "open" | "sealed" | "empty" | null;
+};
 
 const emptyStats: LibraryStats = {
   total: 0,
+  status: { open: 0, sealed: 0, unspecified: 0 },
+  brands: [],
   distillers: [],
   age: {
     knownCount: 0,
@@ -78,7 +101,9 @@ function createLibraryStatsAccumulator(): LibraryStatsAccumulator {
     total: 0,
     ages: [],
     categoryCounts: new Map(),
+    brandCounts: new Map(),
     distillerCounts: new Map(),
+    status: { open: 0, sealed: 0, unspecified: 0 },
     unstatedAgeCount: 0,
   };
 }
@@ -103,31 +128,26 @@ function accumulateLibraryStats(
     if (bottle.category !== null) {
       incrementCount(accumulator.categoryCounts, bottle.category);
     }
+    incrementCount(accumulator.brandCounts, bottle.brandId);
     for (const distillerId of bottle.distillerIds) {
       incrementCount(accumulator.distillerCounts, distillerId);
     }
+    if (bottle.status === "open") accumulator.status.open += 1;
+    else if (bottle.status === "sealed") accumulator.status.sealed += 1;
+    else accumulator.status.unspecified += 1;
   }
 }
 
-async function finalizeLibraryStats(
-  accumulator: LibraryStatsAccumulator,
-): Promise<LibraryStats> {
-  const distillerIds = Array.from(accumulator.distillerCounts.keys());
-  const distillerList = distillerIds.length
-    ? await db.query.entities.findMany({
-        where: inArray(entities.id, distillerIds),
-        columns: { id: true, name: true },
-      })
-    : [];
-  const distillersById = new Map(
-    distillerList.map((distiller) => [distiller.id, distiller]),
-  );
-  const distillers = Array.from(accumulator.distillerCounts, ([id, count]) => {
-    const distiller = distillersById.get(id);
-    if (!distiller) {
-      throw new Error(`Bottle references missing distiller: ${id}`);
+function rankedEntities(
+  counts: Map<number, number>,
+  entitiesById: Map<number, { id: number; name: string }>,
+) {
+  return Array.from(counts, ([id, count]) => {
+    const entity = entitiesById.get(id);
+    if (!entity) {
+      throw new Error(`Bottle references missing entity: ${id}`);
     }
-    return { id, name: distiller.name, count };
+    return { id, name: entity.name, count };
   })
     .sort((left, right) =>
       right.count === left.count
@@ -135,6 +155,26 @@ async function finalizeLibraryStats(
         : right.count - left.count,
     )
     .slice(0, 5);
+}
+
+async function finalizeLibraryStats(
+  accumulator: LibraryStatsAccumulator,
+): Promise<LibraryStats> {
+  const entityIds = Array.from(
+    new Set([
+      ...accumulator.brandCounts.keys(),
+      ...accumulator.distillerCounts.keys(),
+    ]),
+  );
+  const entityList = entityIds.length
+    ? await db.query.entities.findMany({
+        where: inArray(entities.id, entityIds),
+        columns: { id: true, name: true },
+      })
+    : [];
+  const entitiesById = new Map(entityList.map((entity) => [entity.id, entity]));
+  const brands = rankedEntities(accumulator.brandCounts, entitiesById);
+  const distillers = rankedEntities(accumulator.distillerCounts, entitiesById);
   const categories = Array.from(
     accumulator.categoryCounts,
     ([category, count]) => ({
@@ -151,6 +191,8 @@ async function finalizeLibraryStats(
 
   return {
     total: accumulator.total,
+    status: accumulator.status,
+    brands,
     distillers,
     age: buildAgeStats(accumulator.ages, accumulator.unstatedAgeCount),
     categories,
@@ -163,7 +205,7 @@ export default procedure
     path: "/users/{user}/library/stats",
     summary: "Get user Library statistics",
     description:
-      "Retrieve distillery, age, and category insights for non-empty bottles in a visible user's Library",
+      "Retrieve producer, status, age, and category insights for non-empty bottles in a visible user's Library",
     operationId: "getUserLibraryStats",
   })
   .input(
@@ -209,6 +251,7 @@ export default procedure
               statedAge: bottles.statedAge,
             },
             retiredBottleId: bottleTombstones.bottleId,
+            status: collectionBottles.status,
           })
           .from(collectionBottles)
           .leftJoin(bottles, eq(bottles.id, collectionBottles.bottleId))
@@ -247,12 +290,13 @@ export default procedure
         }
         accumulateLibraryStats(
           accumulator,
-          directBottles.map((bottle) =>
+          directBottles.map((bottle, index) =>
             bottle === null
               ? null
               : {
                   ...bottle,
                   distillerIds: distillerIdsByBottleId.get(bottle.id) ?? [],
+                  status: rows[index]!.status,
                 },
           ),
         );

--- a/apps/server/src/orpc/routes/users/tasting-stats.test.ts
+++ b/apps/server/src/orpc/routes/users/tasting-stats.test.ts
@@ -14,6 +14,7 @@ describe("GET /users/:user/tasting-stats", () => {
       await fixtures.Tasting({
         bottleId: bottle.id,
         createdById: defaults.user.id,
+        rating: null,
       });
     }
 
@@ -27,6 +28,9 @@ describe("GET /users/:user/tasting-stats", () => {
 
     expect(data).toEqual({
       total: 5,
+      uniqueBottles: 5,
+      ratings: { total: 0, pass: 0, sip: 0, savor: 0 },
+      mostTastedBottle: null,
       age: {
         knownCount: 4,
         median: 15,
@@ -52,12 +56,55 @@ describe("GET /users/:user/tasting-stats", () => {
     );
 
     expect(data.total).toBe(0);
+    expect(data.uniqueBottles).toBe(0);
+    expect(data.ratings).toEqual({ total: 0, pass: 0, sip: 0, savor: 0 });
+    expect(data.mostTastedBottle).toBeNull();
     expect(data.age).toMatchObject({
       knownCount: 0,
       median: null,
       oldest: null,
     });
     expect(data.age.buckets.every((bucket) => bucket.count === 0)).toBe(true);
+  });
+
+  test("summarizes ratings and repeated bottles", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const favorite = await fixtures.Bottle({ fullName: "Favorite Bottle" });
+    const occasional = await fixtures.Bottle({ fullName: "Occasional Bottle" });
+    const tastingInputs = [
+      { bottleId: favorite.id, rating: 2, day: 1 },
+      { bottleId: favorite.id, rating: 2, day: 2 },
+      { bottleId: favorite.id, rating: 1, day: 3 },
+      { bottleId: occasional.id, rating: -1, day: 4 },
+      { bottleId: occasional.id, rating: null, day: 5 },
+    ];
+
+    for (const { bottleId, rating, day } of tastingInputs) {
+      await fixtures.Tasting({
+        bottleId,
+        rating,
+        createdById: defaults.user.id,
+        createdAt: new Date(`2026-01-0${day}T00:00:00.000Z`),
+      });
+    }
+
+    const data = await routerClient.users.tastingStats(
+      { user: defaults.user.id },
+      { context: { user: defaults.user } },
+    );
+
+    expect(data).toMatchObject({
+      total: 5,
+      uniqueBottles: 2,
+      ratings: { total: 4, pass: 1, sip: 1, savor: 2 },
+      mostTastedBottle: {
+        id: favorite.id,
+        name: favorite.fullName,
+        count: 3,
+      },
+    });
   });
 
   test("does not expose a private profile", async ({ fixtures }) => {

--- a/apps/server/src/orpc/routes/users/tasting-stats.ts
+++ b/apps/server/src/orpc/routes/users/tasting-stats.ts
@@ -1,6 +1,9 @@
+import { SIMPLE_RATING_VALUES } from "@peated/server/constants";
 import { db } from "@peated/server/db";
+import { bottles } from "@peated/server/db/schema";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
 import { procedure } from "@peated/server/orpc";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 import { AgeStatsSchema, buildAgeStats } from "./age-stats";
 import {
@@ -10,6 +13,20 @@ import {
 
 const TastingStatsSchema = z.object({
   total: z.number(),
+  uniqueBottles: z.number(),
+  ratings: z.object({
+    total: z.number(),
+    pass: z.number(),
+    sip: z.number(),
+    savor: z.number(),
+  }),
+  mostTastedBottle: z
+    .object({
+      id: z.number(),
+      name: z.string(),
+      count: z.number(),
+    })
+    .nullable(),
   age: AgeStatsSchema,
 });
 
@@ -18,7 +35,8 @@ export default procedure
     method: "GET",
     path: "/users/{user}/tasting-stats",
     summary: "Get user tasting statistics",
-    description: "Retrieve age insights for bottles tasted by a visible user",
+    description:
+      "Retrieve rating, exploration, and age insights for bottles tasted by a visible user",
     operationId: "getUserTastingStats",
   })
   .input(
@@ -42,13 +60,29 @@ export default procedure
     }
 
     const ages: number[] = [];
+    const bottleCounts = new Map<number, number>();
+    const ratings = { total: 0, pass: 0, sip: 0, savor: 0 };
     let total = 0;
     let unstatedCount = 0;
 
     try {
       for await (const rows of scanUserTastingBottles(user.id)) {
         total += rows.length;
-        for (const { bottle } of rows) {
+        for (const { bottle, rating } of rows) {
+          if (rating === SIMPLE_RATING_VALUES.PASS) {
+            ratings.pass += 1;
+            ratings.total += 1;
+          } else if (rating === SIMPLE_RATING_VALUES.SIP) {
+            ratings.sip += 1;
+            ratings.total += 1;
+          } else if (rating === SIMPLE_RATING_VALUES.SAVOR) {
+            ratings.savor += 1;
+            ratings.total += 1;
+          }
+
+          if (bottle) {
+            bottleCounts.set(bottle.id, (bottleCounts.get(bottle.id) ?? 0) + 1);
+          }
           if (bottle?.statedAge === null || !bottle) {
             unstatedCount += 1;
           } else {
@@ -63,8 +97,31 @@ export default procedure
       throw error;
     }
 
+    const [mostTastedBottleId, mostTastedCount] = Array.from(bottleCounts)
+      .filter(([, count]) => count > 1)
+      .sort(
+        ([leftId, leftCount], [rightId, rightCount]) =>
+          rightCount - leftCount || leftId - rightId,
+      )[0] ?? [null, 0];
+    const mostTastedBottle =
+      mostTastedBottleId === null
+        ? null
+        : await db.query.bottles.findFirst({
+            where: eq(bottles.id, mostTastedBottleId),
+            columns: { id: true, fullName: true },
+          });
+
     return {
       total,
+      uniqueBottles: bottleCounts.size,
+      ratings,
+      mostTastedBottle: mostTastedBottle
+        ? {
+            id: mostTastedBottle.id,
+            name: mostTastedBottle.fullName,
+            count: mostTastedCount,
+          }
+        : null,
       age: buildAgeStats(ages, unstatedCount),
     };
   });

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.test.tsx
@@ -8,6 +8,8 @@ type LibraryStats = Outputs["users"]["libraryStats"];
 function makeStats(overrides: Partial<LibraryStats> = {}): LibraryStats {
   return {
     total: 4,
+    status: { open: 2, sealed: 1, unspecified: 1 },
+    brands: [{ id: 2, name: "Example Brand", count: 4 }],
     distillers: [{ id: 1, name: "Example Distillery", count: 3 }],
     age: {
       knownCount: 3,
@@ -28,12 +30,16 @@ function makeStats(overrides: Partial<LibraryStats> = {}): LibraryStats {
 }
 
 describe("LibraryInsightsContent", () => {
-  test("shows distilleries and age distribution with enough age data", () => {
+  test("shows producers, status, and age distribution with enough age data", () => {
     const html = renderToStaticMarkup(
       <LibraryInsightsContent stats={makeStats()} username="collector" />,
     );
 
-    expect(html).toContain("Top distilleries");
+    expect(html).toContain("Most collected");
+    expect(html).toContain("Brands");
+    expect(html).toContain("Example Brand");
+    expect(html).toContain("Example Brand: 4 bottles");
+    expect(html).toContain("Distilleries");
     expect(html).toContain("Example Distillery");
     expect(html).toContain("Example Distillery: 3 bottles");
     expect(html).toContain("Bottle ages");
@@ -42,7 +48,30 @@ describe("LibraryInsightsContent", () => {
     expect(html).toContain("Age stated for 3 of 4 bottles");
     expect(html).toContain("data-age-profile-chart");
     expect(html).toContain("min-h-28 flex-1");
+    expect(html).toContain("Bottle status");
+    expect(html).toContain("Open");
+    expect(html).toContain("Sealed");
+    expect(html).toContain("Not set");
     expect(html).not.toContain("Library types");
+  });
+
+  test("keeps each producer group to its top three entries", () => {
+    const stats = makeStats({
+      brands: [
+        { id: 1, name: "First Brand", count: 4 },
+        { id: 2, name: "Second Brand", count: 3 },
+        { id: 3, name: "Third Brand", count: 2 },
+        { id: 4, name: "Fourth Brand", count: 1 },
+      ],
+      distillers: [],
+    });
+    const html = renderToStaticMarkup(
+      <LibraryInsightsContent stats={stats} username="collector" />,
+    );
+
+    expect(html).toContain("First Brand");
+    expect(html).toContain("Third Brand");
+    expect(html).not.toContain("Fourth Brand");
   });
 
   test("falls back to category mix when age data is limited", () => {

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/library/libraryInsights.tsx
@@ -8,6 +8,7 @@ import {
   InsightCardSkeleton,
   RankedInsightBars,
 } from "@peated/web/components/insightCard";
+import Link from "@peated/web/components/link";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useQuery } from "@tanstack/react-query";
@@ -16,6 +17,122 @@ import { useEffect } from "react";
 type LibraryStats = Outputs["users"]["libraryStats"];
 
 const MINIMUM_AGE_SAMPLE = 3;
+
+function ProducerInsights({
+  stats,
+  username,
+}: {
+  stats: LibraryStats;
+  username: string;
+}) {
+  const producerGroups = [
+    {
+      id: "brands",
+      title: "Brands",
+      items: stats.brands,
+      filter: "brand",
+    },
+    {
+      id: "distillers",
+      title: "Distilleries",
+      items: stats.distillers,
+      filter: "distiller",
+    },
+  ].filter((group) => group.items.length > 0);
+
+  if (!producerGroups.length) return null;
+
+  return (
+    <InsightCard title="Most collected" className="lg:col-span-2">
+      <div
+        className={`grid gap-4 ${producerGroups.length > 1 ? "sm:grid-cols-2 sm:divide-x sm:divide-slate-800" : ""}`}
+      >
+        {producerGroups.map((group, index) => (
+          <div key={group.id} className={index ? "sm:pl-5" : ""}>
+            <h4 className="text-muted mb-2 text-xs font-medium uppercase tracking-wide">
+              {group.title}
+            </h4>
+            <RankedInsightBars
+              unit="bottle"
+              items={group.items.slice(0, 3).map((entity) => ({
+                id: entity.id,
+                label: entity.name,
+                count: entity.count,
+                href: `/users/${username}/library?${group.filter}=${entity.id}`,
+              }))}
+            />
+          </div>
+        ))}
+      </div>
+    </InsightCard>
+  );
+}
+
+function LibraryStatus({
+  stats,
+  username,
+}: {
+  stats: LibraryStats;
+  username: string;
+}) {
+  const items = [
+    {
+      id: "open",
+      label: "Open",
+      count: stats.status.open,
+      color: "bg-highlight",
+    },
+    {
+      id: "sealed",
+      label: "Sealed",
+      count: stats.status.sealed,
+      color: "bg-slate-400",
+    },
+    {
+      id: "unset",
+      label: "Not set",
+      count: stats.status.unspecified,
+      color: "bg-slate-700",
+    },
+  ].filter((item) => item.count > 0);
+
+  if (!stats.status.open && !stats.status.sealed) return null;
+
+  return (
+    <InsightCard title="Bottle status" detail={`${stats.total} bottles`}>
+      <div
+        className="mb-5 flex h-3 overflow-hidden rounded-full bg-slate-800"
+        aria-hidden="true"
+      >
+        {items.map((item) => (
+          <div
+            key={item.id}
+            className={item.color}
+            style={{ width: `${(item.count / stats.total) * 100}%` }}
+          />
+        ))}
+      </div>
+      <ul className="space-y-3">
+        {items.map((item) => (
+          <li key={item.id}>
+            <Link
+              href={`/users/${username}/library?status=${item.id}`}
+              className="focus-visible:ring-highlight group flex items-center justify-between rounded text-xs focus-visible:outline-none focus-visible:ring-2"
+            >
+              <span className="flex items-center gap-2 font-medium text-slate-200 group-hover:text-white">
+                <span className={`h-2 w-2 rounded-full ${item.color}`} />
+                {item.label}
+              </span>
+              <span className="text-muted tabular-nums">
+                {item.count.toLocaleString()}
+              </span>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </InsightCard>
+  );
+}
 
 function CategoryDistribution({ stats }: { stats: LibraryStats }) {
   return (
@@ -43,8 +160,12 @@ export function LibraryInsightsContent({
 
   const showAge = stats.age.knownCount >= MINIMUM_AGE_SAMPLE;
   const showCategories = !showAge && stats.categories.length > 0;
-  const showDistillers = stats.distillers.length > 0;
-  const cardCount = Number(showDistillers) + Number(showAge || showCategories);
+  const showProducers = stats.brands.length > 0 || stats.distillers.length > 0;
+  const showStatus = stats.status.open > 0 || stats.status.sealed > 0;
+  const cardCount =
+    Number(showProducers) +
+    Number(showStatus) +
+    Number(showAge || showCategories);
 
   if (!cardCount) return null;
 
@@ -52,19 +173,10 @@ export function LibraryInsightsContent({
     <div
       className={`mb-4 grid grid-cols-1 gap-3 ${cardCount > 1 ? "lg:grid-cols-2" : ""}`}
     >
-      {showDistillers ? (
-        <InsightCard title="Top distilleries">
-          <RankedInsightBars
-            unit="bottle"
-            items={stats.distillers.map((distiller) => ({
-              id: distiller.id,
-              label: distiller.name,
-              count: distiller.count,
-              href: `/users/${username}/library?distiller=${distiller.id}`,
-            }))}
-          />
-        </InsightCard>
+      {showProducers ? (
+        <ProducerInsights stats={stats} username={username} />
       ) : null}
+      {showStatus ? <LibraryStatus stats={stats} username={username} /> : null}
       {showAge ? (
         <AgeInsightCard
           age={stats.age}
@@ -81,6 +193,7 @@ export function LibraryInsightsContent({
 function LibraryInsightsSkeleton() {
   return (
     <div className="mb-4 grid grid-cols-1 gap-3 lg:grid-cols-2">
+      <InsightCardSkeleton className="lg:col-span-2" />
       <InsightCardSkeleton />
       <InsightCardSkeleton />
     </div>

--- a/apps/web/src/app/(default)/users/[username]/layout.tsx
+++ b/apps/web/src/app/(default)/users/[username]/layout.tsx
@@ -181,7 +181,7 @@ export default async function Layout(props: {
         <ProfileProvider userId={user.id}>
           <Tabs border aria-label={`${user.username}'s profile`}>
             <TabItem as={Link} href={`/users/${user.username}`} controlled>
-              Profile
+              Overview
             </TabItem>
             <TabItem
               as={Link}

--- a/apps/web/src/components/simpleRatingStats.tsx
+++ b/apps/web/src/components/simpleRatingStats.tsx
@@ -28,47 +28,10 @@ export default function SimpleRatingStats({ stats, className }: Props) {
     );
   }
 
-  const { percentage, total } = stats;
-
-  // Find the dominant rating
-  const dominant = Object.entries(percentage).reduce((a, b) =>
-    b[1] > a[1] ? b : a,
-  )[0] as keyof typeof percentage;
-
-  const dominantConfig = {
-    pass: {
-      label: "would pass",
-      color: "text-slate-600",
-      bgColor: "bg-slate-100",
-    },
-    sip: {
-      label: "would sip",
-      color: "text-slate-600",
-      bgColor: "bg-slate-100",
-    },
-    savor: {
-      label: "would savor",
-      color: "text-slate-600",
-      bgColor: "bg-slate-100",
-    },
-  };
-
-  const config = dominantConfig[dominant];
+  const { percentage } = stats;
 
   return (
     <div className={className}>
-      {/* Summary */}
-      <div className="mb-3">
-        <span className="text-lg font-semibold">
-          {Math.round(percentage[dominant])}%
-        </span>
-        <span className="ml-1">{config.label}</span>
-        <span className="text-muted ml-2 text-sm">
-          ({total} {total === 1 ? "rating" : "ratings"})
-        </span>
-      </div>
-
-      {/* Distribution bars */}
       <div className="space-y-2">
         <RatingBar
           label="Savor"

--- a/apps/web/src/components/userTastingInsights.test.tsx
+++ b/apps/web/src/components/userTastingInsights.test.tsx
@@ -1,0 +1,60 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { TastingSnapshotCard } from "./userTastingInsights";
+
+const age = {
+  knownCount: 3,
+  median: 12,
+  oldest: 18,
+  buckets: [
+    { id: "under10" as const, label: "Under 10", count: 0 },
+    { id: "from10To12" as const, label: "10–12", count: 2 },
+    { id: "from13To17" as const, label: "13–17", count: 0 },
+    { id: "from18To24" as const, label: "18–24", count: 1 },
+    { id: "atLeast25" as const, label: "25+", count: 0 },
+    { id: "unstated" as const, label: "Unstated", count: 1 },
+  ],
+};
+
+describe("TastingSnapshotCard", () => {
+  test("shows rating mix, exploration, and the most revisited bottle", () => {
+    const html = renderToStaticMarkup(
+      <TastingSnapshotCard
+        stats={{
+          total: 10,
+          uniqueBottles: 8,
+          ratings: { total: 8, pass: 1, sip: 3, savor: 4 },
+          mostTastedBottle: { id: 42, name: "Favorite Bottle", count: 3 },
+          age,
+        }}
+      />,
+    );
+
+    expect(html).toContain("Tasting snapshot");
+    expect(html).toContain("4 (50%)");
+    expect(html).toContain("2</span><span");
+    expect(html).toContain("repeat pours");
+    expect(html).toContain("Favorite Bottle");
+    expect(html).toContain("3 times");
+    expect(html).toContain('href="/bottles/42"');
+  });
+
+  test("handles an unrated one-off tasting", () => {
+    const html = renderToStaticMarkup(
+      <TastingSnapshotCard
+        stats={{
+          total: 1,
+          uniqueBottles: 1,
+          ratings: { total: 0, pass: 0, sip: 0, savor: 0 },
+          mostTastedBottle: null,
+          age,
+        }}
+      />,
+    );
+
+    expect(html).toContain("No ratings yet");
+    expect(html).toContain("0</span><span");
+    expect(html).toContain("repeat pours");
+    expect(html).not.toContain("Most revisited");
+  });
+});

--- a/apps/web/src/components/userTastingInsights.tsx
+++ b/apps/web/src/components/userTastingInsights.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { formatFlavorProfile } from "@peated/server/lib/format";
+import type { Outputs } from "@peated/server/orpc/router";
 import AgeInsightCard from "@peated/web/components/ageInsightCard";
 import {
   InsightCard,
   InsightCardSkeleton,
   RankedInsightBars,
 } from "@peated/web/components/insightCard";
+import Link from "@peated/web/components/link";
+import SimpleRatingStats from "@peated/web/components/simpleRatingStats";
 import classNames from "@peated/web/lib/classNames";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
@@ -33,9 +36,11 @@ function UserTastingInsightsContent({ userId }: { userId: number }) {
   const regions = regionsQuery.data.results;
   const flavors = flavorsQuery.data.results;
   const stats = statsQuery.data;
+  const showSnapshot = stats.total > 0;
   const showAge = stats.age.knownCount >= 3;
-  const cardCount =
+  const insightCardCount =
     Number(regions.length > 0) + Number(flavors.length > 0) + Number(showAge);
+  const cardCount = Number(showSnapshot) + insightCardCount;
 
   if (!cardCount) return null;
 
@@ -53,10 +58,19 @@ function UserTastingInsightsContent({ userId }: { userId: number }) {
       <div
         className={classNames(
           "grid grid-cols-1 gap-3",
-          cardCount === 2 && "lg:grid-cols-2",
-          cardCount >= 3 && "lg:grid-cols-3",
+          insightCardCount === 2 && "lg:grid-cols-2",
+          insightCardCount >= 3 && "lg:grid-cols-3",
         )}
       >
+        {showSnapshot ? (
+          <TastingSnapshotCard
+            stats={stats}
+            className={classNames(
+              insightCardCount === 2 && "lg:col-span-2",
+              insightCardCount >= 3 && "lg:col-span-3",
+            )}
+          />
+        ) : null}
         {regions.length ? (
           <InsightCard title="Top regions">
             <RankedInsightBars
@@ -99,6 +113,62 @@ function UserTastingInsightsContent({ userId }: { userId: number }) {
         ) : null}
       </div>
     </section>
+  );
+}
+
+type TastingStats = Outputs["users"]["tastingStats"];
+
+export function TastingSnapshotCard({
+  stats,
+  className,
+}: {
+  stats: TastingStats;
+  className?: string;
+}) {
+  const ratingPercentage = (count: number) =>
+    stats.ratings.total ? (count / stats.ratings.total) * 100 : 0;
+  const repeatPours = stats.total - stats.uniqueBottles;
+
+  return (
+    <InsightCard title="Tasting snapshot" className={className}>
+      <div className="grid flex-1 gap-6 sm:grid-cols-[minmax(0,1.35fr)_minmax(12rem,0.65fr)] sm:divide-x sm:divide-slate-800">
+        <SimpleRatingStats
+          stats={{
+            ...stats.ratings,
+            avg: null,
+            percentage: {
+              pass: ratingPercentage(stats.ratings.pass),
+              sip: ratingPercentage(stats.ratings.sip),
+              savor: ratingPercentage(stats.ratings.savor),
+            },
+          }}
+        />
+        <div className="flex flex-col justify-center sm:pl-6">
+          <div className="flex items-baseline gap-2">
+            <span className="text-3xl font-bold text-white">
+              {repeatPours.toLocaleString()}
+            </span>
+            <span className="text-sm font-medium text-slate-200">
+              {repeatPours === 1 ? "repeat pour" : "repeat pours"}
+            </span>
+          </div>
+          {stats.mostTastedBottle ? (
+            <p className="text-muted mt-3 text-xs">
+              Most revisited{" "}
+              <Link
+                href={`/bottles/${stats.mostTastedBottle.id}`}
+                className="font-medium text-slate-200 hover:text-white"
+              >
+                {stats.mostTastedBottle.name}
+              </Link>{" "}
+              <span className="whitespace-nowrap">
+                · {stats.mostTastedBottle.count.toLocaleString()} times
+              </span>
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </InsightCard>
   );
 }
 


### PR DESCRIPTION
The profile landing tab is now “Overview” and adds a compact tasting snapshot with the Savor/Sip/Pass distribution, repeat pours, and a most-revisited bottle when one exists. Library insights now show the three most collected brands and distilleries together, plus open/sealed status alongside the existing age view.

The supporting user-stat endpoints expose the new rating, revisit, brand, and status aggregates in the same batched scans used by the existing insights. Region and age cards remain unchanged, and sections still disappear when there is not enough useful data to render.
