### PR TITLE
feat(admin): add catalog coverage report

### DIFF
--- a/apps/server/src/orpc/routes/admin/catalog-coverage.test.ts
+++ b/apps/server/src/orpc/routes/admin/catalog-coverage.test.ts
@@ -1,0 +1,115 @@
+import { db } from "@peated/server/db";
+import { bottleTombstones } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+
+describe("GET /admin/catalog/coverage", () => {
+  test("reports active catalog and visible source-item coverage", async ({
+    fixtures,
+  }) => {
+    const admin = await fixtures.User({ admin: true });
+    const coveredBottle = await fixtures.Bottle({
+      description: "A useful description",
+      imageUrl: "https://example.com/covered.jpg",
+    });
+    await fixtures.Bottle({
+      description: "   ",
+      imageUrl: "",
+    });
+    const hiddenOnlyBottle = await fixtures.Bottle();
+    await fixtures.LegacyBottle({
+      description: "Legacy description",
+      imageUrl: "https://example.com/legacy.jpg",
+    });
+    const retiredBottle = await fixtures.Bottle({
+      description: "Retired description",
+      imageUrl: "https://example.com/retired.jpg",
+    });
+    await db.insert(bottleTombstones).values({
+      bottleId: retiredBottle.id,
+      newBottleId: coveredBottle.id,
+    });
+
+    await fixtures.Review({
+      bottleId: coveredBottle.id,
+      name: "Covered review one",
+    });
+    await fixtures.Review({
+      bottleId: coveredBottle.id,
+      name: "Covered review two",
+    });
+    await fixtures.Review({
+      bottleId: retiredBottle.id,
+      name: "Retired bottle review",
+    });
+    await fixtures.Review({
+      bottleId: null,
+      name: "Unmatched review",
+    });
+    await fixtures.Review({
+      bottleId: hiddenOnlyBottle.id,
+      name: "Hidden review",
+      hidden: true,
+    });
+
+    await fixtures.StorePrice({
+      bottleId: coveredBottle.id,
+      name: "Covered listing one",
+    });
+    await fixtures.StorePrice({
+      bottleId: coveredBottle.id,
+      name: "Covered listing two",
+    });
+    await fixtures.StorePrice({
+      bottleId: retiredBottle.id,
+      name: "Retired bottle listing",
+    });
+    await fixtures.StorePrice({
+      bottleId: null,
+      name: "Unmatched listing",
+    });
+    await fixtures.StorePrice({
+      bottleId: hiddenOnlyBottle.id,
+      name: "Hidden listing",
+      hidden: true,
+    });
+
+    const result = await routerClient.admin.catalogCoverage(undefined, {
+      context: { user: admin },
+    });
+
+    expect(result).toEqual({
+      bottles: {
+        total: 3,
+        withDescription: 1,
+        withImage: 1,
+        withReviews: 1,
+        withPriceListings: 1,
+      },
+      reviews: {
+        total: 4,
+        matched: 3,
+        unmatched: 1,
+      },
+      priceListings: {
+        total: 4,
+        matched: 3,
+        unmatched: 1,
+      },
+    });
+  });
+
+  test("requires an administrator", async ({ defaults }) => {
+    const anonymousError = await waitError(
+      routerClient.admin.catalogCoverage(),
+    );
+    const userError = await waitError(
+      routerClient.admin.catalogCoverage(undefined, {
+        context: { user: defaults.user },
+      }),
+    );
+
+    expect(anonymousError).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+    expect(userError).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+});

--- a/apps/server/src/orpc/routes/admin/catalog-coverage.ts
+++ b/apps/server/src/orpc/routes/admin/catalog-coverage.ts
@@ -1,0 +1,128 @@
+import { db } from "@peated/server/db";
+import {
+  bottleTombstones,
+  bottles,
+  reviews,
+  storePrices,
+} from "@peated/server/db/schema";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
+import { z } from "zod";
+
+const itemCoverageSchema = z.object({
+  total: z.number().int().nonnegative(),
+  matched: z.number().int().nonnegative(),
+  unmatched: z.number().int().nonnegative(),
+});
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "GET",
+    path: "/admin/catalog/coverage",
+    summary: "Get catalog aggregation coverage",
+    description:
+      "Retrieve active bottle content coverage and visible external item matching coverage",
+    spec: (spec) => ({
+      ...spec,
+      operationId: "getCatalogCoverage",
+    }),
+  })
+  .output(
+    z.object({
+      bottles: z.object({
+        total: z.number().int().nonnegative(),
+        withDescription: z.number().int().nonnegative(),
+        withImage: z.number().int().nonnegative(),
+        withReviews: z.number().int().nonnegative(),
+        withPriceListings: z.number().int().nonnegative(),
+      }),
+      reviews: itemCoverageSchema,
+      priceListings: itemCoverageSchema,
+    }),
+  )
+  .handler(async () => {
+    const [
+      [bottleContentCoverage],
+      [reviewBottleCoverage],
+      [priceListingBottleCoverage],
+      [reviewCoverage],
+      [priceListingCoverage],
+    ] = await Promise.all([
+      db
+        .select({
+          total: sql<number>`count(*)::int`,
+          withDescription: sql<number>`count(*) filter (where nullif(btrim(${bottles.description}), '') is not null)::int`,
+          withImage: sql<number>`count(*) filter (where nullif(btrim(${bottles.imageUrl}), '') is not null)::int`,
+        })
+        .from(bottles)
+        .where(
+          and(
+            isNotNull(bottles.groupId),
+            sql`not exists (
+                select 1 from ${bottleTombstones}
+                where ${bottleTombstones.bottleId} = ${bottles.id}
+              )`,
+          ),
+        ),
+      db
+        .select({
+          total: sql<number>`count(distinct ${reviews.bottleId})::int`,
+        })
+        .from(reviews)
+        .innerJoin(bottles, eq(reviews.bottleId, bottles.id))
+        .where(
+          and(
+            eq(reviews.hidden, false),
+            isNotNull(bottles.groupId),
+            sql`not exists (
+                select 1 from ${bottleTombstones}
+                where ${bottleTombstones.bottleId} = ${bottles.id}
+              )`,
+          ),
+        ),
+      db
+        .select({
+          total: sql<number>`count(distinct ${storePrices.bottleId})::int`,
+        })
+        .from(storePrices)
+        .innerJoin(bottles, eq(storePrices.bottleId, bottles.id))
+        .where(
+          and(
+            eq(storePrices.hidden, false),
+            isNotNull(bottles.groupId),
+            sql`not exists (
+                select 1 from ${bottleTombstones}
+                where ${bottleTombstones.bottleId} = ${bottles.id}
+              )`,
+          ),
+        ),
+      db
+        .select({
+          total: sql<number>`count(*)::int`,
+          matched: sql<number>`count(*) filter (where ${reviews.bottleId} is not null)::int`,
+          unmatched: sql<number>`count(*) filter (where ${reviews.bottleId} is null)::int`,
+        })
+        .from(reviews)
+        .where(eq(reviews.hidden, false)),
+      db
+        .select({
+          total: sql<number>`count(*)::int`,
+          matched: sql<number>`count(*) filter (where ${storePrices.bottleId} is not null)::int`,
+          unmatched: sql<number>`count(*) filter (where ${storePrices.bottleId} is null)::int`,
+        })
+        .from(storePrices)
+        .where(eq(storePrices.hidden, false)),
+    ]);
+
+    return {
+      bottles: {
+        ...bottleContentCoverage!,
+        withReviews: reviewBottleCoverage!.total,
+        withPriceListings: priceListingBottleCoverage!.total,
+      },
+      reviews: reviewCoverage!,
+      priceListings: priceListingCoverage!,
+    };
+  });

