### PR TITLE
ci(evals): publish aggregate classifier scores

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -15,6 +15,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Model behavior has qualitative variance, so the aggregate suite owns the
+# quality gate. Missing or invalid result reports remain hard failures.
+env:
+  EVAL_MIN_PASS_RATE: "0.8"
+
 jobs:
   gate:
     name: "evals / gate"
@@ -65,6 +70,7 @@ jobs:
             echo "- evals_requested: $evals_requested"
             echo "- gateway_ready: $gateway_ready"
             echo "- will_run: $should_run"
+            echo "- min_pass_rate: $EVAL_MIN_PASS_RATE"
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$evals_requested" == "true" && "$gateway_ready" != "true" ]]; then
@@ -77,6 +83,9 @@ jobs:
     needs: gate
     if: needs.gate.outputs.should_run == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
     env:
       AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
       BRAVE_API_KEY: ${{ secrets.BRAVE_API_KEY }}
@@ -96,15 +105,37 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
       - name: Run classifier evals
+        id: run
+        continue-on-error: true
         run: >-
           pnpm --filter @peated/bottle-classifier evals --
           --reporter=vitest-evals/reporter
           --reporter=json
           --outputFile.json=vitest-results.json
 
+      - name: Require classifier eval results
+        id: results
+        if: steps.run.conclusion != 'skipped'
+        run: >-
+          test -f packages/bottle-classifier/vitest-results.json
+
       - name: Upload classifier eval report
-        if: ${{ always() && hashFiles('packages/bottle-classifier/vitest-results.json') != '' }}
+        if: steps.results.conclusion == 'success'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bottle-classifier-eval-report
           path: packages/bottle-classifier/vitest-results.json
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Publish classifier eval report
+        if: steps.results.conclusion == 'success'
+        uses: getsentry/vitest-evals@abea6a519955e5df56ecb2a2d83bae9c821561e1 # v0.16.1
+        with:
+          results: packages/bottle-classifier/vitest-results.json
+          publish-check: true
+          check-name: classifier eval score
+          min-pass-rate: ${{ env.EVAL_MIN_PASS_RATE }}
+          # Keep the existing workflow job blocking until branch protection
+          # explicitly requires the dedicated Check Run.
+          soft-fail: false

--- a/packages/bottle-classifier/README.md
+++ b/packages/bottle-classifier/README.md
@@ -259,6 +259,13 @@ recording and record a new one on a miss automatically.
 Replay JSON is reproducible eval evidence, not a disposable local cache. Review
 and commit replay changes only when they are intentional.
 
+Classifier eval CI publishes the native `vitest-evals` summary and a dedicated
+`classifier eval score` Check Run. The check requires at least 80% of cases to
+pass so isolated qualitative misses remain visible without hiding the suite's
+aggregate signal. The workflow job also fails below that floor, so the gate does
+not depend on branch-protection configuration. Missing or invalid Vitest result
+reports are infrastructure failures and still fail the workflow job directly.
+
 ## Related Docs
 
 - [`docs/architecture/bottle-classifier.md`](../../docs/architecture/bottle-classifier.md)

