### PR TITLE
fix(classifier): keep SMWS codes out of edition

### DIFF
--- a/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-smws-10.258-code-already-in-name.json
+++ b/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-smws-10.258-code-already-in-name.json
@@ -1,0 +1,174 @@
+{
+  "id": "audit-production-smws-10.258-code-already-in-name",
+  "name": "audit: enrich SMWS 10.258 without duplicating its code as edition",
+  "scenario": "bottle_update",
+  "input": {
+    "audit": {
+      "bottleId": 25608,
+      "origin": "moderator"
+    },
+    "context": {
+      "currentBottle": {
+        "bottleId": 25608,
+        "fullName": "SMWS 10.258 Quo vadis?",
+        "brand": "The Scotch Malt Whisky Society",
+        "bottler": "The Scotch Malt Whisky Society",
+        "distillery": ["Bunnahabhain"],
+        "category": "single_malt",
+        "statedAge": 9,
+        "edition": null,
+        "abv": null,
+        "singleCask": null,
+        "caskStrength": null,
+        "vintageYear": null,
+        "releaseYear": null,
+        "score": 1,
+        "source": ["context"]
+      },
+      "bottleContexts": [
+        {
+          "bottleId": 25608,
+          "fullName": "SMWS 10.258 Quo vadis?",
+          "groupId": 16244,
+          "shared": {
+            "name": "10.258 Quo vadis?",
+            "statedAge": 9,
+            "series": null,
+            "category": "single_malt",
+            "brand": {
+              "entityId": 4263,
+              "name": "The Scotch Malt Whisky Society"
+            },
+            "distillers": [
+              {
+                "entityId": 144,
+                "name": "Bunnahabhain"
+              }
+            ],
+            "bottler": {
+              "entityId": 4263,
+              "name": "The Scotch Malt Whisky Society"
+            }
+          },
+          "exact": {
+            "edition": null,
+            "statedAge": null,
+            "abv": null,
+            "singleCask": null,
+            "caskStrength": null,
+            "vintageYear": null,
+            "releaseYear": null,
+            "caskSize": null,
+            "caskType": null,
+            "caskFill": null
+          },
+          "siblings": [],
+          "aliases": [],
+          "observations": [],
+          "imageSources": []
+        }
+      ]
+    }
+  },
+  "searchResponses": [
+    {
+      "when": ["smws"],
+      "results": [
+        {
+          "bottleId": 25608,
+          "fullName": "SMWS 10.258 Quo vadis?",
+          "brand": "The Scotch Malt Whisky Society",
+          "bottler": "The Scotch Malt Whisky Society",
+          "distillery": ["Bunnahabhain"],
+          "category": "single_malt",
+          "statedAge": 9,
+          "edition": null,
+          "abv": null,
+          "singleCask": null,
+          "caskStrength": null,
+          "vintageYear": null,
+          "releaseYear": null,
+          "score": 1,
+          "source": ["search"]
+        }
+      ]
+    }
+  ],
+  "provenance": {
+    "source": "production_miss",
+    "verifiedSourceUrls": [
+      "https://peated.com/bottles/25608",
+      "https://smwsa.com/products/cask-no-10-258",
+      "https://www.smws.com.tw/product/list/43?max=8&offset=32",
+      "https://www.whiskygoodness.com/whiskies/bunnahabhain-quo-vadis"
+    ],
+    "dbOutcome": {
+      "bottleId": 25608,
+      "createsBottle": false,
+      "createsRelease": false,
+      "summary": "Keep Bottle 25608 and its canonical name 10.258 Quo vadis?. Add exact ABV 58.1%, singleCask true, and vintageYear 2013. Leave edition null because the SMWS code is already materialized in the Bottle name."
+    },
+    "catalogFieldObservations": [
+      {
+        "target": "candidate_bottle",
+        "bottleId": 25608,
+        "field": "abv",
+        "productionValue": null,
+        "evidenceValue": 58.1,
+        "source": "production_search",
+        "issue": "missing_in_production",
+        "safeToAutoFill": false,
+        "notes": "Official SMWS product catalogs identify cask 10.258 at 58.1% ABV."
+      },
+      {
+        "target": "candidate_bottle",
+        "bottleId": 25608,
+        "field": "singleCask",
+        "productionValue": null,
+        "evidenceValue": true,
+        "source": "production_search",
+        "issue": "missing_in_production",
+        "safeToAutoFill": false,
+        "notes": "Official SMWS product catalogs market 10.258 as one Society cask."
+      },
+      {
+        "target": "candidate_bottle",
+        "bottleId": 25608,
+        "field": "vintageYear",
+        "productionValue": null,
+        "evidenceValue": 2013,
+        "source": "production_search",
+        "issue": "missing_in_production",
+        "safeToAutoFill": false,
+        "notes": "The official SMWS Taiwan catalog gives the distillation date as 2013-10-17."
+      }
+    ],
+    "notes": "Observed August 3, 2026 from Audit #29 and operation #26 for production Bottle 25608. The audit correctly identified SMWS 10.258 Quo vadis? and proposed ABV 58.1%, singleCask true, and vintageYear 2013, but it also proposed edition 10.258. Because the stored shared name already begins with 10.258, applying that patch would render the code twice. The failed operation cited the older Whisky Goodness URL https://www.whiskygoodness.com/smws/10/10.258; that content now resolves under the verified canonical URL recorded above."
+  },
+  "expected": {
+    "summary": "Bottle 25608 is SMWS 10.258 Quo vadis?; its code is already canonical in the Bottle name, while its supported ABV, single-cask flag, and 2013 vintage are missing.",
+    "proposedOperations": [
+      {
+        "type": "update_bottle",
+        "input": {
+          "bottleId": 25608,
+          "patch": {
+            "exact": {
+              "abv": 58.1,
+              "singleCask": true,
+              "vintageYear": 2013
+            }
+          }
+        },
+        "rationale": "Official SMWS product evidence identifies cask 10.258 at 58.1% ABV and as a 2013 single-cask distillation; the code is already present in the canonical Bottle name and does not belong in edition.",
+        "evidenceRefs": [
+          {
+            "kind": "bottle",
+            "bottleId": 25608
+          }
+        ]
+      }
+    ],
+    "findings": []
+  }
+}

