### PR TITLE
docs(policies): sync engineering guidance

### DIFF
--- a/docs/policies/README.md
+++ b/docs/policies/README.md
@@ -1,23 +1,23 @@
 # Policies
 
-Policies are durable repo-wide engineering rules and defaults. They are the
-highest-authority repository documentation below executable configuration and
-must remain consistent with code-enforced constraints.
+Policies are durable repo-wide engineering rules and defaults. They sit below
+executable configuration and must match code-enforced constraints.
 
-Use a policy when the repository needs to say "this is how we do this here"
-across multiple packages or features.
+Use a policy when the repo must say "this is how we do this here" across
+packages or features. Examples include testing, comments, security, privacy,
+error handling, interface design, and background work.
 
 Do not use policies for:
 
-- one feature's architecture or lifecycle;
-- implementation plans, status, TODOs, or rollout tracking;
-- copied schemas, commands, or test inventories;
-- public product documentation.
+- one feature's design or state changes
+- plans, status notes, TODOs, or rollout tracking
+- copied schemas, commands, or test inventories
+- public product docs
 
-Feature architecture and non-obvious invariants belong in the owning package,
-module, or feature documentation. Code, runtime schemas, exported types, and
-tests define the implemented contract. Temporary implementation plans live
-under `../../openspec/changes/` and cannot override policy.
+Put feature architecture and non-obvious rules in the owning package, module,
+or feature documentation. Code, runtime schemas, exported types, and tests
+define the real contract. Temporary plans live under `../../openspec/changes/`
+and cannot override policy.
 
 Current policies:
 
@@ -39,8 +39,10 @@ Backend and frontend testing expectations live in
 [../development/frontend-testing.md](../development/frontend-testing.md). Keep
 those documents as the source of truth instead of duplicating them here.
 
-Keep policies short: explain the intent, state the default, and name only
-meaningful exceptions. Update the policy directly when the repo intends to
-change the default; silence elsewhere does not create an exception.
+Keep policies short. Use common words, active voice, short sentences, and one
+idea per sentence. Keep required domain terms, but explain them when the reader
+may not know them. Remove other jargon. State the intent, the default, and only
+real exceptions. Update the policy when the repo changes the default. Silence
+elsewhere does not create an exception.
 
 Use [policy-template.md](policy-template.md) for new policies.

--- a/docs/policies/agent-design.md
+++ b/docs/policies/agent-design.md
@@ -32,6 +32,14 @@
 - Prompts must keep required stable domain and decision policy separate from
   dynamic context. Put tool mechanics in tool descriptions and live facts in
   runtime context.
+- Prefer structured contracts, schemas, runtime gates, and code invariants over
+  adding natural-language prompt lines for deterministic behavior.
+- Give each steering rule one home. Put cross-tool decision policy in the
+  prompt, field meaning and call mechanics in the relevant schema or tool
+  description, and runtime authority in code.
+- Do not repeat one rule across prompts, tool descriptions, and runtime guidance
+  unless each copy serves a distinct enforcement path. Delete obsolete prompt
+  guidance when code, schemas, or runtime gates take ownership.
 - Improve retrieval, candidates, and source context before expanding prompts.
 - Treat user input, retrieved content, and source facts as data, not
   instructions or runtime authority.

--- a/docs/policies/code-comments.md
+++ b/docs/policies/code-comments.md
@@ -2,35 +2,35 @@
 
 ## Intent
 
-Comments are for non-obvious intent, ownership, invariants, and tradeoffs.
+Comments are for non-obvious intent, module ownership, rules, and tradeoffs.
 
 They are not there to narrate obvious code.
 
 ## Policy
 
