### PR TITLE
perf(moderation): speed up inbox queries

### DIFF
--- a/apps/server/src/lib/bottleChecks.ts
+++ b/apps/server/src/lib/bottleChecks.ts
@@ -33,6 +33,7 @@ import {
 } from "@peated/server/lib/bottleOperationReview";
 import {
   and,
+  asc,
   desc,
   eq,
   exists,
@@ -283,6 +284,26 @@ export type ListActionableBottleChecksInput = z.input<
 >;
 export type BottleCheckWithOperations = BottleCheck & {
   operations: BottleOperation[];
+};
+
+/** Narrow actionable-check projection; full audit context stays in review reads. */
+export type ActionableBottleCheckSummary = Pick<
+  BottleCheck,
+  | "bottleId"
+  | "completedAt"
+  | "createdAt"
+  | "id"
+  | "intent"
+  | "origin"
+  | "schemaVersion"
+  | "sourceKind"
+> & {
+  findingCount: number;
+  hasOutput: boolean;
+  operations: Pick<
+    BottleOperation,
+    "checkId" | "createdAt" | "id" | "proposal" | "status"
+  >[];
 };
 
 export type CreateBottleCheckResult = {
@@ -755,6 +776,50 @@ export async function listActionableBottleChecks(
 ): Promise<ActionableBottleCheckList> {
   const input = ListActionableBottleChecksInputSchema.parse(rawInput);
   const offset = (input.cursor - 1) * input.limit;
+  const rows = await database
+    .select()
+    .from(bottleChecks)
+    .where(actionableBottleCheckWhere(database, input.source))
+    .orderBy(desc(bottleChecks.createdAt), desc(bottleChecks.id))
+    .limit(input.limit + 1)
+    .offset(offset);
+  const hasNextPage = rows.length > input.limit;
+  const page = rows.slice(0, input.limit);
+  const operations = page.length
+    ? await database
+        .select()
+        .from(bottleOperations)
+        .where(
+          inArray(
+            bottleOperations.checkId,
+            page.map(({ id }) => id),
+          ),
+        )
+        .orderBy(bottleOperations.id)
+    : [];
+  const operationsByCheckId = Map.groupBy(
+    operations,
+    (operation) => operation.checkId,
+  );
+
+  return {
+    results: page.map((check) => ({
+      ...check,
+      operations: operationsByCheckId.get(check.id) ?? [],
+    })),
+    rel: {
+      nextCursor: hasNextPage ? input.cursor + 1 : null,
+      prevCursor: input.cursor > 1 ? input.cursor - 1 : null,
+    },
+  };
+}
+
+function actionableBottleCheckWhere(
+  database: AnyDatabase,
+  source?: "incoming_listing" | "moderator" | "new_bottle" | "photo_scan",
+) {
+  // List and targeted reads share this predicate so stable task keys always
+  // revalidate the same source-owned actionability rules.
   const hasFindings = sql<boolean>`CASE
     WHEN jsonb_typeof(${bottleChecks.output}->'findings') = 'array'
     THEN jsonb_array_length(${bottleChecks.output}->'findings') > 0
@@ -803,7 +868,7 @@ export async function listActionableBottleChecks(
     ),
     completedStorePriceCheck,
   );
-  switch (input.source) {
+  switch (source) {
     case "incoming_listing":
       sourceFilter = completedStorePriceCheck;
       break;
@@ -828,33 +893,67 @@ export async function listActionableBottleChecks(
     case undefined:
       break;
   }
-  const rows = await database
-    .select()
+  return and(
+    sourceFilter,
+    isNull(bottleChecks.closedAt),
+    or(
+      ne(bottleChecks.schemaVersion, BOTTLE_CHECK_SCHEMA_VERSION),
+      hasFindings,
+      hasActionableOperation,
+    ),
+  );
+}
+
+async function findActionableBottleCheckSummaries(
+  {
+    checkId,
+    limit,
+  }: {
+    checkId?: number;
+    limit: number;
+  },
+  database: AnyDatabase,
+): Promise<ActionableBottleCheckSummary[]> {
+  const checks = await database
+    .select({
+      bottleId: bottleChecks.bottleId,
+      completedAt: bottleChecks.completedAt,
+      createdAt: bottleChecks.createdAt,
+      findingCount: sql<number>`CASE
+        WHEN jsonb_typeof(${bottleChecks.output}->'findings') = 'array'
+        THEN jsonb_array_length(${bottleChecks.output}->'findings')
+        ELSE 0
+      END`,
+      hasOutput: sql<boolean>`${bottleChecks.output} IS NOT NULL`,
+      id: bottleChecks.id,
+      intent: bottleChecks.intent,
+      origin: bottleChecks.origin,
+      schemaVersion: bottleChecks.schemaVersion,
+      sourceKind: bottleChecks.sourceKind,
+    })
     .from(bottleChecks)
     .where(
       and(
-        sourceFilter,
-        isNull(bottleChecks.closedAt),
-        or(
-          ne(bottleChecks.schemaVersion, BOTTLE_CHECK_SCHEMA_VERSION),
-          hasFindings,
-          hasActionableOperation,
-        ),
+        checkId === undefined ? undefined : eq(bottleChecks.id, checkId),
+        actionableBottleCheckWhere(database),
       ),
     )
-    .orderBy(desc(bottleChecks.createdAt), desc(bottleChecks.id))
-    .limit(input.limit + 1)
-    .offset(offset);
-  const hasNextPage = rows.length > input.limit;
-  const page = rows.slice(0, input.limit);
-  const operations = page.length
+    .orderBy(asc(bottleChecks.createdAt), asc(bottleChecks.id))
+    .limit(limit);
+  const operations = checks.length
     ? await database
-        .select()
+        .select({
+          checkId: bottleOperations.checkId,
+          createdAt: bottleOperations.createdAt,
+          id: bottleOperations.id,
+          proposal: bottleOperations.proposal,
+          status: bottleOperations.status,
+        })
         .from(bottleOperations)
         .where(
           inArray(
             bottleOperations.checkId,
-            page.map(({ id }) => id),
+            checks.map(({ id }) => id),
           ),
         )
         .orderBy(bottleOperations.id)
@@ -864,16 +963,30 @@ export async function listActionableBottleChecks(
     (operation) => operation.checkId,
   );
 
-  return {
-    results: page.map((check) => ({
-      ...check,
-      operations: operationsByCheckId.get(check.id) ?? [],
-    })),
-    rel: {
-      nextCursor: hasNextPage ? input.cursor + 1 : null,
-      prevCursor: input.cursor > 1 ? input.cursor - 1 : null,
-    },
-  };
+  return checks.map((check) => ({
+    ...check,
+    operations: operationsByCheckId.get(check.id) ?? [],
+  }));
+}
+
+/** Returns oldest actionable summaries without loading full audit records. */
+export async function listActionableBottleCheckSummaries(
+  limit: number,
+  database: AnyDatabase = db,
+): Promise<ActionableBottleCheckSummary[]> {
+  return findActionableBottleCheckSummaries({ limit }, database);
+}
+
+/** Revalidates one check against the same membership rules as the list. */
+export async function getActionableBottleCheckSummary(
+  checkId: number,
+  database: AnyDatabase = db,
+): Promise<ActionableBottleCheckSummary | null> {
+  return (
+    (
+      await findActionableBottleCheckSummaries({ checkId, limit: 1 }, database)
+    ).at(0) ?? null
+  );
 }
 
 export async function getBottleCheckForReview(

--- a/apps/server/src/lib/moderationTasks.ts
+++ b/apps/server/src/lib/moderationTasks.ts
@@ -1,16 +1,23 @@
+// Inbox tasks are narrow projections of source-owned decisions. This module
+// must not load full listing or audit detail while listing or locating them.
 import { db } from "@peated/server/db";
-import type { bottleChecks, bottleOperations } from "@peated/server/db/schema";
 import {
+  bottleOperations,
   externalSites,
   storePriceMatchProposals,
   storePrices,
 } from "@peated/server/db/schema";
 import { isSupportedBottleCheckSchemaVersion } from "@peated/server/lib/bottleCheckSchemaVersion";
-import { listActionableBottleChecks } from "@peated/server/lib/bottleChecks";
+import {
+  getActionableBottleCheckSummary,
+  listActionableBottleCheckSummaries,
+  type ActionableBottleCheckSummary,
+} from "@peated/server/lib/bottleChecks";
 import type { ModerationTaskSummary } from "@peated/server/orpc/routes/admin/moderation/schemas";
 import { and, asc, eq, inArray, isNull, lte, or } from "drizzle-orm";
 
 const MAX_PROJECTED_SOURCE_ROWS = 10_000;
+const OPERATIONAL_STATUSES = new Set(["applying", "stale", "failed"]);
 
 function listingQuestion(proposalType: string): string {
   switch (proposalType) {
@@ -57,7 +64,7 @@ function operationCopy(
   }
 }
 
-function checkSourceLabel(check: typeof bottleChecks.$inferSelect): string {
+function checkSourceLabel(check: ActionableBottleCheckSummary): string {
   if (check.intent === "audit_bottle") {
     return check.origin === "moderator" ? "Moderator audit" : "Catalog audit";
   }
@@ -67,47 +74,30 @@ function checkSourceLabel(check: typeof bottleChecks.$inferSelect): string {
   return "Bottle check";
 }
 
-function persistedFindings(
-  check: typeof bottleChecks.$inferSelect,
-): unknown[] | null {
-  if (!isSupportedBottleCheckSchemaVersion(check) || check.output === null) {
+function persistedFindingCount(
+  check: ActionableBottleCheckSummary,
+): number | null {
+  if (!isSupportedBottleCheckSchemaVersion(check) || !check.hasOutput) {
     return null;
   }
-  const findings = check.output.findings;
-  return Array.isArray(findings) ? findings : [];
+  return check.findingCount;
 }
 
-async function listingTasks(): Promise<ModerationTaskSummary[]> {
-  const rows = await db
-    .select({
-      proposal: storePriceMatchProposals,
-      price: storePrices,
-      site: externalSites,
-    })
-    .from(storePriceMatchProposals)
-    .innerJoin(
-      storePrices,
-      eq(storePrices.id, storePriceMatchProposals.priceId),
-    )
-    .innerJoin(externalSites, eq(externalSites.id, storePrices.externalSiteId))
-    .where(
-      and(
-        eq(storePrices.hidden, false),
-        inArray(storePriceMatchProposals.status, ["pending_review", "errored"]),
-        or(
-          isNull(storePriceMatchProposals.processingExpiresAt),
-          lte(storePriceMatchProposals.processingExpiresAt, new Date()),
-        ),
-      ),
-    )
-    .orderBy(
-      asc(storePriceMatchProposals.enteredQueueAt),
-      asc(storePriceMatchProposals.createdAt),
-      asc(storePriceMatchProposals.id),
-    )
-    .limit(MAX_PROJECTED_SOURCE_ROWS);
+type ListingTaskRow = {
+  proposal: Pick<
+    typeof storePriceMatchProposals.$inferSelect,
+    "createdAt" | "enteredQueueAt" | "id" | "proposalType" | "status"
+  >;
+  price: Pick<typeof storePrices.$inferSelect, "name">;
+  site: Pick<typeof externalSites.$inferSelect, "name">;
+};
 
-  return rows.map(({ proposal, price, site }) => ({
+function listingTask({
+  proposal,
+  price,
+  site,
+}: ListingTaskRow): ModerationTaskSummary {
+  return {
     key: `listing:${proposal.id}`,
     kind: "listing",
     category: "listing",
@@ -126,94 +116,164 @@ async function listingTasks(): Promise<ModerationTaskSummary[]> {
           : proposal.proposalType.replaceAll("_", " "),
     attentionAt: (proposal.enteredQueueAt ?? proposal.createdAt).toISOString(),
     source: { kind: "listing", proposalId: proposal.id },
-  }));
+  };
+}
+
+async function listingTasks(
+  proposalId?: number,
+): Promise<ModerationTaskSummary[]> {
+  const rows = await db
+    .select({
+      proposal: {
+        createdAt: storePriceMatchProposals.createdAt,
+        enteredQueueAt: storePriceMatchProposals.enteredQueueAt,
+        id: storePriceMatchProposals.id,
+        proposalType: storePriceMatchProposals.proposalType,
+        status: storePriceMatchProposals.status,
+      },
+      price: { name: storePrices.name },
+      site: { name: externalSites.name },
+    })
+    .from(storePriceMatchProposals)
+    .innerJoin(
+      storePrices,
+      eq(storePrices.id, storePriceMatchProposals.priceId),
+    )
+    .innerJoin(externalSites, eq(externalSites.id, storePrices.externalSiteId))
+    .where(
+      and(
+        proposalId === undefined
+          ? undefined
+          : eq(storePriceMatchProposals.id, proposalId),
+        eq(storePrices.hidden, false),
+        inArray(storePriceMatchProposals.status, ["pending_review", "errored"]),
+        or(
+          isNull(storePriceMatchProposals.processingExpiresAt),
+          lte(storePriceMatchProposals.processingExpiresAt, new Date()),
+        ),
+      ),
+    )
+    .orderBy(
+      asc(storePriceMatchProposals.enteredQueueAt),
+      asc(storePriceMatchProposals.createdAt),
+      asc(storePriceMatchProposals.id),
+    )
+    .limit(MAX_PROJECTED_SOURCE_ROWS);
+
+  return rows.map(listingTask);
+}
+
+function catalogTasksForCheck(
+  check: ActionableBottleCheckSummary,
+): ModerationTaskSummary[] {
+  if (check.operations.some(({ status }) => OPERATIONAL_STATUSES.has(status))) {
+    return [];
+  }
+
+  const operations = check.operations.filter(
+    ({ status }) => status === "pending_review" || status === "blocked",
+  );
+  if (operations.length > 0) {
+    return operations.map((operation): ModerationTaskSummary => {
+      const copy = operationCopy(operation.proposal);
+      return {
+        key: `operation:${operation.id}`,
+        kind: "operation",
+        category: "catalog",
+        state: operation.status === "blocked" ? "blocked" : "ready",
+        inconclusive: false,
+        title: copy.title,
+        sourceLabel: checkSourceLabel(check),
+        question: copy.question,
+        statusLabel:
+          operation.status === "blocked" ? "Blocked" : "Suggested change",
+        attentionAt: operation.createdAt.toISOString(),
+        source: {
+          kind: "operation",
+          checkId: check.id,
+          operationId: operation.id,
+        },
+      };
+    });
+  }
+
+  const findingCount = persistedFindingCount(check);
+  if (findingCount === null || findingCount > 0) {
+    const subject = check.bottleId
+      ? `Bottle #${check.bottleId}`
+      : `Check #${check.id}`;
+    return [
+      {
+        key: `finding:${check.id}`,
+        kind: "finding" as const,
+        category: "catalog" as const,
+        state:
+          findingCount === null ? ("blocked" as const) : ("ready" as const),
+        inconclusive: false,
+        title: subject,
+        sourceLabel: checkSourceLabel(check),
+        question:
+          findingCount === null
+            ? "How should this unavailable check be resolved?"
+            : "Have these catalog findings been resolved?",
+        statusLabel:
+          findingCount === null
+            ? "Unsupported check version"
+            : `${findingCount} ${findingCount === 1 ? "finding" : "findings"}`,
+        attentionAt: (check.completedAt ?? check.createdAt).toISOString(),
+        source: { kind: "finding" as const, checkId: check.id },
+      },
+    ];
+  }
+  return [];
 }
 
 async function catalogTasks(): Promise<ModerationTaskSummary[]> {
-  const checks: Awaited<
-    ReturnType<typeof listActionableBottleChecks>
-  >["results"] = [];
-  for (let cursor = 1; checks.length < MAX_PROJECTED_SOURCE_ROWS; cursor += 1) {
-    const page = await listActionableBottleChecks({ cursor, limit: 100 });
-    checks.push(...page.results);
-    if (page.rel.nextCursor === null) break;
-  }
-
-  return checks.flatMap((check) => {
-    const operationalStatuses = new Set(["applying", "stale", "failed"]);
-    if (
-      check.operations.some(({ status }) => operationalStatuses.has(status))
-    ) {
-      return [];
-    }
-
-    const operations = check.operations.filter(
-      ({ status }) => status === "pending_review" || status === "blocked",
-    );
-    if (operations.length > 0) {
-      return operations.map((operation): ModerationTaskSummary => {
-        const copy = operationCopy(operation.proposal);
-        return {
-          key: `operation:${operation.id}`,
-          kind: "operation",
-          category: "catalog",
-          state: operation.status === "blocked" ? "blocked" : "ready",
-          inconclusive: false,
-          title: copy.title,
-          sourceLabel: checkSourceLabel(check),
-          question: copy.question,
-          statusLabel:
-            operation.status === "blocked" ? "Blocked" : "Suggested change",
-          attentionAt: operation.createdAt.toISOString(),
-          source: {
-            kind: "operation",
-            checkId: check.id,
-            operationId: operation.id,
-          },
-        };
-      });
-    }
-
-    const findings = persistedFindings(check);
-    if (findings === null || findings.length > 0) {
-      const subject = check.bottleId
-        ? `Bottle #${check.bottleId}`
-        : `Check #${check.id}`;
-      return [
-        {
-          key: `finding:${check.id}`,
-          kind: "finding" as const,
-          category: "catalog" as const,
-          state: findings === null ? ("blocked" as const) : ("ready" as const),
-          inconclusive: false,
-          title: subject,
-          sourceLabel: checkSourceLabel(check),
-          question:
-            findings === null
-              ? "How should this unavailable check be resolved?"
-              : "Have these catalog findings been resolved?",
-          statusLabel:
-            findings === null
-              ? "Unsupported check version"
-              : `${findings.length} ${findings.length === 1 ? "finding" : "findings"}`,
-          attentionAt: (check.completedAt ?? check.createdAt).toISOString(),
-          source: { kind: "finding" as const, checkId: check.id },
-        },
-      ];
-    }
-    return [];
-  });
+  const checks = await listActionableBottleCheckSummaries(
+    MAX_PROJECTED_SOURCE_ROWS,
+  );
+  return checks.flatMap(catalogTasksForCheck);
 }
 
 export async function projectModerationTasks(): Promise<
   ModerationTaskSummary[]
 > {
-  const tasks = [...(await listingTasks()), ...(await catalogTasks())];
+  const [listings, catalog] = await Promise.all([
+    listingTasks(),
+    catalogTasks(),
+  ]);
+  const tasks = [...listings, ...catalog];
   return tasks.sort(
     (left, right) =>
       left.attentionAt.localeCompare(right.attentionAt) ||
       left.key.localeCompare(right.key),
   );
+}
+
+export async function locateModerationTask(
+  key: string,
+): Promise<ModerationTaskSummary | null> {
+  const [kind, rawId] = key.split(":");
+  const id = Number(rawId);
+  if (kind === "listing") return (await listingTasks(id)).at(0) ?? null;
+
+  const checkId =
+    kind === "finding"
+      ? id
+      : kind === "operation"
+        ? (
+            await db.query.bottleOperations.findFirst({
+              columns: { checkId: true },
+              where: eq(bottleOperations.id, id),
+            })
+          )?.checkId
+        : undefined;
+  if (checkId === undefined) return null;
+
+  const check = await getActionableBottleCheckSummary(checkId);
+  return check
+    ? (catalogTasksForCheck(check).find((task) => task.key === key) ?? null)
+    : null;
 }
 
 export function filterModerationTasks(

--- a/apps/server/src/orpc/routes/admin/moderation/list-tasks.test.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/list-tasks.test.ts
@@ -105,6 +105,22 @@ describe("admin moderation tasks", () => {
       blocked: 1,
       inconclusive: 0,
     });
+    await expect(
+      routerClient.admin.moderation.task(
+        { key: `listing:${listing!.id}` },
+        { context: { user: admin } },
+      ),
+    ).resolves.toEqual({
+      task: expect.objectContaining({ key: `listing:${listing!.id}` }),
+    });
+    await expect(
+      routerClient.admin.moderation.task(
+        { key: `operation:${operations[0]!.id}` },
+        { context: { user: admin } },
+      ),
+    ).resolves.toEqual({
+      task: expect.objectContaining({ key: `operation:${operations[0]!.id}` }),
+    });
 
     const blocked = await routerClient.admin.moderation.listTasks(
       { blocked: true },
@@ -270,7 +286,19 @@ describe("admin moderation tasks", () => {
       { context: { user: admin } },
     );
     expect(result.results).toEqual([
-      expect.objectContaining({ key: `finding:${check!.id}`, kind: "finding" }),
+      expect.objectContaining({
+        key: `finding:${check!.id}`,
+        kind: "finding",
+        statusLabel: "1 finding",
+      }),
     ]);
+    await expect(
+      routerClient.admin.moderation.task(
+        { key: `finding:${check!.id}` },
+        { context: { user: admin } },
+      ),
+    ).resolves.toEqual({
+      task: expect.objectContaining({ key: `finding:${check!.id}` }),
+    });
   });
 });

