### PR TITLE
feat(cli): add OAuth API client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,9 @@ AI_GATEWAY_API_KEY=
 # Required for classifier web evidence. Without it, no web-search tool is exposed.
 # FIRECRAWL_API_KEY=
 # FIRECRAWL_API_URL=https://api.firecrawl.dev
+
+# Optional override for the public OAuth client used by `pnpm cli auth login`.
+# PEATED_OAUTH_CLIENT_ID=
 # OPENAI_IMAGE_EXTRACTION_MODEL=gpt-5.6-luna
 # OPENAI_IMAGE_EXTRACTION_REASONING_EFFORT=high
 # Optional for GPT-5: none, low, medium, high, or xhigh.

--- a/README.md
+++ b/README.md
@@ -92,3 +92,30 @@ checks, use `pnpm dev:server:api`.
 The web app runs on Vercel and the API and worker run on Render. Use the
 [Production Debugging](./docs/development/production-debugging.md) playbook for
 current hosts, logs, traces, and diagnostic commands.
+
+### Authenticated API maintenance
+
+The CLI can authorize against production without storing a password. The
+checked-in public OAuth client uses the registered redirect URI
+`http://127.0.0.1/oauth/callback`. `PEATED_OAUTH_CLIENT_ID` or the login
+command's `--client-id` option can override that client for another deployment.
+
+Log in and inspect the current credential with:
+
+```bash
+pnpm cli auth login
+pnpm cli auth status
+```
+
+The CLI chooses an available callback port and stores the seven-day bearer token
+in `$XDG_CONFIG_HOME/peated/credentials.json`, or `~/.config/peated` when
+`XDG_CONFIG_HOME` is unset. It never prints the token.
+
+Authenticated API reads produce JSON. Mutations require an interactive
+confirmation or an explicit `--yes`, and JSON bodies are read from files:
+
+```bash
+pnpm cli api get /bottles/123
+pnpm cli api patch /bottles/123 --input ./change.json --yes
+pnpm cli auth logout
+```

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -14,6 +14,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@orpc/client": "catalog:",
+    "@orpc/server": "catalog:",
     "@peated/bottle-classifier": "workspace:*",
     "@peated/server": "workspace:*",
     "@peated/tsconfig": "workspace:*",
@@ -24,7 +26,8 @@
     "drizzle-orm": "catalog:",
     "pg": "catalog:",
     "tsx": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/apps/cli/src/api/client.test.ts
+++ b/apps/cli/src/api/client.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test, vi } from "vitest";
+import type { PeatedApiError } from "./client";
+import { requestPeatedApi } from "./client";
+
+describe("requestPeatedApi", () => {
+  test("sends authenticated JSON to a v1 API path", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+      Response.json({ id: 123, name: "Example" }),
+    );
+
+    await expect(
+      requestPeatedApi({
+        accessToken: "secret-token",
+        apiServer: "https://api.peated.com",
+        method: "patch",
+        path: "/bottles/123",
+        body: { name: "Example" },
+        fetch,
+      }),
+    ).resolves.toEqual({ id: 123, name: "Example" });
+
+    const [url, init] = fetch.mock.calls[0];
+    expect(url).toBeInstanceOf(URL);
+    expect((url as URL).href).toBe("https://api.peated.com/v1/bottles/123");
+    expect(init).toMatchObject({
+      method: "PATCH",
+      body: JSON.stringify({ name: "Example" }),
+      headers: {
+        authorization: "Bearer secret-token",
+        "content-type": "application/json",
+      },
+    });
+  });
+
+  test("keeps API error responses available without putting them in the message", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () =>
+      Response.json({ error: "invalid update" }, { status: 400 }),
+    );
+
+    const request = requestPeatedApi({
+      accessToken: "secret-token",
+      apiServer: "https://api.peated.com",
+      method: "PATCH",
+      path: "/bottles/123",
+      fetch,
+    });
+
+    await expect(request).rejects.toMatchObject({
+      status: 400,
+      body: { error: "invalid update" },
+      message: "Peated API PATCH /bottles/123 failed with HTTP 400.",
+    } satisfies Partial<PeatedApiError>);
+  });
+
+  test("rejects paths that could send credentials to another origin", async () => {
+    for (const path of ["//evil.example/bottles", "/../oauth/token"]) {
+      await expect(
+        requestPeatedApi({
+          accessToken: "secret-token",
+          apiServer: "https://api.peated.com",
+          method: "GET",
+          path,
+        }),
+      ).rejects.toThrow("Invalid Peated API path");
+    }
+  });
+});