--- a/packages/bottle-classifier/src/runtime/bottleCheckRuntime.ts
+++ b/packages/bottle-classifier/src/runtime/bottleCheckRuntime.ts
@@ -535,6 +535,15 @@ export function createRunProposalCollector({
         Array.from(state.bottleContexts.values()).some(
           (context) => context.shared.series?.seriesId === seriesId,
         ),
+      getBottleBranding: (bottleId) => {
+        const context = state.bottleContexts.get(bottleId);
+        return context
+          ? {
+              brand: context.shared.brand.name,
+              bottler: context.shared.bottler?.name ?? null,
+            }
+          : null;
+      },
     },
   });
 }

--- a/packages/bottle-classifier/src/tools/proposeOperations.test.ts
+++ b/packages/bottle-classifier/src/tools/proposeOperations.test.ts
@@ -18,6 +18,13 @@ function createHarness() {
       isBottleInspected: (bottleId) => inspectedBottleIds.has(bottleId),
       isEntityInspected: (entityId) => inspectedEntityIds.has(entityId),
       isSeriesInspected: (seriesId) => seriesId === 71,
+      getBottleBranding: (bottleId) =>
+        bottleId === 10
+          ? {
+              brand: "The Scotch Malt Whisky Society",
+              bottler: "The Scotch Malt Whisky Society",
+            }
+          : { brand: "Example Distillery", bottler: null },
     },
   });
   return {
@@ -215,6 +222,67 @@ describe("Bottle proposal tools", () => {
         },
       }),
     ]);
