### PR TITLE
ref(bottles): use one flat creation boundary

### DIFF
--- a/apps/server/src/lib/bottleSchemas.ts
+++ b/apps/server/src/lib/bottleSchemas.ts
@@ -5,7 +5,7 @@
 import { BottleInputSchema } from "@peated/server/schemas";
 import { z } from "zod";
 
-const StableBottleGroupFieldsSchema = BottleInputSchema.pick({
+const BottleGroupFieldsSchema = BottleInputSchema.pick({
   name: true,
   statedAge: true,
   series: true,
@@ -20,8 +20,8 @@ const StableBottleGroupFieldsSchema = BottleInputSchema.pick({
   })
   .strict();
 
-function validateStableChoiceIds(
-  input: Partial<z.infer<typeof StableBottleGroupFieldsSchema>>,
+function validateGroupChoiceIds(
+  input: Partial<z.infer<typeof BottleGroupFieldsSchema>>,
   ctx: z.RefinementCtx,
 ) {
   const validateChoiceId = (
@@ -45,10 +45,6 @@ function validateStableChoiceIds(
     validateChoiceId(distiller, ["distillers", index]),
   );
 }
-
-const StableBottleGroupInputSchema = StableBottleGroupFieldsSchema.superRefine(
-  validateStableChoiceIds,
-);
 
 const ExactBottleInputSchema = BottleInputSchema.pick({
   edition: true,
@@ -84,8 +80,11 @@ const ExactBottleInputSchema = BottleInputSchema.pick({
   })
   .strict();
 
-const IndependentBottleCreateRouteFieldsSchema =
-  StableBottleGroupFieldsSchema.extend({
+const BottleCreateFieldsSchema = BottleGroupFieldsSchema.omit({
+  statedAge: true,
+})
+  .extend({
+    statedAge: ExactBottleInputSchema.shape.statedAge,
     edition: ExactBottleInputSchema.shape.edition,
     abv: ExactBottleInputSchema.shape.abv,
     singleCask: ExactBottleInputSchema.shape.singleCask,
@@ -98,41 +97,43 @@ const IndependentBottleCreateRouteFieldsSchema =
     description: ExactBottleInputSchema.shape.description,
     descriptionSrc: ExactBottleInputSchema.shape.descriptionSrc,
     tastingNotes: ExactBottleInputSchema.shape.tastingNotes,
-  }).strict();
+  })
+  .strict();
 
 /**
- * Public independent creation reuses stable/exact validation without exposing
- * group authority or image-upload fields; uploads use a separate route.
+ * Flat Bottle creation is the only creation contract. The service owns which
+ * fields are stored as BottleGroup authority and which fields stay exact.
  */
-export const IndependentBottleCreateRouteInputSchema =
-  IndependentBottleCreateRouteFieldsSchema.superRefine(validateStableChoiceIds);
+export const BottleCreateInputSchema = BottleCreateFieldsSchema.superRefine(
+  validateGroupChoiceIds,
+);
+
+export type BottleCreateInput = z.infer<typeof BottleCreateInputSchema>;
 
 const BottleSharedPatchSchema = z
   .object({
-    name: StableBottleGroupFieldsSchema.shape.name.optional(),
+    name: BottleGroupFieldsSchema.shape.name.optional(),
     statedAge: z.number().int().min(0).max(100).nullable().optional(),
-    series: StableBottleGroupFieldsSchema.shape.series
+    series: BottleGroupFieldsSchema.shape.series
       .unwrap()
       .removeDefault()
       .optional(),
-    category: StableBottleGroupFieldsSchema.shape.category
-      .removeDefault()
-      .optional(),
-    brand: StableBottleGroupFieldsSchema.shape.brand.optional(),
-    distillers: StableBottleGroupFieldsSchema.shape.distillers
+    category: BottleGroupFieldsSchema.shape.category.removeDefault().optional(),
+    brand: BottleGroupFieldsSchema.shape.brand.optional(),
+    distillers: BottleGroupFieldsSchema.shape.distillers
       .unwrap()
       .removeDefault()
       .optional(),
-    bottler: StableBottleGroupFieldsSchema.shape.bottler
+    bottler: BottleGroupFieldsSchema.shape.bottler
       .unwrap()
       .removeDefault()
       .optional(),
-    flavorProfile: StableBottleGroupFieldsSchema.shape.flavorProfile
+    flavorProfile: BottleGroupFieldsSchema.shape.flavorProfile
       .removeDefault()
       .optional(),
   })
   .strict()
-  .superRefine(validateStableChoiceIds);
+  .superRefine(validateGroupChoiceIds);
 
 const BottleExactPatchSchema = z
   .object({
@@ -202,13 +203,3 @@ export const SystemBottleUpdateInputSchema = z
 export type SystemBottleUpdateInput = z.infer<
   typeof SystemBottleUpdateInputSchema
 >;
-
-/** Runtime contract for independently complete singleton Bottle creation. */
-export const BottleCreateInputSchema = z
-  .object({
-    stable: StableBottleGroupInputSchema,
-    exact: ExactBottleInputSchema,
-  })
-  .strict();
-
-export type BottleCreateInput = z.infer<typeof BottleCreateInputSchema>;

--- a/apps/server/src/lib/classifierDecisionCreateInputs.test.ts
+++ b/apps/server/src/lib/classifierDecisionCreateInputs.test.ts
@@ -33,8 +33,8 @@ test("materializes a classifier draft into one independently complete Bottle", (
     caskSize: "barrel",
     caskFill: "2nd_fill",
   });
-  expect(bottleInput.stable.name).toBe("A Midwinter Night's Dram");
-  expect(bottleInput.exact).toMatchObject({
+  expect(bottleInput.name).toBe("A Midwinter Night's Dram");
+  expect(bottleInput).toMatchObject({
     edition: "Act 10 Scene 4",
     releaseYear: 2022,
     abv: 49.3,
@@ -45,21 +45,21 @@ test("materializes a classifier draft into one independently complete Bottle", (
   expect(
     materializeBottleIdentity({
       stable: {
-        name: bottleInput.stable.name,
-        fullName: `High West ${bottleInput.stable.name}`,
-        statedAge: bottleInput.stable.statedAge,
+        name: bottleInput.name,
+        fullName: `High West ${bottleInput.name}`,
+        statedAge: null,
       },
       exact: {
-        edition: bottleInput.exact.edition ?? null,
-        statedAge: bottleInput.exact.statedAge ?? null,
-        releaseYear: bottleInput.exact.releaseYear ?? null,
-        vintageYear: bottleInput.exact.vintageYear ?? null,
-        abv: bottleInput.exact.abv ?? null,
-        singleCask: bottleInput.exact.singleCask ?? null,
-        caskStrength: bottleInput.exact.caskStrength ?? null,
-        caskType: bottleInput.exact.caskType ?? null,
-        caskSize: bottleInput.exact.caskSize ?? null,
-        caskFill: bottleInput.exact.caskFill ?? null,
+        edition: bottleInput.edition ?? null,
+        statedAge: bottleInput.statedAge ?? null,
+        releaseYear: bottleInput.releaseYear ?? null,
+        vintageYear: bottleInput.vintageYear ?? null,
+        abv: bottleInput.abv ?? null,
+        singleCask: bottleInput.singleCask ?? null,
+        caskStrength: bottleInput.caskStrength ?? null,
+        caskType: bottleInput.caskType ?? null,
+        caskSize: bottleInput.caskSize ?? null,
+        caskFill: bottleInput.caskFill ?? null,
       },
     }),
   ).toEqual({
@@ -92,26 +92,25 @@ test("keeps a marketed age exact without duplicating its name wording", () => {
 
   const bottleInput = buildClassifierBottleInput(proposedBottle);
 
-  expect(bottleInput.stable.statedAge).toBeNull();
-  expect(bottleInput.exact.statedAge).toBe(12);
+  expect(bottleInput.statedAge).toBe(12);
   expect(
     materializeBottleIdentity({
       stable: {
-        name: bottleInput.stable.name,
-        fullName: `Shieldaig ${bottleInput.stable.name}`,
-        statedAge: bottleInput.stable.statedAge,
+        name: bottleInput.name,
+        fullName: `Shieldaig ${bottleInput.name}`,
+        statedAge: null,
       },
       exact: {
-        edition: bottleInput.exact.edition ?? null,
-        statedAge: bottleInput.exact.statedAge ?? null,
-        releaseYear: bottleInput.exact.releaseYear ?? null,
-        vintageYear: bottleInput.exact.vintageYear ?? null,
-        abv: bottleInput.exact.abv ?? null,
-        singleCask: bottleInput.exact.singleCask ?? null,
-        caskStrength: bottleInput.exact.caskStrength ?? null,
-        caskType: bottleInput.exact.caskType ?? null,
-        caskSize: bottleInput.exact.caskSize ?? null,
-        caskFill: bottleInput.exact.caskFill ?? null,
+        edition: bottleInput.edition ?? null,
+        statedAge: bottleInput.statedAge ?? null,
+        releaseYear: bottleInput.releaseYear ?? null,
+        vintageYear: bottleInput.vintageYear ?? null,
+        abv: bottleInput.abv ?? null,
+        singleCask: bottleInput.singleCask ?? null,
+        caskStrength: bottleInput.caskStrength ?? null,
+        caskType: bottleInput.caskType ?? null,
+        caskSize: bottleInput.caskSize ?? null,
+        caskFill: bottleInput.caskFill ?? null,
       },
     }),
   ).toEqual({

--- a/apps/server/src/lib/classifierDecisionCreateInputs.ts
+++ b/apps/server/src/lib/classifierDecisionCreateInputs.ts
@@ -1,5 +1,8 @@
 import type { ProposedBottle } from "@peated/bottle-classifier/internal/types";
-import type { BottleCreateInput } from "@peated/server/lib/bottleSchemas";
+import {
+  BottleCreateInputSchema,
+  type BottleCreateInput,
+} from "@peated/server/lib/bottleSchemas";
 import type { BottleInputSchema } from "@peated/server/schemas";
 import type { z } from "zod";
 
@@ -67,32 +70,7 @@ export function buildBottleInputFromProposedBottle(
 export function buildClassifierBottleInput(
   proposedBottle: ProposedBottle,
 ): BottleCreateInput {
-  const input = buildBottleInputFromProposedBottle(proposedBottle);
-  return {
-    stable: {
-      name: input.name,
-      statedAge: null,
-      series: input.series,
-      category: input.category,
-      brand: input.brand,
-      distillers: input.distillers,
-      bottler: input.bottler,
-      flavorProfile: input.flavorProfile,
-    },
-    exact: {
-      edition: input.edition,
-      statedAge: input.statedAge,
-      abv: input.abv,
-      singleCask: input.singleCask,
-      caskStrength: input.caskStrength,
-      vintageYear: input.vintageYear,
-      releaseYear: input.releaseYear,
-      caskSize: input.caskSize,
-      caskType: input.caskType,
-      caskFill: input.caskFill,
-      description: input.description,
-      descriptionSrc: input.descriptionSrc,
-      tastingNotes: input.tastingNotes,
-    },
-  };
+  const { imageUrl: _imageUrl, ...input } =
+    buildBottleInputFromProposedBottle(proposedBottle);
+  return BottleCreateInputSchema.parse(input);
 }

--- a/apps/server/src/lib/createBottle.test.ts
+++ b/apps/server/src/lib/createBottle.test.ts
@@ -28,7 +28,7 @@ function contextFor(user: Parameters<typeof getUserActor>[0]) {
 }
 
 describe("Bottle creation", () => {
-  test("creates an atomic singleton graph with stable and exact field ownership", async ({
+  test("creates an atomic singleton graph from flat Bottle input", async ({
     defaults,
     fixtures,
   }) => {
@@ -52,24 +52,19 @@ describe("Bottle creation", () => {
     const result = await createBottle({
       context: contextFor(defaults.user),
       input: {
-        stable: {
-          name: "Cask Strength",
-          statedAge: 12,
-          brand: brand.id,
-          bottler: bottler.id,
-          distillers: [distiller.id],
-          series: series.id,
-          category: "single_malt",
-          flavorProfile: "peated",
-        },
-        exact: {
-          edition: "Batch 24",
-          statedAge: 13,
-          releaseYear: 2026,
-          abv: 55.4,
-          caskStrength: true,
-          description: "Exact release content",
-        },
+        name: "Cask Strength",
+        statedAge: 13,
+        brand: brand.id,
+        bottler: bottler.id,
+        distillers: [distiller.id],
+        series: series.id,
+        category: "single_malt",
+        flavorProfile: "peated",
+        edition: "Batch 24",
+        releaseYear: 2026,
+        abv: 55.4,
+        caskStrength: true,
+        description: "Exact release content",
       },
     });
 
@@ -89,7 +84,7 @@ describe("Bottle creation", () => {
       ...stableCompatibilityFields,
       name: "Cask Strength",
       fullName: "Creation Test Brand Cask Strength",
-      statedAge: 12,
+      statedAge: null,
       totalBottles: 1,
       representativeBottleId: result.bottle.id,
     });
@@ -166,8 +161,8 @@ describe("Bottle creation", () => {
     const result = await createBottle({
       context: contextFor(defaults.user),
       input: {
-        stable: { name: "Canonical Alias", brand: brand.id },
-        exact: {},
+        name: "Canonical Alias",
+        brand: brand.id,
       },
     });
 
@@ -196,7 +191,7 @@ describe("Bottle creation", () => {
     expect(failedAliasName).not.toBeNull();
   });
 
-  test("preserves classifier exact age through singleton creation and shared rematerialization", async ({
+  test("gives manual and classifier statedAge the same storage owner", async ({
     fixtures,
   }) => {
     const mod = await fixtures.User({ mod: true });
@@ -228,16 +223,21 @@ describe("Bottle creation", () => {
       creationSource: "bottle_classifier",
       input,
     });
+    const manual = await createBottle({
+      context: contextFor(mod),
+      input: {
+        ...input,
+        name: "Manual 12-year-old",
+      },
+    });
 
-    expect(created.group).toMatchObject({
-      name: "Speyside 12-year-old",
-      statedAge: null,
-    });
-    expect(created.bottle).toMatchObject({
-      name: "Speyside 12-year-old",
-      fullName: "Classifier Exact Age Brand Speyside 12-year-old",
-      statedAge: 12,
-    });
+    for (const result of [created, manual]) {
+      expect(result.group.statedAge).toBeNull();
+      expect(result.bottle.statedAge).toBe(12);
+    }
+    expect(created.bottle.fullName).toBe(
+      "Classifier Exact Age Brand Speyside 12-year-old",
+    );
 
     const rematerialized = await updateBottle({
       bottleId: created.bottle.id,
@@ -261,8 +261,8 @@ describe("Bottle creation", () => {
     const result = await createBottle({
       context: contextFor(defaults.user),
       input: {
-        stable: { name: "Old Malt 12 years old", brand: brand.id },
-        exact: {},
+        name: "Old Malt 12 years old",
+        brand: brand.id,
       },
     });
 
@@ -284,14 +284,10 @@ describe("Bottle creation", () => {
     const result = await createBottle({
       context: contextFor(defaults.user),
       input: {
-        stable: {
-          name: "Distillers Edition 2011 Release Cask Strength",
-          brand: brand.id,
-        },
-        exact: {
-          vintageYear: 1998,
-          singleCask: true,
-        },
+        name: "Distillers Edition 2011 Release Cask Strength",
+        brand: brand.id,
+        vintageYear: 1998,
+        singleCask: true,
       },
     });
 
@@ -347,8 +343,10 @@ describe("Bottle creation", () => {
       const result = await createBottle({
         context,
         input: {
-          stable: { name: "Exact Cask Expression", brand: brand.id },
-          exact: { edition: "Cask Selection", ...exactCask },
+          name: "Exact Cask Expression",
+          brand: brand.id,
+          edition: "Cask Selection",
+          ...exactCask,
         },
       });
       expect(result.bottle).toMatchObject({
@@ -363,21 +361,15 @@ describe("Bottle creation", () => {
   });
 
   test.each([
-    ["stable stated age", { stable: { statedAge: 12.5 } }],
-    ["exact stated age", { exact: { statedAge: 12.5 } }],
-    ["exact vintage year", { exact: { vintageYear: 2000.5 } }],
-    ["exact release year", { exact: { releaseYear: 2020.5 } }],
+    ["stated age", { statedAge: 12.5 }],
+    ["vintage year", { vintageYear: 2000.5 }],
+    ["release year", { releaseYear: 2020.5 }],
   ])("rejects a fractional %s", (_label, overrides) => {
-    const stableOverrides = "stable" in overrides ? overrides.stable : {};
-    const exactOverrides = "exact" in overrides ? overrides.exact : {};
     expect(() =>
       BottleCreateInputSchema.parse({
-        stable: {
-          name: "Integer Boundary",
-          brand: 1,
-          ...stableOverrides,
-        },
-        exact: { ...exactOverrides },
+        name: "Integer Boundary",
+        brand: 1,
+        ...overrides,
       }),
     ).toThrow();
   });
@@ -394,34 +386,41 @@ describe("Bottle creation", () => {
       "nested distiller",
       { distillers: [{ id: 0, name: "Invalid Distiller" }] },
     ],
-  ])("rejects an invalid %s id", (_label, stableOverrides) => {
+  ])("rejects an invalid %s id", (_label, overrides) => {
     expect(() =>
       BottleCreateInputSchema.parse({
-        stable: {
-          name: "Entity ID Boundary",
-          brand: 1,
-          ...stableOverrides,
-        },
-        exact: {},
+        name: "Entity ID Boundary",
+        brand: 1,
+        ...overrides,
       }),
     ).toThrow();
   });
 
   test.each([
     {
+      label: "caller-selected storage scopes",
+      input: {
+        name: "Unauthorized Storage Scope",
+        brand: 1,
+        stable: {},
+        exact: {},
+      },
+    },
+    {
       label: "source Bottle authority",
       input: {
         kind: "source_bottle",
         sourceBottleId: 1,
-        exact: {},
+        name: "Unauthorized Source",
+        brand: 1,
       },
     },
     {
       label: "raw group authority",
       input: {
         groupId: 1,
-        stable: { name: "Unauthorized Group Reuse", brand: 1 },
-        exact: {},
+        name: "Unauthorized Group Reuse",
+        brand: 1,
       },
     },
   ])("rejects $label at the runtime boundary", ({ input }) => {
@@ -435,8 +434,9 @@ describe("Bottle creation", () => {
     const context = contextFor(defaults.user);
     const brand = await fixtures.Entity({ name: "Duplicate Test Brand" });
     const input = {
-      stable: { name: "Duplicate Expression", brand: brand.id },
-      exact: { edition: "Batch 1" },
+      name: "Duplicate Expression",
+      brand: brand.id,
+      edition: "Batch 1",
     };
     const first = await createBottle({ context, input });
 
@@ -463,12 +463,10 @@ describe("Bottle creation", () => {
       createBottle({
         context,
         input: {
-          stable: {
-            name: "35.331",
-            brand: smws.id,
-            bottler: smws.id,
-          },
-          exact: { singleCask: true },
+          name: "35.331",
+          brand: smws.id,
+          bottler: smws.id,
+          singleCask: true,
         },
       }),
     ).rejects.toEqual(
@@ -487,8 +485,9 @@ describe("Bottle creation", () => {
     const brand = await fixtures.Entity({ name: "Reuse Result Brand" });
     const actor = await getUserActor(defaults.user);
     const input = BottleCreateInputSchema.parse({
-      stable: { name: "Reuse Result Expression", brand: brand.id },
-      exact: { edition: "Batch 1" },
+      name: "Reuse Result Expression",
+      brand: brand.id,
+      edition: "Batch 1",
     });
     const created = await createBottle({
       context: contextFor(defaults.user),
@@ -535,11 +534,8 @@ describe("Bottle creation", () => {
         name: `Inactive Reuse Brand ${index}`,
       });
       const input = BottleCreateInputSchema.parse({
-        stable: {
-          name: `Inactive Reuse Expression ${index}`,
-          brand: brand.id,
-        },
-        exact: {},
+        name: `Inactive Reuse Expression ${index}`,
+        brand: brand.id,
       });
       const created = await createBottle({ context, input });
       await scenario.retire(created);
@@ -582,8 +578,8 @@ describe("Bottle creation", () => {
       createBottle({
         context: contextFor(defaults.user),
         input: {
-          stable: { name: "Blocked Expression", brand: brand.id },
-          exact: {},
+          name: "Blocked Expression",
+          brand: brand.id,
         },
       }),
     ).rejects.toEqual(
@@ -633,15 +629,17 @@ describe("Bottle creation", () => {
     const first = await createBottle({
       context,
       input: {
-        stable: { name: "Shared Expression", brand: brand.id },
-        exact: { edition: "Batch 1" },
+        name: "Shared Expression",
+        brand: brand.id,
+        edition: "Batch 1",
       },
     });
     const second = await createBottle({
       context,
       input: {
-        stable: { name: "Shared Expression", brand: brand.id },
-        exact: { edition: "Batch 2" },
+        name: "Shared Expression",
+        brand: brand.id,
+        edition: "Batch 2",
       },
     });
 
@@ -665,8 +663,9 @@ describe("Bottle creation", () => {
     const brand = await fixtures.Entity({ name: "Rollback Test Brand" });
     const actor = await getUserActor(defaults.user);
     const input = {
-      stable: { name: "Rollback Expression", brand: brand.id },
-      exact: { edition: "Retryable" },
+      name: "Rollback Expression",
+      brand: brand.id,
+      edition: "Retryable",
     };
     const parsedInput = BottleCreateInputSchema.parse(input);
     const attempt: {
@@ -745,8 +744,8 @@ describe("Bottle creation", () => {
     const result = await createBottle({
       context: contextFor(defaults.user),
       input: {
-        stable: { name: "Committed Before Queue", brand: brand.id },
-        exact: {},
+        name: "Committed Before Queue",
+        brand: brand.id,
       },
     });
 

--- a/apps/server/src/lib/createBottle.ts
+++ b/apps/server/src/lib/createBottle.ts
@@ -1,6 +1,6 @@
 /**
  * Owns preparation and persistence for complete Bottle transactions.
- * Stable fields and distiller joins are durable parts of each Bottle's
+ * Group-owned fields and distiller joins are durable parts of each Bottle's
  * independently renderable identity.
  */
 import {
@@ -98,20 +98,76 @@ type PreparedBottleCreate = {
   distillerIds: number[];
   newEntityIds: number[];
   seriesCreated: boolean;
-  stableFullName: string;
-  stableName: string;
+  groupFullName: string;
+  groupName: string;
 };
 
 type BottleIdentityPreparation = {
   exactNormalizedFields: Pick<
-    BottleCreateInput["exact"],
+    BottleCreateInput,
     "statedAge" | "vintageYear" | "releaseYear" | "singleCask" | "caskStrength"
   >;
-  stableName: string;
-  stableStatedAge: number | null;
+  groupName: string;
+  groupStatedAge: number | null;
 };
 
-type StableBottleGroupInput = BottleCreateInput["stable"];
+type BottleGroupCreateInput = Pick<
+  BottleCreateInput,
+  | "name"
+  | "series"
+  | "category"
+  | "brand"
+  | "distillers"
+  | "bottler"
+  | "flavorProfile"
+> & { statedAge: number | null };
+
+type ExactBottleCreateInput = Pick<
+  BottleCreateInput,
+  | "edition"
+  | "statedAge"
+  | "abv"
+  | "singleCask"
+  | "caskStrength"
+  | "vintageYear"
+  | "releaseYear"
+  | "caskSize"
+  | "caskType"
+  | "caskFill"
+  | "description"
+  | "descriptionSrc"
+  | "tastingNotes"
+>;
+
+/** The server owns storage scope. New singleton groups have no shared age. */
+function splitBottleCreateInput(input: BottleCreateInput): {
+  group: BottleGroupCreateInput;
+  exact: ExactBottleCreateInput;
+} {
+  const {
+    name,
+    series,
+    category,
+    brand,
+    distillers,
+    bottler,
+    flavorProfile,
+    ...exact
+  } = input;
+  return {
+    group: {
+      name,
+      statedAge: null,
+      series,
+      category,
+      brand,
+      distillers,
+      bottler,
+      flavorProfile,
+    },
+    exact,
+  };
+}
 
 export type BottleCreateResult = PersistedBottleResult & {
   group: BottleGroup;
@@ -139,7 +195,7 @@ async function prepareBottleCreateInTransaction(
   const bottleData: BottlePreviewResult & Record<string, any> =
     await bottleNormalize({ input, context, entityDb: tx });
   if (bottleIdentity) {
-    // Explicit exact input overrides traits inferred from the stable name.
+    // Explicit exact input overrides traits inferred from the group name.
     Object.assign(bottleData, bottleIdentity.exactNormalizedFields);
   }
 
@@ -150,16 +206,16 @@ async function prepareBottleCreateInTransaction(
       (input.description && input.description !== null ? "user" : null);
   }
 
-  const stableName = stripDuplicateBrandPrefixFromBottleName(
-    bottleIdentity?.stableName ?? bottleData.name,
+  const groupName = stripDuplicateBrandPrefixFromBottleName(
+    bottleIdentity?.groupName ?? bottleData.name,
     bottleData.brand.name,
   );
 
-  if (!stableName) {
+  if (!groupName) {
     throw new BottleCreateBadRequestError("Invalid bottle name.");
   }
 
-  if (bottleNameDuplicatesBrand(stableName, bottleData.brand.name)) {
+  if (bottleNameDuplicatesBrand(groupName, bottleData.brand.name)) {
     throw new BottleCreateBadRequestError(
       "Bottle name must identify an expression distinct from the brand.",
     );
@@ -262,15 +318,15 @@ async function prepareBottleCreateInTransaction(
     }
   }
 
-  const stableFullName = formatBottleName({
-    name: `${brand.shortName || brand.name} ${stableName}`,
+  const groupFullName = formatBottleName({
+    name: `${brand.shortName || brand.name} ${groupName}`,
   });
   const bottleName = bottleIdentity
     ? materializeBottleIdentity({
         stable: {
-          name: stableName,
-          fullName: stableFullName,
-          statedAge: bottleIdentity.stableStatedAge,
+          name: groupName,
+          fullName: groupFullName,
+          statedAge: bottleIdentity.groupStatedAge,
         },
         exact: {
           edition: bottleData.edition ?? null,
@@ -311,8 +367,8 @@ async function prepareBottleCreateInTransaction(
     distillerIds,
     newEntityIds: Array.from(newEntityIds),
     seriesCreated,
-    stableFullName,
-    stableName,
+    groupFullName,
+    groupName,
   };
 }
 
@@ -430,18 +486,18 @@ async function insertPreparedBottleInTransaction(
 }
 
 function buildBottleInput(
-  stable: StableBottleGroupInput,
-  exact: BottleCreateInput["exact"],
+  group: BottleGroupCreateInput,
+  exact: ExactBottleCreateInput,
 ): z.infer<typeof BottleInputSchema> {
   const input: z.infer<typeof BottleInputSchema> = {
-    name: stable.name,
+    name: group.name,
     imageUrl: null,
-    brand: stable.brand,
-    distillers: stable.distillers,
-    bottler: stable.bottler,
-    series: stable.series,
-    category: stable.category,
-    flavorProfile: stable.flavorProfile,
+    brand: group.brand,
+    distillers: group.distillers,
+    bottler: group.bottler,
+    series: group.series,
+    category: group.category,
+    flavorProfile: group.flavorProfile,
     ...exact,
   };
   return input;
@@ -452,9 +508,9 @@ async function createIndependentGroupPrefix(
   tx: AnyTransaction,
   {
     actorId,
-    stable,
-    stableFullName,
-    stableName,
+    fields,
+    groupFullName,
+    groupName,
     brandId,
     bottlerId,
     seriesId,
@@ -463,9 +519,9 @@ async function createIndependentGroupPrefix(
     distillerIds,
   }: {
     actorId: number;
-    stable: StableBottleGroupInput;
-    stableFullName: string;
-    stableName: string;
+    fields: BottleGroupCreateInput;
+    groupFullName: string;
+    groupName: string;
     brandId: number;
     bottlerId: number | null;
     seriesId: number | null;
@@ -477,9 +533,9 @@ async function createIndependentGroupPrefix(
   const [group] = await tx
     .insert(bottleGroups)
     .values({
-      fullName: stableFullName,
-      name: stableName,
-      statedAge: stable.statedAge,
+      fullName: groupFullName,
+      name: groupName,
+      statedAge: fields.statedAge,
       seriesId,
       category,
       brandId,
@@ -517,38 +573,39 @@ export async function createBottleInTransaction(
     context: Context & { user: User };
   },
 ): Promise<BottleCreateResult> {
+  const { group: storageGroup, exact } = splitBottleCreateInput(input);
   // Exact age is name-normalization context only; it cannot become group-owned state.
-  const normalizedStable = normalizeBottleAge({
-    name: normalizeBottleAliasKey(input.stable.name),
-    statedAge: input.stable.statedAge ?? input.exact.statedAge,
+  const normalizedGroup = normalizeBottleAge({
+    name: normalizeBottleAliasKey(storageGroup.name),
+    statedAge: exact.statedAge,
   });
-  const stable = {
-    ...input.stable,
-    name: normalizedStable.name,
+  const groupFields = {
+    ...storageGroup,
+    name: normalizedGroup.name,
   };
   const prepared = await prepareBottleCreateInTransaction(tx, {
     creationSource,
     bottleIdentity: {
       exactNormalizedFields: {
-        statedAge: input.exact.statedAge,
-        vintageYear: input.exact.vintageYear,
-        releaseYear: input.exact.releaseYear,
-        singleCask: input.exact.singleCask,
-        caskStrength: input.exact.caskStrength,
+        statedAge: exact.statedAge,
+        vintageYear: exact.vintageYear,
+        releaseYear: exact.releaseYear,
+        singleCask: exact.singleCask,
+        caskStrength: exact.caskStrength,
       },
-      stableName: stable.name,
-      stableStatedAge: stable.statedAge,
+      groupName: groupFields.name,
+      groupStatedAge: groupFields.statedAge,
     },
     createdByActorId,
-    input: buildBottleInput(stable, input.exact),
+    input: buildBottleInput(groupFields, exact),
     context,
   });
 
   const group = await createIndependentGroupPrefix(tx, {
     actorId: createdByActorId,
-    stable,
-    stableFullName: prepared.stableFullName,
-    stableName: prepared.stableName,
+    fields: groupFields,
+    groupFullName: prepared.groupFullName,
+    groupName: prepared.groupName,
     brandId: prepared.bottleInsertData.brandId,
     bottlerId: prepared.bottleInsertData.bottlerId ?? null,
     seriesId: prepared.bottleInsertData.seriesId ?? null,

--- a/apps/server/src/lib/flatBottleInput.ts
+++ b/apps/server/src/lib/flatBottleInput.ts
@@ -1,6 +1,6 @@
 import {
+  BottleCreateInputSchema,
   BottleUpdateInputSchema,
-  IndependentBottleCreateRouteInputSchema,
   type BottleCreateInput,
   type BottleUpdateInput,
 } from "@peated/server/lib/bottleSchemas";
@@ -13,8 +13,8 @@ type FlatBottleInput = z.input<typeof BottleInputSchema>;
  * Translates the retained flat Bottle input into the strict Bottle create
  * route contract without carrying legacy response or image fields forward.
  */
-export function buildIndependentBottleRouteInput(input: FlatBottleInput) {
-  return IndependentBottleCreateRouteInputSchema.parse({
+export function buildBottleCreateInput(input: FlatBottleInput) {
+  return BottleCreateInputSchema.parse({
     name: input.name,
     statedAge: input.statedAge,
     series: input.series,
@@ -38,42 +38,9 @@ export function buildIndependentBottleRouteInput(input: FlatBottleInput) {
   });
 }
 
-/** Maps the public flat create contract to canonical independent creation. */
-export function buildIndependentBottleCreateInput(
-  input: ReturnType<typeof buildIndependentBottleRouteInput>,
-): BottleCreateInput {
-  return {
-    stable: {
-      name: input.name,
-      statedAge: input.statedAge,
-      series: input.series,
-      category: input.category,
-      brand: input.brand,
-      distillers: input.distillers,
-      bottler: input.bottler,
-      flavorProfile: input.flavorProfile,
-    },
-    exact: {
-      edition: input.edition,
-      statedAge: null,
-      abv: input.abv,
-      singleCask: input.singleCask,
-      caskStrength: input.caskStrength,
-      vintageYear: input.vintageYear,
-      releaseYear: input.releaseYear,
-      caskSize: input.caskSize,
-      caskType: input.caskType,
-      caskFill: input.caskFill,
-      description: input.description,
-      descriptionSrc: input.descriptionSrc,
-      tastingNotes: input.tastingNotes,
-    },
-  };
-}
-
 /** Maps a parsed flat upsert input to the canonical shared/exact patch. */
 export function buildBottleUpdatePatch(
-  input: ReturnType<typeof buildIndependentBottleRouteInput>,
+  input: BottleCreateInput,
 ): BottleUpdateInput {
   return BottleUpdateInputSchema.parse({
     shared: {

--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -24,10 +24,7 @@ import {
   searchBottleCandidates,
 } from "@peated/server/lib/bottleReferenceCandidates";
 import type * as CatalogVerificationModule from "@peated/server/lib/catalogVerification";
-import {
-  buildIndependentBottleCreateInput,
-  buildIndependentBottleRouteInput,
-} from "@peated/server/lib/flatBottleInput";
+import { buildBottleCreateInput } from "@peated/server/lib/flatBottleInput";
 import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import {
   applyApprovedStorePriceMatch,
@@ -813,9 +810,7 @@ describe("priceMatching", () => {
       flavorProfile: null,
     };
 
-    const bottleInput = buildIndependentBottleCreateInput(
-      buildIndependentBottleRouteInput(input),
-    );
+    const bottleInput = buildBottleCreateInput(input);
     const result = await createBottleFromStorePriceMatchProposal({
       proposalId: proposal.id,
       bottleInput,
@@ -922,9 +917,7 @@ describe("priceMatching", () => {
       imageUrl: null,
       flavorProfile: null,
     };
-    const bottleInput = buildIndependentBottleCreateInput(
-      buildIndependentBottleRouteInput(input),
-    );
+    const bottleInput = buildBottleCreateInput(input);
 
     const first = await createBottleFromStorePriceMatchProposal({
       proposalId: firstProposal.id,

--- a/apps/server/src/lib/scraper.ts
+++ b/apps/server/src/lib/scraper.ts
@@ -19,8 +19,8 @@ import type {
 } from "../schemas";
 import BatchQueue from "./batchQueue";
 import {
+  buildBottleCreateInput,
   buildBottleUpdatePatch,
-  buildIndependentBottleRouteInput,
 } from "./flatBottleInput";
 import { formatBottleName } from "./format";
 
@@ -175,9 +175,9 @@ export async function handleBottle(
       },
     });
 
-    let createInput: ReturnType<typeof buildIndependentBottleRouteInput>;
+    let createInput: ReturnType<typeof buildBottleCreateInput>;
     try {
-      createInput = buildIndependentBottleRouteInput(bottle);
+      createInput = buildBottleCreateInput(bottle);
     } catch (error) {
       logError(error, {
         extra: {

--- a/apps/server/src/lib/updateBottle.test.ts
+++ b/apps/server/src/lib/updateBottle.test.ts
@@ -12,6 +12,7 @@ import {
   entities,
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
+import { materializeBottleForGroup } from "@peated/server/lib/bottleIdentity";
 import { createBottle } from "@peated/server/lib/createBottle";
 import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
@@ -55,11 +56,36 @@ async function createGroup({
 
   const first = await createBottle({
     context: contextFor(user) as Parameters<typeof createBottle>[0]["context"],
-    input: {
-      stable,
-      exact: exacts[0],
-    },
+    input: { ...stable, ...exacts[0] },
   });
+  if ("statedAge" in stable) {
+    const statedAge = stable.statedAge as number | null;
+    const materialized = materializeBottleForGroup({
+      group: { ...first.group, statedAge },
+      exact: {
+        edition: first.bottle.edition,
+        statedAge: exacts[0].statedAge ?? null,
+        releaseYear: first.bottle.releaseYear,
+        vintageYear: first.bottle.vintageYear,
+        abv: first.bottle.abv,
+        singleCask: first.bottle.singleCask,
+        caskStrength: first.bottle.caskStrength,
+        caskType: first.bottle.caskType,
+        caskSize: first.bottle.caskSize,
+        caskFill: first.bottle.caskFill,
+      },
+    });
+    await db
+      .update(bottleGroups)
+      .set({ statedAge })
+      .where(eq(bottleGroups.id, first.group.id));
+    await db
+      .update(bottles)
+      .set(materialized)
+      .where(eq(bottles.id, first.bottle.id));
+    Object.assign(first.group, { statedAge });
+    Object.assign(first.bottle, materialized);
+  }
   const members: Array<{ bottle: Bottle }> = [first];
   for (const exact of exacts.slice(1)) {
     members.push({
@@ -1679,8 +1705,9 @@ describe("Bottle updates", () => {
     const outsider = await createBottle({
       context: contextFor(mod) as Parameters<typeof createBottle>[0]["context"],
       input: {
-        stable: { name: "Collision Label", brand: brand.id },
-        exact: { edition: "Two" },
+        name: "Collision Label",
+        brand: brand.id,
+        edition: "Two",
       },
     });
     const memberIds = members.map(({ bottle }) => bottle.id);
@@ -1724,8 +1751,8 @@ describe("Bottle updates", () => {
     const aliasOwner = await createBottle({
       context: contextFor(mod) as Parameters<typeof createBottle>[0]["context"],
       input: {
-        stable: { name: "Unrelated Alias Owner", brand: brand.id },
-        exact: {},
+        name: "Unrelated Alias Owner",
+        brand: brand.id,
       },
     });
     const conflictingAliasName = "Collision Brand Alias Collision Label - Two";

--- a/apps/server/src/orpc/routes/bottleSeries/delete.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/delete.test.ts
@@ -64,8 +64,10 @@ async function createGroup({
   const first = await createBottle({
     context: { user },
     input: {
-      stable: { name, brand: brandId, series: seriesId },
-      exact: { edition: "Batch One" },
+      name,
+      brand: brandId,
+      series: seriesId,
+      edition: "Batch One",
     },
   });
   const second = {

--- a/apps/server/src/orpc/routes/bottles/create.test.ts
+++ b/apps/server/src/orpc/routes/bottles/create.test.ts
@@ -313,7 +313,7 @@ describe("POST /bottles", () => {
       bottlerId: distiller.id,
       distillerIds: [distiller.id],
       category: "single_malt",
-      statedAge: 12,
+      statedAge: null,
       flavorProfile: FLAVOR_PROFILES[0],
       representativeBottleId: data.id,
       totalBottles: 1,
@@ -325,7 +325,7 @@ describe("POST /bottles", () => {
       .where(eq(bottles.id, data.id));
     expect(bottle).toMatchObject({
       groupId: data.group!.id,
-      name: "Delicious Wood - Batch 7 - 2024 Release - 2010 Vintage - 57.1% ABV - Single Cask - Cask Strength - Bourbon Cask - Hogshead - 1st Fill",
+      name: "Delicious Wood - Batch 7 - 12-year-old - 2024 Release - 2010 Vintage - 57.1% ABV - Single Cask - Cask Strength - Bourbon Cask - Hogshead - 1st Fill",
       brandId: brand.id,
       bottlerId: distiller.id,
       category: "single_malt",

--- a/apps/server/src/orpc/routes/bottles/create.ts
+++ b/apps/server/src/orpc/routes/bottles/create.ts
@@ -1,10 +1,9 @@
-import { IndependentBottleCreateRouteInputSchema } from "@peated/server/lib/bottleSchemas";
+import { BottleCreateInputSchema } from "@peated/server/lib/bottleSchemas";
 import {
   BottleAlreadyExistsError,
   BottleCreateBadRequestError,
   createBottle,
 } from "@peated/server/lib/createBottle";
-import { buildIndependentBottleCreateInput } from "@peated/server/lib/flatBottleInput";
 import { procedure } from "@peated/server/orpc";
 import {
   requireTosAccepted,
@@ -28,13 +27,13 @@ export default procedure
       operationId: "createBottle",
     }),
   })
-  .input(IndependentBottleCreateRouteInputSchema)
+  .input(BottleCreateInputSchema)
   .output(BottleSchema)
   .handler(async function ({ input, context, errors }) {
     try {
       const result = await createBottle({
         context,
-        input: buildIndependentBottleCreateInput(input),
+        input,
       });
       return await serialize(
         BottleSerializer,

--- a/apps/server/src/orpc/routes/bottles/edit-context.test.ts
+++ b/apps/server/src/orpc/routes/bottles/edit-context.test.ts
@@ -1,10 +1,12 @@
 import { db } from "@peated/server/db";
 import type { User } from "@peated/server/db/schema";
 import {
+  bottleGroups,
   bottleTombstones,
   bottles,
   bottlesToDistillers,
 } from "@peated/server/db/schema";
+import { materializeBottleForGroup } from "@peated/server/lib/bottleIdentity";
 import { createBottle } from "@peated/server/lib/createBottle";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
 import waitError from "@peated/server/lib/test/waitError";
@@ -23,8 +25,36 @@ async function createGroup(
 ) {
   const first = await createBottle({
     context: { user },
-    input: { stable, exact: exacts[0] },
+    input: { ...stable, ...exacts[0] },
   });
+  if ("statedAge" in stable) {
+    const statedAge = stable.statedAge as number | null;
+    const materialized = materializeBottleForGroup({
+      group: { ...first.group, statedAge },
+      exact: {
+        edition: first.bottle.edition,
+        statedAge: exacts[0].statedAge ?? null,
+        releaseYear: first.bottle.releaseYear,
+        vintageYear: first.bottle.vintageYear,
+        abv: first.bottle.abv,
+        singleCask: first.bottle.singleCask,
+        caskStrength: first.bottle.caskStrength,
+        caskType: first.bottle.caskType,
+        caskSize: first.bottle.caskSize,
+        caskFill: first.bottle.caskFill,
+      },
+    });
+    await db
+      .update(bottleGroups)
+      .set({ statedAge })
+      .where(eq(bottleGroups.id, first.group.id));
+    await db
+      .update(bottles)
+      .set(materialized)
+      .where(eq(bottles.id, first.bottle.id));
+    Object.assign(first.group, { statedAge });
+    Object.assign(first.bottle, materialized);
+  }
   for (const exact of exacts.slice(1)) {
     await testFixtures.BottleGroupMember({
       groupId: first.group.id,

--- a/apps/server/src/orpc/routes/bottles/update.test.ts
+++ b/apps/server/src/orpc/routes/bottles/update.test.ts
@@ -9,6 +9,7 @@ import {
   changes,
   entities,
 } from "@peated/server/db/schema";
+import { materializeBottleForGroup } from "@peated/server/lib/bottleIdentity";
 import { createBottle } from "@peated/server/lib/createBottle";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
 import waitError from "@peated/server/lib/test/waitError";
@@ -32,8 +33,36 @@ async function createGroup(
 ) {
   const first = await createBottle({
     context: { user },
-    input: { stable, exact: exacts[0] },
+    input: { ...stable, ...exacts[0] },
   });
+  if ("statedAge" in stable) {
+    const statedAge = stable.statedAge as number | null;
+    const materialized = materializeBottleForGroup({
+      group: { ...first.group, statedAge },
+      exact: {
+        edition: first.bottle.edition,
+        statedAge: exacts[0].statedAge ?? null,
+        releaseYear: first.bottle.releaseYear,
+        vintageYear: first.bottle.vintageYear,
+        abv: first.bottle.abv,
+        singleCask: first.bottle.singleCask,
+        caskStrength: first.bottle.caskStrength,
+        caskType: first.bottle.caskType,
+        caskSize: first.bottle.caskSize,
+        caskFill: first.bottle.caskFill,
+      },
+    });
+    await db
+      .update(bottleGroups)
+      .set({ statedAge })
+      .where(eq(bottleGroups.id, first.group.id));
+    await db
+      .update(bottles)
+      .set(materialized)
+      .where(eq(bottles.id, first.bottle.id));
+    Object.assign(first.group, { statedAge });
+    Object.assign(first.bottle, materialized);
+  }
   const members: Array<{ bottle: Bottle }> = [first];
   for (const exact of exacts.slice(1)) {
     members.push({

--- a/apps/server/src/orpc/routes/bottles/upsert.ts
+++ b/apps/server/src/orpc/routes/bottles/upsert.ts
@@ -1,5 +1,5 @@
 import { call, ORPCError } from "@orpc/server";
-import { IndependentBottleCreateRouteInputSchema } from "@peated/server/lib/bottleSchemas";
+import { BottleCreateInputSchema } from "@peated/server/lib/bottleSchemas";
 import { buildBottleUpdatePatch } from "@peated/server/lib/flatBottleInput";
 import { logInfo } from "@peated/server/lib/log";
 import { procedure } from "@peated/server/orpc";
@@ -27,7 +27,7 @@ export default procedure
       operationId: "upsertBottle",
     }),
   })
-  .input(IndependentBottleCreateRouteInputSchema)
+  .input(BottleCreateInputSchema)
   .output(BottleSchema)
   .handler(async function ({ input, context }) {
     try {

--- a/apps/server/src/orpc/routes/prices/matchQueue/create-bottle.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/create-bottle.ts
@@ -3,12 +3,11 @@ import {
   ExactBottleAliasConflictError,
   FailedToSaveBottleAliasError,
 } from "@peated/server/lib/bottleAliases";
-import { IndependentBottleCreateRouteInputSchema } from "@peated/server/lib/bottleSchemas";
+import { BottleCreateInputSchema } from "@peated/server/lib/bottleSchemas";
 import {
   BottleAlreadyExistsError,
   BottleCreateBadRequestError,
 } from "@peated/server/lib/createBottle";
-import { buildIndependentBottleCreateInput } from "@peated/server/lib/flatBottleInput";
 import {
   createBottleFromStorePriceMatchProposal,
   InvalidStorePriceMatchProposalTypeError,
@@ -27,7 +26,7 @@ import { z } from "zod";
 const IndependentInputSchema = z
   .object({
     proposal: z.coerce.number(),
-    independentBottle: IndependentBottleCreateRouteInputSchema,
+    independentBottle: BottleCreateInputSchema,
   })
   .strict();
 
@@ -48,7 +47,7 @@ export default procedure
       const actor = await getUserActor(context.user);
       const result = await createBottleFromStorePriceMatchProposal({
         proposalId: input.proposal,
-        bottleInput: buildIndependentBottleCreateInput(input.independentBottle),
+        bottleInput: input.independentBottle,
         user: context.user,
         actor,
       });

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -2693,7 +2693,7 @@ describe("price match queue", () => {
     expect(createdBottle?.groupId).not.toBe(sourceBottle.groupId);
     expect(createdGroup).toMatchObject({
       name: "Trusted Expression",
-      statedAge: 14,
+      statedAge: null,
       seriesId: durableSeries.id,
       category: "bourbon",
       brandId: durableBrand.id,
@@ -2787,9 +2787,9 @@ describe("price match queue", () => {
     });
     const existing = await fixtures.BottleGroupMember({
       groupId: sourceBottle.groupId!,
-      edition: "Batch 9",
-      statedAge: 15,
-      abv: 54,
+      edition: "Batch 8",
+      statedAge: 14,
+      abv: 53,
     });
     const price = await fixtures.StorePrice({
       name: "Retry Expression Batch 9 Listing",

--- a/apps/server/src/worker/jobs/generateBottleDetails.test.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.test.ts
@@ -64,14 +64,10 @@ async function createTwoMemberGroup(user: User, brandId: number) {
   const source = await createBottle({
     context: contextFor(user),
     input: {
-      stable: {
-        name: "Generated Details",
-        brand: brandId,
-        category: "single_malt",
-      },
-      exact: {
-        edition: "Batch 1",
-      },
+      name: "Generated Details",
+      brand: brandId,
+      category: "single_malt",
+      edition: "Batch 1",
     },
   });
   const siblingBottle = await testFixtures.BottleGroupMember({
@@ -427,12 +423,10 @@ test("does not fan out after the selected Bottle moves groups", async ({
   const destination = await createBottle({
     context: contextFor(defaults.user),
     input: {
-      stable: {
-        name: "Generated Membership Destination",
-        brand: brand.id,
-        category: "single_malt",
-      },
-      exact: { edition: "Destination" },
+      name: "Generated Membership Destination",
+      brand: brand.id,
+      category: "single_malt",
+      edition: "Destination",
     },
   });
   const deferred = deferModelResult();

--- a/apps/server/src/worker/jobs/mergeEntity.test.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.test.ts
@@ -595,8 +595,9 @@ test("preflights exact batch duplicates from BottleGroup authority", async ({
   const destinationBatch = await createBottle({
     context: contextFor(defaults.user),
     input: {
-      stable: { brand: destinationEntity.id, name: "Annual" },
-      exact: { edition: "Batch 2" },
+      brand: destinationEntity.id,
+      name: "Annual",
+      edition: "Batch 2",
     },
   });
   await db

--- a/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/queue/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { IndependentBottleCreateRouteInputSchema } from "@peated/server/lib/bottleSchemas";
+import { BottleCreateInputSchema } from "@peated/server/lib/bottleSchemas";
 import type { Bottle } from "@peated/server/types";
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
@@ -240,9 +240,7 @@ export default function Page() {
 
     const created = await createBottleMutation.mutateAsync({
       proposal: item.id,
-      independentBottle: IndependentBottleCreateRouteInputSchema.parse(
-        item.proposedBottle,
-      ),
+      independentBottle: BottleCreateInputSchema.parse(item.proposedBottle),
     });
     await refreshQueueList();
     flash(

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -12,7 +12,7 @@ import {
   CATEGORY_LIST,
   FLAVOR_PROFILES,
 } from "@peated/server/constants";
-import { IndependentBottleCreateRouteInputSchema } from "@peated/server/lib/bottleSchemas";
+import { BottleCreateInputSchema } from "@peated/server/lib/bottleSchemas";
 import {
   formatCategoryName,
   formatFlavorProfile,
@@ -76,10 +76,8 @@ const caskTypeList = CASK_TYPES.map(({ id }) => ({
   name: toTitleCase(id),
 }));
 
-type CreateFormSchemaType = z.infer<
-  typeof IndependentBottleCreateRouteInputSchema
->;
-const BottleFormSchema = IndependentBottleCreateRouteInputSchema;
+type CreateFormSchemaType = z.infer<typeof BottleCreateInputSchema>;
+const BottleFormSchema = BottleCreateInputSchema;
 type FormSchemaType = CreateFormSchemaType;
 type ChoiceLike = {
   id?: number | null;

--- a/docs/architecture/whisky-identity-model.md
+++ b/docs/architecture/whisky-identity-model.md
@@ -42,6 +42,10 @@ does not create another catalog identity layer.
 - Ordinary creation atomically creates a complete Bottle and a singleton
   BottleGroup. “Add a similar bottle” only prefills a new Bottle draft; it does
   not reuse the source Bottle's group.
+- Creation accepts one flat Bottle input. The server assigns storage ownership.
+  A submitted `statedAge` starts as the Bottle's exact age. The singleton
+  BottleGroup starts with no shared age because one release does not prove that
+  the age is invariant across a future group.
 - Semantic grouping happens outside ordinary creation. Similar names, a shared
   brand, or a shared BottleSeries may suggest a relationship but do not prove
   same-expression identity. This release does not ship an automatic regrouping

--- a/docs/features/bottle-entry-workflow.md
+++ b/docs/features/bottle-entry-workflow.md
@@ -6,8 +6,10 @@ field ownership, grouping, and merge semantics.
 
 ## Creation
 
-- Add Bottle accepts the shared expression and exact marketed-release fields in
-  one submission and returns one independently complete Bottle.
+- Add Bottle accepts one flat Bottle input. The server owns field storage and
+  returns one independently complete Bottle.
+- A submitted stated age belongs to the new Bottle. The singleton BottleGroup
+  starts without a shared age. A reviewed shared edit can establish one later.
 - Creation atomically creates a singleton BottleGroup. Users do not select,
   name, or submit authority for a group.
 - Deterministic alias duplicate checks remain in the request path. Slow catalog


### PR DESCRIPTION
Bottle creation now accepts one flat `BottleCreateInput` across manual entry, classifier-driven creation, price moderation, scraper ingestion, and the web form. The server alone maps those fields to durable Bottle and BottleGroup storage, so callers no longer construct `stable`/`exact` creation payloads. A submitted `statedAge` now belongs to the Bottle for every caller, while the new singleton BottleGroup starts without a shared age.

This is the first PR-sized part of slice 6 in #566. The existing `shared`/`exact` update contract is intentionally unchanged; a follow-up will flatten `BottlePatch` and move update storage ownership behind the same server boundary. Regression coverage proves manual and classifier age parity and exercises the affected route, price, scraper, duplicate-reuse, and OpenAPI paths.

Refs #566
