### PR TITLE
feat(scrapers): add Bruichladdich pricing

### DIFF
--- a/apps/server/__fixtures__/bruichladdich/bottle-list.json
+++ b/apps/server/__fixtures__/bruichladdich/bottle-list.json
@@ -1,0 +1,115 @@
+{
+  "products": [
+    {
+      "title": "Bruichladdich Bere Barley 2013",
+      "handle": "bruichladdich-bere-barley-2013",
+      "product_type": "Unpeated Islay Single Malt Scotch Whisky",
+      "vendor": "Bruichladdich Distillery",
+      "tags": ["Bruichladdich", "Single Malt"],
+      "variants": [{"available": true, "price": "100.00", "title": "70cl"}],
+      "images": [{"src": "https://cdn.shopify.com/s/files/bruichladdich-bere-barley.png"}]
+    },
+    {
+      "title": "Port Charlotte 10",
+      "handle": "port-charlotte-10",
+      "product_type": "Heavily Peated Islay Single Malt Scotch Whisky",
+      "vendor": "Bruichladdich Distillery",
+      "tags": ["Port Charlotte"],
+      "variants": [{"available": true, "price": "60", "title": "700ml"}],
+      "images": [{"src": "https://cdn.shopify.com/s/files/port-charlotte-10.png"}]
+    },
+    {
+      "title": "Octomore Edition 16.1",
+      "handle": "octomore-16-1",
+      "product_type": "Super Heavily Peated Islay Single Malt Scotch Whisky",
+      "vendor": "Bruichladdich Distillery",
+      "tags": ["Octomore"],
+      "variants": [{"available": true, "price": "140.00", "title": "70CL"}],
+      "images": [{"src": "https://www.bruichladdich.com/cdn/shop/files/octomore-16-1.png"}]
+    },
+    {
+      "title": "The Biodynamic Project",
+      "handle": "the-biodynamic-project",
+      "product_type": "Islay Single Malt Scotch Whisky",
+      "vendor": "Bruichladdich Distillery",
+      "tags": ["Single Malt"],
+      "variants": [{"available": true, "price": "100.00", "title": "70 cl"}],
+      "images": [{"src": "https://cdn.shopify.com/s/files/biodynamic-project.png"}]
+    },
+    {
+      "title": "Bruichladdich Sold Out",
+      "handle": "bruichladdich-sold-out",
+      "product_type": "Unpeated Islay Single Malt Scotch Whisky",
+      "vendor": "Bruichladdich Distillery",
+      "tags": ["Bruichladdich"],
+      "variants": [{"available": false, "price": "85.00", "title": "70cl"}],
+      "images": [{"src": "https://cdn.shopify.com/s/files/sold-out.png"}]
+    },
+    {
+      "title": "Bruichladdich Zero Price",
+      "handle": "bruichladdich-zero-price",
+      "product_type": "Unpeated Islay Single Malt Scotch Whisky",
+      "vendor": "Bruichladdich Distillery",
+      "tags": ["Bruichladdich"],
+      "variants": [{"available": true, "price": "0.00", "title": "700ml"}],
+      "images": [{"src": "https://cdn.shopify.com/s/files/zero-price.png"}]
+    },
+    {
+      "title": "The Botanist Islay Dry Gin",
+      "handle": "the-botanist-islay-dry-gin",
+      "product_type": "Islay Dry Gin",
+      "vendor": "Bruichladdich Distillery",
+      "tags": ["The Botanist"],
+      "variants": [{"available": true, "price": "35.00", "title": "70cl"}],
+      "images": [{"src": "https://cdn.shopify.com/s/files/botanist.png"}]
+    },
+    {
+      "title": "Bruichladdich Small Batch",
+      "handle": "bruichladdich-small-batch",
+      "product_type": "Unpeated Islay Single Malt Scotch Whisky",
+      "vendor": "Bruichladdich Distillery",
+      "tags": ["Bruichladdich"],
+      "variants": [{"available": true, "price": "45.00", "title": "50cl"}],
+      "images": [{"src": "https://cdn.shopify.com/s/files/small-batch.png"}]
+    },
+    {
+      "title": "Bruichladdich Variant Release",
+      "handle": "bruichladdich-variant-release",
+      "product_type": "Unpeated Islay Single Malt Scotch Whisky",
+      "vendor": "Bruichladdich Distillery",
+      "tags": ["Bruichladdich"],
+      "variants": [
+        {"available": true, "price": "50.00", "title": "70cl"},
+        {"available": true, "price": "60.00", "title": "70cl"}
+      ],
+      "images": [{"src": "https://cdn.shopify.com/s/files/variant-release.png"}]
+    },
+    {
+      "title": "Unknown Project",
+      "handle": "unknown-project",
+      "product_type": "Islay Single Malt Scotch Whisky",
+      "vendor": "Unknown Vendor",
+      "tags": ["Single Malt"],
+      "variants": [{"available": true, "price": "90.00", "title": "70cl"}],
+      "images": [{"src": "https://cdn.shopify.com/s/files/unknown-project.png"}]
+    },
+    {
+      "title": "Bruichladdich Invalid Image",
+      "handle": "bruichladdich-invalid-image",
+      "product_type": "Unpeated Islay Single Malt Scotch Whisky",
+      "vendor": "Bruichladdich Distillery",
+      "tags": ["Bruichladdich"],
+      "variants": [{"available": true, "price": "70.00", "title": "70cl"}],
+      "images": [{"src": "https://example.com/not-official.png"}]
+    },
+    {
+      "title": "Broken Product",
+      "handle": null,
+      "product_type": null,
+      "vendor": null,
+      "tags": null,
+      "variants": null,
+      "images": null
+    }
+  ]
+}

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -25,6 +25,7 @@ export const SERVING_STYLE_LIST = ["neat", "rocks", "splash"] as const;
 export const EXTERNAL_SITE_TYPE_LIST = [
   "astorwines",
   "berrybrosrudd",
+  "bruichladdich",
   "cadenheads",
   "compassbox",
   "decadentdrinks",

--- a/apps/server/src/schemas/externalSites.test.ts
+++ b/apps/server/src/schemas/externalSites.test.ts
@@ -1,15 +1,15 @@
 import { ExternalSiteInputSchema, ExternalSiteTypeEnum } from "./externalSites";
 
 test("accepts registered external-site types", () => {
-  expect(ExternalSiteTypeEnum.parse("glenallachie")).toBe("glenallachie");
+  expect(ExternalSiteTypeEnum.parse("bruichladdich")).toBe("bruichladdich");
   expect(
     ExternalSiteInputSchema.parse({
-      name: "The GlenAllachie",
-      type: "glenallachie",
+      name: "Bruichladdich",
+      type: "bruichladdich",
     }),
   ).toMatchObject({
-    name: "The GlenAllachie",
-    type: "glenallachie",
+    name: "Bruichladdich",
+    type: "bruichladdich",
   });
 });
 

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -25,6 +25,7 @@ import reconcileStorePriceMatchProposals from "./reconcileStorePriceMatchProposa
 import resolveStorePriceBottle from "./resolveStorePriceBottle";
 import scrapeAstorWines from "./scrapeAstorWines";
 import scrapeBerryBrosRudd from "./scrapeBerryBrosRudd";
+import scrapeBruichladdich from "./scrapeBruichladdich";
 import scrapeCadenheads from "./scrapeCadenheads";
 import scrapeCompassBox from "./scrapeCompassBox";
 import scrapeDecadentDrinks from "./scrapeDecadentDrinks";
@@ -79,6 +80,7 @@ registry.add("ResolveStorePriceBottle", resolveStorePriceBottle);
 const scraperJobs = [
   ["ScrapeAstorWines", "astorwines", scrapeAstorWines],
   ["ScrapeBerryBrosRudd", "berrybrosrudd", scrapeBerryBrosRudd],
+  ["ScrapeBruichladdich", "bruichladdich", scrapeBruichladdich],
   ["ScrapeCadenheads", "cadenheads", scrapeCadenheads],
   ["ScrapeCompassBox", "compassbox", scrapeCompassBox],
   ["ScrapeDecadentDrinks", "decadentdrinks", scrapeDecadentDrinks],

--- a/apps/server/src/worker/jobs/scrapeBruichladdich.test.ts
+++ b/apps/server/src/worker/jobs/scrapeBruichladdich.test.ts
@@ -1,0 +1,90 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { StorePriceInputSchema } from "@peated/server/schemas";
+import { getJobForSite } from "@peated/server/worker/utils";
+import scrapeBruichladdich, { scrapeProducts } from "./scrapeBruichladdich";
+
+process.env.DISABLE_HTTP_CACHE = "1";
+
+const firstPageUrl =
+  "https://www.bruichladdich.com/collections/all/products.json?country=GB&limit=250&page=1";
+const secondPageUrl =
+  "https://www.bruichladdich.com/collections/all/products.json?country=GB&limit=250&page=2";
+
+test("routes the Bruichladdich source to its scraper job", () => {
+  expect(getJobForSite("bruichladdich")).toBe("ScrapeBruichladdich");
+});
+
+test("scrapes available full-size whisky and excludes unsupported products", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("bruichladdich", "bottle-list.json");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+
+  const items: unknown[] = [];
+  await scrapeProducts(firstPageUrl, async (item) => {
+    items.push(StorePriceInputSchema.parse(item));
+  });
+
+  expect(items).toEqual([
+    {
+      currency: "gbp",
+      imageUrl: "https://cdn.shopify.com/s/files/bruichladdich-bere-barley.png",
+      name: "Bruichladdich Bere Barley 2013",
+      price: 10000,
+      url: "https://www.bruichladdich.com/products/bruichladdich-bere-barley-2013",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl: "https://cdn.shopify.com/s/files/port-charlotte-10.png",
+      name: "Port Charlotte 10",
+      price: 6000,
+      url: "https://www.bruichladdich.com/products/port-charlotte-10",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl:
+        "https://www.bruichladdich.com/cdn/shop/files/octomore-16-1.png",
+      name: "Octomore Edition 16.1",
+      price: 14000,
+      url: "https://www.bruichladdich.com/products/octomore-16-1",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl: "https://cdn.shopify.com/s/files/biodynamic-project.png",
+      name: "Bruichladdich The Biodynamic Project",
+      price: 10000,
+      url: "https://www.bruichladdich.com/products/the-biodynamic-project",
+      volume: 700,
+    },
+  ]);
+});
+
+test("rejects malformed Shopify payloads", async ({ axiosMock }) => {
+  axiosMock.onGet(firstPageUrl).reply(200, { items: [] });
+
+  await expect(scrapeProducts(firstPageUrl, async () => {})).rejects.toThrow();
+});
+
+test("paginates a dry run and stops after an empty page", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("bruichladdich", "bottle-list.json");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+  axiosMock.onGet(secondPageUrl).reply(200, { products: [] });
+
+  await expect(scrapeBruichladdich({ dryRun: true })).resolves.toBe(4);
+  expect(axiosMock.history.get).toHaveLength(2);
+});
+
+test("fails when a complete scrape yields no supported listings", async ({
+  axiosMock,
+}) => {
+  axiosMock.onGet(firstPageUrl).reply(200, { products: [] });
+
+  await expect(scrapeBruichladdich({ dryRun: true })).rejects.toThrow(
+    "Failed to scrape any products.",
+  );
+});

