### PR TITLE
fix(classifier): prevent image-only audit overwrites

### DIFF
--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -71,6 +71,13 @@ shows the assignment is wrong. Likewise, change a populated exact field only
 with evidence for the same Bottle. Values from other batches or releases show
 variation, not a correction.
 
+A single public-image extraction may fill a missing scalar Bottle field, but it
+cannot replace a populated scalar value. Replacement requires a cited exact-product
+web result, a matching structured Bottle observation, or two distinct label
+images whose structured extractions agree. The audited Bottle name, not its
+image extraction, seeds initial candidate retrieval so one OCR or vision error
+cannot redirect the investigation before the agent sees the complete context.
+
 The classifier is bottle-centric. Price-match terms such as `match_existing`,
 `correction`, and `create_new` are downstream proposal policy, not classifier
 policy.

--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -72,11 +72,13 @@ with evidence for the same Bottle. Values from other batches or releases show
 variation, not a correction.
 
 A single public-image extraction may fill a missing scalar Bottle field, but it
-cannot replace a populated scalar value. Replacement requires a cited exact-product
-web result, a matching structured Bottle observation, or two distinct label
-images whose structured extractions agree. The audited Bottle name, not its
-image extraction, seeds initial candidate retrieval so one OCR or vision error
-cannot redirect the investigation before the agent sees the complete context.
+cannot replace a populated scalar value. Replacement requires a matching
+structured Bottle observation or two distinct label images whose structured
+extractions agree. An unstructured web result may inform moderator review but
+cannot authorize the replacement because it does not identify the field and
+value it supports. The audited Bottle name, not its image extraction, seeds
+initial candidate retrieval so one OCR or vision error cannot redirect the
+investigation before the agent sees the complete context.
 
 The classifier is bottle-centric. Price-match terms such as `match_existing`,
 `correction`, and `create_new` are downstream proposal policy, not classifier

--- a/packages/bottle-classifier/src/auditBottle.test.ts
+++ b/packages/bottle-classifier/src/auditBottle.test.ts
@@ -131,10 +131,7 @@ describe("auditBottle", () => {
           imageUrl: "https://example.com/bottles/45146.webp",
           currentBottleId: 45146,
         });
-        expect(extractedIdentity).toMatchObject({
-          edition: "Warehouse 1",
-          release_year: 2022,
-        });
+        expect(extractedIdentity).toBeNull();
         expect(initialCandidates).toEqual([
           expect.objectContaining({ bottleId: 45146 }),
         ]);
