### PR TITLE
chore(dev): standardize worktree environment setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Copy this file to `.env.local` for local development.
+# `.env.local` is intentionally ignored and should never be committed.
+
 DATABASE_URL=postgresql://postgres:postgres@localhost:15432/peated
 REDIS_URL=redis://@localhost:16379
 JWT_SECRET=super-duper-s3cret

--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,3 @@
 layout node
 
-dotenv .env
-# dotenv .env.local
+dotenv .env.local

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@ dev-dist/
 
 # misc
 .DS_Store
+# Safety only: Peated does not load the legacy root `.env` file.
 .env
+# Canonical local runtime configuration.
 .env.local
 .env.development.local
 .env.test.local

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,2 @@
+# Codex-managed worktrees need the same local runtime configuration.
+.env.local

--- a/README.md
+++ b/README.md
@@ -39,7 +39,24 @@ Local Postgres is published on `localhost:15432` and Redis is published on
 tracked local test database config in `apps/server/.env.test` uses the same
 host ports.
 
-Note: If you need to tweak default settings, `cp .env.example .env` and go to town.
+Copy the example environment file into your local-only configuration:
+
+```bash
+cp .env.example .env.local
+```
+
+`.env.local` is ignored and is copied into Codex-managed worktrees through
+`.worktreeinclude`.
+
+For the Codex local environment setup script, use:
+
+```bash
+test -f .env.local || cp .env.example .env.local
+SKIP_INSTALL_SIMPLE_GIT_HOOKS=1 pnpm install --frozen-lockfile
+```
+
+Git hooks are shared with the primary checkout, so worktrees do not need to
+install them again.
 
 Setup the database:
 

--- a/packages/bottle-classifier/AGENTS.md
+++ b/packages/bottle-classifier/AGENTS.md
@@ -76,5 +76,5 @@ Before changing classifier behavior, read:
 - Live evals are expensive. Run focused live evals only for intentional
   model-sensitive work. Commit replay recordings required by deliberate fixture
   or harness changes.
-- Live evals load repo-root `.env`/`.env.local`, then package-root equivalents;
-  shell-provided environment variables take precedence.
+- Live evals load repo-root `.env.local`; shell-provided environment variables
+  take precedence.

--- a/packages/bottle-classifier/README.md
+++ b/packages/bottle-classifier/README.md
@@ -194,8 +194,8 @@ pnpm --filter @peated/bottle-classifier evals -- src/classifier.eval.test.ts
 `pnpm evals` is the intended repo-root entrypoint. It forwards extra Vitest args
 to the package runner and uses the `vitest-evals` reporter configured in
 [`vitest.evals.config.mts`](./vitest.evals.config.mts).
-The eval config loads the repo-root `.env` and then `.env.local`, with later
-files overriding earlier ones. Shell-provided env vars still take precedence.
+The eval config loads the repo-root `.env.local`. Shell-provided env vars still
+take precedence.
 `AI_GATEWAY_API_KEY` or `OPENAI_API_KEY` is required. The gateway key takes
 precedence when both are set. With the gateway, `OPENAI_MODEL` defaults to
 `openai/gpt-5.4` and `OPENAI_EVAL_MODEL` defaults to

--- a/packages/bottle-classifier/vitest.evals.config.mts
+++ b/packages/bottle-classifier/vitest.evals.config.mts
@@ -8,38 +8,26 @@ const packageRoot = fileURLToPath(new URL(".", import.meta.url));
 const workspaceRoot = path.resolve(packageRoot, "../..");
 const replayRoot = path.resolve(packageRoot, ".vitest-evals/recordings");
 
-function createEnvFileLoader(
+function applyEnvFile(
+  absolutePath: string,
   targetEnv: NodeJS.ProcessEnv = process.env,
-): (absolutePath: string) => void {
+): void {
+  if (!fs.existsSync(absolutePath)) {
+    return;
+  }
+
   const protectedKeys = new Set(Object.keys(targetEnv));
-  const loadedKeys = new Set<string>();
-
-  return (absolutePath: string) => {
-    if (!fs.existsSync(absolutePath)) {
-      return;
+  const values = parseEnv(fs.readFileSync(absolutePath, "utf8"));
+  for (const [name, value] of Object.entries(values)) {
+    if (protectedKeys.has(name)) {
+      continue;
     }
 
-    const values = parseEnv(fs.readFileSync(absolutePath, "utf8"));
-    for (const [name, value] of Object.entries(values)) {
-      if (protectedKeys.has(name) && !loadedKeys.has(name)) {
-        continue;
-      }
-
-      targetEnv[name] = value;
-      loadedKeys.add(name);
-    }
-  };
+    targetEnv[name] = value;
+  }
 }
 
-const applyEnvFile = createEnvFileLoader();
-for (const envFile of [
-  path.resolve(workspaceRoot, ".env"),
-  path.resolve(workspaceRoot, ".env.local"),
-  path.resolve(packageRoot, ".env"),
-  path.resolve(packageRoot, ".env.local"),
-]) {
-  applyEnvFile(envFile);
-}
+applyEnvFile(path.resolve(workspaceRoot, ".env.local"));
 
 function pickDefinedEnv(keys: string[]): Record<string, string> {
   return Object.fromEntries(


### PR DESCRIPTION
Peated now uses the repo-root `.env.local` as its single local runtime
configuration across direnv, development commands, CLI commands, and
classifier evals. Codex-managed worktrees copy that file through
`.worktreeinclude`, and the development docs provide a worktree-safe setup
script that installs locked dependencies without trying to reinstall shared
Git hooks.

The legacy root `.env` remains ignored as a secret-safety measure but is no
longer loaded. Existing developers should merge any values from `.env` into
`.env.local` before removing the old file; the tracked backend `.env.test`
behavior is unchanged.
