### PR TITLE
feat(moderation): add clear inconclusive listing actions

### DIFF
--- a/apps/server/src/lib/moderationTasks.ts
+++ b/apps/server/src/lib/moderationTasks.ts
@@ -20,6 +20,8 @@ function listingQuestion(proposalType: string): string {
       return "Should this Bottle be added to the catalog?";
     case "correction":
       return "Should this Bottle record be corrected?";
+    case "no_match":
+      return "No Bottle match was found. Should this listing be ignored?";
     default:
       return "How should this listing be resolved?";
   }
@@ -110,13 +112,18 @@ async function listingTasks(): Promise<ModerationTaskSummary[]> {
     kind: "listing",
     category: "listing",
     state: proposal.status === "errored" ? "blocked" : "ready",
+    inconclusive:
+      proposal.status === "pending_review" &&
+      proposal.proposalType === "no_match",
     title: price.name,
     sourceLabel: site.name,
     question: listingQuestion(proposal.proposalType),
     statusLabel:
       proposal.status === "errored"
         ? "Needs recovery"
-        : proposal.proposalType.replaceAll("_", " "),
+        : proposal.proposalType === "no_match"
+          ? "Inconclusive"
+          : proposal.proposalType.replaceAll("_", " "),
     attentionAt: (proposal.enteredQueueAt ?? proposal.createdAt).toISOString(),
     source: { kind: "listing", proposalId: proposal.id },
   }));
