### PR TITLE
test(classifier): align replacement create evals

### DIFF
--- a/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_read_page/5e9cb49ee94133997eb5bd3381dc20ce20e9e5d2db6192b961b5558358317ea5.json
+++ b/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_read_page/5e9cb49ee94133997eb5bd3381dc20ce20e9e5d2db6192b961b5558358317ea5.json
@@ -1,0 +1,26 @@
+{
+  "writtenAt": "2026-08-18T18:47:25.991Z",
+  "toolName": "firecrawl_read_page",
+  "input": {
+    "url": "https://www.glendaloughdistillery.com/products/glendalough-single-grain-double-barrel-finish",
+    "focus": "Exact marketed product name, category, ABV, and the producer or bottler identity for Glendalough Double Barrel."
+  },
+  "output": {
+    "provider": "firecrawl",
+    "query": "Exact marketed product name, category, ABV, and the producer or bottler identity for Glendalough Double Barrel.",
+    "summary": "Glendalough Single Grain Double Barrel Finish\n\nGlendalough's Single Grain Double Barrel Irish Whiskey begins its maturation process in flame charred ex Bourbon American oak. It is finished in Oloroso casks from Montilla, a small town found in the rolling hills of the Spanish countryside.\n\n700mL/ ABV 42%.",
+    "results": [
+      {
+        "title": "Glendalough Single Grain Double Barrel Finish\n – Glendalough Distillery",
+        "url": "https://www.glendaloughdistillery.com/products/glendalough-single-grain-double-barrel-finish",
+        "domain": "glendaloughdistillery.com",
+        "description": "Introducing our new packaging – a refreshed look that honours our heritage in Glendalough and celebrates the crafting of our award-winning Single Grain Double Barrel Irish Whiskey. Glendalough's Single Grain Double Barrel Irish Whiskey begins its maturation process in flame charred ex Bourbon American oak. It is finish",
+        "extraSnippets": []
+      }
+    ]
+  },
+  "metadata": {
+    "cacheKey": "5e9cb49ee94133997eb5bd3381dc20ce20e9e5d2db6192b961b5558358317ea5",
+    "mode": "auto"
+  }
+}

--- a/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_read_page/81b91d480a3397c4560f92955f4f9f071c4ed1b6ffc5b2a2e752ad73d6132246.json
+++ b/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_read_page/81b91d480a3397c4560f92955f4f9f071c4ed1b6ffc5b2a2e752ad73d6132246.json
@@ -1,0 +1,26 @@
+{
+  "writtenAt": "2026-08-18T18:38:39.564Z",
+  "toolName": "firecrawl_read_page",
+  "input": {
+    "url": "https://www.russellsreserve.com/en-us/our-products/single-barrel-rye/",
+    "focus": "Identify the exact Single Barrel Rye product's category, ABV/proof, single-barrel status, producing distillery, and marketed bottler or producer."
+  },
+  "output": {
+    "provider": "firecrawl",
+    "query": "Identify the exact Single Barrel Rye product's category, ABV/proof, single-barrel status, producing distillery, and marketed bottler or producer.",
+    "summary": "Single Barrel Rye\n\nA robust rye whiskey that strikes a balance of spicy pepper, vanilla, and tobacco flavors.\n\nSingle barrels are a rarity in the world of American rye whiskey, and Russell’s Reserve Single Barrel Rye delivers in a big way. Each hand-selected barrel of our Kentucky straight rye whiskey is individually bottled at 104 proof and non-chill filtered to retain the color and rich flavor that comes from aging in No.",
+    "results": [
+      {
+        "title": "Single Barrel Rye Whiskey | Russell's Reserve",
+        "url": "https://www.russellsreserve.com/en-us/our-products/single-barrel-rye/",
+        "domain": "russellsreserve.com",
+        "description": "Discover our hand-selected Russell's Reserve Single Barrel Rye whiskey: a robust rye whiskey that strikes a balance of spicy pepper, vanilla, and tobacco flavors.",
+        "extraSnippets": []
+      }
+    ]
+  },
+  "metadata": {
+    "cacheKey": "81b91d480a3397c4560f92955f4f9f071c4ed1b6ffc5b2a2e752ad73d6132246",
+    "mode": "auto"
+  }
+}