--- a/apps/cli/src/api/client.ts
+++ b/apps/cli/src/api/client.ts
@@ -1,0 +1,102 @@
+import { createORPCClient } from "@orpc/client";
+import { RPCLink } from "@orpc/client/fetch";
+import type { RouterClient } from "@orpc/server";
+import type { Router } from "@peated/server/orpc/router";
+import { normalizeServerUrl } from "./config";
+
+export type PeatedClient = RouterClient<Router>;
+
+export function createPeatedClient({
+  accessToken,
+  apiServer,
+}: {
+  accessToken: string;
+  apiServer: string;
+}): PeatedClient {
+  const server = normalizeServerUrl(apiServer);
+  const link = new RPCLink({
+    url: `${server}/rpc`,
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      "user-agent": "@peated/cli (orpc/client)",
+    },
+  });
+
+  return createORPCClient(link);
+}
+
+export class PeatedApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly body: unknown,
+  ) {
+    super(message);
+    this.name = "PeatedApiError";
+  }
+}
+
+function apiUrl(apiServer: string, path: string): URL {
+  if (!path.startsWith("/") || path.startsWith("//")) {
+    throw new Error(
+      `Invalid Peated API path: ${path}. Use a path such as /bottles/123.`,
+    );
+  }
+  const url = new URL(`/v1${path}`, `${normalizeServerUrl(apiServer)}/`);
+  if (!url.pathname.startsWith("/v1/")) {
+    throw new Error(
+      `Invalid Peated API path: ${path}. The path must stay under /v1.`,
+    );
+  }
+  return url;
+}
+
+async function responseBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    return JSON.parse(text) as unknown;
+  }
+  return text;
+}
+
+export async function requestPeatedApi({
+  accessToken,
+  apiServer,
+  method,
+  path,
+  body,
+  fetch: fetchImplementation = fetch,
+}: {
+  accessToken: string;
+  apiServer: string;
+  method: string;
+  path: string;
+  body?: unknown;
+  fetch?: typeof fetch;
+}): Promise<unknown> {
+  const normalizedMethod = method.toUpperCase();
+  const response = await fetchImplementation(apiUrl(apiServer, path), {
+    method: normalizedMethod,
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${accessToken}`,
+      ...(body === undefined ? {} : { "content-type": "application/json" }),
+      "user-agent": "@peated/cli (openapi/client)",
+    },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const parsedBody = await responseBody(response);
+
+  if (!response.ok) {
+    throw new PeatedApiError(
+      `Peated API ${normalizedMethod} ${path} failed with HTTP ${response.status}.`,
+      response.status,
+      parsedBody,
+    );
+  }
+
+  return parsedBody;
+}

--- a/apps/cli/src/api/config.test.ts
+++ b/apps/cli/src/api/config.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "vitest";
+import {
+  DEFAULT_OAUTH_CLIENT_ID,
+  normalizeServerUrl,
+  resolveOAuthClientId,
+} from "./config";
+
+describe("resolveOAuthClientId", () => {
+  test("uses the flag, environment override, then checked-in public client", () => {
+    expect(
+      resolveOAuthClientId("flag-client", {
+        PEATED_OAUTH_CLIENT_ID: "env-client",
+      }),
+    ).toBe("flag-client");
+    expect(
+      resolveOAuthClientId(undefined, {
+        PEATED_OAUTH_CLIENT_ID: "env-client",
+      }),
+    ).toBe("env-client");
+    expect(resolveOAuthClientId(undefined, {})).toBe(DEFAULT_OAUTH_CLIENT_ID);
+  });
+});
+
+describe("normalizeServerUrl", () => {
+  test.each([
+    ["https://api.peated.com/", "https://api.peated.com"],
+    ["http://localhost:3200/", "http://localhost:3200"],
+    ["http://127.0.0.1:3200", "http://127.0.0.1:3200"],
+  ])("normalizes an allowed server URL", (input, expected) => {
+    expect(normalizeServerUrl(input)).toBe(expected);
+  });
+
+  test.each([
+    "http://api.peated.com",
+    "https://user@example.com",
+    "https://api.peated.com/base",
+    "https://api.peated.com?token=secret",
+  ])("rejects an unsafe server URL", (input) => {
+    expect(() => normalizeServerUrl(input)).toThrow();
+  });
+});

--- a/apps/cli/src/api/config.ts
+++ b/apps/cli/src/api/config.ts
@@ -1,0 +1,40 @@
+export const DEFAULT_API_SERVER = "https://api.peated.com";
+export const DEFAULT_WEB_SERVER = "https://peated.com";
+export const DEFAULT_OAUTH_CLIENT_ID = "CTQLxbH7tzvZnIMYvniLthOk";
+export const OAUTH_CALLBACK_PATH = "/oauth/callback";
+export const OAUTH_REGISTERED_REDIRECT_URI = `http://127.0.0.1${OAUTH_CALLBACK_PATH}`;
+
+export function resolveOAuthClientId(
+  option: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return option ?? env.PEATED_OAUTH_CLIENT_ID ?? DEFAULT_OAUTH_CLIENT_ID;
+}
+
+export function normalizeServerUrl(value: string): string {
+  const url = new URL(value);
+  const isLoopback =
+    url.hostname === "localhost" ||
+    url.hostname === "127.0.0.1" ||
+    url.hostname === "[::1]";
+
+  if (url.protocol !== "https:" && !(url.protocol === "http:" && isLoopback)) {
+    throw new Error(
+      `Refusing insecure Peated server URL: ${value}. Use HTTPS or an HTTP loopback URL.`,
+    );
+  }
+
+  if (
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error(
+      `Invalid Peated server URL: ${value}. Use an origin without credentials, a path, a query, or a fragment.`,
+    );
+  }
+
+  return url.toString().replace(/\/$/, "");
+}

--- a/apps/cli/src/api/credentials.test.ts
+++ b/apps/cli/src/api/credentials.test.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  credentialsExpired,
+  deleteCredentials,
+  loadCredentials,
+  saveCredentials,
+  type Credentials,
+} from "./credentials";
+
+const credentials: Credentials = {
+  accessToken: "secret-token",
+  apiServer: "https://api.peated.com",
+  clientId: "peated-cli",
+  expiresAt: "2030-01-01T00:00:00.000Z",
+};
+
+const temporaryDirectories: string[] = [];
+
+async function temporaryCredentialsPath(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "peated-cli-test-"));
+  temporaryDirectories.push(directory);
+  return join(directory, "config", "credentials.json");
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
+  );
+});
+
+describe("Peated CLI credentials", () => {
+  test("stores, loads, and deletes a private credential file", async () => {
+    const path = await temporaryCredentialsPath();
+
+    await saveCredentials(credentials, path);
+
+    expect(await loadCredentials(path)).toEqual(credentials);
+    expect((await stat(path)).mode & 0o777).toBe(0o600);
+    expect(await deleteCredentials(path)).toBe(true);
+    expect(await deleteCredentials(path)).toBe(false);
+    expect(await loadCredentials(path)).toBeNull();
+  });
+
+  test("rejects malformed durable credentials", async () => {
+    const path = await temporaryCredentialsPath();
+    await saveCredentials(credentials, path);
+    await writeFile(path, JSON.stringify({ ...credentials, extra: true }));
+
+    await expect(loadCredentials(path)).rejects.toThrow(
+      `Invalid Peated credentials file: ${path}`,
+    );
+  });
+
+  test("checks the stored expiration boundary", () => {
+    const expiration = Date.parse(credentials.expiresAt);
+    expect(credentialsExpired(credentials, expiration - 1)).toBe(false);
+    expect(credentialsExpired(credentials, expiration)).toBe(true);
+  });
+});

