### PR TITLE
feat(scrapers): track durable run health

### DIFF
--- a/apps/server/migrations/0210_wandering_roulette.sql
+++ b/apps/server/migrations/0210_wandering_roulette.sql
@@ -1,0 +1,23 @@
+CREATE TYPE "public"."external_site_run_status" AS ENUM('queued', 'running', 'succeeded', 'failed');
+CREATE TYPE "public"."external_site_run_trigger" AS ENUM('scheduled', 'manual');
+CREATE TABLE "external_site_run" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"external_site_id" bigint NOT NULL,
+	"status" "external_site_run_status" DEFAULT 'queued' NOT NULL,
+	"trigger" "external_site_run_trigger" NOT NULL,
+	"requested_by_id" bigint,
+	"attempt_count" integer DEFAULT 0 NOT NULL,
+	"item_count" integer,
+	"error" text,
+	"started_at" timestamp,
+	"completed_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+
+ALTER TABLE "external_site" ADD COLUMN "last_run_id" bigint;
+ALTER TABLE "external_site_run" ADD CONSTRAINT "external_site_run_external_site_id_external_site_id_fk" FOREIGN KEY ("external_site_id") REFERENCES "public"."external_site"("id") ON DELETE cascade ON UPDATE no action;
+ALTER TABLE "external_site_run" ADD CONSTRAINT "external_site_run_requested_by_id_user_id_fk" FOREIGN KEY ("requested_by_id") REFERENCES "public"."user"("id") ON DELETE no action ON UPDATE no action;
+CREATE UNIQUE INDEX "external_site_run_active_unq" ON "external_site_run" USING btree ("external_site_id") WHERE "external_site_run"."status" IN ('queued', 'running');
+CREATE INDEX "external_site_run_site_created_idx" ON "external_site_run" USING btree ("external_site_id","created_at");
+CREATE INDEX "external_site_run_site_status_completed_idx" ON "external_site_run" USING btree ("external_site_id","status","completed_at");
+ALTER TABLE "external_site" ADD CONSTRAINT "external_site_last_run_id_external_site_run_id_fk" FOREIGN KEY ("last_run_id") REFERENCES "public"."external_site_run"("id") ON DELETE set null ON UPDATE no action;

