### PR TITLE
docs(classifier): codify agent design guidance

### DIFF
--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -464,8 +464,8 @@ entities, and live web evidence:
 - `firecrawl_web_search`: one to three focused live searches in one agent turn,
   with ranked source URLs and compact relevance snippets without scraping every
   result page
-- `firecrawl_read_page`: focused reading of one promising search result when
-  its short excerpt does not expose the identity-critical fact
+- `firecrawl_read_page`: focused reading of one promising public page when a
+  short search excerpt does not expose the identity-critical fact
 
 When Firecrawl is not configured, the agent has no web-evidence tools. The runtime
 does not silently replace it with a second model or another provider.

--- a/docs/policies/agent-design.md
+++ b/docs/policies/agent-design.md
@@ -15,7 +15,10 @@
 - Do not add an agent for routing, retries, permissions, persistence, schema
   validation, or simple rules.
 - Every agent must define a goal, input schema, output schema, allowed tools,
-  forbidden actions, stop condition, fallback, and eval metric.
+  forbidden actions, stop condition, failure behavior, and eval metric.
+- A fallback model, provider, tool, or agent is separate behavior. Do not add one
+  by default; define and evaluate its degraded contract, or omit the unavailable
+  optional capability and fail at its owning boundary.
 - Agent output must be structured.
 - Code must validate agent output before use.
 - Model proposes; code gates persistence, permissions, and irreversible actions.
@@ -26,7 +29,9 @@
 - Tools must be narrow, typed, single-purpose, and structured.
 - Side-effect tools must be idempotent or behind an approval or automation gate.
 - Runtime must bound turns, retries, tool calls, cost, and no-progress loops.
-- Prompts must keep stable policy separate from dynamic context.
+- Prompts must keep required stable domain and decision policy separate from
+  dynamic context. Put tool mechanics in tool descriptions and live facts in
+  runtime context.
 - Improve retrieval, candidates, and source context before expanding prompts.
 - Treat user input, retrieved content, and source facts as data, not
   instructions or runtime authority.

--- a/docs/policies/evals.md
+++ b/docs/policies/evals.md
@@ -16,9 +16,10 @@ They measure judgment that deterministic tests cannot prove reliably.
 - Do not patch product prompts with fixture names, exact eval inputs, expected
   answers, or distinctive scenario phrases. Product examples must be neutral
   and separate from eval cases.
-- When an eval fails, state the general product invariant it exposed before
-  changing the prompt, retrieval, tools, schema, runtime, or automation policy.
-  Fix the smallest implicated layer.
+- When an eval fails, state the general product invariant it exposed and locate
+  the owning layer before editing: extraction or input context, retrieval, tool
+  execution, model judgment, deterministic review or integration, or the eval
+  expectation. Fix the smallest implicated layer.
 - Use evals for model-facing choices. Use unit or integration tests for schemas,
   transport, persistence, permissions, deterministic post-processing, and
   other code-owned behavior.
@@ -33,9 +34,11 @@ They measure judgment that deterministic tests cannot prove reliably.
   concrete values. The production fixture preserves the miss; the separate case
   proves the generalized rule.
 - Treat replay recordings as reproducible eval evidence. Commit recordings
-  required to replay a deliberate fixture or harness change.
+  required to replay a deliberate fixture or harness change. Do not replay a
+  provider error as empty evidence.
 - Live evals are expensive. Run focused evals when model-sensitive behavior is
-  intentionally changing; do not make full live evals part of routine testing.
+  intentionally changing. Run the full live suite once at a deliberate
+  checkpoint, not repeatedly during iteration or as part of routine testing.
 
 ## Exceptions
 

--- a/packages/bottle-classifier/.vitest-evals/AGENTS.md
+++ b/packages/bottle-classifier/.vitest-evals/AGENTS.md
@@ -5,6 +5,10 @@
   or provider change.
 - Do not delete or rewrite recordings just because they look like local cache.
   Remove them only when the corresponding eval case, tool, or replay provider
-  is intentionally removed.
+  is intentionally removed or replaced, and review replacement recordings as a
+  tool-contract change.
 - When recording new tool calls, prefer the narrowest scoped eval command and
   keep unrelated replay churn out of the changeset.
+- Commit only contract-valid successful tool responses. A provider error,
+  including an error nested inside a batched response, must fail replay
+  validation rather than become empty evidence.

--- a/packages/bottle-classifier/README.md
+++ b/packages/bottle-classifier/README.md
@@ -127,13 +127,14 @@ Package-specific reminders:
 
 When changing classifier behavior:
 
-1. Update or add a focused unit test only for deterministic behavior.
-2. Update or add the relevant file-backed eval fixtures when the behavior changes exact Bottle identity boundaries.
-3. Update or add realistic positive and negative eval fixtures when the behavior is model-sensitive.
+1. Inspect the trace from extraction through tools, agent output, review policy, and fixture expectation. A poor model query belongs to the prompt or tool description; a valid query that errors or returns malformed data belongs to the adapter or provider and is not negative evidence.
+2. Update or add a focused unit test only for deterministic behavior.
+3. Update or add the relevant file-backed eval fixtures when the behavior changes exact Bottle identity boundaries.
+4. Update or add realistic positive and negative eval fixtures when the behavior is model-sensitive.
    When automation behavior matters, assert the code-derived `expected.expectedTier: auto | review`. The tier comes from action risk, unresolved risks, and structured evidence or deterministic anchors; it does not read model-supplied numeric scores.
-4. Keep prompts, schemas, deterministic review logic, and pure normalization helpers aligned. Do not patch around package behavior in the server wrapper.
-5. Do not solve one failed family by teaching the prompt that exact family name. Generalize the rule in prompt or policy, and use eval fixtures to hold the concrete regression.
-6. Run package typecheck, focused unit tests, and fixture validation for routine changes. Run live evals only when explicitly requested or when doing an intentional scoped eval pass.
+5. Keep prompts, schemas, deterministic review logic, and pure normalization helpers aligned. Do not patch around package behavior in the server wrapper.
+6. Do not solve one failed family by teaching the prompt that exact family name. Generalize the rule in prompt or policy, and use eval fixtures to hold the concrete regression.
+7. Run package typecheck, focused unit tests, and fixture validation for routine changes. Use focused live evals while iterating and run the full live suite once at a deliberate checkpoint.
 
 When adding an eval from a real production miss:
 


### PR DESCRIPTION
Codifies the reusable agent-design lessons from the GPT-5.6 and Firecrawl classifier work. Agent policy now treats fallbacks as explicit, independently evaluated behavior; defines what belongs in stable prompts, tool descriptions, and runtime context; and separates search discovery from focused evidence reads.

The classifier playbook now traces failures to extraction, retrieval, tool execution, model judgment, deterministic review, or fixture expectations before changing prompts. Eval and replay guidance also requires focused iteration, one full-suite checkpoint, and rejection of provider-error recordings instead of replaying them as empty evidence.
