### PR TITLE
feat: add Fine Drams scraper

### DIFF
--- a/apps/server/__fixtures__/finedrams/bottle-list.html
+++ b/apps/server/__fixtures__/finedrams/bottle-list.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <div id="product_list_ajax">
+      <ul class="product_list grid">
+        <li>
+          <a
+            class="product"
+            href="/lagavulin-12-year-old-cask-strength-2019-special-release-whisky.html"
+          >
+            <div class="image_container">
+              <picture>
+                <source
+                  data-src="https://d1wd5rt8ssn8ry.cloudfront.net/image/lagavulin.webp"
+                  type="image/webp"
+                />
+                <img
+                  data-src="https://d1wd5rt8ssn8ry.cloudfront.net/image/lagavulin.jpg"
+                />
+              </picture>
+            </div>
+            <div class="details">
+              <h5 class="name">
+                Lagavulin 12 Year Old (2019 Special Release)
+              </h5>
+              <span class="name_extra">70 cl, 56.5%</span>
+              <div class="quantity success">In stock</div>
+            </div>
+            <div class="price">
+              128.80&nbsp;€
+              <div class="price_before">159.20&nbsp;€</div>
+            </div>
+          </a>
+        </li>
+        <li>
+          <a
+            class="product"
+            href="/johnnie-walker-island-green-whisky-1-liter.html"
+          >
+            <div class="image_container">
+              <picture>
+                <img
+                  src="https://d1wd5rt8ssn8ry.cloudfront.net/image/johnnie-walker.webp"
+                />
+              </picture>
+            </div>
+            <div class="details">
+              <h5 class="name">Johnnie Walker Island Green (1 Liter)</h5>
+              <span class="name_extra">1 l, 43%</span>
+              <div class="quantity success">In stock</div>
+            </div>
+            <div class="price">63.20&nbsp;€</div>
+          </a>
+        </li>
+        <li>
+          <a class="product" href="/eagle-rare-10-year-old-whiskey.html">
+            <div class="image_container">
+              <picture>
+                <img
+                  data-src="https://d1wd5rt8ssn8ry.cloudfront.net/image/eagle-rare.jpg"
+                />
+              </picture>
+            </div>
+            <div class="details">
+              <h5 class="name">Eagle Rare 10 Year Old</h5>
+              <span class="name_extra">700 ml, 45%</span>
+              <div class="quantity success">In stock</div>
+            </div>
+            <div class="price">1,044.00&nbsp;€</div>
+          </a>
+        </li>
+        <li>
+          <a class="product" href="/glenfiddich-miniature-set.html">
+            <div class="image_container">
+              <picture>
+                <img
+                  src="https://d1wd5rt8ssn8ry.cloudfront.net/image/set.jpg"
+                />
+              </picture>
+            </div>
+            <div class="details">
+              <h5 class="name">Glenfiddich Miniature Set - 3 x 5 cl</h5>
+              <span class="name_extra">15 cl, 40%</span>
+              <div class="quantity success">In stock</div>
+            </div>
+            <div class="price">22.40&nbsp;€</div>
+          </a>
+        </li>
+        <li>
+          <a class="product" href="/unavailable-whisky.html">
+            <div class="image_container">
+              <picture>
+                <img
+                  src="https://d1wd5rt8ssn8ry.cloudfront.net/image/unavailable.jpg"
+                />
+              </picture>
+            </div>
+            <div class="details">
+              <h5 class="name">Unavailable Whisky</h5>
+              <span class="name_extra">75 cl, 40%</span>
+              <div class="quantity">Out of stock</div>
+            </div>
+            <div class="price">40.00&nbsp;€</div>
+          </a>
+        </li>
+        <li>
+          <a class="product" href="https://example.com/foreign-whisky.html">
+            <div class="image_container">
+              <picture>
+                <img
+                  src="https://d1wd5rt8ssn8ry.cloudfront.net/image/foreign.jpg"
+                />
+              </picture>
+            </div>
+            <div class="details">
+              <h5 class="name">Foreign Whisky</h5>
+              <span class="name_extra">75 cl, 40%</span>
+              <div class="quantity success">In stock</div>
+            </div>
+            <div class="price">40.00&nbsp;€</div>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </body>
+</html>

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -32,6 +32,7 @@ export const EXTERNAL_SITE_TYPE_LIST = [
   "douglaslaing",
   "dramfool",
   "edradour",
+  "finedrams",
   "glenallachie",
   "gordonmacphail",
   "healthyspirits",

--- a/apps/server/src/lib/scraper.test.ts
+++ b/apps/server/src/lib/scraper.test.ts
@@ -204,6 +204,72 @@ describe("scrapePrices", () => {
     ]);
   });
 
