### PR TITLE
feat(reviews): link ingestion to review articles

### DIFF
--- a/apps/server/src/externalReviews/backfill.test.ts
+++ b/apps/server/src/externalReviews/backfill.test.ts
@@ -31,6 +31,7 @@ describe("review article backfill migration", () => {
     const secondSite = await fixtures.ExternalSite({ type: "totalwine" });
     const bottle = await fixtures.Bottle();
     await fixtures.Review({
+      articleId: null,
       externalSiteId: firstSite.id,
       bottleId: bottle.id,
       name: "Visible matched review",
@@ -42,6 +43,7 @@ describe("review article backfill migration", () => {
       updatedAt: new Date("2024-01-02T00:00:00Z"),
     });
     await fixtures.Review({
+      articleId: null,
       externalSiteId: firstSite.id,
       bottleId: null,
       name: "Hidden unresolved review",
@@ -53,6 +55,7 @@ describe("review article backfill migration", () => {
       updatedAt: new Date("2024-02-02T00:00:00Z"),
     });
     await fixtures.Review({
+      articleId: null,
       externalSiteId: secondSite.id,
       bottleId: bottle.id,
       name: "Second-site review",

--- a/apps/server/src/lib/createExternalReview.ts
+++ b/apps/server/src/lib/createExternalReview.ts
@@ -3,7 +3,12 @@ import {
   normalizeBottleAliasKey,
 } from "@peated/bottle-classifier/normalize";
 import { db } from "@peated/server/db";
-import { externalSites, reviews, storePrices } from "@peated/server/db/schema";
+import {
+  externalSites,
+  reviewArticles,
+  reviews,
+  storePrices,
+} from "@peated/server/db/schema";
 import { getPeatedSystemActor } from "@peated/server/lib/actors";
 import {
   assignBottleAliasInTransaction,
@@ -56,14 +61,27 @@ export class ExternalReviewBottleStateError extends Error {
 
 export const ExternalReviewInputSchema = ReviewInputSchema.strict();
 
+type ExternalReviewContext =
+  | { initiatedByUserId: number }
+  | { externalSiteId: number; sourceKey: string };
+
 export async function createExternalReview(
   rawInput: unknown,
-  { initiatedByUserId }: { initiatedByUserId?: number } = {},
+  context: ExternalReviewContext,
 ) {
   const input = ExternalReviewInputSchema.parse(rawInput);
+  const initiatedByUserId =
+    "initiatedByUserId" in context ? context.initiatedByUserId : undefined;
+  const sourceKey = "sourceKey" in context ? context.sourceKey : input.url;
   const systemActor = await getPeatedSystemActor();
   const site = await db.query.externalSites.findFirst({
-    where: eq(externalSites.type, input.site),
+    where:
+      "externalSiteId" in context
+        ? and(
+            eq(externalSites.id, context.externalSiteId),
+            eq(externalSites.type, input.site),
+          )
+        : eq(externalSites.type, input.site),
   });
   if (!site) throw new ExternalSiteNotFoundError(input.site);
 
@@ -96,6 +114,23 @@ export async function createExternalReview(
   const reviewNameCandidates = [reviewName.toLowerCase()];
 
   const { review, aliasAssignment } = await db.transaction(async (tx) => {
+    const [article] = await tx
+      .insert(reviewArticles)
+      .values({
+        externalSiteId: site.id,
+        canonicalUrl: input.url,
+        issue: input.issue,
+      })
+      .onConflictDoUpdate({
+        target: [reviewArticles.externalSiteId, reviewArticles.canonicalUrl],
+        set: {
+          issue: input.issue,
+          updatedAt: sql`NOW()`,
+        },
+      })
+      .returning({ id: reviewArticles.id });
+    if (!article) throw new Error("Unable to store review article.");
+
     if (bottleId !== null) {
       try {
         await resolveActiveBottleIds(tx, [bottleId], { lock: "update" });
@@ -160,17 +195,22 @@ export async function createExternalReview(
       [review] = await tx
         .update(reviews)
         .set({
+          articleId: article.id,
           bottleId: incomingIdentityIsAuthoritative
             ? bottleId
             : existingReview.bottleId,
+          issue: input.issue,
           name: reviewName,
           rating: input.rating,
+          sourceKey,
           url: input.url,
           updatedAt: sql`NOW()`,
         })
         .where(eq(reviews.id, existingReview.id))
         .returning();
     } else {
+      // Keep the row on the legacy partial index until this conflict resolves.
+      // That serializes rolling-deploy writers before the row is linked below.
       const { rows } = await tx.execute(
         sql`INSERT INTO ${reviews} (bottle_id, external_site_id, name, issue, rating, url)
             VALUES (${bottleId}, ${site.id}, ${reviewName}, ${input.issue}, ${input.rating}, ${input.url})
@@ -189,7 +229,14 @@ export async function createExternalReview(
             RETURNING *`,
       );
       [review] = mapRows(rows, reviews);
+      if (!review) throw new Error("Unable to store review.");
+      [review] = await tx
+        .update(reviews)
+        .set({ articleId: article.id, sourceKey })
+        .where(eq(reviews.id, review.id))
+        .returning();
     }
+    if (!review) throw new Error("Unable to link review article.");
 
     const appliedIncomingIdentity = review.bottleId === bottleId;
     if (!bottleId || !appliedIncomingIdentity) {

--- a/apps/server/src/lib/test/fixtures.test.ts
+++ b/apps/server/src/lib/test/fixtures.test.ts
@@ -7,6 +7,7 @@ import {
   bottlesToDistillers,
   changes,
   flightBottles,
+  reviewArticles,
 } from "../../db/schema";
 
 describe("catalog identity fixtures", () => {
@@ -23,7 +24,7 @@ describe("catalog identity fixtures", () => {
     const price = await fixtures.StorePrice({ bottleId: bottle.id });
     const alias = await fixtures.BottleAlias({ bottleId: bottle.id });
     const flight = await fixtures.Flight({ bottles: [bottle.id] });
-    const [flightBottle, canonicalAlias] = await Promise.all([
+    const [flightBottle, canonicalAlias, reviewArticle] = await Promise.all([
       db.query.flightBottles.findFirst({
         where: eq(flightBottles.flightId, flight.id),
       }),
@@ -33,10 +34,18 @@ describe("catalog identity fixtures", () => {
           eq(bottleAliases.name, bottle.fullName),
         ),
       }),
+      db.query.reviewArticles.findFirst({
+        where: eq(reviewArticles.id, review.articleId as number),
+      }),
     ]);
 
     expect(tasting.bottleId).toBe(bottle.id);
     expect(review.bottleId).toBe(bottle.id);
+    expect(review.sourceKey).toBe(review.url);
+    expect(reviewArticle).toMatchObject({
+      canonicalUrl: review.url,
+      externalSiteId: review.externalSiteId,
+    });
     expect(price.bottleId).toBe(bottle.id);
     expect(alias.bottleId).toBe(bottle.id);
     expect(canonicalAlias?.assignmentSource).toBe("canonical");

--- a/apps/server/src/lib/test/fixtures.ts
+++ b/apps/server/src/lib/test/fixtures.ts
@@ -25,6 +25,7 @@ import {
   follows,
   oauthClients,
   passkeys,
+  reviewArticles,
   reviews,
   storePriceHistories,
   storePrices,
@@ -1111,17 +1112,38 @@ export const Review = async (
 
     data.bottleId = await resolveFixtureBottleId(data, tx);
 
+    const externalSiteId =
+      data.externalSiteId || (await ExternalSiteOrExisting({}, tx)).id;
+    const issue = data.issue ?? "Default";
+    const url = data.url ?? faker.internet.url();
+    let articleId = data.articleId;
+    let sourceKey = data.sourceKey;
+    if (articleId === undefined) {
+      const [article] = await tx
+        .insert(reviewArticles)
+        .values({ externalSiteId, canonicalUrl: url, issue })
+        .onConflictDoUpdate({
+          target: [reviewArticles.externalSiteId, reviewArticles.canonicalUrl],
+          set: { issue },
+        })
+        .returning({ id: reviewArticles.id });
+      if (!article) throw new Error("Unable to create ReviewArticle fixture");
+      articleId = article.id;
+      if (sourceKey === undefined) sourceKey = url;
+    }
+
     return await tx
       .insert(reviews)
       .values({
         name: "",
-        externalSiteId:
-          data.externalSiteId || (await ExternalSiteOrExisting({}, tx)).id,
+        externalSiteId,
         rating: faker.number.int({ min: 59, max: 100 }),
-        url: faker.internet.url(),
-        issue: "Default",
+        url,
+        issue,
         createdAt: new Date(),
         ...data,
+        articleId,
+        sourceKey,
       })
       .returning();
   });

--- a/apps/server/src/orpc/routes/reviews/create.test.ts
+++ b/apps/server/src/orpc/routes/reviews/create.test.ts
@@ -4,6 +4,7 @@ import {
   bottleAliases,
   bottleTombstones,
   incomingBottleDecisionLogs,
+  reviewArticles,
   reviews,
 } from "@peated/server/db/schema";
 import { getPeatedSystemActor } from "@peated/server/lib/actors";
@@ -163,11 +164,26 @@ describe("POST /reviews", () => {
       { context: { user: admin } },
     );
 
-    expect(await findReviewByUrl(url)).toMatchObject({
+    const review = await findReviewByUrl(url);
+    expect(review).toMatchObject({
       id: result.id,
+      articleId: expect.any(Number),
       bottleId: null,
       name: "Unresolved Review Bottle",
       rating: 89,
+      sourceKey: url,
+    });
+    expect(
+      await db.query.reviewArticles.findFirst({
+        where: eq(reviewArticles.id, review!.articleId!),
+      }),
+    ).toMatchObject({
+      externalSiteId: site.id,
+      canonicalUrl: url,
+      issue: "Default",
+      title: null,
+      contentHash: null,
+      fetchedAt: null,
     });
     expect(
       await db.query.bottleAliases.findFirst({

--- a/apps/server/src/scraper/sinks/externalReviews.test.ts
+++ b/apps/server/src/scraper/sinks/externalReviews.test.ts
@@ -1,0 +1,66 @@
+import { db } from "@peated/server/db";
+import { reviewArticles, reviews } from "@peated/server/db/schema";
+import { and, eq } from "drizzle-orm";
+import { expect, test } from "vitest";
+import { whiskyAdvocateReviewSink } from "./externalReviews";
+
+test("Whisky Advocate observations use article and source identity", async ({
+  fixtures,
+}) => {
+  const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
+  const bottle = await fixtures.Bottle({ name: "Sink Review Bottle" });
+  const url = "https://whiskyadvocate.com/reviews/sink-review";
+  const observation = {
+    sourceKey: "whisky-advocate-review-123",
+    value: {
+      name: bottle.fullName,
+      category: bottle.category,
+      rating: 92,
+      url,
+      issue: "Fall 2026",
+    },
+  };
+
+  await whiskyAdvocateReviewSink({ externalSiteId: site.id, observation });
+  await whiskyAdvocateReviewSink({
+    externalSiteId: site.id,
+    observation: {
+      ...observation,
+      value: { ...observation.value, rating: 93 },
+    },
+  });
+
+  const storedReviews = await db
+    .select()
+    .from(reviews)
+    .where(eq(reviews.externalSiteId, site.id));
+  expect(storedReviews).toMatchObject([
+    {
+      articleId: expect.any(Number),
+      bottleId: bottle.id,
+      name: bottle.fullName,
+      rating: 93,
+      sourceKey: observation.sourceKey,
+      url,
+    },
+  ]);
+  expect(
+    await db
+      .select()
+      .from(reviewArticles)
+      .where(
+        and(
+          eq(reviewArticles.externalSiteId, site.id),
+          eq(reviewArticles.canonicalUrl, url),
+        ),
+      ),
+  ).toMatchObject([
+    {
+      id: storedReviews[0]!.articleId,
+      issue: "Fall 2026",
+      title: null,
+      contentHash: null,
+      fetchedAt: null,
+    },
+  ]);
+});

--- a/apps/server/src/scraper/sinks/externalReviews.ts
+++ b/apps/server/src/scraper/sinks/externalReviews.ts
@@ -8,12 +8,18 @@ import type { ScraperSink } from "../types";
 
 export const whiskyAdvocateReviewSink: ScraperSink<
   WhiskyAdvocateObservation
-> = async ({ observation }) => {
+> = async ({ externalSiteId, observation }) => {
   try {
-    await createExternalReview({
-      site: "whiskyadvocate",
-      ...observation.value,
-    });
+    await createExternalReview(
+      {
+        site: "whiskyadvocate",
+        ...observation.value,
+      },
+      {
+        externalSiteId,
+        sourceKey: observation.sourceKey,
+      },
+    );
   } catch (error) {
     if (!(error instanceof ExternalReviewBottleStateError)) throw error;
 

--- a/openspec/changes/pilot-external-review-indexing/tasks.md
+++ b/openspec/changes/pilot-external-review-indexing/tasks.md
@@ -29,9 +29,10 @@
 - [x] 3.1 Automatically backfill one review article for every existing review
       in the schema migration while preserving source, URL, issue, rating,
       Bottle assignment, and visibility without fetching publisher pages
-- [ ] 3.2 Switch review ingestion, queries, serializers, moderation, and fixtures
-      to the article/review model
-- [ ] 3.3 Migrate the Whisky Advocate job to the shared article ingestion
+- [x] 3.2a Switch review ingestion and fixtures to the article/review model
+- [ ] 3.2b Switch review queries, serializers, and moderation to article-owned
+      metadata
+- [x] 3.3 Migrate the Whisky Advocate job to the shared article ingestion
       boundary without expanding its current collection or summary behavior
 - [x] 3.4 Add migration verification for total, visible, unresolved, Bottle-linked,
       and canonical-URL counts


### PR DESCRIPTION
New admin and Whisky Advocate review writes now create or reuse a review article and link the review to it in the same transaction. Scraped reviews preserve their durable source key, while existing Bottle resolution, visibility, normalized ratings, and legacy compatibility fields continue to behave as before.

The cutover deliberately leaves review queries and moderation on their current compatibility fields for the next slice. Legacy writes remain safe during rollout, and sparse Whisky Advocate data does not overwrite richer article metadata.

Covered by 29 focused server integration tests, server typecheck, repository lint, OpenSpec validation, and the full production build.
