### PR TITLE
feat(scrapers): add Nc'nean pricing

### DIFF
--- a/apps/server/__fixtures__/ncnean/bottle-list.json
+++ b/apps/server/__fixtures__/ncnean/bottle-list.json
@@ -1,0 +1,136 @@
+{
+  "products": [
+    {
+      "title": "AON 17-163 MADEIRA CASK (SINGLE CASK)",
+      "handle": "aon-17-163-madeira-single-cask",
+      "body_html": "<p>Unpeated single malt / 57.1% abv / 70cl / natural colour</p>",
+      "tags": ["All Products", "Limited Edition Whiskies", "Whiskies"],
+      "vendor": "Nc'nean Distillery ",
+      "images": [{ "src": "https://cdn.shopify.com/s/files/ncnean-aon.png" }],
+      "variants": [{ "available": true, "price": "94.95", "title": "Default Title" }]
+    },
+    {
+      "title": "ORGANIC SINGLE MALT SCOTCH WHISKY",
+      "handle": "organic-single-malt",
+      "body_html": "<p>Organic single malt / 46% abv / 70cl</p>",
+      "tags": ["All Products", "Whiskies"],
+      "vendor": "Nc'nean Distillery",
+      "images": [{ "src": "https://ncnean.com/cdn/shop/files/organic.png" }],
+      "variants": [
+        { "available": true, "price": "55.95", "title": "Without gift tube - £55.95" },
+        { "available": true, "price": "58.95", "title": "With gift tube - £58.95" }
+      ]
+    },
+    {
+      "title": "NC'NEAN QUIET REBELS: SIMON (LIMITED EDITION)",
+      "handle": "quiet-rebels-simon",
+      "body_html": "<p>Limited release. 0.7 litre bottle.</p>",
+      "tags": ["All Products", "Limited Edition Whiskies", "Whiskies"],
+      "vendor": "Nc'nean Distillery",
+      "images": [{ "src": "https://cdn.shopify.com/s/files/quiet-rebels-simon.png" }],
+      "variants": [{ "available": true, "price": "79.95", "title": "Default Title" }]
+    },
+    {
+      "title": "CASK STRENGTH MINIATURE",
+      "handle": "cask-strength-miniature",
+      "body_html": "<p>5cl miniature</p>",
+      "tags": ["All Products", "Miniatures", "Whiskies"],
+      "vendor": "Nc'nean Distillery",
+      "images": [{ "src": "https://cdn.shopify.com/s/files/miniature.png" }],
+      "variants": [{ "available": true, "price": "9.95", "title": "Default Title" }]
+    },
+    {
+      "title": "WHISKY SIX SET",
+      "handle": "whisky-six-set",
+      "body_html": "<p>A gift set with one 70cl whisky bottle.</p>",
+      "tags": ["All Products", "Gift Sets"],
+      "vendor": "Nc'nean Distillery",
+      "images": [{ "src": "https://cdn.shopify.com/s/files/gift-set.png" }],
+      "variants": [{ "available": true, "price": "90.25", "title": "Default Title" }]
+    },
+    {
+      "title": "SOLD OUT WHISKY",
+      "handle": "sold-out-whisky",
+      "body_html": "<p>70cl single malt</p>",
+      "tags": ["All Products", "Whiskies"],
+      "vendor": "Nc'nean Distillery",
+      "images": [{ "src": "https://cdn.shopify.com/s/files/sold-out.png" }],
+      "variants": [{ "available": false, "price": "60.00", "title": "Default Title" }]
+    },
+    {
+      "title": "ORGANIC BOTANICAL SPIRIT",
+      "handle": "botanical-spirit",
+      "body_html": "<p>70cl botanical spirit</p>",
+      "tags": ["All Products", "Other Spirits"],
+      "vendor": "Nc'nean Distillery",
+      "images": [{ "src": "https://cdn.shopify.com/s/files/botanical.png" }],
+      "variants": [{ "available": true, "price": "34.95", "title": "Default Title" }]
+    },
+    {
+      "title": "SMALL FORMAT WHISKY",
+      "handle": "small-format-whisky",
+      "body_html": "<p>50cl single malt</p>",
+      "tags": ["All Products", "Whiskies"],
+      "vendor": "Nc'nean Distillery",
+      "images": [{ "src": "https://cdn.shopify.com/s/files/small-format.png" }],
+      "variants": [{ "available": true, "price": "45.00", "title": "Default Title" }]
+    },
+    {
+      "title": "MULTI-SIZE WHISKY",
+      "handle": "multi-size-whisky",
+      "body_html": "<p>Available as a 70cl bottle with a 5cl sample.</p>",
+      "tags": ["All Products", "Whiskies"],
+      "vendor": "Nc'nean Distillery",
+      "images": [{ "src": "https://cdn.shopify.com/s/files/multi-size.png" }],
+      "variants": [{ "available": true, "price": "65.00", "title": "Default Title" }]
+    },
+    {
+      "title": "AMBIGUOUS PACKAGING",
+      "handle": "ambiguous-packaging",
+      "body_html": "<p>70cl single malt</p>",
+      "tags": ["All Products", "Whiskies"],
+      "vendor": "Nc'nean Distillery",
+      "images": [{ "src": "https://cdn.shopify.com/s/files/ambiguous.png" }],
+      "variants": [
+        { "available": true, "price": "60.00", "title": "Standard" },
+        { "available": true, "price": "65.00", "title": "Presentation box" }
+      ]
+    },
+    {
+      "title": "UNKNOWN VENDOR WHISKY",
+      "handle": "unknown-vendor-whisky",
+      "body_html": "<p>70cl single malt</p>",
+      "tags": ["All Products", "Whiskies"],
+      "vendor": "Unknown Distillery",
+      "images": [{ "src": "https://cdn.shopify.com/s/files/unknown-vendor.png" }],
+      "variants": [{ "available": true, "price": "60.00", "title": "Default Title" }]
+    },
+    {
+      "title": "ZERO PRICE WHISKY",
+      "handle": "zero-price-whisky",
+      "body_html": "<p>70cl single malt</p>",
+      "tags": ["All Products", "Whiskies"],
+      "vendor": "Nc'nean Distillery",
+      "images": [{ "src": "https://cdn.shopify.com/s/files/zero-price.png" }],
+      "variants": [{ "available": true, "price": "0.00", "title": "Default Title" }]
+    },
+    {
+      "title": "INVALID IMAGE WHISKY",
+      "handle": "invalid-image-whisky",
+      "body_html": "<p>70cl single malt</p>",
+      "tags": ["All Products", "Whiskies"],
+      "vendor": "Nc'nean Distillery",
+      "images": [{ "src": "https://images.example.com/invalid.png" }],
+      "variants": [{ "available": true, "price": "60.00", "title": "Default Title" }]
+    },
+    {
+      "title": "BROKEN PRODUCT",
+      "handle": "broken product",
+      "body_html": null,
+      "tags": ["Whiskies"],
+      "vendor": "Nc'nean Distillery",
+      "images": [],
+      "variants": []
+    }
+  ]
+}

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -36,6 +36,7 @@ export const EXTERNAL_SITE_TYPE_LIST = [
   "gordonmacphail",
   "healthyspirits",
   "kilchoman",
+  "ncnean",
   "northstarspirits",
   "reservebar",
   "singlecasknation",

--- a/apps/server/src/schemas/externalSites.test.ts
+++ b/apps/server/src/schemas/externalSites.test.ts
@@ -1,15 +1,15 @@
 import { ExternalSiteInputSchema, ExternalSiteTypeEnum } from "./externalSites";
 
 test("accepts registered external-site types", () => {
-  expect(ExternalSiteTypeEnum.parse("bruichladdich")).toBe("bruichladdich");
+  expect(ExternalSiteTypeEnum.parse("ncnean")).toBe("ncnean");
   expect(
     ExternalSiteInputSchema.parse({
-      name: "Bruichladdich",
-      type: "bruichladdich",
+      name: "Nc'nean",
+      type: "ncnean",
     }),
   ).toMatchObject({
-    name: "Bruichladdich",
-    type: "bruichladdich",
+    name: "Nc'nean",
+    type: "ncnean",
   });
 });
 

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -36,6 +36,7 @@ import scrapeGlenAllachie from "./scrapeGlenAllachie";
 import scrapeGordonMacphail from "./scrapeGordonMacphail";
 import scrapeHealthySpirits from "./scrapeHealthySpirits";
 import scrapeKilchoman from "./scrapeKilchoman";
+import scrapeNcnean from "./scrapeNcnean";
 import scrapeNorthStarSpirits from "./scrapeNorthStarSpirits";
 import scrapeReserveBar from "./scrapeReserveBar";
 import scrapeSingleCaskNation from "./scrapeSingleCaskNation";
@@ -91,6 +92,7 @@ const scraperJobs = [
   ["ScrapeGordonMacphail", "gordonmacphail", scrapeGordonMacphail],
   ["ScrapeHealthySpirits", "healthyspirits", scrapeHealthySpirits],
   ["ScrapeKilchoman", "kilchoman", scrapeKilchoman],
+  ["ScrapeNcnean", "ncnean", scrapeNcnean],
   ["ScrapeNorthStarSpirits", "northstarspirits", scrapeNorthStarSpirits],
   ["ScrapeReserveBar", "reservebar", scrapeReserveBar],
   ["ScrapeSingleCaskNation", "singlecasknation", scrapeSingleCaskNation],

--- a/apps/server/src/worker/jobs/scrapeNcnean.test.ts
+++ b/apps/server/src/worker/jobs/scrapeNcnean.test.ts
@@ -1,0 +1,81 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { StorePriceInputSchema } from "@peated/server/schemas";
+import { getJobForSite } from "@peated/server/worker/utils";
+import scrapeNcnean, { scrapeProducts } from "./scrapeNcnean";
+
+process.env.DISABLE_HTTP_CACHE = "1";
+
+const firstPageUrl =
+  "https://ncnean.com/collections/all/products.json?country=GB&limit=250&page=1";
+const secondPageUrl =
+  "https://ncnean.com/collections/all/products.json?country=GB&limit=250&page=2";
+
+test("routes the Nc'nean source to its scraper job", () => {
+  expect(getJobForSite("ncnean")).toBe("ScrapeNcnean");
+});
+
+test("scrapes available full-size whisky and excludes unsupported products", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("ncnean", "bottle-list.json");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+
+  const items: unknown[] = [];
+  await scrapeProducts(firstPageUrl, async (item) => {
+    items.push(StorePriceInputSchema.parse(item));
+  });
+
+  expect(items).toEqual([
+    {
+      currency: "gbp",
+      imageUrl: "https://cdn.shopify.com/s/files/ncnean-aon.png",
+      name: "Nc'nean Aon 17-163 Madeira Cask (Single Cask)",
+      price: 9495,
+      url: "https://ncnean.com/products/aon-17-163-madeira-single-cask",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl: "https://ncnean.com/cdn/shop/files/organic.png",
+      name: "Nc'nean Organic Single Malt Scotch Whisky",
+      price: 5595,
+      url: "https://ncnean.com/products/organic-single-malt",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl: "https://cdn.shopify.com/s/files/quiet-rebels-simon.png",
+      name: "Nc'nean Quiet Rebels: Simon (Limited Edition)",
+      price: 7995,
+      url: "https://ncnean.com/products/quiet-rebels-simon",
+      volume: 700,
+    },
+  ]);
+});
+
+test("rejects malformed Shopify payloads", async ({ axiosMock }) => {
+  axiosMock.onGet(firstPageUrl).reply(200, { items: [] });
+
+  await expect(scrapeProducts(firstPageUrl, async () => {})).rejects.toThrow();
+});
+
+test("paginates a dry run and stops after an empty page", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("ncnean", "bottle-list.json");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+  axiosMock.onGet(secondPageUrl).reply(200, { products: [] });
+
+  await expect(scrapeNcnean({ dryRun: true })).resolves.toBe(3);
+  expect(axiosMock.history.get).toHaveLength(2);
+});
+
+test("fails when a complete scrape yields no supported listings", async ({
+  axiosMock,
+}) => {
+  axiosMock.onGet(firstPageUrl).reply(200, { products: [] });
+
+  await expect(scrapeNcnean({ dryRun: true })).rejects.toThrow(
+    "Failed to scrape any products.",
+  );
+});

