### PR TITLE
feat(server): add Mission Liquor scraper

### DIFF
--- a/apps/server/__fixtures__/missionliquor/bottle-list.json
+++ b/apps/server/__fixtures__/missionliquor/bottle-list.json
@@ -1,0 +1,135 @@
+{
+  "products": [
+    {
+      "title": "E.H. Taylor Small Batch Bottled In Bond Kentucky Straight Bourbon Whiskey 750ml",
+      "handle": "eh-taylor-small-batch",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-750ML", "varietal-BOURBON"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/eh-taylor.png" }],
+      "variants": [{ "available": true, "price": "49.99" }]
+    },
+    {
+      "title": "The Macallan Sherry Oak Single Malt Scotch Whisky 12 Year Old 700ml",
+      "handle": "macallan-sherry-oak-12",
+      "product_type": "WHISKEY",
+      "tags": ["country-SCOTLAND", "size-700ML", "varietal-SINGLE MALT"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/macallan.png" }],
+      "variants": [{ "available": true, "price": "89.99" }]
+    },
+    {
+      "title": "Minor Case Sherry Cask Rye Whiskey 750ml",
+      "handle": "minor-case-sherry-cask-rye",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-750ML", "varietal-RYE"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/minor-case.png" }],
+      "variants": [{ "available": true, "price": "43.99" }]
+    },
+    {
+      "title": "Collector's Edition Semi Truck American Whiskey 1L (IN STORE PICK UP ONLY)",
+      "handle": "collectors-edition-semi-truck",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-1L", "varietal-WHISKEY"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/collector-truck.png" }],
+      "variants": [{ "available": true, "price": "99.99" }]
+    },
+    {
+      "title": "Highland Harvest Organic Blended Scotch Whiskey",
+      "handle": "highland-harvest-organic",
+      "product_type": "WHISKEY",
+      "tags": ["country-SCOTLAND", "size-750ML-ND", "varietal-BLENDED"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/highland-harvest.png" }],
+      "variants": [{ "available": true, "price": "35.99" }]
+    },
+    {
+      "title": "Doc Holliday Straight Bourbon Whiskey Gift Set 10 Year Old 700ml",
+      "handle": "doc-holliday-gift-set",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-700ML"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/doc-holliday.png" }],
+      "variants": [{ "available": true, "price": "199.99" }]
+    },
+    {
+      "title": "Whistlepig Barrel Aged Gift Set 3x375ml",
+      "handle": "whistlepig-three-pack",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-375ML"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/whistlepig.png" }],
+      "variants": [{ "available": true, "price": "114.99" }]
+    },
+    {
+      "title": "Old Crow Bourbon Whiskey 1.75L",
+      "handle": "old-crow-bourbon",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-750ML"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/old-crow.png" }],
+      "variants": [{ "available": true, "price": "19.99" }]
+    },
+    {
+      "title": "Small Format Bourbon Whiskey 375ml",
+      "handle": "small-format-bourbon",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-375ML"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/small-format.png" }],
+      "variants": [{ "available": true, "price": "19.99" }]
+    },
+    {
+      "title": "Sold Out Bourbon Whiskey 750ml",
+      "handle": "sold-out-bourbon",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-750ML"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/sold-out.png" }],
+      "variants": [{ "available": false, "price": "39.99" }]
+    },
+    {
+      "title": "Ambiguous Bourbon Whiskey 750ml",
+      "handle": "ambiguous-bourbon",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-750ML"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/ambiguous.png" }],
+      "variants": [
+        { "available": true, "price": "39.99" },
+        { "available": true, "price": "49.99" }
+      ]
+    },
+    {
+      "title": "Gin 750ml",
+      "handle": "gin",
+      "product_type": "GIN",
+      "tags": ["country-USA", "size-750ML"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/gin.png" }],
+      "variants": [{ "available": true, "price": "29.99" }]
+    },
+    {
+      "title": "BUY 2, SAVE $6",
+      "handle": "buy-two-save-six",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-750ML"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/promo.png" }],
+      "variants": [{ "available": true, "price": "59.99" }]
+    },
+    {
+      "title": "Zero Price Bourbon Whiskey 750ml",
+      "handle": "zero-price-bourbon",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-750ML"],
+      "images": [{ "src": "https://cdn.shopify.com/s/files/zero-price.png" }],
+      "variants": [{ "available": true, "price": "0.00" }]
+    },
+    {
+      "title": "Invalid Image Bourbon Whiskey 750ml",
+      "handle": "invalid-image-bourbon",
+      "product_type": "WHISKEY",
+      "tags": ["country-USA", "size-750ML"],
+      "images": [{ "src": "https://images.example.com/invalid.png" }],
+      "variants": [{ "available": true, "price": "39.99" }]
+    },
+    {
+      "title": "Broken Product 750ml",
+      "handle": "broken product",
+      "product_type": "WHISKEY",
+      "tags": ["size-750ML"],
+      "images": [],
+      "variants": []
+    }
+  ]
+}

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -36,6 +36,7 @@ export const EXTERNAL_SITE_TYPE_LIST = [
   "gordonmacphail",
   "healthyspirits",
   "kilchoman",
+  "missionliquor",
   "ncnean",
   "northstarspirits",
   "reservebar",

--- a/apps/server/src/schemas/externalSites.test.ts
+++ b/apps/server/src/schemas/externalSites.test.ts
@@ -1,15 +1,15 @@
 import { ExternalSiteInputSchema, ExternalSiteTypeEnum } from "./externalSites";
 
 test("accepts registered external-site types", () => {
-  expect(ExternalSiteTypeEnum.parse("ncnean")).toBe("ncnean");
+  expect(ExternalSiteTypeEnum.parse("missionliquor")).toBe("missionliquor");
   expect(
     ExternalSiteInputSchema.parse({
-      name: "Nc'nean",
-      type: "ncnean",
+      name: "Mission Liquor",
+      type: "missionliquor",
     }),
   ).toMatchObject({
-    name: "Nc'nean",
-    type: "ncnean",
+    name: "Mission Liquor",
+    type: "missionliquor",
   });
 });
 

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -36,6 +36,7 @@ import scrapeGlenAllachie from "./scrapeGlenAllachie";
 import scrapeGordonMacphail from "./scrapeGordonMacphail";
 import scrapeHealthySpirits from "./scrapeHealthySpirits";
 import scrapeKilchoman from "./scrapeKilchoman";
+import scrapeMissionLiquor from "./scrapeMissionLiquor";
 import scrapeNcnean from "./scrapeNcnean";
 import scrapeNorthStarSpirits from "./scrapeNorthStarSpirits";
 import scrapeReserveBar from "./scrapeReserveBar";
@@ -92,6 +93,7 @@ const scraperJobs = [
   ["ScrapeGordonMacphail", "gordonmacphail", scrapeGordonMacphail],
   ["ScrapeHealthySpirits", "healthyspirits", scrapeHealthySpirits],
   ["ScrapeKilchoman", "kilchoman", scrapeKilchoman],
+  ["ScrapeMissionLiquor", "missionliquor", scrapeMissionLiquor],
   ["ScrapeNcnean", "ncnean", scrapeNcnean],
   ["ScrapeNorthStarSpirits", "northstarspirits", scrapeNorthStarSpirits],
   ["ScrapeReserveBar", "reservebar", scrapeReserveBar],

--- a/apps/server/src/worker/jobs/scrapeMissionLiquor.test.ts
+++ b/apps/server/src/worker/jobs/scrapeMissionLiquor.test.ts
@@ -1,0 +1,97 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { StorePriceInputSchema } from "@peated/server/schemas";
+import { getJobForSite } from "@peated/server/worker/utils";
+import scrapeMissionLiquor, { scrapeProducts } from "./scrapeMissionLiquor";
+
+process.env.DISABLE_HTTP_CACHE = "1";
+
+const firstPageUrl =
+  "https://www.missionliquor.com/collections/whiskey/products.json?limit=250&page=1";
+const secondPageUrl =
+  "https://www.missionliquor.com/collections/whiskey/products.json?limit=250&page=2";
+
+test("routes the Mission Liquor source to its scraper job", () => {
+  expect(getJobForSite("missionliquor")).toBe("ScrapeMissionLiquor");
+});
+
+test("scrapes available single bottles and excludes unsupported products", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("missionliquor", "bottle-list.json");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+
+  const items: unknown[] = [];
+  await scrapeProducts(firstPageUrl, async (item) => {
+    items.push(StorePriceInputSchema.parse(item));
+  });
+
+  expect(items).toEqual([
+    {
+      currency: "usd",
+      imageUrl: "https://cdn.shopify.com/s/files/eh-taylor.png",
+      name: "E.H. Taylor Small Batch Bottled In Bond Kentucky Straight Bourbon Whiskey",
+      price: 4999,
+      url: "https://www.missionliquor.com/products/eh-taylor-small-batch",
+      volume: 750,
+    },
+    {
+      currency: "usd",
+      imageUrl: "https://cdn.shopify.com/s/files/macallan.png",
+      name: "The Macallan Sherry Oak Single Malt Scotch Whisky 12-year-old",
+      price: 8999,
+      url: "https://www.missionliquor.com/products/macallan-sherry-oak-12",
+      volume: 700,
+    },
+    {
+      currency: "usd",
+      imageUrl: "https://cdn.shopify.com/s/files/minor-case.png",
+      name: "Minor Case Sherry Cask Rye Whiskey",
+      price: 4399,
+      url: "https://www.missionliquor.com/products/minor-case-sherry-cask-rye",
+      volume: 750,
+    },
+    {
+      currency: "usd",
+      imageUrl: "https://cdn.shopify.com/s/files/collector-truck.png",
+      name: "Collector's Edition Semi Truck American Whiskey (IN STORE PICK UP ONLY)",
+      price: 9999,
+      url: "https://www.missionliquor.com/products/collectors-edition-semi-truck",
+      volume: 1000,
+    },
+    {
+      currency: "usd",
+      imageUrl: "https://cdn.shopify.com/s/files/highland-harvest.png",
+      name: "Highland Harvest Organic Blended Scotch Whiskey",
+      price: 3599,
+      url: "https://www.missionliquor.com/products/highland-harvest-organic",
+      volume: 750,
+    },
+  ]);
+});
+
+test("rejects malformed Shopify payloads", async ({ axiosMock }) => {
+  axiosMock.onGet(firstPageUrl).reply(200, { items: [] });
+
+  await expect(scrapeProducts(firstPageUrl, async () => {})).rejects.toThrow();
+});
+
+test("paginates a dry run and stops after an empty page", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("missionliquor", "bottle-list.json");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+  axiosMock.onGet(secondPageUrl).reply(200, { products: [] });
+
+  await expect(scrapeMissionLiquor({ dryRun: true })).resolves.toBe(5);
+  expect(axiosMock.history.get).toHaveLength(2);
+});
+
+test("fails when a complete scrape yields no supported listings", async ({
+  axiosMock,
+}) => {
+  axiosMock.onGet(firstPageUrl).reply(200, { products: [] });
+
+  await expect(scrapeMissionLiquor({ dryRun: true })).rejects.toThrow(
+    "Failed to scrape any products.",
+  );
+});

