### PR TITLE
fix(scraper): tolerate incomplete SMWS metadata

### DIFF
--- a/apps/server/src/worker/jobs/scrapeSMWS.test.ts
+++ b/apps/server/src/worker/jobs/scrapeSMWS.test.ts
@@ -91,3 +91,31 @@ test("bottle list", async ({ axiosMock }) => {
     ]
   `);
 });
+
+test("continues when optional SMWS catalog fields are absent", async ({
+  axiosMock,
+}) => {
+  const url = "https://smws.com/all-whisky?filter-page=1&per-page=128";
+  const payload = JSON.parse(await loadFixture("smws", "bottle-list.json")) as {
+    items: Record<string, unknown>[];
+  };
+
+  payload.items[0].cask_no = null;
+  payload.items[1].cask_type = null;
+  delete payload.items[2].distilleddate;
+  axiosMock.onGet(url).reply(200, payload);
+
+  const items: any[] = [];
+  await scrapeBottles(url, async (...item) => {
+    items.push(item);
+  });
+
+  expect(items).toHaveLength(127);
+  expect(items[0][0]).toMatchObject({
+    name: "3.350 Gladrags of yesteryear",
+    caskFill: null,
+    caskType: null,
+    caskSize: null,
+  });
+  expect(items[1][0].name).toBe("4.303 A nocturne sipper");
+});

--- a/apps/server/src/worker/jobs/scrapeSMWS.ts
+++ b/apps/server/src/worker/jobs/scrapeSMWS.ts
@@ -51,13 +51,12 @@ const SMWSPayloadSchema = z.object({
       name: z.string(),
       age: z.number().nullable(),
       abv: z.union([z.string(), z.number()]).nullable(),
-      cask_no: z.string(),
-      cask_type: z.string(),
+      cask_no: z.string().nullish(),
+      cask_type: z.string().nullish(),
       categories: z.array(z.string()),
       price: z.number(),
       url: z.string(),
       release_date: z.string().nullable(),
-      distilleddate: z.string(),
       image: z.string(),
     }),
   ),
@@ -82,17 +81,25 @@ export async function scrapeBottles(
           logScrapeWarning(SITE, "Cannot find cask name for product");
           return;
         }
-        const details = parseDetailsFromName(`${item.cask_no} ${caskName}`);
+        const caskNumber = item.cask_no;
+        if (!caskNumber) {
+          logScrapeWarning(SITE, "Cannot find cask number for product", {
+            caskName,
+          });
+          return;
+        }
+
+        const details = parseDetailsFromName(`${caskNumber} ${caskName}`);
         if (!details?.distiller) {
           logScrapeWarning(SITE, "Cannot find distiller", {
-            caskNumber: item.cask_no,
+            caskNumber,
             caskName,
           });
           return;
         }
         if (!details?.category) {
           logScrapeWarning(SITE, "Unsupported spirit", {
-            caskNumber: item.cask_no,
+            caskNumber,
             caskName,
           });
           return;
@@ -120,7 +127,9 @@ export async function scrapeBottles(
 
         const abv = parseAbv(item.abv);
 
-        const [caskFill, caskType, caskSize] = parseCaskType(item.cask_type);
+        const [caskFill, caskType, caskSize] = item.cask_type
+          ? parseCaskType(item.cask_type)
+          : [null, null, null];
         // "2nd fill ex-bourbon hogshead"
 
         await cb(


### PR DESCRIPTION
SMWS scraping now tolerates intermittent catalog items that omit the cask number, cask type, or unused distillation date. Products without an identifying cask number are skipped with a warning, while a missing cask type produces null cask metadata, so one incomplete catalog item no longer aborts the entire scrape.

The payload boundary previously required all three fields even though only the cask number is essential. This adds mixed-payload regression coverage for the fallback behavior. Server typechecking, formatting, linting, and a focused scraper smoke check pass; the package Vitest run is currently blocked by the local test database already containing the `bottle_check_close_reason` enum from a pending migration.