--- a/apps/server/src/orpc/routes/admin/index.ts
+++ b/apps/server/src/orpc/routes/admin/index.ts
@@ -1,8 +1,10 @@
 import { base } from "../..";
+import catalogCoverage from "./catalog-coverage";
 import moderation from "./moderation";
 import oauthClients from "./oauth-clients";
 
 export default base.tag("admin").router({
+  catalogCoverage,
   moderation,
   oauthClients,
 });

--- a/openspec/changes/add-aggregation-coverage-report/.openspec.yaml
+++ b/openspec/changes/add-aggregation-coverage-report/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-18

--- a/openspec/changes/add-aggregation-coverage-report/design.md
+++ b/openspec/changes/add-aggregation-coverage-report/design.md
@@ -1,0 +1,66 @@
+## Context
+
+Peated already stores a large canonical bottle catalog plus external reviews and store-price listings, but its public statistics only expose total bottles, entities, and tastings. Existing external-site health endpoints describe individual scraper runs; they do not answer how much of the active catalog those sources cover or how many source items remain unmatched.
+
+This first aggregation slice needs an exact, inexpensive-to-maintain baseline that uses current table semantics. Active bottles are independently complete Bottle rows (`groupId` is present) without a tombstone. Public review and price reads already define visible source items as rows where `hidden = false`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give admins one read-only snapshot of active catalog content coverage.
+- Measure distinct active bottles supported by visible reviews and price listings.
+- Measure visible review and price inventory split into matched and unmatched items.
+- Reuse the same active-bottle and visibility rules as current product reads.
+- Prove the counting contract through the real route and test database.
+
+**Non-Goals:**
+
+- A frontend dashboard, historical snapshots, trends, or scheduled materialization.
+- Source freshness or per-source health; existing external-site health remains the current operational view.
+- Percentages or quality scores that can be derived from exact counts.
+- Richer review evidence, release/news ingestion, grounded AI synthesis, bottle-page changes, feeds, follows, or alerts.
+
+## Decisions
+
+### Add a separate admin endpoint
+
+Add `GET /admin/catalog/coverage` as `admin.catalogCoverage` rather than extending public `GET /stats`. The report is operational, has a different audience, and performs more work than the lightweight public counters. Admin authorization also keeps future source-quality details from becoming an accidental public API commitment.
+
+Alternative considered: add fields to `/stats`. This would couple public about-page traffic and its stable response to internal aggregation metrics.
+
+### Return exact counts grouped by domain
+
+Return three groups:
+
+- `bottles`: `total`, `withDescription`, `withImage`, `withReviews`, and `withPriceListings`.
+- `reviews`: `total`, `matched`, and `unmatched` visible review items.
+- `priceListings`: `total`, `matched`, and `unmatched` visible store-price items.
+
+Counts preserve the facts and let later clients derive percentages without rounding behavior in the API. “Price listings” is used instead of “prices” because this slice does not impose a freshness window.
+
+### Keep catalog and source-inventory semantics separate
+
+Bottle coverage only counts active bottles and uses separate distinct Bottle ID aggregates so several reviews or listings for one bottle count once. Keeping review and price coverage in independent queries avoids multiplying rows when one Bottle has several of both. Source inventory counts every visible item and defines matched as a non-null Bottle ID. A source item attached to a retired Bottle can therefore remain matched while not contributing to active catalog coverage; this distinction exposes rather than hides cleanup work.
+
+Descriptions and images count only non-null, non-blank values. Hidden reviews and listings do not contribute to either source inventory or bottle coverage, matching current public list behavior.
+
+### Compute on demand from existing tables
+
+Use a small fixed set of aggregate SQL queries and no schema changes. At the current catalog size, on-demand admin access is simpler than materialized counters or a scheduled snapshot. The route owns the definition so future dashboards and CLI commands share one contract.
+
+## Risks / Trade-offs
+
+- **Aggregate queries become slow as the catalog grows** → Keep the endpoint admin-only and rely on existing bottle/source indexes; measure before introducing materialization.
+- **All-time price listings overstate current availability** → Name the field `withPriceListings`; add explicitly defined freshness metrics in a later slice.
+- **A single snapshot cannot show progress over time** → Defer persistence until the baseline report is useful and the desired reporting cadence is known.
+- **Matched items can point at retired bottles** → Preserve that truth in source inventory while limiting catalog coverage to active bottles; a later quality report can expose stale matches directly.
+
+## Aggregation Roadmap
+
+1. Establish exact catalog and source-item coverage with this change.
+2. Expand review evidence and ingest several additional review/release sources.
+3. Produce source-backed bottle synthesis with citations and regeneration provenance.
+4. Redesign bottle pages around critic evidence, release facts, and availability.
+5. Build latest-release/review discovery surfaces from the same source items.
+6. Add bottle/entity follows, alerts, and digests after the event stream is reliable.

