### PR TITLE
perf(prices): avoid repeat automatic classification

### DIFF
--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -5774,6 +5774,34 @@ describe("priceMatching", () => {
     expect(result.reviewedById).toBe(reviewer.id);
   });
 
+  test("does not reevaluate reviewable proposals during automatic resolution", async ({
+    fixtures,
+  }) => {
+    const { classifyBottleReference, runBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
+
+    for (const status of ["verified", "pending_review", "errored"] as const) {
+      const price = await fixtures.StorePrice({
+        name: `Already Classified ${status}`,
+      });
+      const [proposal] = await db
+        .insert(storePriceMatchProposals)
+        .values({
+          priceId: price.id,
+          status,
+          proposalType: "no_match",
+        })
+        .returning();
+
+      const result = await resolveStorePriceMatchProposal(price.id);
+
+      expect(result).toEqual(proposal);
+    }
+
+    expect(runBottleReference).not.toHaveBeenCalled();
+    expect(classifyBottleReference).not.toHaveBeenCalled();
+  });
+
   test("force reevaluation reopens closed proposals and clears review metadata", async ({
     fixtures,
   }) => {
@@ -6668,7 +6696,7 @@ describe("priceMatching", () => {
         [price.id],
       );
 
-      resolution = resolveStorePriceMatchProposal(price.id);
+      resolution = resolveStorePriceMatchProposal(price.id, { force: true });
       void resolution.catch(() => undefined);
       await waitForSessionBlockedBy(observer, blockerPid);
 
@@ -6954,7 +6982,7 @@ describe("priceMatching", () => {
         "LOCK TABLE store_price_match_attempt IN ACCESS EXCLUSIVE MODE",
       );
 
-      resolution = resolveStorePriceMatchProposal(price.id);
+      resolution = resolveStorePriceMatchProposal(price.id, { force: true });
       void resolution.catch(() => undefined);
       const resolverPid = await waitForSessionBlockedBy(
         observer,

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -52,7 +52,7 @@ import {
   type IncomingBottleDecisionActor,
   type IncomingBottleDecisionType,
 } from "@peated/server/lib/incomingBottleDecisionLog";
-import { logError } from "@peated/server/lib/log";
+import { logError, logInfo } from "@peated/server/lib/log";
 import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import {
   getStorePriceMatchAutomationAssessment,
@@ -64,10 +64,7 @@ import {
   refreshStorePriceMatchProposalProcessingLease,
   releaseStorePriceMatchProposalProcessingLease,
 } from "@peated/server/lib/priceMatchingProcessingLease";
-import {
-  CLOSED_STORE_PRICE_MATCH_PROPOSAL_STATUSES,
-  REVIEWABLE_STORE_PRICE_MATCH_PROPOSAL_STATUSES,
-} from "@peated/server/lib/priceMatchingStatus";
+import { REVIEWABLE_STORE_PRICE_MATCH_PROPOSAL_STATUSES } from "@peated/server/lib/priceMatchingStatus";
 import { resolveActiveBottleIds } from "@peated/server/lib/resolveActiveBottleIds";
 import { getAutomationModeratorUser } from "@peated/server/lib/systemUser";
 import {
@@ -1023,13 +1020,17 @@ export async function resolveStorePriceMatchProposal(
   const existingProposal = await db.query.storePriceMatchProposals.findFirst({
     where: eq(storePriceMatchProposals.priceId, price.id),
   });
-  if (
-    existingProposal &&
-    CLOSED_STORE_PRICE_MATCH_PROPOSAL_STATUSES.includes(
-      existingProposal.status,
-    ) &&
-    !force
-  ) {
+  // The proposal is the durable classification receipt. Automatic scraper and
+  // image redispatches must not spend model work again; explicit retries own
+  // reevaluation through force or a processing lease.
+  if (existingProposal && !force && !processingToken) {
+    logInfo("Skipped automatic store-price classification", {
+      extra: {
+        priceId: price.id,
+        proposalId: existingProposal.id,
+        proposalStatus: existingProposal.status,
+      },
+    });
     return existingProposal;
   }
 


### PR DESCRIPTION
Store-price resolution now treats any existing match proposal as the durable receipt for automatic classification, preventing scraper and image redispatches from invoking the bottle classifier again. Forced runs and processing-lease retries continue to reevaluate, and skipped automatic work emits structured telemetry.

Regression coverage verifies that verified, pending-review, and errored proposals return unchanged while intentional concurrency and retry scenarios explicitly request reprocessing. This reduces agent spend without changing first-time classification or retry controls.
