### PR TITLE
ref(scrapers): centralize Shopify ingestion

### DIFF
--- a/apps/server/src/lib/batchQueue.test.ts
+++ b/apps/server/src/lib/batchQueue.test.ts
@@ -41,27 +41,27 @@ describe("BatchQueue", () => {
     expect(processBatchMock).toHaveBeenNthCalledWith(2, [4, 5, 6]);
   });
 
-  test("handles errors during batch processing", async () => {
+  test("propagates errors during batch processing", async () => {
     processBatchMock.mockRejectedValue(new Error("Processing error"));
 
     await batchQueue.push(1);
     await batchQueue.push(2);
-    await batchQueue.push(3);
+    await expect(batchQueue.push(3)).rejects.toThrow("Processing error");
 
     expect(processBatchMock).toHaveBeenCalledTimes(1);
   });
 
-  test("continues processing after an error", async () => {
+  test("can process a later batch after an error", async () => {
     processBatchMock
       .mockRejectedValueOnce(new Error("Processing error"))
       .mockResolvedValueOnce(undefined);
 
-    for (let i = 1; i <= 6; i++) {
-      await batchQueue.push(i);
-    }
-
-    // Add a small delay to allow for async processing
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await batchQueue.push(1);
+    await batchQueue.push(2);
+    await expect(batchQueue.push(3)).rejects.toThrow("Processing error");
+    await batchQueue.push(4);
+    await batchQueue.push(5);
+    await batchQueue.push(6);
 
     expect(processBatchMock).toHaveBeenCalledTimes(2);
     expect(processBatchMock).toHaveBeenNthCalledWith(1, [1, 2, 3]);

--- a/apps/server/src/lib/batchQueue.ts
+++ b/apps/server/src/lib/batchQueue.ts
@@ -1,5 +1,4 @@
-import { logTelemetryError } from "./log";
-
+/** Batches work without changing error ownership; callback failures escape. */
 export default class BatchQueue<T> {
   private queue: T[] = [];
   private batchSize: number;
@@ -36,12 +35,6 @@ export default class BatchQueue<T> {
     const batch = this.queue.splice(0, this.batchSize);
     try {
       await this.processBatchCallback(batch);
-    } catch (error) {
-      logTelemetryError(error, {
-        extra: {
-          batchSize: batch.length,
-        },
-      });
     } finally {
       this.processingBatch = false;
     }

--- a/apps/server/src/lib/scraper.test.ts
+++ b/apps/server/src/lib/scraper.test.ts
@@ -361,6 +361,27 @@ describe("scrapePrices", () => {
     );
   });
 
+  it("propagates price persistence failures", async () => {
+    const scrapeProducts = async (url: string, cb: ScrapePricesCallback) => {
+      if (!url.endsWith("/1")) return;
+      await cb({
+        name: "Unpersisted Product",
+        price: 1000,
+        currency: "gbp",
+        url: "https://test.com/unpersisted-product",
+        volume: 700,
+      });
+    };
+
+    await expect(
+      scrapePrices(
+        "bruichladdich",
+        (page) => `https://test.com/page/${page}`,
+        scrapeProducts,
+      ),
+    ).rejects.toThrow("External site not found: bruichladdich");
+  });
+
   it("does not persist an explicit dry run", async ({ fixtures }) => {
     const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
     const scrapeProducts = async (url: string, cb: ScrapePricesCallback) => {

--- a/apps/server/src/lib/shopify.test.ts
+++ b/apps/server/src/lib/shopify.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  getShopifyImageUrl,
+  parseShopifyPrice,
+  scrapeShopifyProducts,
+} from "./shopify";
+
+process.env.DISABLE_HTTP_CACHE = "1";
+
+describe("parseShopifyPrice", () => {
+  test.each([
+    ["1", 100],
+    ["1.2", 120],
+    ["1.23", 123],
+    ["0", null],
+    ["1.234", null],
+    ["£1.23", null],
+  ])("parses %s", (value, expected) => {
+    expect(parseShopifyPrice(value)).toBe(expected);
+  });
+});
+
+describe("getShopifyImageUrl", () => {
+  test("allows Shopify CDN and the storefront", () => {
+    expect(
+      getShopifyImageUrl({ src: "https://cdn.shopify.com/files/bottle.png" }, [
+        "shop.example.com",
+      ]),
+    ).toBe("https://cdn.shopify.com/files/bottle.png");
+    expect(
+      getShopifyImageUrl({ src: "https://shop.example.com/cdn/bottle.png" }, [
+        "shop.example.com",
+      ]),
+    ).toBe("https://shop.example.com/cdn/bottle.png");
+  });
+
+  test("rejects other image hosts", () => {
+    expect(
+      getShopifyImageUrl({ src: "https://images.example.com/bottle.png" }, [
+        "shop.example.com",
+      ]),
+    ).toBeNull();
+  });
+});
+
+test("reports source products when every listing is filtered", async ({
+  axiosMock,
+}) => {
+  const url = "https://shop.example.com/products.json?page=1";
+  axiosMock.onGet(url).reply(200, { products: [{ title: "Gift set" }] });
+  const callback = vi.fn();
+
+  const result = await scrapeShopifyProducts(url, callback, () => []);
+
+  expect(result).toEqual({ hasSourceProducts: true });
+  expect(callback).not.toHaveBeenCalled();
+});
+
+test("rejects malformed catalog payloads", async ({ axiosMock }) => {
+  const url = "https://shop.example.com/products.json?page=1";
+  axiosMock.onGet(url).reply(200, { items: [] });
+
+  await expect(
+    scrapeShopifyProducts(
+      url,
+      async () => {},
+      () => [],
+    ),
+  ).rejects.toThrow();
+});

--- a/apps/server/src/lib/shopify.ts
+++ b/apps/server/src/lib/shopify.ts
@@ -1,0 +1,79 @@
+import type {
+  ScrapePricesCallback,
+  ScrapePricesPageResult,
+  StorePrice,
+} from "@peated/server/lib/scraper";
+import { getUrl } from "@peated/server/lib/scraper";
+import { z } from "zod";
+
+export const ShopifyCatalogSchema = z
+  .object({
+    products: z.array(z.unknown()),
+  })
+  .passthrough();
+
+export const ShopifyVariantSchema = z
+  .object({
+    available: z.boolean(),
+    price: z.string(),
+  })
+  .passthrough();
+
+export const ShopifyImageSchema = z
+  .object({
+    src: z.string().url(),
+  })
+  .passthrough();
+
+export const ShopifyProductSchema = z
+  .object({
+    title: z.string().trim().min(1),
+    handle: z.string().trim().min(1),
+    images: z.array(z.unknown()),
+    variants: z.array(ShopifyVariantSchema),
+  })
+  .passthrough();
+
+export function getShopifyProductTitle(input: unknown): string | null {
+  if (!input || typeof input !== "object" || !("title" in input)) return null;
+  return typeof input.title === "string" ? input.title : null;
+}
+
+export function parseShopifyPrice(value: string): number | null {
+  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
+  if (!match) return null;
+
+  const majorUnits = Number.parseInt(match[1], 10);
+  const minorUnits = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
+  const price = majorUnits * 100 + minorUnits;
+  return Number.isSafeInteger(price) && price > 0 ? price : null;
+}
+
+export function getShopifyImageUrl(
+  value: unknown,
+  storeHostnames: string[],
+): string | null {
+  const result = ShopifyImageSchema.safeParse(value);
+  if (!result.success) return null;
+
+  const url = new URL(result.data.src);
+  return url.protocol === "https:" &&
+    (url.hostname === "cdn.shopify.com" ||
+      storeHostnames.includes(url.hostname))
+    ? url.toString()
+    : null;
+}
+
+/** A non-empty source page advances pagination even if every listing is filtered. */
+export async function scrapeShopifyProducts(
+  url: string,
+  cb: ScrapePricesCallback,
+  parseProducts: (input: unknown, sourceUrl: string) => StorePrice[],
+): Promise<ScrapePricesPageResult> {
+  const data = await getUrl(url);
+  const catalog = ShopifyCatalogSchema.parse(JSON.parse(data));
+  const products = parseProducts(catalog, url);
+  await Promise.all(products.map(cb));
+
+  return { hasSourceProducts: catalog.products.length > 0 };
+}

--- a/apps/server/src/worker/jobs/scrapeBruichladdich.test.ts
+++ b/apps/server/src/worker/jobs/scrapeBruichladdich.test.ts
@@ -79,6 +79,31 @@ test("paginates a dry run and stops after an empty page", async ({
   expect(axiosMock.history.get).toHaveLength(2);
 });
 
+test("continues after a page whose products are all filtered", async ({
+  axiosMock,
+}) => {
+  const result: { products: Array<{ title?: unknown }> } = JSON.parse(
+    await loadFixture("bruichladdich", "bottle-list.json"),
+  );
+  const filteredProduct = result.products.find(
+    (product) => product.title === "The Botanist Islay Dry Gin",
+  );
+  expect(filteredProduct).toBeDefined();
+
+  axiosMock.onGet(firstPageUrl).reply(200, {
+    products: [filteredProduct],
+  });
+  axiosMock.onGet(secondPageUrl).reply(200, result);
+  axiosMock
+    .onGet(
+      "https://www.bruichladdich.com/collections/all/products.json?country=GB&limit=250&page=3",
+    )
+    .reply(200, { products: [] });
+
+  await expect(scrapeBruichladdich({ dryRun: true })).resolves.toBe(4);
+  expect(axiosMock.history.get).toHaveLength(3);
+});
+
 test("fails when a complete scrape yields no supported listings", async ({
   axiosMock,
 }) => {

--- a/apps/server/src/worker/jobs/scrapeBruichladdich.ts
+++ b/apps/server/src/worker/jobs/scrapeBruichladdich.ts
@@ -3,7 +3,16 @@ import type {
   ScrapePricesCallback,
   StorePrice,
 } from "@peated/server/lib/scraper";
-import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import scrapePrices from "@peated/server/lib/scraper";
+import {
+  getShopifyImageUrl,
+  getShopifyProductTitle,
+  parseShopifyPrice,
+  scrapeShopifyProducts,
+  ShopifyCatalogSchema,
+  ShopifyProductSchema,
+  ShopifyVariantSchema,
+} from "@peated/server/lib/shopify";
 import { z } from "zod";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 
@@ -23,55 +32,21 @@ const BRAND_TAGS = new Map([
   ["port charlotte", "Port Charlotte"],
 ]);
 
-const CatalogSchema = z
-  .object({
-    products: z.array(z.unknown()),
-  })
-  .passthrough();
+const VariantSchema = ShopifyVariantSchema.extend({
+  title: z.string().trim().min(1),
+});
 
-const VariantSchema = z
-  .object({
-    available: z.boolean(),
-    price: z.string(),
-    title: z.string().trim().min(1),
-  })
-  .passthrough();
-
-const ProductSchema = z
-  .object({
-    title: z.string().trim().min(1),
-    handle: z
-      .string()
-      .trim()
-      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
-    product_type: z.string(),
-    tags: z.array(z.string()),
-    vendor: z.string(),
-    images: z.array(z.unknown()).min(1),
-    variants: z.array(VariantSchema),
-  })
-  .passthrough();
-
-const ImageSchema = z
-  .object({
-    src: z.string().url(),
-  })
-  .passthrough();
-
-function getRawName(input: unknown): string | null {
-  if (!input || typeof input !== "object" || !("title" in input)) return null;
-  return typeof input.title === "string" ? input.title : null;
-}
-
-function parsePrice(value: string): number | null {
-  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
-  if (!match) return null;
-
-  const pounds = Number.parseInt(match[1], 10);
-  const pence = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
-  const price = pounds * 100 + pence;
-  return Number.isSafeInteger(price) && price > 0 ? price : null;
-}
+const ProductSchema = ShopifyProductSchema.extend({
+  handle: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+  product_type: z.string(),
+  tags: z.array(z.string()),
+  vendor: z.string(),
+  images: z.array(z.unknown()).min(1),
+  variants: z.array(VariantSchema),
+});
 
 function parseVolume(value: string): number | null {
   const match = value.match(/^(\d+(?:\.\d+)?)\s*(ml|cl|l)$/i);
@@ -107,27 +82,15 @@ function getProductName(
   return brand ? normalizeBottle({ name: `${brand} ${title}` }).name : null;
 }
 
-function getImageUrl(value: unknown): string | null {
-  const result = ImageSchema.safeParse(value);
-  if (!result.success) return null;
-
-  const url = new URL(result.data.src);
-  return url.protocol === "https:" &&
-    (url.hostname === "cdn.shopify.com" ||
-      url.hostname === "www.bruichladdich.com")
-    ? url.toString()
-    : null;
-}
-
 export function parseBruichladdichProducts(input: unknown): StorePrice[] {
-  const payload = CatalogSchema.parse(input);
+  const payload = ShopifyCatalogSchema.parse(input);
   const products: StorePrice[] = [];
 
   for (const productInput of payload.products) {
     const productResult = ProductSchema.safeParse(productInput);
     if (!productResult.success) {
       logScrapeWarning(SITE, "Invalid product record", {
-        rawName: getRawName(productInput),
+        rawName: getShopifyProductTitle(productInput),
       });
       continue;
     }
@@ -159,7 +122,7 @@ export function parseBruichladdichProducts(input: unknown): StorePrice[] {
       continue;
     }
 
-    const price = parsePrice(variant.price);
+    const price = parseShopifyPrice(variant.price);
     if (price === null) {
       logScrapeWarning(SITE, "Invalid product price", {
         rawName: product.title,
@@ -176,7 +139,9 @@ export function parseBruichladdichProducts(input: unknown): StorePrice[] {
       continue;
     }
 
-    const imageUrl = getImageUrl(product.images[0]);
+    const imageUrl = getShopifyImageUrl(product.images[0], [
+      "www.bruichladdich.com",
+    ]);
     if (!imageUrl) {
       logScrapeWarning(SITE, "Invalid product image URL", {
         rawName: product.title,
@@ -201,9 +166,7 @@ export function parseBruichladdichProducts(input: unknown): StorePrice[] {
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
-  const data = await getUrl(url);
-  const products = parseBruichladdichProducts(JSON.parse(data));
-  await Promise.all(products.map(cb));
+  return scrapeShopifyProducts(url, cb, parseBruichladdichProducts);
 }
 
 export default async function scrapeBruichladdich({

--- a/apps/server/src/worker/jobs/scrapeDouglasLaing.ts
+++ b/apps/server/src/worker/jobs/scrapeDouglasLaing.ts
@@ -10,7 +10,14 @@ import type {
   ScrapePricesCallback,
   StorePrice,
 } from "@peated/server/lib/scraper";
-import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import scrapePrices from "@peated/server/lib/scraper";
+import {
+  parseShopifyPrice,
+  scrapeShopifyProducts,
+  ShopifyCatalogSchema,
+  ShopifyImageSchema,
+  ShopifyProductSchema,
+} from "@peated/server/lib/shopify";
 import { absoluteUrl } from "@peated/server/lib/urls";
 import { z } from "zod";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
@@ -39,46 +46,16 @@ const PRODUCT_TYPE_CATEGORIES = new Map<
   ["Whisky", null],
 ]);
 
-const DouglasLaingProductsSchema = z
-  .object({
-    products: z.array(
-      z
-        .object({
-          title: z.string().trim().min(1),
-          handle: z.string().trim().min(1),
-          vendor: z.string().trim().min(1),
-          product_type: z.string(),
-          tags: z.array(z.string()),
-          images: z.array(
-            z
-              .object({
-                src: z.string().url(),
-              })
-              .passthrough(),
-          ),
-          variants: z.array(
-            z
-              .object({
-                available: z.boolean(),
-                price: z.string(),
-              })
-              .passthrough(),
-          ),
-        })
-        .passthrough(),
-    ),
-  })
-  .passthrough();
+const DouglasLaingProductSchema = ShopifyProductSchema.extend({
+  vendor: z.string().trim().min(1),
+  product_type: z.string(),
+  tags: z.array(z.string()),
+  images: z.array(ShopifyImageSchema),
+});
 
-function parsePrice(value: string): number | null {
-  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
-  if (!match) return null;
-
-  const dollars = Number.parseInt(match[1], 10);
-  const cents = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
-  const price = dollars * 100 + cents;
-  return Number.isSafeInteger(price) && price > 0 ? price : null;
-}
+const DouglasLaingProductsSchema = ShopifyCatalogSchema.extend({
+  products: z.array(DouglasLaingProductSchema),
+});
 
 function extractAbv(tags: string[]): number | null {
   const abvTag = tags.find((tag) => /^Abv:/i.test(tag));
@@ -155,7 +132,7 @@ export function parseDouglasLaingProducts(
     const pricedVariant = product.variants
       .map((variant) => ({
         ...variant,
-        parsedPrice: parsePrice(variant.price),
+        parsedPrice: parseShopifyPrice(variant.price),
       }))
       .find((variant) => variant.available && variant.parsedPrice !== null);
     if (!pricedVariant || pricedVariant.parsedPrice === null) continue;
@@ -187,9 +164,7 @@ export function parseDouglasLaingProducts(
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
-  const data = await getUrl(url);
-  const products = parseDouglasLaingProducts(JSON.parse(data), url);
-  await Promise.all(products.map(cb));
+  return scrapeShopifyProducts(url, cb, parseDouglasLaingProducts);
 }
 
 export default async function scrapeDouglasLaing({

--- a/apps/server/src/worker/jobs/scrapeGlenAllachie.ts
+++ b/apps/server/src/worker/jobs/scrapeGlenAllachie.ts
@@ -3,7 +3,16 @@ import type {
   ScrapePricesCallback,
   StorePrice,
 } from "@peated/server/lib/scraper";
-import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import scrapePrices from "@peated/server/lib/scraper";
+import {
+  getShopifyImageUrl,
+  getShopifyProductTitle,
+  parseShopifyPrice,
+  scrapeShopifyProducts,
+  ShopifyCatalogSchema,
+  ShopifyProductSchema,
+  ShopifyVariantSchema,
+} from "@peated/server/lib/shopify";
 import { z } from "zod";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 
@@ -18,54 +27,19 @@ const SUPPORTED_PRODUCT_TYPES = new Set([
   "Single Malt Scotch Whisky",
 ]);
 
-const GlenAllachieCatalogSchema = z
-  .object({
-    products: z.array(z.unknown()),
-  })
-  .passthrough();
+const GlenAllachieProductSchema = ShopifyProductSchema.extend({
+  handle: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+  body_html: z.string(),
+  product_type: z.string(),
+  tags: z.array(z.string()),
+  images: z.array(z.unknown()),
+  variants: z.array(z.unknown()),
+});
 
-const GlenAllachieProductSchema = z
-  .object({
-    title: z.string().trim().min(1),
-    handle: z
-      .string()
-      .trim()
-      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
-    body_html: z.string(),
-    product_type: z.string(),
-    tags: z.array(z.string()),
-    images: z.array(z.unknown()),
-    variants: z.array(z.unknown()),
-  })
-  .passthrough();
-
-const GlenAllachieVariantSchema = z
-  .object({
-    available: z.boolean(),
-    price: z.string(),
-  })
-  .passthrough();
-
-const GlenAllachieImageSchema = z
-  .object({
-    src: z.string().url(),
-  })
-  .passthrough();
-
-function getRawName(input: unknown): string | null {
-  if (!input || typeof input !== "object" || !("title" in input)) return null;
-  return typeof input.title === "string" ? input.title : null;
-}
-
-function parsePrice(value: string): number | null {
-  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
-  if (!match) return null;
-
-  const pounds = Number.parseInt(match[1], 10);
-  const pence = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
-  const price = pounds * 100 + pence;
-  return Number.isSafeInteger(price) && price > 0 ? price : null;
-}
+const GlenAllachieVariantSchema = ShopifyVariantSchema;
 
 function parseExplicitVolumes(value: string): number[] {
   const volumes = new Set<number>();
@@ -96,27 +70,15 @@ function getProductName(title: string, tags: string[]): string | null {
   return null;
 }
 
-function getImageUrl(value: unknown): string | null {
-  const result = GlenAllachieImageSchema.safeParse(value);
-  if (!result.success) return null;
-
-  const url = new URL(result.data.src);
-  return url.protocol === "https:" &&
-    (url.hostname === "cdn.shopify.com" ||
-      url.hostname === "shop.theglenallachie.com")
-    ? url.toString()
-    : null;
-}
-
 export function parseGlenAllachieProducts(input: unknown): StorePrice[] {
-  const payload = GlenAllachieCatalogSchema.parse(input);
+  const payload = ShopifyCatalogSchema.parse(input);
   const products: StorePrice[] = [];
 
   for (const productInput of payload.products) {
     const productResult = GlenAllachieProductSchema.safeParse(productInput);
     if (!productResult.success) {
       logScrapeWarning(SITE, "Invalid product record", {
-        rawName: getRawName(productInput),
+        rawName: getShopifyProductTitle(productInput),
       });
       continue;
     }
@@ -152,7 +114,7 @@ export function parseGlenAllachieProducts(input: unknown): StorePrice[] {
     const variant = availableVariants[0];
     if (!variant) continue;
 
-    const price = parsePrice(variant.price);
+    const price = parseShopifyPrice(variant.price);
     if (price === null) {
       logScrapeWarning(SITE, "Invalid product price", {
         rawName: product.title,
@@ -169,7 +131,9 @@ export function parseGlenAllachieProducts(input: unknown): StorePrice[] {
       continue;
     }
 
-    const imageUrl = getImageUrl(product.images[0]);
+    const imageUrl = getShopifyImageUrl(product.images[0], [
+      "shop.theglenallachie.com",
+    ]);
     if (!imageUrl) {
       logScrapeWarning(SITE, "Invalid product image URL", {
         rawName: product.title,
@@ -196,9 +160,7 @@ export function parseGlenAllachieProducts(input: unknown): StorePrice[] {
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
-  const data = await getUrl(url);
-  const products = parseGlenAllachieProducts(JSON.parse(data));
-  await Promise.all(products.map(cb));
+  return scrapeShopifyProducts(url, cb, parseGlenAllachieProducts);
 }
 
 export default async function scrapeGlenAllachie({

--- a/apps/server/src/worker/jobs/scrapeGordonMacphail.ts
+++ b/apps/server/src/worker/jobs/scrapeGordonMacphail.ts
@@ -4,52 +4,28 @@ import type {
   ScrapePricesCallback,
   StorePrice,
 } from "@peated/server/lib/scraper";
-import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import scrapePrices from "@peated/server/lib/scraper";
+import {
+  parseShopifyPrice,
+  scrapeShopifyProducts,
+  ShopifyCatalogSchema,
+  ShopifyImageSchema,
+  ShopifyProductSchema,
+} from "@peated/server/lib/shopify";
 import { absoluteUrl } from "@peated/server/lib/urls";
 import { z } from "zod";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 
 const SITE = "gordonmacphail";
 
-const GordonMacphailProductsSchema = z
-  .object({
-    products: z.array(
-      z
-        .object({
-          title: z.string().trim().min(1),
-          handle: z.string().trim().min(1),
-          body_html: z.string().nullish(),
-          images: z.array(
-            z
-              .object({
-                src: z.string().url(),
-              })
-              .passthrough(),
-          ),
-          variants: z.array(
-            z
-              .object({
-                available: z.boolean(),
-                price: z.string(),
-              })
-              .passthrough(),
-          ),
-        })
-        // Shopify owns additional catalog fields that this parser does not use.
-        .passthrough(),
-    ),
-  })
-  .passthrough();
+const GordonMacphailProductSchema = ShopifyProductSchema.extend({
+  body_html: z.string().nullish(),
+  images: z.array(ShopifyImageSchema),
+});
 
-function parsePrice(value: string): number | null {
-  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
-  if (!match) return null;
-
-  const pounds = Number.parseInt(match[1], 10);
-  const pence = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
-  const price = pounds * 100 + pence;
-  return Number.isSafeInteger(price) && price > 0 ? price : null;
-}
+const GordonMacphailProductsSchema = ShopifyCatalogSchema.extend({
+  products: z.array(GordonMacphailProductSchema),
+});
 
 function parseVolume(amountRaw: string, unit: string): number | null {
   const amount = Number.parseFloat(amountRaw);
@@ -106,7 +82,7 @@ export function parseGordonMacphailProducts(
     const pricedVariant = product.variants
       .map((variant) => ({
         ...variant,
-        parsedPrice: parsePrice(variant.price),
+        parsedPrice: parseShopifyPrice(variant.price),
       }))
       .find((variant) => variant.available && variant.parsedPrice !== null);
     if (!pricedVariant || pricedVariant.parsedPrice === null) continue;
@@ -141,9 +117,7 @@ export function parseGordonMacphailProducts(
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
-  const data = await getUrl(url);
-  const products = parseGordonMacphailProducts(JSON.parse(data), url);
-  await Promise.all(products.map(cb));
+  return scrapeShopifyProducts(url, cb, parseGordonMacphailProducts);
 }
 
 export default async function scrapeGordonMacphail({

--- a/apps/server/src/worker/jobs/scrapeMissionLiquor.ts
+++ b/apps/server/src/worker/jobs/scrapeMissionLiquor.ts
@@ -4,7 +4,16 @@ import type {
   ScrapePricesCallback,
   StorePrice,
 } from "@peated/server/lib/scraper";
-import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import scrapePrices from "@peated/server/lib/scraper";
+import {
+  getShopifyImageUrl,
+  getShopifyProductTitle,
+  parseShopifyPrice,
+  scrapeShopifyProducts,
+  ShopifyCatalogSchema,
+  ShopifyProductSchema,
+  ShopifyVariantSchema,
+} from "@peated/server/lib/shopify";
 import { z } from "zod";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 
@@ -16,53 +25,18 @@ const TITLE_VOLUME_PATTERN = /(\d+(?:\.\d+)?)\s*(ml|cl|l)\b/gi;
 const MULTIPRODUCT_PATTERN =
   /\b(?:gift|tasting)\s+set\b|\bsampler\b|\bbundle\b|\b\d+\s*(?:x|×)\s*\d+(?:\.\d+)?\s*(?:ml|cl|l)\b|\b\d+\s*(?:pack|pk)\b/i;
 
-const CatalogSchema = z
-  .object({
-    products: z.array(z.unknown()),
-  })
-  .passthrough();
+const VariantSchema = ShopifyVariantSchema;
 
-const VariantSchema = z
-  .object({
-    available: z.boolean(),
-    price: z.string(),
-  })
-  .passthrough();
-
-const ProductSchema = z
-  .object({
-    title: z.string().trim().min(1),
-    handle: z
-      .string()
-      .trim()
-      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
-    product_type: z.string().trim(),
-    tags: z.array(z.string()),
-    images: z.array(z.unknown()).min(1),
-    variants: z.array(VariantSchema),
-  })
-  .passthrough();
-
-const ImageSchema = z
-  .object({
-    src: z.string().url(),
-  })
-  .passthrough();
-
-function getRawName(input: unknown): string | null {
-  if (!input || typeof input !== "object" || !("title" in input)) return null;
-  return typeof input.title === "string" ? input.title : null;
-}
-
-function parsePrice(value: string): number | null {
-  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
-  if (!match) return null;
-
-  const dollars = Number.parseInt(match[1], 10);
-  const cents = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
-  const price = dollars * 100 + cents;
-  return Number.isSafeInteger(price) && price > 0 ? price : null;
-}
+const ProductSchema = ShopifyProductSchema.extend({
+  handle: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+  product_type: z.string().trim(),
+  tags: z.array(z.string()),
+  images: z.array(z.unknown()).min(1),
+  variants: z.array(VariantSchema),
+});
 
 function parseVolume(amountRaw: string, unitRaw: string): number | null {
   const amount = Number.parseFloat(amountRaw);
@@ -103,27 +77,15 @@ function getProductName(title: string): string | null {
   return normalizeBottle({ name: withoutTerminalVolume }).name;
 }
 
-function getImageUrl(value: unknown): string | null {
-  const result = ImageSchema.safeParse(value);
-  if (!result.success) return null;
-
-  const url = new URL(result.data.src);
-  return url.protocol === "https:" &&
-    (url.hostname === "cdn.shopify.com" ||
-      url.hostname === "www.missionliquor.com")
-    ? url.toString()
-    : null;
-}
-
 export function parseMissionLiquorProducts(input: unknown): StorePrice[] {
-  const payload = CatalogSchema.parse(input);
+  const payload = ShopifyCatalogSchema.parse(input);
   const products: StorePrice[] = [];
 
   for (const productInput of payload.products) {
     const productResult = ProductSchema.safeParse(productInput);
     if (!productResult.success) {
       logScrapeWarning(SITE, "Invalid product record", {
-        rawName: getRawName(productInput),
+        rawName: getShopifyProductTitle(productInput),
       });
       continue;
     }
@@ -164,7 +126,7 @@ export function parseMissionLiquorProducts(input: unknown): StorePrice[] {
       continue;
     }
 
-    const price = parsePrice(availableVariants[0].price);
+    const price = parseShopifyPrice(availableVariants[0].price);
     if (price === null) {
       logScrapeWarning(SITE, "Invalid product price", {
         rawName: product.title,
@@ -181,7 +143,9 @@ export function parseMissionLiquorProducts(input: unknown): StorePrice[] {
       continue;
     }
 
-    const imageUrl = getImageUrl(product.images[0]);
+    const imageUrl = getShopifyImageUrl(product.images[0], [
+      "www.missionliquor.com",
+    ]);
     if (!imageUrl) {
       logScrapeWarning(SITE, "Invalid product image URL", {
         rawName: product.title,
@@ -206,9 +170,7 @@ export function parseMissionLiquorProducts(input: unknown): StorePrice[] {
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
-  const data = await getUrl(url);
-  const products = parseMissionLiquorProducts(JSON.parse(data));
-  await Promise.all(products.map(cb));
+  return scrapeShopifyProducts(url, cb, parseMissionLiquorProducts);
 }
 
 export default async function scrapeMissionLiquor({

--- a/apps/server/src/worker/jobs/scrapeNcnean.ts
+++ b/apps/server/src/worker/jobs/scrapeNcnean.ts
@@ -3,7 +3,16 @@ import type {
   ScrapePricesCallback,
   StorePrice,
 } from "@peated/server/lib/scraper";
-import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import scrapePrices from "@peated/server/lib/scraper";
+import {
+  getShopifyImageUrl,
+  getShopifyProductTitle,
+  parseShopifyPrice,
+  scrapeShopifyProducts,
+  ShopifyCatalogSchema,
+  ShopifyProductSchema,
+  ShopifyVariantSchema,
+} from "@peated/server/lib/shopify";
 import { z } from "zod";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 
@@ -13,57 +22,23 @@ const CATALOG_URL = `${STORE_ORIGIN}/collections/all/products.json?country=GB&li
 const SUPPORTED_VOLUME = 700;
 const DISTILLERY_VENDOR = "Nc'nean Distillery";
 
-const CatalogSchema = z
-  .object({
-    products: z.array(z.unknown()),
-  })
-  .passthrough();
+const VariantSchema = ShopifyVariantSchema.extend({
+  title: z.string().trim().min(1),
+});
 
-const VariantSchema = z
-  .object({
-    available: z.boolean(),
-    price: z.string(),
-    title: z.string().trim().min(1),
-  })
-  .passthrough();
-
-const ProductSchema = z
-  .object({
-    title: z.string().trim().min(1),
-    handle: z
-      .string()
-      .trim()
-      .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
-    body_html: z.string(),
-    tags: z.array(z.string()),
-    vendor: z.string(),
-    images: z.array(z.unknown()).min(1),
-    variants: z.array(VariantSchema),
-  })
-  .passthrough();
-
-const ImageSchema = z
-  .object({
-    src: z.string().url(),
-  })
-  .passthrough();
+const ProductSchema = ShopifyProductSchema.extend({
+  handle: z
+    .string()
+    .trim()
+    .regex(/^[a-z0-9]+(?:-[a-z0-9]+)*$/),
+  body_html: z.string(),
+  tags: z.array(z.string()),
+  vendor: z.string(),
+  images: z.array(z.unknown()).min(1),
+  variants: z.array(VariantSchema),
+});
 
 type Variant = z.infer<typeof VariantSchema>;
-
-function getRawName(input: unknown): string | null {
-  if (!input || typeof input !== "object" || !("title" in input)) return null;
-  return typeof input.title === "string" ? input.title : null;
-}
-
-function parsePrice(value: string): number | null {
-  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
-  if (!match) return null;
-
-  const pounds = Number.parseInt(match[1], 10);
-  const pence = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
-  const price = pounds * 100 + pence;
-  return Number.isSafeInteger(price) && price > 0 ? price : null;
-}
 
 function parseVolume(amountRaw: string, unitRaw: string): number | null {
   const amount = Number.parseFloat(amountRaw);
@@ -126,26 +101,15 @@ function getProductName(title: string, vendor: string): string | null {
   return normalizeBottle({ name: publishedName }).name;
 }
 
-function getImageUrl(value: unknown): string | null {
-  const result = ImageSchema.safeParse(value);
-  if (!result.success) return null;
-
-  const url = new URL(result.data.src);
-  return url.protocol === "https:" &&
-    (url.hostname === "cdn.shopify.com" || url.hostname === "ncnean.com")
-    ? url.toString()
-    : null;
-}
-
 export function parseNcneanProducts(input: unknown): StorePrice[] {
-  const payload = CatalogSchema.parse(input);
+  const payload = ShopifyCatalogSchema.parse(input);
   const products: StorePrice[] = [];
 
   for (const productInput of payload.products) {
     const productResult = ProductSchema.safeParse(productInput);
     if (!productResult.success) {
       logScrapeWarning(SITE, "Invalid product record", {
-        rawName: getRawName(productInput),
+        rawName: getShopifyProductTitle(productInput),
       });
       continue;
     }
@@ -166,7 +130,7 @@ export function parseNcneanProducts(input: unknown): StorePrice[] {
     const variant = getPricedVariant(product.variants, product.title);
     if (!variant) continue;
 
-    const price = parsePrice(variant.price);
+    const price = parseShopifyPrice(variant.price);
     if (price === null) {
       logScrapeWarning(SITE, "Invalid product price", {
         rawName: product.title,
@@ -183,7 +147,7 @@ export function parseNcneanProducts(input: unknown): StorePrice[] {
       continue;
     }
 
-    const imageUrl = getImageUrl(product.images[0]);
+    const imageUrl = getShopifyImageUrl(product.images[0], ["ncnean.com"]);
     if (!imageUrl) {
       logScrapeWarning(SITE, "Invalid product image URL", {
         rawName: product.title,
@@ -208,9 +172,7 @@ export function parseNcneanProducts(input: unknown): StorePrice[] {
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
-  const data = await getUrl(url);
-  const products = parseNcneanProducts(JSON.parse(data));
-  await Promise.all(products.map(cb));
+  return scrapeShopifyProducts(url, cb, parseNcneanProducts);
 }
 
 export default async function scrapeNcnean({

--- a/apps/server/src/worker/jobs/scrapeNorthStarSpirits.ts
+++ b/apps/server/src/worker/jobs/scrapeNorthStarSpirits.ts
@@ -4,7 +4,14 @@ import type {
   ScrapePricesCallback,
   StorePrice,
 } from "@peated/server/lib/scraper";
-import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import scrapePrices from "@peated/server/lib/scraper";
+import {
+  parseShopifyPrice,
+  scrapeShopifyProducts,
+  ShopifyCatalogSchema,
+  ShopifyImageSchema,
+  ShopifyProductSchema,
+} from "@peated/server/lib/shopify";
 import { absoluteUrl } from "@peated/server/lib/urls";
 import { z } from "zod";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
@@ -12,36 +19,14 @@ import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 const SITE = "northstarspirits";
 const DEFAULT_VOLUME = 700;
 
-const NorthStarProductsSchema = z.object({
-  products: z.array(
-    z.object({
-      title: z.string().trim().min(1),
-      handle: z.string().trim().min(1),
-      body_html: z.string().nullish(),
-      images: z.array(
-        z.object({
-          src: z.string().url(),
-        }),
-      ),
-      variants: z.array(
-        z.object({
-          available: z.boolean(),
-          price: z.string(),
-        }),
-      ),
-    }),
-  ),
+const NorthStarProductSchema = ShopifyProductSchema.extend({
+  body_html: z.string().nullish(),
+  images: z.array(ShopifyImageSchema),
 });
 
-function parsePrice(value: string): number | null {
-  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
-  if (!match) return null;
-
-  const pounds = Number.parseInt(match[1], 10);
-  const pence = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
-  const price = pounds * 100 + pence;
-  return price > 0 ? price : null;
-}
+const NorthStarProductsSchema = ShopifyCatalogSchema.extend({
+  products: z.array(NorthStarProductSchema),
+});
 
 function extractVolume(title: string, bodyHtml: string | null): number {
   const match = `${title} ${bodyHtml ?? ""}`.match(
@@ -83,7 +68,7 @@ export function parseNorthStarProducts(
     const pricedVariant = product.variants
       .map((variant) => ({
         ...variant,
-        parsedPrice: parsePrice(variant.price),
+        parsedPrice: parseShopifyPrice(variant.price),
       }))
       .find((variant) => variant.available && variant.parsedPrice !== null);
     if (!pricedVariant || pricedVariant.parsedPrice === null) continue;
@@ -118,9 +103,7 @@ export function parseNorthStarProducts(
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
-  const data = await getUrl(url);
-  const products = parseNorthStarProducts(JSON.parse(data), url);
-  await Promise.all(products.map(cb));
+  return scrapeShopifyProducts(url, cb, parseNorthStarProducts);
 }
 
 export default async function scrapeNorthStarSpirits({

--- a/apps/server/src/worker/jobs/scrapeSingleCaskNation.ts
+++ b/apps/server/src/worker/jobs/scrapeSingleCaskNation.ts
@@ -3,7 +3,14 @@ import type {
   ScrapePricesCallback,
   StorePrice,
 } from "@peated/server/lib/scraper";
-import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
+import scrapePrices from "@peated/server/lib/scraper";
+import {
+  parseShopifyPrice,
+  scrapeShopifyProducts,
+  ShopifyCatalogSchema,
+  ShopifyImageSchema,
+  ShopifyProductSchema,
+} from "@peated/server/lib/shopify";
 import { absoluteUrl } from "@peated/server/lib/urls";
 import { z } from "zod";
 import { logScrapedProduct } from "./scrapeLogging";
@@ -20,44 +27,14 @@ const SUPPORTED_PRODUCT_TYPES = new Set([
   "Straight Rye Whisky",
 ]);
 
-const SingleCaskNationProductsSchema = z
-  .object({
-    products: z.array(
-      z
-        .object({
-          title: z.string().trim().min(1),
-          handle: z.string().trim().min(1),
-          product_type: z.string(),
-          images: z.array(
-            z
-              .object({
-                src: z.string().url(),
-              })
-              .passthrough(),
-          ),
-          variants: z.array(
-            z
-              .object({
-                available: z.boolean(),
-                price: z.string(),
-              })
-              .passthrough(),
-          ),
-        })
-        .passthrough(),
-    ),
-  })
-  .passthrough();
+const SingleCaskNationProductSchema = ShopifyProductSchema.extend({
+  product_type: z.string(),
+  images: z.array(ShopifyImageSchema),
+});
 
-function parsePrice(value: string): number | null {
-  const match = value.match(/^(\d+)(?:\.(\d{1,2}))?$/);
-  if (!match) return null;
-
-  const dollars = Number.parseInt(match[1], 10);
-  const cents = Number.parseInt((match[2] ?? "").padEnd(2, "0"), 10) || 0;
-  const price = dollars * 100 + cents;
-  return Number.isSafeInteger(price) && price > 0 ? price : null;
-}
+const SingleCaskNationProductsSchema = ShopifyCatalogSchema.extend({
+  products: z.array(SingleCaskNationProductSchema),
+});
 
 export function parseSingleCaskNationProducts(
   input: unknown,
@@ -72,7 +49,7 @@ export function parseSingleCaskNationProducts(
     const pricedVariant = product.variants
       .map((variant) => ({
         ...variant,
-        parsedPrice: parsePrice(variant.price),
+        parsedPrice: parseShopifyPrice(variant.price),
       }))
       .find((variant) => variant.available && variant.parsedPrice !== null);
     if (!pricedVariant || pricedVariant.parsedPrice === null) continue;
@@ -100,9 +77,7 @@ export function parseSingleCaskNationProducts(
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
-  const data = await getUrl(url);
-  const products = parseSingleCaskNationProducts(JSON.parse(data), url);
-  await Promise.all(products.map(cb));
+  return scrapeShopifyProducts(url, cb, parseSingleCaskNationProducts);
 }
 
 export default async function scrapeSingleCaskNation({


### PR DESCRIPTION
Shopify-backed price scrapers now share catalog schemas, price and image parsing, and page ingestion. A non-empty Shopify source page continues pagination even when every listing is filtered, preventing eligible products on later pages from being missed.

Batch persistence errors now escape to the worker boundary instead of being logged and discarded, so failed writes mark the scrape failed and follow normal job retry behavior. Source-specific filtering and bottle identity rules remain in individual scrapers.

Regression coverage exercises filtered-only pagination and persistence failures across the full worker-job test suite.