--- a/openspec/changes/add-aggregation-coverage-report/proposal.md
+++ b/openspec/changes/add-aggregation-coverage-report/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Peated cannot currently measure how much of its active bottle catalog is supported by scraped reviews, prices, images, and descriptions. A small, exact coverage report is needed before choosing new sources or redesigning bottle pages so that aggregation work can be prioritized from evidence instead of intuition.
+
+## What Changes
+
+- Add an admin-only API report for active bottle catalog coverage.
+- Report exact counts for active bottles with descriptions, images, visible external reviews, and visible store prices.
+- Report visible review and price item totals split into matched and unmatched items.
+- Keep the report read-only and compute it from existing catalog and source tables; no new persistence, scheduled jobs, or UI are introduced in this slice.
+- Define the broader aggregation roadmap while leaving richer source evidence, grounded synthesis, bottle-page presentation, feeds, and alerts to later changes.
+
+## Capabilities
+
+### New Capabilities
+
+- `catalog-coverage`: Admins can retrieve an exact snapshot of catalog content coverage and scraped-item matching coverage.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds one admin oRPC route and response contract under `apps/server`.
+- Reads existing bottle, tombstone, review, and store-price tables without changing their schemas.
+- Adds integration coverage for authorization, active-bottle filtering, hidden source records, and matched versus unmatched totals.
+- Does not change the public `/stats` response or add frontend behavior.

