### PR TITLE
feat(entities): add role-aware catalog overviews

### DIFF
--- a/apps/server/src/orpc/routes/entities/catalog.test.ts
+++ b/apps/server/src/orpc/routes/entities/catalog.test.ts
@@ -1,0 +1,128 @@
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+describe("GET /entities/:entity/catalog", () => {
+  test("summarizes overlapping bottle roles and related entities", async ({
+    fixtures,
+  }) => {
+    const entity = await fixtures.Entity({
+      name: "Summary Entity",
+      type: ["brand", "bottler", "distiller"],
+    });
+    const alphaBrand = await fixtures.Entity({ name: "Alpha Brand" });
+    const betaBrand = await fixtures.Entity({ name: "Beta Brand" });
+    const outsideBottler = await fixtures.Entity({ name: "Outside Bottler" });
+    const sourceA = await fixtures.Entity({ name: "Source A" });
+    const sourceB = await fixtures.Entity({ name: "Source B" });
+
+    await fixtures.Bottle({
+      name: "Overlapping Roles",
+      brandId: entity.id,
+      bottlerId: entity.id,
+      distillerIds: [entity.id],
+      category: "bourbon",
+      totalTastings: 3,
+      avgRating: 1.5,
+    });
+    await fixtures.Bottle({
+      name: "Bottled Release",
+      brandId: alphaBrand.id,
+      bottlerId: entity.id,
+      distillerIds: [sourceA.id, sourceB.id],
+      category: "blend",
+      totalTastings: 2,
+    });
+    await fixtures.Bottle({
+      name: "Distilled Release",
+      brandId: betaBrand.id,
+      bottlerId: outsideBottler.id,
+      distillerIds: [entity.id],
+      category: "single_malt",
+      totalTastings: 1,
+    });
+    await fixtures.Bottle({
+      name: "Unrelated Release",
+      brandId: alphaBrand.id,
+      bottlerId: outsideBottler.id,
+      distillerIds: [sourceA.id],
+      category: "rye",
+    });
+
+    const data = await routerClient.entities.catalog({ entity: entity.id });
+
+    expect(data).toEqual({
+      totalBottles: 3,
+      relationships: { brand: 1, bottler: 2, distiller: 2 },
+      distilleryCoverage: { documented: 3, total: 3 },
+      categories: [
+        { category: "blend", count: 1 },
+        { category: "bourbon", count: 1 },
+        { category: "single_malt", count: 1 },
+      ],
+      related: {
+        brands: [
+          { id: alphaBrand.id, name: "Alpha Brand", shortName: null, count: 1 },
+          { id: betaBrand.id, name: "Beta Brand", shortName: null, count: 1 },
+        ],
+        bottlers: [
+          {
+            id: outsideBottler.id,
+            name: "Outside Bottler",
+            shortName: null,
+            count: 1,
+          },
+        ],
+        distillers: [
+          { id: sourceA.id, name: "Source A", shortName: null, count: 1 },
+          { id: sourceB.id, name: "Source B", shortName: null, count: 1 },
+        ],
+      },
+      notableBottles: [
+        {
+          id: expect.any(Number),
+          fullName: "Summary Entity Overlapping Roles",
+          totalTastings: 3,
+          avgRating: 1.5,
+        },
+        {
+          id: expect.any(Number),
+          fullName: "Alpha Brand Bottled Release",
+          totalTastings: 2,
+          avgRating: null,
+        },
+        {
+          id: expect.any(Number),
+          fullName: "Beta Brand Distilled Release",
+          totalTastings: 1,
+          avgRating: null,
+        },
+      ],
+    });
+  });
+
+  test("returns an empty summary when an entity has no bottles", async ({
+    fixtures,
+  }) => {
+    const entity = await fixtures.Entity();
+
+    await expect(
+      routerClient.entities.catalog({ entity: entity.id }),
+    ).resolves.toEqual({
+      totalBottles: 0,
+      relationships: { brand: 0, bottler: 0, distiller: 0 },
+      distilleryCoverage: { documented: 0, total: 0 },
+      categories: [],
+      related: { brands: [], bottlers: [], distillers: [] },
+      notableBottles: [],
+    });
+  });
+
+  test("throws for an unknown entity", async () => {
+    const err = await waitError(
+      routerClient.entities.catalog({ entity: 999999 }),
+    );
+
+    expect(err).toMatchInlineSnapshot(`[Error: Entity not found.]`);
+  });
+});

