### PR TITLE
feat(prices): persist classifier Bottle checks

### DIFF
--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -225,53 +225,59 @@ async function countBottles() {
 }
 
 function normalizeMockBottleClassifierDecision(decision: Record<string, any>) {
-  if (
-    decision.action === "match" ||
-    decision.action === "create_bottle" ||
-    decision.action === "repair_bottle" ||
-    decision.action === "no_match"
-  ) {
-    return {
-      identityScope: "product",
-      observation: null,
-      ...decision,
-    };
-  }
+  const action =
+    decision.action === "match_existing" || decision.action === "correction"
+      ? "match"
+      : decision.action === "create_new"
+        ? "create_bottle"
+        : decision.action;
+  const base = {
+    rationale: decision.rationale ?? null,
+    candidateBottleIds: decision.candidateBottleIds ?? [],
+    identityScope: decision.identityScope ?? "product",
+    aliasScope: decision.aliasScope,
+    observation: decision.observation ?? null,
+    identityBasis: decision.identityBasis ?? null,
+    confidenceBasis: decision.confidenceBasis ?? null,
+  };
 
-  if (
-    decision.action === "match_existing" ||
-    decision.action === "correction"
-  ) {
+  if (action === "match") {
     return {
-      action: "match",
-      confidence: decision.confidence ?? 0,
-      rationale: decision.rationale ?? null,
-      candidateBottleIds: decision.candidateBottleIds ?? [],
-      identityScope: decision.identityScope ?? "product",
-      observation: decision.observation ?? null,
-      identityBasis: decision.identityBasis ?? null,
-      confidenceBasis: decision.confidenceBasis ?? null,
-      matchedBottleId: decision.suggestedBottleId,
+      ...base,
+      action,
+      matchedBottleId: decision.matchedBottleId ?? decision.suggestedBottleId,
       proposedBottle: null,
     };
   }
 
-  if (decision.action === "create_new") {
+  if (action === "create_bottle") {
     return {
-      action: "create_bottle",
-      confidence: decision.confidence ?? 0,
-      rationale: decision.rationale ?? null,
-      candidateBottleIds: decision.candidateBottleIds ?? [],
-      identityScope: decision.identityScope ?? "product",
-      observation: decision.observation ?? null,
-      identityBasis: decision.identityBasis ?? null,
-      confidenceBasis: decision.confidenceBasis ?? null,
+      ...base,
+      action,
       matchedBottleId: null,
       proposedBottle: decision.proposedBottle ?? null,
     };
   }
 
-  return decision;
+  if (action === "repair_bottle") {
+    return {
+      ...base,
+      action,
+      matchedBottleId: decision.matchedBottleId,
+      proposedBottle: decision.proposedBottle ?? null,
+    };
+  }
+
+  if (action === "no_match") {
+    return {
+      ...base,
+      action,
+      matchedBottleId: null,
+      proposedBottle: null,
+    };
+  }
+
+  return { ...base, action };
 }
 
 describe("priceMatching", () => {
@@ -2538,9 +2544,7 @@ describe("priceMatching", () => {
       }),
     );
 
-    const proposal = await resolveStorePriceMatchProposal(price.id, {
-      generateBottleCheck: true,
-    });
+    const proposal = await resolveStorePriceMatchProposal(price.id);
 
     expect(proposal.status).toBe("pending_review");
     expect(proposal.proposalType).toBe("correction");
@@ -7830,9 +7834,7 @@ describe("priceMatching", () => {
     });
   });
 
-  test("does not persist a Bottle check when the caller opts out", async ({
-    fixtures,
-  }) => {
+  test("persists a linked Bottle check by default", async ({ fixtures }) => {
     const { classifyBottleReference } =
       await import("@peated/server/agents/bottleClassifier");
     const bottle = await fixtures.Bottle();
@@ -7869,9 +7871,7 @@ describe("priceMatching", () => {
       }),
     );
 
-    const proposal = await resolveStorePriceMatchProposal(price.id, {
-      generateBottleCheck: false,
-    });
+    const proposal = await resolveStorePriceMatchProposal(price.id);
 
     expect(proposal).toMatchObject({
       status: "pending_review",
@@ -7879,8 +7879,82 @@ describe("priceMatching", () => {
       suggestedBottleId: bottle.id,
     });
     expect(await db.select().from(storePriceMatchAttempts)).toHaveLength(1);
+    expect(await db.select().from(bottleChecks)).toEqual([
+      expect.objectContaining({
+        intent: "resolve_reference",
+        sourceKind: "store_price",
+        sourceId: String(price.id),
+        storePriceMatchProposalId: proposal.id,
+      }),
+    ]);
+    expect(await db.select().from(bottleOperations)).toEqual([
+      expect.objectContaining({
+        status: "blocked",
+        preparationError: expect.objectContaining({
+          code: "target_not_inspected",
+        }),
+      }),
+    ]);
+  });
+
+  test("does not retain a successful match when its linked check cannot persist", async ({
+    fixtures,
+  }) => {
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
+    const bottle = await fixtures.Bottle();
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      name: "Unpersistable Classifier Evidence",
+      imageUrl: null,
+    });
+    const candidate = await getBottleCandidateById(bottle.id);
+    expect(candidate).not.toBeNull();
+    vi.mocked(classifyBottleReference).mockResolvedValue(
+      buildMockBottleReferenceClassification({
+        decision: {
+          action: "match",
+          rationale: "The source matches the inspected Bottle.",
+          candidateBottleIds: [bottle.id],
+          aliasScope: "none",
+          matchedBottleId: bottle.id,
+          proposedBottle: null,
+        },
+        candidateBottles: [candidate],
+        proposedOperations: [],
+        findings: [
+          {
+            scope: "bottle",
+            summary: "This finding cites evidence the run did not collect.",
+            evidenceRefs: [
+              {
+                kind: "web_result",
+                url: "https://example.com/missing-evidence",
+              },
+            ],
+          },
+        ],
+      }),
+    );
+
+    const proposal = await resolveStorePriceMatchProposal(price.id);
+
+    expect(proposal).toMatchObject({
+      status: "errored",
+      proposalType: "no_match",
+      suggestedBottleId: null,
+      error: expect.stringContaining(
+        "Evidence reference was not collected by this Bottle check",
+      ),
+    });
+    expect(await db.select().from(storePriceMatchAttempts)).toEqual([
+      expect.objectContaining({
+        proposalId: proposal.id,
+        initialStatus: "errored",
+        finalStatus: "errored",
+      }),
+    ]);
     expect(await db.select().from(bottleChecks)).toHaveLength(0);
-    expect(await db.select().from(bottleOperations)).toHaveLength(0);
   });
 
   test("blocks a proposal that would retire the classifier's matched Bottle", async ({
@@ -7937,9 +8011,7 @@ describe("priceMatching", () => {
       }),
     );
 
-    const proposal = await resolveStorePriceMatchProposal(price.id, {
-      generateBottleCheck: true,
-    });
+    const proposal = await resolveStorePriceMatchProposal(price.id);
     const check = await db.query.bottleChecks.findFirst({
       where: eq(bottleChecks.storePriceMatchProposalId, proposal.id),
       with: { operations: true },
@@ -8038,7 +8110,6 @@ describe("priceMatching", () => {
     const firstProposal = await resolveStorePriceMatchProposal(price.id);
     const secondProposal = await resolveStorePriceMatchProposal(price.id, {
       force: true,
-      generateBottleCheck: true,
     });
 
     expect(secondProposal).toMatchObject({
@@ -8061,8 +8132,10 @@ describe("priceMatching", () => {
       with: { operations: true },
     });
     expect(attempts).toHaveLength(2);
-    expect(checks).toHaveLength(1);
-    expect(checks[0]?.storePriceMatchAttemptId).toBe(attempts[1]?.id);
+    expect(checks).toHaveLength(2);
+    expect(
+      checks.map(({ storePriceMatchAttemptId }) => storePriceMatchAttemptId),
+    ).toEqual(expect.arrayContaining(attempts.map(({ id }) => id)));
     expect(classifyBottleReference).toHaveBeenNthCalledWith(
       1,
       expect.any(Object),
@@ -8126,9 +8199,7 @@ describe("priceMatching", () => {
       }),
     );
 
-    const proposal = await resolveStorePriceMatchProposal(price.id, {
-      generateBottleCheck: true,
-    });
+    const proposal = await resolveStorePriceMatchProposal(price.id);
     const attempt = await db.query.storePriceMatchAttempts.findFirst({
       where: eq(storePriceMatchAttempts.proposalId, proposal.id),
     });

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -730,49 +730,38 @@ async function recordStorePriceMatchAttempt({
   return attempt;
 }
 
-async function tryPersistStorePriceBottleCheck({
-  attempt,
+async function persistStorePriceBottleCheck({
+  attemptId,
   classificationInput,
   classification,
+  database,
+  model,
   modelMetadata,
-  price,
-  proposal,
+  priceId,
 }: {
-  attempt: { id: number; suggestedBottleId: number | null };
+  attemptId: number;
   classificationInput: ClassifyBottleReferenceInput;
   classification: BottleClassificationResult;
+  database: AnyDatabase;
+  model: StorePriceMatchProposal["model"];
   modelMetadata: BottleReferenceRun["modelMetadata"];
-  price: StorePrice;
-  proposal: StorePriceMatchProposal;
+  priceId: number;
 }) {
-  try {
-    await createBottleCheck({
+  await createBottleCheck(
+    {
       intent: "resolve_reference",
       sourceKind: "store_price",
-      sourceId: price.id,
+      sourceId: priceId,
       input: classificationInput,
       result: classification,
       storePrice: {
-        attemptId: attempt.id,
+        attemptId,
       },
-      model: proposal.model,
+      model,
       modelMetadata,
-    });
-  } catch (error) {
-    logError(error, {
-      price: {
-        id: price.id,
-        name: price.name,
-      },
-      proposal: {
-        id: proposal.id,
-      },
-      extra: {
-        attemptId: attempt.id,
-        phase: "persist_store_price_bottle_check",
-      },
-    });
-  }
+    },
+    database,
+  );
 }
 
 async function markLatestStorePriceMatchAttemptFinalInTransaction(
@@ -1284,18 +1273,20 @@ export async function createBottleFromStorePriceMatchProposal({
   };
 }
 
+/**
+ * Owns full store-price classification persistence: the proposal, attempt, and
+ * linked Bottle check commit together before any automated catalog mutation.
+ */
 export async function resolveStorePriceMatchProposal(
   priceId: number,
   {
     candidateExpansion = "open",
     force = false,
-    generateBottleCheck = false,
     processingToken,
     reuseExistingExtraction = false,
   }: {
     candidateExpansion?: CandidateExpansionMode;
     force?: boolean;
-    generateBottleCheck?: boolean;
     processingToken?: string;
     reuseExistingExtraction?: boolean;
   } = {},
@@ -1349,7 +1340,6 @@ export async function resolveStorePriceMatchProposal(
   let candidates: PriceMatchCandidate[] = [];
   let searchEvidence: SearchEvidence[] = [];
   let classificationModelMetadata: BottleReferenceRun["modelMetadata"] = null;
-  const shouldGenerateBottleCheck = generateBottleCheck;
   try {
     // Price matching consumes the generic bottle classifier and only layers
     // price-specific persistence and automation policy on top of its result.
@@ -1393,13 +1383,22 @@ export async function resolveStorePriceMatchProposal(
           expectedProcessingToken: processingToken,
           tx,
         });
-      const ignoredResult = await db.transaction(async (tx) => {
+      const ignoredProposal = await db.transaction(async (tx) => {
         const proposal = await upsertIgnoredProposal(tx);
         const attempt = await recordStorePriceMatchAttempt({ proposal, tx });
+        await persistStorePriceBottleCheck({
+          attemptId: attempt.id,
+          classificationInput,
+          classification,
+          database: tx,
+          model: proposal.model,
+          modelMetadata: classificationModelMetadata,
+          priceId: price.id,
+        });
         if (
           !canClearIgnoredStorePriceAssignment({ proposal, processingToken })
         ) {
-          return { proposal, attempt };
+          return proposal;
         }
 
         if (price.bottleId !== null) {
@@ -1409,19 +1408,9 @@ export async function resolveStorePriceMatchProposal(
           });
         }
 
-        return { proposal, attempt };
+        return proposal;
       });
-      if (shouldGenerateBottleCheck) {
-        await tryPersistStorePriceBottleCheck({
-          attempt: ignoredResult.attempt,
-          classificationInput,
-          classification,
-          modelMetadata: classificationModelMetadata,
-          price,
-          proposal: ignoredResult.proposal,
-        });
-      }
-      return ignoredResult.proposal;
+      return ignoredProposal;
     }
 
     const classifierDecision = normalizeClassifierDecisionForPriceMatching(
@@ -1445,36 +1434,40 @@ export async function resolveStorePriceMatchProposal(
       webEvidenceJudgment:
         classification.decision.confidenceBasis?.webEvidence ?? null,
     });
-    const proposal = await upsertStorePriceMatchProposal({
-      price,
-      extractedLabel,
-      candidates,
-      decision,
-      decisionEvidence: {
-        hasUnresolvedRisks:
-          (classification.decision.confidenceBasis?.unresolvedRisks.length ??
-            0) > 0,
-        webEvidence:
-          classification.decision.confidenceBasis?.webEvidence ?? null,
-      },
-      automationAssessment,
-      searchEvidence,
-      expectedProcessingToken: processingToken,
-    });
-    const attempt = await recordStorePriceMatchAttempt({
-      proposal,
-      automationAssessment,
-    });
-    if (shouldGenerateBottleCheck) {
-      await tryPersistStorePriceBottleCheck({
-        attempt,
+    const { proposal, attempt } = await db.transaction(async (tx) => {
+      const proposal = await upsertStorePriceMatchProposal({
+        price,
+        extractedLabel,
+        candidates,
+        decision,
+        decisionEvidence: {
+          hasUnresolvedRisks:
+            (classification.decision.confidenceBasis?.unresolvedRisks.length ??
+              0) > 0,
+          webEvidence:
+            classification.decision.confidenceBasis?.webEvidence ?? null,
+        },
+        automationAssessment,
+        searchEvidence,
+        expectedProcessingToken: processingToken,
+        tx,
+      });
+      const attempt = await recordStorePriceMatchAttempt({
+        proposal,
+        automationAssessment,
+        tx,
+      });
+      await persistStorePriceBottleCheck({
+        attemptId: attempt.id,
         classificationInput,
         classification,
+        database: tx,
+        model: proposal.model,
         modelMetadata: classificationModelMetadata,
-        price,
-        proposal,
+        priceId: price.id,
       });
-    }
+      return { proposal, attempt };
+    });
 
     const shouldAutoCreate = shouldAutoCreateStorePriceMatchProposal({
       decision,

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -3349,7 +3349,6 @@ describe("price match queue", () => {
       {
         priceId: price.id,
         force: true,
-        generateBottleCheck: true,
         processingToken: expect.any(String),
       },
     );

--- a/apps/server/src/orpc/routes/prices/matchQueue/retry-utils.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/retry-utils.ts
@@ -33,7 +33,6 @@ export async function enqueueStorePriceMatchRetry({
     await pushUniqueJob("ResolveStorePriceBottle", {
       priceId,
       force: true,
-      generateBottleCheck: true,
       processingToken: lease.processingToken,
     });
 

--- a/apps/server/src/worker/jobs/resolveStorePriceBottle.ts
+++ b/apps/server/src/worker/jobs/resolveStorePriceBottle.ts
@@ -3,17 +3,14 @@ import { resolveStorePriceMatchProposal } from "@peated/server/lib/priceMatching
 export default async ({
   priceId,
   force,
-  generateBottleCheck,
   processingToken,
 }: {
   priceId: number;
   force?: boolean;
-  generateBottleCheck?: boolean;
   processingToken?: string;
 }) => {
   await resolveStorePriceMatchProposal(priceId, {
     force,
-    generateBottleCheck,
     processingToken,
   });
 };

--- a/docs/features/store-price-matching.md
+++ b/docs/features/store-price-matching.md
@@ -42,9 +42,9 @@ For each `store_price`, the matcher should decide one of four outcomes:
 The system persists one `store_price_match_proposal` row per `store_price`.
 
 The primary match proposal remains authoritative for the listing decision.
-When enabled, the classifier may also persist a linked Bottle check with
-supplemental proposed operations. That check does not replace, delay, or
-reinterpret the primary proposal.
+Every full classifier run also persists a linked Bottle check with supplemental
+proposed operations. That check does not replace or reinterpret the primary
+proposal.
 
 ## Matching Modes
 
@@ -98,11 +98,20 @@ Evaluation order:
 6. map and sanitize classifier output against real candidates and resolved entities
 7. compute automation eligibility from deterministic checks
 8. upsert the proposal row
-9. auto-create only when the deterministic gate says it is safe
+9. record the match attempt and a linked Bottle check from the classifier result
+10. auto-create only when the deterministic gate says it is safe
 
-A full reference run may also create a `resolve_reference` Bottle check from
-the same reviewed artifacts. Its proposed operations are supplemental catalog
-work, not additional price-match outcomes.
+Every full reference run creates a `resolve_reference` Bottle check from the
+same reviewed artifacts. This includes initial unresolved listings, ignored
+results, and individual or bulk retries. Its proposed operations are
+supplemental catalog work, not additional price-match outcomes. Deterministic
+accepted-alias matches do not create a check because they do not run the
+classifier.
+
+The proposal, attempt, and linked check commit as one transaction before
+automation begins. If the check cannot be validated or persisted, the resolver
+rolls back that successful match state and records an errored proposal and
+attempt for inspection or retry.
 
 ## Observation Persistence
 

--- a/openspec/changes/persist-store-price-bottle-checks/.openspec.yaml
+++ b/openspec/changes/persist-store-price-bottle-checks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-04

--- a/openspec/changes/persist-store-price-bottle-checks/design.md
+++ b/openspec/changes/persist-store-price-bottle-checks/design.md
@@ -1,0 +1,54 @@
+## Context
+
+Store-price matching already runs the shared Bottle reference classifier and stores its primary decision in a store-price match proposal and attempt. The same classifier result can also be stored as a linked `resolve_reference` Bottle check, which retains findings and proposed Bottle operations for moderator review. That persistence is currently guarded by a `generateBottleCheck` option: individual retries set it, while initial ingestion and bulk retries do not.
+
+The linked-check schema, moderation controls, and Incoming Listings presentation already exist. The missing behavior is at the resolver boundary, not in classification or UI.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Retain the complete Bottle-check output for every full store-price classifier run.
+- Make this invariant owned by the store-price resolver instead of its callers.
+- Commit the proposal, attempt, and linked check as one durable transition.
+- Preserve the existing separation between the primary price-match decision and supplemental Bottle operations.
+
+**Non-Goals:**
+
+- Run the classifier for deterministic alias matches that currently bypass it.
+- Change classifier prompts, schemas, operation approval, or queue presentation.
+- Add scraper source identity, reorder image capture, correlate later audits, or migrate other classifier consumers.
+
+## Decisions
+
+### Persist at the resolver boundary
+
+After a full classifier result has produced a store-price proposal and attempt, the resolver will always pass that result to the existing Bottle-check persistence helper. This covers initial ingestion and every retry path because they all converge on the resolver.
+
+The alternative was to set the existing option in every caller. That would leave a continuing footgun: any new caller could silently discard classifier operations. Removing the option makes retention the invariant of the component that owns the classifier run.
+
+### Reuse the linked-check review model
+
+The store-price proposal remains authoritative for selecting or creating the listing's Bottle. The linked check retains classifier findings and supplemental Bottle operations, associates them with the exact match attempt, and continues to render within the existing Incoming Listings row. Operations retain their existing moderator-only approval rules.
+
+Creating a second queue item or translating the primary match decision into a generic Bottle operation would duplicate ownership and create conflicting review paths.
+
+### Commit classifier persistence atomically
+
+The resolver commits the primary proposal, immutable attempt, and linked Bottle check in one transaction. If check validation or persistence fails, that transaction rolls back and the resolver uses its existing error path to record an errored proposal and attempt. Automation starts only after the complete classifier record commits.
+
+The alternative was to retain the previous catch-and-log helper. That would violate the persistence invariant by presenting a successful price-match attempt after silently discarding classifier findings and operations.
+
+## Risks / Trade-offs
+
+- **More Bottle-check rows and proposed operations** → Reuse the existing linked-check UI and moderation gates; no new inbox is introduced.
+- **Invalid supplemental evidence can prevent a match proposal from completing** → Record the failure in the existing errored proposal and attempt flow so it can be inspected and retried without partial classifier state.
+- **Deterministic alias matches still have no linked classifier check** → Treat this as intentional because no classifier run occurred; separately revisit only if alias matches need auditing.
+
+## Migration Plan
+
+Deploy the resolver transaction and caller type changes together. No data migration or backfill is required. Rollback restores the optional parameter behavior; checks created while the change is active remain valid review records.
+
+## Open Questions
+
+None for the MVP.

--- a/openspec/changes/persist-store-price-bottle-checks/proposal.md
+++ b/openspec/changes/persist-store-price-bottle-checks/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+Full store-price classifier runs already return Bottle findings and proposed operations, but most callers discard them because linked Bottle-check persistence is opt-in. Initial ingestion and bulk retries should retain the same review evidence as individual retries without requiring each caller to know about a feature flag.
+
+## What Changes
+
+- Persist a linked Bottle check after every full store-price classifier run, including initial ingestion and bulk or individual retries.
+- Commit the primary proposal, match attempt, and linked check together before automation can begin.
+- Remove the `generateBottleCheck` option from store-price resolution and job payloads.
+- Keep the store-price match proposal as the authoritative pricing decision while exposing supplemental Bottle operations through the existing Incoming Listings review flow.
+- Leave deterministic alias matches, source identity, image capture ordering, post-create audits, and other classifier consumers unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `store-price-bottle-checks`: Defines when store-price classification persists linked Bottle review evidence and how it relates to the primary price-match proposal.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+This affects the store-price match resolver, its background-job and retry callers, targeted server tests, and the store-price matching feature documentation. It does not require a database migration, classifier prompt change, or new review UI.

--- a/openspec/changes/persist-store-price-bottle-checks/specs/store-price-bottle-checks/spec.md
+++ b/openspec/changes/persist-store-price-bottle-checks/specs/store-price-bottle-checks/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: Full store-price classification retains Bottle review evidence
+
+The system SHALL create a linked `resolve_reference` Bottle check after each completed full store-price classifier run. The check SHALL retain the run's findings and proposed Bottle operations and SHALL link to the exact store-price match attempt produced by that run.
+
+#### Scenario: Initial unresolved listing is classified
+
+- **WHEN** initial store-price ingestion requires a full classifier run
+- **THEN** the system records the primary store-price match proposal and attempt
+- **AND** creates a Bottle check linked to that attempt from the same classifier result
+
+#### Scenario: Store-price match is retried
+
+- **WHEN** an individual or bulk retry completes a full classifier run
+- **THEN** the system creates a Bottle check linked to the retry's match attempt without requiring a caller option
+
+#### Scenario: Classifier ignores the reference
+
+- **WHEN** a full store-price classifier run returns an ignored result
+- **THEN** the system creates a Bottle check linked to the ignored match attempt from that classifier result
+
+#### Scenario: Deterministic alias match bypasses classification
+
+- **WHEN** store-price ingestion assigns a Bottle through the deterministic alias path without a full classifier run
+- **THEN** the system does not create a classifier-derived Bottle check
+
+#### Scenario: Linked check cannot be persisted
+
+- **WHEN** the linked Bottle check from a full classifier result fails validation or persistence
+- **THEN** the system does not retain a successful match proposal or attempt from that run
+- **AND** records the run through the existing errored proposal and attempt path
+- **AND** does not begin automated catalog mutation
+
+### Requirement: Price matching and Bottle operations keep separate authority
+
+The system SHALL keep the store-price match proposal authoritative for the listing's Bottle assignment. Supplemental Bottle operations SHALL remain attached to the linked Bottle check and SHALL require their existing moderator review.
+
+#### Scenario: Classifier proposes supplemental Bottle operations
+
+- **WHEN** a full store-price classifier run returns proposed Bottle operations
+- **THEN** the operations are available through the linked check in the existing Incoming Listings review flow
+- **AND** the operations do not replace or implicitly approve the primary store-price match decision

--- a/openspec/changes/persist-store-price-bottle-checks/tasks.md
+++ b/openspec/changes/persist-store-price-bottle-checks/tasks.md
@@ -1,0 +1,11 @@
+## 1. Resolver Behavior
+
+- [x] 1.1 Remove the `generateBottleCheck` resolver option and always persist the linked check after a completed full classification.
+- [x] 1.2 Remove the obsolete option from background-job and retry callers.
+- [x] 1.3 Commit the proposal, attempt, and linked check atomically before automation.
+
+## 2. Verification and Documentation
+
+- [x] 2.1 Update targeted store-price tests to prove default check persistence, atomic failure behavior, ignored results, and the new retry job contract.
+- [x] 2.2 Update store-price matching documentation to describe unconditional linked-check persistence for full classifier runs.
+- [x] 2.3 Run OpenSpec validation, targeted tests, lint, formatting, and server typechecking.


### PR DESCRIPTION
Every completed full store-price classifier run now persists a linked `resolve_reference` Bottle check from the same result. Initial unresolved ingestion, ignored results, and bulk or individual retries therefore retain classifier findings and supplemental Bottle operations without callers opting in; the obsolete `generateBottleCheck` resolver and job option is removed.

The resolver commits the proposal, immutable attempt, and linked check in one transaction before automation begins. A check validation or persistence failure rolls that successful state back and records an errored proposal and attempt instead of silently dropping classifier work. The store-price proposal remains authoritative for Bottle assignment, supplemental operations keep their existing moderator gates, and deterministic alias matches remain unchanged because they do not invoke the classifier.

The focused OpenSpec is complete, 138 targeted integration tests pass, and server typechecking, formatting, lint, and strict OpenSpec validation pass.