--- a/packages/bottle-classifier/package.json
+++ b/packages/bottle-classifier/package.json
@@ -101,7 +101,7 @@
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:",
-    "vitest-evals": "0.15.0"
+    "vitest-evals": "0.16.1"
   },
   "volta": {
     "extends": "../../package.json"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -637,8 +637,8 @@ importers:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1(supports-color@8.1.1))(vite@8.2.1(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest-evals:
-        specifier: 0.15.0
-        version: 0.15.0(tinyrainbow@2.0.0)(vitest@4.1.4)(zod@4.3.6)
+        specifier: 0.16.1
+        version: 0.16.1(tinyrainbow@2.0.0)(vitest@4.1.4)(zod@4.3.6)
 
   packages/catalog-verifier:
     dependencies:
@@ -4940,11 +4940,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest-evals/core@0.15.0':
-    resolution: {integrity: sha512-kqyg3ocVtZxr3rP9oh01oAycRgXNRasvTgLZ8MbFGBJ4BRd4tk7Bgww253HY7fw7ZFUp4UPYNmDp5AcHajm++w==}
+  '@vitest-evals/core@0.16.1':
+    resolution: {integrity: sha512-e4BfGirm4HOP2HfoYvE61iWp7K389tYwUOdPj+CS8lCI1D2efIlLptClU1knhDocLVaU6F/9ty2+p7u1tDkaIg==}
 
-  '@vitest-evals/report-ui@0.15.0':
-    resolution: {integrity: sha512-icrutiRhZ2T1MrHo2RW09hcEwfi/tV/FgsGAE76Wd0C02tZyCleQRjt11RWhBJiYDPpsjjjTHGCHIO6tmtX5zQ==}
+  '@vitest-evals/report-ui@0.16.1':
+    resolution: {integrity: sha512-3oHbMntbksRWQB1Nu1j8UXIy8+we6iUng24wAKxhSli7vjIgkaX02JjjfXgK4CWG4DhgOQkwJqw+wNaOMduY5A==}
 
   '@vitest/coverage-v8@4.1.4':
     resolution: {integrity: sha512-x7FptB5oDruxNPDNY2+S8tCh0pcq7ymCe1gTHcsp733jYjrJl8V1gMUlVysuCD9Kz46Xz9t1akkv08dPcYDs1w==}
@@ -9714,8 +9714,8 @@ packages:
       yaml:
         optional: true
 
-  vitest-evals@0.15.0:
-    resolution: {integrity: sha512-bOYALQdLXKYFRCV8aQ+yLeH7XkmYsTxUWQxLHzJdIEcIBx2v/kPgG3Zg6m231jMCphuoM6xH4YQB3+0pDP7LLw==}
+  vitest-evals@0.16.1:
+    resolution: {integrity: sha512-MuPVetClAOn55ewgajxGxZcQDFWUftrQ19/rZQn8zXvaxHri+ElgEb5W0OIMRQwSvF5TBYIsE5rWdQB/qrWJkg==}
     hasBin: true
     peerDependencies:
       ai: '>=4 <7'
@@ -14260,13 +14260,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest-evals/core@0.15.0':
+  '@vitest-evals/core@0.16.1':
     dependencies:
       zod: 3.25.76
 
-  '@vitest-evals/report-ui@0.15.0':
+  '@vitest-evals/report-ui@0.16.1':
     dependencies:
-      '@vitest-evals/core': 0.15.0
+      '@vitest-evals/core': 0.16.1
 
   '@vitest/coverage-v8@4.1.4(vitest@4.1.4)':
     dependencies:
@@ -19840,10 +19840,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vitest-evals@0.15.0(tinyrainbow@2.0.0)(vitest@4.1.4)(zod@4.3.6):
+  vitest-evals@0.16.1(tinyrainbow@2.0.0)(vitest@4.1.4)(zod@4.3.6):
     dependencies:
-      '@vitest-evals/core': 0.15.0
-      '@vitest-evals/report-ui': 0.15.0
+      '@vitest-evals/core': 0.16.1
+      '@vitest-evals/report-ui': 0.16.1
       tinyrainbow: 2.0.0
       vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1(supports-color@8.1.1))(vite@8.2.1(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
     optionalDependencies:


### PR DESCRIPTION
Classifier eval CI now uses `vitest-evals` 0.16.1 to publish a dedicated score check gated at an 80% aggregate pass rate. Individual qualitative misses remain visible without making one stochastic result the entire suite verdict.

Runs below the floor still fail the workflow job, so enforcement does not depend on branch protection already recognizing the new check. Missing or invalid result reports also remain hard infrastructure failures, and the classifier eval documentation now records these semantics.
