### PR TITLE
feat(scrapers): add GlenAllachie pricing

### DIFF
--- a/apps/server/__fixtures__/glenallachie/bottle-list.json
+++ b/apps/server/__fixtures__/glenallachie/bottle-list.json
@@ -1,0 +1,118 @@
+{
+  "products": [
+    {
+      "title": "The GlenAllachie 12 Year Old",
+      "handle": "the-glenallachie-12-year-old",
+      "body_html": "<p>Our flagship single malt.</p>",
+      "product_type": "Single Malt Scotch Whisky",
+      "tags": ["glenallachie"],
+      "images": [{"src": "https://cdn.shopify.com/s/files/glenallachie-12.png"}],
+      "variants": [{"available": true, "price": "54.99"}]
+    },
+    {
+      "title": "Online-Exclusive 3.0 2021 Chinquapin Virgin Oak Barrel #2300",
+      "handle": "online-exclusive-3-0-chinquapin-virgin-oak",
+      "body_html": "<p>A heavily peated single malt.</p>",
+      "product_type": "Peated Single Malt Whisky",
+      "tags": ["meikle toir", "online exclusive"],
+      "images": [{"src": "https://cdn.shopify.com/s/files/meikle-toir-exclusive.png"}],
+      "variants": [{"available": true, "price": "69.99"}]
+    },
+    {
+      "title": "White Heather 15 Year Old",
+      "handle": "white-heather-15-year-old",
+      "body_html": "<p>Blended Scotch whisky.</p>",
+      "product_type": "Blended Scotch Whisky",
+      "tags": [],
+      "images": [{"src": "https://cdn.shopify.com/s/files/white-heather-15.png"}],
+      "variants": [{"available": true, "price": "49"}]
+    },
+    {
+      "title": "MacNair’s Lum Reek 10 Year Old Cask Strength",
+      "handle": "macnairs-lum-reek-10-year-old-cask-strength",
+      "body_html": "<p>Blended malt whisky in a 70cl bottle.</p>",
+      "product_type": "Blended Malt Whisky",
+      "tags": [],
+      "images": [{"src": "https://shop.theglenallachie.com/cdn/shop/files/lum-reek-10.png"}],
+      "variants": [{"available": true, "price": "62.50"}]
+    },
+    {
+      "title": "The GlenAllachie 18 Year Old",
+      "handle": "the-glenallachie-18-year-old",
+      "body_html": "",
+      "product_type": "Single Malt Scotch Whisky",
+      "tags": [],
+      "images": [{"src": "https://cdn.shopify.com/s/files/glenallachie-18.png"}],
+      "variants": [{"available": false, "price": "94.99"}]
+    },
+    {
+      "title": "Meikle Tòir The Original Miniature 5cl",
+      "handle": "meikle-toir-the-original-miniature",
+      "body_html": "",
+      "product_type": "Peated Single Malt Whisky",
+      "tags": ["meikle toir"],
+      "images": [{"src": "https://cdn.shopify.com/s/files/meikle-toir-miniature.png"}],
+      "variants": [{"available": true, "price": "6.50"}]
+    },
+    {
+      "title": "MacNair’s Exploration Rum",
+      "handle": "macnairs-exploration-rum",
+      "body_html": "",
+      "product_type": "Rum",
+      "tags": [],
+      "images": [{"src": "https://cdn.shopify.com/s/files/rum.png"}],
+      "variants": [{"available": true, "price": "49.99"}]
+    },
+    {
+      "title": "Mystery 10 Year Old",
+      "handle": "mystery-10-year-old",
+      "body_html": "",
+      "product_type": "Single Malt Scotch Whisky",
+      "tags": [],
+      "images": [{"src": "https://cdn.shopify.com/s/files/mystery.png"}],
+      "variants": [{"available": true, "price": "60.00"}]
+    },
+    {
+      "title": "The GlenAllachie Variant Release",
+      "handle": "the-glenallachie-variant-release",
+      "body_html": "",
+      "product_type": "Single Malt Scotch Whisky",
+      "tags": [],
+      "images": [{"src": "https://cdn.shopify.com/s/files/variant-release.png"}],
+      "variants": [
+        {"available": true, "price": "50.00"},
+        {"available": true, "price": "60.00"}
+      ]
+    },
+    {
+      "title": "The GlenAllachie Special Edition 500ml",
+      "handle": "the-glenallachie-special-edition",
+      "body_html": "",
+      "product_type": "Single Malt Scotch Whisky",
+      "tags": [],
+      "images": [{"src": "https://cdn.shopify.com/s/files/special-edition.png"}],
+      "variants": [{"available": true, "price": "45.00"}]
+    },
+    {
+      "title": "The GlenAllachie Invalid Price",
+      "handle": "the-glenallachie-invalid-price",
+      "body_html": "",
+      "product_type": "Single Malt Scotch Whisky",
+      "tags": [],
+      "images": [{"src": "https://cdn.shopify.com/s/files/invalid-price.png"}],
+      "variants": [{"available": true, "price": "free"}]
+    },
+    {
+      "title": "The GlenAllachie Invalid Image",
+      "handle": "the-glenallachie-invalid-image",
+      "body_html": "",
+      "product_type": "Single Malt Scotch Whisky",
+      "tags": [],
+      "images": [{"src": "https://example.com/not-official.png"}],
+      "variants": [{"available": true, "price": "55.00"}]
+    },
+    {
+      "title": "Broken Product"
+    }
+  ]
+}

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -31,6 +31,7 @@ export const EXTERNAL_SITE_TYPE_LIST = [
   "douglaslaing",
   "dramfool",
   "edradour",
+  "glenallachie",
   "gordonmacphail",
   "healthyspirits",
   "kilchoman",

--- a/apps/server/src/schemas/externalSites.test.ts
+++ b/apps/server/src/schemas/externalSites.test.ts
@@ -1,15 +1,15 @@
 import { ExternalSiteInputSchema, ExternalSiteTypeEnum } from "./externalSites";
 
 test("accepts registered external-site types", () => {
-  expect(ExternalSiteTypeEnum.parse("edradour")).toBe("edradour");
+  expect(ExternalSiteTypeEnum.parse("glenallachie")).toBe("glenallachie");
   expect(
     ExternalSiteInputSchema.parse({
-      name: "Edradour",
-      type: "edradour",
+      name: "The GlenAllachie",
+      type: "glenallachie",
     }),
   ).toMatchObject({
-    name: "Edradour",
-    type: "edradour",
+    name: "The GlenAllachie",
+    type: "glenallachie",
   });
 });
 

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -31,6 +31,7 @@ import scrapeDecadentDrinks from "./scrapeDecadentDrinks";
 import scrapeDouglasLaing from "./scrapeDouglasLaing";
 import scrapeDramfool from "./scrapeDramfool";
 import scrapeEdradour from "./scrapeEdradour";
+import scrapeGlenAllachie from "./scrapeGlenAllachie";
 import scrapeGordonMacphail from "./scrapeGordonMacphail";
 import scrapeHealthySpirits from "./scrapeHealthySpirits";
 import scrapeKilchoman from "./scrapeKilchoman";
@@ -84,6 +85,7 @@ const scraperJobs = [
   ["ScrapeDouglasLaing", "douglaslaing", scrapeDouglasLaing],
   ["ScrapeDramfool", "dramfool", scrapeDramfool],
   ["ScrapeEdradour", "edradour", scrapeEdradour],
+  ["ScrapeGlenAllachie", "glenallachie", scrapeGlenAllachie],
   ["ScrapeGordonMacphail", "gordonmacphail", scrapeGordonMacphail],
   ["ScrapeHealthySpirits", "healthyspirits", scrapeHealthySpirits],
   ["ScrapeKilchoman", "kilchoman", scrapeKilchoman],

--- a/apps/server/src/worker/jobs/scrapeGlenAllachie.test.ts
+++ b/apps/server/src/worker/jobs/scrapeGlenAllachie.test.ts
@@ -1,0 +1,90 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { StorePriceInputSchema } from "@peated/server/schemas";
+import { getJobForSite } from "@peated/server/worker/utils";
+import scrapeGlenAllachie, { scrapeProducts } from "./scrapeGlenAllachie";
+
+process.env.DISABLE_HTTP_CACHE = "1";
+
+const firstPageUrl =
+  "https://shop.theglenallachie.com/collections/all-products/products.json?country=GB&limit=250&page=1";
+const secondPageUrl =
+  "https://shop.theglenallachie.com/collections/all-products/products.json?country=GB&limit=250&page=2";
+
+test("routes the GlenAllachie source to its scraper job", () => {
+  expect(getJobForSite("glenallachie")).toBe("ScrapeGlenAllachie");
+});
+
+test("scrapes available full-size whisky and excludes unsupported products", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("glenallachie", "bottle-list.json");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+
+  const items: unknown[] = [];
+  await scrapeProducts(firstPageUrl, async (item) => {
+    items.push(StorePriceInputSchema.parse(item));
+  });
+
+  expect(items).toEqual([
+    {
+      currency: "gbp",
+      imageUrl: "https://cdn.shopify.com/s/files/glenallachie-12.png",
+      name: "The GlenAllachie 12-year-old",
+      price: 5499,
+      url: "https://shop.theglenallachie.com/products/the-glenallachie-12-year-old",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl: "https://cdn.shopify.com/s/files/meikle-toir-exclusive.png",
+      name: "Meikle Tòir Online-Exclusive 3.0 2021 Chinquapin Virgin Oak Barrel #2300",
+      price: 6999,
+      url: "https://shop.theglenallachie.com/products/online-exclusive-3-0-chinquapin-virgin-oak",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl: "https://cdn.shopify.com/s/files/white-heather-15.png",
+      name: "White Heather 15-year-old",
+      price: 4900,
+      url: "https://shop.theglenallachie.com/products/white-heather-15-year-old",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl:
+        "https://shop.theglenallachie.com/cdn/shop/files/lum-reek-10.png",
+      name: "MacNair's Lum Reek 10-year-old Cask Strength",
+      price: 6250,
+      url: "https://shop.theglenallachie.com/products/macnairs-lum-reek-10-year-old-cask-strength",
+      volume: 700,
+    },
+  ]);
+});
+
+test("rejects malformed Shopify payloads", async ({ axiosMock }) => {
+  axiosMock.onGet(firstPageUrl).reply(200, { items: [] });
+
+  await expect(scrapeProducts(firstPageUrl, async () => {})).rejects.toThrow();
+});
+
+test("paginates a dry run and stops after an empty page", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("glenallachie", "bottle-list.json");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+  axiosMock.onGet(secondPageUrl).reply(200, { products: [] });
+
+  await expect(scrapeGlenAllachie({ dryRun: true })).resolves.toBe(4);
+  expect(axiosMock.history.get).toHaveLength(2);
+});
+
+test("fails when a complete scrape yields no supported listings", async ({
+  axiosMock,
+}) => {
+  axiosMock.onGet(firstPageUrl).reply(200, { products: [] });
+
+  await expect(scrapeGlenAllachie({ dryRun: true })).rejects.toThrow(
+    "Failed to scrape any products.",
+  );
+});

