### PR TITLE
fix(scrapers): preserve SMWS aliases and run diagnostics

### DIFF
--- a/apps/server/src/lib/bottleConflicts.ts
+++ b/apps/server/src/lib/bottleConflicts.ts
@@ -129,7 +129,9 @@ function rowHasSmwsCode(
 /**
  * Finds an equivalent SMWS reference outside the Bottles replaced atomically.
  * The per-code transaction advisory lock serializes create/update decisions
- * until the caller's transaction completes.
+ * until the caller's transaction completes. SMWS subtitles are mutable names:
+ * the cask code owns the Bottle, and canonical updates preserve old names as
+ * aliases rather than creating another Bottle for a renamed subtitle.
  */
 export async function findConflictingSmwsBottleId(
   tx: AnyTransaction,

--- a/apps/server/src/lib/externalSiteRuns.test.ts
+++ b/apps/server/src/lib/externalSiteRuns.test.ts
@@ -7,6 +7,7 @@ import {
   queueScheduledExternalSiteRun,
   redispatchStaleExternalSiteRuns,
 } from "@peated/server/lib/externalSiteRuns";
+import * as Sentry from "@sentry/node";
 import { eq } from "drizzle-orm";
 import { expect, test, vi } from "vitest";
 
@@ -100,7 +101,13 @@ test("worker persists a safe failure and rethrows", async ({ fixtures }) => {
     throw failure;
   });
 
-  await expect(job({ runId: run.id })).rejects.toBe(failure);
+  await Sentry.withIsolationScope(async (scope) => {
+    await expect(job({ runId: run.id })).rejects.toBe(failure);
+    expect(scope.getScopeData().contexts?.externalSiteRun).toEqual({
+      id: run.id,
+      site: "decadentdrinks",
+    });
+  });
 
   const [storedRun] = await db
     .select()
@@ -109,7 +116,7 @@ test("worker persists a safe failure and rethrows", async ({ fixtures }) => {
   expect(storedRun).toMatchObject({
     status: "failed",
     attemptCount: 1,
-    error: "Unexpected scraper failure. See Sentry using this run id.",
+    error: "Unexpected scraper failure. See Sentry for this run.",
   });
   expect(storedRun?.error).not.toContain("secret");
 });

--- a/apps/server/src/lib/externalSiteRuns.ts
+++ b/apps/server/src/lib/externalSiteRuns.ts
@@ -268,7 +268,7 @@ function summarizeExternalSiteRunError(error: unknown): string {
       return error.message;
     }
   }
-  return "Unexpected scraper failure. See Sentry using this run id.";
+  return "Unexpected scraper failure. See Sentry for this run.";
 }
 
 export function createExternalSiteRunJob(
@@ -311,19 +311,23 @@ export function createExternalSiteRunJob(
 
     if (!run) return;
 
-    return Sentry.withScope(async (scope) => {
-      scope.setContext("externalSiteRun", { id: run.id, site: siteType });
-      try {
-        const itemCount = await scrape();
-        await completeExternalSiteRun({ run, status: "succeeded", itemCount });
-      } catch (error) {
-        await completeExternalSiteRun({
-          run,
-          status: "failed",
-          error: summarizeExternalSiteRunError(error),
-        });
-        throw error;
-      }
+    // The worker registry owns error capture after this handler rejects, so
+    // correlation must live on its job isolation scope rather than a child
+    // scope that would close before the exception reaches that boundary.
+    Sentry.getIsolationScope().setContext("externalSiteRun", {
+      id: run.id,
+      site: siteType,
     });
+    try {
+      const itemCount = await scrape();
+      await completeExternalSiteRun({ run, status: "succeeded", itemCount });
+    } catch (error) {
+      await completeExternalSiteRun({
+        run,
+        status: "failed",
+        error: summarizeExternalSiteRunError(error),
+      });
+      throw error;
+    }
   };
 }

--- a/apps/server/src/lib/scraper.test.ts
+++ b/apps/server/src/lib/scraper.test.ts
@@ -1,5 +1,10 @@
 import { db } from "@peated/server/db";
-import { bottles, entities, storePrices } from "@peated/server/db/schema";
+import {
+  bottleAliases,
+  bottles,
+  entities,
+  storePrices,
+} from "@peated/server/db/schema";
 import { getPeatedSystemActor } from "@peated/server/lib/actors";
 import { and, eq } from "drizzle-orm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -85,6 +90,42 @@ describe("handleBottle", () => {
     expect(matchingBottles).toHaveLength(1);
     expect(matchingBottles[0]).toMatchObject({
       description: "Updated description",
+    });
+  });
+
+  it("treats an SMWS subtitle rename as an alias for the same cask", async () => {
+    const society = "The Scotch Malt Whisky Society";
+    const originalName = "35.331 Ultra hoggie";
+    const renamedName = "35.331 Citrus on the sea";
+    const sharedInput = {
+      brand: { name: society },
+      bottler: { name: society },
+      statedAge: 9,
+      abv: 60.2,
+      singleCask: true,
+      category: "single_malt" as const,
+    };
+
+    await handleBottle({ ...sharedInput, name: originalName });
+    const [original] = await db.select().from(bottles);
+    expect(original).toBeDefined();
+
+    await handleBottle({ ...sharedInput, name: renamedName });
+
+    const persisted = await db.select().from(bottles);
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({
+      id: original!.id,
+      name: expect.stringContaining(renamedName),
+    });
+    expect(
+      await db
+        .select({ bottleId: bottleAliases.bottleId, name: bottleAliases.name })
+        .from(bottleAliases)
+        .where(eq(bottleAliases.bottleId, original!.id)),
+    ).toContainEqual({
+      bottleId: original!.id,
+      name: original!.fullName,
     });
   });
 