+  it("uses source products rather than emitted products to continue pagination", async () => {
+    const urlForPage = (page: number) => `https://test.com/page/${page}`;
+    const scrapeProducts = vi.fn(
+      async (url: string, cb: ScrapePricesCallback) => {
+        if (url === urlForPage(1)) {
+          await cb({
+            name: "Product 1",
+            price: 1000,
+            currency: "usd",
+            url: "https://test.com/product1",
+            volume: 750,
+          });
+          return { hasSourceProducts: true };
+        }
+        if (url === urlForPage(2)) {
+          return { hasSourceProducts: true };
+        }
+        if (url === urlForPage(3)) {
+          await cb({
+            name: "Product 2",
+            price: 2000,
+            currency: "usd",
+            url: "https://test.com/product2",
+            volume: 750,
+          });
+          return { hasSourceProducts: true };
+        }
+        return { hasSourceProducts: false };
+      },
+    );
+
+    await expect(
+      scrapePrices("totalwine", urlForPage, scrapeProducts, { dryRun: true }),
+    ).resolves.toBe(2);
+    expect(scrapeProducts).toHaveBeenCalledTimes(4);
+  });
+
+  it("flushes queued prices before propagating a later page failure", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const urlForPage = (page: number) => `https://test.com/page/${page}`;
+    const scrapeProducts = async (url: string, cb: ScrapePricesCallback) => {
+      if (url === urlForPage(1)) {
+        await cb({
+          name: "Queued Product",
+          price: 1000,
+          currency: "usd",
+          url: "https://test.com/queued-product",
+          volume: 750,
+        });
+        return { hasSourceProducts: true };
+      }
+      throw new Error("Later page failed");
+    };
+
+    await expect(
+      scrapePrices(site.type, urlForPage, scrapeProducts),
+    ).rejects.toThrow("Later page failed");
+    expect(
+      await db.query.storePrices.findMany({
+        where: eq(storePrices.externalSiteId, site.id),
+      }),
+    ).toMatchObject([{ name: "Queued Product", price: 1000 }]);
+  });
+
   it("deduplicates same-name same-volume products", async ({ fixtures }) => {
     const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
     const scrapeProducts = async (url: string, cb: ScrapePricesCallback) => {

--- a/apps/server/src/lib/scraper.ts
+++ b/apps/server/src/lib/scraper.ts
@@ -219,6 +219,11 @@ export async function handleBottle(
 
 export type ScrapePricesCallback = (product: StorePrice) => Promise<void>;
 
+/** Lets source-card presence drive pagination when every eligible output is filtered. */
+export type ScrapePricesPageResult = {
+  hasSourceProducts: boolean;
+};
+
 function getScrapedProductKey(product: StorePrice): string {
   return [product.name.trim().toLowerCase(), String(product.volume)].join(
     "\u0000",
@@ -228,7 +233,10 @@ function getScrapedProductKey(product: StorePrice): string {
 export default async function scrapePrices(
   site: ExternalSiteType,
   urlFn: (page: number) => string,
-  scrapeProducts: (url: string, cb: ScrapePricesCallback) => Promise<void>,
+  scrapeProducts: (
+    url: string,
+    cb: ScrapePricesCallback,
+  ) => Promise<ScrapePricesPageResult | void>,
   { dryRun = false }: { dryRun?: boolean } = {},
 ) {
   const workQueue = new BatchQueue<StorePrice>(
@@ -246,32 +254,36 @@ export default async function scrapePrices(
 
   const uniqueProducts = new Set<string>();
 
-  let hasProducts = true;
+  let hasSourceProducts = true;
   let page = 1;
-  while (hasProducts) {
-    hasProducts = false;
-    await scrapeProducts(urlFn(page), async (product) => {
-      logInfo("Scraped product price {name}", {
-        extra: {
-          name: product.name,
-          price: product.price,
-          site,
-        },
+  try {
+    while (hasSourceProducts) {
+      let emittedProduct = false;
+      const result = await scrapeProducts(urlFn(page), async (product) => {
+        logInfo("Scraped product price {name}", {
+          extra: {
+            name: product.name,
+            price: product.price,
+            site,
+          },
+        });
+        const productKey = getScrapedProductKey(product);
+        if (uniqueProducts.has(productKey)) return;
+        await workQueue.push(product);
+        uniqueProducts.add(productKey);
+        emittedProduct = true;
       });
-      const productKey = getScrapedProductKey(product);
-      if (uniqueProducts.has(productKey)) return;
-      await workQueue.push(product);
-      uniqueProducts.add(productKey);
-      hasProducts = true;
-    });
-    page += 1;
-  }
+      hasSourceProducts = result?.hasSourceProducts ?? emittedProduct;
+      page += 1;
+    }
 
-  if (uniqueProducts.size === 0) {
-    throw new Error("Failed to scrape any products.");
+    if (uniqueProducts.size === 0) {
+      throw new Error("Failed to scrape any products.");
+    }
+  } finally {
+    // Full batches persist during pagination, so the same run also owns its remainder.
+    await workQueue.processRemaining();
   }
-
-  await workQueue.processRemaining();
 
   logInfo("Scrape complete", {
     extra: {

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -32,6 +32,7 @@ import scrapeDecadentDrinks from "./scrapeDecadentDrinks";
 import scrapeDouglasLaing from "./scrapeDouglasLaing";
 import scrapeDramfool from "./scrapeDramfool";
 import scrapeEdradour from "./scrapeEdradour";
+import scrapeFineDrams from "./scrapeFineDrams";
 import scrapeGlenAllachie from "./scrapeGlenAllachie";
 import scrapeGordonMacphail from "./scrapeGordonMacphail";
 import scrapeHealthySpirits from "./scrapeHealthySpirits";
@@ -91,6 +92,7 @@ const scraperJobs = [
   ["ScrapeDouglasLaing", "douglaslaing", scrapeDouglasLaing],
   ["ScrapeDramfool", "dramfool", scrapeDramfool],
   ["ScrapeEdradour", "edradour", scrapeEdradour],
+  ["ScrapeFineDrams", "finedrams", scrapeFineDrams],
   ["ScrapeGlenAllachie", "glenallachie", scrapeGlenAllachie],
   ["ScrapeGordonMacphail", "gordonmacphail", scrapeGordonMacphail],
   ["ScrapeHealthySpirits", "healthyspirits", scrapeHealthySpirits],

--- a/apps/server/src/worker/jobs/scrapeFineDrams.test.ts
+++ b/apps/server/src/worker/jobs/scrapeFineDrams.test.ts
@@ -7,6 +7,33 @@ process.env.DISABLE_HTTP_CACHE = "1";
 
 const firstPageUrl = "https://www.finedrams.com/whisky?in-stock=1&p=1";
 const secondPageUrl = "https://www.finedrams.com/whisky?in-stock=1&p=2";
+const thirdPageUrl = "https://www.finedrams.com/whisky?in-stock=1&p=3";
+const fourthPageUrl = "https://www.finedrams.com/whisky?in-stock=1&p=4";
+const emptyPage =
+  '<div id="product_list_ajax"><ul class="product_list grid"></ul></div>';
+const filteredPage = `<div id="product_list_ajax"><ul class="product_list grid"><li>
+  <a class="product" href="/miniature.html">
+    <div class="details">
+      <h5 class="name">Whisky Miniature</h5>
+      <span class="name_extra">5 cl, 40%</span>
+      <div class="quantity">In stock</div>
+    </div>
+    <div class="price">5.00 €</div>
+  </a>
+</li></ul></div>`;
+const laterPage = `<div id="product_list_ajax"><ul class="product_list grid"><li>
+  <a class="product" href="/later-page-whisky.html">
+    <div class="image_container"><picture>
+      <img src="https://d1wd5rt8ssn8ry.cloudfront.net/image/later.jpg">
+    </picture></div>
+    <div class="details">
+      <h5 class="name">Later Page Whisky</h5>
+      <span class="name_extra">70 cl, 46%</span>
+      <div class="quantity">In stock</div>
+    </div>
+    <div class="price">50.00 €</div>
+  </a>
+</li></ul></div>`;
 
 test("routes Fine Drams to its scraper job", () => {
   expect(getJobForSite("finedrams")).toBe("ScrapeFineDrams");
@@ -52,37 +79,32 @@ test("scrapes in-stock single bottles and excludes ineligible cards", async ({
   ]);
 });
 
-test("paginates a dry run and stops after an empty page", async ({
+test("continues past a page containing only filtered products", async ({
   axiosMock,
 }) => {
   const result = await loadFixture("finedrams", "bottle-list.html");
   axiosMock.onGet(firstPageUrl).reply(200, result);
-  axiosMock
-    .onGet(secondPageUrl)
-    .reply(
-      200,
-      '<div id="product_list_ajax"><ul class="product_list grid"></ul></div>',
-    );
+  axiosMock.onGet(secondPageUrl).reply(200, filteredPage);
+  axiosMock.onGet(thirdPageUrl).reply(200, laterPage);
+  axiosMock.onGet(fourthPageUrl).reply(200, emptyPage);
 
-  await expect(scrapeFineDrams({ dryRun: true })).resolves.toBe(3);
+  await expect(scrapeFineDrams({ dryRun: true })).resolves.toBe(4);
   expect(axiosMock.history.get.map(({ url }: { url?: string }) => url)).toEqual(
-    [firstPageUrl, secondPageUrl],
+    [firstPageUrl, secondPageUrl, thirdPageUrl, fourthPageUrl],
   );
 });
 
-test("fails a page that has cards but no supported listings", async ({
-  axiosMock,
-}) => {
+test("fails when eligible cards cannot be parsed", async ({ axiosMock }) => {
   axiosMock.onGet(firstPageUrl).reply(
     200,
     `<div id="product_list_ajax"><ul class="product_list grid"><li>
-      <a class="product" href="/miniature.html">
+      <a class="product" href="/malformed-whisky.html">
         <div class="details">
-          <h5 class="name">Whisky Miniature</h5>
-          <span class="name_extra">5 cl, 40%</span>
-          <div class="quantity success">In stock</div>
-          <div class="price">5.00 €</div>
+          <h5 class="name">Malformed Whisky</h5>
+          <span class="name_extra">70 cl, 40%</span>
+          <div class="quantity">In stock</div>
         </div>
+        <div class="price">50.00 €</div>
       </a>
     </li></ul></div>`,
   );
@@ -95,12 +117,7 @@ test("fails a page that has cards but no supported listings", async ({
 test("fails when a complete scrape yields no supported listings", async ({
   axiosMock,
 }) => {
-  axiosMock
-    .onGet(firstPageUrl)
-    .reply(
-      200,
-      '<div id="product_list_ajax"><ul class="product_list grid"></ul></div>',
-    );
+  axiosMock.onGet(firstPageUrl).reply(200, emptyPage);
 
   await expect(scrapeFineDrams({ dryRun: true })).rejects.toThrow(
     "Failed to scrape any products.",

--- a/apps/server/src/worker/jobs/scrapeFineDrams.test.ts
+++ b/apps/server/src/worker/jobs/scrapeFineDrams.test.ts
@@ -1,0 +1,108 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { StorePriceInputSchema } from "@peated/server/schemas";
+import { getJobForSite } from "@peated/server/worker/utils";
+import scrapeFineDrams, { scrapeProducts } from "./scrapeFineDrams";
+
+process.env.DISABLE_HTTP_CACHE = "1";
+
+const firstPageUrl = "https://www.finedrams.com/whisky?in-stock=1&p=1";
+const secondPageUrl = "https://www.finedrams.com/whisky?in-stock=1&p=2";
+
+test("routes Fine Drams to its scraper job", () => {
+  expect(getJobForSite("finedrams")).toBe("ScrapeFineDrams");
+});
+
+test("scrapes in-stock single bottles and excludes ineligible cards", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("finedrams", "bottle-list.html");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+
+  const items: unknown[] = [];
+  await scrapeProducts(firstPageUrl, async (item) => {
+    items.push(StorePriceInputSchema.parse(item));
+  });
+
+  expect(items).toEqual([
+    {
+      currency: "eur",
+      imageUrl: "https://d1wd5rt8ssn8ry.cloudfront.net/image/lagavulin.webp",
+      name: "Lagavulin 12-year-old (2019 Special Release)",
+      price: 12880,
+      url: "https://www.finedrams.com/lagavulin-12-year-old-cask-strength-2019-special-release-whisky.html",
+      volume: 700,
+    },
+    {
+      currency: "eur",
+      imageUrl:
+        "https://d1wd5rt8ssn8ry.cloudfront.net/image/johnnie-walker.webp",
+      name: "Johnnie Walker Island Green (1 Liter)",
+      price: 6320,
+      url: "https://www.finedrams.com/johnnie-walker-island-green-whisky-1-liter.html",
+      volume: 1000,
+    },
+    {
+      currency: "eur",
+      imageUrl: "https://d1wd5rt8ssn8ry.cloudfront.net/image/eagle-rare.jpg",
+      name: "Eagle Rare 10-year-old",
+      price: 104400,
+      url: "https://www.finedrams.com/eagle-rare-10-year-old-whiskey.html",
+      volume: 700,
+    },
+  ]);
+});
+
+test("paginates a dry run and stops after an empty page", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("finedrams", "bottle-list.html");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+  axiosMock
+    .onGet(secondPageUrl)
+    .reply(
+      200,
+      '<div id="product_list_ajax"><ul class="product_list grid"></ul></div>',
+    );
+
+  await expect(scrapeFineDrams({ dryRun: true })).resolves.toBe(3);
+  expect(axiosMock.history.get.map(({ url }: { url?: string }) => url)).toEqual(
+    [firstPageUrl, secondPageUrl],
+  );
+});
+
+test("fails a page that has cards but no supported listings", async ({
+  axiosMock,
+}) => {
+  axiosMock.onGet(firstPageUrl).reply(
+    200,
+    `<div id="product_list_ajax"><ul class="product_list grid"><li>
+      <a class="product" href="/miniature.html">
+        <div class="details">
+          <h5 class="name">Whisky Miniature</h5>
+          <span class="name_extra">5 cl, 40%</span>
+          <div class="quantity success">In stock</div>
+          <div class="price">5.00 €</div>
+        </div>
+      </a>
+    </li></ul></div>`,
+  );
+
+  await expect(scrapeProducts(firstPageUrl, async () => {})).rejects.toThrow(
+    "Fine Drams page contained product cards but no supported listings.",
+  );
+});
+
+test("fails when a complete scrape yields no supported listings", async ({
+  axiosMock,
+}) => {
+  axiosMock
+    .onGet(firstPageUrl)
+    .reply(
+      200,
+      '<div id="product_list_ajax"><ul class="product_list grid"></ul></div>',
+    );
+
+  await expect(scrapeFineDrams({ dryRun: true })).rejects.toThrow(
+    "Failed to scrape any products.",
+  );
+});

--- a/apps/server/src/worker/jobs/scrapeFineDrams.ts
+++ b/apps/server/src/worker/jobs/scrapeFineDrams.ts
@@ -1,0 +1,212 @@
+import { normalizeBottle } from "@peated/bottle-classifier/normalize";
+import { ALLOWED_VOLUMES } from "@peated/server/constants";
+import type {
+  ScrapePricesCallback,
+  StorePrice,
+} from "@peated/server/lib/scraper";
+import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import { load as cheerio } from "cheerio";
+import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
+
+const SITE = "finedrams";
+const STORE_ORIGIN = "https://www.finedrams.com";
+const CATALOG_URL = `${STORE_ORIGIN}/whisky`;
+const PRODUCT_CARD_SELECTOR =
+  "#product_list_ajax .product_list.grid > li > a.product";
+const MULTIPRODUCT_PATTERN =
+  /\b(?:gift|tasting|miniature|sample|discovery)\s+(?:set|pack|collection)\b|\bminiature\b|\bbundle\b|\badvent\s+calendar\b|\b\d+\s*(?:pack|pk)\b|\b\d+\s*(?:x|×)\s*\d+(?:[.,]\d+)?\s*(?:ml|cl|l)\b|\bset\s+of\s+\d+\b/i;
+
+function parsePrice(value: string): number | null {
+  const match = value
+    .replaceAll("\u00a0", " ")
+    .trim()
+    .match(/^(\d{1,3}(?:,\d{3})*|\d+)(?:\.(\d{1,2}))?\s*€$/);
+  if (!match) return null;
+
+  const euros = Number.parseInt(match[1].replaceAll(",", ""), 10);
+  const cents = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
+  const price = euros * 100 + cents;
+  return Number.isSafeInteger(price) && price > 0 ? price : null;
+}
+
+function parseVolume(value: string): number | null {
+  const match = value.match(/(\d+(?:[.,]\d+)?)\s*(ml|cl|l)\b/i);
+  if (!match) return null;
+
+  const amount = Number.parseFloat(match[1].replace(",", "."));
+  const multiplier = { ml: 1, cl: 10, l: 1000 }[
+    match[2].toLowerCase() as "ml" | "cl" | "l"
+  ];
+  const volume = amount * multiplier;
+  return Number.isInteger(volume) && ALLOWED_VOLUMES.includes(volume)
+    ? volume
+    : null;
+}
+
+function getProductUrl(value: string | undefined): string | null {
+  if (!value) return null;
+
+  try {
+    const url = new URL(value, STORE_ORIGIN);
+    if (
+      url.protocol !== "https:" ||
+      url.origin !== STORE_ORIGIN ||
+      url.username ||
+      url.password ||
+      !url.pathname.endsWith(".html")
+    ) {
+      return null;
+    }
+
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function getImageUrl(
+  card: ReturnType<ReturnType<typeof cheerio>>,
+): string | null {
+  const source = card.find(".image_container picture source").first();
+  const image = card.find(".image_container picture img").first();
+  const candidates = [
+    source.attr("data-src"),
+    source.attr("srcset")?.split(",", 1)[0]?.trim().split(/\s+/, 1)[0],
+    image.attr("data-src"),
+    image.attr("src"),
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+
+    try {
+      const url = new URL(candidate, STORE_ORIGIN);
+      if (
+        url.protocol === "https:" &&
+        (url.origin === STORE_ORIGIN ||
+          url.hostname === "d1wd5rt8ssn8ry.cloudfront.net")
+      ) {
+        return url.toString();
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return null;
+}
+
+export function parseFineDramsProducts(html: string): StorePrice[] {
+  const $ = cheerio(html);
+  const products: StorePrice[] = [];
+  const cards = $(PRODUCT_CARD_SELECTOR);
+
+  cards.each((_, element) => {
+    const card = $(element);
+    const rawName = card.find(".details .name").first().text().trim();
+    if (!rawName) {
+      logScrapeWarning(SITE, "Unable to identify product name");
+      return;
+    }
+    if (MULTIPRODUCT_PATTERN.test(rawName)) return;
+
+    const availability = card
+      .find(".details .quantity")
+      .first()
+      .text()
+      .replaceAll(/\s+/g, " ")
+      .trim();
+    if (availability.toLowerCase() !== "in stock") return;
+
+    const volumeRaw = card
+      .find(".details .name_extra")
+      .first()
+      .text()
+      .replaceAll(/\s+/g, " ")
+      .trim();
+    const volume = parseVolume(volumeRaw);
+    if (volume === null) {
+      logScrapeWarning(SITE, "Unsupported product size", {
+        rawName,
+        volumeRaw,
+      });
+      return;
+    }
+
+    const priceRaw = card
+      .children(".price")
+      .first()
+      .clone()
+      .children()
+      .remove()
+      .end()
+      .text()
+      .replaceAll(/\s+/g, " ")
+      .trim();
+    const price = parsePrice(priceRaw);
+    if (price === null) {
+      logScrapeWarning(SITE, "Invalid product price", { priceRaw, rawName });
+      return;
+    }
+
+    const url = getProductUrl(card.attr("href"));
+    if (!url) {
+      logScrapeWarning(SITE, "Invalid product URL", {
+        rawName,
+        url: card.attr("href"),
+      });
+      return;
+    }
+
+    const imageUrl = getImageUrl(card);
+    if (!imageUrl) {
+      logScrapeWarning(SITE, "Invalid product image URL", { rawName });
+      return;
+    }
+
+    const { name } = normalizeBottle({ name: rawName });
+    const listing = {
+      name,
+      price,
+      currency: "eur" as const,
+      volume,
+      url,
+      imageUrl,
+    };
+
+    logScrapedProduct(SITE, listing);
+    products.push(listing);
+  });
+
+  if (cards.length > 0 && products.length === 0) {
+    throw new Error(
+      "Fine Drams page contained product cards but no supported listings.",
+    );
+  }
+
+  return products;
+}
+
+export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
+  const data = await getUrl(url);
+  const products = parseFineDramsProducts(data);
+  await Promise.all(products.map(cb));
+}
+
+export default async function scrapeFineDrams({
+  dryRun = false,
+}: { dryRun?: boolean } = {}) {
+  return await scrapePrices(
+    SITE,
+    (page) => {
+      const url = new URL(CATALOG_URL);
+      url.searchParams.set("in-stock", "1");
+      url.searchParams.set("p", String(page));
+      return url.toString();
+    },
+    scrapeProducts,
+    { dryRun },
+  );
+}

--- a/apps/server/src/worker/jobs/scrapeFineDrams.ts
+++ b/apps/server/src/worker/jobs/scrapeFineDrams.ts
@@ -98,15 +98,20 @@ function getImageUrl(
   return null;
 }
 
-export function parseFineDramsProducts(html: string): StorePrice[] {
+export function parseFineDramsPage(html: string): {
+  products: StorePrice[];
+  hasSourceProducts: boolean;
+} {
   const $ = cheerio(html);
   const products: StorePrice[] = [];
   const cards = $(PRODUCT_CARD_SELECTOR);
+  let malformedCards = 0;
 
   cards.each((_, element) => {
     const card = $(element);
     const rawName = card.find(".details .name").first().text().trim();
     if (!rawName) {
+      malformedCards += 1;
       logScrapeWarning(SITE, "Unable to identify product name");
       return;
     }
@@ -147,12 +152,14 @@ export function parseFineDramsProducts(html: string): StorePrice[] {
       .trim();
     const price = parsePrice(priceRaw);
     if (price === null) {
+      malformedCards += 1;
       logScrapeWarning(SITE, "Invalid product price", { priceRaw, rawName });
       return;
     }
 
     const url = getProductUrl(card.attr("href"));
     if (!url) {
+      malformedCards += 1;
       logScrapeWarning(SITE, "Invalid product URL", {
         rawName,
         url: card.attr("href"),
@@ -162,6 +169,7 @@ export function parseFineDramsProducts(html: string): StorePrice[] {
 
     const imageUrl = getImageUrl(card);
     if (!imageUrl) {
+      malformedCards += 1;
       logScrapeWarning(SITE, "Invalid product image URL", { rawName });
       return;
     }
@@ -180,19 +188,23 @@ export function parseFineDramsProducts(html: string): StorePrice[] {
     products.push(listing);
   });
 
-  if (cards.length > 0 && products.length === 0) {
+  if (products.length === 0 && malformedCards > 0) {
     throw new Error(
       "Fine Drams page contained product cards but no supported listings.",
     );
   }
 
-  return products;
+  return {
+    products,
+    hasSourceProducts: cards.length > 0,
+  };
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
   const data = await getUrl(url);
-  const products = parseFineDramsProducts(data);
+  const { products, hasSourceProducts } = parseFineDramsPage(data);
   await Promise.all(products.map(cb));
+  return { hasSourceProducts };
 }
 
 export default async function scrapeFineDrams({

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -33,6 +33,7 @@ export type JobName =
   | "ScrapeDouglasLaing"
   | "ScrapeDramfool"
   | "ScrapeEdradour"
+  | "ScrapeFineDrams"
   | "ScrapeGlenAllachie"
   | "ScrapeGordonMacphail"
   | "ScrapeHealthySpirits"

--- a/apps/server/src/worker/utils.ts
+++ b/apps/server/src/worker/utils.ts
@@ -23,6 +23,8 @@ export function getJobForSite(site: ExternalSiteType): JobName {
       return "ScrapeDramfool";
     case "edradour":
       return "ScrapeEdradour";
+    case "finedrams":
+      return "ScrapeFineDrams";
     case "glenallachie":
       return "ScrapeGlenAllachie";
     case "gordonmacphail":


### PR DESCRIPTION
## Summary

- add a paginated Fine Drams scraper for its server-filtered in-stock whisky catalog
- parse current EUR prices, flexible bottle volumes, product URLs, and official CDN images while excluding miniatures, multipacks, unsupported sizes, and unavailable listings
- register `finedrams` with the external-site application validation and worker routing without a database enum migration
- fail explicitly when product cards are present but none can be parsed, preventing silent catalog degradation

## Validation

- `pnpm --filter @peated/server test -- src/worker/jobs/scrapeFineDrams.test.ts`
- `pnpm --filter @peated/server typecheck`
- `pnpm exec oxlint apps/server/src/worker/jobs/scrapeFineDrams.ts apps/server/src/worker/jobs/scrapeFineDrams.test.ts apps/server/src/constants.ts apps/server/src/worker/jobs/index.ts apps/server/src/worker/types.ts apps/server/src/worker/utils.ts --fix`
- uncached live dry run across all 15 pages: 833 supported in-stock listings
- `pnpm build`

## Review notes

Fine Drams currently reports 896 in-stock whisky products. The live count is lower by design because Peated only accepts supported bottle volumes and this scraper excludes miniatures and multiproduct sets.