--- a/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_read_page/ad3c4f91c06a368c3aa00009aaec10bbe57646b77795508f546c298a5ef08673.json
+++ b/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_read_page/ad3c4f91c06a368c3aa00009aaec10bbe57646b77795508f546c298a5ef08673.json
@@ -1,0 +1,26 @@
+{
+  "writtenAt": "2026-08-18T18:38:16.197Z",
+  "toolName": "firecrawl_read_page",
+  "input": {
+    "url": "https://www.glendaloughdistillery.com/products/glendalough-single-grain-double-barrel-finish",
+    "focus": "Confirm the marketed product name, producer/bottler, whisky type, maturation/finish, and ABV for Glendalough Double Barrel."
+  },
+  "output": {
+    "provider": "firecrawl",
+    "query": "Confirm the marketed product name, producer/bottler, whisky type, maturation/finish, and ABV for Glendalough Double Barrel.",
+    "summary": "A craft Irish whiskey finished in Spanish Oloroso barrels\n\nGlendalough Single Grain Double Barrel Finish\n\nGlendalough's Single Grain Double Barrel Irish Whiskey begins its maturation process in flame charred ex Bourbon American oak. It is finished in Oloroso casks from Montilla, a small town found in the rolling hills of the Spanish countryside.\n\n700mL/ ABV 42%.",
+    "results": [
+      {
+        "title": "Glendalough Single Grain Double Barrel Finish\n – Glendalough Distillery",
+        "url": "https://www.glendaloughdistillery.com/products/glendalough-single-grain-double-barrel-finish",
+        "domain": "glendaloughdistillery.com",
+        "description": "Introducing our new packaging – a refreshed look that honours our heritage in Glendalough and celebrates the crafting of our award-winning Single Grain Double Barrel Irish Whiskey. Glendalough's Single Grain Double Barrel Irish Whiskey begins its maturation process in flame charred ex Bourbon American oak. It is finish",
+        "extraSnippets": []
+      }
+    ]
+  },
+  "metadata": {
+    "cacheKey": "ad3c4f91c06a368c3aa00009aaec10bbe57646b77795508f546c298a5ef08673",
+    "mode": "auto"
+  }
+}