--- a/apps/server/src/worker/jobs/scrapeMissionLiquor.ts
+++ b/apps/server/src/worker/jobs/scrapeMissionLiquor.ts
@@ -1,0 +1,223 @@
+import { normalizeBottle } from "@peated/bottle-classifier/normalize";
+import { ALLOWED_VOLUMES } from "@peated/server/constants";
+import type {
+  ScrapePricesCallback,
+  StorePrice,
+} from "@peated/server/lib/scraper";
+import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import { z } from "zod";
+import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
+
+const SITE = "missionliquor";
+const STORE_ORIGIN = "https://www.missionliquor.com";
+const CATALOG_URL = `${STORE_ORIGIN}/collections/whiskey/products.json?limit=250`;
+const SIZE_TAG_PATTERN = /^size-(\d+(?:\.\d+)?)(ml|cl|l)(?:-[a-z]+)?$/i;
+const TITLE_VOLUME_PATTERN = /(\d+(?:\.\d+)?)\s*(ml|cl|l)\b/gi;
+const MULTIPRODUCT_PATTERN =
+  /\b(?:gift|tasting)\s+set\b|\bsampler\b|\bbundle\b|\b\d+\s*(?:x|×)\s*\d+(?:\.\d+)?\s*(?:ml|cl|l)\b|\b\d+\s*(?:pack|pk)\b/i;
+
+const CatalogSchema = z
+  .object({
+    products: z.array(z.unknown()),
+  })
+  .passthrough();
+
+const VariantSchema = z
+  .object({
+    available: z.boolean(),
+    price: z.string(),
+  })
+  .passthrough();
+
+const ProductSchema = z
+  .object({
+    title: z.string().trim().min(1),
+    handle: z
+      .string()
+      .trim()
+      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+    product_type: z.string().trim(),
+    tags: z.array(z.string()),
+    images: z.array(z.unknown()).min(1),
+    variants: z.array(VariantSchema),
+  })
+  .passthrough();
+
+const ImageSchema = z
+  .object({
+    src: z.string().url(),
+  })
+  .passthrough();
+
+function getRawName(input: unknown): string | null {
+  if (!input || typeof input !== "object" || !("title" in input)) return null;
+  return typeof input.title === "string" ? input.title : null;
+}
+
+function parsePrice(value: string): number | null {
+  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
+  if (!match) return null;
+
+  const dollars = Number.parseInt(match[1], 10);
+  const cents = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
+  const price = dollars * 100 + cents;
+  return Number.isSafeInteger(price) && price > 0 ? price : null;
+}
+
+function parseVolume(amountRaw: string, unitRaw: string): number | null {
+  const amount = Number.parseFloat(amountRaw);
+  const unit = unitRaw.toLowerCase();
+  const volume =
+    unit === "cl" ? amount * 10 : unit === "l" ? amount * 1000 : amount;
+  return Number.isInteger(volume) && volume > 0 ? volume : null;
+}
+
+function getTaggedVolume(tags: string[]): number | null {
+  const matches = tags
+    .map((tag) => tag.trim().match(SIZE_TAG_PATTERN))
+    .filter((match): match is RegExpMatchArray => match !== null);
+  if (matches.length !== 1) return null;
+
+  const volume = parseVolume(matches[0][1], matches[0][2]);
+  return volume !== null && ALLOWED_VOLUMES.includes(volume) ? volume : null;
+}
+
+function getTitleVolumes(title: string): number[] {
+  const volumes: number[] = [];
+  for (const match of title.matchAll(TITLE_VOLUME_PATTERN)) {
+    const volume = parseVolume(match[1], match[2]);
+    if (volume !== null) volumes.push(volume);
+  }
+  return volumes;
+}
+
+function isMultiproduct(title: string): boolean {
+  return MULTIPRODUCT_PATTERN.test(title) || /^buy\b/i.test(title.trim());
+}
+
+function getProductName(title: string): string | null {
+  const withoutTerminalVolume = title
+    .replace(/\s*\d+(?:\.\d+)?\s*(?:ml|cl|l)(?=\s*(?:\([^)]*\))?\s*$)/i, "")
+    .trim();
+  if (!withoutTerminalVolume) return null;
+  return normalizeBottle({ name: withoutTerminalVolume }).name;
+}
+
+function getImageUrl(value: unknown): string | null {
+  const result = ImageSchema.safeParse(value);
+  if (!result.success) return null;
+
+  const url = new URL(result.data.src);
+  return url.protocol === "https:" &&
+    (url.hostname === "cdn.shopify.com" ||
+      url.hostname === "www.missionliquor.com")
+    ? url.toString()
+    : null;
+}
+
+export function parseMissionLiquorProducts(input: unknown): StorePrice[] {
+  const payload = CatalogSchema.parse(input);
+  const products: StorePrice[] = [];
+
+  for (const productInput of payload.products) {
+    const productResult = ProductSchema.safeParse(productInput);
+    if (!productResult.success) {
+      logScrapeWarning(SITE, "Invalid product record", {
+        rawName: getRawName(productInput),
+      });
+      continue;
+    }
+
+    const product = productResult.data;
+    if (product.product_type !== "WHISKEY") continue;
+    if (isMultiproduct(product.title)) continue;
+
+    const volume = getTaggedVolume(product.tags);
+    if (volume === null) {
+      logScrapeWarning(SITE, "Unsupported product size", {
+        rawName: product.title,
+        tags: product.tags.filter((tag) => /^size-/i.test(tag.trim())),
+      });
+      continue;
+    }
+
+    const titleVolumes = getTitleVolumes(product.title);
+    if (titleVolumes.some((titleVolume) => titleVolume !== volume)) {
+      logScrapeWarning(SITE, "Product title and tag sizes disagree", {
+        rawName: product.title,
+        titleVolumes,
+        volume,
+      });
+      continue;
+    }
+
+    const availableVariants = product.variants.filter(
+      (variant) => variant.available,
+    );
+    if (availableVariants.length !== 1) {
+      if (availableVariants.length > 1) {
+        logScrapeWarning(SITE, "Ambiguous available product variants", {
+          rawName: product.title,
+          variantCount: availableVariants.length,
+        });
+      }
+      continue;
+    }
+
+    const price = parsePrice(availableVariants[0].price);
+    if (price === null) {
+      logScrapeWarning(SITE, "Invalid product price", {
+        rawName: product.title,
+        price: availableVariants[0].price,
+      });
+      continue;
+    }
+
+    const name = getProductName(product.title);
+    if (!name) {
+      logScrapeWarning(SITE, "Invalid product name", {
+        rawName: product.title,
+      });
+      continue;
+    }
+
+    const imageUrl = getImageUrl(product.images[0]);
+    if (!imageUrl) {
+      logScrapeWarning(SITE, "Invalid product image URL", {
+        rawName: product.title,
+      });
+      continue;
+    }
+
+    const listing = {
+      name,
+      price,
+      currency: "usd" as const,
+      volume,
+      url: `${STORE_ORIGIN}/products/${product.handle}`,
+      imageUrl,
+    };
+
+    logScrapedProduct(SITE, listing);
+    products.push(listing);
+  }
+
+  return products;
+}
+
+export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
+  const data = await getUrl(url);
+  const products = parseMissionLiquorProducts(JSON.parse(data));
+  await Promise.all(products.map(cb));
+}
+
+export default async function scrapeMissionLiquor({
+  dryRun = false,
+}: { dryRun?: boolean } = {}) {
+  return await scrapePrices(
+    SITE,
+    (page) => `${CATALOG_URL}&page=${page}`,
+    scrapeProducts,
+    { dryRun },
+  );
+}

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -37,6 +37,7 @@ export type JobName =
   | "ScrapeGordonMacphail"
   | "ScrapeHealthySpirits"
   | "ScrapeKilchoman"
