### PR TITLE
fix(web): preserve bottle series in grouped lists

### DIFF
--- a/apps/web/src/components/bottleIdentity.test.tsx
+++ b/apps/web/src/components/bottleIdentity.test.tsx
@@ -105,25 +105,70 @@ describe("BottleIdentity", () => {
     const html = renderToStaticMarkup(
       <BottleIdentity
         bottle={makeBottle({
-          brand: { id: 2, name: "Decadent Drinks" } as Bottle["brand"],
+          brand: { id: 2, name: "Woodford Reserve" } as Bottle["brand"],
           series: {
             id: 3,
-            name: "Whiskyland",
+            name: "Master's Collection",
           } as Bottle["series"],
           group: {
             ...makeBottle().group!,
-            name: "Glenburgie 38-year-old",
+            name: "Batch Proof",
           },
-          edition: "Chapter Thirty Two",
+          edition: null,
         })}
       />,
     );
 
-    expect(html).toContain("Decadent Drinks");
-    expect(html).toContain("Whiskyland");
+    expect(html).toContain("Woodford Reserve");
+    expect(html).toContain("Master&#x27;s Collection");
     expect(html).toContain('href="/bottles?series=3"');
-    expect(html).toContain("Glenburgie 38-year-old");
-    expect(html).toContain("Chapter Thirty Two");
+    expect(html).toContain("Batch Proof");
+  });
+
+  it("keeps series context when the surrounding view supplies the Brand", () => {
+    const html = renderToStaticMarkup(
+      <BottleIdentity
+        bottle={makeBottle({
+          brand: { id: 2, name: "Woodford Reserve" } as Bottle["brand"],
+          series: {
+            id: 3,
+            name: "Master's Collection",
+          } as Bottle["series"],
+          group: {
+            ...makeBottle().group!,
+            name: "Batch Proof",
+          },
+          edition: null,
+        })}
+        showBrand={false}
+      />,
+    );
+
+    expect(html).not.toContain("Woodford Reserve");
+    expect(html).toContain("Master&#x27;s Collection");
+    expect(html).toContain('href="/bottles?series=3"');
+    expect(html).toContain("Batch Proof");
+  });
+
+  it("does not repeat a historical Series that equals the Brand", () => {
+    const html = renderToStaticMarkup(
+      <BottleIdentity
+        bottle={makeBottle({
+          brand: { id: 2, name: "Whiskyland" } as Bottle["brand"],
+          series: { id: 3, name: "Whiskyland" } as Bottle["series"],
+          group: {
+            ...makeBottle().group!,
+            name: "Pittyvaich",
+          },
+          edition: "Chapter Thirty",
+        })}
+        showBrand={false}
+      />,
+    );
+
+    expect(html).not.toContain('href="/bottles?series=3"');
+    expect(html).toContain("Pittyvaich");
+    expect(html).toContain("Chapter Thirty");
   });
 
   it("does not use exact age as a subtitle when the family title includes it", () => {

--- a/apps/web/src/components/bottleIdentity.tsx
+++ b/apps/web/src/components/bottleIdentity.tsx
@@ -75,14 +75,21 @@ export function getAbsoluteBottleLabel(bottle: BottleIdentitySource) {
 }
 
 export function getBottleIdentitySeriesName(
-  bottle: Pick<BottleIdentitySource, "series">,
+  bottle: Pick<BottleIdentitySource, "brand" | "series">,
   displayedIdentity: string,
 ) {
+  if (!bottle.series) {
+    return null;
+  }
+
+  const normalizedSeriesName = bottle.series.name.toLocaleLowerCase();
+  const normalizedBrandNames = [bottle.brand.name, bottle.brand.shortName]
+    .filter((name): name is string => Boolean(name))
+    .map((name) => name.toLocaleLowerCase());
+
   if (
-    !bottle.series ||
-    displayedIdentity
-      .toLocaleLowerCase()
-      .includes(bottle.series.name.toLocaleLowerCase())
+    normalizedBrandNames.includes(normalizedSeriesName) ||
+    displayedIdentity.toLocaleLowerCase().includes(normalizedSeriesName)
   ) {
     return null;
   }
@@ -366,17 +373,19 @@ export default function BottleIdentity({
 
   return (
     <div className={classNames("min-w-0", className)}>
-      {isAbsolute && showBrand ? (
+      {isAbsolute && (showBrand || seriesName) ? (
         <div className="text-muted flex min-w-0 items-center gap-1.5 truncate text-xs font-medium uppercase tracking-wide">
-          <Link
-            href={`/entities/${bottle.brand.id}`}
-            className="truncate hover:underline"
-          >
-            {bottle.brand.shortName || bottle.brand.name}
-          </Link>
+          {showBrand ? (
+            <Link
+              href={`/entities/${bottle.brand.id}`}
+              className="truncate hover:underline"
+            >
+              {bottle.brand.shortName || bottle.brand.name}
+            </Link>
+          ) : null}
           {seriesName ? (
             <>
-              <span aria-hidden="true">&middot;</span>
+              {showBrand ? <span aria-hidden="true">&middot;</span> : null}
               <Link
                 href={`/bottles?series=${bottle.series!.id}`}
                 className="truncate hover:underline"

--- a/apps/web/src/components/bottleTable.test.tsx
+++ b/apps/web/src/components/bottleTable.test.tsx
@@ -1,10 +1,11 @@
-import type { CollectionBottle } from "@peated/server/types";
+import type { Bottle, CollectionBottle } from "@peated/server/types";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 import BottleTable from "./bottleTable";
 
 vi.mock("next/navigation", () => ({
+  usePathname: () => "/entities/3/bottles",
   useSearchParams: () => new URLSearchParams(),
 }));
 
@@ -55,5 +56,34 @@ describe("BottleTable", () => {
     expect(namePosition).toBeGreaterThan(-1);
     expect(statusPosition).toBeGreaterThan(namePosition);
     expect(metadataPosition).toBeGreaterThan(statusPosition);
+  });
+
+  it("groups by the Bottle while retaining its nonduplicative Series", () => {
+    const collectionBottle = makeCollectionBottle();
+    const bottle = {
+      ...collectionBottle.bottle,
+      fullName: "Woodford Reserve Batch Proof",
+      name: "Batch Proof",
+      brand: { id: 3, name: "Woodford Reserve", shortName: null },
+      group: { name: "Batch Proof", statedAge: null },
+      series: { id: 4, name: "Master's Collection" },
+      edition: null,
+    } as Bottle;
+    const html = renderToStaticMarkup(
+      <BottleTable
+        bottleList={[bottle]}
+        groupBy={(item) => item.brand}
+        groupItem={(item) => item.name}
+        groupTo={(group) => `/entities/${group.id}`}
+        showBottleStats={false}
+      />,
+    );
+
+    const visibleText = html.replace(/<[^>]*>/g, "");
+    expect(visibleText.match(/Woodford Reserve/g)).toHaveLength(1);
+    expect(html).toContain('href="/entities/3"');
+    expect(html).toContain("Master&#x27;s Collection");
+    expect(html).toContain('href="/bottles?series=4"');
+    expect(html).toContain("Batch Proof");
   });
 });

--- a/apps/web/src/components/bottleTable.tsx
+++ b/apps/web/src/components/bottleTable.tsx
@@ -31,8 +31,14 @@ export default function BottleTable({
   showBottleStats = true,
   showRatingSummary = false,
   compactIdentity = false,
+  groupBy,
+  groupItem,
+  groupTo,
   ...props
-}: Omit<ComponentProps<typeof Table>, "items" | "rel" | "columns"> & {
+}: Omit<
+  ComponentProps<typeof Table<BottleRow, Bottle["brand"]>>,
+  "items" | "rel" | "columns" | "groupBy" | "groupItem" | "groupTo"
+> & {
   bottleList: (Bottle | CollectionBottle)[];
   rel?: PagingRel;
   renderCollectionBottleImage?: (item: CollectionBottle) => ReactNode;
@@ -42,6 +48,9 @@ export default function BottleTable({
   showBottleStats?: boolean;
   showRatingSummary?: boolean;
   compactIdentity?: boolean;
+  groupBy?: (item: Bottle) => Bottle["brand"];
+  groupItem?: (item: Bottle["brand"]) => ReactNode;
+  groupTo?: (group: Bottle["brand"]) => string;
 }) {
   const rows: BottleRow[] = bottleList.map((item) =>
     "bottle" in item
@@ -54,10 +63,13 @@ export default function BottleTable({
   );
 
   return (
-    <Table<BottleRow>
+    <Table<BottleRow, Bottle["brand"]>
       items={rows}
       primaryKey={(item) => item.key}
       rel={rel}
+      groupBy={groupBy ? (item) => groupBy(item.bottle) : undefined}
+      groupItem={groupItem}
+      groupTo={groupTo}
       columns={[
         {
           name: "name",
@@ -100,7 +112,7 @@ export default function BottleTable({
                     bottle={bottle}
                     mode="absolute"
                     metadataVariant={compactIdentity ? "summary" : "full"}
-                    showBrand={!props.groupBy}
+                    showBrand={!groupBy}
                     trailingContent={statusIndicators}
                   />
                   {collectionMeta ? (

--- a/docs/architecture/bottle-identity-presentation.md
+++ b/docs/architecture/bottle-identity-presentation.md
@@ -287,17 +287,17 @@ marketed expression or edition.
 Examples validate these branches; they must not become named special cases in
 the implementation.
 
-| Bottle                                                                | Important identity                                                              | Concise consequence                                                    |
-| --------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
-| Decadent Drinks Whiskyland Glenburgie 38-year-old, Chapter Thirty Two | `Whiskyland` is the series; `Chapter Thirty Two` is the release marker          | Show both; omit 1988 vintage and 2026 release from the ordinary header |
-| High West A Midwinter Night's Dram, Act 12 Scene 9                    | Act and scene identify the release                                              | Prefer the edition; do not also require its release year               |
-| Elijah Craig Barrel Proof, Batch C923                                 | `Barrel Proof` is marketed expression wording; the batch identifies the release | Preserve the expression and batch; do not add a cask-strength flag     |
-| Four Roses Limited Edition Small Batch 2017                           | The year is the annual release identity when no stronger marker exists          | Show the release year                                                  |
-| Macallan Sherry Oak 18-year-old, 1994 Vintage                         | Vintage is the marketed discriminator                                           | Show the vintage and do not manufacture another year label             |
-| Willett Family Estate, Barrel 4769                                    | The exact barrel code identifies the marketed release                           | Show the code; do not add `Single cask` merely from the boolean        |
-| SMWS 95.71 Prepare for Winter                                         | The society code and subtitle are marketed identity                             | Preserve them; age and ABV may support the detailed header             |
-| Highland Park Cask Strength No. 5                                     | `Cask Strength` belongs to the expression                                       | Keep the words in the title; do not repeat them as metadata            |
-| Pōkeno Exploration Series No. 1 Totara Cask                           | Series wording is already present in the marketed expression                    | Do not repeat the series in a second visible token                     |
+| Bottle                                                | Important identity                                                              | Concise consequence                                                    |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| Whiskyland Glenburgie 38-year-old, Chapter Thirty Two | `Whiskyland` is the Brand; `Chapter Thirty Two` is the release marker           | Show both; omit 1988 vintage and 2026 release from the ordinary header |
+| High West A Midwinter Night's Dram, Act 12 Scene 9    | Act and scene identify the release                                              | Prefer the edition; do not also require its release year               |
+| Elijah Craig Barrel Proof, Batch C923                 | `Barrel Proof` is marketed expression wording; the batch identifies the release | Preserve the expression and batch; do not add a cask-strength flag     |
+| Four Roses Limited Edition Small Batch 2017           | The year is the annual release identity when no stronger marker exists          | Show the release year                                                  |
+| Macallan Sherry Oak 18-year-old, 1994 Vintage         | Vintage is the marketed discriminator                                           | Show the vintage and do not manufacture another year label             |
+| Willett Family Estate, Barrel 4769                    | The exact barrel code identifies the marketed release                           | Show the code; do not add `Single cask` merely from the boolean        |
+| SMWS 95.71 Prepare for Winter                         | The society code and subtitle are marketed identity                             | Preserve them; age and ABV may support the detailed header             |
+| Highland Park Cask Strength No. 5                     | `Cask Strength` belongs to the expression                                       | Keep the words in the title; do not repeat them as metadata            |
+| Pōkeno Exploration Series No. 1 Totara Cask           | Series wording is already present in the marketed expression                    | Do not repeat the series in a second visible token                     |
 
 ## Implementation Map
 


### PR DESCRIPTION
Brand-grouped bottle lists now render their Brand headings and retain nonduplicative BottleSeries context within each row. This makes ranges such as Whiskyland visible on the Decadent Drinks bottle page without repeating the Brand on every Bottle.

`BottleTable` previously wrapped each Bottle before passing it to the shared table, but forwarded the caller's Bottle-level grouping callback unchanged. That prevented group headings from rendering even as the row identity suppressed its Brand. The table now adapts grouping callbacks to the underlying Bottle, while `BottleIdentity` suppresses Brand and Series independently and hides historical Series values that merely repeat their Brand.

The presentation example now reflects Whiskyland's reviewed Brand classification. Desktop and mobile checks against the read-only Decadent Drinks catalog confirmed Brand headings, linked Series context, and equal Brand/Series deduplication.

Refs #566
