### PR TITLE
ref(classifier)!: remove legacy Bottle terms

### DIFF
--- a/apps/server/src/lib/bottleConflicts.ts
+++ b/apps/server/src/lib/bottleConflicts.ts
@@ -10,37 +10,37 @@ import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import { and, asc, eq, notInArray, or, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 
-export type ConcreteBottleIdentityEntity = {
+export type BottleIdentityEntity = {
   name: string;
   shortName?: string | null;
 };
 
-export type ConcreteBottleIdentityState = {
+export type BottleIdentityState = {
   name: string;
   fullName: string;
-  brand: ConcreteBottleIdentityEntity;
-  bottler: ConcreteBottleIdentityEntity | null;
+  brand: BottleIdentityEntity;
+  bottler: BottleIdentityEntity | null;
 };
 
-export type ConcreteBottleIdentityCandidate = {
+export type BottleIdentityCandidate = {
   bottleId: number;
-  current: ConcreteBottleIdentityState;
-  desired: ConcreteBottleIdentityState;
+  current: BottleIdentityState;
+  desired: BottleIdentityState;
 };
 
-export type ConcreteBottleIdentityConflictCause =
+export type BottleIdentityConflictCause =
   | "full_name"
   | "smws_code"
   | "exact_alias";
 
-export class ConcreteBottleIdentityConflictError extends Error {
+export class BottleIdentityConflictError extends Error {
   constructor(
     readonly conflictingBottleId: number | null,
-    readonly conflictCause: ConcreteBottleIdentityConflictCause,
+    readonly conflictCause: BottleIdentityConflictCause,
     options?: ErrorOptions,
   ) {
     super("Bottle identity conflicts with an existing Bottle.", options);
-    this.name = "ConcreteBottleIdentityConflictError";
+    this.name = "BottleIdentityConflictError";
   }
 }
 
@@ -63,7 +63,7 @@ function valuesHaveSmwsCode(
 }
 
 function entityNameVariants(
-  entity: ConcreteBottleIdentityEntity | null,
+  entity: BottleIdentityEntity | null,
   name: string | null,
 ) {
   if (!entity || !name) {
@@ -85,8 +85,8 @@ export function getSmwsCodeForBottleIdentity({
 }: {
   name: string;
   fullName: string;
-  brand: ConcreteBottleIdentityEntity;
-  bottler: ConcreteBottleIdentityEntity | null;
+  brand: BottleIdentityEntity;
+  bottler: BottleIdentityEntity | null;
 }) {
   return getSmwsCodeFromValues([
     fullName,
@@ -141,8 +141,8 @@ export async function findConflictingSmwsBottleId(
   }: {
     name: string;
     fullName: string;
-    brand: ConcreteBottleIdentityEntity;
-    bottler: ConcreteBottleIdentityEntity | null;
+    brand: BottleIdentityEntity;
+    bottler: BottleIdentityEntity | null;
   },
   { excludeBottleIds = [] }: { excludeBottleIds?: number[] } = {},
 ): Promise<number | null> {
@@ -216,16 +216,16 @@ export async function findConflictingSmwsBottleId(
 }
 
 /**
- * Preflights concrete identities and reserves their old/new exact aliases.
+ * Preflights Bottle identities and reserves their old/new exact aliases.
  * Callers explicitly choose which current Bottle rows are replaced atomically.
  */
-export async function reserveConcreteBottleIdentitiesInTransaction(
+export async function reserveBottleIdentitiesInTransaction(
   tx: AnyTransaction,
   {
     candidates,
     assignedByActorId,
   }: {
-    candidates: ConcreteBottleIdentityCandidate[];
+    candidates: BottleIdentityCandidate[];
     assignedByActorId: number;
   },
 ): Promise<{
@@ -243,7 +243,7 @@ export async function reserveConcreteBottleIdentitiesInTransaction(
     const key = candidate.desired.fullName.toLowerCase();
     const owner = fullNameOwners.get(key);
     if (owner !== undefined && owner !== candidate.bottleId) {
-      throw new ConcreteBottleIdentityConflictError(owner, "full_name");
+      throw new BottleIdentityConflictError(owner, "full_name");
     }
     fullNameOwners.set(key, candidate.bottleId);
   }
@@ -269,10 +269,7 @@ export async function reserveConcreteBottleIdentitiesInTransaction(
       .orderBy(asc(bottles.id))
       .limit(1);
     if (conflictingBottle) {
-      throw new ConcreteBottleIdentityConflictError(
-        conflictingBottle.id,
-        "full_name",
-      );
+      throw new BottleIdentityConflictError(conflictingBottle.id, "full_name");
     }
   }
 
@@ -296,7 +293,7 @@ export async function reserveConcreteBottleIdentitiesInTransaction(
 
       const owner = smwsCodeOwners.get(code);
       if (owner !== undefined && owner !== candidate.bottleId) {
-        throw new ConcreteBottleIdentityConflictError(owner, "smws_code");
+        throw new BottleIdentityConflictError(owner, "smws_code");
       }
       smwsCodeOwners.set(code, candidate.bottleId);
     }
@@ -312,10 +309,7 @@ export async function reserveConcreteBottleIdentitiesInTransaction(
         { excludeBottleIds: sortedCandidates.map(({ bottleId }) => bottleId) },
       );
       if (conflictingBottleId !== null) {
-        throw new ConcreteBottleIdentityConflictError(
-          conflictingBottleId,
-          "smws_code",
-        );
+        throw new BottleIdentityConflictError(conflictingBottleId, "smws_code");
       }
     }
   }
@@ -333,10 +327,7 @@ export async function reserveConcreteBottleIdentitiesInTransaction(
       const key = normalizeBottleAliasKey(name).toLowerCase();
       const existing = reservations.get(key);
       if (existing && existing.bottleId !== candidate.bottleId) {
-        throw new ConcreteBottleIdentityConflictError(
-          existing.bottleId,
-          "exact_alias",
-        );
+        throw new BottleIdentityConflictError(existing.bottleId, "exact_alias");
       }
       reservations.set(key, {
         name,
@@ -348,7 +339,7 @@ export async function reserveConcreteBottleIdentitiesInTransaction(
     const literalKey = literalName.toLowerCase();
     const existingLiteral = literalReservations.get(literalKey);
     if (existingLiteral && existingLiteral.bottleId !== candidate.bottleId) {
-      throw new ConcreteBottleIdentityConflictError(
+      throw new BottleIdentityConflictError(
         existingLiteral.bottleId,
         "exact_alias",
       );
@@ -376,7 +367,7 @@ export async function reserveConcreteBottleIdentitiesInTransaction(
       }
     } catch (error) {
       if (error instanceof ExactBottleAliasConflictError) {
-        throw new ConcreteBottleIdentityConflictError(
+        throw new BottleIdentityConflictError(
           error.conflictingBottleId,
           "exact_alias",
           { cause: error },

--- a/apps/server/src/lib/bottleIdentity.test.ts
+++ b/apps/server/src/lib/bottleIdentity.test.ts
@@ -1,8 +1,8 @@
 import {
-  getConcreteBottleExactIdentity,
-  materializeConcreteBottleForGroup,
-  materializeConcreteBottleIdentity,
-} from "./concreteBottleIdentity";
+  getBottleExactIdentity,
+  materializeBottleForGroup,
+  materializeBottleIdentity,
+} from "./bottleIdentity";
 
 const exactIdentity = {
   edition: null,
@@ -38,7 +38,7 @@ test.each([
   },
 ])("$label", ({ exactStatedAge, expectedName, expectedStatedAge }) => {
   expect(
-    materializeConcreteBottleIdentity({
+    materializeBottleIdentity({
       stable: {
         name: "Old Malt",
         fullName: "Example Brand Old Malt",
@@ -55,14 +55,14 @@ test.each([
 
 test("classifies patched exact identity against the source group age", () => {
   expect(
-    getConcreteBottleExactIdentity({
+    getBottleExactIdentity({
       bottle: { ...exactIdentity, statedAge: 13 },
       sourceGroupStatedAge: 12,
     }),
   ).toEqual({ ...exactIdentity, statedAge: 13 });
 
   expect(
-    getConcreteBottleExactIdentity({
+    getBottleExactIdentity({
       bottle: { ...exactIdentity, statedAge: 13 },
       sourceGroupStatedAge: 12,
       exactPatch: { edition: "Batch 2", statedAge: 12, abv: 48 },
@@ -77,7 +77,7 @@ test("classifies patched exact identity against the source group age", () => {
 
 test("materializes only durable shared Bottle fields", () => {
   expect(
-    materializeConcreteBottleForGroup({
+    materializeBottleForGroup({
       group: {
         name: "Old Malt",
         fullName: "Example Brand Old Malt",

--- a/apps/server/src/lib/bottleIdentity.ts
+++ b/apps/server/src/lib/bottleIdentity.ts
@@ -1,18 +1,18 @@
-import { formatCanonicalReleaseName } from "@peated/bottle-classifier/releaseIdentity";
+import { formatCanonicalBottleName } from "@peated/bottle-classifier/bottleIdentity";
 import type { Bottle, BottleGroup } from "@peated/server/db/schema";
 import { toTitleCase } from "@peated/server/lib/strings";
 
-type StableConcreteBottleIdentity = Pick<
+type StableBottleIdentity = Pick<
   BottleGroup,
   "name" | "fullName" | "statedAge"
 >;
 
-type MaterializedConcreteBottleIdentity = Pick<
+type MaterializedBottleIdentity = Pick<
   Bottle,
   "name" | "fullName" | "statedAge"
 >;
 
-export type ConcreteBottleExactIdentity = Pick<
+export type BottleExactIdentity = Pick<
   Bottle,
   | "edition"
   | "statedAge"
@@ -26,10 +26,9 @@ export type ConcreteBottleExactIdentity = Pick<
   | "caskFill"
 >;
 
-export type ConcreteBottleExactIdentityPatch =
-  Partial<ConcreteBottleExactIdentity>;
+export type BottleExactIdentityPatch = Partial<BottleExactIdentity>;
 
-export type ConcreteBottleGroupMaterialization = Pick<
+export type BottleGroupMaterialization = Pick<
   BottleGroup,
   | "name"
   | "fullName"
@@ -41,7 +40,7 @@ export type ConcreteBottleGroupMaterialization = Pick<
   | "flavorProfile"
 >;
 
-export type MaterializedConcreteBottleForGroup = Pick<
+export type MaterializedBottleForGroup = Pick<
   Bottle,
   | "name"
   | "fullName"
@@ -58,7 +57,7 @@ function valueOrCurrent<T>(value: T | undefined, current: T): T {
 }
 
 /** Returns only a non-redundant exact age relative to the shared age. */
-export function getConcreteBottleExactStatedAge({
+export function getBottleExactStatedAge({
   bottleStatedAge,
   stableStatedAge,
 }: {
@@ -71,18 +70,18 @@ export function getConcreteBottleExactStatedAge({
 }
 
 /** Applies an exact patch while classifying age against the source group. */
-export function getConcreteBottleExactIdentity({
+export function getBottleExactIdentity({
   bottle,
   sourceGroupStatedAge,
   exactPatch,
 }: {
-  bottle: ConcreteBottleExactIdentity;
+  bottle: BottleExactIdentity;
   sourceGroupStatedAge: number | null;
-  exactPatch?: ConcreteBottleExactIdentityPatch;
-}): ConcreteBottleExactIdentity {
+  exactPatch?: BottleExactIdentityPatch;
+}): BottleExactIdentity {
   return {
     edition: valueOrCurrent(exactPatch?.edition, bottle.edition),
-    statedAge: getConcreteBottleExactStatedAge({
+    statedAge: getBottleExactStatedAge({
       bottleStatedAge: valueOrCurrent(exactPatch?.statedAge, bottle.statedAge),
       stableStatedAge: sourceGroupStatedAge,
     }),
@@ -97,7 +96,7 @@ export function getConcreteBottleExactIdentity({
   };
 }
 
-function formatConcreteCaskIdentity({
+function formatExactCaskIdentity({
   fullName,
   name,
   caskType,
@@ -131,27 +130,27 @@ function formatConcreteCaskIdentity({
 }
 
 /** Materializes the complete exact identity without retaining redundant age overrides. */
-export function materializeConcreteBottleIdentity({
+export function materializeBottleIdentity({
   stable,
   exact,
 }: {
-  stable: StableConcreteBottleIdentity;
-  exact: ConcreteBottleExactIdentity;
-}): MaterializedConcreteBottleIdentity {
-  const exactStatedAge = getConcreteBottleExactStatedAge({
+  stable: StableBottleIdentity;
+  exact: BottleExactIdentity;
+}): MaterializedBottleIdentity {
+  const exactStatedAge = getBottleExactStatedAge({
     bottleStatedAge: exact.statedAge,
     stableStatedAge: stable.statedAge,
   });
-  const identity = formatConcreteCaskIdentity({
-    ...formatCanonicalReleaseName({
+  const identity = formatExactCaskIdentity({
+    ...formatCanonicalBottleName({
       bottleName: stable.name,
       bottleFullName: stable.fullName,
-      bottleReleaseTraits: {
+      bottleNameTraits: {
         caskStrength: exact.caskStrength,
         singleCask: exact.singleCask,
       },
       bottleStatedAge: stable.statedAge,
-      release: {
+      exact: {
         ...exact,
         statedAge: exactStatedAge,
       },
@@ -168,15 +167,15 @@ export function materializeConcreteBottleIdentity({
 }
 
 /** Materializes only the durable Bottle fields owned by shared group identity. */
-export function materializeConcreteBottleForGroup({
+export function materializeBottleForGroup({
   group,
   exact,
 }: {
-  group: ConcreteBottleGroupMaterialization;
-  exact: ConcreteBottleExactIdentity;
-}): MaterializedConcreteBottleForGroup {
+  group: BottleGroupMaterialization;
+  exact: BottleExactIdentity;
+}): MaterializedBottleForGroup {
   return {
-    ...materializeConcreteBottleIdentity({ stable: group, exact }),
+    ...materializeBottleIdentity({ stable: group, exact }),
     brandId: group.brandId,
     bottlerId: group.bottlerId,
     seriesId: group.seriesId,

--- a/apps/server/src/lib/bottleOperationExecution.ts
+++ b/apps/server/src/lib/bottleOperationExecution.ts
@@ -3,13 +3,13 @@ import type { User } from "@peated/server/db/schema";
 import { getUserActorForDatabase } from "@peated/server/lib/actors";
 import type { PreparedOperationExecution } from "@peated/server/lib/bottleOperationReview";
 import {
-  finalizeConcreteBottleMerge,
-  mergeConcreteBottlesInTransaction,
-} from "@peated/server/lib/mergeConcreteBottles";
+  finalizeBottleMerge,
+  mergeBottlesInTransaction,
+} from "@peated/server/lib/mergeBottles";
 import {
-  finalizeConcreteBottleUpdate,
-  updateConcreteBottleInTransaction,
-} from "@peated/server/lib/updateConcreteBottle";
+  finalizeBottleUpdate,
+  updateBottleInTransaction,
+} from "@peated/server/lib/updateBottle";
 import {
   finalizeEntityUpdate,
   updateEntityInTransaction,
@@ -67,7 +67,7 @@ export async function executePreparedOperationInTransaction({
 
   switch (prepared.type) {
     case "update_bottle": {
-      const manifest = await updateConcreteBottleInTransaction(transaction, {
+      const manifest = await updateBottleInTransaction(transaction, {
         ...prepared.canonicalInput,
         user: approvingModerator,
         actorId,
@@ -81,11 +81,11 @@ export async function executePreparedOperationInTransaction({
           groupId: manifest.group.id,
           changed: manifest.changed,
         }),
-        afterCommit: async () => await finalizeConcreteBottleUpdate(manifest),
+        afterCommit: async () => await finalizeBottleUpdate(manifest),
       };
     }
     case "merge_bottles": {
-      const manifest = await mergeConcreteBottlesInTransaction(transaction, {
+      const manifest = await mergeBottlesInTransaction(transaction, {
         ...prepared.canonicalInput,
         actorId,
       });
@@ -97,7 +97,7 @@ export async function executePreparedOperationInTransaction({
           destinationBottleId: manifest.destinationBottleId,
           changed: manifest.changed,
         }),
-        afterCommit: async () => await finalizeConcreteBottleMerge(manifest),
+        afterCommit: async () => await finalizeBottleMerge(manifest),
       };
     }
     case "update_entity": {

--- a/apps/server/src/lib/bottleOperationReview/bottleShared.ts
+++ b/apps/server/src/lib/bottleOperationReview/bottleShared.ts
@@ -15,9 +15,9 @@ import {
   entities,
 } from "@peated/server/db/schema";
 import {
-  getConcreteBottleExactIdentity,
-  type ConcreteBottleExactIdentity,
-} from "@peated/server/lib/concreteBottleIdentity";
+  getBottleExactIdentity,
+  type BottleExactIdentity,
+} from "@peated/server/lib/bottleIdentity";
 import { asc, eq } from "drizzle-orm";
 import { fail, loadEntity } from "./shared";
 
@@ -128,10 +128,8 @@ export function existingEntityChoice(entity: Entity) {
   };
 }
 
-export function bottleExact(
-  resource: BottleResource,
-): ConcreteBottleExactIdentity {
-  return getConcreteBottleExactIdentity({
+export function bottleExact(resource: BottleResource): BottleExactIdentity {
+  return getBottleExactIdentity({
     bottle: resource.bottle,
     sourceGroupStatedAge: resource.group.statedAge,
   });

--- a/apps/server/src/lib/bottleOperationReview/bottleUpdate.ts
+++ b/apps/server/src/lib/bottleOperationReview/bottleUpdate.ts
@@ -13,18 +13,18 @@ import type { AnyDatabase } from "@peated/server/db";
 import type { BottleSeries, Entity } from "@peated/server/db/schema";
 import { bottleAliases, bottles, bottleSeries } from "@peated/server/db/schema";
 import {
-  getConcreteBottleExactIdentity,
-  materializeConcreteBottleIdentity,
-} from "@peated/server/lib/concreteBottleIdentity";
+  getBottleExactIdentity,
+  materializeBottleIdentity,
+} from "@peated/server/lib/bottleIdentity";
 import {
-  ConcreteBottleUpdateInputSchema,
-  type ConcreteBottleUpdateInput,
-} from "@peated/server/lib/concreteBottleSchemas";
+  BottleUpdateInputSchema,
+  type BottleUpdateInput,
+} from "@peated/server/lib/bottleSchemas";
 import { formatBottleName } from "@peated/server/lib/format";
 import {
-  concreteBottleUpdateExpectedSelectedBottleState,
-  concreteBottleUpdateExpectedSharedState,
-} from "@peated/server/lib/updateConcreteBottle";
+  bottleUpdateExpectedSelectedBottleState,
+  bottleUpdateExpectedSharedState,
+} from "@peated/server/lib/updateBottle";
 import { and, asc, count, eq, isNotNull, sql } from "drizzle-orm";
 import type { z } from "zod";
 import {
@@ -539,33 +539,32 @@ export async function prepareBottleUpdate(
     delete canonicalSharedPatch.bottler;
     delete canonicalSharedPatch.distillers;
   }
-  const canonicalInput: ConcreteBottleUpdateInput =
-    ConcreteBottleUpdateInputSchema.parse({
-      ...(proposal.input.patch.shared
-        ? {
-            shared: {
-              ...canonicalSharedPatch,
-              ...(proposal.input.patch.shared.seriesId !== undefined
-                ? { series: seriesId }
-                : {}),
-              ...(proposal.input.patch.shared.brand !== undefined
-                ? { brand: brand.canonical }
-                : {}),
-              ...(proposal.input.patch.shared.bottler !== undefined
-                ? { bottler: bottler.canonical }
-                : {}),
-              ...(proposal.input.patch.shared.distillers !== undefined
-                ? {
-                    distillers: distillers.map(({ canonical }) => canonical),
-                  }
-                : {}),
-            },
-          }
-        : {}),
-      ...(proposal.input.patch.exact
-        ? { exact: proposal.input.patch.exact }
-        : {}),
-    });
+  const canonicalInput: BottleUpdateInput = BottleUpdateInputSchema.parse({
+    ...(proposal.input.patch.shared
+      ? {
+          shared: {
+            ...canonicalSharedPatch,
+            ...(proposal.input.patch.shared.seriesId !== undefined
+              ? { series: seriesId }
+              : {}),
+            ...(proposal.input.patch.shared.brand !== undefined
+              ? { brand: brand.canonical }
+              : {}),
+            ...(proposal.input.patch.shared.bottler !== undefined
+              ? { bottler: bottler.canonical }
+              : {}),
+            ...(proposal.input.patch.shared.distillers !== undefined
+              ? {
+                  distillers: distillers.map(({ canonical }) => canonical),
+                }
+              : {}),
+          },
+        }
+      : {}),
+    ...(proposal.input.patch.exact
+      ? { exact: proposal.input.patch.exact }
+      : {}),
+  });
 
   let sharedName =
     canonicalInput.shared?.name === undefined
@@ -603,12 +602,12 @@ export async function prepareBottleUpdate(
   const stableFullName = formatBottleName({
     name: `${brandShortName || brandName} ${sharedName}`,
   });
-  const exactAfter = getConcreteBottleExactIdentity({
+  const exactAfter = getBottleExactIdentity({
     bottle: resource.bottle,
     sourceGroupStatedAge: resource.group.statedAge,
     exactPatch: canonicalInput.exact,
   });
-  const materialized = materializeConcreteBottleIdentity({
+  const materialized = materializeBottleIdentity({
     stable: {
       name: sharedName,
       fullName: stableFullName,
@@ -653,13 +652,13 @@ export async function prepareBottleUpdate(
       const desired =
         member.id === resource.bottle.id
           ? after
-          : materializeConcreteBottleIdentity({
+          : materializeBottleIdentity({
               stable: {
                 name: sharedName,
                 fullName: stableFullName,
                 statedAge: sharedStatedAge,
               },
-              exact: getConcreteBottleExactIdentity({
+              exact: getBottleExactIdentity({
                 bottle: member,
                 sourceGroupStatedAge: resource.group.statedAge,
               }),
@@ -739,11 +738,12 @@ export async function prepareBottleUpdate(
     canonicalInput: {
       bottleId: proposal.input.bottleId,
       input: canonicalInput,
-      expectedSelectedBottleState:
-        concreteBottleUpdateExpectedSelectedBottleState(resource.bottle),
+      expectedSelectedBottleState: bottleUpdateExpectedSelectedBottleState(
+        resource.bottle,
+      ),
       ...(proposal.input.patch.shared
         ? {
-            expectedSharedState: concreteBottleUpdateExpectedSharedState({
+            expectedSharedState: bottleUpdateExpectedSharedState({
               group: resource.group,
               distillerIds: resource.distillerIds,
               referencedEntities: stateToken.referencedEntities.map(

--- a/apps/server/src/lib/bottleOperationReview/entity.ts
+++ b/apps/server/src/lib/bottleOperationReview/entity.ts
@@ -11,9 +11,9 @@ import {
   entityTombstones,
 } from "@peated/server/db/schema";
 import {
-  getConcreteBottleExactIdentity,
-  materializeConcreteBottleIdentity,
-} from "@peated/server/lib/concreteBottleIdentity";
+  getBottleExactIdentity,
+  materializeBottleIdentity,
+} from "@peated/server/lib/bottleIdentity";
 import { formatBottleName } from "@peated/server/lib/format";
 import {
   EntityUpdateInputSchema,
@@ -399,13 +399,13 @@ async function entityMergeCollisions(
       const stableFullName = formatBottleName({
         name: `${destination.entity.shortName || destination.entity.name} ${group.name}`,
       });
-      return materializeConcreteBottleIdentity({
+      return materializeBottleIdentity({
         stable: {
           name: group.name,
           fullName: stableFullName,
           statedAge: group.statedAge,
         },
-        exact: getConcreteBottleExactIdentity({
+        exact: getBottleExactIdentity({
           bottle,
           sourceGroupStatedAge: group.statedAge,
         }),

--- a/apps/server/src/lib/bottleOperationReview/orchestrator.ts
+++ b/apps/server/src/lib/bottleOperationReview/orchestrator.ts
@@ -4,11 +4,11 @@ import {
 } from "@peated/bottle-classifier";
 import type { AnyDatabase } from "@peated/server/db";
 import { bottles, entities } from "@peated/server/db/schema";
-import { lockConcreteBottleMergeDependencies } from "@peated/server/lib/mergeConcreteBottles";
+import { lockBottleMergeDependencies } from "@peated/server/lib/mergeBottles";
 import {
-  ConcreteBottleUpdateGraphError,
-  lockConcreteBottleUpdateDependencies,
-} from "@peated/server/lib/updateConcreteBottle";
+  BottleUpdateGraphError,
+  lockBottleUpdateDependencies,
+} from "@peated/server/lib/updateBottle";
 import { eq, inArray } from "drizzle-orm";
 import type { z } from "zod";
 import {
@@ -285,22 +285,19 @@ export async function prepareOperationForExecution({
   const proposal = ProposedOperationSchema.parse(operation.proposal);
   if (proposal.type === "update_bottle") {
     try {
-      await lockConcreteBottleUpdateDependencies(
+      await lockBottleUpdateDependencies(
         rawContext.database,
         proposal.input.bottleId,
         proposedBottleUpdateEntityIds(proposal),
       );
     } catch (error) {
-      if (error instanceof ConcreteBottleUpdateGraphError) {
+      if (error instanceof BottleUpdateGraphError) {
         fail("invalid_current_state", error.message);
       }
       throw error;
     }
   } else if (proposal.type === "merge_bottles") {
-    await lockConcreteBottleMergeDependencies(
-      rawContext.database,
-      proposal.input,
-    );
+    await lockBottleMergeDependencies(rawContext.database, proposal.input);
   } else if (proposal.type === "update_entity") {
     await rawContext.database
       .select({ id: entities.id })

--- a/apps/server/src/lib/bottleOperationReview/shared.ts
+++ b/apps/server/src/lib/bottleOperationReview/shared.ts
@@ -6,12 +6,12 @@ import {
 import { db, type AnyDatabase, type AnyTransaction } from "@peated/server/db";
 import type { Entity } from "@peated/server/db/schema";
 import { countries, entities, regions } from "@peated/server/db/schema";
-import type { ConcreteBottleUpdateInput } from "@peated/server/lib/concreteBottleSchemas";
+import type { BottleUpdateInput } from "@peated/server/lib/bottleSchemas";
 import { findEntityByExactNameOrAlias } from "@peated/server/lib/db";
 import type {
-  ConcreteBottleUpdateExpectedSelectedBottleState,
-  ConcreteBottleUpdateExpectedSharedState,
-} from "@peated/server/lib/updateConcreteBottle";
+  BottleUpdateExpectedSelectedBottleState,
+  BottleUpdateExpectedSharedState,
+} from "@peated/server/lib/updateBottle";
 import type {
   EntityUpdateExpectedState,
   EntityUpdateInput,
@@ -54,9 +54,9 @@ export type PreparedOperationExecution =
       review: z.infer<typeof PreparedBottleUpdateDataSchema>;
       canonicalInput: {
         bottleId: number;
-        input: ConcreteBottleUpdateInput;
-        expectedSelectedBottleState: ConcreteBottleUpdateExpectedSelectedBottleState;
-        expectedSharedState?: ConcreteBottleUpdateExpectedSharedState;
+        input: BottleUpdateInput;
+        expectedSelectedBottleState: BottleUpdateExpectedSelectedBottleState;
+        expectedSharedState?: BottleUpdateExpectedSharedState;
       };
     }
   | {

--- a/apps/server/src/lib/bottleReferenceResolution.ts
+++ b/apps/server/src/lib/bottleReferenceResolution.ts
@@ -17,10 +17,10 @@ import { type User } from "@peated/server/db/schema";
 import type { BottleAliasIdentitySnapshot } from "@peated/server/lib/bottleAliases";
 import { findBottleAliasAssignment } from "@peated/server/lib/bottleFinder";
 import {
-  createOrReuseConcreteBottleInTransaction,
+  createOrReuseBottleInTransaction,
   finalizeCreatedBottle,
-} from "@peated/server/lib/createConcreteBottle";
-import { buildClassifierConcreteBottleInput } from "./classifierDecisionCreateInputs";
+} from "@peated/server/lib/createBottle";
+import { buildClassifierBottleInput } from "./classifierDecisionCreateInputs";
 import {
   ActiveBottleSelectionError,
   resolveActiveBottleIds,
@@ -142,9 +142,9 @@ export async function applyClassifierCreateDecision({
   createdBottle: boolean;
   assignment: BottleReferenceAssignment;
 }> {
-  const input = buildClassifierConcreteBottleInput(decision.proposedBottle);
+  const input = buildClassifierBottleInput(decision.proposedBottle);
   const result = await db.transaction(async (tx) =>
-    createOrReuseConcreteBottleInTransaction(tx, {
+    createOrReuseBottleInTransaction(tx, {
       creationSource: "bottle_classifier",
       createdByActorId,
       input,

--- a/apps/server/src/lib/bottleReferenceSearchName.test.ts
+++ b/apps/server/src/lib/bottleReferenceSearchName.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, test } from "vitest";
 
-import { stripReleaseIdentityFromSearchName } from "./bottleReferenceSearchName";
+import { stripBottleIdentityFromSearchName } from "./bottleReferenceSearchName";
 
-describe("stripReleaseIdentityFromSearchName", () => {
+describe("stripBottleIdentityFromSearchName", () => {
   test("strips bare annual release years from parent search names", () => {
     expect(
-      stripReleaseIdentityFromSearchName(
+      stripBottleIdentityFromSearchName(
         "Example Limited Edition Small Batch 2017",
         {
           edition: null,
@@ -17,7 +17,7 @@ describe("stripReleaseIdentityFromSearchName", () => {
     ).toBe("Example Limited Edition Small Batch");
 
     expect(
-      stripReleaseIdentityFromSearchName(
+      stripBottleIdentityFromSearchName(
         "Lagavulin Distiller's Edition 2023 Islay Single Malt Scotch Whisky",
         {
           edition: null,
@@ -31,7 +31,7 @@ describe("stripReleaseIdentityFromSearchName", () => {
 
   test("strips numbered edition markers with flexible punctuation", () => {
     expect(
-      stripReleaseIdentityFromSearchName(
+      stripBottleIdentityFromSearchName(
         "Highland Park Cask Strength Release No. 5",
         {
           edition: "No. 5",
@@ -43,15 +43,12 @@ describe("stripReleaseIdentityFromSearchName", () => {
     ).toBe("Highland Park Cask Strength");
 
     expect(
-      stripReleaseIdentityFromSearchName(
-        "Heaven's Door Bootleg Vol 3 Whiskey",
-        {
-          edition: "Vol. 3",
-          releaseYear: null,
-          statedAge: null,
-          vintageYear: null,
-        },
-      ),
+      stripBottleIdentityFromSearchName("Heaven's Door Bootleg Vol 3 Whiskey", {
+        edition: "Vol. 3",
+        releaseYear: null,
+        statedAge: null,
+        vintageYear: null,
+      }),
     ).toBe("Heaven's Door Bootleg Whiskey");
   });
 });

--- a/apps/server/src/lib/bottleReferenceSearchName.ts
+++ b/apps/server/src/lib/bottleReferenceSearchName.ts
@@ -43,7 +43,7 @@ function buildLooseEditionPattern(edition: string) {
   return escapeRegExp(normalizedEdition).replace(/\\ /g, "\\s+");
 }
 
-export function stripReleaseIdentityFromSearchName(
+export function stripBottleIdentityFromSearchName(
   name: string,
   signals: BottleReferenceSearchSignals,
 ) {

--- a/apps/server/src/lib/bottleSchemas.ts
+++ b/apps/server/src/lib/bottleSchemas.ts
@@ -84,7 +84,7 @@ const ExactBottleInputSchema = BottleInputSchema.pick({
   })
   .strict();
 
-const IndependentConcreteBottleCreateRouteFieldsSchema =
+const IndependentBottleCreateRouteFieldsSchema =
   StableBottleGroupFieldsSchema.extend({
     edition: ExactBottleInputSchema.shape.edition,
     abv: ExactBottleInputSchema.shape.abv,
@@ -104,12 +104,10 @@ const IndependentConcreteBottleCreateRouteFieldsSchema =
  * Public independent creation reuses stable/exact validation without exposing
  * group authority or image-upload fields; uploads use a separate route.
  */
-export const IndependentConcreteBottleCreateRouteInputSchema =
-  IndependentConcreteBottleCreateRouteFieldsSchema.superRefine(
-    validateStableChoiceIds,
-  );
+export const IndependentBottleCreateRouteInputSchema =
+  IndependentBottleCreateRouteFieldsSchema.superRefine(validateStableChoiceIds);
 
-const ConcreteBottleSharedPatchSchema = z
+const BottleSharedPatchSchema = z
   .object({
     name: StableBottleGroupFieldsSchema.shape.name.optional(),
     statedAge: z.number().int().min(0).max(100).nullable().optional(),
@@ -136,7 +134,7 @@ const ConcreteBottleSharedPatchSchema = z
   .strict()
   .superRefine(validateStableChoiceIds);
 
-const ConcreteBottleExactPatchSchema = z
+const BottleExactPatchSchema = z
   .object({
     edition: ExactBottleInputSchema.shape.edition.removeDefault().optional(),
     statedAge: z.number().int().min(0).max(100).nullable().optional(),
@@ -177,45 +175,40 @@ const ConcreteBottleExactPatchSchema = z
   })
   .strict();
 
-const ModeratorConcreteBottleExactPatchSchema =
-  ConcreteBottleExactPatchSchema.omit({
-    suggestedTags: true,
-  });
+const ModeratorBottleExactPatchSchema = BottleExactPatchSchema.omit({
+  suggestedTags: true,
+});
 
-export const ConcreteBottleUpdateInputSchema = z
+export const BottleUpdateInputSchema = z
   .object({
-    shared: ConcreteBottleSharedPatchSchema.optional(),
-    exact: ModeratorConcreteBottleExactPatchSchema.optional(),
+    shared: BottleSharedPatchSchema.optional(),
+    exact: ModeratorBottleExactPatchSchema.optional(),
   })
   .strict();
 
-export type ConcreteBottleUpdateInput = z.infer<
-  typeof ConcreteBottleUpdateInputSchema
->;
+export type BottleUpdateInput = z.infer<typeof BottleUpdateInputSchema>;
 
 /**
  * Internal update contract for system-owned exact content such as generated
  * tags. Public moderator input remains limited to user-editable fields.
  */
-export const SystemConcreteBottleUpdateInputSchema = z
+export const SystemBottleUpdateInputSchema = z
   .object({
-    shared: ConcreteBottleSharedPatchSchema.optional(),
-    exact: ConcreteBottleExactPatchSchema.optional(),
+    shared: BottleSharedPatchSchema.optional(),
+    exact: BottleExactPatchSchema.optional(),
   })
   .strict();
 
-export type SystemConcreteBottleUpdateInput = z.infer<
-  typeof SystemConcreteBottleUpdateInputSchema
+export type SystemBottleUpdateInput = z.infer<
+  typeof SystemBottleUpdateInputSchema
 >;
 
 /** Runtime contract for independently complete singleton Bottle creation. */
-export const ConcreteBottleCreateInputSchema = z
+export const BottleCreateInputSchema = z
   .object({
     stable: StableBottleGroupInputSchema,
     exact: ExactBottleInputSchema,
   })
   .strict();
 
-export type ConcreteBottleCreateInput = z.infer<
-  typeof ConcreteBottleCreateInputSchema
->;
+export type BottleCreateInput = z.infer<typeof BottleCreateInputSchema>;

--- a/apps/server/src/lib/classifierDecisionCreateInputs.test.ts
+++ b/apps/server/src/lib/classifierDecisionCreateInputs.test.ts
@@ -1,9 +1,9 @@
 import type { ProposedBottle } from "@peated/bottle-classifier/internal/types";
+import { materializeBottleIdentity } from "./bottleIdentity";
 import {
   buildBottleInputFromProposedBottle,
-  buildClassifierConcreteBottleInput,
+  buildClassifierBottleInput,
 } from "./classifierDecisionCreateInputs";
-import { materializeConcreteBottleIdentity } from "./concreteBottleIdentity";
 
 test("materializes a classifier draft into one independently complete Bottle", () => {
   const proposedBottle: ProposedBottle = {
@@ -25,16 +25,16 @@ test("materializes a classifier draft into one independently complete Bottle", (
     bottler: null,
   };
 
-  const bottleInput = buildBottleInputFromProposedBottle(proposedBottle);
-  const concreteInput = buildClassifierConcreteBottleInput(proposedBottle);
+  const routeInput = buildBottleInputFromProposedBottle(proposedBottle);
+  const bottleInput = buildClassifierBottleInput(proposedBottle);
 
-  expect(bottleInput).toMatchObject({
+  expect(routeInput).toMatchObject({
     caskType: "ruby_port",
     caskSize: "barrel",
     caskFill: "2nd_fill",
   });
-  expect(concreteInput.stable.name).toBe("A Midwinter Night's Dram");
-  expect(concreteInput.exact).toMatchObject({
+  expect(bottleInput.stable.name).toBe("A Midwinter Night's Dram");
+  expect(bottleInput.exact).toMatchObject({
     edition: "Act 10 Scene 4",
     releaseYear: 2022,
     abv: 49.3,
@@ -43,23 +43,23 @@ test("materializes a classifier draft into one independently complete Bottle", (
     caskFill: "2nd_fill",
   });
   expect(
-    materializeConcreteBottleIdentity({
+    materializeBottleIdentity({
       stable: {
-        name: concreteInput.stable.name,
-        fullName: `High West ${concreteInput.stable.name}`,
-        statedAge: concreteInput.stable.statedAge,
+        name: bottleInput.stable.name,
+        fullName: `High West ${bottleInput.stable.name}`,
+        statedAge: bottleInput.stable.statedAge,
       },
       exact: {
-        edition: concreteInput.exact.edition ?? null,
-        statedAge: concreteInput.exact.statedAge ?? null,
-        releaseYear: concreteInput.exact.releaseYear ?? null,
-        vintageYear: concreteInput.exact.vintageYear ?? null,
-        abv: concreteInput.exact.abv ?? null,
-        singleCask: concreteInput.exact.singleCask ?? null,
-        caskStrength: concreteInput.exact.caskStrength ?? null,
-        caskType: concreteInput.exact.caskType ?? null,
-        caskSize: concreteInput.exact.caskSize ?? null,
-        caskFill: concreteInput.exact.caskFill ?? null,
+        edition: bottleInput.exact.edition ?? null,
+        statedAge: bottleInput.exact.statedAge ?? null,
+        releaseYear: bottleInput.exact.releaseYear ?? null,
+        vintageYear: bottleInput.exact.vintageYear ?? null,
+        abv: bottleInput.exact.abv ?? null,
+        singleCask: bottleInput.exact.singleCask ?? null,
+        caskStrength: bottleInput.exact.caskStrength ?? null,
+        caskType: bottleInput.exact.caskType ?? null,
+        caskSize: bottleInput.exact.caskSize ?? null,
+        caskFill: bottleInput.exact.caskFill ?? null,
       },
     }),
   ).toEqual({
@@ -90,28 +90,28 @@ test("keeps a marketed age exact without duplicating its name wording", () => {
     bottler: null,
   };
 
-  const concreteInput = buildClassifierConcreteBottleInput(proposedBottle);
+  const bottleInput = buildClassifierBottleInput(proposedBottle);
 
-  expect(concreteInput.stable.statedAge).toBeNull();
-  expect(concreteInput.exact.statedAge).toBe(12);
+  expect(bottleInput.stable.statedAge).toBeNull();
+  expect(bottleInput.exact.statedAge).toBe(12);
   expect(
-    materializeConcreteBottleIdentity({
+    materializeBottleIdentity({
       stable: {
-        name: concreteInput.stable.name,
-        fullName: `Shieldaig ${concreteInput.stable.name}`,
-        statedAge: concreteInput.stable.statedAge,
+        name: bottleInput.stable.name,
+        fullName: `Shieldaig ${bottleInput.stable.name}`,
+        statedAge: bottleInput.stable.statedAge,
       },
       exact: {
-        edition: concreteInput.exact.edition ?? null,
-        statedAge: concreteInput.exact.statedAge ?? null,
-        releaseYear: concreteInput.exact.releaseYear ?? null,
-        vintageYear: concreteInput.exact.vintageYear ?? null,
-        abv: concreteInput.exact.abv ?? null,
-        singleCask: concreteInput.exact.singleCask ?? null,
-        caskStrength: concreteInput.exact.caskStrength ?? null,
-        caskType: concreteInput.exact.caskType ?? null,
-        caskSize: concreteInput.exact.caskSize ?? null,
-        caskFill: concreteInput.exact.caskFill ?? null,
+        edition: bottleInput.exact.edition ?? null,
+        statedAge: bottleInput.exact.statedAge ?? null,
+        releaseYear: bottleInput.exact.releaseYear ?? null,
+        vintageYear: bottleInput.exact.vintageYear ?? null,
+        abv: bottleInput.exact.abv ?? null,
+        singleCask: bottleInput.exact.singleCask ?? null,
+        caskStrength: bottleInput.exact.caskStrength ?? null,
+        caskType: bottleInput.exact.caskType ?? null,
+        caskSize: bottleInput.exact.caskSize ?? null,
+        caskFill: bottleInput.exact.caskFill ?? null,
       },
     }),
   ).toEqual({

--- a/apps/server/src/lib/classifierDecisionCreateInputs.ts
+++ b/apps/server/src/lib/classifierDecisionCreateInputs.ts
@@ -1,9 +1,9 @@
 import type { ProposedBottle } from "@peated/bottle-classifier/internal/types";
-import type { ConcreteBottleCreateInput } from "@peated/server/lib/concreteBottleSchemas";
+import type { BottleCreateInput } from "@peated/server/lib/bottleSchemas";
 import type { BottleInputSchema } from "@peated/server/schemas";
 import type { z } from "zod";
 
-type BottleCreateInput = z.infer<typeof BottleInputSchema>;
+type RouteBottleInput = z.infer<typeof BottleInputSchema>;
 
 function buildBottleEntityInput(
   choice: {
@@ -11,7 +11,7 @@ function buildBottleEntityInput(
     name: string;
   },
   entityType: "brand" | "distiller" | "bottler",
-): BottleCreateInput["brand"] {
+): RouteBottleInput["brand"] {
   return (
     choice.id ?? {
       name: choice.name,
@@ -36,7 +36,7 @@ function buildBottleEntityInput(
  */
 export function buildBottleInputFromProposedBottle(
   proposedBottle: ProposedBottle,
-): BottleCreateInput {
+): RouteBottleInput {
   return {
     ...proposedBottle,
     series: proposedBottle.series
@@ -64,9 +64,9 @@ export function buildBottleInputFromProposedBottle(
  * creation. Group assignment is automatic; classifier output never selects a
  * parent or existing group.
  */
-export function buildClassifierConcreteBottleInput(
+export function buildClassifierBottleInput(
   proposedBottle: ProposedBottle,
-): ConcreteBottleCreateInput {
+): BottleCreateInput {
   const input = buildBottleInputFromProposedBottle(proposedBottle);
   return {
     stable: {

--- a/apps/server/src/lib/createBottle.test.ts
+++ b/apps/server/src/lib/createBottle.test.ts
@@ -9,22 +9,22 @@ import {
   changes,
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
-import { buildClassifierConcreteBottleInput } from "@peated/server/lib/classifierDecisionCreateInputs";
+import { buildClassifierBottleInput } from "@peated/server/lib/classifierDecisionCreateInputs";
 import {
   BottleAlreadyExistsError,
-  ConcreteBottleCreateInputSchema,
-  createConcreteBottle,
-  createConcreteBottleInTransaction,
-  createOrReuseConcreteBottleInTransaction,
-} from "@peated/server/lib/createConcreteBottle";
+  BottleCreateInputSchema,
+  createBottle,
+  createBottleInTransaction,
+  createOrReuseBottleInTransaction,
+} from "@peated/server/lib/createBottle";
 import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
-import { updateConcreteBottle } from "@peated/server/lib/updateConcreteBottle";
+import { updateBottle } from "@peated/server/lib/updateBottle";
 import * as workerClient from "@peated/server/worker/client";
 import { and, eq } from "drizzle-orm";
 import { vi } from "vitest";
 
 function contextFor(user: Parameters<typeof getUserActor>[0]) {
-  return { user } as Parameters<typeof createConcreteBottle>[0]["context"];
+  return { user } as Parameters<typeof createBottle>[0]["context"];
 }
 
 describe("Bottle creation", () => {
@@ -49,7 +49,7 @@ describe("Bottle creation", () => {
       flavorProfile: "peated" as const,
     };
 
-    const result = await createConcreteBottle({
+    const result = await createBottle({
       context: contextFor(defaults.user),
       input: {
         stable: {
@@ -163,7 +163,7 @@ describe("Bottle creation", () => {
       },
     );
 
-    const result = await createConcreteBottle({
+    const result = await createBottle({
       context: contextFor(defaults.user),
       input: {
         stable: { name: "Canonical Alias", brand: brand.id },
@@ -204,7 +204,7 @@ describe("Bottle creation", () => {
       name: "Classifier Exact Age Brand",
       type: ["brand"],
     });
-    const input = buildClassifierConcreteBottleInput({
+    const input = buildClassifierBottleInput({
       name: "Speyside 12-year-old",
       series: null,
       category: "single_malt",
@@ -223,7 +223,7 @@ describe("Bottle creation", () => {
       bottler: null,
     });
 
-    const created = await createConcreteBottle({
+    const created = await createBottle({
       context: contextFor(mod),
       creationSource: "bottle_classifier",
       input,
@@ -239,7 +239,7 @@ describe("Bottle creation", () => {
       statedAge: 12,
     });
 
-    const rematerialized = await updateConcreteBottle({
+    const rematerialized = await updateBottle({
       bottleId: created.bottle.id,
       input: { shared: { statedAge: 15 } },
       context: contextFor(mod),
@@ -258,7 +258,7 @@ describe("Bottle creation", () => {
     fixtures,
   }) => {
     const brand = await fixtures.Entity({ name: "Stable Age Brand" });
-    const result = await createConcreteBottle({
+    const result = await createBottle({
       context: contextFor(defaults.user),
       input: {
         stable: { name: "Old Malt 12 years old", brand: brand.id },
@@ -281,7 +281,7 @@ describe("Bottle creation", () => {
     fixtures,
   }) => {
     const brand = await fixtures.Entity({ name: "Stable Text Brand" });
-    const result = await createConcreteBottle({
+    const result = await createBottle({
       context: contextFor(defaults.user),
       input: {
         stable: {
@@ -344,7 +344,7 @@ describe("Bottle creation", () => {
     ];
 
     for (const { exactCask, nameSuffix } of variants) {
-      const result = await createConcreteBottle({
+      const result = await createBottle({
         context,
         input: {
           stable: { name: "Exact Cask Expression", brand: brand.id },
@@ -371,7 +371,7 @@ describe("Bottle creation", () => {
     const stableOverrides = "stable" in overrides ? overrides.stable : {};
     const exactOverrides = "exact" in overrides ? overrides.exact : {};
     expect(() =>
-      ConcreteBottleCreateInputSchema.parse({
+      BottleCreateInputSchema.parse({
         stable: {
           name: "Integer Boundary",
           brand: 1,
@@ -396,7 +396,7 @@ describe("Bottle creation", () => {
     ],
   ])("rejects an invalid %s id", (_label, stableOverrides) => {
     expect(() =>
-      ConcreteBottleCreateInputSchema.parse({
+      BottleCreateInputSchema.parse({
         stable: {
           name: "Entity ID Boundary",
           brand: 1,
@@ -425,7 +425,7 @@ describe("Bottle creation", () => {
       },
     },
   ])("rejects $label at the runtime boundary", ({ input }) => {
-    expect(() => ConcreteBottleCreateInputSchema.parse(input)).toThrow();
+    expect(() => BottleCreateInputSchema.parse(input)).toThrow();
   });
 
   test("blocks exact canonical aliases and duplicate SMWS codes", async ({
@@ -438,11 +438,9 @@ describe("Bottle creation", () => {
       stable: { name: "Duplicate Expression", brand: brand.id },
       exact: { edition: "Batch 1" },
     };
-    const first = await createConcreteBottle({ context, input });
+    const first = await createBottle({ context, input });
 
-    await expect(
-      createConcreteBottle({ context, input }),
-    ).rejects.toMatchObject({
+    await expect(createBottle({ context, input })).rejects.toMatchObject({
       bottleId: first.bottle.id,
       collision: {
         kind: "canonical_name",
@@ -462,7 +460,7 @@ describe("Bottle creation", () => {
       singleCask: true,
     });
     await expect(
-      createConcreteBottle({
+      createBottle({
         context,
         input: {
           stable: {
@@ -488,17 +486,17 @@ describe("Bottle creation", () => {
   }) => {
     const brand = await fixtures.Entity({ name: "Reuse Result Brand" });
     const actor = await getUserActor(defaults.user);
-    const input = ConcreteBottleCreateInputSchema.parse({
+    const input = BottleCreateInputSchema.parse({
       stable: { name: "Reuse Result Expression", brand: brand.id },
       exact: { edition: "Batch 1" },
     });
-    const created = await createConcreteBottle({
+    const created = await createBottle({
       context: contextFor(defaults.user),
       input,
     });
 
     const reused = await db.transaction((tx) =>
-      createOrReuseConcreteBottleInTransaction(tx, {
+      createOrReuseBottleInTransaction(tx, {
         creationSource: "bottle_classifier",
         createdByActorId: actor.id,
         input,
@@ -523,9 +521,7 @@ describe("Bottle creation", () => {
     const scenarios = [
       {
         reason: "bottle_retired",
-        retire: async (
-          bottle: Awaited<ReturnType<typeof createConcreteBottle>>,
-        ) => {
+        retire: async (bottle: Awaited<ReturnType<typeof createBottle>>) => {
           await db.insert(bottleTombstones).values({
             bottleId: bottle.bottle.id,
             newBottleId: replacement.id,
@@ -538,19 +534,19 @@ describe("Bottle creation", () => {
       const brand = await fixtures.Entity({
         name: `Inactive Reuse Brand ${index}`,
       });
-      const input = ConcreteBottleCreateInputSchema.parse({
+      const input = BottleCreateInputSchema.parse({
         stable: {
           name: `Inactive Reuse Expression ${index}`,
           brand: brand.id,
         },
         exact: {},
       });
-      const created = await createConcreteBottle({ context, input });
+      const created = await createBottle({ context, input });
       await scenario.retire(created);
 
       await expect(
         db.transaction((tx) =>
-          createOrReuseConcreteBottleInTransaction(tx, {
+          createOrReuseBottleInTransaction(tx, {
             creationSource: "bottle_classifier",
             createdByActorId: actor.id,
             input,
@@ -583,7 +579,7 @@ describe("Bottle creation", () => {
     });
     const changesBefore = await db.select({ id: changes.id }).from(changes);
     await expect(
-      createConcreteBottle({
+      createBottle({
         context: contextFor(defaults.user),
         input: {
           stable: { name: "Blocked Expression", brand: brand.id },
@@ -634,14 +630,14 @@ describe("Bottle creation", () => {
   }) => {
     const context = contextFor(defaults.user);
     const brand = await fixtures.Entity({ name: "Singleton Test Brand" });
-    const first = await createConcreteBottle({
+    const first = await createBottle({
       context,
       input: {
         stable: { name: "Shared Expression", brand: brand.id },
         exact: { edition: "Batch 1" },
       },
     });
-    const second = await createConcreteBottle({
+    const second = await createBottle({
       context,
       input: {
         stable: { name: "Shared Expression", brand: brand.id },
@@ -672,14 +668,14 @@ describe("Bottle creation", () => {
       stable: { name: "Rollback Expression", brand: brand.id },
       exact: { edition: "Retryable" },
     };
-    const parsedInput = ConcreteBottleCreateInputSchema.parse(input);
+    const parsedInput = BottleCreateInputSchema.parse(input);
     const attempt: {
-      result?: Awaited<ReturnType<typeof createConcreteBottleInTransaction>>;
+      result?: Awaited<ReturnType<typeof createBottleInTransaction>>;
     } = {};
 
     await expect(
       db.transaction(async (tx) => {
-        attempt.result = await createConcreteBottleInTransaction(tx, {
+        attempt.result = await createBottleInTransaction(tx, {
           createdByActorId: actor.id,
           input: parsedInput,
           context: contextFor(defaults.user),
@@ -723,7 +719,7 @@ describe("Bottle creation", () => {
         ),
     ).toEqual([]);
 
-    const retried = await createConcreteBottle({
+    const retried = await createBottle({
       context: contextFor(defaults.user),
       input,
     });
@@ -746,7 +742,7 @@ describe("Bottle creation", () => {
       throw new Error("queue unavailable");
     });
 
-    const result = await createConcreteBottle({
+    const result = await createBottle({
       context: contextFor(defaults.user),
       input: {
         stable: { name: "Committed Before Queue", brand: brand.id },

--- a/apps/server/src/lib/createBottle.ts
+++ b/apps/server/src/lib/createBottle.ts
@@ -53,15 +53,15 @@ import type { z } from "zod";
 import {
   findConflictingSmwsBottleId,
   getSmwsCodeForBottleIdentity,
-} from "./concreteBottleConflicts";
-import { materializeConcreteBottleIdentity } from "./concreteBottleIdentity";
+} from "./bottleConflicts";
+import { materializeBottleIdentity } from "./bottleIdentity";
 import {
-  ConcreteBottleCreateInputSchema,
-  type ConcreteBottleCreateInput,
-} from "./concreteBottleSchemas";
+  BottleCreateInputSchema,
+  type BottleCreateInput,
+} from "./bottleSchemas";
 
-export { ConcreteBottleCreateInputSchema } from "./concreteBottleSchemas";
-export type { ConcreteBottleCreateInput } from "./concreteBottleSchemas";
+export { BottleCreateInputSchema } from "./bottleSchemas";
+export type { BottleCreateInput } from "./bottleSchemas";
 
 export class BottleCreateBadRequestError extends Error {
   constructor(message: string) {
@@ -84,7 +84,7 @@ export class BottleAlreadyExistsError extends Error {
   }
 }
 
-export type CreateBottleResult = {
+type PersistedBottleResult = {
   bottle: Bottle;
   newAliases: string[];
   newEntityIds: number[];
@@ -102,18 +102,18 @@ type PreparedBottleCreate = {
   stableName: string;
 };
 
-type ConcreteIdentityPreparation = {
+type BottleIdentityPreparation = {
   exactNormalizedFields: Pick<
-    ConcreteBottleCreateInput["exact"],
+    BottleCreateInput["exact"],
     "statedAge" | "vintageYear" | "releaseYear" | "singleCask" | "caskStrength"
   >;
   stableName: string;
   stableStatedAge: number | null;
 };
 
-type StableBottleGroupInput = ConcreteBottleCreateInput["stable"];
+type StableBottleGroupInput = BottleCreateInput["stable"];
 
-export type ConcreteBottleCreateResult = CreateBottleResult & {
+export type BottleCreateResult = PersistedBottleResult & {
   group: BottleGroup;
 };
 
@@ -122,13 +122,13 @@ async function prepareBottleCreateInTransaction(
   tx: AnyTransaction,
   {
     creationSource = "manual_entry",
-    concreteIdentity,
+    bottleIdentity,
     createdByActorId,
     input,
     context,
   }: {
     creationSource?: CatalogVerificationCreationSource;
-    concreteIdentity?: ConcreteIdentityPreparation;
+    bottleIdentity?: BottleIdentityPreparation;
     createdByActorId: number;
     input: z.infer<typeof BottleInputSchema>;
     context: Context & { user: User };
@@ -138,9 +138,9 @@ async function prepareBottleCreateInTransaction(
   const actorId = createdByActorId;
   const bottleData: BottlePreviewResult & Record<string, any> =
     await bottleNormalize({ input, context, entityDb: tx });
-  if (concreteIdentity) {
+  if (bottleIdentity) {
     // Explicit exact input overrides traits inferred from the stable name.
-    Object.assign(bottleData, concreteIdentity.exactNormalizedFields);
+    Object.assign(bottleData, bottleIdentity.exactNormalizedFields);
   }
 
   if (input.description !== undefined) {
@@ -151,7 +151,7 @@ async function prepareBottleCreateInTransaction(
   }
 
   const stableName = stripDuplicateBrandPrefixFromBottleName(
-    concreteIdentity?.stableName ?? bottleData.name,
+    bottleIdentity?.stableName ?? bottleData.name,
     bottleData.brand.name,
   );
 
@@ -265,12 +265,12 @@ async function prepareBottleCreateInTransaction(
   const stableFullName = formatBottleName({
     name: `${brand.shortName || brand.name} ${stableName}`,
   });
-  const concreteName = concreteIdentity
-    ? materializeConcreteBottleIdentity({
+  const bottleName = bottleIdentity
+    ? materializeBottleIdentity({
         stable: {
           name: stableName,
           fullName: stableFullName,
-          statedAge: concreteIdentity.stableStatedAge,
+          statedAge: bottleIdentity.stableStatedAge,
         },
         exact: {
           edition: bottleData.edition ?? null,
@@ -287,7 +287,7 @@ async function prepareBottleCreateInTransaction(
       })
     : null;
   const fullName =
-    concreteName?.fullName ??
+    bottleName?.fullName ??
     formatBottleName({
       ...bottleData,
       name: `${brand.shortName || brand.name} ${bottleData.name}`,
@@ -295,8 +295,8 @@ async function prepareBottleCreateInTransaction(
 
   const bottleInsertData: NewBottle = {
     ...bottleData,
-    name: concreteName?.name ?? bottleData.name,
-    statedAge: concreteName ? concreteName.statedAge : bottleData.statedAge,
+    name: bottleName?.name ?? bottleData.name,
+    statedAge: bottleName ? bottleName.statedAge : bottleData.statedAge,
     brandId: brand.id,
     bottlerId: bottler?.id || null,
     seriesId,
@@ -373,7 +373,7 @@ async function insertPreparedBottleInTransaction(
   tx: AnyTransaction,
   prepared: PreparedBottleCreate,
   { groupId = null }: { groupId?: number | null } = {},
-): Promise<CreateBottleResult> {
+): Promise<PersistedBottleResult> {
   const {
     bottleInsertData,
     creationSource,
@@ -429,9 +429,9 @@ async function insertPreparedBottleInTransaction(
   };
 }
 
-function buildConcreteBottleInput(
+function buildBottleInput(
   stable: StableBottleGroupInput,
-  exact: ConcreteBottleCreateInput["exact"],
+  exact: BottleCreateInput["exact"],
 ): z.infer<typeof BottleInputSchema> {
   const input: z.infer<typeof BottleInputSchema> = {
     name: stable.name,
@@ -503,7 +503,7 @@ async function createIndependentGroupPrefix(
 }
 
 /** Owns the complete singleton Bottle graph transaction. */
-export async function createConcreteBottleInTransaction(
+export async function createBottleInTransaction(
   tx: AnyTransaction,
   {
     creationSource = "manual_entry",
@@ -513,10 +513,10 @@ export async function createConcreteBottleInTransaction(
   }: {
     creationSource?: CatalogVerificationCreationSource;
     createdByActorId: number;
-    input: ConcreteBottleCreateInput;
+    input: BottleCreateInput;
     context: Context & { user: User };
   },
-): Promise<ConcreteBottleCreateResult> {
+): Promise<BottleCreateResult> {
   // Exact age is name-normalization context only; it cannot become group-owned state.
   const normalizedStable = normalizeBottleAge({
     name: normalizeBottleAliasKey(input.stable.name),
@@ -528,7 +528,7 @@ export async function createConcreteBottleInTransaction(
   };
   const prepared = await prepareBottleCreateInTransaction(tx, {
     creationSource,
-    concreteIdentity: {
+    bottleIdentity: {
       exactNormalizedFields: {
         statedAge: input.exact.statedAge,
         vintageYear: input.exact.vintageYear,
@@ -540,7 +540,7 @@ export async function createConcreteBottleInTransaction(
       stableStatedAge: stable.statedAge,
     },
     createdByActorId,
-    input: buildConcreteBottleInput(stable, input.exact),
+    input: buildBottleInput(stable, input.exact),
     context,
   });
 
@@ -573,12 +573,12 @@ export async function createConcreteBottleInTransaction(
   };
 }
 
-export type ConcreteBottleCreateOrReuseResult = {
+export type BottleCreateOrReuseResult = {
   bottle: Bottle;
-  createResult: ConcreteBottleCreateResult | null;
+  createResult: BottleCreateResult | null;
 };
 
-function isSafeConcreteBottleReuse(
+function isSafeBottleReuse(
   error: BottleAlreadyExistsError,
   existingBottle: Bottle,
 ) {
@@ -605,11 +605,11 @@ function isSafeConcreteBottleReuse(
 }
 
 /**
- * Owns the savepoint-backed concrete create-or-safe-reuse decision. Reuse is
+ * Owns the savepoint-backed create-or-safe-reuse decision. Reuse is
  * limited to an exact canonical-name collision or the structurally verified
  * SMWS code that caused creation to conflict.
  */
-export async function createOrReuseConcreteBottleInTransaction(
+export async function createOrReuseBottleInTransaction(
   tx: AnyTransaction,
   {
     creationSource,
@@ -619,13 +619,13 @@ export async function createOrReuseConcreteBottleInTransaction(
   }: {
     creationSource: CatalogVerificationCreationSource;
     createdByActorId: number;
-    input: ConcreteBottleCreateInput;
+    input: BottleCreateInput;
     context: Context & { user: User };
   },
-): Promise<ConcreteBottleCreateOrReuseResult> {
+): Promise<BottleCreateOrReuseResult> {
   try {
     const createResult = await tx.transaction(async (creationTx) =>
-      createConcreteBottleInTransaction(creationTx, {
+      createBottleInTransaction(creationTx, {
         creationSource,
         createdByActorId,
         input,
@@ -644,7 +644,7 @@ export async function createOrReuseConcreteBottleInTransaction(
     const existingBottle = await tx.query.bottles.findFirst({
       where: eq(bottles.id, error.bottleId),
     });
-    if (!existingBottle || !isSafeConcreteBottleReuse(error, existingBottle)) {
+    if (!existingBottle || !isSafeBottleReuse(error, existingBottle)) {
       throw error;
     }
 
@@ -657,12 +657,7 @@ export async function createOrReuseConcreteBottleInTransaction(
 
 /** Dispatches unique, best-effort work only after the Bottle transaction commits. */
 export async function finalizeCreatedBottle(
-  {
-    bottle,
-    seriesCreated,
-    newAliases,
-    newEntityIds,
-  }: ConcreteBottleCreateResult,
+  { bottle, seriesCreated, newAliases, newEntityIds }: BottleCreateResult,
   {
     creationSource = "manual_entry",
   }: {
@@ -747,13 +742,10 @@ export async function finalizeCreatedBottle(
   }
 }
 
-export type CreateConcreteBottleResult = Pick<
-  ConcreteBottleCreateResult,
-  "bottle" | "group"
->;
+export type CreateBottleResult = Pick<BottleCreateResult, "bottle" | "group">;
 
 /** Parses untrusted input once and owns transaction plus post-commit dispatch. */
-export async function createConcreteBottle({
+export async function createBottle({
   creationSource = "manual_entry",
   input: rawInput,
   context,
@@ -761,11 +753,11 @@ export async function createConcreteBottle({
   creationSource?: CatalogVerificationCreationSource;
   input: unknown;
   context: Context & { user: User };
-}): Promise<CreateConcreteBottleResult> {
-  const input = ConcreteBottleCreateInputSchema.parse(rawInput);
+}): Promise<CreateBottleResult> {
+  const input = BottleCreateInputSchema.parse(rawInput);
   const actor = await getUserActor(context.user);
   const result = await db.transaction(async (tx) =>
-    createConcreteBottleInTransaction(tx, {
+    createBottleInTransaction(tx, {
       creationSource,
       createdByActorId: actor.id,
       input,

--- a/apps/server/src/lib/flatBottleInput.ts
+++ b/apps/server/src/lib/flatBottleInput.ts
@@ -1,22 +1,20 @@
 import {
-  ConcreteBottleUpdateInputSchema,
-  IndependentConcreteBottleCreateRouteInputSchema,
-  type ConcreteBottleCreateInput,
-  type ConcreteBottleUpdateInput,
-} from "@peated/server/lib/concreteBottleSchemas";
+  BottleUpdateInputSchema,
+  IndependentBottleCreateRouteInputSchema,
+  type BottleCreateInput,
+  type BottleUpdateInput,
+} from "@peated/server/lib/bottleSchemas";
 import type { BottleInputSchema } from "@peated/server/schemas";
 import type { z } from "zod";
 
 type FlatBottleInput = z.input<typeof BottleInputSchema>;
 
 /**
- * Translates the retained flat Bottle input into the strict concrete create
+ * Translates the retained flat Bottle input into the strict Bottle create
  * route contract without carrying legacy response or image fields forward.
  */
-export function buildIndependentConcreteBottleRouteInput(
-  input: FlatBottleInput,
-) {
-  return IndependentConcreteBottleCreateRouteInputSchema.parse({
+export function buildIndependentBottleRouteInput(input: FlatBottleInput) {
+  return IndependentBottleCreateRouteInputSchema.parse({
     name: input.name,
     statedAge: input.statedAge,
     series: input.series,
@@ -41,9 +39,9 @@ export function buildIndependentConcreteBottleRouteInput(
 }
 
 /** Maps the public flat create contract to canonical independent creation. */
-export function buildIndependentConcreteBottleCreateInput(
-  input: ReturnType<typeof buildIndependentConcreteBottleRouteInput>,
-): ConcreteBottleCreateInput {
+export function buildIndependentBottleCreateInput(
+  input: ReturnType<typeof buildIndependentBottleRouteInput>,
+): BottleCreateInput {
   return {
     stable: {
       name: input.name,
@@ -74,10 +72,10 @@ export function buildIndependentConcreteBottleCreateInput(
 }
 
 /** Maps a parsed flat upsert input to the canonical shared/exact patch. */
-export function buildConcreteBottleUpdatePatch(
-  input: ReturnType<typeof buildIndependentConcreteBottleRouteInput>,
-): ConcreteBottleUpdateInput {
-  return ConcreteBottleUpdateInputSchema.parse({
+export function buildBottleUpdatePatch(
+  input: ReturnType<typeof buildIndependentBottleRouteInput>,
+): BottleUpdateInput {
+  return BottleUpdateInputSchema.parse({
     shared: {
       name: input.name,
       statedAge: input.statedAge,

--- a/apps/server/src/lib/mergeBottles.test.ts
+++ b/apps/server/src/lib/mergeBottles.test.ts
@@ -22,18 +22,18 @@ import {
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
 import {
-  ConcreteBottleMergeAuthorizationError,
-  ConcreteBottleMergeConflictError,
-  ConcreteBottleMergeGraphError,
-  mergeConcreteBottles,
-  mergeConcreteBottlesInTransaction,
-} from "@peated/server/lib/mergeConcreteBottles";
+  BottleMergeAuthorizationError,
+  BottleMergeConflictError,
+  BottleMergeGraphError,
+  mergeBottles,
+  mergeBottlesInTransaction,
+} from "@peated/server/lib/mergeBottles";
 import * as workerClient from "@peated/server/worker/client";
 import { and, eq, inArray } from "drizzle-orm";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 function contextFor(user: User | null) {
-  return { user } as Parameters<typeof mergeConcreteBottles>[0]["context"];
+  return { user } as Parameters<typeof mergeBottles>[0]["context"];
 }
 
 describe("exact Bottle merges", () => {
@@ -197,7 +197,7 @@ describe("exact Bottle merges", () => {
       count: 3,
     });
 
-    const result = await mergeConcreteBottles({
+    const result = await mergeBottles({
       sourceBottleId: source.id,
       destinationBottleId: destination.id,
       context: contextFor(mod),
@@ -379,7 +379,7 @@ describe("exact Bottle merges", () => {
     });
 
     expect(
-      await mergeConcreteBottles({
+      await mergeBottles({
         sourceBottleId: source.id,
         destinationBottleId: destination.id,
         context: contextFor(mod),
@@ -425,7 +425,7 @@ describe("exact Bottle merges", () => {
     ]);
 
     await db.transaction((tx) =>
-      mergeConcreteBottlesInTransaction(tx, {
+      mergeBottlesInTransaction(tx, {
         sourceBottleId: source.id,
         destinationBottleId: destination.id,
         actorId: actor.id,
@@ -471,7 +471,7 @@ describe("exact Bottle merges", () => {
     });
 
     const manifest = await db.transaction((tx) =>
-      mergeConcreteBottlesInTransaction(tx, {
+      mergeBottlesInTransaction(tx, {
         sourceBottleId: source.id,
         destinationBottleId: destination.id,
         actorId: actor.id,
@@ -507,7 +507,7 @@ describe("exact Bottle merges", () => {
     });
 
     await db.transaction((tx) =>
-      mergeConcreteBottlesInTransaction(tx, {
+      mergeBottlesInTransaction(tx, {
         sourceBottleId: source.id,
         destinationBottleId: destination.id,
         actorId: actor.id,
@@ -562,7 +562,7 @@ describe("exact Bottle merges", () => {
     if (!canonicalAlias) throw new Error("Expected the canonical alias.");
 
     await db.transaction((tx) =>
-      mergeConcreteBottlesInTransaction(tx, {
+      mergeBottlesInTransaction(tx, {
         sourceBottleId: source.id,
         destinationBottleId: destination.id,
         actorId: actor.id,
@@ -603,7 +603,7 @@ describe("exact Bottle merges", () => {
     if (!canonicalAlias) throw new Error("Expected the canonical alias.");
 
     await db.transaction((tx) =>
-      mergeConcreteBottlesInTransaction(tx, {
+      mergeBottlesInTransaction(tx, {
         sourceBottleId: source.id,
         destinationBottleId: destination.id,
         actorId: actor.id,
@@ -636,7 +636,7 @@ describe("exact Bottle merges", () => {
       .where(eq(bottleAliases.name, source.fullName));
 
     await db.transaction((tx) =>
-      mergeConcreteBottlesInTransaction(tx, {
+      mergeBottlesInTransaction(tx, {
         sourceBottleId: source.id,
         destinationBottleId: destination.id,
         actorId: actor.id,
@@ -673,15 +673,13 @@ describe("exact Bottle merges", () => {
 
     await expect(
       db.transaction((tx) =>
-        mergeConcreteBottlesInTransaction(tx, {
+        mergeBottlesInTransaction(tx, {
           sourceBottleId: source.id,
           destinationBottleId: destination.id,
           actorId: actor.id,
         }),
       ),
-    ).rejects.toEqual(
-      new ConcreteBottleMergeConflictError("identity_conflict"),
-    );
+    ).rejects.toEqual(new BottleMergeConflictError("identity_conflict"));
     expect(
       await db.query.bottles.findFirst({
         where: eq(bottles.id, source.id),
@@ -712,15 +710,13 @@ describe("exact Bottle merges", () => {
 
     await expect(
       db.transaction((tx) =>
-        mergeConcreteBottlesInTransaction(tx, {
+        mergeBottlesInTransaction(tx, {
           sourceBottleId: source.id,
           destinationBottleId: destination.id,
           actorId: actor.id,
         }),
       ),
-    ).rejects.toEqual(
-      new ConcreteBottleMergeConflictError("consumer_conflict"),
-    );
+    ).rejects.toEqual(new BottleMergeConflictError("consumer_conflict"));
     expect(
       await db.query.bottles.findFirst({
         where: eq(bottles.id, source.id),
@@ -746,7 +742,7 @@ describe("exact Bottle merges", () => {
     });
 
     await db.transaction((tx) =>
-      mergeConcreteBottlesInTransaction(tx, {
+      mergeBottlesInTransaction(tx, {
         sourceBottleId: source.id,
         destinationBottleId: firstDestination.id,
         actorId: actor.id,
@@ -755,35 +751,35 @@ describe("exact Bottle merges", () => {
 
     await expect(
       db.transaction((tx) =>
-        mergeConcreteBottlesInTransaction(tx, {
+        mergeBottlesInTransaction(tx, {
           sourceBottleId: source.id,
           destinationBottleId: otherDestination.id,
           actorId: actor.id,
         }),
       ),
     ).rejects.toEqual(
-      new ConcreteBottleMergeConflictError("retired_to_other_destination"),
+      new BottleMergeConflictError("retired_to_other_destination"),
     );
     await expect(
       db.transaction((tx) =>
-        mergeConcreteBottlesInTransaction(tx, {
+        mergeBottlesInTransaction(tx, {
           sourceBottleId: otherDestination.id,
           destinationBottleId: source.id,
           actorId: actor.id,
         }),
       ),
-    ).rejects.toEqual(new ConcreteBottleMergeGraphError("retired", source.id));
+    ).rejects.toEqual(new BottleMergeGraphError("retired", source.id));
   });
 
   test("enforces moderator authorization at the public boundary", async ({
     defaults,
   }) => {
     await expect(
-      mergeConcreteBottles({
+      mergeBottles({
         sourceBottleId: 1,
         destinationBottleId: 2,
         context: contextFor(defaults.user),
       }),
-    ).rejects.toBeInstanceOf(ConcreteBottleMergeAuthorizationError);
+    ).rejects.toBeInstanceOf(BottleMergeAuthorizationError);
   });
 });

--- a/apps/server/src/lib/mergeBottles.ts
+++ b/apps/server/src/lib/mergeBottles.ts
@@ -36,71 +36,70 @@ import type { Context } from "@peated/server/orpc/context";
 import { pushUniqueJob } from "@peated/server/worker/client";
 import { and, asc, eq, inArray, or, sql } from "drizzle-orm";
 
-export class ConcreteBottleMergeAuthorizationError extends Error {
+export class BottleMergeAuthorizationError extends Error {
   constructor() {
     super("Moderator authorization is required to merge Bottles.");
-    this.name = "ConcreteBottleMergeAuthorizationError";
+    this.name = "BottleMergeAuthorizationError";
   }
 }
 
-export class ConcreteBottleMergeInputError extends Error {
+export class BottleMergeInputError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "ConcreteBottleMergeInputError";
+    this.name = "BottleMergeInputError";
   }
 }
 
-export type ConcreteBottleMergeGraphErrorCode =
+export type BottleMergeGraphErrorCode =
   | "not_found"
   | "retired"
   | "unmigrated"
   | "invalid_catalog_graph";
 
-export class ConcreteBottleMergeGraphError extends Error {
+export class BottleMergeGraphError extends Error {
   constructor(
-    readonly code: ConcreteBottleMergeGraphErrorCode,
+    readonly code: BottleMergeGraphErrorCode,
     readonly bottleId: number,
     options?: ErrorOptions,
   ) {
     super(`Cannot merge Bottle ${bottleId}: ${code}.`, options);
-    this.name = "ConcreteBottleMergeGraphError";
+    this.name = "BottleMergeGraphError";
   }
 }
 
-export type ConcreteBottleMergeConflictCode =
+export type BottleMergeConflictCode =
   | "same_bottle"
   | "retired_to_other_destination"
   | "identity_conflict"
   | "consumer_conflict";
 
-export class ConcreteBottleMergeConflictError extends Error {
+export class BottleMergeConflictError extends Error {
   constructor(
-    readonly code: ConcreteBottleMergeConflictCode,
+    readonly code: BottleMergeConflictCode,
     options?: ErrorOptions,
   ) {
     super(`Bottle merge failed: ${code}.`, options);
-    this.name = "ConcreteBottleMergeConflictError";
+    this.name = "BottleMergeConflictError";
   }
 }
 
-export type ConcreteBottleMergeResult = {
+export type BottleMergeResult = {
   sourceBottleId: number;
   destinationBottleId: number;
   destinationBottle: Bottle;
   changed: boolean;
 };
 
-export type ConcreteBottleMergeFinalizationManifest =
-  ConcreteBottleMergeResult & {
-    aliasNames: string[];
-    entityIds: number[];
-    seriesIds: number[];
-  };
+export type BottleMergeFinalizationManifest = BottleMergeResult & {
+  aliasNames: string[];
+  entityIds: number[];
+  seriesIds: number[];
+};
 
 function inertManifest(
   sourceBottleId: number,
   destinationBottle: Bottle,
-): ConcreteBottleMergeFinalizationManifest {
+): BottleMergeFinalizationManifest {
   return {
     sourceBottleId,
     destinationBottleId: destinationBottle.id,
@@ -123,17 +122,17 @@ function validateMergeInput(
   destinationBottleId: number,
 ) {
   if (!Number.isInteger(sourceBottleId) || sourceBottleId <= 0) {
-    throw new ConcreteBottleMergeInputError(
+    throw new BottleMergeInputError(
       "Source Bottle ID must be a positive integer.",
     );
   }
   if (!Number.isInteger(destinationBottleId) || destinationBottleId <= 0) {
-    throw new ConcreteBottleMergeInputError(
+    throw new BottleMergeInputError(
       "Destination Bottle ID must be a positive integer.",
     );
   }
   if (sourceBottleId === destinationBottleId) {
-    throw new ConcreteBottleMergeConflictError("same_bottle");
+    throw new BottleMergeConflictError("same_bottle");
   }
 }
 
@@ -295,7 +294,7 @@ async function assertNoTastingCollision(
   for (const { createdById, createdAt } of rows) {
     const key = `${createdById}:${createdAt.getTime()}`;
     if (projectedKeys.has(key)) {
-      throw new ConcreteBottleMergeConflictError("consumer_conflict");
+      throw new BottleMergeConflictError("consumer_conflict");
     }
     projectedKeys.add(key);
   }
@@ -372,7 +371,7 @@ async function repointBottleConsumers(
  * rows are blocked by the owning Bottle locks, so preparation remains stable
  * until the caller executes or rolls back.
  */
-export async function lockConcreteBottleMergeDependencies(
+export async function lockBottleMergeDependencies(
   tx: AnyTransaction,
   {
     sourceBottleId,
@@ -534,7 +533,7 @@ export async function lockConcreteBottleMergeDependencies(
  * Commits one exact duplicate merge inside the caller-owned transaction. The
  * returned manifest must only be finalized after the outermost commit.
  */
-export async function mergeConcreteBottlesInTransaction(
+export async function mergeBottlesInTransaction(
   tx: AnyTransaction,
   {
     sourceBottleId,
@@ -545,12 +544,10 @@ export async function mergeConcreteBottlesInTransaction(
     destinationBottleId: number;
     actorId: number;
   },
-): Promise<ConcreteBottleMergeFinalizationManifest> {
+): Promise<BottleMergeFinalizationManifest> {
   validateMergeInput(sourceBottleId, destinationBottleId);
   if (!Number.isInteger(actorId) || actorId <= 0) {
-    throw new ConcreteBottleMergeInputError(
-      "Actor ID must be a positive integer.",
-    );
+    throw new BottleMergeInputError("Actor ID must be a positive integer.");
   }
 
   const requestedBottleIds = [sourceBottleId, destinationBottleId].sort(
@@ -567,10 +564,10 @@ export async function mergeConcreteBottlesInTransaction(
   const discoveredSource = discoveredById.get(sourceBottleId);
   const discoveredDestination = discoveredById.get(destinationBottleId);
   if (discoveredSource?.groupId === null) {
-    throw new ConcreteBottleMergeGraphError("unmigrated", sourceBottleId);
+    throw new BottleMergeGraphError("unmigrated", sourceBottleId);
   }
   if (discoveredDestination?.groupId === null) {
-    throw new ConcreteBottleMergeGraphError("unmigrated", destinationBottleId);
+    throw new BottleMergeGraphError("unmigrated", destinationBottleId);
   }
 
   const groupIds = uniqueSorted([
@@ -610,12 +607,12 @@ export async function mergeConcreteBottlesInTransaction(
   );
 
   if (tombstoneByBottleId.has(destinationBottleId)) {
-    throw new ConcreteBottleMergeGraphError("retired", destinationBottleId);
+    throw new BottleMergeGraphError("retired", destinationBottleId);
   }
   const sourceTombstone = tombstoneByBottleId.get(sourceBottleId);
   if (sourceTombstone?.newBottleId === destinationBottleId) {
     if (!destination || destination.groupId === null) {
-      throw new ConcreteBottleMergeGraphError(
+      throw new BottleMergeGraphError(
         "invalid_catalog_graph",
         destinationBottleId,
       );
@@ -630,7 +627,7 @@ export async function mergeConcreteBottlesInTransaction(
           groupId === destinationGroup.id,
       )
     ) {
-      throw new ConcreteBottleMergeGraphError(
+      throw new BottleMergeGraphError(
         "invalid_catalog_graph",
         destinationBottleId,
       );
@@ -638,31 +635,31 @@ export async function mergeConcreteBottlesInTransaction(
     return inertManifest(sourceBottleId, destination);
   }
   if (sourceTombstone) {
-    throw new ConcreteBottleMergeConflictError("retired_to_other_destination");
+    throw new BottleMergeConflictError("retired_to_other_destination");
   }
   if (!source) {
-    throw new ConcreteBottleMergeGraphError(
+    throw new BottleMergeGraphError(
       discoveredSource ? "invalid_catalog_graph" : "not_found",
       sourceBottleId,
     );
   }
   if (!destination) {
-    throw new ConcreteBottleMergeGraphError(
+    throw new BottleMergeGraphError(
       discoveredDestination ? "invalid_catalog_graph" : "not_found",
       destinationBottleId,
     );
   }
   if (source.groupId === null) {
-    throw new ConcreteBottleMergeGraphError("unmigrated", sourceBottleId);
+    throw new BottleMergeGraphError("unmigrated", sourceBottleId);
   }
   if (destination.groupId === null) {
-    throw new ConcreteBottleMergeGraphError("unmigrated", destinationBottleId);
+    throw new BottleMergeGraphError("unmigrated", destinationBottleId);
   }
   if (
     source.groupId !== discoveredSource?.groupId ||
     destination.groupId !== discoveredDestination?.groupId
   ) {
-    throw new ConcreteBottleMergeGraphError(
+    throw new BottleMergeGraphError(
       "invalid_catalog_graph",
       source.groupId !== discoveredSource?.groupId
         ? sourceBottleId
@@ -675,7 +672,7 @@ export async function mergeConcreteBottlesInTransaction(
   const sourceGroup = groupById.get(sourceGroupId);
   const destinationGroup = groupById.get(destinationGroupId);
   if (!sourceGroup || !destinationGroup) {
-    throw new ConcreteBottleMergeGraphError(
+    throw new BottleMergeGraphError(
       "invalid_catalog_graph",
       !sourceGroup ? sourceBottleId : destinationBottleId,
     );
@@ -696,10 +693,7 @@ export async function mergeConcreteBottlesInTransaction(
       ({ id }) => id === destinationGroup.representativeBottleId,
     )
   ) {
-    throw new ConcreteBottleMergeGraphError(
-      "invalid_catalog_graph",
-      sourceBottleId,
-    );
+    throw new BottleMergeGraphError("invalid_catalog_graph", sourceBottleId);
   }
   const crossGroup = sourceGroupId !== destinationGroupId;
   const survivingSourceMembers = sourceMembers.filter(
@@ -737,7 +731,7 @@ export async function mergeConcreteBottlesInTransaction(
     typeof canonicalAliasOwnerId === "number" &&
     !bottleById.has(canonicalAliasOwnerId)
   ) {
-    throw new ConcreteBottleMergeConflictError("identity_conflict");
+    throw new BottleMergeConflictError("identity_conflict");
   }
 
   let consumerCounts: Record<string, number>;
@@ -753,7 +747,7 @@ export async function mergeConcreteBottlesInTransaction(
         postgresConstraint(error) ?? "",
       )
     ) {
-      throw new ConcreteBottleMergeConflictError("consumer_conflict", {
+      throw new BottleMergeConflictError("consumer_conflict", {
         cause: error,
       });
     }
@@ -934,7 +928,7 @@ export async function mergeConcreteBottlesInTransaction(
     .where(eq(bottles.id, destinationBottleId))
     .limit(1);
   if (!destinationBottle) {
-    throw new ConcreteBottleMergeGraphError(
+    throw new BottleMergeGraphError(
       "invalid_catalog_graph",
       destinationBottleId,
     );
@@ -972,8 +966,8 @@ export async function mergeConcreteBottlesInTransaction(
 }
 
 /** Dispatches only idempotent derived work after the outermost commit. */
-export async function finalizeConcreteBottleMerge(
-  manifest: ConcreteBottleMergeFinalizationManifest,
+export async function finalizeBottleMerge(
+  manifest: BottleMergeFinalizationManifest,
 ) {
   if (!manifest.changed) return;
   const jobs: Array<
@@ -1008,7 +1002,7 @@ export async function finalizeConcreteBottleMerge(
 }
 
 /** Authorizes, commits, and finalizes one exact Bottle duplicate merge. */
-export async function mergeConcreteBottles({
+export async function mergeBottles({
   sourceBottleId,
   destinationBottleId,
   context,
@@ -1016,21 +1010,21 @@ export async function mergeConcreteBottles({
   sourceBottleId: number;
   destinationBottleId: number;
   context: Context;
-}): Promise<ConcreteBottleMergeResult> {
+}): Promise<BottleMergeResult> {
   if (!context.user?.admin && !context.user?.mod) {
-    throw new ConcreteBottleMergeAuthorizationError();
+    throw new BottleMergeAuthorizationError();
   }
   validateMergeInput(sourceBottleId, destinationBottleId);
   const user: User = context.user;
   const actor = await getUserActor(user);
   const manifest = await db.transaction((tx) =>
-    mergeConcreteBottlesInTransaction(tx, {
+    mergeBottlesInTransaction(tx, {
       sourceBottleId,
       destinationBottleId,
       actorId: actor.id,
     }),
   );
-  await finalizeConcreteBottleMerge(manifest);
+  await finalizeBottleMerge(manifest);
   return {
     sourceBottleId,
     destinationBottleId,

--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -26,9 +26,9 @@ import {
 } from "@peated/server/lib/bottleReferenceCandidates";
 import type * as CatalogVerificationModule from "@peated/server/lib/catalogVerification";
 import {
-  buildIndependentConcreteBottleCreateInput,
-  buildIndependentConcreteBottleRouteInput,
-} from "@peated/server/lib/flatConcreteBottleInput";
+  buildIndependentBottleCreateInput,
+  buildIndependentBottleRouteInput,
+} from "@peated/server/lib/flatBottleInput";
 import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import {
   applyApprovedStorePriceMatch,
@@ -823,12 +823,12 @@ describe("priceMatching", () => {
       flavorProfile: null,
     };
 
-    const concreteInput = buildIndependentConcreteBottleCreateInput(
-      buildIndependentConcreteBottleRouteInput(input),
+    const bottleInput = buildIndependentBottleCreateInput(
+      buildIndependentBottleRouteInput(input),
     );
     const result = await createBottleFromStorePriceMatchProposal({
       proposalId: proposal.id,
-      concreteInput,
+      bottleInput,
       user: reviewer,
       actor: await getUserActor(reviewer),
     });
@@ -932,19 +932,19 @@ describe("priceMatching", () => {
       imageUrl: null,
       flavorProfile: null,
     };
-    const concreteInput = buildIndependentConcreteBottleCreateInput(
-      buildIndependentConcreteBottleRouteInput(input),
+    const bottleInput = buildIndependentBottleCreateInput(
+      buildIndependentBottleRouteInput(input),
     );
 
     const first = await createBottleFromStorePriceMatchProposal({
       proposalId: firstProposal.id,
-      concreteInput,
+      bottleInput,
       user: reviewer,
       actor: await getUserActor(reviewer),
     });
     const second = await createBottleFromStorePriceMatchProposal({
       proposalId: secondProposal.id,
-      concreteInput,
+      bottleInput,
       user: reviewer,
       actor: await getUserActor(reviewer),
     });
@@ -979,7 +979,7 @@ describe("priceMatching", () => {
     await expect(
       createBottleFromStorePriceMatchProposal({
         proposalId: ignoredProposal.id,
-        concreteInput,
+        bottleInput,
         user: reviewer,
         actor: await getUserActor(reviewer),
       }),

--- a/apps/server/src/lib/priceMatchingAutomation.test.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.test.ts
@@ -554,7 +554,7 @@ describe("priceMatchingAutomation", () => {
     });
 
     expect(assessment.automationBlockers).toContain(
-      "auto-create requires a concrete whisky category",
+      "auto-create requires a known whisky category",
     );
     expect(
       shouldVerifyStorePriceMatch({

--- a/apps/server/src/lib/priceMatchingAutomation.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.ts
@@ -647,7 +647,7 @@ function getCreateNewScore({
   const automationBlockers: string[] = [];
 
   if (!proposedBottle?.category) {
-    automationBlockers.push("auto-create requires a concrete whisky category");
+    automationBlockers.push("auto-create requires a known whisky category");
   }
 
   if (proposedBottle?.brand.name) {

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -37,15 +37,15 @@ import {
   finalizeBottleAliasAssignment,
 } from "@peated/server/lib/bottleAliases";
 import { createBottleCheck } from "@peated/server/lib/bottleChecks";
+import type { BottleCreateInput } from "@peated/server/lib/bottleSchemas";
 import {
   buildBottleInputFromProposedBottle,
-  buildClassifierConcreteBottleInput,
+  buildClassifierBottleInput,
 } from "@peated/server/lib/classifierDecisionCreateInputs";
-import type { ConcreteBottleCreateInput } from "@peated/server/lib/concreteBottleSchemas";
 import {
-  createOrReuseConcreteBottleInTransaction,
+  createOrReuseBottleInTransaction,
   finalizeCreatedBottle,
-} from "@peated/server/lib/createConcreteBottle";
+} from "@peated/server/lib/createBottle";
 import {
   recordIncomingBottleDecisionInTransaction,
   shouldRecordIncomingBottleDecision,
@@ -75,10 +75,10 @@ import {
 import { resolveActiveBottleIds } from "@peated/server/lib/resolveActiveBottleIds";
 import { getAutomationModeratorUser } from "@peated/server/lib/systemUser";
 import {
-  finalizeConcreteBottleUpdate,
-  updateConcreteBottleInTransaction,
-  type ConcreteBottleUpdateInput,
-} from "@peated/server/lib/updateConcreteBottle";
+  finalizeBottleUpdate,
+  updateBottleInTransaction,
+  type BottleUpdateInput,
+} from "@peated/server/lib/updateBottle";
 import type { PriceMatchSearchEvidenceSchema } from "@peated/server/schemas";
 import {
   ProposedBottleSchema,
@@ -235,15 +235,15 @@ function normalizeClassifierDecisionForPriceMatching(
  * drafts retain the legacy shared-age contract. Unknown null fields or empty
  * distiller lists are omitted rather than cleared.
  */
-function buildConcreteBottleRepairInput(
+function buildBottleRepairInput(
   proposedBottle: StorePriceBottleRepairDraft,
-): ConcreteBottleUpdateInput {
+): BottleUpdateInput {
   const proposedInput = buildBottleInputFromProposedBottle(proposedBottle);
-  const shared: NonNullable<ConcreteBottleUpdateInput["shared"]> = {
+  const shared: NonNullable<BottleUpdateInput["shared"]> = {
     name: proposedInput.name,
     brand: proposedInput.brand,
   };
-  const exact: NonNullable<ConcreteBottleUpdateInput["exact"]> = {};
+  const exact: NonNullable<BottleUpdateInput["exact"]> = {};
 
   if (proposedBottle.series !== null) shared.series = proposedInput.series!;
   if (proposedBottle.category !== null) {
@@ -944,16 +944,16 @@ async function canContinueStorePriceMatchProcessing(
   );
 }
 
-function buildStorePriceMatchConcreteInput(
+function buildStorePriceMatchBottleInput(
   decision: StorePriceMatchDecision,
-): ConcreteBottleCreateInput {
+): BottleCreateInput {
   if (decision.action !== "create_new" || decision.proposedBottle === null) {
     throw new Error(
       "Price match decision does not contain one Bottle creation input.",
     );
   }
 
-  return buildClassifierConcreteBottleInput(decision.proposedBottle);
+  return buildClassifierBottleInput(decision.proposedBottle);
 }
 
 function getStorePriceBottleRepairDraft(
@@ -1164,14 +1164,14 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
   tx: AnyTransaction,
   {
     proposalId,
-    concreteInput,
+    bottleInput,
     user,
     creationSource,
     actor,
     expectedProcessingToken,
   }: {
     proposalId: number;
-    concreteInput: ConcreteBottleCreateInput;
+    bottleInput: BottleCreateInput;
     user: User;
     creationSource: CatalogVerificationCreationSource;
     actor: IncomingBottleDecisionActor;
@@ -1186,10 +1186,10 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
   });
 
   const { createResult, bottle: resolvedBottle } =
-    await createOrReuseConcreteBottleInTransaction(tx, {
+    await createOrReuseBottleInTransaction(tx, {
       creationSource,
       createdByActorId: writeActor.id,
-      input: concreteInput,
+      input: bottleInput,
       context: { user },
     });
 
@@ -1235,14 +1235,14 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
 
 export async function createBottleFromStorePriceMatchProposal({
   proposalId,
-  concreteInput,
+  bottleInput,
   user,
   creationSource = "price_match_review",
   actor,
   expectedProcessingToken,
 }: {
   proposalId: number;
-  concreteInput: ConcreteBottleCreateInput;
+  bottleInput: BottleCreateInput;
   user: User;
   creationSource?: CatalogVerificationCreationSource;
   actor: IncomingBottleDecisionActor;
@@ -1251,7 +1251,7 @@ export async function createBottleFromStorePriceMatchProposal({
   const result = await db.transaction(async (tx) =>
     createBottleFromStorePriceMatchProposalInTransaction(tx, {
       proposalId,
-      concreteInput,
+      bottleInput,
       user,
       creationSource,
       actor,
@@ -1512,11 +1512,11 @@ export async function resolveStorePriceMatchProposal(
         return await reloadStorePriceMatchProposal(proposal.id);
       }
 
-      const concreteInput = buildStorePriceMatchConcreteInput(decision);
+      const bottleInput = buildStorePriceMatchBottleInput(decision);
 
       await createBottleFromStorePriceMatchProposal({
         proposalId: proposal.id,
-        concreteInput,
+        bottleInput,
         user: automationUser,
         creationSource: "price_match_automation",
         actor: await getPeatedSystemActor(),
@@ -1953,9 +1953,9 @@ export async function applyStorePriceBottleRepairFromProposal({
     });
     // The Bottle writer acquires and validates the active Bottle graph
     // before the proposal and its consumers are locked below.
-    const updateManifest = await updateConcreteBottleInTransaction(tx, {
+    const updateManifest = await updateBottleInTransaction(tx, {
       bottleId: repairBottleId,
-      input: buildConcreteBottleRepairInput(proposedBottle),
+      input: buildBottleRepairInput(proposedBottle),
       user,
       actorId: writeActor.id,
       creationSource: "price_match_review",
@@ -1999,7 +1999,7 @@ export async function applyStorePriceBottleRepairFromProposal({
       id: updateManifest.bottle.id,
     },
   });
-  await finalizeConcreteBottleUpdate(updateManifest);
+  await finalizeBottleUpdate(updateManifest);
 
   return updateManifest.bottle;
 }

--- a/apps/server/src/lib/repairBottleBrandDistilleryAssignments.ts
+++ b/apps/server/src/lib/repairBottleBrandDistilleryAssignments.ts
@@ -14,16 +14,16 @@ import {
 } from "@peated/server/db/schema";
 import { getUserActorByIdForDatabase } from "@peated/server/lib/actors";
 import {
-  getConcreteBottleExactIdentity,
-  materializeConcreteBottleForGroup,
-} from "@peated/server/lib/concreteBottleIdentity";
+  getBottleExactIdentity,
+  materializeBottleForGroup,
+} from "@peated/server/lib/bottleIdentity";
 import { formatBottleName } from "@peated/server/lib/format";
 import { logError } from "@peated/server/lib/log";
 import {
-  concreteBottleUpdateExpectedSharedState,
-  finalizeConcreteBottleUpdate,
-  updateConcreteBottleInTransaction,
-} from "@peated/server/lib/updateConcreteBottle";
+  bottleUpdateExpectedSharedState,
+  finalizeBottleUpdate,
+  updateBottleInTransaction,
+} from "@peated/server/lib/updateBottle";
 import { and, asc, eq, ilike, inArray, sql } from "drizzle-orm";
 
 type RepairSeriesAction = "none" | "reuse_existing" | "create_new";
@@ -103,9 +103,9 @@ function materializeTargetBottle({
       name: `${brand.shortName || brand.name} ${group.name}`,
     }),
   };
-  return materializeConcreteBottleForGroup({
+  return materializeBottleForGroup({
     group: targetGroup,
-    exact: getConcreteBottleExactIdentity({
+    exact: getBottleExactIdentity({
       bottle,
       sourceGroupStatedAge: group.statedAge,
     }),
@@ -303,9 +303,9 @@ export async function repairBottleBrandDistilleryAssignments({
           throw new Error(`Repair user ${user!.id} no longer exists.`);
         }
         const actor = await getUserActorByIdForDatabase(tx, persistedUser.id);
-        return updateConcreteBottleInTransaction(tx, {
+        return updateBottleInTransaction(tx, {
           bottleId: selectedBottle.id,
-          expectedSharedState: concreteBottleUpdateExpectedSharedState({
+          expectedSharedState: bottleUpdateExpectedSharedState({
             group,
             distillerIds,
             referencedSeries: targetSeries ? [targetSeries] : [],
@@ -336,7 +336,7 @@ export async function repairBottleBrandDistilleryAssignments({
           creationSource: "repair_workflow",
         });
       });
-      await finalizeConcreteBottleUpdate(manifest);
+      await finalizeBottleUpdate(manifest);
       items.push({
         bottleFullName: manifest.bottle.fullName,
         bottleId: selectedBottle.id,

--- a/apps/server/src/lib/scraper.test.ts
+++ b/apps/server/src/lib/scraper.test.ts
@@ -113,7 +113,7 @@ describe("handleBottle", () => {
     });
   });
 
-  it("directs a canonical create conflict to the strict concrete update", async () => {
+  it("directs a canonical create conflict to the strict Bottle update", async () => {
     const conflictBottleId = 52;
     const bottle = bottleResult({ bottleId: conflictBottleId });
     vi.mocked(orpcClient.bottles.create).mockRejectedValue(
@@ -158,7 +158,7 @@ describe("handleBottle", () => {
     expect(orpcClient.prices.createBatch).not.toHaveBeenCalled();
   });
 
-  it("does not call the API when flat input cannot satisfy concrete creation", async () => {
+  it("does not call the API when flat input cannot satisfy Bottle creation", async () => {
     await handleBottle({ ...bottleInput, name: "" }, priceInput);
 
     expect(orpcClient.bottles.create).not.toHaveBeenCalled();

--- a/apps/server/src/lib/scraper.ts
+++ b/apps/server/src/lib/scraper.ts
@@ -19,9 +19,9 @@ import type {
 } from "../schemas";
 import BatchQueue from "./batchQueue";
 import {
-  buildConcreteBottleUpdatePatch,
-  buildIndependentConcreteBottleRouteInput,
-} from "./flatConcreteBottleInput";
+  buildBottleUpdatePatch,
+  buildIndependentBottleRouteInput,
+} from "./flatBottleInput";
 import { formatBottleName } from "./format";
 
 const CACHE = ".cache";
@@ -175,11 +175,9 @@ export async function handleBottle(
       },
     });
 
-    let createInput: ReturnType<
-      typeof buildIndependentConcreteBottleRouteInput
-    >;
+    let createInput: ReturnType<typeof buildIndependentBottleRouteInput>;
     try {
-      createInput = buildIndependentConcreteBottleRouteInput(bottle);
+      createInput = buildIndependentBottleRouteInput(bottle);
     } catch (error) {
       logError(error, {
         extra: {
@@ -216,7 +214,7 @@ export async function handleBottle(
       const updateResult = await safe(
         orpcClient.bottles.update({
           bottle: conflict.data.bottle,
-          ...buildConcreteBottleUpdatePatch(createInput),
+          ...buildBottleUpdatePatch(createInput),
         }),
       );
       if (updateResult.error) {

--- a/apps/server/src/lib/test/fixtures.ts
+++ b/apps/server/src/lib/test/fixtures.ts
@@ -45,7 +45,7 @@ import {
 } from "../../constants";
 import { getUserActorByIdForDatabase } from "../actors";
 import { createAccessToken, generatePasswordHash } from "../auth";
-import { materializeConcreteBottleForGroup } from "../concreteBottleIdentity";
+import { materializeBottleForGroup } from "../bottleIdentity";
 import { mapRows } from "../db";
 import { formatBottleName } from "../format";
 import { choose, random, sample } from "../rand";
@@ -524,7 +524,7 @@ async function createBottleFixture(
 
     const baseName = data.name ?? chooseBottleName();
     const materializedGroupFields = existingGroup
-      ? materializeConcreteBottleForGroup({
+      ? materializeBottleForGroup({
           group: existingGroup,
           exact: {
             edition: data.edition ?? null,

--- a/apps/server/src/lib/updateBottle.test.ts
+++ b/apps/server/src/lib/updateBottle.test.ts
@@ -12,29 +12,29 @@ import {
   entities,
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
-import { createConcreteBottle } from "@peated/server/lib/createConcreteBottle";
+import { createBottle } from "@peated/server/lib/createBottle";
 import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
 import waitError from "@peated/server/lib/test/waitError";
 import {
-  ConcreteBottleUpdateAuthorizationError,
-  ConcreteBottleUpdateConflictError,
-  ConcreteBottleUpdateExpectedStateError,
-  ConcreteBottleUpdateGraphError,
-  ConcreteBottleUpdateInputError,
-  ConcreteBottleUpdateInputSchema,
-  concreteBottleUpdateExpectedSharedState,
-  finalizeConcreteBottleUpdate,
-  updateConcreteBottle,
-  updateConcreteBottleInTransaction,
-} from "@peated/server/lib/updateConcreteBottle";
+  BottleUpdateAuthorizationError,
+  BottleUpdateConflictError,
+  BottleUpdateExpectedStateError,
+  BottleUpdateGraphError,
+  BottleUpdateInputError,
+  BottleUpdateInputSchema,
+  bottleUpdateExpectedSharedState,
+  finalizeBottleUpdate,
+  updateBottle,
+  updateBottleInTransaction,
+} from "@peated/server/lib/updateBottle";
 import * as workerClient from "@peated/server/worker/client";
 import { and, asc, eq, inArray } from "drizzle-orm";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { ZodError } from "zod";
 
 function contextFor(user: User | null) {
-  return { user } as Parameters<typeof updateConcreteBottle>[0]["context"];
+  return { user } as Parameters<typeof updateBottle>[0]["context"];
 }
 
 type GroupMemberExact = Omit<
@@ -53,10 +53,8 @@ async function createGroup({
 }) {
   if (!exacts.length) throw new Error("At least one exact Bottle is required.");
 
-  const first = await createConcreteBottle({
-    context: contextFor(user) as Parameters<
-      typeof createConcreteBottle
-    >[0]["context"],
+  const first = await createBottle({
+    context: contextFor(user) as Parameters<typeof createBottle>[0]["context"],
     input: {
       stable,
       exact: exacts[0],
@@ -146,28 +144,28 @@ describe("Bottle updates", () => {
     };
     for (const user of [null, defaults.user]) {
       const error = await waitError(
-        updateConcreteBottle({
+        updateBottle({
           bottleId: 999_999,
           input: invalidRawInput,
           context: contextFor(user),
         }),
-        ConcreteBottleUpdateAuthorizationError,
+        BottleUpdateAuthorizationError,
       );
-      expect(error).toBeInstanceOf(ConcreteBottleUpdateAuthorizationError);
+      expect(error).toBeInstanceOf(BottleUpdateAuthorizationError);
     }
 
     const bottle = await fixtures.Bottle();
     const mod = await fixtures.User({ mod: true });
     const admin = await fixtures.User({ admin: true });
     await expect(
-      updateConcreteBottle({
+      updateBottle({
         bottleId: bottle.id,
         input: {},
         context: contextFor(mod),
       }),
     ).resolves.toMatchObject({ changed: false });
     await expect(
-      updateConcreteBottle({
+      updateBottle({
         bottleId: bottle.id,
         input: {},
         context: contextFor(admin),
@@ -183,7 +181,7 @@ describe("Bottle updates", () => {
     ]) {
       expect(
         await waitError(
-          updateConcreteBottle({
+          updateBottle({
             bottleId: bottle.id,
             input,
             context: contextFor(mod),
@@ -193,14 +191,14 @@ describe("Bottle updates", () => {
     }
     expect(
       await waitError(
-        updateConcreteBottle({
+        updateBottle({
           bottleId: 0,
           input: {},
           context: contextFor(mod),
         }),
-        ConcreteBottleUpdateInputError,
+        BottleUpdateInputError,
       ),
-    ).toBeInstanceOf(ConcreteBottleUpdateInputError);
+    ).toBeInstanceOf(BottleUpdateInputError);
     expect(await loadUpdateAudits([bottle.id])).toEqual([]);
   });
 
@@ -229,12 +227,12 @@ describe("Bottle updates", () => {
       .where(eq(bottleGroups.id, first.group.id));
     const aliasesBefore = await loadAliases([first.bottle.id]);
 
-    const empty = await updateConcreteBottle({
+    const empty = await updateBottle({
       bottleId: first.bottle.id,
       input: {},
       context: contextFor(mod),
     });
-    const semantic = await updateConcreteBottle({
+    const semantic = await updateBottle({
       bottleId: first.bottle.id,
       input: {
         shared: {
@@ -278,9 +276,9 @@ describe("Bottle updates", () => {
     resetQueueMock();
 
     const manifest = await db.transaction(async (tx) => {
-      const result = await updateConcreteBottleInTransaction(tx, {
+      const result = await updateBottleInTransaction(tx, {
         bottleId: first.bottle.id,
-        input: ConcreteBottleUpdateInputSchema.parse({
+        input: BottleUpdateInputSchema.parse({
           shared: {
             brand: { name: "Composed Review Brand" },
             distillers: [{ name: "Composed Review Distillery" }],
@@ -304,7 +302,7 @@ describe("Bottle updates", () => {
     });
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
 
-    await finalizeConcreteBottleUpdate(manifest);
+    await finalizeBottleUpdate(manifest);
 
     const createdEntities = await db
       .select({ id: entities.id })
@@ -353,13 +351,13 @@ describe("Bottle updates", () => {
       .select({ distillerId: bottleGroupDistillers.distillerId })
       .from(bottleGroupDistillers)
       .where(eq(bottleGroupDistillers.groupId, first.group.id));
-    const expectedSharedState = concreteBottleUpdateExpectedSharedState({
+    const expectedSharedState = bottleUpdateExpectedSharedState({
       group: groupBefore,
       distillerIds: distillersBefore.map(({ distillerId }) => distillerId),
       series: null,
     });
 
-    await updateConcreteBottle({
+    await updateBottle({
       bottleId: first.bottle.id,
       input: { shared: { name: "New Authority" } },
       context: contextFor(mod),
@@ -367,7 +365,7 @@ describe("Bottle updates", () => {
 
     const error = await waitError(
       db.transaction((tx) =>
-        updateConcreteBottleInTransaction(tx, {
+        updateBottleInTransaction(tx, {
           bottleId: first.bottle.id,
           input: { shared: { brand: targetBrand.id } },
           expectedSharedState,
@@ -376,7 +374,7 @@ describe("Bottle updates", () => {
           creationSource: "repair_workflow",
         }),
       ),
-      ConcreteBottleUpdateExpectedStateError,
+      BottleUpdateExpectedStateError,
     );
     expect(error).toMatchObject({ groupId: first.group.id });
     expect(
@@ -405,7 +403,7 @@ describe("Bottle updates", () => {
       where: eq(bottleGroups.id, first.group.id),
     });
     if (!groupBefore) throw new Error("Expected BottleGroup fixture.");
-    const expectedSharedState = concreteBottleUpdateExpectedSharedState({
+    const expectedSharedState = bottleUpdateExpectedSharedState({
       group: groupBefore,
       distillerIds: [],
       referencedSeries: [targetSeries],
@@ -421,7 +419,7 @@ describe("Bottle updates", () => {
 
     const error = await waitError(
       db.transaction((tx) =>
-        updateConcreteBottleInTransaction(tx, {
+        updateBottleInTransaction(tx, {
           bottleId: first.bottle.id,
           input: { shared: { series: targetSeries.id } },
           expectedSharedState,
@@ -430,7 +428,7 @@ describe("Bottle updates", () => {
           creationSource: "repair_workflow",
         }),
       ),
-      ConcreteBottleUpdateExpectedStateError,
+      BottleUpdateExpectedStateError,
     );
 
     expect(error).toMatchObject({ groupId: first.group.id });
@@ -468,7 +466,7 @@ describe("Bottle updates", () => {
     });
     resetQueueMock();
 
-    const result = await updateConcreteBottle({
+    const result = await updateBottle({
       bottleId: first.bottle.id,
       input: {
         shared: {
@@ -540,7 +538,7 @@ describe("Bottle updates", () => {
       },
     );
 
-    const result = await updateConcreteBottle({
+    const result = await updateBottle({
       bottleId: first.bottle.id,
       input: { shared: { brand: { name: brand.name } } },
       context: contextFor(mod),
@@ -624,7 +622,7 @@ describe("Bottle updates", () => {
       },
     );
 
-    await updateConcreteBottle({
+    await updateBottle({
       bottleId: first.bottle.id,
       input: {
         shared: {
@@ -657,7 +655,7 @@ describe("Bottle updates", () => {
 
     resetQueueMock();
     await expect(
-      updateConcreteBottle({
+      updateBottle({
         bottleId: first.bottle.id,
         input: {
           shared: {
@@ -694,7 +692,7 @@ describe("Bottle updates", () => {
       exacts: [{ edition: "One" }, { edition: "Two" }],
     });
 
-    const result = await updateConcreteBottle({
+    const result = await updateBottle({
       bottleId: first.bottle.id,
       input: { shared: { brand: newBrand.id } },
       context: contextFor(mod),
@@ -765,7 +763,7 @@ describe("Bottle updates", () => {
       exacts: [{ edition: "One" }],
     });
 
-    const result = await updateConcreteBottle({
+    const result = await updateBottle({
       bottleId: moving.first.bottle.id,
       input: { shared: { brand: newBrand.id } },
       context: contextFor(mod),
@@ -823,7 +821,7 @@ describe("Bottle updates", () => {
       exacts: [{ edition: "One" }],
     });
 
-    const result = await updateConcreteBottle({
+    const result = await updateBottle({
       bottleId: first.bottle.id,
       input: { shared: { brand: newBrand.id } },
       context: contextFor(mod),
@@ -869,14 +867,14 @@ describe("Bottle updates", () => {
     resetQueueMock();
 
     const error = await waitError(
-      updateConcreteBottle({
+      updateBottle({
         bottleId: first.bottle.id,
         input: {
           shared: { brand: newBrand.id, series: otherSeries.id },
         },
         context: contextFor(mod),
       }),
-      ConcreteBottleUpdateInputError,
+      BottleUpdateInputError,
     );
     expect(error.message).toMatch(/series/i);
 
@@ -941,7 +939,7 @@ describe("Bottle updates", () => {
       .from(bottleGroups)
       .where(eq(bottleGroups.id, first.group.id));
 
-    const identityResult = await updateConcreteBottle({
+    const identityResult = await updateBottle({
       bottleId: selectedBefore.id,
       input: {
         exact: {
@@ -1010,7 +1008,7 @@ describe("Bottle updates", () => {
     expect(identityResult.group).toEqual(groupBefore);
 
     const identityBeforeContent = identityResult.bottle;
-    const contentResult = await updateConcreteBottle({
+    const contentResult = await updateBottle({
       bottleId: selectedBefore.id,
       input: { exact: { description: "Updated exact content" } },
       context: contextFor(mod),
@@ -1051,7 +1049,7 @@ describe("Bottle updates", () => {
       .where(eq(bottles.id, first.bottle.id));
     resetQueueMock();
 
-    const result = await updateConcreteBottle({
+    const result = await updateBottle({
       bottleId: first.bottle.id,
       input: { exact: { edition: "Updated" } },
       context: contextFor(mod),
@@ -1221,7 +1219,7 @@ describe("Bottle updates", () => {
       .where(eq(bottlesToDistillers.bottleId, members[1].bottle.id));
     resetQueueMock();
 
-    const result = await updateConcreteBottle({
+    const result = await updateBottle({
       bottleId: members[0].bottle.id,
       input: {
         shared: {
@@ -1327,7 +1325,7 @@ describe("Bottle updates", () => {
       })
       .where(eq(bottleGroups.id, first.group.id));
 
-    const repair = await updateConcreteBottle({
+    const repair = await updateBottle({
       bottleId: members[0].bottle.id,
       input: {
         shared: {
@@ -1370,7 +1368,7 @@ describe("Bottle updates", () => {
       .where(eq(bottleGroups.id, first.group.id));
     const membersBeforeNameOnly = await loadGroupMembers(first.group.id);
     const distillersBeforeNameOnly = await loadBottleDistillers(memberIds);
-    const nameOnly = await updateConcreteBottle({
+    const nameOnly = await updateBottle({
       bottleId: members[0].bottle.id,
       input: { shared: { name: "Omission Label" } },
       context: contextFor(mod),
@@ -1453,7 +1451,7 @@ describe("Bottle updates", () => {
     resetQueueMock();
 
     const error = await waitError(
-      updateConcreteBottle({
+      updateBottle({
         bottleId: members[0].bottle.id,
         input: {
           shared: {
@@ -1463,7 +1461,7 @@ describe("Bottle updates", () => {
         },
         context: contextFor(mod),
       }),
-      ConcreteBottleUpdateGraphError,
+      BottleUpdateGraphError,
     );
 
     expect(error).toMatchObject({
@@ -1495,7 +1493,7 @@ describe("Bottle updates", () => {
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
 
     resetQueueMock();
-    const exactResult = await updateConcreteBottle({
+    const exactResult = await updateBottle({
       bottleId: members[0].bottle.id,
       input: { exact: { description: "Selected Bottle content" } },
       context: contextFor(mod),
@@ -1564,7 +1562,7 @@ describe("Bottle updates", () => {
     });
     resetQueueMock();
 
-    await updateConcreteBottle({
+    await updateBottle({
       bottleId: members[0].bottle.id,
       input: {
         shared: {
@@ -1619,7 +1617,7 @@ describe("Bottle updates", () => {
     });
     resetQueueMock();
 
-    const mixed = await updateConcreteBottle({
+    const mixed = await updateBottle({
       bottleId: members[0].bottle.id,
       input: {
         shared: { statedAge: 15 },
@@ -1632,7 +1630,7 @@ describe("Bottle updates", () => {
     let persisted = await loadGroupMembers(first.group.id);
     expect(persisted.map(({ statedAge }) => statedAge)).toEqual([15, 13, 15]);
 
-    const cleared = await updateConcreteBottle({
+    const cleared = await updateBottle({
       bottleId: members[1].bottle.id,
       input: { exact: { statedAge: null } },
       context: contextFor(mod),
@@ -1643,7 +1641,7 @@ describe("Bottle updates", () => {
       members.map(({ bottle }) => bottle.id),
     );
     resetQueueMock();
-    const equal = await updateConcreteBottle({
+    const equal = await updateBottle({
       bottleId: members[1].bottle.id,
       input: { exact: { statedAge: 15 } },
       context: contextFor(mod),
@@ -1654,7 +1652,7 @@ describe("Bottle updates", () => {
     ).toEqual(auditsBeforeEqual);
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
 
-    await updateConcreteBottle({
+    await updateBottle({
       bottleId: members[0].bottle.id,
       input: { shared: { statedAge: 18 } },
       context: contextFor(mod),
@@ -1678,10 +1676,8 @@ describe("Bottle updates", () => {
       },
       exacts: [{ edition: "One" }, { edition: "Two" }],
     });
-    const outsider = await createConcreteBottle({
-      context: contextFor(mod) as Parameters<
-        typeof createConcreteBottle
-      >[0]["context"],
+    const outsider = await createBottle({
+      context: contextFor(mod) as Parameters<typeof createBottle>[0]["context"],
       input: {
         stable: { name: "Collision Label", brand: brand.id },
         exact: { edition: "Two" },
@@ -1698,7 +1694,7 @@ describe("Bottle updates", () => {
     resetQueueMock();
 
     const error = await waitError(
-      updateConcreteBottle({
+      updateBottle({
         bottleId: members[0].bottle.id,
         input: {
           shared: {
@@ -1708,7 +1704,7 @@ describe("Bottle updates", () => {
         },
         context: contextFor(mod),
       }),
-      ConcreteBottleUpdateConflictError,
+      BottleUpdateConflictError,
     );
     expect(error).toMatchObject({ conflictingBottleId: outsider.bottle.id });
     expect(
@@ -1725,10 +1721,8 @@ describe("Bottle updates", () => {
     expect(await loadUpdateAudits(memberIds)).toEqual([]);
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
 
-    const aliasOwner = await createConcreteBottle({
-      context: contextFor(mod) as Parameters<
-        typeof createConcreteBottle
-      >[0]["context"],
+    const aliasOwner = await createBottle({
+      context: contextFor(mod) as Parameters<typeof createBottle>[0]["context"],
       input: {
         stable: { name: "Unrelated Alias Owner", brand: brand.id },
         exact: {},
@@ -1754,7 +1748,7 @@ describe("Bottle updates", () => {
     resetQueueMock();
 
     const aliasError = await waitError(
-      updateConcreteBottle({
+      updateBottle({
         bottleId: members[0].bottle.id,
         input: {
           shared: {
@@ -1764,7 +1758,7 @@ describe("Bottle updates", () => {
         },
         context: contextFor(mod),
       }),
-      ConcreteBottleUpdateConflictError,
+      BottleUpdateConflictError,
     );
     expect(aliasError).toMatchObject({
       conflictingBottleId: aliasOwner.bottle.id,
@@ -1817,12 +1811,12 @@ describe("Bottle updates", () => {
     resetQueueMock();
 
     const error = await waitError(
-      updateConcreteBottle({
+      updateBottle({
         bottleId: first.bottle.id,
         input: { shared: { name: "35.331 Alternate hoggie" } },
         context: contextFor(mod),
       }),
-      ConcreteBottleUpdateConflictError,
+      BottleUpdateConflictError,
     );
     expect(error).toMatchObject({ conflictingBottleId: existing.id });
     const [persistedGroup] = await db
@@ -1868,12 +1862,12 @@ describe("Bottle updates", () => {
     resetQueueMock();
 
     const error = await waitError(
-      updateConcreteBottle({
+      updateBottle({
         bottleId: first.bottle.id,
         input: { shared: { bottler: smws.id } },
         context: contextFor(mod),
       }),
-      ConcreteBottleUpdateConflictError,
+      BottleUpdateConflictError,
     );
 
     expect(error).toMatchObject({ conflictingBottleId: existing.id });
@@ -1918,7 +1912,7 @@ describe("Bottle updates", () => {
     resetQueueMock();
 
     const error = await waitError(
-      updateConcreteBottle({
+      updateBottle({
         bottleId: members[0].bottle.id,
         input: {
           shared: {
@@ -1929,7 +1923,7 @@ describe("Bottle updates", () => {
         },
         context: contextFor(mod),
       }),
-      ConcreteBottleUpdateConflictError,
+      BottleUpdateConflictError,
     );
 
     expect(error).toMatchObject({
@@ -1968,12 +1962,12 @@ describe("Bottle updates", () => {
     ] as const;
     for (const expected of cases) {
       const error = await waitError(
-        updateConcreteBottle({
+        updateBottle({
           bottleId: expected.bottleId,
           input: { exact: { edition: "Must Not Persist" } },
           context: contextFor(mod),
         }),
-        ConcreteBottleUpdateGraphError,
+        BottleUpdateGraphError,
       );
       expect(error).toMatchObject(expected);
     }
@@ -2003,7 +1997,7 @@ describe("Bottle updates", () => {
     });
     resetQueueMock();
 
-    await updateConcreteBottle({
+    await updateBottle({
       bottleId: members[0].bottle.id,
       input: { shared: { series: newSeries.id } },
       context: contextFor(mod),
@@ -2054,7 +2048,7 @@ describe("Bottle updates", () => {
       },
     );
 
-    const result = await updateConcreteBottle({
+    const result = await updateBottle({
       bottleId: first.bottle.id,
       input: {
         shared: {

--- a/apps/server/src/lib/updateBottle.ts
+++ b/apps/server/src/lib/updateBottle.ts
@@ -2,7 +2,7 @@
  * Transactional moderator editing for Bottles. Shared patches fan out
  * durable member Bottle materialization; exact patches remain isolated.
  */
-// TODO(dcramer): Rename this module's ConcreteBottleUpdate symbols now that
+// TODO(dcramer): Rename this module's BottleUpdate symbols now that
 // the Bottle/BottleRelease distinction is retired.
 import { ORPCError } from "@orpc/server";
 import {
@@ -31,21 +31,21 @@ import {
   entities,
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
+import {
+  BottleIdentityConflictError,
+  reserveBottleIdentitiesInTransaction,
+} from "@peated/server/lib/bottleConflicts";
 import { processSeries } from "@peated/server/lib/bottleHelpers";
+import {
+  getBottleExactIdentity,
+  materializeBottleForGroup,
+} from "@peated/server/lib/bottleIdentity";
+import {
+  BottleUpdateInputSchema,
+  type BottleUpdateInput,
+  type SystemBottleUpdateInput,
+} from "@peated/server/lib/bottleSchemas";
 import { queueEntityCreationVerification } from "@peated/server/lib/catalogVerification";
-import {
-  ConcreteBottleIdentityConflictError,
-  reserveConcreteBottleIdentitiesInTransaction,
-} from "@peated/server/lib/concreteBottleConflicts";
-import {
-  getConcreteBottleExactIdentity,
-  materializeConcreteBottleForGroup,
-} from "@peated/server/lib/concreteBottleIdentity";
-import {
-  ConcreteBottleUpdateInputSchema,
-  type ConcreteBottleUpdateInput,
-  type SystemConcreteBottleUpdateInput,
-} from "@peated/server/lib/concreteBottleSchemas";
 import { coerceToUpsert, upsertEntity } from "@peated/server/lib/db";
 import { formatBottleName } from "@peated/server/lib/format";
 import { logError } from "@peated/server/lib/log";
@@ -53,81 +53,80 @@ import type { Context } from "@peated/server/orpc/context";
 import { pushUniqueJob } from "@peated/server/worker/client";
 import { and, asc, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 
-export { ConcreteBottleUpdateInputSchema } from "@peated/server/lib/concreteBottleSchemas";
-export type { ConcreteBottleUpdateInput } from "@peated/server/lib/concreteBottleSchemas";
+export { BottleUpdateInputSchema } from "@peated/server/lib/bottleSchemas";
+export type { BottleUpdateInput } from "@peated/server/lib/bottleSchemas";
 
-type SharedPatch = NonNullable<ConcreteBottleUpdateInput["shared"]>;
-type ExactPatch = NonNullable<SystemConcreteBottleUpdateInput["exact"]>;
+type SharedPatch = NonNullable<BottleUpdateInput["shared"]>;
+type ExactPatch = NonNullable<SystemBottleUpdateInput["exact"]>;
 
-export class ConcreteBottleUpdateAuthorizationError extends Error {
+export class BottleUpdateAuthorizationError extends Error {
   constructor() {
     super("Moderator authorization is required to update a Bottle.");
-    this.name = "ConcreteBottleUpdateAuthorizationError";
+    this.name = "BottleUpdateAuthorizationError";
   }
 }
 
-export type ConcreteBottleUpdateGraphErrorCode =
+export type BottleUpdateGraphErrorCode =
   | "not_found"
   | "retired"
   | "missing_group"
   | "invalid_catalog_graph";
 
-export class ConcreteBottleUpdateGraphError extends Error {
+export class BottleUpdateGraphError extends Error {
   constructor(
-    readonly code: ConcreteBottleUpdateGraphErrorCode,
+    readonly code: BottleUpdateGraphErrorCode,
     readonly bottleId: number,
     readonly groupId: number | null = null,
   ) {
     super(`Cannot update Bottle ${bottleId}: ${code}.`);
-    this.name = "ConcreteBottleUpdateGraphError";
+    this.name = "BottleUpdateGraphError";
   }
 }
 
-export class ConcreteBottleUpdateInputError extends Error {
+export class BottleUpdateInputError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = "ConcreteBottleUpdateInputError";
+    this.name = "BottleUpdateInputError";
   }
 }
 
-export class ConcreteBottleUpdateConflictError extends Error {
+export class BottleUpdateConflictError extends Error {
   constructor(readonly conflictingBottleId: number | null) {
     super("Bottle identity conflicts with an existing Bottle.");
-    this.name = "ConcreteBottleUpdateConflictError";
+    this.name = "BottleUpdateConflictError";
   }
 }
 
-export class ConcreteBottleUpdateExpectedStateError extends Error {
+export class BottleUpdateExpectedStateError extends Error {
   constructor(readonly groupId: number) {
     super(`BottleGroup ${groupId} shared authority changed before update.`);
-    this.name = "ConcreteBottleUpdateExpectedStateError";
+    this.name = "BottleUpdateExpectedStateError";
   }
 }
 
-export class ConcreteBottleUpdateExpectedBottleStateError extends Error {
+export class BottleUpdateExpectedBottleStateError extends Error {
   constructor(readonly bottleId: number) {
     super(
       `Bottle ${bottleId} exact content or membership changed before update.`,
     );
-    this.name = "ConcreteBottleUpdateExpectedBottleStateError";
+    this.name = "BottleUpdateExpectedBottleStateError";
   }
 }
 
-export type ConcreteBottleUpdateResult = {
+export type BottleUpdateResult = {
   bottle: Bottle;
   group: BottleGroup;
   changed: boolean;
 };
 
-export type ConcreteBottleUpdateFinalizationManifest =
-  ConcreteBottleUpdateResult & {
-    creationSource: CatalogVerificationCreationSource;
-    changedBottleIds: number[];
-    changedAliasNames: string[];
-    changedEntityIds: number[];
-    newEntityIds: number[];
-    affectedSeriesIds: number[];
-  };
+export type BottleUpdateFinalizationManifest = BottleUpdateResult & {
+  creationSource: CatalogVerificationCreationSource;
+  changedBottleIds: number[];
+  changedAliasNames: string[];
+  changedEntityIds: number[];
+  newEntityIds: number[];
+  affectedSeriesIds: number[];
+};
 
 type DesiredBottle = Pick<
   Bottle,
@@ -188,15 +187,15 @@ type ExpectedSeries = Pick<
   BottleSeries,
   "id" | "brandId" | "name" | "fullName" | "description"
 >;
-export type ConcreteBottleUpdateExpectedEntityState = Pick<
+export type BottleUpdateExpectedEntityState = Pick<
   Entity,
   "id" | "name" | "shortName" | "type"
 >;
 
-export type ConcreteBottleUpdateExpectedSharedState = {
+export type BottleUpdateExpectedSharedState = {
   group: Pick<BottleGroup, (typeof expectedGroupKeys)[number]>;
   distillerIds: number[];
-  referencedEntities: ConcreteBottleUpdateExpectedEntityState[];
+  referencedEntities: BottleUpdateExpectedEntityState[];
   series: ExpectedSeries | null;
   referencedSeries: ExpectedSeries[];
 };
@@ -213,22 +212,22 @@ const expectedSelectedBottleKeys = [
   "suggestedTags",
 ] as const satisfies ReadonlyArray<keyof Bottle>;
 
-export type ConcreteBottleUpdateExpectedSelectedBottleState = Pick<
+export type BottleUpdateExpectedSelectedBottleState = Pick<
   Bottle,
   (typeof expectedSelectedBottleKeys)[number]
 >;
 
 /** Captures selected-Bottle state used to plan an exact-content edit. */
-export function concreteBottleUpdateExpectedSelectedBottleState(
+export function bottleUpdateExpectedSelectedBottleState(
   bottle: Bottle,
-): ConcreteBottleUpdateExpectedSelectedBottleState {
+): BottleUpdateExpectedSelectedBottleState {
   return Object.fromEntries(
     expectedSelectedBottleKeys.map((key) => [key, bottle[key]]),
-  ) as ConcreteBottleUpdateExpectedSelectedBottleState;
+  ) as BottleUpdateExpectedSelectedBottleState;
 }
 
 /** Captures the shared authority a maintenance caller used to plan an edit. */
-export function concreteBottleUpdateExpectedSharedState({
+export function bottleUpdateExpectedSharedState({
   group,
   distillerIds,
   referencedEntities = [],
@@ -237,14 +236,14 @@ export function concreteBottleUpdateExpectedSharedState({
 }: {
   group: BottleGroup;
   distillerIds: number[];
-  referencedEntities?: ConcreteBottleUpdateExpectedEntityState[];
+  referencedEntities?: BottleUpdateExpectedEntityState[];
   referencedSeries?: BottleSeries[];
   series: BottleSeries | null;
-}): ConcreteBottleUpdateExpectedSharedState {
+}): BottleUpdateExpectedSharedState {
   return {
     group: Object.fromEntries(
       expectedGroupKeys.map((key) => [key, group[key]]),
-    ) as ConcreteBottleUpdateExpectedSharedState["group"],
+    ) as BottleUpdateExpectedSharedState["group"],
     distillerIds: [...distillerIds].sort((left, right) => left - right),
     referencedEntities: referencedEntities
       .map(({ id, name, shortName, type }) => ({
@@ -290,9 +289,7 @@ function existingEntityChoiceId(choice: unknown): number | null {
   return null;
 }
 
-function existingEntityIdsForUpdate(
-  input: SystemConcreteBottleUpdateInput,
-): number[] {
+function existingEntityIdsForUpdate(input: SystemBottleUpdateInput): number[] {
   const choices = [
     input.shared?.brand,
     input.shared?.bottler,
@@ -357,12 +354,12 @@ function desiredBottleFor({
   materializeSharedFields: boolean;
   regenerateIdentity: boolean;
 }): DesiredBottle {
-  const exact = getConcreteBottleExactIdentity({
+  const exact = getBottleExactIdentity({
     bottle,
     sourceGroupStatedAge: oldGroupStatedAge,
     exactPatch,
   });
-  const sharedMaterialization = materializeConcreteBottleForGroup({
+  const sharedMaterialization = materializeBottleForGroup({
     group: stable,
     exact,
   });
@@ -467,7 +464,7 @@ async function loadEntity(tx: AnyTransaction, entityId: number) {
     .where(eq(entities.id, entityId))
     .limit(1);
   if (!entity) {
-    throw new ConcreteBottleUpdateInputError(
+    throw new BottleUpdateInputError(
       `Entity ${entityId} could not be resolved.`,
     );
   }
@@ -476,7 +473,7 @@ async function loadEntity(tx: AnyTransaction, entityId: number) {
 
 function requireUpdateUser(user: User | undefined): User {
   if (!user) {
-    throw new ConcreteBottleUpdateInputError(
+    throw new BottleUpdateInputError(
       "A user is required to create or resolve shared catalog choices.",
     );
   }
@@ -511,7 +508,7 @@ async function addEntityRoleIfNeeded({
     type: role,
   });
   if (!result) {
-    throw new ConcreteBottleUpdateInputError(
+    throw new BottleUpdateInputError(
       `Entity ${entity.id} could not be resolved.`,
     );
   }
@@ -603,7 +600,7 @@ async function resolveStableState(
       type: "brand",
     });
     if (!result) {
-      throw new ConcreteBottleUpdateInputError("Brand could not be resolved.");
+      throw new BottleUpdateInputError("Brand could not be resolved.");
     }
     brand = result.result;
     if (result.changed) changedEntityIds.add(result.id);
@@ -630,9 +627,7 @@ async function resolveStableState(
       type: "bottler",
     });
     if (!result) {
-      throw new ConcreteBottleUpdateInputError(
-        "Bottler could not be resolved.",
-      );
+      throw new BottleUpdateInputError("Bottler could not be resolved.");
     }
     bottler = result.result;
     if (result.changed) changedEntityIds.add(result.id);
@@ -660,9 +655,7 @@ async function resolveStableState(
         type: "distiller",
       });
       if (!result) {
-        throw new ConcreteBottleUpdateInputError(
-          "Distiller could not be resolved.",
-        );
+        throw new BottleUpdateInputError("Distiller could not be resolved.");
       }
       distillerIds.push(result.id);
       if (result.changed) changedEntityIds.add(result.id);
@@ -685,7 +678,7 @@ async function resolveStableState(
   }
   name = stripDuplicateBrandPrefixFromBottleName(name, brand.name);
   if (!name || bottleNameDuplicatesBrand(name, brand.name)) {
-    throw new ConcreteBottleUpdateInputError(
+    throw new BottleUpdateInputError(
       "Bottle name must identify an expression distinct from the brand.",
     );
   }
@@ -707,7 +700,7 @@ async function resolveStableState(
           error.code,
         )
       ) {
-        throw new ConcreteBottleUpdateInputError(error.message);
+        throw new BottleUpdateInputError(error.message);
       }
       throw error;
     }
@@ -724,7 +717,7 @@ async function resolveStableState(
       .limit(1)
       .for("update");
     if (!currentSeries) {
-      throw new ConcreteBottleUpdateInputError(
+      throw new BottleUpdateInputError(
         `Series ${seriesId} could not be resolved.`,
       );
     }
@@ -800,7 +793,7 @@ async function resolveStableState(
               error.code,
             )
           ) {
-            throw new ConcreteBottleUpdateInputError(error.message);
+            throw new BottleUpdateInputError(error.message);
           }
           throw error;
         }
@@ -814,12 +807,12 @@ async function resolveStableState(
       .where(eq(bottleSeries.id, seriesId))
       .limit(1);
     if (!series) {
-      throw new ConcreteBottleUpdateInputError(
+      throw new BottleUpdateInputError(
         `Series ${seriesId} could not be resolved.`,
       );
     }
     if (series.brandId !== brand.id) {
-      throw new ConcreteBottleUpdateInputError(
+      throw new BottleUpdateInputError(
         `Series ${seriesId} does not belong to brand ${brand.id}.`,
       );
     }
@@ -859,7 +852,7 @@ function emptyResult(
   bottle: Bottle,
   group: BottleGroup,
   creationSource: CatalogVerificationCreationSource,
-): ConcreteBottleUpdateFinalizationManifest {
+): BottleUpdateFinalizationManifest {
   return {
     bottle,
     group,
@@ -877,7 +870,7 @@ function emptyResult(
  * Locks existing Entity choices before the selected BottleGroup and Bottle.
  * The order matches Entity writers and is safe to repeat before execution.
  */
-export async function lockConcreteBottleUpdateDependencies(
+export async function lockBottleUpdateDependencies(
   tx: AnyTransaction,
   bottleId: number,
   referencedEntityIds: readonly number[] = [],
@@ -890,7 +883,7 @@ export async function lockConcreteBottleUpdateDependencies(
     (left, right) => left - right,
   );
   if (entityIds.some((id) => !Number.isInteger(id) || id <= 0)) {
-    throw new ConcreteBottleUpdateInputError(
+    throw new BottleUpdateInputError(
       "Referenced Entity IDs must be positive integers.",
     );
   }
@@ -909,10 +902,10 @@ export async function lockConcreteBottleUpdateDependencies(
     .where(eq(bottles.id, bottleId))
     .limit(1);
   if (!discoveredBottle) {
-    throw new ConcreteBottleUpdateGraphError("not_found", bottleId);
+    throw new BottleUpdateGraphError("not_found", bottleId);
   }
   if (discoveredBottle.groupId === null) {
-    throw new ConcreteBottleUpdateGraphError("missing_group", bottleId);
+    throw new BottleUpdateGraphError("missing_group", bottleId);
   }
   const groupId = discoveredBottle.groupId;
 
@@ -923,7 +916,7 @@ export async function lockConcreteBottleUpdateDependencies(
     .limit(1)
     .for("update");
   if (!group) {
-    throw new ConcreteBottleUpdateGraphError(
+    throw new BottleUpdateGraphError(
       "invalid_catalog_graph",
       bottleId,
       groupId,
@@ -937,7 +930,7 @@ export async function lockConcreteBottleUpdateDependencies(
     .limit(1)
     .for("update");
   if (!bottle || bottle.groupId !== groupId) {
-    throw new ConcreteBottleUpdateGraphError(
+    throw new BottleUpdateGraphError(
       "invalid_catalog_graph",
       bottleId,
       groupId,
@@ -953,7 +946,7 @@ export async function lockConcreteBottleUpdateDependencies(
  * commits. Optional expected shared state is compared while its dependencies
  * remain locked.
  */
-export async function updateConcreteBottleInTransaction(
+export async function updateBottleInTransaction(
   tx: AnyTransaction,
   {
     bottleId,
@@ -965,21 +958,21 @@ export async function updateConcreteBottleInTransaction(
     creationSource,
   }: {
     bottleId: number;
-    input: SystemConcreteBottleUpdateInput;
-    expectedSelectedBottleState?: ConcreteBottleUpdateExpectedSelectedBottleState;
-    expectedSharedState?: ConcreteBottleUpdateExpectedSharedState;
+    input: SystemBottleUpdateInput;
+    expectedSelectedBottleState?: BottleUpdateExpectedSelectedBottleState;
+    expectedSharedState?: BottleUpdateExpectedSharedState;
     user?: User;
     actorId: number;
     creationSource: CatalogVerificationCreationSource;
   },
-): Promise<ConcreteBottleUpdateFinalizationManifest> {
+): Promise<BottleUpdateFinalizationManifest> {
   const expectedReferencedEntityIds =
     expectedSharedState?.referencedEntities.map(({ id }) => id) ?? [];
   const {
     bottle: lockedBottle,
     group,
     referencedEntities,
-  } = await lockConcreteBottleUpdateDependencies(tx, bottleId, [
+  } = await lockBottleUpdateDependencies(tx, bottleId, [
     ...expectedReferencedEntityIds,
     ...existingEntityIdsForUpdate(input),
   ]);
@@ -992,7 +985,7 @@ export async function updateConcreteBottleInTransaction(
         JSON.stringify(expectedSelectedBottleState[key]),
     )
   ) {
-    throw new ConcreteBottleUpdateExpectedBottleStateError(bottleId);
+    throw new BottleUpdateExpectedBottleStateError(bottleId);
   }
 
   const [bottleTombstone] = await tx
@@ -1001,7 +994,7 @@ export async function updateConcreteBottleInTransaction(
     .where(eq(bottleTombstones.bottleId, bottleId))
     .limit(1);
   if (bottleTombstone) {
-    throw new ConcreteBottleUpdateGraphError("retired", bottleId, groupId);
+    throw new BottleUpdateGraphError("retired", bottleId, groupId);
   }
 
   const sharedIntent = hasFields(input.shared);
@@ -1032,7 +1025,7 @@ export async function updateConcreteBottleInTransaction(
       group.representativeBottleId === null ||
       !members.some(({ id }) => id === group.representativeBottleId)
     ) {
-      throw new ConcreteBottleUpdateGraphError(
+      throw new BottleUpdateGraphError(
         "invalid_catalog_graph",
         bottleId,
         groupId,
@@ -1100,7 +1093,7 @@ export async function updateConcreteBottleInTransaction(
       seriesChanged ||
       referencedEntitiesChanged
     ) {
-      throw new ConcreteBottleUpdateExpectedStateError(groupId);
+      throw new BottleUpdateExpectedStateError(groupId);
     }
   }
   const changedEntityIds = new Set<number>();
@@ -1231,33 +1224,30 @@ export async function updateConcreteBottleInTransaction(
         : await loadEntity(tx, group.bottlerId);
   let changedAliasNames: string[];
   try {
-    ({ changedAliasNames } = await reserveConcreteBottleIdentitiesInTransaction(
-      tx,
-      {
-        candidates: affectedMembers.map((member) => {
-          const desired = desiredByBottleId.get(member.id)!;
-          return {
-            bottleId: member.id,
-            current: {
-              name: member.name,
-              fullName: member.fullName,
-              brand: currentBrand,
-              bottler: currentBottler,
-            },
-            desired: {
-              name: desired.name,
-              fullName: desired.fullName,
-              brand: stable.brand,
-              bottler: stable.bottler,
-            },
-          };
-        }),
-        assignedByActorId: actorId,
-      },
-    ));
+    ({ changedAliasNames } = await reserveBottleIdentitiesInTransaction(tx, {
+      candidates: affectedMembers.map((member) => {
+        const desired = desiredByBottleId.get(member.id)!;
+        return {
+          bottleId: member.id,
+          current: {
+            name: member.name,
+            fullName: member.fullName,
+            brand: currentBrand,
+            bottler: currentBottler,
+          },
+          desired: {
+            name: desired.name,
+            fullName: desired.fullName,
+            brand: stable.brand,
+            bottler: stable.bottler,
+          },
+        };
+      }),
+      assignedByActorId: actorId,
+    }));
   } catch (error) {
-    if (error instanceof ConcreteBottleIdentityConflictError) {
-      throw new ConcreteBottleUpdateConflictError(error.conflictingBottleId);
+    if (error instanceof BottleIdentityConflictError) {
+      throw new BottleUpdateConflictError(error.conflictingBottleId);
     }
     throw error;
   }
@@ -1280,7 +1270,7 @@ export async function updateConcreteBottleInTransaction(
       .where(eq(bottleGroups.id, groupId))
       .returning();
     if (!persistedGroup) {
-      throw new ConcreteBottleUpdateGraphError(
+      throw new BottleUpdateGraphError(
         "invalid_catalog_graph",
         bottleId,
         groupId,
@@ -1323,7 +1313,7 @@ export async function updateConcreteBottleInTransaction(
       .where(and(eq(bottles.id, member.id), eq(bottles.groupId, groupId)))
       .returning();
     if (!updated) {
-      throw new ConcreteBottleUpdateGraphError(
+      throw new BottleUpdateGraphError(
         "invalid_catalog_graph",
         bottleId,
         groupId,
@@ -1405,8 +1395,8 @@ export async function updateConcreteBottleInTransaction(
 }
 
 /** Dispatches idempotent update work only after the outer transaction commits. */
-export async function finalizeConcreteBottleUpdate(
-  result: ConcreteBottleUpdateFinalizationManifest,
+export async function finalizeBottleUpdate(
+  result: BottleUpdateFinalizationManifest,
 ) {
   for (const bottleId of result.changedBottleIds) {
     try {
@@ -1452,7 +1442,7 @@ export async function finalizeConcreteBottleUpdate(
 }
 
 /** Authorizes and parses an untrusted moderator update before touching storage. */
-export async function updateConcreteBottle({
+export async function updateBottle({
   bottleId,
   input: rawInput,
   context,
@@ -1460,20 +1450,18 @@ export async function updateConcreteBottle({
   bottleId: number;
   input: unknown;
   context: Context;
-}): Promise<ConcreteBottleUpdateResult> {
+}): Promise<BottleUpdateResult> {
   if (!context.user?.admin && !context.user?.mod) {
-    throw new ConcreteBottleUpdateAuthorizationError();
+    throw new BottleUpdateAuthorizationError();
   }
   if (!Number.isInteger(bottleId) || bottleId <= 0) {
-    throw new ConcreteBottleUpdateInputError(
-      "Bottle ID must be a positive integer.",
-    );
+    throw new BottleUpdateInputError("Bottle ID must be a positive integer.");
   }
-  const input = ConcreteBottleUpdateInputSchema.parse(rawInput);
+  const input = BottleUpdateInputSchema.parse(rawInput);
   const user = context.user;
   const actor = await getUserActor(user);
   const result = await db.transaction((tx) =>
-    updateConcreteBottleInTransaction(tx, {
+    updateBottleInTransaction(tx, {
       bottleId,
       input,
       user,
@@ -1481,7 +1469,7 @@ export async function updateConcreteBottle({
       creationSource: "manual_entry",
     }),
   );
-  await finalizeConcreteBottleUpdate(result);
+  await finalizeBottleUpdate(result);
   return {
     bottle: result.bottle,
     group: result.group,

--- a/apps/server/src/lib/updateEntity.ts
+++ b/apps/server/src/lib/updateEntity.ts
@@ -17,13 +17,13 @@ import {
 import { arraysEqual } from "@peated/server/lib/equals";
 import { logError } from "@peated/server/lib/log";
 import {
-  ConcreteBottleUpdateConflictError,
-  ConcreteBottleUpdateGraphError,
-  ConcreteBottleUpdateInputError,
-  finalizeConcreteBottleUpdate,
-  updateConcreteBottleInTransaction,
-  type ConcreteBottleUpdateFinalizationManifest,
-} from "@peated/server/lib/updateConcreteBottle";
+  BottleUpdateConflictError,
+  BottleUpdateGraphError,
+  BottleUpdateInputError,
+  finalizeBottleUpdate,
+  updateBottleInTransaction,
+  type BottleUpdateFinalizationManifest,
+} from "@peated/server/lib/updateBottle";
 import { EntityInputSchema } from "@peated/server/schemas";
 import { pushUniqueJob } from "@peated/server/worker/client";
 import { asc, eq, sql } from "drizzle-orm";
@@ -113,7 +113,7 @@ function isEntityNameConflict(error: unknown): boolean {
 export type EntityUpdateFinalizationManifest = {
   entity: Entity;
   changed: boolean;
-  bottleUpdates: ConcreteBottleUpdateFinalizationManifest[];
+  bottleUpdates: BottleUpdateFinalizationManifest[];
 };
 
 export type EntityUpdateExpectedState = {
@@ -287,7 +287,7 @@ export async function updateEntityInTransaction(
   }
 
   let newEntity: Entity | undefined;
-  const bottleUpdates: ConcreteBottleUpdateFinalizationManifest[] = [];
+  const bottleUpdates: BottleUpdateFinalizationManifest[] = [];
   try {
     [newEntity] = await transaction
       .update(entities)
@@ -341,7 +341,7 @@ export async function updateEntityInTransaction(
           throw new BottleGroupRepresentativeMissingError(group.id);
         }
         bottleUpdates.push(
-          await updateConcreteBottleInTransaction(transaction, {
+          await updateBottleInTransaction(transaction, {
             bottleId: group.representativeBottleId,
             input: { shared: { brand: newEntity.id } },
             user,
@@ -362,9 +362,9 @@ export async function updateEntityInTransaction(
     });
   } catch (error) {
     if (
-      error instanceof ConcreteBottleUpdateConflictError ||
-      error instanceof ConcreteBottleUpdateGraphError ||
-      error instanceof ConcreteBottleUpdateInputError ||
+      error instanceof BottleUpdateConflictError ||
+      error instanceof BottleUpdateGraphError ||
+      error instanceof BottleUpdateInputError ||
       error instanceof ExactBottleAliasConflictError ||
       error instanceof BottleGroupRepresentativeMissingError
     ) {
@@ -381,7 +381,7 @@ export async function finalizeEntityUpdate(
 ) {
   if (!result.changed) return;
   for (const bottleUpdate of result.bottleUpdates) {
-    await finalizeConcreteBottleUpdate(bottleUpdate);
+    await finalizeBottleUpdate(bottleUpdate);
   }
 
   try {

--- a/apps/server/src/orpc/routes/bottleSeries/delete.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/delete.test.ts
@@ -7,7 +7,7 @@ import {
   bottleSeries,
   changes,
 } from "@peated/server/db/schema";
-import { createConcreteBottle } from "@peated/server/lib/createConcreteBottle";
+import { createBottle } from "@peated/server/lib/createBottle";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
@@ -61,7 +61,7 @@ async function createGroup({
   seriesId: number;
   name: string;
 }) {
-  const first = await createConcreteBottle({
+  const first = await createBottle({
     context: { user },
     input: {
       stable: { name, brand: brandId, series: seriesId },

--- a/apps/server/src/orpc/routes/bottleSeries/delete.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/delete.ts
@@ -7,10 +7,10 @@ import {
 } from "@peated/server/db/schema";
 import { getUserActorForDatabase } from "@peated/server/lib/actors";
 import {
-  finalizeConcreteBottleUpdate,
-  updateConcreteBottleInTransaction,
-  type ConcreteBottleUpdateFinalizationManifest,
-} from "@peated/server/lib/updateConcreteBottle";
+  finalizeBottleUpdate,
+  updateBottleInTransaction,
+  type BottleUpdateFinalizationManifest,
+} from "@peated/server/lib/updateBottle";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
 import { and, asc, eq, isNull } from "drizzle-orm";
@@ -51,7 +51,7 @@ export default procedure
         .where(eq(bottleGroups.seriesId, series.id))
         .orderBy(asc(bottleGroups.id))
         .for("update");
-      const manifests: ConcreteBottleUpdateFinalizationManifest[] = [];
+      const manifests: BottleUpdateFinalizationManifest[] = [];
 
       for (const group of groups) {
         if (group.representativeBottleId === null) {
@@ -60,7 +60,7 @@ export default procedure
           });
         }
         manifests.push(
-          await updateConcreteBottleInTransaction(tx, {
+          await updateBottleInTransaction(tx, {
             bottleId: group.representativeBottleId,
             input: { shared: { series: null } },
             user: context.user,
@@ -91,7 +91,7 @@ export default procedure
 
     for (const manifest of manifests) {
       // The deleted series has no search vector to rebuild.
-      await finalizeConcreteBottleUpdate({
+      await finalizeBottleUpdate({
         ...manifest,
         affectedSeriesIds: manifest.affectedSeriesIds.filter(
           (seriesId) => seriesId !== input.series,

--- a/apps/server/src/orpc/routes/bottles/apply-brand-repair-group.ts
+++ b/apps/server/src/orpc/routes/bottles/apply-brand-repair-group.ts
@@ -14,7 +14,7 @@ export default procedure
     path: "/bottles/apply-brand-repair-group",
     summary: "Apply BottleGroup-wide brand/entity repairs",
     description:
-      "Group eligible candidate Bottles by BottleGroup, then fan each shared brand, optional distillery, and series repair out to every concrete member. Requires moderator privileges",
+      "Group eligible candidate Bottles by BottleGroup. Apply each shared brand, optional distillery, and series repair to every Bottle in the group. Requires moderator privileges",
     spec: (spec) => ({
       ...spec,
       operationId: "applyBottleBrandRepairGroup",

--- a/apps/server/src/orpc/routes/bottles/create.test.ts
+++ b/apps/server/src/orpc/routes/bottles/create.test.ts
@@ -300,7 +300,7 @@ describe("POST /bottles", () => {
         caskSize: "hogshead",
         caskType: "bourbon",
         caskFill: "1st_fill",
-        description: "A complete concrete release.",
+        description: "A complete Bottle description.",
         descriptionSrc: "user",
       },
       { context: { user: defaults.user } },
@@ -340,7 +340,7 @@ describe("POST /bottles", () => {
       caskSize: "hogshead",
       caskType: "bourbon",
       caskFill: "1st_fill",
-      description: "A complete concrete release.",
+      description: "A complete Bottle description.",
       descriptionSrc: "user",
     });
     expect(data).toMatchObject({

--- a/apps/server/src/orpc/routes/bottles/create.ts
+++ b/apps/server/src/orpc/routes/bottles/create.ts
@@ -1,10 +1,10 @@
-import { IndependentConcreteBottleCreateRouteInputSchema } from "@peated/server/lib/concreteBottleSchemas";
+import { IndependentBottleCreateRouteInputSchema } from "@peated/server/lib/bottleSchemas";
 import {
   BottleAlreadyExistsError,
   BottleCreateBadRequestError,
-  createConcreteBottle,
-} from "@peated/server/lib/createConcreteBottle";
-import { buildIndependentConcreteBottleCreateInput } from "@peated/server/lib/flatConcreteBottleInput";
+  createBottle,
+} from "@peated/server/lib/createBottle";
+import { buildIndependentBottleCreateInput } from "@peated/server/lib/flatBottleInput";
 import { procedure } from "@peated/server/orpc";
 import {
   requireTosAccepted,
@@ -28,13 +28,13 @@ export default procedure
       operationId: "createBottle",
     }),
   })
-  .input(IndependentConcreteBottleCreateRouteInputSchema)
+  .input(IndependentBottleCreateRouteInputSchema)
   .output(BottleSchema)
   .handler(async function ({ input, context, errors }) {
     try {
-      const result = await createConcreteBottle({
+      const result = await createBottle({
         context,
-        input: buildIndependentConcreteBottleCreateInput(input),
+        input: buildIndependentBottleCreateInput(input),
       });
       return await serialize(
         BottleSerializer,

--- a/apps/server/src/orpc/routes/bottles/edit-context.test.ts
+++ b/apps/server/src/orpc/routes/bottles/edit-context.test.ts
@@ -5,7 +5,7 @@ import {
   bottles,
   bottlesToDistillers,
 } from "@peated/server/db/schema";
-import { createConcreteBottle } from "@peated/server/lib/createConcreteBottle";
+import { createBottle } from "@peated/server/lib/createBottle";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
@@ -21,7 +21,7 @@ async function createGroup(
   stable: Record<string, unknown>,
   exacts: GroupMemberExact[],
 ) {
-  const first = await createConcreteBottle({
+  const first = await createBottle({
     context: { user },
     input: { stable, exact: exacts[0] },
   });

--- a/apps/server/src/orpc/routes/bottles/edit-context.ts
+++ b/apps/server/src/orpc/routes/bottles/edit-context.ts
@@ -7,10 +7,7 @@ import {
 import { absoluteUrl } from "@peated/server/lib/urls";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware/auth";
-import {
-  BottleGroupV1Schema,
-  ConcreteBottleV1Schema,
-} from "@peated/server/schemas";
+import { BottleGroupV1Schema, BottleV1Schema } from "@peated/server/schemas";
 import { z } from "zod";
 
 const BottleEditChoiceSchema = z
@@ -33,7 +30,7 @@ const BottleEditSharedContextSchema = z
   })
   .strict();
 
-const BottleEditExactContextSchema = ConcreteBottleV1Schema.pick({
+const BottleEditExactContextSchema = BottleV1Schema.pick({
   edition: true,
   statedAge: true,
   abv: true,

--- a/apps/server/src/orpc/routes/bottles/merge.ts
+++ b/apps/server/src/orpc/routes/bottles/merge.ts
@@ -1,9 +1,9 @@
 import {
-  ConcreteBottleMergeConflictError,
-  ConcreteBottleMergeGraphError,
-  ConcreteBottleMergeInputError,
-  mergeConcreteBottles,
-} from "@peated/server/lib/mergeConcreteBottles";
+  BottleMergeConflictError,
+  BottleMergeGraphError,
+  BottleMergeInputError,
+  mergeBottles,
+} from "@peated/server/lib/mergeBottles";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
 import { BottleSchema } from "@peated/server/schemas";
@@ -39,7 +39,7 @@ export default procedure
       input.direction === "mergeInto" ? input.other : input.bottle;
 
     try {
-      const result = await mergeConcreteBottles({
+      const result = await mergeBottles({
         sourceBottleId,
         destinationBottleId,
         context,
@@ -51,21 +51,21 @@ export default procedure
       );
     } catch (error) {
       if (
-        error instanceof ConcreteBottleMergeInputError ||
-        (error instanceof ConcreteBottleMergeConflictError &&
+        error instanceof BottleMergeInputError ||
+        (error instanceof BottleMergeConflictError &&
           error.code === "same_bottle")
       ) {
         throw errors.BAD_REQUEST({ message: error.message, cause: error });
       }
       if (
-        error instanceof ConcreteBottleMergeGraphError &&
+        error instanceof BottleMergeGraphError &&
         error.code === "not_found"
       ) {
         throw errors.NOT_FOUND({ message: error.message, cause: error });
       }
       if (
-        error instanceof ConcreteBottleMergeGraphError ||
-        error instanceof ConcreteBottleMergeConflictError
+        error instanceof BottleMergeGraphError ||
+        error instanceof BottleMergeConflictError
       ) {
         throw errors.CONFLICT({ message: error.message, cause: error });
       }

--- a/apps/server/src/orpc/routes/bottles/update.test.ts
+++ b/apps/server/src/orpc/routes/bottles/update.test.ts
@@ -9,7 +9,7 @@ import {
   changes,
   entities,
 } from "@peated/server/db/schema";
-import { createConcreteBottle } from "@peated/server/lib/createConcreteBottle";
+import { createBottle } from "@peated/server/lib/createBottle";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
@@ -30,7 +30,7 @@ async function createGroup(
   stable: Record<string, unknown>,
   exacts: GroupMemberExact[],
 ) {
-  const first = await createConcreteBottle({
+  const first = await createBottle({
     context: { user },
     input: { stable, exact: exacts[0] },
   });

--- a/apps/server/src/orpc/routes/bottles/update.ts
+++ b/apps/server/src/orpc/routes/bottles/update.ts
@@ -1,10 +1,10 @@
-import { ConcreteBottleUpdateInputSchema } from "@peated/server/lib/concreteBottleSchemas";
+import { BottleUpdateInputSchema } from "@peated/server/lib/bottleSchemas";
 import {
-  ConcreteBottleUpdateConflictError,
-  ConcreteBottleUpdateGraphError,
-  ConcreteBottleUpdateInputError,
-  updateConcreteBottle,
-} from "@peated/server/lib/updateConcreteBottle";
+  BottleUpdateConflictError,
+  BottleUpdateGraphError,
+  BottleUpdateInputError,
+  updateBottle,
+} from "@peated/server/lib/updateBottle";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware/auth";
 import { BottleSchema } from "@peated/server/schemas";
@@ -12,7 +12,7 @@ import { serialize } from "@peated/server/serializers";
 import { BottleSerializer } from "@peated/server/serializers/bottle";
 import { z } from "zod";
 
-const InputSchema = ConcreteBottleUpdateInputSchema.extend({
+const InputSchema = BottleUpdateInputSchema.extend({
   bottle: z.coerce.number().int().positive(),
 }).strict();
 
@@ -37,7 +37,7 @@ export default procedure
   .output(BottleSchema)
   .handler(async function ({ input, context, errors }) {
     try {
-      const result = await updateConcreteBottle({
+      const result = await updateBottle({
         bottleId: input.bottle,
         input: { shared: input.shared, exact: input.exact },
         context,
@@ -51,22 +51,22 @@ export default procedure
         { includeGroupSummary: true },
       );
     } catch (error) {
-      if (error instanceof ConcreteBottleUpdateInputError) {
+      if (error instanceof BottleUpdateInputError) {
         throw errors.BAD_REQUEST({ message: error.message, cause: error });
       }
 
       if (
-        error instanceof ConcreteBottleUpdateGraphError &&
+        error instanceof BottleUpdateGraphError &&
         error.code === "not_found"
       ) {
         throw errors.NOT_FOUND({ message: error.message, cause: error });
       }
 
-      if (error instanceof ConcreteBottleUpdateGraphError) {
+      if (error instanceof BottleUpdateGraphError) {
         throw errors.CONFLICT({ message: error.message, cause: error });
       }
 
-      if (error instanceof ConcreteBottleUpdateConflictError) {
+      if (error instanceof BottleUpdateConflictError) {
         throw errors.CONFLICT({
           message: error.message,
           data:

--- a/apps/server/src/orpc/routes/bottles/upsert.ts
+++ b/apps/server/src/orpc/routes/bottles/upsert.ts
@@ -1,6 +1,6 @@
 import { call, ORPCError } from "@orpc/server";
-import { IndependentConcreteBottleCreateRouteInputSchema } from "@peated/server/lib/concreteBottleSchemas";
-import { buildConcreteBottleUpdatePatch } from "@peated/server/lib/flatConcreteBottleInput";
+import { IndependentBottleCreateRouteInputSchema } from "@peated/server/lib/bottleSchemas";
+import { buildBottleUpdatePatch } from "@peated/server/lib/flatBottleInput";
 import { logInfo } from "@peated/server/lib/log";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
@@ -27,7 +27,7 @@ export default procedure
       operationId: "upsertBottle",
     }),
   })
-  .input(IndependentConcreteBottleCreateRouteInputSchema)
+  .input(IndependentBottleCreateRouteInputSchema)
   .output(BottleSchema)
   .handler(async function ({ input, context }) {
     try {
@@ -48,7 +48,7 @@ export default procedure
           update,
           {
             bottle: err.data.bottle,
-            ...buildConcreteBottleUpdatePatch(input),
+            ...buildBottleUpdatePatch(input),
           },
           { context },
         );

--- a/apps/server/src/orpc/routes/prices/matchQueue/apply-bottle-repair.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/apply-bottle-repair.ts
@@ -12,10 +12,10 @@ import {
   UnknownStorePriceMatchProposalError,
 } from "@peated/server/lib/priceMatching";
 import {
-  ConcreteBottleUpdateConflictError,
-  ConcreteBottleUpdateGraphError,
-  ConcreteBottleUpdateInputError,
-} from "@peated/server/lib/updateConcreteBottle";
+  BottleUpdateConflictError,
+  BottleUpdateGraphError,
+  BottleUpdateInputError,
+} from "@peated/server/lib/updateBottle";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
 import { BottleSchema } from "@peated/server/schemas";
@@ -79,28 +79,25 @@ export default procedure
         });
       }
 
-      if (err instanceof ConcreteBottleUpdateInputError) {
+      if (err instanceof BottleUpdateInputError) {
         throw errors.BAD_REQUEST({
           message: err.message,
         });
       }
 
-      if (
-        err instanceof ConcreteBottleUpdateGraphError &&
-        err.code === "not_found"
-      ) {
+      if (err instanceof BottleUpdateGraphError && err.code === "not_found") {
         throw errors.NOT_FOUND({
           message: err.message,
         });
       }
 
-      if (err instanceof ConcreteBottleUpdateGraphError) {
+      if (err instanceof BottleUpdateGraphError) {
         throw errors.CONFLICT({
           message: err.message,
         });
       }
 
-      if (err instanceof ConcreteBottleUpdateConflictError) {
+      if (err instanceof BottleUpdateConflictError) {
         throw errors.CONFLICT({
           message: err.message,
           data:

--- a/apps/server/src/orpc/routes/prices/matchQueue/create-bottle.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/create-bottle.ts
@@ -3,12 +3,12 @@ import {
   ExactBottleAliasConflictError,
   FailedToSaveBottleAliasError,
 } from "@peated/server/lib/bottleAliases";
-import { IndependentConcreteBottleCreateRouteInputSchema } from "@peated/server/lib/concreteBottleSchemas";
+import { IndependentBottleCreateRouteInputSchema } from "@peated/server/lib/bottleSchemas";
 import {
   BottleAlreadyExistsError,
   BottleCreateBadRequestError,
-} from "@peated/server/lib/createConcreteBottle";
-import { buildIndependentConcreteBottleCreateInput } from "@peated/server/lib/flatConcreteBottleInput";
+} from "@peated/server/lib/createBottle";
+import { buildIndependentBottleCreateInput } from "@peated/server/lib/flatBottleInput";
 import {
   createBottleFromStorePriceMatchProposal,
   InvalidStorePriceMatchProposalTypeError,
@@ -27,7 +27,7 @@ import { z } from "zod";
 const IndependentInputSchema = z
   .object({
     proposal: z.coerce.number(),
-    independentBottle: IndependentConcreteBottleCreateRouteInputSchema,
+    independentBottle: IndependentBottleCreateRouteInputSchema,
   })
   .strict();
 
@@ -48,9 +48,7 @@ export default procedure
       const actor = await getUserActor(context.user);
       const result = await createBottleFromStorePriceMatchProposal({
         proposalId: input.proposal,
-        concreteInput: buildIndependentConcreteBottleCreateInput(
-          input.independentBottle,
-        ),
+        bottleInput: buildIndependentBottleCreateInput(input.independentBottle),
         user: context.user,
         actor,
       });

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -2541,7 +2541,7 @@ describe("price match queue", () => {
     expect(decisionLogs).toEqual([priorDecision]);
   });
 
-  test("creates an independent Bottle from a complete concrete input", async ({
+  test("creates an independent Bottle from a complete Bottle input", async ({
     fixtures,
   }) => {
     const user = await fixtures.User({ mod: true });

--- a/apps/server/src/orpc/routes/tastings/photo-identification-create.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification-create.ts
@@ -7,7 +7,7 @@ import { db } from "@peated/server/db";
 import { bottles } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
 import { applyClassifierCreateDecision } from "@peated/server/lib/bottleReferenceResolution";
-import { BottleAlreadyExistsError } from "@peated/server/lib/createConcreteBottle";
+import { BottleAlreadyExistsError } from "@peated/server/lib/createBottle";
 import { logError } from "@peated/server/lib/log";
 import {
   copyPendingImageToBottle,

--- a/apps/server/src/schemas/catalogIdentity.test.ts
+++ b/apps/server/src/schemas/catalogIdentity.test.ts
@@ -1,4 +1,4 @@
-import { BottleGroupV1Schema, ConcreteBottleV1Schema } from "./catalogIdentity";
+import { BottleGroupV1Schema, BottleV1Schema } from "./catalogIdentity";
 
 const ratingStats = {
   pass: 0,
@@ -31,7 +31,7 @@ const group = BottleGroupV1Schema.parse({
   updatedAt: "2026-07-14T00:00:00.000Z",
 });
 
-const bottle = ConcreteBottleV1Schema.parse({
+const bottle = BottleV1Schema.parse({
   schemaVersion: 1,
   id: 3,
   groupId: 1,
@@ -69,7 +69,7 @@ const bottle = ConcreteBottleV1Schema.parse({
 describe("catalog identity runtime schemas", () => {
   test("parses BottleGroup and independently complete Bottle results", () => {
     expect(BottleGroupV1Schema.parse(group)).toEqual(group);
-    expect(ConcreteBottleV1Schema.parse(bottle)).toMatchObject({
+    expect(BottleV1Schema.parse(bottle)).toMatchObject({
       id: 3,
       groupId: 1,
       brandId: 2,
@@ -84,6 +84,6 @@ describe("catalog identity runtime schemas", () => {
   test("rejects a Bottle without its independently owned identity", () => {
     const { brandId: _, ...incompleteBottle } = bottle;
 
-    expect(() => ConcreteBottleV1Schema.parse(incompleteBottle)).toThrow();
+    expect(() => BottleV1Schema.parse(incompleteBottle)).toThrow();
   });
 });

--- a/apps/server/src/schemas/catalogIdentity.ts
+++ b/apps/server/src/schemas/catalogIdentity.ts
@@ -56,8 +56,8 @@ export const BottleGroupV1Schema = z.object({
   updatedAt: z.string().datetime(),
 });
 
-/** Runtime-owned v1 result for one concrete marketed release. */
-export const ConcreteBottleV1Schema = z.object({
+/** Runtime-owned v1 result for one complete Bottle. */
+export const BottleV1Schema = z.object({
   schemaVersion: CatalogIdentitySchemaVersion,
   id: z.number().int().positive(),
   groupId: z.number().int().positive(),
@@ -93,4 +93,4 @@ export const ConcreteBottleV1Schema = z.object({
 });
 
 export type BottleGroupV1 = z.infer<typeof BottleGroupV1Schema>;
-export type ConcreteBottleV1 = z.infer<typeof ConcreteBottleV1Schema>;
+export type BottleV1 = z.infer<typeof BottleV1Schema>;

--- a/apps/server/src/worker/jobs/generateBottleDetails.test.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.test.ts
@@ -7,10 +7,10 @@ import {
   bottleTombstones,
   changes,
 } from "@peated/server/db/schema";
-import { createConcreteBottle } from "@peated/server/lib/createConcreteBottle";
+import { createBottle } from "@peated/server/lib/createBottle";
 import { getStructuredResponse } from "@peated/server/lib/openai";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
-import { updateConcreteBottle } from "@peated/server/lib/updateConcreteBottle";
+import { updateBottle } from "@peated/server/lib/updateBottle";
 import * as workerClient from "@peated/server/worker/client";
 import { and, asc, eq } from "drizzle-orm";
 import { beforeEach, expect, test, vi } from "vitest";
@@ -35,7 +35,7 @@ vi.mock("@peated/server/lib/openai", () => ({
 function contextFor(user: User) {
   return {
     user,
-  } as Parameters<typeof createConcreteBottle>[0]["context"];
+  } as Parameters<typeof createBottle>[0]["context"];
 }
 
 function generatedDetails(): GeneratedBottleDetails {
@@ -61,7 +61,7 @@ function deferModelResult() {
 }
 
 async function createTwoMemberGroup(user: User, brandId: number) {
-  const source = await createConcreteBottle({
+  const source = await createBottle({
     context: contextFor(user),
     input: {
       stable: {
@@ -234,7 +234,7 @@ test("preserves a concurrent moderator exact-content edit", async ({
   const work = generateBottleDetails({ bottleId: source.bottle.id });
   await vi.waitFor(() => expect(getStructuredResponse).toHaveBeenCalledOnce());
 
-  await updateConcreteBottle({
+  await updateBottle({
     bottleId: source.bottle.id,
     input: {
       exact: {
@@ -289,7 +289,7 @@ test("discards generated work planned from stale exact identity", async ({
   const work = generateBottleDetails({ bottleId: source.bottle.id });
   await vi.waitFor(() => expect(getStructuredResponse).toHaveBeenCalledOnce());
 
-  await updateConcreteBottle({
+  await updateBottle({
     bottleId: source.bottle.id,
     input: {
       exact: {
@@ -348,7 +348,7 @@ test("preserves a concurrent moderator shared-flavor edit", async ({
   const work = generateBottleDetails({ bottleId: source.bottle.id });
   await vi.waitFor(() => expect(getStructuredResponse).toHaveBeenCalledOnce());
 
-  await updateConcreteBottle({
+  await updateBottle({
     bottleId: source.bottle.id,
     input: { shared: { flavorProfile: "lightly_peated" } },
     context: contextFor(mod),
@@ -424,7 +424,7 @@ test("does not fan out after the selected Bottle moves groups", async ({
     defaults.user,
     brand.id,
   );
-  const destination = await createConcreteBottle({
+  const destination = await createBottle({
     context: contextFor(defaults.user),
     input: {
       stable: {

--- a/apps/server/src/worker/jobs/generateBottleDetails.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.ts
@@ -11,22 +11,22 @@ import {
 } from "@peated/server/db/schema";
 import { getPeatedSystemActorForDatabase } from "@peated/server/lib/actors";
 import {
-  SystemConcreteBottleUpdateInputSchema,
-  type SystemConcreteBottleUpdateInput,
-} from "@peated/server/lib/concreteBottleSchemas";
+  SystemBottleUpdateInputSchema,
+  type SystemBottleUpdateInput,
+} from "@peated/server/lib/bottleSchemas";
 import { arraysEqual, objectsShallowEqual } from "@peated/server/lib/equals";
 import { notesForProfile } from "@peated/server/lib/format";
 import { logError, logWarn } from "@peated/server/lib/log";
 import { getStructuredResponse } from "@peated/server/lib/openai";
 import { withSentryConversation } from "@peated/server/lib/openaiClient";
 import {
-  ConcreteBottleUpdateExpectedBottleStateError,
-  concreteBottleUpdateExpectedSelectedBottleState,
-  concreteBottleUpdateExpectedSharedState,
-  ConcreteBottleUpdateExpectedStateError,
-  finalizeConcreteBottleUpdate,
-  updateConcreteBottleInTransaction,
-} from "@peated/server/lib/updateConcreteBottle";
+  BottleUpdateExpectedBottleStateError,
+  bottleUpdateExpectedSelectedBottleState,
+  bottleUpdateExpectedSharedState,
+  BottleUpdateExpectedStateError,
+  finalizeBottleUpdate,
+  updateBottleInTransaction,
+} from "@peated/server/lib/updateBottle";
 import { CategoryEnum, FlavorProfileEnum } from "@peated/server/schemas";
 import { and, eq, isNull } from "drizzle-orm";
 import { z } from "zod";
@@ -172,8 +172,8 @@ export default async function generateBottleDetails(rawJobArgs: unknown) {
     .from(bottleGroupDistillers)
     .where(eq(bottleGroupDistillers.groupId, owned.group.id));
   const expectedSelectedBottleState =
-    concreteBottleUpdateExpectedSelectedBottleState(bottle);
-  const expectedSharedState = concreteBottleUpdateExpectedSharedState({
+    bottleUpdateExpectedSelectedBottleState(bottle);
+  const expectedSharedState = bottleUpdateExpectedSharedState({
     group: owned.group,
     distillerIds: groupDistillers.map(({ distillerId }) => distillerId),
     series: owned.series,
@@ -204,7 +204,7 @@ export default async function generateBottleDetails(rawJobArgs: unknown) {
     throw new Error(`Failed to generate details for bottle: ${bottleId}`);
   }
 
-  const exact: NonNullable<SystemConcreteBottleUpdateInput["exact"]> = {};
+  const exact: NonNullable<SystemBottleUpdateInput["exact"]> = {};
 
   if (
     generateDesc &&
@@ -242,7 +242,7 @@ export default async function generateBottleDetails(rawJobArgs: unknown) {
     }
   }
 
-  let shared: SystemConcreteBottleUpdateInput["shared"];
+  let shared: SystemBottleUpdateInput["shared"];
   if (!bottle.flavorProfile) {
     const flavorProfile = owned.group.flavorProfile ?? result.flavorProfile;
     if (flavorProfile) {
@@ -251,7 +251,7 @@ export default async function generateBottleDetails(rawJobArgs: unknown) {
   }
 
   if (!shared && Object.keys(exact).length === 0) return;
-  const input = SystemConcreteBottleUpdateInputSchema.parse({
+  const input = SystemBottleUpdateInputSchema.parse({
     shared,
     exact: Object.keys(exact).length ? exact : undefined,
   });
@@ -259,7 +259,7 @@ export default async function generateBottleDetails(rawJobArgs: unknown) {
   try {
     update = await db.transaction(async (tx) => {
       const actor = await getPeatedSystemActorForDatabase(tx);
-      return await updateConcreteBottleInTransaction(tx, {
+      return await updateBottleInTransaction(tx, {
         bottleId: bottle.id,
         input,
         expectedSelectedBottleState,
@@ -272,12 +272,12 @@ export default async function generateBottleDetails(rawJobArgs: unknown) {
     // Generated details belong only to the snapshot sent to the model. A newer
     // authoritative edit supersedes them, so the stale result is discarded.
     if (
-      error instanceof ConcreteBottleUpdateExpectedBottleStateError ||
-      error instanceof ConcreteBottleUpdateExpectedStateError
+      error instanceof BottleUpdateExpectedBottleStateError ||
+      error instanceof BottleUpdateExpectedStateError
     ) {
       return;
     }
     throw error;
   }
-  await finalizeConcreteBottleUpdate(update);
+  await finalizeBottleUpdate(update);
 }

--- a/apps/server/src/worker/jobs/mergeEntity.test.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.test.ts
@@ -18,7 +18,7 @@ import {
 import type { getUserActor } from "@peated/server/lib/actors";
 import { createBottleCheck } from "@peated/server/lib/bottleChecks";
 import { prepareOperation } from "@peated/server/lib/bottleOperationReview";
-import { createConcreteBottle } from "@peated/server/lib/createConcreteBottle";
+import { createBottle } from "@peated/server/lib/createBottle";
 import { loadEntityMergeOperation } from "@peated/server/lib/entityMergeOperation";
 import { pushUniqueJob } from "@peated/server/worker/client";
 import { and, eq, inArray } from "drizzle-orm";
@@ -85,7 +85,7 @@ async function deleteDestinationWhileMergeWaits(
 }
 
 function contextFor(user: Parameters<typeof getUserActor>[0]) {
-  return { user } as Parameters<typeof createConcreteBottle>[0]["context"];
+  return { user } as Parameters<typeof createBottle>[0]["context"];
 }
 
 beforeEach(async ({ fixtures }) => {
@@ -599,7 +599,7 @@ test("preflights exact batch duplicates from BottleGroup authority", async ({
     groupId: source.groupId as number,
     edition: "Batch 2",
   });
-  const destinationBatch = await createConcreteBottle({
+  const destinationBatch = await createBottle({
     context: contextFor(defaults.user),
     input: {
       stable: { brand: destinationEntity.id, name: "Annual" },

--- a/apps/server/src/worker/jobs/mergeEntity.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.ts
@@ -15,9 +15,9 @@ import {
   getUserActorForDatabase,
 } from "@peated/server/lib/actors";
 import {
-  getConcreteBottleExactIdentity,
-  materializeConcreteBottleForGroup,
-} from "@peated/server/lib/concreteBottleIdentity";
+  getBottleExactIdentity,
+  materializeBottleForGroup,
+} from "@peated/server/lib/bottleIdentity";
 import {
   EntityMergeOperationExecutionError,
   loadEntityMergeOperation,
@@ -29,17 +29,17 @@ import {
 import { formatBottleName } from "@peated/server/lib/format";
 import { logError, logInfo, logWarn } from "@peated/server/lib/log";
 import {
-  finalizeConcreteBottleMerge,
-  mergeConcreteBottlesInTransaction,
-  type ConcreteBottleMergeFinalizationManifest,
-} from "@peated/server/lib/mergeConcreteBottles";
+  finalizeBottleMerge,
+  mergeBottlesInTransaction,
+  type BottleMergeFinalizationManifest,
+} from "@peated/server/lib/mergeBottles";
 import { getAutomationModeratorUser } from "@peated/server/lib/systemUser";
 import {
-  concreteBottleUpdateExpectedSharedState,
-  finalizeConcreteBottleUpdate,
-  updateConcreteBottleInTransaction,
-  type ConcreteBottleUpdateFinalizationManifest,
-} from "@peated/server/lib/updateConcreteBottle";
+  bottleUpdateExpectedSharedState,
+  finalizeBottleUpdate,
+  updateBottleInTransaction,
+  type BottleUpdateFinalizationManifest,
+} from "@peated/server/lib/updateBottle";
 import { pushUniqueJob } from "@peated/server/worker/client";
 import {
   EntityMergeJobInputSchema,
@@ -127,8 +127,8 @@ async function performEntityMerge({
     },
   });
 
-  const bottleMergeManifests: ConcreteBottleMergeFinalizationManifest[] = [];
-  const bottleUpdateManifests: ConcreteBottleUpdateFinalizationManifest[] = [];
+  const bottleMergeManifests: BottleMergeFinalizationManifest[] = [];
+  const bottleUpdateManifests: BottleUpdateFinalizationManifest[] = [];
   let completedOperationResult: ReturnType<typeof buildOperationResult> | null =
     null;
   let performedMutation = false;
@@ -355,9 +355,9 @@ async function performEntityMerge({
           }),
         };
         for (const member of members) {
-          const desired = materializeConcreteBottleForGroup({
+          const desired = materializeBottleForGroup({
             group: targetGroup,
-            exact: getConcreteBottleExactIdentity({
+            exact: getBottleExactIdentity({
               bottle: member,
               sourceGroupStatedAge: group.statedAge,
             }),
@@ -382,7 +382,7 @@ async function performEntityMerge({
             .limit(1);
           if (!duplicate) continue;
           bottleMergeManifests.push(
-            await mergeConcreteBottlesInTransaction(tx, {
+            await mergeBottlesInTransaction(tx, {
               sourceBottleId: member.id,
               destinationBottleId: duplicate.id,
               actorId: actor.id,
@@ -403,9 +403,9 @@ async function performEntityMerge({
         throw new Error(`BottleGroup ${groupId} has no representative Bottle.`);
       }
       bottleUpdateManifests.push(
-        await updateConcreteBottleInTransaction(tx, {
+        await updateBottleInTransaction(tx, {
           bottleId: selectedBottleId,
-          expectedSharedState: concreteBottleUpdateExpectedSharedState({
+          expectedSharedState: bottleUpdateExpectedSharedState({
             group,
             distillerIds: groupDistillers.map(({ distillerId }) => distillerId),
             series: currentSeries,
@@ -572,10 +572,10 @@ async function performEntityMerge({
   }
 
   for (const manifest of bottleMergeManifests) {
-    await finalizeConcreteBottleMerge(manifest);
+    await finalizeBottleMerge(manifest);
   }
   for (const manifest of bottleUpdateManifests) {
-    await finalizeConcreteBottleUpdate(manifest);
+    await finalizeBottleUpdate(manifest);
   }
   try {
     await pushUniqueJob(

--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -293,7 +293,7 @@ test.describe("create bottle", () => {
     ).toBeVisible();
   });
 
-  test("adds the created concrete bottle to library from a proposal", async ({
+  test("adds the created Bottle to the library from a proposal", async ({
     context,
     page,
   }, testInfo) => {
@@ -332,7 +332,7 @@ test.describe("create bottle", () => {
     ).toBeVisible();
   });
 
-  test("uploads a replacement scan to the created concrete Bottle", async ({
+  test("uploads a replacement scan to the created Bottle", async ({
     context,
     page,
   }, testInfo) => {

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -284,17 +284,17 @@ export const exactMatchedBottle = {
  *   series: {id: number} | null
  * }} FixtureBottle
  */
-/** @typedef {import("@peated/server/schemas").ConcreteBottleV1} ConcreteBottleV1 */
+/** @typedef {import("@peated/server/schemas").BottleV1} BottleV1 */
 /**
  * @typedef {Omit<FixtureBottle,
  *   "edition" | "statedAge" | "abv" | "singleCask" | "caskStrength" |
  *   "vintageYear" | "releaseYear" | "caskSize" | "caskType" | "caskFill" |
  *   "imageUrl"
- * > & Pick<ConcreteBottleV1,
+ * > & Pick<BottleV1,
  *   "edition" | "statedAge" | "abv" | "singleCask" | "caskStrength" |
  *   "vintageYear" | "releaseYear" | "caskSize" | "caskType" | "caskFill" |
  *   "imageUrl"
- * >} ConcreteFixtureBottle
+ * >} CatalogFixtureBottle
  */
 /** @typedef {import("@peated/server/schemas").BottleGroupV1} BottleGroupV1 */
 /** @typedef {import("@peated/server/types").CollectionBottle} CollectionBottle */
@@ -304,7 +304,7 @@ export const exactMatchedBottle = {
  * @property {number} [id]
  * @property {string} [fullName]
  * @property {string} [name]
- * @property {FixtureBottle | ConcreteFixtureBottle} [bottle]
+ * @property {FixtureBottle | CatalogFixtureBottle} [bottle]
  * @property {number | null} [representativeBottleId]
  */
 
@@ -342,7 +342,7 @@ export function buildBottleGroup({
   };
 }
 
-/** @type {ConcreteFixtureBottle} */
+/** @type {CatalogFixtureBottle} */
 const homeBottleWithoutGroup = {
   ...buildBottle({
     id: 50_000,
@@ -382,7 +382,7 @@ const bottleGroupRatingStats = {
   },
 };
 
-/** @type {ConcreteFixtureBottle} */
+/** @type {CatalogFixtureBottle} */
 export const bottleGroupRepresentative = {
   ...buildBottle({
     id: 50_101,
@@ -403,7 +403,7 @@ export const bottleGroupRepresentative = {
   caskSize: "hogshead",
 };
 
-/** @type {ConcreteFixtureBottle} */
+/** @type {CatalogFixtureBottle} */
 export const bottleGroupMember = {
   ...buildBottle({
     id: 50_102,
@@ -418,7 +418,7 @@ export const bottleGroupMember = {
   releaseYear: 2023,
 };
 
-/** @type {ConcreteFixtureBottle} */
+/** @type {CatalogFixtureBottle} */
 const bottleGroupThirdMember = {
   ...buildBottle({
     id: 50_103,
@@ -446,7 +446,7 @@ export const bottleGroup = {
   totalBottles: 3,
 };
 
-/** @type {(ConcreteFixtureBottle & {group: BottleGroupV1})[]} */
+/** @type {(CatalogFixtureBottle & {group: BottleGroupV1})[]} */
 export const bottleGroupMembers = [
   bottleGroupRepresentative,
   bottleGroupMember,
@@ -625,7 +625,7 @@ export function buildCollection({
 /**
  * @param {{
  *   id?: number,
- *   bottle?: FixtureBottle | ConcreteFixtureBottle,
+ *   bottle?: FixtureBottle | CatalogFixtureBottle,
  *   notes?: string,
  *   rating?: number,
  *   tags?: string[],

--- a/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { IndependentConcreteBottleCreateRouteInputSchema } from "@peated/server/lib/concreteBottleSchemas";
+import { IndependentBottleCreateRouteInputSchema } from "@peated/server/lib/bottleSchemas";
 import type { Bottle } from "@peated/server/types";
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
@@ -240,7 +240,7 @@ export default function Page() {
 
     const created = await createBottleMutation.mutateAsync({
       proposal: item.id,
-      independentBottle: IndependentConcreteBottleCreateRouteInputSchema.parse(
+      independentBottle: IndependentBottleCreateRouteInputSchema.parse(
         item.proposedBottle,
       ),
     });

--- a/apps/web/src/app/(admin)/admin/(default)/queue/queueItemCard.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/queueItemCard.tsx
@@ -290,7 +290,7 @@ function getChoiceName(
   return typeof choice === "object" && choice?.name ? choice.name : null;
 }
 
-function getConcreteBottleDraftFields(
+function getBottleDraftFields(
   bottle: NonNullable<QueueItem["proposedBottle"]>,
 ): RecommendationField[] {
   const fields: RecommendationField[] = [
@@ -710,7 +710,7 @@ function renderRecommendationOutcome(item: QueueItem): ReactNode {
       <RecommendationSection
         label="Bottle Draft"
         title={item.price.name}
-        fields={getConcreteBottleDraftFields(item.proposedBottle)}
+        fields={getBottleDraftFields(item.proposedBottle)}
       />
     </div>
   );

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/buildBottleUpdateInput.test.ts
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/buildBottleUpdateInput.test.ts
@@ -4,7 +4,7 @@ import type {
   BottleFormSubmitValue,
 } from "@peated/web/components/bottleForm";
 import { describe, expect, test } from "vitest";
-import { buildConcreteBottleUpdateInput } from "./buildConcreteBottleUpdateInput";
+import { buildBottleUpdateInput } from "./buildBottleUpdateInput";
 
 function formValue(
   overrides: Partial<BottleFormSubmitValue> = {},
@@ -41,25 +41,22 @@ function submitMeta(
   return { dirtyFields: new Set(dirtyFields) };
 }
 
-describe("buildConcreteBottleUpdateInput", () => {
+describe("buildBottleUpdateInput", () => {
   test("omits both scopes when the age field is not dirty", () => {
     expect(
-      buildConcreteBottleUpdateInput(
-        formValue({ statedAge: 18 }),
-        submitMeta(),
-      ),
+      buildBottleUpdateInput(formValue({ statedAge: 18 }), submitMeta()),
     ).toEqual({});
   });
 
   test("builds an exact-only patch without shared values", () => {
     expect(
-      buildConcreteBottleUpdateInput(formValue(), submitMeta("edition", "abv")),
+      buildBottleUpdateInput(formValue(), submitMeta("edition", "abv")),
     ).toEqual({ exact: { edition: "Batch 24", abv: 57.2 } });
   });
 
   test("routes an exact-owned age without exposing a second form field", () => {
     expect(
-      buildConcreteBottleUpdateInput(
+      buildBottleUpdateInput(
         formValue({ statedAge: 15 }),
         submitMeta("statedAge"),
         { statedAgeScope: "exact" },
@@ -69,7 +66,7 @@ describe("buildConcreteBottleUpdateInput", () => {
 
   test("clears an exact-owned age without changing shared values", () => {
     expect(
-      buildConcreteBottleUpdateInput(
+      buildBottleUpdateInput(
         formValue({ statedAge: null }),
         submitMeta("statedAge"),
         { statedAgeScope: "exact" },
@@ -79,10 +76,7 @@ describe("buildConcreteBottleUpdateInput", () => {
 
   test("builds a shared-only patch without exact values", () => {
     expect(
-      buildConcreteBottleUpdateInput(
-        formValue(),
-        submitMeta("name", "statedAge"),
-      ),
+      buildBottleUpdateInput(formValue(), submitMeta("name", "statedAge")),
     ).toEqual({
       shared: { name: "Springbank 12 Cask Strength", statedAge: 12 },
     });
@@ -90,7 +84,7 @@ describe("buildConcreteBottleUpdateInput", () => {
 
   test("maps the complete shared and exact form contract", () => {
     expect(
-      buildConcreteBottleUpdateInput(
+      buildBottleUpdateInput(
         formValue({
           series: 3,
           brand: 4,
@@ -154,11 +148,11 @@ describe("buildConcreteBottleUpdateInput", () => {
 
   test("clears a removed image but leaves a new canvas to the upload route", () => {
     expect(
-      buildConcreteBottleUpdateInput(formValue({ image: null }), submitMeta()),
+      buildBottleUpdateInput(formValue({ image: null }), submitMeta()),
     ).toEqual({ exact: { image: null } });
 
     expect(
-      buildConcreteBottleUpdateInput(
+      buildBottleUpdateInput(
         formValue({ image: {} as HTMLCanvasElement }),
         submitMeta(),
       ),

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/buildBottleUpdateInput.ts
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/buildBottleUpdateInput.ts
@@ -1,18 +1,18 @@
-import type { ConcreteBottleUpdateInput } from "@peated/server/lib/concreteBottleSchemas";
+import type { BottleUpdateInput } from "@peated/server/lib/bottleSchemas";
 import type {
   BottleFormSubmitMeta,
   BottleFormSubmitValue,
 } from "@peated/web/components/bottleForm";
 
-type SharedPatch = NonNullable<ConcreteBottleUpdateInput["shared"]>;
-type ExactPatch = NonNullable<ConcreteBottleUpdateInput["exact"]>;
+type SharedPatch = NonNullable<BottleUpdateInput["shared"]>;
+type ExactPatch = NonNullable<BottleUpdateInput["exact"]>;
 
 /**
  * Partitions only dirty fields rendered by the live form into sparse
  * shared/exact patches. The edit context keeps stated-age ownership internal
  * while the form presents one effective value.
  */
-export function buildConcreteBottleUpdateInput(
+export function buildBottleUpdateInput(
   value: BottleFormSubmitValue,
   { dirtyFields }: BottleFormSubmitMeta,
   {
@@ -20,7 +20,7 @@ export function buildConcreteBottleUpdateInput(
   }: {
     statedAgeScope?: "shared" | "exact";
   } = {},
-): ConcreteBottleUpdateInput {
+): BottleUpdateInput {
   const shared: SharedPatch = {};
   const exact: ExactPatch = {};
 

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
@@ -10,7 +10,7 @@ import { useORPC } from "@peated/web/lib/orpc/context";
 import { formQueryOptions } from "@peated/web/lib/orpc/query";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
-import { buildConcreteBottleUpdateInput } from "./buildConcreteBottleUpdateInput";
+import { buildBottleUpdateInput } from "./buildBottleUpdateInput";
 
 export default function Page(props: { params: Promise<{ bottleId: string }> }) {
   const params = use(props.params);
@@ -48,7 +48,7 @@ function BottleEditForm({ bottleId }: { bottleId: string }) {
         const { image } = value;
         await bottleUpdateMutation.mutateAsync({
           bottle: context.bottleId,
-          ...buildConcreteBottleUpdateInput(value, meta, {
+          ...buildBottleUpdateInput(value, meta, {
             statedAgeScope:
               context.exact.statedAge === null ? "shared" : "exact",
           }),

--- a/apps/web/src/components/bottleExactMetadata.tsx
+++ b/apps/web/src/components/bottleExactMetadata.tsx
@@ -1,11 +1,11 @@
 import { formatCategoryName } from "@peated/server/lib/format";
 import { toTitleCase } from "@peated/server/lib/strings";
-import type { BottleGroupV1, ConcreteBottleV1 } from "@peated/server/schemas";
+import type { BottleGroupV1, BottleV1 } from "@peated/server/schemas";
 import classNames from "@peated/web/lib/classNames";
 import type { ReactNode } from "react";
 
 export type BottleExactMetadataSource = Pick<
-  ConcreteBottleV1,
+  BottleV1,
   | "category"
   | "statedAge"
   | "abv"
@@ -17,7 +17,7 @@ export type BottleExactMetadataSource = Pick<
   | "caskType"
   | "caskSize"
 > & {
-  edition?: ConcreteBottleV1["edition"];
+  edition?: BottleV1["edition"];
   group?: Partial<Pick<BottleGroupV1, "statedAge">>;
 };
 

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -12,7 +12,7 @@ import {
   CATEGORY_LIST,
   FLAVOR_PROFILES,
 } from "@peated/server/constants";
-import { IndependentConcreteBottleCreateRouteInputSchema } from "@peated/server/lib/concreteBottleSchemas";
+import { IndependentBottleCreateRouteInputSchema } from "@peated/server/lib/bottleSchemas";
 import {
   formatCategoryName,
   formatFlavorProfile,
@@ -77,9 +77,9 @@ const caskTypeList = CASK_TYPES.map(({ id }) => ({
 }));
 
 type CreateFormSchemaType = z.infer<
-  typeof IndependentConcreteBottleCreateRouteInputSchema
+  typeof IndependentBottleCreateRouteInputSchema
 >;
-const BottleFormSchema = IndependentConcreteBottleCreateRouteInputSchema;
+const BottleFormSchema = IndependentBottleCreateRouteInputSchema;
 type FormSchemaType = CreateFormSchemaType;
 type ChoiceLike = {
   id?: number | null;

--- a/docs/architecture/bottle-creation-alias-system.md
+++ b/docs/architecture/bottle-creation-alias-system.md
@@ -45,7 +45,7 @@ Related architecture:
 
 Peated has three relevant identity layers:
 
-- `Bottle`: one concrete marketed version with a stable expression plus every
+- `Bottle`: one complete product release with a stable expression plus every
   supported structured exact field.
 - `BottleGroup`: a same-expression relationship aggregate established by
   singleton creation or deterministic legacy migration. It owns shared editing

--- a/docs/architecture/whisky-identity-model.md
+++ b/docs/architecture/whisky-identity-model.md
@@ -11,7 +11,7 @@ Classifier terms are governed by the
 
 ## Identity Objects
 
-- **Bottle** is one concrete marketed release. It has its own stable identity
+- **Bottle** is one complete product release. It has its own stable identity
   and durably stores every field needed to search, render, and understand that
   release without loading its BottleGroup.
 - **BottleGroup** relates releases of the same expression. It owns the shared

--- a/docs/features/photo-tasting-entry.md
+++ b/docs/features/photo-tasting-entry.md
@@ -19,7 +19,7 @@ action.
 3. The server processes the image, creates an owned pending upload, extracts
    label evidence, searches the local catalog, and runs the Bottle classifier.
 4. The resolver presents one of three outcomes:
-   - a concrete existing Bottle match;
+   - an existing Bottle match;
    - an approved proposal for one new, independently complete Bottle; or
    - manual search when the evidence is insufficient or conflicting.
 5. After resolving a Bottle, the user may log a tasting, add it to their

--- a/packages/bottle-classifier/README.md
+++ b/packages/bottle-classifier/README.md
@@ -33,8 +33,8 @@ The package root is intentionally small. It should export only the core ways we 
 import {
   createBottleClassifier,
   createWhiskyLabelExtractor,
-  formatCanonicalReleaseName,
-  getResolvedReleaseIdentity,
+  formatCanonicalBottleName,
+  getResolvedBottleIdentity,
   normalizeBottle,
   normalizeProposedBottleDraft,
 } from "@peated/bottle-classifier";
@@ -118,7 +118,7 @@ Package-specific reminders:
 - [`src/instructions.ts`](./src/instructions.ts): classifier and extractor prompts
 - [`src/extractor.ts`](./src/extractor.ts): bottle-label extraction
 - [`src/normalize.ts`](./src/normalize.ts): bottle/name/category/volume normalization
-- [`src/releaseIdentity.ts`](./src/releaseIdentity.ts): canonical Bottle name and exact-trait normalization shared with staged migration consumers
+- [`src/bottleIdentity.ts`](./src/bottleIdentity.ts): canonical Bottle name and exact-trait normalization shared with staged migration consumers
 - [`src/bottleCreationDrafts.ts`](./src/bottleCreationDrafts.ts): create-draft normalization
 - [`src/priceMatchingEvidence.ts`](./src/priceMatchingEvidence.ts): shared evidence checks
 - [`src/smws.ts`](./src/smws.ts): SMWS parsing and exact-code behavior

--- a/packages/bottle-classifier/package.json
+++ b/packages/bottle-classifier/package.json
@@ -39,9 +39,9 @@
       "types": "./src/error.ts",
       "default": "./src/error.ts"
     },
-    "./releaseIdentity": {
-      "types": "./src/releaseIdentity.ts",
-      "default": "./src/releaseIdentity.ts"
+    "./bottleIdentity": {
+      "types": "./src/bottleIdentity.ts",
+      "default": "./src/bottleIdentity.ts"
     },
     "./bottleSchemaGuidance": {
       "types": "./src/bottleSchemaGuidance.ts",

--- a/packages/bottle-classifier/scripts/check-terms.mjs
+++ b/packages/bottle-classifier/scripts/check-terms.mjs
@@ -27,6 +27,8 @@ const textExtensions = new Set([
 ]);
 
 const prohibitedTerms = [
+  /\b(?:ConcreteBottle|concreteBottle)\w*\b/gu,
+  /\breleaseIdentity\b/giu,
   /\bconcrete[\s-]+bottles?\b/giu,
   /\bparent[\s-]+bottles?\b/giu,
   /\bproposed[\s-]+operations?\b/giu,

--- a/packages/bottle-classifier/src/bottleIdentity.test.ts
+++ b/packages/bottle-classifier/src/bottleIdentity.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, test } from "vitest";
 
 import {
   bottleMarketsStatedAge,
-  formatCanonicalReleaseName,
-  getResolvedReleaseIdentity,
-  hasDirtyBottleLevelStatedAgeConflict,
-} from "./releaseIdentity";
+  formatCanonicalBottleName,
+  getResolvedBottleIdentity,
+  hasBottleStatedAgeConflict,
+} from "./bottleIdentity";
 
-describe("releaseIdentity", () => {
+describe("bottleIdentity", () => {
   test("tracks when the bottle itself markets its stated age", () => {
     expect(
       bottleMarketsStatedAge({
@@ -26,38 +26,38 @@ describe("releaseIdentity", () => {
     ).toBe(false);
   });
 
-  test("flags dirty parent age conflicts only when the parent does not market that age", () => {
+  test("flags shared-age conflicts only when the Bottle does not market that age", () => {
     expect(
-      hasDirtyBottleLevelStatedAgeConflict({
+      hasBottleStatedAgeConflict({
         bottle: {
           name: "Private Selection",
           fullName: "Maker's Mark Private Selection",
           statedAge: 10,
         },
-        releaseStatedAge: 12,
+        exactStatedAge: 12,
       }),
     ).toBe(true);
 
     expect(
-      hasDirtyBottleLevelStatedAgeConflict({
+      hasBottleStatedAgeConflict({
         bottle: {
           name: "Lagavulin 16",
           fullName: "Lagavulin 16-year-old",
           statedAge: 16,
         },
-        releaseStatedAge: 12,
+        exactStatedAge: 12,
       }),
     ).toBe(false);
   });
 
-  test("resolves release identity and canonical naming without duplicating parent age", () => {
-    const resolved = getResolvedReleaseIdentity({
+  test("resolves Bottle identity without duplicating the shared age", () => {
+    const resolved = getResolvedBottleIdentity({
       bottle: {
         name: "Lagavulin Distillers Edition",
         fullName: "Lagavulin Distillers Edition",
         statedAge: 16,
       },
-      release: {
+      exact: {
         edition: null,
         statedAge: 16,
         releaseYear: 2011,
@@ -70,11 +70,11 @@ describe("releaseIdentity", () => {
 
     expect(resolved.statedAge).toBe(16);
     expect(
-      formatCanonicalReleaseName({
+      formatCanonicalBottleName({
         bottleName: "Lagavulin Distillers Edition",
         bottleFullName: "Lagavulin Distillers Edition",
         bottleStatedAge: 16,
-        release: resolved,
+        exact: resolved,
       }),
     ).toEqual({
       name: "Lagavulin Distillers Edition - 2011 Release - 43.0% ABV",
@@ -84,11 +84,11 @@ describe("releaseIdentity", () => {
 
   test("does not duplicate exact age already marketed in the stable name", () => {
     expect(
-      formatCanonicalReleaseName({
+      formatCanonicalBottleName({
         bottleName: "Speyside 12-year-old",
         bottleFullName: "Shieldaig Speyside 12-year-old",
         bottleStatedAge: null,
-        release: {
+        exact: {
           edition: null,
           statedAge: 12,
           releaseYear: null,
@@ -105,13 +105,13 @@ describe("releaseIdentity", () => {
   });
 
   test("does not duplicate a release year already encoded by the edition", () => {
-    const release = getResolvedReleaseIdentity({
+    const exact = getResolvedBottleIdentity({
       bottle: {
         name: "Annual Selection",
         fullName: "Example Annual Selection",
         statedAge: null,
       },
-      release: {
+      exact: {
         edition: "2022 Edition",
         statedAge: null,
         releaseYear: 2022,
@@ -122,16 +122,16 @@ describe("releaseIdentity", () => {
       },
     });
 
-    expect(release).toMatchObject({
+    expect(exact).toMatchObject({
       edition: "2022 Edition",
       releaseYear: 2022,
     });
     expect(
-      formatCanonicalReleaseName({
+      formatCanonicalBottleName({
         bottleName: "Annual Selection",
         bottleFullName: "Example Annual Selection",
         bottleStatedAge: null,
-        release,
+        exact,
       }),
     ).toEqual({
       name: "Annual Selection - 2022 Edition",
@@ -141,11 +141,11 @@ describe("releaseIdentity", () => {
 
   test("matches YEAR Edition case-insensitively for display deduplication", () => {
     expect(
-      formatCanonicalReleaseName({
+      formatCanonicalBottleName({
         bottleName: "Annual Selection",
         bottleFullName: "Example Annual Selection",
         bottleStatedAge: null,
-        release: {
+        exact: {
           edition: "2022 EDITION",
           statedAge: null,
           releaseYear: 2022,
@@ -191,11 +191,11 @@ describe("releaseIdentity", () => {
     "keeps release year separate from $edition",
     ({ edition, releaseYear, expectedEdition }) => {
       expect(
-        formatCanonicalReleaseName({
+        formatCanonicalBottleName({
           bottleName: "Annual Selection",
           bottleFullName: "Example Annual Selection",
           bottleStatedAge: null,
-          release: {
+          exact: {
             edition,
             statedAge: null,
             releaseYear,
@@ -212,16 +212,16 @@ describe("releaseIdentity", () => {
     },
   );
 
-  test("does not duplicate inherited stable parent traits in release naming", () => {
+  test("does not duplicate traits already present in the Bottle name", () => {
     expect(
-      formatCanonicalReleaseName({
+      formatCanonicalBottleName({
         bottleName: "Glendronach 1972 Single Cask",
         bottleFullName: "Glendronach 1972 Single Cask",
-        bottleReleaseTraits: {
+        bottleNameTraits: {
           singleCask: true,
         },
         bottleStatedAge: 48,
-        release: {
+        exact: {
           edition: "Batch 1",
           statedAge: 48,
           releaseYear: null,

--- a/packages/bottle-classifier/src/bottleIdentity.ts
+++ b/packages/bottle-classifier/src/bottleIdentity.ts
@@ -1,5 +1,5 @@
 /**
- * Pure exact-Bottle identity rules for materializing already extracted release
+ * Pure exact-Bottle identity rules for materializing already extracted exact
  * traits.
  *
  * Keep this module structurally safe and brand-agnostic. If a decision depends
@@ -9,7 +9,7 @@
  */
 import { normalizeBottle } from "./normalize";
 
-export type ReleaseIdentityInput = {
+export type BottleExactIdentityInput = {
   edition: string | null;
   statedAge: number | null;
   releaseYear: number | null;
@@ -22,10 +22,9 @@ export type ReleaseIdentityInput = {
   caskFill?: string | null;
 };
 
-type BottleLevelReleaseTraitsInput = Omit<ReleaseIdentityInput, "statedAge">;
+type BottleNameTraitsInput = Omit<BottleExactIdentityInput, "statedAge">;
 
-type BottleReleaseIdentityBottleInput = BottleNameInput &
-  Partial<BottleLevelReleaseTraitsInput>;
+type BottleNameIdentityInput = BottleNameInput & Partial<BottleNameTraitsInput>;
 
 type BottleNameInput = {
   fullName: string | null | undefined;
@@ -33,7 +32,7 @@ type BottleNameInput = {
   statedAge: number | null | undefined;
 };
 
-const RELEASE_IDENTITY_FIELDS = [
+const BOTTLE_EXACT_IDENTITY_FIELDS = [
   "edition",
   "statedAge",
   "releaseYear",
@@ -44,12 +43,12 @@ const RELEASE_IDENTITY_FIELDS = [
   "caskType",
   "caskSize",
   "caskFill",
-] as const satisfies ReadonlyArray<keyof ReleaseIdentityInput>;
+] as const satisfies ReadonlyArray<keyof BottleExactIdentityInput>;
 
-const STABLE_BOTTLE_LEVEL_RELEASE_TRAIT_FIELDS = [
+const BOTTLE_NAME_TRAIT_FIELDS = [
   "singleCask",
   "caskStrength",
-] as const satisfies ReadonlyArray<keyof BottleLevelReleaseTraitsInput>;
+] as const satisfies ReadonlyArray<keyof BottleNameTraitsInput>;
 
 function bottleNameMarketsPattern(
   bottle: BottleNameInput,
@@ -64,9 +63,9 @@ function bottleNameMarketsPattern(
   });
 }
 
-function bottleMarketsInheritedReleaseTrait(
+function bottleNameMarketsTrait(
   bottle: BottleNameInput,
-  field: (typeof STABLE_BOTTLE_LEVEL_RELEASE_TRAIT_FIELDS)[number],
+  field: (typeof BOTTLE_NAME_TRAIT_FIELDS)[number],
 ): boolean {
   switch (field) {
     case "singleCask":
@@ -82,19 +81,19 @@ function bottleMarketsInheritedReleaseTrait(
   }
 }
 
-function isInheritedBottleLevelReleaseTrait({
+function isTraitAlreadyInBottleName({
   bottle,
   field,
-  release,
+  exact,
 }: {
-  bottle: BottleReleaseIdentityBottleInput;
-  field: (typeof STABLE_BOTTLE_LEVEL_RELEASE_TRAIT_FIELDS)[number];
-  release: Partial<ReleaseIdentityInput>;
+  bottle: BottleNameIdentityInput;
+  field: (typeof BOTTLE_NAME_TRAIT_FIELDS)[number];
+  exact: Partial<BottleExactIdentityInput>;
 }) {
   return (
     bottle[field] === true &&
-    release[field] === true &&
-    bottleMarketsInheritedReleaseTrait(bottle, field)
+    exact[field] === true &&
+    bottleNameMarketsTrait(bottle, field)
   );
 }
 
@@ -132,27 +131,27 @@ export function bottleMarketsStatedAge(bottle: BottleNameInput) {
   );
 }
 
-export function hasDirtyBottleLevelStatedAgeConflict({
+export function hasBottleStatedAgeConflict({
   bottle,
-  releaseStatedAge,
+  exactStatedAge,
 }: {
   bottle: BottleNameInput;
-  releaseStatedAge: number | null | undefined;
+  exactStatedAge: number | null | undefined;
 }) {
   return (
     bottle.statedAge !== null &&
     bottle.statedAge !== undefined &&
-    releaseStatedAge !== null &&
-    releaseStatedAge !== undefined &&
-    bottle.statedAge !== releaseStatedAge &&
+    exactStatedAge !== null &&
+    exactStatedAge !== undefined &&
+    bottle.statedAge !== exactStatedAge &&
     !bottleMarketsStatedAge(bottle)
   );
 }
 
-function formatReleaseTraitLabel(
-  field: (typeof RELEASE_IDENTITY_FIELDS)[number],
+function formatExactIdentityLabel(
+  field: (typeof BOTTLE_EXACT_IDENTITY_FIELDS)[number],
   value: NonNullable<
-    ReleaseIdentityInput[(typeof RELEASE_IDENTITY_FIELDS)[number]]
+    BottleExactIdentityInput[(typeof BOTTLE_EXACT_IDENTITY_FIELDS)[number]]
   >,
 ): string | null {
   switch (field) {
@@ -193,82 +192,82 @@ function editionIncludesReleaseYearEditionPhrase({
 }
 
 /**
- * Produces the canonical release identity after accounting for bottle-level
- * stated-age carryover and dirty-parent conflicts.
+ * Produces the canonical exact identity after accounting for bottle-level
+ * stated-age carryover and shared-age conflicts.
  */
-export function getResolvedReleaseIdentity({
+export function getResolvedBottleIdentity({
   bottle,
-  release,
+  exact,
 }: {
   bottle: BottleNameInput;
-  release: ReleaseIdentityInput;
-}): ReleaseIdentityInput {
-  const hasDirtyParentStatedAgeConflict = hasDirtyBottleLevelStatedAgeConflict({
+  exact: BottleExactIdentityInput;
+}): BottleExactIdentityInput {
+  const statedAgeConflicts = hasBottleStatedAgeConflict({
     bottle,
-    releaseStatedAge: release.statedAge,
+    exactStatedAge: exact.statedAge,
   });
 
   return {
-    edition: release.edition ?? null,
-    statedAge: hasDirtyParentStatedAgeConflict
-      ? (release.statedAge ?? null)
-      : (bottle.statedAge ?? release.statedAge ?? null),
-    releaseYear: release.releaseYear ?? null,
-    vintageYear: release.vintageYear ?? null,
-    abv: release.abv ?? null,
-    singleCask: release.singleCask ?? null,
-    caskStrength: release.caskStrength ?? null,
-    caskType: release.caskType ?? null,
-    caskSize: release.caskSize ?? null,
-    caskFill: release.caskFill ?? null,
+    edition: exact.edition ?? null,
+    statedAge: statedAgeConflicts
+      ? (exact.statedAge ?? null)
+      : (bottle.statedAge ?? exact.statedAge ?? null),
+    releaseYear: exact.releaseYear ?? null,
+    vintageYear: exact.vintageYear ?? null,
+    abv: exact.abv ?? null,
+    singleCask: exact.singleCask ?? null,
+    caskStrength: exact.caskStrength ?? null,
+    caskType: exact.caskType ?? null,
+    caskSize: exact.caskSize ?? null,
+    caskFill: exact.caskFill ?? null,
   };
 }
 
-export function formatCanonicalReleaseName({
+export function formatCanonicalBottleName({
   bottleName,
   bottleFullName,
-  bottleReleaseTraits,
+  bottleNameTraits,
   bottleStatedAge,
-  release,
+  exact,
 }: {
   bottleName: string;
   bottleFullName: string;
-  bottleReleaseTraits?: Partial<BottleLevelReleaseTraitsInput>;
+  bottleNameTraits?: Partial<BottleNameTraitsInput>;
   bottleStatedAge: number | null;
-  release: ReleaseIdentityInput;
+  exact: BottleExactIdentityInput;
 }): {
   fullName: string;
   name: string;
 } {
-  const resolvedRelease = getResolvedReleaseIdentity({
+  const resolvedIdentity = getResolvedBottleIdentity({
     bottle: {
       name: bottleName,
       fullName: bottleFullName,
       statedAge: bottleStatedAge,
     },
-    release,
+    exact,
   });
 
   const nameBits = [bottleName];
   const fullNameBits = [bottleFullName];
 
-  for (const field of RELEASE_IDENTITY_FIELDS) {
+  for (const field of BOTTLE_EXACT_IDENTITY_FIELDS) {
     if (
       field === "releaseYear" &&
-      editionIncludesReleaseYearEditionPhrase(resolvedRelease)
+      editionIncludesReleaseYearEditionPhrase(resolvedIdentity)
     ) {
       continue;
     }
 
     if (
       field === "statedAge" &&
-      resolvedRelease.statedAge !== null &&
+      resolvedIdentity.statedAge !== null &&
       ((bottleStatedAge !== null &&
-        resolvedRelease.statedAge === bottleStatedAge) ||
+        resolvedIdentity.statedAge === bottleStatedAge) ||
         bottleMarketsStatedAge({
           name: bottleName,
           fullName: bottleFullName,
-          statedAge: resolvedRelease.statedAge,
+          statedAge: resolvedIdentity.statedAge,
         }))
     ) {
       continue;
@@ -276,26 +275,26 @@ export function formatCanonicalReleaseName({
 
     if (
       (field === "singleCask" || field === "caskStrength") &&
-      isInheritedBottleLevelReleaseTrait({
+      isTraitAlreadyInBottleName({
         bottle: {
           name: bottleName,
           fullName: bottleFullName,
           statedAge: bottleStatedAge,
-          ...bottleReleaseTraits,
+          ...bottleNameTraits,
         },
         field,
-        release: resolvedRelease,
+        exact: resolvedIdentity,
       })
     ) {
       continue;
     }
 
-    const value = resolvedRelease[field];
+    const value = resolvedIdentity[field];
     if (value === null || value === undefined) {
       continue;
     }
 
-    const label = formatReleaseTraitLabel(field, value);
+    const label = formatExactIdentityLabel(field, value);
     if (!label) {
       continue;
     }

--- a/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-hibiki-21-missing-abv-not-bottler.json
+++ b/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-hibiki-21-missing-abv-not-bottler.json
@@ -104,7 +104,6 @@
     "dbOutcome": {
       "bottleId": 11863,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Keep Bottle 11863, add exact ABV 43%, and leave bottler null. Do not create or assign a Suntory bottler Entity and do not merge or create a Bottle."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-laphroaig-cairdeas-2022-malformed-duplicate.json
+++ b/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-laphroaig-cairdeas-2022-malformed-duplicate.json
@@ -343,7 +343,6 @@
     "dbOutcome": {
       "bottleId": 45146,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Merge malformed Bottle 39096 into complete Warehouse 1 Bottle 45146, create a Bottle tombstone from 39096 to 45146, and repoint Bottle consumers and aliases including tasting 223 to 45146. Leave generic Càirdeas Bottle 44288 unchanged. Do not create a Bottle or propose a BottleGroup mutation."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-pokeno-single-cask-missing-vintage.json
+++ b/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-pokeno-single-cask-missing-vintage.json
@@ -111,7 +111,6 @@
     "dbOutcome": {
       "bottleId": 45174,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Keep Bottle 45174 and add vintageYear 2019. Preserve its stored name, edition, age, 55.8% ABV, singleCask true, caskStrength true, and releaseYear null. Do not merge or create a Bottle."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-proof-and-wood-representative-retains-bottler-and-batch-abv.json
+++ b/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-proof-and-wood-representative-retains-bottler-and-batch-abv.json
@@ -118,7 +118,6 @@
     "dbOutcome": {
       "bottleId": 45249,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Keep Bottle 45249, retain Proof and Wood Entity 365733 as both Brand and bottler, preserve the stored 57.97% ABV because the cited 57.4% belongs to a different batch, add caskStrength true, and add singleCask false because the release is a blend of about 20 barrels. Do not merge or create a Bottle."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-smws-10.258-code-already-in-name.json
+++ b/packages/bottle-classifier/src/eval-fixtures/audit-cases/production-smws-10.258-code-already-in-name.json
@@ -105,7 +105,6 @@
     "dbOutcome": {
       "bottleId": 25608,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Keep Bottle 25608 and its canonical name 10.258 Quo vadis?. Add exact ABV 58.1%, singleCask true, and vintageYear 2013. Leave edition null because the SMWS code is already materialized in the Bottle name."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-composes-smws-1-285-from-label-components.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-composes-smws-1-285-from-label-components.json
@@ -90,10 +90,8 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/smws-1.285.jpg",
     "dbOutcome": {
       "bottleId": 11940,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
-      "summary": "Production DB outcome: match bottle 11940, SMWS 1.285 (name '1.285 Party in the afternoon'), releaseId null, identityScope exact_cask. The bottle already carries statedAge 11, abv 63.4, vintageYear 2011, caskStrength true, singleCask true, so nothing is missing to backfill."
+      "summary": "Production DB outcome: match Bottle 11940, SMWS 1.285 (name '1.285 Party in the afternoon'), with identityScope exact_cask. The Bottle already carries statedAge 11, abv 63.4, vintageYear 2011, caskStrength true, and singleCask true. No field needs a backfill."
     },
     "notes": "Added from a failed image addBottle flow using the checked-in photo as the observed source. The classifier extracted the cask number '285' but never composed the SMWS code because '1.285' is printed nowhere on the label; the label instead prints the identity as separate 'Society Distillery No. 1' and 'Single Cask No. 285' components. Documented Society practice composes 'Distillery No. X' + 'Cask No. Y' into code 'X.Y', so deterministic composition yields '1.285' and matches existing bottle 11940. This is the SMWS 40th-anniversary 'Maverick's 40' replica-1983 handwritten presentation signed by founder Pip Hills (Glenfarclas, distillery code 1). The label's distillation date '6.8.11' is a format variant of whiskybase's 08.06.2011 (8 June 2011), so vintageYear stays 2011."
   },

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-and-repairs-compass-box-rogues-banquet.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-and-repairs-compass-box-rogues-banquet.json
@@ -162,9 +162,7 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/compass-box-rogues-banquet-official.png",
     "dbOutcome": {
       "bottleId": 13364,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Keep existing Bottle 13364 and propose its missing Limited Edition marker, 46% ABV, 2020 release year, Compass Box bottler, and Glen Elgin, Clynelish, Miltonduff, and North British distillers."
     },
     "notes": "The original user-uploaded scan and its exact extraction were no longer available, so this is deliberately a curated regression rather than a production_miss fixture. Its image evidence contains only facts visible on the official bottle art; the classifier must gather ABV, release year, bottler, and component distilleries through focused web evidence. The incomplete catalog snapshot models the reported pre-repair state; the public API now shows Bottle 13364 after manual correction with 46% ABV, releaseYear 2020, Compass Box as bottler, and all four component distilleries. The official product page explicitly says the whisky was released in March 2020 and bottled at 46%; the recipe sheet names all four components; Whiskybase independently corroborates the bottler, distilleries, bottling date, and ABV. Cask type, size, and fill are intentionally outside this expectation."

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-high-west-high-country-batch-23j12.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-high-west-high-country-batch-23j12.json
@@ -82,9 +82,7 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/high-west-high-country-batch-23j12.jpg",
     "dbOutcome": {
       "bottleId": 12825,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Original production outcome matched flattened lot-code row 44284, High West High Country - Batch No. 23J12. Re-verification on 2026-07-06 established High Country is an ongoing product sold as one undifferentiated SKU whose year-prefixed 'Batch No.' codes (22J11, 19I04, 23J12) are bottling lot codes, not marketed batch identity, so the correct catalog outcome is match plain Bottle 12825 with the lot code preserved as an observation; row 44284 is downstream repair, not a match target."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-laphroaig-elements-l2-0-bottle.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-laphroaig-elements-l2-0-bottle.json
@@ -152,16 +152,14 @@
     ],
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp",
     "dbOutcome": {
-      "bottleId": 44286,
-      "releaseId": null,
+      "bottleId": 43018,
       "createsBottle": false,
-      "createsRelease": true,
-      "summary": "Historical production DB outcome under the legacy model: bottle 44286 stored Laphroaig Elements and the desired catalog change was a new L2.0 child release. Nearby release 412 is L1.0 and must not be used for this L2.0 photo. The flattened model instead creates one complete L2.0 Bottle without repairing bottle 44286."
+      "summary": "Match complete Laphroaig Elements L2.0 Bottle 43018. Do not use broad Elements Bottle 44286 or the L1.0 Bottle represented by fixture id -412."
     },
     "catalogFieldObservations": [
       {
-        "target": "candidate_release",
-        "releaseId": 412,
+        "target": "candidate_bottle",
+        "bottleId": -412,
         "field": "edition",
         "productionValue": "L1.0",
         "evidenceValue": "L2.0",

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-pappy-van-winkle-15-family-reserve.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-pappy-van-winkle-15-family-reserve.json
@@ -209,10 +209,8 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/pappy-van-winkle-15-family-reserve.jpg",
     "dbOutcome": {
       "bottleId": 11868,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
-      "summary": "Assign the photo tasting to existing Peated bottle 11868, Pappy Van Winkle's 15-year-old Family Reserve, with releaseId null. Do not create a new Pappy Van Winkle bottle and do not match the 20-year sibling."
+      "summary": "Assign the photo tasting to existing Peated Bottle 11868, Pappy Van Winkle's 15-year-old Family Reserve. Do not create another Pappy Van Winkle Bottle. Do not match the 20-year Bottle."
     },
     "notes": "Added from a failed production photo auto-match using the preserved uploaded image. The label visibly shows Pappy Van Winkle's Family Reserve, Kentucky Straight Bourbon Whiskey, 15 years old, 750ml, 53.5% ABV / 107 proof. External sources verify the Pappy Van Winkle's Family Reserve family, the 15/20/23-year variants, and the 15-year expression at 107 proof. At the time of the production miss, bottle 11868 had no stored ABV; missing stored ABV is not a conflict when the label age and product identity disambiguate the existing bottle. Production search surfaced both existing Pappy candidates, 11868 and 11867; the expected outcome is bottle 11868 because the label age disambiguates it from the 20-year sibling."
   },

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-pokeno-exploration-series-totara-cask.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-pokeno-exploration-series-totara-cask.json
@@ -102,10 +102,8 @@
     ],
     "dbOutcome": {
       "bottleId": 44263,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
-      "summary": "Assign the photo tasting to existing Peated bottle 44263, Pōkeno Exploration Series No. 1 Totara Cask, with releaseId null. Do not create a new Pōkeno bottle or release for this photo."
+      "summary": "Assign the photo tasting to existing Peated Bottle 44263, Pōkeno Exploration Series No. 1 Totara Cask. Do not create another Bottle for this photo."
     },
     "notes": "Added from a failed /addTasting photo-identification attempt using the preserved uploaded image. The label visibly shows Pōkeno Aotearoa New Zealand Single Malt Whisky, Exploration Series No. 01, Totara Cask, 700ml, 40% ABV. The official Pokeno product page and blog verify Totara Cask as part of the Exploration Series."
   },

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-smws-95-71-prepare-for-winter.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-smws-95-71-prepare-for-winter.json
@@ -89,10 +89,8 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/smws-95-71-prepare-for-winter.jpg",
     "dbOutcome": {
       "bottleId": 11939,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
-      "summary": "Production DB outcome: match bottle 11939 with releaseId null. Nearby non-target row: bottle 38409, SMWS 95.71 Serrano-wrapped plums."
+      "summary": "Production DB outcome: match Bottle 11939. Nearby non-target Bottle 38409 is SMWS 95.71 Serrano-wrapped plums."
     },
     "catalogFieldObservations": [
       {

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-springbank-open-day-may-2026-30-year-old.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-springbank-open-day-may-2026-30-year-old.json
@@ -87,10 +87,8 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/springbank-open-day-may-2026-30-year-old.jpg",
     "dbOutcome": {
       "bottleId": 44256,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
-      "summary": "Production DB outcome: match existing bottle 44256, Springbank Open Day, releaseId null. Do not create a second Springbank Open Day May 2026 bottle from this photo."
+      "summary": "Production DB outcome: match existing Bottle 44256, Springbank Open Day. Do not create a second Springbank Open Day May 2026 Bottle from this photo."
     },
     "catalogFieldObservations": [
       {

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-trestle-spirit-of-eclipse.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-trestle-spirit-of-eclipse.json
@@ -122,9 +122,7 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/trestle-spirit-of-eclipse.jpg",
     "dbOutcome": {
       "bottleId": 38004,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Production DB outcome: match Bottle 38004 with no release; the Bottle still stores releaseYear 2011 and null ABV."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-woodford-reserve-double-double-oaked-2022-release.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-woodford-reserve-double-double-oaked-2022-release.json
@@ -158,23 +158,21 @@
     ],
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/woodford-reserve-double-double-oaked-2022.jpg",
     "dbOutcome": {
-      "bottleId": 44022,
-      "releaseId": 195,
+      "bottleId": -195,
       "createsBottle": false,
-      "createsRelease": false,
-      "summary": "Production DB outcome: match existing release 195, Woodford Reserve Double Double Oaked - 2022 Release, under bottle 44022. Do not match plain Double Oaked bottle 11855 or create another 2022 release."
+      "summary": "Match the complete Woodford Reserve Double Double Oaked 2022 Bottle represented by fixture id -195. Do not match plain Double Oaked Bottle 11855. Do not create another 2022 Bottle."
     },
     "catalogFieldObservations": [
       {
-        "target": "matched_release",
-        "releaseId": 195,
+        "target": "matched_bottle",
+        "bottleId": -195,
         "field": "abv",
         "productionValue": null,
         "evidenceValue": 45.2,
         "source": "image_evidence",
         "issue": "missing_in_production",
         "safeToAutoFill": false,
-        "notes": "The photo label gives 45.2% ABV for the 2022 release, but this eval is about routing to the existing release rather than enriching it."
+        "notes": "The photo label gives 45.2% ABV for the 2022 Bottle. This eval checks routing to the existing Bottle and does not require enrichment."
       }
     ],
     "notes": "Added from failed image photo-identification trace 413c334005c60d8dcc8dbf109761c5e3. The observed pending upload was t2l6vj6tc6zixonbv54lc87o at https://api.peated.com/uploads/pending-uploads/pending-upload-o5klpnm5zbjknwcu8w0sm3fd.webp, expiring 2026-07-10T02:41:47.889Z. The form returned suggestedNextStep manual_search even though classification matched the captured exact 2022 Bottle candidate. This fixture requires the eligible exact match to route to confirm_match automatically. The label evidence reads Woodford Reserve Double Double Oaked, 2022 release, 45.2% ABV, Distillery Series."

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-repairs-spice-tree-extravaganza.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-repairs-spice-tree-extravaganza.json
@@ -170,9 +170,7 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/compass-box-spice-tree-extravaganza.webp",
     "dbOutcome": {
       "bottleId": 45175,
-      "releaseId": null,
       "createsBottle": true,
-      "createsRelease": false,
       "summary": "Production created Bottle 45175 with null ABV, release year, bottler, and distillers; a moderator later repaired it to 46% ABV, releaseYear 2016, Compass Box bottler, and six component distilleries. Bottle 9900 already represented the same product with malformed identity data."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/smws-listing-matches-an-existing-exact-cask-bottle-by-code.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/smws-listing-matches-an-existing-exact-cask-bottle-by-code.json
@@ -86,9 +86,7 @@
     ],
     "dbOutcome": {
       "bottleId": 43260,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Current Peated outcome: match Bottle 43260, SMWS RW6.5 Appley ever after."
     },
     "notes": "Re-verified July 31, 2026. The official SMWS product page identifies cask RW6.5 as Appley ever after, and Peated Bottle 43260 stores that exact single-cask rye identity."

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/store-listing-matches-hudson-back-room-deal-peated-scotch-barrel-finished-as-bottle-identity.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/store-listing-matches-hudson-back-room-deal-peated-scotch-barrel-finished-as-bottle-identity.json
@@ -117,10 +117,8 @@
     ],
     "dbOutcome": {
       "bottleId": 11904,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
-      "summary": "Assign the store price to bottle 11904 with releaseId null. Do not create a bottle_release or a separate generic Back Room Deal parent; preserve the listing's peated Scotch barrel finish wording as source observation evidence."
+      "summary": "Assign the store price to Bottle 11904. Do not create another Back Room Deal Bottle. Preserve the listing's peated Scotch barrel finish wording as source observation evidence."
     },
     "notes": "Hudson treats Back Room Deal as a named range product: New York Straight Rye Whiskey finished in peated Scotch barrels at 46% ABV. The finish is part of the marketed bottle identity, not a child-release discriminator."
   },

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/store-listing-matches-laphroaig-cairdeas-2022-warehouse-1-and-merges-malformed-duplicate.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/store-listing-matches-laphroaig-cairdeas-2022-warehouse-1-and-merges-malformed-duplicate.json
@@ -548,9 +548,7 @@
     ],
     "dbOutcome": {
       "bottleId": 45146,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Assign source listing 11828042 to the existing independently complete Warehouse 1 Bottle 45146. Propose retiring malformed duplicate Bottle 39096 by merging it into Bottle 45146 so tasting 223 and its public Warehouse 1 label image follow the surviving exact Bottle. Leave generic Càirdeas Bottle 44288 unchanged."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/text-only-smws-listing-matches-an-existing-exact-cask-bottle-by-code.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/text-only-smws-listing-matches-an-existing-exact-cask-bottle-by-code.json
@@ -68,9 +68,7 @@
     ],
     "dbOutcome": {
       "bottleId": 43260,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Current Peated outcome: match Bottle 43260, SMWS RW6.5 Appley ever after."
     },
     "notes": "Re-verified July 31, 2026. The official SMWS product page identifies cask RW6.5 as Appley ever after, and Peated Bottle 43260 stores that exact single-cask rye identity."

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-compass-box-hedonism-squared.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-compass-box-hedonism-squared.json
@@ -85,9 +85,7 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/compass-box-hedonism-squared.jpg",
     "dbOutcome": {
       "bottleId": null,
-      "releaseId": null,
       "createsBottle": false,
-      "createsRelease": false,
       "summary": "Production search on 2026-08-02 returned eight other Hedonism bottles but no Hedonism² row. Photo identification proposed creation but routed the user to the manual Bottle form, so the observed flow created no Bottle automatically."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-complete-high-west-midwinter-act-10-scene-4-bottle.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-complete-high-west-midwinter-act-10-scene-4-bottle.json
@@ -78,23 +78,21 @@
     ],
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/high-west-midwinter-act-10-scene-4.jpg",
     "dbOutcome": {
-      "bottleId": 43397,
-      "releaseId": null,
-      "createsBottle": false,
-      "createsRelease": true,
-      "summary": "Historical production DB outcome under the legacy model: create a new release under bottle 43397. Nearby broad release row: release 3, Act 10. The flattened model creates one complete Act 10 Scene 4 Bottle instead of selecting that parent."
+      "bottleId": null,
+      "createsBottle": true,
+      "summary": "Create one complete Act 10 Scene 4 Bottle. Do not use broad Act 10 Bottle -3 or Bottle 43397."
     },
     "catalogFieldObservations": [
       {
-        "target": "candidate_release",
-        "releaseId": 3,
+        "target": "candidate_bottle",
+        "bottleId": -3,
         "field": "edition",
         "productionValue": "Act 10",
         "evidenceValue": "Act 10 Scene 4",
         "source": "image_evidence",
         "issue": "competing_candidate",
         "safeToAutoFill": false,
-        "notes": "The observed label uses the fuller release edition Act 10 Scene 4; the existing production release is the broader Act 10 row."
+        "notes": "The observed label uses the full edition Act 10 Scene 4. The existing Bottle is the broader Act 10 product."
       }
     ],
     "notes": "Added from a failed image addBottle flow using the checked-in photo as the observed source. The label explicitly reads A Midwinter Night's Dram, Act 10 Scene 4, 49.3% ABV. High West names these releases by act and scene, so Act 10 Scene 4 is the bottling edition rather than incidental label text."

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-complete-high-west-midwinter-act-12-scene-9-bottle.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-complete-high-west-midwinter-act-12-scene-9-bottle.json
@@ -159,11 +159,9 @@
     ],
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/high-west-midwinter-act-12-scene-9.jpg",
     "dbOutcome": {
-      "bottleId": 43397,
-      "releaseId": null,
-      "createsBottle": false,
-      "createsRelease": true,
-      "summary": "Historical production DB outcome under the legacy model: bottle 43397 stored the reusable A Midwinter Night's Dram identity and the desired catalog change was a new Act 12 Scene 9 child release. The observed production response returned no_match because legacy create-release handling was blocked by release-like parent traits. The flattened model instead creates one complete Act 12 Scene 9 Bottle and does not repair bottle 43397."
+      "bottleId": null,
+      "createsBottle": true,
+      "summary": "Create one complete Act 12 Scene 9 Bottle. Do not repair or select broad Bottle 43397."
     },
     "catalogFieldObservations": [
       {
@@ -178,15 +176,15 @@
         "notes": "Bottle 43397 historically carried Act 12 traits. Under the flattened model, the observed Act 12 Scene 9 product becomes its own complete Bottle and this candidate is not repaired by classification."
       },
       {
-        "target": "candidate_release",
-        "releaseId": 1,
+        "target": "candidate_bottle",
+        "bottleId": -1,
         "field": "edition",
         "productionValue": "Act 12",
         "evidenceValue": "Act 12 Scene 9",
         "source": "image_evidence",
         "issue": "competing_candidate",
         "safeToAutoFill": false,
-        "notes": "The observed label uses the fuller release edition Act 12 Scene 9; the existing production release is the broader Act 12 row."
+        "notes": "The observed label uses the full edition Act 12 Scene 9. The existing Bottle is the broader Act 12 product."
       }
     ],
     "notes": "Added from failed image photo-identification trace 73ec524d6a6298dfe005cbf3a6778e58. The observed pending upload was zg6qndh3rdnoch7roonscz8v at https://api.peated.com/uploads/pending-uploads/pending-upload-xex5u9xbjkd2g08367qt384b.webp, expiring 2026-07-10T02:45:26.290Z, and the checked-in image preserves that label evidence for replay. The production response returned suggestedNextStep manual_search and decision no_match even though diagnostics identified the observed product as Act 12 Scene 9 under legacy catalog row 43397. The old downgrade reason was a dirty-parent conflict; the flattened contract removes that intervention and expects one independently complete Act 12 Scene 9 Bottle. Kept as curated_regression because independent online verification of the exact Act 12 Scene 9 release was unavailable during fixture review."

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-exclusive-malts-islay-single-cask-as-bottle.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-exclusive-malts-islay-single-cask-as-bottle.json
@@ -93,12 +93,10 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/exclusive-malts-islay-2007.jpg",
     "dbOutcome": {
       "bottleId": 44274,
-      "releaseId": 407,
       "createsBottle": true,
-      "createsRelease": true,
-      "summary": "Production photo identification created bottle 44274 as the generic The Exclusive Malts Islay row, then created release 407 with the observed 8-year age, 2007 vintage, 2016 release year, 57.1% ABV, cask-strength flag, and uploaded image. The generic Bottle page therefore displayed null age and null vintage/ABV despite the label-specific identity being the only useful marketed form."
+      "summary": "Production photo identification created Bottle 44274 with incomplete identity. The Bottle must include the observed 8-year age, 2007 vintage, 2016 release year, 57.1% ABV, cask-strength flag, and uploaded image."
     },
-    "notes": "The checked-in fixture image is the observed source. Text search did not find a reliable public product page for this exact cask, so the fixture preserves the photo itself as verification rather than inventing external evidence. The label reads The Exclusive Malts Scotch Single Malt Whisky, 2007, aged 8 years, distilled at an Islay distillery, Islay, distilled 17 October 2007, bottled May 2016, cask no. 1661, one of 312 bottles, 750ml, 57.1%, cask strength, natural colour. The desired outcome keeps this one-off independent bottling as a single canonical bottle instead of creating a weak generic parent plus one child release."
+    "notes": "The checked-in fixture image is the observed source. Text search did not find a reliable public product page for this exact cask, so the fixture preserves the photo itself as verification rather than inventing external evidence. The label reads The Exclusive Malts Scotch Single Malt Whisky, 2007, aged 8 years, distilled at an Islay distillery, Islay, distilled 17 October 2007, bottled May 2016, cask no. 1661, one of 312 bottles, 750ml, 57.1%, cask strength, natural colour. The desired outcome keeps this one-off independent bottling as one complete Bottle."
   },
   "expected": {
     "status": "classified",

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-mars-komagatake-2022-edition.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-mars-komagatake-2022-edition.json
@@ -36,9 +36,7 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/mars-komagatake-2022-edition.webp",
     "dbOutcome": {
       "bottleId": 44298,
-      "releaseId": null,
       "createsBottle": true,
-      "createsRelease": false,
       "summary": "Production add-bottle flow created bottle 44298 because no Mars Komagatake parent existed. The submitted draft used existing brand Mars (entity 1169) and distiller Shinshu (entity 238555), with expression Komagatake, category single malt, 50% ABV, release year 2022, and edition 2022 Edition flattened onto the bottle row."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-watchpost-whiskey.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-watchpost-whiskey.json
@@ -33,9 +33,7 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/watchpost-8-year-old.webp",
     "dbOutcome": {
       "bottleId": 44299,
-      "releaseId": null,
       "createsBottle": true,
-      "createsRelease": false,
       "summary": "At capture, the production add-bottle flow created Watchpost Watchpost with new brand Watchpost (entity 365682), category blend, stated age 8, 42.5% ABV, and new distiller Westland Distillery Co. (entity 365683) even though Westland Distillery (entity 1987) and Westland (entity 1481) already existed."
     },
     "notes": "The exact observed extraction is preserved above, including the null age because the numeric age is not reliably readable in the image crop. At classification time the Watchpost brand and bottle did not exist, while Westland Distillery and Westland already existed as distiller candidates. Official Watchpost and Westland pages establish that the product is an eight-year-old American blended whiskey created by the Westland team at 42.5% ABV. The current API record was later corrected to Watchpost 8-year-old with stated age 8, while the duplicate Westland Distillery Co. entity 365683 remains attached."

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-willett-family-estate-barrel-4769.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/image-backed-photo-creates-willett-family-estate-barrel-4769.json
@@ -91,9 +91,7 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/willett-family-estate-barrel-4769.jpg",
     "dbOutcome": {
       "bottleId": null,
-      "releaseId": null,
       "createsBottle": true,
-      "createsRelease": false,
       "summary": "Production DB outcome: no bottle found for barrel no. 4769; create a new exact-cask bottle. Nearby rows: bottle 2, bottle 43924, and bottle 17073."
     },
     "catalogFieldObservations": [

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-creag-isle-12-year-old-island-single-malt.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-creag-isle-12-year-old-island-single-malt.json
@@ -307,7 +307,6 @@
     ],
     "dbOutcome": {
       "createsBottle": true,
-      "createsRelease": false,
       "summary": "No safe Peated bottle or release matched the observed candidate set; the correct reviewed outcome is a new product-scope Creag Isle 12-year-old Island Single Malt bottle."
     },
     "notes": "Production match queue proposal 23 returned no_match with empty searchEvidence even though independent sources verify the product."

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-elijah-craig-18-single-barrel-when-local-candidate-is-barrel-specific.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-elijah-craig-18-single-barrel-when-local-candidate-is-barrel-specific.json
@@ -325,9 +325,7 @@
     ],
     "dbOutcome": {
       "bottleId": null,
-      "releaseId": null,
       "createsBottle": true,
-      "createsRelease": false,
       "summary": "The observed Peated queue proposal had no current or suggested bottle/release target. The nearest local row was bottle 16142, Elijah Craig Single Barrel 18-year-old (No. 4040), which is barrel-specific and therefore too narrow for the Astor listing. The correct outcome is a new uncoded Elijah Craig 18-year-old Single Barrel bottle."
     },
     "notes": "Heaven Hill's official Elijah Craig 18-Year-Old Single Barrel page verifies the stable product identity, states the bottle is from one barrel, and lists Proof: 90 Proof and Age: 18 Years Old. For U.S. spirits labeling, 90 proof is 45% ABV, matching the extracted identity. The production automation snapshot blocked because deterministic web-evidence validation did not recognize proof as ABV evidence."

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-mastersons-french-oak-finish-instead-of-matching-plain-rye-or-barrel-specific-bottle.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-mastersons-french-oak-finish-instead-of-matching-plain-rye-or-barrel-specific-bottle.json
@@ -155,9 +155,7 @@
     ],
     "dbOutcome": {
       "bottleId": null,
-      "releaseId": null,
       "createsBottle": true,
-      "createsRelease": false,
       "summary": "Create a complete Masterson's 10-year-old Straight Rye French Oak Finish Bottle for the store price. Do not redirect to the plain Masterson's 10-year-old Rye Bottle 44029 or its batch-coded legacy candidates; do not match the narrower Barrel F2-038 Bottle 16442."
     },
     "notes": "Caskers search results list Masterson's 10 Year Old Straight Rye Whiskey and Masterson's 10 Year Old Rye Whiskey Barrel Finished in French Oak as separate product pages, so the French Oak wording is not merely an optional title suffix for the plain rye candidate. The existing Barrel F2-038 bottle is narrower than the observed store listing, so the correct current DB outcome is a clean French Oak bottle creation."

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-shieldaig-speyside-21-year-old-with-age-in-bottle-name.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-shieldaig-speyside-21-year-old-with-age-in-bottle-name.json
@@ -30,13 +30,11 @@
       "https://thedailypour.com/spirit/shieldaig-speyside-single-malt-scotch-whisky-21-year/"
     ],
     "dbOutcome": {
-      "bottleId": 44175,
-      "releaseId": null,
-      "createsBottle": false,
-      "createsRelease": false,
-      "summary": "Production proposal 28 selected bottle 44175, a Shieldaig Speyside row with a conflicting structured age of 18, as the parent for a 21-year child release. The corrected outcome is a separate Shieldaig Speyside 21-year-old bottle, not a release under the 18-year product."
+      "bottleId": null,
+      "createsBottle": true,
+      "summary": "Create a separate Shieldaig Speyside 21-year-old Bottle. Do not use Bottle 44175 because its structured age is 18."
     },
-    "notes": "Production match queue proposal 28 redirected the supported 21-year source listing to a child release under bottle 44175 even though the parent row carried conflicting statedAge 18. The observed web evidence included Total Wine plus independent Shieldaig Speyside 21-year pages. The localCatalog models the relevant Peated state that should inform the decision. Age is a marketed bottle-level differentiator for this Shieldaig Speyside family, so the display name must include the age."
+    "notes": "Production match queue proposal 28 selected Bottle 44175 even though its statedAge is 18. The observed web evidence included Total Wine plus independent Shieldaig Speyside 21-year pages. The localCatalog models the relevant Peated state that should inform the decision. Age identifies this marketed Bottle, so the display name must include the age."
   },
   "expected": {
     "status": "classified",

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-shieldaig-speyside-30-year-old-with-age-in-bottle-name.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-shieldaig-speyside-30-year-old-with-age-in-bottle-name.json
@@ -30,9 +30,7 @@
     ],
     "dbOutcome": {
       "bottleId": 44266,
-      "releaseId": null,
       "createsBottle": true,
-      "createsRelease": false,
       "summary": "Peated now contains bottle 44266 as Shieldaig Speyside 30-year-old. The regression being protected is the earlier classifier-created draft that used the confusing display name Shieldaig Speyside while storing the 30-year age only as structured bottle metadata."
     },
     "notes": "Total Wine markets this as Shieldaig Speyside Sin Malt 30Yr Scotch Whisky and describes it as matured for at least 30 years. The eval simulates the pre-creation local-search state: the 30-year bottle is absent, but a same-family Shieldaig Speyside 18-year-old bottle exists, so the agent must include the bottle-level age in the new bottle display name instead of hiding it only in statedAge."

--- a/packages/bottle-classifier/src/eval-fixtures/new-bottles/watchpost-8-year-old.json
+++ b/packages/bottle-classifier/src/eval-fixtures/new-bottles/watchpost-8-year-old.json
@@ -18,9 +18,7 @@
     "fixtureImagePath": "packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/watchpost-8-year-old.webp",
     "dbOutcome": {
       "bottleId": 44299,
-      "releaseId": null,
       "createsBottle": true,
-      "createsRelease": false,
       "summary": "At capture, the production add-bottle flow created bottle 44299 as Watchpost Watchpost with category blend, stated age 8, 42.5% ABV, and a new Westland Distillery Co. entity 365683 instead of preserving a distinct expression and reusing an existing Westland distillery candidate."
     },
     "notes": "Added from the exact failed image add-bottle flow and its persisted production image. The crop shows Watchpost, An American Blended Whiskey, 42.5% Alc/Vol, and Westland Distillery Co.; the numeric age is not reliably readable in the crop. Official Watchpost and Westland pages establish that the product is an eight-year-old American blended whiskey made by the Westland team. This fixture preserves the pre-creation local state. The current API record was later corrected to Watchpost 8-year-old with stated age 8, while the duplicate Westland Distillery Co. entity 365683 remains attached."

--- a/packages/bottle-classifier/src/evalFixtureSchemas.ts
+++ b/packages/bottle-classifier/src/evalFixtureSchemas.ts
@@ -32,24 +32,24 @@ export const searchResponseFixtureSchema = z.object({
 
 const evalFixtureDbOutcomeSchema = z
   .object({
-    bottleId: z.number().int().positive().nullable().optional(),
-    releaseId: z.number().int().positive().nullable().optional(),
+    bottleId: z
+      .number()
+      .int()
+      .refine((id) => id !== 0)
+      .nullable()
+      .optional(),
     createsBottle: z.boolean().optional(),
-    createsRelease: z.boolean().optional(),
     summary: z.string().min(1),
   })
   .strict();
 
 const evalFixtureCatalogFieldObservationSchema = z
   .object({
-    target: z.enum([
-      "matched_bottle",
-      "matched_release",
-      "candidate_bottle",
-      "candidate_release",
-    ]),
-    bottleId: z.number().int().positive().optional(),
-    releaseId: z.number().int().positive().optional(),
+    target: z.enum(["matched_bottle", "candidate_bottle"]),
+    bottleId: z
+      .number()
+      .int()
+      .refine((id) => id !== 0),
     field: z.string().trim().min(1),
     productionValue: z.unknown().optional(),
     evidenceValue: z.unknown(),
@@ -62,32 +62,7 @@ const evalFixtureCatalogFieldObservationSchema = z
     safeToAutoFill: z.boolean(),
     notes: z.string().trim().min(1).optional(),
   })
-  .strict()
-  .superRefine((value, ctx) => {
-    if (
-      (value.target === "matched_bottle" ||
-        value.target === "candidate_bottle") &&
-      value.bottleId === undefined
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Bottle field observations must include bottleId.",
-        path: ["bottleId"],
-      });
-    }
-
-    if (
-      (value.target === "matched_release" ||
-        value.target === "candidate_release") &&
-      value.releaseId === undefined
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Release field observations must include releaseId.",
-        path: ["releaseId"],
-      });
-    }
-  });
+  .strict();
 
 export const evalFixtureProvenanceSchema = z
   .object({

--- a/packages/bottle-classifier/src/evalFixtures.validate.test.ts
+++ b/packages/bottle-classifier/src/evalFixtures.validate.test.ts
@@ -162,7 +162,6 @@ describe("eval fixture validation", () => {
     expect(fixture?.provenance.dbOutcome).toMatchObject({
       bottleId: 45146,
       createsBottle: false,
-      createsRelease: false,
     });
   });
 
@@ -232,7 +231,6 @@ describe("eval fixture validation", () => {
     expect(fixture?.provenance.dbOutcome).toMatchObject({
       bottleId: 45249,
       createsBottle: false,
-      createsRelease: false,
     });
   });
 
@@ -585,7 +583,6 @@ describe("eval fixture validation", () => {
     expect(fixture.provenance?.dbOutcome).toMatchObject({
       bottleId: 45146,
       createsBottle: false,
-      createsRelease: false,
     });
   });
 

--- a/packages/bottle-classifier/src/index.ts
+++ b/packages/bottle-classifier/src/index.ts
@@ -1,5 +1,10 @@
 export { normalizeProposedBottleDraft } from "./bottleCreationDrafts";
 export {
+  formatCanonicalBottleName,
+  getResolvedBottleIdentity,
+} from "./bottleIdentity";
+export type { BottleExactIdentityInput } from "./bottleIdentity";
+export {
   BottleClassifierRunMetadataSchema,
   createBottleClassifier,
   type BottleClassifier,
@@ -130,8 +135,3 @@ export type {
   ImageTextSpan,
 } from "./imageEvidence";
 export { normalizeBottle, type NormalizedBottle } from "./normalize";
-export {
-  formatCanonicalReleaseName,
-  getResolvedReleaseIdentity,
-} from "./releaseIdentity";
-export type { ReleaseIdentityInput } from "./releaseIdentity";

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -584,7 +584,7 @@ function stripSafeStrengthPhrases(value: string): string {
   );
 }
 
-function stripExtractedReleaseIdentityFromReferenceName(
+function stripExtractedBottleIdentityFromReferenceName(
   referenceName: string,
   extractedIdentity: BottleClassificationArtifacts["extractedIdentity"],
 ): string {
@@ -625,7 +625,7 @@ function buildReferenceNameTokenVariants({
     variants.push(referenceTokens);
   }
 
-  const strippedReferenceName = stripExtractedReleaseIdentityFromReferenceName(
+  const strippedReferenceName = stripExtractedBottleIdentityFromReferenceName(
     referenceName,
     extractedIdentity,
   );


### PR DESCRIPTION
Peated now uses **Bottle** throughout active classifier, server, and web contracts. This hard cut renames the ConcreteBottle schemas, create/update/merge services, canonical identity helpers, files, tests, and consumers without compatibility aliases. Active eval provenance now uses Bottle-only targets and removes releaseId, createsRelease, matched_release, and candidate_release; historical migrations and retained migration fields stay unchanged.

This is slice 2 of #566 and follows the controlled glossary from #570. The changed imports and schemas are intentionally breaking internal contracts, while classifier decisions and persistence behavior remain unchanged. Deterministic classifier, server, and web tests, package typechecks, fixture validation, terminology checks, Oxlint, and ast-grep pass.

Refs #566