### PR TITLE
feat(activity): group nearby tastings into sessions

### DIFF
--- a/apps/server/src/lib/activityFeed.ts
+++ b/apps/server/src/lib/activityFeed.ts
@@ -272,63 +272,77 @@ export async function getTastingSessions({
 }): Promise<TastingSessionGroup[]> {
   if (!limit) return [];
 
-  const result = await db.execute<TastingSessionRow>(sql`
-    WITH marked_tastings AS (
-      ${markedTastingsSql({ userCondition, snapshotAt })}
-    ),
-    numbered_tastings AS (
-      SELECT
-        marked_tastings.*,
-        SUM(marked_tastings.is_session_start) OVER (
-          PARTITION BY marked_tastings.created_by_id
-          ORDER BY marked_tastings.created_at, marked_tastings.id
-          ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
-        ) AS session_number
-      FROM marked_tastings
-    ),
-    tasting_sessions AS (
-      SELECT
-        MIN(numbered_tastings.id) AS session_id,
-        numbered_tastings.created_by_id,
-        MIN(numbered_tastings.created_at) AS started_at,
-        MAX(numbered_tastings.created_at) AS last_activity_at,
-        ARRAY_AGG(
-          numbered_tastings.id
-          ORDER BY numbered_tastings.created_at DESC, numbered_tastings.id DESC
-        ) AS tasting_ids
-      FROM numbered_tastings
-      GROUP BY
-        numbered_tastings.created_by_id,
-        numbered_tastings.session_number
-    )
-    SELECT *
-    FROM tasting_sessions
-    ORDER BY tasting_sessions.last_activity_at DESC, tasting_sessions.session_id DESC
-    OFFSET ${offset}
-    LIMIT ${limit}
-  `);
+  // Session membership and hydration must share one MVCC snapshot so a
+  // concurrent deletion cannot leave an aggregate referencing a missing row.
+  return await db.transaction(
+    async (tx) => {
+      const result = await tx.execute<TastingSessionRow>(sql`
+        WITH marked_tastings AS (
+          ${markedTastingsSql({ userCondition, snapshotAt })}
+        ),
+        numbered_tastings AS (
+          SELECT
+            marked_tastings.*,
+            SUM(marked_tastings.is_session_start) OVER (
+              PARTITION BY marked_tastings.created_by_id
+              ORDER BY marked_tastings.created_at, marked_tastings.id
+              ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+            ) AS session_number
+          FROM marked_tastings
+        ),
+        tasting_sessions AS (
+          SELECT
+            MIN(numbered_tastings.id) AS session_id,
+            numbered_tastings.created_by_id,
+            MIN(numbered_tastings.created_at) AS started_at,
+            MAX(numbered_tastings.created_at) AS last_activity_at,
+            ARRAY_AGG(
+              numbered_tastings.id
+              ORDER BY numbered_tastings.created_at DESC, numbered_tastings.id DESC
+            ) AS tasting_ids
+          FROM numbered_tastings
+          GROUP BY
+            numbered_tastings.created_by_id,
+            numbered_tastings.session_number
+        )
+        SELECT *
+        FROM tasting_sessions
+        ORDER BY tasting_sessions.last_activity_at DESC, tasting_sessions.session_id DESC
+        OFFSET ${offset}
+        LIMIT ${limit}
+      `);
 
-  const tastingIds = result.rows.flatMap((row) => row.tasting_ids.map(Number));
-  const tastingRows = tastingIds.length
-    ? await db.select().from(tastings).where(inArray(tastings.id, tastingIds))
-    : [];
-  const tastingsById = new Map(
-    tastingRows.map((tasting) => [tasting.id, tasting]),
+      const tastingIds = result.rows.flatMap((row) =>
+        row.tasting_ids.map(Number),
+      );
+      const tastingRows = tastingIds.length
+        ? await tx
+            .select()
+            .from(tastings)
+            .where(inArray(tastings.id, tastingIds))
+        : [];
+      const tastingsById = new Map(
+        tastingRows.map((tasting) => [tasting.id, tasting]),
+      );
+
+      return result.rows.map((row) => ({
+        id: Number(row.session_id),
+        createdById: Number(row.created_by_id),
+        startedAt: coerceActivityDate(row.started_at),
+        lastActivityAt: coerceActivityDate(row.last_activity_at),
+        tastings: row.tasting_ids.map((id) => {
+          const tasting = tastingsById.get(Number(id));
+          if (!tasting) {
+            throw new Error(
+              `Activity session references missing Tasting ${id}.`,
+            );
+          }
+          return tasting;
+        }),
+      }));
+    },
+    { accessMode: "read only", isolationLevel: "repeatable read" },
   );
-
-  return result.rows.map((row) => ({
-    id: Number(row.session_id),
-    createdById: Number(row.created_by_id),
-    startedAt: coerceActivityDate(row.started_at),
-    lastActivityAt: coerceActivityDate(row.last_activity_at),
-    tastings: row.tasting_ids.map((id) => {
-      const tasting = tastingsById.get(Number(id));
-      if (!tasting) {
-        throw new Error(`Activity session references missing Tasting ${id}.`);
-      }
-      return tasting;
-    }),
-  }));
 }
 
 /** Serializes logical tasting sessions into the shared activity contract. */

--- a/apps/server/src/lib/activityFeed.ts
+++ b/apps/server/src/lib/activityFeed.ts
@@ -1,6 +1,6 @@
 import { db } from "@peated/server/db";
 import type { Collection, Tasting, User } from "@peated/server/db/schema";
-import { collectionBottles } from "@peated/server/db/schema";
+import { collectionBottles, tastings, users } from "@peated/server/db/schema";
 import { getReservedCollection } from "@peated/server/lib/db";
 import { serialize } from "@peated/server/serializers";
 import { CollectionSerializer } from "@peated/server/serializers/collection";
@@ -11,15 +11,28 @@ import type {
   ActivityCollectionAddEntry,
   ActivityEntry,
 } from "@peated/server/types";
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, gte, inArray, lte, sql, type SQL } from "drizzle-orm";
 
 export const COLLECTION_PREVIEW_LIMIT = 4;
 export const SECONDARY_ENTRY_LIMIT_WITH_PRIMARY = 2;
