### PR TITLE
fix(web): allow photo library in add bottle flow

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -43,6 +43,9 @@ test.describe("create bottle", () => {
       page.getByRole("heading", { name: "Add Bottle" }),
     ).toBeVisible();
     await expect(page.getByText("Take or upload a photo")).toBeVisible();
+    const photoInput = page.locator('input[type="file"]');
+    await expect(photoInput).toHaveAttribute("accept", "image/*");
+    await expect(photoInput).not.toHaveAttribute("capture");
     await expectNoHorizontalOverflow(page);
   });
 

--- a/apps/web/src/components/bottleResolver/index.tsx
+++ b/apps/web/src/components/bottleResolver/index.tsx
@@ -439,7 +439,6 @@ export default function BottleResolver({
         className="hidden"
         type="file"
         accept="image/*"
-        capture="environment"
         onChange={onFileChange}
       />
 


### PR DESCRIPTION
The Add Bottle photo chooser no longer forces rear-camera capture, so iOS users can select an existing image from their photo library or files while retaining the browser-provided camera option. The input continues to accept images through `accept="image/*"`.

The root cause was `capture="environment"`, which iOS treats as a direct rear-camera request even though the UI promises “Take or upload a photo.” Browser coverage now asserts that the resolver keeps the image accept filter without restoring the capture attribute; the focused desktop/mobile Playwright check and web typecheck pass.
