### PR TITLE
ref(entity-classifier)!: remove numeric confidence

### DIFF
--- a/apps/server/src/orpc/routes/entities/classify.test.ts
+++ b/apps/server/src/orpc/routes/entities/classify.test.ts
@@ -70,7 +70,6 @@ describe("POST /entities/{entity}/classify", () => {
     classifyEntityMock.mockResolvedValue({
       decision: {
         verdict: "reassign_bottles_to_existing_brand",
-        confidence: 97,
         rationale: "Bottle evidence supports Canadian Club.",
         targetEntityId: canadianClub.id,
         targetEntityName: canadianClub.name,

--- a/packages/entity-classifier/src/classifierTypes.ts
+++ b/packages/entity-classifier/src/classifierTypes.ts
@@ -137,10 +137,11 @@ export const EntityClassificationMetadataPatchSchema = z
   .strict()
   .default({});
 
+// No live eval gives a numeric confidence score a measured meaning. The
+// verdict, blockers, and evidence carry the review recommendation.
 export const EntityClassificationDecisionSchema = z
   .object({
     verdict: EntityClassificationVerdictEnum,
-    confidence: z.number().int().min(0).max(100),
     rationale: z.string().trim().min(1),
     targetEntityId: z.number().int().nullable().default(null),
     targetEntityName: z.string().trim().nullable().default(null),

--- a/packages/entity-classifier/src/contract.test.ts
+++ b/packages/entity-classifier/src/contract.test.ts
@@ -63,7 +63,6 @@ describe("entity classifier contract", () => {
       EntityClassificationResultSchema.parse({
         decision: {
           verdict: "reassign_bottles_to_existing_brand",
-          confidence: 95,
           rationale:
             "Bottle evidence and official branding support Canadian Club as the correct target.",
           targetEntityId: 2,
@@ -80,5 +79,37 @@ describe("entity classifier contract", () => {
         },
       }),
     ).toBeTruthy();
+  });
+
+  test("rejects an unmeasured numeric confidence score", () => {
+    const result = EntityClassificationResultSchema.safeParse({
+      decision: {
+        verdict: "keep_as_is",
+        confidence: 95,
+        rationale: "The reviewed evidence supports the current Entity.",
+        targetEntityId: null,
+        targetEntityName: null,
+        reassignBottleIds: [],
+        preserveSourceAsDistillery: false,
+        metadataPatch: {},
+        blockers: [],
+        evidenceUrls: [],
+      },
+      artifacts: {
+        resolvedEntities: [],
+        searchEvidence: [],
+      },
+    });
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toContainEqual(
+        expect.objectContaining({
+          code: "unrecognized_keys",
+          keys: ["confidence"],
+          path: ["decision"],
+        }),
+      );
+    }
   });
 });

--- a/packages/entity-classifier/src/reviewPolicy.test.ts
+++ b/packages/entity-classifier/src/reviewPolicy.test.ts
@@ -51,7 +51,6 @@ describe("finalizeEntityClassification", () => {
       artifacts: buildEntityClassificationArtifacts({}),
       decision: {
         verdict: "reassign_bottles_to_existing_brand",
-        confidence: 95,
         rationale: "Canadian Club owns the verified bottle.",
         targetEntityId: 2,
         targetEntityName: "Wrong model text",
@@ -79,7 +78,6 @@ describe("finalizeEntityClassification", () => {
       artifacts: buildEntityClassificationArtifacts({}),
       decision: {
         verdict: "reassign_bottles_to_existing_brand",
-        confidence: 95,
         rationale: "Move it.",
         targetEntityId: 999,
         targetEntityName: "Invented",
@@ -94,6 +92,9 @@ describe("finalizeEntityClassification", () => {
     expect(result.verdict).toBe("manual_review");
     expect(result.targetEntityId).toBeNull();
     expect(result.reassignBottleIds).toEqual([]);
+    expect(result.blockers).toContain(
+      "Server downgraded reassignment because target entity 999 was not present in local candidates or resolved entities.",
+    );
   });
 
   test("requires evidence URLs for metadata patches", () => {
@@ -102,7 +103,6 @@ describe("finalizeEntityClassification", () => {
       artifacts: buildEntityClassificationArtifacts({}),
       decision: {
         verdict: "fix_entity_metadata",
-        confidence: 90,
         rationale: "Looks like a distillery.",
         targetEntityId: null,
         targetEntityName: null,

--- a/packages/entity-classifier/src/reviewPolicy.ts
+++ b/packages/entity-classifier/src/reviewPolicy.ts
@@ -37,7 +37,6 @@ function manualReviewDecision({
   return {
     ...decision,
     verdict: "manual_review",
-    confidence: Math.min(decision.confidence, 60),
     targetEntityId: null,
     targetEntityName: null,
     reassignBottleIds: [],


### PR DESCRIPTION
Entity classification decisions no longer emit or accept the unmeasured numeric `confidence` field. The strict package schema and moderator `/entities/{entity}/classify` response now use the verdict, blockers, rationale, and evidence URLs as the complete review recommendation; review-policy downgrades no longer rewrite an arbitrary score.

This is a hard contract cut for the internal entity-classifier boundary. Callers and fixtures must stop sending `confidence`, and the strict schema now rejects legacy payloads. The entity classifier has no live eval set that calibrates a 0–100 score, so retaining it suggested meaning the system could not verify. Deterministic package, route, and OpenAPI coverage plus entity-classifier and server type checks pass.

Refs #566
