### PR TITLE
ref(classifier): remove sparse-reference token gate

### DIFF
--- a/openspec/changes/define-bottle-classifier-agent-contract/audit/review-policy-audit.md
+++ b/openspec/changes/define-bottle-classifier-agent-contract/audit/review-policy-audit.md
@@ -26,15 +26,15 @@ Use these classes:
 | Infer or rewrite `identityScope` from general cask-number and name patterns                                       | Second-classifier drift | Narrow in a later slice. Code must not promote product scope from semantic text patterns. Keep only explicit scope validation and the SMWS exception. |
 | Rewrite Bottle names to restore age text or remove exact traits                                                   | Second-classifier drift | Remove or narrow in later eval-backed slices. The agent owns common marketed Bottle identity and field placement.                                     |
 | Reject a Bottle draft because its normalized name duplicates the Brand or becomes empty after exact-trait removal | Second-classifier drift | Narrow in a later slice to schema-level empty-name validation. Do not infer the correct expression in code.                                           |
-| Reject `create_bottle` when token counts say that the proposal expanded beyond a sparse reference                 | Second-classifier drift | Remove in a later eval-backed slice. Source interpretation belongs to the agent.                                                                      |
-| Reject `create_bottle` when normalized or possessive-insensitive candidate names look like the proposed Bottle    | Second-classifier drift | Removed in this slice. The comparison could hide a valid create when the candidate had an unsupported release trait.                                  |
+| Reject `create_bottle` when token counts say that the proposal expanded beyond a sparse reference                 | Second-classifier drift | Removed. Source interpretation belongs to the agent.                                                                                                  |
+| Reject `create_bottle` when normalized or possessive-insensitive candidate names look like the proposed Bottle    | Second-classifier drift | Removed. The comparison could hide a valid create when the candidate had an unsupported release trait.                                                |
 | Reject obvious non-whisky, multi-item, packaging-only, or damaged-sale references before classification           | Closed-form gate        | Keep. This is the documented non-whisky and impossible-input boundary.                                                                                |
 
 ## Removal order
 
-1. Remove the generic duplicate-create name classifier. This slice completes
-   that removal and keeps the exact-cask code collision gate.
-2. Remove the sparse-reference token gate.
+1. Remove the generic duplicate-create name classifier. Removed. The exact-cask
+   code collision gate remains.
+2. Remove the sparse-reference token gate. Removed.
 3. Stop rewriting and rejecting common Bottle identity from age and exact-trait
    name patterns.
 4. Narrow identity-scope checks to explicit structured facts and the SMWS code

--- a/openspec/changes/define-bottle-classifier-agent-contract/tasks.md
+++ b/openspec/changes/define-bottle-classifier-agent-contract/tasks.md
@@ -38,7 +38,7 @@
 
 ## 5. Review Policy Boundary Audit
 
-- [x] 5.1 Audit `reviewPolicy.ts` transforms against the determinism boundary in `docs/architecture/bottle-classifier.md` (Review Policy Audit section); classify each transform as schema validation, closed-form gate, or second-classifier drift, and list drift candidates for removal or narrowing with eval proof. (2026-08-10: added `audit/review-policy-audit.md`; removed the generic duplicate-create name classifier while retaining the exact-cask code collision gate.)
+- [x] 5.1 Audit `reviewPolicy.ts` transforms against the determinism boundary in `docs/architecture/bottle-classifier.md` (Review Policy Audit section); classify each transform as schema validation, closed-form gate, or second-classifier drift, and list drift candidates for removal or narrowing with eval proof. (2026-08-10: added `audit/review-policy-audit.md`; removed the generic duplicate-create name classifier and sparse-reference token gate while retaining the exact-cask code collision gate.)
 
 ## 6. Eval And Fixture Review
 

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -2374,7 +2374,7 @@ describe("createBottleClassifier", () => {
     });
   });
 
