### PR TITLE
test(classifier): cover wrong bottle correction regressions

### DIFF
--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-glendalough-double-barrel-instead-of-matching-forty-creek.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-glendalough-double-barrel-instead-of-matching-forty-creek.json
@@ -1,0 +1,67 @@
+{
+  "id": "store-listing-creates-glendalough-double-barrel-instead-of-matching-forty-creek",
+  "name": "store listing: creates Glendalough Double Barrel instead of matching Forty Creek",
+  "input": {
+    "reference": {
+      "id": 21116,
+      "name": "Glendalough Double Barrel",
+      "url": "https://www.reservebar.com/products/glendalough-double-barrel/GROUPING-98272?utm=peated",
+      "imageUrl": "https://api.peated.com/uploads/prices-cr0njx6wfke6qvahgxsckyyd.webp",
+      "currentBottleId": 16351
+    },
+    "extractedIdentity": null,
+    "initialCandidates": [
+      {
+        "bottleId": 16351,
+        "alias": null,
+        "fullName": "Forty Creek Double Barrel",
+        "brand": "Forty Creek",
+        "bottler": null,
+        "series": null,
+        "distillery": [],
+        "category": "spirit",
+        "statedAge": null,
+        "edition": null,
+        "caskStrength": null,
+        "singleCask": null,
+        "caskType": null,
+        "caskSize": null,
+        "caskFill": null,
+        "abv": null,
+        "vintageYear": null,
+        "releaseYear": null
+      }
+    ]
+  },
+  "provenance": {
+    "source": "production_miss",
+    "verifiedSourceUrls": [
+      "https://www.glendaloughdistillery.com/products/glendalough-single-grain-double-barrel-finish",
+      "https://api.peated.com/v1/bottles/16351"
+    ],
+    "dbOutcome": {
+      "bottleId": null,
+      "createsBottle": true,
+      "summary": "Create the missing Glendalough Single Grain Double Barrel Bottle and move the price away from Forty Creek Double Barrel Bottle 16351."
+    },
+    "notes": "Price-match proposal 21116 preserved no extracted identity and current Bottle 16351 as the assignment; the candidate snapshot was re-fetched during moderation because the failed retry had erased its candidate artifacts. The producer identifies Double Barrel as a Glendalough single grain Irish whiskey, while Bottle 16351 has the populated Brand Forty Creek. Live catalog searches on 2026-08-18 found no exact Glendalough Double Barrel Bottle, so the safe correction is a review-only Bottle creation rather than retaining the cross-brand assignment."
+  },
+  "expected": {
+    "status": "classified",
+    "action": "create_bottle",
+    "identityScope": "product",
+    "matchedBottleId": null,
+    "proposedBottle": {
+      "brand": {
+        "name": "Glendalough"
+      },
+      "category": "single_grain"
+    },
+    "proposedBottleNameIncludes": ["Double Barrel"],
+    "proposedBottleNameExcludes": ["Forty Creek"],
+    "expectedTier": "review",
+    "verifyEligible": false,
+    "suggestedNextStep": "manual_search",
+    "summary": "Create the missing Glendalough Double Barrel product for review. The only local candidate belongs to Forty Creek and cannot represent this listing."
+  }
+}

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-russells-reserve-single-barrel-rye-instead-of-matching-bourbon.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-russells-reserve-single-barrel-rye-instead-of-matching-bourbon.json
@@ -1,0 +1,69 @@
+{
+  "id": "store-listing-creates-russells-reserve-single-barrel-rye-instead-of-matching-bourbon",
+  "name": "store listing: creates Russell's Reserve Single Barrel Rye instead of matching bourbon",
+  "input": {
+    "reference": {
+      "id": 20927,
+      "name": "Russell's Reserve Single Barrel Rye",
+      "url": "https://www.reservebar.com/products/russells-reserve-single-barrel-rye/GROUPING-324016?utm=peated",
+      "imageUrl": "https://api.peated.com/uploads/prices-yxp58h9ji2ycuxyjlowwz7qx.webp",
+      "currentBottleId": 15868
+    },
+    "extractedIdentity": null,
+    "initialCandidates": [
+      {
+        "bottleId": 15868,
+        "alias": null,
+        "fullName": "Russell's Reserve Single Barrel",
+        "brand": "Russell's Reserve",
+        "bottler": null,
+        "series": null,
+        "distillery": [],
+        "category": "bourbon",
+        "statedAge": null,
+        "edition": null,
+        "caskStrength": null,
+        "singleCask": true,
+        "caskType": null,
+        "caskSize": null,
+        "caskFill": null,
+        "abv": null,
+        "vintageYear": null,
+        "releaseYear": null
+      }
+    ]
+  },
+  "provenance": {
+    "source": "production_miss",
+    "verifiedSourceUrls": [
+      "https://www.russellsreserve.com/our-products/single-barrel-rye/",
+      "https://api.peated.com/v1/bottles/15868"
+    ],
+    "dbOutcome": {
+      "bottleId": null,
+      "createsBottle": true,
+      "summary": "Create the missing Russell's Reserve Single Barrel Rye Bottle and move the price away from bourbon Bottle 15868."
+    },
+    "notes": "Price-match proposal 20927 preserved no extracted identity and current Bottle 15868 as the assignment; the candidate snapshot was re-fetched during moderation because the failed retry had erased its candidate artifacts. The producer identifies Single Barrel Rye as Kentucky straight rye whiskey bottled at 104 proof, while Bottle 15868 has the populated category bourbon. Live catalog searches on 2026-08-18 found no exact Single Barrel Rye Bottle, so the safe correction is a review-only Bottle creation rather than retaining the cross-category assignment."
+  },
+  "expected": {
+    "status": "classified",
+    "action": "create_bottle",
+    "identityScope": "product",
+    "matchedBottleId": null,
+    "proposedBottle": {
+      "brand": {
+        "name": "Russell's Reserve"
+      },
+      "category": "rye",
+      "singleCask": true,
+      "abv": 52
+    },
+    "proposedBottleNameIncludes": ["Single Barrel", "Rye"],
+    "proposedBottleNameExcludes": ["Bourbon"],
+    "expectedTier": "review",
+    "verifyEligible": false,
+    "suggestedNextStep": "manual_search",
+    "summary": "Create the missing Russell's Reserve Single Barrel Rye product for review. The only local candidate is bourbon and cannot represent this rye listing."
+  }
+}