--- a/apps/cli/src/api/credentials.ts
+++ b/apps/cli/src/api/credentials.ts
@@ -1,0 +1,80 @@
+import { mkdir, readFile, rename, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { z } from "zod";
+
+const CredentialsSchema = z
+  .object({
+    accessToken: z.string().min(1),
+    apiServer: z.string().url(),
+    clientId: z.string().min(1),
+    expiresAt: z.string().datetime(),
+  })
+  .strict();
+
+export type Credentials = z.infer<typeof CredentialsSchema>;
+
+export function credentialsPath(env: NodeJS.ProcessEnv = process.env): string {
+  const configHome = env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+  return join(configHome, "peated", "credentials.json");
+}
+
+export async function loadCredentials(
+  path = credentialsPath(),
+): Promise<Credentials | null> {
+  let contents: string;
+  try {
+    contents = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(contents);
+  } catch {
+    throw new Error(`Invalid Peated credentials file: ${path}`);
+  }
+
+  const parsed = CredentialsSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new Error(`Invalid Peated credentials file: ${path}`);
+  }
+  return parsed.data;
+}
+
+export async function saveCredentials(
+  credentials: Credentials,
+  path = credentialsPath(),
+): Promise<void> {
+  const parsed = CredentialsSchema.parse(credentials);
+  const directory = dirname(path);
+  const temporaryPath = `${path}.${process.pid}.tmp`;
+
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  await writeFile(temporaryPath, `${JSON.stringify(parsed, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await rename(temporaryPath, path);
+}
+
+export async function deleteCredentials(
+  path = credentialsPath(),
+): Promise<boolean> {
+  try {
+    await rm(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export function credentialsExpired(
+  credentials: Credentials,
+  now = Date.now(),
+): boolean {
+  return Date.parse(credentials.expiresAt) <= now;
+}

--- a/apps/cli/src/api/oauth.test.ts
+++ b/apps/cli/src/api/oauth.test.ts
@@ -1,0 +1,98 @@
+import { createHash } from "node:crypto";
+import { describe, expect, test, vi } from "vitest";
+import { authorizeWithOAuth } from "./oauth";
+
+describe("authorizeWithOAuth", () => {
+  test("completes PKCE through a loopback callback and exchanges the code", async () => {
+    const now = Date.parse("2026-08-12T00:00:00.000Z");
+    let authorizationUrl: URL | undefined;
+    const tokenFetch = vi.fn<typeof globalThis.fetch>(async (_url, init) => {
+      expect(init?.body).toBeInstanceOf(URLSearchParams);
+      const tokenRequest = init?.body as URLSearchParams;
+      const verifier = tokenRequest.get("code_verifier") ?? "";
+      expect(tokenRequest.get("code")).toBe("authorization-code");
+      expect(tokenRequest.get("redirect_uri")).toBe(
+        authorizationUrl?.searchParams.get("redirect_uri"),
+      );
+      expect(createHash("sha256").update(verifier).digest("base64url")).toBe(
+        authorizationUrl?.searchParams.get("code_challenge"),
+      );
+      return Response.json({
+        access_token: "secret-token",
+        token_type: "Bearer",
+        expires_in: 604800,
+      });
+    });
+
+    const credentials = await authorizeWithOAuth({
+      apiServer: "https://api.peated.com",
+      webServer: "https://peated.com",
+      clientId: "peated-cli",
+      now: () => now,
+      fetch: tokenFetch,
+      onAuthorize: async (url) => {
+        authorizationUrl = new URL(url);
+        const redirectUri = authorizationUrl.searchParams.get("redirect_uri");
+        const state = authorizationUrl.searchParams.get("state");
+        expect(redirectUri).toMatch(
+          /^http:\/\/127\.0\.0\.1:\d+\/oauth\/callback$/,
+        );
+        expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe(
+          "S256",
+        );
+        const invalidCallback = new URL(redirectUri!);
+        invalidCallback.search = new URLSearchParams({
+          code: "attacker-code",
+          state: "wrong-state",
+        }).toString();
+        expect((await globalThis.fetch(invalidCallback)).status).toBe(400);
+
+        const callback = new URL(redirectUri!);
+        callback.search = new URLSearchParams({
+          code: "authorization-code",
+          state: state!,
+        }).toString();
+        const callbackResponse = await globalThis.fetch(callback);
+        expect(callbackResponse.status).toBe(200);
+        expect(callbackResponse.headers.get("connection")).toBe("close");
+      },
+    });
+
+    expect(credentials).toEqual({
+      accessToken: "secret-token",
+      apiServer: "https://api.peated.com",
+      clientId: "peated-cli",
+      expiresAt: "2026-08-19T00:00:00.000Z",
+    });
+    expect(tokenFetch).toHaveBeenCalledOnce();
+    expect(tokenFetch.mock.calls[0][0]).toBeInstanceOf(URL);
+    expect((tokenFetch.mock.calls[0][0] as URL).href).toBe(
+      "https://api.peated.com/oauth/token",
+    );
+  });
+
+  test("rejects a denied authorization without exchanging a token", async () => {
+    const tokenFetch = vi.fn<typeof globalThis.fetch>();
+
+    await expect(
+      authorizeWithOAuth({
+        apiServer: "https://api.peated.com",
+        webServer: "https://peated.com",
+        clientId: "peated-cli",
+        fetch: tokenFetch,
+        onAuthorize: async (url) => {
+          const authorizationUrl = new URL(url);
+          const callback = new URL(
+            authorizationUrl.searchParams.get("redirect_uri")!,
+          );
+          callback.search = new URLSearchParams({
+            error: "access_denied",
+            state: authorizationUrl.searchParams.get("state")!,
+          }).toString();
+          expect((await globalThis.fetch(callback)).status).toBe(400);
+        },
+      }),
+    ).rejects.toThrow("Peated authorization failed: access_denied");
+    expect(tokenFetch).not.toHaveBeenCalled();
+  });
+});

--- a/apps/cli/src/api/oauth.ts
+++ b/apps/cli/src/api/oauth.ts
@@ -1,0 +1,229 @@
+import { spawn } from "node:child_process";
+import { createHash, randomBytes } from "node:crypto";
+import { createServer, type Server, type ServerResponse } from "node:http";
+import { z } from "zod";
+import { normalizeServerUrl, OAUTH_CALLBACK_PATH } from "./config";
+import type { Credentials } from "./credentials";
+
+const OAuthTokenResponseSchema = z
+  .object({
+    access_token: z.string().min(1),
+    token_type: z.literal("Bearer"),
+    expires_in: z.number().int().positive(),
+  })
+  .strict();
+
+const OAuthErrorResponseSchema = z
+  .object({ error: z.string().min(1) })
+  .passthrough();
+
+type CallbackServer = {
+  redirectUri: string;
+  waitForCode: () => Promise<string>;
+  close: () => Promise<void>;
+};
+
+function sendCallbackResponse(
+  response: ServerResponse,
+  status: number,
+  message: string,
+  onSent?: () => void,
+): void {
+  response.writeHead(status, {
+    "cache-control": "no-store",
+    connection: "close",
+    "content-type": "text/plain; charset=utf-8",
+  });
+  response.end(`${message}\n`, onSent);
+}
+
+async function startCallbackServer({
+  state,
+  timeoutMs,
+}: {
+  state: string;
+  timeoutMs: number;
+}): Promise<CallbackServer> {
+  let resolveCode!: (code: string) => void;
+  let rejectCode!: (error: Error) => void;
+  let settled = false;
+  const code = new Promise<string>((resolve, reject) => {
+    resolveCode = resolve;
+    rejectCode = reject;
+  });
+
+  const server: Server = createServer((request, response) => {
+    const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (
+      request.method !== "GET" ||
+      requestUrl.pathname !== OAUTH_CALLBACK_PATH
+    ) {
+      sendCallbackResponse(response, 404, "Not found.");
+      return;
+    }
+    if (requestUrl.searchParams.get("state") !== state) {
+      sendCallbackResponse(response, 400, "Invalid OAuth state.");
+      return;
+    }
+
+    const oauthError = requestUrl.searchParams.get("error");
+    if (oauthError) {
+      sendCallbackResponse(
+        response,
+        400,
+        "Peated authorization was denied.",
+        () => {
+          settled = true;
+          rejectCode(new Error(`Peated authorization failed: ${oauthError}`));
+        },
+      );
+      return;
+    }
+
+    const authorizationCode = requestUrl.searchParams.get("code");
+    if (!authorizationCode) {
+      sendCallbackResponse(response, 400, "Missing authorization code.");
+      return;
+    }
+
+    sendCallbackResponse(
+      response,
+      200,
+      "Peated authorization complete. You can return to the terminal.",
+      () => {
+        settled = true;
+        resolveCode(authorizationCode);
+      },
+    );
+  });
+
+  server.on("error", (error) => {
+    if (!settled) rejectCode(error);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("listening", resolve);
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1");
+  });
+
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    server.close();
+    throw new Error("Unable to determine the OAuth callback port.");
+  }
+
+  const timeout = setTimeout(() => {
+    if (!settled) {
+      settled = true;
+      rejectCode(new Error("Timed out waiting for Peated authorization."));
+    }
+  }, timeoutMs);
+
+  return {
+    redirectUri: `http://127.0.0.1:${address.port}${OAUTH_CALLBACK_PATH}`,
+    waitForCode: () => code,
+    close: async () => {
+      clearTimeout(timeout);
+      if (!server.listening) return;
+      // The callback owns this short-lived listener and must not let a browser
+      // keep-alive connection hold the CLI open after the response is flushed.
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      });
+    },
+  };
+}
+
+export function openBrowser(url: string): void {
+  const command =
+    process.platform === "darwin"
+      ? "open"
+      : process.platform === "win32"
+        ? "explorer.exe"
+        : "xdg-open";
+  const child = spawn(command, [url], { detached: true, stdio: "ignore" });
+  // Opening the browser is best-effort because the authorization URL is also
+  // printed for terminals without desktop integration.
+  child.once("error", () => undefined);
+  child.unref();
+}
+
+export async function authorizeWithOAuth({
+  apiServer,
+  webServer,
+  clientId,
+  onAuthorize,
+  fetch: fetchImplementation = fetch,
+  now = Date.now,
+  timeoutMs = 5 * 60 * 1000,
+}: {
+  apiServer: string;
+  webServer: string;
+  clientId: string;
+  onAuthorize: (url: string) => void | Promise<void>;
+  fetch?: typeof fetch;
+  now?: () => number;
+  timeoutMs?: number;
+}): Promise<Credentials> {
+  const normalizedApiServer = normalizeServerUrl(apiServer);
+  const normalizedWebServer = normalizeServerUrl(webServer);
+  const state = randomBytes(32).toString("base64url");
+  const verifier = randomBytes(64).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  const callback = await startCallbackServer({ state, timeoutMs });
+
+  try {
+    const authorizationUrl = new URL("/oauth/authorize", normalizedWebServer);
+    authorizationUrl.search = new URLSearchParams({
+      response_type: "code",
+      client_id: clientId,
+      redirect_uri: callback.redirectUri,
+      state,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    }).toString();
+
+    const [authorizationCode] = await Promise.all([
+      callback.waitForCode(),
+      onAuthorize(authorizationUrl.toString()),
+    ]);
+    const response = await fetchImplementation(
+      new URL("/oauth/token", normalizedApiServer),
+      {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/x-www-form-urlencoded",
+          "user-agent": "@peated/cli (oauth/client)",
+        },
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code: authorizationCode,
+          client_id: clientId,
+          redirect_uri: callback.redirectUri,
+          code_verifier: verifier,
+        }),
+      },
+    );
+    const responseBody: unknown = await response.json();
+
+    if (!response.ok) {
+      const parsedError = OAuthErrorResponseSchema.safeParse(responseBody);
+      throw new Error(
+        `Peated token exchange failed: ${parsedError.success ? parsedError.data.error : `HTTP ${response.status}`}`,
+      );
+    }
+
+    const token = OAuthTokenResponseSchema.parse(responseBody);
+    return {
+      accessToken: token.access_token,
+      apiServer: normalizedApiServer,
+      clientId,
+      expiresAt: new Date(now() + token.expires_in * 1000).toISOString(),
+    };
+  } finally {
+    await callback.close();
+  }
+}