@@ -217,11 +214,7 @@ describe("auditBottle", () => {
         },
       ],
       artifacts: {
-        extractedIdentity: {
-          expression: "Càirdeas",
-          edition: "Warehouse 1",
-          release_year: 2022,
-        },
+        extractedIdentity: null,
         candidates: [{ bottleId: 45146 }],
         bottleContexts: [
           {
@@ -280,7 +273,7 @@ describe("auditBottle", () => {
       expect.objectContaining({
         query: "Laphroaig Càirdeas 2022 Warehouse 1",
         currentBottleId: 45146,
-        edition: "Warehouse 1",
+        edition: null,
       }),
     );
   });

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -719,11 +719,11 @@ export function prepareBottleAuditAgentRun(
     currentBottleId: audit.bottleId,
   };
   const normalizedExtractedIdentity =
-    extractedIdentity ??
-    currentBottleContext.publicImages.find(
-      ({ labelEvidence }) => labelEvidence.extractedIdentity !== null,
-    )?.labelEvidence.extractedIdentity ??
-    null;
+    extractedIdentity !== undefined
+      ? extractedIdentity
+      : (currentBottleContext.publicImages.find(
+          ({ labelEvidence }) => labelEvidence.extractedIdentity !== null,
+        )?.labelEvidence.extractedIdentity ?? null);
   const state: BottleClassifierAgentRunState = {
     searchEvidence: [...searchEvidence],
     candidateBottles: new Map(),
@@ -1157,8 +1157,9 @@ export function createBottleClassifier(
       };
       const preparedEvidence = await prepareBottleReferenceEvidence({
         reference,
-        extractedIdentity:
-          preferredImage?.labelEvidence.extractedIdentity ?? null,
+        // The audited Bottle name seeds retrieval. A fallible image extraction
+        // stays visible as context evidence but must not steer candidate search.
+        extractedIdentity: null,
         imageEvidence: null,
         candidateExpansion: "open",
         allowAutoIgnore: false,

--- a/packages/bottle-classifier/src/contextTools.test.ts
+++ b/packages/bottle-classifier/src/contextTools.test.ts
@@ -123,6 +123,80 @@ describe("Bottle-check context tools", () => {
     ).toEqual([]);
   });
 
+  test("does not let one label extraction overwrite populated Bottle fields", async () => {
+    const currentBottleContext: BottleContext = {
+      ...bottleContext(),
+      publicImages: [
+        {
+          source: { kind: "bottle" },
+          url: "https://example.com/bottles/45146.webp",
+          labelEvidence: {
+            sourceImageId: "bottle:45146",
+            model: "test-model",
+            extractedIdentity: {
+              brand: "Laphroaig",
+              bottler: null,
+              expression: "Càirdeas",
+              series: "Càirdeas",
+              distillery: ["Laphroaig"],
+              category: "single_malt",
+              stated_age: null,
+              abv: 56.4,
+              release_year: 2022,
+              vintage_year: null,
+              cask_strength: true,
+              single_cask: false,
+              cask_type: null,
+              cask_size: null,
+              cask_fill: null,
+              edition: "Cask 7445",
+            },
+            rawLabelText: "CASK 7445 56.4% ABV",
+          },
+        },
+      ],
+    };
+    const prepared = prepareBottleAuditAgentRun(
+      {
+        client: {} as OpenAI,
+        model: "test-model",
+        maxSearchQueries: 0,
+        adapters: {
+          searchBottles: vi.fn(async () => []),
+          getBottleContext: vi.fn(async () => null),
+        },
+      },
+      {
+        audit: {
+          bottleId: currentBottleContext.bottleId,
+          origin: "post_user_creation",
+        },
+        extractedIdentity: null,
+        currentBottleContext,
+        conversationId: "single-image-replacement",
+      },
+    );
+
+    expect(
+      await invokePreparedTool(prepared, "propose_update_bottle", {
+        bottleId: currentBottleContext.bottleId,
+        patch: { edition: "Cask 7445", abv: 56.4 },
+        rationale: "The single image extraction conflicts with stored fields.",
+        evidenceRefs: [
+          { kind: "bottle", bottleId: currentBottleContext.bottleId },
+        ],
+      }),
+    ).toMatchObject({
+      status: "rejected",
+      reason: expect.stringContaining('field "edition"'),
+    });
+    expect(
+      prepared.getOutput({
+        finalOutput: { summary: "No supported replacement remains." },
+      }).proposedOperations,
+    ).toEqual([]);
+  });
+
   test("offers bounded reference context without catalog-change tools", async () => {
     const prepared = await prepareBottleClassifierAgentRun(
       {

--- a/packages/bottle-classifier/src/contextTools.test.ts
+++ b/packages/bottle-classifier/src/contextTools.test.ts
@@ -123,7 +123,7 @@ describe("Bottle-check context tools", () => {
     ).toEqual([]);
   });
 
-  test("does not let one label extraction overwrite populated Bottle fields", async () => {
+  test("does not let unrelated web evidence or one label extraction overwrite populated Bottle fields", async () => {
     const currentBottleContext: BottleContext = {
       ...bottleContext(),
       publicImages: [
@@ -156,11 +156,32 @@ describe("Bottle-check context tools", () => {
         },
       ],
     };
+    const unrelatedWebUrl = "https://example.com/laphroaig";
     const prepared = prepareBottleAuditAgentRun(
       {
         client: {} as OpenAI,
         model: "test-model",
-        maxSearchQueries: 0,
+        maxSearchQueries: 1,
+        firecrawlApiKey: "firecrawl-test-key",
+        executeWebSearch: async () => ({
+          evidence: [
+            {
+              provider: "firecrawl",
+              query: "Laphroaig brand",
+              summary: "General information about the Laphroaig brand.",
+              results: [
+                {
+                  title: "Laphroaig",
+                  url: unrelatedWebUrl,
+                  domain: "example.com",
+                  description: "The history of the Laphroaig brand.",
+                  extraSnippets: [],
+                },
+              ],
+            },
+          ],
+          errors: [],
+        }),
         adapters: {
           searchBottles: vi.fn(async () => []),
           getBottleContext: vi.fn(async () => null),
@@ -177,6 +198,10 @@ describe("Bottle-check context tools", () => {
       },
     );
 
+    await invokePreparedTool(prepared, "firecrawl_web_search", {
+      queries: ["Laphroaig brand"],
+    });
+
     expect(
       await invokePreparedTool(prepared, "propose_update_bottle", {
         bottleId: currentBottleContext.bottleId,
@@ -184,6 +209,7 @@ describe("Bottle-check context tools", () => {
         rationale: "The single image extraction conflicts with stored fields.",
         evidenceRefs: [
           { kind: "bottle", bottleId: currentBottleContext.bottleId },
+          { kind: "web_result", url: unrelatedWebUrl },
         ],
       }),
     ).toMatchObject({

--- a/packages/bottle-classifier/src/eval-fixtures/audit-cases/image-only-extraction-does-not-overwrite-populated-fields.json
+++ b/packages/bottle-classifier/src/eval-fixtures/audit-cases/image-only-extraction-does-not-overwrite-populated-fields.json
@@ -1,0 +1,143 @@
+{
+  "id": "audit-image-only-extraction-does-not-overwrite-populated-fields",
+  "name": "audit: one image extraction does not overwrite populated exact fields",
+  "scenario": "clean",
+  "input": {
+    "audit": {
+      "bottleId": 45453,
+      "origin": "post_user_creation"
+    },
+    "context": {
+      "currentBottle": {
+        "bottleId": 45453,
+        "fullName": "Single Cask Nation Mannochmore - Red Wine Barrique - Cask 173445 - 17-year-old - 2024 Release - 2007 Vintage - 53.0% ABV - Cask Strength - Other Cask - Barrique - Refill",
+        "brand": "Single Cask Nation",
+        "bottler": "Single Cask Nation",
+        "distillery": ["Mannochmore"],
+        "category": "single_malt",
+        "statedAge": 17,
+        "edition": "Red Wine Barrique - Cask 173445",
+        "caskStrength": true,
+        "singleCask": true,
+        "caskType": "other",
+        "caskSize": "barrique",
+        "caskFill": "refill",
+        "abv": 53,
+        "vintageYear": 2007,
+        "releaseYear": 2024,
+        "score": 1,
+        "source": ["context"]
+      },
+      "bottleContexts": [
+        {
+          "bottleId": 45453,
+          "fullName": "Single Cask Nation Mannochmore - Red Wine Barrique - Cask 173445 - 17-year-old - 2024 Release - 2007 Vintage - 53.0% ABV - Cask Strength - Other Cask - Barrique - Refill",
+          "groupId": 18413,
+          "shared": {
+            "name": "Mannochmore",
+            "statedAge": null,
+            "series": null,
+            "category": "single_malt",
+            "brand": {
+              "entityId": 365762,
+              "name": "Single Cask Nation"
+            },
+            "distillers": [
+              {
+                "entityId": 1168,
+                "name": "Mannochmore"
+              }
+            ],
+            "bottler": {
+              "entityId": 365762,
+              "name": "Single Cask Nation"
+            }
+          },
+          "exact": {
+            "edition": "Red Wine Barrique - Cask 173445",
+            "statedAge": 17,
+            "abv": 53,
+            "singleCask": true,
+            "caskStrength": true,
+            "vintageYear": 2007,
+            "releaseYear": 2024,
+            "caskSize": "barrique",
+            "caskType": "other",
+            "caskFill": "refill"
+          },
+          "siblings": [],
+          "aliases": [],
+          "observations": [],
+          "imageSources": [
+            {
+              "source": {
+                "kind": "bottle"
+              },
+              "url": "https://api.peated.com/uploads/prices-wq9juag4geacz75tq1rbgy8o.webp"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "searchResponses": [
+    {
+      "when": ["mannochmore"],
+      "results": [
+        {
+          "bottleId": 45453,
+          "fullName": "Single Cask Nation Mannochmore - Red Wine Barrique - Cask 173445 - 17-year-old - 2024 Release - 2007 Vintage - 53.0% ABV - Cask Strength - Other Cask - Barrique - Refill",
+          "brand": "Single Cask Nation",
+          "bottler": "Single Cask Nation",
+          "distillery": ["Mannochmore"],
+          "category": "single_malt",
+          "statedAge": 17,
+          "edition": "Red Wine Barrique - Cask 173445",
+          "caskStrength": true,
+          "singleCask": true,
+          "caskType": "other",
+          "caskSize": "barrique",
+          "caskFill": "refill",
+          "abv": 53,
+          "vintageYear": 2007,
+          "releaseYear": 2024,
+          "score": 1,
+          "source": ["search"]
+        }
+      ]
+    }
+  ],
+  "provenance": {
+    "source": "curated_regression",
+    "verifiedSourceUrls": [
+      "https://api.peated.com/v1/bottles/45453",
+      "https://api.peated.com/uploads/prices-wq9juag4geacz75tq1rbgy8o.webp",
+      "https://www.skurnik.com/sku/mannochmore-2007-17-year-red-wine-barrique-cask-173445-single-cask-nation/",
+      "https://impexbev.com/single-cask-nation/"
+    ],
+    "dbOutcome": {
+      "bottleId": 45453,
+      "createsBottle": false,
+      "summary": "Keep Bottle 45453 unchanged. Its marketed release is cask 173445, finished in a refill red-wine barrique and bottled at 53% ABV."
+    },
+    "catalogFieldObservations": [
+      {
+        "target": "candidate_bottle",
+        "bottleId": 45453,
+        "field": "edition",
+        "productionValue": "Red Wine Barrique - Cask 173445",
+        "evidenceValue": "Cask 7445",
+        "source": "image_evidence",
+        "issue": "conflicts_with_evidence",
+        "safeToAutoFill": false,
+        "notes": "A low-resolution extraction can misread the cask number and must not replace the populated edition without independent support."
+      }
+    ],
+    "notes": "Curated from Bottle Check 1135 and its public Bottle image. The admin export omitted the original stored artifacts, so this fixture preserves the observed Bottle, image, failed operation, and independently verified DB outcome without claiming to reproduce unavailable observation rows."
+  },
+  "expected": {
+    "summary": "The available exact-product evidence supports the stored red-wine-barrique cask 173445 release at 53% ABV; no catalog change is supported.",
+    "proposedOperations": [],
+    "findings": []
+  }
+}

--- a/packages/bottle-classifier/src/instructions.ts
+++ b/packages/bottle-classifier/src/instructions.ts
@@ -102,6 +102,7 @@ const BOTTLE_OPERATION_POLICY = [
     "Before an identity-changing Bottle update, search for the corrected identity. If an independently complete canonical Bottle already represents it, merge the malformed duplicate into that survivor.",
     "Remove a populated Brand, bottler, distillery, series, category, or shared age only when product evidence shows it is wrong. Omission or one Entity filling multiple roles is not enough.",
     "Change a populated exact field only with evidence for the same Bottle. A value from another batch, edition, year, or exact cask does not qualify.",
+    "One label-image extraction can fill a missing scalar Bottle field, but it cannot replace a populated value by itself. A replacement needs a cited exact-product web result, a matching structured Bottle observation, or two agreeing label images.",
     "If evidence says an expression's batches are cask strength, barrel proof, or barrel strength but their ABVs vary, keep each Bottle's own ABV and set `caskStrength` to true.",
     "Never update a Bottle that is also a merge source in the same run. Keep Suggested Changes independent. Include only fields that change.",
     "Use `update_entity` and `merge_entities` only for inspected Entities materially related to the checked Bottle. Create a related Entity only through an explicit `kind: create` choice in an `update_bottle` patch.",

--- a/packages/bottle-classifier/src/instructions.ts
+++ b/packages/bottle-classifier/src/instructions.ts
@@ -102,7 +102,7 @@ const BOTTLE_OPERATION_POLICY = [
     "Before an identity-changing Bottle update, search for the corrected identity. If an independently complete canonical Bottle already represents it, merge the malformed duplicate into that survivor.",
     "Remove a populated Brand, bottler, distillery, series, category, or shared age only when product evidence shows it is wrong. Omission or one Entity filling multiple roles is not enough.",
     "Change a populated exact field only with evidence for the same Bottle. A value from another batch, edition, year, or exact cask does not qualify.",
-    "One label-image extraction can fill a missing scalar Bottle field, but it cannot replace a populated value by itself. A replacement needs a cited exact-product web result, a matching structured Bottle observation, or two agreeing label images.",
+    "One label-image extraction can fill a missing scalar Bottle field, but it cannot replace a populated value by itself. A replacement needs a matching structured Bottle observation or two agreeing label images; an unstructured web result may inform review but does not prove a field value.",
     "If evidence says an expression's batches are cask strength, barrel proof, or barrel strength but their ABVs vary, keep each Bottle's own ABV and set `caskStrength` to true.",
     "Never update a Bottle that is also a merge source in the same run. Keep Suggested Changes independent. Include only fields that change.",
     "Use `update_entity` and `merge_entities` only for inspected Entities materially related to the checked Bottle. Create a related Entity only through an explicit `kind: create` choice in an `update_bottle` patch.",

--- a/packages/bottle-classifier/src/runtime/bottleCheckRuntime.ts
+++ b/packages/bottle-classifier/src/runtime/bottleCheckRuntime.ts
@@ -45,6 +45,7 @@ import {
   bottleContextToCandidate,
   createBottleContextLoader,
 } from "./bottleCheckContext";
+import { findUnsupportedPopulatedBottlePatchField } from "./bottlePatchEvidence";
 import { mergeBottleCandidate, mergeResolvedEntity } from "./candidates";
 
 export type BottleClassifierDataSource = {
@@ -540,6 +541,20 @@ export function createRunProposalCollector({
               brand: context.shared.brand.name,
               bottler: context.shared.bottler?.name ?? null,
             }
+          : null;
+      },
+      getUnsupportedPopulatedBottlePatchField: (
+        bottleId,
+        patch,
+        evidenceRefs,
+      ) => {
+        const context = state.bottleContexts.get(bottleId);
+        return context
+          ? findUnsupportedPopulatedBottlePatchField({
+              context,
+              patch,
+              evidenceRefs,
+            })
           : null;
       },
     },

--- a/packages/bottle-classifier/src/runtime/bottleCheckRuntime.ts
+++ b/packages/bottle-classifier/src/runtime/bottleCheckRuntime.ts
@@ -543,17 +543,12 @@ export function createRunProposalCollector({
             }
           : null;
       },
-      getUnsupportedPopulatedBottlePatchField: (
-        bottleId,
-        patch,
-        evidenceRefs,
-      ) => {
+      getUnsupportedPopulatedBottlePatchField: (bottleId, patch) => {
         const context = state.bottleContexts.get(bottleId);
         return context
           ? findUnsupportedPopulatedBottlePatchField({
               context,
               patch,
-              evidenceRefs,
             })
           : null;
       },

--- a/packages/bottle-classifier/src/runtime/bottlePatchEvidence.test.ts
+++ b/packages/bottle-classifier/src/runtime/bottlePatchEvidence.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "vitest";
+
+import type { BottleContext } from "../bottleContextContract";
+import { findUnsupportedPopulatedBottlePatchField } from "./bottlePatchEvidence";
+
+function bottleContext({
+  abv = 53,
+  imageAbvs = [],
+  observationAbv,
+}: {
+  abv?: number | null;
+  imageAbvs?: number[];
+  observationAbv?: number;
+} = {}): BottleContext {
+  return {
+    bottleId: 45453,
+    fullName: "Example Bottle - 53.0% ABV",
+    groupId: 18413,
+    shared: {
+      name: "Example Bottle",
+      statedAge: null,
+      series: null,
+      category: "single_malt",
+      brand: { entityId: 1, name: "Example Brand" },
+      distillers: [{ entityId: 2, name: "Example Distillery" }],
+      bottler: null,
+    },
+    exact: {
+      edition: "Cask 173445",
+      statedAge: null,
+      abv,
+      singleCask: true,
+      caskStrength: true,
+      vintageYear: 2007,
+      releaseYear: 2024,
+      caskSize: "barrique",
+      caskType: "other",
+      caskFill: "refill",
+    },
+    siblings: [],
+    aliases: [],
+    observations:
+      observationAbv === undefined
+        ? []
+        : [
+            {
+              sourceType: "producer_factsheet",
+              sourceKey: "example-bottle",
+              sourceName: "Example Bottle factsheet",
+              sourceUrl: "https://example.com/bottle",
+              rawText: `Bottled at ${observationAbv}% ABV`,
+              parsedIdentity: { abv: observationAbv },
+              facts: null,
+            },
+          ],
+    publicImages: imageAbvs.map((imageAbv, index) => ({
+      source:
+        index === 0
+          ? { kind: "bottle" as const }
+          : { kind: "tasting" as const, tastingId: index },
+      url: `https://example.com/bottle-${index}.webp`,
+      labelEvidence: {
+        sourceImageId: `image:${index}`,
+        model: "test-model",
+        extractedIdentity: {
+          brand: "Example Brand",
+          bottler: null,
+          expression: "Example Bottle",
+          series: null,
+          distillery: ["Example Distillery"],
+          category: "single_malt",
+          stated_age: null,
+          abv: imageAbv,
+          release_year: 2024,
+          vintage_year: 2007,
+          cask_strength: true,
+          single_cask: true,
+          cask_type: "other",
+          cask_size: "barrique",
+          cask_fill: "refill",
+          edition: "Cask 7445",
+        },
+        rawLabelText: null,
+      },
+    })),
+  };
+}
+
+describe("populated Bottle patch evidence", () => {
+  test("rejects a populated-field replacement supported by only one image extraction", () => {
+    expect(
+      findUnsupportedPopulatedBottlePatchField({
+        context: bottleContext({ imageAbvs: [56.4] }),
+        patch: { abv: 56.4 },
+        evidenceRefs: [{ kind: "bottle", bottleId: 45453 }],
+      }),
+    ).toBe("abv");
+  });
+
+  test("accepts independent structured or web support for a replacement", () => {
+    expect(
+      findUnsupportedPopulatedBottlePatchField({
+        context: bottleContext({
+          imageAbvs: [56.4],
+          observationAbv: 56.4,
+        }),
+        patch: { abv: 56.4 },
+        evidenceRefs: [{ kind: "bottle", bottleId: 45453 }],
+      }),
+    ).toBeNull();
+    expect(
+      findUnsupportedPopulatedBottlePatchField({
+        context: bottleContext({ imageAbvs: [56.4] }),
+        patch: { abv: 56.4 },
+        evidenceRefs: [
+          { kind: "bottle", bottleId: 45453 },
+          { kind: "web_result", url: "https://example.com/bottle" },
+        ],
+      }),
+    ).toBeNull();
+  });
+
+  test("accepts two agreeing image extractions and one image for a missing field", () => {
+    expect(
+      findUnsupportedPopulatedBottlePatchField({
+        context: bottleContext({ imageAbvs: [56.4, 56.4] }),
+        patch: { abv: 56.4 },
+        evidenceRefs: [{ kind: "bottle", bottleId: 45453 }],
+      }),
+    ).toBeNull();
+    expect(
+      findUnsupportedPopulatedBottlePatchField({
+        context: bottleContext({ abv: null, imageAbvs: [56.4] }),
+        patch: { abv: 56.4 },
+        evidenceRefs: [{ kind: "bottle", bottleId: 45453 }],
+      }),
+    ).toBeNull();
+  });
+
+  test("checks every populated field in a mixed patch", () => {
+    expect(
+      findUnsupportedPopulatedBottlePatchField({
+        context: bottleContext({ observationAbv: 56.4 }),
+        patch: { abv: 56.4, edition: "Cask 7445" },
+        evidenceRefs: [{ kind: "bottle", bottleId: 45453 }],
+      }),
+    ).toBe("edition");
+  });
+});

--- a/packages/bottle-classifier/src/runtime/bottlePatchEvidence.test.ts
+++ b/packages/bottle-classifier/src/runtime/bottlePatchEvidence.test.ts
@@ -92,12 +92,11 @@ describe("populated Bottle patch evidence", () => {
       findUnsupportedPopulatedBottlePatchField({
         context: bottleContext({ imageAbvs: [56.4] }),
         patch: { abv: 56.4 },
-        evidenceRefs: [{ kind: "bottle", bottleId: 45453 }],
       }),
     ).toBe("abv");
   });
 
-  test("accepts independent structured or web support for a replacement", () => {
+  test("accepts matching structured support for a replacement", () => {
     expect(
       findUnsupportedPopulatedBottlePatchField({
         context: bottleContext({
@@ -105,17 +104,6 @@ describe("populated Bottle patch evidence", () => {
           observationAbv: 56.4,
         }),
         patch: { abv: 56.4 },
-        evidenceRefs: [{ kind: "bottle", bottleId: 45453 }],
-      }),
-    ).toBeNull();
-    expect(
-      findUnsupportedPopulatedBottlePatchField({
-        context: bottleContext({ imageAbvs: [56.4] }),
-        patch: { abv: 56.4 },
-        evidenceRefs: [
-          { kind: "bottle", bottleId: 45453 },
-          { kind: "web_result", url: "https://example.com/bottle" },
-        ],
       }),
     ).toBeNull();
   });
@@ -125,14 +113,12 @@ describe("populated Bottle patch evidence", () => {
       findUnsupportedPopulatedBottlePatchField({
         context: bottleContext({ imageAbvs: [56.4, 56.4] }),
         patch: { abv: 56.4 },
-        evidenceRefs: [{ kind: "bottle", bottleId: 45453 }],
       }),
     ).toBeNull();
     expect(
       findUnsupportedPopulatedBottlePatchField({
         context: bottleContext({ abv: null, imageAbvs: [56.4] }),
         patch: { abv: 56.4 },
-        evidenceRefs: [{ kind: "bottle", bottleId: 45453 }],
       }),
     ).toBeNull();
   });
@@ -142,7 +128,6 @@ describe("populated Bottle patch evidence", () => {
       findUnsupportedPopulatedBottlePatchField({
         context: bottleContext({ observationAbv: 56.4 }),
         patch: { abv: 56.4, edition: "Cask 7445" },
-        evidenceRefs: [{ kind: "bottle", bottleId: 45453 }],
       }),
     ).toBe("edition");
   });

--- a/packages/bottle-classifier/src/runtime/bottlePatchEvidence.ts
+++ b/packages/bottle-classifier/src/runtime/bottlePatchEvidence.ts
@@ -1,4 +1,4 @@
-import type { BottlePatch, EvidenceRef } from "../bottleCheckContract";
+import type { BottlePatch } from "../bottleCheckContract";
 import type { BottleContext } from "../bottleContextContract";
 
 const GUARDED_PATCH_FIELDS = [
@@ -105,22 +105,17 @@ function agreeingImageCount(
 
 /**
  * Protects populated scalar Bottle identity from a single fallible image pass.
- * Missing fields can still use one label; replacements need independent
- * structured context or a cited web result before they reach moderator review.
+ * Missing fields can still use one label; replacements need structured
+ * field-level context before they reach moderator review. Unstructured web
+ * results cannot prove which value they support.
  */
 export function findUnsupportedPopulatedBottlePatchField({
   context,
   patch,
-  evidenceRefs,
 }: {
   context: BottleContext;
   patch: BottlePatch;
-  evidenceRefs: readonly EvidenceRef[];
 }): GuardedPatchField | null {
-  if (evidenceRefs.some(({ kind }) => kind === "web_result")) {
-    return null;
-  }
-
   for (const field of GUARDED_PATCH_FIELDS) {
     const proposedValue = patch[field];
     if (proposedValue === undefined) continue;

--- a/packages/bottle-classifier/src/runtime/bottlePatchEvidence.ts
+++ b/packages/bottle-classifier/src/runtime/bottlePatchEvidence.ts
@@ -1,0 +1,143 @@
+import type { BottlePatch, EvidenceRef } from "../bottleCheckContract";
+import type { BottleContext } from "../bottleContextContract";
+
+const GUARDED_PATCH_FIELDS = [
+  "name",
+  "statedAge",
+  "category",
+  "edition",
+  "abv",
+  "singleCask",
+  "caskStrength",
+  "vintageYear",
+  "releaseYear",
+  "caskSize",
+  "caskType",
+  "caskFill",
+] as const satisfies readonly (keyof BottlePatch)[];
+
+type GuardedPatchField = (typeof GUARDED_PATCH_FIELDS)[number];
+
+const EVIDENCE_FIELD_NAMES = {
+  name: ["name", "expression"],
+  statedAge: ["statedAge", "stated_age"],
+  category: ["category"],
+  edition: ["edition"],
+  abv: ["abv"],
+  singleCask: ["singleCask", "single_cask"],
+  caskStrength: ["caskStrength", "cask_strength"],
+  vintageYear: ["vintageYear", "vintage_year"],
+  releaseYear: ["releaseYear", "release_year"],
+  caskSize: ["caskSize", "cask_size"],
+  caskType: ["caskType", "cask_type"],
+  caskFill: ["caskFill", "cask_fill"],
+} as const satisfies Record<GuardedPatchField, readonly string[]>;
+
+function currentFieldValue(
+  context: BottleContext,
+  field: GuardedPatchField,
+): unknown {
+  switch (field) {
+    case "name":
+      return context.shared.name;
+    case "statedAge":
+      return context.exact.statedAge ?? context.shared.statedAge;
+    case "category":
+      return context.shared.category;
+    case "edition":
+    case "abv":
+    case "singleCask":
+    case "caskStrength":
+    case "vintageYear":
+    case "releaseYear":
+    case "caskSize":
+    case "caskType":
+    case "caskFill":
+      return context.exact[field];
+  }
+}
+
+function recordSupportsValue(
+  record: Record<string, unknown> | null,
+  field: GuardedPatchField,
+  value: unknown,
+) {
+  if (!record) return false;
+
+  return EVIDENCE_FIELD_NAMES[field].some(
+    (fieldName) =>
+      Object.prototype.hasOwnProperty.call(record, fieldName) &&
+      Object.is(record[fieldName], value),
+  );
+}
+
+function observationSupportsValue(
+  context: BottleContext,
+  field: GuardedPatchField,
+  value: unknown,
+) {
+  return context.observations.some(
+    ({ parsedIdentity, facts }) =>
+      recordSupportsValue(parsedIdentity, field, value) ||
+      recordSupportsValue(facts, field, value),
+  );
+}
+
+function agreeingImageCount(
+  context: BottleContext,
+  field: GuardedPatchField,
+  value: unknown,
+) {
+  const sourceImageIds = new Set<string>();
+  for (const { labelEvidence } of context.publicImages) {
+    if (
+      recordSupportsValue(
+        labelEvidence.extractedIdentity as Record<string, unknown> | null,
+        field,
+        value,
+      )
+    ) {
+      sourceImageIds.add(labelEvidence.sourceImageId);
+    }
+  }
+  return sourceImageIds.size;
+}
+
+/**
+ * Protects populated scalar Bottle identity from a single fallible image pass.
+ * Missing fields can still use one label; replacements need independent
+ * structured context or a cited web result before they reach moderator review.
+ */
+export function findUnsupportedPopulatedBottlePatchField({
+  context,
+  patch,
+  evidenceRefs,
+}: {
+  context: BottleContext;
+  patch: BottlePatch;
+  evidenceRefs: readonly EvidenceRef[];
+}): GuardedPatchField | null {
+  if (evidenceRefs.some(({ kind }) => kind === "web_result")) {
+    return null;
+  }
+
+  for (const field of GUARDED_PATCH_FIELDS) {
+    const proposedValue = patch[field];
+    if (proposedValue === undefined) continue;
+
+    const currentValue = currentFieldValue(context, field);
+    if (currentValue === null || Object.is(currentValue, proposedValue)) {
+      continue;
+    }
+    if (observationSupportsValue(context, field, proposedValue)) {
+      continue;
+    }
+    if (agreeingImageCount(context, field, proposedValue) >= 2) {
+      continue;
+    }
+
+    return field;
+  }
+
+  return null;
+}

--- a/packages/bottle-classifier/src/tools/proposeOperations.test.ts
+++ b/packages/bottle-classifier/src/tools/proposeOperations.test.ts
@@ -25,6 +25,7 @@ function createHarness() {
               bottler: "The Scotch Malt Whisky Society",
             }
           : { brand: "Example Distillery", bottler: null },
+      getUnsupportedPopulatedBottlePatchField: () => null,
     },
   });
   return {
@@ -220,6 +221,41 @@ describe("Bottle proposal tools", () => {
         },
       }),
     ]);
+  });
+
+  test("returns the evidence boundary reason for an unsupported populated-field replacement", async () => {
+    const inspectedBottleIds = new Set([10]);
+    const collector = createBottleProposalCollector({
+      context: {
+        hasBottleEvidence: (bottleId) => inspectedBottleIds.has(bottleId),
+        hasEntityEvidence: () => false,
+        hasSourceEvidence: () => false,
+        hasWebEvidence: () => false,
+        isBottleInspected: (bottleId) => inspectedBottleIds.has(bottleId),
+        isEntityInspected: () => false,
+        isSeriesInspected: () => false,
+        getBottleBranding: () => ({
+          brand: "Example Distillery",
+          bottler: null,
+        }),
+        getUnsupportedPopulatedBottlePatchField: () => "abv",
+      },
+    });
+    const tools = createBottleProposalTools(collector);
+
+    expect(
+      await invoke(tools, "propose_update_bottle", {
+        bottleId: 10,
+        patch: { abv: 56.4 },
+        rationale: "A single label extraction contradicts the stored ABV.",
+        evidenceRefs: [{ kind: "bottle", bottleId: 10 }],
+      }),
+    ).toEqual({
+      status: "rejected",
+      reason:
+        'Changing populated Bottle field "abv" requires a cited web result, a matching structured Bottle observation, or two agreeing label images. One image extraction cannot overwrite an existing value.',
+    });
+    expect(collector.getProposals()).toEqual([]);
   });
 
   test("rejects an SMWS cask code as edition while keeping the other exact repairs", async () => {

--- a/packages/bottle-classifier/src/tools/proposeOperations.test.ts
+++ b/packages/bottle-classifier/src/tools/proposeOperations.test.ts
@@ -253,7 +253,7 @@ describe("Bottle proposal tools", () => {
     ).toEqual({
       status: "rejected",
       reason:
-        'Changing populated Bottle field "abv" requires a cited web result, a matching structured Bottle observation, or two agreeing label images. One image extraction cannot overwrite an existing value.',
+        'Changing populated Bottle field "abv" requires a matching structured Bottle observation or two agreeing label images. Unstructured web results and one image extraction cannot overwrite an existing value.',
     });
     expect(collector.getProposals()).toEqual([]);
   });

--- a/packages/bottle-classifier/src/tools/proposeOperations.ts
+++ b/packages/bottle-classifier/src/tools/proposeOperations.ts
@@ -45,7 +45,6 @@ type ProposalCollectionContext = {
   getUnsupportedPopulatedBottlePatchField: (
     bottleId: number,
     patch: BottlePatch,
-    evidenceRefs: readonly EvidenceRef[],
   ) => keyof BottlePatch | null;
 };
 
@@ -304,12 +303,11 @@ export function createBottleProposalCollector({
           context.getUnsupportedPopulatedBottlePatchField(
             proposal.input.bottleId,
             proposal.input.patch,
-            proposal.evidenceRefs,
           );
         if (unsupportedField) {
           return {
             status: "rejected",
-            reason: `Changing populated Bottle field ${JSON.stringify(unsupportedField)} requires a cited web result, a matching structured Bottle observation, or two agreeing label images. One image extraction cannot overwrite an existing value.`,
+            reason: `Changing populated Bottle field ${JSON.stringify(unsupportedField)} requires a matching structured Bottle observation or two agreeing label images. Unstructured web results and one image extraction cannot overwrite an existing value.`,
           };
         }
       }
@@ -363,7 +361,7 @@ export function createBottleProposalTools(collector: BottleProposalCollector) {
     tool({
       name: "propose_update_bottle",
       description: proposalToolDescription(
-        "Record one read-only proposal to update one inspected Bottle. Include every supported field change for that Bottle in one sparse patch. Use only after investigating the Bottle and collecting every cited piece of evidence. Remove a populated relationship or change a populated exact field only when evidence for that Bottle shows it is wrong; omission is not enough. One label-image extraction may fill a missing scalar field but cannot replace a populated value without a cited exact-product web result, a matching structured Bottle observation, or a second agreeing label image. Do not propose an update solely for cask type, size, or fill. This does not mutate or approve catalog data.",
+        "Record one read-only proposal to update one inspected Bottle. Include every supported field change for that Bottle in one sparse patch. Use only after investigating the Bottle and collecting every cited piece of evidence. Remove a populated relationship or change a populated exact field only when evidence for that Bottle shows it is wrong; omission is not enough. One label-image extraction may fill a missing scalar field but cannot replace a populated value without a matching structured Bottle observation or a second agreeing label image. Unstructured web results may inform review but cannot authorize the replacement. Do not propose an update solely for cask type, size, or fill. This does not mutate or approve catalog data.",
       ),
       parameters: nonStrictJsonSchema(UpdateBottleProposalArgsSchema),
       strict: false,

--- a/packages/bottle-classifier/src/tools/proposeOperations.ts
+++ b/packages/bottle-classifier/src/tools/proposeOperations.ts
@@ -8,6 +8,7 @@ import {
   ProposedOperationSchema,
   UpdateBottleOperationSchema,
   UpdateEntityOperationSchema,
+  type BottlePatch,
   type EvidenceRef,
   type ProposedOperation,
 } from "../bottleCheckContract";
@@ -41,6 +42,11 @@ type ProposalCollectionContext = {
   getBottleBranding: (
     bottleId: number,
   ) => { brand: string; bottler: string | null } | null;
+  getUnsupportedPopulatedBottlePatchField: (
+    bottleId: number,
+    patch: BottlePatch,
+    evidenceRefs: readonly EvidenceRef[],
+  ) => keyof BottlePatch | null;
 };
 
 type ProposalRecordResult =
@@ -293,6 +299,21 @@ export function createBottleProposalCollector({
         };
       }
 
+      if (proposal.type === "update_bottle") {
+        const unsupportedField =
+          context.getUnsupportedPopulatedBottlePatchField(
+            proposal.input.bottleId,
+            proposal.input.patch,
+            proposal.evidenceRefs,
+          );
+        if (unsupportedField) {
+          return {
+            status: "rejected",
+            reason: `Changing populated Bottle field ${JSON.stringify(unsupportedField)} requires a cited web result, a matching structured Bottle observation, or two agreeing label images. One image extraction cannot overwrite an existing value.`,
+          };
+        }
+      }
+
       const key = JSON.stringify({
         type: proposal.type,
         input: proposal.input,
@@ -342,7 +363,7 @@ export function createBottleProposalTools(collector: BottleProposalCollector) {
     tool({
       name: "propose_update_bottle",
       description: proposalToolDescription(
-        "Record one read-only proposal to update one inspected Bottle. Include every supported field change for that Bottle in one sparse patch. Use only after investigating the Bottle and collecting every cited piece of evidence. Remove a populated relationship or change a populated exact field only when evidence for that Bottle shows it is wrong; omission is not enough. Do not propose an update solely for cask type, size, or fill. This does not mutate or approve catalog data.",
+        "Record one read-only proposal to update one inspected Bottle. Include every supported field change for that Bottle in one sparse patch. Use only after investigating the Bottle and collecting every cited piece of evidence. Remove a populated relationship or change a populated exact field only when evidence for that Bottle shows it is wrong; omission is not enough. One label-image extraction may fill a missing scalar field but cannot replace a populated value without a cited exact-product web result, a matching structured Bottle observation, or a second agreeing label image. Do not propose an update solely for cask type, size, or fill. This does not mutate or approve catalog data.",
       ),
       parameters: nonStrictJsonSchema(UpdateBottleProposalArgsSchema),
       strict: false,


### PR DESCRIPTION
Bottle audits no longer treat one fallible label-image extraction as authority for populated scalar fields. Candidate retrieval starts from the stored Bottle identity while image extraction remains available as context; one image may fill a missing value, but replacing an existing value requires a matching structured Bottle observation or two distinct label images whose extractions agree.

Unstructured web results remain visible to moderators but cannot authorize a replacement because the current evidence reference proves only that a URL was collected, not which exact product, field, or value it supports. This intentionally favors rejecting web-only corrections until web evidence has a field-scoped structured contract. A regression based on the reported cask-number and ABV misread also verifies that citing an unrelated collected web result does not bypass the boundary. The classifier's 377 deterministic tests, fixture validation, typecheck, formatting, and lint pass.
