### PR TITLE
fix(bottles): normalize review entity short names

### DIFF
--- a/apps/server/src/lib/bottleOperationReview.test.ts
+++ b/apps/server/src/lib/bottleOperationReview.test.ts
@@ -268,6 +268,49 @@ describe("Bottle operation review preparation", () => {
     });
   });
 
+  test("normalizes legacy blank distiller short names in Bottle update previews", async ({
+    fixtures,
+  }) => {
+    const distiller = await fixtures.Entity({
+      name: "Legacy Blank Short Name Distillery",
+      shortName: "",
+      type: ["distiller"],
+    });
+    const bottle = await fixtures.Bottle({
+      name: "Legacy Distiller Preview",
+      distillerIds: [distiller.id],
+    });
+
+    const result = await prepareOperation({
+      operation: {
+        id: 5,
+        proposal: {
+          type: "update_bottle",
+          input: {
+            bottleId: bottle.id,
+            patch: { exact: { edition: "Reviewed Edition" } },
+          },
+          rationale: "The inspected evidence confirms this edition.",
+          evidenceRefs: [{ kind: "bottle", bottleId: bottle.id }],
+        },
+      },
+      artifacts: artifacts({ bottleIds: [bottle.id] }),
+    });
+
+    expect(result).toMatchObject({
+      status: "pending_review",
+      type: "update_bottle",
+      preview: {
+        before: {
+          shared: { distillers: [{ shortName: null }] },
+        },
+        after: {
+          shared: { distillers: [{ shortName: null }] },
+        },
+      },
+    });
+  });
+
   test("reports merge membership and identity collisions as canonical merge warnings", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/bottleOperationReview/bottleShared.ts
+++ b/apps/server/src/lib/bottleOperationReview/bottleShared.ts
@@ -123,7 +123,7 @@ export function existingEntityChoice(entity: Entity) {
     kind: "existing" as const,
     entityId: entity.id,
     name: entity.name,
-    shortName: entity.shortName,
+    shortName: entity.shortName?.trim() || null,
     roles: [...entity.type].sort(),
   };
 }

--- a/apps/server/src/lib/bottleOperationReview/bottleUpdate.ts
+++ b/apps/server/src/lib/bottleOperationReview/bottleUpdate.ts
@@ -92,10 +92,7 @@ async function resolveEntityChoice({
       roles: [...current.entity.type].sort() as Entity["type"],
     };
     return {
-      preview: {
-        kind: "existing",
-        ...dependency,
-      },
+      preview: existingEntityChoice(current.entity),
       canonical: current.entity.id,
       dependency,
     };


### PR DESCRIPTION
Bottle update review previews now treat legacy blank or whitespace-only Entity short names as absent (`null`), allowing valid update proposals to reach moderation instead of failing prepared-review schema validation. Existing Entity proposals now reuse the same preview builder, so before/after previews remain consistent.

The database historically permits empty `short_name` values, while the prepared-review contract accepts only non-empty text or `null`. Raw dependency state remains unchanged for concurrency validation; only reviewer-facing preview values are normalized. Regression coverage reproduces an exact Bottle update with an affected distiller. The targeted 20-test review suite, server typecheck, lint, and formatting checks pass.
