### PR TITLE
fix(bottles): add missing entity roles on update

### DIFF
--- a/apps/server/src/lib/updateConcreteBottle.test.ts
+++ b/apps/server/src/lib/updateConcreteBottle.test.ts
@@ -441,7 +441,7 @@ describe("concrete Bottle updates", () => {
     ).toMatchObject({ seriesId: null });
   });
 
-  test("rejects numeric entities that lack the requested shared role", async ({
+  test("adds requested roles to existing numeric entities", async ({
     fixtures,
   }) => {
     const mod = await fixtures.User({ mod: true });
@@ -449,53 +449,61 @@ describe("concrete Bottle updates", () => {
       name: "Role Validation Brand",
       type: ["brand"],
     });
-    const invalidEntity = await fixtures.Entity({
-      name: "Roleless Entity",
+    const rolelessBrand = await fixtures.Entity({
+      name: "Roleless Brand",
       type: [],
     });
-    const { first, members } = await createGroup({
+    const rolelessBottler = await fixtures.Entity({
+      name: "Roleless Bottler",
+      type: [],
+    });
+    const rolelessDistiller = await fixtures.Entity({
+      name: "Roleless Distiller",
+      type: [],
+    });
+    const { first } = await createGroup({
       user: mod,
       stable: { name: "Role Validation Label", brand: brand.id },
       exacts: [{ edition: "One" }],
     });
-    const [groupBefore] = await db
-      .select()
-      .from(bottleGroups)
-      .where(eq(bottleGroups.id, first.group.id));
-    const membersBefore = await loadGroupMembers(first.group.id);
-    const aliasesBefore = await loadAliases(
-      members.map(({ bottle }) => bottle.id),
-    );
     resetQueueMock();
 
-    for (const [role, shared] of [
-      ["brand", { brand: invalidEntity.id }],
-      ["bottler", { bottler: invalidEntity.id }],
-      ["distiller", { distillers: [invalidEntity.id] }],
-    ] as const) {
-      const error = await waitError(
-        updateConcreteBottle({
-          bottleId: first.bottle.id,
-          input: { shared },
-          context: contextFor(mod),
-        }),
-        ConcreteBottleUpdateInputError,
-      );
-      expect(error.message).toMatch(new RegExp(role, "i"));
-    }
+    const result = await updateConcreteBottle({
+      bottleId: first.bottle.id,
+      input: {
+        shared: {
+          brand: rolelessBrand.id,
+          bottler: rolelessBottler.id,
+          distillers: [rolelessDistiller.id],
+        },
+      },
+      context: contextFor(mod),
+    });
 
-    expect(
-      (
-        await db
-          .select()
-          .from(bottleGroups)
-          .where(eq(bottleGroups.id, first.group.id))
-      )[0],
-    ).toEqual(groupBefore);
-    expect(await loadGroupMembers(first.group.id)).toEqual(membersBefore);
-    expect(await loadAliases([first.bottle.id])).toEqual(aliasesBefore);
-    expect(await loadUpdateAudits([first.bottle.id])).toEqual([]);
-    expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
+    expect(result.changed).toBe(true);
+    expect(result.group).toMatchObject({
+      brandId: rolelessBrand.id,
+      bottlerId: rolelessBottler.id,
+    });
+    for (const [entityId, role] of [
+      [rolelessBrand.id, "brand"],
+      [rolelessBottler.id, "bottler"],
+      [rolelessDistiller.id, "distiller"],
+    ] as const) {
+      expect(
+        await db.query.entities.findFirst({
+          where: eq(entities.id, entityId),
+        }),
+      ).toMatchObject({ type: [role] });
+      expect(workerClient.pushUniqueJob).toHaveBeenCalledWith(
+        "OnEntityChange",
+        { entityId },
+      );
+    }
+    expect(await loadBottleDistillers([first.bottle.id])).toMatchObject([
+      { bottleId: first.bottle.id, distillerId: rolelessDistiller.id },
+    ]);
+    expect(await loadUpdateAudits([first.bottle.id])).toHaveLength(1);
   });
 
   test("accounts for a role added while resolving an existing entity", async ({

--- a/apps/server/src/lib/updateConcreteBottle.ts
+++ b/apps/server/src/lib/updateConcreteBottle.ts
@@ -2,6 +2,8 @@
  * Transactional moderator editing for concrete Bottles. Shared patches fan out
  * durable member Bottle materialization; exact patches remain isolated.
  */
+// TODO(dcramer): Rename this module's ConcreteBottleUpdate symbols now that
+// the Bottle/BottleRelease distinction is retired.
 import { ORPCError } from "@orpc/server";
 import {
   bottleNameDuplicatesBrand,
@@ -472,18 +474,6 @@ async function loadEntity(tx: AnyTransaction, entityId: number) {
   return entity;
 }
 
-function requireEntityRole(
-  entity: Entity,
-  role: Entity["type"][number],
-  label: string,
-) {
-  if (!entity.type.includes(role)) {
-    throw new ConcreteBottleUpdateInputError(
-      `${label} entity ${entity.id} does not have the ${role} role.`,
-    );
-  }
-}
-
 function requireUpdateUser(user: User | undefined): User {
   if (!user) {
     throw new ConcreteBottleUpdateInputError(
@@ -491,6 +481,42 @@ function requireUpdateUser(user: User | undefined): User {
     );
   }
   return user;
+}
+
+async function addEntityRoleIfNeeded({
+  tx,
+  entity,
+  role,
+  user,
+  actorId,
+  creationSource,
+  changedEntityIds,
+}: {
+  tx: AnyTransaction;
+  entity: Entity;
+  role: Entity["type"][number];
+  user?: User;
+  actorId: number;
+  creationSource: CatalogVerificationCreationSource;
+  changedEntityIds: Set<number>;
+}): Promise<Entity> {
+  if (entity.type.includes(role)) return entity;
+
+  const result = await upsertEntity({
+    db: tx,
+    data: entity.id,
+    creationSource,
+    userId: requireUpdateUser(user).id,
+    createdByActorId: actorId,
+    type: role,
+  });
+  if (!result) {
+    throw new ConcreteBottleUpdateInputError(
+      `Entity ${entity.id} could not be resolved.`,
+    );
+  }
+  if (result.changed) changedEntityIds.add(result.id);
+  return result.result;
 }
 
 /**
@@ -519,21 +545,48 @@ async function resolveStableState(
     newEntityIds: Set<number>;
   },
 ): Promise<StableState> {
-  const numericBrand =
+  let numericBrand =
     typeof patch?.brand === "number" ? await loadEntity(tx, patch.brand) : null;
-  if (numericBrand) requireEntityRole(numericBrand, "brand", "Brand");
+  if (numericBrand) {
+    numericBrand = await addEntityRoleIfNeeded({
+      tx,
+      entity: numericBrand,
+      role: "brand",
+      user,
+      actorId,
+      creationSource,
+      changedEntityIds,
+    });
+  }
 
-  const numericBottler =
+  let numericBottler =
     typeof patch?.bottler === "number"
       ? await loadEntity(tx, patch.bottler)
       : null;
-  if (numericBottler) requireEntityRole(numericBottler, "bottler", "Bottler");
+  if (numericBottler) {
+    numericBottler = await addEntityRoleIfNeeded({
+      tx,
+      entity: numericBottler,
+      role: "bottler",
+      user,
+      actorId,
+      creationSource,
+      changedEntityIds,
+    });
+  }
 
   const numericDistillers = new Map<number, Entity>();
   for (const choice of patch?.distillers ?? []) {
     if (typeof choice !== "number" || numericDistillers.has(choice)) continue;
-    const distiller = await loadEntity(tx, choice);
-    requireEntityRole(distiller, "distiller", "Distiller");
+    const distiller = await addEntityRoleIfNeeded({
+      tx,
+      entity: await loadEntity(tx, choice),
+      role: "distiller",
+      user,
+      actorId,
+      creationSource,
+      changedEntityIds,
+    });
     numericDistillers.set(choice, distiller);
   }
 

--- a/apps/server/src/orpc/routes/bottles/update.test.ts
+++ b/apps/server/src/orpc/routes/bottles/update.test.ts
@@ -7,6 +7,7 @@ import {
   bottles,
   bottlesToDistillers,
   changes,
+  entities,
 } from "@peated/server/db/schema";
 import { createConcreteBottle } from "@peated/server/lib/createConcreteBottle";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
@@ -184,7 +185,7 @@ describe("PATCH /bottles/{bottle}", () => {
     const newBrand = await fixtures.Entity({ name: "New Route Brand" });
     const newBottler = await fixtures.Entity({
       name: "New Route Bottler",
-      type: ["bottler"],
+      type: [],
     });
     const newDistillers = [
       await fixtures.Entity({ name: "New Route Distiller A" }),
@@ -278,6 +279,11 @@ describe("PATCH /bottles/{bottle}", () => {
         .from(bottleGroupDistillers)
         .where(eq(bottleGroupDistillers.groupId, first.group.id)),
     ).toHaveLength(newDistillers.length);
+    expect(
+      await db.query.entities.findFirst({
+        where: eq(entities.id, newBottler.id),
+      }),
+    ).toMatchObject({ type: ["bottler"] });
   });
 
   test("maps input, graph, and identity failures to stable statuses", async ({
@@ -315,14 +321,10 @@ describe("PATCH /bottles/{bottle}", () => {
     );
     expect(retiredError).toMatchObject({ status: 409 });
 
-    const roleless = await fixtures.Entity({
-      name: "Not A Route Brand",
-      type: [],
-    });
     const valid = await fixtures.Bottle({ name: "Invalid Route Input" });
     const badInput = await waitError(
       routerClient.bottles.update(
-        { bottle: valid.id, shared: { brand: roleless.id } },
+        { bottle: valid.id, shared: { brand: 999_999 } },
         { context: { user: mod } },
       ),
     );


### PR DESCRIPTION
Updating a Bottle with an existing Entity now adds a missing brand, bottler, or distiller role instead of rejecting the save. The update also records the Entity as changed so the existing post-commit indexing work runs, with service- and route-level regression coverage for the persisted roles.

The previous path loaded numeric Entity choices and validated their roles directly, unlike Bottle creation and object choices, which use the role-merging upsert path. This makes those paths consistent and leaves an owned TODO to remove the migration-era `ConcreteBottleUpdate` naming now that the Bottle/BottleRelease distinction is retired.