-- Major entry-point and boundary modules need a short design comment naming what
-  they own, what stays outside the boundary, and the invariants a maintainer
-  must preserve.
-- When a repository policy is implemented by a specific module or exported
-  interface, add or update a nearby module comment or JSDoc. State the
-  policy-bearing behavior and link the owning policy when that helps discovery;
-  do not copy the whole policy into code.
-- Shared exported functions need brief intent-focused JSDoc when their name and
-  type do not communicate important side effects, omissions, trust boundaries,
-  or failure behavior.
-- Private helpers also need JSDoc when they define an internal interface such as
-  a wire or storage format, signing boundary, durable state transition,
-  telemetry/error boundary, or retry/resume policy.
-- Document intentionally omitted behavior when a maintainer would reasonably
-  expect it and the omission affects correctness, security, privacy,
-  observability, delivery, or recovery.
-- Keep comments short and concrete. Explain why the code exists or what
-  boundary it protects.
-- Delete or rewrite stale comments immediately when behavior changes.
+- Major entry-point modules need a short design comment: ownership, boundary,
+  and key rules.
+- Exported functions need a brief JSDoc comment that explains intent when the
+  name and type do not make important behavior clear.
+- Public TypeScript interfaces and their comments are the canonical internal
+  API documentation. Public HTTP contracts remain owned by route schemas and
+  the generated OpenAPI specification.
+- Private functions also need JSDoc when they define an internal interface:
+  handlers or factories, wire or storage formats, signing, durable state
+  changes, telemetry or error boundaries, or retry and resume policy.
+- Comment non-obvious rules, tradeoffs, and policy-driven behavior.
+- When an owning boundary intentionally omits behavior a maintainer would
+  reasonably expect, document that absence when it affects correctness,
+  security, privacy, delivery, observability, or recovery.
+- Transitional compatibility branches and fallbacks require a concrete removal
+  TODO. Name the legacy state or behavior and the release, issue, or condition
+  that removes it. Do not only say "clean up later."
+- Keep comments short, concrete, and current.
 
 ## Exceptions
 
 - Do not comment obvious transformations or control flow.
 - Do not add comments that simply restate the code in English.
-- Small, obvious leaf helpers do not need comments merely because they are
-  exported.
+- Small obvious leaf helpers do not need comments.
+- If there is no concrete release or condition for removing a compatibility
+  path, prefer a hard cutover instead of adding the path.

--- a/docs/policies/correctness-complexity.md
+++ b/docs/policies/correctness-complexity.md
@@ -2,34 +2,35 @@
 
 ## Intent
 
-Correct behavior is required, but correctness work should not default to the
-most exhaustive design an agent can imagine. A change is better only when its
+Correct behavior is required. Correctness work should not default to the most
+exhaustive design an agent can invent. A change is better only when its
 correctness gain is worth the added code, states, callbacks, and maintenance
-burden.
+cost.
 
 ## Policy
 
-- Evaluate non-trivial changes on correctness, simplicity, understandability
-  for an average repo developer, and maintainability.
+- Judge non-trivial changes on four axes: correctness, simplicity,
+  understandability for an average repo developer, and maintainability.
 - Prefer the smallest design that closes the proven failure mode. Do not add
   speculative states, abstractions, retries, fallbacks, configuration, or
-  recovery paths for failures outside the current contract.
-- When correctness requires complexity, name the invariant at the owning
-  boundary and keep the implementation local to that boundary.
-- Avoid spreading one invariant across callbacks in multiple layers. If several
-  layers must participate, one layer owns the lifecycle transition and the
-  others expose narrow capabilities.
+  recovery paths for failures that are not part of the current contract.
+- When correctness needs complexity, name the rule at the owning boundary and
+  keep the implementation local to that boundary.
+- Avoid spreading one rule across callbacks in many layers. If several layers
+  must take part, one layer should own the lifecycle change. The others should
+  expose narrow capabilities.
 - Do not hide complexity behind best-effort logging, ambient context, or
-  one-hop wrappers. If a future maintainer must know about hidden state to
+  one-hop wrappers. If a future developer must know about the hidden state to
   change behavior safely, the design is not simple.
-- Require a simplification pass when a change is more correct but materially
-  harder to understand, unless the risk is urgent and documented.
-- Tests should prove the invariant at the highest useful boundary instead of
-  encoding every internal step.
+- A review that finds "more correct but harder to understand" should require a
+  simplification pass before merge unless the risk is urgent and documented.
+- Tests should prove the rule at the highest useful boundary. They should not
+  encode every internal step of a complex implementation.
 
 ## Exceptions
 
 - Security, privacy, data-loss, and duplicate-side-effect fixes may temporarily
