### PR TITLE
fix(otel): align GenAI telemetry and eval traces

### DIFF
--- a/apps/server/src/lib/genAiTelemetry.test.ts
+++ b/apps/server/src/lib/genAiTelemetry.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "vitest";
+import {
+  normalizeGenAiSpan,
+  normalizeStreamedGenAiSpan,
+} from "./genAiTelemetry";
+
+describe("normalizeGenAiSpan", () => {
+  test("adds the current provider attribute to Sentry OpenAI spans", () => {
+    expect(
+      normalizeGenAiSpan({
+        op: "gen_ai.chat",
+        data: {
+          "gen_ai.system": "openai",
+          "gen_ai.operation.name": "chat",
+          "gen_ai.request.model": "gpt-5.6-terra",
+        },
+      }),
+    ).toEqual({
+      op: "gen_ai.chat",
+      data: {
+        "gen_ai.system": "openai",
+        "gen_ai.operation.name": "chat",
+        "gen_ai.provider.name": "openai",
+        "gen_ai.request.model": "gpt-5.6-terra",
+      },
+    });
+  });
+
+  test("does not assign a provider to unrelated spans", () => {
+    const span = { op: "http.client", data: {} };
+    expect(normalizeGenAiSpan(span)).toBe(span);
+  });
+
+  test("normalizes the streamed span shape used by the server", () => {
+    const span = {
+      trace_id: "trace",
+      span_id: "span",
+      name: "chat gpt-5.6-terra",
+      start_timestamp: 1,
+      end_timestamp: 2,
+      status: "ok" as const,
+      is_segment: false,
+      attributes: {
+        "sentry.op": "gen_ai.chat",
+        "gen_ai.system": "openai",
+      },
+    };
+
+    expect(normalizeStreamedGenAiSpan(span).attributes).toMatchObject({
+      "gen_ai.provider.name": "openai",
+    });
+  });
+});

--- a/apps/server/src/lib/genAiTelemetry.ts
+++ b/apps/server/src/lib/genAiTelemetry.ts
@@ -1,0 +1,64 @@
+import type { StreamedSpanJSON } from "@sentry/core";
+
+type SentrySpanJson = {
+  op?: string;
+  data?: Record<string, unknown>;
+};
+
+/**
+ * Bridges Sentry's OpenAI integration from the legacy `gen_ai.system`
+ * discriminator to the current OpenTelemetry provider attribute.
+ */
+export function normalizeGenAiSpan<T extends SentrySpanJson>(span: T): T {
+  if (
+    !span.op?.startsWith("gen_ai.") ||
+    span.data?.["gen_ai.provider.name"] !== undefined ||
+    span.data?.["gen_ai.system"] !== "openai"
+  ) {
+    return span;
+  }
+
+  return {
+    ...span,
+    data: {
+      ...span.data,
+      "gen_ai.provider.name": "openai",
+    },
+  };
+}
+
+/** Adds the current provider attribute to Sentry's streamed span format. */
+export function normalizeStreamedGenAiSpan(
+  span: StreamedSpanJSON,
+): StreamedSpanJSON {
+  const attributes = span.attributes;
+  if (!attributes) {
+    return span;
+  }
+
+  const operation = attributeValue(attributes?.["sentry.op"]);
+  if (operation !== "gen_ai.chat" && operation !== "gen_ai.embeddings") {
+    return span;
+  }
+
+  if (
+    attributes["gen_ai.provider.name"] !== undefined ||
+    attributeValue(attributes["gen_ai.system"]) !== "openai"
+  ) {
+    return span;
+  }
+
+  return {
+    ...span,
+    attributes: {
+      ...attributes,
+      "gen_ai.provider.name": "openai",
+    },
+  };
+}
+
+function attributeValue(value: unknown): unknown {
+  return value && typeof value === "object" && "value" in value
+    ? (value as { value: unknown }).value
+    : value;
+}

--- a/apps/server/src/lib/openai.test.ts
+++ b/apps/server/src/lib/openai.test.ts
@@ -5,6 +5,26 @@ import { OpenAIBottleDetailsValidationSchema } from "../worker/jobs/generateBott
 import { OpenAICountryDetailsSchema } from "../worker/jobs/generateCountryDetails";
 import { OpenAIEntityDetailsValidationSchema } from "../worker/jobs/generateEntityDetails";
 import { OpenAIRegionDetailsSchema } from "../worker/jobs/generateRegionDetails";
