### PR TITLE
fix(scrapers): make legacy pagination source-aware

### DIFF
--- a/apps/server/src/lib/scraper.test.ts
+++ b/apps/server/src/lib/scraper.test.ts
@@ -241,6 +241,28 @@ describe("scrapePrices", () => {
     expect(scrapeProducts).toHaveBeenCalledTimes(4);
   });
 
+  it("prefers an explicit next-page signal over source product presence", async () => {
+    const scrapeProducts = vi.fn(
+      async (_url: string, cb: ScrapePricesCallback) => {
+        await cb({
+          name: "Product 1",
+          price: 1000,
+          currency: "usd",
+          url: "https://test.com/product1",
+          volume: 750,
+        });
+        return { hasNextPage: false, hasSourceProducts: true };
+      },
+    );
+
+    await expect(
+      scrapePrices("totalwine", () => "https://test.com/page", scrapeProducts, {
+        dryRun: true,
+      }),
+    ).resolves.toBe(1);
+    expect(scrapeProducts).toHaveBeenCalledOnce();
+  });
+
   it("flushes queued prices before propagating a later page failure", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/scraper.ts
+++ b/apps/server/src/lib/scraper.ts
@@ -219,9 +219,10 @@ export async function handleBottle(
 
 export type ScrapePricesCallback = (product: StorePrice) => Promise<void>;
 
-/** Lets source-card presence drive pagination when every eligible output is filtered. */
+/** Lets a source own pagination when emitted products are not a reliable signal. */
 export type ScrapePricesPageResult = {
-  hasSourceProducts: boolean;
+  hasSourceProducts?: boolean;
+  hasNextPage?: boolean;
 };
 
 function getScrapedProductKey(product: StorePrice): string {
@@ -254,10 +255,10 @@ export default async function scrapePrices(
 
   const uniqueProducts = new Set<string>();
 
-  let hasSourceProducts = true;
+  let hasMorePages = true;
   let page = 1;
   try {
-    while (hasSourceProducts) {
+    while (hasMorePages) {
       let emittedProduct = false;
       const result = await scrapeProducts(urlFn(page), async (product) => {
         logInfo("Scraped product price {name}", {
@@ -273,7 +274,8 @@ export default async function scrapePrices(
         uniqueProducts.add(productKey);
         emittedProduct = true;
       });
-      hasSourceProducts = result?.hasSourceProducts ?? emittedProduct;
+      hasMorePages =
+        result?.hasNextPage ?? result?.hasSourceProducts ?? emittedProduct;
       page += 1;
     }
 

--- a/apps/server/src/worker/jobs/scrapeAstorWines.test.ts
+++ b/apps/server/src/worker/jobs/scrapeAstorWines.test.ts
@@ -10,11 +10,11 @@ test("simple", async ({ axiosMock }) => {
 
   const items: any[] = [];
 
-  const fn = scrapeProducts(url, async (item) => {
+  const page = scrapeProducts(url, async (item) => {
     items.push(item);
   });
 
-  await fn;
+  await expect(page).resolves.toEqual({ hasNextPage: true });
 
   expect(items.length).toMatchInlineSnapshot(`12`);
   expect(items[0]).toMatchInlineSnapshot(`

--- a/apps/server/src/worker/jobs/scrapeAstorWines.ts
+++ b/apps/server/src/worker/jobs/scrapeAstorWines.ts
@@ -10,13 +10,15 @@ import { load as cheerio } from "cheerio";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 
 const SITE = "astorwines";
+const PRODUCT_CARD_SELECTOR = "#search-results .item-teaser";
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
   const data = await getUrl(url);
   const $ = cheerio(data);
 
   const promises: Promise<void>[] = [];
-  $("#search-results .item-teaser").each((_, el) => {
+  const cards = $(PRODUCT_CARD_SELECTOR);
+  cards.each((_, el) => {
     const rawName = ($(".header > h2", el).first().attr("title") || "").trim();
     if (!rawName) {
       logScrapeWarning(SITE, "Unable to identify product name");
@@ -64,14 +66,21 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
   });
 
   await Promise.all(promises);
+  const hasNextPage = $(".pagination a")
+    .toArray()
+    .some((link) => $(link).find(".fa-angle-right").length);
+  return { hasNextPage };
 }
 
-export default async function scrapeAstorWines() {
+export default async function scrapeAstorWines({
+  dryRun = false,
+}: { dryRun?: boolean } = {}) {
   const scotchCount = await scrapePrices(
     SITE,
     (page) =>
       `https://www.astorwines.com/SpiritsSearchResult.aspx?search=Advanced&searchtype=Contains&term=&cat=2&style=3_41&srt=1&instockonly=True&Page=${page}`,
     scrapeProducts,
+    { dryRun },
   );
 
   const whiskeyCount = await scrapePrices(
@@ -79,6 +88,7 @@ export default async function scrapeAstorWines() {
     (page) =>
       `https://www.astorwines.com/SpiritsSearchResult.aspx?search=Advanced&searchtype=Contains&term=&cat=2&style=2_32&srt=1&instockonly=True&Page=${page}`,
     scrapeProducts,
+    { dryRun },
   );
   return scotchCount + whiskeyCount;
 }

--- a/apps/server/src/worker/jobs/scrapeBerryBrosRudd.test.ts
+++ b/apps/server/src/worker/jobs/scrapeBerryBrosRudd.test.ts
@@ -21,9 +21,10 @@ test("scrapes purchasable own-selection bottles and excludes ineligible cards", 
   axiosMock.onGet(firstPageUrl).reply(200, result);
 
   const items: unknown[] = [];
-  await scrapeProducts(firstPageUrl, async (item) => {
+  const page = scrapeProducts(firstPageUrl, async (item) => {
     items.push(StorePriceInputSchema.parse(item));
   });
+  await expect(page).resolves.toEqual({ hasSourceProducts: true });
 
   expect(items).toEqual([
     {
@@ -65,6 +66,24 @@ test("paginates a dry run and stops after an empty page", async ({
   expect(axiosMock.history.get.map(({ url }: { url?: string }) => url)).toEqual(
     [firstPageUrl, secondPageUrl],
   );
+});
+
+test("continues after a page whose products are all filtered", async ({
+  axiosMock,
+}) => {
+  const filteredPage = `<div data-testid="product-card" class="sf-product-card">
+    <span class="body--strong">Unavailable whisky</span>
+    <button class="add-item">Sold out</button>
+  </div>`;
+  const result = await loadFixture("berrybrosrudd", "bottle-list.html");
+  const thirdPageUrl =
+    "https://www.bbr.com/search?page=3&spirit_type=Scotch%20Whisky&own_selection=true";
+  axiosMock.onGet(firstPageUrl).reply(200, filteredPage);
+  axiosMock.onGet(secondPageUrl).reply(200, result);
+  axiosMock.onGet(thirdPageUrl).reply(200, "<main></main>");
+
+  await expect(scrapeBerryBrosRudd({ dryRun: true })).resolves.toBe(3);
+  expect(axiosMock.history.get).toHaveLength(3);
 });
 
 test("fails when a complete scrape yields no supported listings", async ({

--- a/apps/server/src/worker/jobs/scrapeBerryBrosRudd.ts
+++ b/apps/server/src/worker/jobs/scrapeBerryBrosRudd.ts
@@ -38,14 +38,15 @@ function parseVolume(value: string): number | null {
   return Number.isInteger(volume) ? volume : null;
 }
 
-export function parseBerryBrosRuddProducts(
+export function parseBerryBrosRuddPage(
   html: string,
   sourceUrl: string,
-): StorePrice[] {
+): { products: StorePrice[]; hasSourceProducts: boolean } {
   const $ = cheerio(html);
   const products: StorePrice[] = [];
+  const cards = $(PRODUCT_CARD_SELECTOR);
 
-  $(PRODUCT_CARD_SELECTOR).each((_, element) => {
+  cards.each((_, element) => {
     const card = $(element);
     const rawName = card.find("span.body--strong").first().text().trim();
     const action = card.find("button.add-item").first().text().trim();
@@ -109,13 +110,14 @@ export function parseBerryBrosRuddProducts(
     products.push(listing);
   });
 
-  return products;
+  return { products, hasSourceProducts: cards.length > 0 };
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
   const data = await getUrl(url);
-  const products = parseBerryBrosRuddProducts(data, url);
+  const { products, hasSourceProducts } = parseBerryBrosRuddPage(data, url);
   await Promise.all(products.map(cb));
+  return { hasSourceProducts };
 }
 
 export default async function scrapeBerryBrosRudd({

--- a/apps/server/src/worker/jobs/scrapeDecadentDrinks.test.ts
+++ b/apps/server/src/worker/jobs/scrapeDecadentDrinks.test.ts
@@ -11,9 +11,10 @@ test("scrapes whisky listings and ignores unsupported sizes", async ({
   axiosMock.onGet(url).reply(200, result);
 
   const items: any[] = [];
-  await scrapeProducts(url, async (item) => {
+  const page = scrapeProducts(url, async (item) => {
     items.push(StorePriceInputSchema.parse(item));
   });
+  await expect(page).resolves.toEqual({ hasSourceProducts: true });
 
   expect(items).toEqual([
     {

--- a/apps/server/src/worker/jobs/scrapeDecadentDrinks.ts
+++ b/apps/server/src/worker/jobs/scrapeDecadentDrinks.ts
@@ -7,6 +7,8 @@ import { load as cheerio } from "cheerio";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 
 const SITE = "decadentdrinks";
+const PRODUCT_CARD_SELECTOR =
+  ".catalog-results .view-content > .col > .product-card";
 const DEFAULT_VOLUME = 700;
 
 function extractVolume(name: string): [string, number] {
@@ -39,7 +41,8 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
   const $ = cheerio(data);
 
   const promises: Promise<void>[] = [];
-  $(".catalog-results .view-content > .col > .product-card").each((_, el) => {
+  const cards = $(PRODUCT_CARD_SELECTOR);
+  cards.each((_, el) => {
     const rawName = $(".product-card__title", el).first().text().trim();
     if (!rawName) {
       logScrapeWarning(SITE, "Unable to identify product name");
@@ -83,12 +86,16 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
   });
 
   await Promise.all(promises);
+  return { hasSourceProducts: cards.length > 0 };
 }
 
-export default async function scrapeDecadentDrinks() {
+export default async function scrapeDecadentDrinks({
+  dryRun = false,
+}: { dryRun?: boolean } = {}) {
   return scrapePrices(
     SITE,
     (page) => `https://decadent-drinks.com/shop?category=5&page=${page - 1}`,
     scrapeProducts,
+    { dryRun },
   );
 }

--- a/apps/server/src/worker/jobs/scrapeEdradour.test.ts
+++ b/apps/server/src/worker/jobs/scrapeEdradour.test.ts
@@ -48,9 +48,10 @@ test("scrapes purchasable whisky and excludes unsupported products", async ({
   await mockFirstPage(axiosMock);
 
   const items: unknown[] = [];
-  await scrapeProducts(firstPageUrl, async (item) => {
+  const page = scrapeProducts(firstPageUrl, async (item) => {
     items.push(StorePriceInputSchema.parse(item));
   });
+  await expect(page).resolves.toEqual({ hasSourceProducts: true });
 
   expect(items).toEqual([
     {

--- a/apps/server/src/worker/jobs/scrapeEdradour.ts
+++ b/apps/server/src/worker/jobs/scrapeEdradour.ts
@@ -193,6 +193,8 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
     const product = parseEdradourProduct(detail, productCard.url);
     if (product) await cb(product);
   }
+
+  return { hasSourceProducts: productCards.length > 0 };
 }
 
 export default async function scrapeEdradour({

--- a/apps/server/src/worker/jobs/scrapeTotalWine.test.ts
+++ b/apps/server/src/worker/jobs/scrapeTotalWine.test.ts
@@ -10,11 +10,11 @@ test("simple", async ({ axiosMock }) => {
 
   const items: any[] = [];
 
-  const fn = scrapeProducts(url, async (item) => {
+  const page = scrapeProducts(url, async (item) => {
     items.push(item);
   });
 
-  await fn;
+  await expect(page).resolves.toEqual({ hasNextPage: true });
 
   expect(items.length).toMatchInlineSnapshot(`112`);
   expect(items[0]).toMatchInlineSnapshot(`

--- a/apps/server/src/worker/jobs/scrapeTotalWine.ts
+++ b/apps/server/src/worker/jobs/scrapeTotalWine.ts
@@ -10,13 +10,15 @@ import { load as cheerio } from "cheerio";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 
 const SITE = "totalwine";
+const PRODUCT_CARD_SELECTOR = "#main article";
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
   const data = await getUrl(url);
   const $ = cheerio(data);
 
   const promises: Promise<void>[] = [];
-  $("#main article").each((_, el) => {
+  const cards = $(PRODUCT_CARD_SELECTOR);
+  cards.each((_, el) => {
     const rawName = $("h2.title__2RoYeYuO > a", el).first().text();
     if (!rawName) {
       logScrapeWarning(SITE, "Unable to identify product name");
@@ -60,14 +62,24 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
   });
 
   await Promise.all(promises);
+  const nextPage = $('[data-at="product-search-pagination-nextlink"]');
+  return {
+    hasNextPage:
+      nextPage.length > 0 &&
+      !nextPage.is("[disabled]") &&
+      nextPage.attr("aria-disabled") !== "true",
+  };
 }
 
-export default async function scrapeTotalWine() {
+export default async function scrapeTotalWine({
+  dryRun = false,
+}: { dryRun?: boolean } = {}) {
   const scotchCount = await scrapePrices(
     SITE,
     (page) =>
       `https://www.totalwine.com/spirits/scotch/c/000887?viewall=true&pageSize=120&aty=0,0,0,0&page=${page}`,
     scrapeProducts,
+    { dryRun },
   );
 
   const whiskeyCount = await scrapePrices(
@@ -75,6 +87,7 @@ export default async function scrapeTotalWine() {
     (page) =>
       `https://www.totalwine.com/spirits/whiskey/c/9238919?viewall=true&pageSize=120&aty=0,0,0,0&page=${page}`,
     scrapeProducts,
+    { dryRun },
   );
   return scotchCount + whiskeyCount;
 }

--- a/apps/server/src/worker/jobs/scrapeWhiskyWorld.test.ts
+++ b/apps/server/src/worker/jobs/scrapeWhiskyWorld.test.ts
@@ -21,9 +21,10 @@ test("scrapes directly buyable bottles and excludes ineligible cards", async ({
   axiosMock.onGet(firstPageUrl).reply(200, result);
 
   const items: unknown[] = [];
-  await scrapeProducts(firstPageUrl, async (item) => {
+  const page = scrapeProducts(firstPageUrl, async (item) => {
     items.push(StorePriceInputSchema.parse(item));
   });
+  await expect(page).resolves.toEqual({ hasNextPage: false });
 
   expect(items).toEqual([
     {
@@ -77,7 +78,10 @@ test("scrapes directly buyable bottles and excludes ineligible cards", async ({
 test("paginates a dry run and stops after an empty page", async ({
   axiosMock,
 }) => {
-  const result = await loadFixture("whiskyworld", "bottle-list.html");
+  const result = `<link rel="next" href="${secondPageUrl}">${await loadFixture(
+    "whiskyworld",
+    "bottle-list.html",
+  )}`;
   axiosMock.onGet(firstPageUrl).reply(200, result);
   axiosMock.onGet(secondPageUrl).reply(200, "<main></main>");
 
@@ -87,24 +91,30 @@ test("paginates a dry run and stops after an empty page", async ({
   );
 });
 
-test("fails a page that has cards but no supported listings", async ({
+test("continues after a page whose products are all filtered", async ({
   axiosMock,
 }) => {
-  axiosMock.onGet(firstPageUrl).reply(
-    200,
-    `<main id="js-search-results-products__list">
+  const filteredPage = `<link rel="next" href="${secondPageUrl}">
+    <main id="js-search-results-products__list">
       <div class="product" id="product_1_1">
         <div class="product__details__title">
           <a href="/unavailable-whisky-p1">Unavailable Whisky</a>
         </div>
         <a class="product__options__view"><span>View</span></a>
       </div>
-    </main>`,
-  );
+    </main>`;
+  const thirdPageUrl =
+    "https://www.thewhiskyworld.com/whisky-c7/70cl-t24?show=48&page=3";
+  const result = `<link rel="next" href="${thirdPageUrl}">${await loadFixture(
+    "whiskyworld",
+    "bottle-list.html",
+  )}`;
+  axiosMock.onGet(firstPageUrl).reply(200, filteredPage);
+  axiosMock.onGet(secondPageUrl).reply(200, result);
+  axiosMock.onGet(thirdPageUrl).reply(200, "<main></main>");
 
-  await expect(scrapeProducts(firstPageUrl, async () => {})).rejects.toThrow(
-    "Whisky World page contained product cards but no supported listings.",
-  );
+  await expect(scrapeWhiskyWorld({ dryRun: true })).resolves.toBe(5);
+  expect(axiosMock.history.get).toHaveLength(3);
 });
 
 test("fails when a complete scrape yields no supported listings", async ({

--- a/apps/server/src/worker/jobs/scrapeWhiskyWorld.ts
+++ b/apps/server/src/worker/jobs/scrapeWhiskyWorld.ts
@@ -72,7 +72,10 @@ function isMultiproduct(title: string): boolean {
   return MULTIPRODUCT_PATTERN.test(title);
 }
 
-export function parseWhiskyWorldProducts(html: string): StorePrice[] {
+export function parseWhiskyWorldPage(html: string): {
+  products: StorePrice[];
+  hasNextPage: boolean;
+} {
   const $ = cheerio(html);
   const products: StorePrice[] = [];
   const cards = $(PRODUCT_CARD_SELECTOR);
@@ -132,19 +135,17 @@ export function parseWhiskyWorldProducts(html: string): StorePrice[] {
     products.push(listing);
   });
 
-  if (cards.length > 0 && products.length === 0) {
-    throw new Error(
-      "Whisky World page contained product cards but no supported listings.",
-    );
-  }
-
-  return products;
+  return {
+    products,
+    hasNextPage: $('link[rel="next"]').length > 0,
+  };
 }
 
 export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
   const data = await getUrl(url);
-  const products = parseWhiskyWorldProducts(data);
+  const { products, hasNextPage } = parseWhiskyWorldPage(data);
   await Promise.all(products.map(cb));
+  return { hasNextPage };
 }
 
 export default async function scrapeWhiskyWorld({

--- a/apps/server/src/worker/jobs/scrapeWoodenCork.test.ts
+++ b/apps/server/src/worker/jobs/scrapeWoodenCork.test.ts
@@ -9,11 +9,11 @@ test("simple", async ({ axiosMock }) => {
 
   const items: any[] = [];
 
-  const fn = scrapeProducts(url, async (item) => {
+  const page = scrapeProducts(url, async (item) => {
     items.push(item);
   });
 
-  await fn;
+  await expect(page).resolves.toEqual({ hasNextPage: true });
 
   expect(items.length).toBe(38);
   expect(items[0]).toMatchInlineSnapshot(`
@@ -25,4 +25,37 @@ test("simple", async ({ axiosMock }) => {
       "volume": 750,
     }
   `);
+});
+
+test("supports the current collection card markup", async ({ axiosMock }) => {
+  const url = "https://woodencork.com/collections/whiskey?cursor=1";
+  axiosMock.onGet(url).reply(
+    200,
+    `<div class="collection-grid">
+      <div class="product-grid-item">
+        <div class="grid-product__title">New Product 700ml</div>
+        <a class="grid-item__link" href="products/new-product"></a>
+        <span class="grid-product__price--current">
+          <span class="visually-hidden">$42.00</span>
+        </span>
+      </div>
+    </div>`,
+  );
+
+  const items: any[] = [];
+  await expect(
+    scrapeProducts(url, async (item) => {
+      items.push(item);
+    }),
+  ).resolves.toEqual({ hasNextPage: false });
+
+  expect(items).toEqual([
+    {
+      name: "New Product",
+      price: 4200,
+      currency: "usd",
+      volume: 700,
+      url: "https://woodencork.com/products/new-product",
+    },
+  ]);
 });

--- a/apps/server/src/worker/jobs/scrapeWoodenCork.ts
+++ b/apps/server/src/worker/jobs/scrapeWoodenCork.ts
@@ -9,6 +9,8 @@ import { load as cheerio } from "cheerio";
 import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 
 const SITE = "woodencork";
+const PRODUCT_CARD_SELECTOR =
+  "#CollectionAjaxContent div.grid-item, .collection-grid .product-grid-item";
 
 function extractVolume(name: string) {
   const match = name.match(/^(.+)\s([\d.]+(?:ml|l))$/i);
@@ -35,7 +37,8 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
   const $ = cheerio(data);
 
   const promises: Promise<void>[] = [];
-  $("#CollectionAjaxContent div.grid-item").each((_, el) => {
+  const cards = $(PRODUCT_CARD_SELECTOR);
+  cards.each((_, el) => {
     const bottle = $("div.grid-product__title", el).first().text();
     if (!bottle) {
       logScrapeWarning(SITE, "Unable to identify product name");
@@ -93,18 +96,25 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
         currency: "usd",
         volume,
         // image,
-        url: absoluteUrl(url, productUrl),
+        url: absoluteUrl("https://woodencork.com", productUrl),
       }),
     );
   });
 
   await Promise.all(promises);
+  return {
+    hasNextPage:
+      $('link[rel="next"]').length > 0 || $(".pagination .next a").length > 0,
+  };
 }
 
-export default async function scrapeWoodenCork() {
+export default async function scrapeWoodenCork({
+  dryRun = false,
+}: { dryRun?: boolean } = {}) {
   return scrapePrices(
     SITE,
     (page) => `https://woodencork.com/collections/whiskey?cursor=${page}`,
     scrapeProducts,
+    { dryRun },
   );
 }


### PR DESCRIPTION
Legacy paginated scrapers now tell the shared runner whether another source page exists, so a page whose listings are all filtered no longer truncates the scrape. Sources with real pagination controls use those controls directly, which also prevents loops on sites such as Whisky World that reset out-of-range requests to page 1.

This updates Astor Wines, Berry Bros. & Rudd, Decadent Drinks, Edradour, Total Wine, Whisky World, and Wooden Cork. The affected legacy entrypoints support dry runs, and Wooden Cork also recognizes its current card markup. Regression coverage includes filtered-only pages and explicit next-page precedence; all 225 worker tests, server typecheck, touched-file lint, and the full monorepo build pass. Live checks completed for Berry Bros. & Rudd, Decadent Drinks, Edradour, Whisky World’s first and terminal pages, and Wooden Cork; Astor Wines and Total Wine blocked this environment with their bot challenges and remain covered by fixtures.