+  });
+
+  test("rejects an SMWS cask code as edition while keeping the other exact repairs", async () => {
+    const { collector, tools } = createHarness();
+    const evidenceRefs = [{ kind: "bottle" as const, bottleId: 10 }];
+
+    expect(
+      await invoke(tools, "propose_update_bottle", {
+        bottleId: 10,
+        patch: {
+          exact: {
+            edition: "95.71",
+            abv: 57,
+            singleCask: true,
+            vintageYear: 2007,
+          },
+        },
+        rationale: "Add the verified exact Bottle traits.",
+        evidenceRefs,
+      }),
+    ).toEqual({
+      status: "rejected",
+      reason:
+        "SMWS exact-cask codes belong in the Bottle name, not exact.edition. Omit the edition field from this proposal.",
+    });
+    expect(collector.getProposals()).toEqual([]);
+
+    expect(
+      await invoke(tools, "propose_update_bottle", {
+        bottleId: 10,
+        patch: {
+          exact: { abv: 57, singleCask: true, vintageYear: 2007 },
+        },
+        rationale: "Add the verified exact Bottle traits.",
+        evidenceRefs,
+      }),
+    ).toMatchObject({ status: "recorded", proposalIndex: 0 });
+    expect(collector.getProposals()).toEqual([
+      expect.objectContaining({
+        input: {
+          bottleId: 10,
+          patch: {
+            exact: { abv: 57, singleCask: true, vintageYear: 2007 },
+          },
+        },
+      }),
+    ]);
+  });
+
+  test("does not apply SMWS field placement to other exact-cask programs", async () => {
+    const { collector, tools } = createHarness();
+
+    expect(
+      await invoke(tools, "propose_update_bottle", {
+        bottleId: 11,
+        patch: { exact: { edition: "10.258" } },
+        rationale: "Add the marketed release code.",
+        evidenceRefs: [{ kind: "bottle", bottleId: 11 }],
+      }),
+    ).toMatchObject({ status: "recorded", proposalIndex: 0 });
+    expect(collector.getProposals()).toHaveLength(1);
   });
 
   test("requires evidence refs for every existing operation target", async () => {

--- a/packages/bottle-classifier/src/tools/proposeOperations.ts
+++ b/packages/bottle-classifier/src/tools/proposeOperations.ts
@@ -11,6 +11,8 @@ import {
   type EvidenceRef,
   type ProposedOperation,
 } from "../bottleCheckContract";
+import { getExactCaskCodeAnchor } from "../exactCask";
+import { isSmwsIdentityAnchor } from "../smwsPolicy";
 
 const ProposalEnvelopeArgsShape = {
   rationale: UpdateBottleOperationSchema.shape.rationale,
@@ -36,6 +38,9 @@ type ProposalCollectionContext = {
   isBottleInspected: (bottleId: number) => boolean;
   isEntityInspected: (entityId: number) => boolean;
   isSeriesInspected: (seriesId: number) => boolean;
+  getBottleBranding: (
+    bottleId: number,
+  ) => { brand: string; bottler: string | null } | null;
 };
 
 type ProposalRecordResult =
@@ -189,6 +194,32 @@ function changesOnlyOptionalCaskMetadata(proposal: ProposedOperation) {
   );
 }
 
+function getSmwsEditionError(
+  proposal: ProposedOperation,
+  context: ProposalCollectionContext,
+): string | null {
+  if (proposal.type !== "update_bottle") {
+    return null;
+  }
+
+  const edition = proposal.input.patch.exact?.edition;
+  if (!edition || !getExactCaskCodeAnchor(edition)) {
+    return null;
+  }
+
+  const branding = context.getBottleBranding(proposal.input.bottleId);
+  if (
+    !branding ||
+    ![branding.brand, branding.bottler].some(isSmwsIdentityAnchor)
+  ) {
+    return null;
+  }
+
+  // SMWS code identity is materialized in the Bottle name by the package's
+  // deterministic SMWS policy; accepting it as edition would render it twice.
+  return "SMWS exact-cask codes belong in the Bottle name, not exact.edition. Omit the edition field from this proposal.";
+}
+
 export function createBottleProposalCollector({
   context,
   maxProposals = DEFAULT_MAX_PROPOSED_OPERATIONS,
@@ -233,6 +264,11 @@ export function createBottleProposalCollector({
           reason:
             "Bottle updates cannot change only optional cask type, size, or fill metadata.",
         };
+      }
+
+      const smwsEditionError = getSmwsEditionError(proposal, context);
+      if (smwsEditionError) {
+        return { status: "rejected", reason: smwsEditionError };
       }
 
       const targetError = uninspectedTarget(proposal, context);


### PR DESCRIPTION
SMWS audit proposals now reject exact cask codes placed in `edition`, where they would duplicate the code already materialized in the Bottle name. The audit agent receives retryable feedback and can preserve supported ABV, vintage, and single-cask repairs; non-SMWS exact-cask programs retain their existing field-placement behavior.

The regression coverage preserves production Audit #29 for Bottle 25608 and uses a different SMWS code to prove the deterministic rule. The bottle-classifier suite, fixture validation, typecheck, and lint pass on the rebased branch.
