### PR TITLE
fix(auth): handle existing accounts before passkey creation

### DIFF
--- a/apps/server/src/orpc/client.ts
+++ b/apps/server/src/orpc/client.ts
@@ -16,7 +16,7 @@ export function createClient(
         "user-agent": "@peated (orpc/proxy)",
       };
     },
-    interceptors: [sentryInterceptor({ captureInputs: true })],
+    interceptors: [sentryInterceptor()],
   });
 
   return createORPCClient(link);

--- a/apps/server/src/orpc/index.ts
+++ b/apps/server/src/orpc/index.ts
@@ -71,6 +71,4 @@ export const base = os
     },
   });
 
-// Base procedure with Sentry error tracking for all routes
-// Base procedure with Sentry only; ToS is enforced in UI flows
-export const procedure = base.use(sentryMiddleware({ captureInputs: true }));
+export const procedure = base.use(sentryMiddleware());

--- a/apps/server/src/orpc/routes/auth/register-challenge.test.ts
+++ b/apps/server/src/orpc/routes/auth/register-challenge.test.ts
@@ -1,3 +1,4 @@
+import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 
 describe("POST /auth/register/challenge", () => {
@@ -48,5 +49,49 @@ describe("POST /auth/register/challenge", () => {
     );
 
     expect(data.options).toBeDefined();
+  });
+
+  test("rejects an existing email before generating a credential", async ({
+    fixtures,
+  }) => {
+    await fixtures.User({ email: "existing@example.com" });
+
+    const error = await waitError(
+      routerClient.auth.registerChallenge(
+        {
+          username: "new-user",
+          email: "Existing@Example.com",
+        },
+        { context: { ip: "127.0.0.1" } },
+      ),
+    );
+
+    expect(error).toMatchObject({
+      status: 409,
+      message: "An account with this email already exists.",
+      data: { field: "email" },
+    });
+  });
+
+  test("rejects an existing username before generating a credential", async ({
+    fixtures,
+  }) => {
+    await fixtures.User({ username: "existing-user" });
+
+    const error = await waitError(
+      routerClient.auth.registerChallenge(
+        {
+          username: "Existing-User",
+          email: "new@example.com",
+        },
+        { context: { ip: "127.0.0.1" } },
+      ),
+    );
+
+    expect(error).toMatchObject({
+      status: 409,
+      message: "An account with this username already exists.",
+      data: { field: "username" },
+    });
   });
 });

--- a/apps/server/src/orpc/routes/auth/register-challenge.ts
+++ b/apps/server/src/orpc/routes/auth/register-challenge.ts
@@ -1,8 +1,11 @@
+import { db } from "@peated/server/db";
+import { users } from "@peated/server/db/schema";
 import { generatePasskeyChallenge } from "@peated/server/lib/passkey";
 import { procedure } from "@peated/server/orpc";
 import { authRateLimit } from "@peated/server/orpc/middleware";
 import type { PublicKeyCredentialCreationOptionsJSON } from "@simplewebauthn/server";
 import { createHash } from "crypto";
+import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
 export default procedure
@@ -20,7 +23,10 @@ export default procedure
   })
   .input(
     z.object({
-      username: z.string().describe("Username for the new account"),
+      username: z
+        .string()
+        .toLowerCase()
+        .describe("Username for the new account"),
       email: z
         .string()
         .email()
@@ -34,7 +40,34 @@ export default procedure
       signedChallenge: z.string(),
     }),
   )