--- a/apps/cli/src/commands/api.ts
+++ b/apps/cli/src/commands/api.ts
@@ -1,0 +1,98 @@
+import program from "@peated/cli/program";
+import { readFile } from "node:fs/promises";
+import { createInterface } from "node:readline/promises";
+import { requestPeatedApi } from "../api/client";
+import {
+  credentialsExpired,
+  loadCredentials,
+  type Credentials,
+} from "../api/credentials";
+
+type ApiCommandOptions = {
+  input?: string;
+  yes?: boolean;
+};
+
+async function requireCredentials(): Promise<Credentials> {
+  const credentials = await loadCredentials();
+  if (!credentials) {
+    throw new Error("Not logged in. Run `pnpm cli auth login` first.");
+  }
+  if (credentialsExpired(credentials)) {
+    throw new Error("Peated login expired. Run `pnpm cli auth login` again.");
+  }
+  return credentials;
+}
+
+async function readInput(path: string | undefined): Promise<unknown> {
+  if (!path) return undefined;
+
+  const contents = await readFile(path, "utf8");
+  try {
+    return JSON.parse(contents) as unknown;
+  } catch {
+    throw new Error(`Invalid JSON input file: ${path}`);
+  }
+}
+
+async function confirmMutation(method: string, path: string): Promise<void> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    throw new Error(
+      `Refusing non-interactive ${method} ${path} without explicit --yes.`,
+    );
+  }
+
+  const prompt = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  try {
+    const answer = await prompt.question(`Send ${method} ${path}? [y/N] `);
+    if (answer.trim().toLowerCase() !== "y") {
+      throw new Error("API mutation cancelled.");
+    }
+  } finally {
+    prompt.close();
+  }
+}
+
+async function runApiCommand(
+  method: string,
+  path: string,
+  options: ApiCommandOptions,
+): Promise<void> {
+  const credentials = await requireCredentials();
+  const body = await readInput(options.input);
+
+  if (method !== "GET" && !options.yes) {
+    await confirmMutation(method, path);
+  }
+
+  const result = await requestPeatedApi({
+    ...credentials,
+    method,
+    path,
+    body,
+  });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+const subcommand = program
+  .command("api")
+  .description("Make authenticated requests to the Peated JSON API");
+
+subcommand
+  .command("get")
+  .description("Read a Peated API resource")
+  .argument("<path>", "API path, such as /bottles/123")
+  .action(async (path) => runApiCommand("GET", path, {}));
+
+for (const method of ["POST", "PUT", "PATCH", "DELETE"] as const) {
+  subcommand
+    .command(method.toLowerCase())
+    .description(`Send an authenticated ${method} request`)
+    .argument("<path>", "API path, such as /bottles/123")
+    .option("--input <file>", "Read the JSON request body from a file")
+    .option("--yes", "Send the mutation without an interactive confirmation")
+    .action(async (path, options) => runApiCommand(method, path, options));
+}

--- a/apps/cli/src/commands/auth.ts
+++ b/apps/cli/src/commands/auth.ts
@@ -1,0 +1,85 @@
+import program from "@peated/cli/program";
+import { createPeatedClient } from "../api/client";
+import {
+  DEFAULT_API_SERVER,
+  DEFAULT_WEB_SERVER,
+  resolveOAuthClientId,
+} from "../api/config";
+import {
+  credentialsExpired,
+  deleteCredentials,
+  loadCredentials,
+  saveCredentials,
+} from "../api/credentials";
+import { authorizeWithOAuth, openBrowser } from "../api/oauth";
+
+const subcommand = program
+  .command("auth")
+  .description("Authenticate the local CLI with Peated OAuth");
+
+subcommand
+  .command("login")
+  .description("Authorize this CLI through Peated in your browser")
+  .option(
+    "--client-id <id>",
+    "OAuth public client ID (or PEATED_OAUTH_CLIENT_ID)",
+  )
+  .option(
+    "--api-server <url>",
+    "Peated API server",
+    process.env.PEATED_API_SERVER ?? DEFAULT_API_SERVER,
+  )
+  .option(
+    "--web-server <url>",
+    "Peated web server",
+    process.env.PEATED_WEB_SERVER ?? DEFAULT_WEB_SERVER,
+  )
+  .option("--no-open", "Print the authorization URL without opening a browser")
+  .action(async (options) => {
+    const clientId = resolveOAuthClientId(options.clientId);
+
+    const credentials = await authorizeWithOAuth({
+      apiServer: options.apiServer,
+      webServer: options.webServer,
+      clientId,
+      onAuthorize: (url) => {
+        console.log(`Authorize Peated CLI:\n${url}`);
+        if (options.open) openBrowser(url);
+      },
+    });
+    const { user } = await createPeatedClient(credentials).auth.me();
+    await saveCredentials(credentials);
+    console.log(
+      `Logged in to ${credentials.apiServer} as @${user.username}. Token expires ${credentials.expiresAt}.`,
+    );
+  });
+
+subcommand
+  .command("status")
+  .description("Show the current local Peated login")
+  .action(async () => {
+    const credentials = await loadCredentials();
+    if (!credentials) {
+      console.log("Not logged in. Run `pnpm cli auth login`.");
+      return;
+    }
+    if (credentialsExpired(credentials)) {
+      console.log(
+        `Peated login expired ${credentials.expiresAt}. Run \`pnpm cli auth login\` again.`,
+      );
+      return;
+    }
+
+    const { user } = await createPeatedClient(credentials).auth.me();
+    console.log(
+      `Logged in to ${credentials.apiServer} as @${user.username}. Token expires ${credentials.expiresAt}.`,
+    );
+  });
+
+subcommand
+  .command("logout")
+  .description("Delete the locally stored Peated token")
+  .action(async () => {
+    const deleted = await deleteCredentials();
+    console.log(deleted ? "Logged out of Peated." : "Not logged in.");
+  });

--- a/apps/cli/src/commands/index.ts
+++ b/apps/cli/src/commands/index.ts
@@ -1,3 +1,5 @@
+export * from "./api";
+export * from "./auth";
 export * from "./badges";
 export * from "./bottles";
 export * from "./classifier";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,6 +185,12 @@ importers:
 
   apps/cli:
     dependencies:
+      '@orpc/client':
+        specifier: 'catalog:'
+        version: 1.15.0(@opentelemetry/api@1.9.1)
+      '@orpc/server':
+        specifier: 'catalog:'
+        version: 1.15.0(@opentelemetry/api@1.9.1)(ws@8.18.3)
       '@peated/bottle-classifier':
         specifier: workspace:*
         version: link:../../packages/bottle-classifier
@@ -218,6 +224,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      zod:
+        specifier: 'catalog:'
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
Peated's CLI can now authenticate against production through the existing OAuth authorization-code flow with PKCE. `peated auth login` listens on an ephemeral loopback port, validates the returned state, exchanges the code, verifies the authenticated account, and stores the seven-day credential in a private XDG config file without printing the token. The checked-in public client ID works out of the box, while flags and environment variables support other deployments.

A reusable typed oRPC client and JSON-oriented `peated api` commands make authenticated maintenance scripts practical. Reads return JSON; POST, PUT, PATCH, and DELETE require either an interactive confirmation or explicit `--yes`, and request bodies come from JSON files. The API client restricts requests to HTTPS or loopback origins and paths under `/v1`.

The production OAuth flow was exercised end to end as part of the implementation. Regression coverage includes PKCE exchange and state validation, browser keep-alive shutdown, credential permissions and expiry, server/path safety, authenticated JSON requests, and client-ID override precedence.