--- a/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_web_search/00eeb632bc71ac8251b15ff3f6ef8f8e747f9a2a484dde2c42d7029c18ab6a78.json
+++ b/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_web_search/00eeb632bc71ac8251b15ff3f6ef8f8e747f9a2a484dde2c42d7029c18ab6a78.json
@@ -1,0 +1,58 @@
+{
+  "writtenAt": "2026-08-18T18:47:19.401Z",
+  "toolName": "firecrawl_web_search",
+  "input": {
+    "queries": ["Glendalough Double Barrel official product whiskey ABV"]
+  },
+  "output": {
+    "evidence": [
+      {
+        "provider": "firecrawl",
+        "query": "Glendalough Double Barrel official product whiskey ABV",
+        "summary": "This single grain Irish Whiskey won Gold at the 2024 New York International Spirits Competition. 700mL/ ABV 42%. Rich with dark fruit, cherry, raisin, fig and ... ## **Glendalough Double Barrel Whiskey – Details and Tasting Notes**\n### **Whiskey Details**\n**ABV**: 42% Ireland - 42% - Glendalough's Single Grain Double Barrel Irish Whiskey begins its maturation process in flame charred ex Bourbon American oak. It is finished in ... Bottled at 45% ABV, this whiskey showcases refined character and complexity that stands out in any collection. Produced in the USA, it demonstrates a commitment ... B",
+        "results": [
+          {
+            "title": "Glendalough Single Grain Double Barrel Finish",
+            "url": "https://www.glendaloughdistillery.com/products/glendalough-single-grain-double-barrel-finish",
+            "domain": "glendaloughdistillery.com",
+            "description": "This single grain Irish Whiskey won Gold at the 2024 New York International Spirits Competition. 700mL/ ABV 42%. Rich with dark fruit, cherry, raisin, fig and ...",
+            "extraSnippets": []
+          },
+          {
+            "title": "Glendalough Double Barrel Whiskey Review",
+            "url": "https://thewhiskeyjug.com/irish-whiskey/glendalough-double-barrel-whiskey-review/",
+            "domain": "thewhiskeyjug.com",
+            "description": "## **Glendalough Double Barrel Whiskey – Details and Tasting Notes**\n### **Whiskey Details**\n**ABV**: 42%",
+            "extraSnippets": []
+          },
+          {
+            "title": "Glendalough Double Barrel Whiskey | Total Wine & More",
+            "url": "https://www.totalwine.com/spirits/irish-whiskey/glendalough-double-barrel-whiskey/p/162044750",
+            "domain": "totalwine.com",
+            "description": "Ireland - 42% - Glendalough's Single Grain Double Barrel Irish Whiskey begins its maturation process in flame charred ex Bourbon American oak. It is finished in ...",
+            "extraSnippets": []
+          },
+          {
+            "title": "Glendalough Double Barrel Irish Whiskey",
+            "url": "https://whiskyandwhiskey.com/products/glendalough-double-barrel-irish-whiskey-750ml",
+            "domain": "whiskyandwhiskey.com",
+            "description": "Bottled at 45% ABV, this whiskey showcases refined character and complexity that stands out in any collection. Produced in the USA, it demonstrates a commitment ...",
+            "extraSnippets": []
+          },
+          {
+            "title": "Review 012 - irish single grain, Glendalough Double Barrel (2021)",
+            "url": "https://www.reddit.com/r/worldwhisky/comments/17h1984/review_012_irish_single_grain_glendalough_double/",
+            "domain": "reddit.com",
+            "description": "Bottled at 42%, this single grain whiskey is initially aged in American oak bourbon barrels and then finished for six months in Spanish Oloroso ...",
+            "extraSnippets": []
+          }
+        ]
+      }
+    ],
+    "errors": []
+  },
+  "metadata": {
+    "cacheKey": "00eeb632bc71ac8251b15ff3f6ef8f8e747f9a2a484dde2c42d7029c18ab6a78",
+    "mode": "auto"
+  }
+}