--- a/apps/server/src/worker/jobs/scrapeNcnean.ts
+++ b/apps/server/src/worker/jobs/scrapeNcnean.ts
@@ -1,0 +1,225 @@
+import { normalizeBottle } from "@peated/bottle-classifier/normalize";
+import type {
+  ScrapePricesCallback,
+  StorePrice,
+} from "@peated/server/lib/scraper";
+import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import { z } from "zod";
+import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
+
+const SITE = "ncnean";
+const STORE_ORIGIN = "https://ncnean.com";
+const CATALOG_URL = `${STORE_ORIGIN}/collections/all/products.json?country=GB&limit=250`;
+const SUPPORTED_VOLUME = 700;
+const DISTILLERY_VENDOR = "Nc'nean Distillery";
+
+const CatalogSchema = z
+  .object({
+    products: z.array(z.unknown()),
+  })
+  .passthrough();
+
+const VariantSchema = z
+  .object({
+    available: z.boolean(),
+    price: z.string(),
+    title: z.string().trim().min(1),
+  })
+  .passthrough();
+
+const ProductSchema = z
+  .object({
+    title: z.string().trim().min(1),
+    handle: z
+      .string()
+      .trim()
+      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+    body_html: z.string(),
+    tags: z.array(z.string()),
+    vendor: z.string(),
+    images: z.array(z.unknown()).min(1),
+    variants: z.array(VariantSchema),
+  })
+  .passthrough();
+
+const ImageSchema = z
+  .object({
+    src: z.string().url(),
+  })
+  .passthrough();
+
+type Variant = z.infer<typeof VariantSchema>;
+
+function getRawName(input: unknown): string | null {
+  if (!input || typeof input !== "object" || !("title" in input)) return null;
+  return typeof input.title === "string" ? input.title : null;
+}
+
+function parsePrice(value: string): number | null {
+  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
+  if (!match) return null;
+
+  const pounds = Number.parseInt(match[1], 10);
+  const pence = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
+  const price = pounds * 100 + pence;
+  return Number.isSafeInteger(price) && price > 0 ? price : null;
+}
+
+function parseVolume(amountRaw: string, unitRaw: string): number | null {
+  const amount = Number.parseFloat(amountRaw);
+  const unit = unitRaw.toLowerCase();
+  const volume =
+    unit === "cl"
+      ? amount * 10
+      : unit === "l" || unit.startsWith("lit")
+        ? amount * 1000
+        : amount;
+  return Number.isInteger(volume) ? volume : null;
+}
+
+function getDescriptionVolumes(bodyHtml: string): number[] {
+  const volumes: number[] = [];
+  for (const match of bodyHtml.matchAll(
+    /\b(\d+(?:\.\d+)?)\s*(ml|cl|l|lit(?:re|er)s?)\b/gi,
+  )) {
+    const volume = parseVolume(match[1], match[2]);
+    if (volume !== null) volumes.push(volume);
+  }
+  return volumes;
+}
+
+function getPricedVariant(
+  variants: Variant[],
+  rawName: string,
+): Variant | null {
+  const availableVariants = variants.filter((variant) => variant.available);
+  if (availableVariants.length === 1) return availableVariants[0] ?? null;
+  if (availableVariants.length === 0) return null;
+
+  const bottleOnlyVariants = availableVariants.filter((variant) =>
+    /^without gift tube\b/i.test(variant.title),
+  );
+  if (bottleOnlyVariants.length === 1) return bottleOnlyVariants[0] ?? null;
+
+  logScrapeWarning(SITE, "Ambiguous available product variants", {
+    rawName,
+    variantCount: availableVariants.length,
+  });
+  return null;
+}
+
+function formatProductTitle(title: string): string {
+  if (title !== title.toUpperCase()) return title;
+
+  return title
+    .toLowerCase()
+    .replace(/(^|[\s(:-])\p{L}/gu, (value) => value.toUpperCase());
+}
+
+function getProductName(title: string, vendor: string): string | null {
+  if (vendor.trim() !== DISTILLERY_VENDOR) return null;
+
+  const formattedTitle = formatProductTitle(title);
+  const publishedName = /^(?:nc['’]nean)\b/i.test(formattedTitle)
+    ? formattedTitle
+    : `Nc'nean ${formattedTitle}`;
+  return normalizeBottle({ name: publishedName }).name;
+}
+
+function getImageUrl(value: unknown): string | null {
+  const result = ImageSchema.safeParse(value);
+  if (!result.success) return null;
+
+  const url = new URL(result.data.src);
+  return url.protocol === "https:" &&
+    (url.hostname === "cdn.shopify.com" || url.hostname === "ncnean.com")
+    ? url.toString()
+    : null;
+}
+
+export function parseNcneanProducts(input: unknown): StorePrice[] {
+  const payload = CatalogSchema.parse(input);
+  const products: StorePrice[] = [];
+
+  for (const productInput of payload.products) {
+    const productResult = ProductSchema.safeParse(productInput);
+    if (!productResult.success) {
+      logScrapeWarning(SITE, "Invalid product record", {
+        rawName: getRawName(productInput),
+      });
+      continue;
+    }
+
+    const product = productResult.data;
+    if (!product.tags.includes("Whiskies")) continue;
+    if (product.tags.includes("Miniatures")) continue;
+
+    const volumes = getDescriptionVolumes(product.body_html);
+    if (volumes.length !== 1 || volumes[0] !== SUPPORTED_VOLUME) {
+      logScrapeWarning(SITE, "Unsupported product size", {
+        rawName: product.title,
+        volumes,
+      });
+      continue;
+    }
+
+    const variant = getPricedVariant(product.variants, product.title);
+    if (!variant) continue;
+
+    const price = parsePrice(variant.price);
+    if (price === null) {
+      logScrapeWarning(SITE, "Invalid product price", {
+        rawName: product.title,
+        price: variant.price,
+      });
+      continue;
+    }
+
+    const name = getProductName(product.title, product.vendor);
+    if (!name) {
+      logScrapeWarning(SITE, "Unrecognized product identity", {
+        rawName: product.title,
+      });
+      continue;
+    }
+
+    const imageUrl = getImageUrl(product.images[0]);
+    if (!imageUrl) {
+      logScrapeWarning(SITE, "Invalid product image URL", {
+        rawName: product.title,
+      });
+      continue;
+    }
+
+    const listing = {
+      name,
+      price,
+      currency: "gbp" as const,
+      volume: SUPPORTED_VOLUME,
+      url: `${STORE_ORIGIN}/products/${product.handle}`,
+      imageUrl,
+    };
+
+    logScrapedProduct(SITE, listing);
+    products.push(listing);
+  }
+
+  return products;
+}
+
+export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
+  const data = await getUrl(url);
+  const products = parseNcneanProducts(JSON.parse(data));
+  await Promise.all(products.map(cb));
+}
+
+export default async function scrapeNcnean({
+  dryRun = false,
+}: { dryRun?: boolean } = {}) {
+  return await scrapePrices(
+    SITE,
+    (page) => `${CATALOG_URL}&page=${page}`,
+    scrapeProducts,
+    { dryRun },
+  );
+}

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -37,6 +37,7 @@ export type JobName =
   | "ScrapeGordonMacphail"
   | "ScrapeHealthySpirits"
   | "ScrapeKilchoman"
+  | "ScrapeNcnean"
   | "ScrapeNorthStarSpirits"
   | "ScrapeReserveBar"
   | "ScrapeSingleCaskNation"

--- a/apps/server/src/worker/utils.ts
+++ b/apps/server/src/worker/utils.ts
@@ -29,6 +29,8 @@ export function getJobForSite(site: ExternalSiteType): JobName {
       return "ScrapeGordonMacphail";
     case "kilchoman":
       return "ScrapeKilchoman";
+    case "ncnean":
+      return "ScrapeNcnean";
     case "northstarspirits":
       return "ScrapeNorthStarSpirits";
     case "reservebar":

--- a/openspec/changes/add-ncnean-scraper/.openspec.yaml
+++ b/openspec/changes/add-ncnean-scraper/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/add-ncnean-scraper/design.md
+++ b/openspec/changes/add-ncnean-scraper/design.md
@@ -1,0 +1,59 @@
+## Context
+
+Nc'nean's official UK shop is backed by Shopify. Its public all-products catalog exposes tags, availability, GBP prices, descriptions, handles, vendor identity, and official images without credentials or product-detail requests. The same catalog contains merchandise, gift sets, botanical spirit, and miniatures alongside full-size whisky.
+
+Whisky products use the exact `Whiskies` tag, miniatures also use `Miniatures`, and full-size descriptions publish a 70 cl specification. Titles commonly omit the distillery name, while the exact vendor identifies Nc'nean. The flagship bottle currently has separate with-tube and without-tube packaging variants.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Collect first-party prices for available 70 cl whisky sold through the official Great Britain shop.
+- Preserve release names while supplying source-owned Nc'nean identity.
+- Use exact tags, description volume, availability, and packaging metadata rather than broad name guessing.
+- Keep malformed individual records from aborting valid results while retaining the shared empty-run failure.
+
+**Non-Goals:**
+
+- Scrape miniatures, gift sets, botanical spirit, merchandise, unavailable products, or unsupported bottle sizes.
+- Infer bottle size from price, title conventions, or product handles.
+- Create bottles or persist prices during local verification.
+
+## Decisions
+
+### Parse the Great Britain-localized Shopify catalog
+
+The worker will request numbered pages from the official all-products JSON endpoint with `country=GB` and `limit=250`. This makes GBP localization explicit and supplies all required fields in one structured response. An empty product page ends pagination.
+
+### Gate eligibility with exact source metadata
+
+Products require the exact `Whiskies` tag and must not carry `Miniatures`. Their descriptions must contain exactly one parseable bottle-volume token and it must resolve to 700 ml. This is preferred over product type because the live catalog's product type field is largely empty and contains at least one known merchandise misclassification.
+
+### Select an unambiguous purchasable variant
+
+A product with one available variant uses that price. A product with multiple available variants is accepted only when exactly one variant begins with `Without gift tube`; this selects the bottle-only flagship price without treating optional packaging as a separate bottle. Other multi-variant products are warned about and skipped.
+
+### Preserve source-owned Nc'nean identity
+
+Eligible products must use the exact trimmed `Nc'nean Distillery` vendor. Titles already beginning with Nc'nean pass through shared normalization; other eligible titles receive the Nc'nean prefix. This keeps identity source-owned without trusting incidental title text.
+
+The source publishes catalog titles in all caps. Those titles are converted to readable title case before shared normalization while punctuation and numeric cask identifiers are preserved.
+
+### Validate official URLs and isolate malformed records
+
+Product URLs are constructed from strict Shopify handles on the official origin. Images must use HTTPS on the official shop or Shopify CDN. Invalid individual products are warned about and skipped; request failures and invalid top-level payloads escape to the worker boundary. A complete run with no valid listings fails through the shared scraper guard.
+
+## Risks / Trade-offs
+
+- **The shop renames its whisky tag** → Unknown taxonomy remains excluded, and total taxonomy loss triggers the shared empty-run failure.
+- **Descriptions publish multiple volume-like tokens** → Warn and skip rather than guess which token describes the bottle.
+- **The flagship packaging labels change** → Skip the ambiguous product until the verified label is updated with fixture coverage.
+- **Regional behavior changes** → Keep `country=GB` explicit and verify it in every uncached live dry run.
+
+## Migration Plan
+
+Deploy the registered worker, then configure Nc'nean through the existing administrative path. External-site types are stored as text and validated by the application, so no database migration is required. Rollback consists of disabling the source and worker job.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-ncnean-scraper/proposal.md
+++ b/openspec/changes/add-ncnean-scraper/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Peated does not collect first-party prices from Nc'nean Distillery, despite its official shop carrying a focused catalog of active organic single malt releases. Adding this source expands direct distillery coverage with structured current GBP data.
+
+## What Changes
+
+- Register Nc'nean as an external price source and scheduled worker job.
+- Scrape the official Great Britain-localized Shopify catalog for available full-size whisky bottles.
+- Normalize source-owned identity, explicit description volume, GBP price, official product URL, and image.
+- Exclude miniatures, gift sets, non-whisky, unavailable, unsupported-volume, ambiguous, and malformed products.
+- Handle the flagship's gift-tube packaging options by selecting its explicit bottle-only variant.
+- Add fixture-backed coverage and an uncached local live dry run.
+
+## Capabilities
+
+### New Capabilities
+
+- `ncnean-price-scraping`: Collect valid current GBP whisky prices from Nc'nean's official catalog while rejecting unavailable or unsupported products.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds a server worker scraper, routing, fixtures, and tests.
+- Reads Nc'nean's public Shopify catalog; no protected credential, runtime dependency, or database migration is required.

--- a/openspec/changes/add-ncnean-scraper/specs/ncnean-price-scraping/spec.md
+++ b/openspec/changes/add-ncnean-scraper/specs/ncnean-price-scraping/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Fetch the official localized catalog
+
+The Nc'nean scraper SHALL request numbered pages from the official all-products catalog with Great Britain localization and SHALL stop after a page contains no products.
+
+#### Scenario: Catalog page contains products
+
+- **WHEN** a numbered catalog page contains products
+- **THEN** the scraper evaluates those products in GBP and requests the next numbered page
+
+#### Scenario: End of catalog
+
+- **WHEN** a numbered catalog page contains no products
+- **THEN** the scraper stops requesting additional pages
+
+### Requirement: Emit eligible whisky listings
+
+The scraper SHALL emit only available products with the source's exact whisky taxonomy, one explicit 700 ml description volume, a positive GBP bottle price, recognized Nc'nean vendor identity, valid official product URL, and valid official image.
+
+#### Scenario: Eligible bottle
+
+- **WHEN** a product has the exact whisky tag, no miniature tag, one 70 cl description volume, one valid bottle price, recognized vendor identity, official URL, and valid image
+- **THEN** the scraper emits its normalized name, price, GBP currency, 700 ml volume, URL, and image URL
+
+#### Scenario: Unsupported catalog product
+
+- **WHEN** a product is unavailable, non-whisky, a miniature, a gift set, ambiguously variant-priced, or has a missing or unsupported description volume
+- **THEN** the scraper does not emit a listing for that product
+
+### Requirement: Resolve optional gift-tube packaging
+
+The scraper SHALL treat Nc'nean's explicitly labeled bottle-only flagship variant as the bottle price and SHALL reject other ambiguous multi-variant products.
+
+#### Scenario: Bottle has optional gift tube
+
+- **WHEN** an eligible product has multiple available variants and exactly one begins with `Without gift tube`
+- **THEN** the scraper emits the price of that bottle-only variant
+
+#### Scenario: Multiple variants lack a unique bottle-only option
+
+- **WHEN** an otherwise eligible product has multiple available variants without exactly one recognized bottle-only label
+- **THEN** the scraper warns and skips that product
+
+### Requirement: Preserve distillery identity
+
+The scraper SHALL require Nc'nean's exact source-owned vendor identity and SHALL prefix eligible release titles that omit the distillery name.
+
+#### Scenario: Published title has Nc'nean identity
+
+- **WHEN** an eligible title already begins with Nc'nean
+- **THEN** the scraper does not duplicate the published identity
+
+#### Scenario: Eligible release title omits identity
+
+- **WHEN** an eligible title omits Nc'nean and its exact vendor identifies Nc'nean Distillery
+- **THEN** the scraper prefixes the title with Nc'nean before shared normalization
+
+#### Scenario: Product has unrecognized vendor identity
+
+- **WHEN** an otherwise eligible product does not use the exact Nc'nean Distillery vendor
+- **THEN** the scraper warns and skips the product
+
+### Requirement: Degrade individual malformed products visibly
+
+The scraper SHALL log and skip an invalid individual product without aborting valid products from the same catalog page, while retaining the shared complete-run failure when no valid products are emitted.
+
+#### Scenario: One malformed product among valid products
+
+- **WHEN** a catalog page contains a malformed product and at least one valid product
+- **THEN** the malformed product is warned about and valid products are emitted
+
+#### Scenario: Invalid catalog payload
+
+- **WHEN** the catalog response itself is not valid source JSON
+- **THEN** the scraper fails the run instead of reporting success
+
+#### Scenario: Complete empty run
+
+- **WHEN** the complete paginated run emits no supported listings
+- **THEN** the scraper fails explicitly instead of reporting success

--- a/openspec/changes/add-ncnean-scraper/tasks.md
+++ b/openspec/changes/add-ncnean-scraper/tasks.md
@@ -1,0 +1,16 @@
+## 1. Source Registration
+
+- [x] 1.1 Register `ncnean` in the external-site type list and worker routing
+- [x] 1.2 Verify registered types remain accepted and unknown types remain rejected by application validation
+
+## 2. Scraper Implementation
+
+- [x] 2.1 Implement Great Britain-localized paginated Shopify catalog fetching and response validation
+- [x] 2.2 Parse exact whisky taxonomy, description volume, Nc'nean identity, bottle-only packaging, GBP prices, official URLs, and images
+- [x] 2.3 Exclude miniatures, gift sets, non-whisky, unavailable, ambiguous, unsupported-volume, and malformed products while retaining complete-run failure
+
+## 3. Verification
+
+- [x] 3.1 Add representative fixtures and focused routing, parsing, exclusion, packaging, pagination, and failure tests
+- [x] 3.2 Run targeted tests, typecheck, lint, source formatting, and strict OpenSpec validation
+- [x] 3.3 Run an uncached live dry run, build the server package, and run the full repository test gate


### PR DESCRIPTION
Adds first-party GBP price collection from Nc'nean Distillery's official Great Britain Shopify catalog. The worker paginates the catalog and emits available 70 cl whisky while excluding miniatures, gift sets, other spirits, unavailable products, ambiguous variants, unsupported description volumes, and malformed records.

Nc'nean's exact tags and vendor identity define eligibility because its product-type field is unreliable. The flagship's explicitly labeled bottle-without-tube variant supplies the bottle price, and all-caps source titles are normalized for readable catalog names. External-site registration remains application-validated, so this adds no database migration.

Validated with focused scraper and schema tests, server typechecking and build, strict OpenSpec validation, an uncached live dry run yielding 9 listings, and the full repository test gate.
