### PR TITLE
fix(web): allow manual creation from uncertain scans

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -1277,7 +1277,7 @@ test.describe("add bottle flow", () => {
     await expectNoHorizontalOverflow(page);
   });
 
-  test("does not offer manual creation for an uncertain scan match", async ({
+  test("carries uncertain scan details into manual bottle creation", async ({
     context,
     page,
   }, testInfo) => {
@@ -1288,26 +1288,46 @@ test.describe("add bottle flow", () => {
     await page.goto("/addBottle");
     await uploadLabel(page);
 
-    await expect(
-      page.getByText("We couldn't identify this bottle"),
-    ).toBeVisible();
+    await expect(page.getByText("We couldn't find this bottle")).toBeVisible();
     await expect(
       page.getByText(
-        "We found a possible match, but it was not reliable enough to use automatically.",
+        "We found label details, but not enough to choose an existing bottle automatically.",
       ),
     ).toBeVisible();
     await expect(
       page.getByRole("link", { name: "Search Bottles" }),
     ).toBeVisible();
-    await expect(
-      page.getByRole("link", { name: "Create Manually" }),
-    ).toBeHidden();
-    await expect(
-      page.getByRole("link", { name: "Create Bottle" }),
-    ).toBeHidden();
+    const createBottleLink = page.getByRole("link", {
+      name: "Create Bottle",
+    });
+    await expect(createBottleLink).toBeVisible();
+    const href = await createBottleLink.getAttribute("href");
+    expect(href).not.toBeNull();
+    const createUrl = new URL(href!, page.url());
+    expect(createUrl.pathname).toBe("/bottles/new");
+    expect(createUrl.searchParams.get("returnAction")).toBe("addBottle");
+    expect(createUrl.searchParams.get("pendingImageId")).toBe(
+      "playwright-photo-upload",
+    );
+    expect(createUrl.searchParams.get("pendingImageUrl")).toBe(
+      pendingScanImageUrl,
+    );
+    expect(createUrl.searchParams.get("brandName")).toBe(testBrand.name);
+    expect(createUrl.searchParams.get("name")).toBe(existingBottle.name);
     await expect(
       page.getByRole("button", { name: "Start Over" }),
     ).toBeVisible();
+    await createBottleLink.click();
+    await expect(
+      page.getByRole("textbox", { name: "Bottle Name", exact: true }),
+    ).toHaveValue(existingBottle.name);
+    await expect(
+      page.getByRole("button", { name: testBrand.name }).first(),
+    ).toBeVisible();
+    await expect(page.getByAltText("uploaded image")).toHaveAttribute(
+      "src",
+      pendingScanImageUrl,
+    );
     await expectNoHorizontalOverflow(page);
   });
 

--- a/apps/web/src/components/bottleResolver/helpers.test.ts
+++ b/apps/web/src/components/bottleResolver/helpers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "vitest";
 import {
   getCreateBottlePrefill,
   getCreateNameSeed,
+  getManualResultCopy,
   type PhotoIdentification,
 } from "./helpers";
 
@@ -125,6 +126,32 @@ describe("photo create prefill", () => {
       edition: "2024 Edition",
       abv: 48,
       releaseYear: 2024,
+    });
+  });
+
+  test("offers creation from extracted details when catalog candidates are uncertain", () => {
+    const result = buildPhotoResult();
+    result.classification = {
+      status: "classified",
+      decision: { action: "no_match" },
+      artifacts: {
+        candidates: [
+          {
+            fullName: "Possible Existing Bottle",
+          },
+        ],
+      },
+    };
+
+    expect(getManualResultCopy(result)).toMatchObject({
+      title: "We couldn't find this bottle",
+      createLabel: "Create Bottle",
+      primaryAction: "create",
+    });
+    expect(getCreateBottlePrefill(result)).toMatchObject({
+      brandName: "Raw Label Brand",
+      category: "single_malt",
+      distillers: [{ id: null, name: "Qualified Existing Distillery Co." }],
     });
   });
 });

--- a/apps/web/src/components/bottleResolver/helpers.ts
+++ b/apps/web/src/components/bottleResolver/helpers.ts
@@ -239,18 +239,6 @@ export function getManualResultCopy(
   }
 
   if (action === "no_match") {
-    if (
-      result?.classification.status === "classified" &&
-      result.classification.artifacts.candidates.length > 0
-    ) {
-      return {
-        title: "We couldn't identify this bottle",
-        description:
-          "We found a possible match, but it was not reliable enough to use automatically. Search can still find the right bottle.",
-        createLabel: undefined,
-      };
-    }
-
     if (hasRecognizedLabelDetails(result)) {
       return {
         title: "We couldn't find this bottle",


### PR DESCRIPTION
Uncertain bottle scans now keep manual creation available whenever OCR recognized useful label details, even when the classifier also found weak catalog candidates. Choosing **Create Bottle** carries the recognized fields and pending photo into the editable bottle form, while search and start-over remain available.

The prior result-state branch treated the presence of any candidate as a reason to hide creation, leaving users unable to use otherwise useful OCR output. Regression coverage now follows that exact weak-candidate flow through the populated creation form on both desktop and mobile layouts.
