### PR TITLE
ref(classifier): stop rewriting agent bottle names

### DIFF
--- a/openspec/changes/define-bottle-classifier-agent-contract/audit/review-policy-audit.md
+++ b/openspec/changes/define-bottle-classifier-agent-contract/audit/review-policy-audit.md
@@ -24,8 +24,8 @@ Use these classes:
 | Resolve and validate SMWS exact-cask codes                                                                        | Closed-form gate        | Keep. SMWS codes are the documented closed identifier exception.                                                                                      |
 | Reject exact-cask creation when the same reviewed candidate has the same exact code and no direct field conflict  | Closed-form gate        | Keep. The code anchor, not a fuzzy name score, proves the collision.                                                                                  |
 | Infer or rewrite `identityScope` from general cask-number and name patterns                                       | Second-classifier drift | Narrow in a later slice. Code must not promote product scope from semantic text patterns. Keep only explicit scope validation and the SMWS exception. |
-| Rewrite Bottle names to restore age text or remove exact traits                                                   | Second-classifier drift | Remove or narrow in later eval-backed slices. The agent owns common marketed Bottle identity and field placement.                                     |
-| Reject a Bottle draft because its normalized name duplicates the Brand or becomes empty after exact-trait removal | Second-classifier drift | Narrow in a later slice to schema-level empty-name validation. Do not infer the correct expression in code.                                           |
+| Rewrite Bottle names to restore age text or remove exact traits                                                   | Second-classifier drift | Removed. The agent owns common marketed Bottle identity and field placement.                                                                          |
+| Reject a Bottle draft because its normalized name duplicates the Brand or becomes empty after exact-trait removal | Second-classifier drift | Removed. The strict Bottle draft schema still rejects an empty name.                                                                                  |
 | Reject `create_bottle` when token counts say that the proposal expanded beyond a sparse reference                 | Second-classifier drift | Removed. Source interpretation belongs to the agent.                                                                                                  |
 | Reject `create_bottle` when normalized or possessive-insensitive candidate names look like the proposed Bottle    | Second-classifier drift | Removed. The comparison could hide a valid create when the candidate had an unsupported release trait.                                                |
 | Reject obvious non-whisky, multi-item, packaging-only, or damaged-sale references before classification           | Closed-form gate        | Keep. This is the documented non-whisky and impossible-input boundary.                                                                                |
@@ -36,7 +36,7 @@ Use these classes:
    code collision gate remains.
 2. Remove the sparse-reference token gate. Removed.
 3. Stop rewriting and rejecting common Bottle identity from age and exact-trait
-   name patterns.
+   name patterns. Removed. The strict schema still rejects empty names.
 4. Narrow identity-scope checks to explicit structured facts and the SMWS code
    exception.
 

--- a/openspec/changes/define-bottle-classifier-agent-contract/tasks.md
+++ b/openspec/changes/define-bottle-classifier-agent-contract/tasks.md
@@ -38,7 +38,7 @@
 
 ## 5. Review Policy Boundary Audit
 
