### PR TITLE
fix(web): prevent unstable hook dependencies from retriggering requests

### DIFF
--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -212,7 +212,9 @@ async function handleRpcRequest({ request, response, url }) {
       );
       const expectedIncludes = bottleGroupWorkflow
         ? ["bottles", "users", "entities"]
-        : ["bottles"];
+        : input?.query === "playwright search"
+          ? ["bottles", "entities"]
+          : ["bottles"];
       if (
         !Array.isArray(input?.include) ||
         input.include.length !== expectedIncludes.length ||

--- a/apps/web/e2e/search.spec.ts
+++ b/apps/web/e2e/search.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+test("search settles after one request", async ({ page }, testInfo) => {
+  test.skip(
+    testInfo.project.name !== "chromium-desktop",
+    "The request lifecycle is viewport-independent.",
+  );
+
+  let searchRequestCount = 0;
+  let searchRequestBody: unknown;
+  page.on("request", (request) => {
+    if (request.method() === "POST" && request.url().endsWith("/rpc/search")) {
+      searchRequestCount += 1;
+      searchRequestBody = request.postDataJSON();
+    }
+  });
+
+  await page.goto("/search?q=playwright+search", { waitUntil: "commit" });
+
+  await expect(
+    page.getByRole("link", { name: "Can't find a bottle?" }),
+  ).toBeVisible();
+  await page.waitForLoadState("networkidle", { timeout: 10_000 });
+
+  expect(searchRequestCount).toBe(1);
+  expect(searchRequestBody).toEqual({
+    json: {
+      query: "playwright search",
+      limit: 50,
+      include: ["bottles", "entities"],
+    },
+  });
+});

--- a/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
@@ -134,23 +134,23 @@ export default function Page() {
   const actionableCount = proposalList.stats.actionableCount;
   const activeRetryRun =
     activeRetryRunQuery.data ?? activeRetryRunListQuery.data?.run ?? null;
+  const activeRetryRunStatus = activeRetryRun?.status ?? null;
   const retryRunIsActive =
-    activeRetryRun?.status === "pending" ||
-    activeRetryRun?.status === "running";
+    activeRetryRunStatus === "pending" || activeRetryRunStatus === "running";
 
   const refreshQueueList = useCallback(async (): Promise<void> => {
     await queryClient.invalidateQueries({
-      queryKey: listQueryOptions.queryKey,
+      queryKey: orpc.prices.matchQueue.list.key(),
     });
-  }, [listQueryOptions.queryKey, queryClient]);
+  }, [orpc, queryClient]);
 
   useEffect(() => {
-    if (!activeRetryRun || retryRunIsActive) {
+    if (!activeRetryRunStatus || retryRunIsActive) {
       return;
     }
 
     void refreshQueueList();
-  }, [activeRetryRun, refreshQueueList, retryRunIsActive]);
+  }, [activeRetryRunStatus, refreshQueueList, retryRunIsActive]);
 
   async function handleRetryAll(): Promise<void> {
     if (

--- a/apps/web/src/components/flash.tsx
+++ b/apps/web/src/components/flash.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { createContext, useContext, useState, type ReactNode } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
 import { useInterval } from "usehooks-ts";
 import classNames from "../lib/classNames";
 
@@ -53,30 +60,35 @@ export default function FlashMessages({ children }: { children: ReactNode }) {
   useInterval(() => {
     setMessages((messages) => {
       const cutoff = new Date().getTime() - ALIVE_TIME;
-      return messages.filter((m) => m.createdAt > cutoff);
+      const activeMessages = messages.filter((m) => m.createdAt > cutoff);
+      return activeMessages.length === messages.length
+        ? messages
+        : activeMessages;
     });
   }, 1000);
 
+  const flash = useCallback(
+    (message: string | ReactNode, type: FlashType = "success") => {
+      setMessages((messages) => {
+        const cutoff = new Date().getTime() - ALIVE_TIME;
+        return [
+          ...messages.filter((m) => m.createdAt > cutoff),
+          {
+            message,
+            type,
+            id: messageNum,
+            createdAt: new Date().getTime(),
+          },
+        ];
+      });
+      messageNum += 1;
+    },
+    [],
+  );
+  const contextValue = useMemo(() => ({ flash }), [flash]);
+
   return (
-    <FlashContext.Provider
-      value={{
-        flash: (message: string | ReactNode, type: FlashType = "success") => {
-          setMessages((messages) => {
-            const cutoff = new Date().getTime() - ALIVE_TIME;
-            return [
-              ...messages.filter((m) => m.createdAt > cutoff),
-              {
-                message,
-                type,
-                id: messageNum,
-                createdAt: new Date().getTime(),
-              },
-            ];
-          });
-          messageNum += 1;
-        },
-      }}
-    >
+    <FlashContext.Provider value={contextValue}>
       <div className="fixed right-0 top-0 z-50 flex max-w-xl flex-col gap-y-4 p-4">
         {messages.map((m) => (
           <Message {...m} key={m.id} />

--- a/apps/web/src/components/search/panel.tsx
+++ b/apps/web/src/components/search/panel.tsx
@@ -105,7 +105,7 @@ export default function SearchPanel({
       setState("ready");
       setInitialState("ready");
     },
-    [addBottleIntent, directToTasting, orpc.search, searchType, user],
+    [addBottleIntent, directToTasting, orpc, searchType, user],
   );
 
   // TODO: handle errors
@@ -114,9 +114,8 @@ export default function SearchPanel({
   useEffect(() => {
     const curValue = initialValue ?? value ?? "";
     setQuery(curValue);
-    if (onQueryChange) onQueryChange(curValue);
     void onQuery(curValue);
-  }, [initialValue, value, onQuery, onQueryChange]);
+  }, [initialValue, value, onQuery]);
 
   return (
     <Layout

--- a/apps/web/src/lib/orpc/context.tsx
+++ b/apps/web/src/lib/orpc/context.tsx
@@ -7,6 +7,10 @@ type ORPCQueryUtils = RouterUtils<RouterClient<Router>>;
 
 export const ORPCContext = createContext<ORPCQueryUtils | undefined>(undefined);
 
+/**
+ * Returns the stable router root. Nested utilities are proxy-generated per
+ * access, so React hook dependencies must depend on this root instead.
+ */
 export function useORPC(): ORPCQueryUtils {
   const orpc = use(ORPCContext);
   if (!orpc) {


### PR DESCRIPTION
Search now settles after one request instead of continuously calling `/rpc/search`. Nested oRPC router utilities are proxy-generated on access, so callbacks now depend on the stable router root. The same audit stabilizes moderator queue refresh dependencies and Flash context identity, preventing equivalent effect retriggers elsewhere; controlled search callbacks now run only for actual input changes.

A browser regression proves the initial search issues one POST with the expected input. This was also validated with the web typecheck, 213 unit tests, the authenticated queue workflow, and desktop/mobile browser smoke checks.