@@ -151,6 +158,7 @@ async function catalogTasks(): Promise<ModerationTaskSummary[]> {
           kind: "operation",
           category: "catalog",
           state: operation.status === "blocked" ? "blocked" : "ready",
+          inconclusive: false,
           title: copy.title,
           sourceLabel: checkSourceLabel(check),
           question: copy.question,
@@ -177,6 +185,7 @@ async function catalogTasks(): Promise<ModerationTaskSummary[]> {
           kind: "finding" as const,
           category: "catalog" as const,
           state: findings === null ? ("blocked" as const) : ("ready" as const),
+          inconclusive: false,
           title: subject,
           sourceLabel: checkSourceLabel(check),
           question:
@@ -213,11 +222,18 @@ export function filterModerationTasks(
     query?: string;
     category?: "listing" | "catalog";
     blocked?: boolean;
+    inconclusive?: boolean;
   },
 ): ModerationTaskSummary[] {
   const query = input.query?.toLocaleLowerCase();
   return tasks.filter((task) => {
     if (input.category && task.category !== input.category) return false;
+    if (
+      input.inconclusive !== undefined &&
+      task.inconclusive !== input.inconclusive
+    ) {
+      return false;
+    }
     if (
       input.blocked !== undefined &&
       (task.state === "blocked") !== input.blocked

--- a/apps/server/src/lib/priceMatching.ts
+++ b/apps/server/src/lib/priceMatching.ts
@@ -20,6 +20,7 @@ export {
   canClearIgnoredStorePriceAssignment,
   createBottleFromStorePriceMatchProposal,
   getStorePriceMatchProposalForReviewInTransaction,
+  ignoreInconclusiveStorePriceMatchProposals,
   ignoreStorePriceMatchProposal,
   resolveStorePriceMatchProposal,
   upsertStorePriceMatchProposal,

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -79,7 +79,7 @@ import {
   StorePriceMatchDecisionSchema,
 } from "@peated/server/schemas";
 import { pushUniqueJob } from "@peated/server/worker/client";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { isDeepStrictEqual } from "node:util";
 import type { z } from "zod";
 
@@ -1771,5 +1771,71 @@ export async function ignoreStorePriceMatchProposal({
       finalStatus: "ignored",
       reviewedById,
     });
+  });
+}
+
+export async function ignoreInconclusiveStorePriceMatchProposals({
+  reviewedById,
+  actor,
+}: {
+  reviewedById: number;
+  actor: IncomingBottleDecisionActor;
+}): Promise<number> {
+  return await db.transaction(async (tx) => {
+    await getPriceMatchWriteActorForDatabase(tx, actor, {
+      userId: reviewedById,
+    });
+
+    // Bulk moderation owns only pending, unleased no-match proposals that are
+    // visible in the listing inbox. Other proposal outcomes keep their normal
+    // per-item review boundary.
+    const ignored = await tx
+      .update(storePriceMatchProposals)
+      .set({
+        status: "ignored",
+        reviewedById,
+        reviewedAt: sql`NOW()`,
+        updatedAt: sql`NOW()`,
+        processingToken: null,
+        processingQueuedAt: null,
+        processingExpiresAt: null,
+        error: null,
+      })
+      .where(
+        and(
+          eq(storePriceMatchProposals.status, "pending_review"),
+          eq(storePriceMatchProposals.proposalType, "no_match"),
+          sql`(${storePriceMatchProposals.processingExpiresAt} IS NULL OR ${storePriceMatchProposals.processingExpiresAt} <= NOW())`,
+          sql`EXISTS (
+            SELECT 1
+            FROM ${storePrices}
+            WHERE ${storePrices.id} = ${storePriceMatchProposals.priceId}
+              AND ${storePrices.hidden} = false
+          )`,
+        ),
+      )
+      .returning({ id: storePriceMatchProposals.id });
+
+    for (let offset = 0; offset < ignored.length; offset += 10_000) {
+      const proposalIds = ignored
+        .slice(offset, offset + 10_000)
+        .map(({ id }) => id);
+      await tx.execute(sql`
+        UPDATE ${storePriceMatchAttempts}
+        SET
+          final_status = 'ignored',
+          reviewed_by_id = ${reviewedById},
+          reviewed_at = NOW(),
+          updated_at = NOW()
+        WHERE id IN (
+          SELECT MAX(id)
+          FROM ${storePriceMatchAttempts}
+          WHERE ${inArray(storePriceMatchAttempts.proposalId, proposalIds)}
+          GROUP BY ${storePriceMatchAttempts.proposalId}
+        )
+      `);
+    }
+
+    return ignored.length;
   });
 }

--- a/apps/server/src/orpc/routes/admin/moderation/ignore-inconclusive.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/ignore-inconclusive.ts
@@ -1,0 +1,24 @@
+import { getUserActor } from "@peated/server/lib/actors";
+import { ignoreInconclusiveStorePriceMatchProposals } from "@peated/server/lib/priceMatching";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import { z } from "zod";
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "POST",
+    path: "/admin/moderation/listings/inconclusive/ignore",
+    summary: "Ignore inconclusive listing proposals",
+    description:
+      "Ignore every visible, actionable no-match listing proposal. Requires administrator privileges.",
+    operationId: "ignoreInconclusiveModerationListings",
+  })
+  .input(z.object({}).strict().default({}))
+  .output(z.object({ ignored: z.number().int().min(0) }).strict())
+  .handler(async ({ context }) => ({
+    ignored: await ignoreInconclusiveStorePriceMatchProposals({
+      reviewedById: context.user.id,
+      actor: await getUserActor(context.user),
+    }),
+  }));

--- a/apps/server/src/orpc/routes/admin/moderation/index.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/index.ts
@@ -1,6 +1,7 @@
 import { base } from "@peated/server/orpc";
 import automation from "./automation";
 import historyDetails from "./history-details";
+import ignoreInconclusive from "./ignore-inconclusive";
 import listHistory from "./list-history";
 import listTasks from "./list-tasks";
 import task from "./task";
@@ -8,6 +9,7 @@ import task from "./task";
 export default base.router({
   automation,
   historyDetails,
+  ignoreInconclusive,
   listHistory,
   listTasks,
   task,

--- a/apps/server/src/orpc/routes/admin/moderation/list-tasks.test.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/list-tasks.test.ts
@@ -2,6 +2,7 @@ import { db } from "@peated/server/db";
 import {
   bottleChecks,
   bottleOperations,
+  storePriceMatchAttempts,
   storePriceMatchProposals,
 } from "@peated/server/db/schema";
 import { BOTTLE_CHECK_SCHEMA_VERSION } from "@peated/server/lib/bottleChecks";
@@ -102,6 +103,7 @@ describe("admin moderation tasks", () => {
       listing: 1,
       catalog: 2,
       blocked: 1,
+      inconclusive: 0,
     });
 
     const blocked = await routerClient.admin.moderation.listTasks(
@@ -114,6 +116,7 @@ describe("admin moderation tasks", () => {
         state: "blocked",
       }),
     ]);
+    expect(blocked.counts).toMatchObject({ all: 3, blocked: 1 });
 
     await db
       .update(bottleOperations)
@@ -128,6 +131,116 @@ describe("admin moderation tasks", () => {
     expect(error.message).toBe(
       "This moderation task no longer needs attention.",
     );
+  });
+
+  test("filters and bulk-ignores only actionable inconclusive listings", async ({
+    fixtures,
+  }) => {
+    const admin = await fixtures.User({ admin: true });
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const inconclusivePrice = await fixtures.StorePrice({
+      bottleId: null,
+      externalSiteId: site.id,
+      name: "Unresolved listing",
+    });
+    const matchedPrice = await fixtures.StorePrice({
+      bottleId: null,
+      externalSiteId: site.id,
+      name: "Matched listing",
+    });
+    const processingPrice = await fixtures.StorePrice({
+      bottleId: null,
+      externalSiteId: site.id,
+      name: "Processing unresolved listing",
+    });
+    const hiddenPrice = await fixtures.StorePrice({
+      bottleId: null,
+      externalSiteId: site.id,
+      hidden: true,
+      name: "Hidden unresolved listing",
+    });
+    const [inconclusive, matched, processing, hidden] = await db
+      .insert(storePriceMatchProposals)
+      .values([
+        {
+          priceId: inconclusivePrice.id,
+          proposalType: "no_match",
+          status: "pending_review",
+        },
+        {
+          priceId: matchedPrice.id,
+          proposalType: "match_existing",
+          status: "pending_review",
+        },
+        {
+          priceId: processingPrice.id,
+          proposalType: "no_match",
+          status: "pending_review",
+          processingExpiresAt: new Date(Date.now() + 60_000),
+          processingToken: "active-classification",
+        },
+        {
+          priceId: hiddenPrice.id,
+          proposalType: "no_match",
+          status: "pending_review",
+        },
+      ])
+      .returning();
+    const [attempt] = await db
+      .insert(storePriceMatchAttempts)
+      .values({
+        priceId: inconclusivePrice.id,
+        proposalId: inconclusive!.id,
+        proposalType: "no_match",
+        initialStatus: "pending_review",
+      })
+      .returning();
+
+    const filtered = await routerClient.admin.moderation.listTasks(
+      { inconclusive: true },
+      { context: { user: admin } },
+    );
+    expect(filtered.results).toEqual([
+      expect.objectContaining({
+        key: `listing:${inconclusive!.id}`,
+        inconclusive: true,
+        question: "No Bottle match was found. Should this listing be ignored?",
+        statusLabel: "Inconclusive",
+      }),
+    ]);
+    expect(filtered.counts.inconclusive).toBe(1);
+
+    await expect(
+      routerClient.admin.moderation.ignoreInconclusive(
+        {},
+        { context: { user: await fixtures.User({ mod: true }) } },
+      ),
+    ).rejects.toThrow("Unauthorized");
+
+    await expect(
+      routerClient.admin.moderation.ignoreInconclusive(
+        {},
+        { context: { user: admin } },
+      ),
+    ).resolves.toEqual({ ignored: 1 });
+
+    const proposals = await db.query.storePriceMatchProposals.findMany();
+    expect(
+      Object.fromEntries(proposals.map(({ id, status }) => [id, status])),
+    ).toMatchObject({
+      [inconclusive!.id]: "ignored",
+      [matched!.id]: "pending_review",
+      [processing!.id]: "pending_review",
+      [hidden!.id]: "pending_review",
+    });
+    await expect(
+      db.query.storePriceMatchAttempts.findFirst({
+        where: eq(storePriceMatchAttempts.id, attempt!.id),
+      }),
+    ).resolves.toMatchObject({
+      finalStatus: "ignored",
+      reviewedById: admin.id,
+    });
   });
 
   test("projects findings only after independent operations are resolved", async ({

--- a/apps/server/src/orpc/routes/admin/moderation/list-tasks.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/list-tasks.ts
@@ -22,16 +22,21 @@ export default procedure
   .input(ModerationTaskListInputSchema)
   .output(ModerationTaskListResponseSchema)
   .handler(async ({ input }) => {
-    const tasks = filterModerationTasks(await projectModerationTasks(), input);
+    const allTasks = await projectModerationTasks();
+    const tasks = filterModerationTasks(allTasks, input);
     const offset = (input.cursor - 1) * input.limit;
     const page = tasks.slice(offset, offset + input.limit);
     return {
       results: page,
       counts: {
-        all: tasks.length,
-        listing: tasks.filter(({ category }) => category === "listing").length,
-        catalog: tasks.filter(({ category }) => category === "catalog").length,
-        blocked: tasks.filter(({ state }) => state === "blocked").length,
+        all: allTasks.length,
+        listing: allTasks.filter(({ category }) => category === "listing")
+          .length,
+        catalog: allTasks.filter(({ category }) => category === "catalog")
+          .length,
+        blocked: allTasks.filter(({ state }) => state === "blocked").length,
+        inconclusive: allTasks.filter(({ inconclusive }) => inconclusive)
+          .length,
       },
       rel: {
         nextCursor:

--- a/apps/server/src/orpc/routes/admin/moderation/schemas.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/schemas.ts
@@ -40,6 +40,7 @@ export const ModerationTaskSummarySchema = z
     kind: ModerationTaskKindSchema,
     category: ModerationTaskCategorySchema,
     state: ModerationTaskStateSchema,
+    inconclusive: z.boolean(),
     title: z.string(),
     sourceLabel: z.string(),
     question: z.string(),
@@ -56,6 +57,7 @@ export const ModerationTaskListInputSchema = z
     query: z.string().trim().max(200).optional(),
     category: ModerationTaskCategorySchema.optional(),
     blocked: z.coerce.boolean().optional(),
+    inconclusive: z.coerce.boolean().optional(),
   })
   .strict()
   .default({ cursor: 1, limit: 50 });
@@ -69,6 +71,7 @@ export const ModerationTaskListResponseSchema = z
         listing: z.number().int().min(0),
         catalog: z.number().int().min(0),
         blocked: z.number().int().min(0),
+        inconclusive: z.number().int().min(0),
       })
       .strict(),
     rel: z

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -71,7 +71,9 @@ const mockUploadImage = Buffer.from(
 
 const collectionStateByToken = new Map();
 const pendingUploadStateByToken = new Map();
+const userModeratorStateByToken = new Map();
 const appliedQueueProposalTokens = new Set();
+const ignoredInconclusiveProposalTokens = new Set();
 let collectionBottleId = 1;
 let pendingUploadId = 1;
 
@@ -313,6 +315,22 @@ async function handleRpcRequest({ request, response, url }) {
     }
     case "admin/moderation/listTasks": {
       const token = getAccessToken(request);
+      if (token.includes("queue-inconclusive")) {
+        const ignored = ignoredInconclusiveProposalTokens.has(token);
+        const tasks = ignored ? [] : buildInconclusiveModerationTasks();
+        sendRpcResponse(response, {
+          results: tasks,
+          counts: {
+            all: tasks.length,
+            listing: tasks.length,
+            catalog: 0,
+            blocked: 0,
+            inconclusive: tasks.length,
+          },
+          rel: { nextCursor: null, prevCursor: null },
+        });
+        return true;
+      }
       const task =
         token.includes("queue-direct-bottle") &&
         !appliedQueueProposalTokens.has(token)
@@ -325,9 +343,21 @@ async function handleRpcRequest({ request, response, url }) {
           listing: task ? 1 : 0,
           catalog: 0,
           blocked: 0,
+          inconclusive: 0,
         },
         rel: { nextCursor: null, prevCursor: null },
       });
+      return true;
+    }
+    case "admin/moderation/ignoreInconclusive": {
+      const token = getAccessToken(request);
+      if (!token.includes("queue-inconclusive")) return false;
+      if (input && Object.keys(input).length > 0) {
+        sendRpcError(response, "Unexpected bulk inconclusive input");
+        return true;
+      }
+      ignoredInconclusiveProposalTokens.add(token);
+      sendRpcResponse(response, { ignored: 2 });
       return true;
     }
     case "admin/moderation/task": {
@@ -877,7 +907,12 @@ async function handleRpcRequest({ request, response, url }) {
         input?.user === testUser.id ||
         input?.user === testUser.username
       ) {
-        sendRpcResponse(response, testUser);
+        sendRpcResponse(response, {
+          ...testUser,
+          mod:
+            userModeratorStateByToken.get(getAccessToken(request)) ??
+            testUser.mod,
+        });
         return true;
       }
       if (input?.user === adminUser.id || input?.user === adminUser.username) {
@@ -895,6 +930,21 @@ async function handleRpcRequest({ request, response, url }) {
 
       sendRpcError(response, "Unexpected user details payload");
       return true;
+    case "users/update": {
+      const token = getAccessToken(request);
+      if (
+        !token.includes("profile-role-update") ||
+        input?.user !== testUser.id ||
+        typeof input?.mod !== "boolean"
+      ) {
+        sendRpcError(response, "Unexpected user update payload");
+        return true;
+      }
+
+      userModeratorStateByToken.set(token, input.mod);
+      sendRpcResponse(response, { ...testUser, mod: input.mod });
+      return true;
+    }
     case "users/libraryStats":
       sendRpcResponse(response, libraryInsightsStats);
       return true;
@@ -1473,6 +1523,7 @@ function buildDirectBottleModerationTask() {
     kind: "listing",
     category: "listing",
     state: "ready",
+    inconclusive: false,
     title: proposal.price.name,
     sourceLabel: proposal.price.site.name,
     question: "Should this Bottle be added to the catalog?",
@@ -1480,6 +1531,22 @@ function buildDirectBottleModerationTask() {
     attentionAt: proposal.createdAt,
     source: { kind: "listing", proposalId: proposal.id },
   };
+}
+
+function buildInconclusiveModerationTasks() {
+  return [9921, 9922].map((proposalId, index) => ({
+    key: `listing:${proposalId}`,
+    kind: "listing",
+    category: "listing",
+    state: "ready",
+    inconclusive: true,
+    title: `Unresolved whisky listing ${index + 1}`,
+    sourceLabel: "Example Store",
+    question: "No Bottle match was found. Should this listing be ignored?",
+    statusLabel: "Inconclusive",
+    attentionAt: new Date(Date.UTC(2026, 7, 12, 10 + index)).toISOString(),
+    source: { kind: "listing", proposalId },
+  }));
 }
 
 function isExpectedDirectBottleQueueCreateInput(input) {

--- a/apps/web/e2e/mock-rpc/bottle-checks.mjs
+++ b/apps/web/e2e/mock-rpc/bottle-checks.mjs
@@ -192,6 +192,7 @@ export function createBottleCheckMock({
         listing: 0,
         catalog: tasks.length,
         blocked: tasks.filter(({ state }) => state === "blocked").length,
+        inconclusive: 0,
       },
       rel: { nextCursor: null, prevCursor: null },
     };
@@ -213,6 +214,7 @@ export function createBottleCheckMock({
       kind: "operation",
       category: "catalog",
       state: operation.status === "blocked" ? "blocked" : "ready",
+      inconclusive: false,
       title: copy.title,
       sourceLabel:
         audit.intent === "resolve_reference"

--- a/apps/web/e2e/moderation-inbox.spec.ts
+++ b/apps/web/e2e/moderation-inbox.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test, type TestInfo } from "@playwright/test";
+
+import { expectNoHorizontalOverflow } from "./assertions";
+import { testAccessToken, testUser } from "./rpc-fixtures.mjs";
+import { signIn } from "./session";
+
+test("bulk-ignores listings with no clear Bottle outcome", async ({
+  context,
+  page,
+}, testInfo) => {
+  await signIn(context, {
+    accessToken: uniqueAccessToken(testInfo),
+    user: { ...testUser, admin: true, mod: true },
+  });
+
+  await page.goto("/admin/moderation/inbox?inconclusive=true");
+
+  await expect(
+    page.getByRole("link", { name: "Inconclusive 2" }),
+  ).toHaveAttribute("aria-current", "page");
+  await expect(
+    page.getByText(
+      "No Bottle match was found. Should this listing be ignored?",
+    ),
+  ).toHaveCount(2);
+  await expectNoHorizontalOverflow(page);
+
+  await page.getByRole("button", { name: "Ignore all 2 inconclusive" }).click();
+  await expect(
+    page.getByRole("heading", { name: "Ignore all inconclusive listings?" }),
+  ).toBeVisible();
+
+  const ignoreRequest = page.waitForRequest((request) =>
+    request.url().includes("/rpc/admin/moderation/ignoreInconclusive"),
+  );
+  await page.getByRole("button", { name: "Ignore 2 listings" }).click();
+  await ignoreRequest;
+
+  await expect(page).toHaveURL("/admin/moderation/inbox?inconclusive=true");
+  await expect(page.getByText("Nothing needs a decision")).toBeVisible();
+  await expect(page.getByRole("button", { name: /Ignore all/ })).toHaveCount(0);
+});
+
+function uniqueAccessToken(testInfo: TestInfo): string {
+  return `${testAccessToken}-queue-inconclusive-${testInfo.project.name}-${testInfo.workerIndex}`;
+}

--- a/apps/web/e2e/profile-header.spec.ts
+++ b/apps/web/e2e/profile-header.spec.ts
@@ -1,7 +1,12 @@
 import { expect, test } from "@playwright/test";
 
 import { expectNoHorizontalOverflow } from "./assertions";
-import { adminUser, moderatorUser, testAccessToken } from "./rpc-fixtures.mjs";
+import {
+  adminUser,
+  moderatorUser,
+  testAccessToken,
+  testUser,
+} from "./rpc-fixtures.mjs";
 import { signIn } from "./session";
 
 const roleProfiles = [
@@ -67,3 +72,23 @@ for (const { label, slug, user } of roleProfiles) {
     }
   });
 }
+
+test("refreshes the profile after an administrator changes the moderator role", async ({
+  context,
+  page,
+}, testInfo) => {
+  await signIn(context, {
+    accessToken: `${testAccessToken}-profile-role-update-${testInfo.project.name}`,
+    user: adminUser,
+  });
+
+  await page.goto(`/users/${testUser.username}/activity`, {
+    waitUntil: "commit",
+  });
+  await page.getByRole("button", { name: "Manage user" }).click();
+  await page.getByRole("menuitem", { name: "Add Moderator Role" }).click();
+
+  await expect(page.getByText("Moderator", { exact: true })).toBeVisible();
+  await page.reload();
+  await expect(page.getByText("Moderator", { exact: true })).toBeVisible();
+});

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -62,6 +62,8 @@ export const moderatorUser = {
 
 export const libraryInsightsStats = {
   total: 76,
+  status: { open: 12, sealed: 64, unspecified: 0 },
+  brands: [{ id: 201, name: "Islay Favorites", count: 12 }],
   distillers: [
     { id: 101, name: "Laphroaig", count: 8 },
     { id: 102, name: "Caol Ila", count: 4 },

--- a/apps/web/src/app/(default)/users/[username]/modActions.tsx
+++ b/apps/web/src/app/(default)/users/[username]/modActions.tsx
@@ -7,23 +7,29 @@ import Button from "@peated/web/components/button";
 import useAuth from "@peated/web/hooks/useAuth";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useMutation } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 
 export default function ModActions({ user }: { user: User }) {
   const { user: currentUser } = useAuth();
   const orpc = useORPC();
+  const router = useRouter();
 
-  const userUpdateMutation = useMutation(orpc.users.update.mutationOptions());
+  const userUpdateMutation = useMutation({
+    ...orpc.users.update.mutationOptions(),
+    onSuccess: () => router.refresh(),
+  });
 
   if (!currentUser?.admin) return null;
 
   return (
     <Menu as="div" className="menu">
-      <MenuButton as={Button}>
+      <MenuButton as={Button} aria-label="Manage user">
         <EllipsisVerticalIcon className="h-5 w-5" />
       </MenuButton>
       <MenuItems className="absolute right-0 z-40 mt-2 w-64 origin-top-right">
         <MenuItem
           as="button"
+          disabled={userUpdateMutation.isPending}
           onClick={() => {
             userUpdateMutation.mutate({
               user: user.id,
@@ -31,7 +37,11 @@ export default function ModActions({ user }: { user: User }) {
             });
           }}
         >
-          {user.mod ? "Remove Moderator Role" : "Add Moderator Role"}
+          {userUpdateMutation.isPending
+            ? "Updating Moderator Role…"
+            : user.mod
+              ? "Remove Moderator Role"
+              : "Add Moderator Role"}
         </MenuItem>
       </MenuItems>
     </Menu>

--- a/apps/web/src/components/admin/moderation/inboxList.test.tsx
+++ b/apps/web/src/components/admin/moderation/inboxList.test.tsx
@@ -15,6 +15,7 @@ const operationTask = {
   kind: "operation",
   category: "catalog",
   state: "ready",
+  inconclusive: false,
   title: "Update Entity #42",
   sourceLabel: "Moderator audit",
   question: "Apply these changes to the Entity?",
@@ -28,6 +29,7 @@ const listingTask = {
   kind: "listing",
   category: "listing",
   state: "blocked",
+  inconclusive: false,
   title: "Mystery whisky listing",
   sourceLabel: "Example Store",
   question: "How should this listing be resolved?",
@@ -42,7 +44,13 @@ describe("Moderation Inbox list", () => {
       <InboxList
         data={{
           results: [listingTask, operationTask],
-          counts: { all: 2, listing: 1, catalog: 1, blocked: 1 },
+          counts: {
+            all: 2,
+            listing: 1,
+            catalog: 1,
+            blocked: 1,
+            inconclusive: 0,
+          },
           rel: { nextCursor: null, prevCursor: null },
         }}
         selectedKey="operation:22"

--- a/apps/web/src/components/admin/moderation/inboxList.tsx
+++ b/apps/web/src/components/admin/moderation/inboxList.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import type { Outputs } from "@peated/server/orpc/router";
+import Button from "@peated/web/components/button";
+import ConfirmationDialog from "@peated/web/components/confirmationDialog.client";
 import Link from "@peated/web/components/link";
 import classNames from "@peated/web/lib/classNames";
 import { buildQueryString } from "@peated/web/lib/urls";
 import { usePathname, useSearchParams } from "next/navigation";
+import { useState } from "react";
 
 type Task = Outputs["admin"]["moderation"]["listTasks"]["results"][number];
 
@@ -31,15 +34,23 @@ export function inboxTaskHref(
 export default function InboxList({
   data,
   selectedKey,
+  onIgnoreInconclusive,
+  ignoreInconclusivePending = false,
+  bulkError,
 }: {
   data: Outputs["admin"]["moderation"]["listTasks"];
   selectedKey?: string;
+  onIgnoreInconclusive?: () => Promise<void>;
+  ignoreInconclusivePending?: boolean;
+  bulkError?: string | null;
 }) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const category = searchParams.get("category");
   const blocked = searchParams.get("blocked") === "true";
+  const inconclusive = searchParams.get("inconclusive") === "true";
   const query = searchParams.get("query") ?? "";
+  const [confirmingIgnore, setConfirmingIgnore] = useState(false);
   const listPath = pathname.includes("/inbox/")
     ? "/admin/moderation/inbox"
     : pathname;
@@ -63,6 +74,9 @@ export default function InboxList({
             <input name="category" type="hidden" value={category} />
           ) : null}
           {blocked ? <input name="blocked" type="hidden" value="true" /> : null}
+          {inconclusive ? (
+            <input name="inconclusive" type="hidden" value="true" />
+          ) : null}
           <label className="sr-only" htmlFor="moderation-search">
             Search Inbox
           </label>
@@ -79,23 +93,39 @@ export default function InboxList({
           {[
             {
               label: `All ${data.counts.all}`,
-              active: !category,
-              href: filterHref({ category: null }),
+              active: !category && !blocked && !inconclusive,
+              href: filterHref({
+                category: null,
+                blocked: null,
+                inconclusive: null,
+              }),
             },
             {
               label: `Listings ${data.counts.listing}`,
               active: category === "listing",
-              href: filterHref({ category: "listing" }),
+              href: filterHref({ category: "listing", inconclusive: null }),
             },
             {
               label: `Catalog ${data.counts.catalog}`,
               active: category === "catalog",
-              href: filterHref({ category: "catalog" }),
+              href: filterHref({ category: "catalog", inconclusive: null }),
+            },
+            {
+              label: `Inconclusive ${data.counts.inconclusive}`,
+              active: inconclusive,
+              href: filterHref({
+                inconclusive: inconclusive ? null : "true",
+                category: null,
+                blocked: null,
+              }),
             },
             {
               label: `Blocked ${data.counts.blocked}`,
               active: blocked,
-              href: filterHref({ blocked: blocked ? null : "true" }),
+              href: filterHref({
+                blocked: blocked ? null : "true",
+                inconclusive: null,
+              }),
             },
           ].map((filter) => (
             <Link
@@ -113,7 +143,41 @@ export default function InboxList({
             </Link>
           ))}
         </div>
+        {inconclusive && data.counts.inconclusive > 0 ? (
+          <div className="mt-4">
+            <Button
+              color="danger"
+              disabled={ignoreInconclusivePending}
+              fullWidth
+              loading={ignoreInconclusivePending}
+              onClick={() => setConfirmingIgnore(true)}
+            >
+              Ignore all {data.counts.inconclusive} inconclusive
+            </Button>
+            <p className="mt-2 text-xs leading-5 text-slate-400">
+              These listings have no recommended Bottle. Ignoring them removes
+              them from the inbox without assigning one.
+            </p>
+          </div>
+        ) : null}
+        {bulkError ? (
+          <p className="mt-3 text-sm text-red-300" role="alert">
+            {bulkError}
+          </p>
+        ) : null}
       </div>
+
+      <ConfirmationDialog
+        continueLabel={`Ignore ${data.counts.inconclusive} listings`}
+        isOpen={confirmingIgnore}
+        message="Every actionable inconclusive listing will leave the moderation inbox without a Bottle assignment. Listings with a match, proposed Bottle, correction, error, or active classification will not be changed."
+        onCancel={() => setConfirmingIgnore(false)}
+        onContinue={() => {
+          setConfirmingIgnore(false);
+          void onIgnoreInconclusive?.();
+        }}
+        title="Ignore all inconclusive listings?"
+      />
 
       {data.results.length ? (
         <ol className="divide-y divide-slate-800 overflow-y-auto">

--- a/apps/web/src/components/admin/moderation/inboxPage.tsx
+++ b/apps/web/src/components/admin/moderation/inboxPage.tsx
@@ -2,7 +2,11 @@
 
 import Button from "@peated/web/components/button";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState } from "react";
 import InboxList, { inboxTaskHref } from "./inboxList";
@@ -34,10 +38,17 @@ export default function InboxPage({
       ? { category: searchParams.get("category") as "listing" | "catalog" }
       : {}),
     ...(searchParams.get("blocked") === "true" ? { blocked: true } : {}),
+    ...(searchParams.get("inconclusive") === "true"
+      ? { inconclusive: true }
+      : {}),
   };
   const listOptions = orpc.admin.moderation.listTasks.queryOptions({ input });
   const { data } = useSuspenseQuery(listOptions);
+  const ignoreInconclusive = useMutation(
+    orpc.admin.moderation.ignoreInconclusive.mutationOptions(),
+  );
   const [announcement, setAnnouncement] = useState("");
+  const [bulkError, setBulkError] = useState<string | null>(null);
   const selectedKey = selected ? `${selected.kind}:${selected.id}` : undefined;
 
   function openTask(index: number) {
@@ -59,6 +70,31 @@ export default function InboxPage({
     );
   }
 
+  async function ignoreAllInconclusive() {
+    setBulkError(null);
+    try {
+      const { ignored } = await ignoreInconclusive.mutateAsync({});
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: orpc.admin.moderation.listTasks.key(),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: orpc.prices.matchQueue.key(),
+        }),
+      ]);
+      setAnnouncement(
+        `${ignored} inconclusive ${ignored === 1 ? "listing" : "listings"} ignored.`,
+      );
+      router.push("/admin/moderation/inbox?inconclusive=true");
+    } catch (cause) {
+      setBulkError(
+        cause instanceof Error
+          ? cause.message
+          : "The inconclusive listings could not be ignored.",
+      );
+    }
+  }
+
   const selectedIndex = selectedKey
     ? data.results.findIndex(({ key }) => key === selectedKey)
     : -1;
@@ -67,7 +103,13 @@ export default function InboxPage({
     <div className="min-h-[calc(100vh-4rem)] bg-slate-950 lg:grid lg:grid-cols-[22rem_minmax(0,1fr)]">
       <ModerationNav />
       <div className={selected ? "hidden lg:block" : "block"}>
-        <InboxList data={data} selectedKey={selectedKey} />
+        <InboxList
+          bulkError={bulkError}
+          data={data}
+          ignoreInconclusivePending={ignoreInconclusive.isPending}
+          onIgnoreInconclusive={ignoreAllInconclusive}
+          selectedKey={selectedKey}
+        />
       </div>
       <main className={selected ? "block min-w-0" : "hidden lg:block"}>
         <div aria-live="polite" className="sr-only">

--- a/apps/web/src/components/admin/moderation/taskDetail.tsx
+++ b/apps/web/src/components/admin/moderation/taskDetail.tsx
@@ -304,6 +304,15 @@ function ListingTask({
           <p className="mt-1">{item.error}</p>
         </div>
       ) : null}
+      {item.proposalType === "no_match" && item.status !== "errored" ? (
+        <div className="rounded-lg border border-slate-700 bg-slate-900/60 p-4 text-sm text-slate-200">
+          <strong>No clear Bottle outcome was found.</strong>
+          <p className="mt-1 text-slate-400">
+            Choose a Bottle if you recognize the listing. Otherwise, ignore it
+            to remove it from moderation without assigning a Bottle.
+          </p>
+        </div>
+      ) : null}
       {item.rationale ? (
         <p className="text-sm leading-6 text-slate-300">{item.rationale}</p>
       ) : null}
@@ -328,7 +337,7 @@ function ListingTask({
           disabled={busy}
           onClick={() => setSelecting(true)}
         >
-          Choose another Bottle
+          {item.suggestedBottle ? "Choose another Bottle" : "Choose Bottle"}
         </Button>
         {item.proposalType === "create_new" && item.proposedBottle ? (
           <Button
@@ -349,7 +358,9 @@ function ListingTask({
             )
           }
         >
-          Ignore listing
+          {item.proposalType === "no_match"
+            ? "Ignore as inconclusive"
+            : "Ignore listing"}
         </Button>
       </div>
 


### PR DESCRIPTION
Moderation now identifies pending no-match listing proposals as **Inconclusive**, explains the available outcome on each card, and provides an administrator-only bulk-ignore action with explicit confirmation. The bulk operation is intentionally limited to visible, pending, unleased no-match proposals, records the reviewer on the latest matching attempt, and leaves matched, hidden, errored, and actively classified listings unchanged.

The profile moderator-role menu now refreshes the profile after a successful update so the new role is visible and persists after reload. The browser fixture also matches the current library-insights response contract, fixing the page crash behind the reported profile CI failure.

Regression coverage includes server integration tests for the bulk-operation boundary and desktop/mobile browser flows for both moderation and role updates. The full build, typechecks, 203 web tests, and 162 browser tests pass.
