### PR TITLE
fix(server): reconcile series on bottle brand changes

### DIFF
--- a/apps/server/src/lib/updateConcreteBottle.test.ts
+++ b/apps/server/src/lib/updateConcreteBottle.test.ts
@@ -672,7 +672,176 @@ describe("concrete Bottle updates", () => {
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
   });
 
-  test("rejects a retained or explicit series owned by another brand", async ({
+  test("migrates an exclusively used retained series when the brand changes", async ({
+    fixtures,
+  }) => {
+    const mod = await fixtures.User({ mod: true });
+    const oldBrand = await fixtures.Entity({ name: "Old Series Brand" });
+    const newBrand = await fixtures.Entity({ name: "New Series Brand" });
+    const oldSeries = await fixtures.BottleSeries({
+      brandId: oldBrand.id,
+      name: "Shared Range",
+      fullName: `${oldBrand.name} Shared Range`,
+      description: "A range that survives a brand correction.",
+    });
+    const { first, members } = await createGroup({
+      user: mod,
+      stable: {
+        name: "Series Label",
+        brand: oldBrand.id,
+        series: oldSeries.id,
+      },
+      exacts: [{ edition: "One" }, { edition: "Two" }],
+    });
+
+    const result = await updateConcreteBottle({
+      bottleId: first.bottle.id,
+      input: { shared: { brand: newBrand.id } },
+      context: contextFor(mod),
+    });
+
+    const migratedSeries = await db.query.bottleSeries.findFirst({
+      where: eq(bottleSeries.id, oldSeries.id),
+    });
+    expect(migratedSeries).toMatchObject({
+      id: oldSeries.id,
+      name: oldSeries.name,
+      fullName: `${newBrand.name} ${oldSeries.name}`,
+      description: oldSeries.description,
+      brandId: newBrand.id,
+      numReleases: members.length,
+    });
+    expect(result.group).toMatchObject({
+      brandId: newBrand.id,
+      seriesId: oldSeries.id,
+    });
+    expect(await loadGroupMembers(first.group.id)).toEqual(
+      expect.arrayContaining(
+        members.map(({ bottle }) =>
+          expect.objectContaining({
+            id: bottle.id,
+            brandId: newBrand.id,
+            seriesId: oldSeries.id,
+          }),
+        ),
+      ),
+    );
+    expect(
+      await db
+        .select()
+        .from(bottleSeries)
+        .where(eq(bottleSeries.name, oldSeries.name)),
+    ).toHaveLength(1);
+  });
+
+  test("duplicates a retained series still used by another BottleGroup", async ({
+    fixtures,
+  }) => {
+    const mod = await fixtures.User({ mod: true });
+    const oldBrand = await fixtures.Entity({ name: "Shared Series Brand" });
+    const newBrand = await fixtures.Entity({ name: "Split Series Brand" });
+    const oldSeries = await fixtures.BottleSeries({
+      brandId: oldBrand.id,
+      name: "Shared Range",
+      fullName: `${oldBrand.name} Shared Range`,
+      description: "A range shared by multiple bottle groups.",
+    });
+    const moving = await createGroup({
+      user: mod,
+      stable: {
+        name: "Moving Label",
+        brand: oldBrand.id,
+        series: oldSeries.id,
+      },
+      exacts: [{ edition: "One" }],
+    });
+    const staying = await createGroup({
+      user: mod,
+      stable: {
+        name: "Staying Label",
+        brand: oldBrand.id,
+        series: oldSeries.id,
+      },
+      exacts: [{ edition: "One" }],
+    });
+
+    const result = await updateConcreteBottle({
+      bottleId: moving.first.bottle.id,
+      input: { shared: { brand: newBrand.id } },
+      context: contextFor(mod),
+    });
+
+    const destinationSeries = await db.query.bottleSeries.findFirst({
+      where: and(
+        eq(bottleSeries.brandId, newBrand.id),
+        eq(bottleSeries.name, oldSeries.name),
+      ),
+    });
+    expect(destinationSeries).toMatchObject({
+      description: oldSeries.description,
+      numReleases: 1,
+    });
+    expect(destinationSeries?.id).not.toBe(oldSeries.id);
+    expect(result.group.seriesId).toBe(destinationSeries?.id);
+    expect(
+      await db.query.bottleGroups.findFirst({
+        where: eq(bottleGroups.id, staying.first.group.id),
+      }),
+    ).toMatchObject({ brandId: oldBrand.id, seriesId: oldSeries.id });
+    expect(
+      await db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, oldSeries.id),
+      }),
+    ).toMatchObject({ brandId: oldBrand.id, numReleases: 1 });
+  });
+
+  test("reuses a matching destination series when the brand changes", async ({
+    fixtures,
+  }) => {
+    const mod = await fixtures.User({ mod: true });
+    const oldBrand = await fixtures.Entity({ name: "Source Series Brand" });
+    const newBrand = await fixtures.Entity({
+      name: "Destination Series Brand",
+    });
+    const oldSeries = await fixtures.BottleSeries({
+      brandId: oldBrand.id,
+      name: "Shared Range",
+      fullName: `${oldBrand.name} Shared Range`,
+    });
+    const destinationSeries = await fixtures.BottleSeries({
+      brandId: newBrand.id,
+      name: oldSeries.name,
+      fullName: `${newBrand.name} ${oldSeries.name}`,
+    });
+    const { first } = await createGroup({
+      user: mod,
+      stable: {
+        name: "Series Label",
+        brand: oldBrand.id,
+        series: oldSeries.id,
+      },
+      exacts: [{ edition: "One" }],
+    });
+
+    const result = await updateConcreteBottle({
+      bottleId: first.bottle.id,
+      input: { shared: { brand: newBrand.id } },
+      context: contextFor(mod),
+    });
+
+    expect(result.group).toMatchObject({
+      brandId: newBrand.id,
+      seriesId: destinationSeries.id,
+    });
+    expect(
+      await db
+        .select()
+        .from(bottleSeries)
+        .where(eq(bottleSeries.brandId, newBrand.id)),
+    ).toHaveLength(1);
+  });
+
+  test("rejects an explicit series owned by another brand", async ({
     fixtures,
   }) => {
     const mod = await fixtures.User({ mod: true });
@@ -699,17 +868,17 @@ describe("concrete Bottle updates", () => {
     const aliasesBefore = await loadAliases(memberIds);
     resetQueueMock();
 
-    for (const shared of [{ brand: newBrand.id }, { series: otherSeries.id }]) {
-      const error = await waitError(
-        updateConcreteBottle({
-          bottleId: first.bottle.id,
-          input: { shared },
-          context: contextFor(mod),
-        }),
-        ConcreteBottleUpdateInputError,
-      );
-      expect(error.message).toMatch(/series/i);
-    }
+    const error = await waitError(
+      updateConcreteBottle({
+        bottleId: first.bottle.id,
+        input: {
+          shared: { brand: newBrand.id, series: otherSeries.id },
+        },
+        context: contextFor(mod),
+      }),
+      ConcreteBottleUpdateInputError,
+    );
+    expect(error.message).toMatch(/series/i);
 
     expect(
       (

--- a/apps/server/src/lib/updateConcreteBottle.ts
+++ b/apps/server/src/lib/updateConcreteBottle.ts
@@ -51,7 +51,7 @@ import { formatBottleName } from "@peated/server/lib/format";
 import { logError } from "@peated/server/lib/log";
 import type { Context } from "@peated/server/orpc/context";
 import { pushUniqueJob } from "@peated/server/worker/client";
-import { and, asc, eq, inArray, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 
 export { ConcreteBottleUpdateInputSchema } from "@peated/server/lib/concreteBottleSchemas";
 export type { ConcreteBottleUpdateInput } from "@peated/server/lib/concreteBottleSchemas";
@@ -711,6 +711,101 @@ async function resolveStableState(
       }
       throw error;
     }
+  } else if (
+    patch?.brand !== undefined &&
+    brand.id !== group.brandId &&
+    seriesId !== null
+  ) {
+    // Move the series row only when no other catalog group depends on it.
+    const [currentSeries] = await tx
+      .select()
+      .from(bottleSeries)
+      .where(eq(bottleSeries.id, seriesId))
+      .limit(1)
+      .for("update");
+    if (!currentSeries) {
+      throw new ConcreteBottleUpdateInputError(
+        `Series ${seriesId} could not be resolved.`,
+      );
+    }
+
+    const destinationFullName = `${brand.name} ${currentSeries.name}`;
+    const [destinationSeries] = await tx
+      .select({ id: bottleSeries.id })
+      .from(bottleSeries)
+      .where(
+        eq(
+          sql`LOWER(${bottleSeries.fullName})`,
+          destinationFullName.toLowerCase(),
+        ),
+      )
+      .limit(1);
+    if (destinationSeries && destinationSeries.id !== currentSeries.id) {
+      seriesId = destinationSeries.id;
+    } else {
+      const [otherGroup] = await tx
+        .select({ id: bottleGroups.id })
+        .from(bottleGroups)
+        .where(
+          and(
+            eq(bottleGroups.seriesId, currentSeries.id),
+            ne(bottleGroups.id, group.id),
+          ),
+        )
+        .limit(1);
+      const [ungroupedBottle] = await tx
+        .select({ id: bottles.id })
+        .from(bottles)
+        .where(
+          and(eq(bottles.seriesId, currentSeries.id), isNull(bottles.groupId)),
+        )
+        .limit(1);
+
+      if (!otherGroup && !ungroupedBottle) {
+        await tx
+          .update(bottleSeries)
+          .set({
+            brandId: brand.id,
+            fullName: destinationFullName,
+            updatedAt: new Date(),
+          })
+          .where(eq(bottleSeries.id, currentSeries.id));
+        await tx.insert(changes).values({
+          objectId: currentSeries.id,
+          objectType: "bottle_series",
+          type: "update",
+          displayName: destinationFullName,
+          data: {
+            brandId: brand.id,
+            fullName: destinationFullName,
+          },
+          actorId,
+        });
+      } else {
+        try {
+          [seriesId] = await processSeries({
+            tx,
+            series: {
+              name: currentSeries.name,
+              description: currentSeries.description,
+            },
+            brand,
+            userId: requireUpdateUser(user).id,
+            createdByActorId: actorId,
+          });
+        } catch (error) {
+          if (
+            error instanceof ORPCError &&
+            ["NOT_FOUND", "BAD_REQUEST", "INPUT_VALIDATION_FAILED"].includes(
+              error.code,
+            )
+          ) {
+            throw new ConcreteBottleUpdateInputError(error.message);
+          }
+          throw error;
+        }
+      }
+    }
   }
   if (patch !== undefined && seriesId !== null) {
     const [series] = await tx
@@ -1267,18 +1362,24 @@ export async function updateConcreteBottleInTransaction(
       (member) =>
         member.seriesId !== desiredByBottleId.get(member.id)!.seriesId,
     );
-  const affectedSeriesIds = memberSeriesChanged
-    ? Array.from(
-        new Set(
-          affectedMembers
-            .flatMap((member) => [
-              member.seriesId,
-              desiredByBottleId.get(member.id)!.seriesId,
-            ])
-            .filter((seriesId): seriesId is number => seriesId !== null),
-        ),
-      ).sort((left, right) => left - right)
-    : [];
+  const seriesOwnershipChanged =
+    sharedChanged &&
+    group.brandId !== stable.brandId &&
+    group.seriesId !== null &&
+    group.seriesId === stable.seriesId;
+  const affectedSeriesIds =
+    memberSeriesChanged || seriesOwnershipChanged
+      ? Array.from(
+          new Set(
+            affectedMembers
+              .flatMap((member) => [
+                member.seriesId,
+                desiredByBottleId.get(member.id)!.seriesId,
+              ])
+              .filter((seriesId): seriesId is number => seriesId !== null),
+          ),
+        ).sort((left, right) => left - right)
+      : [];
   for (const seriesId of affectedSeriesIds) {
     await tx
       .update(bottleSeries)


### PR DESCRIPTION
Changing a bottle’s brand now reconciles retained series ownership instead of rejecting the update. When the edited BottleGroup is the series’ only consumer, the existing series moves to the new brand; when another group still depends on it, the update creates a destination-brand copy or reuses an existing match. Release counts, audit history, and search indexing stay synchronized, while explicitly selecting an incompatible series remains rejected.

Regression coverage exercises exclusive migration, shared-series duplication, destination reuse, and incompatible explicit selection.