-  increase complexity when a smaller safe design is not available.
-- Temporary complexity must be explicit in the pull request or follow-up issue,
-  including the invariant it protects and the simplification that remains.
+  increase complexity when a smaller safe design is not available in the same
+  change.
+- Temporary complexity must be explicit in the pull request or follow-up issue.
+  Name the rule it protects and the simplification that remains.

--- a/docs/policies/data-redaction.md
+++ b/docs/policies/data-redaction.md
@@ -12,8 +12,11 @@ to collect unrestricted user or provider data.
   authorization headers, API keys, signed callbacks, or credential-bearing
   URLs in logs, traces, errors, or attachments.
 - Do not record complete tasting text, comments, email bodies, model prompts or
-  responses, tool payloads, uploaded image contents, SQL parameters containing
-  user data, or unrestricted third-party responses.
+  responses, unrestricted tool payloads, uploaded image contents, SQL parameters
+  containing user data, or unrestricted third-party responses.
+- Classifier tool telemetry may record bounded arguments and results when they
+  contain only public catalog or source evidence. Do not include private user
+  data, credentials, uploaded image contents, or unrestricted provider payloads.
 - Prefer stable identifiers, operation names, counts, sizes, classifications,
   status values, and bounded error summaries.
 - Persist normalized product fields instead of complete provider webhook, SDK,

--- a/docs/policies/error-handling.md
+++ b/docs/policies/error-handling.md
@@ -14,8 +14,8 @@ duplicate diagnostics.
 - Catch errors only when the current layer can recover, translate an expected
   boundary failure into a typed domain result, or add required cleanup that
   cannot be expressed with `finally`.
-- If a catch block handles an error, it must complete the recovery or rethrow
-  with useful domain context. Avoid log-and-rethrow duplicates.
+- If a catch block handles an error, it must either finish the recovery or
+  rethrow with useful domain context. Avoid log-and-rethrow duplicates.
 - Use `finally` for cleanup that must run without changing error ownership.
 - Keep best-effort observers explicit. If correctness depends on the operation,
   it is not best-effort.
@@ -24,5 +24,6 @@ duplicate diagnostics.
 
 - External systems with expected transient failures may catch at the boundary
   that owns retry, backoff, authentication pause, or typed fallback behavior.
-- Product surfaces that intentionally degrade may catch locally when dropping
-  the failure is part of their contract.
+- Product surfaces that intentionally degrade, such as optional UI streaming or
+  non-critical observer callbacks, may catch locally when dropping the failure
+  is part of their contract.

--- a/docs/policies/interface-design.md
+++ b/docs/policies/interface-design.md
@@ -2,43 +2,64 @@
 
 ## Intent
 
-Interfaces should expose the smallest useful capability while keeping
-ownership, lifecycle, and security boundaries obvious. Module paths, file
-names, type names, and function names are all part of the interface.
+Interfaces should expose the smallest useful capability while keeping ownership,
+lifecycle, and security boundaries obvious. Module paths, file names, type names,
+and function names are all part of that interface.
 
 ## Policy
 
 - Prefer narrow capability functions over broad dependency bags or access to
-  underlying clients and services.
+  underlying services.
 - Expose lifecycle-oriented operations such as `dispatch`, `store`, `verify`,
   or `resolve` instead of raw runners, clients, routes, or storage adapters.
-- Return projections by default. Do not expose full internal records when a
-  caller only needs status, ids, or a summary.
-- Make ownership explicit. A caller should only read or mutate records it owns
-  unless cross-owner access is the feature and is checked at the boundary.
-- Keep provider and framework details inside their owning layer. Shared code
-  should depend on Peated-owned contracts rather than SDK types.
-- Require idempotency keys for interfaces that create durable work from
+- Return views by default. Do not expose full internal records when callers only
+  need status, ids, or summaries.
+- Make ownership explicit at the API boundary. A caller should only read or
+  change records it owns unless cross-owner access is the feature and is checked
+  there.
+- Keep framework and external-service details inside their owning layer. Shared
+  code should depend on Peated-owned contracts rather than SDK types.
+- Require idempotency keys for APIs that create durable work from
   retryable contexts.