-  test("does not invent a branded bottle from sparse generic batch wording", async () => {
+  test("preserves a create decision for a sparse source reference", async () => {
     const runBottleClassifierAgent = vi.fn(
       async (): Promise<ReasoningResult> => ({
         decision: {
@@ -2439,12 +2439,21 @@ describe("createBottleClassifier", () => {
     }
 
     expect(result.decision).toMatchObject({
-      action: "no_match",
+      action: "create_bottle",
       matchedBottleId: null,
+      proposedBottle: {
+        name: "Blenders' Sherry Cask Finish 12-year-old",
+        series: {
+          name: "Blenders' Batch",
+        },
+        edition: "EXP#7",
+        statedAge: 12,
+        releaseYear: 2018,
+        brand: {
+          name: "Johnnie Walker",
+        },
+      },
     });
-    expect(result.decision.rationale).toContain(
-      "expanded too far beyond a sparse unanchored reference",
-    );
   });
 
   test("keeps a matched bottle when the only name difference is a canonical proof suffix", async () => {

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -243,89 +243,12 @@ function getComparableNameTokens(value: string | null | undefined): string[] {
     .filter((token) => token.length > 0 && !GENERIC_NAME_TOKENS.has(token));
 }
 
-function getStrictComparableNameTokens(
-  value: string | null | undefined,
-): string[] {
-  return normalizeNameTokenizationText(value)
-    .replace(/\b\d+(?:\.\d+)?\s?(?:ml|cl|l|oz)\b/g, " ")
-    .split(/[^a-z0-9]+/g)
-    .filter((token) => token.length > 0);
-}
-
 function normalizeNameTokenizationText(
   value: string | null | undefined,
 ): string {
   return normalizeComparableText(value)
     .replace(/\b([a-z0-9]+)'s\b/g, "$1s")
     .replace(/\b([a-z0-9]+)s'\b/g, "$1s");
-}
-
-function getReferenceAnchoredCreateTokens({
-  proposedBottle,
-}: {
-  proposedBottle: NonNullable<BottleClassificationDecision["proposedBottle"]>;
-}): string[] {
-  return Array.from(
-    new Set([
-      ...getStrictComparableNameTokens(proposedBottle.brand.name),
-      ...getStrictComparableNameTokens(proposedBottle.series?.name),
-      ...getStrictComparableNameTokens(proposedBottle.name),
-      ...getStrictComparableNameTokens(
-        proposedBottle.releaseYear != null
-          ? String(proposedBottle.releaseYear)
-          : null,
-      ),
-    ]),
-  );
-}
-
-function hasReferenceAnchoredSparseCreateProposal({
-  reference,
-  extractedIdentity,
-  candidates,
-  proposedBottle,
-}: {
-  reference: BottleReference;
-  extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
-  candidates: BottleCandidate[];
-  proposedBottle: NonNullable<BottleClassificationDecision["proposedBottle"]>;
-}): boolean {
-  if (extractedIdentity || candidates.length > 0) {
-    return true;
-  }
-
-  const referenceTokens = new Set(
-    getStrictComparableNameTokens(reference.name),
-  );
-  if (!referenceTokens.size) {
-    return false;
-  }
-
-  const brandTokens = getStrictComparableNameTokens(proposedBottle.brand.name);
-  const seriesTokens = getStrictComparableNameTokens(
-    proposedBottle.series?.name,
-  );
-  const nameTokens = getStrictComparableNameTokens(proposedBottle.name);
-  const proposedTokens = getReferenceAnchoredCreateTokens({ proposedBottle });
-  const introducedTokens = proposedTokens.filter(
-    (token) => !referenceTokens.has(token),
-  );
-  const hasAnchoredBrand =
-    brandTokens.length === 0 ||
-    brandTokens.every((token) => referenceTokens.has(token));
-  const hasAnchoredSeries =
-    seriesTokens.length === 0 ||
-    seriesTokens.some((token) => referenceTokens.has(token));
-  const hasAnchoredName = nameTokens.some((token) =>
-    referenceTokens.has(token),
-  );
-
-  return (
-    hasAnchoredBrand &&
-    hasAnchoredSeries &&
-    hasAnchoredName &&
-    introducedTokens.length <= 2
-  );
 }
 
 function getReferenceBottleName({
@@ -1310,28 +1233,6 @@ function sanitizeClassifierDecision({
           ),
         });
       }
-    }
-
-    if (
-      !hasReferenceAnchoredSparseCreateProposal({
-        reference,
-        extractedIdentity: artifacts.extractedIdentity,
-        candidates: artifacts.candidates,
-        proposedBottle: proposedBottleDraft,
-      })
-    ) {
-      return createNoMatchDecision({
-        decision: {
-          ...decision,
-        },
-        candidateBottleIds: filteredCandidateBottleIds,
-        observation,
-        identityScope: "product",
-        rationale: appendRationale(
-          decision.rationale,
-          "Server downgraded create_bottle because the proposed bottle identity expanded too far beyond a sparse unanchored reference.",
-        ),
-      });
     }
 
     return {


### PR DESCRIPTION
Reference classification now preserves an agent `create_bottle` decision when the source title is sparse instead of replacing it with `no_match` from token overlap. This removes the token-count comparator and its helper chain, and updates deterministic boundary coverage and the review-policy audit.

Schema validation, known-id checks, direct conflict checks, and the exact-cask collision gate remain unchanged. The deterministic classifier suite, typecheck, fixture validation, terminology and static checks, and strict OpenSpec validation pass. The hosted 97-case eval was attempted but skipped because `AI_GATEWAY_API_KEY` is unavailable.

Refs #566
