### PR TITLE
ref(scrapers): centralize WooCommerce ingestion

### DIFF
--- a/apps/server/src/lib/woocommerce.test.ts
+++ b/apps/server/src/lib/woocommerce.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  decodeWooCommerceText,
+  parseWooCommercePrice,
+  scrapeWooCommerceProducts,
+} from "./woocommerce";
+
+process.env.DISABLE_HTTP_CACHE = "1";
+
+describe("parseWooCommercePrice", () => {
+  test.each([
+    ["1", 1],
+    ["5833", 5833],
+    ["0", null],
+    ["1.00", null],
+    ["£100", null],
+  ])("parses %s", (value, expected) => {
+    expect(parseWooCommercePrice(value)).toBe(expected);
+  });
+});
+
+test("decodes product text", () => {
+  expect(decodeWooCommerceText("Cadenhead&#8217;s &amp; Co.")).toBe(
+    "Cadenhead’s & Co.",
+  );
+});
+
+test("reports source products when every listing is filtered", async ({
+  axiosMock,
+}) => {
+  const url = "https://shop.example.com/wp-json/wc/store/v1/products?page=1";
+  axiosMock.onGet(url).reply(200, [{ name: "Gift set" }]);
+  const callback = vi.fn();
+
+  const result = await scrapeWooCommerceProducts(url, callback, () => []);
+
+  expect(result).toEqual({ hasSourceProducts: true });
+  expect(callback).not.toHaveBeenCalled();
+});
+
+test("rejects malformed catalog payloads", async ({ axiosMock }) => {
+  const url = "https://shop.example.com/wp-json/wc/store/v1/products?page=1";
+  axiosMock.onGet(url).reply(200, { products: [] });
+
+  await expect(
+    scrapeWooCommerceProducts(
+      url,
+      async () => {},
+      () => [],
+    ),
+  ).rejects.toThrow();
+});

--- a/apps/server/src/lib/woocommerce.ts
+++ b/apps/server/src/lib/woocommerce.ts
@@ -1,0 +1,65 @@
+import type {
+  ScrapePricesCallback,
+  ScrapePricesPageResult,
+  StorePrice,
+} from "@peated/server/lib/scraper";
+import { getUrl } from "@peated/server/lib/scraper";
+import { load as cheerio } from "cheerio";
+import { z } from "zod";
+
+export const WooCommerceCatalogSchema = z.array(z.unknown());
+
+export const WooCommercePriceSchema = z
+  .object({
+    price: z.string(),
+    currency_code: z.string(),
+    currency_minor_unit: z.number().int(),
+  })
+  .passthrough();
+
+export const WooCommerceImageSchema = z
+  .object({
+    src: z.string().url(),
+  })
+  .passthrough();
+
+export const WooCommerceProductSchema = z
+  .object({
+    name: z.string().trim().min(1),
+    permalink: z.string().trim().min(1),
+    prices: WooCommercePriceSchema,
+    images: z.array(z.unknown()),
+    is_in_stock: z.boolean(),
+    is_purchasable: z.boolean(),
+  })
+  .passthrough();
+
+export function getWooCommerceProductName(input: unknown): string | null {
+  if (!input || typeof input !== "object" || !("name" in input)) return null;
+  return typeof input.name === "string" ? input.name : null;
+}
+
+export function decodeWooCommerceText(value: string): string {
+  const $ = cheerio(`<span>${value}</span>`);
+  return $("span").text().trim();
+}
+
+export function parseWooCommercePrice(value: string): number | null {
+  if (!/^\d+$/.test(value)) return null;
+  const price = Number.parseInt(value, 10);
+  return Number.isSafeInteger(price) && price > 0 ? price : null;
+}
+
+/** A non-empty source page advances pagination even if every listing is filtered. */
+export async function scrapeWooCommerceProducts(
+  url: string,
+  cb: ScrapePricesCallback,
+  parseProducts: (input: unknown) => StorePrice[],
+): Promise<ScrapePricesPageResult> {
+  const data = await getUrl(url);
+  const catalog = WooCommerceCatalogSchema.parse(JSON.parse(data));
+  const products = parseProducts(catalog);
+  await Promise.all(products.map(cb));
+
+  return { hasSourceProducts: catalog.length > 0 };
+}