--- a/apps/server/src/orpc/routes/entities/catalog.ts
+++ b/apps/server/src/orpc/routes/entities/catalog.ts
@@ -1,0 +1,209 @@
+import { db } from "@peated/server/db";
+import {
+  bottleTombstones,
+  bottles,
+  bottlesToDistillers,
+  entities,
+} from "@peated/server/db/schema";
+import { procedure } from "@peated/server/orpc";
+import { CategoryEnum } from "@peated/server/schemas";
+import { and, asc, desc, eq, isNotNull, ne, or, sql } from "drizzle-orm";
+import { z } from "zod";
+
+const RelatedEntitySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  shortName: z.string().nullable(),
+  count: z.number(),
+});
+
+const activeBottleWhere = (entityId: number) =>
+  and(
+    isNotNull(bottles.groupId),
+    sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
+    or(
+      eq(bottles.brandId, entityId),
+      eq(bottles.bottlerId, entityId),
+      sql`EXISTS(
+        SELECT FROM ${bottlesToDistillers}
+        WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
+          AND ${bottlesToDistillers.distillerId} = ${entityId}
+      )`,
+    ),
+  );
+
+export default procedure
+  .route({
+    method: "GET",
+    path: "/entities/{entity}/catalog",
+    summary: "Get an entity catalog summary",
+    description:
+      "Summarize bottle roles, categories, and related entities for a brand, bottler, or distiller",
+    spec: (spec) => ({ ...spec, operationId: "getEntityCatalog" }),
+  })
+  .input(z.object({ entity: z.coerce.number() }))
+  .output(
+    z.object({
+      totalBottles: z.number(),
+      relationships: z.object({
+        brand: z.number(),
+        bottler: z.number(),
+        distiller: z.number(),
+      }),
+      distilleryCoverage: z.object({
+        documented: z.number(),
+        total: z.number(),
+      }),
+      categories: z.array(
+        z.object({
+          category: CategoryEnum.nullable(),
+          count: z.number(),
+        }),
+      ),
+      related: z.object({
+        brands: z.array(RelatedEntitySchema),
+        bottlers: z.array(RelatedEntitySchema),
+        distillers: z.array(RelatedEntitySchema),
+      }),
+      notableBottles: z.array(
+        z.object({
+          id: z.number(),
+          fullName: z.string(),
+          totalTastings: z.number(),
+          avgRating: z.number().nullable(),
+        }),
+      ),
+    }),
+  )
+  .handler(async function ({ input, errors }) {
+    const [entity] = await db
+      .select({ id: entities.id })
+      .from(entities)
+      .where(eq(entities.id, input.entity));
+    if (!entity) {
+      throw errors.NOT_FOUND({ message: "Entity not found." });
+    }
+
+    const associatedBottle = activeBottleWhere(entity.id);
+    const [
+      counts,
+      categoryRows,
+      brandRows,
+      bottlerRows,
+      distillerRows,
+      notableBottleRows,
+    ] = await Promise.all([
+      db
+        .select({
+          totalBottles: sql<string>`COUNT(*)`,
+          brand: sql<string>`COUNT(*) FILTER (WHERE ${bottles.brandId} = ${entity.id})`,
+          bottler: sql<string>`COUNT(*) FILTER (WHERE ${bottles.bottlerId} = ${entity.id})`,
+          distiller: sql<string>`COUNT(*) FILTER (WHERE EXISTS(
+              SELECT FROM ${bottlesToDistillers}
+              WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
+                AND ${bottlesToDistillers.distillerId} = ${entity.id}
+            ))`,
+          documentedDistillery: sql<string>`COUNT(*) FILTER (WHERE EXISTS(
+              SELECT FROM ${bottlesToDistillers}
+              WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
+            ))`,
+        })
+        .from(bottles)
+        .where(associatedBottle),
+      db
+        .select({
+          category: bottles.category,
+          count: sql<string>`COUNT(*)`,
+        })
+        .from(bottles)
+        .where(associatedBottle)
+        .groupBy(bottles.category)
+        .orderBy(desc(sql`COUNT(*)`), asc(bottles.category)),
+      db
+        .select({
+          id: entities.id,
+          name: entities.name,
+          shortName: entities.shortName,
+          count: sql<string>`COUNT(DISTINCT ${bottles.id})`,
+        })
+        .from(bottles)
+        .innerJoin(entities, eq(entities.id, bottles.brandId))
+        .where(and(associatedBottle, ne(entities.id, entity.id)))
+        .groupBy(entities.id)
+        .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
+        .limit(7),
+      db
+        .select({
+          id: entities.id,
+          name: entities.name,
+          shortName: entities.shortName,
+          count: sql<string>`COUNT(DISTINCT ${bottles.id})`,
+        })
+        .from(bottles)
+        .innerJoin(entities, eq(entities.id, bottles.bottlerId))
+        .where(and(associatedBottle, ne(entities.id, entity.id)))
+        .groupBy(entities.id)
+        .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
+        .limit(7),
+      db
+        .select({
+          id: entities.id,
+          name: entities.name,
+          shortName: entities.shortName,
+          count: sql<string>`COUNT(DISTINCT ${bottles.id})`,
+        })
+        .from(bottles)
+        .innerJoin(
+          bottlesToDistillers,
+          eq(bottlesToDistillers.bottleId, bottles.id),
+        )
+        .innerJoin(entities, eq(entities.id, bottlesToDistillers.distillerId))
+        .where(and(associatedBottle, ne(entities.id, entity.id)))
+        .groupBy(entities.id)
+        .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
+        .limit(7),
+      db
+        .select({
+          id: bottles.id,
+          fullName: bottles.fullName,
+          totalTastings: bottles.totalTastings,
+          avgRating: bottles.avgRating,
+        })
+        .from(bottles)
+        .where(associatedBottle)
+        .orderBy(desc(bottles.totalTastings), asc(bottles.fullName))
+        .limit(4),
+    ]);
+
+    const summary = counts[0];
+    if (!summary) {
+      throw new Error(`Missing catalog summary for Entity ${entity.id}.`);
+    }
+
+    const related = (rows: typeof brandRows) =>
+      rows.map((row) => ({ ...row, count: Number(row.count) }));
+    const totalBottles = Number(summary.totalBottles);
+
+    return {
+      totalBottles,
+      relationships: {
+        brand: Number(summary.brand),
+        bottler: Number(summary.bottler),
+        distiller: Number(summary.distiller),
+      },
+      distilleryCoverage: {
+        documented: Number(summary.documentedDistillery),
+        total: totalBottles,
+      },
+      categories: categoryRows.map((row) => ({
+        category: row.category,
+        count: Number(row.count),
+      })),
+      related: {
+        brands: related(brandRows),
+        bottlers: related(bottlerRows),
+        distillers: related(distillerRows),
+      },
+      notableBottles: notableBottleRows,
+    };
+  });