+export const TASTING_SESSION_INACTIVITY_HOURS = 3;
+
+export type ActivityCursor = {
+  page: number;
+  snapshotAt: Date;
+};
+
+export type TastingSessionGroup = {
+  id: number;
+  createdById: number;
+  startedAt: Date;
+  lastActivityAt: Date;
+  tastings: Tasting[];
+};
 
 export type CollectionAddGroup = {
   collection: Collection;
   user: User;
-  bucket: Date | string;
   windowStart: Date;
   windowEnd: Date;
   totalItems: number;
@@ -31,6 +44,29 @@ export type ActivitySourceWindow = {
   secondaryOffset: number;
   secondaryLimit: number;
 };
+
+export function encodeActivityCursor({ page, snapshotAt }: ActivityCursor) {
+  return `${page}:${snapshotAt.getTime()}`;
+}
+
+export function parseActivityCursor(value: string): ActivityCursor | null {
+  const match = /^(\d+):(\d+)$/.exec(value);
+  if (!match) return null;
+
+  const page = Number(match[1]);
+  const timestamp = Number(match[2]);
+  const snapshotAt = new Date(timestamp);
+  if (
+    !Number.isSafeInteger(page) ||
+    page < 1 ||
+    !Number.isSafeInteger(timestamp) ||
+    Number.isNaN(snapshotAt.getTime())
+  ) {
+    return null;
+  }
+
+  return { page, snapshotAt };
+}
 
 /** Coerces database date bucket values into UTC activity timestamps. */
 export function coerceActivityDate(value: Date | string) {
@@ -163,23 +199,179 @@ export function composeActivity({
   };
 }
 
-/** Wraps serialized tastings in the shared activity-entry contract. */
-export async function serializeTastingEntries(
-  tastingRows: Tasting[],
+function markedTastingsSql({
+  userCondition,
+  snapshotAt,
+}: {
+  userCondition: SQL<unknown>;
+  snapshotAt: Date;
+}) {
+  return sql`
+    SELECT
+      ordered_tastings.id,
+      ordered_tastings.created_by_id,
+      ordered_tastings.created_at,
+      CASE
+        WHEN ordered_tastings.previous_created_at IS NULL
+          OR ordered_tastings.created_at - ordered_tastings.previous_created_at
+            > (${TASTING_SESSION_INACTIVITY_HOURS} * INTERVAL '1 hour')
+        THEN 1
+        ELSE 0
+      END AS is_session_start
+    FROM (
+      SELECT
+        ${tastings.id} AS id,
+        ${tastings.createdById} AS created_by_id,
+        ${tastings.createdAt} AS created_at,
+        LAG(${tastings.createdAt}) OVER (
+          PARTITION BY ${tastings.createdById}
+          ORDER BY ${tastings.createdAt}, ${tastings.id}
+        ) AS previous_created_at
+      FROM ${tastings}
+      INNER JOIN ${users} ON ${users.id} = ${tastings.createdById}
+      WHERE ${userCondition}
+        AND ${tastings.createdAt} <= ${snapshotAt}
+    ) ordered_tastings
+  `;
+}
+
+/** Counts logical tasting sessions inside one stable activity snapshot. */
+export async function countTastingSessions({
+  userCondition,
+  snapshotAt,
+}: {
+  userCondition: SQL<unknown>;
+  snapshotAt: Date;
+}) {
+  const result = await db.execute<{ count: string }>(sql`
+    SELECT COALESCE(SUM(marked_tastings.is_session_start), 0) AS count
+    FROM (${markedTastingsSql({ userCondition, snapshotAt })}) marked_tastings
+  `);
+  return Number(result.rows[0]?.count ?? 0);
+}
+
+type TastingSessionRow = {
+  session_id: string;
+  created_by_id: string;
+  started_at: Date | string;
+  last_activity_at: Date | string;
+  tasting_ids: (number | string)[];
+};
+
+/** Returns complete tasting sessions, so feed pagination never splits one. */
+export async function getTastingSessions({
+  userCondition,
+  snapshotAt,
+  offset,
+  limit,
+}: {
+  userCondition: SQL<unknown>;
+  snapshotAt: Date;
+  offset: number;
+  limit: number;
+}): Promise<TastingSessionGroup[]> {
+  if (!limit) return [];
+
+  const result = await db.execute<TastingSessionRow>(sql`
+    WITH marked_tastings AS (
+      ${markedTastingsSql({ userCondition, snapshotAt })}
+    ),
+    numbered_tastings AS (
+      SELECT
+        marked_tastings.*,
+        SUM(marked_tastings.is_session_start) OVER (
+          PARTITION BY marked_tastings.created_by_id
+          ORDER BY marked_tastings.created_at, marked_tastings.id
+          ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+        ) AS session_number
+      FROM marked_tastings
+    ),
+    tasting_sessions AS (
+      SELECT
+        MIN(numbered_tastings.id) AS session_id,
+        numbered_tastings.created_by_id,
+        MIN(numbered_tastings.created_at) AS started_at,
+        MAX(numbered_tastings.created_at) AS last_activity_at,
+        ARRAY_AGG(
+          numbered_tastings.id
+          ORDER BY numbered_tastings.created_at DESC, numbered_tastings.id DESC
+        ) AS tasting_ids
+      FROM numbered_tastings
+      GROUP BY
+        numbered_tastings.created_by_id,
+        numbered_tastings.session_number
+    )
+    SELECT *
+    FROM tasting_sessions
+    ORDER BY tasting_sessions.last_activity_at DESC, tasting_sessions.session_id DESC
+    OFFSET ${offset}
+    LIMIT ${limit}
+  `);
+
+  const tastingIds = result.rows.flatMap((row) => row.tasting_ids.map(Number));
+  const tastingRows = tastingIds.length
+    ? await db.select().from(tastings).where(inArray(tastings.id, tastingIds))
+    : [];
+  const tastingsById = new Map(
+    tastingRows.map((tasting) => [tasting.id, tasting]),
+  );
+
+  return result.rows.map((row) => ({
+    id: Number(row.session_id),
+    createdById: Number(row.created_by_id),
+    startedAt: coerceActivityDate(row.started_at),
+    lastActivityAt: coerceActivityDate(row.last_activity_at),
+    tastings: row.tasting_ids.map((id) => {
+      const tasting = tastingsById.get(Number(id));
+      if (!tasting) {
+        throw new Error(`Activity session references missing Tasting ${id}.`);
+      }
+      return tasting;
+    }),
+  }));
+}
+
+/** Serializes logical tasting sessions into the shared activity contract. */
+export async function serializeTastingSessionEntries(
+  sessions: TastingSessionGroup[],
   currentUser?: User | null,
 ) {
+  const tastingRows = sessions.flatMap((session) => session.tastings);
   const serializedTastings = await serialize(
     TastingSerializer,
     tastingRows,
     currentUser,
   );
-  return tastingRows.map((tasting, index): ActivityEntry => {
+  const serializedById = new Map(
+    tastingRows.map((tasting, index) => [
+      tasting.id,
+      serializedTastings[index]!,
+    ]),
+  );
+
+  return sessions.map((session): ActivityEntry => {
+    const sessionTastings = session.tastings.map((tasting) => {
+      const serialized = serializedById.get(tasting.id);
+      if (!serialized) {
+        throw new Error(
+          `Activity session failed to serialize Tasting ${tasting.id}.`,
+        );
+      }
+      return serialized;
+    });
+    const createdBy = sessionTastings[0]?.createdBy;
+    if (!createdBy) {
+      throw new Error(`Activity session ${session.id} has no tastings.`);
+    }
+
     return {
-      id: `tasting:${tasting.id}`,
-      type: "tasting",
+      id: `tasting_session:${session.createdById}:${session.id}`,
+      type: "tasting_session",
       priority: "primary",
-      createdAt: tasting.createdAt.toISOString(),
-      tasting: serializedTastings[index],
+      startedAt: session.startedAt.toISOString(),
+      lastActivityAt: session.lastActivityAt.toISOString(),
+      createdBy,
+      tastings: sessionTastings,
     };
   });
 }
@@ -255,7 +447,8 @@ export async function serializeCollectionAddEntries({
       .where(
         and(
           eq(collectionBottles.collectionId, group.collection.id),
-          sql`DATE_TRUNC('day', ${collectionBottles.createdAt}) = ${group.bucket}::timestamp`,
+          gte(collectionBottles.createdAt, group.windowStart),
+          lte(collectionBottles.createdAt, group.windowEnd),
         ),
       )
       .orderBy(desc(collectionBottles.createdAt))

--- a/apps/server/src/orpc/routes/activity/list.test.ts
+++ b/apps/server/src/orpc/routes/activity/list.test.ts
@@ -57,15 +57,22 @@ describe("GET /activity", () => {
 
     expect(result.results).toHaveLength(2);
     expect(result.results[0]).toMatchObject({
-      id: `tasting:${tasting.id}`,
-      type: "tasting",
+      id: `tasting_session:${user.id}:${tasting.id}`,
+      type: "tasting_session",
       priority: "primary",
-      tasting: {
-        id: tasting.id,
-        bottle: {
-          id: tasting.bottleId,
-        },
+      startedAt: "2026-01-03T12:30:00.000Z",
+      lastActivityAt: "2026-01-03T12:30:00.000Z",
+      createdBy: {
+        id: user.id,
       },
+      tastings: [
+        {
+          id: tasting.id,
+          bottle: {
+            id: tasting.bottleId,
+          },
+        },
+      ],
     });
     expect(result.results[1]).toMatchObject({
       type: "collection_add",
@@ -121,10 +128,8 @@ describe("GET /activity", () => {
 
     expect(result.results).toHaveLength(1);
     expect(result.results[0]).toMatchObject({
-      type: "tasting",
-      tasting: {
-        id: visibleTasting.id,
-      },
+      type: "tasting_session",
+      tastings: [{ id: visibleTasting.id }],
     });
   });
 
@@ -161,14 +166,12 @@ describe("GET /activity", () => {
     );
 
     expect(result.results.map((entry) => entry.type)).toEqual([
-      "tasting",
+      "tasting_session",
       "collection_add",
     ]);
     expect(result.results[0]).toMatchObject({
-      type: "tasting",
-      tasting: {
-        id: tasting.id,
-      },
+      type: "tasting_session",
+      tastings: [{ id: tasting.id }],
     });
     expect(result.results[1]).toMatchObject({
       type: "collection_add",
@@ -238,10 +241,8 @@ describe("GET /activity", () => {
 
     expect(result.results).toHaveLength(2);
     expect(result.results[0]).toMatchObject({
-      type: "tasting",
-      tasting: {
-        id: friendTasting.id,
-      },
+      type: "tasting_session",
+      tastings: [{ id: friendTasting.id }],
     });
     expect(result.results[1]).toMatchObject({
       type: "collection_add",
@@ -314,10 +315,50 @@ describe("GET /activity", () => {
     });
 
     expect(
-      result.results.filter((entry) => entry.type === "tasting"),
+      result.results.filter((entry) => entry.type === "tasting_session"),
     ).toHaveLength(1);
     expect(
       result.results.filter((entry) => entry.type === "collection_add"),
     ).toHaveLength(2);
+  });
+
+  test("groups each user's nearby tastings despite interleaved activity", async ({
+    fixtures,
+  }) => {
+    const [firstUser, secondUser] = await Promise.all([
+      fixtures.User(),
+      fixtures.User(),
+    ]);
+    const first = await fixtures.Tasting({
+      createdById: firstUser.id,
+      createdAt: new Date("2026-01-03T12:00:00Z"),
+    });
+    const interleaved = await fixtures.Tasting({
+      createdById: secondUser.id,
+      createdAt: new Date("2026-01-03T12:30:00Z"),
+    });
+    const latest = await fixtures.Tasting({
+      createdById: firstUser.id,
+      createdAt: new Date("2026-01-03T13:00:00Z"),
+    });
+
+    const result = await routerClient.activity.list({
+      filter: "global",
+      limit: 10,
+    });
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toMatchObject({
+      type: "tasting_session",
+      createdBy: { id: firstUser.id },
+      startedAt: "2026-01-03T12:00:00.000Z",
+      lastActivityAt: "2026-01-03T13:00:00.000Z",
+      tastings: [{ id: latest.id }, { id: first.id }],
+    });
+    expect(result.results[1]).toMatchObject({
+      type: "tasting_session",
+      createdBy: { id: secondUser.id },
+      tastings: [{ id: interleaved.id }],
+    });
   });
 });

--- a/apps/server/src/orpc/routes/activity/list.ts
+++ b/apps/server/src/orpc/routes/activity/list.ts
@@ -3,21 +3,24 @@ import {
   collectionBottles,
   collections,
   follows,
-  tastings,
   users,
 } from "@peated/server/db/schema";
 import {
   coerceActivityDate,
   composeActivity,
+  countTastingSessions,
+  encodeActivityCursor,
   getActivitySourceWindow,
+  getTastingSessions,
+  parseActivityCursor,
   serializeCollectionAddEntries,
-  serializeTastingEntries,
+  serializeTastingSessionEntries,
   type CollectionAddGroup,
 } from "@peated/server/lib/activityFeed";
 import { procedure } from "@peated/server/orpc";
-import { ActivityEntrySchema, listResponse } from "@peated/server/schemas";
+import { ActivityListResponseSchema } from "@peated/server/schemas";
 import type { SQL } from "drizzle-orm";
-import { and, desc, eq, or, sql } from "drizzle-orm";
+import { and, desc, eq, lte, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 // Main activity is read-time composition over authoritative source tables. The
@@ -29,7 +32,6 @@ type ActivityFilter = "global" | "friends" | "local";
 type CollectionAddGroupRow = {
   collection: typeof collections.$inferSelect;
   user: typeof users.$inferSelect;
-  bucket: Date | string;
   windowStart: Date | string;
   windowEnd: Date | string;
   totalItems: string;
@@ -64,7 +66,7 @@ function visibleActivityUserCondition({
     );
   }
 
-  return or(...visibleUsers);
+  return or(...visibleUsers)!;
 }
 
 export default procedure
@@ -80,16 +82,21 @@ export default procedure
     z
       .object({
         filter: z.enum(["global", "friends", "local"]).default("global"),
-        cursor: z.coerce.number().gte(1).default(1),
+        cursor: z
+          .string()
+          .max(64)
+          .refine((value) => parseActivityCursor(value) !== null, {
+            message: "Invalid activity cursor.",
+          })
+          .optional(),
         limit: z.coerce.number().gte(1).lte(100).default(10),
       })
       .default({
         filter: "global",
-        cursor: 1,
         limit: 10,
       }),
   )
-  .output(listResponse(ActivityEntrySchema))
+  .output(ActivityListResponseSchema)
   .handler(async function ({ input, context, errors }) {
     if (input.filter === "friends" && !context.user) {
       throw errors.UNAUTHORIZED();
@@ -99,17 +106,17 @@ export default procedure
       filter: input.filter,
       currentUserId: context.user?.id,
     });
+    const activityCursor = input.cursor
+      ? parseActivityCursor(input.cursor)!
+      : { page: 1, snapshotAt: new Date() };
     const collectionBucket = sql<Date>`DATE_TRUNC('day', ${collectionBottles.createdAt})`;
     const collectionGroupCreatedAt = sql<Date>`MAX(${collectionBottles.createdAt})`;
 
-    const [primaryCountRows, secondaryCountResult] = await Promise.all([
-      db
-        .select({
-          count: sql<string>`COUNT(${tastings.id})`,
-        })
-        .from(tastings)
-        .innerJoin(users, eq(users.id, tastings.createdById))
-        .where(userCondition),
+    const [totalPrimary, secondaryCountResult] = await Promise.all([
+      countTastingSessions({
+        userCondition,
+        snapshotAt: activityCursor.snapshotAt,
+      }),
       db.execute<{ count: string }>(sql`
         SELECT COUNT(*) as count
         FROM (
@@ -120,33 +127,30 @@ export default procedure
           INNER JOIN ${users}
             ON ${users.id} = ${collections.createdById}
           WHERE ${userCondition}
+            AND ${collectionBottles.createdAt} <= ${activityCursor.snapshotAt}
           GROUP BY ${users.id}, ${collections.id}, DATE_TRUNC('day', ${collectionBottles.createdAt})
         ) activity_groups
       `),
     ]);
-    const totalPrimary = Number(primaryCountRows[0]?.count ?? 0);
     const totalSecondary = Number(secondaryCountResult.rows[0]?.count ?? 0);
     const sourceWindow = getActivitySourceWindow({
-      cursor: input.cursor,
+      cursor: activityCursor.page,
       limit: input.limit,
       totalPrimary,
       totalSecondary,
     });
 
     const [tastingRows, collectionGroupRows] = await Promise.all([
-      db
-        .select({ tasting: tastings })
-        .from(tastings)
-        .innerJoin(users, eq(users.id, tastings.createdById))
-        .where(userCondition)
-        .orderBy(desc(tastings.createdAt))
-        .limit(sourceWindow.primaryLimit)
-        .offset(sourceWindow.primaryOffset),
+      getTastingSessions({
+        userCondition,
+        snapshotAt: activityCursor.snapshotAt,
+        limit: sourceWindow.primaryLimit,
+        offset: sourceWindow.primaryOffset,
+      }),
       db
         .select({
           collection: collections,
           user: users,
-          bucket: collectionBucket,
           windowStart: sql<Date>`MIN(${collectionBottles.createdAt})`,
           windowEnd: sql<Date>`MAX(${collectionBottles.createdAt})`,
           totalItems: sql<string>`COUNT(${collectionBottles.id})`,
@@ -157,15 +161,20 @@ export default procedure
           eq(collections.id, collectionBottles.collectionId),
         )
         .innerJoin(users, eq(users.id, collections.createdById))
-        .where(and(userCondition))
+        .where(
+          and(
+            userCondition,
+            lte(collectionBottles.createdAt, activityCursor.snapshotAt),
+          ),
+        )
         .groupBy(users.id, collections.id, collectionBucket)
         .orderBy(desc(collectionGroupCreatedAt))
         .limit(sourceWindow.secondaryLimit)
         .offset(sourceWindow.secondaryOffset),
     ]);
 
-    const primaryEntries = await serializeTastingEntries(
-      tastingRows.map((row) => row.tasting),
+    const primaryEntries = await serializeTastingSessionEntries(
+      tastingRows,
       context.user,
     );
     const secondaryEntries = await serializeCollectionAddEntries({
@@ -173,7 +182,6 @@ export default procedure
         (row: CollectionAddGroupRow): CollectionAddGroup => ({
           collection: row.collection,
           user: row.user,
-          bucket: row.bucket,
           windowStart: coerceActivityDate(row.windowStart),
           windowEnd: coerceActivityDate(row.windowEnd),
           totalItems: Number(row.totalItems),
@@ -194,8 +202,19 @@ export default procedure
     return {
       results: activity.results,
       rel: {
-        nextCursor: activity.hasNext ? input.cursor + 1 : null,
-        prevCursor: input.cursor > 1 ? input.cursor - 1 : null,
+        nextCursor: activity.hasNext
+          ? encodeActivityCursor({
+              page: activityCursor.page + 1,
+              snapshotAt: activityCursor.snapshotAt,
+            })
+          : null,
+        prevCursor:
+          activityCursor.page > 1
+            ? encodeActivityCursor({
+                page: activityCursor.page - 1,
+                snapshotAt: activityCursor.snapshotAt,
+              })
+            : null,
       },
     };
   });

--- a/apps/server/src/orpc/routes/users/activity/list.test.ts
+++ b/apps/server/src/orpc/routes/users/activity/list.test.ts
@@ -30,13 +30,51 @@ describe("GET /users/:user/activity", () => {
 
     expect(result.results).toHaveLength(1);
     expect(result.results[0]).toMatchObject({
-      id: `tasting:${tasting.id}`,
-      type: "tasting",
+      id: `tasting_session:${defaults.user.id}:${tasting.id}`,
+      type: "tasting_session",
       priority: "primary",
-      createdAt: "2026-01-03T12:00:00.000Z",
-      tasting: {
-        id: tasting.id,
+      startedAt: "2026-01-03T12:00:00.000Z",
+      lastActivityAt: "2026-01-03T12:00:00.000Z",
+      createdBy: {
+        id: defaults.user.id,
       },
+      tastings: [{ id: tasting.id }],
+    });
+  });
+
+  test("groups nearby tastings and starts a new session after inactivity", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const first = await fixtures.Tasting({
+      createdById: defaults.user.id,
+      createdAt: new Date("2026-01-03T12:00:00Z"),
+    });
+    const second = await fixtures.Tasting({
+      createdById: defaults.user.id,
+      createdAt: new Date("2026-01-03T14:00:00Z"),
+    });
+    const third = await fixtures.Tasting({
+      createdById: defaults.user.id,
+      createdAt: new Date("2026-01-03T18:00:00Z"),
+    });
+
+    const result = await routerClient.users.activity.list({
+      user: defaults.user.username,
+    });
+
+    expect(result.results).toHaveLength(2);
+    expect(result.results[0]).toMatchObject({
+      type: "tasting_session",
+      startedAt: "2026-01-03T18:00:00.000Z",
+      lastActivityAt: "2026-01-03T18:00:00.000Z",
+      tastings: [{ id: third.id }],
+    });
+    expect(result.results[1]).toMatchObject({
+      type: "tasting_session",
+      startedAt: "2026-01-03T12:00:00.000Z",
+      lastActivityAt: "2026-01-03T14:00:00.000Z",
+      tastings: [{ id: second.id }, { id: first.id }],
     });
   });
 
@@ -47,7 +85,9 @@ describe("GET /users/:user/activity", () => {
     for (let i = 0; i < 12; i++) {
       await fixtures.Tasting({
         createdById: defaults.user.id,
-        createdAt: new Date(`2026-01-03T${String(i).padStart(2, "0")}:00:00Z`),
+        createdAt: new Date(
+          new Date("2026-01-01T00:00:00Z").getTime() + i * 4 * 60 * 60 * 1000,
+        ),
       });
     }
 
@@ -55,17 +95,24 @@ describe("GET /users/:user/activity", () => {
       user: defaults.user.username,
       limit: 10,
     });
+    expect(firstPage.results).toHaveLength(10);
+    expect(firstPage.rel.nextCursor).toEqual(expect.any(String));
+
+    // New activity must not shift the offset inside an existing feed snapshot.
+    await fixtures.Tasting({
+      createdById: defaults.user.id,
+      createdAt: new Date(Date.now() + 60_000),
+    });
+
     const secondPage = await routerClient.users.activity.list({
       user: defaults.user.username,
-      cursor: firstPage.rel.nextCursor ?? 2,
+      cursor: firstPage.rel.nextCursor!,
       limit: 10,
     });
 
-    expect(firstPage.results).toHaveLength(10);
-    expect(firstPage.results.every((entry) => entry.type === "tasting")).toBe(
-      true,
-    );
-    expect(firstPage.rel.nextCursor).toBe(2);
+    expect(
+      firstPage.results.every((entry) => entry.type === "tasting_session"),
+    ).toBe(true);
     expect(secondPage.results).toHaveLength(2);
     expect(secondPage.rel.nextCursor).toBeNull();
   });
@@ -318,8 +365,8 @@ describe("GET /users/:user/activity", () => {
     });
 
     expect(
-      result.results.filter((entry) => entry.type === "tasting"),
-    ).toHaveLength(3);
+      result.results.filter((entry) => entry.type === "tasting_session"),
+    ).toHaveLength(1);
     expect(
       result.results.filter((entry) => entry.type === "collection_add"),
     ).toHaveLength(2);
@@ -353,17 +400,17 @@ describe("GET /users/:user/activity", () => {
     });
     const secondPage = await routerClient.users.activity.list({
       user: defaults.user.username,
-      cursor: firstPage.rel.nextCursor ?? 2,
+      cursor: firstPage.rel.nextCursor!,
       limit: 3,
     });
 
     expect(
-      firstPage.results.filter((entry) => entry.type === "tasting"),
+      firstPage.results.filter((entry) => entry.type === "tasting_session"),
     ).toHaveLength(1);
     expect(
       firstPage.results.filter((entry) => entry.type === "collection_add"),
     ).toHaveLength(2);
-    expect(firstPage.rel.nextCursor).toBe(2);
+    expect(firstPage.rel.nextCursor).toEqual(expect.any(String));
     expect(secondPage.results).toHaveLength(2);
     expect(
       secondPage.results.every((entry) => entry.type === "collection_add"),
@@ -396,13 +443,13 @@ describe("GET /users/:user/activity", () => {
     });
     const secondPage = await routerClient.users.activity.list({
       user: defaults.user.username,
-      cursor: firstPage.rel.nextCursor ?? 2,
+      cursor: firstPage.rel.nextCursor!,
       limit: 1,
     });
 
     expect(firstPage.results).toHaveLength(1);
-    expect(firstPage.results[0].type).toBe("tasting");
-    expect(firstPage.rel.nextCursor).toBe(2);
+    expect(firstPage.results[0].type).toBe("tasting_session");
+    expect(firstPage.rel.nextCursor).toEqual(expect.any(String));
     expect(secondPage.results).toHaveLength(1);
     expect(secondPage.results[0].type).toBe("collection_add");
     expect(secondPage.rel.nextCursor).toBeNull();

--- a/apps/server/src/orpc/routes/users/activity/list.ts
+++ b/apps/server/src/orpc/routes/users/activity/list.ts
@@ -2,28 +2,28 @@ import { db } from "@peated/server/db";
 import {
   collectionBottles,
   collections,
-  tastings,
+  users,
 } from "@peated/server/db/schema";
 import {
   coerceActivityDate,
   composeActivity,
+  countTastingSessions,
+  encodeActivityCursor,
   getActivitySourceWindow,
+  getTastingSessions,
+  parseActivityCursor,
   serializeCollectionAddEntries,
-  serializeTastingEntries,
+  serializeTastingSessionEntries,
   type CollectionAddGroup,
 } from "@peated/server/lib/activityFeed";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
 import { procedure } from "@peated/server/orpc";
-import {
-  ProfileActivityEntrySchema,
-  listResponse,
-} from "@peated/server/schemas";
-import { and, desc, eq, sql } from "drizzle-orm";
+import { ActivityListResponseSchema } from "@peated/server/schemas";
+import { and, desc, eq, lte, sql } from "drizzle-orm";
 import { z } from "zod";
 
 type CollectionAddGroupRow = {
   collection: typeof collections.$inferSelect;
-  bucket: Date | string;
   windowStart: Date | string;
   windowEnd: Date | string;
   totalItems: string;
@@ -41,11 +41,17 @@ export default procedure
   .input(
     z.object({
       user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
-      cursor: z.coerce.number().gte(1).default(1),
+      cursor: z
+        .string()
+        .max(64)
+        .refine((value) => parseActivityCursor(value) !== null, {
+          message: "Invalid activity cursor.",
+        })
+        .optional(),
       limit: z.coerce.number().gte(1).lte(100).default(10),
     }),
   )
-  .output(listResponse(ProfileActivityEntrySchema))
+  .output(ActivityListResponseSchema)
   .handler(async function ({ input, context, errors }) {
     const user = await getUserFromId(db, input.user, context.user);
     if (!user) {
@@ -63,15 +69,17 @@ export default procedure
       });
     }
 
+    const activityCursor = input.cursor
+      ? parseActivityCursor(input.cursor)!
+      : { page: 1, snapshotAt: new Date() };
+    const userCondition = eq(users.id, user.id);
     const collectionBucket = sql<Date>`DATE_TRUNC('day', ${collectionBottles.createdAt})`;
     const collectionGroupCreatedAt = sql<Date>`MAX(${collectionBottles.createdAt})`;
-    const [primaryCountRows, secondaryCountResult] = await Promise.all([
-      db
-        .select({
-          count: sql<string>`COUNT(${tastings.id})`,
-        })
-        .from(tastings)
-        .where(eq(tastings.createdById, user.id)),
+    const [totalPrimary, secondaryCountResult] = await Promise.all([
+      countTastingSessions({
+        userCondition,
+        snapshotAt: activityCursor.snapshotAt,
+      }),
       db.execute<{ count: string }>(sql`
         SELECT COUNT(*) as count
         FROM (
@@ -80,31 +88,29 @@ export default procedure
           INNER JOIN ${collections}
             ON ${collections.id} = ${collectionBottles.collectionId}
             AND ${collections.createdById} = ${user.id}
+          WHERE ${collectionBottles.createdAt} <= ${activityCursor.snapshotAt}
           GROUP BY ${collections.id}, DATE_TRUNC('day', ${collectionBottles.createdAt})
         ) activity_groups
       `),
     ]);
-    const totalPrimary = Number(primaryCountRows[0]?.count ?? 0);
     const totalSecondary = Number(secondaryCountResult.rows[0]?.count ?? 0);
     const sourceWindow = getActivitySourceWindow({
-      cursor: input.cursor,
+      cursor: activityCursor.page,
       limit: input.limit,
       totalPrimary,
       totalSecondary,
     });
 
     const [tastingRows, collectionGroupRows] = await Promise.all([
-      db
-        .select()
-        .from(tastings)
-        .where(eq(tastings.createdById, user.id))
-        .orderBy(desc(tastings.createdAt))
-        .limit(sourceWindow.primaryLimit)
-        .offset(sourceWindow.primaryOffset),
+      getTastingSessions({
+        userCondition,
+        snapshotAt: activityCursor.snapshotAt,
+        limit: sourceWindow.primaryLimit,
+        offset: sourceWindow.primaryOffset,
+      }),
       db
         .select({
           collection: collections,
-          bucket: collectionBucket,
           windowStart: sql<Date>`MIN(${collectionBottles.createdAt})`,
           windowEnd: sql<Date>`MAX(${collectionBottles.createdAt})`,
           totalItems: sql<string>`COUNT(${collectionBottles.id})`,
@@ -117,13 +123,14 @@ export default procedure
             eq(collections.createdById, user.id),
           ),
         )
+        .where(lte(collectionBottles.createdAt, activityCursor.snapshotAt))
         .groupBy(collections.id, collectionBucket)
         .orderBy(desc(collectionGroupCreatedAt))
         .limit(sourceWindow.secondaryLimit)
         .offset(sourceWindow.secondaryOffset),
     ]);
 
-    const primaryEntries = await serializeTastingEntries(
+    const primaryEntries = await serializeTastingSessionEntries(
       tastingRows,
       context.user,
     );
@@ -132,7 +139,6 @@ export default procedure
         (row: CollectionAddGroupRow): CollectionAddGroup => ({
           collection: row.collection,
           user,
-          bucket: row.bucket,
           windowStart: coerceActivityDate(row.windowStart),
           windowEnd: coerceActivityDate(row.windowEnd),
           totalItems: Number(row.totalItems),
@@ -153,8 +159,19 @@ export default procedure
     return {
       results: activity.results,
       rel: {
-        nextCursor: activity.hasNext ? input.cursor + 1 : null,
-        prevCursor: input.cursor > 1 ? input.cursor - 1 : null,
+        nextCursor: activity.hasNext
+          ? encodeActivityCursor({
+              page: activityCursor.page + 1,
+              snapshotAt: activityCursor.snapshotAt,
+            })
+          : null,
+        prevCursor:
+          activityCursor.page > 1
+            ? encodeActivityCursor({
+                page: activityCursor.page - 1,
+                snapshotAt: activityCursor.snapshotAt,
+              })
+            : null,
       },
     };
   });

--- a/apps/server/src/schemas/profileActivity.ts
+++ b/apps/server/src/schemas/profileActivity.ts
@@ -3,16 +3,27 @@ import { CollectionBottleSchema, CollectionSchema } from "./collections";
 import { TastingSchema } from "./tastings";
 import { UserSchema } from "./users";
 
-export const ActivityTastingEntrySchema = z.object({
+export const ActivityTastingSessionEntrySchema = z.object({
   id: z.string().describe("Stable activity entry identifier"),
-  type: z.literal("tasting"),
+  type: z.literal("tasting_session"),
   priority: z.literal("primary"),
-  createdAt: z
+  startedAt: z
     .string()
     .datetime()
     .readonly()
-    .describe("Timestamp used to order this activity entry"),
-  tasting: TastingSchema.describe("Tasting represented by this activity entry"),
+    .describe("Timestamp of the first tasting in this session"),
+  lastActivityAt: z
+    .string()
+    .datetime()
+    .readonly()
+    .describe("Timestamp of the latest tasting in this session"),
+  createdBy: UserSchema.readonly().describe(
+    "User who created the tastings in this session",
+  ),
+  tastings: z
+    .array(TastingSchema)
+    .min(1)
+    .describe("Tastings represented by this activity session"),
 });
 
 export const ActivityCollectionSchema = CollectionSchema.extend({
@@ -56,11 +67,28 @@ export const ActivityCollectionAddEntrySchema = z.object({
 });
 
 export const ActivityEntrySchema = z.discriminatedUnion("type", [
-  ActivityTastingEntrySchema,
+  ActivityTastingSessionEntrySchema,
   ActivityCollectionAddEntrySchema,
 ]);
 
-export const ProfileTastingActivitySchema = ActivityTastingEntrySchema;
+export const ActivityCursorSchema = z.object({
+  nextCursor: z
+    .string()
+    .nullable()
+    .describe("Opaque cursor for the next page of activity"),
+  prevCursor: z
+    .string()
+    .nullable()
+    .describe("Opaque cursor for the previous page of activity"),
+});
+
+export const ActivityListResponseSchema = z.object({
+  results: z.array(ActivityEntrySchema),
+  rel: ActivityCursorSchema,
+});
+
+export const ProfileTastingSessionActivitySchema =
+  ActivityTastingSessionEntrySchema;
 export const ProfileCollectionActivityCollectionSchema =
   ActivityCollectionSchema;
 export const ProfileCollectionAddActivitySchema =

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -2,6 +2,7 @@ import type { z } from "zod";
 import type {
   ActivityCollectionAddEntrySchema,
   ActivityEntrySchema,
+  ActivityTastingSessionEntrySchema,
   BadgeAwardSchema,
   BadgeCheckSchema,
   BadgeCheckTypeEnum,
@@ -37,7 +38,7 @@ import type {
   PointSchema,
   ProfileActivityEntrySchema,
   ProfileCollectionAddActivitySchema,
-  ProfileTastingActivitySchema,
+  ProfileTastingSessionActivitySchema,
   RegionSchema,
   ReviewSchema,
   ServingStyleEnum,
@@ -70,12 +71,15 @@ export type ActivityEntry = z.infer<typeof ActivityEntrySchema>;
 export type ActivityCollectionAddEntry = z.infer<
   typeof ActivityCollectionAddEntrySchema
 >;
+export type ActivityTastingSessionEntry = z.infer<
+  typeof ActivityTastingSessionEntrySchema
+>;
 export type ProfileActivityEntry = z.infer<typeof ProfileActivityEntrySchema>;
 export type ProfileCollectionAddActivity = z.infer<
   typeof ProfileCollectionAddActivitySchema
 >;
-export type ProfileTastingActivity = z.infer<
-  typeof ProfileTastingActivitySchema
+export type ProfileTastingSessionActivity = z.infer<
+  typeof ProfileTastingSessionActivitySchema
 >;
 
 export type Badge = z.infer<typeof BadgeSchema>;

--- a/apps/web/e2e/activity-feed.spec.ts
+++ b/apps/web/e2e/activity-feed.spec.ts
@@ -1,7 +1,12 @@
 import { expect, test } from "@playwright/test";
 
 import { expectNoHorizontalOverflow } from "./assertions";
-import { homeBottle, tastingNotes, testUser } from "./rpc-fixtures.mjs";
+import {
+  existingBottle,
+  homeBottle,
+  tastingNotes,
+  testUser,
+} from "./rpc-fixtures.mjs";
 
 test.describe("activity feed", () => {
   test("renders tasting and Library addition activity", async ({ page }) => {
@@ -17,6 +22,19 @@ test.describe("activity feed", () => {
         exact: true,
       }),
     ).toBeVisible();
+    await expect(page.getByText(tastingNotes)).toBeVisible();
+    await expect(page.getByText("1/2")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Previous tasting" }),
+    ).toBeDisabled();
+    await page.getByRole("button", { name: "Next tasting" }).click();
+    await expect(page.getByText("2/2")).toBeVisible();
+    await expect(page.getByText(tastingNotes)).toBeHidden();
+    await expect(
+      page.getByRole("link", { name: existingBottle.group.fullName }),
+    ).toBeVisible();
+    await page.getByRole("button", { name: "Previous tasting" }).click();
+    await expect(page.getByText("1/2")).toBeVisible();
     await expect(page.getByText(tastingNotes)).toBeVisible();
     const collectionAddRow = page.locator("li").filter({
       hasText: `${testUser.username} added 1 bottle to Library`,
@@ -38,8 +56,54 @@ test.describe("activity feed", () => {
     });
 
     await expect(page.getByText(tastingNotes)).toBeVisible();
+    await expect(page.getByText("1/2")).toBeVisible();
     await expect(page.getByText("Personal Favorites")).toHaveCount(0);
     await expect(page.getByRole("img", { name: "Favorite" })).toHaveCount(0);
     await expectNoHorizontalOverflow(page);
+  });
+
+  test("supports swiping between tastings on touch screens", async ({
+    page,
+  }, testInfo) => {
+    test.skip(!testInfo.project.name.includes("mobile"), "Mobile-only flow");
+
+    await page.goto("/", { waitUntil: "commit" });
+    await expect(page.getByText("1/2")).toBeVisible();
+
+    await page.getByTestId("tasting-session-slides").evaluate((element) => {
+      const start = new Touch({
+        identifier: 1,
+        target: element,
+        clientX: 300,
+        clientY: 200,
+      });
+      const end = new Touch({
+        identifier: 1,
+        target: element,
+        clientX: 50,
+        clientY: 200,
+      });
+      element.dispatchEvent(
+        new TouchEvent("touchstart", {
+          bubbles: true,
+          cancelable: true,
+          touches: [start],
+          changedTouches: [start],
+        }),
+      );
+      element.dispatchEvent(
+        new TouchEvent("touchend", {
+          bubbles: true,
+          cancelable: true,
+          touches: [],
+          changedTouches: [end],
+        }),
+      );
+    });
+
+    await expect(page.getByText("2/2")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: existingBottle.group.fullName }),
+    ).toBeVisible();
   });
 });

--- a/apps/web/e2e/home-feed.spec.ts
+++ b/apps/web/e2e/home-feed.spec.ts
@@ -1,11 +1,10 @@
 import { expect, test } from "@playwright/test";
 
-import { expectNoHorizontalOverflow } from "./assertions";
-import { homeAwards, homeBottle, tastingNotes } from "./rpc-fixtures.mjs";
+import { homeBottle } from "./rpc-fixtures.mjs";
 
 test("home feed favors recognizable bottle names over exact release names", async ({
   page,
-}, testInfo) => {
+}) => {
   await page.goto("/", { waitUntil: "commit" });
 
   await expect(page.getByText(homeBottle.group.fullName).first()).toBeVisible();
@@ -13,52 +12,5 @@ test("home feed favors recognizable bottle names over exact release names", asyn
     page.getByText(homeBottle.fullName, { exact: true }),
   ).toHaveCount(0);
   await expect(page.getByTitle(homeBottle.fullName).first()).toBeVisible();
-  await expect(page.getByText(tastingNotes)).toBeVisible();
   await expect(page.getByText("Single Cask", { exact: true })).toHaveCount(0);
-
-  const tastingCard = page
-    .locator("li")
-    .filter({ hasText: tastingNotes })
-    .first();
-  const [bottleNameBox, notesBox, ratingBox] = await Promise.all([
-    tastingCard
-      .getByRole("link", { name: homeBottle.group.fullName })
-      .boundingBox(),
-    tastingCard.getByText(tastingNotes, { exact: true }).boundingBox(),
-    tastingCard.getByText("Rating", { exact: true }).boundingBox(),
-  ]);
-  expect(bottleNameBox).not.toBeNull();
-  expect(notesBox).not.toBeNull();
-  expect(ratingBox).not.toBeNull();
-  expect(
-    notesBox!.y - (bottleNameBox!.y + bottleNameBox!.height),
-  ).toBeLessThanOrEqual(12);
-  expect(ratingBox!.y - (notesBox!.y + notesBox!.height)).toBeLessThanOrEqual(
-    12,
-  );
-
-  const awardRows = homeAwards.map((award) =>
-    page.getByTitle(award.badge.name, { exact: true }),
-  );
-  await expect(awardRows[0]).toBeVisible();
-  await expect(awardRows[1]).toBeVisible();
-  const [firstAwardBox, secondAwardBox] = await Promise.all(
-    awardRows.map((row) => row.boundingBox()),
-  );
-  expect(firstAwardBox).not.toBeNull();
-  expect(secondAwardBox).not.toBeNull();
-  expect(
-    secondAwardBox!.y - (firstAwardBox!.y + firstAwardBox!.height),
-  ).toBeLessThanOrEqual(1);
-
-  await expectNoHorizontalOverflow(page);
-  if (process.env.PEATED_VISUAL_DIR) {
-    await page.screenshot({
-      path: `${process.env.PEATED_VISUAL_DIR}/peated-home-page-${testInfo.project.name}.png`,
-      fullPage: false,
-    });
-    await page.locator("ul.mt-1").screenshot({
-      path: `${process.env.PEATED_VISUAL_DIR}/peated-home-${testInfo.project.name}.png`,
-    });
-  }
 });

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -153,7 +153,7 @@ async function handleRpcRequest({ request, response, url }) {
         response,
         input?.cursor
           ? buildActivity()
-          : buildFavoriteActivity({ nextCursor: 1 }),
+          : buildFavoriteActivity({ nextCursor: "2:1780833600000" }),
       );
       return true;
     case "users/activity/list":
@@ -161,7 +161,7 @@ async function handleRpcRequest({ request, response, url }) {
         response,
         input?.cursor
           ? buildActivity()
-          : buildFavoriteActivity({ nextCursor: 1 }),
+          : buildFavoriteActivity({ nextCursor: "2:1780833600000" }),
       );
       return true;
     case "entities/list":

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -711,10 +711,17 @@ export const homeAwards = [
 ];
 
 export function buildActivity({
-  tasting = buildTasting({
-    bottle: homeBottle,
-    awards: homeAwards,
-  }),
+  tastingSession = [
+    buildTasting({
+      bottle: homeBottle,
+      awards: homeAwards,
+    }),
+    buildTasting({
+      id: createdTastingId + 1,
+      bottle: existingBottle,
+      notes: "A second tasting from the same session.",
+    }),
+  ],
   collectionBottle = buildCollectionBottle({
     id: 9701,
     bottle: /** @type {CollectionBottle["bottle"]} */ (homeBottle),
@@ -723,11 +730,13 @@ export function buildActivity({
   return {
     results: [
       {
-        id: `tasting:${tasting.id}`,
-        type: "tasting",
+        id: `tasting_session:${testUser.id}:${createdTastingId}`,
+        type: "tasting_session",
         priority: "primary",
-        createdAt: tasting.createdAt,
-        tasting,
+        startedAt: timestamp,
+        lastActivityAt: timestamp,
+        createdBy: testUser,
+        tastings: tastingSession,
       },
       {
         id: "collection_add:9101:9601:1780833600000",

--- a/apps/web/src/app/(default)/users/[username]/(tabs)/activity/page.tsx
+++ b/apps/web/src/app/(default)/users/[username]/(tabs)/activity/page.tsx
@@ -6,6 +6,7 @@ import ActivityList, {
   filterFavoriteActivity,
 } from "@peated/web/components/activityList";
 import EmptyActivity from "@peated/web/components/emptyActivity";
+import { profileActivityQueryKeys } from "@peated/web/lib/activityQueryKeys";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { queryOptions, useSuspenseQuery } from "@tanstack/react-query";
 
@@ -20,10 +21,10 @@ export default function UserActivityPage(props: {
   const orpc = useORPC();
   const { data: activity } = useSuspenseQuery(
     queryOptions({
-      queryKey: ["profile-activity", username, "favorites-hidden"],
+      queryKey: profileActivityQueryKeys.list(username),
       queryFn: async () => {
         const results = [];
-        let cursor: number | undefined;
+        let cursor: string | undefined;
         let fetchedPageCount = 0;
 
         do {

--- a/apps/web/src/components/activityFeed.tsx
+++ b/apps/web/src/components/activityFeed.tsx
@@ -49,7 +49,7 @@ export default function ActivityFeed({
         results: filterFavoriteActivity(page.results),
       };
     },
-    initialPageParam: undefined as number | undefined,
+    initialPageParam: undefined as string | undefined,
     staleTime: Infinity,
     initialData: () => {
       return {

--- a/apps/web/src/components/activityList.tsx
+++ b/apps/web/src/components/activityList.tsx
@@ -3,9 +3,7 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import BottleIdentity from "@peated/web/components/bottleIdentity";
 import Link from "@peated/web/components/link";
-import { AnimatePresence } from "framer-motion";
-import { useState } from "react";
-import TastingListItem from "./tastingListItem";
+import TastingSessionListItem from "./tastingSessionListItem";
 import TimeSince from "./timeSince";
 import UserAvatar from "./userAvatar";
 
@@ -131,36 +129,23 @@ export default function ActivityList({
 }: {
   values: ActivityListResult["results"];
 }) {
-  const [deletedTastingIds, setDeletedTastingIds] = useState<number[]>([]);
-
   return (
     <ul className="mt-1">
-      <AnimatePresence>
-        {values.map((activity) => {
-          switch (activity.type) {
-            case "tasting":
-              if (deletedTastingIds.includes(activity.tasting.id)) {
-                return null;
-              }
-              return (
-                <TastingListItem
-                  key={activity.id}
-                  tasting={activity.tasting}
-                  onDelete={(tasting) => {
-                    setDeletedTastingIds((ids) => [...ids, tasting.id]);
-                  }}
-                />
-              );
-            case "collection_add":
-              return (
-                <CollectionAddActivityItem
-                  key={activity.id}
-                  activity={activity}
-                />
-              );
-          }
-        })}
-      </AnimatePresence>
+      {values.map((activity) => {
+        switch (activity.type) {
+          case "tasting_session":
+            return (
+              <TastingSessionListItem key={activity.id} session={activity} />
+            );
+          case "collection_add":
+            return (
+              <CollectionAddActivityItem
+                key={activity.id}
+                activity={activity}
+              />
+            );
+        }
+      })}
     </ul>
   );
 }

--- a/apps/web/src/components/tastingListItem.tsx
+++ b/apps/web/src/components/tastingListItem.tsx
@@ -74,19 +74,21 @@ function ImageSkeleton() {
   );
 }
 
-export default function TastingListItem({
-  tasting,
-  noBottle,
-  onDelete,
-  onToast,
-  noCommentAction = false,
-}: {
+type TastingContentProps = {
   tasting: Tasting;
   noBottle?: boolean;
   onDelete?: (tasting: Tasting) => void;
   onToast?: (tasting: Tasting) => void;
   noCommentAction?: boolean;
-}) {
+};
+
+export function TastingContent({
+  tasting,
+  noBottle,
+  onDelete,
+  onToast,
+  noCommentAction = false,
+}: TastingContentProps) {
   const { user } = useAuth();
 
   const pathname = usePathname();
@@ -110,27 +112,7 @@ export default function TastingListItem({
   const canToast = Boolean(user && !hasToasted && !isTaster);
 
   return (
-    <li className="-mt-1 flex flex-col gap-y-4 overflow-hidden border border-slate-800 bg-gradient-to-r from-slate-950 to-slate-900">
-      <div className="flex items-center space-x-4 px-3 pt-3 lg:px-5 lg:pt-5">
-        <UserAvatar size={32} user={tasting.createdBy} />
-        <div className="flex-auto space-y-1 font-semibold">
-          <Link
-            href={`/users/${tasting.createdBy.username}`}
-            className="truncate hover:underline"
-          >
-            {tasting.createdBy.username}
-          </Link>
-        </div>
-        <div className="flex flex-col items-end">
-          <Link href={`/tastings/${tasting.id}`} className="hover:underline">
-            <TimeSince
-              className="font-muted block text-sm"
-              date={tasting.createdAt}
-            />
-          </Link>
-        </div>
-      </div>
-
+    <>
       {!noBottle && (
         <div className="px-3 sm:px-5">
           <TastingBottleIdentity bottle={tasting.bottle} variant="inline" />
@@ -335,6 +317,38 @@ export default function TastingListItem({
           </Menu>
         )}
       </aside>
+    </>
+  );
+}
+
+export default function TastingListItem(props: TastingContentProps) {
+  const { tasting } = props;
+
+  return (
+    <li className="-mt-1 overflow-hidden border border-slate-800 bg-gradient-to-r from-slate-950 to-slate-900">
+      <article className="flex flex-col gap-y-4">
+        <div className="flex items-center space-x-4 px-3 pt-3 lg:px-5 lg:pt-5">
+          <UserAvatar size={32} user={tasting.createdBy} />
+          <div className="flex-auto space-y-1 font-semibold">
+            <Link
+              href={`/users/${tasting.createdBy.username}`}
+              className="truncate hover:underline"
+            >
+              {tasting.createdBy.username}
+            </Link>
+          </div>
+          <div className="flex flex-col items-end">
+            <Link href={`/tastings/${tasting.id}`} className="hover:underline">
+              <TimeSince
+                className="font-muted block text-sm"
+                date={tasting.createdAt}
+              />
+            </Link>
+          </div>
+        </div>
+
+        <TastingContent {...props} />
+      </article>
     </li>
   );
 }

--- a/apps/web/src/components/tastingSessionListItem.tsx
+++ b/apps/web/src/components/tastingSessionListItem.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/20/solid";
+import type { ActivityTastingSessionEntry } from "@peated/server/types";
+import { useQueryClient } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+import { profileActivityQueryKeys } from "../lib/activityQueryKeys";
+import { useORPC } from "../lib/orpc/context";
+import Link from "./link";
+import TastingListItem, { TastingContent } from "./tastingListItem";
+import TimeSince from "./timeSince";
+import UserAvatar from "./userAvatar";
+
+const carouselButtonClassName =
+  "inline-flex h-10 w-10 items-center justify-center border border-slate-700 bg-slate-900 text-white transition-colors hover:bg-slate-800 focus-visible:z-10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-peated disabled:cursor-default disabled:text-slate-600";
+
+export default function TastingSessionListItem({
+  session,
+}: {
+  session: ActivityTastingSessionEntry;
+}) {
+  const orpc = useORPC();
+  const queryClient = useQueryClient();
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [deletedTastingIds, setDeletedTastingIds] = useState<number[]>([]);
+  const touchStart = useRef<{ x: number; y: number } | null>(null);
+  const visibleTastings = session.tastings.filter(
+    (tasting) => !deletedTastingIds.includes(tasting.id),
+  );
+
+  const refreshActivity = () => {
+    void Promise.all([
+      queryClient.invalidateQueries({
+        // Every activity filter can contain this tasting.
+        // oxlint-disable-next-line @tanstack/query/prefer-query-options
+        queryKey: orpc.activity.list.key({ type: "query" }),
+      }),
+      queryClient.invalidateQueries({ queryKey: profileActivityQueryKeys.all }),
+    ]);
+  };
+
+  const deleteTasting = (tastingId: number) => {
+    const remainingCount = visibleTastings.length - 1;
+    setDeletedTastingIds((ids) => [...ids, tastingId]);
+    setActiveIndex((index) => Math.min(index, Math.max(remainingCount - 1, 0)));
+    refreshActivity();
+  };
+
+  if (!visibleTastings.length) return null;
+
+  if (visibleTastings.length === 1) {
+    return (
+      <TastingListItem
+        tasting={visibleTastings[0]!}
+        onDelete={(tasting) => deleteTasting(tasting.id)}
+        onToast={refreshActivity}
+      />
+    );
+  }
+
+  const currentIndex = Math.min(activeIndex, visibleTastings.length - 1);
+  const activeTasting = visibleTastings[currentIndex]!;
+  const latestVisibleTasting = visibleTastings[0]!;
+  const showPrevious = currentIndex > 0;
+  const showNext = currentIndex < visibleTastings.length - 1;
+
+  const move = (direction: -1 | 1) => {
+    setActiveIndex((index) =>
+      Math.max(0, Math.min(index + direction, visibleTastings.length - 1)),
+    );
+  };
+
+  return (
+    <li className="-mt-1 overflow-hidden border border-slate-800 bg-gradient-to-r from-slate-950 to-slate-900">
+      <section
+        aria-label={`${session.createdBy.username}'s tasting session`}
+        aria-roledescription="carousel"
+      >
+        <div className="flex items-center gap-x-3 border-b border-slate-800 px-3 py-3 lg:px-5">
+          <UserAvatar size={32} user={session.createdBy} />
+          <div className="min-w-0 flex-1">
+            <Link
+              href={`/users/${session.createdBy.username}`}
+              className="block truncate text-sm font-semibold text-white hover:underline"
+            >
+              {session.createdBy.username}
+            </Link>
+            <div className="text-muted flex items-center gap-x-1 text-xs">
+              <span>
+                {visibleTastings.length.toLocaleString()} tasting
+                {visibleTastings.length === 1 ? "" : "s"}
+              </span>
+              <span aria-hidden="true">·</span>
+              <TimeSince date={latestVisibleTasting.createdAt} />
+            </div>
+          </div>
+
+          <div
+            className="flex shrink-0 items-center"
+            role="group"
+            aria-label="Choose tasting"
+          >
+            <button
+              type="button"
+              className={`${carouselButtonClassName} rounded-l-full`}
+              aria-label="Previous tasting"
+              disabled={!showPrevious}
+              onClick={() => move(-1)}
+            >
+              <ChevronLeftIcon className="h-5 w-5" aria-hidden="true" />
+            </button>
+            <div
+              className="flex h-10 min-w-12 items-center justify-center border-y border-slate-700 bg-slate-900 px-2 text-xs font-semibold tabular-nums text-white"
+              aria-live="polite"
+              aria-atomic="true"
+            >
+              <span className="sr-only">
+                Showing {activeTasting.bottle.fullName}, tasting
+              </span>{" "}
+              {currentIndex + 1}/{visibleTastings.length}
+            </div>
+            <button
+              type="button"
+              className={`${carouselButtonClassName} rounded-r-full`}
+              aria-label="Next tasting"
+              disabled={!showNext}
+              onClick={() => move(1)}
+            >
+              <ChevronRightIcon className="h-5 w-5" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
+
+        <div
+          data-testid="tasting-session-slides"
+          className="touch-pan-y"
+          onTouchStart={(event) => {
+            const touch = event.touches[0];
+            if (touch) {
+              touchStart.current = { x: touch.clientX, y: touch.clientY };
+            }
+          }}
+          onTouchEnd={(event) => {
+            const start = touchStart.current;
+            const touch = event.changedTouches[0];
+            touchStart.current = null;
+            if (!start || !touch) return;
+
+            const deltaX = touch.clientX - start.x;
+            const deltaY = touch.clientY - start.y;
+            if (Math.abs(deltaX) < 50 || Math.abs(deltaX) <= Math.abs(deltaY)) {
+              return;
+            }
+            move(deltaX < 0 ? 1 : -1);
+          }}
+          onTouchCancel={() => {
+            touchStart.current = null;
+          }}
+        >
+          {visibleTastings.map((tasting, index) => (
+            <article
+              key={tasting.id}
+              hidden={index !== currentIndex}
+              role="group"
+              aria-roledescription="slide"
+              aria-label={`Tasting ${index + 1} of ${visibleTastings.length}`}
+              className={
+                index === currentIndex
+                  ? "flex flex-col gap-y-4 pt-3 lg:pt-4"
+                  : "hidden"
+              }
+            >
+              <TastingContent
+                tasting={tasting}
+                onDelete={(deletedTasting) => deleteTasting(deletedTasting.id)}
+                onToast={refreshActivity}
+              />
+            </article>
+          ))}
+        </div>
+      </section>
+    </li>
+  );
+}

--- a/apps/web/src/lib/activityQueryKeys.ts
+++ b/apps/web/src/lib/activityQueryKeys.ts
@@ -1,0 +1,5 @@
+export const profileActivityQueryKeys = {
+  all: ["profile-activity"] as const,
+  list: (username: string) =>
+    ["profile-activity", username, "favorites-hidden"] as const,
+};


### PR DESCRIPTION
Activity feeds now group each person's tastings into sessions separated by a three-hour inactivity window. Home and profile feeds render multi-tasting sessions as one card with button and swipe navigation, while one-tasting sessions keep the existing card presentation. Tasting content is shared between both frames, carousel slides retain their local UI state, and tasting mutations refresh both activity caches.

The API now returns complete `tasting_session` entries before composing them with collection activity, so pagination cannot split a session. Snapshot-bound opaque cursors keep later pages stable if new activity arrives; this is a hard cutover from individual `tasting` entries and numeric activity cursors, with both web consumers updated here.

Integration coverage exercises session boundaries and snapshot pagination, and browser coverage verifies the global/profile presentation plus desktop controls and mobile swiping.

Fixes #634