-- [x] 5.1 Audit `reviewPolicy.ts` transforms against the determinism boundary in `docs/architecture/bottle-classifier.md` (Review Policy Audit section); classify each transform as schema validation, closed-form gate, or second-classifier drift, and list drift candidates for removal or narrowing with eval proof. (2026-08-10: added `audit/review-policy-audit.md`; removed the generic duplicate-create name classifier and sparse-reference token gate while retaining the exact-cask code collision gate.)
+- [x] 5.1 Audit `reviewPolicy.ts` transforms against the determinism boundary in `docs/architecture/bottle-classifier.md` (Review Policy Audit section); classify each transform as schema validation, closed-form gate, or second-classifier drift, and list drift candidates for removal or narrowing with eval proof. (2026-08-10: added `audit/review-policy-audit.md`; removed the generic duplicate-create name classifier, sparse-reference token gate, and age/exact-trait name rewrites while retaining the exact-cask code collision gate.)
 
 ## 6. Eval And Fixture Review
 

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -2442,7 +2442,7 @@ describe("createBottleClassifier", () => {
       action: "create_bottle",
       matchedBottleId: null,
       proposedBottle: {
-        name: "Blenders' Sherry Cask Finish 12-year-old",
+        name: "Blenders' Sherry Cask Finish EXP#7 12-year-old",
         series: {
           name: "Blenders' Batch",
         },
@@ -3204,7 +3204,7 @@ describe("createBottleClassifier", () => {
       matchedBottleId: null,
       identityScope: "product",
       proposedBottle: {
-        name: "Reserve 9-year-old",
+        name: "Reserve",
         statedAge: 9,
       },
     });
@@ -3551,7 +3551,7 @@ describe("createBottleClassifier", () => {
       action: "create_bottle",
       identityScope: "product",
       proposedBottle: {
-        name: "The Distillers Edition",
+        name: "2001 The Distillers Edition",
         brand: {
           name: "Talisker",
         },
@@ -3561,7 +3561,7 @@ describe("createBottleClassifier", () => {
     });
   });
 
-  test("preserves exact-cask age and vintage in standalone bottle display names", async () => {
+  test("preserves the agent name and structured exact-cask age and vintage", async () => {
     const extractedIdentity: BottleExtractedDetails = {
       brand: "The Exclusive Malts",
       bottler: "Creative Whisky Company",
@@ -3650,14 +3650,14 @@ describe("createBottleClassifier", () => {
       action: "create_bottle",
       identityScope: "exact_cask",
       proposedBottle: {
-        name: "Islay 8-year-old",
+        name: "Islay",
         statedAge: 8,
         vintageYear: 2007,
       },
     });
   });
 
-  test("keeps an exact-cask marker structured outside the stable bottle name", async () => {
+  test("keeps an exact-cask marker structured without rewriting the agent name", async () => {
     const extractedIdentity: BottleExtractedDetails = {
       brand: "Willett",
       bottler: null,
@@ -3737,7 +3737,7 @@ describe("createBottleClassifier", () => {
       action: "create_bottle",
       identityScope: "exact_cask",
       proposedBottle: {
-        name: "Family Estate Bottled Single Barrel Bourbon 5-year-old",
+        name: "Family Estate Bottled Single Barrel Bourbon",
         edition: "Barrel No. 4769",
       },
     });

--- a/packages/bottle-classifier/src/reviewPolicy.test.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.test.ts
@@ -199,20 +199,16 @@ function classifyAgeCreationWithoutSiblingConflict(
 function classifyStructuredExactName({
   referenceName,
   proposedName,
-  brand = "Example",
   expression,
-  edition = null,
   vintageYear = null,
-  releaseYear = null,
 }: {
   referenceName: string;
   proposedName: string;
-  brand?: string;
   expression: string | null;
-  edition?: string | null;
   vintageYear?: number | null;
-  releaseYear?: number | null;
 }) {
+  const brand = "Example";
+
   return finalizeBottleReferenceClassification({
     reference: { name: referenceName },
     decision: {
@@ -226,7 +222,7 @@ function classifyStructuredExactName({
         name: proposedName,
         series: null,
         category: "single_malt",
-        edition,
+        edition: null,
         statedAge: null,
         caskStrength: null,
         singleCask: null,
@@ -235,7 +231,7 @@ function classifyStructuredExactName({
         caskFill: null,
         abv: null,
         vintageYear,
-        releaseYear,
+        releaseYear: null,
         brand: { id: null, name: brand },
         distillers: [],
         bottler: null,
@@ -252,96 +248,21 @@ function classifyStructuredExactName({
         category: "single_malt",
         stated_age: null,
         abv: null,
-        release_year: releaseYear,
+        release_year: null,
         vintage_year: vintageYear,
         cask_strength: null,
         single_cask: null,
         cask_type: null,
         cask_size: null,
         cask_fill: null,
-        edition,
+        edition: null,
       },
     }),
   });
 }
 
 describe("finalizeBottleReferenceClassification", () => {
-  test("removes a parenthesized structured edition without leaving empty punctuation", () => {
-    const result = classifyStructuredExactName({
-      referenceName: "Elijah Craig Barrel Proof Batch C923",
-      proposedName: "Barrel Proof (Batch C923)",
-      brand: "Elijah Craig",
-      expression: "Barrel Proof",
-      edition: "Batch C923",
-    });
-
-    expect(result).toMatchObject({
-      action: "create_bottle",
-      proposedBottle: {
-        name: "Barrel Proof",
-        edition: "Batch C923",
-      },
-    });
-  });
-
-  test("collapses internal dash separators after removing a structured edition", () => {
-    const result = classifyStructuredExactName({
-      referenceName: "Example Special Reserve Batch 2 Cask Strength",
-      proposedName: "Special Reserve - Batch 2 - Cask Strength",
-      expression: "Special Reserve Cask Strength",
-      edition: "Batch 2",
-    });
-
-    expect(result).toMatchObject({
-      action: "create_bottle",
-      proposedBottle: {
-        name: "Special Reserve - Cask Strength",
-        edition: "Batch 2",
-      },
-    });
-  });
-
-  test("collapses internal comma separators after removing a structured edition", () => {
-    const result = classifyStructuredExactName({
-      referenceName: "Example Special Reserve Batch 2 Cask Strength",
-      proposedName: "Special Reserve, Batch 2, Cask Strength",
-      expression: "Special Reserve Cask Strength",
-      edition: "Batch 2",
-    });
-
-    expect(result).toMatchObject({
-      action: "create_bottle",
-      proposedBottle: {
-        name: "Special Reserve Cask Strength",
-        edition: "Batch 2",
-      },
-    });
-  });
-
-  test.each(["Classic Cut 2021 Edition", "Classic Cut - 2021 Edition"])(
-    "keeps the stable Macallan expression after removing structured edition and year from %s",
-    (proposedName) => {
-      const result = classifyStructuredExactName({
-        referenceName: "The Macallan Classic Cut 2021 Edition",
-        proposedName,
-        brand: "The Macallan",
-        expression: "Classic Cut",
-        edition: "2021 Edition",
-        releaseYear: 2021,
-      });
-
-      expect(result).toMatchObject({
-        action: "create_bottle",
-        proposedBottle: {
-          name: "Classic Cut",
-          edition: "2021 Edition",
-          releaseYear: 2021,
-        },
-      });
-    },
-  );
-
-  test("removes a labeled structured vintage from the stable expression", () => {
+  test("preserves exact-trait wording selected by the agent", () => {
     const result = classifyStructuredExactName({
       referenceName: "Example Special Reserve 1994 Vintage",
       proposedName: "Special Reserve 1994 Vintage",
@@ -352,13 +273,13 @@ describe("finalizeBottleReferenceClassification", () => {
     expect(result).toMatchObject({
       action: "create_bottle",
       proposedBottle: {
-        name: "Special Reserve",
+        name: "Special Reserve 1994 Vintage",
         vintageYear: 1994,
       },
     });
   });
 
-  test("rejects a create draft whose name contains only structured exact identity", () => {
+  test("preserves a valid create whose name contains only structured exact identity", () => {
     const result = classifyStructuredExactName({
       referenceName: "Example 1994 Vintage",
       proposedName: "1994 Vintage",
@@ -367,15 +288,16 @@ describe("finalizeBottleReferenceClassification", () => {
     });
 
     expect(result).toMatchObject({
-      action: "no_match",
-      proposedBottle: null,
+      action: "create_bottle",
+      matchedBottleId: null,
+      proposedBottle: {
+        name: "1994 Vintage",
+        vintageYear: 1994,
+      },
     });
-    expect(result.rationale).toContain(
-      "no stable expression distinct from the brand",
-    );
   });
 
-  test("rejects a create draft when exact-trait removal leaves only the brand", () => {
+  test("preserves a valid create when exact-trait removal would leave the brand", () => {
     const result = classifyStructuredExactName({
       referenceName: "Example 1994 Vintage",
       proposedName: "1994 Vintage Example",
@@ -384,8 +306,12 @@ describe("finalizeBottleReferenceClassification", () => {
     });
 
     expect(result).toMatchObject({
-      action: "no_match",
-      proposedBottle: null,
+      action: "create_bottle",
+      matchedBottleId: null,
+      proposedBottle: {
+        name: "1994 Vintage Example",
+        vintageYear: 1994,
+      },
     });
   });
 
@@ -635,7 +561,7 @@ describe("finalizeBottleReferenceClassification", () => {
     });
   });
 
-  test("restores source-marketed bottle age in the display name", () => {
+  test("preserves an agent name that omits structured age wording", () => {
     const result = classifyShieldaigAgeCreation(
       buildShieldaigAgeCreationDecision("Speyside"),
     );
@@ -644,13 +570,13 @@ describe("finalizeBottleReferenceClassification", () => {
       action: "create_bottle",
       matchedBottleId: null,
       proposedBottle: {
-        name: "Speyside 30-year-old",
+        name: "Speyside",
         statedAge: 30,
       },
     });
   });
 
-  test("restores source-marketed bottle age without sibling conflict evidence", () => {
+  test("preserves an agent name without age wording when no siblings exist", () => {
     const result = classifyAgeCreationWithoutSiblingConflict(
       buildShieldaigAgeCreationDecision("Speyside"),
     );
@@ -658,7 +584,7 @@ describe("finalizeBottleReferenceClassification", () => {
     expect(result).toMatchObject({
       action: "create_bottle",
       proposedBottle: {
-        name: "Speyside 30-year-old",
+        name: "Speyside",
         statedAge: 30,
       },
     });
@@ -739,18 +665,19 @@ describe("finalizeBottleReferenceClassification", () => {
     });
   });
 
-  test("rejects bottle creation when the expression duplicates the brand", () => {
+  test("preserves a valid create when the expression duplicates the brand", () => {
     const result = classifyShieldaigAgeCreation(
       buildShieldaigAgeCreationDecision("Shieldaig"),
     );
 
     expect(result).toMatchObject({
-      action: "no_match",
-      proposedBottle: null,
+      action: "create_bottle",
+      matchedBottleId: null,
+      proposedBottle: {
+        name: "Shieldaig",
+        statedAge: 30,
+      },
     });
-    expect(result.rationale).toContain(
-      "proposed bottle name duplicates the brand",
-    );
   });
 
   test("keeps bottle creation when bottle-level age is displayed as a word-age name", () => {

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -30,12 +30,7 @@ import {
   inferBottleIdentityScope,
 } from "./exactCaskPolicy";
 import { listMatchesExpectedValue } from "./identityEvidenceCore";
-import {
-  bottleNameDuplicatesBrand,
-  normalizeBottle,
-  normalizeString,
-  stripDuplicateBrandPrefixFromBottleName,
-} from "./normalize";
+import { normalizeString } from "./normalize";
 import { normalizeObservation } from "./observation";
 import {
   candidateLooksSmws,
@@ -114,40 +109,6 @@ const GIFT_SET_PACKAGING_TOKENS = new Set([
   "unknown",
   "with",
 ]);
-const AGE_WORD_ONES = [
-  "",
-  "one",
-  "two",
-  "three",
-  "four",
-  "five",
-  "six",
-  "seven",
-  "eight",
-  "nine",
-] as const;
-const AGE_WORD_TEENS = [
-  "ten",
-  "eleven",
-  "twelve",
-  "thirteen",
-  "fourteen",
-  "fifteen",
-  "sixteen",
-  "seventeen",
-  "eighteen",
-  "nineteen",
-] as const;
-const AGE_WORD_TENS: Record<number, string> = {
-  20: "twenty",
-  30: "thirty",
-  40: "forty",
-  50: "fifty",
-  60: "sixty",
-  70: "seventy",
-  80: "eighty",
-  90: "ninety",
-};
 function appendRationale(
   rationale: string | null,
   addition: string,
@@ -168,42 +129,6 @@ function normalizeComparableText(value: string | null | undefined): string {
 
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function getComparableAgeStatementPattern(statedAge: number): RegExp {
-  const age = escapeRegExp(String(statedAge));
-
-  return new RegExp(
-    `\\b${age}(?:\\s|-)?(?:year|yr)s?(?:\\s|-)?old\\b|\\b${age}(?:\\s|-)?(?:year|yr)s?\\b|\\b${age}(?:\\s|-)?y(?:\\.?o\\.?)?\\b`,
-    "i",
-  );
-}
-
-function stripComparableAgeStatement(
-  value: string,
-  statedAge: number | null | undefined,
-): string {
-  if (statedAge === null || statedAge === undefined) {
-    return value;
-  }
-
-  return value
-    .replace(getComparableAgeStatementPattern(statedAge), " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function comparableTextMarketsStatedAge(
-  value: string | null | undefined,
-  statedAge: number | null | undefined,
-): boolean {
-  if (!value || statedAge === null || statedAge === undefined) {
-    return false;
-  }
-
-  return getComparableAgeStatementPattern(statedAge).test(
-    normalizeComparableText(value),
-  );
 }
 
 function containsComparablePhrase(haystack: string, needle: string): boolean {
@@ -249,316 +174,6 @@ function normalizeNameTokenizationText(
   return normalizeComparableText(value)
     .replace(/\b([a-z0-9]+)'s\b/g, "$1s")
     .replace(/\b([a-z0-9]+)s'\b/g, "$1s");
-}
-
-function getReferenceBottleName({
-  reference,
-  brandName,
-  extractedBrand,
-}: {
-  reference: BottleReference;
-  brandName: string;
-  extractedBrand: string | null | undefined;
-}): string {
-  return stripDuplicateBrandPrefixFromBottleName(
-    stripDuplicateBrandPrefixFromBottleName(reference.name, brandName),
-    extractedBrand,
-  ).trim();
-}
-
-function stripReferenceBottleSuffixNoise(name: string): string {
-  return name
-    .replace(/\b(?:scotch\s+)?whisk(?:e)?y\b\.?$/i, "")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function restoreSparseAgeOnlyBottleName({
-  reference,
-  extractedIdentity,
-  proposedBottle,
-  forceAgeStatement = false,
-}: {
-  reference: BottleReference;
-  extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
-  proposedBottle: NonNullable<BottleClassificationDecision["proposedBottle"]>;
-  forceAgeStatement?: boolean;
-}): NonNullable<BottleClassificationDecision["proposedBottle"]> {
-  const statedAge = proposedBottle.statedAge ?? extractedIdentity?.stated_age;
-  const normalizedProposedName = normalizeComparableText(proposedBottle.name);
-  const ageStrippedProposedName = stripComparableAgeStatement(
-    normalizedProposedName,
-    statedAge,
-  );
-  const isAgeOnlyName =
-    !ageStrippedProposedName || normalizedProposedName === String(statedAge);
-  if (statedAge === null || statedAge === undefined) {
-    return proposedBottle;
-  }
-
-  if (
-    forceAgeStatement &&
-    !isAgeOnlyName &&
-    (comparableTextMarketsStatedAge(reference.name, statedAge) ||
-      extractedIdentity?.stated_age === statedAge) &&
-    !comparableTextMarketsStatedAge(proposedBottle.name, statedAge)
-  ) {
-    const normalizedName = normalizeBottle({
-      name: proposedBottle.name,
-      statedAge,
-    }).name;
-
-    return {
-      ...proposedBottle,
-      name: comparableTextMarketsStatedAge(normalizedName, statedAge)
-        ? normalizedName
-        : `${normalizedName} ${statedAge}-year-old`,
-      statedAge,
-    };
-  }
-
-  const referenceBottleName = stripReferenceBottleSuffixNoise(
-    getReferenceBottleName({
-      reference,
-      brandName: proposedBottle.brand.name,
-      extractedBrand: extractedIdentity?.brand,
-    }),
-  );
-  if (
-    !isAgeOnlyName ||
-    !referenceBottleName ||
-    referenceBottleName.length > 120 ||
-    !comparableTextMarketsStatedAge(referenceBottleName, statedAge) ||
-    normalizeComparableText(referenceBottleName) ===
-      normalizeComparableText(proposedBottle.name)
-  ) {
-    return proposedBottle;
-  }
-
-  return {
-    ...proposedBottle,
-    name: referenceBottleName,
-    statedAge,
-  };
-}
-
-function shouldRestoreMissingBottleAgeStatement(
-  missingTraits: string[],
-): boolean {
-  return missingTraits.length === 1 && missingTraits[0] === "statedAge";
-}
-
-function restoreExactCaskBottleDisplayName({
-  reference,
-  extractedIdentity,
-  proposedBottle,
-}: {
-  reference: BottleReference;
-  extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
-  proposedBottle: NonNullable<BottleClassificationDecision["proposedBottle"]>;
-}): NonNullable<BottleClassificationDecision["proposedBottle"]> {
-  let name = proposedBottle.name;
-  const statedAge = proposedBottle.statedAge ?? extractedIdentity?.stated_age;
-
-  if (
-    statedAge !== null &&
-    statedAge !== undefined &&
-    (comparableTextMarketsStatedAge(reference.name, statedAge) ||
-      extractedIdentity?.stated_age === statedAge) &&
-    !comparableTextMarketsStatedAge(name, statedAge)
-  ) {
-    name = `${name} ${statedAge}-year-old`;
-  }
-
-  return name === proposedBottle.name
-    ? proposedBottle
-    : {
-        ...proposedBottle,
-        name: normalizeString(name),
-      };
-}
-
-function stripStructuredExactTraitsFromStableBottleName(
-  proposedBottle: NonNullable<BottleClassificationDecision["proposedBottle"]>,
-): NonNullable<BottleClassificationDecision["proposedBottle"]> | null {
-  let name = proposedBottle.name;
-  const exactPhrases = [
-    proposedBottle.edition,
-    proposedBottle.vintageYear != null
-      ? `${proposedBottle.vintageYear} Vintage`
-      : null,
-    proposedBottle.vintageYear != null
-      ? `Vintage ${proposedBottle.vintageYear}`
-      : null,
-    proposedBottle.releaseYear != null
-      ? `${proposedBottle.releaseYear} Release`
-      : null,
-    proposedBottle.releaseYear != null
-      ? `Release ${proposedBottle.releaseYear}`
-      : null,
-    proposedBottle.releaseYear != null
-      ? `${proposedBottle.releaseYear} Bottling`
-      : null,
-    proposedBottle.releaseYear != null
-      ? `Bottled ${proposedBottle.releaseYear}`
-      : null,
-    proposedBottle.vintageYear != null
-      ? String(proposedBottle.vintageYear)
-      : null,
-    proposedBottle.releaseYear != null
-      ? String(proposedBottle.releaseYear)
-      : null,
-  ];
-
-  for (const phrase of exactPhrases) {
-    const normalizedPhrase = normalizeString(phrase ?? "");
-    if (!normalizedPhrase) {
-      continue;
-    }
-
-    name = name
-      .replace(
-        new RegExp(
-          `(^|[^a-z0-9])${escapeRegExp(normalizedPhrase)}(?=$|[^a-z0-9])`,
-          "gi",
-        ),
-        "$1",
-      )
-      .replace(/\(\s*\)|\[\s*\]|\{\s*\}/g, " ");
-  }
-
-  name = normalizeString(name)
-    .replace(/([,;:/|–—-])(?:\s*[,;:/|–—-])+/g, "$1")
-    .replace(/\s+([,;:])/g, "$1")
-    .replace(/^[\s,;:/|\-–—]+|[\s,;:/|\-–—]+$/g, "")
-    .replace(/\s+/g, " ")
-    .trim();
-
-  if (
-    !name ||
-    bottleNameDuplicatesBrand(name, proposedBottle.brand.name) ||
-    normalizeComparableText(name) ===
-      normalizeComparableText(proposedBottle.brand.name)
-  ) {
-    return null;
-  }
-
-  return name === proposedBottle.name
-    ? proposedBottle
-    : { ...proposedBottle, name };
-}
-
-function sourceMarketsProposedBottleAge({
-  reference,
-  extractedIdentity,
-  statedAge,
-}: {
-  reference: BottleReference;
-  extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
-  statedAge: number | null | undefined;
-}): boolean {
-  if (statedAge === null || statedAge === undefined) {
-    return false;
-  }
-
-  return (
-    comparableTextMarketsStatedAge(reference.name, statedAge) ||
-    extractedIdentity?.stated_age === statedAge
-  );
-}
-
-function proposedBottleNameMarketsStatedAge({
-  proposedBottle,
-  statedAge,
-}: {
-  proposedBottle: NonNullable<BottleClassificationDecision["proposedBottle"]>;
-  statedAge: number | null | undefined;
-}): boolean {
-  if (statedAge === null || statedAge === undefined) {
-    return false;
-  }
-
-  return (
-    comparableTextMarketsStatedAge(proposedBottle.name, statedAge) ||
-    comparableTextMarketsWordAge(proposedBottle.name, statedAge) ||
-    comparableTextMarketsStatedAge(
-      normalizeBottle({
-        name: proposedBottle.name,
-        statedAge: null,
-      }).name,
-      statedAge,
-    )
-  );
-}
-
-function getComparableAgeWordPhrase(statedAge: number): string | null {
-  if (statedAge >= 1 && statedAge < 10) {
-    return AGE_WORD_ONES[statedAge] ?? null;
-  }
-
-  if (statedAge >= 10 && statedAge < 20) {
-    return AGE_WORD_TEENS[statedAge - 10] ?? null;
-  }
-
-  if (statedAge >= 20 && statedAge < 100) {
-    const tens = Math.floor(statedAge / 10) * 10;
-    const ones = statedAge % 10;
-    const tensWord = AGE_WORD_TENS[tens];
-    const onesWord = AGE_WORD_ONES[ones];
-    if (!tensWord) {
-      return null;
-    }
-
-    return onesWord ? `${tensWord} ${onesWord}` : tensWord;
-  }
-
-  return null;
-}
-
-function comparableTextMarketsWordAge(
-  value: string | null | undefined,
-  statedAge: number | null | undefined,
-): boolean {
-  if (!value || statedAge === null || statedAge === undefined) {
-    return false;
-  }
-
-  const ageWords = getComparableAgeWordPhrase(statedAge);
-  if (!ageWords) {
-    return false;
-  }
-
-  const normalizedValue = normalizeComparableText(value).replace(/-/g, " ");
-  return containsComparablePhrase(normalizedValue, ageWords);
-}
-
-function getCreateBottleDisplayIdentityMissingTraits({
-  reference,
-  extractedIdentity,
-  proposedBottle,
-}: {
-  reference: BottleReference;
-  extractedIdentity: BottleClassificationArtifacts["extractedIdentity"];
-  proposedBottle: NonNullable<BottleClassificationDecision["proposedBottle"]>;
-}): string[] {
-  const missingTraits: string[] = [];
-  const statedAge = proposedBottle.statedAge;
-
-  if (
-    sourceMarketsProposedBottleAge({
-      reference,
-      extractedIdentity,
-      statedAge,
-    }) &&
-    !proposedBottleNameMarketsStatedAge({
-      proposedBottle,
-      statedAge,
-    })
-  ) {
-    missingTraits.push("statedAge");
-  }
-
-  return missingTraits;
 }
 
 function getMatchedTarget(
@@ -1114,52 +729,14 @@ function sanitizeClassifierDecision({
 
     const sanitizedBottleDraft = normalizeSmwsExactCaskProposedBottleDraft({
       extractedIdentity: artifacts.extractedIdentity,
-      proposedBottle: restoreSparseAgeOnlyBottleName({
-        reference,
-        extractedIdentity: artifacts.extractedIdentity,
-        proposedBottle: sanitizeProposedBottleDraft(
-          decision.proposedBottle,
-          resolvedEntitiesById,
-        ),
-      }),
+      proposedBottle: sanitizeProposedBottleDraft(
+        decision.proposedBottle,
+        resolvedEntitiesById,
+      ),
       reference,
     });
-    let proposedBottleDraft =
+    const proposedBottleDraft =
       normalizeProposedBottleDraft(sanitizedBottleDraft);
-
-    if (
-      bottleNameDuplicatesBrand(
-        proposedBottleDraft.name,
-        proposedBottleDraft.brand.name,
-      )
-    ) {
-      return createNoMatchDecision({
-        decision,
-        candidateBottleIds: filteredCandidateBottleIds,
-        observation,
-        identityScope: "product",
-        rationale: appendRationale(
-          decision.rationale,
-          "Server downgraded create_bottle because the proposed bottle name duplicates the brand instead of naming an expression.",
-        ),
-      });
-    }
-
-    const stableBottleDraft =
-      stripStructuredExactTraitsFromStableBottleName(proposedBottleDraft);
-    if (!stableBottleDraft) {
-      return createNoMatchDecision({
-        decision,
-        candidateBottleIds: filteredCandidateBottleIds,
-        observation,
-        identityScope: "product",
-        rationale: appendRationale(
-          decision.rationale,
-          "Server downgraded create_bottle because removing structured exact traits leaves no stable expression distinct from the brand.",
-        ),
-      });
-    }
-    proposedBottleDraft = stableBottleDraft;
     const smwsAnchorDecision: BottleClassificationDecision = {
       ...decision,
       action: "create_bottle",
@@ -1175,65 +752,6 @@ function sanitizeClassifierDecision({
         artifacts,
       }),
     );
-
-    if (
-      (decision.identityScope ?? "product") === "exact_cask" &&
-      !hasSmwsCodeAnchor
-    ) {
-      proposedBottleDraft = restoreExactCaskBottleDisplayName({
-        reference,
-        extractedIdentity: artifacts.extractedIdentity,
-        proposedBottle: proposedBottleDraft,
-      });
-    }
-
-    if ((decision.identityScope ?? "product") !== "exact_cask") {
-      const displayIdentityMissingTraits =
-        getCreateBottleDisplayIdentityMissingTraits({
-          reference,
-          extractedIdentity: artifacts.extractedIdentity,
-          proposedBottle: proposedBottleDraft,
-        });
-
-      if (
-        shouldRestoreMissingBottleAgeStatement(displayIdentityMissingTraits)
-      ) {
-        const ageRestoredBottleDraft = restoreSparseAgeOnlyBottleName({
-          reference,
-          extractedIdentity: artifacts.extractedIdentity,
-          proposedBottle: proposedBottleDraft,
-          forceAgeStatement: true,
-        });
-        proposedBottleDraft = normalizeProposedBottleDraft(
-          ageRestoredBottleDraft,
-        );
-      }
-    }
-
-    if ((decision.identityScope ?? "product") !== "exact_cask") {
-      const displayIdentityMissingTraits =
-        getCreateBottleDisplayIdentityMissingTraits({
-          reference,
-          extractedIdentity: artifacts.extractedIdentity,
-          proposedBottle: proposedBottleDraft,
-        });
-      if (displayIdentityMissingTraits.length > 0) {
-        return createNoMatchDecision({
-          decision: {
-            ...decision,
-          },
-          candidateBottleIds: filteredCandidateBottleIds,
-          observation,
-          identityScope: "product",
-          rationale: appendRationale(
-            decision.rationale,
-            `Server downgraded create_bottle because the proposed bottle display name omits bottle-level traits (${displayIdentityMissingTraits.join(
-              "; ",
-            )}) that the source markets; include those traits in proposedBottle.name.`,
-          ),
-        });
-      }
-    }
 
     return {
       action: "create_bottle",
@@ -1379,21 +897,12 @@ export function finalizeBottleReferenceClassification({
     decision: agentEvidenceAdjustedDecision,
     artifacts,
   });
-  const finalDecision = reviewedDecision.proposedBottle
-    ? {
-        ...reviewedDecision,
-        proposedBottle: restoreSparseAgeOnlyBottleName({
-          reference,
-          extractedIdentity: artifacts.extractedIdentity,
-          proposedBottle: reviewedDecision.proposedBottle,
-        }),
-      }
-    : reviewedDecision;
 
   return BottleClassificationDecisionSchema.parse({
-    ...finalDecision,
-    aliasScope: finalDecision.aliasScope ?? parsedDecision.aliasScope ?? "none",
+    ...reviewedDecision,
+    aliasScope:
+      reviewedDecision.aliasScope ?? parsedDecision.aliasScope ?? "none",
     confidenceBasis:
-      finalDecision.confidenceBasis ?? parsedDecision.confidenceBasis,
+      reviewedDecision.confidenceBasis ?? parsedDecision.confidenceBasis,
   });
 }


### PR DESCRIPTION
Reference classification now preserves valid agent `create_bottle` names instead of appending age text, removing exact-trait wording, or downgrading drafts whose expression duplicates the Brand. The strict schema still rejects empty names, while known-id validation, direct extracted-field conflicts, SMWS resolution, and the exact-cask collision gate remain unchanged.

This completes the third review-policy removal step in #566 and reduces `reviewPolicy.ts` by 491 lines. Deterministic coverage now proves that agent-selected age and exact-trait placement survives finalization. The 372-test classifier suite, package typecheck, fixture validation, lint and static checks, terminology checks, and strict OpenSpec validation pass. The hosted 97-case classifier eval was invoked but skipped because `AI_GATEWAY_API_KEY` is unavailable.

Refs #566