--- a/apps/server/src/orpc/routes/entities/index.ts
+++ b/apps/server/src/orpc/routes/entities/index.ts
@@ -1,6 +1,7 @@
 import { base } from "@peated/server/orpc";
 import aliases from "./aliases";
 import auditCandidates from "./audit-candidates";
+import catalog from "./catalog";
 import categories from "./categories";
 import classify from "./classify";
 import create from "./create";
@@ -12,6 +13,7 @@ import update from "./update";
 
 export default base.tag("entities").router({
   auditCandidates,
+  catalog,
   classify,
   details,
   list,

--- a/apps/web/src/app/(default)/entities/[entityId]/(tabs)/page.tsx
+++ b/apps/web/src/app/(default)/entities/[entityId]/(tabs)/page.tsx
@@ -3,6 +3,7 @@ import { use } from "react";
 
 import { MapIcon } from "@heroicons/react/24/outline";
 import RobotImage from "@peated/web/assets/robot.png";
+import EntityCatalogOverview from "@peated/web/components/entityCatalogOverview";
 import EntityMap from "@peated/web/components/entityMap";
 import Link from "@peated/web/components/link";
 import Markdown from "@peated/web/components/markdown";
@@ -43,6 +44,8 @@ export default function EntityDetails(props: {
             />
           </div>
         )}
+
+        <EntityCatalogOverview entity={entity} />
 
         <div className="prose prose-invert max-w-none flex-auto">
           <dl>

--- a/apps/web/src/components/entityCatalogOverview.tsx
+++ b/apps/web/src/components/entityCatalogOverview.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import { formatCategoryName } from "@peated/server/lib/format";
+import type { Outputs } from "@peated/server/orpc/router";
+import type { Entity } from "@peated/server/types";
+import Link from "@peated/web/components/link";
+import SimpleRatingIndicator from "@peated/web/components/simpleRatingIndicator";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+type Catalog = Outputs["entities"]["catalog"];
+type RelatedEntity = Catalog["related"]["distillers"][number];
+
+function RankedBars({
+  items,
+  maxCount,
+}: {
+  items: { id: string | number; label: string; count: number; href?: string }[];
+  maxCount: number;
+}) {
+  return (
+    <ol className="space-y-3">
+      {items.slice(0, 5).map((item) => (
+        <li key={item.id}>
+          <div className="mb-1 flex items-baseline justify-between gap-3 text-sm">
+            {item.href ? (
+              <Link href={item.href} className="truncate hover:underline">
+                {item.label}
+              </Link>
+            ) : (
+              <span className="truncate">{item.label}</span>
+            )}
+            <span className="text-muted tabular-nums">
+              {item.count.toLocaleString()}
+            </span>
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-slate-800">
+            <div
+              className="bg-highlight h-full rounded-full"
+              style={{
+                width: `${Math.max((item.count / maxCount) * 100, 2)}%`,
+              }}
+            />
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+function InsightCard({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <section className="rounded-lg border border-slate-800 bg-slate-900/40 p-4 sm:p-5">
+      <div className="mb-4">
+        <h3 className="font-semibold">{title}</h3>
+        {description ? (
+          <div className="text-muted mt-1 text-xs">{description}</div>
+        ) : null}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+function selectRelatedEntities(entity: Entity, catalog: Catalog) {
+  const views: {
+    title: string;
+    items: RelatedEntity[];
+    coverage?: ReactNode;
+  }[] = [];
+
+  const showSourceDistilleries =
+    catalog.related.distillers.length > 1 ||
+    (entity.type.includes("bottler") && catalog.related.distillers.length > 0);
+
+  if (showSourceDistilleries) {
+    const { documented, total } = catalog.distilleryCoverage;
+    views.push({
+      title: "Source distilleries",
+      items: catalog.related.distillers,
+      coverage:
+        total > 0
+          ? `Documented for ${documented.toLocaleString()} of ${total.toLocaleString()} bottles`
+          : undefined,
+    });
+  }
+  if (entity.type.includes("distiller") && catalog.related.bottlers.length) {
+    views.push({ title: "Bottled by", items: catalog.related.bottlers });
+  }
+  if (entity.type.includes("distiller") && catalog.related.brands.length) {
+    views.push({ title: "Released as", items: catalog.related.brands });
+  }
+
+  return views[0] ?? null;
+}
+
+export default function EntityCatalogOverview({ entity }: { entity: Entity }) {
+  const orpc = useORPC();
+  const { data: catalog } = useSuspenseQuery(
+    orpc.entities.catalog.queryOptions({ input: { entity: entity.id } }),
+  );
+
+  if (!catalog.totalBottles) return null;
+
+  const relationshipStats = [
+    { label: "as brand", count: catalog.relationships.brand },
+    { label: "bottled", count: catalog.relationships.bottler },
+    { label: "distilled", count: catalog.relationships.distiller },
+  ].filter((item) => item.count > 0);
+  const categoryItems = catalog.categories.map(({ category, count }) => ({
+    id: category ?? "uncategorized",
+    label: category ? formatCategoryName(category) : "Uncategorized",
+    count,
+    href: category
+      ? `/bottles?entity=${entity.id}&category=${encodeURIComponent(category)}`
+      : undefined,
+  }));
+  const relatedView = selectRelatedEntities(entity, catalog);
+
+  return (
+    <section className="my-8" aria-labelledby="catalog-heading">
+      <div className="mb-4 flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 id="catalog-heading" className="text-xl font-semibold">
+            Catalog at a glance
+          </h2>
+          <p className="text-muted mt-1 text-sm">
+            {catalog.totalBottles.toLocaleString()} associated bottles
+          </p>
+        </div>
+        <div className="text-muted mt-2 flex flex-wrap gap-2 text-xs sm:mt-0">
+          {relationshipStats.map((item) => (
+            <span
+              key={item.label}
+              className="rounded-full bg-slate-900 px-2.5 py-1"
+            >
+              {item.count.toLocaleString()} {item.label}
+            </span>
+          ))}
+        </div>
+      </div>
+
+      <div className={relatedView ? "grid gap-4 lg:grid-cols-2" : "grid gap-4"}>
+        {categoryItems.length ? (
+          <InsightCard title="Whisky types">
+            <RankedBars
+              items={categoryItems}
+              maxCount={Math.max(...categoryItems.map((item) => item.count))}
+            />
+          </InsightCard>
+        ) : null}
+
+        {relatedView ? (
+          <InsightCard
+            title={relatedView.title}
+            description={relatedView.coverage}
+          >
+            <RankedBars
+              items={relatedView.items.map((item) => ({
+                id: item.id,
+                label: item.shortName || item.name,
+                count: item.count,
+                href: `/entities/${item.id}`,
+              }))}
+              maxCount={Math.max(
+                ...relatedView.items.map((item) => item.count),
+              )}
+            />
+          </InsightCard>
+        ) : null}
+      </div>
+
+      {catalog.notableBottles.length ? (
+        <section className="mt-6" aria-labelledby="notable-bottles-heading">
+          <div className="mb-3 flex items-baseline justify-between gap-4">
+            <h3 id="notable-bottles-heading" className="font-semibold">
+              {catalog.notableBottles.some((bottle) => bottle.totalTastings > 0)
+                ? "Most tasted bottles"
+                : "Catalog bottles"}
+            </h3>
+            <Link
+              href={`/entities/${entity.id}/bottles?sort=-tastings`}
+              className="text-highlight text-sm hover:underline"
+            >
+              View all
+            </Link>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {catalog.notableBottles.map((bottle) => (
+              <article
+                key={bottle.id}
+                className="flex min-w-0 items-center justify-between gap-4 rounded-lg border border-slate-800 px-4 py-3"
+              >
+                <Link
+                  href={`/bottles/${bottle.id}`}
+                  className="min-w-0 flex-1 truncate font-semibold hover:underline"
+                  title={bottle.fullName}
+                >
+                  {bottle.fullName}
+                </Link>
+                <div className="flex shrink-0 items-center gap-3">
+                  <SimpleRatingIndicator avgRating={bottle.avgRating} />
+                  {bottle.totalTastings > 0 ? (
+                    <div className="text-right">
+                      <div className="font-semibold tabular-nums">
+                        {bottle.totalTastings.toLocaleString()}
+                      </div>
+                      <div className="text-muted text-[11px]">tastings</div>
+                    </div>
+                  ) : null}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </section>
+  );
+}


### PR DESCRIPTION
Entity overview pages now show a role-aware catalog summary with distinct associated bottle counts, whisky-type distribution, related entities, and the most-tasted releases. Bottler and brand pages emphasize source distilleries, while distiller pages emphasize who bottles or releases their whisky; brand-only pages suppress a single redundant source, and empty catalogs keep the existing overview unchanged.

The new anonymous `GET /entities/{entity}/catalog` endpoint aggregates active, grouped bottles without double-counting entities that have overlapping roles. Integration coverage exercises overlapping brand, bottler, and distiller relationships plus empty and unknown entities.

Server and web typechecks, formatting, lint, API checks, desktop/mobile QA, and accessibility checks pass. The targeted backend test is currently blocked during global setup by the existing duplicate `bottle_check_close_reason` migration state.