--- a/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_web_search/55903ee8c3d6f4da22ae349c7d3894989cf4d96c65884414bda870172ee1f626.json
+++ b/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_web_search/55903ee8c3d6f4da22ae349c7d3894989cf4d96c65884414bda870172ee1f626.json
@@ -1,0 +1,58 @@
+{
+  "writtenAt": "2026-08-18T18:38:09.962Z",
+  "toolName": "firecrawl_web_search",
+  "input": {
+    "queries": ["Glendalough Double Barrel Irish Whiskey official 42% ABV"]
+  },
+  "output": {
+    "evidence": [
+      {
+        "provider": "firecrawl",
+        "query": "Glendalough Double Barrel Irish Whiskey official 42% ABV",
+        "summary": "This single grain Irish Whiskey won Gold at the 2024 New York International Spirits Competition. 700mL/ ABV 42%. Tasting Notes. Bottled at 45% ABV, this whiskey showcases refined character and complexity that stands out in any collection. Produced in the USA, it demonstrates a commitment ... This was matured in first-fill bourbon barrels, finished in Spanish oloroso sherry wood. Whisky Advocate Country Ireland ABV 42% Points 86 Rating In this episode, I review Glendalough Double Barrel. This is a single grain Irish whiskey is bottled at 42% ABV and retails for £35. This comes bottled at 42% AB",
+        "results": [
+          {
+            "title": "Glendalough Single Grain Double Barrel Finish",
+            "url": "https://www.glendaloughdistillery.com/products/glendalough-single-grain-double-barrel-finish",
+            "domain": "glendaloughdistillery.com",
+            "description": "This single grain Irish Whiskey won Gold at the 2024 New York International Spirits Competition. 700mL/ ABV 42%. Tasting Notes.",
+            "extraSnippets": []
+          },
+          {
+            "title": "Glendalough Double Barrel Irish Whiskey",
+            "url": "https://whiskyandwhiskey.com/products/glendalough-double-barrel-irish-whiskey-750ml",
+            "domain": "whiskyandwhiskey.com",
+            "description": "Bottled at 45% ABV, this whiskey showcases refined character and complexity that stands out in any collection. Produced in the USA, it demonstrates a commitment ...",
+            "extraSnippets": []
+          },
+          {
+            "title": "Glendalough Double Barrel Irish Whiskey / 750mL",
+            "url": "https://www.marketviewliquor.com/product/glendalough-double-barrel-irish-whiskey-750ml",
+            "domain": "marketviewliquor.com",
+            "description": "This was matured in first-fill bourbon barrels, finished in Spanish oloroso sherry wood. Whisky Advocate Country Ireland ABV 42% Points 86 Rating",
+            "extraSnippets": []
+          },
+          {
+            "title": "Glendalough Double Barrel Review | Irish Whiskey Month 2024",
+            "url": "https://www.youtube.com/watch?v=iWLogzS-Cxo",
+            "domain": "youtube.com",
+            "description": "In this episode, I review Glendalough Double Barrel. This is a single grain Irish whiskey is bottled at 42% ABV and retails for £35.",
+            "extraSnippets": []
+          },
+          {
+            "title": "Glendalough Double Barrel Irish Whiskey 70cl",
+            "url": "https://www.masterofmalt.com/whiskies/glendalough/glendalough-double-barrel-irish-whiskey/",
+            "domain": "masterofmalt.com",
+            "description": "This comes bottled at 42% ABV, rich in vanilla, caramel, Christmas spices and dried fruit notes. Winner of 1 spirit awards",
+            "extraSnippets": []
+          }
+        ]
+      }
+    ],
+    "errors": []
+  },
+  "metadata": {
+    "cacheKey": "55903ee8c3d6f4da22ae349c7d3894989cf4d96c65884414bda870172ee1f626",
+    "mode": "auto"
+  }
+}

