### PR TITLE
feat(auth): add OAuth PKCE authorization for public clients

### DIFF
--- a/apps/server/migrations/0200_yummy_polaris.sql
+++ b/apps/server/migrations/0200_yummy_polaris.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "oauth_authorization_code" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"code_digest" varchar(64) NOT NULL,
+	"oauth_client_id" bigint NOT NULL,
+	"user_id" bigint NOT NULL,
+	"redirect_uri" text NOT NULL,
+	"code_challenge" varchar(128) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"consumed_at" timestamp
+);
+
+CREATE TABLE "oauth_client" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"client_id" varchar(64) NOT NULL,
+	"name" varchar(120) NOT NULL,
+	"redirect_uris" text[] NOT NULL,
+	"active" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+ALTER TABLE "oauth_authorization_code" ADD CONSTRAINT "oauth_authorization_code_oauth_client_id_oauth_client_id_fk" FOREIGN KEY ("oauth_client_id") REFERENCES "public"."oauth_client"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "oauth_authorization_code" ADD CONSTRAINT "oauth_authorization_code_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;
+CREATE UNIQUE INDEX "oauth_authorization_code_digest_unq" ON "oauth_authorization_code" USING btree ("code_digest");
+CREATE INDEX "oauth_authorization_code_client_idx" ON "oauth_authorization_code" USING btree ("oauth_client_id");
+CREATE INDEX "oauth_authorization_code_user_idx" ON "oauth_authorization_code" USING btree ("user_id");
+CREATE INDEX "oauth_authorization_code_expires_idx" ON "oauth_authorization_code" USING btree ("expires_at");
+CREATE UNIQUE INDEX "oauth_client_client_id_unq" ON "oauth_client" USING btree ("client_id");