+import { buildStructuredResponseSpanContext } from "./openai";
+
+test("uses GenAI workflow semantics for structured responses", () => {
+  expect(
+    buildStructuredResponseSpanContext(
+      "generateBottleDetails",
+      "gpt-5.6-terra",
+    ),
+  ).toEqual({
+    op: "gen_ai.invoke_workflow",
+    name: "invoke_workflow generateBottleDetails",
+    attributes: {
+      "gen_ai.operation.name": "invoke_workflow",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.workflow.name": "generateBottleDetails",
+      "gen_ai.request.model": "gpt-5.6-terra",
+      "gen_ai.output.type": "json",
+    },
+  });
+});
 
 describe("openai structured output schemas", () => {
   test("compile to strict json schema without optional fields", () => {

--- a/apps/server/src/lib/openai.ts
+++ b/apps/server/src/lib/openai.ts
@@ -28,6 +28,23 @@ export const GENERATION_PERSONA_PROMPT = [
   "</rules>",
 ].join("\n");
 
+export function buildStructuredResponseSpanContext(
+  pipelineName: string,
+  model: string,
+) {
+  return {
+    op: "gen_ai.invoke_workflow",
+    name: `invoke_workflow ${pipelineName}`,
+    attributes: {
+      "gen_ai.operation.name": "invoke_workflow",
+      "gen_ai.provider.name": "openai",
+      "gen_ai.workflow.name": pipelineName,
+      "gen_ai.request.model": model,
+      "gen_ai.output.type": "json",
+    },
+  };
+}
+
 export async function getStructuredResponse<Schema extends ZodSchema<any>>(
   pipelineName: string,
   prompt: string | Message[],
@@ -66,17 +83,8 @@ export async function getStructuredResponse<
     typeof prompt === "string" ? [{ role: "user", content: prompt }] : prompt;
 
   const response = await startSpan(
-    {
-      op: "ai.run",
-      name: "getStructuredResponse",
-    },
+    buildStructuredResponseSpanContext(pipelineName, model),
     async (span) => {
-      span.setAttribute("ai.pipeline.name", pipelineName);
-      span.setAttribute("ai.instructions", GENERATION_PERSONA_PROMPT);
-      span.setAttribute("ai.input_messages", JSON.stringify(inputMessages));
-      span.setAttribute("ai.model_id", model);
-      span.setAttribute("ai.streaming", false);
-
       const result = await openai.responses.create({
         model,
         instructions: GENERATION_PERSONA_PROMPT,
@@ -89,20 +97,26 @@ export async function getStructuredResponse<
         temperature: 0,
       });
 
+      span.setAttribute("gen_ai.response.id", result.id);
+      span.setAttribute("gen_ai.response.model", result.model);
       if (result.usage) {
-        span.setAttribute("ai.total_tokens.used", result.usage.total_tokens);
-        span.setAttribute("ai.prompt_tokens.used", result.usage.input_tokens);
         span.setAttribute(
-          "ai.completion_tokens.used",
+          "gen_ai.usage.input_tokens",
+          result.usage.input_tokens,
+        );
+        span.setAttribute(
+          "gen_ai.usage.cache_read.input_tokens",
+          result.usage.input_tokens_details.cached_tokens,
+        );
+        span.setAttribute(
+          "gen_ai.usage.output_tokens",
           result.usage.output_tokens,
         );
         span.setAttribute(
-          "ai.reasoning_tokens.used",
+          "gen_ai.usage.reasoning.output_tokens",
           result.usage.output_tokens_details.reasoning_tokens,
         );
       }
-
-      span.setAttribute("ai.responses", JSON.stringify(result.output));
 
       return result;
     },

--- a/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
@@ -413,9 +413,12 @@ describe("POST /tastings/photo-identification", () => {
     );
     expect(Sentry.startSpan).toHaveBeenCalledWith(
       expect.objectContaining({
-        op: "gen_ai.invoke_agent",
-        name: "invoke_agent Photo Identification",
+        op: "gen_ai.invoke_workflow",
+        name: "invoke_workflow Photo Identification",
         attributes: expect.objectContaining({
+          "gen_ai.operation.name": "invoke_workflow",
+          "gen_ai.provider.name": "openai",
+          "gen_ai.workflow.name": "Photo Identification",
           "gen_ai.conversation.id": `photo_identification:${response.pendingImage.id}`,
           "photo_identification.pending_image_id": response.pendingImage.id,
         }),

--- a/apps/server/src/orpc/routes/tastings/photo-identification.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.ts
@@ -605,7 +605,7 @@ async function persistPhotoIdentificationReview({
  * gives the full classifier the chance to identify the Bottle and propose any
  * supported catalog repairs.
  *
- * This is the shared Photo Identification agent span boundary for all callers.
+ * This is the shared Photo Identification workflow span boundary for all callers.
  */
 export async function identifyPendingImage({
   pendingImage,
@@ -616,11 +616,12 @@ export async function identifyPendingImage({
 
   return await Sentry.startSpan(
     {
-      op: "gen_ai.invoke_agent",
-      name: "invoke_agent Photo Identification",
+      op: "gen_ai.invoke_workflow",
+      name: "invoke_workflow Photo Identification",
       attributes: {
-        "gen_ai.operation.name": "invoke_agent",
-        "gen_ai.agent.name": "Photo Identification",
+        "gen_ai.operation.name": "invoke_workflow",
+        "gen_ai.provider.name": "openai",
+        "gen_ai.workflow.name": "Photo Identification",
         "gen_ai.conversation.id": conversationId,
         "photo_identification.pending_image_id": pendingImage.id,
         "photo_identification.source_image_url": absoluteUrl(

--- a/apps/server/src/sentry.ts
+++ b/apps/server/src/sentry.ts
@@ -1,5 +1,6 @@
 import * as Sentry from "@sentry/hono/node";
 import config from "./config";
+import { normalizeStreamedGenAiSpan } from "./lib/genAiTelemetry";
 import { configureLogging } from "./lib/log";
 
 type HonoNodeOptionsWithLocalVariables = Parameters<typeof Sentry.init>[0] & {
@@ -13,6 +14,7 @@ if (config.ENV !== "test") {
     tracesSampleRate: 1.0,
     enableLogs: true,
     streamGenAiSpans: true,
+    beforeSendSpan: Sentry.withStreamedSpan(normalizeStreamedGenAiSpan),
     tracePropagationTargets: ["localhost", "api.peated.com", "peated.com"],
     includeLocalVariables: true,
     sendDefaultPii: true,

--- a/apps/server/src/worker/jobs/generateBottleDetails.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.ts
@@ -26,7 +26,6 @@ import {
   updateConcreteBottleInTransaction,
 } from "@peated/server/lib/updateConcreteBottle";
 import { CategoryEnum, FlavorProfileEnum } from "@peated/server/schemas";
-import { startSpan } from "@sentry/node";
 import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
 
@@ -123,25 +122,17 @@ export async function getGeneratedBottleDetails(
   return await withSentryConversation(
     conversationId,
     async () =>
-      await startSpan(
+      await getStructuredResponse(
+        "generateBottleDetails",
+        generatePrompt(bottle, tagList),
+        OpenAIBottleDetailsSchema,
+        OpenAIBottleDetailsValidationSchema,
+        undefined,
         {
-          op: "ai.pipeline",
-          name: "generateBottleDetails",
-        },
-        async (span) => {
-          return await getStructuredResponse(
-            "generateBottleDetails",
-            generatePrompt(bottle, tagList),
-            OpenAIBottleDetailsSchema,
-            OpenAIBottleDetailsValidationSchema,
-            undefined,
-            {
-              bottle: {
-                id: bottle.id,
-                fullName: bottle.fullName,
-              },
-            },
-          );
+          bottle: {
+            id: bottle.id,
+            fullName: bottle.fullName,
+          },
         },
       ),
   );

--- a/apps/server/src/worker/jobs/generateCountryDetails.ts
+++ b/apps/server/src/worker/jobs/generateCountryDetails.ts
@@ -5,7 +5,6 @@ import { logWarn } from "@peated/server/lib/log";
 import { getStructuredResponse } from "@peated/server/lib/openai";
 import { withSentryConversation } from "@peated/server/lib/openaiClient";
 import { type Country } from "@peated/server/types";
-import { startSpan } from "@sentry/node";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -45,25 +44,17 @@ export async function getGeneratedCountryDetails(
   return await withSentryConversation(
     `country_details:${country.slug ?? country.name ?? "draft"}`,
     async () =>
-      await startSpan(
+      await getStructuredResponse(
+        "getGeneratedCountryDetails",
+        generatePrompt(country),
+        OpenAICountryDetailsSchema,
+        undefined,
+        undefined,
         {
-          op: "ai.pipeline",
-          name: "getGeneratedCountryDetails",
-        },
-        async (span) => {
-          return await getStructuredResponse(
-            "getGeneratedCountryDetails",
-            generatePrompt(country),
-            OpenAICountryDetailsSchema,
-            undefined,
-            undefined,
-            {
-              country: {
-                id: country.slug,
-                name: country.name,
-              },
-            },
-          );
+          country: {
+            id: country.slug,
+            name: country.name,
+          },
         },
       ),
   );

--- a/apps/server/src/worker/jobs/generateEntityDetails.ts
+++ b/apps/server/src/worker/jobs/generateEntityDetails.ts
@@ -8,7 +8,6 @@ import { logTelemetryError, logWarn } from "@peated/server/lib/log";
 import { getStructuredResponse } from "@peated/server/lib/openai";
 import { withSentryConversation } from "@peated/server/lib/openaiClient";
 import { EntityTypeEnum } from "@peated/server/schemas";
-import { startSpan } from "@sentry/node";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -98,25 +97,17 @@ export async function getGeneratedEntityDetails(
   return await withSentryConversation(
     conversationId,
     async () =>
-      await startSpan(
+      await getStructuredResponse(
+        "getGeneratedEntityDetails",
+        generatePrompt(entity),
+        OpenAIEntityDetailsSchema,
+        OpenAIEntityDetailsValidationSchema,
+        undefined,
         {
-          op: "ai.pipeline",
-          name: "getGeneratedEntityDetails",
-        },
-        async (span) => {
-          return await getStructuredResponse(
-            "getGeneratedEntityDetails",
-            generatePrompt(entity),
-            OpenAIEntityDetailsSchema,
-            OpenAIEntityDetailsValidationSchema,
-            undefined,
-            {
-              entity: {
-                id: entity.id,
-                name: entity.name,
-              },
-            },
-          );
+          entity: {
+            id: entity.id,
+            name: entity.name,
+          },
         },
       ),
   );

--- a/apps/server/src/worker/jobs/generateRegionDetails.ts
+++ b/apps/server/src/worker/jobs/generateRegionDetails.ts
@@ -5,7 +5,6 @@ import { logWarn } from "@peated/server/lib/log";
 import { getStructuredResponse } from "@peated/server/lib/openai";
 import { withSentryConversation } from "@peated/server/lib/openaiClient";
 import { type Region } from "@peated/server/types";
-import { startSpan } from "@sentry/node";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -42,31 +41,23 @@ export async function getGeneratedRegionDetails(
   return await withSentryConversation(
     conversationId,
     async () =>
-      await startSpan(
+      await getStructuredResponse(
+        "getGeneratedRegionDetails",
+        generatePrompt(region),
+        OpenAIRegionDetailsSchema,
+        undefined,
+        undefined,
         {
-          op: "ai.pipeline",
-          name: "getGeneratedRegionDetails",
-        },
-        async (span) => {
-          return await getStructuredResponse(
-            "getGeneratedRegionDetails",
-            generatePrompt(region),
-            OpenAIRegionDetailsSchema,
-            undefined,
-            undefined,
-            {
-              region: {
-                id: region.id,
-                slug: region.slug,
-                name: region.name,
-              },
-              country: {
-                id: region.country.id,
-                slug: region.country.slug,
-                name: region.country.slug,
-              },
-            },
-          );
+          region: {
+            id: region.id,
+            slug: region.slug,
+            name: region.name,
+          },
+          country: {
+            id: region.country.id,
+            slug: region.country.slug,
+            name: region.country.slug,
+          },
         },
       ),
   );

--- a/packages/bottle-classifier/package.json
+++ b/packages/bottle-classifier/package.json
@@ -101,7 +101,7 @@
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "vitest-evals": "0.14.0"
+    "vitest-evals": "0.15.0"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/bottle-classifier/src/classifier.eval.test.ts
+++ b/packages/bottle-classifier/src/classifier.eval.test.ts
@@ -58,6 +58,7 @@ import {
   evalClassifierReasoningEffort,
   hasEvalOpenAICredentials,
 } from "./evalSupport";
+import { withEvalModelCallCapture } from "./evalTelemetry";
 import { createLocalCatalogDataSource } from "./localCatalog";
 import { exactBottleIdentityMatches } from "./normalizationEvalScoring";
 import {
@@ -739,13 +740,16 @@ const classifierHarness = createHarness<ClassifierScenarioEvalCase, JsonValue>({
   run: async ({ input }) => {
     const startedAt = performance.now();
     const evalRuntime = createEvalRuntime();
-    const classifier = createBottleClassifier({
-      ...createClassifierOptions(input),
-      ...evalRuntime.options,
+    const {
+      result: { result, modelMetadata },
+      modelCalls,
+    } = await withEvalModelCallCapture(async () => {
+      const classifier = createBottleClassifier({
+        ...createClassifierOptions(input),
+        ...evalRuntime.options,
+      });
+      return await classifier.runBottleReference(input.testCase.input);
     });
-    const { result, modelMetadata } = await classifier.runBottleReference(
-      input.testCase.input,
-    );
     const output = toJsonValue(result) ?? null;
 
     return {
@@ -764,6 +768,11 @@ const classifierHarness = createHarness<ClassifierScenarioEvalCase, JsonValue>({
         modelMetadata,
         reasoningEffort: evalClassifierReasoningEffort,
         totalMs: performance.now() - startedAt,
+        modelCalls,
+        trace: {
+          name: "Bottle Classifier",
+          operationName: "invoke_agent",
+        },
       }),
     };
   },
@@ -828,13 +837,16 @@ const auditHarness = createHarness<AuditBottleEvalFixture, JsonValue>({
   run: async ({ input }) => {
     const startedAt = performance.now();
     const evalRuntime = createEvalRuntime();
-    const classifier = createBottleClassifier({
-      ...createAuditEvalClassifierOptions(input),
-      ...evalRuntime.options,
+    const {
+      result: { result, modelMetadata },
+      modelCalls,
+    } = await withEvalModelCallCapture(async () => {
+      const classifier = createBottleClassifier({
+        ...createAuditEvalClassifierOptions(input),
+        ...evalRuntime.options,
+      });
+      return await classifier.runBottleAudit(input.input.audit);
     });
-    const { result, modelMetadata } = await classifier.runBottleAudit(
-      input.input.audit,
-    );
     const output = toJsonValue(result) ?? null;
 
     return {
@@ -853,6 +865,11 @@ const auditHarness = createHarness<AuditBottleEvalFixture, JsonValue>({
         modelMetadata,
         reasoningEffort: evalClassifierReasoningEffort,
         totalMs: performance.now() - startedAt,
+        modelCalls,
+        trace: {
+          name: "Bottle Auditor",
+          operationName: "invoke_agent",
+        },
       }),
     };
   },

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -1673,7 +1673,7 @@ export function createBottleClassifier(
           currentBottleContext,
           conversationId,
         });
-        output = await startAgentSpan({
+        const agentRun = await startAgentSpan({
           name: "Bottle Auditor",
           conversationId: preparedRun.conversationId,
           attributes: {
@@ -1688,17 +1688,22 @@ export function createBottleClassifier(
               preparedRun.input,
               preparedRun.runOptions,
             );
-            modelMetadata = getBottleClassifierRunMetadata({
+            const runMetadata = getBottleClassifierRunMetadata({
               result,
               durationMs: performance.now() - startedAt,
             });
             try {
-              return preparedRun.getOutput(result);
+              return {
+                output: preparedRun.getOutput(result),
+                modelMetadata: runMetadata,
+              };
             } finally {
               artifacts = preparedRun.getArtifacts();
             }
           },
         });
+        output = agentRun.output;
+        modelMetadata = agentRun.modelMetadata;
       }
 
       return {

--- a/packages/bottle-classifier/src/evalCost.ts
+++ b/packages/bottle-classifier/src/evalCost.ts
@@ -51,7 +51,7 @@ const STANDARD_SHORT_CONTEXT_PRICING: TokenPricing[] = [
 ];
 
 export type EvalRunCostMetadata = {
-  scope: "agent_loop_only";
+  scope: "agent_loop_only" | "full_llm_run";
   costCoverage:
     | "priced_model_tokens"
     | "cached_input_unreported_assumed_uncached"
@@ -60,6 +60,7 @@ export type EvalRunCostMetadata = {
     | "usage_unavailable"
     | "unsupported_model";
   estimatedAgentLoopCostUsd?: number;
+  estimatedLlmRunCostUsd?: number;
   pricingModel?: string;
   pricingEffectiveDate: string;
   pricingSource: string;
@@ -105,24 +106,28 @@ function resolveTokenPricing(model: string): TokenPricing | undefined {
 }
 
 /**
- * Estimates only measured agent-loop model tokens. Extraction, separate web
- * search responses and fees, and pricing adjustments stay outside this scope.
+ * Estimates the measured model tokens in the supplied usage scope. Provider
+ * tool fees and pricing adjustments remain outside the token estimate.
  */
 export function getEvalRunCostMetadata({
   model,
   usage,
+  scope = "agent_loop_only",
 }: {
   model: string;
   usage: BottleClassifierRunMetadata["usage"];
+  scope?: EvalRunCostMetadata["scope"];
 }): EvalRunCostMetadata {
   const metadata = getEvalModelCostMetadata({ model, usage });
   const { estimatedCostUsd, ...sharedMetadata } = metadata;
   return {
     ...sharedMetadata,
-    scope: "agent_loop_only",
+    scope,
     ...(estimatedCostUsd === undefined
       ? {}
-      : { estimatedAgentLoopCostUsd: estimatedCostUsd }),
+      : scope === "full_llm_run"
+        ? { estimatedLlmRunCostUsd: estimatedCostUsd }
+        : { estimatedAgentLoopCostUsd: estimatedCostUsd }),
   };
 }
 

--- a/packages/bottle-classifier/src/evalMeasurements.ts
+++ b/packages/bottle-classifier/src/evalMeasurements.ts
@@ -1,5 +1,10 @@
 import type { JsonValue, UsageSummary } from "vitest-evals/harness";
 import { getEvalModelCostMetadata, getEvalRunCostMetadata } from "./evalCost";
+import {
+  buildEvalModelCallTrace,
+  summarizeEvalModelCalls,
+  type EvalModelCall,
+} from "./evalTelemetry";
 import type { WhiskyLabelExtractionMetadata } from "./extractor";
 import type { OpenAIReasoningEffort } from "./openaiModelSettings";
 import type { BottleClassifierRunMetadata } from "./runtime/runMetadata";
@@ -9,45 +14,96 @@ export function buildEvalHarnessMeasurements({
   modelMetadata,
   reasoningEffort,
   totalMs,
+  modelCalls,
+  trace,
 }: {
   model: string;
   modelMetadata: BottleClassifierRunMetadata | null;
   reasoningEffort?: OpenAIReasoningEffort;
   totalMs: number;
+  modelCalls?: EvalModelCall[];
+  trace?: {
+    name: string;
+    operationName: "invoke_agent" | "invoke_workflow";
+  };
 }) {
-  const costMetadata = modelMetadata
-    ? getEvalRunCostMetadata({ model, usage: modelMetadata.usage })
+  const capturedUsage = modelCalls
+    ? summarizeEvalModelCalls(modelCalls)
+    : undefined;
+  const measuredUsage =
+    capturedUsage?.inputTokens === undefined
+      ? modelMetadata?.usage
+      : {
+          requests: modelCalls?.length ?? 0,
+          inputTokens: capturedUsage.inputTokens,
+          ...(typeof capturedUsage.metadata?.cachedInputTokens === "number"
+            ? {
+                cachedInputTokens: capturedUsage.metadata.cachedInputTokens,
+              }
+            : {}),
+          ...(typeof capturedUsage.metadata?.cacheWriteTokens === "number"
+            ? { cacheWriteTokens: capturedUsage.metadata.cacheWriteTokens }
+            : {}),
+          outputTokens: capturedUsage.outputTokens ?? 0,
+          totalTokens: capturedUsage.totalTokens ?? 0,
+        };
+  const usageScope =
+    capturedUsage?.inputTokens === undefined
+      ? "agent_loop_only"
+      : "full_llm_run";
+  const costMetadata = measuredUsage
+    ? getEvalRunCostMetadata({ model, usage: measuredUsage, scope: usageScope })
     : null;
+  const usage = measuredUsage
+    ? {
+        provider: "openai",
+        model: capturedUsage?.model ?? model,
+        inputTokens: measuredUsage.inputTokens,
+        outputTokens: measuredUsage.outputTokens,
+        ...((capturedUsage?.reasoningTokens ??
+          modelMetadata?.usage.reasoningTokens) === undefined
+          ? {}
+          : {
+              reasoningTokens:
+                capturedUsage?.reasoningTokens ??
+                modelMetadata?.usage.reasoningTokens,
+            }),
+        totalTokens: measuredUsage.totalTokens,
+        toolCalls: modelMetadata?.toolCalls.count ?? 0,
+        metadata: {
+          ...costMetadata,
+          reasoningEffort: reasoningEffort ?? "provider_default",
+          requests: measuredUsage.requests,
+          ...(measuredUsage.cachedInputTokens === undefined
+            ? {}
+            : { cachedInputTokens: measuredUsage.cachedInputTokens }),
+          ...(measuredUsage.cacheWriteTokens === undefined
+            ? {}
+            : { cacheWriteTokens: measuredUsage.cacheWriteTokens }),
+          toolNames: modelMetadata?.toolCalls.names ?? [],
+          ...(capturedUsage?.metadata?.models
+            ? { models: capturedUsage.metadata.models }
+            : {}),
+        } satisfies Record<string, JsonValue>,
+      }
+    : undefined;
 
   return {
-    usage: modelMetadata
-      ? {
-          provider: "openai",
-          model,
-          inputTokens: modelMetadata.usage.inputTokens,
-          outputTokens: modelMetadata.usage.outputTokens,
-          totalTokens: modelMetadata.usage.totalTokens,
-          toolCalls: modelMetadata.toolCalls.count,
-          metadata: {
-            ...costMetadata,
-            reasoningEffort: reasoningEffort ?? "provider_default",
-            requests: modelMetadata.usage.requests,
-            ...(modelMetadata.usage.cachedInputTokens === undefined
-              ? {}
-              : { cachedInputTokens: modelMetadata.usage.cachedInputTokens }),
-            ...(modelMetadata.usage.cacheWriteTokens === undefined
-              ? {}
-              : { cacheWriteTokens: modelMetadata.usage.cacheWriteTokens }),
-            toolNames: modelMetadata.toolCalls.names,
-          } satisfies Record<string, JsonValue>,
-        }
-      : undefined,
+    usage,
     timings: {
       totalMs,
       ...(modelMetadata
         ? { metadata: { agentDurationMs: modelMetadata.agentDurationMs } }
         : {}),
     },
+    ...(trace && modelCalls
+      ? {
+          traces: buildEvalModelCallTrace({
+            ...trace,
+            modelCalls,
+          }),
+        }
+      : {}),
   };
 }
 
@@ -104,16 +160,24 @@ export function formatEvalUsageAnnotation(
 ): string {
   const metadata = usage?.metadata;
   const estimate =
-    metadata?.estimatedCostUsd ?? metadata?.estimatedAgentLoopCostUsd;
-  const coverage = metadata?.costCoverage ?? "usage_unavailable";
-  const reasoningEffort = metadata?.reasoningEffort ?? "provider_default";
-  const reasoningSummary = `effort ${String(reasoningEffort).replace("_", " ")}`;
-  const scopeSummary =
-    metadata?.scope === "image_extraction_only"
+    metadata?.estimatedCostUsd ??
+    metadata?.estimatedLlmRunCostUsd ??
+    metadata?.estimatedAgentLoopCostUsd;
+  const scope = metadata?.scope ?? "agent_loop_only";
+  const scopeLabel =
+    scope === "image_extraction_only"
       ? "image extraction only"
-      : "agent loop only";
+      : scope === "full_llm_run"
+        ? "full LLM run"
+        : "agent loop only";
+  const coverage = metadata?.costCoverage ?? "usage_unavailable";
+  const reasoningEffort =
+    typeof metadata?.reasoningEffort === "string"
+      ? metadata.reasoningEffort
+      : "provider_default";
+  const reasoningSummary = `effort ${reasoningEffort.replace("_", " ")}`;
   if (coverage === "usage_unavailable") {
-    return `usage unavailable | ${reasoningSummary} · ${scopeSummary}`;
+    return `usage unavailable | ${reasoningSummary} · ${scopeLabel}`;
   }
 
   const inputTokens = usage?.inputTokens ?? 0;
@@ -135,8 +199,8 @@ export function formatEvalUsageAnnotation(
   ].join(" | ");
 
   if (typeof estimate === "number") {
-    return `${tokenSummary} | ${reasoningSummary} | est. $${estimate.toFixed(6)} · ${scopeSummary}`;
+    return `${tokenSummary} | ${reasoningSummary} | est. $${estimate.toFixed(6)} · ${scopeLabel}`;
   }
 
-  return `${tokenSummary} | ${reasoningSummary} | cost unavailable (unsupported model) · ${scopeSummary}`;
+  return `${tokenSummary} | ${reasoningSummary} | cost unavailable (unsupported model) · ${scopeLabel}`;
 }

--- a/packages/bottle-classifier/src/evalSupport.ts
+++ b/packages/bottle-classifier/src/evalSupport.ts
@@ -3,6 +3,10 @@ import type {
   BottleClassifierDataSource,
   CreateBottleClassifierOptions,
 } from "./classifierRuntime";
+import {
+  getActiveEvalModelCallStore,
+  recordEvalOpenAIResponse,
+} from "./evalTelemetry";
 import { resolveOpenAICompatibleConfig } from "./openaiCompatibleConfig";
 import {
   getStableOpenAISettings,
@@ -25,12 +29,43 @@ export const evalJudgeModel = evalOpenAIConfig.evalModel;
 export const hasEvalOpenAICredentials = Boolean(evalOpenAIConfig.apiKey);
 
 export function createEvalOpenAIClient() {
-  return new OpenAI({
+  const client = new OpenAI({
     apiKey: evalOpenAIConfig.apiKey,
     baseURL: evalOpenAIConfig.baseURL,
     organization: evalOpenAIConfig.organization,
     project: evalOpenAIConfig.project,
   });
+  const originalCreate = client.responses.create.bind(client.responses);
+
+  const instrumentedCreate = (...args: Parameters<typeof originalCreate>) => {
+    const request = args[0];
+    const store = getActiveEvalModelCallStore();
+    const startedAt = new Date();
+    const requestPromise = originalCreate(...args);
+
+    if (store && request?.stream !== true) {
+      void requestPromise.then(
+        (response) => {
+          recordEvalOpenAIResponse({
+            request,
+            response,
+            startedAt,
+            store,
+          });
+        },
+        () => undefined,
+      );
+    }
+
+    return requestPromise;
+  };
+
+  Object.defineProperty(client.responses, "create", {
+    configurable: true,
+    value: instrumentedCreate as typeof client.responses.create,
+  });
+
+  return client;
 }
 
 export function createEvalClassifierOptions(

--- a/packages/bottle-classifier/src/evalTelemetry.test.ts
+++ b/packages/bottle-classifier/src/evalTelemetry.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "vitest";
+import { createHarness } from "vitest-evals";
+import { spansByKind } from "vitest-evals/harness";
+import {
+  buildEvalModelCallTrace,
+  getEvalModelCall,
+  recordEvalOpenAIResponse,
+  summarizeEvalModelCalls,
+  withEvalModelCallCapture,
+} from "./evalTelemetry";
+
+const startedAt = new Date("2026-08-02T12:00:00.000Z");
+const finishedAt = new Date("2026-08-02T12:00:01.250Z");
+
+function modelCall() {
+  return getEvalModelCall({
+    request: { model: "openai/gpt-5.6-terra" },
+    response: {
+      id: "resp_123",
+      model: "gpt-5.6-terra-2026-08-01",
+      usage: {
+        input_tokens: 100,
+        input_tokens_details: {
+          cached_tokens: 40,
+          cache_write_tokens: 5,
+        },
+        output_tokens: 20,
+        output_tokens_details: { reasoning_tokens: 7 },
+        total_tokens: 120,
+      },
+    },
+    startedAt,
+    finishedAt,
+  });
+}
+
+describe("eval GenAI telemetry", () => {
+  test("normalizes OpenAI response models and token details", () => {
+    expect(modelCall()).toEqual({
+      operationName: "chat",
+      providerName: "openai",
+      requestModel: "openai/gpt-5.6-terra",
+      responseModel: "gpt-5.6-terra-2026-08-01",
+      responseId: "resp_123",
+      inputTokens: 100,
+      cachedInputTokens: 40,
+      cacheWriteTokens: 5,
+      outputTokens: 20,
+      reasoningTokens: 7,
+      totalTokens: 120,
+      startedAt: startedAt.toISOString(),
+      finishedAt: finishedAt.toISOString(),
+      durationMs: 1_250,
+    });
+  });
+
+  test("captures calls within one async eval boundary", async () => {
+    const capture = await withEvalModelCallCapture(async () => {
+      recordEvalOpenAIResponse({
+        request: { model: "gpt-5.6-terra" },
+        response: {
+          model: "gpt-5.6-terra",
+          usage: { input_tokens: 10, output_tokens: 2, total_tokens: 12 },
+        },
+        startedAt,
+        finishedAt,
+      });
+      return "done";
+    });
+
+    expect(capture.result).toBe("done");
+    expect(capture.modelCalls).toHaveLength(1);
+  });
+
+  test("builds Vitest Evals model spans with OTel operation names", () => {
+    const call = modelCall();
+    expect(call).not.toBeNull();
+    const usage = summarizeEvalModelCalls([call!]);
+    const traces = buildEvalModelCallTrace({
+      name: "Bottle Classifier",
+      operationName: "invoke_agent",
+      modelCalls: [call!],
+    });
+
+    expect(usage).toMatchObject({
+      provider: "openai",
+      model: "gpt-5.6-terra-2026-08-01",
+      inputTokens: 100,
+      outputTokens: 20,
+      reasoningTokens: 7,
+      totalTokens: 120,
+      metadata: {
+        scope: "full_llm_run",
+        requests: 1,
+        cachedInputTokens: 40,
+        cacheWriteTokens: 5,
+      },
+    });
+    expect(traces?.[0]?.spans).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "invoke_agent Bottle Classifier",
+          kind: "agent",
+          attributes: expect.objectContaining({
+            "gen_ai.operation.name": "invoke_agent",
+            "gen_ai.provider.name": "openai",
+          }),
+        }),
+        expect.objectContaining({
+          name: "chat openai/gpt-5.6-terra",
+          kind: "model",
+          attributes: expect.objectContaining({
+            "gen_ai.operation.name": "chat",
+            "gen_ai.request.model": "openai/gpt-5.6-terra",
+            "gen_ai.response.model": "gpt-5.6-terra-2026-08-01",
+            "gen_ai.usage.input_tokens": 100,
+            "gen_ai.usage.output_tokens": 20,
+          }),
+        }),
+      ]),
+    );
+  });
+
+  test("survives Vitest Evals 0.15 harness normalization", async () => {
+    const call = modelCall();
+    expect(call).not.toBeNull();
+    const harness = createHarness<string, string>({
+      name: "otel-conformance",
+      run: async ({ input }) => ({
+        output: "done",
+        events: [
+          { type: "message", role: "user", content: input },
+          { type: "message", role: "assistant", content: "done" },
+        ],
+        usage: summarizeEvalModelCalls([call!]),
+        traces: buildEvalModelCallTrace({
+          name: "Bottle Classifier",
+          operationName: "invoke_agent",
+          modelCalls: [call!],
+        }),
+      }),
+    });
+    const run = await harness.run("classify this bottle", {
+      artifacts: {},
+      setArtifact: () => undefined,
+    });
+
+    expect(spansByKind(run, "model")).toEqual([
+      expect.objectContaining({
+        name: "chat openai/gpt-5.6-terra",
+        attributes: expect.objectContaining({
+          "gen_ai.operation.name": "chat",
+          "gen_ai.provider.name": "openai",
+          "gen_ai.request.model": "openai/gpt-5.6-terra",
+          "gen_ai.response.model": "gpt-5.6-terra-2026-08-01",
+          "gen_ai.usage.input_tokens": 100,
+          "gen_ai.usage.output_tokens": 20,
+        }),
+      }),
+    ]);
+  });
+});

--- a/packages/bottle-classifier/src/evalTelemetry.ts
+++ b/packages/bottle-classifier/src/evalTelemetry.ts
@@ -1,0 +1,344 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type {
+  GenAiOperationName,
+  SimpleTraceRecord,
+  UsageSummary,
+} from "vitest-evals/harness";
+
+export type EvalModelCall = {
+  operationName: "chat";
+  providerName: "openai";
+  requestModel: string;
+  responseModel: string;
+  responseId?: string;
+  inputTokens: number;
+  cachedInputTokens?: number;
+  cacheWriteTokens?: number;
+  outputTokens: number;
+  reasoningTokens?: number;
+  totalTokens: number;
+  startedAt: string;
+  finishedAt: string;
+  durationMs: number;
+};
+
+export type EvalModelCallStore = {
+  calls: EvalModelCall[];
+};
+
+const evalModelCallStorage = new AsyncLocalStorage<EvalModelCallStore>();
+let nextEvalTraceId = 0;
+
+function objectProperty(value: unknown, property: string): unknown {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)[property]
+    : undefined;
+}
+
+function finiteNonnegativeNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? Math.round(value)
+    : undefined;
+}
+
+function usageNumber(usage: unknown, ...properties: string[]): number {
+  for (const property of properties) {
+    const measured = finiteNonnegativeNumber(objectProperty(usage, property));
+    if (measured !== undefined) {
+      return measured;
+    }
+  }
+
+  return 0;
+}
+
+function usageDetailNumber(
+  usage: unknown,
+  detailProperties: string[],
+  valueProperties: string[],
+): number | undefined {
+  for (const detailProperty of detailProperties) {
+    const details = objectProperty(usage, detailProperty);
+    for (const valueProperty of valueProperties) {
+      const measured = finiteNonnegativeNumber(
+        objectProperty(details, valueProperty),
+      );
+      if (measured !== undefined) {
+        return measured;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/** Normalizes one non-streaming OpenAI Responses result for eval reporting. */
+export function getEvalModelCall({
+  request,
+  response,
+  startedAt,
+  finishedAt = new Date(),
+}: {
+  request: unknown;
+  response: unknown;
+  startedAt: Date;
+  finishedAt?: Date;
+}): EvalModelCall | null {
+  const requestModel = objectProperty(request, "model");
+  if (typeof requestModel !== "string" || requestModel.length === 0) {
+    return null;
+  }
+
+  const responseModel = objectProperty(response, "model");
+  const usage = objectProperty(response, "usage");
+  const inputTokens = usageNumber(usage, "input_tokens", "inputTokens");
+  const outputTokens = usageNumber(usage, "output_tokens", "outputTokens");
+  const totalTokens = usageNumber(usage, "total_tokens", "totalTokens");
+  const responseId = objectProperty(response, "id");
+
+  return {
+    operationName: "chat",
+    providerName: "openai",
+    requestModel,
+    responseModel:
+      typeof responseModel === "string" && responseModel.length > 0
+        ? responseModel
+        : requestModel,
+    ...(typeof responseId === "string" && responseId.length > 0
+      ? { responseId }
+      : {}),
+    inputTokens,
+    ...(usageDetailNumber(
+      usage,
+      ["input_tokens_details", "inputTokensDetails"],
+      ["cached_tokens", "cachedTokens"],
+    ) === undefined
+      ? {}
+      : {
+          cachedInputTokens: usageDetailNumber(
+            usage,
+            ["input_tokens_details", "inputTokensDetails"],
+            ["cached_tokens", "cachedTokens"],
+          ),
+        }),
+    ...(usageDetailNumber(
+      usage,
+      ["input_tokens_details", "inputTokensDetails"],
+      ["cache_write_tokens", "cacheWriteTokens"],
+    ) === undefined
+      ? {}
+      : {
+          cacheWriteTokens: usageDetailNumber(
+            usage,
+            ["input_tokens_details", "inputTokensDetails"],
+            ["cache_write_tokens", "cacheWriteTokens"],
+          ),
+        }),
+    outputTokens,
+    ...(usageDetailNumber(
+      usage,
+      ["output_tokens_details", "outputTokensDetails"],
+      ["reasoning_tokens", "reasoningTokens"],
+    ) === undefined
+      ? {}
+      : {
+          reasoningTokens: usageDetailNumber(
+            usage,
+            ["output_tokens_details", "outputTokensDetails"],
+            ["reasoning_tokens", "reasoningTokens"],
+          ),
+        }),
+    totalTokens: totalTokens || inputTokens + outputTokens,
+    startedAt: startedAt.toISOString(),
+    finishedAt: finishedAt.toISOString(),
+    durationMs: Math.max(0, finishedAt.getTime() - startedAt.getTime()),
+  };
+}
+
+/** Records an OpenAI response when an eval model-call capture is active. */
+export function recordEvalOpenAIResponse({
+  request,
+  response,
+  startedAt,
+  finishedAt,
+  store = evalModelCallStorage.getStore(),
+}: {
+  request: unknown;
+  response: unknown;
+  startedAt: Date;
+  finishedAt?: Date;
+  store?: EvalModelCallStore;
+}) {
+  const call = getEvalModelCall({ request, response, startedAt, finishedAt });
+  if (call && store) {
+    store.calls.push(call);
+  }
+}
+
+/** Captures every instrumented OpenAI Responses call made by one eval run. */
+export async function withEvalModelCallCapture<T>(
+  callback: () => Promise<T>,
+): Promise<{ result: T; modelCalls: EvalModelCall[] }> {
+  const store: EvalModelCallStore = { calls: [] };
+  const result = await evalModelCallStorage.run(store, callback);
+  return { result, modelCalls: store.calls };
+}
+
+/** Returns the active capture store for the eval OpenAI client wrapper. */
+export function getActiveEvalModelCallStore() {
+  return evalModelCallStorage.getStore();
+}
+
+export function summarizeEvalModelCalls(
+  modelCalls: EvalModelCall[],
+): UsageSummary {
+  if (modelCalls.length === 0) {
+    return {};
+  }
+
+  const models = new Set(modelCalls.map((call) => call.responseModel));
+  const cachedInputTokens = modelCalls.reduce(
+    (total, call) => total + (call.cachedInputTokens ?? 0),
+    0,
+  );
+  const cacheWriteTokens = modelCalls.reduce(
+    (total, call) => total + (call.cacheWriteTokens ?? 0),
+    0,
+  );
+  const reasoningTokens = modelCalls.reduce(
+    (total, call) => total + (call.reasoningTokens ?? 0),
+    0,
+  );
+
+  return {
+    provider: "openai",
+    ...(models.size === 1 ? { model: modelCalls[0]?.responseModel } : {}),
+    inputTokens: modelCalls.reduce(
+      (total, call) => total + call.inputTokens,
+      0,
+    ),
+    outputTokens: modelCalls.reduce(
+      (total, call) => total + call.outputTokens,
+      0,
+    ),
+    ...(modelCalls.some((call) => call.reasoningTokens !== undefined)
+      ? { reasoningTokens }
+      : {}),
+    totalTokens: modelCalls.reduce(
+      (total, call) => total + call.totalTokens,
+      0,
+    ),
+    metadata: {
+      scope: "full_llm_run",
+      requests: modelCalls.length,
+      ...(modelCalls.some((call) => call.cachedInputTokens !== undefined)
+        ? { cachedInputTokens }
+        : {}),
+      ...(modelCalls.some((call) => call.cacheWriteTokens !== undefined)
+        ? { cacheWriteTokens }
+        : {}),
+      models: Array.from(models),
+    },
+  };
+}
+
+function usageAttributes(usage: UsageSummary) {
+  const metadata = usage.metadata;
+  return {
+    "gen_ai.provider.name": usage.provider,
+    "gen_ai.usage.input_tokens": usage.inputTokens,
+    "gen_ai.usage.cache_read.input_tokens": metadata?.cachedInputTokens,
+    "gen_ai.usage.cache_creation.input_tokens": metadata?.cacheWriteTokens,
+    "gen_ai.usage.output_tokens": usage.outputTokens,
+    "gen_ai.usage.reasoning.output_tokens": usage.reasoningTokens,
+  };
+}
+
+/** Builds the normalized trace shape documented for Vitest Evals harnesses. */
+export function buildEvalModelCallTrace({
+  name,
+  operationName,
+  modelCalls,
+}: {
+  name: string;
+  operationName: Extract<
+    GenAiOperationName,
+    "invoke_agent" | "invoke_workflow"
+  >;
+  modelCalls: EvalModelCall[];
+}): SimpleTraceRecord[] | undefined {
+  if (modelCalls.length === 0) {
+    return undefined;
+  }
+
+  const traceId = `peated_eval_${++nextEvalTraceId}`;
+  const rootSpanId = `${traceId}:run`;
+  const usage = summarizeEvalModelCalls(modelCalls);
+  const startedAt = modelCalls[0]?.startedAt;
+  const finishedAt = modelCalls[modelCalls.length - 1]?.finishedAt;
+  const durationMs = Math.max(
+    0,
+    new Date(finishedAt ?? 0).getTime() - new Date(startedAt ?? 0).getTime(),
+  );
+  const requestModels = new Set(modelCalls.map((call) => call.requestModel));
+  const responseModels = new Set(modelCalls.map((call) => call.responseModel));
+
+  return [
+    {
+      id: traceId,
+      name,
+      startedAt,
+      finishedAt,
+      durationMs,
+      metadata: { source: "peated-openai-capture" },
+      spans: [
+        {
+          id: rootSpanId,
+          traceId,
+          name: `${operationName} ${name}`,
+          kind: operationName === "invoke_agent" ? "agent" : "run",
+          startedAt,
+          finishedAt,
+          durationMs,
+          status: "ok",
+          attributes: {
+            "gen_ai.operation.name": operationName,
+            ...(operationName === "invoke_agent"
+              ? { "gen_ai.agent.name": name }
+              : { "gen_ai.workflow.name": name }),
+            ...usageAttributes(usage),
+            ...(requestModels.size === 1
+              ? { "gen_ai.request.model": modelCalls[0]?.requestModel }
+              : {}),
+            ...(responseModels.size === 1
+              ? { "gen_ai.response.model": modelCalls[0]?.responseModel }
+              : {}),
+          },
+        },
+        ...modelCalls.map((call, index) => ({
+          id: `${traceId}:model:${index + 1}`,
+          traceId,
+          parentId: rootSpanId,
+          name: `${call.operationName} ${call.requestModel}`,
+          kind: "model" as const,
+          startedAt: call.startedAt,
+          finishedAt: call.finishedAt,
+          durationMs: call.durationMs,
+          status: "ok" as const,
+          attributes: {
+            "gen_ai.operation.name": call.operationName,
+            "gen_ai.provider.name": call.providerName,
+            "gen_ai.request.model": call.requestModel,
+            "gen_ai.response.model": call.responseModel,
+            "gen_ai.response.id": call.responseId,
+            "gen_ai.usage.input_tokens": call.inputTokens,
+            "gen_ai.usage.cache_read.input_tokens": call.cachedInputTokens,
+            "gen_ai.usage.cache_creation.input_tokens": call.cacheWriteTokens,
+            "gen_ai.usage.output_tokens": call.outputTokens,
+            "gen_ai.usage.reasoning.output_tokens": call.reasoningTokens,
+          },
+        })),
+      ],
+    },
+  ];
+}

--- a/packages/bottle-classifier/src/imageExtraction.eval.test.ts
+++ b/packages/bottle-classifier/src/imageExtraction.eval.test.ts
@@ -1,9 +1,14 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
-import { describe, expect, test } from "vitest";
-import type { BottleExtractedDetails } from "./classifierTypes";
+import { expect } from "vitest";
+import { createHarness, describeEval } from "vitest-evals";
+import { toJsonValue, type JsonValue } from "vitest-evals/harness";
 import {
-  buildImageExtractionEvalMeasurements,
+  BottleExtractedDetailsSchema,
+  type BottleExtractedDetails,
+} from "./classifierTypes";
+import {
+  buildEvalHarnessMeasurements,
   formatEvalUsageAnnotation,
 } from "./evalMeasurements";
 import {
@@ -12,6 +17,7 @@ import {
   evalImageExtractionReasoningEffort,
   hasEvalOpenAICredentials,
 } from "./evalSupport";
+import { withEvalModelCallCapture } from "./evalTelemetry";
 import { createWhiskyLabelExtractor } from "./extractor";
 import {
   IMAGE_EXTRACTION_EVAL_CASES,
@@ -120,33 +126,70 @@ function assertExtractionExpectation(
   }
 }
 
-describe.skipIf(!hasEvalOpenAICredentials)("image extraction evals", () => {
-  const extractor = createWhiskyLabelExtractor({
-    client: createEvalOpenAIClient(),
-    model: evalImageExtractionModel,
-    reasoningEffort: evalImageExtractionReasoningEffort,
-  });
+const imageExtractionHarness = createHarness<
+  ImageExtractionEvalCase,
+  JsonValue
+>({
+  name: "image-extraction",
+  run: async ({ input }) => {
+    const startedAt = performance.now();
+    const { result: extractedIdentity, modelCalls } =
+      await withEvalModelCallCapture(async () => {
+        const extractor = createWhiskyLabelExtractor({
+          client: createEvalOpenAIClient(),
+          model: evalImageExtractionModel,
+          reasoningEffort: evalImageExtractionReasoningEffort,
+        });
+        return await extractor.extractFromImage(
+          imageFileToDataUrl(input.imagePath),
+        );
+      });
+    const output = toJsonValue(extractedIdentity) ?? null;
 
-  test.for(IMAGE_EXTRACTION_EVAL_CASES)("$name", async (testCase, context) => {
-    const extraction = await extractor.extractFromImageWithMetadata(
-      imageFileToDataUrl(testCase.imagePath),
-    );
-    const measurements = buildImageExtractionEvalMeasurements({
-      model: evalImageExtractionModel,
-      reasoningEffort: evalImageExtractionReasoningEffort,
-      metadata: extraction,
-    });
-    await context.annotate(
-      formatEvalUsageAnnotation(measurements.usage),
-      "usage",
-    );
-    await context.annotate(
-      `image extraction ${Math.round(extraction.durationMs).toLocaleString("en-US")} ms`,
-      "timing",
-    );
-
-    const extractedIdentity = extraction.result;
-    expect(extractedIdentity).not.toBeNull();
-    assertExtractionExpectation(testCase, extractedIdentity!);
-  });
+    return {
+      output,
+      events: [
+        {
+          type: "message",
+          role: "user",
+          content: `Extract the whisky label in fixture ${input.name}.`,
+        },
+        { type: "message", role: "assistant", content: output },
+      ],
+      ...buildEvalHarnessMeasurements({
+        model: evalImageExtractionModel,
+        modelMetadata: null,
+        reasoningEffort: evalImageExtractionReasoningEffort,
+        totalMs: performance.now() - startedAt,
+        modelCalls,
+        trace: {
+          name: "Image Extraction",
+          operationName: "invoke_workflow",
+        },
+      }),
+    };
+  },
 });
+
+describeEval(
+  "image extraction evals",
+  {
+    skipIf: () => !hasEvalOpenAICredentials,
+    harness: imageExtractionHarness,
+  },
+  (it) => {
+    it.for(IMAGE_EXTRACTION_EVAL_CASES)(
+      "$name",
+      async (testCase, { run, annotate }) => {
+        const result = await run(testCase);
+        await annotate(formatEvalUsageAnnotation(result.usage), "usage");
+        const extractedIdentity = BottleExtractedDetailsSchema.nullable().parse(
+          result.output,
+        );
+
+        expect(extractedIdentity).not.toBeNull();
+        assertExtractionExpectation(testCase, extractedIdentity!);
+      },
+    );
+  },
+);

--- a/packages/bottle-classifier/src/observability.test.ts
+++ b/packages/bottle-classifier/src/observability.test.ts
@@ -28,6 +28,7 @@ describe("observability span contexts", () => {
       name: "invoke_agent Bottle Classifier",
       attributes: {
         "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.provider.name": "openai",
         "gen_ai.agent.name": "Bottle Classifier",
         "gen_ai.conversation.id": "photo_identification:pending-1",
         "bottle_classifier.reference_id": "pending-1",
@@ -80,6 +81,43 @@ describe("observability span contexts", () => {
         }),
       }),
       expect.any(Function),
+    );
+  });
+
+  test("records aggregate agent token usage on the invocation span", async () => {
+    const setAttribute = vi.fn();
+    vi.mocked(Sentry.startSpan).mockImplementationOnce(
+      async (_context, callback) =>
+        await callback({ setAttribute } as unknown as Parameters<
+          typeof callback
+        >[0]),
+    );
+
+    await startAgentSpan({
+      name: "Bottle Classifier",
+      conversationId: "bottle_reference:usage",
+      callback: async () => ({
+        modelMetadata: {
+          usage: {
+            inputTokens: 100,
+            cachedInputTokens: 40,
+            cacheWriteTokens: 5,
+            outputTokens: 20,
+            reasoningTokens: 7,
+          },
+        },
+      }),
+    });
+
+    expect(setAttribute).toHaveBeenCalledWith("gen_ai.usage.input_tokens", 100);
+    expect(setAttribute).toHaveBeenCalledWith(
+      "gen_ai.usage.cache_read.input_tokens",
+      40,
+    );
+    expect(setAttribute).toHaveBeenCalledWith("gen_ai.usage.output_tokens", 20);
+    expect(setAttribute).toHaveBeenCalledWith(
+      "gen_ai.usage.reasoning.output_tokens",
+      7,
     );
   });
 

--- a/packages/bottle-classifier/src/observability.ts
+++ b/packages/bottle-classifier/src/observability.ts
@@ -1,6 +1,7 @@
 import { startSpan } from "@sentry/core";
 
 const MAX_ATTRIBUTE_LENGTH = 12_000;
+const OPENAI_PROVIDER = "openai";
 
 export type AgentSpanAttributes = Record<
   string,
@@ -14,6 +15,91 @@ function compactJson(value: unknown): string {
   }
 
   return `${serialized.slice(0, MAX_ATTRIBUTE_LENGTH)}...`;
+}
+
+function objectProperty(value: unknown, property: string): unknown {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)[property]
+    : undefined;
+}
+
+function measuredNumber(value: unknown, property: string): number | undefined {
+  const candidate = objectProperty(value, property);
+  return typeof candidate === "number" && Number.isFinite(candidate)
+    ? candidate
+    : undefined;
+}
+
+function usageDetailTotal(
+  usage: unknown,
+  detailsProperty: string,
+  valueProperties: string[],
+): number | undefined {
+  const details = objectProperty(usage, detailsProperty);
+  const entries = Array.isArray(details) ? details : details ? [details] : [];
+  let measured = false;
+  let total = 0;
+
+  for (const entry of entries) {
+    for (const property of valueProperties) {
+      const value = measuredNumber(entry, property);
+      if (value !== undefined) {
+        measured = true;
+        total += value;
+        break;
+      }
+    }
+  }
+
+  return measured ? total : undefined;
+}
+
+function getAgentResultUsage(result: unknown): unknown {
+  const metadataUsage = objectProperty(
+    objectProperty(result, "modelMetadata"),
+    "usage",
+  );
+  return (
+    metadataUsage ??
+    objectProperty(objectProperty(result, "state"), "usage") ??
+    objectProperty(objectProperty(result, "runContext"), "usage") ??
+    objectProperty(result, "usage")
+  );
+}
+
+function setAgentResultAttributes(
+  span: { setAttribute: (key: string, value: string | number) => void },
+  result: unknown,
+) {
+  const usage = getAgentResultUsage(result);
+  const attributes = {
+    "gen_ai.usage.input_tokens": measuredNumber(usage, "inputTokens"),
+    "gen_ai.usage.cache_read.input_tokens":
+      measuredNumber(usage, "cachedInputTokens") ??
+      usageDetailTotal(usage, "inputTokensDetails", [
+        "cached_tokens",
+        "cachedTokens",
+      ]),
+    "gen_ai.usage.cache_creation.input_tokens":
+      measuredNumber(usage, "cacheWriteTokens") ??
+      usageDetailTotal(usage, "inputTokensDetails", [
+        "cache_write_tokens",
+        "cacheWriteTokens",
+      ]),
+    "gen_ai.usage.output_tokens": measuredNumber(usage, "outputTokens"),
+    "gen_ai.usage.reasoning.output_tokens":
+      measuredNumber(usage, "reasoningTokens") ??
+      usageDetailTotal(usage, "outputTokensDetails", [
+        "reasoning_tokens",
+        "reasoningTokens",
+      ]),
+  };
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value !== undefined) {
+      span.setAttribute(key, value);
+    }
+  }
 }
 
 /**
@@ -33,6 +119,7 @@ export function buildAgentSpanContext({
     name: `invoke_agent ${name}`,
     attributes: {
       "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.provider.name": OPENAI_PROVIDER,
       "gen_ai.agent.name": name,
       "gen_ai.conversation.id": conversationId,
       ...attributes,
@@ -81,7 +168,11 @@ export async function startAgentSpan<T>({
 }): Promise<T> {
   return await startSpan(
     buildAgentSpanContext({ name, conversationId, attributes }),
-    callback,
+    async (span) => {
+      const result = await callback();
+      setAgentResultAttributes(span, result);
+      return result;
+    },
   );
 }
 

--- a/packages/bottle-classifier/src/runtime/runMetadata.test.ts
+++ b/packages/bottle-classifier/src/runtime/runMetadata.test.ts
@@ -19,6 +19,10 @@ describe("getBottleClassifierRunMetadata", () => {
                 { cached_tokens: 20 },
               ],
               outputTokens: 20,
+              outputTokensDetails: [
+                { reasoning_tokens: 7 },
+                { reasoningTokens: 3 },
+              ],
               totalTokens: 120,
             },
           },
@@ -46,6 +50,7 @@ describe("getBottleClassifierRunMetadata", () => {
         cachedInputTokens: 60,
         cacheWriteTokens: 10,
         outputTokens: 20,
+        reasoningTokens: 10,
         totalTokens: 120,
       },
       toolCalls: {

--- a/packages/bottle-classifier/src/runtime/runMetadata.ts
+++ b/packages/bottle-classifier/src/runtime/runMetadata.ts
@@ -12,6 +12,7 @@ export const BottleClassifierRunMetadataSchema = z
         cachedInputTokens: NonnegativeIntegerSchema.optional(),
         cacheWriteTokens: NonnegativeIntegerSchema.optional(),
         outputTokens: NonnegativeIntegerSchema,
+        reasoningTokens: NonnegativeIntegerSchema.optional(),
         totalTokens: NonnegativeIntegerSchema,
       })
       .strict(),
@@ -41,8 +42,12 @@ function numberProperty(value: unknown, property: string): number {
     : 0;
 }
 
-function inputTokenDetail(usage: unknown, keys: string[]): number | undefined {
-  const details = objectProperty(usage, "inputTokensDetails");
+function tokenDetail(
+  usage: unknown,
+  detailsProperty: string,
+  keys: string[],
+): number | undefined {
+  const details = objectProperty(usage, detailsProperty);
   const entries = Array.isArray(details) ? details : details ? [details] : [];
   let measured = false;
   let total = 0;
@@ -81,13 +86,17 @@ export function getBottleClassifierRunMetadata({
     objectProperty(objectProperty(result, "state"), "usage") ??
     objectProperty(objectProperty(result, "runContext"), "usage") ??
     objectProperty(result, "usage");
-  const measuredCachedInputTokens = inputTokenDetail(usage, [
+  const measuredCachedInputTokens = tokenDetail(usage, "inputTokensDetails", [
     "cached_tokens",
     "cachedTokens",
   ]);
-  const measuredCacheWriteTokens = inputTokenDetail(usage, [
+  const measuredCacheWriteTokens = tokenDetail(usage, "inputTokensDetails", [
     "cache_write_tokens",
     "cacheWriteTokens",
+  ]);
+  const measuredReasoningTokens = tokenDetail(usage, "outputTokensDetails", [
+    "reasoning_tokens",
+    "reasoningTokens",
   ]);
   const toolNames: string[] = [];
   let toolCallCount = 0;
@@ -121,6 +130,9 @@ export function getBottleClassifierRunMetadata({
         ? {}
         : { cacheWriteTokens: measuredCacheWriteTokens }),
       outputTokens: numberProperty(usage, "outputTokens"),
+      ...(measuredReasoningTokens === undefined
+        ? {}
+        : { reasoningTokens: measuredReasoningTokens }),
       totalTokens: numberProperty(usage, "totalTokens"),
     },
     toolCalls: {

--- a/packages/entity-classifier/src/observability.test.ts
+++ b/packages/entity-classifier/src/observability.test.ts
@@ -28,6 +28,7 @@ describe("observability span contexts", () => {
       name: "invoke_agent Entity Classifier",
       attributes: {
         "gen_ai.operation.name": "invoke_agent",
+        "gen_ai.provider.name": "openai",
         "gen_ai.agent.name": "Entity Classifier",
         "gen_ai.conversation.id": "entity:42",
         "entity_classifier.entity_id": "42",
@@ -80,6 +81,42 @@ describe("observability span contexts", () => {
         }),
       }),
       expect.any(Function),
+    );
+  });
+
+  test("records aggregate agent token usage on the invocation span", async () => {
+    const setAttribute = vi.fn();
+    vi.mocked(Sentry.startSpan).mockImplementationOnce(
+      async (_context, callback) =>
+        await callback({ setAttribute } as unknown as Parameters<
+          typeof callback
+        >[0]),
+    );
+
+    await startAgentSpan({
+      name: "Entity Classifier",
+      conversationId: "entity:usage",
+      callback: async () => ({
+        state: {
+          usage: {
+            inputTokens: 100,
+            inputTokensDetails: [{ cached_tokens: 40 }],
+            outputTokens: 20,
+            outputTokensDetails: [{ reasoning_tokens: 7 }],
+          },
+        },
+      }),
+    });
+
+    expect(setAttribute).toHaveBeenCalledWith("gen_ai.usage.input_tokens", 100);
+    expect(setAttribute).toHaveBeenCalledWith(
+      "gen_ai.usage.cache_read.input_tokens",
+      40,
+    );
+    expect(setAttribute).toHaveBeenCalledWith("gen_ai.usage.output_tokens", 20);
+    expect(setAttribute).toHaveBeenCalledWith(
+      "gen_ai.usage.reasoning.output_tokens",
+      7,
     );
   });
 

--- a/packages/entity-classifier/src/observability.ts
+++ b/packages/entity-classifier/src/observability.ts
@@ -1,6 +1,7 @@
 import { startSpan } from "@sentry/core";
 
 const MAX_ATTRIBUTE_LENGTH = 12_000;
+const OPENAI_PROVIDER = "openai";
 
 export type AgentSpanAttributes = Record<
   string,
@@ -14,6 +15,83 @@ function compactJson(value: unknown): string {
   }
 
   return `${serialized.slice(0, MAX_ATTRIBUTE_LENGTH)}...`;
+}
+
+function objectProperty(value: unknown, property: string): unknown {
+  return value && typeof value === "object"
+    ? (value as Record<string, unknown>)[property]
+    : undefined;
+}
+
+function measuredNumber(value: unknown, property: string): number | undefined {
+  const candidate = objectProperty(value, property);
+  return typeof candidate === "number" && Number.isFinite(candidate)
+    ? candidate
+    : undefined;
+}
+
+function usageDetailTotal(
+  usage: unknown,
+  detailsProperty: string,
+  valueProperties: string[],
+): number | undefined {
+  const details = objectProperty(usage, detailsProperty);
+  const entries = Array.isArray(details) ? details : details ? [details] : [];
+  let measured = false;
+  let total = 0;
+
+  for (const entry of entries) {
+    for (const property of valueProperties) {
+      const value = measuredNumber(entry, property);
+      if (value !== undefined) {
+        measured = true;
+        total += value;
+        break;
+      }
+    }
+  }
+
+  return measured ? total : undefined;
+}
+
+function getAgentResultUsage(result: unknown): unknown {
+  return (
+    objectProperty(objectProperty(result, "state"), "usage") ??
+    objectProperty(objectProperty(result, "runContext"), "usage") ??
+    objectProperty(result, "usage")
+  );
+}
+
+function setAgentResultAttributes(
+  span: { setAttribute: (key: string, value: string | number) => void },
+  result: unknown,
+) {
+  const usage = getAgentResultUsage(result);
+  const attributes = {
+    "gen_ai.usage.input_tokens": measuredNumber(usage, "inputTokens"),
+    "gen_ai.usage.cache_read.input_tokens": usageDetailTotal(
+      usage,
+      "inputTokensDetails",
+      ["cached_tokens", "cachedTokens"],
+    ),
+    "gen_ai.usage.cache_creation.input_tokens": usageDetailTotal(
+      usage,
+      "inputTokensDetails",
+      ["cache_write_tokens", "cacheWriteTokens"],
+    ),
+    "gen_ai.usage.output_tokens": measuredNumber(usage, "outputTokens"),
+    "gen_ai.usage.reasoning.output_tokens": usageDetailTotal(
+      usage,
+      "outputTokensDetails",
+      ["reasoning_tokens", "reasoningTokens"],
+    ),
+  };
+
+  for (const [key, value] of Object.entries(attributes)) {
+    if (value !== undefined) {
+      span.setAttribute(key, value);
+    }
+  }
 }
 
 /**
@@ -33,6 +111,7 @@ export function buildAgentSpanContext({
     name: `invoke_agent ${name}`,
     attributes: {
       "gen_ai.operation.name": "invoke_agent",
+      "gen_ai.provider.name": OPENAI_PROVIDER,
       "gen_ai.agent.name": name,
       "gen_ai.conversation.id": conversationId,
       ...attributes,
@@ -81,7 +160,11 @@ export async function startAgentSpan<T>({
 }): Promise<T> {
   return await startSpan(
     buildAgentSpanContext({ name, conversationId, attributes }),
-    callback,
+    async (span) => {
+      const result = await callback();
+      setAgentResultAttributes(span, result);
+      return result;
+    },
   );
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -692,8 +692,8 @@ importers:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest-evals:
-        specifier: 0.14.0
-        version: 0.14.0(tinyrainbow@2.0.0)(vitest@4.1.4)(zod@4.3.6)
+        specifier: 0.15.0
+        version: 0.15.0(tinyrainbow@2.0.0)(vitest@4.1.4)(zod@4.3.6)
 
   packages/catalog-verifier:
     dependencies:
@@ -5081,11 +5081,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest-evals/core@0.14.0':
-    resolution: {integrity: sha512-N7Weau1IdLADKKsyiieNptYBsOLuzv96C/Ki3qxT0u3+TbAnnVxAR1Aruz+pAwsK1Nks5pJ+4GbrAmrgaDWS3g==}
+  '@vitest-evals/core@0.15.0':
+    resolution: {integrity: sha512-kqyg3ocVtZxr3rP9oh01oAycRgXNRasvTgLZ8MbFGBJ4BRd4tk7Bgww253HY7fw7ZFUp4UPYNmDp5AcHajm++w==}
 
-  '@vitest-evals/report-ui@0.14.0':
-    resolution: {integrity: sha512-TfkL4/i4bE9Q1+8KMFmxP9v8oOBvcR70wOMYhfB3Ziv4f+pUlKbUkcgrggRjukzdm8g6P7qHvTGrx2mGCvaj0A==}
+  '@vitest-evals/report-ui@0.15.0':
+    resolution: {integrity: sha512-icrutiRhZ2T1MrHo2RW09hcEwfi/tV/FgsGAE76Wd0C02tZyCleQRjt11RWhBJiYDPpsjjjTHGCHIO6tmtX5zQ==}
 
   '@vitest/coverage-v8@4.1.4':
     resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
@@ -9917,8 +9917,8 @@ packages:
       yaml:
         optional: true
 
-  vitest-evals@0.14.0:
-    resolution: {integrity: sha512-CugWWm6LMgCknSMBOFy2Y1RkbScbAqJ6c61+kU9EEerq1ELMH0AurvDGU36lkaXrmz6CPRABNx5CzBvwEUh3+w==}
+  vitest-evals@0.15.0:
+    resolution: {integrity: sha512-bOYALQdLXKYFRCV8aQ+yLeH7XkmYsTxUWQxLHzJdIEcIBx2v/kPgG3Zg6m231jMCphuoM6xH4YQB3+0pDP7LLw==}
     hasBin: true
     peerDependencies:
       ai: '>=4 <7'
@@ -14742,13 +14742,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest-evals/core@0.14.0':
+  '@vitest-evals/core@0.15.0':
     dependencies:
       zod: 3.25.76
 
-  '@vitest-evals/report-ui@0.14.0':
+  '@vitest-evals/report-ui@0.15.0':
     dependencies:
-      '@vitest-evals/core': 0.14.0
+      '@vitest-evals/core': 0.15.0
 
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
@@ -20333,10 +20333,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vitest-evals@0.14.0(tinyrainbow@2.0.0)(vitest@4.1.4)(zod@4.3.6):
+  vitest-evals@0.15.0(tinyrainbow@2.0.0)(vitest@4.1.4)(zod@4.3.6):
     dependencies:
-      '@vitest-evals/core': 0.14.0
-      '@vitest-evals/report-ui': 0.14.0
+      '@vitest-evals/core': 0.15.0
+      '@vitest-evals/report-ui': 0.15.0
       tinyrainbow: 2.0.0
       vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1)(vite@8.0.8(@types/node@24.13.2)(esbuild@0.27.7)(jiti@1.21.7)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:


### PR DESCRIPTION
LLM observability now emits current OpenTelemetry GenAI semantics across direct OpenAI calls, agent runs, and multi-step workflows. Request and response models plus input, output, cached-input, cache-creation, and reasoning token counts are preserved where the provider exposes them; redundant legacy `ai.*` workflow spans have been removed.

Vitest Evals now records every OpenAI Responses call made by classifier, audit, extraction, and web-search paths as normalized per-model spans while retaining full-run usage. Image extraction now runs through the documented `createHarness`/`describeEval` custom-harness contract, and the package is upgraded to Vitest Evals 0.15 to match the current upstream API.

Review should start with the runtime span normalizer and eval telemetry capture boundary. Existing model behavior and persisted classifier output contracts are unchanged.
