### PR TITLE
fix(web): streamline bottle tasting actions

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -153,12 +153,9 @@ test.describe("create bottle", () => {
       ),
     );
     await expect(
-      page.getByRole("heading", { name: "Add Bottle" }),
+      page.getByRole("heading", { name: "Log Tasting" }),
     ).toBeVisible();
-    await expect(getBottleIdentityLink(page, createdBottleName)).toBeVisible();
-    await expect(
-      page.getByRole("button", { name: "Log Tasting" }),
-    ).toBeVisible();
+    await expect(page.getByTitle(createdBottleName)).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });
 
@@ -178,10 +175,6 @@ test.describe("create bottle", () => {
         `/addBottle\\?bottle=${createdBottleId}&resultSource=created&intent=tasting$`,
       ),
     );
-    await expect(
-      page.getByRole("heading", { name: "Add Bottle" }),
-    ).toBeVisible();
-    await page.getByRole("button", { name: "Log Tasting" }).click();
     await expect(
       page.getByRole("heading", { name: "Log Tasting" }),
     ).toBeVisible();
@@ -518,6 +511,16 @@ test.describe("add bottle flow", () => {
     ).toBeVisible();
     await expect(
       getBottleIdentityLink(page, destinationBottleGroup.name),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Log Tasting" }),
+    ).toHaveAttribute("href", `/bottles/${existingBottle.id}/addTasting`);
+    await expect(
+      page.getByRole("link", { name: "View Bottle" }),
+    ).toHaveAttribute("href", `/bottles/${existingBottle.id}`);
+    await page.getByRole("link", { name: "Log Tasting" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Log Tasting" }),
     ).toBeVisible();
     await expectNoHorizontalOverflow(page);
   });

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -22,29 +22,23 @@ test.describe("log tasting", () => {
   test("logs a tasting for a fixture bottle", async ({ context, page }) => {
     await signIn(context);
 
-    await page.goto(`/bottles/${existingBottle.id}/addTasting`);
+    await page.goto(`/bottles/${existingBottle.id}`);
+    const logTastingLink = page.getByRole("link", { name: "Log Tasting" });
+    await expect(logTastingLink).toHaveAttribute(
+      "href",
+      `/bottles/${existingBottle.id}/addTasting`,
+    );
+    await logTastingLink.click();
 
     await expect(page).toHaveURL(
       new RegExp(`/addBottle\\?bottle=${existingBottle.id}&intent=tasting$`),
     );
     await expect(
-      page.getByRole("heading", { name: "Add Bottle" }),
-    ).toBeVisible();
-    await expect(
-      getBottleIdentityLink(page, destinationBottleGroup.name),
-    ).toBeVisible();
-    await expect(
-      page
-        .locator("main section")
-        .filter({ hasText: "Bottle found" })
-        .getByRole("button")
-        .first(),
-    ).toHaveText("Log Tasting");
-    await page.getByRole("button", { name: "Log Tasting" }).click();
-
-    await expect(
       page.getByRole("heading", { name: "Log Tasting" }),
     ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Bottle found" }),
+    ).toBeHidden();
     await expect(page.getByTitle(existingBottle.fullName)).toBeVisible();
     await page.getByRole("button", { name: "Savor" }).click();
     await page.getByLabel("Comments").fill(tastingNotes);
@@ -74,7 +68,9 @@ test.describe("log tasting", () => {
     });
 
     await page.goto(`/bottles/${existingBottle.id}/addTasting`);
-    await page.getByRole("button", { name: "Log Tasting" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Log Tasting" }),
+    ).toBeVisible();
     await page.getByRole("button", { name: "Savor" }).click();
     await page.getByLabel("Comments").fill(tastingNotes);
     await uploadTastingImage(page);

--- a/apps/web/src/app/(default)/bottles/[bottleId]/bottleFullHeader.tsx
+++ b/apps/web/src/app/(default)/bottles/[bottleId]/bottleFullHeader.tsx
@@ -6,7 +6,6 @@ import CollectionAction from "@peated/web/components/collectionAction";
 import FlavorProfile from "@peated/web/components/flavorProfile";
 import ShareButton from "@peated/web/components/shareButton";
 import SkeletonButton from "@peated/web/components/skeletonButton";
-import { getAddBottleHref } from "@peated/web/lib/addBottle";
 import { getBottlePlainTextIdentity } from "@peated/web/lib/bottleLabel";
 import { Suspense } from "react";
 import BottleActions from "./bottleActions";
@@ -35,13 +34,7 @@ export default function BottleFullHeader({
             <CollectionAction bottleId={bottle.id} />
           </Suspense>
 
-          <Button
-            href={getAddBottleHref({
-              bottleId: bottle.id,
-              intent: "tasting",
-            })}
-            color="primary"
-          >
+          <Button href={`/bottles/${bottle.id}/addTasting`} color="primary">
             <PeatedGlyph className="h-4 w-4" /> Log Tasting
           </Button>
 

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -555,6 +555,20 @@ function AddedToLibrary({
         <div className="grid gap-3 sm:grid-cols-2">
           <Button
             color="highlight"
+            href={`/bottles/${entry.bottle.id}/addTasting`}
+            fullWidth
+            icon={<Wine className="h-4 w-4" />}
+          >
+            Log Tasting
+          </Button>
+          <Button
+            href={getViewBottleHref(entry.bottle)}
+            fullWidth
+            icon={<Eye className="h-4 w-4" />}
+          >
+            View Bottle
+          </Button>
+          <Button
             fullWidth
             icon={<Plus className="h-4 w-4" />}
             onClick={onAddAnother}
@@ -599,10 +613,15 @@ function AddBottleFlowContent() {
   const requestedBottleKey = useMemo(() => {
     const pendingImageKey = requestedPendingImage?.id ?? "no-image";
     if (requestedBottleId) {
-      return `bottle:${requestedBottleId}:${pendingImageKey}:${requestedResultSource ?? "found"}`;
+      return `bottle:${requestedBottleId}:${pendingImageKey}:${requestedResultSource ?? "found"}:${intent}`;
     }
     return null;
-  }, [requestedBottleId, requestedPendingImage?.id, requestedResultSource]);
+  }, [
+    intent,
+    requestedBottleId,
+    requestedPendingImage?.id,
+    requestedResultSource,
+  ]);
 
   const [loadedBottleKey, setLoadedBottleKey] = useState<string | null>(null);
   const [loadingBottle, setLoadingBottle] = useState(false);
@@ -670,14 +689,38 @@ function AddBottleFlowContent() {
 
         if (cancelled) return;
         const libraryEntry = collectionStatus.results[0] ?? null;
-        setSelectedBottle({
+        const selection: FlowBottle = {
           bottle,
           hasLibraryEntry: Boolean(libraryEntry),
           libraryEntryImageUrl: libraryEntry?.imageUrl ?? null,
           pendingImage: requestedPendingImage,
           previewUrl: requestedPendingImage?.imageUrl || null,
           resultSource: requestedResultSource,
-        });
+        };
+
+        if (intent === "tasting") {
+          try {
+            const suggestedTags = await orpc.bottles.suggestedTags.call({
+              bottle: selection.bottle.id,
+            });
+            if (cancelled) return;
+            setSelectedBottle(null);
+            setTastingDraft({
+              ...selection,
+              suggestedTags,
+              createdAt: new Date().toISOString(),
+            });
+          } catch (err) {
+            logError(err);
+            if (cancelled) return;
+            setSelectedBottle(selection);
+            setTastingLoadError(
+              "We couldn't load the tasting form. Try again or search for the bottle.",
+            );
+          }
+        } else {
+          setSelectedBottle(selection);
+        }
         setLoadedBottleKey(requestedBottleKey);
       } catch (err) {
         logError(err);
@@ -700,6 +743,7 @@ function AddBottleFlowContent() {
       cancelled = true;
     };
   }, [
+    intent,
     loadedBottleKey,
     orpc,
     requestedBottleId,


### PR DESCRIPTION
Known Bottle tasting actions now open the tasting form immediately instead of pausing on the generic “Bottle found” outcome. The Added to Library confirmation also presents Log Tasting as the primary follow-up and adds an explicit View Bottle action, while retaining Add Another Bottle and View Library.

This keeps scan and search resolution unchanged while removing an unnecessary confirmation step when Bottle identity is already known. Coverage now exercises the bottle-detail link, created-Bottle tasting continuations, and post-Library tasting navigation; the affected Playwright specs passed on desktop and mobile, and the web typecheck, lint, and visual QA passed.