--- a/apps/server/migrations/meta/0200_snapshot.json
+++ b/apps/server/migrations/meta/0200_snapshot.json
@@ -1,0 +1,8065 @@
+{
+  "id": "c3c6fe70-21ec-4ff6-a64e-8cc940c5e7c7",
+  "prevId": "3e9cffc1-93af-41bf-895a-5f89965bf81c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bottle_release_promotion": {
+      "name": "bottle_release_promotion",
+      "schema": "",
+      "columns": {
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "promoted_bottle_id": {
+          "name": "promoted_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_release_promotion_bottle_idx": {
+          "name": "bottle_release_promotion_bottle_idx",
+          "columns": [
+            {
+              "expression": "promoted_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_release": {
+      "name": "bottle_release",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vintage_year": {
+          "name": "vintage_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abv": {
+          "name": "abv",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "single_cask": {
+          "name": "single_cask",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_strength": {
+          "name": "cask_strength",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_age": {
+          "name": "stated_age",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_size": {
+          "name": "cask_size",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_type": {
+          "name": "cask_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_fill": {
+          "name": "cask_fill",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasting_notes": {
+          "name": "tasting_notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_tags": {
+          "name": "suggested_tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_release_bottle_idx": {
+          "name": "bottle_release_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_release_created_by_actor_idx": {
+          "name": "bottle_release_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_release_full_name_idx": {
+          "name": "bottle_release_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_release_bottle_id_bottle_id_fk": {
+          "name": "bottle_release_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_release",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_release_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_release_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_release",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bottle_release_stated_age_check": {
+          "name": "bottle_release_stated_age_check",
+          "value": "\"bottle_release\".\"stated_age\" IS NULL OR (\"bottle_release\".\"stated_age\" >= 0 AND \"bottle_release\".\"stated_age\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.legacy_release_repair_review": {
+      "name": "legacy_release_repair_review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "legacy_bottle_id": {
+          "name": "legacy_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_parent_full_name": {
+          "name": "proposed_parent_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_bottle_fingerprint": {
+          "name": "legacy_bottle_fingerprint",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_candidates_fingerprint": {
+          "name": "parent_candidates_fingerprint",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_edition": {
+          "name": "release_edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "legacy_release_repair_review_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_parent_bottle_id": {
+          "name": "reviewed_parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_version": {
+          "name": "review_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legacy_release_repair_review_bottle_idx": {
+          "name": "legacy_release_repair_review_bottle_idx",
+          "columns": [
+            {
+              "expression": "legacy_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_release_repair_review_parent_idx": {
+          "name": "legacy_release_repair_review_parent_idx",
+          "columns": [
+            {
+              "expression": "reviewed_parent_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_release_repair_review_resolution_idx": {
+          "name": "legacy_release_repair_review_resolution_idx",
+          "columns": [
+            {
+              "expression": "resolution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor": {
+      "name": "actor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "actor_type_key_unq": {
+          "name": "actor_type_key_unq",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "actor_user_idx": {
+          "name": "actor_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actor_user_id_user_id_fk": {
+          "name": "actor_user_id_user_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badge_award_tracked_object": {
+      "name": "badge_award_tracked_object",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "award_id": {
+          "name": "award_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "badge_award_object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "badge_award_tracked_object_unq": {
+          "name": "badge_award_tracked_object_unq",
+          "columns": [
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "badge_award_tracked_object_award_id_badge_award_id_fk": {
+          "name": "badge_award_tracked_object_award_id_badge_award_id_fk",
+          "tableFrom": "badge_award_tracked_object",
+          "tableTo": "badge_award",
+          "columnsFrom": [
+            "award_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badge_award": {
+      "name": "badge_award",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp": {
+          "name": "xp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level": {
+          "name": "level",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "badge_award_unq": {
+          "name": "badge_award_unq",
+          "columns": [
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "badge_award_badge_id_badges_id_fk": {
+          "name": "badge_award_badge_id_badges_id_fk",
+          "tableFrom": "badge_award",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "badge_award_user_id_user_id_fk": {
+          "name": "badge_award_user_id_user_id_fk",
+          "tableFrom": "badge_award",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_level": {
+          "name": "max_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "tracker": {
+          "name": "tracker",
+          "type": "badge_award_object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bottle'"
+        },
+        "formula": {
+          "name": "formula",
+          "type": "badge_formula",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "checks": {
+          "name": "checks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "badge_name_unq": {
+          "name": "badge_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_check": {
+      "name": "bottle_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "bottle_check_intent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "bottle_check_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_event_key": {
+          "name": "background_event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_snapshot": {
+          "name": "input_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_metadata": {
+          "name": "model_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_price_match_proposal_id": {
+          "name": "store_price_match_proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_price_match_attempt_id": {
+          "name": "store_price_match_attempt_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_id": {
+          "name": "closed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "bottle_check_close_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_note": {
+          "name": "close_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bottle_check_subject_created_idx": {
+          "name": "bottle_check_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_bottle_idx": {
+          "name": "bottle_check_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_source_idx": {
+          "name": "bottle_check_source_idx",
+          "columns": [
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_background_event_unq": {
+          "name": "bottle_check_background_event_unq",
+          "columns": [
+            {
+              "expression": "background_event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_store_price_proposal_idx": {
+          "name": "bottle_check_store_price_proposal_idx",
+          "columns": [
+            {
+              "expression": "store_price_match_proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_store_price_attempt_idx": {
+          "name": "bottle_check_store_price_attempt_idx",
+          "columns": [
+            {
+              "expression": "store_price_match_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_closed_idx": {
+          "name": "bottle_check_closed_idx",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_check_bottle_id_bottle_id_fk": {
+          "name": "bottle_check_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bottle_check_store_price_match_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "bottle_check_store_price_match_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "store_price_match_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bottle_check_store_price_match_attempt_id_store_price_match_attempt_id_fk": {
+          "name": "bottle_check_store_price_match_attempt_id_store_price_match_attempt_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "store_price_match_attempt",
+          "columnsFrom": [
+            "store_price_match_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bottle_check_closed_by_id_user_id_fk": {
+          "name": "bottle_check_closed_by_id_user_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "user",
+          "columnsFrom": [
+            "closed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_operation": {
+      "name": "bottle_operation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal": {
+          "name": "proposal",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state_token": {
+          "name": "state_token",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preparation_error": {
+          "name": "preparation_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "bottle_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "bottle_operation_rejection_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_completed_at": {
+          "name": "execution_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bottle_operation_check_idx": {
+          "name": "bottle_operation_check_idx",
+          "columns": [
+            {
+              "expression": "check_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_operation_status_idx": {
+          "name": "bottle_operation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_operation_reviewer_idx": {
+          "name": "bottle_operation_reviewer_idx",
+          "columns": [
+            {
+              "expression": "reviewed_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_operation_check_id_bottle_check_id_fk": {
+          "name": "bottle_operation_check_id_bottle_check_id_fk",
+          "tableFrom": "bottle_operation",
+          "tableTo": "bottle_check",
+          "columnsFrom": [
+            "check_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_operation_reviewed_by_id_user_id_fk": {
+          "name": "bottle_operation_reviewed_by_id_user_id_fk",
+          "tableFrom": "bottle_operation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_alias": {
+      "name": "bottle_alias",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(3072)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored": {
+          "name": "ignored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "bottle_alias_assignment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy'"
+        },
+        "assigned_by_actor_id": {
+          "name": "assigned_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bottle_alias_name_idx": {
+          "name": "bottle_alias_name_idx",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_alias_bottle_idx": {
+          "name": "bottle_alias_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_alias_release_idx": {
+          "name": "bottle_alias_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_alias_assigned_by_actor_idx": {
+          "name": "bottle_alias_assigned_by_actor_idx",
+          "columns": [
+            {
+              "expression": "assigned_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_alias_bottle_id_bottle_id_fk": {
+          "name": "bottle_alias_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_alias",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_alias_assigned_by_actor_id_actor_id_fk": {
+          "name": "bottle_alias_assigned_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_alias",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "assigned_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_barcode": {
+      "name": "bottle_barcode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gtin14": {
+          "name": "gtin14",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_barcode_gtin14_unq": {
+          "name": "bottle_barcode_gtin14_unq",
+          "columns": [
+            {
+              "expression": "gtin14",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_barcode_bottle_idx": {
+          "name": "bottle_barcode_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_barcode_created_by_actor_idx": {
+          "name": "bottle_barcode_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_barcode_bottle_id_bottle_id_fk": {
+          "name": "bottle_barcode_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_barcode",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_barcode_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_barcode_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_barcode",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bottle_barcode_value_check": {
+          "name": "bottle_barcode_value_check",
+          "value": "\"bottle_barcode\".\"value\" ~ '^[0-9]+$' AND char_length(\"bottle_barcode\".\"value\") IN (8, 12, 13, 14)"
+        },
+        "bottle_barcode_gtin14_check": {
+          "name": "bottle_barcode_gtin14_check",
+          "value": "\"bottle_barcode\".\"gtin14\" ~ '^[0-9]{14}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bottle_flavor_profile": {
+      "name": "bottle_flavor_profile",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_flavor_profile_bottle_id_bottle_id_fk": {
+          "name": "bottle_flavor_profile_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_flavor_profile",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_flavor_profile_bottle_id_flavor_profile_pk": {
+          "name": "bottle_flavor_profile_bottle_id_flavor_profile_pk",
+          "columns": [
+            "bottle_id",
+            "flavor_profile"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_group_distiller": {
+      "name": "bottle_group_distiller",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distiller_id": {
+          "name": "distiller_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_group_distiller_group_id_bottle_group_id_fk": {
+          "name": "bottle_group_distiller_group_id_bottle_group_id_fk",
+          "tableFrom": "bottle_group_distiller",
+          "tableTo": "bottle_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_distiller_distiller_id_entity_id_fk": {
+          "name": "bottle_group_distiller_distiller_id_entity_id_fk",
+          "tableFrom": "bottle_group_distiller",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "distiller_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_group_distiller_group_id_distiller_id_pk": {
+          "name": "bottle_group_distiller_group_id_distiller_id_pk",
+          "columns": [
+            "group_id",
+            "distiller_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_group": {
+      "name": "bottle_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stated_age": {
+          "name": "stated_age",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottler_id": {
+          "name": "bottler_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_bottle_id": {
+          "name": "representative_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_stats": {
+          "name": "rating_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pass\":0,\"sip\":0,\"savor\":0,\"total\":0,\"avg\":null,\"percentage\":{\"pass\":0,\"sip\":0,\"savor\":0}}'::jsonb"
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_group_brand_idx": {
+          "name": "bottle_group_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_bottler_idx": {
+          "name": "bottle_group_bottler_idx",
+          "columns": [
+            {
+              "expression": "bottler_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_series_idx": {
+          "name": "bottle_group_series_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_category_idx": {
+          "name": "bottle_group_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_representative_bottle_idx": {
+          "name": "bottle_group_representative_bottle_idx",
+          "columns": [
+            {
+              "expression": "representative_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_created_by_actor_idx": {
+          "name": "bottle_group_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_group_series_id_bottle_series_id_fk": {
+          "name": "bottle_group_series_id_bottle_series_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "bottle_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_brand_id_entity_id_fk": {
+          "name": "bottle_group_brand_id_entity_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_bottler_id_entity_id_fk": {
+          "name": "bottle_group_bottler_id_entity_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "bottler_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_group_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_representative_membership_fk": {
+          "name": "bottle_group_representative_membership_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "representative_bottle_id",
+            "id"
+          ],
+          "columnsTo": [
+            "id",
+            "group_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bottle_group_stated_age_check": {
+          "name": "bottle_group_stated_age_check",
+          "value": "\"bottle_group\".\"stated_age\" IS NULL OR (\"bottle_group\".\"stated_age\" >= 0 AND \"bottle_group\".\"stated_age\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bottle_observation": {
+      "name": "bottle_observation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_identity": {
+          "name": "parsed_identity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facts": {
+          "name": "facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bottle_observation_source_idx": {
+          "name": "bottle_observation_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_bottle_idx": {
+          "name": "bottle_observation_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_release_idx": {
+          "name": "bottle_observation_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_external_site_idx": {
+          "name": "bottle_observation_external_site_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_observation_bottle_id_bottle_id_fk": {
+          "name": "bottle_observation_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_observation_external_site_id_external_site_id_fk": {
+          "name": "bottle_observation_external_site_id_external_site_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_observation_created_by_id_user_id_fk": {
+          "name": "bottle_observation_created_by_id_user_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_series": {
+      "name": "bottle_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_releases": {
+          "name": "num_releases",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_series_full_name_key": {
+          "name": "bottle_series_full_name_key",
+          "columns": [
+            {
+              "expression": "LOWER(\"full_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_series_search_idx": {
+          "name": "bottle_series_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bottle_series_brand_idx": {
+          "name": "bottle_series_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_series_created_by_actor_idx": {
+          "name": "bottle_series_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_series_brand_id_entity_id_fk": {
+          "name": "bottle_series_brand_id_entity_id_fk",
+          "tableFrom": "bottle_series",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_series_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_series_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_series",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_tag": {
+      "name": "bottle_tag",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_tag_bottle_id_bottle_id_fk": {
+          "name": "bottle_tag_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_tag",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_tag_bottle_id_tag_pk": {
+          "name": "bottle_tag_bottle_id_tag_pk",
+          "columns": [
+            "bottle_id",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_tombstone": {
+      "name": "bottle_tombstone",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_bottle_id": {
+          "name": "new_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle": {
+      "name": "bottle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stated_age": {
+          "name": "stated_age",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottler_id": {
+          "name": "bottler_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abv": {
+          "name": "abv",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "single_cask": {
+          "name": "single_cask",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_strength": {
+          "name": "cask_strength",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vintage_year": {
+          "name": "vintage_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_size": {
+          "name": "cask_size",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_type": {
+          "name": "cask_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_fill": {
+          "name": "cask_fill",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasting_notes": {
+          "name": "tasting_notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_tags": {
+          "name": "suggested_tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_stats": {
+          "name": "rating_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pass\":0,\"sip\":0,\"savor\":0,\"total\":0,\"avg\":null,\"percentage\":{\"pass\":0,\"sip\":0,\"savor\":0}}'::jsonb"
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_releases": {
+          "name": "num_releases",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_group_idx": {
+          "name": "bottle_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_search_idx": {
+          "name": "bottle_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bottle_brand_idx": {
+          "name": "bottle_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_bottler_idx": {
+          "name": "bottle_bottler_idx",
+          "columns": [
+            {
+              "expression": "bottler_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_created_by_actor_idx": {
+          "name": "bottle_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_category_idx": {
+          "name": "bottle_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_flavor_profile_idx": {
+          "name": "bottle_flavor_profile_idx",
+          "columns": [
+            {
+              "expression": "flavor_profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_group_id_bottle_group_id_fk": {
+          "name": "bottle_group_id_bottle_group_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "bottle_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_series_id_bottle_series_id_fk": {
+          "name": "bottle_series_id_bottle_series_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "bottle_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_brand_id_entity_id_fk": {
+          "name": "bottle_brand_id_entity_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_bottler_id_entity_id_fk": {
+          "name": "bottle_bottler_id_entity_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "bottler_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bottle_id_group_id_unq": {
+          "name": "bottle_id_group_id_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bottle_stated_age_check": {
+          "name": "bottle_stated_age_check",
+          "value": "\"bottle\".\"stated_age\" IS NULL OR (\"bottle\".\"stated_age\" >= 0 AND \"bottle\".\"stated_age\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bottle_distiller": {
+      "name": "bottle_distiller",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distiller_id": {
+          "name": "distiller_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_distiller_bottle_id_bottle_id_fk": {
+          "name": "bottle_distiller_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_distiller",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_distiller_distiller_id_entity_id_fk": {
+          "name": "bottle_distiller_distiller_id_entity_id_fk",
+          "tableFrom": "bottle_distiller",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "distiller_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_distiller_bottle_id_distiller_id_pk": {
+          "name": "bottle_distiller_bottle_id_distiller_id_pk",
+          "columns": [
+            "bottle_id",
+            "distiller_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change": {
+      "name": "change",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'add'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "change_actor_idx": {
+          "name": "change_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_actor_id_actor_id_fk": {
+          "name": "change_actor_id_actor_id_fk",
+          "tableFrom": "change",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection_bottle": {
+      "name": "collection_bottle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "collection_bottle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_bottle_bottle_idx": {
+          "name": "collection_bottle_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_bottle_release_idx": {
+          "name": "collection_bottle_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_bottle_collection_id_collection_id_fk": {
+          "name": "collection_bottle_collection_id_collection_id_fk",
+          "tableFrom": "collection_bottle",
+          "tableTo": "collection",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collection_bottle_bottle_id_bottle_id_fk": {
+          "name": "collection_bottle_bottle_id_bottle_id_fk",
+          "tableFrom": "collection_bottle",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collection_bottle_collection_id_bottle_id_unique": {
+          "name": "collection_bottle_collection_id_bottle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "collection_id",
+            "bottle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection": {
+      "name": "collection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "collection_name_unq": {
+          "name": "collection_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\"), \"created_by_id\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_created_by_idx": {
+          "name": "collection_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_created_by_id_user_id_fk": {
+          "name": "collection_created_by_id_user_id_fk",
+          "tableFrom": "collection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "comment_unq": {
+          "name": "comment_unq",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_tasting_id_tasting_id_fk": {
+          "name": "comments_tasting_id_tasting_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_created_by_id_user_id_fk": {
+          "name": "comments_created_by_id_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alpha2": {
+          "name": "alpha2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_distillers": {
+          "name": "total_distillers",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "country_name_unq": {
+          "name": "country_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "country_slug_unq": {
+          "name": "country_slug_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity": {
+      "name": "entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "entity_type[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year_established": {
+          "name": "year_established",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_name_unq": {
+          "name": "entity_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_search_idx": {
+          "name": "entity_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "entity_country_by_idx": {
+          "name": "entity_country_by_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_region_idx": {
+          "name": "entity_region_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_created_by_actor_idx": {
+          "name": "entity_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_country_id_country_id_fk": {
+          "name": "entity_country_id_country_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_region_id_region_id_fk": {
+          "name": "entity_region_id_region_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_created_by_actor_id_actor_id_fk": {
+          "name": "entity_created_by_actor_id_actor_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_parent_fk": {
+          "name": "entity_parent_fk",
+          "tableFrom": "entity",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_alias": {
+      "name": "entity_alias",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entity_alias_entity_idx": {
+          "name": "entity_alias_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_alias_name_idx": {
+          "name": "entity_alias_name_idx",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_alias_entity_id_entity_id_fk": {
+          "name": "entity_alias_entity_id_entity_id_fk",
+          "tableFrom": "entity_alias",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_tombstone": {
+      "name": "entity_tombstone",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_entity_id": {
+          "name": "new_entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event": {
+      "name": "event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repeats": {
+          "name": "repeats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_name_unq": {
+          "name": "event_name_unq",
+          "columns": [
+            {
+              "expression": "date_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_country_id": {
+          "name": "event_country_id",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_country_id_country_id_fk": {
+          "name": "event_country_id_country_id_fk",
+          "tableFrom": "event",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_site_config": {
+      "name": "external_site_config",
+      "schema": "",
+      "columns": {
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "external_site_config_external_site_id_external_site_id_fk": {
+          "name": "external_site_config_external_site_id_external_site_id_fk",
+          "tableFrom": "external_site_config",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "external_site_config_external_site_id_key_pk": {
+          "name": "external_site_config_external_site_id_key_pk",
+          "columns": [
+            "external_site_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_site": {
+      "name": "external_site",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "external_site_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_every": {
+          "name": "run_every",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_site_type": {
+          "name": "external_site_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight_bottle": {
+      "name": "flight_bottle",
+      "schema": "",
+      "columns": {
+        "flight_id": {
+          "name": "flight_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flight_bottle_bottle_idx": {
+          "name": "flight_bottle_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flight_bottle_release_idx": {
+          "name": "flight_bottle_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flight_bottle_flight_id_flight_id_fk": {
+          "name": "flight_bottle_flight_id_flight_id_fk",
+          "tableFrom": "flight_bottle",
+          "tableTo": "flight",
+          "columnsFrom": [
+            "flight_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "flight_bottle_bottle_id_bottle_id_fk": {
+          "name": "flight_bottle_bottle_id_bottle_id_fk",
+          "tableFrom": "flight_bottle",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flight_bottle_flight_id_bottle_id_unique": {
+          "name": "flight_bottle_flight_id_bottle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flight_id",
+            "bottle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight": {
+      "name": "flight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "flight_public_id": {
+          "name": "flight_public_id",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flight_created_by_id_user_id_fk": {
+          "name": "flight_created_by_id_user_id_fk",
+          "tableFrom": "flight",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follow": {
+      "name": "follow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "follow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_unq": {
+          "name": "follow_unq",
+          "columns": [
+            {
+              "expression": "from_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_to_user_idx": {
+          "name": "follow_to_user_idx",
+          "columns": [
+            {
+              "expression": "to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_from_user_id_user_id_fk": {
+          "name": "follow_from_user_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "follow_to_user_id_user_id_fk": {
+          "name": "follow_to_user_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity": {
+      "name": "identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "identity_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "identity_unq": {
+          "name": "identity_unq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_user_idx": {
+          "name": "identity_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_user_id_user_id_fk": {
+          "name": "identity_user_id_user_id_fk",
+          "tableFrom": "identity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incoming_bottle_decision_log": {
+      "name": "incoming_bottle_decision_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "incoming_bottle_decision_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "incoming_bottle_decision_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_bottle": {
+          "name": "created_bottle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_release": {
+          "name": "created_release",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incoming_bottle_decision_source_unq": {
+          "name": "incoming_bottle_decision_source_unq",
+          "columns": [
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_created_idx": {
+          "name": "incoming_bottle_decision_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_external_site_idx": {
+          "name": "incoming_bottle_decision_external_site_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_bottle_idx": {
+          "name": "incoming_bottle_decision_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_release_idx": {
+          "name": "incoming_bottle_decision_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_actor_ref_idx": {
+          "name": "incoming_bottle_decision_actor_ref_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incoming_bottle_decision_log_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "incoming_bottle_decision_log_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_external_site_id_external_site_id_fk": {
+          "name": "incoming_bottle_decision_log_external_site_id_external_site_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_actor_id_actor_id_fk": {
+          "name": "incoming_bottle_decision_log_actor_id_actor_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_bottle_id_bottle_id_fk": {
+          "name": "incoming_bottle_decision_log_bottle_id_bottle_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "notifications_unq": {
+          "name": "notifications_unq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_from_user_id_user_id_fk": {
+          "name": "notifications_from_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_code": {
+      "name": "oauth_authorization_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_digest": {
+          "name": "code_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_authorization_code_digest_unq": {
+          "name": "oauth_authorization_code_digest_unq",
+          "columns": [
+            {
+              "expression": "code_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_code_client_idx": {
+          "name": "oauth_authorization_code_client_idx",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_code_user_idx": {
+          "name": "oauth_authorization_code_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_code_expires_idx": {
+          "name": "oauth_authorization_code_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_code_oauth_client_id_oauth_client_id_fk": {
+          "name": "oauth_authorization_code_oauth_client_id_oauth_client_id_fk",
+          "tableFrom": "oauth_authorization_code",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "oauth_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_code_user_id_user_id_fk": {
+          "name": "oauth_authorization_code_user_id_user_id_fk",
+          "tableFrom": "oauth_authorization_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id_unq": {
+          "name": "oauth_client_client_id_unq",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_credential_id_unq": {
+          "name": "passkey_credential_id_unq",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_user_idx": {
+          "name": "passkey_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_upload": {
+      "name": "pending_upload",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "pendingUploadKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "pendingUploadPurpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pendingUploadStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_to_type": {
+          "name": "attached_to_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_to_id": {
+          "name": "attached_to_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_deleted_at": {
+          "name": "object_deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_upload_created_by_idx": {
+          "name": "pending_upload_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_upload_status_expires_at_idx": {
+          "name": "pending_upload_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_upload_created_by_id_user_id_fk": {
+          "name": "pending_upload_created_by_id_user_id_fk",
+          "tableFrom": "pending_upload",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_upload_idempotency_key": {
+          "name": "pending_upload_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "created_by_id",
+            "purpose",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.region": {
+      "name": "region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_distillers": {
+          "name": "total_distillers",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "region_name_unq": {
+          "name": "region_name_unq",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "region_slug_unq": {
+          "name": "region_slug_unq",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "region_country_idx": {
+          "name": "region_country_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "region_country_id_country_id_fk": {
+          "name": "region_country_id_country_id_fk",
+          "tableFrom": "region",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue": {
+          "name": "issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_unq_name": {
+          "name": "review_unq_name",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_bottle_idx": {
+          "name": "review_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_release_idx": {
+          "name": "review_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_external_site_id_external_site_id_fk": {
+          "name": "review_external_site_id_external_site_id_fk",
+          "tableFrom": "review",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_bottle_id_bottle_id_fk": {
+          "name": "review_bottle_id_bottle_id_fk",
+          "tableFrom": "review",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_url_unique": {
+          "name": "review_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_history": {
+      "name": "store_price_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_history_unq": {
+          "name": "store_price_history_unq",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "volume",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_history_price_id_store_price_id_fk": {
+          "name": "store_price_history_price_id_store_price_id_fk",
+          "tableFrom": "store_price_history",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_attempt": {
+      "name": "store_price_match_attempt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "store_price_match_proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_status": {
+          "name": "initial_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_status": {
+          "name": "final_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bottle_id": {
+          "name": "current_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_release_id": {
+          "name": "current_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_bottle_id": {
+          "name": "suggested_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_release_id": {
+          "name": "suggested_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_bottle_id": {
+          "name": "parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_target": {
+          "name": "creation_target",
+          "type": "store_price_match_creation_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_eligible": {
+          "name": "automation_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "automation_score": {
+          "name": "automation_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_attempt_price_idx": {
+          "name": "store_price_match_attempt_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_proposal_idx": {
+          "name": "store_price_match_attempt_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_created_idx": {
+          "name": "store_price_match_attempt_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_final_status_idx": {
+          "name": "store_price_match_attempt_final_status_idx",
+          "columns": [
+            {
+              "expression": "final_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_attempt_price_id_store_price_id_fk": {
+          "name": "store_price_match_attempt_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "store_price_match_attempt_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_current_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_current_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "current_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_suggested_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_suggested_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "suggested_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_parent_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_parent_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "parent_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_reviewed_by_id_user_id_fk": {
+          "name": "store_price_match_attempt_reviewed_by_id_user_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_proposal": {
+      "name": "store_price_match_proposal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "store_price_match_proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bottle_id": {
+          "name": "current_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_release_id": {
+          "name": "current_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_bottle_id": {
+          "name": "suggested_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_release_id": {
+          "name": "suggested_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_bottle_id": {
+          "name": "parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_target": {
+          "name": "creation_target",
+          "type": "store_price_match_creation_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_scope": {
+          "name": "alias_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_bottles": {
+          "name": "candidate_bottles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "extracted_label": {
+          "name": "extracted_label",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_bottle": {
+          "name": "proposed_bottle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_release": {
+          "name": "proposed_release",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_evidence": {
+          "name": "search_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "automation_assessment": {
+          "name": "automation_assessment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entered_queue_at": {
+          "name": "entered_queue_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_token": {
+          "name": "processing_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_queued_at": {
+          "name": "processing_queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_expires_at": {
+          "name": "processing_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_proposal_price_idx": {
+          "name": "store_price_match_proposal_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_status_idx": {
+          "name": "store_price_match_proposal_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_type_idx": {
+          "name": "store_price_match_proposal_type_idx",
+          "columns": [
+            {
+              "expression": "proposal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_current_bottle_idx": {
+          "name": "store_price_match_proposal_current_bottle_idx",
+          "columns": [
+            {
+              "expression": "current_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_current_release_idx": {
+          "name": "store_price_match_proposal_current_release_idx",
+          "columns": [
+            {
+              "expression": "current_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_processing_expires_idx": {
+          "name": "store_price_match_proposal_processing_expires_idx",
+          "columns": [
+            {
+              "expression": "processing_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_entered_queue_idx": {
+          "name": "store_price_match_proposal_entered_queue_idx",
+          "columns": [
+            {
+              "expression": "entered_queue_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_suggested_bottle_idx": {
+          "name": "store_price_match_proposal_suggested_bottle_idx",
+          "columns": [
+            {
+              "expression": "suggested_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_suggested_release_idx": {
+          "name": "store_price_match_proposal_suggested_release_idx",
+          "columns": [
+            {
+              "expression": "suggested_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_parent_bottle_idx": {
+          "name": "store_price_match_proposal_parent_bottle_idx",
+          "columns": [
+            {
+              "expression": "parent_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_reviewed_by_idx": {
+          "name": "store_price_match_proposal_reviewed_by_idx",
+          "columns": [
+            {
+              "expression": "reviewed_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_proposal_price_id_store_price_id_fk": {
+          "name": "store_price_match_proposal_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_current_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_current_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "current_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_suggested_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_suggested_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "suggested_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_parent_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_parent_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "parent_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_reviewed_by_id_user_id_fk": {
+          "name": "store_price_match_proposal_reviewed_by_id_user_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_retry_run_item": {
+      "name": "store_price_match_retry_run_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_retry_run_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_retry_run_item_unq": {
+          "name": "store_price_match_retry_run_item_unq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_run_status_idx": {
+          "name": "store_price_match_retry_run_item_run_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_proposal_idx": {
+          "name": "store_price_match_retry_run_item_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_price_idx": {
+          "name": "store_price_match_retry_run_item_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_retry_run_item_run_id_store_price_match_retry_run_id_fk": {
+          "name": "store_price_match_retry_run_item_run_id_store_price_match_retry_run_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price_match_retry_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_retry_run_item_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "store_price_match_retry_run_item_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_retry_run_item_price_id_store_price_id_fk": {
+          "name": "store_price_match_retry_run_item_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_retry_run": {
+      "name": "store_price_match_retry_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "store_price_match_retry_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "store_price_match_retry_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_web'"
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_retry_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "matched_count": {
+          "name": "matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_count": {
+          "name": "processed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_count": {
+          "name": "resolved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviewable_count": {
+          "name": "reviewable_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errored_count": {
+          "name": "errored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_retry_run_status_idx": {
+          "name": "store_price_match_retry_run_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_created_by_idx": {
+          "name": "store_price_match_retry_run_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_created_at_idx": {
+          "name": "store_price_match_retry_run_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_retry_run_created_by_id_user_id_fk": {
+          "name": "store_price_match_retry_run_created_by_id_user_id_fk",
+          "tableFrom": "store_price_match_retry_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price": {
+      "name": "store_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_unq_name": {
+          "name": "store_price_unq_name",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "volume",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_bottle_idx": {
+          "name": "store_price_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_release_idx": {
+          "name": "store_price_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_external_site_id_external_site_id_fk": {
+          "name": "store_price_external_site_id_external_site_id_fk",
+          "tableFrom": "store_price",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_bottle_id_bottle_id_fk": {
+          "name": "store_price_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "store_price_url_unique": {
+          "name": "store_price_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag": {
+      "name": "tag",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "synonyms": {
+          "name": "synonyms",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "tag_category": {
+          "name": "tag_category",
+          "type": "tag_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasting_badge_award": {
+      "name": "tasting_badge_award",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "award_id": {
+          "name": "award_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasting_badge_award_key": {
+          "name": "tasting_badge_award_key",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_badge_award_award_id": {
+          "name": "tasting_badge_award_award_id",
+          "columns": [
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasting_badge_award_tasting_id_tasting_id_fk": {
+          "name": "tasting_badge_award_tasting_id_tasting_id_fk",
+          "tableFrom": "tasting_badge_award",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasting_badge_award_award_id_badge_award_id_fk": {
+          "name": "tasting_badge_award_award_id_badge_award_id_fk",
+          "tableFrom": "tasting_badge_award",
+          "tableTo": "badge_award",
+          "columnsFrom": [
+            "award_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasting": {
+      "name": "tasting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "color": {
+          "name": "color",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_legacy": {
+          "name": "rating_legacy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_style": {
+          "name": "serving_style",
+          "type": "servingStyle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "friends": {
+          "name": "friends",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::bigint[]"
+        },
+        "flight_id": {
+          "name": "flight_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "toasts": {
+          "name": "toasts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tasting_bottle_idx": {
+          "name": "tasting_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_release_idx": {
+          "name": "tasting_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_flight_idx": {
+          "name": "tasting_flight_idx",
+          "columns": [
+            {
+              "expression": "flight_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_created_by_idx": {
+          "name": "tasting_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasting_bottle_id_bottle_id_fk": {
+          "name": "tasting_bottle_id_bottle_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasting_flight_id_flight_id_fk": {
+          "name": "tasting_flight_id_flight_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "flight",
+          "columnsFrom": [
+            "flight_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasting_created_by_id_user_id_fk": {
+          "name": "tasting_created_by_id_user_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tasting_unq": {
+          "name": "tasting_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bottle_id",
+            "created_by_id",
+            "created_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.toasts": {
+      "name": "toasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "toast_unq": {
+          "name": "toast_unq",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "toasts_tasting_id_tasting_id_fk": {
+          "name": "toasts_tasting_id_tasting_id_fk",
+          "tableFrom": "toasts",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "toasts_created_by_id_user_id_fk": {
+          "name": "toasts_created_by_id_user_id_fk",
+          "tableFrom": "toasts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "admin": {
+          "name": "admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mod": {
+          "name": "mod",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_comments": {
+          "name": "notify_comments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_unq": {
+          "name": "user_email_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_username_unq": {
+          "name": "user_username_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.legacy_release_repair_review_resolution": {
+      "name": "legacy_release_repair_review_resolution",
+      "schema": "public",
+      "values": [
+        "allow_create_parent",
+        "blocked",
+        "reuse_existing_parent"
+      ]
+    },
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "system",
+        "user"
+      ]
+    },
+    "public.badge_award_object_type": {
+      "name": "badge_award_object_type",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "entity",
+        "country",
+        "region"
+      ]
+    },
+    "public.badge_formula": {
+      "name": "badge_formula",
+      "schema": "public",
+      "values": [
+        "default",
+        "linear",
+        "fibonacci"
+      ]
+    },
+    "public.bottle_check_close_reason": {
+      "name": "bottle_check_close_reason",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "resolved_manually"
+      ]
+    },
+    "public.bottle_check_intent": {
+      "name": "bottle_check_intent",
+      "schema": "public",
+      "values": [
+        "resolve_reference",
+        "audit_bottle"
+      ]
+    },
+    "public.bottle_check_origin": {
+      "name": "bottle_check_origin",
+      "schema": "public",
+      "values": [
+        "moderator",
+        "post_user_creation"
+      ]
+    },
+    "public.bottle_operation_rejection_reason": {
+      "name": "bottle_operation_rejection_reason",
+      "schema": "public",
+      "values": [
+        "wrong_target",
+        "wrong_change",
+        "insufficient_evidence",
+        "resolved_manually",
+        "other"
+      ]
+    },
+    "public.bottle_operation_status": {
+      "name": "bottle_operation_status",
+      "schema": "public",
+      "values": [
+        "blocked",
+        "pending_review",
+        "rejected",
+        "applying",
+        "applied",
+        "stale",
+        "failed"
+      ]
+    },
+    "public.bottle_alias_assignment_source": {
+      "name": "bottle_alias_assignment_source",
+      "schema": "public",
+      "values": [
+        "legacy",
+        "canonical",
+        "source_approved",
+        "classifier_approved",
+        "human_approved"
+      ]
+    },
+    "public.type": {
+      "name": "type",
+      "schema": "public",
+      "values": [
+        "add",
+        "update",
+        "delete"
+      ]
+    },
+    "public.collection_bottle_status": {
+      "name": "collection_bottle_status",
+      "schema": "public",
+      "values": [
+        "sealed",
+        "open",
+        "empty"
+      ]
+    },
+    "public.entity_type": {
+      "name": "entity_type",
+      "schema": "public",
+      "values": [
+        "brand",
+        "distiller",
+        "bottler"
+      ]
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "public",
+      "values": [
+        "blend",
+        "bourbon",
+        "rye",
+        "single_grain",
+        "single_malt",
+        "single_pot_still",
+        "spirit"
+      ]
+    },
+    "public.content_source": {
+      "name": "content_source",
+      "schema": "public",
+      "values": [
+        "generated",
+        "user"
+      ]
+    },
+    "public.flavor_profile": {
+      "name": "flavor_profile",
+      "schema": "public",
+      "values": [
+        "young_spritely",
+        "sweet_fruit_mellow",
+        "spicy_sweet",
+        "spicy_dry",
+        "deep_rich_dried_fruit",
+        "old_dignified",
+        "light_delicate",
+        "juicy_oak_vanilla",
+        "oily_coastal",
+        "lightly_peated",
+        "peated",
+        "heavily_peated"
+      ]
+    },
+    "public.object_type": {
+      "name": "object_type",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "bottle_group",
+        "bottle_release",
+        "bottle_series",
+        "comment",
+        "entity",
+        "tasting",
+        "toast",
+        "follow"
+      ]
+    },
+    "public.tag_category": {
+      "name": "tag_category",
+      "schema": "public",
+      "values": [
+        "cereal",
+        "fruity",
+        "floral",
+        "peaty",
+        "feinty",
+        "sulphury",
+        "woody",
+        "winey"
+      ]
+    },
+    "public.external_site_type": {
+      "name": "external_site_type",
+      "schema": "public",
+      "values": [
+        "astorwines",
+        "healthyspirits",
+        "reservebar",
+        "smws",
+        "smwsa",
+        "totalwine",
+        "woodencork",
+        "whiskyadvocate"
+      ]
+    },
+    "public.follow_status": {
+      "name": "follow_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "pending",
+        "following"
+      ]
+    },
+    "public.identity_provider": {
+      "name": "identity_provider",
+      "schema": "public",
+      "values": [
+        "google",
+        "passkey"
+      ]
+    },
+    "public.incoming_bottle_decision_source_kind": {
+      "name": "incoming_bottle_decision_source_kind",
+      "schema": "public",
+      "values": [
+        "review",
+        "store_price"
+      ]
+    },
+    "public.incoming_bottle_decision_type": {
+      "name": "incoming_bottle_decision_type",
+      "schema": "public",
+      "values": [
+        "match_existing",
+        "create_bottle",
+        "create_release",
+        "create_bottle_and_release"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "comment",
+        "toast",
+        "friend_request"
+      ]
+    },
+    "public.pendingUploadKind": {
+      "name": "pendingUploadKind",
+      "schema": "public",
+      "values": [
+        "image"
+      ]
+    },
+    "public.pendingUploadPurpose": {
+      "name": "pendingUploadPurpose",
+      "schema": "public",
+      "values": [
+        "photo_tasting_entry",
+        "tasting_image",
+        "bottle_image",
+        "bottle_release_image",
+        "badge_image",
+        "avatar"
+      ]
+    },
+    "public.pendingUploadStatus": {
+      "name": "pendingUploadStatus",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attached",
+        "expired"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "usd",
+        "gbp",
+        "eur"
+      ]
+    },
+    "public.store_price_match_creation_target": {
+      "name": "store_price_match_creation_target",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "release",
+        "bottle_and_release"
+      ]
+    },
+    "public.store_price_match_proposal_status": {
+      "name": "store_price_match_proposal_status",
+      "schema": "public",
+      "values": [
+        "verified",
+        "pending_review",
+        "approved",
+        "ignored",
+        "errored"
+      ]
+    },
+    "public.store_price_match_proposal_type": {
+      "name": "store_price_match_proposal_type",
+      "schema": "public",
+      "values": [
+        "match_existing",
+        "create_new",
+        "correction",
+        "no_match"
+      ]
+    },
+    "public.store_price_match_retry_run_item_status": {
+      "name": "store_price_match_retry_run_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.store_price_match_retry_run_kind": {
+      "name": "store_price_match_retry_run_kind",
+      "schema": "public",
+      "values": [
+        "create_new",
+        "match_existing",
+        "correction",
+        "errored"
+      ]
+    },
+    "public.store_price_match_retry_run_mode": {
+      "name": "store_price_match_retry_run_mode",
+      "schema": "public",
+      "values": [
+        "no_web",
+        "full"
+      ]
+    },
+    "public.store_price_match_retry_run_status": {
+      "name": "store_price_match_retry_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.servingStyle": {
+      "name": "servingStyle",
+      "schema": "public",
+      "values": [
+        "neat",
+        "rocks",
+        "splash"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/migrations/meta/_journal.json
+++ b/apps/server/migrations/meta/_journal.json
@@ -1401,6 +1401,13 @@
       "when": 1785689993133,
       "tag": "0199_expand_tasting_note_vocabulary",
       "breakpoints": false
+    },
+    {
+      "idx": 200,
+      "version": "7",
+      "when": 1785694143634,
+      "tag": "0200_yummy_polaris",
+      "breakpoints": false
     }
   ]
 }

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -30,6 +30,7 @@ import { userToActorContext, withActorContext } from "./lib/actorContext";
 import { getUserFromHeader } from "./lib/auth";
 import { httpLogger, logError, logInfo, logWarn } from "./lib/log";
 import { readFile as readUploadFile } from "./lib/uploads";
+import { oauthTokenHandler } from "./oauth/token";
 import router from "./orpc/router";
 import {
   AuthSchema,
@@ -218,6 +219,7 @@ export const app = honoApp
   .get("/_health", (c) => {
     return c.json({ ok: true });
   })
+  .post("/oauth/token", oauthTokenHandler)
   .get("/robots.txt", (c) => {
     return c.text("User-agent: *\nDisallow: /");
   })

--- a/apps/server/src/db/schema/index.ts
+++ b/apps/server/src/db/schema/index.ts
@@ -15,6 +15,7 @@ export * from "./follows";
 export * from "./identities";
 export * from "./incomingBottleDecisionLogs";
 export * from "./notifications";
+export * from "./oauth";
 export * from "./passkeys";
 export * from "./pendingUploads";
 export * from "./regions";

--- a/apps/server/src/db/schema/oauth.ts
+++ b/apps/server/src/db/schema/oauth.ts
@@ -1,0 +1,78 @@
+import { relations } from "drizzle-orm";
+import {
+  bigint,
+  bigserial,
+  boolean,
+  index,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+import { users } from "./users";
+
+export const oauthClients = pgTable(
+  "oauth_client",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    clientId: varchar("client_id", { length: 64 }).notNull(),
+    name: varchar("name", { length: 120 }).notNull(),
+    redirectUris: text("redirect_uris").array().notNull(),
+    active: boolean("active").default(true).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => [uniqueIndex("oauth_client_client_id_unq").on(table.clientId)],
+);
+
+export const oauthAuthorizationCodes = pgTable(
+  "oauth_authorization_code",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    codeDigest: varchar("code_digest", { length: 64 }).notNull(),
+    oauthClientId: bigint("oauth_client_id", { mode: "number" })
+      .references(() => oauthClients.id, { onDelete: "cascade" })
+      .notNull(),
+    userId: bigint("user_id", { mode: "number" })
+      .references(() => users.id, { onDelete: "cascade" })
+      .notNull(),
+    redirectUri: text("redirect_uri").notNull(),
+    codeChallenge: varchar("code_challenge", { length: 128 }).notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    expiresAt: timestamp("expires_at").notNull(),
+    consumedAt: timestamp("consumed_at"),
+  },
+  (table) => [
+    uniqueIndex("oauth_authorization_code_digest_unq").on(table.codeDigest),
+    index("oauth_authorization_code_client_idx").on(table.oauthClientId),
+    index("oauth_authorization_code_user_idx").on(table.userId),
+    index("oauth_authorization_code_expires_idx").on(table.expiresAt),
+  ],
+);
+
+export const oauthClientsRelations = relations(oauthClients, ({ many }) => ({
+  authorizationCodes: many(oauthAuthorizationCodes),
+}));
+
+export const oauthAuthorizationCodesRelations = relations(
+  oauthAuthorizationCodes,
+  ({ one }) => ({
+    client: one(oauthClients, {
+      fields: [oauthAuthorizationCodes.oauthClientId],
+      references: [oauthClients.id],
+    }),
+    user: one(users, {
+      fields: [oauthAuthorizationCodes.userId],
+      references: [users.id],
+    }),
+  }),
+);
+
+export type OAuthClient = typeof oauthClients.$inferSelect;
+export type NewOAuthClient = typeof oauthClients.$inferInsert;
+export type OAuthAuthorizationCode =
+  typeof oauthAuthorizationCodes.$inferSelect;
+export type NewOAuthAuthorizationCode =
+  typeof oauthAuthorizationCodes.$inferInsert;

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -17,6 +17,8 @@ import { default as jsonwebtoken } from "jsonwebtoken";
 import { sendVerificationEmail } from "./email";
 const { sign, verify } = jsonwebtoken;
 
+export const ACCESS_TOKEN_EXPIRES_IN_SECONDS = 7 * 24 * 60 * 60;
+
 export function signPayload(payload: string | object): Promise<string> {
   return new Promise<string>((res, rej) => {
     sign(payload, config.JWT_SECRET, { expiresIn: "7d" }, (err, token) => {

--- a/apps/server/src/lib/oauth.test.ts
+++ b/apps/server/src/lib/oauth.test.ts
@@ -1,0 +1,79 @@
+import {
+  createS256CodeChallenge,
+  isRegisteredRedirectUri,
+  isValidPkceVerifier,
+  isValidS256CodeChallenge,
+  parseRegisteredRedirectUri,
+  verifyS256CodeChallenge,
+} from "@peated/server/lib/oauth";
+import { describe, expect, test } from "vitest";
+
+const verifier = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG";
+
+describe("OAuth PKCE helpers", () => {
+  test("validates and verifies S256 PKCE values", () => {
+    const challenge = createS256CodeChallenge(verifier);
+
+    expect(isValidPkceVerifier(verifier)).toBe(true);
+    expect(isValidS256CodeChallenge(challenge)).toBe(true);
+    expect(verifyS256CodeChallenge(verifier, challenge)).toBe(true);
+    expect(verifyS256CodeChallenge(`${verifier}x`, challenge)).toBe(false);
+    expect(isValidPkceVerifier("short")).toBe(false);
+  });
+
+  test("matches exact HTTPS and loopback redirects", () => {
+    expect(
+      isRegisteredRedirectUri("https://tools.peated.com/oauth/callback", [
+        "https://tools.peated.com/oauth/callback",
+      ]),
+    ).toBe(true);
+    expect(
+      isRegisteredRedirectUri("http://127.0.0.1:49152/callback?source=cli", [
+        "http://127.0.0.1/callback?source=cli",
+      ]),
+    ).toBe(true);
+    expect(
+      isRegisteredRedirectUri("http://[::1]:49152/callback", [
+        "http://[::1]/callback",
+      ]),
+    ).toBe(true);
+  });
+
+  test("rejects redirect changes outside the loopback port exception", () => {
+    expect(
+      isRegisteredRedirectUri("https://evil.example/oauth/callback", [
+        "https://tools.peated.com/oauth/callback",
+      ]),
+    ).toBe(false);
+    expect(
+      isRegisteredRedirectUri("http://127.0.0.1:49152/other", [
+        "http://127.0.0.1/callback",
+      ]),
+    ).toBe(false);
+    expect(
+      isRegisteredRedirectUri("http://localhost:49152/callback", [
+        "http://127.0.0.1/callback",
+      ]),
+    ).toBe(false);
+    expect(
+      parseRegisteredRedirectUri("https://example.com/callback#fragment"),
+    ).toBeNull();
+    expect(
+      parseRegisteredRedirectUri("https://example.com/callback#"),
+    ).toBeNull();
+    expect(
+      parseRegisteredRedirectUri("https://@example.com/callback"),
+    ).toBeNull();
+    expect(parseRegisteredRedirectUri("http://2130706433/callback")).toBeNull();
+    expect(
+      isRegisteredRedirectUri("http://127.1:49152/callback", [
+        "http://127.0.0.1/callback",
+      ]),
+    ).toBe(false);
+    expect(
+      isRegisteredRedirectUri("http://127.0.0.1:49152/a/../callback", [
+        "http://127.0.0.1/callback",
+      ]),
+    ).toBe(false);
+  });
+});

--- a/apps/server/src/lib/oauth.ts
+++ b/apps/server/src/lib/oauth.ts
@@ -1,0 +1,106 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+
+const PKCE_VALUE_PATTERN = /^[A-Za-z0-9._~-]{43,128}$/;
+const LOOPBACK_REDIRECT_PATTERN =
+  /^http:\/\/(127\.0\.0\.1|\[::1\])(?::[0-9]+)?(?=\/|\?|$)/;
+const URI_USERINFO_PATTERN = /^[A-Za-z][A-Za-z0-9+.-]*:\/\/[^/?#]*@/;
+
+function hasDisallowedRedirectSyntax(value: string, url: URL): boolean {
+  return (
+    value.includes("#") ||
+    URI_USERINFO_PATTERN.test(value) ||
+    url.hostname.includes("*")
+  );
+}
+
+function loopbackRedirectComparisonValue(value: string): string | null {
+  const match = LOOPBACK_REDIRECT_PATTERN.exec(value);
+  if (!match) return null;
+
+  return `http://${match[1]}${value.slice(match[0].length)}`;
+}
+
+export function generateOAuthClientId(): string {
+  return randomBytes(18).toString("base64url");
+}
+
+export function generateAuthorizationCode(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+export function digestAuthorizationCode(code: string): string {
+  return createHash("sha256").update(code).digest("hex");
+}
+
+export function createS256CodeChallenge(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+export function isValidPkceVerifier(verifier: string): boolean {
+  return PKCE_VALUE_PATTERN.test(verifier);
+}
+
+export function isValidS256CodeChallenge(challenge: string): boolean {
+  return /^[A-Za-z0-9_-]{43}$/.test(challenge);
+}
+
+export function verifyS256CodeChallenge(
+  verifier: string,
+  expectedChallenge: string,
+): boolean {
+  if (!isValidPkceVerifier(verifier)) return false;
+
+  const actual = Buffer.from(createS256CodeChallenge(verifier));
+  const expected = Buffer.from(expectedChallenge);
+  return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+export function parseRegisteredRedirectUri(value: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return null;
+  }
+
+  if (hasDisallowedRedirectSyntax(value, url)) {
+    return null;
+  }
+
+  const isLoopback = loopbackRedirectComparisonValue(value) !== null;
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && isLoopback)) {
+    return null;
+  }
+
+  return url;
+}
+
+export function isRegisteredRedirectUri(
+  requestedValue: string,
+  registeredValues: string[],
+): boolean {
+  let requested: URL;
+  try {
+    requested = new URL(requestedValue);
+  } catch {
+    return false;
+  }
+
+  if (hasDisallowedRedirectSyntax(requestedValue, requested)) return false;
+
+  return registeredValues.some((registeredValue) => {
+    const registered = parseRegisteredRedirectUri(registeredValue);
+    if (!registered) return false;
+    if (requestedValue === registeredValue) return true;
+
+    const registeredComparison =
+      loopbackRedirectComparisonValue(registeredValue);
+    const requestedComparison = loopbackRedirectComparisonValue(requestedValue);
+    // Compare raw URI text so URL normalization cannot widen this exception.
+    return (
+      registeredComparison !== null &&
+      requestedComparison !== null &&
+      requestedComparison === registeredComparison
+    );
+  });
+}

--- a/apps/server/src/lib/oauthAuthorization.test.ts
+++ b/apps/server/src/lib/oauthAuthorization.test.ts
@@ -1,0 +1,199 @@
+import { db } from "@peated/server/db";
+import {
+  oauthAuthorizationCodes,
+  oauthClients,
+} from "@peated/server/db/schema";
+import {
+  createS256CodeChallenge,
+  digestAuthorizationCode,
+} from "@peated/server/lib/oauth";
+import {
+  exchangeOAuthAuthorizationCode,
+  findOAuthClientForAuthorization,
+  issueOAuthAuthorizationCode,
+} from "@peated/server/lib/oauthAuthorization";
+import type { OAuthAuthorizationRequest } from "@peated/server/schemas";
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+const verifier = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG";
+
+function request(
+  clientId: string,
+  overrides: Partial<OAuthAuthorizationRequest> = {},
+): OAuthAuthorizationRequest {
+  return {
+    responseType: "code",
+    clientId,
+    redirectUri: "http://127.0.0.1:45678/callback",
+    state: "opaque-state",
+    codeChallenge: createS256CodeChallenge(verifier),
+    codeChallengeMethod: "S256",
+    ...overrides,
+  };
+}
+
+describe("OAuth authorization codes", () => {
+  test("validates active clients, registered redirects, and opaque state", async ({
+    fixtures,
+  }) => {
+    const client = await fixtures.OAuthClient({
+      redirectUris: ["http://127.0.0.1/callback"],
+    });
+
+    expect(
+      await findOAuthClientForAuthorization(request(client.clientId)),
+    ).toEqual(client);
+    expect(
+      await findOAuthClientForAuthorization(
+        request(client.clientId, { state: "state-kept-opaque" }),
+      ),
+    ).toEqual(client);
+    expect(
+      await findOAuthClientForAuthorization(
+        request(client.clientId, {
+          redirectUri: "http://127.0.0.1:45678/other",
+        }),
+      ),
+    ).toBeNull();
+
+    await db
+      .update(oauthClients)
+      .set({ active: false })
+      .where(eq(oauthClients.id, client.id));
+    expect(
+      await findOAuthClientForAuthorization(request(client.clientId)),
+    ).toBeNull();
+  });
+
+  test("stores only a digest and exchanges a code once", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User();
+    const client = await fixtures.OAuthClient();
+    const authorization = await issueOAuthAuthorizationCode({
+      request: request(client.clientId),
+      user,
+    });
+
+    expect(authorization).not.toBeNull();
+    expect(authorization?.state).toBe("opaque-state");
+    const [stored] = await db.select().from(oauthAuthorizationCodes);
+    expect(stored.codeDigest).toBe(
+      digestAuthorizationCode(authorization?.code ?? ""),
+    );
+    expect(stored.codeDigest).not.toBe(authorization?.code);
+
+    const exchange = {
+      code: authorization?.code ?? "",
+      clientId: client.clientId,
+      redirectUri: request(client.clientId).redirectUri,
+      codeVerifier: verifier,
+    };
+    expect((await exchangeOAuthAuthorizationCode(exchange))?.id).toBe(user.id);
+    expect(await exchangeOAuthAuthorizationCode(exchange)).toBeNull();
+  });
+
+  test("does not consume a code for an invalid binding", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User();
+    const client = await fixtures.OAuthClient();
+    const authorization = await issueOAuthAuthorizationCode({
+      request: request(client.clientId),
+      user,
+    });
+    const code = authorization?.code ?? "";
+
+    expect(
+      await exchangeOAuthAuthorizationCode({
+        code,
+        clientId: client.clientId,
+        redirectUri: request(client.clientId).redirectUri,
+        codeVerifier: `${verifier}x`,
+      }),
+    ).toBeNull();
+    expect(
+      await exchangeOAuthAuthorizationCode({
+        code,
+        clientId: client.clientId,
+        redirectUri: "http://127.0.0.1:45678/other",
+        codeVerifier: verifier,
+      }),
+    ).toBeNull();
+    expect(
+      (
+        await exchangeOAuthAuthorizationCode({
+          code,
+          clientId: client.clientId,
+          redirectUri: request(client.clientId).redirectUri,
+          codeVerifier: verifier,
+        })
+      )?.id,
+    ).toBe(user.id);
+  });
+
+  test("rejects expired codes and deactivated clients", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User();
+    const client = await fixtures.OAuthClient();
+    const issuedAt = new Date("2030-01-01T00:00:00.000Z");
+    const expired = await issueOAuthAuthorizationCode({
+      request: request(client.clientId),
+      user,
+      now: issuedAt,
+    });
+
+    expect(
+      await exchangeOAuthAuthorizationCode(
+        {
+          code: expired?.code ?? "",
+          clientId: client.clientId,
+          redirectUri: request(client.clientId).redirectUri,
+          codeVerifier: verifier,
+        },
+        db,
+        new Date("2030-01-01T00:03:00.000Z"),
+      ),
+    ).toBeNull();
+
+    const fresh = await issueOAuthAuthorizationCode({
+      request: request(client.clientId),
+      user,
+    });
+    await db
+      .update(oauthClients)
+      .set({ active: false })
+      .where(eq(oauthClients.id, client.id));
+    expect(
+      await exchangeOAuthAuthorizationCode({
+        code: fresh?.code ?? "",
+        clientId: client.clientId,
+        redirectUri: request(client.clientId).redirectUri,
+        codeVerifier: verifier,
+      }),
+    ).toBeNull();
+  });
+
+  test("allows only one concurrent exchange", async ({ fixtures }) => {
+    const user = await fixtures.User();
+    const client = await fixtures.OAuthClient();
+    const authorization = await issueOAuthAuthorizationCode({
+      request: request(client.clientId),
+      user,
+    });
+    const exchange = {
+      code: authorization?.code ?? "",
+      clientId: client.clientId,
+      redirectUri: request(client.clientId).redirectUri,
+      codeVerifier: verifier,
+    };
+
+    const results = await Promise.all([
+      exchangeOAuthAuthorizationCode(exchange),
+      exchangeOAuthAuthorizationCode(exchange),
+    ]);
+    expect(results.filter(Boolean)).toHaveLength(1);
+  });
+});

--- a/apps/server/src/lib/oauthAuthorization.ts
+++ b/apps/server/src/lib/oauthAuthorization.ts
@@ -1,0 +1,143 @@
+import { db, type AnyDatabase } from "@peated/server/db";
+import {
+  oauthAuthorizationCodes,
+  oauthClients,
+  users,
+  type OAuthClient,
+  type User,
+} from "@peated/server/db/schema";
+import {
+  digestAuthorizationCode,
+  generateAuthorizationCode,
+  isRegisteredRedirectUri,
+  verifyS256CodeChallenge,
+} from "@peated/server/lib/oauth";
+import {
+  OAuthAuthorizationRequestSchema,
+  type OAuthAuthorizationRequest,
+} from "@peated/server/schemas/oauth";
+import { and, eq, gt, isNull } from "drizzle-orm";
+
+export const AUTHORIZATION_CODE_TTL_MS = 2 * 60 * 1000;
+
+export async function findOAuthClientForAuthorization(
+  request: OAuthAuthorizationRequest,
+  conn: AnyDatabase = db,
+): Promise<OAuthClient | null> {
+  const parsed = OAuthAuthorizationRequestSchema.safeParse(request);
+  if (!parsed.success) return null;
+
+  const [client] = await conn
+    .select()
+    .from(oauthClients)
+    .where(
+      and(
+        eq(oauthClients.clientId, parsed.data.clientId),
+        eq(oauthClients.active, true),
+      ),
+    );
+
+  if (
+    !client ||
+    !isRegisteredRedirectUri(parsed.data.redirectUri, client.redirectUris)
+  ) {
+    return null;
+  }
+
+  return client;
+}
+
+export async function issueOAuthAuthorizationCode({
+  request,
+  user,
+  conn = db,
+  now = new Date(),
+}: {
+  request: OAuthAuthorizationRequest;
+  user: User;
+  conn?: AnyDatabase;
+  now?: Date;
+}): Promise<{ code: string; redirectUri: string; state: string } | null> {
+  const client = await findOAuthClientForAuthorization(request, conn);
+  if (!client || !user.active) return null;
+
+  const code = generateAuthorizationCode();
+  const [created] = await conn
+    .insert(oauthAuthorizationCodes)
+    .values({
+      codeDigest: digestAuthorizationCode(code),
+      oauthClientId: client.id,
+      userId: user.id,
+      redirectUri: request.redirectUri,
+      codeChallenge: request.codeChallenge,
+      expiresAt: new Date(now.getTime() + AUTHORIZATION_CODE_TTL_MS),
+    })
+    .returning({ id: oauthAuthorizationCodes.id });
+
+  if (!created) return null;
+  return { code, redirectUri: request.redirectUri, state: request.state };
+}
+
+export interface OAuthAuthorizationCodeExchange {
+  code: string;
+  clientId: string;
+  redirectUri: string;
+  codeVerifier: string;
+}
+
+export async function exchangeOAuthAuthorizationCode(
+  input: OAuthAuthorizationCodeExchange,
+  conn: AnyDatabase = db,
+  now = new Date(),
+): Promise<User | null> {
+  return await conn.transaction(async (tx) => {
+    const [record] = await tx
+      .select({
+        authorizationCode: oauthAuthorizationCodes,
+        client: oauthClients,
+        user: users,
+      })
+      .from(oauthAuthorizationCodes)
+      .innerJoin(
+        oauthClients,
+        eq(oauthClients.id, oauthAuthorizationCodes.oauthClientId),
+      )
+      .innerJoin(users, eq(users.id, oauthAuthorizationCodes.userId))
+      .where(
+        eq(
+          oauthAuthorizationCodes.codeDigest,
+          digestAuthorizationCode(input.code),
+        ),
+      );
+
+    if (
+      !record ||
+      !record.client.active ||
+      !record.user.active ||
+      record.client.clientId !== input.clientId ||
+      record.authorizationCode.redirectUri !== input.redirectUri ||
+      record.authorizationCode.expiresAt <= now ||
+      record.authorizationCode.consumedAt ||
+      !verifyS256CodeChallenge(
+        input.codeVerifier,
+        record.authorizationCode.codeChallenge,
+      )
+    ) {
+      return null;
+    }
+
+    const [consumed] = await tx
+      .update(oauthAuthorizationCodes)
+      .set({ consumedAt: now })
+      .where(
+        and(
+          eq(oauthAuthorizationCodes.id, record.authorizationCode.id),
+          isNull(oauthAuthorizationCodes.consumedAt),
+          gt(oauthAuthorizationCodes.expiresAt, now),
+        ),
+      )
+      .returning({ id: oauthAuthorizationCodes.id });
+
+    return consumed ? record.user : null;
+  });
+}

--- a/apps/server/src/lib/test/fixtures.ts
+++ b/apps/server/src/lib/test/fixtures.ts
@@ -22,6 +22,7 @@ import {
   flightBottles,
   flights,
   follows,
+  oauthClients,
   passkeys,
   reviews,
   storePriceHistories,
@@ -30,6 +31,7 @@ import {
   toasts,
   users,
 } from "@peated/server/db/schema";
+import { generateOAuthClientId } from "@peated/server/lib/oauth";
 import { generatePublicId } from "@peated/server/lib/publicId";
 import { type ExternalSiteType } from "@peated/server/types";
 import slugify from "@sindresorhus/slugify";
@@ -204,6 +206,24 @@ export const Passkey = async (
     })
     .returning();
   if (!result) throw new Error("Unable to create Passkey fixture");
+  return result;
+};
+
+export const OAuthClient = async (
+  { ...data }: Partial<Omit<dbSchema.NewOAuthClient, "id">> = {},
+  db: AnyDatabase = dbConn,
+): Promise<dbSchema.OAuthClient> => {
+  const [result] = await db
+    .insert(oauthClients)
+    .values({
+      clientId: data.clientId ?? generateOAuthClientId(),
+      name: data.name ?? faker.company.name(),
+      redirectUris: data.redirectUris ?? ["http://127.0.0.1/callback"],
+      active: data.active ?? true,
+      ...data,
+    })
+    .returning();
+  if (!result) throw new Error("Unable to create OAuth client fixture");
   return result;
 };
 

--- a/apps/server/src/oauth/token.test.ts
+++ b/apps/server/src/oauth/token.test.ts
@@ -1,0 +1,126 @@
+import { app } from "@peated/server/app";
+import { createS256CodeChallenge } from "@peated/server/lib/oauth";
+import { issueOAuthAuthorizationCode } from "@peated/server/lib/oauthAuthorization";
+import type * as FixtureModule from "@peated/server/lib/test/fixtures";
+import { describe, expect, test } from "vitest";
+
+const verifier = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG";
+type Fixtures = typeof FixtureModule;
+
+async function issueCode(fixtures: Fixtures) {
+  const user = await fixtures.User();
+  const client = await fixtures.OAuthClient();
+  const redirectUri = "http://127.0.0.1:45678/callback";
+  const authorization = await issueOAuthAuthorizationCode({
+    user,
+    request: {
+      responseType: "code",
+      clientId: client.clientId,
+      redirectUri,
+      state: "opaque-state",
+      codeChallenge: createS256CodeChallenge(verifier),
+      codeChallengeMethod: "S256",
+    },
+  });
+  if (!authorization)
+    throw new Error("Failed to issue test authorization code");
+
+  return { user, client, redirectUri, code: authorization.code };
+}
+
+function tokenRequest(values: Record<string, string>) {
+  return app.request("/oauth/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams(values),
+  });
+}
+
+describe("POST /oauth/token", () => {
+  test("exchanges a PKCE code for the existing bearer token", async ({
+    fixtures,
+  }) => {
+    const { user, client, redirectUri, code } = await issueCode(fixtures);
+    const response = await tokenRequest({
+      grant_type: "authorization_code",
+      code,
+      client_id: client.clientId,
+      redirect_uri: redirectUri,
+      code_verifier: verifier,
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("pragma")).toBe("no-cache");
+    const token = (await response.json()) as {
+      access_token: string;
+      token_type: string;
+      expires_in: number;
+    };
+    expect(token.token_type).toBe("Bearer");
+    expect(token.expires_in).toBe(604800);
+
+    const me = await app.request(
+      "/v1/auth/me",
+      {
+        headers: { Authorization: `Bearer ${token.access_token}` },
+      },
+      {
+        incoming: {
+          socket: {
+            remoteAddress: "127.0.0.1",
+            remotePort: 12345,
+            remoteFamily: "IPv4",
+          },
+        },
+      },
+    );
+    expect(me.status).toBe(200);
+    expect(await me.json()).toMatchObject({ user: { id: user.id } });
+  });
+
+  test("returns standard errors for malformed and unsupported requests", async () => {
+    const wrongContentType = await app.request("/oauth/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ grant_type: "authorization_code" }),
+    });
+    expect(wrongContentType.status).toBe(400);
+    expect(await wrongContentType.json()).toEqual({ error: "invalid_request" });
+
+    const unsupported = await tokenRequest({ grant_type: "refresh_token" });
+    expect(unsupported.status).toBe(400);
+    expect(await unsupported.json()).toEqual({
+      error: "unsupported_grant_type",
+    });
+
+    const missingCode = await tokenRequest({
+      grant_type: "authorization_code",
+    });
+    expect(missingCode.status).toBe(400);
+    expect(await missingCode.json()).toEqual({ error: "invalid_request" });
+  });
+
+  test("rejects an invalid verifier and replay", async ({ fixtures }) => {
+    const { client, redirectUri, code } = await issueCode(fixtures);
+    const input = {
+      grant_type: "authorization_code",
+      code,
+      client_id: client.clientId,
+      redirect_uri: redirectUri,
+      code_verifier: verifier,
+    };
+
+    const invalid = await tokenRequest({
+      ...input,
+      code_verifier: `${verifier}x`,
+    });
+    expect(invalid.status).toBe(400);
+    expect(await invalid.json()).toEqual({ error: "invalid_grant" });
+
+    expect((await tokenRequest(input)).status).toBe(200);
+    const replay = await tokenRequest(input);
+    expect(replay.status).toBe(400);
+    expect(await replay.json()).toEqual({ error: "invalid_grant" });
+  });
+});

--- a/apps/server/src/oauth/token.ts
+++ b/apps/server/src/oauth/token.ts
@@ -1,0 +1,57 @@
+import {
+  ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+  createAccessToken,
+} from "@peated/server/lib/auth";
+import { exchangeOAuthAuthorizationCode } from "@peated/server/lib/oauthAuthorization";
+import { OAuthTokenRequestSchema } from "@peated/server/schemas";
+import type { Context } from "hono";
+
+function oauthResponse(
+  context: Context,
+  body: Record<string, string | number>,
+  status: 200 | 400,
+) {
+  context.header("Cache-Control", "no-store");
+  context.header("Pragma", "no-cache");
+  return context.json(body, status);
+}
+
+export async function oauthTokenHandler(context: Context) {
+  const contentType = context.req.header("content-type")?.split(";", 1)[0];
+  if (contentType !== "application/x-www-form-urlencoded") {
+    return oauthResponse(context, { error: "invalid_request" }, 400);
+  }
+
+  const body = await context.req.parseBody();
+  const grantType = OAuthTokenRequestSchema.shape.grant_type.safeParse(
+    body.grant_type,
+  );
+  if (grantType.success && grantType.data !== "authorization_code") {
+    return oauthResponse(context, { error: "unsupported_grant_type" }, 400);
+  }
+
+  const parsed = OAuthTokenRequestSchema.safeParse(body);
+  if (!parsed.success || parsed.data.grant_type !== "authorization_code") {
+    return oauthResponse(context, { error: "invalid_request" }, 400);
+  }
+
+  const user = await exchangeOAuthAuthorizationCode({
+    code: parsed.data.code,
+    clientId: parsed.data.client_id,
+    redirectUri: parsed.data.redirect_uri,
+    codeVerifier: parsed.data.code_verifier,
+  });
+  if (!user) {
+    return oauthResponse(context, { error: "invalid_grant" }, 400);
+  }
+
+  return oauthResponse(
+    context,
+    {
+      access_token: await createAccessToken(user),
+      token_type: "Bearer",
+      expires_in: ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+    },
+    200,
+  );
+}

--- a/apps/server/src/orpc/routes/admin/index.ts
+++ b/apps/server/src/orpc/routes/admin/index.ts
@@ -1,10 +1,12 @@
 import { base } from "../..";
 import incomingBottleDecisions from "./incoming-bottle-decisions";
+import oauthClients from "./oauth-clients";
 import queueInfo from "./queue-info";
 import reviewWorkbenchStats from "./review-workbench-stats";
 
 export default base.tag("admin").router({
   incomingBottleDecisions,
+  oauthClients,
   queueInfo,
   reviewWorkbenchStats,
 });

--- a/apps/server/src/orpc/routes/admin/oauth-clients/create.test.ts
+++ b/apps/server/src/orpc/routes/admin/oauth-clients/create.test.ts
@@ -1,0 +1,67 @@
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+describe("POST /admin/oauth-clients", () => {
+  test("requires an administrator", async ({ defaults }) => {
+    const error = await waitError(
+      routerClient.admin.oauthClients.create(
+        {
+          name: "Peated CLI",
+          redirectUris: ["http://127.0.0.1/callback"],
+        },
+        { context: { user: defaults.user } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("registers an active public client", async ({ fixtures }) => {
+    const admin = await fixtures.User({ admin: true });
+    const first = await routerClient.admin.oauthClients.create(
+      {
+        name: "Peated CLI",
+        redirectUris: ["http://127.0.0.1/callback"],
+      },
+      { context: { user: admin } },
+    );
+    const second = await routerClient.admin.oauthClients.create(
+      {
+        name: "Data Cleanup Tool",
+        redirectUris: ["https://tools.peated.com/oauth/callback"],
+      },
+      { context: { user: admin } },
+    );
+
+    expect(first).toMatchObject({
+      name: "Peated CLI",
+      redirectUris: ["http://127.0.0.1/callback"],
+      active: true,
+    });
+    expect(first.clientId).not.toEqual(second.clientId);
+  });
+
+  test("rejects unsafe redirect URIs", async ({ fixtures }) => {
+    const admin = await fixtures.User({ admin: true });
+
+    for (const redirectUri of [
+      "http://example.com/callback",
+      "http://localhost/callback",
+      "https://*.example.com/callback",
+      "https://user@example.com/callback",
+      "https://@example.com/callback",
+      "https://example.com/callback#fragment",
+      "https://example.com/callback#",
+    ]) {
+      const error = await waitError(
+        routerClient.admin.oauthClients.create(
+          { name: "Unsafe client", redirectUris: [redirectUri] },
+          { context: { user: admin } },
+        ),
+      );
+
+      expect(error, redirectUri).toBeDefined();
+    }
+  });
+});

--- a/apps/server/src/orpc/routes/admin/oauth-clients/create.ts
+++ b/apps/server/src/orpc/routes/admin/oauth-clients/create.ts
@@ -1,0 +1,40 @@
+import { db } from "@peated/server/db";
+import { oauthClients } from "@peated/server/db/schema";
+import { generateOAuthClientId } from "@peated/server/lib/oauth";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import {
+  OAuthClientInputSchema,
+  OAuthClientSchema,
+} from "@peated/server/schemas";
+import { serialize } from "@peated/server/serializers";
+import { OAuthClientSerializer } from "@peated/server/serializers/oauthClient";
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "POST",
+    path: "/admin/oauth-clients",
+    summary: "Register OAuth client",
+    operationId: "createOAuthClient",
+  })
+  .input(OAuthClientInputSchema)
+  .output(OAuthClientSchema)
+  .handler(async ({ input, context, errors }) => {
+    const [client] = await db
+      .insert(oauthClients)
+      .values({
+        clientId: generateOAuthClientId(),
+        name: input.name,
+        redirectUris: input.redirectUris,
+      })
+      .returning();
+
+    if (!client) {
+      throw errors.INTERNAL_SERVER_ERROR({
+        message: "Failed to register OAuth client.",
+      });
+    }
+
+    return await serialize(OAuthClientSerializer, client, context.user);
+  });

--- a/apps/server/src/orpc/routes/admin/oauth-clients/details.test.ts
+++ b/apps/server/src/orpc/routes/admin/oauth-clients/details.test.ts
@@ -1,0 +1,45 @@
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+describe("GET /admin/oauth-clients/{clientId}", () => {
+  test("requires an administrator", async ({ defaults }) => {
+    const error = await waitError(
+      routerClient.admin.oauthClients.details(
+        { clientId: "oauth_client" },
+        { context: { user: defaults.user } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("returns a registered client", async ({ fixtures }) => {
+    const admin = await fixtures.User({ admin: true });
+    const client = await fixtures.OAuthClient({ name: "Peated CLI" });
+
+    const result = await routerClient.admin.oauthClients.details(
+      { clientId: client.clientId },
+      { context: { user: admin } },
+    );
+
+    expect(result).toMatchObject({
+      clientId: client.clientId,
+      name: client.name,
+      redirectUris: client.redirectUris,
+      active: true,
+    });
+  });
+
+  test("returns NOT_FOUND for an unknown client", async ({ fixtures }) => {
+    const admin = await fixtures.User({ admin: true });
+    const error = await waitError(
+      routerClient.admin.oauthClients.details(
+        { clientId: "oauth_client" },
+        { context: { user: admin } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: OAuth client not found.]`);
+  });
+});

--- a/apps/server/src/orpc/routes/admin/oauth-clients/details.ts
+++ b/apps/server/src/orpc/routes/admin/oauth-clients/details.ts
@@ -1,0 +1,32 @@
+import { db } from "@peated/server/db";
+import { oauthClients } from "@peated/server/db/schema";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import { OAuthClientSchema } from "@peated/server/schemas";
+import { serialize } from "@peated/server/serializers";
+import { OAuthClientSerializer } from "@peated/server/serializers/oauthClient";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "GET",
+    path: "/admin/oauth-clients/{clientId}",
+    summary: "Get OAuth client",
+    operationId: "getOAuthClient",
+  })
+  .input(z.object({ clientId: z.string().min(1) }))
+  .output(OAuthClientSchema)
+  .handler(async ({ input, context, errors }) => {
+    const [client] = await db
+      .select()
+      .from(oauthClients)
+      .where(eq(oauthClients.clientId, input.clientId));
+
+    if (!client) {
+      throw errors.NOT_FOUND({ message: "OAuth client not found." });
+    }
+
+    return await serialize(OAuthClientSerializer, client, context.user);
+  });

--- a/apps/server/src/orpc/routes/admin/oauth-clients/index.ts
+++ b/apps/server/src/orpc/routes/admin/oauth-clients/index.ts
@@ -1,0 +1,12 @@
+import { base } from "@peated/server/orpc";
+import create from "./create";
+import details from "./details";
+import list from "./list";
+import update from "./update";
+
+export default base.tag("admin").router({
+  create,
+  details,
+  list,
+  update,
+});

--- a/apps/server/src/orpc/routes/admin/oauth-clients/list.test.ts
+++ b/apps/server/src/orpc/routes/admin/oauth-clients/list.test.ts
@@ -1,0 +1,32 @@
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+describe("GET /admin/oauth-clients", () => {
+  test("requires an administrator", async ({ defaults }) => {
+    const error = await waitError(
+      routerClient.admin.oauthClients.list(
+        {},
+        { context: { user: defaults.user } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("lists clients by name", async ({ fixtures }) => {
+    const admin = await fixtures.User({ admin: true });
+    const second = await fixtures.OAuthClient({ name: "Peated CLI" });
+    const first = await fixtures.OAuthClient({ name: "Data Cleanup Tool" });
+
+    const { results } = await routerClient.admin.oauthClients.list(
+      {},
+      { context: { user: admin } },
+    );
+
+    expect(results.map((client) => client.clientId)).toEqual([
+      first.clientId,
+      second.clientId,
+    ]);
+  });
+});

--- a/apps/server/src/orpc/routes/admin/oauth-clients/list.ts
+++ b/apps/server/src/orpc/routes/admin/oauth-clients/list.ts
@@ -1,0 +1,31 @@
+import { db } from "@peated/server/db";
+import { oauthClients } from "@peated/server/db/schema";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import { OAuthClientSchema, listResponse } from "@peated/server/schemas";
+import { serialize } from "@peated/server/serializers";
+import { OAuthClientSerializer } from "@peated/server/serializers/oauthClient";
+import { asc } from "drizzle-orm";
+import { z } from "zod";
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "GET",
+    path: "/admin/oauth-clients",
+    summary: "List OAuth clients",
+    operationId: "listOAuthClients",
+  })
+  .input(z.object({}))
+  .output(listResponse(OAuthClientSchema))
+  .handler(async ({ context }) => {
+    const results = await db
+      .select()
+      .from(oauthClients)
+      .orderBy(asc(oauthClients.name));
+
+    return {
+      results: await serialize(OAuthClientSerializer, results, context.user),
+      rel: { nextCursor: null, prevCursor: null },
+    };
+  });

--- a/apps/server/src/orpc/routes/admin/oauth-clients/update.test.ts
+++ b/apps/server/src/orpc/routes/admin/oauth-clients/update.test.ts
@@ -1,0 +1,50 @@
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+describe("PATCH /admin/oauth-clients/{clientId}", () => {
+  test("requires an administrator", async ({ defaults }) => {
+    const error = await waitError(
+      routerClient.admin.oauthClients.update(
+        { clientId: "oauth_client", active: false },
+        { context: { user: defaults.user } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("updates and deactivates a client", async ({ fixtures }) => {
+    const admin = await fixtures.User({ admin: true });
+    const client = await fixtures.OAuthClient({ name: "Peated CLI" });
+
+    const result = await routerClient.admin.oauthClients.update(
+      {
+        clientId: client.clientId,
+        name: "Peated Local CLI",
+        redirectUris: ["http://[::1]/oauth/callback"],
+        active: false,
+      },
+      { context: { user: admin } },
+    );
+
+    expect(result).toMatchObject({
+      clientId: client.clientId,
+      name: "Peated Local CLI",
+      redirectUris: ["http://[::1]/oauth/callback"],
+      active: false,
+    });
+  });
+
+  test("returns NOT_FOUND for an unknown client", async ({ fixtures }) => {
+    const admin = await fixtures.User({ admin: true });
+    const error = await waitError(
+      routerClient.admin.oauthClients.update(
+        { clientId: "oauth_client", active: false },
+        { context: { user: admin } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: OAuth client not found.]`);
+  });
+});

--- a/apps/server/src/orpc/routes/admin/oauth-clients/update.ts
+++ b/apps/server/src/orpc/routes/admin/oauth-clients/update.ts
@@ -1,0 +1,42 @@
+import { db } from "@peated/server/db";
+import { oauthClients } from "@peated/server/db/schema";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import {
+  OAuthClientInputSchema,
+  OAuthClientSchema,
+} from "@peated/server/schemas";
+import { serialize } from "@peated/server/serializers";
+import { OAuthClientSerializer } from "@peated/server/serializers/oauthClient";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "PATCH",
+    path: "/admin/oauth-clients/{clientId}",
+    summary: "Update OAuth client",
+    operationId: "updateOAuthClient",
+  })
+  .input(
+    OAuthClientInputSchema.partial().extend({
+      clientId: z.string().min(1),
+      active: z.boolean().optional(),
+    }),
+  )
+  .output(OAuthClientSchema)
+  .handler(async ({ input, context, errors }) => {
+    const { clientId, ...updates } = input;
+    const [client] = await db
+      .update(oauthClients)
+      .set({ ...updates, updatedAt: new Date() })
+      .where(eq(oauthClients.clientId, clientId))
+      .returning();
+
+    if (!client) {
+      throw errors.NOT_FOUND({ message: "OAuth client not found." });
+    }
+
+    return await serialize(OAuthClientSerializer, client, context.user);
+  });

--- a/apps/server/src/orpc/routes/index.ts
+++ b/apps/server/src/orpc/routes/index.ts
@@ -20,6 +20,7 @@ import externalSites from "./external-sites";
 import flights from "./flights";
 import friends from "./friends";
 import notifications from "./notifications";
+import oauth from "./oauth";
 import pendingUploads from "./pendingUploads";
 import prices from "./prices";
 import regions from "./regions";
@@ -57,6 +58,7 @@ export interface Router {
   flights: typeof flights;
   friends: typeof friends;
   notifications: typeof notifications;
+  oauth: typeof oauth;
   pendingUploads: typeof pendingUploads;
   prices: typeof prices;
   regions: typeof regions;
@@ -96,6 +98,7 @@ export default {
   friends,
   smws,
   notifications,
+  oauth,
   pendingUploads,
   prices,
   regions,

--- a/apps/server/src/orpc/routes/oauth/authorization-details.test.ts
+++ b/apps/server/src/orpc/routes/oauth/authorization-details.test.ts
@@ -1,0 +1,45 @@
+import { createS256CodeChallenge } from "@peated/server/lib/oauth";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+const verifier = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG";
+
+function request(clientId: string) {
+  return {
+    responseType: "code" as const,
+    clientId,
+    redirectUri: "http://127.0.0.1:45678/callback",
+    state: "opaque-state",
+    codeChallenge: createS256CodeChallenge(verifier),
+    codeChallengeMethod: "S256" as const,
+  };
+}
+
+describe("GET /oauth/authorization-details", () => {
+  test("returns public client details for a valid request", async ({
+    fixtures,
+  }) => {
+    const client = await fixtures.OAuthClient();
+
+    const result = await routerClient.oauth.authorizationDetails(
+      request(client.clientId),
+    );
+
+    expect(result).toEqual({ clientId: client.clientId, name: client.name });
+  });
+
+  test("rejects an invalid redirect URI", async ({ fixtures }) => {
+    const client = await fixtures.OAuthClient();
+    const error = await waitError(
+      routerClient.oauth.authorizationDetails({
+        ...request(client.clientId),
+        redirectUri: "https://evil.example/callback",
+      }),
+    );
+
+    expect(error).toMatchInlineSnapshot(
+      `[Error: Invalid authorization request.]`,
+    );
+  });
+});

--- a/apps/server/src/orpc/routes/oauth/authorization-details.ts
+++ b/apps/server/src/orpc/routes/oauth/authorization-details.ts
@@ -1,0 +1,24 @@
+import { findOAuthClientForAuthorization } from "@peated/server/lib/oauthAuthorization";
+import { procedure } from "@peated/server/orpc";
+import {
+  OAuthAuthorizationClientSchema,
+  OAuthAuthorizationRequestSchema,
+} from "@peated/server/schemas";
+
+export default procedure
+  .route({
+    method: "GET",
+    path: "/oauth/authorization-details",
+    summary: "Validate OAuth authorization request",
+    operationId: "getOAuthAuthorizationDetails",
+  })
+  .input(OAuthAuthorizationRequestSchema)
+  .output(OAuthAuthorizationClientSchema)
+  .handler(async ({ input, errors }) => {
+    const client = await findOAuthClientForAuthorization(input);
+    if (!client) {
+      throw errors.BAD_REQUEST({ message: "Invalid authorization request." });
+    }
+
+    return { clientId: client.clientId, name: client.name };
+  });

--- a/apps/server/src/orpc/routes/oauth/authorize.test.ts
+++ b/apps/server/src/orpc/routes/oauth/authorize.test.ts
@@ -1,0 +1,47 @@
+import { db } from "@peated/server/db";
+import { oauthAuthorizationCodes } from "@peated/server/db/schema";
+import { createS256CodeChallenge } from "@peated/server/lib/oauth";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+const verifier = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG";
+
+function request(clientId: string) {
+  return {
+    responseType: "code" as const,
+    clientId,
+    redirectUri: "http://127.0.0.1:45678/callback",
+    state: "opaque-state",
+    codeChallenge: createS256CodeChallenge(verifier),
+    codeChallengeMethod: "S256" as const,
+  };
+}
+
+describe("POST /oauth/authorization-code", () => {
+  test("requires authentication", async ({ fixtures }) => {
+    const client = await fixtures.OAuthClient();
+    const error = await waitError(
+      routerClient.oauth.authorize(request(client.clientId)),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("issues and persists an authorization code", async ({ fixtures }) => {
+    const client = await fixtures.OAuthClient();
+    const user = await fixtures.User();
+    const input = request(client.clientId);
+
+    const result = await routerClient.oauth.authorize(input, {
+      context: { user },
+    });
+
+    expect(result).toMatchObject({
+      redirectUri: input.redirectUri,
+      state: input.state,
+    });
+    expect(result.code).toBeTruthy();
+    expect(await db.select().from(oauthAuthorizationCodes)).toHaveLength(1);
+  });
+});

--- a/apps/server/src/orpc/routes/oauth/authorize.ts
+++ b/apps/server/src/orpc/routes/oauth/authorize.ts
@@ -1,0 +1,29 @@
+import { issueOAuthAuthorizationCode } from "@peated/server/lib/oauthAuthorization";
+import { procedure } from "@peated/server/orpc";
+import { requireAuth } from "@peated/server/orpc/middleware";
+import {
+  OAuthAuthorizationCodeSchema,
+  OAuthAuthorizationRequestSchema,
+} from "@peated/server/schemas";
+
+export default procedure
+  .use(requireAuth)
+  .route({
+    method: "POST",
+    path: "/oauth/authorization-code",
+    summary: "Approve OAuth authorization request",
+    operationId: "createOAuthAuthorizationCode",
+  })
+  .input(OAuthAuthorizationRequestSchema)
+  .output(OAuthAuthorizationCodeSchema)
+  .handler(async ({ input, context, errors }) => {
+    const result = await issueOAuthAuthorizationCode({
+      request: input,
+      user: context.user,
+    });
+    if (!result) {
+      throw errors.BAD_REQUEST({ message: "Invalid authorization request." });
+    }
+
+    return result;
+  });

--- a/apps/server/src/orpc/routes/oauth/index.ts
+++ b/apps/server/src/orpc/routes/oauth/index.ts
@@ -1,0 +1,8 @@
+import { base } from "@peated/server/orpc";
+import authorizationDetails from "./authorization-details";
+import authorize from "./authorize";
+
+export default base.tag("oauth").router({
+  authorizationDetails,
+  authorize,
+});

--- a/apps/server/src/schemas/index.ts
+++ b/apps/server/src/schemas/index.ts
@@ -19,6 +19,7 @@ export * from "./follows";
 export * from "./friends";
 export * from "./magicLink";
 export * from "./notifications";
+export * from "./oauth";
 export * from "./pendingUploads";
 export * from "./priceMatches";
 export * from "./profileActivity";

--- a/apps/server/src/schemas/oauth.ts
+++ b/apps/server/src/schemas/oauth.ts
@@ -1,0 +1,86 @@
+import { parseRegisteredRedirectUri } from "@peated/server/lib/oauth";
+import { z } from "zod";
+
+export const OAuthRedirectUriSchema = z
+  .string()
+  .trim()
+  .superRefine((value, ctx) => {
+    if (!parseRegisteredRedirectUri(value)) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "Use an HTTPS URL or an HTTP loopback IP URL without userinfo, wildcards, or fragments.",
+      });
+    }
+  });
+
+export const OAuthClientSchema = z.object({
+  id: z.number(),
+  clientId: z.string(),
+  name: z.string(),
+  redirectUris: z.array(z.string()),
+  active: z.boolean(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export const OAuthClientInputSchema = z.object({
+  name: z.string().trim().min(1, "Required").max(120),
+  redirectUris: z
+    .array(OAuthRedirectUriSchema)
+    .min(1, "Add at least one redirect URI.")
+    .max(20)
+    .transform((values) => [...new Set(values)]),
+});
+
+export const OAuthAuthorizationRequestSchema = z.object({
+  responseType: z.literal("code"),
+  clientId: z.string().min(1),
+  redirectUri: z.string().min(1),
+  state: z.string().min(1).max(2048),
+  codeChallenge: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
+  codeChallengeMethod: z.literal("S256"),
+});
+
+export const OAuthAuthorizationQuerySchema = z
+  .object({
+    response_type: z.literal("code"),
+    client_id: z.string().min(1),
+    redirect_uri: z.string().min(1),
+    state: z.string().min(1).max(2048),
+    code_challenge: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
+    code_challenge_method: z.literal("S256"),
+  })
+  .transform((value) => ({
+    responseType: value.response_type,
+    clientId: value.client_id,
+    redirectUri: value.redirect_uri,
+    state: value.state,
+    codeChallenge: value.code_challenge,
+    codeChallengeMethod: value.code_challenge_method,
+  }))
+  .pipe(OAuthAuthorizationRequestSchema);
+
+export const OAuthAuthorizationClientSchema = z.object({
+  clientId: z.string(),
+  name: z.string(),
+});
+
+export const OAuthAuthorizationCodeSchema = z.object({
+  code: z.string(),
+  redirectUri: z.string(),
+  state: z.string(),
+});
+
+export const OAuthTokenRequestSchema = z.object({
+  grant_type: z.string().min(1),
+  code: z.string().min(1),
+  client_id: z.string().min(1),
+  redirect_uri: z.string().min(1),
+  code_verifier: z.string().min(1),
+});
+
+export type OAuthAuthorizationRequest = z.infer<
+  typeof OAuthAuthorizationRequestSchema
+>;
+export type OAuthTokenRequest = z.infer<typeof OAuthTokenRequestSchema>;

--- a/apps/server/src/serializers/oauthClient.ts
+++ b/apps/server/src/serializers/oauthClient.ts
@@ -1,0 +1,21 @@
+import type { OAuthClient, User } from "@peated/server/db/schema";
+import type { OAuthClientSchema } from "@peated/server/schemas";
+import type { z } from "zod";
+import { serializer } from ".";
+
+export const OAuthClientSerializer = serializer({
+  name: "oauthClient",
+  item: (
+    item: OAuthClient,
+    _attrs: Record<string, never>,
+    _currentUser?: User | null,
+  ): z.infer<typeof OAuthClientSchema> => ({
+    id: item.id,
+    clientId: item.clientId,
+    name: item.name,
+    redirectUris: item.redirectUris,
+    active: item.active,
+    createdAt: item.createdAt.toISOString(),
+    updatedAt: item.updatedAt.toISOString(),
+  }),
+});

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -32,6 +32,7 @@ import type {
   FriendSchema,
   FriendStatusEnum,
   NotificationSchema,
+  OAuthClientSchema,
   ObjectTypeEnum,
   PointSchema,
   ProfileActivityEntrySchema,
@@ -94,6 +95,7 @@ export type Flight = z.infer<typeof FlightSchema>;
 export type Follow = z.infer<typeof FollowSchema>;
 export type Friend = z.infer<typeof FriendSchema>;
 export type Notification = z.infer<typeof NotificationSchema>;
+export type OAuthClient = z.infer<typeof OAuthClientSchema>;
 export type Review = z.infer<typeof ReviewSchema>;
 export type StorePrice = z.infer<typeof StorePriceSchema>;
 export type Tasting = z.infer<typeof TastingSchema>;

--- a/apps/web/src/app/(admin)/admin/(default)/oauth-clients/[clientId]/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/oauth-clients/[clientId]/page.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
+import Button from "@peated/web/components/button";
+import DefinitionList from "@peated/web/components/definitionList";
+import PageHeader from "@peated/web/components/pageHeader";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { use } from "react";
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ clientId: string }>;
+}) {
+  const { clientId } = use(params);
+  const orpc = useORPC();
+  const { data: client, refetch } = useSuspenseQuery(
+    orpc.admin.oauthClients.details.queryOptions({ input: { clientId } }),
+  );
+  const update = useMutation(orpc.admin.oauthClients.update.mutationOptions());
+
+  return (
+    <div className="w-full p-3 lg:py-0">
+      <Breadcrumbs
+        pages={[
+          { name: "Admin", href: "/admin" },
+          { name: "OAuth Clients", href: "/admin/oauth-clients" },
+          {
+            name: client.name,
+            href: `/admin/oauth-clients/${client.clientId}`,
+            current: true,
+          },
+        ]}
+      />
+      <PageHeader
+        title={client.name}
+        metadata={
+          <div className="flex gap-2">
+            <Button
+              onClick={async () => {
+                await update.mutateAsync({
+                  clientId: client.clientId,
+                  active: !client.active,
+                });
+                await refetch();
+              }}
+              loading={update.isPending}
+              color={client.active ? "danger" : "primary"}
+            >
+              {client.active ? "Deactivate" : "Activate"}
+            </Button>
+            <Button href={`/admin/oauth-clients/${client.clientId}/edit`}>
+              Edit Client
+            </Button>
+          </div>
+        }
+      />
+      <DefinitionList>
+        <DefinitionList.Term>Client ID</DefinitionList.Term>
+        <DefinitionList.Details>
+          <code className="break-all">{client.clientId}</code>
+        </DefinitionList.Details>
+        <DefinitionList.Term>Status</DefinitionList.Term>
+        <DefinitionList.Details>
+          {client.active ? "Active" : "Inactive"}
+        </DefinitionList.Details>
+        <DefinitionList.Term>Redirect URIs</DefinitionList.Term>
+        <DefinitionList.Details>
+          <ul className="space-y-1">
+            {client.redirectUris.map((uri) => (
+              <li key={uri}>
+                <code className="break-all">{uri}</code>
+              </li>
+            ))}
+          </ul>
+        </DefinitionList.Details>
+      </DefinitionList>
+    </div>
+  );
+}

--- a/apps/web/src/app/(admin)/admin/(default)/oauth-clients/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/oauth-clients/page.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import OAuthClientTable from "@peated/web/components/admin/oauthClientTable";
+import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
+import Button from "@peated/web/components/button";
+import EmptyActivity from "@peated/web/components/emptyActivity";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { useSuspenseQuery } from "@tanstack/react-query";
+
+export default function Page() {
+  const orpc = useORPC();
+  const { data } = useSuspenseQuery(
+    orpc.admin.oauthClients.list.queryOptions({ input: {} }),
+  );
+
+  return (
+    <div>
+      <Breadcrumbs
+        pages={[
+          { name: "Admin", href: "/admin" },
+          {
+            name: "OAuth Clients",
+            href: "/admin/oauth-clients",
+            current: true,
+          },
+        ]}
+      />
+      <div className="flex items-center justify-end">
+        <Button color="primary" href="/admin/oauth-clients/add">
+          Register Client
+        </Button>
+      </div>
+      {data.results.length ? (
+        <OAuthClientTable clients={data.results} />
+      ) : (
+        <EmptyActivity>No OAuth clients are registered yet.</EmptyActivity>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(admin)/admin/(layout-free)/oauth-clients/[clientId]/edit/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(layout-free)/oauth-clients/[clientId]/edit/page.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import OAuthClientForm from "@peated/web/components/admin/oauthClientForm";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { formQueryOptions } from "@peated/web/lib/orpc/query";
+import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { use } from "react";
+
+export default function Page({
+  params,
+}: {
+  params: Promise<{ clientId: string }>;
+}) {
+  const { clientId } = use(params);
+  const router = useRouter();
+  const orpc = useORPC();
+  const { data: client } = useSuspenseQuery(
+    formQueryOptions(
+      orpc.admin.oauthClients.details.queryOptions({ input: { clientId } }),
+    ),
+  );
+  const update = useMutation(orpc.admin.oauthClients.update.mutationOptions());
+
+  return (
+    <OAuthClientForm
+      title="Edit OAuth Client"
+      initialData={client}
+      onSubmit={async (data) => {
+        const updated = await update.mutateAsync({ clientId, ...data });
+        router.push(`/admin/oauth-clients/${updated.clientId}`);
+      }}
+    />
+  );
+}

--- a/apps/web/src/app/(admin)/admin/(layout-free)/oauth-clients/add/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(layout-free)/oauth-clients/add/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import OAuthClientForm from "@peated/web/components/admin/oauthClientForm";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+
+export default function Page() {
+  const router = useRouter();
+  const orpc = useORPC();
+  const create = useMutation(orpc.admin.oauthClients.create.mutationOptions());
+
+  return (
+    <OAuthClientForm
+      onSubmit={async (data) => {
+        const client = await create.mutateAsync(data);
+        router.push(`/admin/oauth-clients/${client.clientId}`);
+      }}
+    />
+  );
+}

--- a/apps/web/src/app/(layout-free)/oauth/authorize/actions.test.ts
+++ b/apps/web/src/app/(layout-free)/oauth/authorize/actions.test.ts
@@ -1,0 +1,75 @@
+import { createS256CodeChallenge } from "@peated/server/lib/oauth";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  authorize: vi.fn(),
+  authorizationDetails: vi.fn(),
+  redirect: vi.fn(),
+}));
+
+vi.mock("@peated/web/lib/orpc/client.server", () => ({
+  createServerClient: async () => ({
+    client: { oauth: { authorize: mocks.authorize } },
+  }),
+  createAnonymousServerClient: async () => ({
+    client: {
+      oauth: { authorizationDetails: mocks.authorizationDetails },
+    },
+  }),
+}));
+vi.mock("next/navigation", () => ({ redirect: mocks.redirect }));
+
+import { approveOAuthAuthorization, denyOAuthAuthorization } from "./actions";
+
+const verifier = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG";
+
+function authorizationFormData() {
+  const formData = new FormData();
+  formData.set("response_type", "code");
+  formData.set("client_id", "peated-cli");
+  formData.set("redirect_uri", "http://127.0.0.1:45678/callback");
+  formData.set("state", "opaque-state");
+  formData.set("code_challenge", createS256CodeChallenge(verifier));
+  formData.set("code_challenge_method", "S256");
+  return formData;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("OAuth authorization actions", () => {
+  test("approves through the authenticated API and preserves state", async () => {
+    mocks.authorize.mockResolvedValue({
+      code: "authorization-code",
+      redirectUri: "http://127.0.0.1:45678/callback",
+      state: "opaque-state",
+    });
+
+    await approveOAuthAuthorization(authorizationFormData());
+
+    expect(mocks.authorize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "peated-cli",
+        state: "opaque-state",
+      }),
+    );
+    expect(mocks.redirect).toHaveBeenCalledWith(
+      "http://127.0.0.1:45678/callback?code=authorization-code&state=opaque-state",
+    );
+  });
+
+  test("revalidates before redirecting a denial", async () => {
+    mocks.authorizationDetails.mockResolvedValue({
+      clientId: "peated-cli",
+      name: "Peated CLI",
+    });
+
+    await denyOAuthAuthorization(authorizationFormData());
+
+    expect(mocks.authorizationDetails).toHaveBeenCalledOnce();
+    expect(mocks.redirect).toHaveBeenCalledWith(
+      "http://127.0.0.1:45678/callback?error=access_denied&state=opaque-state",
+    );
+  });
+});

--- a/apps/web/src/app/(layout-free)/oauth/authorize/actions.ts
+++ b/apps/web/src/app/(layout-free)/oauth/authorize/actions.ts
@@ -1,0 +1,43 @@
+"use server";
+
+import {
+  oauthAuthorizationFormData,
+  oauthCallbackUrl,
+} from "@peated/web/lib/oauth";
+import {
+  createAnonymousServerClient,
+  createServerClient,
+} from "@peated/web/lib/orpc/client.server";
+import { redirect } from "next/navigation";
+
+export async function approveOAuthAuthorization(formData: FormData) {
+  const parsed = oauthAuthorizationFormData(formData);
+  if (!parsed.success) {
+    throw new Error("Invalid authorization request.");
+  }
+
+  const { client } = await createServerClient();
+  const result = await client.oauth.authorize(parsed.data);
+  redirect(
+    oauthCallbackUrl(result.redirectUri, {
+      code: result.code,
+      state: result.state,
+    }),
+  );
+}
+
+export async function denyOAuthAuthorization(formData: FormData) {
+  const parsed = oauthAuthorizationFormData(formData);
+  if (!parsed.success) {
+    throw new Error("Invalid authorization request.");
+  }
+
+  const { client } = await createAnonymousServerClient();
+  await client.oauth.authorizationDetails(parsed.data);
+  redirect(
+    oauthCallbackUrl(parsed.data.redirectUri, {
+      error: "access_denied",
+      state: parsed.data.state,
+    }),
+  );
+}

--- a/apps/web/src/app/(layout-free)/oauth/authorize/authorizationForm.tsx
+++ b/apps/web/src/app/(layout-free)/oauth/authorize/authorizationForm.tsx
@@ -1,0 +1,51 @@
+import type { OAuthAuthorizationRequest } from "@peated/server/schemas";
+import Button from "@peated/web/components/button";
+import { approveOAuthAuthorization, denyOAuthAuthorization } from "./actions";
+
+function AuthorizationFields({
+  request,
+}: {
+  request: OAuthAuthorizationRequest;
+}) {
+  return (
+    <>
+      <input type="hidden" name="response_type" value={request.responseType} />
+      <input type="hidden" name="client_id" value={request.clientId} />
+      <input type="hidden" name="redirect_uri" value={request.redirectUri} />
+      <input type="hidden" name="state" value={request.state} />
+      <input
+        type="hidden"
+        name="code_challenge"
+        value={request.codeChallenge}
+      />
+      <input
+        type="hidden"
+        name="code_challenge_method"
+        value={request.codeChallengeMethod}
+      />
+    </>
+  );
+}
+
+export default function AuthorizationForm({
+  request,
+}: {
+  request: OAuthAuthorizationRequest;
+}) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row">
+      <form action={approveOAuthAuthorization} className="flex-1">
+        <AuthorizationFields request={request} />
+        <Button type="submit" color="highlight" fullWidth>
+          Allow Access
+        </Button>
+      </form>
+      <form action={denyOAuthAuthorization} className="flex-1">
+        <AuthorizationFields request={request} />
+        <Button type="submit" fullWidth>
+          Deny
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/app/(layout-free)/oauth/authorize/page.test.tsx
+++ b/apps/web/src/app/(layout-free)/oauth/authorize/page.test.tsx
@@ -1,0 +1,104 @@
+import { createS256CodeChallenge } from "@peated/server/lib/oauth";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  authorizationDetails: vi.fn(),
+  getSession: vi.fn(),
+  redirectToAuth: vi.fn(),
+}));
+
+vi.mock("@peated/web/lib/orpc/client.server", () => ({
+  createAnonymousServerClient: async () => ({
+    client: {
+      oauth: { authorizationDetails: mocks.authorizationDetails },
+    },
+  }),
+}));
+vi.mock("@peated/web/lib/session.server", () => ({
+  getSession: mocks.getSession,
+}));
+vi.mock("@peated/web/lib/auth", () => ({
+  redirectToAuth: mocks.redirectToAuth,
+}));
+vi.mock("./authorizationForm", () => ({
+  default: () => <div>Authorize actions</div>,
+}));
+vi.mock("@peated/web/components/layoutSplash", () => ({
+  default: ({ children }: { children: React.ReactNode }) => (
+    <main>{children}</main>
+  ),
+}));
+
+import Page from "./page";
+
+const verifier = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG";
+
+function searchParams(overrides: Record<string, string> = {}) {
+  return Promise.resolve({
+    response_type: "code",
+    client_id: "peated-cli",
+    redirect_uri: "http://127.0.0.1:45678/callback",
+    state: "opaque-state",
+    code_challenge: createS256CodeChallenge(verifier),
+    code_challenge_method: "S256",
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.authorizationDetails.mockResolvedValue({
+    clientId: "peated-cli",
+    name: "Peated CLI",
+  });
+});
+
+describe("OAuth authorization page", () => {
+  test("preserves a valid request through login", async () => {
+    mocks.getSession.mockResolvedValue({ user: null });
+    mocks.redirectToAuth.mockReturnValue(<div>Login redirect</div>);
+
+    await Page({ searchParams: searchParams() });
+
+    expect(mocks.redirectToAuth).toHaveBeenCalledWith({
+      pathname: "/oauth/authorize",
+      searchParams: expect.any(URLSearchParams),
+    });
+    const forwarded = mocks.redirectToAuth.mock.calls[0][0]
+      .searchParams as URLSearchParams;
+    expect(forwarded.get("state")).toBe("opaque-state");
+    expect(forwarded.get("redirect_uri")).toBe(
+      "http://127.0.0.1:45678/callback",
+    );
+  });
+
+  test("renders locally when client or redirect validation fails", async () => {
+    mocks.authorizationDetails.mockRejectedValue(new Error("Bad request"));
+
+    const html = renderToStaticMarkup(
+      await Page({
+        searchParams: searchParams({
+          redirect_uri: "https://evil.example/callback",
+        }),
+      }),
+    );
+
+    expect(html).toContain("Invalid authorization request");
+    expect(mocks.redirectToAuth).not.toHaveBeenCalled();
+    expect(html).not.toContain("evil.example");
+  });
+
+  test("shows the validated client and signed-in user", async () => {
+    mocks.getSession.mockResolvedValue({
+      user: { username: "fizz.buzz" },
+    });
+
+    const html = renderToStaticMarkup(
+      await Page({ searchParams: searchParams() }),
+    );
+    expect(html).toContain("Authorize Peated CLI?");
+    expect(html).toContain("@fizz.buzz");
+    expect(html).toContain("Authorize actions");
+  });
+});

--- a/apps/web/src/app/(layout-free)/oauth/authorize/page.tsx
+++ b/apps/web/src/app/(layout-free)/oauth/authorize/page.tsx
@@ -1,0 +1,80 @@
+import Alert from "@peated/web/components/alert";
+import LayoutSplash from "@peated/web/components/layoutSplash";
+import { redirectToAuth } from "@peated/web/lib/auth";
+import {
+  oauthAuthorizationSearchParams,
+  parseOAuthAuthorizationQuery,
+} from "@peated/web/lib/oauth";
+import { createAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
+import { getSession } from "@peated/web/lib/session.server";
+import type { Metadata } from "next";
+import AuthorizationForm from "./authorizationForm";
+
+export const metadata: Metadata = {
+  title: "Authorize Application",
+  robots: { index: false, follow: false },
+};
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function InvalidAuthorizationRequest() {
+  return (
+    <LayoutSplash>
+      <div className="mb-8">
+        <h1 className="mb-4 text-2xl font-semibold">
+          Invalid authorization request
+        </h1>
+        <Alert noMargin>
+          This application supplied an unknown client, unsafe redirect, or
+          invalid PKCE request. Return to the application and try again.
+        </Alert>
+      </div>
+    </LayoutSplash>
+  );
+}
+
+export default async function Page({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const parsed = parseOAuthAuthorizationQuery(await searchParams);
+  if (!parsed.success) return <InvalidAuthorizationRequest />;
+
+  let clientDetails: { clientId: string; name: string };
+  try {
+    const { client } = await createAnonymousServerClient();
+    clientDetails = await client.oauth.authorizationDetails(parsed.data);
+  } catch {
+    return <InvalidAuthorizationRequest />;
+  }
+
+  const session = await getSession();
+  if (!session.user) {
+    return redirectToAuth({
+      pathname: "/oauth/authorize",
+      searchParams: oauthAuthorizationSearchParams(parsed.data),
+    });
+  }
+
+  return (
+    <LayoutSplash>
+      <div className="mb-8">
+        <div className="text-muted mb-2 text-sm font-semibold uppercase tracking-wide">
+          Application Access
+        </div>
+        <h1 className="mb-4 text-2xl font-semibold">
+          Authorize {clientDetails.name}?
+        </h1>
+        <p className="text-muted mb-4">
+          This application will receive API access as @{session.user.username}.
+        </p>
+        <Alert type="default" noMargin>
+          It can perform the same Peated API actions your account can. Peated
+          does not share your password or sign-in credentials.
+        </Alert>
+      </div>
+      <AuthorizationForm request={parsed.data} />
+    </LayoutSplash>
+  );
+}

--- a/apps/web/src/components/admin/oauthClientForm.test.tsx
+++ b/apps/web/src/components/admin/oauthClientForm.test.tsx
@@ -1,0 +1,61 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test, vi } from "vitest";
+import OAuthClientForm, {
+  OAuthClientFormSchema,
+  parseOAuthClientRedirectUris,
+} from "./oauthClientForm";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/admin/oauth-clients/add",
+  useRouter: () => ({ back: vi.fn() }),
+}));
+vi.mock("./sidebar", () => ({ default: () => <aside>Admin</aside> }));
+
+describe("OAuthClientForm", () => {
+  test("parses and validates one registered redirect per line", () => {
+    const redirectUris = parseOAuthClientRedirectUris(
+      "http://127.0.0.1/callback\n\nhttps://tools.peated.com/callback",
+    );
+
+    expect(redirectUris).toEqual([
+      "http://127.0.0.1/callback",
+      "https://tools.peated.com/callback",
+    ]);
+    expect(
+      OAuthClientFormSchema.safeParse({
+        name: "Peated CLI",
+        redirectUris: redirectUris.join("\n"),
+      }).success,
+    ).toBe(true);
+    expect(
+      OAuthClientFormSchema.safeParse({
+        name: "Peated CLI",
+        redirectUris: "http://localhost/callback",
+      }).success,
+    ).toBe(false);
+  });
+
+  test("uses the same form for registration and editing", () => {
+    const createHtml = renderToStaticMarkup(
+      <OAuthClientForm onSubmit={async () => undefined} />,
+    );
+    expect(createHtml).toContain("Register OAuth Client");
+    expect(createHtml).not.toContain("Public identifier");
+
+    const editHtml = renderToStaticMarkup(
+      <OAuthClientForm
+        title="Edit OAuth Client"
+        initialData={{
+          clientId: "public-client-id",
+          name: "Peated CLI",
+          redirectUris: ["http://127.0.0.1/callback"],
+        }}
+        onSubmit={async () => undefined}
+      />,
+    );
+    expect(editHtml).toContain("Edit OAuth Client");
+    expect(editHtml).toContain("public-client-id");
+    expect(editHtml).toContain("OAuth clients do not have a secret");
+    expect(editHtml).toContain("Redirect URIs");
+  });
+});

--- a/apps/web/src/components/admin/oauthClientForm.tsx
+++ b/apps/web/src/components/admin/oauthClientForm.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import {
+  OAuthClientInputSchema,
+  type OAuthClientSchema,
+} from "@peated/server/schemas";
+import Fieldset from "@peated/web/components/fieldset";
+import Form from "@peated/web/components/form";
+import FormError from "@peated/web/components/formError";
+import FormScreen from "@peated/web/components/formScreen";
+import TextAreaField from "@peated/web/components/textAreaField";
+import TextField from "@peated/web/components/textField";
+import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
+import { zodResolver } from "@peated/web/lib/zodResolver";
+import { useState } from "react";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { z } from "zod";
+import AdminSidebar from "./sidebar";
+
+export function parseOAuthClientRedirectUris(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+export const OAuthClientFormSchema = z
+  .object({
+    name: z.string().trim().min(1, "Required").max(120),
+    redirectUris: z.string().trim().min(1, "Add at least one redirect URI."),
+  })
+  .superRefine((value, ctx) => {
+    const result = OAuthClientInputSchema.safeParse({
+      name: value.name,
+      redirectUris: parseOAuthClientRedirectUris(value.redirectUris),
+    });
+    if (!result.success) {
+      for (const issue of result.error.issues) {
+        if (issue.path[0] === "redirectUris") {
+          ctx.addIssue({
+            code: "custom",
+            path: ["redirectUris"],
+            message: issue.message,
+          });
+        }
+      }
+    }
+  });
+
+type FormData = z.infer<typeof OAuthClientFormSchema>;
+type OAuthClientInput = z.infer<typeof OAuthClientInputSchema>;
+type OAuthClient = z.infer<typeof OAuthClientSchema>;
+
+export default function OAuthClientForm({
+  onSubmit,
+  initialData,
+  title = "Register OAuth Client",
+}: {
+  onSubmit: (data: OAuthClientInput) => Promise<void>;
+  initialData?: Partial<OAuthClient>;
+  title?: string;
+}) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({
+    resolver: zodResolver(OAuthClientFormSchema),
+    defaultValues: {
+      name: initialData?.name ?? "",
+      redirectUris: initialData?.redirectUris?.join("\n") ?? "",
+    },
+  });
+  const [error, setError] = useState<string>();
+
+  const onSubmitHandler: SubmitHandler<FormData> = async (data) => {
+    try {
+      await onSubmit(
+        OAuthClientInputSchema.parse({
+          name: data.name,
+          redirectUris: parseOAuthClientRedirectUris(data.redirectUris),
+        }),
+      );
+    } catch (err) {
+      setError(getFormErrorMessage(err));
+    }
+  };
+
+  return (
+    <FormScreen
+      title={title}
+      saveDisabled={isSubmitting}
+      onSave={handleSubmit(onSubmitHandler)}
+      sidebar={<AdminSidebar />}
+    >
+      {error && <FormError values={[error]} />}
+      <Form
+        onSubmit={handleSubmit(onSubmitHandler)}
+        isSubmitting={isSubmitting}
+      >
+        <Fieldset>
+          {initialData?.clientId && (
+            <TextField
+              name="clientId"
+              label="Client ID"
+              value={initialData.clientId}
+              readOnly
+              helpText="Public identifier; OAuth clients do not have a secret."
+            />
+          )}
+          <TextField
+            {...register("name")}
+            label="Name"
+            placeholder="e.g. Peated CLI"
+            error={errors.name}
+            required
+          />
+          <TextAreaField
+            {...register("redirectUris")}
+            label="Redirect URIs"
+            helpText="One URI per line. Use HTTPS, or HTTP with 127.0.0.1 or [::1] for local clients."
+            error={errors.redirectUris}
+            rows={6}
+            required
+          />
+        </Fieldset>
+      </Form>
+    </FormScreen>
+  );
+}

--- a/apps/web/src/components/admin/oauthClientTable.test.tsx
+++ b/apps/web/src/components/admin/oauthClientTable.test.tsx
@@ -1,0 +1,38 @@
+import type { OAuthClient } from "@peated/server/types";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import OAuthClientTable from "./oauthClientTable";
+
+const timestamp = "2026-08-02T12:00:00.000Z";
+
+describe("OAuthClientTable", () => {
+  test("lists public client ids, redirect counts, and activation state", () => {
+    const clients: OAuthClient[] = [
+      {
+        id: 1,
+        clientId: "peated-cli-id",
+        name: "Peated CLI",
+        redirectUris: ["http://127.0.0.1/callback"],
+        active: true,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+      {
+        id: 2,
+        clientId: "cleanup-tool-id",
+        name: "Cleanup Tool",
+        redirectUris: ["http://127.0.0.1/callback", "http://[::1]/callback"],
+        active: false,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      },
+    ];
+
+    const html = renderToStaticMarkup(<OAuthClientTable clients={clients} />);
+    expect(html).toContain('href="/admin/oauth-clients/peated-cli-id"');
+    expect(html).toContain("peated-cli-id");
+    expect(html).toContain("Active");
+    expect(html).toContain("Inactive");
+    expect(html).toContain(">2<");
+  });
+});

--- a/apps/web/src/components/admin/oauthClientTable.tsx
+++ b/apps/web/src/components/admin/oauthClientTable.tsx
@@ -1,0 +1,53 @@
+import type { OAuthClient } from "@peated/server/types";
+import Link from "@peated/web/components/link";
+
+export default function OAuthClientTable({
+  clients,
+}: {
+  clients: OAuthClient[];
+}) {
+  return (
+    <table className="min-w-full">
+      <thead className="text-muted hidden border-b border-slate-800 text-sm font-semibold sm:table-header-group">
+        <tr>
+          <th scope="col" className="px-3 py-2.5 text-left">
+            Client
+          </th>
+          <th scope="col" className="px-3 py-2.5 text-left">
+            Redirects
+          </th>
+          <th scope="col" className="px-3 py-2.5 text-right">
+            Status
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {clients.map((client) => (
+          <tr
+            key={client.clientId}
+            className="border-b border-slate-800 text-sm"
+          >
+            <td className="max-w-0 px-3 py-3 align-top">
+              <Link
+                href={`/admin/oauth-clients/${client.clientId}`}
+                className="font-medium hover:underline"
+              >
+                {client.name}
+              </Link>
+              <div className="text-muted mt-1 break-all font-mono text-xs">
+                {client.clientId}
+              </div>
+            </td>
+            <td className="px-3 py-3 align-top">
+              <span className="sm:hidden">Redirects: </span>
+              {client.redirectUris.length}
+            </td>
+            <td className="px-3 py-3 text-right align-top">
+              {client.active ? "Active" : "Inactive"}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/web/src/components/admin/sidebar.tsx
+++ b/apps/web/src/components/admin/sidebar.tsx
@@ -79,6 +79,12 @@ export default function AdminSidebar() {
                     Locations
                   </SidebarLink>
                   <SidebarLink
+                    href="/admin/oauth-clients"
+                    active={pathname.startsWith("/admin/oauth-clients")}
+                  >
+                    OAuth Clients
+                  </SidebarLink>
+                  <SidebarLink
                     href="/admin/sites"
                     active={pathname.startsWith("/admin/sites")}
                   >

--- a/apps/web/src/lib/oauth.test.ts
+++ b/apps/web/src/lib/oauth.test.ts
@@ -1,0 +1,67 @@
+import { createS256CodeChallenge } from "@peated/server/lib/oauth";
+import { describe, expect, test } from "vitest";
+import {
+  oauthAuthorizationSearchParams,
+  oauthCallbackUrl,
+  parseOAuthAuthorizationQuery,
+} from "./oauth";
+
+const verifier = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFG";
+
+function query(overrides: Record<string, unknown> = {}) {
+  return {
+    response_type: "code",
+    client_id: "peated-cli",
+    redirect_uri: "http://127.0.0.1:45678/callback",
+    state: "opaque-state",
+    code_challenge: createS256CodeChallenge(verifier),
+    code_challenge_method: "S256",
+    ...overrides,
+  };
+}
+
+describe("OAuth authorization query", () => {
+  test("parses and round-trips the supported request", () => {
+    const parsed = parseOAuthAuthorizationQuery(query());
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+
+    expect(parsed.data.state).toBe("opaque-state");
+    expect(
+      Object.fromEntries(oauthAuthorizationSearchParams(parsed.data)),
+    ).toEqual(query());
+  });
+
+  test("rejects duplicate values and unsupported PKCE methods", () => {
+    expect(
+      parseOAuthAuthorizationQuery(query({ state: ["one", "two"] })).success,
+    ).toBe(false);
+    expect(
+      parseOAuthAuthorizationQuery(query({ code_challenge_method: "plain" }))
+        .success,
+    ).toBe(false);
+  });
+
+  test("adds OAuth results without dropping registered query values", () => {
+    expect(
+      oauthCallbackUrl("http://127.0.0.1:45678/callback?source=cli", {
+        code: "authorization-code",
+        state: "opaque-state",
+      }),
+    ).toBe(
+      "http://127.0.0.1:45678/callback?source=cli&code=authorization-code&state=opaque-state",
+    );
+
+    expect(
+      oauthCallbackUrl(
+        "https://client.example/callback?return=%2Ffoo%20bar&sig=a%2fb",
+        {
+          code: "authorization/code",
+          state: "opaque state",
+        },
+      ),
+    ).toBe(
+      "https://client.example/callback?return=%2Ffoo%20bar&sig=a%2fb&code=authorization%2Fcode&state=opaque+state",
+    );
+  });
+});

--- a/apps/web/src/lib/oauth.ts
+++ b/apps/web/src/lib/oauth.ts
@@ -1,0 +1,50 @@
+import {
+  OAuthAuthorizationQuerySchema,
+  type OAuthAuthorizationRequest,
+} from "@peated/server/schemas";
+
+export function parseOAuthAuthorizationQuery(input: unknown) {
+  return OAuthAuthorizationQuerySchema.safeParse(input);
+}
+
+export function oauthAuthorizationSearchParams(
+  request: OAuthAuthorizationRequest,
+): URLSearchParams {
+  return new URLSearchParams({
+    response_type: request.responseType,
+    client_id: request.clientId,
+    redirect_uri: request.redirectUri,
+    state: request.state,
+    code_challenge: request.codeChallenge,
+    code_challenge_method: request.codeChallengeMethod,
+  });
+}
+
+export function oauthAuthorizationFormData(formData: FormData) {
+  return parseOAuthAuthorizationQuery({
+    response_type: formData.get("response_type"),
+    client_id: formData.get("client_id"),
+    redirect_uri: formData.get("redirect_uri"),
+    state: formData.get("state"),
+    code_challenge: formData.get("code_challenge"),
+    code_challenge_method: formData.get("code_challenge_method"),
+  });
+}
+
+export function oauthCallbackUrl(
+  redirectUri: string,
+  values: Record<string, string>,
+): string {
+  const fragmentIndex = redirectUri.indexOf("#");
+  const base =
+    fragmentIndex === -1 ? redirectUri : redirectUri.slice(0, fragmentIndex);
+  const fragment = fragmentIndex === -1 ? "" : redirectUri.slice(fragmentIndex);
+  const separator = base.includes("?")
+    ? base.endsWith("?") || base.endsWith("&")
+      ? ""
+      : "&"
+    : "?";
+
+  // Preserve the registered URI's query bytes when adding response fields.
+  return `${base}${separator}${new URLSearchParams(values)}${fragment}`;
+}

--- a/apps/web/src/proxy.test.ts
+++ b/apps/web/src/proxy.test.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from "next/server";
+import { describe, expect, test } from "vitest";
+import { proxy } from "./proxy";
+
+describe("web proxy", () => {
+  test("protects the OAuth authorization response", () => {
+    const response = proxy(
+      new NextRequest(
+        "https://peated.com/oauth/authorize?client_id=peated-cli",
+      ),
+    );
+
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+  });
+});

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -18,6 +18,11 @@ export function proxy(request: NextRequest) {
     response.headers.set("Cache-Control", PRIVATE_CACHE_CONTROL);
   }
 
+  if (request.nextUrl.pathname === "/oauth/authorize") {
+    response.headers.set("Cache-Control", "no-store");
+    response.headers.set("Referrer-Policy", "no-referrer");
+  }
+
   return response;
 }
 

--- a/docs/architecture/account-policies.md
+++ b/docs/architecture/account-policies.md
@@ -1,8 +1,32 @@
 # Account Access Policy
 
-This document records the product decisions for Terms of Service acceptance and
-email verification. Middleware, route schemas, and tests define the exact
-implemented coverage.
+This document records the product decisions for OAuth access, Terms of Service
+acceptance, and email verification. Middleware, route schemas, and tests define
+the exact implemented coverage.
+
+## OAuth Public Clients
+
+Peated supports a narrow OAuth authorization-code flow for local and other
+public clients. OAuth clients are system-wide records created and managed only
+by Peated administrators under `/admin/oauth-clients`; there is no public or
+dynamic registration endpoint and clients do not receive secrets.
+
+The supported flow requires PKCE `S256` and an administrator-registered
+redirect URI. Authorization happens at `https://peated.com/oauth/authorize`
+using the existing Peated browser session. Short-lived authorization codes are
+stored only as digests, expire after two minutes, and can be exchanged once at
+`POST https://api.peated.com/oauth/token`.
+
+Successful exchange returns the same seven-day bearer JWT used by existing
+Peated login. It receives no additional permissions: API requests still reload
+the current user and use the existing active-user, ToS, verification,
+moderator, and administrator checks. Deactivating a client stops new
+authorizations and exchanges but does not revoke bearer tokens already issued;
+users reauthorize when the seven-day token expires.
+
+This baseline does not implement refresh tokens, durable grants, per-client
+token revocation, scopes, discovery metadata, dynamic registration, client
+secrets, device authorization, or OpenID Connect.
 
 ## Terms Of Service
 

--- a/openspec/changes/add-cli-oauth-pkce/.openspec.yaml
+++ b/openspec/changes/add-cli-oauth-pkce/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-02

--- a/openspec/changes/add-cli-oauth-pkce/design.md
+++ b/openspec/changes/add-cli-oauth-pkce/design.md
@@ -1,0 +1,137 @@
+## Context
+
+Peated currently issues a seven-day JWT after password, magic-link, passkey, or Google login. API authentication validates that token, reloads the current user, and delegates authorization to existing verified, ToS, moderator, and admin middleware. There is no OAuth authorization-server surface, client registry, or authorization-code exchange.
+
+The immediate consumer is a local CLI, but OAuth clients must not be hard-coded in application code. Peated administrators will register public clients and their allowed redirect URIs. The initial OAuth surface should be correct for authorization code with PKCE without building a general OAuth platform or a second token lifecycle.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Allow administrators to register, inspect, update, and deactivate public OAuth clients.
+- Support browser authorization code flow with mandatory PKCE `S256`.
+- Bind short-lived, single-use authorization codes to a user, client, exact redirect URI, and PKCE challenge.
+- Exchange a valid code for Peated's existing seven-day bearer access token.
+- Preserve all existing user activation, verification, ToS, moderator, and admin checks.
+- Keep authorization codes and verifiers out of logs and traces.
+
+**Non-Goals:**
+
+- Implement refresh tokens, durable user grants, per-token revocation, discovery metadata, token introspection, or granular scopes.
+- Implement dynamic/public client registration, client secrets, confidential clients, third-party self-service, a developer portal, or a client approval workflow beyond administrator registration.
+- Support device authorization, implicit, password, or client-credentials grants, OpenID Connect, or the CLI itself.
+- Replace or redesign Peated's existing JWT access token.
+
+## Decisions
+
+### Decision: Persist administrator-managed public OAuth clients
+
+Add an `oauth_client` table containing:
+
+- server-generated public `clientId`;
+- administrator-controlled display name;
+- registered redirect URI list;
+- active flag;
+- timestamps.
+
+Admin-only oRPC operations will create, list, inspect, update, and deactivate clients. Registration accepts no client secret because every initially supported client is public and must use PKCE. There is no RFC dynamic-client-registration endpoint.
+
+A small UI under `/admin/oauth-clients` will use those operations. It includes an index with client name, public client id, redirect summary, and active state; a shared add/edit form for name and redirect URIs; and explicit activate/deactivate actions. The generated client id is displayed read-only and there is no secret reveal or credential-download workflow. The existing admin layout and sidebar own navigation and coarse page access, while `requireAdmin` on every API operation remains the authoritative boundary.
+
+Rationale: database registration and a modest operational UI let administrators add a future CLI or native tool without deployment, while avoiding tenant ownership, developer portals, approval queues, or secret rotation. Reusing existing admin list and shared-form patterns keeps the UI proportional to the feature.
+
+Alternative considered: a statically configured `peated-cli` client. That is slightly smaller but contradicts the desired operational model and makes every new first-party client a code deployment.
+
+### Decision: Register redirect URIs and compare them before redirecting
+
+Every authorization request must provide `response_type=code`, an active registered `client_id`, a registered `redirect_uri`, a nonempty `state`, a valid `code_challenge`, and `code_challenge_method=S256`. The server treats `state` as opaque and returns it unchanged; generating and validating its entropy belongs to the client.
+
+Redirect matching is exact except for native loopback URIs covered by RFC 8252: when an administrator registers an HTTP URI using the literal host `127.0.0.1` or `[::1]`, the request may select an ephemeral port while scheme, literal host, path, query, userinfo absence, and fragment absence continue to match the registered URI. `localhost`, wildcard hosts, and arbitrary callback paths are rejected.
+
+Invalid client or redirect input is rendered as a local authorization error and is never used as a redirect destination. Once a redirect is validated, user denial may redirect with `error=access_denied` and the original `state`.
+
+Rationale: administrator registration establishes the redirect trust boundary. Port flexibility is the one native-app exception needed by a desktop CLI.
+
+### Decision: Keep the browser authorization endpoint on the web origin
+
+The public authorization endpoint will be `https://peated.com/oauth/authorize`, implemented as a layout-free Next.js server route/page using the existing iron-session. It validates the request and shows the registered client name.
+
+If the user is anonymous, the page sends them through normal Peated login and safely returns to the authorization request. Approve calls a narrow authenticated API operation that revalidates the active client, redirect URI, PKCE fields, and current user before issuing a code. Deny creates no durable state.
+
+The API owns client lookup, validation, code generation, persistence, and token exchange. The web application owns only browser session handling, confirmation, and the final redirect.
+
+Alternative considered: serve authorization directly from `api.peated.com`. The API does not own the Peated browser session, which would require an unnecessary second session or authentication handoff.
+
+### Decision: Persist only short-lived authorization codes
+
+Add an `oauth_authorization_code` table containing:
+
+- random code digest;
+- client and user references;
+- exact request redirect URI;
+- PKCE `S256` challenge;
+- issuance, expiration, and consumed timestamps.
+
+Codes use cryptographically secure random bytes, are stored only as SHA-256 digests, expire after two minutes, and are single-use. Token exchange validates every binding and atomically marks a valid code consumed so concurrent or repeated exchanges cannot both succeed. The implementation may use the database's simplest reliable conditional update or transaction rather than prescribing a locking strategy.
+
+No durable grant or refresh-token table is introduced. The authorization code is the only new credential lifecycle.
+
+### Decision: Reuse the existing access token after successful exchange
+
+The token endpoint calls the existing `createAccessToken(user)` only after validating:
+
+- `grant_type=authorization_code`;
+- active registered public client;
+- unexpired and unconsumed code;
+- exact client and redirect binding;
+- a syntactically valid verifier whose `S256` digest matches the stored challenge;
+- an active current user.
+
+It returns a standard OAuth token response with `access_token`, `token_type=Bearer`, and `expires_in=604800`. The token then behaves exactly like a token issued by existing Peated login. OAuth does not require the access token to expose client or grant details to the client.
+
+Rationale: PKCE authorization and API token semantics are separate concerns. Reusing the existing token keeps this change focused, retains live user checks, and avoids introducing refresh rotation, grant lookup, or a parallel JWT format before there is a demonstrated need.
+
+Trade-off: deactivating an OAuth client stops new authorizations and exchanges but does not revoke already issued bearer tokens. They expire within the existing seven-day lifetime or stop working immediately if the user is deactivated. Per-client token revocation is a future capability, not part of basic PKCE.
+
+### Decision: Expose only the protocol endpoint required for exchange
+
+The server adds `POST /oauth/token` as a dedicated Hono adapter because OAuth token requests use `application/x-www-form-urlencoded` and standard OAuth response/error shapes. It supports only `authorization_code`.
+
+Client administration and browser-to-API code issuance remain typed oRPC operations because they are Peated-owned application surfaces. No discovery, revocation, introspection, or dynamic-registration endpoint is added.
+
+### Decision: Avoid a new scope model
+
+The first authorization page states that the client receives API access as the current Peated user. The authorization request does not negotiate granular scopes, and the returned token has the same capabilities as existing Peated bearer tokens.
+
+Rationale: adding scopes without annotating and enforcing them across the API would create misleading security. Existing role and policy middleware is the real authorization boundary.
+
+### Decision: Keep credential material out of application logging
+
+The token adapter must not log its form body, authorization code, verifier, or returned access token. Token responses and the authorization page use `Cache-Control: no-store`, and the authorization page uses `Referrer-Policy: no-referrer`. This change does not add a new OAuth audit or analytics system.
+
+### Decision: Test the real persistence and HTTP boundaries
+
+Focused server integration tests use the real test database for client registration, successful code exchange, PKCE and redirect rejection, expiry, and replay prevention. Raw Hono tests verify form encoding and the core OAuth response shapes. Minimal web tests cover login continuation, approve/deny behavior, and refusing an invalid redirect.
+
+## Risks / Trade-offs
+
+- [The existing seven-day token cannot be revoked per OAuth client] → Keep this explicit, allow administrators to deactivate clients to stop new issuance, and defer token grants/revocation until required.
+- [Admin-registered redirects can create an open redirect] → Parse and validate at registration, revalidate at authorization, and never redirect invalid client/redirect combinations.
+- [Loopback port matching is intentionally less than exact] → Allow only RFC 8252 loopback IP literals and require every other URI component to match its registered value.
+- [The web and API origins split one flow] → Keep all security decisions in API-owned helpers and revalidate inputs during approval and exchange.
+- [A seven-day token requires periodic CLI reauthorization] → Accept this baseline behavior; refresh tokens can be added later when the CLI experience proves the need.
+- [A broad bearer token gives all current account permissions] → Display this honestly and preserve the existing live user/role/ToS checks rather than inventing unenforced scopes.
+
+## Migration Plan
+
+1. Add OAuth client and authorization-code schema records and generate the Drizzle migration.
+2. Add admin-only public-client management and redirect/PKCE validation helpers.
+3. Add authorization-code issuance and the raw token exchange endpoint.
+4. Add the minimal web authorization/consent route.
+5. Deploy with no registered OAuth clients, then let an administrator register `peated-cli` and its loopback redirects.
+
+Rollback disables the authorization and token routes and deactivates registered clients. Existing bearer tokens and web login remain independent.
+
+## Open Questions
+
+None blocking implementation. Client registration is admin-only, all clients are public PKCE clients, access tokens use the existing seven-day Peated JWT, and advanced OAuth lifecycle features are deferred.

--- a/openspec/changes/add-cli-oauth-pkce/proposal.md
+++ b/openspec/changes/add-cli-oauth-pkce/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Peated's local CLI needs a standards-based way to obtain upstream API access without handling a user's password, passkey, or Google credential. The smallest correct server baseline is an authorization code flow with mandatory PKCE for public OAuth clients registered by Peated administrators.
+
+## What Changes
+
+- Add admin-only OAuth client registration and management for public clients; there is no public or dynamic client-registration endpoint.
+- Add a small internal admin UI to list clients, register one, edit its name and redirect URIs, and activate or deactivate it.
+- Add a narrow OAuth authorization-server profile using only the authorization code grant with mandatory PKCE `S256`.
+- Validate authorization redirect URIs against the selected active client's administrator-registered redirect URIs, including native-app loopback port handling.
+- Add a minimal authenticated browser authorization and consent flow that issues short-lived, single-use authorization codes.
+- Add a form-encoded token endpoint that validates the complete PKCE binding and returns Peated's existing seven-day bearer access token for the authorizing user.
+- Add focused integration coverage for admin client registration, successful authorization and exchange, redirect and PKCE validation, code expiry, and replay prevention.
+- Keep refresh tokens, durable OAuth grants, token revocation, authorization-server discovery, granular scopes, device authorization, dynamic client registration, confidential clients, OpenID Connect, and the CLI command implementation out of scope for this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `oauth-pkce-authorization`: Administrator-managed public OAuth clients and PKCE-protected authorization-code exchange into Peated's existing bearer-token model.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- `apps/server/src/db/schema/` and a generated Drizzle migration for administrator-registered OAuth clients and single-use authorization codes.
+- Admin-only oRPC routes and admin web pages for client registration, listing, inspection, editing, and activation state, plus a dedicated standards-shaped token adapter.
+- `apps/web/src/app/` for the authenticated authorization/consent route that uses the existing Peated session and returns the browser to the loopback redirect URI.
+- Credential-safe request handling, account-policy documentation, and focused tests across the server and minimal web authorization boundary.
+- Existing bearer-token creation, validation, user activation, ToS, moderator, and admin behavior remains authoritative and compatible.

--- a/openspec/changes/add-cli-oauth-pkce/specs/oauth-pkce-authorization/spec.md
+++ b/openspec/changes/add-cli-oauth-pkce/specs/oauth-pkce-authorization/spec.md
@@ -1,0 +1,184 @@
+## ADDED Requirements
+
+### Requirement: Administrators manage public OAuth clients
+
+The system SHALL persist system-wide public OAuth clients with a server-generated client id, administrator-controlled name and registered redirect URIs, active state, and timestamps. Only Peated administrators SHALL create, list, update, or deactivate OAuth clients. The system SHALL NOT expose dynamic or anonymous client registration and SHALL NOT issue client secrets.
+
+#### Scenario: Administrator registers a client
+
+- **WHEN** an authenticated administrator submits a valid name and redirect URI list
+- **THEN** the server creates an active public client with a unique client id and returns its non-secret registration details.
+
+#### Scenario: Non-administrator attempts registration
+
+- **WHEN** a non-administrator or anonymous caller attempts to create or manage an OAuth client
+- **THEN** the server rejects the operation and persists no client change.
+
+#### Scenario: Administrator deactivates a client
+
+- **WHEN** an administrator deactivates an existing OAuth client
+- **THEN** the client can no longer begin authorization or exchange an authorization code.
+
+#### Scenario: Administrator submits an unsafe redirect
+
+- **WHEN** client registration includes a malformed URI, URI fragment, userinfo, wildcard host, or unsupported loopback value
+- **THEN** the server rejects the registration and persists no client.
+
+### Requirement: Administrators have an OAuth client management UI
+
+The web application SHALL provide an admin-only OAuth client management surface using the existing admin layout and administrator-protected client operations. It SHALL list registered clients and their active state, provide a shared add/edit form for name and redirect URIs, display the generated client id as read-only, and provide explicit activate/deactivate actions. It MUST NOT display or imply a client secret.
+
+#### Scenario: Administrator opens the client list
+
+- **WHEN** an authenticated administrator visits the OAuth client admin page
+- **THEN** the page lists each client's name, public client id, redirect summary, and active state and offers registration and editing actions.
+
+#### Scenario: Administrator registers a client through the UI
+
+- **WHEN** an administrator submits valid client data through the add form
+- **THEN** the UI creates the client through the administrator-protected API and navigates to its management view.
+
+#### Scenario: Administrator edits a client through the UI
+
+- **WHEN** an administrator changes a client's name, redirect URIs, or active state
+- **THEN** the UI persists the change through the administrator-protected API and presents the updated registration.
+
+#### Scenario: Non-administrator reaches the admin URL
+
+- **WHEN** an anonymous or non-administrator user requests an OAuth client admin route
+- **THEN** the existing admin access boundary redirects or rejects the user and no client data is disclosed.
+
+### Requirement: Authorization requests require PKCE and a registered redirect
+
+The authorization endpoint MUST require `response_type=code`, an active registered `client_id`, a redirect URI allowed by that client, a nonempty `state`, a valid PKCE code challenge, and `code_challenge_method=S256`. It MUST treat `state` as an opaque client value, return it unchanged, and reject missing PKCE and every other challenge method.
+
+Redirect matching MUST be exact except that a registered HTTP redirect using the literal loopback address `127.0.0.1` or `[::1]` MAY receive an ephemeral request port when all other URI components match. The server MUST NOT treat `localhost`, a wildcard, or a non-loopback address as that exception.
+
+#### Scenario: Registered loopback request is valid
+
+- **WHEN** an active client requests authorization using a registered loopback redirect with a permitted ephemeral port and valid `S256` challenge
+- **THEN** the server makes the request eligible for user authorization.
+
+#### Scenario: Registered exact redirect is valid
+
+- **WHEN** an active client requests authorization using a redirect URI that exactly matches one of its registered URIs and valid `S256` PKCE
+- **THEN** the server makes the request eligible for user authorization.
+
+#### Scenario: Redirect is not registered
+
+- **WHEN** a request changes a registered URI's scheme, non-loopback port, host, path, query, userinfo, or fragment outside the permitted loopback-port exception
+- **THEN** the server renders an invalid-request error and MUST NOT redirect the browser to the submitted URI.
+
+#### Scenario: Client is inactive
+
+- **WHEN** an authorization request names an inactive or unknown client
+- **THEN** the server rejects the request and issues no authorization code.
+
+#### Scenario: PKCE is missing or downgraded
+
+- **WHEN** the challenge is missing, malformed, uses `plain`, or names a method other than `S256`
+- **THEN** the server rejects the request and issues no authorization code.
+
+### Requirement: Authorization uses the existing Peated browser session
+
+The browser authorization endpoint SHALL authenticate the resource owner through the existing Peated web session, preserve a valid request across login, display the registered client name and full Peated API access being requested, and require an explicit approve or deny action.
+
+#### Scenario: Anonymous user opens a valid request
+
+- **WHEN** a valid authorization request reaches the browser endpoint without an authenticated Peated session
+- **THEN** the user is sent through normal Peated login and returned to the same authorization request afterward.
+
+#### Scenario: User approves access
+
+- **WHEN** an authenticated active user approves a still-valid request
+- **THEN** the API creates a short-lived authorization code bound to that user, client, exact redirect URI, and PKCE challenge and returns the browser with the code and original state.
+
+#### Scenario: User denies access
+
+- **WHEN** an authenticated user denies a valid authorization request
+- **THEN** the browser returns to the validated redirect URI with `error=access_denied` and the original state, and no authorization code is created.
+
+### Requirement: Authorization codes are short-lived and single-use
+
+The server SHALL generate authorization codes from cryptographically secure random data, SHALL store only a non-reversible digest, SHALL bind each code to its user, client, exact redirect URI, and PKCE challenge, and SHALL enforce a short expiration and one successful consumption.
+
+#### Scenario: Fresh code is exchanged once
+
+- **WHEN** an unexpired authorization code is presented with its bound active client, exact redirect URI, and valid verifier
+- **THEN** the server atomically consumes the code and issues one existing-format Peated access token.
+
+#### Scenario: Authorization code is replayed
+
+- **WHEN** a consumed authorization code is presented again
+- **THEN** the server returns `invalid_grant` and issues no additional token.
+
+#### Scenario: Authorization code expires
+
+- **WHEN** an authorization code is presented after its configured expiration
+- **THEN** the server returns `invalid_grant` and issues no token.
+
+### Requirement: Token exchange validates the complete PKCE binding
+
+The token endpoint SHALL accept `application/x-www-form-urlencoded` requests for `grant_type=authorization_code` and SHALL validate the authorization code, active public client id, exact redirect URI, verifier syntax, and `S256` transformation before issuing an access token. It SHALL reject every other grant type and SHALL use OAuth token and error response shapes rather than the oRPC envelope.
+
+#### Scenario: Correct verifier completes exchange
+
+- **WHEN** the endpoint receives a fresh code and verifier whose `S256` challenge matches the stored challenge and all client and redirect bindings match
+- **THEN** it returns the existing Peated access token with `token_type=Bearer` and its seven-day `expires_in`.
+
+#### Scenario: Incorrect verifier is submitted
+
+- **WHEN** the submitted verifier does not match the stored PKCE challenge
+- **THEN** the server returns `invalid_grant`, leaves no successful exchange, and issues no token.
+
+#### Scenario: Redirect URI differs during exchange
+
+- **WHEN** the token request redirect URI differs from the exact URI bound to the authorization code, including its selected loopback port
+- **THEN** the server returns `invalid_grant` and issues no token.
+
+#### Scenario: Unsupported grant is requested
+
+- **WHEN** the token endpoint receives a refresh-token, client-credentials, password, device, or other unsupported grant
+- **THEN** it returns `unsupported_grant_type` and issues no token.
+
+#### Scenario: Client is deactivated before exchange
+
+- **WHEN** a client is deactivated after code issuance but before token exchange
+- **THEN** the exchange is rejected and no token is issued.
+
+### Requirement: OAuth tokens use existing Peated API authorization
+
+An access token returned by OAuth code exchange SHALL use the existing Peated bearer-token format and SHALL remain subject to current user activation, verification, ToS, moderator, and admin checks. OAuth authorization MUST NOT elevate the user's permissions.
+
+#### Scenario: OAuth-issued token calls the API
+
+- **WHEN** a valid OAuth-issued access token is presented to an existing API route
+- **THEN** the API authenticates and authorizes it through the existing Peated bearer-token path.
+
+#### Scenario: User permissions change after token issuance
+
+- **WHEN** the user's active, verified, ToS, moderator, or admin state changes after token issuance
+- **THEN** subsequent API requests use the existing current-user behavior rather than treating OAuth authorization as an elevation.
+
+### Requirement: OAuth credential material is not logged
+
+The OAuth token endpoint MUST NOT log its form body, authorization code, code verifier, or returned access token. Token responses and authorization pages MUST use `Cache-Control: no-store`, and authorization pages MUST use `Referrer-Policy: no-referrer`.
+
+#### Scenario: Token exchange fails
+
+- **WHEN** authorization-code exchange fails validation
+- **THEN** application logs exclude the submitted form body, code, and verifier.
+
+#### Scenario: Authorization page is rendered
+
+- **WHEN** the browser displays an authorization request
+- **THEN** the response uses `Cache-Control: no-store` and `Referrer-Policy: no-referrer`.
+
+### Requirement: Existing authentication remains compatible
+
+Adding OAuth PKCE SHALL NOT invalidate existing Peated access tokens or change established login and API authorization behavior.
+
+#### Scenario: Existing token calls the API
+
+- **WHEN** a valid token issued by an existing Peated login flow is presented after OAuth support is deployed
+- **THEN** the API authenticates and authorizes it through the unchanged bearer-token path.

--- a/openspec/changes/add-cli-oauth-pkce/tasks.md
+++ b/openspec/changes/add-cli-oauth-pkce/tasks.md
@@ -1,0 +1,37 @@
+## 1. OAuth Client Registration
+
+- [x] 1.1 Add `oauth_client` and `oauth_authorization_code` Drizzle schemas with active state, registered redirect URIs, code digests, PKCE binding, expiration, consumption, relations, and required indexes.
+- [x] 1.2 Generate the database migration with `pnpm db:generate`, inspect the generated SQL and metadata, and add schema/database coverage without hand-editing migration artifacts.
+- [x] 1.3 Add administrator-only oRPC operations to create, list, inspect, update, and deactivate public OAuth clients, generating a unique public client id and never issuing a client secret.
+- [x] 1.4 Add integration tests proving admin-only client management, unique ids, redirect validation, updates, and deactivation.
+- [x] 1.5 Add `/admin/oauth-clients` list, add, and edit routes using the existing admin layout/sidebar and a shared client form for name and redirect URIs, with a read-only public client id and explicit activate/deactivate controls.
+- [x] 1.6 Add focused frontend tests for the client list and shared create/edit form, including validation and the existing admin access boundary, then manually verify the management flow.
+
+## 2. Authorization Validation and Codes
+
+- [x] 2.1 Add runtime schemas and helpers for authorization requests, registered redirect comparison including the loopback ephemeral-port exception, PKCE verifier/challenge syntax, `S256` calculation, secure code generation, and digesting.
+- [x] 2.2 Add focused tests for exact and loopback redirect matching, unsafe or unregistered redirects, opaque state round-tripping, malformed PKCE, and unknown or inactive clients.
+- [x] 2.3 Implement an authenticated authorization-code issuance service that revalidates the active client, registered redirect, PKCE request, current user, and expiry before persisting only the code digest.
+- [x] 2.4 Implement atomic authorization-code exchange with exact client and redirect binding, verifier checking, two-minute expiration, and single consumption under concurrent or repeated requests.
+- [x] 2.5 Add database integration tests for successful issuance/exchange, expiry, wrong verifier, redirect mismatch, replay, and client deactivation between issuance and exchange.
+
+## 3. OAuth Token Endpoint
+
+- [x] 3.1 Add a dedicated Hono `POST /oauth/token` adapter for form-encoded authorization-code exchange, supporting only public clients and `grant_type=authorization_code`.
+- [x] 3.2 Return the existing Peated access token from `createAccessToken(user)` with standard `access_token`, `token_type=Bearer`, and seven-day `expires_in` fields after successful exchange.
+- [x] 3.3 Return standards-shaped OAuth errors for malformed requests, invalid grants, and unsupported grant types without using the oRPC envelope.
+- [x] 3.4 Add focused raw HTTP tests for form parsing, a successful response, representative OAuth errors, no-store headers, and use of the returned token on an existing authenticated API route.
+
+## 4. Browser Authorization
+
+- [x] 4.1 Add the layout-free `peated.com/oauth/authorize` route/page to parse authorization requests, resolve the registered client through the API, render invalid requests without unsafe redirects, and send anonymous users through existing login with a safe return path.
+- [x] 4.2 Display the registered client name and full Peated API access, then add approve and deny server actions that revalidate the request and redirect only to the validated URI with the original state and either a code or `error=access_denied`.
+- [x] 4.3 Apply `Cache-Control: no-store` and `Referrer-Policy: no-referrer` to the authorization surface.
+- [x] 4.4 Add focused web tests for login continuation, approve, deny, state preservation, and refusing an invalid redirect.
+
+## 5. Security, Documentation, and Verification
+
+- [x] 5.1 Ensure the token endpoint does not log form bodies, codes, verifiers, or access tokens, and apply the specified no-store and no-referrer response headers.
+- [x] 5.2 Update `docs/architecture/account-policies.md` with admin-only public client registration, PKCE authorization, existing token behavior, seven-day reauthorization, and the explicit exclusion of refresh, revocation, discovery, dynamic registration, client secrets, and scopes.
+- [x] 5.3 Run targeted server and web tests, server and web typechecks, and file-scoped lint/format checks for every touched surface.
+- [x] 5.4 Complete local browser verification of the successful loopback flow, denial, authenticated API access, and replay rejection using the local UI verification playbook.


### PR DESCRIPTION
Adds a narrow OAuth authorization-code flow for CLI and other public clients. Administrators can register or deactivate clients and their allowed redirect URIs; users approve access through the existing browser session; clients exchange short-lived, single-use PKCE S256 codes at `POST /oauth/token` for the existing seven-day bearer token.

The implementation intentionally omits client secrets, refresh tokens, scopes, discovery, dynamic registration, device authorization, and OpenID Connect. Authorization codes are stored only as digests, redirect URIs require exact matching except for loopback ports, and issued tokens continue to use the existing account-policy and permission checks. Migration `0200` adds the client and authorization-code tables.

Every server route has a co-located PostgreSQL integration test, supplemented by deterministic helper tests and frontend flow tests. A fresh schema migration, 26 server OAuth tests, 210 web tests, both package typechecks, static analysis, and strict OpenSpec validation pass.
