### PR TITLE
fix(search): treat user queries as plain text

### DIFF
--- a/apps/server/src/lib/search.ts
+++ b/apps/server/src/lib/search.ts
@@ -12,7 +12,7 @@ const CASK_STRENGTH_SEARCH_TERMS =
   "cask strength barrel strength barrel proof full proof natural strength";
 const SINGLE_CASK_SEARCH_TERMS = "single cask single barrel";
 
-/** Parse user-entered names as literal words, never as search operators. */
+/** Parse human search text as words, never as search operators. */
 export function plainTextSearchQuery(query: string) {
   return sql`plainto_tsquery('english', ${query})`;
 }

--- a/apps/server/src/lib/search.ts
+++ b/apps/server/src/lib/search.ts
@@ -1,3 +1,4 @@
+import { sql } from "drizzle-orm";
 import { TSVector } from "../db/columns";
 import type {
   NewBottle,
@@ -10,6 +11,11 @@ import { formatCategoryName } from "./format";
 const CASK_STRENGTH_SEARCH_TERMS =
   "cask strength barrel strength barrel proof full proof natural strength";
 const SINGLE_CASK_SEARCH_TERMS = "single cask single barrel";
+
+/** Parse user-entered names as literal words, never as search operators. */
+export function plainTextSearchQuery(query: string) {
+  return sql`plainto_tsquery('english', ${query})`;
+}
 
 function formatSearchAbv(abv: number | null | undefined) {
   if (abv === null || abv === undefined) {

--- a/apps/server/src/openapi/spec.test.ts
+++ b/apps/server/src/openapi/spec.test.ts
@@ -64,6 +64,27 @@ function expectBottleResponse(schema: any) {
 }
 
 describe("OpenAPI generation ($ref reuse)", () => {
+  it("documents human search input as plain text", async () => {
+    const spec = await generateSpec();
+    const searchPaths = [
+      "/bottles",
+      "/entities",
+      "/bottle-series",
+      "/search",
+      "/users/{user}/collections/{collection}/bottles",
+    ] as const;
+
+    for (const path of searchPaths) {
+      const queryParameter = (
+        spec.paths?.[path]?.get?.parameters as any[]
+      )?.find((parameter) => parameter.name === "query");
+
+      expect(queryParameter?.schema?.description).toBe(
+        "Plain-text search; operator syntax is not supported.",
+      );
+    }
+  });
+
   it("reuses Bottle and Cursor via $ref and composes details via allOf", async () => {
     const spec = await generateSpec();
 

--- a/apps/server/src/orpc/routes/bottleSeries/list.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/list.ts
@@ -20,7 +20,10 @@ export default procedure
   })
   .input(
     z.object({
-      query: z.coerce.string().default(""),
+      query: z.coerce
+        .string()
+        .default("")
+        .describe("Plain-text search; operator syntax is not supported."),
       brand: z.coerce.number(),
       cursor: z.coerce.number().gte(1).default(1),
       limit: z.coerce.number().gte(1).lte(100).default(25),

--- a/apps/server/src/orpc/routes/bottleSeries/list.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/list.ts
@@ -1,5 +1,6 @@
 import { db } from "@peated/server/db";
 import { bottleSeries } from "@peated/server/db/schema";
+import { plainTextSearchQuery } from "@peated/server/lib/search";
 import { procedure } from "@peated/server/orpc";
 import { BottleSeriesSchema, CursorSchema } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
@@ -42,7 +43,7 @@ export default procedure
 
     if (query) {
       where.push(
-        sql`${bottleSeries.searchVector} @@ websearch_to_tsquery ('english', ${query})`,
+        sql`${bottleSeries.searchVector} @@ ${plainTextSearchQuery(query)}`,
       );
     }
 

--- a/apps/server/src/orpc/routes/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/list.test.ts
@@ -31,16 +31,20 @@ describe("GET /bottles", () => {
     expect(results[0].id).toBe(bottle1.id);
   });
 
-  test("treats search punctuation as plain text", async ({ fixtures }) => {
+  test("treats search text as words, not operators", async ({ fixtures }) => {
     const bottle = await fixtures.Bottle({ name: "Triple Distilled" });
     await fixtures.Bottle({ name: "Triple Reserve" });
 
-    const { results } = await routerClient.bottles.list({
-      query: "Triple - Distilled",
-      sort: "rank",
-    });
+    const searches = await Promise.all(
+      ["Triple - Distilled", "Triple OR Distilled"].map((query) =>
+        routerClient.bottles.list({ query, sort: "rank" }),
+      ),
+    );
 
-    expect(results.map(({ id }) => id)).toEqual([bottle.id]);
+    expect(searches.map(({ results }) => results.map(({ id }) => id))).toEqual([
+      [bottle.id],
+      [bottle.id],
+    ]);
   });
 
   test("resolves aliases through direct Bottle ownership", async ({

--- a/apps/server/src/orpc/routes/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/list.test.ts
@@ -31,6 +31,18 @@ describe("GET /bottles", () => {
     expect(results[0].id).toBe(bottle1.id);
   });
 
+  test("treats search punctuation as plain text", async ({ fixtures }) => {
+    const bottle = await fixtures.Bottle({ name: "Triple Distilled" });
+    await fixtures.Bottle({ name: "Triple Reserve" });
+
+    const { results } = await routerClient.bottles.list({
+      query: "Triple - Distilled",
+      sort: "rank",
+    });
+
+    expect(results.map(({ id }) => id)).toEqual([bottle.id]);
+  });
+
   test("resolves aliases through direct Bottle ownership", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -10,6 +10,7 @@ import {
   flights,
   tastings,
 } from "@peated/server/db/schema";
+import { plainTextSearchQuery } from "@peated/server/lib/search";
 import { procedure } from "@peated/server/orpc";
 import {
   BottleSchema,
@@ -87,6 +88,7 @@ export default procedure
   .handler(async function ({ input, context, errors }) {
     const { query, cursor, limit, ...rest } = input;
     const offset = (cursor - 1) * limit;
+    const textQuery = plainTextSearchQuery(query);
     const exactAliasBottleIds = query
       ? (
           await db
@@ -113,7 +115,7 @@ export default procedure
     if (query) {
       where.push(
         or(
-          sql`${bottles.searchVector} @@ websearch_to_tsquery ('english', ${query})`,
+          sql`${bottles.searchVector} @@ ${textQuery}`,
           exactAliasBottleIds.length
             ? inArray(bottles.id, exactAliasBottleIds)
             : undefined,
@@ -194,7 +196,7 @@ export default procedure
     switch (rest.sort) {
       case "rank":
         if (query) {
-          orderBy = sql`ts_rank(${bottles.searchVector}, websearch_to_tsquery('english', ${query})) DESC`;
+          orderBy = sql`ts_rank(${bottles.searchVector}, ${textQuery}) DESC`;
         } else {
           orderBy = desc(bottles.totalTastings);
         }

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -64,7 +64,10 @@ export default procedure
   })
   .input(
     z.object({
-      query: z.coerce.string().default(""),
+      query: z.coerce
+        .string()
+        .default("")
+        .describe("Plain-text search; operator syntax is not supported."),
       brand: z.coerce.number().nullish(),
       distiller: z.coerce.number().nullish(),
       bottler: z.coerce.number().nullish(),

--- a/apps/server/src/orpc/routes/collections/bottles/list.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/list.ts
@@ -42,7 +42,10 @@ export default procedure
           z.coerce.number(),
         ]),
         user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
-        query: z.coerce.string().default(""),
+        query: z.coerce
+          .string()
+          .default("")
+          .describe("Plain-text search; operator syntax is not supported."),
         brand: z.coerce.number().nullish(),
         distiller: z.coerce.number().nullish(),
         bottle: z.number().int().positive().optional(),

--- a/apps/server/src/orpc/routes/collections/bottles/list.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/list.ts
@@ -11,6 +11,7 @@ import {
   isReservedCollectionSlug,
   reservedCollectionSlugs,
 } from "@peated/server/lib/db";
+import { plainTextSearchQuery } from "@peated/server/lib/search";
 import { procedure } from "@peated/server/orpc";
 import {
   CollectionBottleSchema,
@@ -127,7 +128,7 @@ export default procedure
           SELECT FROM ${bottleAliases}
           WHERE ${bottleAliases.bottleId} = ${collectionBottles.bottleId}
             AND LOWER(${bottleAliases.name}) = ${input.query.toLowerCase()}
-        ) OR ${bottles.searchVector} @@ websearch_to_tsquery ('english', ${input.query})`,
+        ) OR ${bottles.searchVector} @@ ${plainTextSearchQuery(input.query)}`,
       );
     }
     if (input.brand) {

--- a/apps/server/src/orpc/routes/entities/list.ts
+++ b/apps/server/src/orpc/routes/entities/list.ts
@@ -9,6 +9,7 @@ import {
   entityAliases,
   regions,
 } from "@peated/server/db/schema";
+import { plainTextSearchQuery } from "@peated/server/lib/search";
 import { procedure } from "@peated/server/orpc";
 import { EntitySchema, listResponse } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
@@ -76,12 +77,11 @@ export default procedure
     errors,
   }) {
     const offset = (cursor - 1) * limit;
+    const textQuery = plainTextSearchQuery(query);
 
     const where: (SQL<unknown> | undefined)[] = [];
     if (query) {
-      where.push(
-        sql`${entities.searchVector} @@ websearch_to_tsquery ('english', ${query})`,
-      );
+      where.push(sql`${entities.searchVector} @@ ${textQuery}`);
     }
     if (input.name) {
       where.push(
@@ -168,7 +168,7 @@ export default procedure
     switch (input.sort) {
       case "rank":
         if (query) {
-          orderBy = sql`ts_rank(${entities.searchVector}, websearch_to_tsquery('english', ${query})) DESC`;
+          orderBy = sql`ts_rank(${entities.searchVector}, ${textQuery}) DESC`;
         } else {
           orderBy = desc(entities.totalTastings);
         }

--- a/apps/server/src/orpc/routes/entities/list.ts
+++ b/apps/server/src/orpc/routes/entities/list.ts
@@ -34,7 +34,10 @@ const SORT_OPTIONS = [
 
 const InputSchema = z
   .object({
-    query: z.string().default(""),
+    query: z
+      .string()
+      .default("")
+      .describe("Plain-text search; operator syntax is not supported."),
     name: z.string().nullish(),
     country: z.coerce.string().nullish().describe("Country slug or id"),
     region: z.coerce.string().nullish().describe("Region slug or id"),

--- a/apps/server/src/orpc/routes/search.ts
+++ b/apps/server/src/orpc/routes/search.ts
@@ -70,7 +70,9 @@ export default procedure
   })
   .input(
     z.object({
-      query: z.coerce.string(),
+      query: z.coerce
+        .string()
+        .describe("Plain-text search; operator syntax is not supported."),
       include: z.array(z.enum(INCLUDE_LIST)).default([...INCLUDE_LIST]),
       limit: z.coerce.number().gte(1).lte(100).default(25),
     }),


### PR DESCRIPTION
Search boxes now consistently treat input as ordinary words across Bottle, entity, bottle-series, collection, and global search. A product-name separator such as `Triple - Distilled` can no longer exclude `Distilled`, and typing `OR` cannot broaden results as hidden query syntax. The public API schemas now state this plain-text contract explicitly.

The root cause was passing human search text to PostgreSQL's web-search query parser. The shared user-facing boundary now uses `plainto_tsquery`, while classifier-internal candidate retrieval remains unchanged. This intentionally does not add fuzzy matching or fallback behavior; it only removes an undocumented advanced-search language. Route-level regression coverage exercises both the separator and operator-word cases, and an OpenAPI regression preserves the public contract.