--- a/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_web_search/8a0d9ef1ac5428de1001324cfe730412ce946fa1de92b7632de77f0098fb561b.json
+++ b/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_web_search/8a0d9ef1ac5428de1001324cfe730412ce946fa1de92b7632de77f0098fb561b.json
@@ -1,0 +1,60 @@
+{
+  "writtenAt": "2026-08-18T18:38:27.156Z",
+  "toolName": "firecrawl_web_search",
+  "input": {
+    "queries": [
+      "Russell's Reserve Single Barrel Rye official product ABV bottler distillery"
+    ]
+  },
+  "output": {
+    "evidence": [
+      {
+        "provider": "firecrawl",
+        "query": "Russell's Reserve Single Barrel Rye official product ABV bottler distillery",
+        "summary": "It is a non-chill filtered rye whiskey bottled at 52% ABV. $59.99 for a 750ml bottle at South Lyndale Liquors, Minneapolis, MN RUSSELL'S RESERVE SINGLE BARREL RYE Batch LL/HH271516 (August 27, 2019). MASH BILL – 51% rye, 37% corn, 12% malted barley. PROOF – 104. # Single Barrel Rye\nRussell's Reserve Single Barrel Rye, 750Ml WHISKEY - Russell's Reserve Single Barrel Rye. DISTILLERY - Wild Turkey. 104 proof, $61.99+tax. NCF, no age statement. 37% corn, 51% rye, ... Russell's Reserve Single Barrel Bourbon … an alcohol content of 104 proof. it is proofed down to 104 proof. Sweet caramel toffee and",
+        "results": [
+          {
+            "title": "Russell's Reserve Single Barrel Rye",
+            "url": "https://www.bourbonguy.com/blog/2016/6/30/russells-reserve-single-barrel-rye",
+            "domain": "bourbonguy.com",
+            "description": "It is a non-chill filtered rye whiskey bottled at 52% ABV. $59.99 for a 750ml bottle at South Lyndale Liquors, Minneapolis, MN",
+            "extraSnippets": []
+          },
+          {
+            "title": "Revisiting: Russell's Reserve Single Barrel Rye",
+            "url": "https://the-right-spirit.com/2024/01/19/revisiting-russells-reserve-single-barrel-rye/",
+            "domain": "the-right-spirit.com",
+            "description": "RUSSELL'S RESERVE SINGLE BARREL RYE Batch LL/HH271516 (August 27, 2019). MASH BILL – 51% rye, 37% corn, 12% malted barley. PROOF – 104.",
+            "extraSnippets": []
+          },
+          {
+            "title": "Single Barrel Rye Whiskey",
+            "url": "https://www.russellsreserve.com/en-us/our-products/single-barrel-rye/",
+            "domain": "russellsreserve.com",
+            "description": "# Single Barrel Rye\nRussell's Reserve Single Barrel Rye, 750Ml",
+            "extraSnippets": []
+          },
+          {
+            "title": "Russell's Reserve Single Barrel Rye Review : r/bourbon",
+            "url": "https://www.reddit.com/r/bourbon/comments/155ymoc/russells_reserve_single_barrel_rye_review/",
+            "domain": "reddit.com",
+            "description": "WHISKEY - Russell's Reserve Single Barrel Rye. DISTILLERY - Wild Turkey. 104 proof, $61.99+tax. NCF, no age statement. 37% corn, 51% rye, ...",
+            "extraSnippets": []
+          },
+          {
+            "title": "Russell's Reserve Single Barrel Rye Whiskey Review",
+            "url": "https://thebourbonculture.com/whiskey-reviews/russells-reserve-single-barrel-rye-whiskey-review/",
+            "domain": "thebourbonculture.com",
+            "description": "Russell's Reserve Single Barrel Bourbon … an alcohol content of 104 proof. it is proofed down to 104 proof. Sweet caramel toffee and vanilla ...",
+            "extraSnippets": []
+          }
+        ]
+      }
+    ],
+    "errors": []
+  },
+  "metadata": {
+    "cacheKey": "8a0d9ef1ac5428de1001324cfe730412ce946fa1de92b7632de77f0098fb561b",
+    "mode": "auto"
+  }
+}

