### PR TITLE
fix(web): align bottle status icons with names

### DIFF
--- a/apps/web/src/app/(default)/flights/[flightId]/page.tsx
+++ b/apps/web/src/app/(default)/flights/[flightId]/page.tsx
@@ -61,16 +61,16 @@ export default function Page(props: { params: Promise<{ flightId: string }> }) {
             return (
               <tr key={bottle.id} className="border-b border-slate-800">
                 <td className="max-w-0 py-4 pl-4 pr-3 text-sm sm:pl-3">
-                  <div className="flex items-center gap-x-1">
-                    <FlightBottleIdentity
-                      bottle={bottle}
-                      flightId={flight.id}
-                    />
-                    <BottleStatusIndicators
-                      hasTasted={flightBottle.hasTasted}
-                      isLibrary={flightBottle.isLibrary}
-                    />
-                  </div>
+                  <FlightBottleIdentity
+                    bottle={bottle}
+                    flightId={flight.id}
+                    trailingContent={
+                      <BottleStatusIndicators
+                        hasTasted={flightBottle.hasTasted}
+                        isLibrary={flightBottle.isLibrary}
+                      />
+                    }
+                  />
                   <div className="mt-3 sm:hidden">
                     <Button
                       color={flightBottle.hasTasted ? "default" : "highlight"}

--- a/apps/web/src/components/bottleTable.test.tsx
+++ b/apps/web/src/components/bottleTable.test.tsx
@@ -1,0 +1,59 @@
+import type { CollectionBottle } from "@peated/server/types";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import BottleTable from "./bottleTable";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+function makeCollectionBottle(): CollectionBottle {
+  return {
+    id: 1,
+    bottle: {
+      id: 42,
+      fullName: "Compass Box No Name No. 1",
+      name: "No Name No. 1",
+      brand: { id: 2, name: "Compass Box", shortName: null },
+      group: { name: "No Name", statedAge: null },
+      series: null,
+      edition: "No. 1",
+      category: "blend",
+      statedAge: null,
+      abv: 48.9,
+      vintageYear: null,
+      releaseYear: null,
+      singleCask: false,
+      caskStrength: false,
+      caskFill: null,
+      caskType: null,
+      caskSize: null,
+      avgRating: null,
+      ratingStats: { total: 0 },
+    },
+    hasTasted: true,
+  } as CollectionBottle;
+}
+
+describe("BottleTable", () => {
+  it("renders bottle status immediately after the bold bottle name", () => {
+    const html = renderToStaticMarkup(
+      <BottleTable
+        bottleList={[makeCollectionBottle()]}
+        compactIdentity
+        hideLibraryStatus
+        noHeaders
+        showBottleStats={false}
+      />,
+    );
+
+    const namePosition = html.indexOf("No Name</a>");
+    const statusPosition = html.indexOf('aria-label="Tasted"');
+    const metadataPosition = html.indexOf("48.9% ABV");
+
+    expect(namePosition).toBeGreaterThan(-1);
+    expect(statusPosition).toBeGreaterThan(namePosition);
+    expect(metadataPosition).toBeGreaterThan(statusPosition);
+  });
+});

--- a/apps/web/src/components/bottleTable.tsx
+++ b/apps/web/src/components/bottleTable.tsx
@@ -101,11 +101,13 @@ export default function BottleTable({
                     mode="absolute"
                     metadataVariant={compactIdentity ? "summary" : "full"}
                     showBrand={!props.groupBy}
+                    trailingContent={statusIndicators}
                   />
-                  <div className="text-muted mt-1 flex min-w-0 flex-wrap items-center gap-x-1 text-sm">
-                    {statusIndicators}
-                    {collectionMeta}
-                  </div>
+                  {collectionMeta ? (
+                    <div className="text-muted mt-1 flex min-w-0 flex-wrap items-center gap-x-1 text-sm">
+                      {collectionMeta}
+                    </div>
+                  ) : null}
                 </div>
                 {showRatingSummary ? (
                   <BottleRatingSummary

--- a/apps/web/src/components/flightBottleIdentity.tsx
+++ b/apps/web/src/components/flightBottleIdentity.tsx
@@ -2,7 +2,7 @@
 
 import type { Bottle } from "@peated/server/types";
 import { getAddBottleHref } from "@peated/web/lib/addBottle";
-import { useState } from "react";
+import { type ReactNode, useState } from "react";
 import BottleIdentity from "./bottleIdentity";
 import BottlePanel from "./bottlePanel";
 import { ClientOnly } from "./clientOnly";
@@ -10,9 +10,11 @@ import { ClientOnly } from "./clientOnly";
 export default function FlightBottleIdentity({
   bottle,
   flightId,
+  trailingContent,
 }: {
   bottle: Bottle;
   flightId: string;
+  trailingContent?: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -22,6 +24,7 @@ export default function FlightBottleIdentity({
         bottle={bottle}
         mode="absolute"
         metadataVariant="summary"
+        trailingContent={trailingContent}
         onClick={(event) => {
           event.preventDefault();
           setOpen(true);


### PR DESCRIPTION
Bottle status indicators now render alongside the bold bottle name in library/catalog tables and flight rows, before release metadata. This keeps tasted/library state attached to the identity it describes instead of appearing as a separate metadata line.

The focused table regression covers the original title/status/metadata ordering without adding broad rendering assertions.