--- a/apps/server/src/worker/jobs/scrapeGlenAllachie.ts
+++ b/apps/server/src/worker/jobs/scrapeGlenAllachie.ts
@@ -1,0 +1,213 @@
+import { normalizeBottle } from "@peated/bottle-classifier/normalize";
+import type {
+  ScrapePricesCallback,
+  StorePrice,
+} from "@peated/server/lib/scraper";
+import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import { z } from "zod";
+import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
+
+const SITE = "glenallachie";
+const STORE_ORIGIN = "https://shop.theglenallachie.com";
+const CATALOG_URL = `${STORE_ORIGIN}/collections/all-products/products.json?country=GB&limit=250`;
+const DEFAULT_VOLUME = 700;
+const SUPPORTED_PRODUCT_TYPES = new Set([
+  "Blended Malt Whisky",
+  "Blended Scotch Whisky",
+  "Peated Single Malt Whisky",
+  "Single Malt Scotch Whisky",
+]);
+
+const GlenAllachieCatalogSchema = z
+  .object({
+    products: z.array(z.unknown()),
+  })
+  .passthrough();
+
+const GlenAllachieProductSchema = z
+  .object({
+    title: z.string().trim().min(1),
+    handle: z
+      .string()
+      .trim()
+      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+    body_html: z.string(),
+    product_type: z.string(),
+    tags: z.array(z.string()),
+    images: z.array(z.unknown()),
+    variants: z.array(z.unknown()),
+  })
+  .passthrough();
+
+const GlenAllachieVariantSchema = z
+  .object({
+    available: z.boolean(),
+    price: z.string(),
+  })
+  .passthrough();
+
+const GlenAllachieImageSchema = z
+  .object({
+    src: z.string().url(),
+  })
+  .passthrough();
+
+function getRawName(input: unknown): string | null {
+  if (!input || typeof input !== "object" || !("title" in input)) return null;
+  return typeof input.title === "string" ? input.title : null;
+}
+
+function parsePrice(value: string): number | null {
+  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
+  if (!match) return null;
+
+  const pounds = Number.parseInt(match[1], 10);
+  const pence = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
+  const price = pounds * 100 + pence;
+  return Number.isSafeInteger(price) && price > 0 ? price : null;
+}
+
+function parseExplicitVolumes(value: string): number[] {
+  const volumes = new Set<number>();
+  for (const match of value.matchAll(/\b(\d+(?:\.\d+)?)\s*(ml|cl|l)\b/gi)) {
+    const amount = Number.parseFloat(match[1]);
+    const unit = match[2].toLowerCase();
+    const volume =
+      unit === "cl" ? amount * 10 : unit === "l" ? amount * 1000 : amount;
+    if (Number.isInteger(volume)) volumes.add(volume);
+  }
+  return [...volumes];
+}
+
+function getProductName(title: string, tags: string[]): string | null {
+  if (
+    /^(?:the\s+)?glenallachie\b/i.test(title) ||
+    /^meikle\s+t(?:ò|o)ir\b/i.test(title) ||
+    /^white\s+heather\b/i.test(title) ||
+    /^macnair[’']s\b/i.test(title)
+  ) {
+    return normalizeBottle({ name: title }).name;
+  }
+
+  if (tags.some((tag) => tag.trim().toLowerCase() === "meikle toir")) {
+    return normalizeBottle({ name: `Meikle Tòir ${title}` }).name;
+  }
+
+  return null;
+}
+
+function getImageUrl(value: unknown): string | null {
+  const result = GlenAllachieImageSchema.safeParse(value);
+  if (!result.success) return null;
+
+  const url = new URL(result.data.src);
+  return url.protocol === "https:" &&
+    (url.hostname === "cdn.shopify.com" ||
+      url.hostname === "shop.theglenallachie.com")
+    ? url.toString()
+    : null;
+}
+
+export function parseGlenAllachieProducts(input: unknown): StorePrice[] {
+  const payload = GlenAllachieCatalogSchema.parse(input);
+  const products: StorePrice[] = [];
+
+  for (const productInput of payload.products) {
+    const productResult = GlenAllachieProductSchema.safeParse(productInput);
+    if (!productResult.success) {
+      logScrapeWarning(SITE, "Invalid product record", {
+        rawName: getRawName(productInput),
+      });
+      continue;
+    }
+
+    const product = productResult.data;
+    if (!SUPPORTED_PRODUCT_TYPES.has(product.product_type)) continue;
+    if (/\bminiatures?\b/i.test(product.title)) continue;
+
+    const explicitVolumes = parseExplicitVolumes(
+      `${product.title} ${product.body_html}`,
+    );
+    if (explicitVolumes.some((volume) => volume !== DEFAULT_VOLUME)) {
+      logScrapeWarning(SITE, "Unsupported product size", {
+        rawName: product.title,
+        volumes: explicitVolumes,
+      });
+      continue;
+    }
+
+    const availableVariants = product.variants
+      .map((variant) => GlenAllachieVariantSchema.safeParse(variant))
+      .filter((result) => result.success && result.data.available)
+      .map((result) => result.data);
+    if (availableVariants.length !== 1) {
+      if (availableVariants.length > 1) {
+        logScrapeWarning(SITE, "Ambiguous available product variants", {
+          rawName: product.title,
+          variantCount: availableVariants.length,
+        });
+      }
+      continue;
+    }
+    const variant = availableVariants[0];
+    if (!variant) continue;
+
+    const price = parsePrice(variant.price);
+    if (price === null) {
+      logScrapeWarning(SITE, "Invalid product price", {
+        rawName: product.title,
+        price: variant.price,
+      });
+      continue;
+    }
+
+    const name = getProductName(product.title, product.tags);
+    if (!name) {
+      logScrapeWarning(SITE, "Unrecognized product identity", {
+        rawName: product.title,
+      });
+      continue;
+    }
+
+    const imageUrl = getImageUrl(product.images[0]);
+    if (!imageUrl) {
+      logScrapeWarning(SITE, "Invalid product image URL", {
+        rawName: product.title,
+      });
+      continue;
+    }
+
+    const listing = {
+      name,
+      price,
+      currency: "gbp" as const,
+      // The source omits volume; its explicitly classified, non-miniature UK
+      // whisky range is 700 ml. Conflicting published sizes are rejected above.
+      volume: DEFAULT_VOLUME,
+      url: `${STORE_ORIGIN}/products/${product.handle}`,
+      imageUrl,
+    };
+
+    logScrapedProduct(SITE, listing);
+    products.push(listing);
+  }
+
+  return products;
+}
+
+export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
+  const data = await getUrl(url);
+  const products = parseGlenAllachieProducts(JSON.parse(data));
+  await Promise.all(products.map(cb));
+}
+
+export default async function scrapeGlenAllachie({
+  dryRun = false,
+}: { dryRun?: boolean } = {}) {
+  return await scrapePrices(
+    SITE,
+    (page) => `${CATALOG_URL}&page=${page}`,
+    scrapeProducts,
+    { dryRun },
+  );
+}

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -32,6 +32,7 @@ export type JobName =
   | "ScrapeDouglasLaing"
   | "ScrapeDramfool"
   | "ScrapeEdradour"