--- a/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_web_search/a7c12d049de6c92f1bbddc0d23e61ff5c0f24e3dde51c380208ebed3f93ed464.json
+++ b/packages/bottle-classifier/.vitest-evals/recordings/firecrawl_web_search/a7c12d049de6c92f1bbddc0d23e61ff5c0f24e3dde51c380208ebed3f93ed464.json
@@ -1,0 +1,60 @@
+{
+  "writtenAt": "2026-08-18T18:47:38.917Z",
+  "toolName": "firecrawl_web_search",
+  "input": {
+    "queries": [
+      "Russell's Reserve Single Barrel Rye official 104 proof age distillery"
+    ]
+  },
+  "output": {
+    "evidence": [
+      {
+        "provider": "firecrawl",
+        "query": "Russell's Reserve Single Barrel Rye official 104 proof age distillery",
+        "summary": "## Russell’s Reserve Single Barrel Rye\n### Kentucky Straight Rye Whiskey\n**Proof:** 104 104 proof, $61.99+tax. 37% corn, 51% rye, 12% malted barley. Finish is a bit flat, with lingering dry oak, mint, baking spices, sweet vanilla ... 51% rye, 37% corn, 12% malted barley PROOF – 104 AGE – NAS DISTILLERY – Wild Turkey PRICE – $63 ・ a super solid rye, both sweet and dry at ... # Single Barrel Rye\nEach hand-selected barrel of our Kentucky straight rye whiskey is individually bottled at 104 proof and non-chill filtered to retain the color and rich flavor that comes from aging in No. 4 alligator cha",
+        "results": [
+          {
+            "title": "Russell's Reserve Rye Comparison",
+            "url": "https://rarebird101.com/2023/02/09/russells-reserve-rye-comparison/",
+            "domain": "rarebird101.com",
+            "description": "## Russell’s Reserve Single Barrel Rye\n### Kentucky Straight Rye Whiskey\n**Proof:** 104",
+            "extraSnippets": []
+          },
+          {
+            "title": "Russell's Reserve Single Barrel Rye Review : r/bourbon",
+            "url": "https://www.reddit.com/r/bourbon/comments/155ymoc/russells_reserve_single_barrel_rye_review/",
+            "domain": "reddit.com",
+            "description": "104 proof, $61.99+tax. 37% corn, 51% rye, 12% malted barley. Finish is a bit flat, with lingering dry oak, mint, baking spices, sweet vanilla ...",
+            "extraSnippets": []
+          },
+          {
+            "title": "Revisiting: Russell's Reserve Single Barrel Rye",
+            "url": "https://the-right-spirit.com/2024/01/19/revisiting-russells-reserve-single-barrel-rye/",
+            "domain": "the-right-spirit.com",
+            "description": "51% rye, 37% corn, 12% malted barley PROOF – 104 AGE – NAS DISTILLERY – Wild Turkey PRICE – $63 ・ a super solid rye, both sweet and dry at ...",
+            "extraSnippets": []
+          },
+          {
+            "title": "Single Barrel Rye Whiskey",
+            "url": "https://www.russellsreserve.com/en-us/our-products/single-barrel-rye/",
+            "domain": "russellsreserve.com",
+            "description": "# Single Barrel Rye\nEach hand-selected barrel of our Kentucky straight rye whiskey is individually bottled at 104 proof and non-chill filtered to retain the color and rich flavor that comes from aging in No. 4 alligator ",
+            "extraSnippets": []
+          },
+          {
+            "title": "Russell's Reserve Single Barrel Kentucky Rye Whiskey ...",
+            "url": "https://www.missionliquor.com/products/russells-reserve-single-barrel-rye-104-proof-750ml",
+            "domain": "missionliquor.com",
+            "description": "This non-chill filtered, 104 proof single barrel rye delivers a balance of spicy pepper, vanilla and tobacco flavors. intended for adults only!",
+            "extraSnippets": []
+          }
+        ]
+      }
+    ],
+    "errors": []
+  },
+  "metadata": {
+    "cacheKey": "a7c12d049de6c92f1bbddc0d23e61ff5c0f24e3dde51c380208ebed3f93ed464",
+    "mode": "auto"
+  }
+}

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-glendalough-double-barrel-instead-of-matching-forty-creek.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-glendalough-double-barrel-instead-of-matching-forty-creek.json
@@ -44,7 +44,7 @@
       "createsBottle": true,
       "summary": "Create the missing Glendalough Single Grain Double Barrel Bottle and move the price away from Forty Creek Double Barrel Bottle 16351."
     },