--- a/apps/server/src/orpc/routes/admin/moderation/task.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/task.ts
@@ -1,4 +1,4 @@
-import { projectModerationTasks } from "@peated/server/lib/moderationTasks";
+import { locateModerationTask } from "@peated/server/lib/moderationTasks";
 import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
 import {
@@ -19,9 +19,7 @@ export default procedure
   .input(ModerationTaskLocatorInputSchema)
   .output(ModerationTaskLocatorResponseSchema)
   .handler(async ({ input, errors }) => {
-    const task = (await projectModerationTasks()).find(
-      ({ key }) => key === input.key,
-    );
+    const task = await locateModerationTask(input.key);
     if (!task) {
       throw errors.NOT_FOUND({
         message: "This moderation task no longer needs attention.",


### PR DESCRIPTION
The moderation inbox now loads actionable catalog checks through one bounded, narrow projection instead of walking every 100-row audit page, and listing summaries no longer fetch large proposal fields. Listing and catalog projections run concurrently, so opening the inbox does substantially less database and payload work.

Task lookup now resolves only the referenced listing, operation, or finding while reusing the same source-owned actionability predicate as the list. This preserves stale-task revalidation without rebuilding the full inbox. Route coverage verifies all three task kinds and the narrow finding-count projection.

Validated with focused moderation and bottle-check tests, server and web typechecks, focused lint/format checks, and a browser smoke test.
