### PR TITLE
feat(scrapers): add The Whisky World pricing

### DIFF
--- a/apps/server/__fixtures__/whiskyworld/bottle-list.html
+++ b/apps/server/__fixtures__/whiskyworld/bottle-list.html
@@ -1,0 +1,128 @@
+<main id="js-search-results-products__list">
+  <div class="product product--0 parent_product_id_13670" id="product_13670_36716">
+    <div class="product__image">
+      <img
+        src="/images/hazelwood-legacy-collection-p13670_thumb.jpg"
+        srcset="/images/hazelwood-legacy-collection-p13670_thumb.jpg 274w, /images/hazelwood-legacy-collection-p13670_medium.jpg 665w"
+      />
+    </div>
+    <div class="product__details__title">
+      <a href="/a-breath-of-fresh-air-house-of-hazelwood-legacy-collection-p13670">
+        A Breath Of Fresh Air - House of Hazelwood Legacy Collection
+      </a>
+    </div>
+    <span class="product-content__price--inc"><span class="GBP">£1,449.90</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_201" id="product_201_1">
+    <div class="product__image">
+      <img
+        src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+        data-src="/images/compass-box-orchard-house-p201_thumb.jpg"
+      />
+    </div>
+    <div class="product__details__title">
+      <a href="/compass-box-orchard-house-p201">Compass Box Orchard House</a>
+    </div>
+    <span class="product-content__price--inc"><span class="GBP">£45.90</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_202" id="product_202_1">
+    <div class="product__image"><img src="/images/minor-case-p202_thumb.jpg" /></div>
+    <div class="product__details__title">
+      <a href="/minor-case-sherry-cask-rye-whiskey-p202">Minor Case Sherry Cask Rye Whiskey</a>
+    </div>
+    <span class="product-content__price--inc"><span class="GBP">£43.99</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_203" id="product_203_1">
+    <div class="product__image"><img src="/images/dalmore-trio-p203_thumb.jpg" /></div>
+    <div class="product__details__title">
+      <a href="/the-dalmore-the-trio-p203">The Dalmore The Trio</a>
+    </div>
+    <span class="product-content__price--inc"><span class="GBP">£89</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_204" id="product_204_1">
+    <div class="product__image"><img src="/images/cask-canvas-p204_thumb.jpg" /></div>
+    <div class="product__details__title">
+      <a href="/cask-and-canvas-the-duo-p204">Cask &amp; Canvas The Duo</a>
+    </div>
+    <span class="product-content__price--inc"><span class="GBP">£60.00</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_301" id="product_301_1">
+    <div class="product__image"><img src="/images/engraved-p301_thumb.jpg" /></div>
+    <div class="product__details__title"><a href="/engraved-whisky-p301">Engraved Whisky</a></div>
+    <span class="product-content__price--inc"><span class="GBP">£70.00</span></span>
+    <a class="product__options__view"><span>View</span></a>
+  </div>
+
+  <div class="product parent_product_id_302" id="product_302_1">
+    <div class="product__image"><img src="/images/gift-set-p302_thumb.jpg" /></div>
+    <div class="product__details__title"><a href="/whisky-gift-set-p302">Whisky Gift Set with Two Glasses</a></div>
+    <span class="product-content__price--inc"><span class="GBP">£75.00</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_303" id="product_303_1">
+    <div class="product__image"><img src="/images/tasting-pack-p303_thumb.jpg" /></div>
+    <div class="product__details__title"><a href="/whisky-tasting-pack-p303">Whisky Tasting Pack</a></div>
+    <span class="product-content__price--inc"><span class="GBP">£35.00</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_304" id="product_304_1">
+    <div class="product__image"><img src="/images/bundle-p304_thumb.jpg" /></div>
+    <div class="product__details__title"><a href="/whisky-bundle-p304">Whisky Bundle</a></div>
+    <span class="product-content__price--inc"><span class="GBP">£99.00</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_305" id="product_305_1">
+    <div class="product__image"><img src="/images/multipack-p305_thumb.jpg" /></div>
+    <div class="product__details__title"><a href="/whisky-3x70cl-p305">Whisky 3x70cl</a></div>
+    <span class="product-content__price--inc"><span class="GBP">£120.00</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_306" id="product_306_1">
+    <div class="product__image"><img src="/images/bad-price-p306_thumb.jpg" /></div>
+    <div class="product__details__title"><a href="/bad-price-p306">Bad Price Whisky</a></div>
+    <span class="product-content__price--inc"><span class="GBP">$50.00</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_307" id="product_307_1">
+    <div class="product__image"><img src="/images/untrusted-p307_thumb.jpg" /></div>
+    <div class="product__details__title"><a href="https://example.com/untrusted-p307">Untrusted Whisky</a></div>
+    <span class="product-content__price--inc"><span class="GBP">£50.00</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_308" id="product_308_1">
+    <div class="product__image"><img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" /></div>
+    <div class="product__details__title"><a href="/placeholder-image-p308">Placeholder Image Whisky</a></div>
+    <span class="product-content__price--inc"><span class="GBP">£50.00</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_309" id="product_309_1">
+    <div class="product__image"><img src="/images/no-id_thumb.jpg" /></div>
+    <div class="product__details__title"><a href="/whisky-without-product-id">Whisky Without Product ID</a></div>
+    <span class="product-content__price--inc"><span class="GBP">£50.00</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+
+  <div class="product parent_product_id_310" id="product_310_1">
+    <div class="product__image"><img src="https://example.com/untrusted-image.jpg" /></div>
+    <div class="product__details__title"><a href="/untrusted-image-p310">Untrusted Image Whisky</a></div>
+    <span class="product-content__price--inc"><span class="GBP">£50.00</span></span>
+    <a class="product__options__view"><span>Buy</span></a>
+  </div>
+</main>

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -47,6 +47,7 @@ export const EXTERNAL_SITE_TYPE_LIST = [
   "totalwine",
   "woodencork",
   "whiskyadvocate",
+  "whiskyworld",
 ] as const;
 
 export const ENTITY_TYPE_LIST = ["brand", "bottler", "distiller"] as const;

