### PR TITLE
fix(prices): use approved barcodes before model matching

### DIFF
--- a/apps/server/src/lib/bottleReferenceCandidates.ts
+++ b/apps/server/src/lib/bottleReferenceCandidates.ts
@@ -14,7 +14,7 @@ import {
   normalizeString,
 } from "@peated/bottle-classifier/normalize";
 import { parseReferenceName as parseSmwsReferenceName } from "@peated/bottle-classifier/smws";
-import { db } from "@peated/server/db";
+import { db, type AnyDatabase } from "@peated/server/db";
 import {
   bottleAliases,
   bottleSeries,
@@ -688,7 +688,10 @@ function buildBottleSiblingContext(
   return siblingContextByBottleId;
 }
 
-async function enrichBottleCandidates(candidates: BottleCandidate[]) {
+async function enrichBottleCandidates(
+  candidates: BottleCandidate[],
+  database: AnyDatabase = db,
+) {
   if (!candidates.length) {
     return candidates;
   }
@@ -698,7 +701,7 @@ async function enrichBottleCandidates(candidates: BottleCandidate[]) {
   const bottlerEntity = alias(entities, "price_match_bottler");
   const distillerEntity = alias(entities, "price_match_distiller");
 
-  const bottleRows = await db
+  const bottleRows = await database
     .select({
       bottleId: bottles.id,
       groupId: bottles.groupId,
@@ -736,7 +739,7 @@ async function enrichBottleCandidates(candidates: BottleCandidate[]) {
   const siblingRows =
     groupIds.length === 0
       ? []
-      : await db
+      : await database
           .select({
             bottleId: bottles.id,
             groupId: bottles.groupId,
@@ -764,7 +767,7 @@ async function enrichBottleCandidates(candidates: BottleCandidate[]) {
     siblingRows,
   );
 
-  const distilleryRows = await db
+  const distilleryRows = await database
     .select({
       bottleId: bottlesToDistillers.bottleId,
       distillery: distillerEntity.name,
@@ -1065,8 +1068,9 @@ async function getBrandCandidates(
 
 async function getOrdinaryBottleCandidateById(
   bottleId: number,
+  database: AnyDatabase = db,
 ): Promise<BottleCandidate | null> {
-  const [result] = await db
+  const [result] = await database
     .select({
       bottleId: bottles.id,
       fullName: bottles.fullName,
@@ -1118,13 +1122,14 @@ async function getOrdinaryBottleCandidateById(
     "current",
   );
 
-  return (await enrichBottleCandidates([candidate]))[0] ?? null;
+  return (await enrichBottleCandidates([candidate], database))[0] ?? null;
 }
 
 export async function getBottleCandidateById(
   bottleId: number,
+  database: AnyDatabase = db,
 ): Promise<BottleCandidate | null> {
-  return await getOrdinaryBottleCandidateById(bottleId);
+  return await getOrdinaryBottleCandidateById(bottleId, database);
 }
 
 async function getExactBottleCandidate(

--- a/apps/server/src/lib/createStorePrices.ts
+++ b/apps/server/src/lib/createStorePrices.ts
@@ -2,10 +2,8 @@ import {
   normalizeBottle,
   normalizeBottleAliasKey,
 } from "@peated/bottle-classifier/normalize";
-import { getExistingMatchIdentityConflicts } from "@peated/bottle-classifier/priceMatchingEvidence";
 import { db, type AnyTransaction } from "@peated/server/db";
 import {
-  bottleBarcodes,
   externalSites,
   storePriceHistories,
   storePrices,
@@ -18,14 +16,10 @@ import {
   BottleAliasBottleRetiredError,
   finalizeBottleAliasAssignment,
 } from "@peated/server/lib/bottleAliases";
-import { findBottleAliasAssignment } from "@peated/server/lib/bottleFinder";
-import { getBottleCandidateById } from "@peated/server/lib/bottleReferenceCandidates";
 import { ExternalSiteNotFoundError } from "@peated/server/lib/externalSites";
 import { normalizeGtin, type NormalizedGtin } from "@peated/server/lib/gtin";
-import {
-  ActiveBottleSelectionError,
-  resolveActiveBottleIds,
-} from "@peated/server/lib/resolveActiveBottleIds";
+import { ActiveBottleSelectionError } from "@peated/server/lib/resolveActiveBottleIds";
+import { resolveStorePriceBottleMatchInTransaction } from "@peated/server/lib/storePriceBottleMatching";
 import {
   ExternalSiteTypeEnum,
   StorePriceInputSchema,
@@ -236,79 +230,37 @@ export async function createStorePrices(rawInput: unknown, actorId: number) {
           sp.barcode === undefined || sp.barcode === null
             ? null
             : normalizeGtin(sp.barcode);
-        const initialBarcode = normalizedBarcode
-          ? await db.query.bottleBarcodes.findFirst({
-              where: eq(bottleBarcodes.gtin14, normalizedBarcode.gtin14),
-            })
-          : null;
-        const barcodeCandidate =
-          initialBarcode && sp.sourceBottleIdentity
-            ? await getBottleCandidateById(initialBarcode.bottleId)
-            : null;
-        const barcodeIdentityConflicts = sp.sourceBottleIdentity
-          ? barcodeCandidate
-            ? getExistingMatchIdentityConflicts({
-                target: barcodeCandidate,
-                extractedLabel: sp.sourceBottleIdentity,
-              })
-            : ["barcode target is not an active Bottle"]
-          : [];
-
         const { price, aliasAssignment } = await db.transaction(async (tx) => {
           const { name } = normalizeBottle({ name: sp.name });
           const aliasKey = normalizeBottleAliasKey(sp.name);
-          // New assignments use the deterministic key, but lookup still
-          // accepts legacy raw aliases created before alias keys existed.
-          let match = await findBottleAliasAssignment(aliasKey, tx);
-          if (!match && aliasKey !== sp.name) {
-            match = await findBottleAliasAssignment(sp.name, tx);
-          }
-          const currentBarcode = normalizedBarcode
-            ? await tx.query.bottleBarcodes.findFirst({
-                where: eq(bottleBarcodes.gtin14, normalizedBarcode.gtin14),
-              })
-            : null;
-          // A canonical barcode bypasses classification only when package
-          // volume, explicit source facts, and any exact alias all agree.
-          const barcodeBottleId =
-            currentBarcode &&
-            currentBarcode.bottleId === initialBarcode?.bottleId &&
-            (currentBarcode.volume === null ||
-              currentBarcode.volume === sp.volume) &&
-            barcodeIdentityConflicts.length === 0
-              ? currentBarcode.bottleId
-              : null;
-          const bottleId = currentBarcode
-            ? barcodeBottleId !== null &&
-              (match === null || match.bottleId === barcodeBottleId)
-              ? barcodeBottleId
-              : null
-            : (match?.bottleId ?? null);
-          if (bottleId !== null) {
-            try {
-              await resolveActiveBottleIds(tx, [bottleId], {
-                lock: "update",
-              });
-            } catch (error) {
-              if (!(error instanceof ActiveBottleSelectionError)) {
-                throw error;
-              }
-              switch (error.reason) {
-                case "missing":
-                  throw new BottleAliasBottleNotFoundError(error.bottleId);
-                case "bottle_retired":
-                  throw new BottleAliasBottleRetiredError(
-                    error.bottleId,
-                    error.replacementBottleId,
-                  );
-                case "unassigned":
-                  throw new BottleAliasBottleInactiveError(
-                    error.bottleId,
-                    error.reason,
-                  );
-              }
+          let bottleMatch;
+          try {
+            bottleMatch = await resolveStorePriceBottleMatchInTransaction(tx, {
+              name: sp.name,
+              normalizedBarcode,
+              sourceBottleIdentity: sp.sourceBottleIdentity ?? null,
+              volume: sp.volume,
+            });
+          } catch (error) {
+            if (!(error instanceof ActiveBottleSelectionError)) {
+              throw error;
+            }
+            switch (error.reason) {
+              case "missing":
+                throw new BottleAliasBottleNotFoundError(error.bottleId);
+              case "bottle_retired":
+                throw new BottleAliasBottleRetiredError(
+                  error.bottleId,
+                  error.replacementBottleId,
+                );
+              case "unassigned":
+                throw new BottleAliasBottleInactiveError(
+                  error.bottleId,
+                  error.reason,
+                );
             }
           }
+          const { aliasMatch: match, bottleId } = bottleMatch;
 
           const persisted = await persistStorePriceInTransaction({
             tx,
@@ -322,7 +274,8 @@ export async function createStorePrices(rawInput: unknown, actorId: number) {
           const persistedBottleId = persisted.bottleId;
           const hasDirectMatch =
             bottleId !== null && persistedBottleId === bottleId;
-          const hasAliasMatch = hasDirectMatch && match?.bottleId === bottleId;
+          const hasAliasMatch =
+            hasDirectMatch && bottleMatch.source === "alias";
           const aliasAssignment = hasAliasMatch
             ? await assignBottleAliasInTransaction(tx, {
                 name: aliasKey,
@@ -352,6 +305,7 @@ export async function createStorePrices(rawInput: unknown, actorId: number) {
               id: priceId,
               imageUrl: persisted.imageUrl,
               hasDirectMatch,
+              directMatchSource: hasDirectMatch ? bottleMatch.source : null,
             },
             aliasAssignment,
           };
@@ -370,7 +324,12 @@ export async function createStorePrices(rawInput: unknown, actorId: number) {
           });
         }
 
-        if (!price.hasDirectMatch) {
+        if (price.directMatchSource === "barcode") {
+          await pushUniqueJob("ResolveStorePriceBottle", {
+            priceId: price.id,
+            force: true,
+          });
+        } else if (!price.hasDirectMatch) {
           await pushUniqueJob("ResolveStorePriceBottle", {
             priceId: price.id,
           });

--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -5,6 +5,7 @@ import { db } from "@peated/server/db";
 import { getPostgresConnectionConfig } from "@peated/server/db/connection";
 import {
   bottleAliases,
+  bottleBarcodes,
   bottleChecks,
   bottleGroups,
   bottleObservations,
@@ -289,6 +290,110 @@ describe("priceMatching", () => {
 
   afterEach(() => {
     config.AI_GATEWAY_API_KEY = originalAIGatewayApiKey;
+  });
+
+  test("uses an approved barcode before calling the classifier", async ({
+    fixtures,
+  }) => {
+    await fixtures.User({
+      username: "dcramer",
+      admin: true,
+      mod: true,
+    });
+    const bottle = await fixtures.Bottle({ name: "Canonical Barcode Bottle" });
+    const actor = await getPeatedSystemActor();
+    await db.insert(bottleBarcodes).values({
+      bottleId: bottle.id,
+      value: "036602301979",
+      gtin14: "00036602301979",
+      volume: 750,
+      createdByActorId: actor.id,
+    });
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      barcode: "036602301979",
+      name: "Generic Retailer Listing",
+      volume: 750,
+    });
+    const { runScrapedBottleReference } =
+      await import("@peated/server/agents/bottleClassifier/scrapedBottleReference");
+
+    const proposal = await resolveStorePriceMatchProposal(price.id);
+
+    expect(proposal).toMatchObject({
+      status: "approved",
+      proposalType: "match_existing",
+      currentBottleId: bottle.id,
+      suggestedBottleId: bottle.id,
+      aliasScope: "none",
+      model: null,
+    });
+    await expect(
+      db.query.storePrices.findFirst({
+        where: eq(storePrices.id, price.id),
+      }),
+    ).resolves.toMatchObject({ bottleId: bottle.id });
+    await expect(
+      db.query.bottleAliases.findFirst({
+        where: eq(bottleAliases.name, normalizeBottleAliasKey(price.name)),
+      }),
+    ).resolves.toBeUndefined();
+    expect(runScrapedBottleReference).not.toHaveBeenCalled();
+  });
+
+  test("an approved barcode retry replaces a stale pending proposal", async ({
+    fixtures,
+  }) => {
+    await fixtures.User({
+      username: "dcramer",
+      admin: true,
+      mod: true,
+    });
+    const bottle = await fixtures.Bottle({ name: "Later Barcode Bottle" });
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      barcode: "036602301979",
+      name: "Unresolved Retailer Listing",
+      volume: 750,
+    });
+    const { runScrapedBottleReference } =
+      await import("@peated/server/agents/bottleClassifier/scrapedBottleReference");
+    vi.mocked(runScrapedBottleReference).mockResolvedValueOnce({
+      result: buildMockBottleReferenceClassification({
+        decision: {
+          action: "no_match",
+          rationale: "No canonical GTIN mapping exists yet.",
+          candidateBottleIds: [],
+          proposedBottle: null,
+        },
+      }),
+      modelMetadata: null,
+    });
+    const pending = await resolveStorePriceMatchProposal(price.id);
+    expect(pending.status).toBe("pending_review");
+
+    const actor = await getPeatedSystemActor();
+    await db.insert(bottleBarcodes).values({
+      bottleId: bottle.id,
+      value: "036602301979",
+      gtin14: "00036602301979",
+      volume: 750,
+      createdByActorId: actor.id,
+    });
+    vi.mocked(runScrapedBottleReference).mockClear();
+
+    const approved = await resolveStorePriceMatchProposal(price.id, {
+      force: true,
+    });
+
+    expect(approved).toMatchObject({
+      id: pending.id,
+      status: "approved",
+      currentBottleId: bottle.id,
+      suggestedBottleId: bottle.id,
+      model: null,
+    });
+    expect(runScrapedBottleReference).not.toHaveBeenCalled();
   });
 
   test("passes normalized source identity to the classifier", async ({

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -22,6 +22,7 @@ import config from "@peated/server/config";
 import { db, type AnyDatabase, type AnyTransaction } from "@peated/server/db";
 import {
   actors,
+  bottleBarcodes,
   bottleObservations,
   bottles,
   storePriceMatchAttempts,
@@ -46,6 +47,7 @@ import {
   createOrReuseBottleInTransaction,
   finalizeCreatedBottle,
 } from "@peated/server/lib/createBottle";
+import { normalizeGtin } from "@peated/server/lib/gtin";
 import {
   recordIncomingBottleDecisionInTransaction,
   type IncomingBottleDecisionActor,
@@ -65,6 +67,7 @@ import {
 } from "@peated/server/lib/priceMatchingProcessingLease";
 import { REVIEWABLE_STORE_PRICE_MATCH_PROPOSAL_STATUSES } from "@peated/server/lib/priceMatchingStatus";
 import { resolveActiveBottleIds } from "@peated/server/lib/resolveActiveBottleIds";
+import { resolveStorePriceBottleMatchInTransaction } from "@peated/server/lib/storePriceBottleMatching";
 import { getAutomationModeratorUser } from "@peated/server/lib/systemUser";
 import {
   finalizeBottleUpdate,
@@ -770,6 +773,7 @@ export async function upsertStorePriceMatchProposal({
   statusOverride,
   preserveExistingDecision = false,
   expectedProcessingToken,
+  model,
   tx = db,
 }: {
   price: StorePrice;
@@ -783,6 +787,7 @@ export async function upsertStorePriceMatchProposal({
   statusOverride?: StorePriceMatchProposal["status"] | null;
   preserveExistingDecision?: boolean;
   expectedProcessingToken?: string;
+  model?: string | null;
   tx?: AnyDatabase;
 }) {
   const parsedDecision = decision
@@ -817,7 +822,7 @@ export async function upsertStorePriceMatchProposal({
     searchEvidence: searchEvidence || [],
     automationAssessment: automationAssessment ?? null,
     rationale: parsedDecision?.rationale ?? null,
-    model: config.BOTTLE_CLASSIFIER_MODEL,
+    model: model === undefined ? config.BOTTLE_CLASSIFIER_MODEL : model,
     error: error || null,
     lastEvaluatedAt: sql`NOW()`,
     enteredQueueAt,
@@ -843,7 +848,7 @@ export async function upsertStorePriceMatchProposal({
             searchEvidence && searchEvidence.length > 0
               ? searchEvidence
               : sql`${storePriceMatchProposals.searchEvidence}`,
-          model: config.BOTTLE_CLASSIFIER_MODEL,
+          model: model === undefined ? config.BOTTLE_CLASSIFIER_MODEL : model,
           error: error || null,
           lastEvaluatedAt: sql`NOW()`,
           enteredQueueAt: getStorePriceQueueEntryUpdateValue(status),
@@ -1014,6 +1019,142 @@ export async function createBottleFromStorePriceMatchProposal({
   };
 }
 
+function hasStorePriceMatchInputChanged(
+  expected: StorePrice,
+  current: StorePrice,
+) {
+  return (
+    expected.name !== current.name ||
+    expected.volume !== current.volume ||
+    expected.barcode !== current.barcode ||
+    !isDeepStrictEqual(
+      expected.sourceBottleIdentity,
+      current.sourceBottleIdentity,
+    )
+  );
+}
+
+/** Applies an approved barcode match without saving the store title as an alias. */
+async function resolveApprovedBarcodeStorePriceMatch({
+  price,
+  existingProposal,
+  processingToken,
+}: {
+  price: StorePrice;
+  existingProposal: StorePriceMatchProposal | null | undefined;
+  processingToken?: string;
+}): Promise<StorePriceMatchProposal | null> {
+  if (!price.barcode) return null;
+
+  const normalizedBarcode = normalizeGtin(price.barcode);
+  const barcodeMapping = await db.query.bottleBarcodes.findFirst({
+    where: eq(bottleBarcodes.gtin14, normalizedBarcode.gtin14),
+  });
+  if (!barcodeMapping) return null;
+
+  const [automationUser, systemActor] = await Promise.all([
+    getAutomationModeratorUser(),
+    getPeatedSystemActor(),
+  ]);
+  const result = await db.transaction(async (tx) => {
+    const sourceBottleIdentity = price.sourceBottleIdentity
+      ? BottleExtractedDetailsSchema.parse(price.sourceBottleIdentity)
+      : null;
+    const match = await resolveStorePriceBottleMatchInTransaction(tx, {
+      name: price.name,
+      normalizedBarcode,
+      sourceBottleIdentity,
+      volume: price.volume,
+    });
+    if (
+      match.source !== "barcode" ||
+      match.bottleId === null ||
+      match.candidate === null
+    ) {
+      return null;
+    }
+
+    const [currentPrice] = await tx
+      .select()
+      .from(storePrices)
+      .where(eq(storePrices.id, price.id))
+      .limit(1)
+      .for("update");
+    if (!currentPrice) {
+      throw new Error(`Unknown price ${price.id}`);
+    }
+    if (hasStorePriceMatchInputChanged(price, currentPrice)) {
+      throw new Error(
+        `Store price details changed during approved barcode matching (${price.id}).`,
+      );
+    }
+    if (
+      currentPrice.bottleId !== null &&
+      currentPrice.bottleId !== match.bottleId
+    ) {
+      return null;
+    }
+
+    const decision: StorePriceMatchDecision = {
+      action: "match_existing",
+      confidence: null,
+      rationale: `Matched approved barcode ${normalizedBarcode.value}. Bottle size and known bottle details agree.`,
+      candidateBottleIds: [match.bottleId],
+      identityScope: "product",
+      aliasScope: "none",
+      suggestedBottleId: match.bottleId,
+      proposedBottle: null,
+    };
+    const proposal = await upsertStorePriceMatchProposal({
+      price: currentPrice,
+      extractedLabel:
+        sourceBottleIdentity ?? parseStoredExtractedLabel(existingProposal),
+      candidates: [match.candidate],
+      decision,
+      searchEvidence: [],
+      statusOverride: "verified",
+      expectedProcessingToken: processingToken,
+      model: null,
+      tx,
+    });
+    if (
+      processingToken &&
+      (proposal.processingToken !== processingToken ||
+        !hasActiveStorePriceMatchProposalProcessingLease(proposal))
+    ) {
+      return proposal.id;
+    }
+
+    await recordStorePriceMatchAttempt({ proposal, tx });
+    const proposalForReview =
+      await getStorePriceMatchProposalForReviewInTransaction(tx, {
+        proposalId: proposal.id,
+        allowedStatuses: ["verified"],
+        expectedProcessingToken: processingToken,
+      });
+    const actor = await getPriceMatchWriteActorForDatabase(tx, systemActor, {
+      userId: automationUser.id,
+      allowSystemActor: true,
+    });
+    await persistApprovedStorePriceMatchInTransaction(tx, {
+      proposal: proposalForReview,
+      reviewedById: automationUser.id,
+      bottleId: match.bottleId,
+      decisionLog: {
+        actor,
+        decision: "match_existing",
+        metadata: {
+          matchingBasis: "canonical_gtin",
+          gtin14: normalizedBarcode.gtin14,
+        },
+      },
+    });
+    return proposal.id;
+  });
+
+  return result === null ? null : await reloadStorePriceMatchProposal(result);
+}
+
 /**
  * Owns full store-price classification persistence: the proposal, attempt, and
  * linked Bottle check commit together before any automated catalog mutation.
@@ -1086,6 +1227,17 @@ export async function resolveStorePriceMatchProposal(
   let searchEvidence: SearchEvidence[] = [];
   let classificationModelMetadata: BottleReferenceRun["modelMetadata"] = null;
   try {
+    const approvedBarcodeProposal = await resolveApprovedBarcodeStorePriceMatch(
+      {
+        price,
+        existingProposal,
+        processingToken,
+      },
+    );
+    if (approvedBarcodeProposal) {
+      return approvedBarcodeProposal;
+    }
+
     // Price matching consumes the generic bottle classifier and only layers
     // price-specific persistence and automation policy on top of its result.
     const classificationInput: ClassifyBottleReferenceInput = {
@@ -1494,6 +1646,73 @@ async function markApprovedStorePriceMatchProposalInTransaction(
   });
 }
 
+async function persistApprovedStorePriceMatchInTransaction(
+  tx: AnyTransaction,
+  {
+    proposal,
+    reviewedById,
+    decisionLog,
+    bottleId,
+  }: {
+    proposal: StorePriceMatchProposalForReview;
+    reviewedById: number;
+    decisionLog: {
+      actor: IncomingBottleDecisionActor;
+      decision: IncomingBottleDecisionType;
+      createdBottle?: boolean;
+      metadata?: Record<string, unknown>;
+    };
+    bottleId: number;
+  },
+) {
+  await tx
+    .update(storePrices)
+    .set({
+      bottleId,
+      updatedAt: sql`NOW()`,
+    })
+    .where(eq(storePrices.id, proposal.price.id));
+
+  await markApprovedStorePriceMatchProposalInTransaction(tx, {
+    proposalId: proposal.id,
+    bottleId,
+    reviewedById,
+  });
+
+  // One approved store price should always leave behind one source record keyed
+  // by the store_price id so moderators can recover the original evidence later.
+  await upsertStorePriceObservationInTransaction(tx, {
+    proposal,
+    bottleId,
+    createdById: reviewedById,
+  });
+
+  // The decision writer is idempotent by source. Always offer a completed
+  // moderation decision so legacy or preassigned prices still gain history.
+  await recordIncomingBottleDecisionInTransaction(tx, {
+    sourceKind: "store_price",
+    sourceId: proposal.price.id,
+    proposalId: proposal.id,
+    externalSiteId: proposal.price.externalSiteId,
+    name: proposal.price.name,
+    url: proposal.price.url,
+    decision: decisionLog.decision,
+    actor: decisionLog.actor,
+    bottleId,
+    createdBottle: decisionLog.createdBottle ?? false,
+    confidence: proposal.confidence,
+    model: proposal.model,
+    rationale: proposal.rationale,
+    metadata: {
+      proposalType: proposal.proposalType,
+      ...(decisionLog.actor.type === "system"
+        ? { initiatedByUserId: reviewedById }
+        : {}),
+      ...decisionLog.metadata,
+    },
+  });
+}
+
 /**
  * Applies one approved proposal to one independently complete Bottle.
  */
@@ -1528,67 +1747,29 @@ export async function applyApprovedStorePriceMatchProposalInTransaction(
   );
 
   const aliasKey = normalizeBottleAliasKey(proposal.price.name);
-  // Alias-safety gate: a newly assigned listing title only becomes a reusable
-  // global alias when the decision asserted `aliasScope = global_alias`. For
-  // "none"/null/missing scope the source listing is still assigned (backfilled)
-  // and retained for provenance, but the new alias is marked ignored so a
-  // generic retailer title cannot be reused for future listings. Aliases that
-  // are already assigned to this target keep their existing ignored state.
-  const reusableGlobalAlias = proposal.aliasScope === "global_alias";
+  // Only `global_alias` lets this store title match future listings. Other
+  // approvals still link this listing to the bottle, but keep its title out of
+  // automatic matching. Existing aliases keep their current setting.
+  const mayReuseAlias = proposal.aliasScope === "global_alias";
   const aliasInput = {
     bottleId,
     externalSiteId: proposal.price.externalSiteId,
     name: aliasKey,
     backfillNames: [proposal.price.name],
     volume: proposal.price.volume,
-    ignored: !reusableGlobalAlias,
+    ignored: !mayReuseAlias,
     assignmentSource: "source_approved",
     assignedByActorId: actor.id,
   } satisfies Parameters<typeof assignBottleAliasInTransaction>[1];
   const aliasResult = await assignBottleAliasInTransaction(tx, aliasInput);
 
-  await tx
-    .update(storePrices)
-    .set({
-      bottleId,
-      updatedAt: sql`NOW()`,
-    })
-    .where(eq(storePrices.id, proposal.price.id));
-
-  await markApprovedStorePriceMatchProposalInTransaction(tx, {
-    proposalId: proposal.id,
-    bottleId,
-    reviewedById,
-  });
-
-  // One approved store price should always leave behind one source record keyed
-  // by the store_price id so moderators can recover the original evidence later.
-  await upsertStorePriceObservationInTransaction(tx, {
+  await persistApprovedStorePriceMatchInTransaction(tx, {
     proposal,
+    reviewedById,
     bottleId,
-    createdById: reviewedById,
-  });
-
-  // The decision writer is idempotent by source. Always offer a completed
-  // moderation decision so legacy or preassigned prices still gain history.
-  await recordIncomingBottleDecisionInTransaction(tx, {
-    sourceKind: "store_price",
-    sourceId: proposal.price.id,
-    proposalId: proposal.id,
-    externalSiteId: proposal.price.externalSiteId,
-    name: proposal.price.name,
-    url: proposal.price.url,
-    decision: decisionLog.decision,
-    actor,
-    bottleId,
-    createdBottle: decisionLog.createdBottle ?? false,
-    confidence: proposal.confidence,
-    model: proposal.model,
-    rationale: proposal.rationale,
-    metadata: {
-      proposalType: proposal.proposalType,
-      ...(actor.type === "system" ? { initiatedByUserId: reviewedById } : {}),
-      ...decisionLog.metadata,
+    decisionLog: {
+      ...decisionLog,
+      actor,
     },
   });
 

--- a/apps/server/src/lib/storePriceBottleMatching.ts
+++ b/apps/server/src/lib/storePriceBottleMatching.ts
@@ -1,0 +1,98 @@
+import type {
+  BottleCandidate,
+  BottleExtractedDetails,
+} from "@peated/bottle-classifier/internal/types";
+import { normalizeBottleAliasKey } from "@peated/bottle-classifier/normalize";
+import { getExistingMatchIdentityConflicts } from "@peated/bottle-classifier/priceMatchingEvidence";
+import type { AnyTransaction } from "@peated/server/db";
+import { bottleBarcodes } from "@peated/server/db/schema";
+import { findBottleAliasAssignment } from "@peated/server/lib/bottleFinder";
+import { getBottleCandidateById } from "@peated/server/lib/bottleReferenceCandidates";
+import type { NormalizedGtin } from "@peated/server/lib/gtin";
+import { resolveActiveBottleIds } from "@peated/server/lib/resolveActiveBottleIds";
+import { eq } from "drizzle-orm";
+
+export type StorePriceBottleMatch = {
+  bottleId: number | null;
+  candidate: BottleCandidate | null;
+  source: "alias" | "barcode" | null;
+  aliasMatch: Awaited<ReturnType<typeof findBottleAliasAssignment>>;
+};
+
+/**
+ * Matches a listing only from an exact saved name or an approved barcode.
+ * A barcode sent by a store is evidence only: this code never approves it or
+ * turns the store's title into an alias.
+ */
+export async function resolveStorePriceBottleMatchInTransaction(
+  tx: AnyTransaction,
+  {
+    name,
+    normalizedBarcode,
+    sourceBottleIdentity,
+    volume,
+  }: {
+    name: string;
+    normalizedBarcode: NormalizedGtin | null;
+    sourceBottleIdentity: BottleExtractedDetails | null;
+    volume: number;
+  },
+): Promise<StorePriceBottleMatch> {
+  const aliasKey = normalizeBottleAliasKey(name);
+  let aliasMatch = await findBottleAliasAssignment(aliasKey, tx);
+  if (!aliasMatch && aliasKey !== name) {
+    aliasMatch = await findBottleAliasAssignment(name, tx);
+  }
+
+  const barcodeBeforeLock = normalizedBarcode
+    ? await tx.query.bottleBarcodes.findFirst({
+        where: eq(bottleBarcodes.gtin14, normalizedBarcode.gtin14),
+      })
+    : null;
+
+  if (!barcodeBeforeLock) {
+    if (!aliasMatch) {
+      return { bottleId: null, candidate: null, source: null, aliasMatch };
+    }
+    await resolveActiveBottleIds(tx, [aliasMatch.bottleId], { lock: "update" });
+    return {
+      bottleId: aliasMatch.bottleId,
+      candidate: null,
+      source: "alias",
+      aliasMatch,
+    };
+  }
+
+  await resolveActiveBottleIds(tx, [barcodeBeforeLock.bottleId], {
+    lock: "update",
+  });
+  const [barcodeAfterLock, candidate] = await Promise.all([
+    tx.query.bottleBarcodes.findFirst({
+      where: eq(bottleBarcodes.gtin14, normalizedBarcode!.gtin14),
+    }),
+    getBottleCandidateById(barcodeBeforeLock.bottleId, tx),
+  ]);
+  const conflicts = candidate
+    ? getExistingMatchIdentityConflicts({
+        target: candidate,
+        extractedLabel: sourceBottleIdentity,
+      })
+    : ["barcode target is not an active Bottle"];
+  const bottleId =
+    barcodeAfterLock?.bottleId === barcodeBeforeLock.bottleId &&
+    (barcodeAfterLock.volume === null || barcodeAfterLock.volume === volume) &&
+    conflicts.length === 0 &&
+    (aliasMatch === null || aliasMatch.bottleId === barcodeAfterLock.bottleId)
+      ? barcodeAfterLock.bottleId
+      : null;
+
+  return {
+    bottleId,
+    candidate:
+      bottleId !== null && candidate
+        ? { ...candidate, source: [...candidate.source, "barcode"] }
+        : null,
+    source: bottleId !== null ? "barcode" : null,
+    aliasMatch,
+  };
+}

--- a/apps/server/src/orpc/routes/prices/create-batch.test.ts
+++ b/apps/server/src/orpc/routes/prices/create-batch.test.ts
@@ -365,7 +365,7 @@ describe("POST /external-sites/:site/prices", () => {
     ).resolves.toHaveLength(2);
   });
 
-  test("uses a canonical barcode only for the matching package volume", async ({
+  test("uses an approved barcode only for the matching package volume", async ({
     fixtures,
   }) => {
     const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
@@ -411,6 +411,13 @@ describe("POST /external-sites/:site/prices", () => {
         ({ externalProductId }) => externalProductId === "matching-volume",
       ),
     ).toMatchObject({ bottleId: bottle.id });
+    const matched = prices.find(
+      ({ externalProductId }) => externalProductId === "matching-volume",
+    );
+    expect(workerClient.pushUniqueJob).toHaveBeenCalledWith(
+      "ResolveStorePriceBottle",
+      { priceId: matched!.id, force: true },
+    );
     const unresolved = prices.find(
       ({ externalProductId }) => externalProductId === "wrong-volume",
     );

--- a/apps/server/src/scraper/adapters/legacy/scrapeAstorWines.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeAstorWines.test.ts
@@ -20,6 +20,7 @@ test("simple", async ({ axiosMock }) => {
   expect(items[0]).toMatchInlineSnapshot(`
     {
       "currency": "usd",
+      "externalProductId": "16747",
       "imageUrl": "https://www.astorwines.com/images/items/16747.jpg",
       "name": "Aberfeldy 12-year-old Single Malt Scotch Whisky",
       "price": 4496,

--- a/apps/server/src/scraper/adapters/legacy/scrapeAstorWines.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeAstorWines.ts
@@ -29,6 +29,10 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 
     const productUrl = $("a.item-name", el).first().attr("href");
     if (!productUrl) throw new Error("Unable to identify Product URL");
+    const absoluteProductUrl = absoluteUrl(url, productUrl);
+    const externalProductId = new URL(absoluteProductUrl).pathname.match(
+      /^\/item\/(\d+)\/?$/,
+    )?.[1];
 
     const volumeRaw = $(".teaser__item__meta__2 > div", el).last().text();
     const volume = volumeRaw ? normalizeVolume(volumeRaw) : null;
@@ -59,8 +63,9 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
         price,
         currency: "usd",
         volume,
-        url: absoluteUrl(url, productUrl),
+        url: absoluteProductUrl,
         imageUrl: imageUrl ? absoluteUrl(url, imageUrl) : null,
+        ...(externalProductId ? { externalProductId } : {}),
       }),
     );
   });

--- a/apps/server/src/scraper/adapters/legacy/scrapeGordonMacphail.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeGordonMacphail.test.ts
@@ -21,6 +21,7 @@ test("scrapes available bottles and excludes unsupported products", async ({
   expect(items).toEqual([
     {
       currency: "gbp",
+      externalProductId: "6631010533443",
       imageUrl:
         "https://cdn.shopify.com/s/files/1/1914/4899/products/G_M_DistilleryLabels_Linkwood15YearsOld_46__70cl.jpg",
       name: "Distillery Labels Linkwood 15-year-old 46%",

--- a/apps/server/src/scraper/adapters/legacy/scrapeGordonMacphail.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeGordonMacphail.ts
@@ -16,6 +16,7 @@ import { logScrapedProduct, logScrapeWarning } from "./scrapeLogging";
 const SITE = "gordonmacphail";
 
 const GordonMacphailProductSchema = ShopifyProductSchema.extend({
+  id: z.number().int().positive().optional(),
   body_html: z.string().nullish(),
   images: z.array(ShopifyImageSchema),
 });
@@ -104,6 +105,7 @@ export function parseGordonMacphailProducts(
         `/products/${encodeURIComponent(product.handle)}`,
       ),
       imageUrl: product.images[0]?.src ?? null,
+      ...(product.id ? { externalProductId: String(product.id) } : {}),
     };
 
     logScrapedProduct(SITE, listing);

--- a/apps/server/src/scraper/adapters/legacy/scrapeSMWS.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSMWS.test.ts
@@ -46,6 +46,7 @@ test("bottle list", async ({ axiosMock }) => {
       },
       {
         "currency": "gbp",
+        "externalProductId": "4399",
         "name": "SMWS RW3.6 Truly a flavour bomb",
         "price": 6500,
         "url": "https://smws.com/truly-a-flavour-bomb/",
@@ -82,6 +83,7 @@ test("bottle list", async ({ axiosMock }) => {
       },
       {
         "currency": "gbp",
+        "externalProductId": "4702",
         "name": "SMWS 3.350 Gladrags of yesteryear",
         "price": 17950,
         "url": "https://smws.com/gladrags-of-yesteryear/",

--- a/apps/server/src/scraper/adapters/legacy/scrapeSMWS.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSMWS.ts
@@ -40,6 +40,7 @@ export default async function scrapeSMWS() {
 const SMWSPayloadSchema = z.object({
   items: z.array(
     z.object({
+      id: z.number().int().positive(),
       name: z.string(),
       age: z.number().nullable(),
       abv: z.union([z.string(), z.number()]).nullable(),
@@ -156,6 +157,7 @@ export async function scrapeBottles(
             currency: "gbp",
             volume: 750,
             url: `https://smws.com${item.url}`,
+            externalProductId: String(item.id),
           },
           item.image,
         );

--- a/apps/server/src/scraper/adapters/legacy/scrapeTotalWine.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeTotalWine.test.ts
@@ -20,6 +20,7 @@ test("simple", async ({ axiosMock }) => {
   expect(items[0]).toMatchInlineSnapshot(`
     {
       "currency": "usd",
+      "externalProductId": "135113175",
       "name": "Grangestone Bourbon Cask Finish Single Malt Scotch Whisky",
       "price": 6499,
       "url": "https://www.totalwine.com/spirits/scotch/single-malt/grangestone-bourbon-cask-finish-single-malt-scotch-whisky/p/135113175?s=1203&igrules=true",

--- a/apps/server/src/scraper/adapters/legacy/scrapeTotalWine.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeTotalWine.ts
@@ -40,6 +40,10 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
 
     const productUrl = $("h2.title__2RoYeYuO > a", el).first().attr("href");
     if (!productUrl) throw new Error("Unable to identify Product URL");
+    const absoluteProductUrl = absoluteUrl(url, productUrl);
+    const externalProductId = new URL(absoluteProductUrl).pathname.match(
+      /\/p\/([^/]+)\/?$/,
+    )?.[1];
 
     const priceRaw =
       $("span.price__1JvDDp_x span.price__1JvDDp_x", el).first().text() ||
@@ -56,7 +60,8 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
         price,
         currency: "usd",
         volume,
-        url: absoluteUrl(url, productUrl),
+        url: absoluteProductUrl,
+        ...(externalProductId ? { externalProductId } : {}),
       }),
     );
   });

--- a/apps/server/src/scraper/adapters/legacy/scrapeWoodenCork.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeWoodenCork.test.ts
@@ -19,6 +19,7 @@ test("simple", async ({ axiosMock }) => {
   expect(items[0]).toMatchInlineSnapshot(`
     {
       "currency": "usd",
+      "externalProductId": "4395720474760",
       "name": "Elmer T. Lee Single Barrel Bourbon",
       "price": 33899,
       "url": "https://woodencork.com/collections/whiskey/products/elmer-t-lee-bourbon",

--- a/apps/server/src/scraper/adapters/legacy/scrapeWoodenCork.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeWoodenCork.ts
@@ -39,6 +39,7 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
   const promises: Promise<void>[] = [];
   const cards = $(PRODUCT_CARD_SELECTOR);
   cards.each((_, el) => {
+    const externalProductId = $(el).attr("data-product-id")?.trim();
     const bottle = $("div.grid-product__title", el).first().text();
     if (!bottle) {
       logScrapeWarning(SITE, "Unable to identify product name");
@@ -97,6 +98,7 @@ export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
         volume,
         // image,
         url: absoluteUrl("https://woodencork.com", productUrl),
+        ...(externalProductId ? { externalProductId } : {}),
       }),
     );
   });


### PR DESCRIPTION
Store prices now use an approved barcode match before asking the model. The match is accepted only when the bottle size, known bottle details, active bottle, and any saved name all agree. We still save an approval record, but we do not turn a store's generic title into a reusable alias or change a listing that already points to a different bottle.

When a scrape finds an approved barcode, it queues this check so an old pending proposal can be replaced. Five existing scrapers also keep the stable product ID already present in their response or URL. A barcode sent by a store is still only evidence; it cannot approve a barcode mapping.
