### PR TITLE
fix(web): load fresh data for edit forms

### DIFF
--- a/apps/web/src/app/(admin)/admin/(layout-free)/badges/[badgeId]/edit/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(layout-free)/badges/[badgeId]/edit/page.tsx
@@ -6,6 +6,7 @@ import { useFlashMessages } from "@peated/web/components/flash";
 import { toBlob } from "@peated/web/lib/blobs";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { formQueryOptions } from "@peated/web/lib/orpc/query";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
@@ -16,11 +17,13 @@ export default function Page(props: { params: Promise<{ badgeId: string }> }) {
 
   const orpc = useORPC();
   const { data: badge } = useSuspenseQuery(
-    orpc.badges.details.queryOptions({
-      input: {
-        badge: parseInt(badgeId, 10),
-      },
-    }),
+    formQueryOptions(
+      orpc.badges.details.queryOptions({
+        input: {
+          badge: parseInt(badgeId, 10),
+        },
+      }),
+    ),
   );
 
   const router = useRouter();

--- a/apps/web/src/app/(admin)/admin/(layout-free)/events/[eventId]/edit/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(layout-free)/events/[eventId]/edit/page.tsx
@@ -3,6 +3,7 @@ import { use } from "react";
 
 import EventForm from "@peated/web/components/admin/eventForm";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { formQueryOptions } from "@peated/web/lib/orpc/query";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
@@ -13,11 +14,13 @@ export default function Page(props: { params: Promise<{ eventId: string }> }) {
 
   const orpc = useORPC();
   const { data: event } = useSuspenseQuery(
-    orpc.events.details.queryOptions({
-      input: {
-        event: parseInt(eventId, 10),
-      },
-    }),
+    formQueryOptions(
+      orpc.events.details.queryOptions({
+        input: {
+          event: parseInt(eventId, 10),
+        },
+      }),
+    ),
   );
 
   const router = useRouter();

--- a/apps/web/src/app/(admin)/admin/(layout-free)/locations/[countrySlug]/edit/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(layout-free)/locations/[countrySlug]/edit/page.tsx
@@ -4,6 +4,7 @@ import { use } from "react";
 import CountryForm from "@peated/web/components/admin/countryForm";
 import { ModRequired } from "@peated/web/hooks/useAuthRequired";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { formQueryOptions } from "@peated/web/lib/orpc/query";
 import {
   useMutation,
   useQueryClient,
@@ -28,9 +29,11 @@ export default function Page(props: {
 function CountryEditForm({ countrySlug }: { countrySlug: string }) {
   const orpc = useORPC();
   const { data: country } = useSuspenseQuery(
-    orpc.countries.details.queryOptions({
-      input: { country: countrySlug },
-    }),
+    formQueryOptions(
+      orpc.countries.details.queryOptions({
+        input: { country: countrySlug },
+      }),
+    ),
   );
 
   const router = useRouter();

--- a/apps/web/src/app/(admin)/admin/(layout-free)/locations/[countrySlug]/regions/[regionSlug]/edit/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(layout-free)/locations/[countrySlug]/regions/[regionSlug]/edit/page.tsx
@@ -4,6 +4,7 @@ import { use } from "react";
 import RegionForm from "@peated/web/components/admin/regionForm";
 import { ModRequired } from "@peated/web/hooks/useAuthRequired";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { formQueryOptions } from "@peated/web/lib/orpc/query";
 import {
   useMutation,
   useQueryClient,
@@ -34,12 +35,14 @@ function RegionEditForm({
 }) {
   const orpc = useORPC();
   const { data: region } = useSuspenseQuery(
-    orpc.regions.details.queryOptions({
-      input: {
-        country: countrySlug,
-        region: regionSlug,
-      },
-    }),
+    formQueryOptions(
+      orpc.regions.details.queryOptions({
+        input: {
+          country: countrySlug,
+          region: regionSlug,
+        },
+      }),
+    ),
   );
 
   const router = useRouter();

--- a/apps/web/src/app/(admin)/admin/(layout-free)/sites/[siteId]/edit/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(layout-free)/sites/[siteId]/edit/page.tsx
@@ -4,6 +4,7 @@ import { use } from "react";
 import { type ExternalSiteType } from "@peated/server/types";
 import SiteForm from "@peated/web/components/admin/siteForm";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { formQueryOptions } from "@peated/web/lib/orpc/query";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
@@ -16,11 +17,13 @@ export default function Page(props: {
 
   const orpc = useORPC();
   const { data: site } = useSuspenseQuery(
-    orpc.externalSites.details.queryOptions({
-      input: {
-        site: siteId as any,
-      },
-    }),
+    formQueryOptions(
+      orpc.externalSites.details.queryOptions({
+        input: {
+          site: siteId as any,
+        },
+      }),
+    ),
   );
 
   const router = useRouter();

--- a/apps/web/src/app/(admin)/admin/(layout-free)/tags/[tagId]/edit/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(layout-free)/tags/[tagId]/edit/page.tsx
@@ -3,6 +3,7 @@ import { use } from "react";
 
 import TagForm from "@peated/web/components/admin/tagForm";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { formQueryOptions } from "@peated/web/lib/orpc/query";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
@@ -13,11 +14,13 @@ export default function Page(props: { params: Promise<{ tagId: string }> }) {
 
   const orpc = useORPC();
   const { data: tag } = useSuspenseQuery(
-    orpc.tags.details.queryOptions({
-      input: {
-        tag: tagId,
-      },
-    }),
+    formQueryOptions(
+      orpc.tags.details.queryOptions({
+        input: {
+          tag: tagId,
+        },
+      }),
+    ),
   );
 
   const router = useRouter();

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
@@ -7,6 +7,7 @@ import { ModRequired } from "@peated/web/hooks/useAuthRequired";
 import { toBlob } from "@peated/web/lib/blobs";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { formQueryOptions } from "@peated/web/lib/orpc/query";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { buildConcreteBottleUpdateInput } from "./buildConcreteBottleUpdateInput";
@@ -26,9 +27,11 @@ export default function Page(props: { params: Promise<{ bottleId: string }> }) {
 function BottleEditForm({ bottleId }: { bottleId: string }) {
   const orpc = useORPC();
   const { data: context } = useSuspenseQuery(
-    orpc.bottles.editContext.queryOptions({
-      input: { bottle: Number(bottleId) },
-    }),
+    formQueryOptions(
+      orpc.bottles.editContext.queryOptions({
+        input: { bottle: Number(bottleId) },
+      }),
+    ),
   );
   const router = useRouter();
   const bottleUpdateMutation = useMutation(

--- a/apps/web/src/app/(layout-free)/entities/[entityId]/edit/page.tsx
+++ b/apps/web/src/app/(layout-free)/entities/[entityId]/edit/page.tsx
@@ -4,6 +4,7 @@ import { use } from "react";
 import EntityForm from "@peated/web/components/entityForm";
 import { ModRequired } from "@peated/web/hooks/useAuthRequired";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { formQueryOptions } from "@peated/web/lib/orpc/query";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
@@ -22,7 +23,11 @@ export default function Page(props: { params: Promise<{ entityId: string }> }) {
 function EntityEditForm({ entityId }: { entityId: string }) {
   const orpc = useORPC();
   const { data: entity } = useSuspenseQuery(
-    orpc.entities.details.queryOptions({ input: { entity: Number(entityId) } }),
+    formQueryOptions(
+      orpc.entities.details.queryOptions({
+        input: { entity: Number(entityId) },
+      }),
+    ),
   );
   const router = useRouter();
 

--- a/apps/web/src/app/(layout-free)/flights/[flightId]/edit/page.tsx
+++ b/apps/web/src/app/(layout-free)/flights/[flightId]/edit/page.tsx
@@ -3,6 +3,7 @@ import { use } from "react";
 
 import FlightForm from "@peated/web/components/flightForm";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { formQueryOptions } from "@peated/web/lib/orpc/query";
 import {
   useMutation,
   useQueryClient,
@@ -17,9 +18,11 @@ export default function Page(props: { params: Promise<{ flightId: string }> }) {
 
   const orpc = useORPC();
   const { data: flight } = useSuspenseQuery(
-    orpc.flights.details.queryOptions({
-      input: { flight: flightId },
-    }),
+    formQueryOptions(
+      orpc.flights.details.queryOptions({
+        input: { flight: flightId },
+      }),
+    ),
   );
 
   const router = useRouter();

--- a/apps/web/src/app/(layout-free)/tastings/[tastingId]/edit/page.tsx
+++ b/apps/web/src/app/(layout-free)/tastings/[tastingId]/edit/page.tsx
@@ -10,6 +10,7 @@ import { AuthRequired } from "@peated/web/hooks/useAuthRequired";
 import { toBlob } from "@peated/web/lib/blobs";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { formQueryOptions } from "@peated/web/lib/orpc/query";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
@@ -31,9 +32,11 @@ function TastingEditForm({ tastingId }: { tastingId: string }) {
   const orpc = useORPC();
 
   const { data: tasting } = useSuspenseQuery(
-    orpc.tastings.details.queryOptions({
-      input: { tasting: Number(tastingId) },
-    }),
+    formQueryOptions(
+      orpc.tastings.details.queryOptions({
+        input: { tasting: Number(tastingId) },
+      }),
+    ),
   );
 
   const router = useRouter();
@@ -85,9 +88,11 @@ function TastingEditFields({
 }) {
   const orpc = useORPC();
   const { data: suggestedTags } = useSuspenseQuery(
-    orpc.bottles.suggestedTags.queryOptions({
-      input: { bottle: tasting.bottle.id },
-    }),
+    formQueryOptions(
+      orpc.bottles.suggestedTags.queryOptions({
+        input: { bottle: tasting.bottle.id },
+      }),
+    ),
   );
 
   return (

--- a/apps/web/src/lib/orpc/query.test.ts
+++ b/apps/web/src/lib/orpc/query.test.ts
@@ -1,0 +1,54 @@
+import { QueryClient, QueryObserver } from "@tanstack/react-query";
+import { describe, expect, it, vi } from "vitest";
+import { formQueryOptions } from "./query";
+
+describe("formQueryOptions", () => {
+  it("configures an isolated, session-stable form query", () => {
+    const queryFn = async () => ({ name: "Current value" });
+    const options = formQueryOptions({
+      queryKey: ["bottles", "details", { bottle: 1 }] as const,
+      queryFn,
+    });
+
+    expect(options).toMatchObject({
+      gcTime: 0,
+      staleTime: "static",
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      refetchOnWindowFocus: false,
+      queryFn,
+    });
+    expect(options.queryKey).toEqual([
+      "bottles",
+      "details",
+      { bottle: 1 },
+      { scope: "form" },
+    ]);
+  });
+
+  it("fetches past read-view data and evicts the form snapshot", async () => {
+    const queryClient = new QueryClient();
+    const queryKey = ["bottles", "details", { bottle: 1 }] as const;
+    const queryFn = vi.fn().mockResolvedValue({ name: "Current value" });
+    const options = formQueryOptions({ queryKey, queryFn });
+    queryClient.setQueryData(queryKey, { name: "Cached value" });
+
+    const observer = new QueryObserver(queryClient, options);
+    const unsubscribe = observer.subscribe(() => undefined);
+
+    await vi.waitFor(() => {
+      expect(observer.getCurrentResult().data).toEqual({
+        name: "Current value",
+      });
+    });
+    expect(queryFn).toHaveBeenCalledOnce();
+    expect(queryClient.getQueryData(queryKey)).toEqual({
+      name: "Cached value",
+    });
+
+    unsubscribe();
+    await vi.waitFor(() => {
+      expect(queryClient.getQueryData(options.queryKey)).toBeUndefined();
+    });
+  });
+});

--- a/apps/web/src/lib/orpc/query.ts
+++ b/apps/web/src/lib/orpc/query.ts
@@ -34,6 +34,26 @@ const createQueryClient = () => {
   return queryClient;
 };
 
+const FORM_QUERY_SCOPE = { scope: "form" } as const;
+
+/**
+ * Isolates form initialization from cached read views and discards the snapshot
+ * as soon as the form unmounts.
+ */
+export function formQueryOptions<
+  const TOptions extends { queryKey: readonly unknown[] },
+>(options: TOptions) {
+  return {
+    ...options,
+    queryKey: [...options.queryKey, FORM_QUERY_SCOPE],
+    gcTime: 0,
+    staleTime: "static" as const,
+    refetchOnMount: false,
+    refetchOnReconnect: false,
+    refetchOnWindowFocus: false,
+  };
+}
+
 let browserQueryClient: QueryClient | undefined = undefined;
 
 // isServerComponent must be true for any server component


### PR DESCRIPTION
Edit routes now initialize forms from an isolated, short-lived query instead of reusing cached detail data. This prevents stale values from being snapshotted into bottle, entity, tasting, flight, and admin forms after client navigation.

The form query loads fresh data once, remains stable for the active editing session to avoid mid-edit resets, and is evicted on unmount. A QueryObserver regression test covers bypassing cached read data and eviction behavior.