--- a/apps/server/src/schemas/externalSites.test.ts
+++ b/apps/server/src/schemas/externalSites.test.ts
@@ -1,15 +1,15 @@
 import { ExternalSiteInputSchema, ExternalSiteTypeEnum } from "./externalSites";
 
 test("accepts registered external-site types", () => {
-  expect(ExternalSiteTypeEnum.parse("missionliquor")).toBe("missionliquor");
+  expect(ExternalSiteTypeEnum.parse("whiskyworld")).toBe("whiskyworld");
   expect(
     ExternalSiteInputSchema.parse({
-      name: "Mission Liquor",
-      type: "missionliquor",
+      name: "The Whisky World",
+      type: "whiskyworld",
     }),
   ).toMatchObject({
-    name: "Mission Liquor",
-    type: "missionliquor",
+    name: "The Whisky World",
+    type: "whiskyworld",
   });
 });
 

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -46,6 +46,7 @@ import scrapeSMWSA from "./scrapeSMWSA";
 import scrapeThompsonBros from "./scrapeThompsonBros";
 import scrapeTotalWine from "./scrapeTotalWine";
 import scrapeWhiskeyAdvocate from "./scrapeWhiskyAdvocate";
+import scrapeWhiskyWorld from "./scrapeWhiskyWorld";
 import scrapeWoodenCork from "./scrapeWoodenCork";
 import updateBottleStats from "./updateBottleStats";
 import updateCountryStats from "./updateCountryStats";
