### PR TITLE
test(server): stabilize flight Bottle ordering

### DIFF
--- a/apps/server/src/orpc/routes/flights/update.test.ts
+++ b/apps/server/src/orpc/routes/flights/update.test.ts
@@ -161,9 +161,12 @@ describe("PATCH /flights/:flight", () => {
     fixtures,
   }) => {
     const user = await fixtures.User({ mod: true });
+    const brand = await fixtures.Entity({
+      name: "Flight Update Ordering Brand",
+    });
     const laterBottle = await fixtures.Bottle({
+      brandId: brand.id,
       name: "Zulu release",
-      fullName: "Zulu release",
     });
     if (laterBottle.groupId === null) {
       throw new Error("Bottle group fixture not found");
@@ -175,7 +178,7 @@ describe("PATCH /flights/:flight", () => {
         brandId: laterBottle.brandId,
         createdByActorId: laterBottle.createdByActorId,
         name: "Alpha release",
-        fullName: "Alpha release",
+        fullName: `${brand.name} Alpha release`,
       })
       .returning();
     if (!firstBottle) throw new Error("Same-group Bottle fixture not found");


### PR DESCRIPTION
The flight update ordering test now creates both same-group Bottles with one explicit brand, making their serialized full names deterministic while preserving the distinct-membership coverage.

Previously, the fixture generated a random brand prefix for the Zulu Bottle while the manually inserted Alpha Bottle had no prefix. Depending on that random brand name, full-name sorting could legitimately return the IDs in either order.
