### PR TITLE
feat(scrapers): add Master of Malt

### DIFF
--- a/apps/server/__fixtures__/masterofmalt/bottle-list.json
+++ b/apps/server/__fixtures__/masterofmalt/bottle-list.json
@@ -1,0 +1,75 @@
+{
+  "nbHits": 7,
+  "hits": [
+    {
+      "bundle_skus": null,
+      "calculated_prices": { "GBP": 72.95 },
+      "image_url": "https://cdn11.bigcommerce.com/s-e8lbekfe7c/images/lagavulin.jpg",
+      "in_stock": true,
+      "name": "Lagavulin 16 Year Old",
+      "sku": "2444",
+      "url": "/whiskies/lagavulin/lagavulin-16-year-old-whisky/",
+      "volume": 70
+    },
+    {
+      "bundle_skus": null,
+      "calculated_prices": { "GBP": 56 },
+      "image_url": "https://cdn11.bigcommerce.com/s-e8lbekfe7c/images/johnnie-walker.jpg",
+      "in_stock": true,
+      "name": "Johnnie Walker Island Green",
+      "sku": "JW-100CL",
+      "url": "/whiskies/johnnie-walker/johnnie-walker-island-green-whisky/",
+      "volume": 100
+    },
+    {
+      "bundle_skus": ["DRAM-1", "DRAM-2"],
+      "calculated_prices": { "GBP": 45 },
+      "image_url": "https://cdn11.bigcommerce.com/s-e8lbekfe7c/images/bundle.jpg",
+      "in_stock": true,
+      "name": "Islay Whisky Bundle",
+      "sku": "BUNDLE-1",
+      "url": "/whiskies/islay/islay-whisky-bundle/",
+      "volume": 70
+    },
+    {
+      "bundle_skus": null,
+      "calculated_prices": { "GBP": 35 },
+      "image_url": "https://cdn11.bigcommerce.com/s-e8lbekfe7c/images/set.jpg",
+      "in_stock": true,
+      "name": "Japanese Whisky Tasting Set",
+      "sku": "SET-1",
+      "url": "/whiskies/japanese/japanese-whisky-tasting-set/",
+      "volume": 70
+    },
+    {
+      "bundle_skus": null,
+      "calculated_prices": { "GBP": 20 },
+      "image_url": "https://cdn11.bigcommerce.com/s-e8lbekfe7c/images/small.jpg",
+      "in_stock": true,
+      "name": "Small Format Whisky",
+      "sku": "SMALL-1",
+      "url": "/whiskies/small/small-format-whisky/",
+      "volume": 20
+    },
+    {
+      "bundle_skus": null,
+      "calculated_prices": { "GBP": 65 },
+      "image_url": "https://images.example.com/wrong-host.jpg",
+      "in_stock": true,
+      "name": "Invalid Image Whisky",
+      "sku": "IMAGE-1",
+      "url": "/whiskies/invalid/invalid-image-whisky/",
+      "volume": 70
+    },
+    {
+      "bundle_skus": null,
+      "calculated_prices": { "GBP": 70 },
+      "image_url": "https://cdn11.bigcommerce.com/s-e8lbekfe7c/images/wrong-url.jpg",
+      "in_stock": true,
+      "name": "Invalid URL Whisky",
+      "sku": "URL-1",
+      "url": "https://example.com/whiskies/invalid-url-whisky/",
+      "volume": 70
+    }
+  ]
+}

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -36,6 +36,7 @@ export const EXTERNAL_SITE_TYPE_LIST = [
   "gordonmacphail",
   "healthyspirits",
   "kilchoman",
+  "masterofmalt",
   "missionliquor",
   "ncnean",
   "northstarspirits",

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -36,6 +36,7 @@ import scrapeGlenAllachie from "./scrapeGlenAllachie";
 import scrapeGordonMacphail from "./scrapeGordonMacphail";
 import scrapeHealthySpirits from "./scrapeHealthySpirits";
 import scrapeKilchoman from "./scrapeKilchoman";
+import scrapeMasterOfMalt from "./scrapeMasterOfMalt";
 import scrapeMissionLiquor from "./scrapeMissionLiquor";
 import scrapeNcnean from "./scrapeNcnean";
 import scrapeNorthStarSpirits from "./scrapeNorthStarSpirits";
@@ -94,6 +95,7 @@ const scraperJobs = [
   ["ScrapeGordonMacphail", "gordonmacphail", scrapeGordonMacphail],
   ["ScrapeHealthySpirits", "healthyspirits", scrapeHealthySpirits],
   ["ScrapeKilchoman", "kilchoman", scrapeKilchoman],
+  ["ScrapeMasterOfMalt", "masterofmalt", scrapeMasterOfMalt],
   ["ScrapeMissionLiquor", "missionliquor", scrapeMissionLiquor],
   ["ScrapeNcnean", "ncnean", scrapeNcnean],
   ["ScrapeNorthStarSpirits", "northstarspirits", scrapeNorthStarSpirits],

--- a/apps/server/src/worker/jobs/scrapeMasterOfMalt.test.ts
+++ b/apps/server/src/worker/jobs/scrapeMasterOfMalt.test.ts
@@ -1,0 +1,110 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { StorePriceInputSchema } from "@peated/server/schemas";
+import { getJobForSite } from "@peated/server/worker/utils";
+import scrapeMasterOfMalt, {
+  parseMasterOfMaltProducts,
+  scrapeProducts,
+} from "./scrapeMasterOfMalt";
+
+const searchUrl =
+  "https://ll7rrres19-dsn.algolia.net/1/indexes/bc_e8lbekfe7c_1736038_d2c_variants/query";
+const firstPartitionUrl = `${searchUrl}?x-algolia-agent=Peated%2F1.0+masterofmalt%2F1`;
+
+test("routes the Master of Malt source to its scraper job", () => {
+  expect(getJobForSite("masterofmalt")).toBe("ScrapeMasterOfMalt");
+});
+
+test("scrapes in-stock single bottles and excludes unsupported products", async ({
+  axiosMock,
+}) => {
+  const fixture = JSON.parse(
+    await loadFixture("masterofmalt", "bottle-list.json"),
+  );
+  axiosMock.onPost(firstPartitionUrl).reply(200, fixture);
+
+  const items: unknown[] = [];
+  await scrapeProducts(firstPartitionUrl, async (item) => {
+    items.push(StorePriceInputSchema.parse(item));
+  });
+
+  expect(items).toEqual([
+    {
+      currency: "gbp",
+      imageUrl:
+        "https://cdn11.bigcommerce.com/s-e8lbekfe7c/images/lagavulin.jpg",
+      name: "Lagavulin 16-year-old",
+      price: 7295,
+      url: "https://www.masterofmalt.com/whiskies/lagavulin/lagavulin-16-year-old-whisky/?sku=2444",
+      volume: 700,
+    },
+    {
+      currency: "gbp",
+      imageUrl:
+        "https://cdn11.bigcommerce.com/s-e8lbekfe7c/images/johnnie-walker.jpg",
+      name: "Johnnie Walker Island Green",
+      price: 5600,
+      url: "https://www.masterofmalt.com/whiskies/johnnie-walker/johnnie-walker-island-green-whisky/?sku=JW-100CL",
+      volume: 1000,
+    },
+  ]);
+
+  const request = JSON.parse(axiosMock.history.post[0].data);
+  expect(request).toMatchObject({
+    filters: expect.stringContaining(
+      'categories_without_path:"Shop all whisky"',
+    ),
+    hitsPerPage: 1000,
+    numericFilters: ["calculated_prices.GBP<40"],
+  });
+});
+
+test("queries every bounded price partition before stopping", async ({
+  axiosMock,
+}) => {
+  axiosMock
+    .onPost(new RegExp(`^${searchUrl}`))
+    .reply((request: { url?: string }) => {
+      const agent = new URL(request.url!).searchParams.get("x-algolia-agent")!;
+      const page = Number.parseInt(agent.split("/").at(-1)!, 10);
+      return [
+        200,
+        {
+          nbHits: 1,
+          hits: [
+            {
+              bundle_skus: null,
+              calculated_prices: { GBP: page + 10 },
+              image_url: `https://cdn11.bigcommerce.com/images/${page}.jpg`,
+              in_stock: true,
+              name: `Partition Whisky ${page}`,
+              sku: `PART-${page}`,
+              url: `/whiskies/partition/partition-whisky-${page}/`,
+              volume: 70,
+            },
+          ],
+        },
+      ];
+    });
+
+  await expect(scrapeMasterOfMalt({ dryRun: true })).resolves.toBe(9);
+  expect(axiosMock.history.post).toHaveLength(9);
+});
+
+test("fails rather than silently truncating an oversized partition", () => {
+  expect(() =>
+    parseMasterOfMaltProducts({
+      nbHits: 1001,
+      hits: [],
+    }),
+  ).toThrow("price partition exceeds the complete-search limit");
+});
+
+test("fails when a configured price partition becomes empty", async ({
+  axiosMock,
+}) => {
+  axiosMock.onPost(firstPartitionUrl).reply(200, { nbHits: 0, hits: [] });
+
+  await expect(scrapeMasterOfMalt({ dryRun: true })).rejects.toThrow(
+    "price partition unexpectedly empty",
+  );
+});

--- a/apps/server/src/worker/jobs/scrapeMasterOfMalt.ts
+++ b/apps/server/src/worker/jobs/scrapeMasterOfMalt.ts
@@ -1,0 +1,262 @@
+import { normalizeBottle } from "@peated/bottle-classifier/normalize";
+import { ALLOWED_VOLUMES } from "@peated/server/constants";
+import type {
+  ScrapePricesCallback,
+  StorePrice,
+} from "@peated/server/lib/scraper";
+import scrapePrices from "@peated/server/lib/scraper";
+import axios from "axios";
+import { z } from "zod";
+import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
+
+const SITE = "masterofmalt";
+const STORE_ORIGIN = "https://www.masterofmalt.com";
+const ALGOLIA_APPLICATION_ID = "LL7RRRES19";
+const ALGOLIA_SEARCH_API_KEY = "c173fd6d86fa29679cd0e5075ed07de5";
+const ALGOLIA_INDEX = "bc_e8lbekfe7c_1736038_d2c_variants";
+const SEARCH_URL = `https://${ALGOLIA_APPLICATION_ID.toLowerCase()}-dsn.algolia.net/1/indexes/${ALGOLIA_INDEX}/query`;
+const HITS_PER_PARTITION = 1000;
+const CATALOG_FILTER =
+  'categories_without_path:"Shop all whisky" AND NOT volume:3 AND NOT variant_metafields.atom.product.is-dram:"1" AND NOT exclude_from_search:true AND NOT exclude_from_category:true AND in_stock:true';
+const PRICE_PARTITIONS = [
+  ["calculated_prices.GBP<40"],
+  ["calculated_prices.GBP>=40", "calculated_prices.GBP<60"],
+  ["calculated_prices.GBP>=60", "calculated_prices.GBP<80"],
+  ["calculated_prices.GBP>=80", "calculated_prices.GBP<100"],
+  ["calculated_prices.GBP>=100", "calculated_prices.GBP<200"],
+  ["calculated_prices.GBP>=200", "calculated_prices.GBP<500"],
+  ["calculated_prices.GBP>=500", "calculated_prices.GBP<1000"],
+  ["calculated_prices.GBP>=1000", "calculated_prices.GBP<5000"],
+  ["calculated_prices.GBP>=5000"],
+] as const;
+const MULTIPRODUCT_PATTERN =
+  /\b(?:gift|tasting|miniature|sample|discovery)\s+(?:set|pack|collection)\b|\bbundle\b|\badvent\s+calendar\b|\b\d+\s*(?:pack|pk)\b|\b\d+\s*(?:x|×)\s*\d+(?:\.\d+)?\s*(?:ml|cl|l)\b|\bset\s+of\s+\d+\b/i;
+
+const SearchResponseSchema = z
+  .object({
+    hits: z.array(z.unknown()),
+    nbHits: z.number().int().nonnegative(),
+  })
+  .passthrough();
+
+const ProductSchema = z
+  .object({
+    bundle_skus: z.array(z.string()).nullable().optional(),
+    calculated_prices: z.object({
+      GBP: z.number().positive(),
+    }),
+    image_url: z.string(),
+    in_stock: z.literal(true),
+    name: z.string().trim().min(1),
+    sku: z.string().trim().min(1),
+    url: z.string().trim().min(1),
+    volume: z.number().positive(),
+  })
+  .passthrough();
+
+function getRawName(input: unknown): string | null {
+  if (!input || typeof input !== "object" || !("name" in input)) return null;
+  return typeof input.name === "string" ? input.name : null;
+}
+
+function parsePrice(value: number): number | null {
+  const price = Math.round(value * 100);
+  return Number.isSafeInteger(price) &&
+    price > 0 &&
+    Math.abs(price / 100 - value) < Number.EPSILON * 100
+    ? price
+    : null;
+}
+
+function parseVolume(value: number): number | null {
+  const volume = value * 10;
+  return Number.isInteger(volume) && ALLOWED_VOLUMES.includes(volume)
+    ? volume
+    : null;
+}
+
+function getProductUrl(path: string, sku: string): string | null {
+  try {
+    const url = new URL(path, STORE_ORIGIN);
+    if (
+      url.protocol !== "https:" ||
+      url.origin !== STORE_ORIGIN ||
+      url.username ||
+      url.password ||
+      !url.pathname.startsWith("/whiskies/")
+    ) {
+      return null;
+    }
+
+    url.search = "";
+    url.hash = "";
+    url.searchParams.set("sku", sku);
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function getImageUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && url.hostname === "cdn11.bigcommerce.com"
+      ? url.toString()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function getPartition(url: string): readonly string[] | null {
+  const agent = new URL(url).searchParams.get("x-algolia-agent");
+  const match = agent?.match(/^Peated\/1\.0 masterofmalt\/(\d+)$/);
+  if (!match) throw new Error("Invalid Master of Malt catalog request URL.");
+
+  const page = Number.parseInt(match[1], 10);
+  return PRICE_PARTITIONS[page - 1] ?? null;
+}
+
+export function parseMasterOfMaltProducts(input: unknown): StorePrice[] {
+  const payload = SearchResponseSchema.parse(input);
+  if (
+    payload.nbHits > HITS_PER_PARTITION ||
+    payload.hits.length !== payload.nbHits
+  ) {
+    throw new Error(
+      "Master of Malt price partition exceeds the complete-search limit.",
+    );
+  }
+
+  const products: StorePrice[] = [];
+  for (const productInput of payload.hits) {
+    const result = ProductSchema.safeParse(productInput);
+    if (!result.success) {
+      logScrapeWarning(SITE, "Invalid product record", {
+        rawName: getRawName(productInput),
+      });
+      continue;
+    }
+
+    const product = result.data;
+    if (
+      product.bundle_skus?.length ||
+      MULTIPRODUCT_PATTERN.test(product.name)
+    ) {
+      continue;
+    }
+
+    const volume = parseVolume(product.volume);
+    if (volume === null) {
+      logScrapeWarning(SITE, "Unsupported product size", {
+        rawName: product.name,
+        volumeCl: product.volume,
+      });
+      continue;
+    }
+
+    const price = parsePrice(product.calculated_prices.GBP);
+    if (price === null) {
+      logScrapeWarning(SITE, "Invalid product price", {
+        price: product.calculated_prices.GBP,
+        rawName: product.name,
+      });
+      continue;
+    }
+
+    const url = getProductUrl(product.url, product.sku);
+    if (!url) {
+      logScrapeWarning(SITE, "Invalid product URL", {
+        rawName: product.name,
+        url: product.url,
+      });
+      continue;
+    }
+
+    const imageUrl = getImageUrl(product.image_url);
+    if (!imageUrl) {
+      logScrapeWarning(SITE, "Invalid product image URL", {
+        imageUrl: product.image_url,
+        rawName: product.name,
+      });
+      continue;
+    }
+
+    const { name } = normalizeBottle({ name: product.name });
+    const listing = {
+      name,
+      price,
+      currency: "gbp" as const,
+      volume,
+      url,
+      imageUrl,
+    };
+
+    logScrapedProduct(SITE, listing);
+    products.push(listing);
+  }
+
+  return products;
+}
+
+export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
+  const numericFilters = getPartition(url);
+  if (!numericFilters) return;
+
+  const { data } = await axios.post(
+    url,
+    {
+      attributesToRetrieve: [
+        "bundle_skus",
+        "calculated_prices.GBP",
+        "image_url",
+        "in_stock",
+        "name",
+        "sku",
+        "url",
+        "volume",
+      ],
+      filters: CATALOG_FILTER,
+      hitsPerPage: HITS_PER_PARTITION,
+      numericFilters,
+      query: "",
+    },
+    {
+      headers: {
+        "x-algolia-api-key": ALGOLIA_SEARCH_API_KEY,
+        "x-algolia-application-id": ALGOLIA_APPLICATION_ID,
+      },
+    },
+  );
+
+  const payload = SearchResponseSchema.parse(data);
+  if (payload.nbHits === 0) {
+    throw new Error("Master of Malt price partition unexpectedly empty.");
+  }
+
+  const products = parseMasterOfMaltProducts(payload);
+  if (products.length === 0) {
+    throw new Error(
+      "Master of Malt price partition contained no supported listings.",
+    );
+  }
+  await Promise.all(products.map(cb));
+}
+
+export default async function scrapeMasterOfMalt({
+  dryRun = false,
+}: { dryRun?: boolean } = {}) {
+  return await scrapePrices(
+    SITE,
+    (page) => {
+      const url = new URL(SEARCH_URL);
+      url.searchParams.set(
+        "x-algolia-agent",
+        `Peated/1.0 masterofmalt/${page}`,
+      );
+      return url.toString();
+    },
+    scrapeProducts,
+    { dryRun },
+  );
+}

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -37,6 +37,7 @@ export type JobName =
   | "ScrapeGordonMacphail"
   | "ScrapeHealthySpirits"
   | "ScrapeKilchoman"
+  | "ScrapeMasterOfMalt"
   | "ScrapeMissionLiquor"
   | "ScrapeNcnean"
   | "ScrapeNorthStarSpirits"

--- a/apps/server/src/worker/utils.ts
+++ b/apps/server/src/worker/utils.ts
@@ -29,6 +29,8 @@ export function getJobForSite(site: ExternalSiteType): JobName {
       return "ScrapeGordonMacphail";
     case "kilchoman":
       return "ScrapeKilchoman";
+    case "masterofmalt":
+      return "ScrapeMasterOfMalt";
     case "missionliquor":
       return "ScrapeMissionLiquor";
     case "ncnean":


### PR DESCRIPTION
Adds Master of Malt as a scheduled external price source. The scraper reads the retailer's public Algolia catalog, keeps in-stock single whisky bottles with supported volumes, uses the current GBP sale price, and emits canonical SKU-specific product URLs and images. The source is registered through application validation and the worker registry without a database migration.

Algolia limits a search to 1,000 results, so the catalog is divided into non-overlapping price partitions. Each partition is checked for completeness and the run fails if a partition becomes empty or exceeds the cap, preventing silent coverage loss as the catalog changes. Focused coverage exercises routing, product filtering, every partition, and both completeness guards.