+  | "ScrapeMissionLiquor"
   | "ScrapeNcnean"
   | "ScrapeNorthStarSpirits"
   | "ScrapeReserveBar"

--- a/apps/server/src/worker/utils.ts
+++ b/apps/server/src/worker/utils.ts
@@ -29,6 +29,8 @@ export function getJobForSite(site: ExternalSiteType): JobName {
       return "ScrapeGordonMacphail";
     case "kilchoman":
       return "ScrapeKilchoman";
+    case "missionliquor":
+      return "ScrapeMissionLiquor";
     case "ncnean":
       return "ScrapeNcnean";
     case "northstarspirits":

--- a/openspec/changes/add-mission-liquor-scraper/.openspec.yaml
+++ b/openspec/changes/add-mission-liquor-scraper/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/add-mission-liquor-scraper/design.md
+++ b/openspec/changes/add-mission-liquor-scraper/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Mission Wine & Spirits publishes its whiskey collection through a public Shopify JSON endpoint. A full uncached audit returned 2,538 products across 11 populated pages, of which 2,458 were available. Every product had one variant, all used the exact `WHISKEY` product type, and all but one available product had one source-owned `size-*` tag. Prices are USD and product images use Shopify's HTTPS CDN.
+
+The catalog mixes standard bottles with miniatures, gift sets, tasting packs, promotional entries, and a few inconsistent title/tag sizes. Peated only accepts known bottle volumes and must not guess when source metadata disagrees.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Collect broad current USD whiskey prices from Mission Liquor's public catalog.
+- Use structured availability, product type, variants, and size tags as the primary eligibility boundary.
+- Reject multiproduct offers and inconsistent records conservatively.
+- Keep malformed individual records from aborting valid results while retaining the shared empty-run failure.
+
+**Non-Goals:**
+
+- Scrape sold-out products, miniatures, gift sets, tasting packs, bundles, or unsupported bottle sizes.
+- Infer a product's size from its price or choose among multiple available variants.
+- Model store location, shipping eligibility, inventory quantity, or sale history.
+- Create bottles or persist prices during local verification.
+
+## Decisions
+
+### Parse the public whiskey collection page by page
+
+The worker will request numbered pages from the official collection JSON endpoint with `limit=250`. Each response supplies the product metadata, variants, prices, handles, and images needed for evaluation. An empty product page ends pagination.
+
+This avoids page scraping and product-detail requests while keeping the source contract narrow and inspectable.
+
+### Require exact whiskey taxonomy and one available variant
+
+Products must use the exact trimmed `WHISKEY` product type and have exactly one available variant. The live catalog currently has one variant per product, so any future multi-variant product is ambiguous and will be skipped rather than assigned an arbitrary price.
+
+### Parse source size tags by syntax
+
+The scraper will require exactly one tag matching the source's `size-<amount><unit>` syntax, with an optional alphabetic source suffix such as `-ND`. It will convert `ml`, `cl`, and `l` to milliliters and accept only Peated's application-level allowed volumes. Pack-like tags such as `size-3pk`, `size-750MLx2`, and `size-2PK-DEPOSIT` do not match and remain excluded.
+
+Parsing the documented syntax is less fragile than an exact map of currently observed tags while still rejecting unknown shapes. When a title contains an explicit volume, it must agree with the tag. A matching terminal title volume is removed before shared bottle-name normalization.
+
+### Exclude multiproduct and promotional offers conservatively
+
+Titles identifying a gift set, tasting set, sampler, bundle, or numeric multipack are excluded. Generic words that are also legitimate release names, such as `case`, are not used as exclusions. Promotional placeholder titles beginning with `BUY` are also excluded.
+
+### Validate official identity and isolate malformed records
+
+Product URLs are constructed from strict Shopify handles on Mission Liquor's official origin. Images must use HTTPS on the official origin or Shopify CDN. Prices must be positive decimal USD amounts.
+
+Invalid individual products are warned about and skipped. Request failures and invalid top-level payloads escape to the worker boundary, and a complete run with no valid listings fails through the shared scraper guard.
+
+## Risks / Trade-offs
+
+- **The source changes its collection taxonomy** → Unknown products remain excluded, and total taxonomy loss triggers the shared empty-run failure.
+- **The source changes its size-tag grammar** → The affected products are warned about and skipped until the syntax is deliberately updated.
+- **A legitimate release name resembles a multipack** → Exclusions use narrow phrases and numeric pack syntax, with fixture coverage for known false-positive words.
+- **Title and tag sizes disagree** → Skip the product rather than publish a potentially incorrect bottle volume.
+- **The catalog becomes location-dependent** → Re-audit the public feed before adding location behavior; this change does not infer a customer location.
+
+## Migration Plan
+
+Deploy the registered worker, then configure Mission Liquor through the existing administrative path. External-site types are stored as text and validated by the application, so no database migration is required. Rollback consists of disabling the source and worker job.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-mission-liquor-scraper/proposal.md
+++ b/openspec/changes/add-mission-liquor-scraper/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Peated's recent scraper additions cover focused distilleries and bottlers but do not add broad catalog coverage. Mission Wine & Spirits publishes a public catalog of more than 2,500 whiskies, including major American, Scotch, Irish, Japanese, and world-whisky brands, with structured current USD prices.
+
+## What Changes
+
+- Register Mission Liquor as an external price source and scheduled worker job.
+- Scrape its public paginated whiskey collection for available single-bottle products.
+- Normalize explicit source size tags, current USD price, product URL, title, and official image.
+- Exclude sold-out products, bundles, gift sets, multipacks, unsupported sizes, and malformed records.
+- Add fixture-backed coverage and an uncached local live dry run.
+
+## Capabilities
+
+### New Capabilities
+
+- `mission-liquor-price-scraping`: Collect valid current USD whiskey prices from Mission Liquor's broad public catalog while rejecting unavailable or ambiguous products.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds a server worker scraper, routing, fixtures, and tests.
+- Reads Mission Liquor's public Shopify collection; no protected credential, runtime dependency, or database migration is required.

--- a/openspec/changes/add-mission-liquor-scraper/specs/mission-liquor-price-scraping/spec.md
+++ b/openspec/changes/add-mission-liquor-scraper/specs/mission-liquor-price-scraping/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Fetch the official paginated catalog
+
+The Mission Liquor scraper SHALL request numbered pages from the official whiskey collection with the source's maximum page size and SHALL stop after a page contains no products.
+
+#### Scenario: Catalog page contains products
+
+- **WHEN** a numbered catalog page contains products
+- **THEN** the scraper evaluates those products in USD and requests the next numbered page
+
+#### Scenario: End of catalog
+
+- **WHEN** a numbered catalog page contains no products
+- **THEN** the scraper stops requesting additional pages
+
+### Requirement: Emit eligible whiskey listings
+
+The scraper SHALL emit only products with the exact whiskey taxonomy, exactly one available variant, one supported source size tag, a positive USD bottle price, a valid official product URL, and a valid official image.
+
+#### Scenario: Eligible bottle
+
+- **WHEN** a product has exact whiskey taxonomy, one available variant, one supported size tag, a valid bottle price, official URL, and valid image
+- **THEN** the scraper emits its normalized name, price, USD currency, parsed volume, URL, and image URL
+
+#### Scenario: Unsupported catalog product
+
+- **WHEN** a product is sold out, non-whiskey, ambiguously variant-priced, unsupported in size, or missing required source metadata
+- **THEN** the scraper does not emit a listing for that product
+
+### Requirement: Reject multiproduct and inconsistent offers
+
+The scraper SHALL reject gift sets, tasting sets, samplers, bundles, numeric multipacks, promotional placeholders, and products whose explicit title volume disagrees with their source size tag.
+
+#### Scenario: Multiproduct offer
+
+- **WHEN** a product title or size tag identifies a gift set, tasting set, sampler, bundle, or numeric multipack
+- **THEN** the scraper does not emit a listing for that product
+
+#### Scenario: Generic release word is not a pack
+
+- **WHEN** an otherwise eligible bottle uses a word such as `case` as part of its release name without pack syntax
+- **THEN** the scraper does not exclude it solely for that word
+
+#### Scenario: Source sizes disagree
+
+- **WHEN** a product's explicit title volume differs from its parsed source size tag
+- **THEN** the scraper warns and skips that product
+
+### Requirement: Normalize source listings
+
+The scraper SHALL remove a matching terminal size label from an eligible product title before shared bottle-name normalization while preserving release identity and other qualifiers.
+
+#### Scenario: Title ends in bottle size
+
+- **WHEN** an eligible product title ends with its matching bottle size, optionally before a trailing qualifier
+- **THEN** the scraper removes the size label and preserves the remaining title for shared normalization
+
+#### Scenario: Title omits bottle size
+
+- **WHEN** an eligible product title has no explicit volume and its source size tag is valid
+- **THEN** the scraper preserves the title and uses the source size tag for volume
+
+### Requirement: Degrade individual malformed products visibly
+
+The scraper SHALL log and skip an invalid individual product without aborting valid products from the same catalog page, while retaining the shared complete-run failure when no valid products are emitted.
+
+#### Scenario: One malformed product among valid products
+
+- **WHEN** a catalog page contains a malformed product and at least one valid product
+- **THEN** the malformed product is warned about and valid products are emitted
+
+#### Scenario: Invalid catalog payload
+
+- **WHEN** the catalog response itself is not valid source JSON
+- **THEN** the scraper fails the run instead of reporting success
+
+#### Scenario: Complete empty run
+
+- **WHEN** the complete paginated run emits no supported listings
+- **THEN** the scraper fails explicitly instead of reporting success

--- a/openspec/changes/add-mission-liquor-scraper/tasks.md
+++ b/openspec/changes/add-mission-liquor-scraper/tasks.md
@@ -1,0 +1,16 @@
+## 1. Source Registration
+
+- [x] 1.1 Register `missionliquor` in the external-site type list and worker routing
+- [x] 1.2 Verify registered types remain accepted and unknown types remain rejected by application validation
+
+## 2. Scraper Implementation
+
+- [x] 2.1 Implement paginated public Shopify collection fetching and response validation
+- [x] 2.2 Parse exact whiskey taxonomy, availability, source size tags, USD prices, product titles, official URLs, and images
+- [x] 2.3 Exclude sold-out, multiproduct, promotional, ambiguous, unsupported-volume, inconsistent, and malformed products while retaining complete-run failure
+
+## 3. Verification
+
+- [x] 3.1 Add representative fixtures and focused routing, parsing, exclusion, pagination, and failure tests
+- [x] 3.2 Run targeted tests, typecheck, lint, source formatting, and strict OpenSpec validation
+- [x] 3.3 Run an uncached live dry run, build the server package, and run the full repository test gate


### PR DESCRIPTION
Adds Mission Liquor as a broad external pricing source, scraping its public Shopify whiskey collection page by page. An uncached live dry run returned 2,377 supported, available bottle listings across major American, Scotch, Japanese, and other whisky brands.

The scraper relies on structured product type, availability, variants, and flexible `size-<amount><unit>` tags. It conservatively skips multiproduct offers, ambiguous variants, unsupported volumes, malformed records, and title/tag size disagreements while preserving the shared complete-run failure.

External-site types remain text-backed and application-validated, so this adds no database enum or schema migration.
