### PR TITLE
test(classifier): correct audited fixture expectations

### DIFF
--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/current-assignment-a-reaffirmed-bottle-match-uses-current-assignment-confidence-basis.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/current-assignment-a-reaffirmed-bottle-match-uses-current-assignment-confidence-basis.json
@@ -55,11 +55,19 @@
       ]
     }
   ],
+  "provenance": {
+    "source": "curated_regression",
+    "verifiedSourceUrls": [
+      "https://www.jamesonwhiskey.com/en/our-whiskey/jameson-cold-brew/",
+      "https://api.peated.com/v1/bottles/13437"
+    ],
+    "notes": "Jameson markets the product as Jameson Cold Brew. The reference's trailing Irish Whiskey wording describes its category rather than a reusable marketed alias, while Peated Bottle 13437 is the correct existing product assignment."
+  },
   "expected": {
     "status": "classified",
     "action": "match",
     "identityScope": "product",
-    "aliasScope": "global_alias",
+    "aliasScope": "none",
     "matchedBottleId": 13437,
     "expectedTier": "auto",
     "summary": "When the classifier reaffirms the already assigned bottle cleanly, mark confidence as current-assignment evidence instead of treating it like a new unmatched assignment."

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-high-west-high-country-batch-23j12.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/image-backed-photo-matches-high-west-high-country-batch-23j12.json
@@ -74,7 +74,10 @@
     "source": "production_miss",
     "verifiedSourceUrls": [
       "https://highwest.com/",
+      "https://highwest.com/pages/product-information",
       "https://ship.highwest.com/products/high-country-american-single-malt",
+      "https://api.peated.com/v1/bottles/12825",
+      "https://api.peated.com/v1/bottles/44284",
       "https://www.breakingbourbon.com/review/high-west-high-country-american-single-malt-2022-release",
       "https://whiskyadvocate.com/High-West-High-Country-American-Single-Malt-Batch-19I04-44",
       "https://raw.githubusercontent.com/dcramer/peated/main/packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/high-west-high-country-batch-23j12.jpg"
@@ -98,7 +101,7 @@
         "notes": "The plain production Bottle lacks ABV; the observed 44% is the ongoing product's label strength seen on this lot-coded bottle, corroborated at 44% on independent batch reviews, but is left to enrichment rather than auto-fill."
       }
     ],
-    "notes": "Added from a failed image addBottle flow using the checked-in photo as the observed source. The label reads High West High Country American Single Malt Whiskey, 44% ABV, batch no. 23J12. Production Bottle 44284 is a legacy standalone row flattened around the lot code; production Bottle 12825 is the plain ongoing product. High West sells High Country as one default product and SKU with no per-batch variants, unlike A Midwinter Night's Dram Act/Scene releases. Batch No. 23J12 therefore remains source lot evidence and the plain Bottle is the correct match target."
+    "notes": "Added from a failed image addBottle flow using the checked-in photo as the observed source. The label reads High West High Country American Single Malt Whiskey, 44% ABV, batch no. 23J12. High West's product information lists High Country as one 44% product without marketed batch variants. The current Peated API resolves legacy Bottle 44284 to plain ongoing Bottle 12825. Batch No. 23J12 therefore remains source lot evidence and the plain Bottle is the correct match target."
   },
   "expected": {
     "status": "classified",

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/store-listing-jameson-cold-brew-reaches-bottle-verification-confidence-from-a-clear-title-match.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/store-listing-jameson-cold-brew-reaches-bottle-verification-confidence-from-a-clear-title-match.json
@@ -54,6 +54,14 @@
       ]
     }
   ],
+  "provenance": {
+    "source": "curated_regression",
+    "verifiedSourceUrls": [
+      "https://www.jamesonwhiskey.com/en/our-whiskey/jameson-cold-brew/",
+      "https://api.peated.com/v1/bottles/13437"
+    ],
+    "notes": "The producer markets Jameson Cold Brew under that concise product name, and Peated Bottle 13437 represents the same product. The store title's trailing Irish Whiskey wording is generic category context."
+  },
   "expected": {
     "status": "classified",
     "action": "match",

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/store-listing-legacy-spirit-category-does-not-block-shibui-grain-select.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/match_existing/store-listing-legacy-spirit-category-does-not-block-shibui-grain-select.json
@@ -62,6 +62,14 @@
       }
     ]
   },