+- Use short JavaScript-facing names for public types and methods. Avoid names
+  that describe implementation mechanics instead of product intent.
 - Use the same domain noun for the same concept across types, fields, functions,
-  storage keys, and documentation. Two names should mean two concepts, not two
-  layers of the same concept.
-- Prefer short names that use module and parent-object context. Avoid suffixes
-  such as `Record`, `State`, `Data`, `Payload`, `Manager`, and `Handler` unless
-  that shape or role is the actual boundary being named.
-- Name modules after the concern they own, not the adapter or mechanism they
+  storage keys, and docs. Two names should mean two concepts, not two layers of
+  the same concept.
+- Prefer simple domain nouns over names that combine the concept with its
+  storage shape.
+- Avoid suffixes such as `Record`, `State`, `Data`, `Payload`, `Manager`, and
+  `Handler` unless that storage shape, lifecycle, or adapter role is the actual
+  boundary being named.
+- Spend local context instead of repeating it. Use module, parent-object,
+  folder, and file context to keep function and field names short.
+- Name modules by the concern they own, not by the adapter or mechanism they
   happen to use.
+- Name indexes, queues, and storage keys by their membership and ordering when
+  they serve more than one consumer. Do not name shared state after one process
+  that happens to use it.
+- Prefer import-site readability over globally unique names. Include a
+  canonical domain term when an exact repo search would otherwise mix unrelated
+  concepts, but do not repeat the module path in every name.
+- When a term is overloaded in the product or platform, define it once in the
+  owning module documentation and avoid using it for nearby concepts.
 - Keep exported interfaces role-shaped and small. Add an interface only when it
   removes real coupling or represents a stable boundary.
-- Avoid one-hop wrappers and renamed aliases that only forward arguments. An
-  intermediate function should enforce an invariant, translate a boundary, or
-  own a lifecycle transition.
+- Avoid one-hop wrappers, renamed aliases, and helper layers that only forward
+  arguments, options, or dependencies. Call the owning capability directly
+  unless the intermediate function enforces a rule, translates a boundary, or
+  owns a lifecycle change.
+- If a helper exists only to hide parameter threading, inline it or move the
+  repeated call shape to the owner that defines the contract.
 
 ## Exceptions
 
-- Low-level infrastructure modules may expose mechanism-specific APIs inside
-  their own ownership boundary.
-- Compatibility names may remain at external boundaries or legacy storage
-  keys. New internal names should use the current domain term.
 - Test fixtures may expose narrower construction seams when the production
   interface remains small.
+- Low-level infrastructure modules may expose mechanism-specific APIs inside
+  their own ownership boundary.
+- Generic names are acceptable inside a tightly scoped module when the import
+  path supplies the missing context. Use longer names only when imported roles
+  would otherwise collide at common call sites.
+- Compatibility names may remain at external boundaries or legacy storage
+  keys. New internal names should still use the current domain term.

--- a/docs/policies/observability.md
+++ b/docs/policies/observability.md
@@ -9,10 +9,13 @@ contract and should not change runtime behavior when a sink is unavailable.
 
 - Logs describe discrete events and decisions. Spans describe timed work and
   causal relationships. Sentry issues represent actionable unexpected failures,
-  not normal control flow.
+  not normal control flow. Derive metrics from stable events or spans when
+  practical instead of adding duplicate instrumentation.
 - Emit stable messages and low-cardinality structured attributes. Put ids and
   occurrence-specific values in attributes rather than message or operation
   names.
+- Use OpenTelemetry semantic attributes when one exists. Keep operation names
+  provider-neutral, stable, and low-cardinality.
 - Bind useful correlation context at the owning boundary: request, user,
   Bottle, tasting, job, agent conversation, or run ids as applicable.
 - Async logging context is not durable runtime context. Queues, callbacks, and
