### PR TITLE
fix(bottles): handle legacy short names in operation reviews

### DIFF
--- a/apps/server/src/lib/bottleOperationReview.test.ts
+++ b/apps/server/src/lib/bottleOperationReview.test.ts
@@ -268,7 +268,7 @@ describe("Bottle operation review preparation", () => {
     });
   });
 
-  test("normalizes legacy blank distiller short names in Bottle update previews", async ({
+  test("supports legacy blank distiller short names in Bottle update review state", async ({
     fixtures,
   }) => {
     const distiller = await fixtures.Entity({
@@ -288,13 +288,22 @@ describe("Bottle operation review preparation", () => {
           type: "update_bottle",
           input: {
             bottleId: bottle.id,
-            patch: { exact: { edition: "Reviewed Edition" } },
+            patch: {
+              shared: {
+                category: "single_malt",
+                distillers: [{ kind: "existing", entityId: distiller.id }],
+              },
+            },
           },
-          rationale: "The inspected evidence confirms this edition.",
+          rationale:
+            "The inspected evidence confirms the category and distiller.",
           evidenceRefs: [{ kind: "bottle", bottleId: bottle.id }],
         },
       },
-      artifacts: artifacts({ bottleIds: [bottle.id] }),
+      artifacts: artifacts({
+        bottleIds: [bottle.id],
+        entities: [distiller],
+      }),
     });
 
     expect(result).toMatchObject({
@@ -307,6 +316,14 @@ describe("Bottle operation review preparation", () => {
         after: {
           shared: { distillers: [{ shortName: null }] },
         },
+      },
+      stateToken: {
+        referencedEntities: expect.arrayContaining([
+          expect.objectContaining({
+            entityId: distiller.id,
+            shortName: "",
+          }),
+        ]),
       },
     });
   });

--- a/apps/server/src/lib/bottleOperationReview.test.ts
+++ b/apps/server/src/lib/bottleOperationReview.test.ts
@@ -372,6 +372,68 @@ describe("Bottle operation review preparation", () => {
     });
   });
 
+  test("supports legacy blank short names in Entity update review state", async ({
+    fixtures,
+  }) => {
+    const entity = await fixtures.Entity({
+      name: "Legacy Blank Update Entity",
+      shortName: "",
+      type: ["brand"],
+    });
+    const context = { artifacts: artifacts({ entities: [entity] }) };
+
+    const shortNameUpdate = await prepareOperation({
+      operation: {
+        id: 7,
+        proposal: {
+          type: "update_entity",
+          input: {
+            entityId: entity.id,
+            patch: { shortName: "Legacy Update" },
+          },
+          rationale: "The inspected Entity uses this short name.",
+          evidenceRefs: [{ kind: "entity", entityId: entity.id }],
+        },
+      },
+      ...context,
+    });
+    const websiteUpdate = await prepareOperation({
+      operation: {
+        id: 8,
+        proposal: {
+          type: "update_entity",
+          input: {
+            entityId: entity.id,
+            patch: { website: "https://legacy-update.example" },
+          },
+          rationale: "The inspected Entity uses this website.",
+          evidenceRefs: [{ kind: "entity", entityId: entity.id }],
+        },
+      },
+      ...context,
+    });
+
+    expect(shortNameUpdate).toMatchObject({
+      status: "pending_review",
+      type: "update_entity",
+      preview: {
+        before: { shortName: null },
+        after: { shortName: "Legacy Update" },
+      },
+      stateToken: {
+        fields: { shortName: "" },
+      },
+    });
+    expect(websiteUpdate).toMatchObject({
+      status: "pending_review",
+      type: "update_entity",
+      preview: {
+        before: { shortName: null },
+        after: { shortName: null },
+      },
+    });
+  });
+
   test("reports merge membership and identity collisions as canonical merge warnings", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/bottleOperationReview.test.ts
+++ b/apps/server/src/lib/bottleOperationReview.test.ts
@@ -328,6 +328,50 @@ describe("Bottle operation review preparation", () => {
     });
   });
 
+  test("supports legacy blank short names in Entity merge review state", async ({
+    fixtures,
+  }) => {
+    const source = await fixtures.Entity({
+      name: "Legacy Blank Merge Source",
+      shortName: "",
+      type: ["distiller"],
+    });
+    const destination = await fixtures.Entity({
+      name: "Legacy Blank Merge Destination",
+      type: ["brand"],
+    });
+
+    const result = await prepareOperation({
+      operation: {
+        id: 6,
+        proposal: {
+          type: "merge_entities",
+          input: {
+            sourceEntityId: source.id,
+            destinationEntityId: destination.id,
+          },
+          rationale: "The inspected records identify the same producer.",
+          evidenceRefs: [
+            { kind: "entity", entityId: source.id },
+            { kind: "entity", entityId: destination.id },
+          ],
+        },
+      },
+      artifacts: artifacts({ entities: [source, destination] }),
+    });
+
+    expect(result).toMatchObject({
+      status: "pending_review",
+      type: "merge_entities",
+      preview: {
+        source: { entityId: source.id, shortName: null },
+      },
+      stateToken: {
+        source: { entityId: source.id, shortName: "" },
+      },
+    });
+  });
+
   test("reports merge membership and identity collisions as canonical merge warnings", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/bottleOperationReview/bottleShared.ts
+++ b/apps/server/src/lib/bottleOperationReview/bottleShared.ts
@@ -123,7 +123,7 @@ export function existingEntityChoice(entity: Entity) {
     kind: "existing" as const,
     entityId: entity.id,
     name: entity.name,
-    shortName: entity.shortName?.trim() || null,
+    shortName: entity.shortName,
     roles: [...entity.type].sort(),
   };
 }

--- a/apps/server/src/lib/bottleOperationReview/shared.ts
+++ b/apps/server/src/lib/bottleOperationReview/shared.ts
@@ -337,7 +337,7 @@ export function entityPreviewState({
   return {
     entityId: entity.id,
     name: entity.name,
-    shortName: entity.shortName,
+    shortName: entity.shortName?.trim() || null,
     roles: [...entity.type].sort(),
     website: entity.website,
     location: {

--- a/apps/server/src/lib/bottleOperationReview/shared.ts
+++ b/apps/server/src/lib/bottleOperationReview/shared.ts
@@ -337,7 +337,7 @@ export function entityPreviewState({
   return {
     entityId: entity.id,
     name: entity.name,
-    shortName: entity.shortName?.trim() || null,
+    shortName: entity.shortName,
     roles: [...entity.type].sort(),
     website: entity.website,
     location: {

--- a/apps/server/src/lib/bottleOperationReviewSchemas.ts
+++ b/apps/server/src/lib/bottleOperationReviewSchemas.ts
@@ -16,8 +16,12 @@ export const MAX_OPERATION_PREVIEW_IDS = 20;
 
 const PositiveIdSchema = z.number().int().positive();
 const NonEmptyTextSchema = z.string().trim().min(1);
-// State tokens retain raw database values so legacy blanks still take part in
-// exact staleness comparisons.
+// Previews canonicalize legacy blanks for reviewers; state tokens retain raw
+// database values for exact staleness comparisons.
+const EntityPreviewShortNameSchema = z
+  .string()
+  .nullable()
+  .transform((value) => value?.trim() || null);
 const RawEntityShortNameSchema = z.string().nullable();
 
 export const PreparationErrorCodeSchema = z.enum([
@@ -83,7 +87,7 @@ export const ExistingEntityPreviewSchema = z
     kind: z.literal("existing"),
     entityId: PositiveIdSchema,
     name: NonEmptyTextSchema,
-    shortName: NonEmptyTextSchema.nullable(),
+    shortName: EntityPreviewShortNameSchema,
     roles: EntityContextSchema.shape.roles,
   })
   .strict();
@@ -127,7 +131,7 @@ export const EntityPreviewStateSchema = z
   .object({
     entityId: PositiveIdSchema,
     name: NonEmptyTextSchema,
-    shortName: NonEmptyTextSchema.nullable(),
+    shortName: EntityPreviewShortNameSchema,
     roles: EntityContextSchema.shape.roles,
     website: EntityContextSchema.shape.website,
     location: EntityLocationSchema,
@@ -327,7 +331,7 @@ export const BottleMergeStateTokenSchema = z
 const EntityPatchStateTokenSchema = z
   .object({
     name: NonEmptyTextSchema.optional(),
-    shortName: NonEmptyTextSchema.nullable().optional(),
+    shortName: RawEntityShortNameSchema.optional(),
     roles: EntityContextSchema.shape.roles.optional(),
     website: EntityContextSchema.shape.website.optional(),
     countryId: PositiveIdSchema.nullable().optional(),

--- a/apps/server/src/lib/bottleOperationReviewSchemas.ts
+++ b/apps/server/src/lib/bottleOperationReviewSchemas.ts
@@ -16,6 +16,9 @@ export const MAX_OPERATION_PREVIEW_IDS = 20;
 
 const PositiveIdSchema = z.number().int().positive();
 const NonEmptyTextSchema = z.string().trim().min(1);
+// State tokens retain raw database values so legacy blanks still take part in
+// exact staleness comparisons.
+const RawEntityShortNameSchema = z.string().nullable();
 
 export const PreparationErrorCodeSchema = z.enum([
   "target_not_inspected",
@@ -252,9 +255,7 @@ const EntityDependencyStateSchema = z
   .object({
     entityId: PositiveIdSchema,
     name: NonEmptyTextSchema,
-    // State tokens retain raw database values so legacy blanks still take part
-    // in exact staleness comparisons.
-    shortName: z.string().nullable(),
+    shortName: RawEntityShortNameSchema,
     roles: EntityContextSchema.shape.roles,
   })
   .strict();
@@ -359,7 +360,7 @@ const EntityMergeIdentityStateSchema = z
   .object({
     entityId: PositiveIdSchema,
     name: NonEmptyTextSchema,
-    shortName: NonEmptyTextSchema.nullable(),
+    shortName: RawEntityShortNameSchema,
     roles: EntityContextSchema.shape.roles,
     aliasDigest: RelationshipDigestSchema,
     tombstoneDestinationEntityId: PositiveIdSchema.nullable(),

--- a/apps/server/src/lib/bottleOperationReviewSchemas.ts
+++ b/apps/server/src/lib/bottleOperationReviewSchemas.ts
@@ -252,7 +252,9 @@ const EntityDependencyStateSchema = z
   .object({
     entityId: PositiveIdSchema,
     name: NonEmptyTextSchema,
-    shortName: NonEmptyTextSchema.nullable(),
+    // State tokens retain raw database values so legacy blanks still take part
+    // in exact staleness comparisons.
+    shortName: z.string().nullable(),
     roles: EntityContextSchema.shape.roles,
   })
   .strict();


### PR DESCRIPTION
Catalog operation reviews now tolerate legacy blank Entity short names across Bottle updates, Entity merges, and direct Entity updates. Reviewer-facing schemas canonicalize blank or whitespace-only values to `null`, while one raw state-token schema preserves exact database values for reliable staleness comparisons.

Owning this distinction in the schemas removes normalization from individual operation builders and makes every current preview and token variant share the same contract. Regression coverage exercises all three operation types, including direct updates that change the short name and updates that leave it untouched; the targeted 22-test review suite, server typecheck, lint, and formatting checks pass.