--- a/apps/server/src/worker/jobs/scrapeCadenheads.test.ts
+++ b/apps/server/src/worker/jobs/scrapeCadenheads.test.ts
@@ -7,6 +7,10 @@ process.env.DISABLE_HTTP_CACHE = "1";
 
 const firstPageUrl =
   "https://www.cadenhead.shop/wp-json/wc/store/v1/products?category=whisky&per_page=100&stock_status=instock&page=1";
+const secondPageUrl =
+  "https://www.cadenhead.shop/wp-json/wc/store/v1/products?category=whisky&per_page=100&stock_status=instock&page=2";
+const thirdPageUrl =
+  "https://www.cadenhead.shop/wp-json/wc/store/v1/products?category=whisky&per_page=100&stock_status=instock&page=3";
 
 test("routes the Cadenhead's source to its scraper job", () => {
   expect(getJobForSite("cadenheads")).toBe("ScrapeCadenheads");
@@ -54,13 +58,28 @@ test("paginates a dry run and stops after an empty page", async ({
 }) => {
   const result = await loadFixture("cadenheads", "bottle-list.json");
   axiosMock.onGet(firstPageUrl).reply(200, result);
-  axiosMock
-    .onGet(
-      "https://www.cadenhead.shop/wp-json/wc/store/v1/products?category=whisky&per_page=100&stock_status=instock&page=2",
-    )
-    .reply(200, []);
+  axiosMock.onGet(secondPageUrl).reply(200, []);
 
   await expect(scrapeCadenheads({ dryRun: true })).resolves.toBe(2);
+});
+
+test("continues after a page whose products are all filtered", async ({
+  axiosMock,
+}) => {
+  const result: Array<{ name?: unknown }> = JSON.parse(
+    await loadFixture("cadenheads", "bottle-list.json"),
+  );
+  const filteredProduct = result.find(
+    (product) => product.name === "Unavailable Tullibardine 11yo 70cl",
+  );
+  expect(filteredProduct).toBeDefined();
+
+  axiosMock.onGet(firstPageUrl).reply(200, [filteredProduct]);
+  axiosMock.onGet(secondPageUrl).reply(200, result);
+  axiosMock.onGet(thirdPageUrl).reply(200, []);
+
+  await expect(scrapeCadenheads({ dryRun: true })).resolves.toBe(2);
+  expect(axiosMock.history.get).toHaveLength(3);
 });
 
 test("fails when a complete scrape yields no supported listings", async ({

--- a/apps/server/src/worker/jobs/scrapeCadenheads.ts
+++ b/apps/server/src/worker/jobs/scrapeCadenheads.ts
@@ -4,62 +4,45 @@ import type {
   ScrapePricesCallback,
   StorePrice,
 } from "@peated/server/lib/scraper";
-import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
-import { load as cheerio } from "cheerio";
+import scrapePrices from "@peated/server/lib/scraper";
+import {
+  decodeWooCommerceText,
+  parseWooCommercePrice,
+  scrapeWooCommerceProducts,
+  WooCommerceImageSchema,
+  WooCommercePriceSchema,
+  WooCommerceProductSchema,
+} from "@peated/server/lib/woocommerce";
 import { z } from "zod";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 
 const SITE = "cadenheads";
 
-const CadenheadsProductsSchema = z.array(
-  z
-    .object({
-      name: z.string().trim().min(1),
-      permalink: z.string().url(),
-      prices: z
-        .object({
-          price: z.string().regex(/^\d+$/),
-          currency_code: z.literal("GBP"),
-          currency_minor_unit: z.literal(2),
-        })
-        .passthrough(),
-      images: z.array(
-        z
-          .object({
-            src: z.string().url(),
-          })
-          .passthrough(),
-      ),
-      attributes: z.array(
-        z
-          .object({
-            taxonomy: z.string(),
-            terms: z.array(
-              z
-                .object({
-                  name: z.string().trim().min(1),
-                })
-                .passthrough(),
-            ),
-          })
-          .passthrough(),
-      ),
-      is_in_stock: z.boolean(),
-      is_purchasable: z.boolean(),
-    })
-    // WooCommerce adds extension fields that are irrelevant to this parser.
-    .passthrough(),
-);
+const CadenheadsProductSchema = WooCommerceProductSchema.extend({
+  permalink: z.string().url(),
+  prices: WooCommercePriceSchema.extend({
+    price: z.string().regex(/^\d+$/),
+    currency_code: z.literal("GBP"),
+    currency_minor_unit: z.literal(2),
+  }),
+  images: z.array(WooCommerceImageSchema),
+  attributes: z.array(
+    z
+      .object({
+        taxonomy: z.string(),
+        terms: z.array(
+          z
+            .object({
+              name: z.string().trim().min(1),
+            })
+            .passthrough(),
+        ),
+      })
+      .passthrough(),
+  ),
+});
 
-function decodeProductName(value: string): string {
-  const $ = cheerio(`<span>${value}</span>`);
-  return $("span").text().trim();
-}
-
-function parsePrice(value: string): number | null {
-  const price = Number.parseInt(value, 10);
-  return Number.isSafeInteger(price) && price > 0 ? price : null;
-}
+const CadenheadsProductsSchema = z.array(CadenheadsProductSchema);
 
 function parseVolume(amountRaw: string, unit = "ml"): number | null {
   const amount = Number.parseFloat(amountRaw);
@@ -98,10 +81,10 @@ export function parseCadenheadsProducts(input: unknown): StorePrice[] {
   for (const product of payload) {
     if (!product.is_in_stock || !product.is_purchasable) continue;
 
-    const price = parsePrice(product.prices.price);
+    const price = parseWooCommercePrice(product.prices.price);
     if (price === null) continue;
 
-    const rawName = decodeProductName(product.name);
+    const rawName = decodeWooCommerceText(product.name);
     const volume = extractVolume(product, rawName);
     if (volume === null || !ALLOWED_VOLUMES.includes(volume)) {
       logScrapeWarning(SITE, "Invalid product size", { rawName, volume });
@@ -126,9 +109,7 @@ export function parseCadenheadsProducts(input: unknown): StorePrice[] {
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
-  const data = await getUrl(url);
-  const products = parseCadenheadsProducts(JSON.parse(data));
-  await Promise.all(products.map(cb));
+  return scrapeWooCommerceProducts(url, cb, parseCadenheadsProducts);
 }
 
 export default async function scrapeCadenheads({

--- a/apps/server/src/worker/jobs/scrapeThompsonBros.ts
+++ b/apps/server/src/worker/jobs/scrapeThompsonBros.ts
@@ -4,56 +4,21 @@ import type {
   ScrapePricesCallback,
   StorePrice,
 } from "@peated/server/lib/scraper";
-import scrapePrices, { getUrl } from "@peated/server/lib/scraper";
-import { load as cheerio } from "cheerio";
-import { z } from "zod";
+import scrapePrices from "@peated/server/lib/scraper";
+import {
+  decodeWooCommerceText,
+  getWooCommerceProductName,
+  parseWooCommercePrice,
+  scrapeWooCommerceProducts,
+  WooCommerceCatalogSchema,
+  WooCommerceImageSchema,
+  WooCommerceProductSchema,
+} from "@peated/server/lib/woocommerce";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 
 const SITE = "thompsonbros";
 const STORE_ORIGIN = "https://www.thompsonbrosdistillers.com";
 const CATALOG_URL = `${STORE_ORIGIN}/wp-json/wc/store/v1/products?category=18&per_page=100&stock_status=instock`;
-
-const ThompsonBrosCatalogSchema = z.array(z.unknown());
-
-const ThompsonBrosProductSchema = z
-  .object({
-    name: z.string().trim().min(1),
-    permalink: z.string().trim().min(1),
-    prices: z
-      .object({
-        price: z.string(),
-        currency_code: z.string(),
-        currency_minor_unit: z.number().int(),
-      })
-      .passthrough(),
-    images: z.array(z.unknown()),
-    is_in_stock: z.boolean(),
-    is_purchasable: z.boolean(),
-  })
-  // WooCommerce adds extension fields that are irrelevant to this parser.
-  .passthrough();
-
-const ProductImageSchema = z
-  .object({
-    src: z.string().url(),
-  })
-  .passthrough();
-
-function getRawName(input: unknown): string | null {
-  if (!input || typeof input !== "object" || !("name" in input)) return null;
-  return typeof input.name === "string" ? input.name : null;
-}
-
-function decodeProductName(value: string): string {
-  const $ = cheerio(`<span>${value}</span>`);
-  return $("span").text().trim();
-}
-
-function parsePrice(value: string): number | null {
-  if (!/^\d+$/.test(value)) return null;
-  const price = Number.parseInt(value, 10);
-  return Number.isSafeInteger(price) && price > 0 ? price : null;
-}
 
 function parseVolume(name: string): number | null {
   const match = name.match(/\b(\d+(?:\.\d+)?)\s*(ml|cl|l)\b/i);
@@ -78,7 +43,7 @@ function getProductUrl(value: string): string | null {
 function getImageUrl(value: unknown, rawName: string): string | null {
   if (value === undefined) return null;
 
-  const result = ProductImageSchema.safeParse(value);
+  const result = WooCommerceImageSchema.safeParse(value);
   if (!result.success) {
     logScrapeWarning(SITE, "Invalid product image URL", { rawName });
     return null;
@@ -87,14 +52,14 @@ function getImageUrl(value: unknown, rawName: string): string | null {
 }
 
 export function parseThompsonBrosProducts(input: unknown): StorePrice[] {
-  const payload = ThompsonBrosCatalogSchema.parse(input);
+  const payload = WooCommerceCatalogSchema.parse(input);
   const products: StorePrice[] = [];
 
   for (const productInput of payload) {
-    const productResult = ThompsonBrosProductSchema.safeParse(productInput);
+    const productResult = WooCommerceProductSchema.safeParse(productInput);
     if (!productResult.success) {
       logScrapeWarning(SITE, "Invalid product record", {
-        rawName: getRawName(productInput),
+        rawName: getWooCommerceProductName(productInput),
       });
       continue;
     }
@@ -102,7 +67,7 @@ export function parseThompsonBrosProducts(input: unknown): StorePrice[] {
     const product = productResult.data;
     if (!product.is_in_stock || !product.is_purchasable) continue;
 
-    const rawName = decodeProductName(product.name);
+    const rawName = decodeWooCommerceText(product.name);
     if (/\brum\b/i.test(rawName)) continue;
 
     const productUrl = getProductUrl(product.permalink);
@@ -123,7 +88,7 @@ export function parseThompsonBrosProducts(input: unknown): StorePrice[] {
     const price =
       product.prices.currency_code === "GBP" &&
       product.prices.currency_minor_unit === 2
-        ? parsePrice(product.prices.price)
+        ? parseWooCommercePrice(product.prices.price)
         : null;
     if (price === null) {
       logScrapeWarning(SITE, "Invalid product price", {
@@ -155,9 +120,7 @@ export function parseThompsonBrosProducts(input: unknown): StorePrice[] {
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
-  const data = await getUrl(url);
-  const products = parseThompsonBrosProducts(JSON.parse(data));
-  await Promise.all(products.map(cb));
+  return scrapeWooCommerceProducts(url, cb, parseThompsonBrosProducts);
 }
 
 export default async function scrapeThompsonBros({


### PR DESCRIPTION
Cadenhead’s and Thompson Bros now share WooCommerce catalog schemas, HTML decoding, minor-unit price parsing, and page ingestion. A non-empty WooCommerce page continues pagination even when every product is filtered, preventing later eligible listings from being missed.

Source-specific bottle identity, volume, URL, and availability rules remain in each scraper. Regression coverage exercises filtered-only pagination, and both scrapers were verified against their live catalogs.