### PR DESCRIPTION
## Why

Moderation review found two black-and-white historical price assignments that crossed populated Bottle identity:

- Glendalough Double Barrel was assigned to Forty Creek Double Barrel.
- Russell's Reserve Single Barrel Rye was assigned to a bourbon Bottle.

The runtime already rejects explicit identity conflicts, so the missing piece was production regression coverage for the full correction decision. Live catalog searches confirmed neither exact product currently exists; both cases should propose review-only Bottle creation instead of retaining the unsafe assignment.

## What changed

- Add a production-miss fixture for price-match proposal 21116, preserving the null extraction, source listing/image, current Forty Creek assignment, verified producer source, and expected Glendalough single-grain creation.
- Add a production-miss fixture for proposal 20927, preserving the same failure state and requiring a Russell's Reserve Single Barrel Rye creation instead of the bourbon assignment.
- Record the re-fetched candidate provenance and current production DB outcome explicitly in each fixture.

## Validation

- `pnpm --filter @peated/bottle-classifier test` — 36 files / 384 tests passed
- `pnpm --filter @peated/bottle-classifier typecheck`
- `pnpm --filter @peated/bottle-classifier terms:check`
- Targeted live eval command was attempted, but the local runner skipped the live suite because this worktree has no AI gateway credential. The new fixtures are available for credentialed eval runs.