@@ -104,6 +105,7 @@ const scraperJobs = [
   ["ScrapeTotalWine", "totalwine", scrapeTotalWine],
   ["ScrapeWoodenCork", "woodencork", scrapeWoodenCork],
   ["ScrapeWhiskyAdvocate", "whiskyadvocate", scrapeWhiskeyAdvocate],
+  ["ScrapeWhiskyWorld", "whiskyworld", scrapeWhiskyWorld],
 ] as const;
 
 for (const [jobName, siteType, scrape] of scraperJobs) {

--- a/apps/server/src/worker/jobs/scrapeWhiskyWorld.test.ts
+++ b/apps/server/src/worker/jobs/scrapeWhiskyWorld.test.ts
@@ -1,0 +1,118 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { StorePriceInputSchema } from "@peated/server/schemas";
+import { getJobForSite } from "@peated/server/worker/utils";
+import scrapeWhiskyWorld, { scrapeProducts } from "./scrapeWhiskyWorld";
+
+process.env.DISABLE_HTTP_CACHE = "1";
+
+const firstPageUrl =
+  "https://www.thewhiskyworld.com/whisky-c7/70cl-t24?show=48&page=1";
+const secondPageUrl =
+  "https://www.thewhiskyworld.com/whisky-c7/70cl-t24?show=48&page=2";
+
+test("routes The Whisky World source to its scraper job", () => {
+  expect(getJobForSite("whiskyworld")).toBe("ScrapeWhiskyWorld");
+});
+
+test("scrapes directly buyable bottles and excludes ineligible cards", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("whiskyworld", "bottle-list.html");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+
+  const items: unknown[] = [];
+  await scrapeProducts(firstPageUrl, async (item) => {
+    items.push(StorePriceInputSchema.parse(item));
+  });
+
+  expect(items).toEqual([
+    {
+      currency: "gbp",
+      imageUrl:
+        "https://www.thewhiskyworld.com/images/hazelwood-legacy-collection-p13670_thumb.jpg",
+      name: "A Breath Of Fresh Air - House of Hazelwood Legacy Collection",
+      price: 144990,
+      url: "https://www.thewhiskyworld.com/a-breath-of-fresh-air-house-of-hazelwood-legacy-collection-p13670",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl:
+        "https://www.thewhiskyworld.com/images/compass-box-orchard-house-p201_thumb.jpg",
+      name: "Compass Box Orchard House",
+      price: 4590,
+      url: "https://www.thewhiskyworld.com/compass-box-orchard-house-p201",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl:
+        "https://www.thewhiskyworld.com/images/minor-case-p202_thumb.jpg",
+      name: "Minor Case Sherry Cask Rye Whiskey",
+      price: 4399,
+      url: "https://www.thewhiskyworld.com/minor-case-sherry-cask-rye-whiskey-p202",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl:
+        "https://www.thewhiskyworld.com/images/dalmore-trio-p203_thumb.jpg",
+      name: "The Dalmore The Trio",
+      price: 8900,
+      url: "https://www.thewhiskyworld.com/the-dalmore-the-trio-p203",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl:
+        "https://www.thewhiskyworld.com/images/cask-canvas-p204_thumb.jpg",
+      name: "Cask & Canvas The Duo",
+      price: 6000,
+      url: "https://www.thewhiskyworld.com/cask-and-canvas-the-duo-p204",
+      volume: 700,
+    },
+  ]);
+});
+
+test("paginates a dry run and stops after an empty page", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("whiskyworld", "bottle-list.html");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+  axiosMock.onGet(secondPageUrl).reply(200, "<main></main>");
+
+  await expect(scrapeWhiskyWorld({ dryRun: true })).resolves.toBe(5);
+  expect(axiosMock.history.get.map(({ url }: { url?: string }) => url)).toEqual(
+    [firstPageUrl, secondPageUrl],
+  );
+});
+
+test("fails a page that has cards but no supported listings", async ({
+  axiosMock,
+}) => {
+  axiosMock.onGet(firstPageUrl).reply(
+    200,
+    `<main id="js-search-results-products__list">
+      <div class="product" id="product_1_1">
+        <div class="product__details__title">
+          <a href="/unavailable-whisky-p1">Unavailable Whisky</a>
+        </div>
+        <a class="product__options__view"><span>View</span></a>
+      </div>
+    </main>`,
+  );
+
+  await expect(scrapeProducts(firstPageUrl, async () => {})).rejects.toThrow(
+    "Whisky World page contained product cards but no supported listings.",
+  );
+});
+
+test("fails when a complete scrape yields no supported listings", async ({
+  axiosMock,
+}) => {
+  axiosMock.onGet(firstPageUrl).reply(200, "<main></main>");
+
+  await expect(scrapeWhiskyWorld({ dryRun: true })).rejects.toThrow(
+    "Failed to scrape any products.",
+  );
+});