@@ -28,6 +31,9 @@ contract and should not change runtime behavior when a sink is unavailable.
 - Logging and tracing entry-point modules must state their ownership and error
   semantics in a module comment. Shared logging APIs must make it clear whether
   a call emits diagnostic telemetry or creates an actionable Sentry issue.
+- Tool spans may attach bounded arguments and results when the tool contract
+  contains public catalog or source evidence and excludes private user data and
+  credentials. Use an explicit safe projection for mixed-sensitivity payloads.
 - Follow [data-redaction.md](data-redaction.md). Telemetry records safe metadata,
   not private content, credentials, or unrestricted payloads.
 - Product tests should assert user-visible or durable outcomes instead of logs,

--- a/docs/policies/policy-template.md
+++ b/docs/policies/policy-template.md
@@ -1,14 +1,18 @@
 # Policy Name
 
+Use common words, active voice, short sentences, and one idea per sentence.
+Keep required domain terms, but explain them when the reader may not know them.
+Remove other jargon.
+
 ## Intent
 
-One short paragraph on why this policy exists.
+In one short paragraph, explain why this policy exists.
 
 ## Policy
 
-- Default rule
-- Second rule if needed
+- State the default rule.
+- Add another rule only when needed.
 
 ## Exceptions
 
-- Only list real exceptions
+- List only real exceptions.

--- a/packages/bottle-classifier/src/observability.ts
+++ b/packages/bottle-classifier/src/observability.ts
@@ -1,3 +1,7 @@
+/**
+ * Owns classifier span metadata. Tool payloads are bounded before they reach
+ * tracing and callers must keep them limited to public catalog/source data.
+ */
 import { startSpan } from "@sentry/core";
 
 const MAX_ATTRIBUTE_LENGTH = 12_000;
@@ -127,9 +131,6 @@ export function buildAgentSpanContext({
   };
 }
 
-/**
- * Builds `gen_ai.execute_tool` metadata with compact JSON tool arguments.
- */
 export function buildToolSpanContext({
   name,
   description,
@@ -176,10 +177,7 @@ export async function startAgentSpan<T>({
   );
 }
 
-/**
- * Wraps tool execution in `gen_ai.execute_tool` and records compact JSON
- * arguments/results so spans stay useful without carrying oversized payloads.
- */
+/** Wraps tool execution and records bounded public catalog/source payloads. */
 export async function startToolSpan<T>({
   name,
   description,

--- a/packages/entity-classifier/src/observability.ts
+++ b/packages/entity-classifier/src/observability.ts
@@ -1,3 +1,7 @@
+/**
+ * Owns classifier span metadata. Tool payloads are bounded before they reach
+ * tracing and callers must keep them limited to public catalog/source data.
+ */
 import { startSpan } from "@sentry/core";
 
 const MAX_ATTRIBUTE_LENGTH = 12_000;
@@ -119,9 +123,6 @@ export function buildAgentSpanContext({
   };
 }
 
-/**
- * Builds `gen_ai.execute_tool` metadata with compact JSON tool arguments.
- */
 export function buildToolSpanContext({
   name,
   description,
@@ -168,10 +169,7 @@ export async function startAgentSpan<T>({
   );
 }
 
-/**
- * Wraps tool execution in `gen_ai.execute_tool` and records compact JSON
- * arguments/results so spans stay useful without carrying oversized payloads.
- */
+/** Wraps tool execution and records bounded public catalog/source payloads. */
 export async function startToolSpan<T>({
   name,
   description,


### PR DESCRIPTION
Refreshes Peated’s generic engineering policies with current guidance for comments, correctness, interfaces, error handling, prompt steering, observability, and plain-language authoring. The redaction rules explicitly preserve bounded classifier tool arguments and results for public catalog or source evidence while continuing to exclude private user data, credentials, uploaded image contents, and unrestricted provider payloads.

Classifier telemetry behavior is unchanged; nearby ownership comments now document its data boundary. Review should focus on whether the generic guidance maps cleanly to Peated’s HTTP and classifier contracts.
