### PR TITLE
fix(moderation): preserve retry decisions and audit approvals

### DIFF
--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -4969,6 +4969,70 @@ describe("priceMatching", () => {
     );
   });
 
+  test("preserves the last semantic decision when a retry fails", async ({
+    fixtures,
+  }) => {
+    config.AI_GATEWAY_API_KEY = undefined;
+
+    const { classifyBottleReference } =
+      await import("@peated/server/agents/bottleClassifier");
+    const bottle = await fixtures.Bottle();
+    const price = await fixtures.StorePrice({
+      name: "Retry Failure Candidate",
+      imageUrl: null,
+    });
+    const [existingProposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "match_existing",
+        confidence: 91,
+        suggestedBottleId: bottle.id,
+        extractedLabel: { brand: "Retained Brand" },
+        candidateBottles: [{ bottleId: bottle.id, fullName: bottle.fullName }],
+        rationale: "The prior run found an exact candidate.",
+      })
+      .returning();
+
+    vi.mocked(classifyBottleReference).mockRejectedValue(
+      new Error("Team budget exceeded"),
+    );
+
+    const proposal = await resolveStorePriceMatchProposal(price.id, {
+      force: true,
+    });
+    const attempts = await db.query.storePriceMatchAttempts.findMany({
+      where: eq(storePriceMatchAttempts.proposalId, existingProposal.id),
+    });
+
+    expect(proposal).toMatchObject({
+      id: existingProposal.id,
+      status: "errored",
+      proposalType: "match_existing",
+      confidence: 91,
+      suggestedBottleId: bottle.id,
+      extractedLabel: { brand: "Retained Brand" },
+      candidateBottles: [
+        expect.objectContaining({
+          bottleId: bottle.id,
+          fullName: bottle.fullName,
+        }),
+      ],
+      rationale: "The prior run found an exact candidate.",
+      error: "Team budget exceeded",
+    });
+    expect(attempts).toEqual([
+      expect.objectContaining({
+        proposalType: "match_existing",
+        initialStatus: "errored",
+        finalStatus: "errored",
+        suggestedBottleId: bottle.id,
+        error: "Team budget exceeded",
+      }),
+    ]);
+  });
+
   test("includes decision-relevant structured bottle fields in candidate search text", async () => {
     config.AI_GATEWAY_API_KEY = "test-gateway-key";
 

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -48,7 +48,6 @@ import {
 } from "@peated/server/lib/createBottle";
 import {
   recordIncomingBottleDecisionInTransaction,
-  shouldRecordIncomingBottleDecision,
   type IncomingBottleDecisionActor,
   type IncomingBottleDecisionType,
 } from "@peated/server/lib/incomingBottleDecisionLog";
@@ -769,6 +768,7 @@ export async function upsertStorePriceMatchProposal({
   searchEvidence,
   error,
   statusOverride,
+  preserveExistingDecision = false,
   expectedProcessingToken,
   tx = db,
 }: {
@@ -781,6 +781,7 @@ export async function upsertStorePriceMatchProposal({
   searchEvidence?: SearchEvidence[];
   error?: string | null;
   statusOverride?: StorePriceMatchProposal["status"] | null;
+  preserveExistingDecision?: boolean;
   expectedProcessingToken?: string;
   tx?: AnyDatabase;
 }) {
@@ -828,10 +829,32 @@ export async function upsertStorePriceMatchProposal({
     ...proposalRuntimeValues,
     enteredQueueAt,
   };
-  const updateValues = {
-    ...proposalRuntimeValues,
-    enteredQueueAt: getStorePriceQueueEntryUpdateValue(status),
-  };
+  const updateValues =
+    preserveExistingDecision && !parsedDecision
+      ? {
+          status,
+          candidateBottles:
+            candidates.length > 0
+              ? candidates
+              : sql`${storePriceMatchProposals.candidateBottles}`,
+          extractedLabel:
+            extractedLabel ?? sql`${storePriceMatchProposals.extractedLabel}`,
+          searchEvidence:
+            searchEvidence && searchEvidence.length > 0
+              ? searchEvidence
+              : sql`${storePriceMatchProposals.searchEvidence}`,
+          model: config.BOTTLE_CLASSIFIER_MODEL,
+          error: error || null,
+          lastEvaluatedAt: sql`NOW()`,
+          enteredQueueAt: getStorePriceQueueEntryUpdateValue(status),
+          reviewedById: null,
+          reviewedAt: null,
+          updatedAt: sql`NOW()`,
+        }
+      : {
+          ...proposalRuntimeValues,
+          enteredQueueAt: getStorePriceQueueEntryUpdateValue(status),
+        };
   const [proposal] = await tx
     .insert(storePriceMatchProposals)
     .values({
@@ -1320,6 +1343,9 @@ export async function resolveStorePriceMatchProposal(
           ? err.artifacts.searchEvidence
           : searchEvidence,
       error: err instanceof Error ? err.message : "Unknown classifier error",
+      // A retry failure is operational, not a new semantic no-match decision.
+      // Preserve the last completed decision while exposing the failed attempt.
+      preserveExistingDecision: true,
       expectedProcessingToken: processingToken,
     });
     await recordStorePriceMatchAttempt({ proposal });
@@ -1543,34 +1569,28 @@ export async function applyApprovedStorePriceMatchProposalInTransaction(
     createdById: reviewedById,
   });
 
-  if (
-    shouldRecordIncomingBottleDecision({
-      previousBottleId: proposal.price.bottleId ?? proposal.currentBottleId,
-      bottleId,
-      decision: decisionLog.decision,
-    })
-  ) {
-    await recordIncomingBottleDecisionInTransaction(tx, {
-      sourceKind: "store_price",
-      sourceId: proposal.price.id,
-      proposalId: proposal.id,
-      externalSiteId: proposal.price.externalSiteId,
-      name: proposal.price.name,
-      url: proposal.price.url,
-      decision: decisionLog.decision,
-      actor,
-      bottleId,
-      createdBottle: decisionLog.createdBottle ?? false,
-      confidence: proposal.confidence,
-      model: proposal.model,
-      rationale: proposal.rationale,
-      metadata: {
-        proposalType: proposal.proposalType,
-        ...(actor.type === "system" ? { initiatedByUserId: reviewedById } : {}),
-        ...decisionLog.metadata,
-      },
-    });
-  }
+  // The decision writer is idempotent by source. Always offer a completed
+  // moderation decision so legacy or preassigned prices still gain history.
+  await recordIncomingBottleDecisionInTransaction(tx, {
+    sourceKind: "store_price",
+    sourceId: proposal.price.id,
+    proposalId: proposal.id,
+    externalSiteId: proposal.price.externalSiteId,
+    name: proposal.price.name,
+    url: proposal.price.url,
+    decision: decisionLog.decision,
+    actor,
+    bottleId,
+    createdBottle: decisionLog.createdBottle ?? false,
+    confidence: proposal.confidence,
+    model: proposal.model,
+    rationale: proposal.rationale,
+    metadata: {
+      proposalType: proposal.proposalType,
+      ...(actor.type === "system" ? { initiatedByUserId: reviewedById } : {}),
+      ...decisionLog.metadata,
+    },
+  });
 
   return aliasResult;
 }

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -2098,6 +2098,51 @@ describe("price match queue", () => {
     );
   });
 
+  test("records moderation history when approving the current Bottle", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const bottle = await fixtures.Bottle();
+    const price = await fixtures.StorePrice({
+      bottleId: bottle.id,
+      name: "Already Assigned Queue Approval",
+    });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "match_existing",
+        currentBottleId: bottle.id,
+        suggestedBottleId: bottle.id,
+      })
+      .returning();
+
+    await routerClient.prices.matchQueue.resolve(
+      {
+        proposal: proposal.id,
+        action: "match",
+        bottle: bottle.id,
+      },
+      { context: { user } },
+    );
+
+    const decisionLog = await db.query.incomingBottleDecisionLogs.findFirst({
+      where: and(
+        eq(incomingBottleDecisionLogs.sourceKind, "store_price"),
+        eq(incomingBottleDecisionLogs.sourceId, price.id),
+      ),
+    });
+
+    expect(decisionLog).toMatchObject({
+      proposalId: proposal.id,
+      actorId: (await getUserActor(user)).id,
+      decision: "match_existing",
+      bottleId: bottle.id,
+      createdBottle: false,
+    });
+  });
+
   test("matches the requested exact Bottle without choosing the group representative", async ({
     fixtures,
   }) => {


### PR DESCRIPTION
Failed price-match retries now mark the proposal errored without replacing its last completed match, creation, or correction decision with a semantic `no_match`. Partial failure artifacts can refresh saved evidence, while empty failure output leaves the prior recommendation and evidence available to moderators.

Approving a listing against its already-assigned Bottle now reaches the idempotent incoming-decision writer. This fills missing moderation history for legacy or preassigned listings while the existing source uniqueness constraint continues to preserve any earlier first decision.

Regression coverage exercises both the retry persistence boundary and the authenticated moderation route; the focused server suites and server typecheck pass.