+  | "ScrapeGlenAllachie"
   | "ScrapeGordonMacphail"
   | "ScrapeHealthySpirits"
   | "ScrapeKilchoman"

--- a/apps/server/src/worker/utils.ts
+++ b/apps/server/src/worker/utils.ts
@@ -21,6 +21,8 @@ export function getJobForSite(site: ExternalSiteType): JobName {
       return "ScrapeDramfool";
     case "edradour":
       return "ScrapeEdradour";
+    case "glenallachie":
+      return "ScrapeGlenAllachie";
     case "gordonmacphail":
       return "ScrapeGordonMacphail";
     case "kilchoman":

--- a/openspec/changes/add-glenallachie-scraper/.openspec.yaml
+++ b/openspec/changes/add-glenallachie-scraper/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/add-glenallachie-scraper/design.md
+++ b/openspec/changes/add-glenallachie-scraper/design.md
@@ -1,0 +1,57 @@
+## Context
+
+The GlenAllachie publishes its UK shop through Shopify. Its public collection JSON exposes product type, availability, GBP price, handle, tags, and official images without credentials or per-product detail requests. The same collection contains rum, gift cards, glassware, miniatures, and unavailable products alongside whisky.
+
+The storefront currently classifies full-size whisky with four explicit product types and sells those bottles at the UK standard 700 ml size. It does not publish volume in the catalog payload or product detail markup. The catalog accepts a `country=GB` query parameter that makes GBP localization deterministic.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Collect first-party prices for available full-size whisky sold through the official GlenAllachie shop.
+- Preserve the shop's published brand identity across The GlenAllachie, Meikle Tòir, White Heather, and MacNair's ranges.
+- Use explicit product type and variant availability boundaries to exclude non-whisky and unavailable products.
+- Keep malformed individual products from aborting useful results while preserving the shared empty-run failure.
+
+**Non-Goals:**
+
+- Scrape rum, gift cards, glassware, miniatures, sold-out products, or unsupported bottle sizes.
+- Infer arbitrary future product categories as whisky.
+- Create bottles or persist prices during local verification.
+
+## Decisions
+
+### Parse the public Shopify collection JSON
+
+The worker will request the official all-products JSON endpoint with `country=GB`, `limit=250`, and an incrementing page number. The structured response exposes every required field except volume, avoids fragile HTML selectors, and removes the need for product-detail requests. An empty product page ends pagination.
+
+### Gate eligibility with source-owned product types and availability
+
+Only products classified as `Single Malt Scotch Whisky`, `Peated Single Malt Whisky`, `Blended Malt Whisky`, or `Blended Scotch Whisky` are eligible. A qualifying product must have exactly one available variant with a positive price. Exact matching is intentional here because Shopify product type is the storefront's explicit taxonomy rather than presentation text.
+
+### Treat eligible non-miniature whisky as 700 ml
+
+The source does not publish bottle volume in machine-readable data or rendered detail pages. Its qualifying full-size whisky range uses the UK standard 700 ml format, while miniatures identify themselves in the title. The scraper will exclude miniature titles, reject a conflicting explicit volume if one appears in future source text, and otherwise assign 700 ml at this source boundary.
+
+### Preserve published brand identity
+
+Published names already identifying The GlenAllachie, Meikle Tòir, White Heather, or MacNair's will pass through shared bottle normalization. The storefront abbreviates one Meikle Tòir exclusive while tagging it `meikle toir`; that tag will supply the missing prefix. A qualifying unbranded product without a recognized identity tag will be warned about and skipped instead of being assigned the wrong producer.
+
+### Isolate malformed products and keep source failures visible
+
+Invalid products, prices, URLs, images, categories, or ambiguous variants will be logged and skipped. Unexpected request or top-level payload failures will escape to the worker boundary. If no valid products remain across the complete run, the shared scraper boundary will fail explicitly.
+
+## Risks / Trade-offs
+
+- **The shop introduces a non-700 ml full-size whisky without publishing volume** → Reject conflicting explicit volume text when available and keep the 700 ml invariant local, documented, and covered so a source-contract update is narrow.
+- **The shop renames its product types** → Unknown types are skipped, and complete coverage loss triggers the shared empty-run failure rather than a false successful run.
+- **A branded title omits its identity without a recognized tag** → Warn and skip it rather than creating an ambiguous catalog identity.
+- **Shopify changes its JSON schema** → Validate the response and each product at the boundary; top-level failure aborts the run while isolated invalid products do not.
+
+## Migration Plan
+
+Register the source and deploy the worker code, then configure GlenAllachie through the existing administrative path. No database migration is needed because external-site types are stored as text and validated by the application. Rollback consists of disabling the external site and worker job.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-glenallachie-scraper/proposal.md
+++ b/openspec/changes/add-glenallachie-scraper/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Peated does not currently collect first-party pricing from The GlenAllachie, despite its official shop carrying active ranges from The GlenAllachie, Meikle Tòir, White Heather, and MacNair's. Adding the source expands direct producer coverage without relying on a third-party retailer.
+
+## What Changes
+
+- Register GlenAllachie as an external price source and worker job.
+- Scrape the official public Shopify catalog for available full-size whisky bottles.
+- Normalize published identities, 700 ml volume, GBP prices, official product URLs, and images.
+- Exclude sold-out products, miniatures, rum, merchandise, gift cards, and malformed products.
+- Add fixture-based coverage and local live verification.
+
+## Capabilities
+
+### New Capabilities
+
+- `glenallachie-price-scraping`: Collect valid current whisky prices from the official GlenAllachie catalog while rejecting unavailable or unsupported products.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds a server worker scraper, routing, fixtures, and tests.
+- Reads the public GlenAllachie Shopify catalog; no new runtime dependency, protected credential, or database migration is required.

--- a/openspec/changes/add-glenallachie-scraper/specs/glenallachie-price-scraping/spec.md
+++ b/openspec/changes/add-glenallachie-scraper/specs/glenallachie-price-scraping/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Fetch the official localized catalog
+
+The GlenAllachie scraper SHALL request numbered pages from the official all-products catalog with Great Britain localization and SHALL stop after a page contains no products.
+
+#### Scenario: Catalog page contains products
+
+- **WHEN** a numbered catalog page contains products
+- **THEN** the scraper evaluates those products in GBP and requests the next numbered page
+
+#### Scenario: End of catalog
+
+- **WHEN** a numbered catalog page contains no products
+- **THEN** the scraper stops requesting additional pages
+
+### Requirement: Emit eligible whisky listings
+
+The scraper SHALL emit only available, full-size products in the source's supported whisky categories with a positive GBP price, recognized brand identity, valid official product URL, and valid official image.
+
+#### Scenario: Eligible bottle
+
+- **WHEN** an available non-miniature product has a supported whisky type, one available positive-price variant, recognized identity, official URL, and valid image
+- **THEN** the scraper emits its normalized name, price, GBP currency, 700 ml volume, URL, and image URL
+
+#### Scenario: Unsupported catalog product
+
+- **WHEN** a product is sold out, a miniature, rum, merchandise, a gift card, ambiguously variant-priced, or has an unsupported explicit volume
+- **THEN** the scraper does not emit a listing for that product
+
+### Requirement: Preserve producer identity
+
+The scraper SHALL retain a published recognized brand identity and SHALL use the source's Meikle Tòir tag when that identity is omitted from an eligible title.
+
+#### Scenario: Published title has recognized identity
+
+- **WHEN** an eligible product title identifies The GlenAllachie, GlenAllachie, Meikle Tòir, White Heather, or MacNair's
+- **THEN** the scraper does not duplicate the published identity
+
+#### Scenario: Meikle Tòir identity is present only in tags
+
+- **WHEN** an eligible title omits a recognized identity and its source tags identify Meikle Tòir
+- **THEN** the scraper prefixes the title with `Meikle Tòir` before shared normalization
+
+#### Scenario: Product has no recognized identity
+
+- **WHEN** an otherwise eligible product has neither a recognized title identity nor a recognized identity tag
+- **THEN** the scraper warns and skips the product
+
+### Requirement: Degrade individual malformed products visibly
+
+The scraper SHALL log and skip an invalid individual product without aborting valid products from the same catalog page, while retaining the shared complete-run failure when no valid products are emitted.
+
+#### Scenario: One malformed product among valid products
+
+- **WHEN** a catalog page contains a malformed product and at least one valid product
+- **THEN** the malformed product is warned about and valid products are emitted
+
+#### Scenario: Invalid catalog payload
+
+- **WHEN** the catalog response itself is not valid source JSON
+- **THEN** the scraper fails the run instead of reporting success
+
+#### Scenario: Complete empty run
+
+- **WHEN** the complete paginated run emits no supported listings
+- **THEN** the scraper fails explicitly instead of reporting success

--- a/openspec/changes/add-glenallachie-scraper/tasks.md
+++ b/openspec/changes/add-glenallachie-scraper/tasks.md
@@ -1,0 +1,16 @@
+## 1. Source Registration
+
+- [x] 1.1 Register `glenallachie` in the external-site type list and worker routing
+- [x] 1.2 Verify registered types remain accepted and unknown types remain rejected by application validation
+
+## 2. Scraper Implementation
+
+- [x] 2.1 Implement localized paginated Shopify catalog fetching and response validation
+- [x] 2.2 Parse and normalize supported whisky identities, 700 ml volume, GBP prices, official URLs, and images
+- [x] 2.3 Exclude sold-out, miniature, non-whisky, ambiguous, and malformed products while retaining complete-run failure
+
+## 3. Verification
+
+- [x] 3.1 Add representative fixtures and focused routing, parsing, exclusion, pagination, and failure tests
+- [x] 3.2 Run targeted tests, typecheck, lint, source formatting, and strict OpenSpec validation
+- [x] 3.3 Run an uncached live dry run, build the server package, and run the full repository test gate


### PR DESCRIPTION
Adds first-party GBP price collection from The GlenAllachie’s official Shopify catalog. The worker paginates the Great Britain-localized feed, emits available 700 ml whisky listings across The GlenAllachie, Meikle Tòir, White Heather, and MacNair’s ranges, and skips unsupported, unavailable, ambiguous, or malformed products.

The source is registered through application validation and worker routing; no database enum or migration is added. Fixture coverage exercises routing, supported identities, pagination, exclusions, malformed payloads, and the shared empty-run failure.

Local verification passed focused tests, server typecheck, formatting/lint hooks, strict OpenSpec validation, the server build, and the full repository test suite. An uncached live dry run returned 23 listings over two pages without database writes.