--- a/apps/server/src/worker/jobs/scrapeWhiskyWorld.ts
+++ b/apps/server/src/worker/jobs/scrapeWhiskyWorld.ts
@@ -1,0 +1,159 @@
+import { normalizeBottle } from "@peated/bottle-classifier/normalize";
+import type {
+  ScrapePricesCallback,
+  StorePrice,
+} from "@peated/server/lib/scraper";
+import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import { load as cheerio } from "cheerio";
+import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
+
+const SITE = "whiskyworld";
+const STORE_ORIGIN = "https://www.thewhiskyworld.com";
+const CATALOG_URL = `${STORE_ORIGIN}/whisky-c7/70cl-t24`;
+const PRODUCT_CARD_SELECTOR =
+  "#js-search-results-products__list .product[id^='product_']";
+const MULTIPRODUCT_PATTERN =
+  /\b(?:gift|tasting|miniature|collection)\s+(?:set|pack)\b|\bbundle\b|\badvent\s+calendar\b|\b\d+\s*(?:pack|pk)\b|\b\d+\s*(?:x|×)\s*\d+(?:\.\d+)?\s*(?:ml|cl|l)\b|\bset\s+of\s+\d+\b/i;
+
+function parsePrice(value: string): number | null {
+  const match = value.match(/^£\s*([\d,]+)(?:\.(\d{1,2}))?$/);
+  if (!match) return null;
+
+  const pounds = Number.parseInt(match[1].replaceAll(",", ""), 10);
+  const pence = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
+  const price = pounds * 100 + pence;
+  return Number.isSafeInteger(price) && price > 0 ? price : null;
+}
+
+function getOfficialUrl(
+  value: string | undefined,
+  { product = false }: { product?: boolean } = {},
+): string | null {
+  if (!value || value.startsWith("data:")) return null;
+
+  try {
+    const url = new URL(value, STORE_ORIGIN);
+    if (
+      url.protocol !== "https:" ||
+      url.origin !== STORE_ORIGIN ||
+      url.username ||
+      url.password
+    ) {
+      return null;
+    }
+    if (product && !/-p\d+\/?$/.test(url.pathname)) return null;
+
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function getImageUrl(
+  image: ReturnType<ReturnType<typeof cheerio>>,
+): string | null {
+  const srcsetUrl = image
+    .attr("srcset")
+    ?.split(",", 1)[0]
+    ?.trim()
+    .split(/\s+/, 1)[0];
+  const candidates = [image.attr("data-src"), image.attr("src"), srcsetUrl];
+
+  for (const candidate of candidates) {
+    const imageUrl = getOfficialUrl(candidate);
+    if (imageUrl) return imageUrl;
+  }
+  return null;
+}
+
+function isMultiproduct(title: string): boolean {
+  return MULTIPRODUCT_PATTERN.test(title);
+}
+
+export function parseWhiskyWorldProducts(html: string): StorePrice[] {
+  const $ = cheerio(html);
+  const products: StorePrice[] = [];
+  const cards = $(PRODUCT_CARD_SELECTOR);
+
+  cards.each((_, element) => {
+    const card = $(element);
+    const titleLink = card.find(".product__details__title a").first();
+    const rawName = titleLink.text().replaceAll(/\s+/g, " ").trim();
+    const action = card
+      .find(".product__options__view span")
+      .first()
+      .text()
+      .trim();
+
+    if (action.toLowerCase() !== "buy") return;
+    if (!rawName) {
+      logScrapeWarning(SITE, "Unable to identify product name");
+      return;
+    }
+    if (isMultiproduct(rawName)) return;
+
+    const url = getOfficialUrl(titleLink.attr("href"), { product: true });
+    if (!url) {
+      logScrapeWarning(SITE, "Invalid product URL", { rawName });
+      return;
+    }
+
+    const priceRaw = card
+      .find(".product-content__price--inc .GBP")
+      .first()
+      .text()
+      .replaceAll(/\s+/g, " ")
+      .trim();
+    const price = parsePrice(priceRaw);
+    if (price === null) {
+      logScrapeWarning(SITE, "Invalid product price", { priceRaw, rawName });
+      return;
+    }
+
+    const imageUrl = getImageUrl(card.find(".product__image img").first());
+    if (!imageUrl) {
+      logScrapeWarning(SITE, "Invalid product image URL", { rawName });
+      return;
+    }
+
+    const { name } = normalizeBottle({ name: rawName });
+    const listing = {
+      name,
+      price,
+      currency: "gbp" as const,
+      volume: 700,
+      url,
+      imageUrl,
+    };
+
+    logScrapedProduct(SITE, listing);
+    products.push(listing);
+  });
+
+  if (cards.length > 0 && products.length === 0) {
+    throw new Error(
+      "Whisky World page contained product cards but no supported listings.",
+    );
+  }
+
+  return products;
+}
+
+export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
+  const data = await getUrl(url);
+  const products = parseWhiskyWorldProducts(data);
+  await Promise.all(products.map(cb));
+}
+
+export default async function scrapeWhiskyWorld({
+  dryRun = false,
+}: { dryRun?: boolean } = {}) {
+  return await scrapePrices(
+    SITE,
+    (page) => `${CATALOG_URL}?show=48&page=${page}`,
+    scrapeProducts,
+    { dryRun },
+  );
+}

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -48,6 +48,7 @@ export type JobName =
   | "ScrapeTotalWine"
   | "ScrapeWoodenCork"
   | "ScrapeWhiskyAdvocate"
+  | "ScrapeWhiskyWorld"
   | "CreateMissingBottles"
   | "UpdateBottleStats"
   | "UpdateCountryStats"

--- a/apps/server/src/worker/utils.ts
+++ b/apps/server/src/worker/utils.ts
@@ -47,6 +47,8 @@ export function getJobForSite(site: ExternalSiteType): JobName {
       return "ScrapeThompsonBros";
     case "whiskyadvocate":
       return "ScrapeWhiskyAdvocate";
+    case "whiskyworld":
+      return "ScrapeWhiskyWorld";
     case "woodencork":
       return "ScrapeWoodenCork";
     case "healthyspirits":

--- a/openspec/changes/add-whisky-world-scraper/.openspec.yaml
+++ b/openspec/changes/add-whisky-world-scraper/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/add-whisky-world-scraper/design.md
+++ b/openspec/changes/add-whisky-world-scraper/design.md
@@ -1,0 +1,63 @@
+## Context
+
+The Whisky World renders its broad whisky catalog as public, paginated Visualsoft HTML. Its source-owned size facets provide an authoritative bottle-volume boundary that is absent from the product cards themselves. An uncached audit of the exact 70 cl facet found 2,734 cards across 57 pages, with 2,697 directly buyable products, stable product paths and IDs, complete GBP prices, and official images. The remaining cards were personalized engraving products whose action is `View` rather than `Buy`.
+
+The broader catalog also exposes other supported sizes, but implementing several independently paginated facets would add orchestration and duplicate-handling complexity. The 70 cl facet alone provides the large-source coverage this change is intended to add.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Collect broad current GBP whisky prices from The Whisky World's exact 70 cl catalog.
+- Use the provider's size facet and direct-buy action as the primary eligibility boundary.
+- Reject clearly multiproduct and malformed offers conservatively.
+- Keep source-contract failures visible while isolating malformed individual cards.
+
+**Non-Goals:**
+
+- Scrape other bottle-size facets, personalized products, unavailable products, gift sets, bundles, or multipacks.
+- Infer volume from titles, prices, or general category membership.
+- Model shipping eligibility, inventory quantity, currency conversion, or sale history.
+- Create bottles or persist prices during local verification.
+
+## Decisions
+
+### Scrape the exact 70 cl facet page by page
+
+The worker will request numbered pages from `/whisky-c7/70cl-t24` with the catalog's 48-product page size. This provider-owned facet is the volume authority, so every eligible result is emitted as 700 ml without product-detail requests or title inference. An empty product page ends pagination. A page with product cards but no supported listings fails explicitly so source drift cannot silently truncate a partial run.
+
+Only this facet is included. Scraping the generic catalog would require thousands of product-detail requests to establish volume, while coordinating every supported size facet would multiply paging and deduplication concerns for limited additional coverage.
+
+### Require the direct-buy action
+
+A listing must expose the product card's exact `Buy` action. Cards that only expose `View` are not directly purchasable from the catalog and are excluded; the current examples are engraving and plaque customizations. This source-owned state is more reliable than guessing availability from CSS classes or titles.
+
+### Parse narrow card-owned fields
+
+The scraper will take the normalized title and canonical URL from the product title link, the GBP amount from the inclusive-price field, and the image from the card's lazy or eager image attributes. Product and image URLs must resolve to The Whisky World's HTTPS origin, and product paths must retain the provider's numeric product identity.
+
+The lazy image attribute is preferred over a placeholder `data:` source. Prices must use a positive `£` decimal amount; the scraper will not infer another currency from browser state.
+
+### Exclude clear multiproduct offers conservatively
+
+Titles identifying gift sets or packs, tasting sets or packs, bundles, advent calendars, miniature sets or packs, numeric packs, numeric `Nx70cl` offers, or `set of N` offers are excluded. Generic words such as `collection`, `case`, `box`, `duo`, and `trio` are not exclusions because they occur in legitimate release names.
+
+### Isolate malformed cards and retain complete-run failure
+
+Invalid individual cards are warned about and skipped so one bad listing does not discard a valid page. A page with cards but no supported listings raises at the provider boundary. Request failures escape to the worker boundary, and a complete run with no cards fails through the existing `scrapePrices` guard.
+
+## Risks / Trade-offs
+
+- **The provider changes or removes its 70 cl facet** → The resulting empty scrape fails explicitly rather than reporting success.
+- **The catalog markup changes partially** → Invalid cards are warned about, while fixture coverage owns the selectors and official-field validation.
+- **A legitimate release title resembles a pack** → Use narrow phrase and numeric-pack patterns and retain known release terms in regression fixtures.
+- **A non-70 cl bottle is misclassified by the provider** → Treat the provider's exact size facet as authoritative; revise only with concrete contradictory source evidence.
+- **Other supported sizes remain uncovered** → Prefer the simple high-volume facet now and add another exact facet only when its incremental value justifies independent pagination and deduplication.
+
+## Migration Plan
+
+Deploy the registered worker, then configure The Whisky World through the existing administrative path. External-site types are stored as text and validated by the application, so no database migration is required. Rollback consists of disabling the source and worker job.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-whisky-world-scraper/proposal.md
+++ b/openspec/changes/add-whisky-world-scraper/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Peated's recent scraper additions cover focused producers and one large US retailer, but broad current UK retail coverage remains thin. The Whisky World publishes an official 70 cl catalog of roughly 2,700 directly buyable whiskies with current GBP prices, canonical product URLs, and official images.
+
+## What Changes
+
+- Register The Whisky World as an external price source and scheduled worker job.
+- Scrape its source-owned 70 cl whisky facet page by page for directly buyable single-bottle products.
+- Normalize current GBP prices, canonical product URLs, titles, and official images into 700 ml listings.
+- Exclude personalized products, gift sets, tasting packs, bundles, numeric multipacks, and malformed records.
+- Add fixture-backed coverage and an uncached local live dry run.
+
+## Capabilities
+
+### New Capabilities
+
+- `whisky-world-price-scraping`: Collect valid current GBP whisky prices from The Whisky World's broad official 70 cl catalog while rejecting non-buyable, multiproduct, or malformed offers.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds a server worker scraper, routing, fixtures, and tests.
+- Reads The Whisky World's public catalog pages; no protected credential, runtime dependency, or database migration is required.

--- a/openspec/changes/add-whisky-world-scraper/specs/whisky-world-price-scraping/spec.md
+++ b/openspec/changes/add-whisky-world-scraper/specs/whisky-world-price-scraping/spec.md
@@ -1,0 +1,76 @@
+## ADDED Requirements
+
+### Requirement: Fetch the official 70 cl catalog
+
+The Whisky World scraper SHALL request numbered pages from the official exact 70 cl whisky facet with the source's supported page size and SHALL stop after a page contains no product cards.
+
+#### Scenario: Catalog page contains products
+
+- **WHEN** a numbered 70 cl catalog page contains product cards
+- **THEN** the scraper evaluates those cards as 700 ml GBP offers and requests the next numbered page
+
+#### Scenario: End of catalog
+
+- **WHEN** a numbered catalog page contains no product cards
+- **THEN** the scraper stops requesting additional pages
+
+### Requirement: Emit directly buyable bottle listings
+
+The scraper SHALL emit only cards with the source's exact direct-buy action, a positive GBP bottle price, a valid official product URL, and a valid official image.
+
+#### Scenario: Eligible bottle
+
+- **WHEN** a 70 cl product card is directly buyable and has a positive GBP price, official product URL, and official image
+- **THEN** the scraper emits its normalized name, price, GBP currency, 700 ml volume, URL, and image URL
+
+#### Scenario: Non-buyable catalog product
+
+- **WHEN** a product card does not expose the source's direct-buy action
+- **THEN** the scraper does not emit a listing for that card
+
+### Requirement: Reject multiproduct offers
+
+The scraper SHALL reject titles that clearly identify gift sets or packs, tasting sets or packs, bundles, advent calendars, miniature sets or packs, numeric packs, numeric multi-bottle volumes, or `set of N` offers.
+
+#### Scenario: Clear multiproduct title
+
+- **WHEN** an otherwise valid product title identifies a supported multiproduct pattern
+- **THEN** the scraper does not emit a listing for that product
+
+#### Scenario: Generic release word is not a pack
+
+- **WHEN** an otherwise eligible bottle uses a word such as `collection`, `case`, `box`, `duo`, or `trio` without pack syntax
+- **THEN** the scraper does not exclude it solely for that word
+
+### Requirement: Validate official listing identity
+
+The scraper MUST require product and image URLs to resolve to The Whisky World's HTTPS origin and MUST require product paths to include the provider's numeric product identity.
+
+#### Scenario: Lazy-loaded official image
+
+- **WHEN** an eligible card contains a placeholder source and an official lazy-loaded image URL
+- **THEN** the scraper emits the official lazy-loaded image URL
+
+#### Scenario: Untrusted listing URL
+
+- **WHEN** a product or image URL resolves outside the official origin or the product path lacks its numeric identity
+- **THEN** the scraper warns and skips that card
+
+### Requirement: Degrade individual malformed cards visibly
+
+The scraper SHALL log and skip an invalid individual card without aborting valid cards from the same catalog page, MUST fail a page that contains cards but no supported listings, and SHALL retain the shared complete-run failure when the catalog contains no cards.
+
+#### Scenario: One malformed card among valid cards
+
+- **WHEN** a catalog page contains a malformed card and at least one valid card
+- **THEN** the malformed card is warned about and valid cards are emitted
+
+#### Scenario: Product cards yield no supported listings
+
+- **WHEN** a catalog page contains product cards but none can be emitted
+- **THEN** the scraper fails the page instead of silently ending pagination
+
+#### Scenario: Complete empty run
+
+- **WHEN** the complete paginated run emits no supported listings
+- **THEN** the scraper fails explicitly instead of reporting success

--- a/openspec/changes/add-whisky-world-scraper/tasks.md
+++ b/openspec/changes/add-whisky-world-scraper/tasks.md
@@ -1,0 +1,16 @@
+## 1. Source Registration
+
+- [x] 1.1 Register `whiskyworld` in the external-site type list and worker routing
+- [x] 1.2 Verify registered types remain accepted and unknown types remain rejected by application validation
+
+## 2. Scraper Implementation
+
+- [x] 2.1 Implement paginated exact-70-cl catalog fetching and card parsing
+- [x] 2.2 Parse direct-buy state, GBP prices, normalized titles, official product URLs, and lazy or eager official images into 700 ml listings
+- [x] 2.3 Exclude non-buyable, multiproduct, untrusted, and malformed cards while retaining complete-run failure
+
+## 3. Verification
+
+- [x] 3.1 Add representative fixtures and focused routing, parsing, exclusion, pagination, and failure tests
+- [x] 3.2 Run targeted tests, typecheck, lint, source formatting, and strict OpenSpec validation
+- [x] 3.3 Run an uncached live dry run, build the server package, and run the full repository test gate


### PR DESCRIPTION
Adds The Whisky World as a scheduled external price source, crawling its official 70 cl whisky facet into normalized 700 ml GBP listings. The scraper requires the source's direct-buy action, positive GBP pricing, canonical product identity, and official images; personalized offers, gift sets, tasting packs, bundles, multipacks, and malformed cards remain excluded.

The exact provider-owned size facet avoids volume inference and thousands of product-detail requests. A page that still contains product cards but yields no supported listings now fails explicitly, preventing source drift from silently truncating a partial run. External-site types remain text-backed and application-validated, so this adds no schema migration.

Fixture-backed parser and routing coverage passes alongside server typecheck/build and the full repository test gate. An uncached live dry run completed with 2,629 unique listings and no scraper warnings.
