### PR TITLE
fix(audits): preserve valid Bottle aliases during merges

### DIFF
--- a/apps/server/src/lib/bottleOperationReview.test.ts
+++ b/apps/server/src/lib/bottleOperationReview.test.ts
@@ -535,6 +535,71 @@ describe("Bottle operation review preparation", () => {
     });
   });
 
+  test("blocks only canonical alias owners outside both merge groups", async ({
+    fixtures,
+  }) => {
+    const sourceGroupBottle = await fixtures.Bottle({
+      name: "Alias Review Source Group",
+    });
+    const source = await fixtures.BottleGroupMember({
+      groupId: sourceGroupBottle.groupId!,
+      edition: "Duplicate Release",
+    });
+    const destinationGroupBottle = await fixtures.Bottle({
+      name: "Alias Review Destination Group",
+    });
+    const destination = await fixtures.BottleGroupMember({
+      groupId: destinationGroupBottle.groupId!,
+      edition: "Canonical Release",
+    });
+    const foreignOwner = await fixtures.Bottle({
+      name: "Alias Review Foreign Owner",
+    });
+    const operation = {
+      id: 12,
+      proposal: {
+        type: "merge_bottles",
+        input: {
+          sourceBottleId: source.id,
+          destinationBottleId: destination.id,
+        },
+        rationale: "The inspected records are exact duplicates.",
+        evidenceRefs: [
+          { kind: "bottle", bottleId: source.id },
+          { kind: "bottle", bottleId: destination.id },
+        ],
+      },
+    } as const;
+    const context = {
+      artifacts: artifacts({ bottleIds: [source.id, destination.id] }),
+    };
+
+    const allowedStateTokens: string[] = [];
+    for (const allowedOwner of [sourceGroupBottle, destinationGroupBottle]) {
+      await db
+        .update(bottleAliases)
+        .set({ bottleId: allowedOwner.id })
+        .where(eq(bottleAliases.name, source.fullName));
+      const prepared = await prepareOperation({ operation, ...context });
+      expect(prepared).toMatchObject({ status: "pending_review" });
+      if (prepared.status !== "blocked" && prepared.type === "merge_bottles") {
+        allowedStateTokens.push(prepared.stateToken.relationshipDigest);
+      }
+    }
+    expect(allowedStateTokens[0]).not.toBe(allowedStateTokens[1]);
+
+    await db
+      .update(bottleAliases)
+      .set({ bottleId: foreignOwner.id })
+      .where(eq(bottleAliases.name, source.fullName));
+    await expect(
+      prepareOperation({ operation, ...context }),
+    ).resolves.toMatchObject({
+      status: "blocked",
+      preparationError: { code: "identity_collision" },
+    });
+  });
+
   test("blocks only invalid or conflicting proposals and keeps valid siblings", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/bottleOperationReview/bottleMerge.ts
+++ b/apps/server/src/lib/bottleOperationReview/bottleMerge.ts
@@ -293,11 +293,7 @@ async function bottleMergeRelationshipState(
     .where(inArray(bottleTombstones.newBottleId, bottleIds))
     .orderBy(asc(bottleTombstones.bottleId));
   const [canonicalAlias] = await database
-    .select({
-      name: bottleAliases.name,
-      bottleId: bottleAliases.bottleId,
-      ignored: bottleAliases.ignored,
-    })
+    .select({ bottleId: bottleAliases.bottleId })
     .from(bottleAliases)
     .where(
       eq(
@@ -320,7 +316,7 @@ async function bottleMergeRelationshipState(
     matchAttempts: matchAttemptRows,
     tags: tagRows,
     flavorProfiles: flavorRows,
-    canonicalAlias: canonicalAlias ?? null,
+    canonicalAliasBottleId: canonicalAlias?.bottleId ?? null,
     incomingTombstones: tombstoneRows.filter(
       (
         row,
@@ -357,16 +353,12 @@ export async function prepareBottleMerge(
     source,
     destination,
   );
-  const canonicalAliasOwnerId = relationships.canonicalAlias?.bottleId;
-  const mergeGroupBottleIds = new Set(
-    relationships.bottleGroups.flatMap(
-      ({ memberBottleIds }) => memberBottleIds,
-    ),
-  );
+  const canonicalAliasOwnerId = relationships.canonicalAliasBottleId;
   if (
     canonicalAliasOwnerId !== null &&
-    canonicalAliasOwnerId !== undefined &&
-    !mergeGroupBottleIds.has(canonicalAliasOwnerId)
+    !relationships.bottles.some(
+      ({ bottleId }) => bottleId === canonicalAliasOwnerId,
+    )
   ) {
     fail(
       "identity_collision",

--- a/apps/server/src/lib/bottleOperationReview/bottleMerge.ts
+++ b/apps/server/src/lib/bottleOperationReview/bottleMerge.ts
@@ -292,6 +292,20 @@ async function bottleMergeRelationshipState(
     .from(bottleTombstones)
     .where(inArray(bottleTombstones.newBottleId, bottleIds))
     .orderBy(asc(bottleTombstones.bottleId));
+  const [canonicalAlias] = await database
+    .select({
+      name: bottleAliases.name,
+      bottleId: bottleAliases.bottleId,
+      ignored: bottleAliases.ignored,
+    })
+    .from(bottleAliases)
+    .where(
+      eq(
+        sql`LOWER(${bottleAliases.name})`,
+        source.bottle.fullName.toLowerCase(),
+      ),
+    )
+    .limit(1);
   return {
     bottleGroups: bottleGroupsState,
     bottles: bottleStates,
@@ -306,6 +320,7 @@ async function bottleMergeRelationshipState(
     matchAttempts: matchAttemptRows,
     tags: tagRows,
     flavorProfiles: flavorRows,
+    canonicalAlias: canonicalAlias ?? null,
     incomingTombstones: tombstoneRows.filter(
       (
         row,
@@ -342,6 +357,22 @@ export async function prepareBottleMerge(
     source,
     destination,
   );
+  const canonicalAliasOwnerId = relationships.canonicalAlias?.bottleId;
+  const mergeGroupBottleIds = new Set(
+    relationships.bottleGroups.flatMap(
+      ({ memberBottleIds }) => memberBottleIds,
+    ),
+  );
+  if (
+    canonicalAliasOwnerId !== null &&
+    canonicalAliasOwnerId !== undefined &&
+    !mergeGroupBottleIds.has(canonicalAliasOwnerId)
+  ) {
+    fail(
+      "identity_collision",
+      `Bottle identity "${source.bottle.fullName}" conflicts with an alias assigned to Bottle ${canonicalAliasOwnerId}.`,
+    );
+  }
   const collisionTotal =
     impact.membershipCollisions.collections +
     impact.membershipCollisions.flights;

--- a/apps/server/src/lib/mergeConcreteBottles.test.ts
+++ b/apps/server/src/lib/mergeConcreteBottles.test.ts
@@ -581,6 +581,47 @@ describe("exact Bottle merges", () => {
     ).toBeUndefined();
   });
 
+  test("keeps a canonical alias assigned to a surviving destination-group Bottle", async ({
+    fixtures,
+  }) => {
+    const actor = await getUserActor(await fixtures.User({ mod: true }));
+    const source = await fixtures.Bottle({
+      name: "Destination Group Alias Source",
+    });
+    const destinationGroupBottle = await fixtures.Bottle({
+      name: "Destination Group Alias Owner",
+    });
+    const destination = await fixtures.BottleGroupMember({
+      groupId: destinationGroupBottle.groupId!,
+      edition: "Canonical Release",
+    });
+    const [canonicalAlias] = await db
+      .update(bottleAliases)
+      .set({ bottleId: destinationGroupBottle.id })
+      .where(eq(bottleAliases.name, source.fullName))
+      .returning();
+    if (!canonicalAlias) throw new Error("Expected the canonical alias.");
+
+    await db.transaction((tx) =>
+      mergeConcreteBottlesInTransaction(tx, {
+        sourceBottleId: source.id,
+        destinationBottleId: destination.id,
+        actorId: actor.id,
+      }),
+    );
+
+    expect(
+      await db.query.bottleAliases.findFirst({
+        where: eq(bottleAliases.name, canonicalAlias.name),
+      }),
+    ).toMatchObject({ bottleId: destinationGroupBottle.id });
+    expect(
+      await db.query.bottles.findFirst({
+        where: eq(bottles.id, source.id),
+      }),
+    ).toBeUndefined();
+  });
+
   test("claims an unassigned canonical alias for the destination", async ({
     fixtures,
   }) => {
@@ -614,7 +655,7 @@ describe("exact Bottle merges", () => {
     });
   });
 
-  test("rejects a canonical alias assigned outside the source group", async ({
+  test("rejects a canonical alias assigned outside both merge groups", async ({
     fixtures,
   }) => {
     const actor = await getUserActor(await fixtures.User({ mod: true }));

--- a/apps/server/src/lib/mergeConcreteBottles.test.ts
+++ b/apps/server/src/lib/mergeConcreteBottles.test.ts
@@ -540,6 +540,114 @@ describe("exact Bottle merges", () => {
     ).toMatchObject({ newBottleId: destination.id });
   });
 
+  test("keeps a canonical alias assigned to a surviving source-group Bottle", async ({
+    fixtures,
+  }) => {
+    const actor = await getUserActor(await fixtures.User({ mod: true }));
+    const sourceGroupBottle = await fixtures.Bottle({
+      name: "Retained General Bottle",
+    });
+    const source = await fixtures.BottleGroupMember({
+      groupId: sourceGroupBottle.groupId!,
+      edition: "Duplicate Release",
+    });
+    const destination = await fixtures.Bottle({
+      name: "Canonical Release",
+    });
+    const [canonicalAlias] = await db
+      .update(bottleAliases)
+      .set({ bottleId: sourceGroupBottle.id })
+      .where(eq(bottleAliases.name, source.fullName))
+      .returning();
+    if (!canonicalAlias) throw new Error("Expected the canonical alias.");
+
+    await db.transaction((tx) =>
+      mergeConcreteBottlesInTransaction(tx, {
+        sourceBottleId: source.id,
+        destinationBottleId: destination.id,
+        actorId: actor.id,
+      }),
+    );
+
+    expect(
+      await db.query.bottleAliases.findFirst({
+        where: eq(bottleAliases.name, canonicalAlias.name),
+      }),
+    ).toMatchObject({ bottleId: sourceGroupBottle.id });
+    expect(
+      await db.query.bottles.findFirst({
+        where: eq(bottles.id, source.id),
+      }),
+    ).toBeUndefined();
+  });
+
+  test("claims an unassigned canonical alias for the destination", async ({
+    fixtures,
+  }) => {
+    const actor = await getUserActor(await fixtures.User({ mod: true }));
+    const source = await fixtures.Bottle({ name: "Unassigned Alias Source" });
+    const destination = await fixtures.Bottle({
+      name: "Unassigned Alias Destination",
+    });
+    await db
+      .update(bottleAliases)
+      .set({ bottleId: null, ignored: true })
+      .where(eq(bottleAliases.name, source.fullName));
+
+    await db.transaction((tx) =>
+      mergeConcreteBottlesInTransaction(tx, {
+        sourceBottleId: source.id,
+        destinationBottleId: destination.id,
+        actorId: actor.id,
+      }),
+    );
+
+    expect(
+      await db.query.bottleAliases.findFirst({
+        where: eq(bottleAliases.name, source.fullName),
+      }),
+    ).toMatchObject({
+      bottleId: destination.id,
+      ignored: false,
+      assignmentSource: "human_approved",
+      assignedByActorId: actor.id,
+    });
+  });
+
+  test("rejects a canonical alias assigned outside the source group", async ({
+    fixtures,
+  }) => {
+    const actor = await getUserActor(await fixtures.User({ mod: true }));
+    const source = await fixtures.Bottle({ name: "Reserved Alias Source" });
+    const destination = await fixtures.Bottle({
+      name: "Reserved Alias Destination",
+    });
+    const conflictingBottle = await fixtures.Bottle({
+      name: "Reserved Alias Owner",
+    });
+    await db
+      .update(bottleAliases)
+      .set({ bottleId: conflictingBottle.id })
+      .where(eq(bottleAliases.name, source.fullName));
+
+    await expect(
+      db.transaction((tx) =>
+        mergeConcreteBottlesInTransaction(tx, {
+          sourceBottleId: source.id,
+          destinationBottleId: destination.id,
+          actorId: actor.id,
+        }),
+      ),
+    ).rejects.toEqual(
+      new ConcreteBottleMergeConflictError("identity_conflict"),
+    );
+    expect(
+      await db.query.bottles.findFirst({
+        where: eq(bottles.id, source.id),
+      }),
+    ).toBeDefined();
+  });
+
   test("rolls back when direct tasting identity would collide", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/mergeConcreteBottles.ts
+++ b/apps/server/src/lib/mergeConcreteBottles.ts
@@ -29,10 +29,6 @@ import {
   tastings,
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
-import {
-  ExactBottleAliasConflictError,
-  reserveLiteralCanonicalBottleAliasInTransaction,
-} from "@peated/server/lib/bottleAliases";
 import { logError } from "@peated/server/lib/log";
 import { recomputeBottleGroupStatsInTransaction } from "@peated/server/lib/recomputeBottleGroupStats";
 import { recomputeBottleStatsInTransaction } from "@peated/server/lib/recomputeBottleStats";
@@ -736,16 +732,10 @@ export async function mergeConcreteBottlesInTransaction(
     .where(sql`LOWER(${bottleAliases.name}) = LOWER(${source.fullName})`)
     .limit(1)
     .for("update");
-  const canonicalAliasOwner = canonicalAlias?.bottleId
-    ? bottleById.get(canonicalAlias.bottleId)
-    : null;
+  const canonicalAliasOwnerId = canonicalAlias?.bottleId;
   if (
-    canonicalAlias &&
-    canonicalAlias.bottleId !== null &&
-    canonicalAlias.bottleId !== sourceBottleId &&
-    canonicalAlias.bottleId !== destinationBottleId &&
-    canonicalAliasOwner?.groupId !== sourceGroupId &&
-    canonicalAliasOwner?.groupId !== destinationGroupId
+    typeof canonicalAliasOwnerId === "number" &&
+    !bottleById.has(canonicalAliasOwnerId)
   ) {
     throw new ConcreteBottleMergeConflictError("identity_conflict");
   }
@@ -774,22 +764,25 @@ export async function mergeConcreteBottlesInTransaction(
     .update(bottleAliases)
     .set({ bottleId: destinationBottleId })
     .where(eq(bottleAliases.bottleId, sourceBottleId));
-  if (!canonicalAlias || canonicalAlias.bottleId === null) {
-    try {
-      await reserveLiteralCanonicalBottleAliasInTransaction(tx, {
+  if (!canonicalAlias) {
+    await tx.insert(bottleAliases).values({
+      name: source.fullName,
+      bottleId: destinationBottleId,
+      assignmentSource: "human_approved",
+      assignedByActorId: actorId,
+    });
+  } else if (canonicalAlias.bottleId === null) {
+    await tx
+      .update(bottleAliases)
+      .set({
         name: source.fullName,
         bottleId: destinationBottleId,
+        ignored: false,
+        embedding: null,
         assignmentSource: "human_approved",
         assignedByActorId: actorId,
-      });
-    } catch (error) {
-      if (error instanceof ExactBottleAliasConflictError) {
-        throw new ConcreteBottleMergeConflictError("identity_conflict", {
-          cause: error,
-        });
-      }
-      throw error;
-    }
+      })
+      .where(eq(bottleAliases.name, canonicalAlias.name));
   }
 
   const sourceTags = await tx

--- a/apps/server/src/lib/mergeConcreteBottles.ts
+++ b/apps/server/src/lib/mergeConcreteBottles.ts
@@ -744,7 +744,8 @@ export async function mergeConcreteBottlesInTransaction(
     canonicalAlias.bottleId !== null &&
     canonicalAlias.bottleId !== sourceBottleId &&
     canonicalAlias.bottleId !== destinationBottleId &&
-    canonicalAliasOwner?.groupId !== sourceGroupId
+    canonicalAliasOwner?.groupId !== sourceGroupId &&
+    canonicalAliasOwner?.groupId !== destinationGroupId
   ) {
     throw new ConcreteBottleMergeConflictError("identity_conflict");
   }

--- a/apps/server/src/lib/mergeConcreteBottles.ts
+++ b/apps/server/src/lib/mergeConcreteBottles.ts
@@ -29,6 +29,10 @@ import {
   tastings,
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
+import {
+  ExactBottleAliasConflictError,
+  reserveLiteralCanonicalBottleAliasInTransaction,
+} from "@peated/server/lib/bottleAliases";
 import { logError } from "@peated/server/lib/log";
 import { recomputeBottleGroupStatsInTransaction } from "@peated/server/lib/recomputeBottleGroupStats";
 import { recomputeBottleStatsInTransaction } from "@peated/server/lib/recomputeBottleStats";
@@ -732,10 +736,15 @@ export async function mergeConcreteBottlesInTransaction(
     .where(sql`LOWER(${bottleAliases.name}) = LOWER(${source.fullName})`)
     .limit(1)
     .for("update");
+  const canonicalAliasOwner = canonicalAlias?.bottleId
+    ? bottleById.get(canonicalAlias.bottleId)
+    : null;
   if (
     canonicalAlias &&
+    canonicalAlias.bottleId !== null &&
     canonicalAlias.bottleId !== sourceBottleId &&
-    canonicalAlias.bottleId !== destinationBottleId
+    canonicalAlias.bottleId !== destinationBottleId &&
+    canonicalAliasOwner?.groupId !== sourceGroupId
   ) {
     throw new ConcreteBottleMergeConflictError("identity_conflict");
   }
@@ -764,13 +773,22 @@ export async function mergeConcreteBottlesInTransaction(
     .update(bottleAliases)
     .set({ bottleId: destinationBottleId })
     .where(eq(bottleAliases.bottleId, sourceBottleId));
-  if (!canonicalAlias) {
-    await tx.insert(bottleAliases).values({
-      name: source.fullName,
-      bottleId: destinationBottleId,
-      assignmentSource: "human_approved",
-      assignedByActorId: actorId,
-    });
+  if (!canonicalAlias || canonicalAlias.bottleId === null) {
+    try {
+      await reserveLiteralCanonicalBottleAliasInTransaction(tx, {
+        name: source.fullName,
+        bottleId: destinationBottleId,
+        assignmentSource: "human_approved",
+        assignedByActorId: actorId,
+      });
+    } catch (error) {
+      if (error instanceof ExactBottleAliasConflictError) {
+        throw new ConcreteBottleMergeConflictError("identity_conflict", {
+          cause: error,
+        });
+      }
+      throw error;
+    }
   }
 
   const sourceTags = await tx


### PR DESCRIPTION
Concrete Bottle merges now preserve a canonical alias when it belongs to any surviving member of either merge group and claim unresolved aliases for the destination. Aliases owned outside both groups remain typed identity conflicts.

Audit preparation now includes canonical-alias ownership in the relationship digest, blocks genuine foreign-owner collisions before approval, and invalidates stale approvals if ownership changes. Focused integration coverage exercises source- and destination-group siblings, unresolved aliases, and foreign owners.