### PR TITLE
fix(classifier): reduce price match false negatives

### DIFF
--- a/apps/server/src/lib/priceMatchingAutomation.test.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.test.ts
@@ -1028,6 +1028,72 @@ describe("priceMatchingAutomation", () => {
     });
   });
 
+  test("allows auto-create when every required check passes below the old metadata score threshold", () => {
+    const assessment = getStorePriceMatchAutomationAssessment({
+      action: "create_new",
+      modelConfidence: 95,
+      price: {
+        bottleId: null,
+        name: "Example Distillery Pedro Ximénez Select Cask",
+        url: "https://shop.example/pedro-ximenez-select-cask",
+      },
+      suggestedBottleId: null,
+      extractedLabel: buildExtractedLabel({
+        brand: "Example Distillery",
+        expression: "Pedro Ximénez Select Cask",
+        distillery: [],
+        stated_age: null,
+        abv: 48,
+        cask_type: null,
+      }),
+      proposedBottle: buildProposedBottle({
+        name: "Pedro Ximénez Select Cask",
+        statedAge: null,
+        abv: 48,
+        brand: { id: null, name: "Example Distillery" },
+        distillers: [],
+      }),
+      searchEvidence: [
+        {
+          provider: "openai",
+          query: '"Example Distillery" "Pedro Ximénez Select Cask" 48%',
+          summary:
+            "The producer lists Example Distillery Pedro Ximénez Select Cask at 48%.",
+          results: [
+            {
+              title: "Example Distillery Pedro Ximénez Select Cask",
+              url: "https://www.exampledistillery.com/pedro-ximenez-select-cask",
+              domain: "exampledistillery.com",
+              description:
+                "Example Distillery Pedro Ximénez Select Cask is bottled at 48%.",
+              extraSnippets: [],
+            },
+          ],
+        },
+      ],
+      candidateBottles: [
+        buildCandidate({
+          fullName: "Example Distillery Oloroso Select Cask",
+          brand: "Example Distillery",
+          distillery: [],
+          statedAge: null,
+          abv: 46,
+          caskType: null,
+        }),
+      ],
+      webEvidenceJudgment: "supportive",
+    });
+
+    expect(assessment.automationScore).toBeLessThan(90);
+    expect(assessment.automationBlockers).toEqual([]);
+    expect(
+      assessment.webEvidenceChecks
+        .filter((check) => check.required)
+        .every((check) => check.validated),
+    ).toBe(true);
+    expect(assessment.automationEligible).toBe(true);
+  });
+
   test("validates auto-create ABV evidence from exact US proof", () => {
     const assessment = getStorePriceMatchAutomationAssessment({
       action: "create_new",

--- a/apps/server/src/lib/priceMatchingAutomation.ts
+++ b/apps/server/src/lib/priceMatchingAutomation.ts
@@ -77,7 +77,7 @@ export type StorePriceMatchAutomationAssessment = z.infer<
   typeof StorePriceMatchAutomationAssessmentSchema
 >;
 
-const AUTO_CREATE_NEW_CONFIDENCE_THRESHOLD = 90;
+const BLOCKED_AUTO_CREATE_SCORE = 89;
 const WEB_VALIDATED_DIFFERENTIATORS = new Set<MatchAttribute>([
   "bottler",
   "series",
@@ -853,9 +853,7 @@ function getCreateNewScore({
   const hasBlockers = automationBlockers.length > 0;
   if (deterministicSmwsExactCaskCreate) {
     return {
-      automationScore: hasBlockers
-        ? AUTO_CREATE_NEW_CONFIDENCE_THRESHOLD - 1
-        : 100,
+      automationScore: hasBlockers ? BLOCKED_AUTO_CREATE_SCORE : 100,
       automationEligible: !hasBlockers,
       automationBlockers: Array.from(new Set(automationBlockers)),
       differentiatingAttributes,
@@ -868,13 +866,13 @@ function getCreateNewScore({
     hasStructuredSourceAnchor && !hasBlockers
       ? 100
       : hasBlockers
-        ? Math.min(clampScore(score), AUTO_CREATE_NEW_CONFIDENCE_THRESHOLD - 1)
+        ? Math.min(clampScore(score), BLOCKED_AUTO_CREATE_SCORE)
         : clampScore(score);
 
   return {
     automationScore,
-    automationEligible:
-      !hasBlockers && automationScore >= AUTO_CREATE_NEW_CONFIDENCE_THRESHOLD,
+    // Blockers own the create safety contract; score is diagnostic metadata.
+    automationEligible: !hasBlockers,
     automationBlockers: Array.from(new Set(automationBlockers)),
     differentiatingAttributes,
     decisiveMatchAttributes: Array.from(

--- a/apps/server/src/orpc/routes/admin/moderation/history-details.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/history-details.ts
@@ -88,6 +88,7 @@ export default procedure
         details: {
           sourceKind: log.sourceKind,
           sourceId: log.sourceId,
+          proposalId: log.proposalId,
           bottleId: log.bottleId,
           confidence: log.confidence,
           model: log.model,

--- a/apps/server/src/orpc/routes/admin/moderation/history.test.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/history.test.ts
@@ -3,6 +3,7 @@ import {
   bottleChecks,
   bottleOperations,
   incomingBottleDecisionLogs,
+  storePriceMatchProposals,
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
 import { BOTTLE_CHECK_SCHEMA_VERSION } from "@peated/server/lib/bottleChecks";
@@ -24,11 +25,20 @@ describe("admin moderation history", () => {
       name: "History listing",
       url: "https://example.com/history-listing",
     });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        proposalType: "match_existing",
+        suggestedBottleId: bottle.id,
+      })
+      .returning();
     const [incoming] = await db
       .insert(incomingBottleDecisionLogs)
       .values({
         sourceKind: "store_price",
         sourceId: price.id,
+        proposalId: proposal!.id,
         externalSiteId: site.id,
         name: price.name,
         url: price.url,
@@ -85,6 +95,15 @@ describe("admin moderation history", () => {
       `incoming:${incoming!.id}`,
       `closure:${check!.id}`,
     ]);
+
+    const incomingDetails = await routerClient.admin.moderation.historyDetails(
+      { key: `incoming:${incoming!.id}` },
+      { context: { user: admin } },
+    );
+    expect(incomingDetails.details).toMatchObject({
+      sourceId: price.id,
+      proposalId: proposal!.id,
+    });
 
     const details = await routerClient.admin.moderation.historyDetails(
       { key: `operation:${operation!.id}` },

--- a/packages/bottle-classifier/src/identityEvidenceCore.ts
+++ b/packages/bottle-classifier/src/identityEvidenceCore.ts
@@ -146,10 +146,11 @@ export function getAbvSupportLevel(
   expectedValue: number,
   options: { usProofEligible?: boolean } = {},
 ): "none" | "close" | "exact" {
+  const expectedPattern = Number.isInteger(expectedValue)
+    ? `${escapeRegExp(String(expectedValue))}(?:\\.0)?`
+    : escapeRegExp(String(expectedValue));
   const exactPattern = new RegExp(
-    `\\b${escapeRegExp(expectedValue.toFixed(1))}%?(?:\\s*abv)?\\b|\\b${escapeRegExp(
-      `${Math.round(expectedValue)}`,
-    )}%\\s*abv\\b`,
+    `\\b${expectedPattern}\\s*%(?:\\s*abv\\b)?(?!\\w)|\\b${expectedPattern}\\s*abv\\b`,
     "i",
   );
 

--- a/packages/bottle-classifier/src/priceMatchingEvidence.test.ts
+++ b/packages/bottle-classifier/src/priceMatchingEvidence.test.ts
@@ -4,7 +4,10 @@ import type {
   BottleExtractedDetails,
   BottleSearchEvidence,
 } from "./classifierTypes";
-import { classifySearchResultSource } from "./identityEvidenceCore";
+import {
+  classifySearchResultSource,
+  getAbvSupportLevel,
+} from "./identityEvidenceCore";
 import {
   agentActionRiskClass,
   type AutomationTierInput,
@@ -78,6 +81,21 @@ function buildSearchEvidence(
 }
 
 describe("priceMatchingEvidence", () => {
+  test.each([
+    ["Bottled at 40%.", 40],
+    ["Bottled at 40.0%", 40],
+    ["40% ABV", 40],
+    ["Alcohol by volume: 40 ABV", 40],
+    ["Bottled at 43.5%", 43.5],
+    ["Bottled at 57.03%", 57.03],
+  ])("recognizes explicit ABV evidence in %s", (text, expectedValue) => {
+    expect(getAbvSupportLevel(text, expectedValue)).toBe("exact");
+  });
+
+  test("does not round decimal ABV evidence to a neighboring integer", () => {
+    expect(getAbvSupportLevel("Bottled at 44%", 43.5)).toBe("none");
+  });
+
   test("ignores optional cask metadata but keeps cask flags decisive for plain-age verification", () => {
     const target = buildBottleCandidate({
       bottleId: 1,


### PR DESCRIPTION
Price-match proposals now auto-create whenever all concrete safety checks pass, instead of requiring an additional score of 90. The score remains available as diagnostic metadata, while explicit ABV evidence accepts common integer and decimal formats without rounding nearby values.

Moderation history details also expose the already-stored proposal ID, allowing the generic API and CLI output to connect queued proposals to their eventual outcomes. Regression coverage exercises the formerly score-only rejection, ABV parsing, and history response contract; source-role classification remains unchanged rather than introducing domain-specific exceptions.