--- a/apps/server/src/lib/scraper.ts
+++ b/apps/server/src/lib/scraper.ts
@@ -187,6 +187,9 @@ export async function handleBottle(
     resultBottle = (await createBottleAsPeated(createInput)).bottle;
   } catch (error) {
     if (!(error instanceof BottleAlreadyExistsError)) throw error;
+    // An SMWS cask code outlives its mutable subtitle. Reuse its Bottle id;
+    // the update boundary makes the new title canonical and retains the old
+    // canonical title as an alias.
     resultBottle = (
       await updateBottleAsPeated({
         bottleId: error.bottleId,

--- a/apps/server/src/orpc/routes/external-sites/health.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.test.ts
@@ -34,7 +34,7 @@ test("health list distinguishes listings from latest execution", async ({
       trigger: "manual",
       requestedById: admin.id,
       attemptCount: 1,
-      error: "Unexpected scraper failure. See Sentry using this run id.",
+      error: "Unexpected scraper failure. See Sentry for this run.",
       startedAt: new Date("2026-08-12T11:59:00.000Z"),
       completedAt,
     })

--- a/apps/web/e2e/bottle-prices.spec.ts
+++ b/apps/web/e2e/bottle-prices.spec.ts
@@ -4,6 +4,7 @@ import {
   firstStorePriceName,
   priceChangeFirstBottle,
   priceSite,
+  priceSiteRun,
   testAccessToken,
   testUser,
   unresolvedStorePriceName,
@@ -75,5 +76,27 @@ test.describe("Bottle prices", () => {
       .locator("tr")
       .filter({ hasText: unresolvedStorePriceName });
     await expect(unresolvedRow.locator('a[href^="/bottles/"]')).toHaveCount(0);
+  });
+
+  test("shows durable run IDs in scraper history", async ({
+    context,
+    page,
+  }, testInfo) => {
+    await signIn(context, {
+      accessToken: `${testAccessToken}-site-runs-${testInfo.project.name}`,
+      user: { ...testUser, admin: true },
+    });
+
+    await page.goto(`/admin/sites/${priceSite.type}/runs`, {
+      waitUntil: "commit",
+    });
+
+    const runEntry = testInfo.project.name.includes("mobile")
+      ? page.locator("article")
+      : page.locator("tr");
+    await expect(runEntry.getByText(`Run #${priceSiteRun.id}`)).toBeVisible();
+    await expect(
+      runEntry.getByText(priceSiteRun.error, { exact: true }),
+    ).toBeVisible();
   });
 });

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -42,6 +42,7 @@ import {
   photoTastingNotes,
   priceChangeList,
   priceSite,
+  priceSiteRuns,
   replacementSourceBottleId,
   storePriceList,
   suggestedTags,
@@ -419,6 +420,13 @@ async function handleRpcRequest({ request, response, url }) {
         return true;
       }
       sendRpcResponse(response, priceSite);
+      return true;
+    case "externalSites/runs":
+      if (input?.site !== priceSite.type) {
+        sendRpcError(response, "Unexpected external site runs payload");
+        return true;
+      }
+      sendRpcResponse(response, priceSiteRuns);
       return true;
     case "bottleGroups/details": {
       const group = getBottleGroup(input?.group);

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -533,6 +533,27 @@ export const priceSite = {
   lastSucceededAt: null,
 };
 
+export const priceSiteRun = {
+  id: 27,
+  status: "failed",
+  trigger: "scheduled",
+  requestedById: null,
+  attemptCount: 1,
+  itemCount: null,
+  error: "Unexpected scraper failure. See Sentry for this run.",
+  startedAt: timestamp,
+  completedAt: timestamp,
+  createdAt: timestamp,
+};
+
+export const priceSiteRuns = {
+  results: [priceSiteRun],
+  rel: {
+    nextCursor: null,
+    prevCursor: null,
+  },
+};
+
 export const firstStorePriceName = "First Bottle store listing";
 export const secondStorePriceName = "Second Bottle store listing";
 export const unresolvedStorePriceName = "Unresolved store listing";

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/runs/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/runs/page.tsx
@@ -70,6 +70,7 @@ export default function Page(props: {
               </span>
             </div>
             <div className="text-muted mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs">
+              <span>Run #{run.id}</span>
               <span className="capitalize">{run.trigger}</span>
               <span>
                 {run.attemptCount} attempt
@@ -101,7 +102,7 @@ export default function Page(props: {
                 <div>
                   <RunStatus status={run.status} />
                   <div className="text-muted mt-1 text-xs">
-                    {run.attemptCount} attempt
+                    Run #{run.id} · {run.attemptCount} attempt
                     {run.attemptCount === 1 ? "" : "s"}
                     {run.itemCount !== null
                       ? ` · ${run.itemCount.toLocaleString("en-US")} items`

--- a/docs/architecture/whisky-identity-model.md
+++ b/docs/architecture/whisky-identity-model.md
@@ -214,7 +214,10 @@ forcing either a new Bottle or a group change.
 
 SMWS codes are exact identity anchors when printed or when deterministically
 composed from an SMWS distillery number and single-cask number visible on the
-label. A code must not invent a missing component or subtitle.
+label. A code must not invent a missing component or subtitle. SMWS may rename
+the subtitle marketed for a cask, but that does not create a new Bottle: the
+code continues to identify the same Bottle, the new subtitle becomes its
+canonical name, and the previous canonical name remains an alias.
 
 ## Activity Identity
 


### PR DESCRIPTION
SMWS cask codes now remain stable Bottle identities when the Society changes a subtitle: scraper updates reuse the existing Bottle, make the new title canonical, and retain the previous full name as an alias. This prevents renamed casks from producing duplicate-Bottle update conflicts, documents the invariant beside its owning code, and adds an integration regression for the rename path.

Scraper run history now displays the durable run number on desktop and mobile. Worker failures attach that run and site to the Sentry isolation scope before the exception reaches the registry capture boundary, while the generic error copy no longer implies that the ID is embedded in the message. Server integration tests, server/web typechecks, lint/format checks, and desktop/mobile browser coverage passed for the affected surfaces.