-  .handler(async function ({ input }) {
+  .handler(async function ({ input, errors }) {
+    // Avoid creating a device credential that cannot be attached to a new
+    // account. The registration transaction still owns the race-safe check.
+    const [emailOwner, usernameOwner] = await Promise.all([
+      db.query.users.findFirst({
+        columns: { id: true },
+        where: eq(sql`LOWER(${users.email})`, input.email),
+      }),
+      db.query.users.findFirst({
+        columns: { id: true },
+        where: eq(sql`LOWER(${users.username})`, input.username),
+      }),
+    ]);
+
+    if (emailOwner) {
+      throw errors.CONFLICT({
+        message: "An account with this email already exists.",
+        data: { field: "email" },
+      });
+    }
+
+    if (usernameOwner) {
+      throw errors.CONFLICT({
+        message: "An account with this username already exists.",
+        data: { field: "username" },
+      });
+    }
+
     // Generate a random userID for WebAuthn
     // We use a hash of username+email to ensure consistency if they retry
     const userIdString = `${input.username}:${input.email}`;

--- a/apps/server/src/orpc/routes/auth/register.test.ts
+++ b/apps/server/src/orpc/routes/auth/register.test.ts
@@ -49,6 +49,10 @@ describe("POST /auth/register", () => {
     expect(err).toMatchInlineSnapshot(
       `[Error: An account with this username already exists.]`,
     );
+    expect(err).toMatchObject({
+      status: 409,
+      data: { field: "username" },
+    });
   });
 
   test("duplicate email", async ({ fixtures }) => {
@@ -68,5 +72,9 @@ describe("POST /auth/register", () => {
     expect(err).toMatchInlineSnapshot(
       `[Error: An account with this email already exists.]`,
     );
+    expect(err).toMatchObject({
+      status: 409,
+      data: { field: "email" },
+    });
   });
 });

--- a/apps/server/src/orpc/routes/auth/register.ts
+++ b/apps/server/src/orpc/routes/auth/register.ts
@@ -106,6 +106,7 @@ export default procedure
               err.constraint === "user_username_unq" ? "username" : "email";
             throw errors.CONFLICT({
               message: `An account with this ${fieldName} already exists.`,
+              data: { field: fieldName },
             });
           }
           throw err;
@@ -182,6 +183,7 @@ export default procedure
             err.constraint === "user_username_unq" ? "username" : "email";
           throw errors.CONFLICT({
             message: `An account with this ${fieldName} already exists.`,
+            data: { field: fieldName },
           });
         }
         throw err;

--- a/apps/web/src/app/recover-account/page.tsx
+++ b/apps/web/src/app/recover-account/page.tsx
@@ -12,6 +12,8 @@ export default async function PasswordReset(props: {
 }) {
   const searchParams = await props.searchParams;
   const token = searchParams.token;
+  const email =
+    typeof searchParams.email === "string" ? searchParams.email : "";
 
   return (
     <LayoutSplash>
@@ -26,7 +28,7 @@ export default async function PasswordReset(props: {
       {token ? (
         <PasswordResetChangeForm token={token} />
       ) : (
-        <PasswordResetForm />
+        <PasswordResetForm initialEmail={email} />
       )}
     </LayoutSplash>
   );

--- a/apps/web/src/components/loginForm.tsx
+++ b/apps/web/src/components/loginForm.tsx
@@ -34,6 +34,7 @@ function FormComponent({ showPassword }: { showPassword: boolean }) {
           required
           placeholder="you@example.com"
           autoFocus
+          defaultValue={searchParams.get("email") ?? ""}
         />
         {showPasswordField && (
           <TextField
@@ -67,6 +68,11 @@ function FormComponent({ showPassword }: { showPassword: boolean }) {
 export default function LoginForm() {
   const [result, formAction] = useActionState(authenticateForm, undefined);
   const [showEmailForm, setShowEmailForm] = useState(false);
+  const searchParams = useSearchParams();
+  const email = searchParams.get("email");
+  const recoveryHref = email
+    ? { pathname: "/recover-account", query: { email } }
+    : "/recover-account";
 
   return (
     <div className="min-w-sm flex flex-auto flex-col gap-y-4">
@@ -101,10 +107,7 @@ export default function LoginForm() {
             </div>
             <div>&middot;</div>
             <div>
-              <Link
-                href="/recover-account"
-                className="text-highlight underline"
-              >
+              <Link href={recoveryHref} className="text-highlight underline">
                 Account Recovery
               </Link>
             </div>
@@ -136,10 +139,7 @@ export default function LoginForm() {
             </div>
             <div>&middot;</div>
             <div>
-              <Link
-                href="/recover-account"
-                className="text-highlight underline"
-              >
+              <Link href={recoveryHref} className="text-highlight underline">
                 Account Recovery
               </Link>
             </div>

--- a/apps/web/src/components/passkeyRegisterButton.tsx
+++ b/apps/web/src/components/passkeyRegisterButton.tsx
@@ -3,6 +3,10 @@
 import Button from "@peated/web/components/button";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import {
+  getRegistrationConflictField,
+  type RegistrationConflictField,
+} from "@peated/web/lib/registration";
 import { startRegistration } from "@simplewebauthn/browser";
 import { useMutation } from "@tanstack/react-query";
 import { KeyRound } from "lucide-react";
@@ -15,12 +19,14 @@ export default function PasskeyRegisterButton({
   email,
   tosAccepted,
   onError,
+  onConflict,
 }: {
   action: (formData: FormData) => Promise<any>;
   username: string;
   email: string;
   tosAccepted: boolean;
   onError?: (error: string) => void;
+  onConflict?: (field: RegistrationConflictField, error: string) => void;
 }) {
   const orpc = useORPC();
   const router = useRouter();
@@ -71,19 +77,30 @@ export default function PasskeyRegisterButton({
 
       // Check if the action returned an error
       if (result?.error) {
-        onError?.(result.error);
+        if (result.conflictField) {
+          onConflict?.(result.conflictField, result.error);
+        } else {
+          onError?.(result.error);
+        }
         setLoading(false);
       }
       // If no error, the action will redirect, so we don't need to do anything
     } catch (err: any) {
-      logError(err, { context: "passkey_registration" });
-
       // Check if user cancelled the passkey prompt
       if (err.name === "NotAllowedError" || err.message?.includes("cancel")) {
         // User cancelled, just re-enable the form without showing an error
         setLoading(false);
         return;
       }
+
+      const conflictField = getRegistrationConflictField(err);
+      if (conflictField) {
+        onConflict?.(conflictField, err.message);
+        setLoading(false);
+        return;
+      }
+
+      logError(err, { context: "passkey_registration" });
 
       // Handle ORPC validation errors
       let errorMessage = "Failed to register with passkey";

--- a/apps/web/src/components/passwordResetForm.tsx
+++ b/apps/web/src/components/passwordResetForm.tsx
@@ -7,7 +7,7 @@ import { useActionState } from "react";
 import { useFormStatus } from "react-dom";
 import Alert from "./alert";
 
-function FormComponent() {
+function FormComponent({ initialEmail }: { initialEmail: string }) {
   const { pending } = useFormStatus();
 
   return (
@@ -21,6 +21,7 @@ function FormComponent() {
           required
           placeholder="you@example.com"
           autoFocus
+          defaultValue={initialEmail}
         />
       </div>
       <div className="flex justify-center gap-x-2">
@@ -32,7 +33,11 @@ function FormComponent() {
   );
 }
 
-export default function PasswordResetForm() {
+export default function PasswordResetForm({
+  initialEmail = "",
+}: {
+  initialEmail?: string;
+}) {
   const [result, formAction] = useActionState(passwordResetForm, undefined);
 
   return (
@@ -44,7 +49,7 @@ export default function PasswordResetForm() {
         </p>
       ) : (
         <form action={formAction}>
-          <FormComponent />
+          <FormComponent initialEmail={initialEmail} />
         </form>
       )}
     </div>

--- a/apps/web/src/components/registerForm.tsx
+++ b/apps/web/src/components/registerForm.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import Button from "@peated/web/components/button";
 import Link from "@peated/web/components/link";
+import PasskeyLoginButton from "@peated/web/components/passkeyLoginButton";
 import PasskeyRegisterButton from "@peated/web/components/passkeyRegisterButton";
 import TextField from "@peated/web/components/textField";
 import { authenticate, register } from "@peated/web/lib/auth.actions";
+import type { RegistrationConflictField } from "@peated/web/lib/registration";
 import { useState } from "react";
 import config from "../config";
 import Alert from "./alert";
@@ -14,6 +17,49 @@ export default function RegisterForm() {
   const [email, setEmail] = useState("");
   const [tosAccepted, setTosAccepted] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [conflictField, setConflictField] =
+    useState<RegistrationConflictField | null>(null);
+
+  const clearFeedback = () => {
+    setError(null);
+    setConflictField(null);
+  };
+
+  if (conflictField === "email") {
+    return (
+      <div className="min-w-sm flex flex-auto flex-col gap-y-4">
+        <Alert>{error}</Alert>
+        <p className="text-muted text-center text-sm">
+          Sign in with an existing passkey, choose another sign-in method, or
+          recover access to your account.
+        </p>
+        <PasskeyLoginButton action={authenticate} />
+        <Button
+          href={{ pathname: "/login", query: { email } }}
+          color="primary"
+          fullWidth
+        >
+          Other Sign-in Options
+        </Button>
+        <div className="mt-4 flex items-center justify-center gap-x-3 text-center text-sm">
+          <Link
+            href={{ pathname: "/recover-account", query: { email } }}
+            className="text-highlight underline"
+          >
+            Account Recovery
+          </Link>
+          <span>&middot;</span>
+          <button
+            type="button"
+            className="text-highlight underline"
+            onClick={clearFeedback}
+          >
+            Use a Different Email
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-w-sm flex flex-auto flex-col gap-y-4">
@@ -50,9 +96,10 @@ export default function RegisterForm() {
           placeholder="you@example.com"
           autoFocus
           value={email}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setEmail(e.target.value)
-          }
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setEmail(e.target.value);
+            clearFeedback();
+          }}
         />
         <TextField
           className="py-3"
@@ -62,9 +109,10 @@ export default function RegisterForm() {
           required
           placeholder="you99"
           value={username}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-            setUsername(e.target.value)
-          }
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setUsername(e.target.value);
+            clearFeedback();
+          }}
         />
         <label className="relative mb-3 block flex items-start gap-2 px-4 py-3 text-sm">
           <input
@@ -89,7 +137,14 @@ export default function RegisterForm() {
         username={username}
         email={email}
         tosAccepted={tosAccepted}
-        onError={setError}
+        onError={(message) => {
+          setConflictField(null);
+          setError(message);
+        }}
+        onConflict={(field, message) => {
+          setConflictField(field);
+          setError(message);
+        }}
       />
 
       <p className="mt-4 text-center text-sm">

--- a/apps/web/src/lib/auth.actions.ts
+++ b/apps/web/src/lib/auth.actions.ts
@@ -5,6 +5,7 @@ import { createServerClient } from "@peated/web/lib/orpc/client.server";
 import { redirect } from "next/navigation";
 import { getSafeRedirect } from "./auth";
 import { logInfo, logTelemetryError } from "./log";
+import { getRegistrationConflictField } from "./registration";
 import type { SessionData } from "./session.server";
 import { getSession } from "./session.server";
 
@@ -154,7 +155,12 @@ export async function register(formData: FormData) {
   );
 
   if (!result.ok) {
-    return { ok: false, error: result.errorMessage };
+    const conflictField = getRegistrationConflictField(result.error);
+    return {
+      ok: false,
+      error: result.errorMessage,
+      ...(conflictField ? { conflictField } : {}),
+    };
   }
 
   await saveAuthSession(session, result.data);
@@ -371,6 +377,7 @@ type Session = Awaited<ReturnType<typeof getSession>>;
 
 type SafeClientCallFailure = {
   error: {
+    data?: unknown;
     message: string;
     name?: string;
   };

--- a/apps/web/src/lib/orpc/link.ts
+++ b/apps/web/src/lib/orpc/link.ts
@@ -113,7 +113,7 @@ export function getLink({
           throw err;
         }
       },
-      sentryInterceptor({ captureInputs: true }),
+      sentryInterceptor(),
     ],
     plugins: [
       new BatchLinkPlugin({

--- a/apps/web/src/lib/registration.test.ts
+++ b/apps/web/src/lib/registration.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { getRegistrationConflictField } from "./registration";
+
+describe("getRegistrationConflictField", () => {
+  it.each(["email", "username"] as const)(
+    "recognizes a structured %s conflict",
+    (field) => {
+      expect(
+        getRegistrationConflictField({
+          name: "CONFLICT",
+          data: { field },
+        }),
+      ).toBe(field);
+    },
+  );
+
+  it("ignores unrelated and malformed errors", () => {
+    expect(
+      getRegistrationConflictField({
+        name: "INTERNAL_SERVER_ERROR",
+        data: { field: "email" },
+      }),
+    ).toBeNull();
+    expect(
+      getRegistrationConflictField({
+        name: "CONFLICT",
+        data: { field: "password" },
+      }),
+    ).toBeNull();
+    expect(getRegistrationConflictField(new Error("Conflict"))).toBeNull();
+  });
+});

--- a/apps/web/src/lib/registration.ts
+++ b/apps/web/src/lib/registration.ts
@@ -1,0 +1,18 @@
+export type RegistrationConflictField = "email" | "username";
+
+export function getRegistrationConflictField(
+  error: unknown,
+): RegistrationConflictField | null {
+  if (!error || typeof error !== "object") return null;
+
+  const { code, data, name } = error as {
+    code?: unknown;
+    data?: unknown;
+    name?: unknown;
+  };
+  if (name !== "CONFLICT" && code !== "CONFLICT") return null;
+  if (!data || typeof data !== "object") return null;
+
+  const field = (data as { field?: unknown }).field;
+  return field === "email" || field === "username" ? field : null;
+}

--- a/packages/orpc/src/server/middleware.ts
+++ b/packages/orpc/src/server/middleware.ts
@@ -1,13 +1,19 @@
-import { os } from "@orpc/server";
+import { ORPCError, os } from "@orpc/server";
 import * as Sentry from "@sentry/core";
 
 type Options = {
   captureInputs?: boolean;
 };
 
+export function shouldCaptureORPCServerError(error: unknown): boolean {
+  if (!(error instanceof ORPCError)) return true;
+  return typeof error.status !== "number" || error.status >= 500;
+}
+
 /**
  * Creates Sentry middleware for oRPC procedures that automatically instruments
- * RPC calls with distributed tracing and error reporting on the server side.
+ * RPC calls with distributed tracing and unexpected error reporting on the
+ * server side.
  *
  * @param options - Configuration options for the middleware
  * @param options.captureInputs - Whether to capture RPC input arguments in span attributes (default: false)
@@ -50,16 +56,18 @@ const sentryMiddleware = (options: Options = {}) =>
             code: 2,
           });
 
-          // Log error to console for development/debugging
-          console.error(
-            `[ORPC Error] ${path.join("/")}:`,
-            error,
-            options.captureInputs
-              ? `\nInput: ${JSON.stringify(input, null, 2)}`
-              : "",
-          );
+          if (shouldCaptureORPCServerError(error)) {
+            // Log error to console for development/debugging
+            console.error(
+              `[ORPC Error] ${path.join("/")}:`,
+              error,
+              options.captureInputs
+                ? `\nInput: ${JSON.stringify(input, null, 2)}`
+                : "",
+            );
 
-          Sentry.captureException(error);
+            Sentry.captureException(error);
+          }
 
           // Re-throw the error so it can be handled by the error handler
           throw error;


### PR DESCRIPTION
Passkey signup now checks email and username availability before opening the WebAuthn creation prompt. Existing-email conflicts move users into the established account-access flow with passkey login, alternate sign-in options, recovery, and a route back to registration; username conflicts remain editable in place.

Expected oRPC 4xx responses no longer create Sentry issues, and RPC inputs are no longer serialized into telemetry. This keeps ordinary account conflicts out of error reporting and avoids sending auth payloads such as passwords or passkey registration material as span attributes.

The database uniqueness constraint remains the race-safe authority; the new challenge check is an early UX guard. Structured conflict metadata covers both the early check and a conflict at final account creation.
