### PR TITLE
fix(web): make bottle metadata ordering deterministic

### DIFF
--- a/apps/web/src/components/bottleExactMetadata.test.tsx
+++ b/apps/web/src/components/bottleExactMetadata.test.tsx
@@ -20,22 +20,22 @@ const exactBottle = {
 } satisfies BottleExactMetadataSource;
 
 describe("BottleExactMetadata", () => {
-  it("renders leading context and exact fields as non-breaking items", () => {
+  it("renders exact fields in canonical order as non-breaking items", () => {
     const html = renderToStaticMarkup(
-      <BottleExactMetadata bottle={exactBottle} leadingContent="Lagavulin" />,
+      <BottleExactMetadata bottle={exactBottle} />,
     );
     const text = html.replace(/<[^>]*>/g, "");
 
     expect(html).toContain("flex-wrap");
     expect(text).toBe(
-      "Lagavulin·2025 Release·Single Malt·21 years·55.1% ABV·2004 vintage·Single cask·Cask strength·1st Fill Oloroso Hogshead cask",
+      "2025 Release·Single Malt·21 years·55.1% ABV·2004 vintage·Single cask·Cask strength·1st Fill Oloroso Hogshead cask",
     );
     expect(html.match(/class="inline-flex whitespace-nowrap"/g)).toHaveLength(
-      9,
+      8,
     );
   });
 
-  it("renders leading content alongside an edition without duplicate keys", () => {
+  it("renders an edition summary without duplicate keys", () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => undefined);
@@ -48,13 +48,11 @@ describe("BottleExactMetadata", () => {
             edition: "Distillers Edition",
             group: { statedAge: exactBottle.statedAge },
           }}
-          leadingContent="Lagavulin"
           variant="summary"
         />,
       );
       const text = html.replace(/<[^>]*>/g, "");
 
-      expect(text).toContain("Lagavulin");
       expect(text).toContain("Distillers Edition");
       expect(consoleError).not.toHaveBeenCalled();
     } finally {

--- a/apps/web/src/components/bottleExactMetadata.tsx
+++ b/apps/web/src/components/bottleExactMetadata.tsx
@@ -149,13 +149,11 @@ export default function BottleExactMetadata({
   bottle,
   className,
   exclude = [],
-  leadingContent,
   variant = "full",
 }: {
   bottle: BottleExactMetadataSource;
   className?: string;
   exclude?: readonly BottleExactMetadataKey[];
-  leadingContent?: ReactNode;
   variant?: "full" | "summary";
 }) {
   const excluded = new Set(exclude);
@@ -164,11 +162,7 @@ export default function BottleExactMetadata({
       ? getBottleReleaseSummary(bottle)
       : getBottleExactMetadata(bottle)
   ).filter(({ key }) => !excluded.has(key));
-  const items: Array<MetadataItem | { key: "leading"; content: ReactNode }> =
-    leadingContent !== undefined
-      ? [{ key: "leading", content: leadingContent }, ...metadata]
-      : metadata;
-  if (!items.length) return null;
+  if (!metadata.length) return null;
 
   return (
     <div
@@ -178,7 +172,7 @@ export default function BottleExactMetadata({
         className,
       )}
     >
-      {items.map(({ key, content }, index) => (
+      {metadata.map(({ key, content }, index) => (
         <span key={key} className="inline-flex whitespace-nowrap">
           {index ? <span className="mx-1.5">&middot;</span> : null}
           {content}

--- a/apps/web/src/components/bottleIdentity.test.tsx
+++ b/apps/web/src/components/bottleIdentity.test.tsx
@@ -81,6 +81,26 @@ describe("BottleIdentity", () => {
     expect(html).toContain('title="Springbank 12 Cask Strength Batch 24"');
   });
 
+  it("keeps exact metadata in canonical order for grouped and ungrouped bottles", () => {
+    const bottle = makeBottle({
+      edition: null,
+      vintageYear: null,
+      releaseYear: 2023,
+    });
+    const groupedText = renderToStaticMarkup(
+      <BottleIdentity bottle={bottle} mode="absolute" />,
+    ).replace(/<[^>]*>/g, "");
+    const ungroupedText = renderToStaticMarkup(
+      <BottleIdentity
+        bottle={{ ...bottle, group: undefined }}
+        mode="absolute"
+      />,
+    ).replace(/<[^>]*>/g, "");
+
+    expect(groupedText).toContain("57.2% ABV·2023 release");
+    expect(ungroupedText).toContain("57.2% ABV·2023 release");
+  });
+
   it("shows a nonduplicative series with producer context", () => {
     const html = renderToStaticMarkup(
       <BottleIdentity

--- a/apps/web/src/components/bottleIdentity.tsx
+++ b/apps/web/src/components/bottleIdentity.tsx
@@ -356,10 +356,7 @@ export default function BottleIdentity({
   }
   if (
     showReleaseYear &&
-    !getMetadataExpressedByTitle(
-      bottle,
-      [title, displayedLeadingContent].filter(Boolean).join(" "),
-    ).includes("release")
+    !getMetadataExpressedByTitle(bottle, title).includes("release")
   ) {
     metadataExclude.delete("release");
   }

--- a/apps/web/src/components/bottleIdentity.tsx
+++ b/apps/web/src/components/bottleIdentity.tsx
@@ -343,17 +343,8 @@ export default function BottleIdentity({
     ? getAbsoluteBottleTitle(bottle)
     : relativeIdentity.label;
   const titleMetadata = getBottleMetadataExclusions(bottle, title);
-  const leadingContent =
-    isAbsolute &&
-    bottle.group &&
-    !relativeIdentity.fallback &&
-    !relativeIdentity.excludeMetadata.some((key) => titleMetadata.has(key))
-      ? relativeIdentity.label
-      : undefined;
-  const displayedLeadingContent =
-    metadataVariant === "summary" ? undefined : leadingContent;
   const metadataExclude = titleMetadata;
-  if (!isAbsolute || displayedLeadingContent) {
+  if (!isAbsolute) {
     relativeIdentity.excludeMetadata.forEach((key) => metadataExclude.add(key));
   }
   if (
@@ -425,7 +416,6 @@ export default function BottleIdentity({
         bottle={bottle}
         variant={metadataVariant}
         exclude={[...metadataExclude]}
-        leadingContent={displayedLeadingContent}
       />
     </div>
   );

--- a/apps/web/src/components/previewBottleCard.test.tsx
+++ b/apps/web/src/components/previewBottleCard.test.tsx
@@ -25,12 +25,14 @@ describe("PreviewBottleCard", () => {
         }}
       />,
     );
+    const text = html.replace(/<[^>]*>/g, "");
 
     expect(html).toContain('aria-label="Bottle preview"');
     expect(html).toContain("Springbank");
     expect(html).toContain("Local Barley");
     expect(html).toContain("12-year-old");
     expect(html).toContain("Batch 24");
+    expect(text).toContain("Batch 24·57.2% ABV");
     expect(html).not.toContain("12 years");
     expect(html).not.toContain("2025");
     expect(html).not.toContain("2013");

--- a/apps/web/src/components/previewBottleCard.tsx
+++ b/apps/web/src/components/previewBottleCard.tsx
@@ -35,14 +35,9 @@ export const PreviewBottleCard = ({
     caskType: data.caskType ?? null,
     caskSize: data.caskSize ?? null,
   };
-  const editionInTitle = Boolean(
-    data.edition &&
-    data.name?.toLocaleLowerCase().includes(data.edition.toLocaleLowerCase()),
-  );
-  const leadingEdition = editionInTitle ? undefined : data.edition || undefined;
   const metadataExclude = getBottleMetadataExclusions(
     exactBottle,
-    [data.name, leadingEdition].filter(Boolean).join(" "),
+    data.name ?? "",
   );
   const showSeries = Boolean(
     series &&
@@ -73,7 +68,6 @@ export const PreviewBottleCard = ({
         className="!text-black/70"
         bottle={exactBottle}
         exclude={[...metadataExclude]}
-        leadingContent={leadingEdition}
       />
     </section>
   );

--- a/apps/web/src/components/search/bottleResult.tsx
+++ b/apps/web/src/components/search/bottleResult.tsx
@@ -96,11 +96,12 @@ export default function BottleResultRow({
           </Link>
           <BottleStatusIcons bottle={bottle} />
         </div>
-        <BottleExactMetadata
-          bottle={bottle}
-          leadingContent={distillerMetadata}
-          exclude={[...metadataExclude]}
-        />
+        {distillerMetadata ? (
+          <div className="text-muted mt-1 text-sm leading-5">
+            {distillerMetadata}
+          </div>
+        ) : null}
+        <BottleExactMetadata bottle={bottle} exclude={[...metadataExclude]} />
         {bottle.group && bottle.group.totalBottles > 1 ? (
           <div className="mt-1 text-xs">
             <Link


### PR DESCRIPTION
Bottle descriptions now render exact metadata in one canonical order whether or not a bottle belongs to a release family. Grouped identities no longer pull a release field into an arbitrary leading slot, so rows consistently show values such as `53.5% ABV · 2021 release`.

`BottleExactMetadata` now accepts only structured bottle data. Preview cards keep editions in that object, while search results render distiller context separately from exact metadata. Regression coverage compares grouped and ungrouped identities, and desktop/mobile QA covered release rows and independently bottled search results.