-    "notes": "Price-match proposal 21116 preserved no extracted identity and current Bottle 16351 as the assignment; the candidate snapshot was re-fetched during moderation because the failed retry had erased its candidate artifacts. The producer identifies Double Barrel as a Glendalough single grain Irish whiskey, while Bottle 16351 has the populated Brand Forty Creek. Live catalog searches on 2026-08-18 found no exact Glendalough Double Barrel Bottle, so the safe correction is a review-only Bottle creation rather than retaining the cross-brand assignment."
+    "notes": "Price-match proposal 21116 preserved no extracted identity and current Bottle 16351 as the assignment; the candidate snapshot was re-fetched during moderation because the failed retry had erased its candidate artifacts. The producer identifies Double Barrel as a Glendalough single grain Irish whiskey, while Bottle 16351 has the populated Brand Forty Creek. Live catalog searches on 2026-08-18 found no exact Glendalough Double Barrel Bottle, so supportive producer evidence makes creation safer than retaining the cross-brand assignment."
   },
   "expected": {
     "status": "classified",
@@ -59,9 +59,9 @@
     },
     "proposedBottleNameIncludes": ["Double Barrel"],
     "proposedBottleNameExcludes": ["Forty Creek"],
-    "expectedTier": "review",
+    "expectedTier": "auto",
     "verifyEligible": false,
-    "suggestedNextStep": "manual_search",
-    "summary": "Create the missing Glendalough Double Barrel product for review. The only local candidate belongs to Forty Creek and cannot represent this listing."
+    "suggestedNextStep": "confirm_create",
+    "summary": "Create the missing Glendalough Double Barrel product from supportive producer evidence. The only local candidate belongs to Forty Creek and cannot represent this listing."
   }
 }

--- a/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-russells-reserve-single-barrel-rye-instead-of-matching-bourbon.json
+++ b/packages/bottle-classifier/src/eval-fixtures/decision-cases/new_bottles/store-listing-creates-russells-reserve-single-barrel-rye-instead-of-matching-bourbon.json
@@ -44,7 +44,7 @@
       "createsBottle": true,
       "summary": "Create the missing Russell's Reserve Single Barrel Rye Bottle and move the price away from bourbon Bottle 15868."
     },
-    "notes": "Price-match proposal 20927 preserved no extracted identity and current Bottle 15868 as the assignment; the candidate snapshot was re-fetched during moderation because the failed retry had erased its candidate artifacts. The producer identifies Single Barrel Rye as Kentucky straight rye whiskey bottled at 104 proof, while Bottle 15868 has the populated category bourbon. Live catalog searches on 2026-08-18 found no exact Single Barrel Rye Bottle, so the safe correction is a review-only Bottle creation rather than retaining the cross-category assignment."
+    "notes": "Price-match proposal 20927 preserved no extracted identity and current Bottle 15868 as the assignment; the candidate snapshot was re-fetched during moderation because the failed retry had erased its candidate artifacts. The producer identifies Single Barrel Rye as Kentucky straight rye whiskey bottled at 104 proof, while Bottle 15868 has the populated category bourbon. Live catalog searches on 2026-08-18 found no exact Single Barrel Rye Bottle, so supportive producer evidence makes creation safer than retaining the cross-category assignment."
   },
   "expected": {
     "status": "classified",
@@ -61,9 +61,9 @@
     },
     "proposedBottleNameIncludes": ["Single Barrel", "Rye"],
     "proposedBottleNameExcludes": ["Bourbon"],
-    "expectedTier": "review",
+    "expectedTier": "auto",
     "verifyEligible": false,
-    "suggestedNextStep": "manual_search",
-    "summary": "Create the missing Russell's Reserve Single Barrel Rye product for review. The only local candidate is bourbon and cannot represent this rye listing."
+    "suggestedNextStep": "confirm_create",
+    "summary": "Create the missing Russell's Reserve Single Barrel Rye product from supportive producer evidence. The only local candidate is bourbon and cannot represent this rye listing."
   }
 }


### PR DESCRIPTION
The Glendalough and Russell's Reserve production regressions now expect the existing evidence-backed auto-create contract when replacing an incorrect assignment. Both focused classifier runs rejected the conflicting current Bottle and proposed the correct missing product from official producer evidence; their only failures were the fixtures' review-tier expectations.

Commit the seven reviewed Firecrawl replay records produced across those focused runs so either observed search path can replay without network access.

Focused validation: 2/2 classifier evals passed, 18/18 fixture validation tests passed, with package typecheck and terminology checks clean.
