### PR TITLE
ref(classifier): order evidence before decisions

### DIFF
--- a/openspec/changes/define-bottle-classifier-agent-contract/tasks.md
+++ b/openspec/changes/define-bottle-classifier-agent-contract/tasks.md
@@ -21,7 +21,7 @@
 
 ## 3. Output Schema
 
-- [ ] 3.1 Reorder the agent decision schema so `confidenceBasis` and `rationale` precede `action`, target ids, and drafts; re-record replays and compare focused evals.
+- [ ] 3.1 Reorder the agent decision schema so `confidenceBasis` and `rationale` precede `action`, target ids, and drafts; re-record replays and compare focused evals. (2026-08-10: implemented the strict schema order and added a schema-boundary test. The local 97-case hosted eval skipped without `AI_GATEWAY_API_KEY`, so the replay and comparison gate remains.)
 - [x] 3.2 Give unresolved risks typed categories and notes. Do not parse freeform risk text in automation policy. (2026-07-06: `unresolvedRisks` moved to `{ category, note }`; the later value audit found no reader for source-locator positive evidence, so task 3.7 removes that field.)
 - [x] 3.3 Remove no-consumer observation subfields (`market`, `exclusive`, `outturn`) or land their first consumer, per the value audit. (2026-08-10: removed the fields from current schemas, prompts, normalization, deterministic producers, and tests; the persisted version 2 read boundary drops the obsolete fields.)
 - [x] 3.4 Remove the unread `identityBasis` object instead of adding a reader for the obsolete Bottle/release split. (2026-08-10: removed from the prompt, agent and reviewed schemas, deterministic producers, server evidence logs, tests, and active architecture documentation; the persisted version 2 read boundary drops the obsolete field.)

--- a/packages/bottle-classifier/src/classifierTypes.test.ts
+++ b/packages/bottle-classifier/src/classifierTypes.test.ts
@@ -42,6 +42,25 @@ describe("BottleClassifierAgentDecisionSchema", () => {
     );
   });
 
+  test("asks for evidence and rationale before the decision", () => {
+    const jsonSchema = z.toJSONSchema(BottleClassifierAgentDecisionSchema) as {
+      properties?: Record<string, unknown>;
+    };
+    const fields = Object.keys(jsonSchema.properties ?? {});
+
+    expect(fields.slice(0, 3)).toEqual([
+      "confidenceBasis",
+      "rationale",
+      "action",
+    ]);
+    expect(fields.indexOf("action")).toBeLessThan(
+      fields.indexOf("matchedBottleId"),
+    );
+    expect(fields.indexOf("action")).toBeLessThan(
+      fields.indexOf("proposedBottle"),
+    );
+  });
+
   test("exposes only the three identity results", () => {
     const actionSchema = BottleClassifierAgentDecisionSchema.shape.action;
 

--- a/packages/bottle-classifier/src/classifierTypes.ts
+++ b/packages/bottle-classifier/src/classifierTypes.ts
@@ -463,8 +463,12 @@ const AgentProposedBottleSchema = ProposedBottleSchema.extend({
   abv: z.number().nullable().default(null),
 });
 
+// Zod preserves this property order in the JSON schema sent to the model.
+// Evidence and rationale must precede the action and its target or draft.
 export const BottleClassifierAgentDecisionSchema = z
   .object({
+    confidenceBasis: BottleConfidenceBasisSchema.nullable().default(null),
+    rationale: z.string().nullable().default(null),
     action: z
       .enum(["match", "create_bottle", "no_match"])
       .describe(
@@ -475,15 +479,13 @@ export const BottleClassifierAgentDecisionSchema = z
           "no_match: no safe existing target and no supported create action, including when an existing Bottle needs a separate Bottle Review before assignment is safe.",
         ].join(" "),
       ),
-    rationale: z.string().nullable().default(null),
+    identityScope: BottleIdentityScopeEnum.nullable().default(null),
+    aliasScope: AliasScopeEnum.nullable().default(null),
+    observation: BottleObservationSchema.nullable().default(null),
     candidateBottleIds: z
       .array(z.number().int())
       .max(MAX_BOTTLE_CANDIDATES)
       .default([]),
-    identityScope: BottleIdentityScopeEnum.nullable().default(null),
-    aliasScope: AliasScopeEnum.nullable().default(null),
-    observation: BottleObservationSchema.nullable().default(null),
-    confidenceBasis: BottleConfidenceBasisSchema.nullable().default(null),
     matchedBottleId: z.number().int().nullable().default(null),
     proposedBottle: AgentProposedBottleSchema.nullable()
       .default(null)


### PR DESCRIPTION
The classifier agent schema now places `confidenceBasis` and `rationale` before `action`, matched targets, and create drafts. Zod preserves property order in the generated JSON schema, so the model must produce its structured risk and web-evidence assessment before committing to an identity result. The decision fields and downstream contract are unchanged.

A schema-boundary test locks this order. Deterministic classifier tests, package typechecking, fixture validation, lint, formatting, and strict OpenSpec validation pass. The local 97-case hosted eval skipped because `AI_GATEWAY_API_KEY` is unavailable, so the OpenSpec task remains open and credentialed CI is the model-quality comparison gate.

Refs #566
