### PR TITLE
fix(photo-identification): resolve exact aliases without model

### DIFF
--- a/apps/server/src/agents/bottleClassifier/findExactAliasBottleCandidate.ts
+++ b/apps/server/src/agents/bottleClassifier/findExactAliasBottleCandidate.ts
@@ -4,8 +4,8 @@ import { findBottleId } from "@peated/server/lib/bottleFinder";
 import { getBottleCandidateById } from "@peated/server/lib/bottleReferenceCandidates";
 
 /**
- * Returns one literal stored-alias candidate. The full classifier still owns
- * the identity decision and receives this result only as deterministic evidence.
+ * Returns one literal stored-alias candidate. A caller can accept its assigned
+ * Bottle as a deterministic Match without a classifier model call.
  */
 export async function findExactAliasBottleCandidate(
   referenceName: string,

--- a/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
@@ -514,7 +514,7 @@ describe("POST /tastings/photo-identification", () => {
     expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
   });
 
-  test("passes exact Peated alias candidates through full photo classification", async ({
+  test("resolves an exact Peated alias without classifier model work", async ({
     fixtures,
     defaults,
   }) => {
@@ -543,25 +543,6 @@ describe("POST /tastings/photo-identification", () => {
         imageEvidence: buildImageEvidence(pendingUpload.id),
       }),
     );
-    classifyBottleReferenceMock.mockResolvedValue(
-      buildClassification(
-        {
-          action: "match",
-          matchedBottleId: bottle.id,
-        },
-        {
-          candidates: [
-            {
-              bottleId: bottle.id,
-              fullName: "Ardbeg Uigeadail",
-              brand: "Ardbeg",
-              source: ["exact"],
-            },
-          ],
-        },
-      ),
-    );
-
     const response = await routerClient.tastings.photoIdentification(
       {
         file: await fixtures.SampleSquareImage(),
@@ -580,18 +561,21 @@ describe("POST /tastings/photo-identification", () => {
         matchedBottle: { id: bottle.id },
       },
     });
-    expect(classifyBottleReferenceMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        initialCandidates: [
-          expect.objectContaining({
-            bottleId: bottle.id,
-            fullName: bottle.fullName,
-            source: expect.arrayContaining(["exact"]),
-          }),
-        ],
-      }),
+    expect(response.classification).toMatchObject({
+      artifacts: {
+        candidates: [{ fullName: bottle.fullName }],
+      },
+    });
+    expect(classifyBottleReferenceMock).not.toHaveBeenCalled();
+    expect(runBottleReferenceMock).not.toHaveBeenCalled();
+    expect(sentrySpanSetAttributeMock).toHaveBeenCalledWith(
+      "photo_identification.final.matched_bottle_id",
+      bottle.id,
     );
-    expect(runBottleReferenceMock).toHaveBeenCalledTimes(1);
+    expect(sentrySpanSetAttributeMock).not.toHaveBeenCalledWith(
+      "photo_identification.final.tool_calls",
+      expect.anything(),
+    );
   });
 
   test("does not run catalog review for a photo match", async ({

--- a/apps/server/src/orpc/routes/tastings/photo-identification.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.ts
@@ -1,6 +1,7 @@
 // This route owns the photo lookup boundary for add-tasting. It may create or
 // reuse a pending upload, but it must not create tastings, bottles, or durable
 // classifier trace rows.
+import { createDecidedBottleClassification } from "@peated/bottle-classifier/contract";
 import {
   agentActionRiskClass,
   deriveAutomationTier,
@@ -560,8 +561,9 @@ function logPhotoIdentificationFailure({
 }
 
 /**
- * Runs label extraction and local candidate discovery for a pending scan, then
- * gives the full classifier the chance to identify the Bottle.
+ * Runs label extraction and local candidate discovery for a pending scan. A
+ * literal accepted alias resolves directly; all other references run the full
+ * classifier once.
  *
  * This is the shared Photo Identification workflow span boundary for all callers.
  */
@@ -609,15 +611,32 @@ export async function identifyPendingImage({
       const exactAliasCandidate = await findExactAliasBottleCandidate(
         classificationInput.reference.name,
       );
-      const classificationInputWithCandidates = {
-        ...classificationInput,
-        ...(exactAliasCandidate
-          ? { initialCandidates: [exactAliasCandidate] }
-          : {}),
-      };
-      const classificationRun = await runBottleReference(
-        classificationInputWithCandidates,
-      );
+      const classificationRun = exactAliasCandidate
+        ? {
+            result: createDecidedBottleClassification({
+              decision: {
+                action: "match",
+                rationale:
+                  "A literal stored Bottle alias identifies this Bottle.",
+                candidateBottleIds: [exactAliasCandidate.bottleId],
+                identityScope: "product",
+                observation: null,
+                confidenceBasis: {
+                  unresolvedRisks: [],
+                  webEvidence: "not_needed",
+                },
+                matchedBottleId: exactAliasCandidate.bottleId,
+                proposedBottle: null,
+              },
+              artifacts: {
+                extractedIdentity,
+                imageEvidence,
+                candidates: [exactAliasCandidate],
+              },
+            }),
+            modelMetadata: null,
+          }
+        : await runBottleReference(classificationInput);
       const classification = classificationRun.result;
       const referenceName = classificationInput.reference.name;
       const diagnostics = buildPhotoIdentificationDiagnostics({

--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -293,14 +293,12 @@ Ignored references do not run the agent.
 Downstream code may gate persistence and automation. It should not promote a
 semantic identity decision the classifier did not make.
 
-### Exact Alias Candidate Preflight
+### Exact Alias Preflight
 
 A caller can look up one unambiguous literal stored alias before full
-classification. The lookup returns a Bottle candidate as deterministic evidence.
-It does not return an identity decision and does not call a model. The caller
-passes the candidate to `classifyBottleReference(...)`, which remains the only
-model-based identification pass. When no exact alias exists, the full classifier
-retrieves local candidates through its normal adapter.
+classification. An accepted alias identifies its assigned Bottle without a
+classifier model call. When no exact alias exists, the full classifier retrieves
+local candidates through its normal adapter.
 
 ## Determinism
 
@@ -509,8 +507,8 @@ because catalog investigation is the intent. This keeps identity quality and
 Suggested Change precision as separate measurements.
 
 Full-classification evals own match quality and candidate recall. Server
-integration tests prove that an exact alias becomes an initial candidate and
-that photo identification invokes only one classifier run.
+integration tests prove that an exact alias skips classification and that other
+photo identification paths invoke only one classifier run.
 
 Production-miss evals must preserve the observed reference, URL, extracted
 identity, current assignment, local candidates, and failed outcome. Verify the
@@ -537,5 +535,6 @@ Keep responsibilities narrow:
 
 `classifyBottleReference` means the full reviewed pipeline.
 `findExactAliasBottleCandidate` means a deterministic evidence lookup. It does
-not make an identity decision.
+not call a model. The caller can accept the assigned Bottle as a deterministic
+Match.
 `runBottleClassifierAgent` means only the raw LLM/tool pass.

--- a/docs/features/photo-tasting-entry.md
+++ b/docs/features/photo-tasting-entry.md
@@ -16,9 +16,9 @@ action.
 1. The user takes or uploads one Bottle photo, or chooses manual search.
 2. The browser shows a local preview immediately and sends the photo to
    `POST /tastings/photo-identification` with an idempotency key.
-3. The server processes the image, creates an owned pending upload, extracts
-   label evidence, checks for one literal stored alias, and runs the Bottle
-   classifier once.
+3. The server processes the image, creates an owned pending upload, and extracts
+   label evidence. One literal stored alias resolves directly. All other
+   references run the Bottle classifier once.
 4. The resolver presents one of three outcomes:
    - an existing Bottle match;
    - an approved proposal for one new, independently complete Bottle; or
@@ -62,8 +62,7 @@ Bottle classifier may propose a match or creation, while server code owns:
 - automation and review thresholds.
 
 Existing-Bottle matches may use strong local evidence without web research.
-An exact alias seeds the full classifier with one candidate. It does not produce
-a separate identity decision or model call.
+An exact alias produces a deterministic Match without a classifier model call.
 Creation requires the classifier's complete `create_bottle` proposal and the
 approved automation tier. Otherwise the flow falls back to search or manual
 creation.

--- a/openspec/changes/define-bottle-classifier-agent-contract/tasks.md
+++ b/openspec/changes/define-bottle-classifier-agent-contract/tasks.md
@@ -55,5 +55,5 @@
 ## 7. Validation
 
 - [x] 7.1 Run `pnpm --filter @peated/bottle-classifier fixtures:validate`. (2026-08-10: all 17 fixture validation checks pass.)
-- [ ] 7.2 Run focused classifier evals for the touched behavior with `pnpm --filter @peated/bottle-classifier evals -- src/classifier.eval.test.ts`. (2026-08-11: invoked after the fixture-contract review; all 97 hosted cases skipped because `AI_GATEWAY_API_KEY` is unavailable.)
-- [ ] 7.3 Summarize any eval regressions by separating prompt failures, fixture expectation errors, and review-policy or deterministic-gate issues.
+- [x] 7.2 Run focused classifier evals for the touched behavior with `pnpm --filter @peated/bottle-classifier evals -- src/classifier.eval.test.ts`. (2026-08-11: the credentialed 97-case run completed with 67 passes and 30 failures. Among 71 cases with an explicit expected action, it produced 9 false `no_match` results and 1 false-positive accepted result. The gate remains below the required quality threshold.)
+- [x] 7.3 Summarize any eval regressions by separating prompt failures, fixture expectation errors, and review-policy or deterministic-gate issues. (2026-08-11: 26 reference failures were model-semantic expectation misses, led by incomplete create fields, unsupported abstentions, wrong match targets, and alias-scope errors. Four audit failures returned incomplete Suggested Change field sets. No fixture expectation was proven wrong or changed. The exact-alias route change is outside the classifier eval runtime and its deterministic integration test passes.)


### PR DESCRIPTION
Photo identification now treats an unambiguous literal stored Bottle alias as a deterministic Match and skips the classifier model. References without an exact alias still run the full Bottle classifier once. The integration coverage asserts that neither classifier model entry point runs for the alias path, while the architecture and workflow documentation now describe the same boundary.

The focused photo-identification suite passes all 22 tests, along with the server typecheck, fixture validation, terminology check, formatting, and strict OpenSpec validation. The hosted classifier suite completed at 67/97; its 30 failures are model-semantic and audit-output misses outside this deterministic route path, so the broader identity-quality gate remains open.

Refs #566