+  "provenance": {
+    "source": "curated_regression",
+    "verifiedSourceUrls": [
+      "https://www.shibuiwhisky.com/grain-select",
+      "https://api.peated.com/v1/bottles/13025"
+    ],
+    "notes": "Shibui describes Grain Select as a grain-led world whisky made from wheat and malt. Peated Bottle 13025 has the exact marketed identity; its legacy generic spirit category is catalog debt rather than evidence of a different product."
+  },
   "expected": {
     "status": "classified",
     "action": "match",

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-mastersons-french-oak-finish-instead-of-matching-plain-rye-or-barrel-specific-bottle.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-mastersons-french-oak-finish-instead-of-matching-plain-rye-or-barrel-specific-bottle.json
@@ -148,6 +148,7 @@
   "provenance": {
     "source": "production_miss",
     "verifiedSourceUrls": [
+      "https://www.3badge.com/wp-content/uploads/2017/04/3BBC_Mastersons-Barrel-Finish-Press-Release.pdf",
       "https://whiskyadvocate.com/Masterson-s-10-year-old-Straight-Rye-French-Oak-Finish-Barrel-F2-038-45",
       "https://www.caskers.com/masterson-s-10-year-old-straight-rye-whiskey/",
       "https://bottlebuzz.com/products/mastersons-straight-rye-whiskey-french-oak-barrel-finished-10-yr?srsltid=AfmBOoqLcNQLm0OzwfezGxzwWX4HYIDymdGjfif0gG9gB6j1_oFyHkYo",
@@ -158,7 +159,7 @@
       "createsBottle": true,
       "summary": "Create a complete Masterson's 10-year-old Straight Rye French Oak Finish Bottle for the store price. Do not redirect to the plain Masterson's 10-year-old Rye Bottle 44029 or its batch-coded legacy candidates; do not match the narrower Barrel F2-038 Bottle 16442."
     },
-    "notes": "Caskers search results list Masterson's 10 Year Old Straight Rye Whiskey and Masterson's 10 Year Old Rye Whiskey Barrel Finished in French Oak as separate product pages, so the French Oak wording is not merely an optional title suffix for the plain rye candidate. The existing Barrel F2-038 bottle is narrower than the observed store listing, so the correct current DB outcome is a clean French Oak bottle creation."
+    "notes": "The producer announcement identifies French Oak Finish as one of Masterson's marketed barrel-finished expressions. Caskers search results separately list the plain rye and French Oak products, so the finish is not merely an optional title suffix. The existing Barrel F2-038 bottle is narrower than the observed store listing, so the correct current DB outcome is a clean French Oak bottle creation."
   },
   "expected": {
     "status": "classified",

--- a/packages/bottle-classifier/src/eval-fixtures/new-bottles/heavens-door-bootleg-vol-3.json
+++ b/packages/bottle-classifier/src/eval-fixtures/new-bottles/heavens-door-bootleg-vol-3.json
@@ -10,11 +10,21 @@
   ],
   "summary": "Treat Heaven's Door Bootleg Vol 3 as one complete Bottle with Volume III as its exact edition; reviewed web evidence may enrich it with the marketed 13-year-old age and Vino de Naranja finish, but the source does not require those optional fields.",
   "peatedBottleIds": [44067],
+  "provenance": {
+    "source": "curated_regression",
+    "verifiedSourceUrls": [
+      "https://www.heavensdoor.com/bootleg-series",
+      "https://www.masterofmalt.com/whiskies/heavens-door/heavens-door-bootleg-series-no3-2021-edition-whiskey/",
+      "https://api.peated.com/v1/bottles/44067"
+    ],
+    "notes": "The producer's Bootleg archive identifies Volume III as the 2021 release. Independent product detail corroborates its 13-year age and Vino de Naranja finish; those enrichments are optional for this sparse reference, while Volume III and release year 2021 are exact release identity."
+  },
   "expected": {
     "handlingStrategy": "classifier_required",
     "classifierExpectation": "bottle",
     "exactBottleIdentity": {
-      "edition": "Volume III"
+      "edition": "Volume III",
+      "releaseYear": 2021
     }
   }
 }