--- a/openspec/changes/add-aggregation-coverage-report/specs/catalog-coverage/spec.md
+++ b/openspec/changes/add-aggregation-coverage-report/specs/catalog-coverage/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Admin-only catalog coverage report
+
+The system SHALL expose the catalog coverage report only to administrators through `GET /admin/catalog/coverage`.
+
+#### Scenario: Administrator requests coverage
+
+- **WHEN** an authenticated administrator requests the catalog coverage report
+- **THEN** the system returns the current coverage snapshot
+
+#### Scenario: Non-administrator requests coverage
+
+- **WHEN** an anonymous or non-administrator user requests the catalog coverage report
+- **THEN** the system rejects the request as unauthorized
+
+### Requirement: Active bottle content coverage
+
+The report SHALL count active independently complete Bottles and SHALL report how many have a non-blank description and a non-blank image URL. A Bottle is active when it belongs to a BottleGroup and has not been tombstoned.
+
+#### Scenario: Active and inactive bottle rows exist
+
+- **WHEN** the catalog contains active Bottles, a legacy Bottle without a group, and a tombstoned Bottle
+- **THEN** only the active non-tombstoned Bottles contribute to `bottles.total` and its content coverage counts
+
+#### Scenario: Blank bottle content exists
+
+- **WHEN** an active Bottle has a null, empty, or whitespace-only description or image URL
+- **THEN** that field does not contribute to its corresponding coverage count
+
+### Requirement: Bottle source coverage
+
+The report SHALL count distinct active Bottles with at least one visible matched review and distinct active Bottles with at least one visible matched price listing.
+
+#### Scenario: Multiple visible source items match one bottle
+
+- **WHEN** an active Bottle has multiple visible reviews or price listings
+- **THEN** the Bottle contributes exactly once to the corresponding bottle coverage count
+
+#### Scenario: Hidden source item matches a bottle
+
+- **WHEN** a Bottle is supported only by a hidden review or hidden price listing
+- **THEN** the Bottle does not contribute to the corresponding bottle coverage count
+
+### Requirement: Source item matching coverage
+
+The report SHALL provide visible review and visible price-listing totals, each split into matched items with a Bottle ID and unmatched items without a Bottle ID.
+
+#### Scenario: Visible matched and unmatched items exist
+
+- **WHEN** visible source items include rows with and without Bottle IDs
+- **THEN** the report returns their exact matched and unmatched counts and a total equal to their sum
+
+#### Scenario: Hidden source items exist
+
+- **WHEN** hidden reviews or price listings exist
+- **THEN** those items do not contribute to source item totals, matched counts, or unmatched counts

--- a/openspec/changes/add-aggregation-coverage-report/tasks.md
+++ b/openspec/changes/add-aggregation-coverage-report/tasks.md
@@ -1,0 +1,14 @@
+## 1. Catalog Coverage API
+
+- [x] 1.1 Implement the admin-only catalog coverage route with exact bottle, review, and price-listing aggregate counts.
+- [x] 1.2 Mount the route in the admin router with the documented operation and response contract.
+
+## 2. Behavioral Coverage
+
+- [x] 2.1 Add an integration test proving active-bottle, non-blank content, distinct source coverage, visibility, and matched/unmatched counting semantics.
+- [x] 2.2 Add integration coverage proving anonymous and non-admin callers are unauthorized.
+
+## 3. Validation
+
+- [x] 3.1 Format and lint the touched files.
+- [x] 3.2 Run the targeted route test and server typecheck.


### PR DESCRIPTION
Adds an admin-only `GET /admin/catalog/coverage` endpoint that reports active bottle content coverage alongside matched and unmatched visible review and price-listing inventory. Active coverage excludes legacy and tombstoned bottles, ignores blank descriptions and images, excludes hidden source items, and counts each covered bottle once even when several source items match it. The public `/stats` contract remains unchanged.

This establishes a measurable baseline before Peated invests in additional review sources or bottle-page aggregation. The report is computed on demand from existing tables, with no schema migration, materialized counters, or frontend surface. Integration coverage exercises duplicate, hidden, unmatched, legacy, and tombstoned records plus administrator authorization; the focused route tests, server typecheck, strict OpenSpec validation, and authenticated/unauthenticated HTTP smoke checks pass.
