### PR TITLE
fix(server): discard stale generated bottle details

### DIFF
--- a/apps/server/src/worker/jobs/generateBottleDetails.test.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.test.ts
@@ -10,10 +10,7 @@ import {
 import { createConcreteBottle } from "@peated/server/lib/createConcreteBottle";
 import { getStructuredResponse } from "@peated/server/lib/openai";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
-import {
-  ConcreteBottleUpdateExpectedBottleStateError,
-  updateConcreteBottle,
-} from "@peated/server/lib/updateConcreteBottle";
+import { updateConcreteBottle } from "@peated/server/lib/updateConcreteBottle";
 import * as workerClient from "@peated/server/worker/client";
 import { and, asc, eq } from "drizzle-orm";
 import { beforeEach, expect, test, vi } from "vitest";
@@ -253,11 +250,8 @@ test("preserves a concurrent moderator exact-content edit", async ({
   });
   vi.mocked(workerClient.pushUniqueJob).mockClear();
 
-  const rejection = expect(work).rejects.toBeInstanceOf(
-    ConcreteBottleUpdateExpectedBottleStateError,
-  );
   deferred.resolve(generatedDetails());
-  await rejection;
+  await expect(work).resolves.toBeUndefined();
 
   expect(
     await db.query.bottles.findFirst({
@@ -282,7 +276,7 @@ test("preserves a concurrent moderator exact-content edit", async ({
   expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
 });
 
-test("rejects generated work planned from stale exact identity", async ({
+test("discards generated work planned from stale exact identity", async ({
   defaults,
   fixtures,
 }) => {
@@ -311,11 +305,8 @@ test("rejects generated work planned from stale exact identity", async ({
   if (!moderatorBottle) throw new Error("Expected updated Bottle.");
   vi.mocked(workerClient.pushUniqueJob).mockClear();
 
-  const rejection = expect(work).rejects.toBeInstanceOf(
-    ConcreteBottleUpdateExpectedBottleStateError,
-  );
   deferred.resolve(generatedDetails());
-  await rejection;
+  await expect(work).resolves.toBeUndefined();
 
   expect(
     await db.query.bottles.findFirst({
@@ -364,11 +355,8 @@ test("preserves a concurrent moderator shared-flavor edit", async ({
   });
   vi.mocked(workerClient.pushUniqueJob).mockClear();
 
-  const rejection = expect(work).rejects.toBeInstanceOf(
-    ConcreteBottleUpdateExpectedBottleStateError,
-  );
   deferred.resolve(generatedDetails());
-  await rejection;
+  await expect(work).resolves.toBeUndefined();
 
   expect(
     await db
@@ -386,6 +374,42 @@ test("preserves a concurrent moderator shared-flavor edit", async ({
       columns: { flavorProfile: true },
     }),
   ).toEqual({ flavorProfile: "lightly_peated" });
+  expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
+});
+
+test("discards generated work planned from stale shared authority", async ({
+  defaults,
+  fixtures,
+}) => {
+  const brand = await fixtures.Entity({
+    name: "Generated Shared Authority Race Brand",
+  });
+  const { source } = await createTwoMemberGroup(defaults.user, brand.id);
+  const deferred = deferModelResult();
+  const work = generateBottleDetails({ bottleId: source.bottle.id });
+  await vi.waitFor(() => expect(getStructuredResponse).toHaveBeenCalledOnce());
+
+  await db
+    .update(bottleGroups)
+    .set({ name: "New shared authority" })
+    .where(eq(bottleGroups.id, source.group.id));
+  vi.mocked(workerClient.pushUniqueJob).mockClear();
+
+  deferred.resolve(generatedDetails());
+  await expect(work).resolves.toBeUndefined();
+
+  expect(
+    await db.query.bottleGroups.findFirst({
+      where: eq(bottleGroups.id, source.group.id),
+      columns: { name: true, flavorProfile: true },
+    }),
+  ).toEqual({ name: "New shared authority", flavorProfile: null });
+  expect(
+    await db.query.bottles.findFirst({
+      where: eq(bottles.id, source.bottle.id),
+      columns: { description: true, tastingNotes: true },
+    }),
+  ).toEqual({ description: null, tastingNotes: null });
   expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
 });
 
@@ -425,11 +449,8 @@ test("does not fan out after the selected Bottle moves groups", async ({
     .where(eq(bottles.id, source.bottle.id));
   vi.mocked(workerClient.pushUniqueJob).mockClear();
 
-  const rejection = expect(work).rejects.toBeInstanceOf(
-    ConcreteBottleUpdateExpectedBottleStateError,
-  );
   deferred.resolve(generatedDetails());
-  await rejection;
+  await expect(work).resolves.toBeUndefined();
 
   expect(
     await db

--- a/apps/server/src/worker/jobs/generateBottleDetails.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.ts
@@ -20,8 +20,10 @@ import { logError, logWarn } from "@peated/server/lib/log";
 import { getStructuredResponse } from "@peated/server/lib/openai";
 import { withSentryConversation } from "@peated/server/lib/openaiClient";
 import {
+  ConcreteBottleUpdateExpectedBottleStateError,
   concreteBottleUpdateExpectedSelectedBottleState,
   concreteBottleUpdateExpectedSharedState,
+  ConcreteBottleUpdateExpectedStateError,
   finalizeConcreteBottleUpdate,
   updateConcreteBottleInTransaction,
 } from "@peated/server/lib/updateConcreteBottle";
@@ -253,16 +255,29 @@ export default async function generateBottleDetails(rawJobArgs: unknown) {
     shared,
     exact: Object.keys(exact).length ? exact : undefined,
   });
-  const update = await db.transaction(async (tx) => {
-    const actor = await getPeatedSystemActorForDatabase(tx);
-    return await updateConcreteBottleInTransaction(tx, {
-      bottleId: bottle.id,
-      input,
-      expectedSelectedBottleState,
-      expectedSharedState,
-      actorId: actor.id,
-      creationSource: "repair_workflow",
+  let update;
+  try {
+    update = await db.transaction(async (tx) => {
+      const actor = await getPeatedSystemActorForDatabase(tx);
+      return await updateConcreteBottleInTransaction(tx, {
+        bottleId: bottle.id,
+        input,
+        expectedSelectedBottleState,
+        expectedSharedState,
+        actorId: actor.id,
+        creationSource: "repair_workflow",
+      });
     });
-  });
+  } catch (error) {
+    // Generated details belong only to the snapshot sent to the model. A newer
+    // authoritative edit supersedes them, so the stale result is discarded.
+    if (
+      error instanceof ConcreteBottleUpdateExpectedBottleStateError ||
+      error instanceof ConcreteBottleUpdateExpectedStateError
+    ) {
+      return;
+    }
+    throw error;
+  }
   await finalizeConcreteBottleUpdate(update);
 }


### PR DESCRIPTION
`GenerateBottleDetails` now treats optimistic snapshot conflicts as superseded AI work. When a Bottle's exact state, membership, or shared authority changes while the model is running, the stale result is discarded and the worker completes normally; model, database, graph, and other unexpected failures still propagate.

The snapshot guard was correctly preventing stale generated content from overwriting a newer authoritative edit, but its typed conflict escaped through worker instrumentation and created an actionable Sentry issue for normal concurrency. The concurrency tests now assert the no-op behavior and add direct coverage for shared-authority drift; the focused 9-test integration suite passes.