--- a/apps/server/src/worker/jobs/scrapeBruichladdich.ts
+++ b/apps/server/src/worker/jobs/scrapeBruichladdich.ts
@@ -1,0 +1,218 @@
+import { normalizeBottle } from "@peated/bottle-classifier/normalize";
+import type {
+  ScrapePricesCallback,
+  StorePrice,
+} from "@peated/server/lib/scraper";
+import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import { z } from "zod";
+import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
+
+const SITE = "bruichladdich";
+const STORE_ORIGIN = "https://www.bruichladdich.com";
+const CATALOG_URL = `${STORE_ORIGIN}/collections/all/products.json?country=GB&limit=250`;
+const SUPPORTED_VOLUME = 700;
+const SUPPORTED_PRODUCT_TYPES = new Set([
+  "Heavily Peated Islay Single Malt Scotch Whisky",
+  "Islay Single Malt Scotch Whisky",
+  "Super Heavily Peated Islay Single Malt Scotch Whisky",
+  "Unpeated Islay Single Malt Scotch Whisky",
+]);
+const BRAND_TAGS = new Map([
+  ["bruichladdich", "Bruichladdich"],
+  ["octomore", "Octomore"],
+  ["port charlotte", "Port Charlotte"],
+]);
+
+const CatalogSchema = z
+  .object({
+    products: z.array(z.unknown()),
+  })
+  .passthrough();
+
+const VariantSchema = z
+  .object({
+    available: z.boolean(),
+    price: z.string(),
+    title: z.string().trim().min(1),
+  })
+  .passthrough();
+
+const ProductSchema = z
+  .object({
+    title: z.string().trim().min(1),
+    handle: z
+      .string()
+      .trim()
+      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+    product_type: z.string(),
+    tags: z.array(z.string()),
+    vendor: z.string(),
+    images: z.array(z.unknown()).min(1),
+    variants: z.array(VariantSchema),
+  })
+  .passthrough();
+
+const ImageSchema = z
+  .object({
+    src: z.string().url(),
+  })
+  .passthrough();
+
+function getRawName(input: unknown): string | null {
+  if (!input || typeof input !== "object" || !("title" in input)) return null;
+  return typeof input.title === "string" ? input.title : null;
+}
+
+function parsePrice(value: string): number | null {
+  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
+  if (!match) return null;
+
+  const pounds = Number.parseInt(match[1], 10);
+  const pence = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
+  const price = pounds * 100 + pence;
+  return Number.isSafeInteger(price) && price > 0 ? price : null;
+}
+
+function parseVolume(value: string): number | null {
+  const match = value.match(/^(\d+(?:\.\d+)?)\s*(ml|cl|l)$/i);
+  if (!match) return null;
+
+  const amount = Number.parseFloat(match[1]);
+  const unit = match[2].toLowerCase();
+  const volume =
+    unit === "cl" ? amount * 10 : unit === "l" ? amount * 1000 : amount;
+  return Number.isInteger(volume) ? volume : null;
+}
+
+function getProductName(
+  title: string,
+  tags: string[],
+  vendor: string,
+): string | null {
+  if (/^(?:bruichladdich|octomore|port charlotte)\b/i.test(title)) {
+    return normalizeBottle({ name: title }).name;
+  }
+
+  const brands = new Set(
+    tags
+      .map((tag) => BRAND_TAGS.get(tag.trim().toLowerCase()))
+      .filter((brand): brand is string => Boolean(brand)),
+  );
+  if (brands.size === 0 && vendor.trim() === "Bruichladdich Distillery") {
+    brands.add("Bruichladdich");
+  }
+  if (brands.size !== 1) return null;
+
+  const brand = [...brands][0];
+  return brand ? normalizeBottle({ name: `${brand} ${title}` }).name : null;
+}
+
+function getImageUrl(value: unknown): string | null {
+  const result = ImageSchema.safeParse(value);
+  if (!result.success) return null;
+
+  const url = new URL(result.data.src);
+  return url.protocol === "https:" &&
+    (url.hostname === "cdn.shopify.com" ||
+      url.hostname === "www.bruichladdich.com")
+    ? url.toString()
+    : null;
+}
+
+export function parseBruichladdichProducts(input: unknown): StorePrice[] {
+  const payload = CatalogSchema.parse(input);
+  const products: StorePrice[] = [];
+
+  for (const productInput of payload.products) {
+    const productResult = ProductSchema.safeParse(productInput);
+    if (!productResult.success) {
+      logScrapeWarning(SITE, "Invalid product record", {
+        rawName: getRawName(productInput),
+      });
+      continue;
+    }
+
+    const product = productResult.data;
+    if (!SUPPORTED_PRODUCT_TYPES.has(product.product_type)) continue;
+
+    const availableVariants = product.variants.filter(
+      (variant) => variant.available,
+    );
+    if (availableVariants.length !== 1) {
+      if (availableVariants.length > 1) {
+        logScrapeWarning(SITE, "Ambiguous available product variants", {
+          rawName: product.title,
+          variantCount: availableVariants.length,
+        });
+      }
+      continue;
+    }
+    const variant = availableVariants[0];
+    if (!variant) continue;
+
+    const volume = parseVolume(variant.title);
+    if (volume !== SUPPORTED_VOLUME) {
+      logScrapeWarning(SITE, "Unsupported product size", {
+        rawName: product.title,
+        variantTitle: variant.title,
+      });
+      continue;
+    }
+
+    const price = parsePrice(variant.price);
+    if (price === null) {
+      logScrapeWarning(SITE, "Invalid product price", {
+        rawName: product.title,
+        price: variant.price,
+      });
+      continue;
+    }
+
+    const name = getProductName(product.title, product.tags, product.vendor);
+    if (!name) {
+      logScrapeWarning(SITE, "Unrecognized product identity", {
+        rawName: product.title,
+      });
+      continue;
+    }
+
+    const imageUrl = getImageUrl(product.images[0]);
+    if (!imageUrl) {
+      logScrapeWarning(SITE, "Invalid product image URL", {
+        rawName: product.title,
+      });
+      continue;
+    }
+
+    const listing = {
+      name,
+      price,
+      currency: "gbp" as const,
+      volume,
+      url: `${STORE_ORIGIN}/products/${product.handle}`,
+      imageUrl,
+    };
+
+    logScrapedProduct(SITE, listing);
+    products.push(listing);
+  }
+
+  return products;
+}
+
+export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
+  const data = await getUrl(url);
+  const products = parseBruichladdichProducts(JSON.parse(data));
+  await Promise.all(products.map(cb));
+}
+
+export default async function scrapeBruichladdich({
+  dryRun = false,
+}: { dryRun?: boolean } = {}) {
+  return await scrapePrices(
+    SITE,
+    (page) => `${CATALOG_URL}&page=${page}`,
+    scrapeProducts,
+    { dryRun },
+  );
+}

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -26,6 +26,7 @@ export type JobName =
   | "ResolveStorePriceBottle"
   | "ScrapeAstorWines"
   | "ScrapeBerryBrosRudd"
