### PR TITLE
fix(classifier): decode entity search results

### DIFF
--- a/apps/server/src/lib/classifierEntitySearch.test.ts
+++ b/apps/server/src/lib/classifierEntitySearch.test.ts
@@ -1,3 +1,4 @@
+import { EntityResolutionSchema } from "@peated/bottle-classifier/internal/types";
 import { searchClassifierEntities } from "@peated/server/lib/classifierEntitySearch";
 
 describe("searchClassifierEntities", () => {
@@ -30,6 +31,31 @@ describe("searchClassifierEntities", () => {
 
     expect(fuzzyResults.map((result) => result.entityId)).not.toContain(
       entity.id,
+    );
+  });
+
+  test("returns schema-valid full-text entity matches", async ({
+    fixtures,
+  }) => {
+    const entity = await fixtures.Entity({
+      name: "Ichiro’s Malt",
+      type: ["brand"],
+    });
+
+    const results = await searchClassifierEntities({
+      query: "Ichiro's Malt",
+      type: "brand",
+      limit: 10,
+    });
+
+    expect(
+      results.map((result) => EntityResolutionSchema.parse(result)),
+    ).toEqual(results);
+    expect(results).toContainEqual(
+      expect.objectContaining({
+        entityId: entity.id,
+        type: ["brand"],
+      }),
     );
   });
 

--- a/apps/server/src/lib/classifierEntitySearch.ts
+++ b/apps/server/src/lib/classifierEntitySearch.ts
@@ -113,28 +113,28 @@ export async function searchClassifierEntities(
     });
   }
 
-  const textMatches = await db.execute<{
-    entityId: number;
-    name: string;
-    shortName: string | null;
-    type: string[];
-    score: number | null;
-  }>(sql`
-    SELECT
-      ${entities.id} AS "entityId",
-      ${entities.name} AS "name",
-      ${entities.shortName} AS "shortName",
-      ${entities.type} AS "type",
-      ts_rank(${entities.searchVector}, websearch_to_tsquery('english', ${args.query})) AS score
-    FROM ${entities}
-    WHERE ${entities.searchVector} IS NOT NULL
-      AND ${entities.searchVector} @@ websearch_to_tsquery('english', ${args.query})
-      ${args.type ? sql`AND ${args.type} = ANY(${entities.type})` : sql``}
-    ORDER BY score DESC, ${entities.name} ASC
-    LIMIT ${args.limit}
-  `);
+  const textQuery = sql`websearch_to_tsquery('english', ${args.query})`;
+  const textScore = sql<number>`ts_rank(${entities.searchVector}, ${textQuery})`;
+  const textMatches = await db
+    .select({
+      entityId: entities.id,
+      name: entities.name,
+      shortName: entities.shortName,
+      type: entities.type,
+      score: textScore,
+    })
+    .from(entities)
+    .where(
+      and(
+        sql`${entities.searchVector} IS NOT NULL`,
+        sql`${entities.searchVector} @@ ${textQuery}`,
+        args.type ? sql`${args.type} = ANY(${entities.type})` : undefined,
+      ),
+    )
+    .orderBy(sql`${textScore} DESC`, entities.name)
+    .limit(args.limit);
 
-  for (const row of textMatches.rows) {
+  for (const row of textMatches) {
     mergeResult(results, {
       entityId: row.entityId,
       name: row.name,


### PR DESCRIPTION
Entity full-text search now selects schema-backed columns through Drizzle, so bigint IDs and enum-array roles are decoded before results reach classifier contract validation. This prevents valid producer lookups from aborting bottle audits before they can propose catalog changes.

Regression coverage recreates the straight-apostrophe lookup for a curly-apostrophe “Ichiro’s Malt” entity and validates every result against `EntityResolutionSchema`. Search matching and ranking behavior remain unchanged.