--- a/apps/server/migrations/meta/0210_snapshot.json
+++ b/apps/server/migrations/meta/0210_snapshot.json
@@ -1,0 +1,8293 @@
+{
+  "id": "d4fe7ff8-16ea-487f-b2b1-2e958bf689af",
+  "prevId": "addf6415-59be-48ae-b8b8-0c367fa97b6f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bottle_release_promotion": {
+      "name": "bottle_release_promotion",
+      "schema": "",
+      "columns": {
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "promoted_bottle_id": {
+          "name": "promoted_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_release_promotion_bottle_idx": {
+          "name": "bottle_release_promotion_bottle_idx",
+          "columns": [
+            {
+              "expression": "promoted_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_release": {
+      "name": "bottle_release",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vintage_year": {
+          "name": "vintage_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abv": {
+          "name": "abv",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "single_cask": {
+          "name": "single_cask",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_strength": {
+          "name": "cask_strength",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_age": {
+          "name": "stated_age",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_size": {
+          "name": "cask_size",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_type": {
+          "name": "cask_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_fill": {
+          "name": "cask_fill",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasting_notes": {
+          "name": "tasting_notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_tags": {
+          "name": "suggested_tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_release_bottle_idx": {
+          "name": "bottle_release_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_release_created_by_actor_idx": {
+          "name": "bottle_release_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_release_full_name_idx": {
+          "name": "bottle_release_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_release_bottle_id_bottle_id_fk": {
+          "name": "bottle_release_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_release",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_release_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_release_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_release",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bottle_release_stated_age_check": {
+          "name": "bottle_release_stated_age_check",
+          "value": "\"bottle_release\".\"stated_age\" IS NULL OR (\"bottle_release\".\"stated_age\" >= 0 AND \"bottle_release\".\"stated_age\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.legacy_release_repair_review": {
+      "name": "legacy_release_repair_review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "legacy_bottle_id": {
+          "name": "legacy_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_parent_full_name": {
+          "name": "proposed_parent_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_bottle_fingerprint": {
+          "name": "legacy_bottle_fingerprint",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_candidates_fingerprint": {
+          "name": "parent_candidates_fingerprint",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_edition": {
+          "name": "release_edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "legacy_release_repair_review_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_parent_bottle_id": {
+          "name": "reviewed_parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_version": {
+          "name": "review_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legacy_release_repair_review_bottle_idx": {
+          "name": "legacy_release_repair_review_bottle_idx",
+          "columns": [
+            {
+              "expression": "legacy_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_release_repair_review_parent_idx": {
+          "name": "legacy_release_repair_review_parent_idx",
+          "columns": [
+            {
+              "expression": "reviewed_parent_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_release_repair_review_resolution_idx": {
+          "name": "legacy_release_repair_review_resolution_idx",
+          "columns": [
+            {
+              "expression": "resolution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor": {
+      "name": "actor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "actor_type_key_unq": {
+          "name": "actor_type_key_unq",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "actor_user_idx": {
+          "name": "actor_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actor_user_id_user_id_fk": {
+          "name": "actor_user_id_user_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badge_award_tracked_object": {
+      "name": "badge_award_tracked_object",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "award_id": {
+          "name": "award_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "badge_award_object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "badge_award_tracked_object_unq": {
+          "name": "badge_award_tracked_object_unq",
+          "columns": [
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "badge_award_tracked_object_award_id_badge_award_id_fk": {
+          "name": "badge_award_tracked_object_award_id_badge_award_id_fk",
+          "tableFrom": "badge_award_tracked_object",
+          "tableTo": "badge_award",
+          "columnsFrom": [
+            "award_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badge_award": {
+      "name": "badge_award",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp": {
+          "name": "xp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level": {
+          "name": "level",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "badge_award_unq": {
+          "name": "badge_award_unq",
+          "columns": [
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "badge_award_badge_id_badges_id_fk": {
+          "name": "badge_award_badge_id_badges_id_fk",
+          "tableFrom": "badge_award",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "badge_award_user_id_user_id_fk": {
+          "name": "badge_award_user_id_user_id_fk",
+          "tableFrom": "badge_award",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_level": {
+          "name": "max_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "tracker": {
+          "name": "tracker",
+          "type": "badge_award_object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bottle'"
+        },
+        "formula": {
+          "name": "formula",
+          "type": "badge_formula",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "checks": {
+          "name": "checks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "badge_name_unq": {
+          "name": "badge_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_check": {
+      "name": "bottle_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "bottle_check_intent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "bottle_check_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_event_key": {
+          "name": "background_event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_snapshot": {
+          "name": "input_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_metadata": {
+          "name": "model_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_price_match_proposal_id": {
+          "name": "store_price_match_proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_price_match_attempt_id": {
+          "name": "store_price_match_attempt_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_id": {
+          "name": "closed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "bottle_check_close_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_note": {
+          "name": "close_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bottle_check_subject_created_idx": {
+          "name": "bottle_check_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_bottle_idx": {
+          "name": "bottle_check_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_source_idx": {
+          "name": "bottle_check_source_idx",
+          "columns": [
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_background_event_unq": {
+          "name": "bottle_check_background_event_unq",
+          "columns": [
+            {
+              "expression": "background_event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_store_price_proposal_idx": {
+          "name": "bottle_check_store_price_proposal_idx",
+          "columns": [
+            {
+              "expression": "store_price_match_proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_store_price_attempt_idx": {
+          "name": "bottle_check_store_price_attempt_idx",
+          "columns": [
+            {
+              "expression": "store_price_match_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_closed_idx": {
+          "name": "bottle_check_closed_idx",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_check_bottle_id_bottle_id_fk": {
+          "name": "bottle_check_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bottle_check_store_price_match_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "bottle_check_store_price_match_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "store_price_match_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bottle_check_store_price_match_attempt_id_store_price_match_attempt_id_fk": {
+          "name": "bottle_check_store_price_match_attempt_id_store_price_match_attempt_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "store_price_match_attempt",
+          "columnsFrom": [
+            "store_price_match_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bottle_check_closed_by_id_user_id_fk": {
+          "name": "bottle_check_closed_by_id_user_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "user",
+          "columnsFrom": [
+            "closed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_operation": {
+      "name": "bottle_operation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal": {
+          "name": "proposal",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_fields": {
+          "name": "excluded_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "state_token": {
+          "name": "state_token",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preparation_error": {
+          "name": "preparation_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "bottle_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "bottle_operation_rejection_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_completed_at": {
+          "name": "execution_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bottle_operation_check_idx": {
+          "name": "bottle_operation_check_idx",
+          "columns": [
+            {
+              "expression": "check_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_operation_status_idx": {
+          "name": "bottle_operation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_operation_reviewer_idx": {
+          "name": "bottle_operation_reviewer_idx",
+          "columns": [
+            {
+              "expression": "reviewed_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_operation_check_id_bottle_check_id_fk": {
+          "name": "bottle_operation_check_id_bottle_check_id_fk",
+          "tableFrom": "bottle_operation",
+          "tableTo": "bottle_check",
+          "columnsFrom": [
+            "check_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_operation_reviewed_by_id_user_id_fk": {
+          "name": "bottle_operation_reviewed_by_id_user_id_fk",
+          "tableFrom": "bottle_operation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_alias": {
+      "name": "bottle_alias",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(3072)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored": {
+          "name": "ignored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "bottle_alias_assignment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy'"
+        },
+        "assigned_by_actor_id": {
+          "name": "assigned_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bottle_alias_name_idx": {
+          "name": "bottle_alias_name_idx",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_alias_bottle_idx": {
+          "name": "bottle_alias_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_alias_release_idx": {
+          "name": "bottle_alias_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_alias_assigned_by_actor_idx": {
+          "name": "bottle_alias_assigned_by_actor_idx",
+          "columns": [
+            {
+              "expression": "assigned_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_alias_bottle_id_bottle_id_fk": {
+          "name": "bottle_alias_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_alias",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_alias_assigned_by_actor_id_actor_id_fk": {
+          "name": "bottle_alias_assigned_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_alias",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "assigned_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_barcode": {
+      "name": "bottle_barcode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gtin14": {
+          "name": "gtin14",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_barcode_gtin14_unq": {
+          "name": "bottle_barcode_gtin14_unq",
+          "columns": [
+            {
+              "expression": "gtin14",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_barcode_bottle_idx": {
+          "name": "bottle_barcode_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_barcode_created_by_actor_idx": {
+          "name": "bottle_barcode_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_barcode_bottle_id_bottle_id_fk": {
+          "name": "bottle_barcode_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_barcode",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_barcode_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_barcode_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_barcode",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bottle_barcode_value_check": {
+          "name": "bottle_barcode_value_check",
+          "value": "\"bottle_barcode\".\"value\" ~ '^[0-9]+$' AND char_length(\"bottle_barcode\".\"value\") IN (8, 12, 13, 14)"
+        },
+        "bottle_barcode_gtin14_check": {
+          "name": "bottle_barcode_gtin14_check",
+          "value": "\"bottle_barcode\".\"gtin14\" ~ '^[0-9]{14}$'"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bottle_flavor_profile": {
+      "name": "bottle_flavor_profile",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_flavor_profile_bottle_id_bottle_id_fk": {
+          "name": "bottle_flavor_profile_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_flavor_profile",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_flavor_profile_bottle_id_flavor_profile_pk": {
+          "name": "bottle_flavor_profile_bottle_id_flavor_profile_pk",
+          "columns": [
+            "bottle_id",
+            "flavor_profile"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_group_distiller": {
+      "name": "bottle_group_distiller",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distiller_id": {
+          "name": "distiller_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_group_distiller_group_id_bottle_group_id_fk": {
+          "name": "bottle_group_distiller_group_id_bottle_group_id_fk",
+          "tableFrom": "bottle_group_distiller",
+          "tableTo": "bottle_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_distiller_distiller_id_entity_id_fk": {
+          "name": "bottle_group_distiller_distiller_id_entity_id_fk",
+          "tableFrom": "bottle_group_distiller",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "distiller_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_group_distiller_group_id_distiller_id_pk": {
+          "name": "bottle_group_distiller_group_id_distiller_id_pk",
+          "columns": [
+            "group_id",
+            "distiller_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_group": {
+      "name": "bottle_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stated_age": {
+          "name": "stated_age",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottler_id": {
+          "name": "bottler_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_bottle_id": {
+          "name": "representative_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_stats": {
+          "name": "rating_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pass\":0,\"sip\":0,\"savor\":0,\"total\":0,\"avg\":null,\"percentage\":{\"pass\":0,\"sip\":0,\"savor\":0}}'::jsonb"
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_group_brand_idx": {
+          "name": "bottle_group_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_bottler_idx": {
+          "name": "bottle_group_bottler_idx",
+          "columns": [
+            {
+              "expression": "bottler_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_series_idx": {
+          "name": "bottle_group_series_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_category_idx": {
+          "name": "bottle_group_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_representative_bottle_idx": {
+          "name": "bottle_group_representative_bottle_idx",
+          "columns": [
+            {
+              "expression": "representative_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_created_by_actor_idx": {
+          "name": "bottle_group_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_group_series_id_bottle_series_id_fk": {
+          "name": "bottle_group_series_id_bottle_series_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "bottle_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_brand_id_entity_id_fk": {
+          "name": "bottle_group_brand_id_entity_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_bottler_id_entity_id_fk": {
+          "name": "bottle_group_bottler_id_entity_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "bottler_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_group_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_representative_membership_fk": {
+          "name": "bottle_group_representative_membership_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "representative_bottle_id",
+            "id"
+          ],
+          "columnsTo": [
+            "id",
+            "group_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bottle_group_stated_age_check": {
+          "name": "bottle_group_stated_age_check",
+          "value": "\"bottle_group\".\"stated_age\" IS NULL OR (\"bottle_group\".\"stated_age\" >= 0 AND \"bottle_group\".\"stated_age\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bottle_observation": {
+      "name": "bottle_observation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_identity": {
+          "name": "parsed_identity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facts": {
+          "name": "facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bottle_observation_source_idx": {
+          "name": "bottle_observation_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_bottle_idx": {
+          "name": "bottle_observation_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_release_idx": {
+          "name": "bottle_observation_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_external_site_idx": {
+          "name": "bottle_observation_external_site_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_observation_bottle_id_bottle_id_fk": {
+          "name": "bottle_observation_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_observation_external_site_id_external_site_id_fk": {
+          "name": "bottle_observation_external_site_id_external_site_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_observation_created_by_id_user_id_fk": {
+          "name": "bottle_observation_created_by_id_user_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_series": {
+      "name": "bottle_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_releases": {
+          "name": "num_releases",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_series_full_name_key": {
+          "name": "bottle_series_full_name_key",
+          "columns": [
+            {
+              "expression": "LOWER(\"full_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_series_search_idx": {
+          "name": "bottle_series_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bottle_series_brand_idx": {
+          "name": "bottle_series_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_series_created_by_actor_idx": {
+          "name": "bottle_series_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_series_brand_id_entity_id_fk": {
+          "name": "bottle_series_brand_id_entity_id_fk",
+          "tableFrom": "bottle_series",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_series_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_series_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_series",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_tag": {
+      "name": "bottle_tag",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_tag_bottle_id_bottle_id_fk": {
+          "name": "bottle_tag_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_tag",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_tag_bottle_id_tag_pk": {
+          "name": "bottle_tag_bottle_id_tag_pk",
+          "columns": [
+            "bottle_id",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_tombstone": {
+      "name": "bottle_tombstone",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_bottle_id": {
+          "name": "new_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle": {
+      "name": "bottle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stated_age": {
+          "name": "stated_age",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottler_id": {
+          "name": "bottler_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abv": {
+          "name": "abv",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "single_cask": {
+          "name": "single_cask",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_strength": {
+          "name": "cask_strength",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vintage_year": {
+          "name": "vintage_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_size": {
+          "name": "cask_size",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_type": {
+          "name": "cask_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_fill": {
+          "name": "cask_fill",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasting_notes": {
+          "name": "tasting_notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_tags": {
+          "name": "suggested_tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_stats": {
+          "name": "rating_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pass\":0,\"sip\":0,\"savor\":0,\"total\":0,\"avg\":null,\"percentage\":{\"pass\":0,\"sip\":0,\"savor\":0}}'::jsonb"
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_releases": {
+          "name": "num_releases",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_group_idx": {
+          "name": "bottle_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_search_idx": {
+          "name": "bottle_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bottle_brand_idx": {
+          "name": "bottle_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_bottler_idx": {
+          "name": "bottle_bottler_idx",
+          "columns": [
+            {
+              "expression": "bottler_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_created_by_actor_idx": {
+          "name": "bottle_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_category_idx": {
+          "name": "bottle_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_flavor_profile_idx": {
+          "name": "bottle_flavor_profile_idx",
+          "columns": [
+            {
+              "expression": "flavor_profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_group_id_bottle_group_id_fk": {
+          "name": "bottle_group_id_bottle_group_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "bottle_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_series_id_bottle_series_id_fk": {
+          "name": "bottle_series_id_bottle_series_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "bottle_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_brand_id_entity_id_fk": {
+          "name": "bottle_brand_id_entity_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_bottler_id_entity_id_fk": {
+          "name": "bottle_bottler_id_entity_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "bottler_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bottle_id_group_id_unq": {
+          "name": "bottle_id_group_id_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bottle_stated_age_check": {
+          "name": "bottle_stated_age_check",
+          "value": "\"bottle\".\"stated_age\" IS NULL OR (\"bottle\".\"stated_age\" >= 0 AND \"bottle\".\"stated_age\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bottle_distiller": {
+      "name": "bottle_distiller",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distiller_id": {
+          "name": "distiller_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_distiller_bottle_id_bottle_id_fk": {
+          "name": "bottle_distiller_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_distiller",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_distiller_distiller_id_entity_id_fk": {
+          "name": "bottle_distiller_distiller_id_entity_id_fk",
+          "tableFrom": "bottle_distiller",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "distiller_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_distiller_bottle_id_distiller_id_pk": {
+          "name": "bottle_distiller_bottle_id_distiller_id_pk",
+          "columns": [
+            "bottle_id",
+            "distiller_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change": {
+      "name": "change",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'add'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "change_actor_idx": {
+          "name": "change_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_actor_id_actor_id_fk": {
+          "name": "change_actor_id_actor_id_fk",
+          "tableFrom": "change",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection_bottle": {
+      "name": "collection_bottle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "collection_bottle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_bottle_bottle_idx": {
+          "name": "collection_bottle_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_bottle_release_idx": {
+          "name": "collection_bottle_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_bottle_collection_id_collection_id_fk": {
+          "name": "collection_bottle_collection_id_collection_id_fk",
+          "tableFrom": "collection_bottle",
+          "tableTo": "collection",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collection_bottle_bottle_id_bottle_id_fk": {
+          "name": "collection_bottle_bottle_id_bottle_id_fk",
+          "tableFrom": "collection_bottle",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collection_bottle_collection_id_bottle_id_unique": {
+          "name": "collection_bottle_collection_id_bottle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "collection_id",
+            "bottle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection": {
+      "name": "collection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "collection_name_unq": {
+          "name": "collection_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\"), \"created_by_id\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_created_by_idx": {
+          "name": "collection_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_created_by_id_user_id_fk": {
+          "name": "collection_created_by_id_user_id_fk",
+          "tableFrom": "collection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "comment_unq": {
+          "name": "comment_unq",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_tasting_id_tasting_id_fk": {
+          "name": "comments_tasting_id_tasting_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_created_by_id_user_id_fk": {
+          "name": "comments_created_by_id_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alpha2": {
+          "name": "alpha2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_distillers": {
+          "name": "total_distillers",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "country_name_unq": {
+          "name": "country_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "country_slug_unq": {
+          "name": "country_slug_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity": {
+      "name": "entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "entity_type[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year_established": {
+          "name": "year_established",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_name_unq": {
+          "name": "entity_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_search_idx": {
+          "name": "entity_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "entity_country_by_idx": {
+          "name": "entity_country_by_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_region_idx": {
+          "name": "entity_region_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_created_by_actor_idx": {
+          "name": "entity_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_country_id_country_id_fk": {
+          "name": "entity_country_id_country_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_region_id_region_id_fk": {
+          "name": "entity_region_id_region_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_created_by_actor_id_actor_id_fk": {
+          "name": "entity_created_by_actor_id_actor_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_parent_fk": {
+          "name": "entity_parent_fk",
+          "tableFrom": "entity",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_alias": {
+      "name": "entity_alias",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entity_alias_entity_idx": {
+          "name": "entity_alias_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_alias_name_idx": {
+          "name": "entity_alias_name_idx",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_alias_entity_id_entity_id_fk": {
+          "name": "entity_alias_entity_id_entity_id_fk",
+          "tableFrom": "entity_alias",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_tombstone": {
+      "name": "entity_tombstone",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_entity_id": {
+          "name": "new_entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event": {
+      "name": "event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repeats": {
+          "name": "repeats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_name_unq": {
+          "name": "event_name_unq",
+          "columns": [
+            {
+              "expression": "date_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_country_id": {
+          "name": "event_country_id",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_country_id_country_id_fk": {
+          "name": "event_country_id_country_id_fk",
+          "tableFrom": "event",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_site_config": {
+      "name": "external_site_config",
+      "schema": "",
+      "columns": {
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "external_site_config_external_site_id_external_site_id_fk": {
+          "name": "external_site_config_external_site_id_external_site_id_fk",
+          "tableFrom": "external_site_config",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "external_site_config_external_site_id_key_pk": {
+          "name": "external_site_config_external_site_id_key_pk",
+          "columns": [
+            "external_site_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_site_run": {
+      "name": "external_site_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "external_site_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "external_site_run_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_id": {
+          "name": "requested_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_site_run_active_unq": {
+          "name": "external_site_run_active_unq",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"external_site_run\".\"status\" IN ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_site_run_site_created_idx": {
+          "name": "external_site_run_site_created_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_site_run_site_status_completed_idx": {
+          "name": "external_site_run_site_status_completed_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_site_run_external_site_id_external_site_id_fk": {
+          "name": "external_site_run_external_site_id_external_site_id_fk",
+          "tableFrom": "external_site_run",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_site_run_requested_by_id_user_id_fk": {
+          "name": "external_site_run_requested_by_id_user_id_fk",
+          "tableFrom": "external_site_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requested_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_site": {
+      "name": "external_site",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "external_site_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_every": {
+          "name": "run_every",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_site_type": {
+          "name": "external_site_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_site_last_run_id_external_site_run_id_fk": {
+          "name": "external_site_last_run_id_external_site_run_id_fk",
+          "tableFrom": "external_site",
+          "tableTo": "external_site_run",
+          "columnsFrom": [
+            "last_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight_bottle": {
+      "name": "flight_bottle",
+      "schema": "",
+      "columns": {
+        "flight_id": {
+          "name": "flight_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flight_bottle_bottle_idx": {
+          "name": "flight_bottle_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flight_bottle_release_idx": {
+          "name": "flight_bottle_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flight_bottle_flight_id_flight_id_fk": {
+          "name": "flight_bottle_flight_id_flight_id_fk",
+          "tableFrom": "flight_bottle",
+          "tableTo": "flight",
+          "columnsFrom": [
+            "flight_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "flight_bottle_bottle_id_bottle_id_fk": {
+          "name": "flight_bottle_bottle_id_bottle_id_fk",
+          "tableFrom": "flight_bottle",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flight_bottle_flight_id_bottle_id_unique": {
+          "name": "flight_bottle_flight_id_bottle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flight_id",
+            "bottle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight": {
+      "name": "flight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "flight_public_id": {
+          "name": "flight_public_id",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flight_created_by_id_user_id_fk": {
+          "name": "flight_created_by_id_user_id_fk",
+          "tableFrom": "flight",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follow": {
+      "name": "follow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "follow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_unq": {
+          "name": "follow_unq",
+          "columns": [
+            {
+              "expression": "from_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_to_user_idx": {
+          "name": "follow_to_user_idx",
+          "columns": [
+            {
+              "expression": "to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_from_user_id_user_id_fk": {
+          "name": "follow_from_user_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "follow_to_user_id_user_id_fk": {
+          "name": "follow_to_user_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity": {
+      "name": "identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "identity_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "identity_unq": {
+          "name": "identity_unq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_user_idx": {
+          "name": "identity_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_user_id_user_id_fk": {
+          "name": "identity_user_id_user_id_fk",
+          "tableFrom": "identity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incoming_bottle_decision_log": {
+      "name": "incoming_bottle_decision_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "incoming_bottle_decision_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "incoming_bottle_decision_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_bottle": {
+          "name": "created_bottle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_release": {
+          "name": "created_release",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incoming_bottle_decision_source_unq": {
+          "name": "incoming_bottle_decision_source_unq",
+          "columns": [
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_created_idx": {
+          "name": "incoming_bottle_decision_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_external_site_idx": {
+          "name": "incoming_bottle_decision_external_site_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_bottle_idx": {
+          "name": "incoming_bottle_decision_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_release_idx": {
+          "name": "incoming_bottle_decision_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_actor_ref_idx": {
+          "name": "incoming_bottle_decision_actor_ref_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incoming_bottle_decision_log_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "incoming_bottle_decision_log_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_external_site_id_external_site_id_fk": {
+          "name": "incoming_bottle_decision_log_external_site_id_external_site_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_actor_id_actor_id_fk": {
+          "name": "incoming_bottle_decision_log_actor_id_actor_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_bottle_id_bottle_id_fk": {
+          "name": "incoming_bottle_decision_log_bottle_id_bottle_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "notifications_unq": {
+          "name": "notifications_unq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_from_user_id_user_id_fk": {
+          "name": "notifications_from_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_code": {
+      "name": "oauth_authorization_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_digest": {
+          "name": "code_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_authorization_code_digest_unq": {
+          "name": "oauth_authorization_code_digest_unq",
+          "columns": [
+            {
+              "expression": "code_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_code_client_idx": {
+          "name": "oauth_authorization_code_client_idx",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_code_user_idx": {
+          "name": "oauth_authorization_code_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_code_expires_idx": {
+          "name": "oauth_authorization_code_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_code_oauth_client_id_oauth_client_id_fk": {
+          "name": "oauth_authorization_code_oauth_client_id_oauth_client_id_fk",
+          "tableFrom": "oauth_authorization_code",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "oauth_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_code_user_id_user_id_fk": {
+          "name": "oauth_authorization_code_user_id_user_id_fk",
+          "tableFrom": "oauth_authorization_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id_unq": {
+          "name": "oauth_client_client_id_unq",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_credential_id_unq": {
+          "name": "passkey_credential_id_unq",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_user_idx": {
+          "name": "passkey_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_upload": {
+      "name": "pending_upload",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "pendingUploadKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "pendingUploadPurpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pendingUploadStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_to_type": {
+          "name": "attached_to_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_to_id": {
+          "name": "attached_to_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_deleted_at": {
+          "name": "object_deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_upload_created_by_idx": {
+          "name": "pending_upload_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_upload_status_expires_at_idx": {
+          "name": "pending_upload_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_upload_created_by_id_user_id_fk": {
+          "name": "pending_upload_created_by_id_user_id_fk",
+          "tableFrom": "pending_upload",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_upload_idempotency_key": {
+          "name": "pending_upload_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "created_by_id",
+            "purpose",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.region": {
+      "name": "region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_distillers": {
+          "name": "total_distillers",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "region_name_unq": {
+          "name": "region_name_unq",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "region_slug_unq": {
+          "name": "region_slug_unq",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "region_country_idx": {
+          "name": "region_country_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "region_country_id_country_id_fk": {
+          "name": "region_country_id_country_id_fk",
+          "tableFrom": "region",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "issue": {
+          "name": "issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_unq_name": {
+          "name": "review_unq_name",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "issue",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_bottle_idx": {
+          "name": "review_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_release_idx": {
+          "name": "review_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_external_site_id_external_site_id_fk": {
+          "name": "review_external_site_id_external_site_id_fk",
+          "tableFrom": "review",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_bottle_id_bottle_id_fk": {
+          "name": "review_bottle_id_bottle_id_fk",
+          "tableFrom": "review",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "review_url_unique": {
+          "name": "review_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_history": {
+      "name": "store_price_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_history_unq": {
+          "name": "store_price_history_unq",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "volume",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_history_price_id_store_price_id_fk": {
+          "name": "store_price_history_price_id_store_price_id_fk",
+          "tableFrom": "store_price_history",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_attempt": {
+      "name": "store_price_match_attempt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "store_price_match_proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_status": {
+          "name": "initial_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_status": {
+          "name": "final_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bottle_id": {
+          "name": "current_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_release_id": {
+          "name": "current_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_bottle_id": {
+          "name": "suggested_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_release_id": {
+          "name": "suggested_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_bottle_id": {
+          "name": "parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_target": {
+          "name": "creation_target",
+          "type": "store_price_match_creation_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_eligible": {
+          "name": "automation_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "automation_score": {
+          "name": "automation_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_attempt_price_idx": {
+          "name": "store_price_match_attempt_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_proposal_idx": {
+          "name": "store_price_match_attempt_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_created_idx": {
+          "name": "store_price_match_attempt_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_final_status_idx": {
+          "name": "store_price_match_attempt_final_status_idx",
+          "columns": [
+            {
+              "expression": "final_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_attempt_price_id_store_price_id_fk": {
+          "name": "store_price_match_attempt_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "store_price_match_attempt_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_current_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_current_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "current_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_suggested_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_suggested_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "suggested_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_parent_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_parent_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "parent_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_reviewed_by_id_user_id_fk": {
+          "name": "store_price_match_attempt_reviewed_by_id_user_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_proposal": {
+      "name": "store_price_match_proposal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "store_price_match_proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bottle_id": {
+          "name": "current_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_release_id": {
+          "name": "current_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_bottle_id": {
+          "name": "suggested_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_release_id": {
+          "name": "suggested_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_bottle_id": {
+          "name": "parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_target": {
+          "name": "creation_target",
+          "type": "store_price_match_creation_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "alias_scope": {
+          "name": "alias_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_bottles": {
+          "name": "candidate_bottles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "extracted_label": {
+          "name": "extracted_label",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_bottle": {
+          "name": "proposed_bottle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_release": {
+          "name": "proposed_release",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_evidence": {
+          "name": "search_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "automation_assessment": {
+          "name": "automation_assessment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entered_queue_at": {
+          "name": "entered_queue_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_token": {
+          "name": "processing_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_queued_at": {
+          "name": "processing_queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_expires_at": {
+          "name": "processing_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_proposal_price_idx": {
+          "name": "store_price_match_proposal_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_status_idx": {
+          "name": "store_price_match_proposal_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_type_idx": {
+          "name": "store_price_match_proposal_type_idx",
+          "columns": [
+            {
+              "expression": "proposal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_current_bottle_idx": {
+          "name": "store_price_match_proposal_current_bottle_idx",
+          "columns": [
+            {
+              "expression": "current_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_current_release_idx": {
+          "name": "store_price_match_proposal_current_release_idx",
+          "columns": [
+            {
+              "expression": "current_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_processing_expires_idx": {
+          "name": "store_price_match_proposal_processing_expires_idx",
+          "columns": [
+            {
+              "expression": "processing_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_entered_queue_idx": {
+          "name": "store_price_match_proposal_entered_queue_idx",
+          "columns": [
+            {
+              "expression": "entered_queue_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_suggested_bottle_idx": {
+          "name": "store_price_match_proposal_suggested_bottle_idx",
+          "columns": [
+            {
+              "expression": "suggested_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_suggested_release_idx": {
+          "name": "store_price_match_proposal_suggested_release_idx",
+          "columns": [
+            {
+              "expression": "suggested_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_parent_bottle_idx": {
+          "name": "store_price_match_proposal_parent_bottle_idx",
+          "columns": [
+            {
+              "expression": "parent_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_reviewed_by_idx": {
+          "name": "store_price_match_proposal_reviewed_by_idx",
+          "columns": [
+            {
+              "expression": "reviewed_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_proposal_price_id_store_price_id_fk": {
+          "name": "store_price_match_proposal_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_current_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_current_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "current_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_suggested_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_suggested_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "suggested_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_parent_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_parent_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "parent_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_reviewed_by_id_user_id_fk": {
+          "name": "store_price_match_proposal_reviewed_by_id_user_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_retry_run_item": {
+      "name": "store_price_match_retry_run_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_retry_run_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_retry_run_item_unq": {
+          "name": "store_price_match_retry_run_item_unq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_run_status_idx": {
+          "name": "store_price_match_retry_run_item_run_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_proposal_idx": {
+          "name": "store_price_match_retry_run_item_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_price_idx": {
+          "name": "store_price_match_retry_run_item_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_retry_run_item_run_id_store_price_match_retry_run_id_fk": {
+          "name": "store_price_match_retry_run_item_run_id_store_price_match_retry_run_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price_match_retry_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_retry_run_item_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "store_price_match_retry_run_item_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_retry_run_item_price_id_store_price_id_fk": {
+          "name": "store_price_match_retry_run_item_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_retry_run": {
+      "name": "store_price_match_retry_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "store_price_match_retry_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "store_price_match_retry_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_web'"
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_retry_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "matched_count": {
+          "name": "matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_count": {
+          "name": "processed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_count": {
+          "name": "resolved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviewable_count": {
+          "name": "reviewable_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errored_count": {
+          "name": "errored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_retry_run_status_idx": {
+          "name": "store_price_match_retry_run_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_created_by_idx": {
+          "name": "store_price_match_retry_run_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_created_at_idx": {
+          "name": "store_price_match_retry_run_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_retry_run_created_by_id_user_id_fk": {
+          "name": "store_price_match_retry_run_created_by_id_user_id_fk",
+          "tableFrom": "store_price_match_retry_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price": {
+      "name": "store_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_unq_name": {
+          "name": "store_price_unq_name",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "volume",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_bottle_idx": {
+          "name": "store_price_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_release_idx": {
+          "name": "store_price_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_external_site_id_external_site_id_fk": {
+          "name": "store_price_external_site_id_external_site_id_fk",
+          "tableFrom": "store_price",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_bottle_id_bottle_id_fk": {
+          "name": "store_price_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "store_price_url_unique": {
+          "name": "store_price_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tag": {
+      "name": "tag",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "synonyms": {
+          "name": "synonyms",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "tag_category": {
+          "name": "tag_category",
+          "type": "tag_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasting_badge_award": {
+      "name": "tasting_badge_award",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "award_id": {
+          "name": "award_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasting_badge_award_key": {
+          "name": "tasting_badge_award_key",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_badge_award_award_id": {
+          "name": "tasting_badge_award_award_id",
+          "columns": [
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasting_badge_award_tasting_id_tasting_id_fk": {
+          "name": "tasting_badge_award_tasting_id_tasting_id_fk",
+          "tableFrom": "tasting_badge_award",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasting_badge_award_award_id_badge_award_id_fk": {
+          "name": "tasting_badge_award_award_id_badge_award_id_fk",
+          "tableFrom": "tasting_badge_award",
+          "tableTo": "badge_award",
+          "columnsFrom": [
+            "award_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasting": {
+      "name": "tasting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "color": {
+          "name": "color",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_legacy": {
+          "name": "rating_legacy",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_style": {
+          "name": "serving_style",
+          "type": "servingStyle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "friends": {
+          "name": "friends",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::bigint[]"
+        },
+        "flight_id": {
+          "name": "flight_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "toasts": {
+          "name": "toasts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tasting_bottle_idx": {
+          "name": "tasting_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_release_idx": {
+          "name": "tasting_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_flight_idx": {
+          "name": "tasting_flight_idx",
+          "columns": [
+            {
+              "expression": "flight_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_created_by_idx": {
+          "name": "tasting_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasting_bottle_id_bottle_id_fk": {
+          "name": "tasting_bottle_id_bottle_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasting_flight_id_flight_id_fk": {
+          "name": "tasting_flight_id_flight_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "flight",
+          "columnsFrom": [
+            "flight_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasting_created_by_id_user_id_fk": {
+          "name": "tasting_created_by_id_user_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tasting_unq": {
+          "name": "tasting_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bottle_id",
+            "created_by_id",
+            "created_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.toasts": {
+      "name": "toasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "toast_unq": {
+          "name": "toast_unq",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "toasts_tasting_id_tasting_id_fk": {
+          "name": "toasts_tasting_id_tasting_id_fk",
+          "tableFrom": "toasts",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "toasts_created_by_id_user_id_fk": {
+          "name": "toasts_created_by_id_user_id_fk",
+          "tableFrom": "toasts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "admin": {
+          "name": "admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mod": {
+          "name": "mod",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_comments": {
+          "name": "notify_comments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_unq": {
+          "name": "user_email_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_username_unq": {
+          "name": "user_username_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.legacy_release_repair_review_resolution": {
+      "name": "legacy_release_repair_review_resolution",
+      "schema": "public",
+      "values": [
+        "allow_create_parent",
+        "blocked",
+        "reuse_existing_parent"
+      ]
+    },
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "system",
+        "user"
+      ]
+    },
+    "public.badge_award_object_type": {
+      "name": "badge_award_object_type",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "entity",
+        "country",
+        "region"
+      ]
+    },
+    "public.badge_formula": {
+      "name": "badge_formula",
+      "schema": "public",
+      "values": [
+        "default",
+        "linear",
+        "fibonacci"
+      ]
+    },
+    "public.bottle_check_close_reason": {
+      "name": "bottle_check_close_reason",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "resolved_manually"
+      ]
+    },
+    "public.bottle_check_intent": {
+      "name": "bottle_check_intent",
+      "schema": "public",
+      "values": [
+        "resolve_reference",
+        "audit_bottle"
+      ]
+    },
+    "public.bottle_check_origin": {
+      "name": "bottle_check_origin",
+      "schema": "public",
+      "values": [
+        "moderator",
+        "post_user_creation"
+      ]
+    },
+    "public.bottle_operation_rejection_reason": {
+      "name": "bottle_operation_rejection_reason",
+      "schema": "public",
+      "values": [
+        "wrong_target",
+        "wrong_change",
+        "insufficient_evidence",
+        "resolved_manually",
+        "other"
+      ]
+    },
+    "public.bottle_operation_status": {
+      "name": "bottle_operation_status",
+      "schema": "public",
+      "values": [
+        "blocked",
+        "pending_review",
+        "rejected",
+        "applying",
+        "applied",
+        "stale",
+        "failed"
+      ]
+    },
+    "public.bottle_alias_assignment_source": {
+      "name": "bottle_alias_assignment_source",
+      "schema": "public",
+      "values": [
+        "legacy",
+        "canonical",
+        "source_approved",
+        "classifier_approved",
+        "human_approved"
+      ]
+    },
+    "public.type": {
+      "name": "type",
+      "schema": "public",
+      "values": [
+        "add",
+        "update",
+        "delete"
+      ]
+    },
+    "public.collection_bottle_status": {
+      "name": "collection_bottle_status",
+      "schema": "public",
+      "values": [
+        "sealed",
+        "open",
+        "empty"
+      ]
+    },
+    "public.entity_type": {
+      "name": "entity_type",
+      "schema": "public",
+      "values": [
+        "brand",
+        "distiller",
+        "bottler"
+      ]
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "public",
+      "values": [
+        "blend",
+        "bourbon",
+        "rye",
+        "single_grain",
+        "single_malt",
+        "single_pot_still",
+        "spirit"
+      ]
+    },
+    "public.content_source": {
+      "name": "content_source",
+      "schema": "public",
+      "values": [
+        "generated",
+        "user"
+      ]
+    },
+    "public.flavor_profile": {
+      "name": "flavor_profile",
+      "schema": "public",
+      "values": [
+        "young_spritely",
+        "sweet_fruit_mellow",
+        "spicy_sweet",
+        "spicy_dry",
+        "deep_rich_dried_fruit",
+        "old_dignified",
+        "light_delicate",
+        "juicy_oak_vanilla",
+        "oily_coastal",
+        "lightly_peated",
+        "peated",
+        "heavily_peated"
+      ]
+    },
+    "public.object_type": {
+      "name": "object_type",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "bottle_group",
+        "bottle_release",
+        "bottle_series",
+        "comment",
+        "entity",
+        "tasting",
+        "toast",
+        "follow"
+      ]
+    },
+    "public.tag_category": {
+      "name": "tag_category",
+      "schema": "public",
+      "values": [
+        "cereal",
+        "fruity",
+        "floral",
+        "peaty",
+        "feinty",
+        "sulphury",
+        "woody",
+        "winey"
+      ]
+    },
+    "public.external_site_run_status": {
+      "name": "external_site_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed"
+      ]
+    },
+    "public.external_site_run_trigger": {
+      "name": "external_site_run_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.external_site_type": {
+      "name": "external_site_type",
+      "schema": "public",
+      "values": [
+        "astorwines",
+        "cadenheads",
+        "compassbox",
+        "decadentdrinks",
+        "douglaslaing",
+        "gordonmacphail",
+        "healthyspirits",
+        "kilchoman",
+        "northstarspirits",
+        "reservebar",
+        "smws",
+        "smwsa",
+        "totalwine",
+        "woodencork",
+        "whiskyadvocate"
+      ]
+    },
+    "public.follow_status": {
+      "name": "follow_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "pending",
+        "following"
+      ]
+    },
+    "public.identity_provider": {
+      "name": "identity_provider",
+      "schema": "public",
+      "values": [
+        "google",
+        "passkey"
+      ]
+    },
+    "public.incoming_bottle_decision_source_kind": {
+      "name": "incoming_bottle_decision_source_kind",
+      "schema": "public",
+      "values": [
+        "review",
+        "store_price"
+      ]
+    },
+    "public.incoming_bottle_decision_type": {
+      "name": "incoming_bottle_decision_type",
+      "schema": "public",
+      "values": [
+        "match_existing",
+        "create_bottle",
+        "create_release",
+        "create_bottle_and_release"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "comment",
+        "toast",
+        "friend_request"
+      ]
+    },
+    "public.pendingUploadKind": {
+      "name": "pendingUploadKind",
+      "schema": "public",
+      "values": [
+        "image"
+      ]
+    },
+    "public.pendingUploadPurpose": {
+      "name": "pendingUploadPurpose",
+      "schema": "public",
+      "values": [
+        "photo_tasting_entry",
+        "tasting_image",
+        "bottle_image",
+        "bottle_release_image",
+        "badge_image",
+        "avatar"
+      ]
+    },
+    "public.pendingUploadStatus": {
+      "name": "pendingUploadStatus",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attached",
+        "expired"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "usd",
+        "gbp",
+        "eur"
+      ]
+    },
+    "public.store_price_match_creation_target": {
+      "name": "store_price_match_creation_target",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "release",
+        "bottle_and_release"
+      ]
+    },
+    "public.store_price_match_proposal_status": {
+      "name": "store_price_match_proposal_status",
+      "schema": "public",
+      "values": [
+        "verified",
+        "pending_review",
+        "approved",
+        "ignored",
+        "errored"
+      ]
+    },
+    "public.store_price_match_proposal_type": {
+      "name": "store_price_match_proposal_type",
+      "schema": "public",
+      "values": [
+        "match_existing",
+        "create_new",
+        "correction",
+        "no_match"
+      ]
+    },
+    "public.store_price_match_retry_run_item_status": {
+      "name": "store_price_match_retry_run_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.store_price_match_retry_run_kind": {
+      "name": "store_price_match_retry_run_kind",
+      "schema": "public",
+      "values": [
+        "create_new",
+        "match_existing",
+        "correction",
+        "errored"
+      ]
+    },
+    "public.store_price_match_retry_run_mode": {
+      "name": "store_price_match_retry_run_mode",
+      "schema": "public",
+      "values": [
+        "no_web",
+        "full"
+      ]
+    },
+    "public.store_price_match_retry_run_status": {
+      "name": "store_price_match_retry_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.servingStyle": {
+      "name": "servingStyle",
+      "schema": "public",
+      "values": [
+        "neat",
+        "rocks",
+        "splash"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/migrations/meta/_journal.json
+++ b/apps/server/migrations/meta/_journal.json
@@ -1471,6 +1471,13 @@
       "when": 1786583221351,
       "tag": "0209_sad_living_lightning",
       "breakpoints": false
+    },
+    {
+      "idx": 210,
+      "version": "7",
+      "when": 1786584292548,
+      "tag": "0210_wandering_roulette",
+      "breakpoints": false
     }
   ]
 }

--- a/apps/server/src/db/schema/externalSites.ts
+++ b/apps/server/src/db/schema/externalSites.ts
@@ -1,6 +1,9 @@
+import { sql } from "drizzle-orm";
 import {
+  type AnyPgColumn,
   bigint,
   bigserial,
+  index,
   integer,
   jsonb,
   pgEnum,
@@ -12,11 +15,24 @@ import {
   varchar,
 } from "drizzle-orm/pg-core";
 import { EXTERNAL_SITE_TYPE_LIST } from "../../constants";
+import { users } from "./users";
 
 export const externalSiteTypeEnum = pgEnum(
   "external_site_type",
   EXTERNAL_SITE_TYPE_LIST,
 );
+
+export const externalSiteRunStatusEnum = pgEnum("external_site_run_status", [
+  "queued",
+  "running",
+  "succeeded",
+  "failed",
+]);
+
+export const externalSiteRunTriggerEnum = pgEnum("external_site_run_trigger", [
+  "scheduled",
+  "manual",
+]);
 
 export const externalSites = pgTable(
   "external_site",
@@ -25,6 +41,10 @@ export const externalSites = pgTable(
     type: externalSiteTypeEnum("type").notNull(),
     name: text("name").notNull(),
     lastRunAt: timestamp("last_run_at"),
+    lastRunId: bigint("last_run_id", { mode: "number" }).references(
+      (): AnyPgColumn => externalSiteRuns.id,
+      { onDelete: "set null" },
+    ),
     nextRunAt: timestamp("next_run_at"),
     // minutes
     runEvery: integer("run_every").default(60),
@@ -35,6 +55,44 @@ export const externalSites = pgTable(
 
 export type ExternalSite = typeof externalSites.$inferSelect;
 export type NewExternalSite = typeof externalSites.$inferInsert;
+
+export const externalSiteRuns = pgTable(
+  "external_site_run",
+  {
+    id: bigserial("id", { mode: "number" }).primaryKey(),
+    externalSiteId: bigint("external_site_id", { mode: "number" })
+      .references(() => externalSites.id, { onDelete: "cascade" })
+      .notNull(),
+    status: externalSiteRunStatusEnum("status").default("queued").notNull(),
+    trigger: externalSiteRunTriggerEnum("trigger").notNull(),
+    requestedById: bigint("requested_by_id", { mode: "number" }).references(
+      () => users.id,
+    ),
+    attemptCount: integer("attempt_count").default(0).notNull(),
+    itemCount: integer("item_count"),
+    error: text("error"),
+    startedAt: timestamp("started_at"),
+    completedAt: timestamp("completed_at"),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+  },
+  (table) => [
+    uniqueIndex("external_site_run_active_unq")
+      .on(table.externalSiteId)
+      .where(sql`${table.status} IN ('queued', 'running')`),
+    index("external_site_run_site_created_idx").on(
+      table.externalSiteId,
+      table.createdAt,
+    ),
+    index("external_site_run_site_status_completed_idx").on(
+      table.externalSiteId,
+      table.status,
+      table.completedAt,
+    ),
+  ],
+);
+
+export type ExternalSiteRun = typeof externalSiteRuns.$inferSelect;
+export type NewExternalSiteRun = typeof externalSiteRuns.$inferInsert;
 
 export const externalSiteConfig = pgTable(
   "external_site_config",

--- a/apps/server/src/lib/createExternalReview.ts
+++ b/apps/server/src/lib/createExternalReview.ts
@@ -244,10 +244,5 @@ export async function createExternalReview(
     });
   }
 
-  await db
-    .update(externalSites)
-    .set({ lastRunAt: sql`NOW()` })
-    .where(eq(externalSites.id, site.id));
-
   return review;
 }

--- a/apps/server/src/lib/externalSiteRuns.test.ts
+++ b/apps/server/src/lib/externalSiteRuns.test.ts
@@ -1,0 +1,288 @@
+import { db } from "@peated/server/db";
+import { externalSiteRuns, externalSites } from "@peated/server/db/schema";
+import {
+  createExternalSiteRunJob,
+  ExternalSiteRunActiveError,
+  queueManualExternalSiteRun,
+  queueScheduledExternalSiteRun,
+  redispatchStaleExternalSiteRuns,
+} from "@peated/server/lib/externalSiteRuns";
+import { eq } from "drizzle-orm";
+import { expect, test, vi } from "vitest";
+
+test("manual run is attributed, dispatched deterministically, and does not move schedule", async ({
+  fixtures,
+}) => {
+  const requestedBy = await fixtures.User({ admin: true });
+  const nextRunAt = new Date(Date.now() + 60_000);
+  const site = await fixtures.ExternalSite({
+    type: "decadentdrinks",
+    nextRunAt,
+  });
+  const enqueue = vi.fn(async () => undefined);
+
+  const run = await queueManualExternalSiteRun({
+    site,
+    requestedById: requestedBy.id,
+    enqueue,
+  });
+
+  expect(run).toMatchObject({
+    externalSiteId: site.id,
+    status: "queued",
+    trigger: "manual",
+    requestedById: requestedBy.id,
+  });
+  expect(enqueue).toHaveBeenCalledWith(
+    "ScrapeDecadentDrinks",
+    { runId: run.id },
+    {
+      jobId: `external-site-run-${run.id}`,
+      removeOnComplete: true,
+      removeOnFail: true,
+    },
+  );
+  const [storedSite] = await db
+    .select()
+    .from(externalSites)
+    .where(eq(externalSites.id, site.id));
+  expect(storedSite?.nextRunAt).toEqual(nextRunAt);
+  expect(storedSite?.lastRunAt).toBeNull();
+});
+
+test("worker owns successful lifecycle and terminal delivery is a no-op", async ({
+  fixtures,
+}) => {
+  const requestedBy = await fixtures.User({ admin: true });
+  const site = await fixtures.ExternalSite({ type: "decadentdrinks" });
+  const run = await queueManualExternalSiteRun({
+    site,
+    requestedById: requestedBy.id,
+    enqueue: async () => undefined,
+  });
+  const scrape = vi.fn(async () => 7);
+  const job = createExternalSiteRunJob("decadentdrinks", scrape);
+
+  await job({ runId: run.id });
+  await job({ runId: run.id });
+
+  const [storedRun] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, run.id));
+  const [storedSite] = await db
+    .select()
+    .from(externalSites)
+    .where(eq(externalSites.id, site.id));
+  expect(storedRun).toMatchObject({
+    status: "succeeded",
+    attemptCount: 1,
+    itemCount: 7,
+    error: null,
+  });
+  expect(storedRun?.startedAt).not.toBeNull();
+  expect(storedRun?.completedAt).not.toBeNull();
+  expect(storedSite?.lastRunId).toBe(run.id);
+  expect(storedSite?.lastRunAt).toEqual(storedRun?.completedAt);
+  expect(scrape).toHaveBeenCalledOnce();
+});
+
+test("worker persists a safe failure and rethrows", async ({ fixtures }) => {
+  const requestedBy = await fixtures.User({ admin: true });
+  const site = await fixtures.ExternalSite({ type: "decadentdrinks" });
+  const run = await queueManualExternalSiteRun({
+    site,
+    requestedById: requestedBy.id,
+    enqueue: async () => undefined,
+  });
+  const failure = new Error("secret provider response");
+  const job = createExternalSiteRunJob("decadentdrinks", async () => {
+    throw failure;
+  });
+
+  await expect(job({ runId: run.id })).rejects.toBe(failure);
+
+  const [storedRun] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, run.id));
+  expect(storedRun).toMatchObject({
+    status: "failed",
+    attemptCount: 1,
+    error: "Unexpected scraper failure. See Sentry using this run id.",
+  });
+  expect(storedRun?.error).not.toContain("secret");
+});
+
+test("active run prevents overlap", async ({ fixtures }) => {
+  const requestedBy = await fixtures.User({ admin: true });
+  const site = await fixtures.ExternalSite({ type: "decadentdrinks" });
+  await queueManualExternalSiteRun({
+    site,
+    requestedById: requestedBy.id,
+    enqueue: async () => undefined,
+  });
+
+  await expect(
+    queueManualExternalSiteRun({
+      site,
+      requestedById: requestedBy.id,
+      enqueue: async () => undefined,
+    }),
+  ).rejects.toBeInstanceOf(ExternalSiteRunActiveError);
+});
+
+test("dispatch failure is terminal and a scheduled site becomes due", async ({
+  fixtures,
+}) => {
+  const site = await fixtures.ExternalSite({
+    type: "decadentdrinks",
+    runEvery: 60,
+    nextRunAt: null,
+  });
+  const failure = new Error("redis unavailable");
+
+  await expect(
+    queueScheduledExternalSiteRun(site.id, async () => {
+      throw failure;
+    }),
+  ).rejects.toBe(failure);
+
+  const [run] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.externalSiteId, site.id));
+  const [storedSite] = await db
+    .select()
+    .from(externalSites)
+    .where(eq(externalSites.id, site.id));
+  expect(run).toMatchObject({
+    status: "failed",
+    trigger: "scheduled",
+    error: "Unable to dispatch scraper job.",
+  });
+  expect(storedSite?.lastRunId).toBe(run?.id);
+  expect(storedSite?.lastRunAt).toEqual(run?.completedAt);
+  expect(storedSite?.nextRunAt?.getTime()).toBeLessThanOrEqual(Date.now());
+});
+
+test("stale active runs are redispatched with their existing queue identity", async ({
+  fixtures,
+}) => {
+  const queuedSite = await fixtures.ExternalSite({ type: "decadentdrinks" });
+  const runningSite = await fixtures.ExternalSite({ type: "cadenheads" });
+  const freshSite = await fixtures.ExternalSite({ type: "smws" });
+  const staleAt = new Date("2026-01-01T00:00:00Z");
+  const staleBefore = new Date("2026-01-01T00:10:00Z");
+  const freshAt = new Date("2026-01-01T00:20:00Z");
+  const [queuedRun, runningRun] = await db
+    .insert(externalSiteRuns)
+    .values([
+      {
+        externalSiteId: queuedSite.id,
+        trigger: "scheduled",
+        createdAt: staleAt,
+      },
+      {
+        externalSiteId: runningSite.id,
+        trigger: "scheduled",
+        status: "running",
+        createdAt: staleAt,
+        startedAt: staleAt,
+      },
+      {
+        externalSiteId: freshSite.id,
+        trigger: "scheduled",
+        createdAt: freshAt,
+      },
+    ])
+    .returning();
+  const enqueue = vi.fn(async () => undefined);
+
+  const count = await redispatchStaleExternalSiteRuns({
+    staleBefore,
+    enqueue,
+  });
+
+  expect(count).toBe(2);
+  expect(enqueue).toHaveBeenCalledTimes(2);
+  expect(enqueue).toHaveBeenCalledWith(
+    "ScrapeDecadentDrinks",
+    { runId: queuedRun?.id },
+    {
+      jobId: `external-site-run-${queuedRun?.id}`,
+      removeOnComplete: true,
+      removeOnFail: true,
+    },
+  );
+  expect(enqueue).toHaveBeenCalledWith(
+    "ScrapeCadenheads",
+    { runId: runningRun?.id },
+    {
+      jobId: `external-site-run-${runningRun?.id}`,
+      removeOnComplete: true,
+      removeOnFail: true,
+    },
+  );
+});
+
+test("failed stale-run redispatch preserves the active run", async ({
+  fixtures,
+}) => {
+  const site = await fixtures.ExternalSite({ type: "decadentdrinks" });
+  const [run] = await db
+    .insert(externalSiteRuns)
+    .values({
+      externalSiteId: site.id,
+      trigger: "scheduled",
+      createdAt: new Date("2026-01-01T00:00:00Z"),
+    })
+    .returning();
+  const failure = new Error("redis unavailable");
+
+  await expect(
+    redispatchStaleExternalSiteRuns({
+      staleBefore: new Date("2026-01-01T00:10:00Z"),
+      enqueue: async () => {
+        throw failure;
+      },
+    }),
+  ).rejects.toBe(failure);
+
+  const [storedRun] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, run!.id));
+  expect(storedRun).toMatchObject({
+    status: "queued",
+    completedAt: null,
+    error: null,
+  });
+});
+
+test("scheduled run advances scheduling without claiming completion", async ({
+  fixtures,
+}) => {
+  const before = Date.now();
+  const site = await fixtures.ExternalSite({
+    type: "decadentdrinks",
+    runEvery: 60,
+    nextRunAt: null,
+  });
+
+  const run = await queueScheduledExternalSiteRun(
+    site.id,
+    async () => undefined,
+  );
+
+  const [storedSite] = await db
+    .select()
+    .from(externalSites)
+    .where(eq(externalSites.id, site.id));
+  expect(run).toMatchObject({ status: "queued", trigger: "scheduled" });
+  expect(storedSite?.nextRunAt?.getTime()).toBeGreaterThanOrEqual(
+    before + 60 * 60_000,
+  );
+  expect(storedSite?.lastRunAt).toBeNull();
+  expect(storedSite?.lastRunId).toBeNull();
+});

--- a/apps/server/src/lib/externalSiteRuns.ts
+++ b/apps/server/src/lib/externalSiteRuns.ts
@@ -1,0 +1,329 @@
+import { db, type AnyDatabase } from "@peated/server/db";
+import {
+  externalSiteRuns,
+  externalSites,
+  type ExternalSite,
+  type ExternalSiteRun,
+} from "@peated/server/db/schema";
+import type { ExternalSiteType } from "@peated/server/types";
+import type { JobName } from "@peated/server/worker/types";
+import { getJobForSite } from "@peated/server/worker/utils";
+import * as Sentry from "@sentry/node";
+import { and, asc, eq, inArray, lte, or, sql } from "drizzle-orm";
+import { z } from "zod";
+
+const STALE_EXTERNAL_SITE_RUN_MS = 10 * 60_000;
+const EXTERNAL_SITE_RUN_RECONCILE_LIMIT = 100;
+
+const ExternalSiteRunJobInputSchema = z
+  .object({ runId: z.number().int().positive() })
+  .strict();
+
+type RunTrigger = ExternalSiteRun["trigger"];
+type Enqueue = (
+  jobName: JobName,
+  args: { runId: number },
+  options: { jobId: string; removeOnComplete: boolean; removeOnFail: boolean },
+) => Promise<unknown>;
+
+export class ExternalSiteRunActiveError extends Error {
+  constructor(readonly status: "queued" | "running" | null) {
+    super(
+      status
+        ? `A scraper run is already ${status}.`
+        : "A scraper run is already active.",
+    );
+  }
+}
+
+function isActiveRunConflict(error: unknown) {
+  const candidate = error as { code?: string; constraint?: string };
+  return (
+    candidate.code === "23505" &&
+    candidate.constraint === "external_site_run_active_unq"
+  );
+}
+
+async function findActiveRun(siteId: number) {
+  const [run] = await db
+    .select({ status: externalSiteRuns.status })
+    .from(externalSiteRuns)
+    .where(
+      and(
+        eq(externalSiteRuns.externalSiteId, siteId),
+        inArray(externalSiteRuns.status, ["queued", "running"]),
+      ),
+    )
+    .limit(1);
+  return run;
+}
+
+async function insertRun(
+  connection: AnyDatabase,
+  siteId: number,
+  trigger: RunTrigger,
+  requestedById?: number,
+) {
+  const [run] = await connection
+    .insert(externalSiteRuns)
+    .values({ externalSiteId: siteId, trigger, requestedById })
+    .returning();
+  if (!run) throw new Error("Failed to create external site run.");
+  return run;
+}
+
+async function translateActiveRunConflict(error: unknown, siteId: number) {
+  if (!isActiveRunConflict(error)) throw error;
+  const activeRun = await findActiveRun(siteId);
+  throw new ExternalSiteRunActiveError(
+    activeRun?.status === "queued" || activeRun?.status === "running"
+      ? activeRun.status
+      : null,
+  );
+}
+
+async function defaultEnqueue(
+  jobName: JobName,
+  args: { runId: number },
+  options: { jobId: string; removeOnComplete: boolean; removeOnFail: boolean },
+) {
+  const { pushJob } = await import("@peated/server/worker/client");
+  return pushJob(jobName, args, options);
+}
+
+async function completeExternalSiteRun({
+  run,
+  status,
+  itemCount,
+  error,
+}: {
+  run: Pick<ExternalSiteRun, "id" | "externalSiteId">;
+  status: "succeeded" | "failed";
+  itemCount?: number;
+  error?: string;
+}) {
+  const completedAt = new Date();
+  await db.transaction(async (tx) => {
+    const [completedRun] = await tx
+      .update(externalSiteRuns)
+      .set({
+        status,
+        itemCount: itemCount ?? null,
+        error: error ?? null,
+        completedAt,
+      })
+      .where(
+        and(
+          eq(externalSiteRuns.id, run.id),
+          inArray(externalSiteRuns.status, ["queued", "running"]),
+        ),
+      )
+      .returning({ id: externalSiteRuns.id });
+
+    if (!completedRun) return;
+
+    // The pointer distinguishes this cache from ambiguous legacy timestamps.
+    await tx
+      .update(externalSites)
+      .set({ lastRunAt: completedAt, lastRunId: run.id })
+      .where(eq(externalSites.id, run.externalSiteId));
+  });
+}
+
+async function dispatchExternalSiteRun(
+  run: ExternalSiteRun,
+  site: ExternalSite,
+  enqueue: Enqueue = defaultEnqueue,
+  { completeOnFailure = true }: { completeOnFailure?: boolean } = {},
+) {
+  try {
+    await enqueue(
+      getJobForSite(site.type),
+      { runId: run.id },
+      {
+        jobId: `external-site-run-${run.id}`,
+        removeOnComplete: true,
+        removeOnFail: true,
+      },
+    );
+  } catch (error) {
+    if (!completeOnFailure) throw error;
+    await completeExternalSiteRun({
+      run,
+      status: "failed",
+      error: "Unable to dispatch scraper job.",
+    });
+    if (run.trigger === "scheduled") {
+      await db
+        .update(externalSites)
+        .set({ nextRunAt: new Date() })
+        .where(eq(externalSites.id, site.id));
+    }
+    throw error;
+  }
+  return run;
+}
+
+// The scheduler owns stale-run recovery and reuses both durable and queue identity.
+export async function redispatchStaleExternalSiteRuns({
+  staleBefore = new Date(Date.now() - STALE_EXTERNAL_SITE_RUN_MS),
+  enqueue = defaultEnqueue,
+}: { staleBefore?: Date; enqueue?: Enqueue } = {}) {
+  const staleRuns = await db
+    .select({ run: externalSiteRuns, site: externalSites })
+    .from(externalSiteRuns)
+    .innerJoin(
+      externalSites,
+      eq(externalSites.id, externalSiteRuns.externalSiteId),
+    )
+    .where(
+      and(
+        inArray(externalSiteRuns.status, ["queued", "running"]),
+        or(
+          and(
+            eq(externalSiteRuns.status, "queued"),
+            lte(externalSiteRuns.createdAt, staleBefore),
+          ),
+          and(
+            eq(externalSiteRuns.status, "running"),
+            lte(externalSiteRuns.startedAt, staleBefore),
+          ),
+        ),
+      ),
+    )
+    .orderBy(asc(externalSiteRuns.createdAt))
+    .limit(EXTERNAL_SITE_RUN_RECONCILE_LIMIT);
+
+  for (const { run, site } of staleRuns) {
+    await dispatchExternalSiteRun(run, site, enqueue, {
+      completeOnFailure: false,
+    });
+  }
+  return staleRuns.length;
+}
+
+export async function queueManualExternalSiteRun({
+  site,
+  requestedById,
+  enqueue,
+}: {
+  site: ExternalSite;
+  requestedById: number;
+  enqueue?: Enqueue;
+}) {
+  let run: ExternalSiteRun;
+  try {
+    run = await insertRun(db, site.id, "manual", requestedById);
+  } catch (error) {
+    await translateActiveRunConflict(error, site.id);
+    throw error;
+  }
+  await dispatchExternalSiteRun(run, site, enqueue);
+  return run;
+}
+
+export async function queueScheduledExternalSiteRun(
+  siteId: number,
+  enqueue?: Enqueue,
+) {
+  let result: { run: ExternalSiteRun; site: ExternalSite } | null;
+  try {
+    result = await db.transaction(async (tx) => {
+      const [site] = await tx
+        .select()
+        .from(externalSites)
+        .where(eq(externalSites.id, siteId))
+        .for("update");
+
+      if (
+        !site ||
+        site.runEvery === null ||
+        (site.nextRunAt !== null && site.nextRunAt > new Date())
+      ) {
+        return null;
+      }
+
+      const run = await insertRun(tx, site.id, "scheduled");
+      await tx
+        .update(externalSites)
+        .set({ nextRunAt: new Date(Date.now() + site.runEvery * 60_000) })
+        .where(eq(externalSites.id, site.id));
+      return { run, site };
+    });
+  } catch (error) {
+    await translateActiveRunConflict(error, siteId);
+    throw error;
+  }
+
+  if (!result) return null;
+  await dispatchExternalSiteRun(result.run, result.site, enqueue);
+  return result.run;
+}
+
+function summarizeExternalSiteRunError(error: unknown): string {
+  if (error instanceof z.ZodError) return "Scraped data failed validation.";
+  if (error instanceof Error) {
+    if (error.name === "PageNotFound") return "Retailer page was not found.";
+    if (error.message === "Failed to scrape any products.") {
+      return error.message;
+    }
+  }
+  return "Unexpected scraper failure. See Sentry using this run id.";
+}
+
+export function createExternalSiteRunJob(
+  siteType: ExternalSiteType,
+  scrape: () => Promise<number>,
+) {
+  return async (input: unknown) => {
+    const { runId } = ExternalSiteRunJobInputSchema.parse(input);
+    const run = await db.transaction(async (tx) => {
+      const [candidate] = await tx
+        .select({
+          run: externalSiteRuns,
+          site: externalSites,
+        })
+        .from(externalSiteRuns)
+        .innerJoin(
+          externalSites,
+          eq(externalSites.id, externalSiteRuns.externalSiteId),
+        )
+        .where(eq(externalSiteRuns.id, runId))
+        .for("update");
+
+      if (!candidate) throw new Error(`External site run ${runId} not found.`);
+      if (candidate.site.type !== siteType) {
+        throw new Error(`External site run ${runId} does not match its job.`);
+      }
+      if (["succeeded", "failed"].includes(candidate.run.status)) return null;
+
+      const [claimed] = await tx
+        .update(externalSiteRuns)
+        .set({
+          status: "running",
+          startedAt: candidate.run.startedAt ?? new Date(),
+          attemptCount: sql`${externalSiteRuns.attemptCount} + 1`,
+        })
+        .where(eq(externalSiteRuns.id, runId))
+        .returning();
+      return claimed ?? null;
+    });
+
+    if (!run) return;
+
+    return Sentry.withScope(async (scope) => {
+      scope.setContext("externalSiteRun", { id: run.id, site: siteType });
+      try {
+        const itemCount = await scrape();
+        await completeExternalSiteRun({ run, status: "succeeded", itemCount });
+      } catch (error) {
+        await completeExternalSiteRun({
+          run,
+          status: "failed",
+          error: summarizeExternalSiteRunError(error),
+        });
+        throw error;
+      }
+    });
+  };
+}

--- a/apps/server/src/lib/scraper.ts
+++ b/apps/server/src/lib/scraper.ts
@@ -30,7 +30,9 @@ const CACHE_EXPIRE = 60 * 60 * 18 * 1000;
 
 mkdirSync(CACHE, { recursive: true });
 
-export class PageNotFound extends Error {}
+export class PageNotFound extends Error {
+  override name = "PageNotFound";
+}
 
 export function downloadFileAsBlob(url: string) {
   return fetch(url).then((res) => res.blob());
@@ -274,4 +276,5 @@ export default async function scrapePrices(
       count: uniqueProducts.size,
     },
   });
+  return uniqueProducts.size;
 }

--- a/apps/server/src/orpc/routes/external-sites/health.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.test.ts
@@ -1,0 +1,68 @@
+import { db } from "@peated/server/db";
+import { externalSiteRuns, storePrices } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { eq } from "drizzle-orm";
+import { expect, test } from "vitest";
+
+test("health list requires an administrator", async () => {
+  const error = await waitError(() =>
+    routerClient.externalSites.healthList({}),
+  );
+  expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+});
+
+test("health list distinguishes listings from latest execution", async ({
+  fixtures,
+}) => {
+  const admin = await fixtures.User({ admin: true });
+  const site = await fixtures.ExternalSite({
+    type: "decadentdrinks",
+    lastRunAt: new Date("2026-08-12T10:00:00.000Z"),
+  });
+  const visiblePrice = await fixtures.StorePrice({ externalSiteId: site.id });
+  await db
+    .update(storePrices)
+    .set({ hidden: false })
+    .where(eq(storePrices.id, visiblePrice.id));
+  const completedAt = new Date("2026-08-12T12:00:00.000Z");
+  const [run] = await db
+    .insert(externalSiteRuns)
+    .values({
+      externalSiteId: site.id,
+      status: "failed",
+      trigger: "manual",
+      requestedById: admin.id,
+      attemptCount: 1,
+      error: "Unexpected scraper failure. See Sentry using this run id.",
+      startedAt: new Date("2026-08-12T11:59:00.000Z"),
+      completedAt,
+    })
+    .returning();
+
+  const result = await routerClient.externalSites.healthList(
+    {},
+    { context: { user: admin } },
+  );
+
+  expect(result.results).toHaveLength(1);
+  expect(result.results[0]).toMatchObject({
+    type: "decadentdrinks",
+    listingCount: 1,
+    lastRunAt: null,
+    latestRun: {
+      id: run?.id,
+      status: "failed",
+      trigger: "manual",
+    },
+    lastSucceededAt: null,
+  });
+});
+
+test("run history is administrator-only", async ({ fixtures }) => {
+  const site = await fixtures.ExternalSite({ type: "decadentdrinks" });
+  const error = await waitError(() =>
+    routerClient.externalSites.runs({ site: site.type }),
+  );
+  expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+});

--- a/apps/server/src/orpc/routes/external-sites/health.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.ts
@@ -1,0 +1,120 @@
+import { db } from "@peated/server/db";
+import {
+  externalSiteRuns,
+  externalSites,
+  storePrices,
+  type ExternalSite,
+} from "@peated/server/db/schema";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import {
+  ExternalSiteHealthSchema,
+  ExternalSiteTypeEnum,
+  listResponse,
+} from "@peated/server/schemas";
+import {
+  serializeExternalSite,
+  serializeExternalSiteRun,
+} from "@peated/server/serializers/externalSite";
+import { and, asc, count, desc, eq, ilike } from "drizzle-orm";
+import { z } from "zod";
+
+async function getHealth(site: ExternalSite) {
+  const [[listing], [latestRun], [lastSucceeded]] = await Promise.all([
+    db
+      .select({ value: count(storePrices.id) })
+      .from(storePrices)
+      .where(
+        and(
+          eq(storePrices.externalSiteId, site.id),
+          eq(storePrices.hidden, false),
+        ),
+      ),
+    db
+      .select()
+      .from(externalSiteRuns)
+      .where(eq(externalSiteRuns.externalSiteId, site.id))
+      .orderBy(desc(externalSiteRuns.createdAt))
+      .limit(1),
+    db
+      .select({ completedAt: externalSiteRuns.completedAt })
+      .from(externalSiteRuns)
+      .where(
+        and(
+          eq(externalSiteRuns.externalSiteId, site.id),
+          eq(externalSiteRuns.status, "succeeded"),
+        ),
+      )
+      .orderBy(desc(externalSiteRuns.completedAt))
+      .limit(1),
+  ]);
+
+  return {
+    ...serializeExternalSite(site),
+    listingCount: listing?.value ?? 0,
+    latestRun: latestRun ? serializeExternalSiteRun(latestRun) : null,
+    lastSucceededAt: lastSucceeded?.completedAt?.toISOString() ?? null,
+  };
+}
+
+const inputSchema = z.object({
+  query: z.coerce.string().default(""),
+  sort: z.enum(["name", "-name"]).default("name"),
+  cursor: z.coerce.number().gte(1).default(1),
+  limit: z.coerce.number().gte(1).lte(100).default(100),
+});
+
+export const healthList = procedure
+  .use(requireAdmin)
+  .route({
+    method: "GET",
+    path: "/admin/external-sites",
+    summary: "List external site health",
+    operationId: "listExternalSiteHealth",
+  })
+  .input(inputSchema)
+  .output(listResponse(ExternalSiteHealthSchema))
+  .handler(async ({ input }) => {
+    const offset = (input.cursor - 1) * input.limit;
+    const results = await db
+      .select()
+      .from(externalSites)
+      .where(
+        input.query ? ilike(externalSites.name, `%${input.query}%`) : undefined,
+      )
+      .orderBy(
+        input.sort === "-name"
+          ? desc(externalSites.name)
+          : asc(externalSites.name),
+      )
+      .limit(input.limit + 1)
+      .offset(offset);
+
+    return {
+      results: await Promise.all(results.slice(0, input.limit).map(getHealth)),
+      rel: {
+        nextCursor: results.length > input.limit ? input.cursor + 1 : null,
+        prevCursor: input.cursor > 1 ? input.cursor - 1 : null,
+      },
+    };
+  });
+
+export const healthDetails = procedure
+  .use(requireAdmin)
+  .route({
+    method: "GET",
+    path: "/admin/external-sites/{site}/health",
+    summary: "Retrieve external site health",
+    operationId: "retrieveExternalSiteHealth",
+  })
+  .input(z.object({ site: ExternalSiteTypeEnum }))
+  .output(ExternalSiteHealthSchema)
+  .handler(async ({ input, errors }) => {
+    const [site] = await db
+      .select()
+      .from(externalSites)
+      .where(eq(externalSites.type, input.site))
+      .limit(1);
+    if (!site) throw errors.NOT_FOUND({ message: "Site not found." });
+    return getHealth(site);
+  });

--- a/apps/server/src/orpc/routes/external-sites/index.ts
+++ b/apps/server/src/orpc/routes/external-sites/index.ts
@@ -2,12 +2,17 @@ import { base } from "@peated/server/orpc";
 import config from "./config";
 import create from "./create";
 import details from "./details";
+import { healthDetails, healthList } from "./health";
 import list from "./list";
+import runs from "./runs";
 import triggerJob from "./trigger-job";
 import update from "./update";
 
 export default base.tag("sites").router({
   list,
+  healthList,
+  healthDetails,
+  runs,
   create,
   details,
   update,

--- a/apps/server/src/orpc/routes/external-sites/runs.ts
+++ b/apps/server/src/orpc/routes/external-sites/runs.ts
@@ -1,0 +1,52 @@
+import { db } from "@peated/server/db";
+import { externalSiteRuns, externalSites } from "@peated/server/db/schema";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import {
+  ExternalSiteRunSchema,
+  ExternalSiteTypeEnum,
+  listResponse,
+} from "@peated/server/schemas";
+import { serializeExternalSiteRun } from "@peated/server/serializers/externalSite";
+import { desc, eq } from "drizzle-orm";
+import { z } from "zod";
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "GET",
+    path: "/admin/external-sites/{site}/runs",
+    summary: "List recent external site runs",
+    operationId: "listExternalSiteRuns",
+  })
+  .input(
+    z.object({
+      site: ExternalSiteTypeEnum,
+      cursor: z.coerce.number().gte(1).default(1),
+      limit: z.coerce.number().gte(1).lte(100).default(20),
+    }),
+  )
+  .output(listResponse(ExternalSiteRunSchema))
+  .handler(async ({ input, errors }) => {
+    const [site] = await db
+      .select({ id: externalSites.id })
+      .from(externalSites)
+      .where(eq(externalSites.type, input.site))
+      .limit(1);
+    if (!site) throw errors.NOT_FOUND({ message: "Site not found." });
+
+    const results = await db
+      .select()
+      .from(externalSiteRuns)
+      .where(eq(externalSiteRuns.externalSiteId, site.id))
+      .orderBy(desc(externalSiteRuns.createdAt))
+      .limit(input.limit + 1)
+      .offset((input.cursor - 1) * input.limit);
+    return {
+      results: results.slice(0, input.limit).map(serializeExternalSiteRun),
+      rel: {
+        nextCursor: results.length > input.limit ? input.cursor + 1 : null,
+        prevCursor: input.cursor > 1 ? input.cursor - 1 : null,
+      },
+    };
+  });

--- a/apps/server/src/orpc/routes/external-sites/trigger-job.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/trigger-job.test.ts
@@ -31,7 +31,11 @@ describe("POST /external-sites/:site/trigger", () => {
       { context: { user: adminUser } },
     );
 
-    expect(result.success).toBe(true);
+    expect(result).toMatchObject({
+      status: "queued",
+      trigger: "manual",
+      requestedById: adminUser.id,
+    });
     expect(pushJob).toHaveBeenCalledOnce();
   });
 });

--- a/apps/server/src/orpc/routes/external-sites/trigger-job.ts
+++ b/apps/server/src/orpc/routes/external-sites/trigger-job.ts
@@ -1,10 +1,17 @@
 import { db } from "@peated/server/db";
 import { externalSites } from "@peated/server/db/schema";
+import {
+  ExternalSiteRunActiveError,
+  queueManualExternalSiteRun,
+} from "@peated/server/lib/externalSiteRuns";
 import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
-import { ExternalSiteTypeEnum } from "@peated/server/schemas";
-import { pushJob } from "@peated/server/worker/client";
-import { getJobForSite } from "@peated/server/worker/utils";
+import {
+  ExternalSiteRunSchema,
+  ExternalSiteTypeEnum,
+} from "@peated/server/schemas";
+import { serialize } from "@peated/server/serializers";
+import { ExternalSiteRunSerializer } from "@peated/server/serializers/externalSite";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 
@@ -23,7 +30,7 @@ export default procedure
       site: ExternalSiteTypeEnum,
     }),
   )
-  .output(z.object({ success: z.boolean() }))
+  .output(ExternalSiteRunSchema)
   .handler(async function ({ input, context, errors }) {
     const [site] = await db
       .select()
@@ -37,9 +44,16 @@ export default procedure
       });
     }
 
-    await pushJob(getJobForSite(site.type));
-
-    return {
-      success: true,
-    };
+    try {
+      const run = await queueManualExternalSiteRun({
+        site,
+        requestedById: context.user.id,
+      });
+      return serialize(ExternalSiteRunSerializer, run, context.user);
+    } catch (error) {
+      if (error instanceof ExternalSiteRunActiveError) {
+        throw errors.CONFLICT({ message: error.message, cause: error });
+      }
+      throw error;
+    }
   });

--- a/apps/server/src/schemas/externalSites.ts
+++ b/apps/server/src/schemas/externalSites.ts
@@ -11,13 +11,36 @@ export const ExternalSiteSchema = z.object({
     .string()
     .datetime()
     .nullable()
-    .describe("Timestamp of the last scraping run"),
+    .describe("Completion timestamp of the latest terminal scraper run"),
   nextRunAt: z
     .string()
     .datetime()
     .nullable()
     .describe("Timestamp of the next scheduled run"),
   runEvery: z.number().nullable().describe("Interval in minutes between runs"),
+});
+
+export const ExternalSiteRunSchema = z.object({
+  id: z.number().describe("Unique identifier for this scraper run"),
+  status: z.enum(["queued", "running", "succeeded", "failed"]),
+  trigger: z.enum(["scheduled", "manual"]),
+  requestedById: z.number().nullable(),
+  attemptCount: z.number().int().min(0),
+  itemCount: z.number().int().min(0).nullable(),
+  error: z.string().nullable(),
+  startedAt: z.string().datetime().nullable(),
+  completedAt: z.string().datetime().nullable(),
+  createdAt: z.string().datetime(),
+});
+
+export const ExternalSiteHealthSchema = ExternalSiteSchema.extend({
+  listingCount: z
+    .number()
+    .int()
+    .min(0)
+    .describe("Number of visible listings currently owned by the site"),
+  latestRun: ExternalSiteRunSchema.nullable(),
+  lastSucceededAt: z.string().datetime().nullable(),
 });
 
 export const ExternalSiteInputSchema = z.object({

--- a/apps/server/src/serializers/externalSite.ts
+++ b/apps/server/src/serializers/externalSite.ts
@@ -1,7 +1,24 @@
 import { type z } from "zod";
 import { serializer } from ".";
-import type { ExternalSite, User } from "../db/schema";
-import { type ExternalSiteSchema } from "../schemas";
+import type { ExternalSite, ExternalSiteRun, User } from "../db/schema";
+import {
+  type ExternalSiteRunSchema,
+  type ExternalSiteSchema,
+} from "../schemas";
+
+export function serializeExternalSite(
+  item: ExternalSite,
+): z.infer<typeof ExternalSiteSchema> {
+  return {
+    id: item.id,
+    name: item.name,
+    type: item.type,
+    lastRunAt:
+      item.lastRunId !== null ? (item.lastRunAt?.toISOString() ?? null) : null,
+    nextRunAt: item.nextRunAt?.toISOString() ?? null,
+    runEvery: item.runEvery,
+  };
+}
 
 export const ExternalSiteSerializer = serializer({
   name: "externalSite",
@@ -10,13 +27,29 @@ export const ExternalSiteSerializer = serializer({
     attrs: Record<string, any>,
     currentUser?: User,
   ): z.infer<typeof ExternalSiteSchema> => {
-    return {
-      id: item.id,
-      name: item.name,
-      type: item.type,
-      lastRunAt: item.lastRunAt?.toISOString() ?? null,
-      nextRunAt: item.nextRunAt?.toISOString() ?? null,
-      runEvery: item.runEvery,
-    };
+    return serializeExternalSite(item);
   },
 });
+
+export const ExternalSiteRunSerializer = serializer({
+  name: "externalSiteRun",
+  item: (item: ExternalSiteRun): z.infer<typeof ExternalSiteRunSchema> =>
+    serializeExternalSiteRun(item),
+});
+
+export function serializeExternalSiteRun(
+  item: ExternalSiteRun,
+): z.infer<typeof ExternalSiteRunSchema> {
+  return {
+    id: item.id,
+    status: item.status,
+    trigger: item.trigger,
+    requestedById: item.requestedById,
+    attemptCount: item.attemptCount,
+    itemCount: item.itemCount,
+    error: item.error,
+    startedAt: item.startedAt?.toISOString() ?? null,
+    completedAt: item.completedAt?.toISOString() ?? null,
+    createdAt: item.createdAt.toISOString(),
+  };
+}

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -1,3 +1,4 @@
+import { createExternalSiteRunJob } from "@peated/server/lib/externalSiteRuns";
 import registry from "../registry";
 import capturePriceImage from "./capturePriceImage";
 import cleanupPendingUploads from "./cleanupPendingUploads";
@@ -69,21 +70,27 @@ registry.add(
   reconcileStorePriceMatchProposals,
 );
 registry.add("ResolveStorePriceBottle", resolveStorePriceBottle);
-registry.add("ScrapeAstorWines", scrapeAstorWines);
-registry.add("ScrapeCadenheads", scrapeCadenheads);
-registry.add("ScrapeCompassBox", scrapeCompassBox);
-registry.add("ScrapeDecadentDrinks", scrapeDecadentDrinks);
-registry.add("ScrapeDouglasLaing", scrapeDouglasLaing);
-registry.add("ScrapeGordonMacphail", scrapeGordonMacphail);
-registry.add("ScrapeHealthySpirits", scrapeHealthySpirits);
-registry.add("ScrapeKilchoman", scrapeKilchoman);
-registry.add("ScrapeNorthStarSpirits", scrapeNorthStarSpirits);
-registry.add("ScrapeReserveBar", scrapeReserveBar);
-registry.add("ScrapeSMWS", scrapeSMWS);
-registry.add("ScrapeSMWSA", scrapeSMWSA);
-registry.add("ScrapeTotalWine", scrapeTotalWine);
-registry.add("ScrapeWoodenCork", scrapeWoodenCork);
-registry.add("ScrapeWhiskyAdvocate", scrapeWhiskeyAdvocate);
+const scraperJobs = [
+  ["ScrapeAstorWines", "astorwines", scrapeAstorWines],
+  ["ScrapeCadenheads", "cadenheads", scrapeCadenheads],
+  ["ScrapeCompassBox", "compassbox", scrapeCompassBox],
+  ["ScrapeDecadentDrinks", "decadentdrinks", scrapeDecadentDrinks],
+  ["ScrapeDouglasLaing", "douglaslaing", scrapeDouglasLaing],
+  ["ScrapeGordonMacphail", "gordonmacphail", scrapeGordonMacphail],
+  ["ScrapeHealthySpirits", "healthyspirits", scrapeHealthySpirits],
+  ["ScrapeKilchoman", "kilchoman", scrapeKilchoman],
+  ["ScrapeNorthStarSpirits", "northstarspirits", scrapeNorthStarSpirits],
+  ["ScrapeReserveBar", "reservebar", scrapeReserveBar],
+  ["ScrapeSMWS", "smws", scrapeSMWS],
+  ["ScrapeSMWSA", "smwsa", scrapeSMWSA],
+  ["ScrapeTotalWine", "totalwine", scrapeTotalWine],
+  ["ScrapeWoodenCork", "woodencork", scrapeWoodenCork],
+  ["ScrapeWhiskyAdvocate", "whiskyadvocate", scrapeWhiskeyAdvocate],
+] as const;
+
+for (const [jobName, siteType, scrape] of scraperJobs) {
+  registry.add(jobName, createExternalSiteRunJob(siteType, scrape));
+}
 registry.add("CreateMissingBottles", createMissingBottles);
 registry.add("UpdateBottleStats", updateBottleStats);
 registry.add("UpdateCountryStats", updateCountryStats);

--- a/apps/server/src/worker/jobs/scheduleScrapers.ts
+++ b/apps/server/src/worker/jobs/scheduleScrapers.ts
@@ -1,12 +1,17 @@
 import { db } from "@peated/server/db";
 import { externalSites } from "@peated/server/db/schema";
-import { pushJob } from "@peated/server/worker/client";
-import { and, eq, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
-import { getJobForSite } from "../utils";
+import {
+  ExternalSiteRunActiveError,
+  queueScheduledExternalSiteRun,
+  redispatchStaleExternalSiteRuns,
+} from "@peated/server/lib/externalSiteRuns";
+import { and, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
 
 export default async function scheduleScrapers() {
+  await redispatchStaleExternalSiteRuns();
+
   const pending = await db
-    .select()
+    .select({ id: externalSites.id })
     .from(externalSites)
     .where(
       and(
@@ -17,20 +22,11 @@ export default async function scheduleScrapers() {
         isNotNull(externalSites.runEvery),
       ),
     );
-
-  await db.transaction(async (tx) => {
-    for (const site of pending) {
-      await pushJob(getJobForSite(site.type));
-      // TODO: have the job update nextRunAt when it finishes
-      await tx
-        .update(externalSites)
-        .set({
-          lastRunAt: sql`NOW()`,
-          nextRunAt: sql`NOW() + INTERVAL '${sql.raw(
-            `${site.runEvery} minutes`,
-          )}'`,
-        })
-        .where(eq(externalSites.id, site.id));
+  for (const site of pending) {
+    try {
+      await queueScheduledExternalSiteRun(site.id);
+    } catch (error) {
+      if (!(error instanceof ExternalSiteRunActiveError)) throw error;
     }
-  });
+  }
 }

--- a/apps/server/src/worker/jobs/scrapeAstorWines.ts
+++ b/apps/server/src/worker/jobs/scrapeAstorWines.ts
@@ -67,17 +67,18 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 }
 
 export default async function scrapeAstorWines() {
-  await scrapePrices(
+  const scotchCount = await scrapePrices(
     SITE,
     (page) =>
       `https://www.astorwines.com/SpiritsSearchResult.aspx?search=Advanced&searchtype=Contains&term=&cat=2&style=3_41&srt=1&instockonly=True&Page=${page}`,
     scrapeProducts,
   );
 
-  await scrapePrices(
+  const whiskeyCount = await scrapePrices(
     SITE,
     (page) =>
       `https://www.astorwines.com/SpiritsSearchResult.aspx?search=Advanced&searchtype=Contains&term=&cat=2&style=2_32&srt=1&instockonly=True&Page=${page}`,
     scrapeProducts,
   );
+  return scotchCount + whiskeyCount;
 }

--- a/apps/server/src/worker/jobs/scrapeCadenheads.test.ts
+++ b/apps/server/src/worker/jobs/scrapeCadenheads.test.ts
@@ -60,7 +60,7 @@ test("paginates a dry run and stops after an empty page", async ({
     )
     .reply(200, []);
 
-  await expect(scrapeCadenheads({ dryRun: true })).resolves.toBeUndefined();
+  await expect(scrapeCadenheads({ dryRun: true })).resolves.toBe(2);
 });
 
 test("fails when a complete scrape yields no supported listings", async ({

--- a/apps/server/src/worker/jobs/scrapeCadenheads.ts
+++ b/apps/server/src/worker/jobs/scrapeCadenheads.ts
@@ -134,7 +134,7 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 export default async function scrapeCadenheads({
   dryRun = false,
 }: { dryRun?: boolean } = {}) {
-  await scrapePrices(
+  return scrapePrices(
     SITE,
     (page) =>
       `https://www.cadenhead.shop/wp-json/wc/store/v1/products?category=whisky&per_page=100&stock_status=instock&page=${page}`,

--- a/apps/server/src/worker/jobs/scrapeCompassBox.test.ts
+++ b/apps/server/src/worker/jobs/scrapeCompassBox.test.ts
@@ -64,7 +64,7 @@ test("runs a single-page dry run and stops on duplicate listings", async ({
   const result = await loadFixture("compassbox", "bottle-list.html");
   axiosMock.onGet(shopUrl).reply(200, result);
 
-  await expect(scrapeCompassBox({ dryRun: true })).resolves.toBeUndefined();
+  await expect(scrapeCompassBox({ dryRun: true })).resolves.toBe(2);
   expect(axiosMock.history.get).toHaveLength(2);
 });
 

--- a/apps/server/src/worker/jobs/scrapeCompassBox.ts
+++ b/apps/server/src/worker/jobs/scrapeCompassBox.ts
@@ -106,5 +106,5 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 export default async function scrapeCompassBox({
   dryRun = false,
 }: { dryRun?: boolean } = {}) {
-  await scrapePrices(SITE, () => SHOP_URL, scrapeProducts, { dryRun });
+  return await scrapePrices(SITE, () => SHOP_URL, scrapeProducts, { dryRun });
 }

--- a/apps/server/src/worker/jobs/scrapeDecadentDrinks.ts
+++ b/apps/server/src/worker/jobs/scrapeDecadentDrinks.ts
@@ -86,7 +86,7 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 }
 
 export default async function scrapeDecadentDrinks() {
-  await scrapePrices(
+  return scrapePrices(
     SITE,
     (page) => `https://decadent-drinks.com/shop?category=5&page=${page - 1}`,
     scrapeProducts,

--- a/apps/server/src/worker/jobs/scrapeDouglasLaing.test.ts
+++ b/apps/server/src/worker/jobs/scrapeDouglasLaing.test.ts
@@ -70,7 +70,7 @@ test("paginates a dry run and stops after an empty page", async ({
     )
     .reply(200, { products: [] });
 
-  await expect(scrapeDouglasLaing({ dryRun: true })).resolves.toBeUndefined();
+  await expect(scrapeDouglasLaing({ dryRun: true })).resolves.toBe(3);
 });
 
 test("fails when a complete scrape yields no supported listings", async ({

--- a/apps/server/src/worker/jobs/scrapeDouglasLaing.ts
+++ b/apps/server/src/worker/jobs/scrapeDouglasLaing.ts
@@ -132,7 +132,7 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 export default async function scrapeDouglasLaing({
   dryRun = false,
 }: { dryRun?: boolean } = {}) {
-  await scrapePrices(
+  return await scrapePrices(
     SITE,
     (page) =>
       `${STORE_ORIGIN}/en-us/collections/scotch-whisky/products.json?limit=250&page=${page}`,

--- a/apps/server/src/worker/jobs/scrapeGordonMacphail.test.ts
+++ b/apps/server/src/worker/jobs/scrapeGordonMacphail.test.ts
@@ -61,7 +61,7 @@ test("paginates a dry run and stops after an empty page", async ({
     .onGet("https://shop.gordonandmacphail.com/products.json?limit=250&page=2")
     .reply(200, { products: [] });
 
-  await expect(scrapeGordonMacphail({ dryRun: true })).resolves.toBeUndefined();
+  await expect(scrapeGordonMacphail({ dryRun: true })).resolves.toBe(2);
 });
 
 test("fails when a complete scrape yields no supported listings", async ({

--- a/apps/server/src/worker/jobs/scrapeGordonMacphail.ts
+++ b/apps/server/src/worker/jobs/scrapeGordonMacphail.ts
@@ -149,7 +149,7 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 export default async function scrapeGordonMacphail({
   dryRun = false,
 }: { dryRun?: boolean } = {}) {
-  await scrapePrices(
+  return scrapePrices(
     SITE,
     (page) =>
       `https://shop.gordonandmacphail.com/products.json?limit=250&page=${page}`,

--- a/apps/server/src/worker/jobs/scrapeHealthySpirits.ts
+++ b/apps/server/src/worker/jobs/scrapeHealthySpirits.ts
@@ -80,7 +80,7 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 }
 
 export default async function scrapeHealthySpirits() {
-  await scrapePrices(
+  return scrapePrices(
     SITE,
     (page) =>
       `https://www.healthyspirits.com/spirits/whiskey/page${page}.html?limit=72`,

--- a/apps/server/src/worker/jobs/scrapeKilchoman.test.ts
+++ b/apps/server/src/worker/jobs/scrapeKilchoman.test.ts
@@ -66,7 +66,7 @@ test("runs a single-page dry run and stops on duplicate listings", async ({
   const result = await loadFixture("kilchoman", "bottle-list.html");
   axiosMock.onGet(shopUrl).reply(200, result);
 
-  await expect(scrapeKilchoman({ dryRun: true })).resolves.toBeUndefined();
+  await expect(scrapeKilchoman({ dryRun: true })).resolves.toBe(2);
   expect(axiosMock.history.get).toHaveLength(2);
 });
 

--- a/apps/server/src/worker/jobs/scrapeKilchoman.ts
+++ b/apps/server/src/worker/jobs/scrapeKilchoman.ts
@@ -97,5 +97,5 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 export default async function scrapeKilchoman({
   dryRun = false,
 }: { dryRun?: boolean } = {}) {
-  await scrapePrices(SITE, () => SHOP_URL, scrapeProducts, { dryRun });
+  return scrapePrices(SITE, () => SHOP_URL, scrapeProducts, { dryRun });
 }

--- a/apps/server/src/worker/jobs/scrapeNorthStarSpirits.test.ts
+++ b/apps/server/src/worker/jobs/scrapeNorthStarSpirits.test.ts
@@ -62,9 +62,7 @@ test("paginates a dry run and stops after an empty page", async ({
     )
     .reply(200, { products: [] });
 
-  await expect(
-    scrapeNorthStarSpirits({ dryRun: true }),
-  ).resolves.toBeUndefined();
+  await expect(scrapeNorthStarSpirits({ dryRun: true })).resolves.toBe(2);
 });
 
 test("fails when a complete scrape yields no supported listings", async ({

--- a/apps/server/src/worker/jobs/scrapeNorthStarSpirits.ts
+++ b/apps/server/src/worker/jobs/scrapeNorthStarSpirits.ts
@@ -126,7 +126,7 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 export default async function scrapeNorthStarSpirits({
   dryRun = false,
 }: { dryRun?: boolean } = {}) {
-  await scrapePrices(
+  return scrapePrices(
     SITE,
     (page) =>
       `https://northstarspirits.com/collections/shop/products.json?limit=250&page=${page}`,

--- a/apps/server/src/worker/jobs/scrapeReserveBar.ts
+++ b/apps/server/src/worker/jobs/scrapeReserveBar.ts
@@ -80,7 +80,7 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 export default async function scrapeReserveBar() {
   const limit = 36;
 
-  await scrapePrices(
+  return scrapePrices(
     SITE,
     (page) =>
       `https://www.reservebar.com/collections/whiskey?start=${page * limit}&sz=${limit}`,

--- a/apps/server/src/worker/jobs/scrapeSMWS.ts
+++ b/apps/server/src/worker/jobs/scrapeSMWS.ts
@@ -31,7 +31,7 @@ function parseAbv(value: string | number | null | undefined): number | null {
 }
 
 export default async function scrapeSMWS() {
-  await scrapeBottles(
+  return scrapeBottles(
     `https://api.smws.com/api/v1/bottles?store_id=uk&parent_id=61&page=1&sortBy=featured&minPrice=0&maxPrice=0&perPage=128`,
     handleBottle,
   );
@@ -64,6 +64,7 @@ export async function scrapeBottles(
 ) {
   const body = await getUrl(url);
   const data = SMWSPayloadSchema.parse(JSON.parse(body));
+  let itemCount = 0;
 
   await chunked(data.items, 10, async (items) => {
     await Promise.all(
@@ -158,7 +159,9 @@ export async function scrapeBottles(
           },
           item.image,
         );
+        itemCount += 1;
       }),
     );
   });
+  return itemCount;
 }

--- a/apps/server/src/worker/jobs/scrapeSMWSA.ts
+++ b/apps/server/src/worker/jobs/scrapeSMWSA.ts
@@ -17,7 +17,7 @@ import { logScrapeWarning } from "./scrapeLogging";
 const SITE = "smwsa";
 
 export default async function scrapeSMWSA() {
-  await scrapeBottles(
+  return scrapeBottles(
     `https://newmake.smwsa.com/collections/all-products`,
     handleBottle,
   );
@@ -33,6 +33,7 @@ export async function scrapeBottles(
 ) {
   const data = await getUrl(url);
   const $ = cheerio(data);
+  let itemCount = 0;
 
   for (const el of $(".product-collection-module__grid-item")) {
     const itemType = $(".product-collection-module__type", el)
@@ -158,5 +159,7 @@ export async function scrapeBottles(
         : null,
       imageUrl,
     );
+    itemCount += 1;
   }
+  return itemCount;
 }

--- a/apps/server/src/worker/jobs/scrapeTotalWine.ts
+++ b/apps/server/src/worker/jobs/scrapeTotalWine.ts
@@ -63,17 +63,18 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 }
 
 export default async function scrapeTotalWine() {
-  await scrapePrices(
+  const scotchCount = await scrapePrices(
     SITE,
     (page) =>
       `https://www.totalwine.com/spirits/scotch/c/000887?viewall=true&pageSize=120&aty=0,0,0,0&page=${page}`,
     scrapeProducts,
   );
 
-  await scrapePrices(
+  const whiskeyCount = await scrapePrices(
     SITE,
     (page) =>
       `https://www.totalwine.com/spirits/whiskey/c/9238919?viewall=true&pageSize=120&aty=0,0,0,0&page=${page}`,
     scrapeProducts,
   );
+  return scotchCount + whiskeyCount;
 }

--- a/apps/server/src/worker/jobs/scrapeWhiskyAdvocate.ts
+++ b/apps/server/src/worker/jobs/scrapeWhiskyAdvocate.ts
@@ -24,7 +24,7 @@ export default async function scrapeWhiskeyAdvocate({
   );
   if (issueList.length === 0) {
     logError("[Whisky Advocate] No issues found");
-    return;
+    return 0;
   }
 
   logInfo("[Whisky Advocate] Found {issueCount} issues", {
@@ -46,7 +46,7 @@ export default async function scrapeWhiskeyAdvocate({
   const newIssues = issueList.filter((i) => !processedIssues.includes(i));
   if (newIssues.length === 0) {
     logInfo("[Whisky Advocate] No unprocessed issues found", {});
-    return;
+    return 0;
   }
 
   logInfo("[Whisky Advocate] Found {issueCount} new issues", {
@@ -55,6 +55,7 @@ export default async function scrapeWhiskeyAdvocate({
     },
   });
 
+  let itemCount = 0;
   for (const issueName of newIssues) {
     logInfo("[Whisky Advocate] Fetching reviews for issue {issueName}", {
       extra: {
@@ -66,6 +67,7 @@ export default async function scrapeWhiskeyAdvocate({
         issueName,
       )}&order_by=published_desc`,
       async (item) => {
+        itemCount += 1;
         if (!dryRun) {
           logInfo("[Whisky Advocate] Submitting {name}", {
             extra: {
@@ -117,6 +119,7 @@ export default async function scrapeWhiskeyAdvocate({
       });
     }
   }
+  return itemCount;
 }
 
 export async function scrapeIssueList(

--- a/apps/server/src/worker/jobs/scrapeWoodenCork.ts
+++ b/apps/server/src/worker/jobs/scrapeWoodenCork.ts
@@ -102,7 +102,7 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 }
 
 export default async function scrapeWoodenCork() {
-  await scrapePrices(
+  return scrapePrices(
     SITE,
     (page) => `https://woodencork.com/collections/whiskey?cursor=${page}`,
     scrapeProducts,

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -413,6 +413,13 @@ async function handleRpcRequest({ request, response, url }) {
       }
       sendRpcResponse(response, priceSite);
       return true;
+    case "externalSites/healthDetails":
+      if (input?.site !== priceSite.type) {
+        sendRpcError(response, "Unexpected external site health payload");
+        return true;
+      }
+      sendRpcResponse(response, priceSite);
+      return true;
     case "bottleGroups/details": {
       const group = getBottleGroup(input?.group);
       if (!group) {

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -528,6 +528,9 @@ export const priceSite = {
   lastRunAt: timestamp,
   nextRunAt: null,
   runEvery: 60,
+  listingCount: 3,
+  latestRun: null,
+  lastSucceededAt: null,
 };
 
 export const firstStorePriceName = "First Bottle store listing";

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/runs/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/runs/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { type ExternalSiteType } from "@peated/server/types";
+import EmptyActivity from "@peated/web/components/emptyActivity";
+import PaginationButtons from "@peated/web/components/paginationButtons";
+import Table from "@peated/web/components/table";
+import TimeSince from "@peated/web/components/timeSince";
+import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
+import classNames from "@peated/web/lib/classNames";
+import { formatDuration } from "@peated/web/lib/format";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { use } from "react";
+
+type Run = {
+  status: "queued" | "running" | "succeeded" | "failed";
+  startedAt: string | Date | null;
+  completedAt: string | Date | null;
+};
+
+function RunStatus({ status }: Pick<Run, "status">) {
+  const colors = {
+    queued: "bg-sky-400",
+    running: "bg-amber-400",
+    succeeded: "bg-green-400",
+    failed: "bg-red-400",
+  } as const;
+
+  return (
+    <span className="inline-flex items-center gap-2 font-medium capitalize">
+      <span
+        aria-hidden="true"
+        className={classNames("h-2 w-2 rounded-full", colors[status])}
+      />
+      {status}
+    </span>
+  );
+}
+
+function runDuration(run: Run) {
+  if (!run.startedAt || !run.completedAt) return "—";
+
+  const duration =
+    new Date(run.completedAt).getTime() - new Date(run.startedAt).getTime();
+  return duration < 1000 ? `${duration} ms` : formatDuration(duration);
+}
+
+export default function Page(props: {
+  params: Promise<{ siteId: ExternalSiteType }>;
+}) {
+  const { siteId } = use(props.params);
+  const queryParams = useApiQueryParams({
+    numericFields: ["cursor", "limit"],
+    overrides: { site: siteId },
+  });
+  const orpc = useORPC();
+  const { data: runList } = useSuspenseQuery(
+    orpc.externalSites.runs.queryOptions({ input: queryParams }),
+  );
+
+  return runList.results.length > 0 ? (
+    <>
+      <div className="divide-y divide-slate-800 sm:hidden">
+        {runList.results.map((run) => (
+          <article key={run.id} className="px-3 py-4">
+            <div className="flex items-start justify-between gap-4">
+              <RunStatus status={run.status} />
+              <span className="text-muted shrink-0 text-xs">
+                <TimeSince date={run.createdAt} />
+              </span>
+            </div>
+            <div className="text-muted mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+              <span className="capitalize">{run.trigger}</span>
+              <span>
+                {run.attemptCount} attempt
+                {run.attemptCount === 1 ? "" : "s"}
+              </span>
+              {run.itemCount !== null ? (
+                <span>{run.itemCount.toLocaleString("en-US")} items</span>
+              ) : null}
+              <span>{runDuration(run)}</span>
+            </div>
+            {run.error ? (
+              <div className="mt-3 rounded-md border border-red-900/70 bg-red-950/30 px-3 py-2 text-xs text-red-200">
+                {run.error}
+              </div>
+            ) : null}
+          </article>
+        ))}
+        <PaginationButtons rel={runList.rel} />
+      </div>
+      <div className="hidden sm:block">
+        <Table
+          items={runList.results}
+          rel={runList.rel}
+          columns={[
+            {
+              name: "status",
+              title: "Run",
+              value: (run) => (
+                <div>
+                  <RunStatus status={run.status} />
+                  <div className="text-muted mt-1 text-xs">
+                    {run.attemptCount} attempt
+                    {run.attemptCount === 1 ? "" : "s"}
+                    {run.itemCount !== null
+                      ? ` · ${run.itemCount.toLocaleString("en-US")} items`
+                      : ""}
+                  </div>
+                  {run.error ? (
+                    <div className="mt-2 text-xs text-red-300">{run.error}</div>
+                  ) : null}
+                </div>
+              ),
+            },
+            {
+              name: "trigger",
+              title: "Trigger",
+              value: (run) => <span className="capitalize">{run.trigger}</span>,
+            },
+            {
+              name: "createdAt",
+              title: "Queued",
+              className: "w-40",
+              cellClassName: "whitespace-nowrap",
+              value: (run) => <TimeSince date={run.createdAt} />,
+            },
+            {
+              name: "duration",
+              title: "Duration",
+              className: "w-36",
+              cellClassName: "whitespace-nowrap",
+              value: (run) => runDuration(run),
+            },
+          ]}
+        />
+      </div>
+    </>
+  ) : (
+    <EmptyActivity>No scraper runs have been recorded yet.</EmptyActivity>
+  );
+}

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { type ExternalSiteSchema } from "@peated/server/schemas";
 import { type ExternalSiteType } from "@peated/server/types";
+import ExternalSiteRunStatus from "@peated/web/components/admin/externalSiteRunStatus";
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
 import Link from "@peated/web/components/link";
@@ -9,13 +9,18 @@ import Tabs, { TabItem } from "@peated/web/components/tabs";
 import TimeSince from "@peated/web/components/timeSince";
 import { formatDuration } from "@peated/web/lib/format";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import { use, useState, type ReactNode } from "react";
 import { type z } from "zod";
 
 function TriggerJobButton({ siteId }: { siteId: ExternalSiteType }) {
   const [isLoading, setLoading] = useState(false);
   const orpc = useORPC();
+  const queryClient = useQueryClient();
   const triggerJobMutation = useMutation(
     orpc.externalSites.triggerJob.mutationOptions(),
   );
@@ -26,10 +31,24 @@ function TriggerJobButton({ siteId }: { siteId: ExternalSiteType }) {
       loading={isLoading}
       onClick={async () => {
         setLoading(true);
-        await triggerJobMutation.mutateAsync({
-          site: siteId,
-        });
-        setLoading(false);
+        try {
+          await triggerJobMutation.mutateAsync({ site: siteId });
+          await Promise.all([
+            queryClient.invalidateQueries({
+              queryKey: orpc.externalSites.healthList.key(),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: orpc.externalSites.healthDetails.key({
+                input: { site: siteId },
+              }),
+            }),
+            queryClient.invalidateQueries({
+              queryKey: orpc.externalSites.runs.key(),
+            }),
+          ]);
+        } finally {
+          setLoading(false);
+        }
       }}
     >
       Run Scraper Now
@@ -48,15 +67,13 @@ export default function Layout(props: {
   const { children } = props;
 
   const orpc = useORPC();
-  const { data: initialSite } = useSuspenseQuery(
-    orpc.externalSites.details.queryOptions({
+  const { data: site } = useSuspenseQuery(
+    orpc.externalSites.healthDetails.queryOptions({
       input: {
         site: siteId as ExternalSiteType,
       },
     }),
   );
-
-  const [site, setSite] = useState(initialSite);
 
   return (
     <div className="w-full p-3 lg:py-0">
@@ -78,46 +95,49 @@ export default function Layout(props: {
         ]}
       />
 
-      <div className="my-8 flex min-w-full flex-wrap gap-y-4 sm:flex-nowrap">
-        <div className="flex w-full flex-col justify-center gap-y-4 px-4 sm:w-auto sm:flex-auto sm:gap-y-2">
-          <h3 className="self-center text-4xl font-semibold text-white sm:self-start">
+      <div className="my-6 flex min-w-full flex-wrap gap-y-5 sm:flex-nowrap">
+        <div className="flex w-full flex-col justify-center px-4 sm:w-auto sm:flex-auto">
+          <h1 className="self-center text-3xl font-semibold text-white sm:self-start sm:text-4xl">
             {site.name}
-          </h3>
-          <div className="text-muted flex flex-col items-center self-center sm:flex-row sm:self-start lg:mb-8">
+          </h1>
+          <div className="text-muted mt-2 self-center sm:self-start">
             {site.type}
           </div>
-          <div className="flex justify-center sm:justify-start">
-            <div className="mr-4 pr-3 text-center">
-              <span className="racking-wide block text-xl  font-bold text-white">
-                {site.lastRunAt ? (
-                  <TimeSince date={site.lastRunAt} />
-                ) : (
-                  <>&mdash;</>
-                )}
-              </span>
-              <span className="text-muted text-sm">Last Run</span>
+          <div className="mt-3 self-center text-sm sm:self-start">
+            <ExternalSiteRunStatus site={site} />
+          </div>
+          <dl className="mt-5 grid w-full max-w-xl grid-cols-3 divide-x divide-slate-800 self-center sm:self-start">
+            <div className="flex flex-col px-3 text-center first:pl-0 sm:text-left">
+              <dt className="text-muted order-2 text-xs sm:text-sm">
+                Listings
+              </dt>
+              <dd className="order-1 text-lg font-bold tracking-wide text-white">
+                {site.listingCount.toLocaleString("en-US")}
+              </dd>
             </div>
-            <div className="mb-4 px-3 text-center">
-              <span className="block text-xl font-bold tracking-wide text-white">
+            <div className="flex flex-col px-3 text-center sm:text-left">
+              <dt className="text-muted order-2 text-xs sm:text-sm">
+                Schedule
+              </dt>
+              <dd className="order-1 text-sm font-bold text-white sm:text-base">
+                {site.runEvery
+                  ? formatDuration(site.runEvery * 60 * 1000)
+                  : "Manual only"}
+              </dd>
+            </div>
+            <div className="flex flex-col px-3 text-center last:pr-0 sm:text-left">
+              <dt className="text-muted order-2 text-xs sm:text-sm">
+                Next Run
+              </dt>
+              <dd className="order-1 text-sm font-bold text-white sm:text-base">
                 {site.nextRunAt ? (
                   <TimeSince date={site.nextRunAt} />
                 ) : (
-                  <>&mdash;</>
+                  "Not scheduled"
                 )}
-              </span>
-              <span className="text-muted text-sm">Next Run</span>
+              </dd>
             </div>
-            <div className="mb-4 px-3 text-center">
-              <span className="block text-xl font-bold tracking-wide text-white">
-                {site.runEvery ? (
-                  formatDuration(site.runEvery * 60 * 1000)
-                ) : (
-                  <>&mdash;</>
-                )}
-              </span>
-              <span className="text-muted text-sm">Schedule</span>
-            </div>
-          </div>
+          </dl>
         </div>
         <div className="flex w-full flex-col items-center justify-center sm:w-auto sm:items-end">
           <div className="flex gap-x-2">
@@ -137,6 +157,9 @@ export default function Layout(props: {
           controlled
         >
           Reviews
+        </TabItem>
+        <TabItem as={Link} href={`/admin/sites/${site.type}/runs`} controlled>
+          Runs
         </TabItem>
       </Tabs>
 

--- a/apps/web/src/app/(admin)/admin/(default)/sites/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ExternalSiteRunStatus from "@peated/web/components/admin/externalSiteRunStatus";
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
 import EmptyActivity from "@peated/web/components/emptyActivity";
@@ -19,7 +20,7 @@ export default function Page() {
 
   const orpc = useORPC();
   const { data: siteList } = useSuspenseQuery(
-    orpc.externalSites.list.queryOptions({
+    orpc.externalSites.healthList.queryOptions({
       input: queryParams,
     }),
   );
@@ -49,16 +50,49 @@ export default function Page() {
         <Table
           items={siteList.results}
           rel={siteList.rel}
-          defaultSort="-created"
+          defaultSort="name"
           primaryKey={(item) => item.type}
           url={(item) => `/admin/sites/${item.type}`}
           columns={[
-            { name: "name", sort: "name", sortDefaultOrder: "asc" },
             {
-              name: "lastRunAt",
-              title: "Last Run",
-              value: (v) =>
-                v.lastRunAt ? <TimeSince date={v.lastRunAt} /> : <>&mdash;</>,
+              name: "name",
+              sort: "name",
+              sortDefaultOrder: "asc",
+              value: (site) => (
+                <div>
+                  <div>{site.name}</div>
+                  <div className="text-muted mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs sm:hidden">
+                    <span>
+                      {site.listingCount.toLocaleString("en-US")} listings
+                    </span>
+                    <ExternalSiteRunStatus site={site} compact />
+                  </div>
+                </div>
+              ),
+            },
+            {
+              name: "listingCount",
+              title: "Listings",
+              align: "right",
+              className: "hidden w-32 sm:table-column",
+              value: (site) => site.listingCount.toLocaleString("en-US"),
+            },
+            {
+              name: "status",
+              title: "Status",
+              className: "hidden w-72 sm:table-column",
+              value: (site) => <ExternalSiteRunStatus site={site} />,
+            },
+            {
+              name: "nextRunAt",
+              title: "Next Run",
+              className: "hidden w-32 sm:table-column",
+              value: (site) =>
+                site.nextRunAt ? (
+                  <TimeSince date={site.nextRunAt} />
+                ) : (
+                  <>&mdash;</>
+                ),
             },
           ]}
         />

--- a/apps/web/src/components/admin/externalSiteRunStatus.tsx
+++ b/apps/web/src/components/admin/externalSiteRunStatus.tsx
@@ -1,0 +1,62 @@
+import { type ExternalSiteHealthSchema } from "@peated/server/schemas";
+import TimeSince from "@peated/web/components/timeSince";
+import classNames from "@peated/web/lib/classNames";
+import { type z } from "zod";
+
+type SiteHealth = z.infer<typeof ExternalSiteHealthSchema>;
+
+export default function ExternalSiteRunStatus({
+  site,
+  compact = false,
+}: {
+  site: SiteHealth;
+  compact?: boolean;
+}) {
+  const run = site.latestRun;
+  const disabled = site.runEvery === null && run === null;
+  const status = disabled ? "disabled" : (run?.status ?? "never");
+  const labels = {
+    disabled: "Disabled",
+    never: "Never recorded",
+    queued: "Queued",
+    running: "Running",
+    succeeded: "Succeeded",
+    failed: "Failed",
+  } as const;
+  const colors = {
+    disabled: "bg-slate-500",
+    never: "bg-slate-500",
+    queued: "bg-sky-400",
+    running: "bg-amber-400",
+    succeeded: "bg-green-400",
+    failed: "bg-red-400",
+  } as const;
+  const timestamp =
+    run?.status === "queued"
+      ? run.createdAt
+      : run?.status === "running"
+        ? run.startedAt
+        : run?.completedAt;
+
+  return (
+    <div className={classNames(compact ? "inline-flex" : "")}>
+      <div className="inline-flex items-center gap-2 font-medium">
+        <span
+          aria-hidden="true"
+          className={classNames("h-2 w-2 rounded-full", colors[status])}
+        />
+        {labels[status]}
+        {timestamp && !disabled ? (
+          <span className="text-muted font-normal">
+            · <TimeSince date={timestamp} />
+          </span>
+        ) : null}
+      </div>
+      {!compact && status === "failed" && site.lastSucceededAt ? (
+        <div className="text-muted mt-1 text-xs">
+          Last succeeded <TimeSince date={site.lastSucceededAt} />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/storePriceTable.tsx
+++ b/apps/web/src/components/admin/storePriceTable.tsx
@@ -13,10 +13,10 @@ export default function StorePriceTable({
 }) {
   return (
     <>
-      <table className="min-w-full">
+      <table className="min-w-full table-fixed sm:table-auto">
         <colgroup>
-          <col className="min-w-full sm:w-1/12" />
-          <col className="min-w-full sm:w-7/12" />
+          <col className="w-16 sm:w-1/12" />
+          <col className="sm:w-7/12" />
           <col className="sm:w-2/12" />
           <col className="sm:w-2/12" />
         </colgroup>
@@ -48,16 +48,16 @@ export default function StorePriceTable({
           {priceList.map((price) => {
             return (
               <tr key={price.id} className="border-b border-slate-800 text-sm">
-                <td>
+                <td className="py-3 align-top">
                   {price.imageUrl && (
                     <img
                       src={price.imageUrl}
                       alt={price.name}
-                      className="max-h-16 max-w-full"
+                      className="mx-auto max-h-16 max-w-14 object-contain"
                     />
                   )}
                 </td>
-                <td className="max-w-0 px-3 py-3">
+                <td className="min-w-0 px-3 py-3 align-top">
                   <Link
                     href={price.url}
                     className="font-medium hover:underline"
@@ -76,8 +76,13 @@ export default function StorePriceTable({
                       <em>No Bottle</em>
                     )}
                   </div>
-                  <div className="text-muted mt-1 text-xs sm:hidden">
-                    Last seen <TimeSince date={price.updatedAt} />
+                  <div className="mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs sm:hidden">
+                    <span className="font-medium text-white">
+                      <Price value={price.price} currency={price.currency} />
+                    </span>
+                    <span className="text-muted">
+                      Last seen <TimeSince date={price.updatedAt} />
+                    </span>
                   </div>
                 </td>
                 <td className="hidden px-3 py-3 text-right sm:table-cell">

--- a/openspec/changes/track-external-site-runs/.openspec.yaml
+++ b/openspec/changes/track-external-site-runs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-12

--- a/openspec/changes/track-external-site-runs/design.md
+++ b/openspec/changes/track-external-site-runs/design.md
@@ -1,0 +1,85 @@
+## Context
+
+`external_site.last_run_at` is currently written when the scheduler dispatches a job and when an individual external review is persisted. Neither write proves that a scraper started or completed. BullMQ state and Sentry telemetry are operational aids, but they are not retained product state and cannot provide reliable administrator history.
+
+External sites already own `runEvery` and `nextRunAt`, while scraper jobs run in the trusted server worker and perform idempotent catalog, listing, and review writes. The change must keep those authority boundaries explicit and must not make administrators infer execution health from listing timestamps.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Persist one durable record per scheduled or manual scraper attempt before queue dispatch.
+- Make one server module own queued, running, succeeded, and failed state transitions.
+- Keep `lastRunAt` as a materialized summary whose sole meaning is the completion time of the latest terminal run.
+- Prevent concurrent active runs for the same external site.
+- Correlate failures with a run id while preserving BullMQ and Sentry error ownership.
+- Give administrators factual current status, last success context, listing totals, and recent run history.
+
+**Non-Goals:**
+
+- Building a generic background-job history system.
+- Persisting every scraped item or full third-party responses in a run record.
+- Automatically judging a run unhealthy from historical item-count variance.
+- Adding a new retry policy for whole scraper jobs.
+- Treating downstream image capture or bottle-resolution jobs as part of scraper completion.
+
+## Decisions
+
+### Durable runs are authoritative; site timestamps are summaries
+
+Add `external_site_run` with site, status, trigger, requesting user, attempt count, item count, bounded error summary, and lifecycle timestamps. A partial unique index allows only one queued or running row per site. Recent and successful runs are derived from this table.
+
+`external_site.last_run_at` remains as an inexpensive completion-time cache, paired with `last_run_id` so readers can distinguish new values from ambiguous legacy timestamps. Only terminal run transitions update both fields in the same transaction as the authoritative run. `runEvery` and `nextRunAt` continue to own scheduling only.
+
+Alternative: add several status and error columns directly to `external_site`. Rejected because it loses history, makes overlapping completion ordering unsafe, and turns one configuration row into a workflow state machine.
+
+Alternative: read BullMQ job history. Rejected because Redis retention is not the product contract and queue records do not own manual attribution or materialized site state.
+
+### One capability owns creation, dispatch, and execution transitions
+
+Add a narrow external-site-run module that creates scheduled or manual runs, queues the existing site-specific job with a strict `{ runId }` payload, and executes a scraper inside the durable lifecycle. Registry entries bind each job name to its fixed site and scraper function; queue payloads cannot choose a site or actor.
+
+The worker atomically claims a queued run, records `startedAt`, increments attempts, and invokes the scraper. It records success only after all authoritative scraper writes return. On failure it records a safe summary and completion time, then rethrows so the existing worker boundary reports the terminal error once.
+
+The scheduler also redispatches stale queued or running rows with the same deterministic job id before creating new runs. Existing waiting or active BullMQ jobs deduplicate that delivery; failed queue records are removable so a later reconciliation can redeliver work whose durable terminal update did not complete. A reconciliation dispatch error preserves the active row for the next scheduler pass and still fails the cron boundary.
+
+Alternative: update run state from BullMQ `active`, `completed`, and `failed` callbacks. Rejected because it spreads one lifecycle invariant across queue observers and can miss application-level context.
+
+### Scheduled and manual triggers share dispatch but not schedule semantics
+
+The scheduler locks and claims each due site, creates a scheduled run, and advances `nextRunAt` in the same transaction. It dispatches after commit with a deterministic BullMQ job id based on the run id. Confirmed dispatch failure marks the run failed, materializes `lastRunAt`, and makes the site immediately eligible for the next scheduler pass.
+
+The administrator trigger route creates a manual run with `requestedById` and returns its summary. Manual runs do not move `nextRunAt`. Both paths reject an overlapping queued or running run through the same database invariant.
+
+### Run item count is reported by the scraper contract
+
+Production scraper entry points return the number of accepted source items observed during that run. Multi-section scrapers sum their sections. A price scraper continues to treat zero products as failure; a review scraper may explicitly return zero when there is no new issue to process. Run health remains based on completion or failure, not on a generic count threshold.
+
+### Operational details remain administrator-only
+
+Add protected administrator summaries and recent-run endpoints. The list summary includes listing count, latest run, and last successful completion. Recent history includes bounded failure summaries but no stack traces, credentials, provider bodies, or unrestricted error data. Sentry scope receives the site and run id for deeper diagnosis.
+
+The admin list uses a single `Status` concept: queued, running, succeeded, failed, disabled, or never recorded. A failed status may include last-success context. The detail page shows recent attempts, duration, trigger, count, and failure summary.
+
+## Risks / Trade-offs
+
+- [A worker exits after partial idempotent writes] → BullMQ stalled delivery reuses the same deterministic run; a terminal run delivery is a no-op and a running delivery increments attempts before retrying.
+- [A dispatch succeeds but its response is lost] → The deterministic BullMQ job id prevents duplicate jobs; a subsequent scheduler pass creates a new run only after the prior run is terminal.
+- [Dispatch and terminal cleanup both fail, or the process exits between persistence and enqueue] → The scheduler redispatches stale active rows using the same run and deterministic queue identity.
+- [A provider error contains sensitive data] → Persist only a bounded allowlisted summary; keep full exceptions in Sentry under the run id context.
+- [Existing `lastRunAt` values look like valid completions] → Treat the cache as valid only when `lastRunId` references a durable terminal run; legacy rows have no pointer and display as never recorded.
+- [Run history grows indefinitely] → Summary-only hourly rows are small at current scale; retention is deferred until measured need exists.
+
+## Migration Plan
+
+1. Add the run status/trigger enums, `external_site_run` table, indexes, and `external_site.last_run_id` cache pointer.
+2. Add lifecycle and dispatch capabilities plus strict queue payload parsing.
+3. Move scheduled and manual dispatch to durable runs, then wrap all scraper registry entries.
+4. Remove unrelated `lastRunAt` writes and expose protected health/history routes.
+5. Update administrator surfaces and verify scheduled, manual, successful, failed, and overlapping behavior.
+
+Rollback restores the previous scheduler and trigger code. The additive run table can remain unused; `lastRunAt` can be repopulated only after choosing an explicit rollback meaning.
+
+## Open Questions
+
+None.

--- a/openspec/changes/track-external-site-runs/proposal.md
+++ b/openspec/changes/track-external-site-runs/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+External-site `lastRunAt` currently records unrelated events such as queue dispatch and individual review persistence, so administrators cannot tell whether a scraper actually completed or why it failed. Production scraper health needs a durable execution record whose status is updated by the worker that owns the run.
+
+## What Changes
+
+- Persist one durable run for every scheduled or manually triggered external-site scraper execution.
+- Record queued, running, succeeded, and failed lifecycle states with trigger attribution, timestamps, item counts, attempts, and bounded failure summaries.
+- Route scheduled and manual scraper dispatch through the same run-owning capability and prevent overlapping active runs for one site.
+- Redefine materialized `lastRunAt` as the completion time of the most recently completed scraper attempt while keeping durable runs authoritative.
+- Expose administrator-only scraper health summaries and recent run history.
+- Show listing totals, factual scraper status, and scheduling information in the admin sites UI.
+- Stop review persistence and queue dispatch from masquerading as completed scraper runs.
+
+## Capabilities
+
+### New Capabilities
+
+- `external-site-run-health`: Durable scraper execution lifecycle, scheduling and manual-trigger integration, administrator health summaries, and recent run history.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds an external-site run table and an auditable pointer for the materialized external-site run timestamp through a generated database migration.
+- Changes scraper queue payloads and worker registration wrappers in `apps/server`.
+- Changes external-site scheduler and manual-trigger behavior, schemas, serializers, and administrator routes.
+- Updates the admin sites list and site detail surfaces in `apps/web`.
+- Adds focused integration tests for lifecycle transitions, dispatch failures, overlap prevention, summaries, and UI-facing contracts.

--- a/openspec/changes/track-external-site-runs/specs/external-site-run-health/spec.md
+++ b/openspec/changes/track-external-site-runs/specs/external-site-run-health/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: Scraper attempts have durable lifecycle state
+
+The system SHALL persist a durable external-site run before dispatching a scheduled or manually requested scraper and SHALL represent its lifecycle as queued, running, succeeded, or failed.
+
+#### Scenario: Scheduled scraper succeeds
+
+- **WHEN** a scheduled scraper is durably queued, starts in a worker, and completes all authoritative writes
+- **THEN** its run SHALL record scheduled trigger attribution, start and completion timestamps, attempt count, observed item count, and succeeded status.
+
+#### Scenario: Scraper execution fails
+
+- **WHEN** a scraper throws before completing its authoritative work
+- **THEN** its run SHALL record failed status, completion time, and a bounded safe failure summary, and the error SHALL still escape to the worker error boundary.
+
+#### Scenario: Manual scraper is requested
+
+- **WHEN** an administrator requests a scraper run
+- **THEN** the system SHALL create a manual run attributed to that administrator before queue dispatch and SHALL return the created run summary.
+
+### Requirement: Materialized site run time has one meaning
+
+The system SHALL define `externalSite.lastRunAt` as the completion time of the durable scraper attempt referenced by `externalSite.lastRunId` and SHALL treat durable run rows as the authoritative history.
+
+#### Scenario: Run reaches a terminal state
+
+- **WHEN** a run succeeds, fails during execution, or fails confirmed queue dispatch
+- **THEN** the system SHALL set `lastRunAt` to that run's completion time in the same durable transition.
+
+#### Scenario: Work is only queued or partially persisted
+
+- **WHEN** a scraper is queued, starts, or an individual listing or review is written
+- **THEN** the system SHALL NOT update `lastRunAt`.
+
+#### Scenario: Legacy timestamp has no durable run
+
+- **WHEN** durable scraper runs are introduced
+- **THEN** the system SHALL treat prior `lastRunAt` values without a `lastRunId` reference as never recorded rather than claiming a completed run.
+
+### Requirement: Active runs do not overlap
+
+The system SHALL prevent more than one queued or running scraper run for the same external site.
+
+#### Scenario: Scheduler encounters an active run
+
+- **WHEN** a site becomes due while its prior run remains queued or running
+- **THEN** the scheduler SHALL leave the active run intact and SHALL NOT dispatch another scraper for that site.
+
+#### Scenario: Administrator requests an overlapping run
+
+- **WHEN** an administrator requests a run for a site with a queued or running run
+- **THEN** the system SHALL reject the request with conflict information identifying the active state.
+
+#### Scenario: Queue delivery is duplicated
+
+- **WHEN** a terminal run payload is delivered again
+- **THEN** the worker SHALL not execute the scraper a second time for that terminal run.
+
+#### Scenario: Active run is left stale across a dispatch boundary
+
+- **WHEN** a queued or running run remains non-terminal after its queue dispatch or durable terminal update is interrupted
+- **THEN** a later scheduler pass SHALL redispatch that same run with its deterministic queue identity rather than leaving the site permanently blocked or creating a second run.
+
+#### Scenario: Stale-run redispatch fails
+
+- **WHEN** the queue is still unavailable while a stale active run is being reconciled
+- **THEN** the system SHALL preserve that run for a later reconciliation attempt and SHALL report the scheduler failure at the cron boundary.
+
+### Requirement: Scheduling and execution state remain separate
+
+The system SHALL keep `runEvery` and `nextRunAt` as scheduling state and SHALL keep execution status in durable run records.
+
+#### Scenario: Scheduled run is claimed
+
+- **WHEN** the scheduler creates a run for a due enabled site
+- **THEN** it SHALL advance `nextRunAt` according to `runEvery` without recording execution success.
+
+#### Scenario: Scheduled dispatch fails
+
+- **WHEN** queue dispatch fails after the run has been persisted
+- **THEN** the system SHALL mark that run failed and make the site eligible for a later scheduler pass.
+
+#### Scenario: Manual run is created
+
+- **WHEN** an administrator manually queues a scraper
+- **THEN** the system SHALL preserve the site's existing `nextRunAt`.
+
+### Requirement: Administrators can inspect scraper health
+
+The system SHALL provide administrator-only summaries and recent history that distinguish listing inventory from scraper execution health.
+
+#### Scenario: Administrator lists sites
+
+- **WHEN** an administrator opens the external-sites list
+- **THEN** each site SHALL show its visible listing count, factual latest run status and timing, last successful completion when relevant, and next scheduled time without using listing-update time as a run proxy.
+
+#### Scenario: Administrator inspects one site
+
+- **WHEN** an administrator opens an external-site detail surface
+- **THEN** the system SHALL expose recent run status, trigger, timing, attempts, item count, and bounded failure summary.
+
+#### Scenario: Anonymous caller requests operational details
+
+- **WHEN** an unauthenticated caller requests scraper health or run history
+- **THEN** the system SHALL reject access rather than exposing operational failures.
+
+### Requirement: Run telemetry is safely correlated
+
+The system SHALL correlate scraper exceptions with the external site and durable run id without persisting unrestricted exception data.
+
+#### Scenario: Unexpected scraper exception reaches Sentry
+
+- **WHEN** a scraper run fails unexpectedly
+- **THEN** the captured worker issue SHALL include the site and run id as safe diagnostic context while the database stores only a bounded summary.

--- a/openspec/changes/track-external-site-runs/tasks.md
+++ b/openspec/changes/track-external-site-runs/tasks.md
@@ -1,0 +1,32 @@
+## 1. Durable Run Model
+
+- [x] 1.1 Add external-site run enums, schema, foreign keys, indexes, and exported types.
+- [x] 1.2 Generate migrations that create run storage and add an auditable `last_run_id` materialization pointer.
+- [x] 1.3 Add run schemas and serializers for protected summary and history responses.
+
+## 2. Lifecycle Ownership
+
+- [x] 2.1 Implement strict run creation, deterministic dispatch, active-run conflict, and terminal materialization capabilities.
+- [x] 2.2 Implement worker execution ownership for claim, attempt, success, failure, safe error summary, and Sentry correlation.
+- [x] 2.3 Update production scraper entry points to return accepted item counts and bind registry jobs to fixed sites and run ids.
+
+## 3. Scheduling and Triggering
+
+- [x] 3.1 Replace scheduler dispatch timestamps with durable scheduled runs and separate `nextRunAt` advancement.
+- [x] 3.2 Replace manual trigger dispatch with attributed durable runs and return the run summary.
+- [x] 3.3 Remove unrelated `lastRunAt` writes from external review persistence.
+
+## 4. Administrator Surfaces
+
+- [x] 4.1 Add protected administrator site-health and recent-run routes with listing totals and last-success context.
+- [x] 4.2 Update the admin sites list to show listings, factual status, and next schedule without duplicate timestamp concepts.
+- [x] 4.3 Update site details with current health and recent run history, including safe failure information.
+- [x] 4.4 Refine the list, detail header, and run history responsive hierarchy after visual review.
+
+## 5. Verification
+
+- [x] 5.1 Add lifecycle, scheduling, manual-trigger, overlap, dispatch-failure, materialization, and authorization tests.
+- [x] 5.2 Run generated migration checks, focused tests, typechecks, lint, and formatting.
+- [x] 5.3 Perform local API plus authenticated desktop and mobile visual QA and clean up disposable data.
+- [x] 5.4 Repeat authenticated desktop and mobile visual QA for the revised layouts.
+- [x] 5.5 Reconcile stale active runs with deterministic redispatch and cover interrupted dispatch and cleanup windows.


### PR DESCRIPTION
Scraper executions now have durable queued, running, succeeded, and failed records owned by the worker lifecycle. Scheduled and manual dispatch share the same active-run guard, deterministic queue identity, actor attribution, item counts, safe error summaries, and terminal `lastRunAt` materialization. Admin site pages now show listing inventory separately from run health, next schedule, and recent run history, with responsive success and failure views.

This replaces the previous `lastRunAt` behavior, which was written at dispatch time and during individual review persistence and therefore could not prove that a scraper completed. Existing timestamps remain hidden unless paired with a durable `lastRunId`; the generated migration adds the run table and pointer. All production scraper registrations—including Cadenhead's, Gordon & MacPhail, and Kilchoman from current main—now use the same wrapper.

Review the lifecycle owner in `apps/server/src/lib/externalSiteRuns.ts` first, then the scheduler and registry integration and the protected admin routes and UI. Validation covered the generated migration, repository test/build gate, lint and typechecks, strict OpenSpec validation, focused scraper contracts, and authenticated desktop/mobile QA using a real 40-item Decadent Drinks run plus a failure fixture.