+  | "ScrapeBruichladdich"
   | "ScrapeCadenheads"
   | "ScrapeCompassBox"
   | "ScrapeDecadentDrinks"

--- a/apps/server/src/worker/utils.ts
+++ b/apps/server/src/worker/utils.ts
@@ -9,6 +9,8 @@ export function getJobForSite(site: ExternalSiteType): JobName {
       return "ScrapeAstorWines";
     case "berrybrosrudd":
       return "ScrapeBerryBrosRudd";
+    case "bruichladdich":
+      return "ScrapeBruichladdich";
     case "cadenheads":
       return "ScrapeCadenheads";
     case "compassbox":

--- a/openspec/changes/add-bruichladdich-scraper/.openspec.yaml
+++ b/openspec/changes/add-bruichladdich-scraper/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/add-bruichladdich-scraper/design.md
+++ b/openspec/changes/add-bruichladdich-scraper/design.md
@@ -1,0 +1,53 @@
+## Context
+
+Bruichladdich's official UK shop is backed by Shopify. Its public all-products catalog exposes product type, variant availability, GBP price, an explicit 70 cl variant title, handle, tags, and official images without credentials or product-detail requests. The same catalog also contains clothing, accessories, and glassware, while unavailable historical whisky records remain present beside purchasable releases.
+
+The active whisky catalog spans Bruichladdich, Port Charlotte, and Octomore. Most titles publish the brand directly; project releases can omit it while retaining a source-owned vendor identity.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Collect first-party prices for available full-size whisky sold through the official Great Britain shop.
+- Preserve published Bruichladdich, Port Charlotte, and Octomore identity.
+- Use source-owned product types, variants, and vendor identity rather than broad name guessing.
+- Keep malformed individual records from aborting valid results while retaining the shared empty-run failure.
+
+**Non-Goals:**
+
+- Scrape gin, merchandise, glassware, unavailable products, zero-price placeholders, or unsupported bottle sizes.
+- Ingest the historical sold-out catalog as bottle observations.
+- Create bottles or persist prices during local verification.
+
+## Decisions
+
+### Parse the Great Britain-localized Shopify catalog
+
+The worker will request numbered pages from the official all-products JSON endpoint with `country=GB` and `limit=250`. This makes GBP localization explicit and supplies the required fields in one structured response. An empty product page ends pagination.
+
+### Gate eligibility with exact source taxonomy
+
+Only the four product types currently owned by the shop's whisky taxonomy are eligible: unpeated, general, heavily peated, and super-heavily peated Islay single malt Scotch whisky. Exact matching is intentional because these values are structured provider classifications. A qualifying product must have exactly one available variant, an explicitly supported 700 ml variant title, and a positive price.
+
+### Preserve source-owned brand identity
+
+Titles beginning with Bruichladdich, Port Charlotte, or Octomore pass through shared bottle normalization. Exact brand tags can supply a missing prefix, while the exact `Bruichladdich Distillery` vendor supplies Bruichladdich identity for project titles that omit a brand tag. An otherwise eligible product without recognized source identity is warned about and skipped rather than assigned to a guessed brand.
+
+### Validate official URLs and isolate malformed records
+
+Product URLs are constructed from strict Shopify handles on the official origin. Images must use HTTPS on the official shop or Shopify CDN. Invalid individual products are warned about and skipped; request failures and invalid top-level payloads escape to the worker boundary. A complete run with no valid listings fails through the shared scraper guard.
+
+## Risks / Trade-offs
+
+- **The shop renames a product type** → Unknown types remain excluded, and total taxonomy loss triggers the shared empty-run failure.
+- **A new volume format appears** → Warn and skip it until the verified alias is added with fixture coverage.
+- **A project release omits title, tag, and recognized vendor identity** → Skip it rather than create an ambiguous catalog identity.
+- **Regional behavior changes** → Keep `country=GB` explicit and verify it in every uncached live dry run.
+
+## Migration Plan
+
+Deploy the registered worker, then configure Bruichladdich through the existing administrative path. External-site types are stored as text and validated by the application, so no database migration is required. Rollback consists of disabling the source and worker job.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-bruichladdich-scraper/proposal.md
+++ b/openspec/changes/add-bruichladdich-scraper/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Peated does not currently collect first-party prices from Bruichladdich Distillery, despite its official shop carrying active Bruichladdich, Port Charlotte, and Octomore releases. Adding this source expands direct distillery coverage with stable structured product data instead of relying on a general retailer.
+
+## What Changes
+
+- Register Bruichladdich as an external price source and scheduled worker job.
+- Scrape the official Great Britain-localized Shopify catalog for available whisky bottles.
+- Normalize published brand identity, explicit bottle volume, GBP price, official product URL, and image.
+- Exclude unavailable, zero-price, non-whisky, unsupported-volume, ambiguous, and malformed products.
+- Add fixture-backed coverage and an uncached local live dry run.
+
+## Capabilities
+
+### New Capabilities
+
+- `bruichladdich-price-scraping`: Collect valid current GBP whisky prices from the official Bruichladdich catalog while rejecting unavailable or unsupported products.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds a server worker scraper, routing, fixtures, and tests.
+- Reads Bruichladdich's public Shopify catalog; no protected credential, runtime dependency, or database migration is required.

--- a/openspec/changes/add-bruichladdich-scraper/specs/bruichladdich-price-scraping/spec.md
+++ b/openspec/changes/add-bruichladdich-scraper/specs/bruichladdich-price-scraping/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: Fetch the official localized catalog
+
+The Bruichladdich scraper SHALL request numbered pages from the official all-products catalog with Great Britain localization and SHALL stop after a page contains no products.
+
+#### Scenario: Catalog page contains products
+
+- **WHEN** a numbered catalog page contains products
+- **THEN** the scraper evaluates those products in GBP and requests the next numbered page
+
+#### Scenario: End of catalog
+
+- **WHEN** a numbered catalog page contains no products
+- **THEN** the scraper stops requesting additional pages
+
+### Requirement: Emit eligible whisky listings
+
+The scraper SHALL emit only available products in the source's supported whisky categories with one explicit supported bottle-size variant, a positive GBP price, recognized brand identity, valid official product URL, and valid official image.
+
+#### Scenario: Eligible bottle
+
+- **WHEN** a product has a supported whisky type, one available 70 cl or 700 ml positive-price variant, recognized identity, official URL, and valid image
+- **THEN** the scraper emits its normalized name, price, GBP currency, 700 ml volume, URL, and image URL
+
+#### Scenario: Unsupported catalog product
+
+- **WHEN** a product is unavailable, non-whisky, zero-price, ambiguously variant-priced, or has an unsupported bottle size
+- **THEN** the scraper does not emit a listing for that product
+
+### Requirement: Preserve distillery brand identity
+
+The scraper SHALL retain published Bruichladdich, Port Charlotte, or Octomore identity and SHALL use recognized source metadata when that identity is omitted from an eligible title.
+
+#### Scenario: Published title has recognized identity
+
+- **WHEN** an eligible title identifies Bruichladdich, Port Charlotte, or Octomore
+- **THEN** the scraper does not duplicate the published identity
+
+#### Scenario: Identity is present only in source metadata
+
+- **WHEN** an eligible title omits its brand identity and an exact source tag or vendor identifies one supported brand
+- **THEN** the scraper prefixes the title with that brand before shared normalization
+
+#### Scenario: Product has no recognized identity
+
+- **WHEN** an otherwise eligible product has no recognized title, tag, or vendor identity
+- **THEN** the scraper warns and skips the product
+
+### Requirement: Degrade individual malformed products visibly
+
+The scraper SHALL log and skip an invalid individual product without aborting valid products from the same catalog page, while retaining the shared complete-run failure when no valid products are emitted.
+
+#### Scenario: One malformed product among valid products
+
+- **WHEN** a catalog page contains a malformed product and at least one valid product
+- **THEN** the malformed product is warned about and valid products are emitted
+
+#### Scenario: Invalid catalog payload
+
+- **WHEN** the catalog response itself is not valid source JSON
+- **THEN** the scraper fails the run instead of reporting success
+
+#### Scenario: Complete empty run
+
+- **WHEN** the complete paginated run emits no supported listings
+- **THEN** the scraper fails explicitly instead of reporting success

--- a/openspec/changes/add-bruichladdich-scraper/tasks.md
+++ b/openspec/changes/add-bruichladdich-scraper/tasks.md
@@ -1,0 +1,16 @@
+## 1. Source Registration
+
+- [x] 1.1 Register `bruichladdich` in the external-site type list and worker routing
+- [x] 1.2 Verify registered types remain accepted and unknown types remain rejected by application validation
+
+## 2. Scraper Implementation
+
+- [x] 2.1 Implement Great Britain-localized paginated Shopify catalog fetching and response validation
+- [x] 2.2 Parse and normalize supported brand identities, explicit 700 ml variants, GBP prices, official URLs, and images
+- [x] 2.3 Exclude unavailable, zero-price, non-whisky, ambiguous, unsupported-volume, and malformed products while retaining complete-run failure
+
+## 3. Verification
+
+- [x] 3.1 Add representative fixtures and focused routing, parsing, exclusion, pagination, and failure tests
+- [x] 3.2 Run targeted tests, typecheck, lint, source formatting, and strict OpenSpec validation
+- [x] 3.3 Run an uncached live dry run, build the server package, and run the full repository test gate


### PR DESCRIPTION
Adds first-party GBP price collection from Bruichladdich Distillery’s official Great Britain Shopify catalog. The worker paginates the catalog and emits available, positive-priced 700 ml whisky across Bruichladdich, Port Charlotte, and Octomore while skipping merchandise, non-whisky, unavailable, zero-price, ambiguous, unsupported-volume, or malformed products.

Product taxonomy, availability, variant size, identity metadata, URLs, and images are validated at the provider boundary. Project releases that omit a brand title can use the source’s exact vendor identity; external-site registration remains application-validated, so this adds no database migration.

Validated with focused scraper/schema tests, server typechecking and build, strict OpenSpec validation, an uncached live dry run yielding 19 listings, and the full repository test gate.
