### PR TITLE
fix(web): show release year in bottle matches

### DIFF
--- a/apps/web/src/components/bottleIdentity.tsx
+++ b/apps/web/src/components/bottleIdentity.tsx
@@ -323,6 +323,7 @@ export default function BottleIdentity({
   className,
   linkClassName,
   showBrand = true,
+  showReleaseYear = false,
 }: {
   bottle: BottleIdentitySource;
   mode?: "absolute" | "relative";
@@ -334,6 +335,7 @@ export default function BottleIdentity({
   className?: string;
   linkClassName?: string;
   showBrand?: boolean;
+  showReleaseYear?: boolean;
 }) {
   const relativeIdentity = getRelativeBottleIdentity(bottle);
   const isAbsolute = mode === "absolute";
@@ -360,6 +362,15 @@ export default function BottleIdentity({
     bottle.statedAge === bottle.group.statedAge
   ) {
     metadataExclude.add("age");
+  }
+  if (
+    showReleaseYear &&
+    !getMetadataExpressedByTitle(
+      bottle,
+      [title, displayedLeadingContent].filter(Boolean).join(" "),
+    ).includes("release")
+  ) {
+    metadataExclude.delete("release");
   }
   const seriesName = isAbsolute
     ? getBottleIdentitySeriesName(bottle, title)

--- a/apps/web/src/components/bottleResolver/states.test.tsx
+++ b/apps/web/src/components/bottleResolver/states.test.tsx
@@ -1,0 +1,74 @@
+import type { Bottle } from "@peated/server/types";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+import type { PhotoIdentification } from "./helpers";
+import { PhotoMatchCreateState } from "./states";
+
+function makeBottle(overrides: Partial<Bottle> = {}): Bottle {
+  return {
+    id: 42,
+    fullName: "Springbank 12-year-old Cask Strength Batch 24",
+    name: "12-year-old Cask Strength Batch 24",
+    group: {
+      id: 7,
+      name: "12-year-old Cask Strength",
+      fullName: "Springbank 12-year-old Cask Strength",
+      statedAge: 12,
+    },
+    brand: { id: 1, name: "Springbank" },
+    series: null,
+    edition: "Batch 24",
+    category: "single_malt",
+    statedAge: 12,
+    abv: 57.2,
+    vintageYear: null,
+    releaseYear: 2023,
+    singleCask: false,
+    caskStrength: true,
+    caskFill: null,
+    caskType: null,
+    caskSize: null,
+    ...overrides,
+  } as Bottle;
+}
+
+const result = {
+  imageEvidence: { fieldCandidates: {} },
+} as unknown as PhotoIdentification;
+
+function renderMatchedBottle(bottle: Bottle) {
+  return renderToStaticMarkup(
+    <PhotoMatchCreateState
+      result={result}
+      previewUrl={null}
+      matchedBottle={bottle}
+      createProposalLabel={null}
+      hasCreateDecision={false}
+      proposedName={null}
+      createPending={false}
+      createActionLabel="Create"
+      resolvingAction={null}
+      hasLibraryEntry={false}
+      pendingImage={null}
+      loadingExactLibraryStatus={false}
+      onLoadBottle={vi.fn()}
+      onAcceptCreateProposal={vi.fn()}
+    />,
+  );
+}
+
+describe("PhotoMatchCreateState", () => {
+  it("shows the matched bottle release year alongside its edition", () => {
+    const html = renderMatchedBottle(makeBottle());
+
+    expect(html).toContain("Batch 24");
+    expect(html).toContain("2023 release");
+  });
+
+  it("does not repeat a release year already expressed by the edition", () => {
+    const html = renderMatchedBottle(makeBottle({ edition: "2023 Release" }));
+
+    expect(html.match(/2023 release/gi)).toHaveLength(1);
+  });
+});

--- a/apps/web/src/components/bottleResolver/states.tsx
+++ b/apps/web/src/components/bottleResolver/states.tsx
@@ -243,6 +243,7 @@ export function PhotoMatchCreateState({
               <BottleIdentity
                 bottle={matchedBottle}
                 linkClassName="font-semibold text-white hover:underline"
+                showReleaseYear
               />
               <EvidencePills result={result} compact />
             </div>


### PR DESCRIPTION
The add-bottle photo match confirmation now keeps the matched bottle’s release year visible when the shared identity presentation would normally suppress it because an edition or vintage is present. Release years already expressed in the identity remain deduplicated, so users get the missing context without repeated metadata.

Resolver-level regression coverage proves both the visible and deduplicated cases. All 215 web tests, web typecheck, lint, and desktop/mobile browser checks passed.
