### PR TITLE
fix(moderation): repair listing review flow

### DIFF
--- a/apps/web/src/components/admin/moderation/inboxPage.test.ts
+++ b/apps/web/src/components/admin/moderation/inboxPage.test.ts
@@ -2,16 +2,60 @@ import { describe, expect, test } from "vitest";
 
 import { nextTaskAfterCompletion } from "./inboxPage";
 
+const task = (key: string) => ({ key });
+
 describe("nextTaskAfterCompletion", () => {
-  test("keeps moving forward after completing a task in the middle", () => {
-    expect(nextTaskAfterCompletion(["A", "C"], 1)).toBe("C");
+  test("opens the task that visibly followed the completed task", () => {
+    expect(
+      nextTaskAfterCompletion(
+        [task("A"), task("B"), task("C")],
+        [task("A"), task("C")],
+        "B",
+      ),
+    ).toEqual(task("C"));
   });
 
-  test("does not wrap after completing the final task", () => {
-    expect(nextTaskAfterCompletion(["A", "B"], 2)).toBeUndefined();
+  test("keeps the visible successor when the refreshed list is reordered", () => {
+    expect(
+      nextTaskAfterCompletion(
+        [task("A"), task("B"), task("C")],
+        [task("D"), task("A"), task("C")],
+        "B",
+      ),
+    ).toEqual(task("C"));
+  });
+
+  test("uses the oldest remaining task when the visible successor is gone", () => {
+    expect(
+      nextTaskAfterCompletion(
+        [task("A"), task("B"), task("C")],
+        [task("D"), task("A")],
+        "B",
+      ),
+    ).toEqual(task("D"));
+  });
+
+  test("wraps after completing the final task", () => {
+    expect(
+      nextTaskAfterCompletion(
+        [task("A"), task("B"), task("C")],
+        [task("A"), task("B")],
+        "C",
+      ),
+    ).toEqual(task("A"));
+  });
+
+  test("returns to the Inbox when no tasks remain", () => {
+    expect(nextTaskAfterCompletion([task("A")], [], "A")).toBeUndefined();
   });
 
   test("starts from the oldest task when the completed task was not listed", () => {
-    expect(nextTaskAfterCompletion(["A", "B"], -1)).toBe("A");
+    expect(
+      nextTaskAfterCompletion(
+        [task("A"), task("B")],
+        [task("A"), task("B")],
+        "C",
+      ),
+    ).toEqual(task("A"));
   });
 });

--- a/apps/web/src/components/admin/moderation/inboxPage.tsx
+++ b/apps/web/src/components/admin/moderation/inboxPage.tsx
@@ -13,11 +13,20 @@ import InboxList, { inboxTaskHref } from "./inboxList";
 import ModerationNav from "./moderationNav";
 import TaskDetail from "./taskDetail";
 
-export function nextTaskAfterCompletion<Task>(
-  tasks: readonly Task[],
-  completedIndex: number,
+export function nextTaskAfterCompletion<Task extends { key: string }>(
+  previousTasks: readonly Task[],
+  refreshedTasks: readonly Task[],
+  completedKey: string,
 ): Task | undefined {
-  return tasks[completedIndex >= 0 ? completedIndex : 0];
+  const completedIndex = previousTasks.findIndex(
+    ({ key }) => key === completedKey,
+  );
+  const nextKey =
+    completedIndex >= 0 ? previousTasks[completedIndex + 1]?.key : undefined;
+  return (
+    (nextKey ? refreshedTasks.find(({ key }) => key === nextKey) : undefined) ??
+    refreshedTasks[0]
+  );
 }
 
 export default function InboxPage({
@@ -64,7 +73,11 @@ export default function InboxPage({
     setAnnouncement(message);
     await queryClient.invalidateQueries({ queryKey: listOptions.queryKey });
     const refreshed = await queryClient.fetchQuery(listOptions);
-    const next = nextTaskAfterCompletion(refreshed.results, selectedIndex);
+    const next = nextTaskAfterCompletion(
+      data.results,
+      refreshed.results,
+      selectedKey ?? "",
+    );
     router.push(
       next ? inboxTaskHref(next, searchParams) : "/admin/moderation/inbox",
     );

--- a/apps/web/src/components/admin/moderation/llmExport.test.ts
+++ b/apps/web/src/components/admin/moderation/llmExport.test.ts
@@ -1,0 +1,173 @@
+import type { Outputs } from "@peated/server/orpc/router";
+import { describe, expect, it } from "vitest";
+
+import { formatPriceMatchQueueLlmExport } from "./llmExport";
+
+type QueueItem = Outputs["prices"]["matchQueue"]["details"];
+type QueueBottle = NonNullable<QueueItem["suggestedBottle"]>;
+
+const timestamp = "2026-07-21T00:00:00.000Z";
+const brand = {
+  id: 1,
+  name: "Springbank",
+  shortName: null,
+  type: ["brand"],
+  description: null,
+  descriptionSrc: null,
+  yearEstablished: null,
+  website: null,
+  country: null,
+  region: null,
+  address: null,
+  location: null,
+  totalTastings: 0,
+  totalBottles: 1,
+  createdAt: timestamp,
+  updatedAt: timestamp,
+} satisfies QueueBottle["brand"];
+
+const suggestedBottle = {
+  id: 19,
+  fullName: "Springbank 12 Cask Strength Batch 24",
+  name: "12 Cask Strength Batch 24",
+  brand,
+  series: null,
+  category: "single_malt",
+  distillers: [],
+  bottler: null,
+  edition: "Batch 24",
+  statedAge: 12,
+  abv: 57.8,
+  caskStrength: true,
+  singleCask: false,
+  vintageYear: null,
+  releaseYear: 2024,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  description: null,
+  descriptionSrc: null,
+  flavorProfile: null,
+  tastingNotes: null,
+  suggestedTags: [],
+  avgRating: null,
+  ratingStats: {
+    pass: 0,
+    sip: 0,
+    savor: 0,
+    total: 0,
+    avg: null,
+    percentage: { pass: 0, sip: 0, savor: 0 },
+  },
+  totalTastings: 0,
+  imageUrl: null,
+  createdAt: timestamp,
+  updatedAt: timestamp,
+  isFavorite: false,
+  isLibrary: false,
+  hasTasted: false,
+} satisfies QueueBottle;
+
+const localCandidate = {
+  bottleId: 19,
+  alias: "Springbank Batch 24",
+  fullName: "Springbank 12 Cask Strength Batch 24",
+  brand: "Springbank",
+  bottler: null,
+  series: null,
+  distillery: ["Springbank"],
+  category: "single_malt",
+  statedAge: 12,
+  edition: "Batch 24",
+  caskStrength: true,
+  singleCask: false,
+  caskType: null,
+  caskSize: null,
+  caskFill: null,
+  abv: 57.8,
+  vintageYear: null,
+  releaseYear: 2024,
+  score: 0.93,
+  source: ["vector"],
+} satisfies QueueItem["candidateBottles"][number];
+
+function queueItem(overrides: Partial<QueueItem> = {}): QueueItem {
+  return {
+    id: 99,
+    status: "pending_review",
+    proposalType: "no_match",
+    confidence: 0.98,
+    modelConfidence: 0.98,
+    model: "test-model",
+    rationale: "The available evidence was inconclusive.",
+    error: null,
+    isProcessing: false,
+    automationScore: 0.95,
+    automationEligible: false,
+    automationBlockers: [],
+    decisiveMatchAttributes: [],
+    plainAgeBottleAutoVerifyEligible: false,
+    differentiatingAttributes: [],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    lastEvaluatedAt: null,
+    reviewedAt: null,
+    processingQueuedAt: null,
+    processingExpiresAt: null,
+    price: {
+      id: 12,
+      name: "Springbank 12 Cask Strength Batch 24",
+      price: 150,
+      currency: "usd",
+      volume: 750,
+      url: "https://example.com/bottle",
+      imageUrl: null,
+      isValid: true,
+      bottle: null,
+      updatedAt: timestamp,
+      site: {
+        id: 3,
+        name: "Example",
+        type: "totalwine",
+        lastRunAt: null,
+        nextRunAt: null,
+        runEvery: null,
+      },
+    },
+    extractedLabel: null,
+    currentBottle: null,
+    suggestedBottle,
+    proposedBottle: null,
+    candidateBottles: [localCandidate],
+    webEvidenceChecks: [],
+    searchEvidence: [],
+    ...overrides,
+  } as QueueItem;
+}
+
+describe("formatPriceMatchQueueLlmExport", () => {
+  it("exports the structured context needed to debug an inconclusive match", () => {
+    const payload = JSON.parse(formatPriceMatchQueueLlmExport(queueItem()));
+
+    expect(payload).toMatchObject({
+      schemaVersion: 4,
+      source: "peated.admin.match_queue",
+      proposal: {
+        id: 99,
+        proposalType: "no_match",
+        rationale: "The available evidence was inconclusive.",
+      },
+      sourceListing: {
+        id: 12,
+        name: "Springbank 12 Cask Strength Batch 24",
+      },
+      recommendation: {
+        suggestedBottle: {
+          id: 19,
+          fullName: "Springbank 12 Cask Strength Batch 24",
+        },
+      },
+      artifacts: { localCandidates: [localCandidate] },
+    });
+  });
+});

--- a/apps/web/src/components/admin/moderation/llmExport.ts
+++ b/apps/web/src/components/admin/moderation/llmExport.ts
@@ -1,0 +1,194 @@
+import type { Outputs } from "@peated/server/orpc/router";
+
+type QueueItem = Outputs["prices"]["matchQueue"]["details"];
+
+type EntityLike = {
+  id: number | null;
+  name: string;
+};
+
+type SeriesLike = {
+  id: number | null;
+  name: string;
+} | null;
+
+type BottleLike = NonNullable<QueueItem["currentBottle"]>;
+type ProposedBottleLike = NonNullable<QueueItem["proposedBottle"]>;
+
+function serializeEntity(value: EntityLike | null) {
+  if (!value) return null;
+
+  return {
+    id: value.id,
+    name: value.name,
+  };
+}
+
+function serializeSeries(value: SeriesLike) {
+  if (!value) return null;
+
+  return {
+    id: value.id,
+    name: value.name,
+  };
+}
+
+function serializeBottleIdentity(value: BottleLike | null) {
+  if (!value) return null;
+
+  return {
+    id: value.id,
+    fullName: value.fullName,
+    name: value.name,
+    brand: serializeEntity(value.brand),
+    series: serializeSeries(value.series),
+    category: value.category,
+    distillers: value.distillers.map((distiller) => ({
+      id: distiller.id,
+      name: distiller.name,
+    })),
+    bottler: serializeEntity(value.bottler),
+    edition: value.edition,
+    statedAge: value.statedAge,
+    abv: value.abv,
+    caskStrength: value.caskStrength,
+    singleCask: value.singleCask,
+    vintageYear: value.vintageYear,
+    releaseYear: value.releaseYear,
+    caskType: value.caskType,
+    caskSize: value.caskSize,
+    caskFill: value.caskFill,
+    imageUrl: value.imageUrl,
+  };
+}
+
+function serializeProposedBottle(value: ProposedBottleLike | null) {
+  if (!value) return null;
+
+  return {
+    name: value.name,
+    brand: serializeEntity(value.brand),
+    series: serializeSeries(value.series),
+    category: value.category,
+    distillers: value.distillers.map((distiller) => ({
+      id: distiller.id,
+      name: distiller.name,
+    })),
+    bottler: serializeEntity(value.bottler),
+    edition: value.edition,
+    statedAge: value.statedAge,
+    abv: value.abv,
+    caskStrength: value.caskStrength,
+    singleCask: value.singleCask,
+    vintageYear: value.vintageYear,
+    releaseYear: value.releaseYear,
+    caskType: value.caskType,
+    caskSize: value.caskSize,
+    caskFill: value.caskFill,
+  };
+}
+
+export function formatPriceMatchQueueLlmExport(item: QueueItem) {
+  return JSON.stringify(
+    {
+      schemaVersion: 4,
+      source: "peated.admin.match_queue",
+      proposal: {
+        id: item.id,
+        status: item.status,
+        proposalType: item.proposalType,
+        confidence: item.confidence,
+        modelConfidence: item.modelConfidence,
+        model: item.model,
+        rationale: item.rationale,
+        error: item.error,
+        isProcessing: item.isProcessing,
+        automation: {
+          score: item.automationScore,
+          eligible: item.automationEligible,
+          blockers: item.automationBlockers,
+          decisiveMatchAttributes: item.decisiveMatchAttributes,
+          plainAgeBottleAutoVerifyEligible:
+            item.plainAgeBottleAutoVerifyEligible,
+          differentiatingAttributes: item.differentiatingAttributes,
+        },
+        timestamps: {
+          createdAt: item.createdAt,
+          updatedAt: item.updatedAt,
+          lastEvaluatedAt: item.lastEvaluatedAt,
+          reviewedAt: item.reviewedAt,
+          processingQueuedAt: item.processingQueuedAt,
+          processingExpiresAt: item.processingExpiresAt,
+        },
+      },
+      sourceListing: {
+        id: item.price.id,
+        name: item.price.name,
+        price: item.price.price,
+        currency: item.price.currency,
+        volumeMl: item.price.volume,
+        url: item.price.url,
+        imageUrl: item.price.imageUrl,
+        updatedAt: item.price.updatedAt,
+        site: {
+          id: item.price.site.id,
+          name: item.price.site.name,
+          type: item.price.site.type,
+        },
+      },
+      extractedIdentity: item.extractedLabel,
+      currentAssignment: serializeBottleIdentity(item.currentBottle),
+      recommendation: {
+        suggestedBottle: serializeBottleIdentity(item.suggestedBottle),
+        proposedBottle: serializeProposedBottle(item.proposedBottle),
+      },
+      artifacts: {
+        localCandidates: item.candidateBottles.map((candidate) => ({
+          bottleId: candidate.bottleId,
+          alias: candidate.alias,
+          fullName: candidate.fullName,
+          brand: candidate.brand,
+          bottler: candidate.bottler,
+          series: candidate.series,
+          distillery: candidate.distillery,
+          category: candidate.category,
+          statedAge: candidate.statedAge,
+          edition: candidate.edition,
+          caskStrength: candidate.caskStrength,
+          singleCask: candidate.singleCask,
+          abv: candidate.abv,
+          vintageYear: candidate.vintageYear,
+          releaseYear: candidate.releaseYear,
+          caskType: candidate.caskType,
+          caskSize: candidate.caskSize,
+          caskFill: candidate.caskFill,
+          score: candidate.score,
+          source: candidate.source,
+        })),
+        webEvidenceChecks: item.webEvidenceChecks.map((check) => ({
+          attribute: check.attribute,
+          expectedValue: check.expectedValue,
+          required: check.required,
+          validated: check.validated,
+          weaklySupported: check.weaklySupported,
+          matchedSourceTiers: check.matchedSourceTiers,
+          matchedSourceUrls: check.matchedSourceUrls,
+        })),
+        searchEvidence: item.searchEvidence.map((evidence) => ({
+          provider: evidence.provider,
+          query: evidence.query,
+          summary: evidence.summary,
+          results: evidence.results.map((result) => ({
+            title: result.title,
+            url: result.url,
+            domain: result.domain,
+            description: result.description,
+            extraSnippets: result.extraSnippets,
+          })),
+        })),
+      },
+    },
+    null,
+    2,
+  );
+}

--- a/apps/web/src/components/admin/moderation/taskDetail.tsx
+++ b/apps/web/src/components/admin/moderation/taskDetail.tsx
@@ -8,6 +8,7 @@ import type { ExcludedOperationField } from "@peated/web/components/bottleChecks
 import OperationCard from "@peated/web/components/bottleChecks/operationCard";
 import Button from "@peated/web/components/button";
 import Link from "@peated/web/components/link";
+import { copyTextToClipboard } from "@peated/web/lib/clipboard";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import {
   useMutation,
@@ -15,8 +16,10 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
+import { Check, Copy, RotateCcw } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import BottleSelector from "./bottleSelector";
+import { formatPriceMatchQueueLlmExport } from "./llmExport";
 
 type Task = Outputs["admin"]["moderation"]["listTasks"]["results"][number];
 type QueueItem = Outputs["prices"]["matchQueue"]["details"];
@@ -53,7 +56,7 @@ function TaskHeader({ task }: { task: Task }) {
 
   return (
     <header className="border-b border-slate-800 pb-5">
-      <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+      <div className="flex flex-wrap items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
         <span>{task.category}</span>
         <span aria-hidden="true">/</span>
         <span
@@ -101,6 +104,9 @@ function ListingTask({
   );
   const retry = useMutation(orpc.prices.matchQueue.retry.mutationOptions());
   const [selecting, setSelecting] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copying" | "copied">(
+    "idle",
+  );
   const [error, setError] = useState<string | null>(null);
   const busy =
     resolve.isPending ||
@@ -134,6 +140,26 @@ function ListingTask({
     setSelecting(false);
   }
 
+  async function copyDetails() {
+    setCopyStatus("copying");
+    setError(null);
+    try {
+      await copyTextToClipboard(formatPriceMatchQueueLlmExport(item));
+      setCopyStatus("copied");
+      window.setTimeout(() => setCopyStatus("idle"), 1800);
+    } catch (cause) {
+      setCopyStatus("idle");
+      setError(errorMessage(cause));
+    }
+  }
+
+  function retryClassification() {
+    return finish(
+      () => retry.mutateAsync({ proposal: item.id }),
+      "Listing requeued for classification.",
+    );
+  }
+
   const primary = (() => {
     if (item.status === "errored") {
       return (
@@ -141,13 +167,9 @@ function ListingTask({
           className="min-h-11"
           color="highlight"
           disabled={busy}
+          icon={<RotateCcw aria-hidden="true" className="h-4 w-4" />}
           loading={retry.isPending}
-          onClick={() =>
-            void finish(
-              () => retry.mutateAsync({ proposal: item.id }),
-              "Listing requeued for classification.",
-            )
-          }
+          onClick={() => void retryClassification()}
         >
           Retry classification
         </Button>
@@ -229,7 +251,7 @@ function ListingTask({
         className="rounded-xl border border-slate-800 bg-slate-950 p-4 sm:p-5"
       >
         <h2
-          className="text-xs font-semibold uppercase tracking-wide text-slate-500"
+          className="text-xs font-semibold uppercase tracking-wide text-slate-400"
           id="listing-source"
         >
           Source listing
@@ -286,7 +308,7 @@ function ListingTask({
           <dl className="mt-4 grid gap-3 sm:grid-cols-2">
             {Object.entries(item.proposedBottle).map(([field, value]) => (
               <div className="border-b border-slate-800 pb-2" key={field}>
-                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">
                   {field.replaceAll("_", " ")}
                 </dt>
                 <dd className="mt-1 text-sm text-slate-200">
@@ -338,6 +360,33 @@ function ListingTask({
           onClick={() => setSelecting(true)}
         >
           {item.suggestedBottle ? "Choose another Bottle" : "Choose Bottle"}
+        </Button>
+        {item.status !== "errored" ? (
+          <Button
+            className="min-h-11"
+            disabled={busy || item.isProcessing}
+            icon={<RotateCcw aria-hidden="true" className="h-4 w-4" />}
+            loading={retry.isPending}
+            onClick={() => void retryClassification()}
+          >
+            Retry classification
+          </Button>
+        ) : null}
+        <Button
+          className="min-h-11"
+          disabled={copyStatus === "copying"}
+          icon={
+            copyStatus === "copied" ? (
+              <Check aria-hidden="true" className="h-4 w-4" />
+            ) : (
+              <Copy aria-hidden="true" className="h-4 w-4" />
+            )
+          }
+          loading={copyStatus === "copying"}
+          onClick={() => void copyDetails()}
+          title="Copy structured listing, identity, evidence, and recommendation data as JSON"
+        >
+          {copyStatus === "copied" ? "Copied details" : "Copy details"}
         </Button>
         {item.proposalType === "create_new" && item.proposedBottle ? (
           <Button


### PR DESCRIPTION
Moderation listing tasks once again expose retry and structured copy actions, with clearer responsive labels, action feedback, and improved metadata contrast. The moderation workspace redesign had limited retries to hard errors and dropped the diagnostic export, leaving inconclusive matches without the recovery and debugging controls moderators relied on.

Successful decisions now follow the stable key of the task that was visibly next before the inbox refetch. This avoids returning to the inbox or opening the wrong task when rows disappear or reorder during refresh; if that successor is gone, review continues from the oldest remaining task.

Regression coverage exercises diagnostic exports and navigation across reordered, removed, final, and empty task lists. Validated with 207 web tests, web typecheck, lint, and desktop/mobile UI checks.