--- a/packages/bottle-classifier/src/eval-fixtures/new-bottles/highland-park-cask-strength-no-5.json
+++ b/packages/bottle-classifier/src/eval-fixtures/new-bottles/highland-park-cask-strength-no-5.json
@@ -4,6 +4,15 @@
   "expectedBottleName": "Highland Park Cask Strength",
   "summary": "Treat Highland Park Cask Strength No. 5 as one complete 2024 Bottle, preserving No. 5 as its exact edition and in the marketed Bottle identity.",
   "peatedBottleIds": [44080],
+  "provenance": {
+    "source": "curated_regression",
+    "verifiedSourceUrls": [
+      "https://www.highlandparkwhisky.com/en/cask-strength-release-no-5",
+      "https://distiller.com/spirits/highland-park-cask-strength-release-no-5",
+      "https://api.peated.com/v1/bottles/44080"
+    ],
+    "notes": "Highland Park markets Cask Strength Release No. 5 as the exact expression at 64.7% ABV. Contemporary release coverage dates its launch to 2024; the broad Peated row lacks the release-specific identity."
+  },
   "expected": {
     "handlingStrategy": "classifier_required",
     "classifierExpectation": "bottle",

--- a/packages/bottle-classifier/src/eval-fixtures/new-bottles/lagavulin-distillers-edition.json
+++ b/packages/bottle-classifier/src/eval-fixtures/new-bottles/lagavulin-distillers-edition.json
@@ -4,6 +4,14 @@
   "expectedBottleName": "Lagavulin Distillers Edition",
   "summary": "Keep Lagavulin Distillers Edition as bottle identity when no release year is present instead of inventing a child annual release from the family wording alone.",
   "peatedBottleIds": [44006],
+  "provenance": {
+    "source": "curated_regression",
+    "verifiedSourceUrls": [
+      "https://www.malts.com/en-us/products/lagavulin-distillers-edition-single-malt-scotch-whisky-750ml",
+      "https://api.peated.com/v1/bottles/44006"
+    ],
+    "notes": "Lagavulin markets Distillers Edition as a complete product. The reference contains no vintage or release year that would establish a separate annual release, and Peated Bottle 44006 is the broad existing product."
+  },
   "expected": {
     "handlingStrategy": "classifier_required",
     "classifierExpectation": "bottle",

--- a/packages/bottle-classifier/src/eval-fixtures/new-bottles/woodford-reserve-double-oaked.json
+++ b/packages/bottle-classifier/src/eval-fixtures/new-bottles/woodford-reserve-double-oaked.json
@@ -4,6 +4,16 @@
   "expectedBottleName": "Woodford Reserve Double Oaked",
   "summary": "Treat Woodford Reserve Double Oaked as a distinct bottle identity and avoid mutating it into the separate Double Double Oaked sibling.",
   "peatedBottleIds": [11855],
+  "provenance": {
+    "source": "curated_regression",
+    "verifiedSourceUrls": [
+      "https://www.woodfordreserve.com/en-uk/our-whiskey/",
+      "https://www.woodfordreserve.com/whiskey/double-double-oaked/",
+      "https://www.prnewswire.com/news-releases/woodford-reserve-introduces-first-permanent-line-extension-in-15-year-history-137570558.html",
+      "https://api.peated.com/v1/bottles/11855"
+    ],
+    "notes": "Woodford Reserve lists Double Oaked as an ongoing expression, and its launch announcement identifies it as a permanent line extension. The producer separately markets Double Double Oaked, so the two names are distinct Bottle identities."
+  },
   "expected": {
     "handlingStrategy": "classifier_required",
     "classifierExpectation": "bottle",


### PR DESCRIPTION
Corrects the remaining classifier eval fixture bookkeeping from #566: Jameson Cold Brew now treats its generic category suffix as source noise rather than a reusable alias, Heaven’s Door Volume III asserts its verified 2021 release year, and the audited Lagavulin, Highland Park, Woodford Reserve, Jameson, Shibui, Masterson’s, and High Country cases carry stronger producer and catalog provenance.

This changes fixture truth only. The classifier prompt and runtime behavior are unchanged, leaving the remaining failures as evidence for conservative compatibility, complete create output, and exact audit-operation work.

Refs #566
