### PR TITLE
ref(reviews): use article-owned metadata

### DIFF
--- a/apps/cli/src/commands/mocks.ts
+++ b/apps/cli/src/commands/mocks.ts
@@ -11,6 +11,8 @@ import {
   bottles,
   collectionBottles,
   externalSites,
+  reviewArticles,
+  reviews,
   tastings,
   users,
 } from "@peated/server/db/schema";
@@ -232,17 +234,23 @@ const loadDefaultBottles = async (
           bottleId: bottle.id,
         }));
 
-      (await db.query.reviews.findFirst({
-        where: (reviews, { eq, and }) =>
+      const [review] = await db
+        .select({ id: reviews.id })
+        .from(reviews)
+        .innerJoin(reviewArticles, eq(reviews.articleId, reviewArticles.id))
+        .where(
           and(
-            eq(reviews.externalSiteId, site.id),
+            eq(reviewArticles.externalSiteId, site.id),
             eq(reviews.bottleId, bottle.id),
           ),
-      })) ||
-        (await Fixtures.Review({
+        )
+        .limit(1);
+      if (!review) {
+        await Fixtures.Review({
           externalSiteId: site.id,
           bottleId: bottle.id,
-        }));
+        });
+      }
 
       await Fixtures.Review({
         externalSiteId: site.id,

--- a/apps/server/src/lib/bottleAliases.ts
+++ b/apps/server/src/lib/bottleAliases.ts
@@ -11,6 +11,7 @@ import {
   bottleAliases,
   bottleTombstones,
   bottles,
+  reviewArticles,
   reviews,
   storePrices,
 } from "@peated/server/db/schema";
@@ -22,7 +23,7 @@ import {
   type ActiveBottleRejectionReason,
 } from "@peated/server/lib/resolveActiveBottleIds";
 import { pushJob, pushUniqueJob } from "@peated/server/worker/client";
-import { and, asc, eq, isNull, or, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 
 /** Lists unresolved, non-ignored aliases for bounded maintenance output. */
 export async function listUnmatchedBottleAliasNames(
@@ -519,7 +520,13 @@ async function syncBottleAliasConsumersInTransaction(
           ...lookupNames.map((value) => eq(sql`LOWER(${reviews.name})`, value)),
         ),
         externalSiteId !== undefined
-          ? eq(reviews.externalSiteId, externalSiteId)
+          ? inArray(
+              reviews.articleId,
+              tx
+                .select({ id: reviewArticles.id })
+                .from(reviewArticles)
+                .where(eq(reviewArticles.externalSiteId, externalSiteId)),
+            )
           : undefined,
         reviewIdentity,
       ),

--- a/apps/server/src/lib/fixBadReviewEntities.test.ts
+++ b/apps/server/src/lib/fixBadReviewEntities.test.ts
@@ -67,28 +67,22 @@ describe("fixBadReviewEntities", () => {
       releaseYear: null,
     });
     const site = await fixtures.ExternalSiteOrExisting();
-    const [review] = await db
-      .insert(reviews)
-      .values({
-        externalSiteId: site.id,
-        bottleId: wrongBottle.id,
-        name: correctBottle.fullName,
-        issue: "Default",
-        rating: 91,
-        url: "https://example.com/review",
-      })
-      .returning();
-    const [sameNameReview] = await db
-      .insert(reviews)
-      .values({
-        externalSiteId: site.id,
-        bottleId: null,
-        name: correctBottle.fullName,
-        issue: "Second",
-        rating: 88,
-        url: "https://example.com/second-review",
-      })
-      .returning();
+    const review = await fixtures.Review({
+      externalSiteId: site.id,
+      bottleId: wrongBottle.id,
+      name: correctBottle.fullName,
+      issue: "Default",
+      rating: 91,
+      url: "https://example.com/review",
+    });
+    const sameNameReview = await fixtures.Review({
+      externalSiteId: site.id,
+      bottleId: null,
+      name: correctBottle.fullName,
+      issue: "Second",
+      rating: 88,
+      url: "https://example.com/second-review",
+    });
     const sameNamePrice = await fixtures.StorePrice({
       externalSiteId: site.id,
       bottleId: null,
@@ -182,17 +176,14 @@ describe("fixBadReviewEntities", () => {
       bottleId: stagedBottle.id,
       name: "Staged Exact Alias Review",
     });
-    const [review] = await db
-      .insert(reviews)
-      .values({
-        externalSiteId: site.id,
-        bottleId: wrongBottle.id,
-        name: alias.name,
-        issue: "Default",
-        rating: 90,
-        url: "https://example.com/staged-exact-alias-review",
-      })
-      .returning();
+    const review = await fixtures.Review({
+      externalSiteId: site.id,
+      bottleId: wrongBottle.id,
+      name: alias.name,
+      issue: "Default",
+      rating: 90,
+      url: "https://example.com/staged-exact-alias-review",
+    });
 
     const summary = await fixBadReviewEntities({ user });
 
@@ -222,17 +213,14 @@ describe("fixBadReviewEntities", () => {
       name: "Unpromoted Match Parent",
     });
     const site = await fixtures.ExternalSiteOrExisting();
-    const [review] = await db
-      .insert(reviews)
-      .values({
-        externalSiteId: site.id,
-        bottleId: wrongBottle.id,
-        name: "Unpromoted Classifier Match Review",
-        issue: "Default",
-        rating: 90,
-        url: "https://example.com/unpromoted-classifier-match-review",
-      })
-      .returning();
+    const review = await fixtures.Review({
+      externalSiteId: site.id,
+      bottleId: wrongBottle.id,
+      name: "Unpromoted Classifier Match Review",
+      issue: "Default",
+      rating: 90,
+      url: "https://example.com/unpromoted-classifier-match-review",
+    });
     classifyBottleReferenceMock.mockResolvedValue(
       buildClassification(
         {
@@ -286,17 +274,14 @@ describe("fixBadReviewEntities", () => {
       releaseYear: null,
     });
     const site = await fixtures.ExternalSiteOrExisting();
-    const [review] = await db
-      .insert(reviews)
-      .values({
-        externalSiteId: site.id,
-        bottleId: bottle.id,
-        name: "Unknown Review Title",
-        issue: "Default",
-        rating: 90,
-        url: "https://example.com/unresolved-review",
-      })
-      .returning();
+    const review = await fixtures.Review({
+      externalSiteId: site.id,
+      bottleId: bottle.id,
+      name: "Unknown Review Title",
+      issue: "Default",
+      rating: 90,
+      url: "https://example.com/unresolved-review",
+    });
 
     const summary = await fixBadReviewEntities({ user });
 
@@ -324,17 +309,14 @@ describe("fixBadReviewEntities", () => {
       releaseYear: null,
     });
     const site = await fixtures.ExternalSiteOrExisting();
-    const [review] = await db
-      .insert(reviews)
-      .values({
-        externalSiteId: site.id,
-        bottleId: bottle.id,
-        name: "Errored Review Title",
-        issue: "Default",
-        rating: 90,
-        url: "https://example.com/errored-review",
-      })
-      .returning();
+    const review = await fixtures.Review({
+      externalSiteId: site.id,
+      bottleId: bottle.id,
+      name: "Errored Review Title",
+      issue: "Default",
+      rating: 90,
+      url: "https://example.com/errored-review",
+    });
 
     classifyBottleReferenceMock.mockRejectedValueOnce(
       new Error("Classifier unavailable"),
@@ -370,17 +352,14 @@ describe("fixBadReviewEntities", () => {
       name: "Conflicting Assignment Bottle",
     });
     const site = await fixtures.ExternalSiteOrExisting();
-    const [review] = await db
-      .insert(reviews)
-      .values({
-        externalSiteId: site.id,
-        bottleId: wrongBottle.id,
-        name: "Assignment Conflict Review",
-        issue: "Default",
-        rating: 90,
-        url: "https://example.com/assignment-conflict-review",
-      })
-      .returning();
+    const review = await fixtures.Review({
+      externalSiteId: site.id,
+      bottleId: wrongBottle.id,
+      name: "Assignment Conflict Review",
+      issue: "Default",
+      rating: 90,
+      url: "https://example.com/assignment-conflict-review",
+    });
 
     classifyBottleReferenceMock.mockImplementationOnce(async () => {
       await db
@@ -426,17 +405,14 @@ describe("fixBadReviewEntities", () => {
       name: "Concurrent Bottle",
     });
     const site = await fixtures.ExternalSiteOrExisting();
-    const [review] = await db
-      .insert(reviews)
-      .values({
-        externalSiteId: site.id,
-        bottleId: wrongBottle.id,
-        name: "Suggested Bottle Review",
-        issue: "Default",
-        rating: 90,
-        url: "https://example.com/concurrent-review",
-      })
-      .returning();
+    const review = await fixtures.Review({
+      externalSiteId: site.id,
+      bottleId: wrongBottle.id,
+      name: "Suggested Bottle Review",
+      issue: "Default",
+      rating: 90,
+      url: "https://example.com/concurrent-review",
+    });
 
     classifyBottleReferenceMock.mockImplementationOnce(async () => {
       await db

--- a/apps/server/src/lib/fixBadReviewEntities.ts
+++ b/apps/server/src/lib/fixBadReviewEntities.ts
@@ -1,6 +1,6 @@
 import { db } from "@peated/server/db";
 import type { User } from "@peated/server/db/schema";
-import { bottles, reviews } from "@peated/server/db/schema";
+import { bottles, reviewArticles, reviews } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
 import {
   assignBottleAliasInTransaction,
@@ -32,12 +32,13 @@ export async function fixBadReviewEntities({
 }): Promise<FixBadReviewEntitiesResult> {
   const actor = await getUserActor(user);
   const results = await db
-    .select({ bottle: bottles, review: reviews })
+    .select({ article: reviewArticles, bottle: bottles, review: reviews })
     .from(bottles)
     .innerJoin(
       reviews,
       and(eq(reviews.bottleId, bottles.id), ne(reviews.name, bottles.fullName)),
-    );
+    )
+    .innerJoin(reviewArticles, eq(reviews.articleId, reviewArticles.id));
 
   const summary: FixBadReviewEntitiesResult = {
     scanned: 0,
@@ -47,7 +48,7 @@ export async function fixBadReviewEntities({
     unchanged: 0,
   };
 
-  for (const { bottle, review } of results) {
+  for (const { article, bottle, review } of results) {
     if (review.name.startsWith(bottle.fullName)) {
       continue;
     }
@@ -57,9 +58,9 @@ export async function fixBadReviewEntities({
     const resolution = await resolveBottleReferenceTarget({
       reference: {
         id: review.id,
-        externalSiteId: review.externalSiteId,
+        externalSiteId: article.externalSiteId,
         name: review.name,
-        url: review.url,
+        url: article.canonicalUrl,
         imageUrl: null,
         currentBottleId: review.bottleId,
       },

--- a/apps/server/src/orpc/routes/external-sites/health.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.test.ts
@@ -2,6 +2,7 @@ import { db } from "@peated/server/db";
 import {
   externalSiteRuns,
   externalSiteScrapeTargets,
+  reviews,
   scrapeOrigins,
   scrapeTargets,
   storePrices,
@@ -177,15 +178,24 @@ test("health details show review inventory and blocked review policy", async ({
 }) => {
   const admin = await fixtures.User({ admin: true });
   const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
-  await fixtures.Review({
+  const legacySite = await fixtures.ExternalSite({ type: "totalwine" });
+  const matchedReview = await fixtures.Review({
     externalSiteId: site.id,
     hidden: false,
   });
-  await fixtures.Review({
+  const unmatchedReview = await fixtures.Review({
     externalSiteId: site.id,
     bottleId: null,
     hidden: false,
   });
+  await db
+    .update(reviews)
+    .set({ externalSiteId: legacySite.id })
+    .where(eq(reviews.id, matchedReview.id));
+  await db
+    .update(reviews)
+    .set({ externalSiteId: legacySite.id })
+    .where(eq(reviews.id, unmatchedReview.id));
   await db.insert(scrapeTargets).values({
     key: "whiskyadvocate",
     enabled: false,

--- a/apps/server/src/orpc/routes/external-sites/health.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.ts
@@ -5,6 +5,7 @@ import {
   externalSiteRuns,
   externalSiteScrapeTargets,
   externalSites,
+  reviewArticles,
   reviews,
   scrapeOrigins,
   scrapeTargets,
@@ -47,19 +48,20 @@ async function getHealthForSites(
   ] = await Promise.all([
     db
       .select({
-        externalSiteId: reviews.externalSiteId,
+        externalSiteId: reviewArticles.externalSiteId,
         total: sql<number>`count(*)::int`,
         matched: sql<number>`count(*) filter (where ${reviews.bottleId} is not null)::int`,
         unmatched: sql<number>`count(*) filter (where ${reviews.bottleId} is null)::int`,
       })
       .from(reviews)
+      .innerJoin(reviewArticles, eq(reviews.articleId, reviewArticles.id))
       .where(
         and(
-          inArray(reviews.externalSiteId, siteIds),
+          inArray(reviewArticles.externalSiteId, siteIds),
           eq(reviews.hidden, false),
         ),
       )
-      .groupBy(reviews.externalSiteId),
+      .groupBy(reviewArticles.externalSiteId),
     db
       .select({
         externalSiteId: storePrices.externalSiteId,

--- a/apps/server/src/orpc/routes/reviews/list.test.ts
+++ b/apps/server/src/orpc/routes/reviews/list.test.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { actors } from "@peated/server/db/schema";
+import { actors, reviews } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq, sql } from "drizzle-orm";
@@ -86,6 +86,52 @@ describe("GET /reviews", () => {
 
     expect(results.length).toBe(1);
     expect(results[0].id).toEqual(review.id);
+  });
+
+  test("uses article-owned source and URL metadata", async ({ fixtures }) => {
+    const user = await fixtures.User({ mod: true });
+    const articleSite = await fixtures.ExternalSite({
+      type: "whiskyadvocate",
+    });
+    const legacySite = await fixtures.ExternalSite({ type: "totalwine" });
+    const review = await fixtures.Review({
+      externalSiteId: articleSite.id,
+      url: "https://example.com/article-owned-review",
+    });
+    await db
+      .update(reviews)
+      .set({
+        externalSiteId: legacySite.id,
+        url: "https://example.com/legacy-review-copy",
+      })
+      .where(eq(reviews.id, review.id));
+
+    const articleResults = await routerClient.reviews.list(
+      { site: articleSite.type },
+      { context: { user } },
+    );
+    const legacyResults = await routerClient.reviews.list(
+      { site: legacySite.type },
+      { context: { user } },
+    );
+    const allResults = await routerClient.reviews.list(
+      {},
+      { context: { user } },
+    );
+
+    expect(articleResults.results).toMatchObject([
+      {
+        id: review.id,
+        url: "https://example.com/article-owned-review",
+      },
+    ]);
+    expect(legacyResults.results).toEqual([]);
+    expect(allResults.results).toMatchObject([
+      {
+        id: review.id,
+        site: { id: articleSite.id },
+      },
+    ]);
   });
 
   test("lists reviews by direct Bottle identity", async ({ fixtures }) => {

--- a/apps/server/src/orpc/routes/reviews/list.ts
+++ b/apps/server/src/orpc/routes/reviews/list.ts
@@ -1,5 +1,9 @@
 import { db } from "@peated/server/db";
-import { externalSites, reviews } from "@peated/server/db/schema";
+import {
+  externalSites,
+  reviewArticles,
+  reviews,
+} from "@peated/server/db/schema";
 import { logWarn } from "@peated/server/lib/log";
 import { procedure } from "@peated/server/orpc";
 import {
@@ -59,7 +63,7 @@ export default procedure
           message: "Site not found.",
         });
       }
-      baseWhere.push(eq(reviews.externalSiteId, site.id));
+      baseWhere.push(eq(reviewArticles.externalSiteId, site.id));
     }
 
     const hasPublicScope = input.bottle !== undefined;
@@ -89,13 +93,15 @@ export default procedure
       baseWhere.push(ilike(reviews.name, `%${query}%`));
     }
 
-    const results = await db
-      .select()
+    const rows = await db
+      .select({ review: reviews })
       .from(reviews)
+      .innerJoin(reviewArticles, eq(reviews.articleId, reviewArticles.id))
       .where(and(...baseWhere, ...identityWhere))
       .limit(limit + 1)
       .offset(offset)
       .orderBy(asc(reviews.name));
+    const results = rows.map(({ review }) => review);
 
     return {
       results: await serialize(

--- a/apps/server/src/orpc/routes/reviews/update.test.ts
+++ b/apps/server/src/orpc/routes/reviews/update.test.ts
@@ -105,6 +105,51 @@ describe("PATCH /reviews/:review", () => {
     });
   });
 
+  test("uses article metadata for moderator decisions", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const nextBottle = await fixtures.Bottle();
+    const articleSite = await fixtures.ExternalSite({
+      type: "whiskyadvocate",
+    });
+    const legacySite = await fixtures.ExternalSite({ type: "totalwine" });
+    const canonicalUrl = "https://example.com/article-owned-review";
+    const review = await fixtures.Review({
+      bottleId: null,
+      externalSiteId: articleSite.id,
+      url: canonicalUrl,
+    });
+    await db
+      .update(reviews)
+      .set({
+        externalSiteId: legacySite.id,
+        url: "https://example.com/legacy-review-copy",
+      })
+      .where(eq(reviews.id, review.id));
+
+    const response = await routerClient.reviews.update(
+      { review: review.id, bottle: nextBottle.id },
+      { context: { user } },
+    );
+
+    expect(response).toMatchObject({
+      url: canonicalUrl,
+      site: { id: articleSite.id },
+    });
+    expect(
+      await db.query.incomingBottleDecisionLogs.findFirst({
+        where: and(
+          eq(incomingBottleDecisionLogs.sourceKind, "review"),
+          eq(incomingBottleDecisionLogs.sourceId, review.id),
+        ),
+      }),
+    ).toMatchObject({
+      externalSiteId: articleSite.id,
+      url: canonicalUrl,
+    });
+  });
+
   test("supports explicit unassignment", async ({ fixtures }) => {
     const user = await fixtures.User({ mod: true });
     const bottle = await fixtures.Bottle();

--- a/apps/server/src/orpc/routes/reviews/update.ts
+++ b/apps/server/src/orpc/routes/reviews/update.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { reviews } from "@peated/server/db/schema";
+import { reviewArticles, reviews } from "@peated/server/db/schema";
 import { getUserActorForDatabase } from "@peated/server/lib/actors";
 import {
   recordIncomingBottleDecisionInTransaction,
@@ -68,15 +68,17 @@ export default procedure
         }
       }
 
-      const [lockedReview] = await tx
-        .select()
+      const [locked] = await tx
+        .select({ article: reviewArticles, review: reviews })
         .from(reviews)
+        .innerJoin(reviewArticles, eq(reviews.articleId, reviewArticles.id))
         .where(eq(reviews.id, reviewId))
         .limit(1)
-        .for("update");
-      if (!lockedReview) {
+        .for("update", { of: reviews });
+      if (!locked) {
         throw errors.NOT_FOUND({ message: "Review not found." });
       }
+      const { article, review: lockedReview } = locked;
 
       const [review] = await tx
         .update(reviews)
@@ -104,9 +106,9 @@ export default procedure
         await recordIncomingBottleDecisionInTransaction(tx, {
           sourceKind: "review",
           sourceId: review.id,
-          externalSiteId: review.externalSiteId,
+          externalSiteId: article.externalSiteId,
           name: review.name,
-          url: review.url,
+          url: article.canonicalUrl,
           decision: "match_existing",
           actor,
           bottleId: nextBottleId,

--- a/apps/server/src/serializers/review.ts
+++ b/apps/server/src/serializers/review.ts
@@ -6,7 +6,9 @@ import {
   bottles,
   bottleTombstones,
   externalSites,
+  reviewArticles,
   type Review,
+  type ReviewArticle,
   type User,
 } from "../db/schema";
 import { type BottleSchema, type ReviewSchema } from "../schemas";
@@ -14,6 +16,7 @@ import { BottleSerializer } from "./bottle";
 import { ExternalSiteSerializer } from "./externalSite";
 
 type ReviewAttrs = {
+  article: Pick<ReviewArticle, "canonicalUrl" | "externalSiteId">;
   bottle: z.infer<typeof BottleSchema> | null;
   site: ReturnType<(typeof ExternalSiteSerializer)["item"]>;
 };
@@ -24,6 +27,28 @@ export const ReviewSerializer = serializer({
     itemList: Review[],
     currentUser?: User,
   ): Promise<Record<string, ReviewAttrs>> => {
+    const articleIds = Array.from(
+      new Set(
+        itemList.map((review) => {
+          if (review.articleId === null) {
+            throw new Error(`Review ${review.id} has no article.`);
+          }
+          return review.articleId;
+        }),
+      ),
+    );
+    const articleList = await db
+      .select({
+        id: reviewArticles.id,
+        canonicalUrl: reviewArticles.canonicalUrl,
+        externalSiteId: reviewArticles.externalSiteId,
+      })
+      .from(reviewArticles)
+      .where(inArray(reviewArticles.id, articleIds));
+    const articlesById = new Map(
+      articleList.map((article) => [article.id, article]),
+    );
+
     const bottleIds = Array.from(
       new Set(
         itemList.flatMap(({ bottleId }) =>
@@ -51,7 +76,9 @@ export const ReviewSerializer = serializer({
       serializedBottles.map((bottle) => [bottle.id, bottle]),
     );
 
-    const siteIds = Array.from(new Set(itemList.map((i) => i.externalSiteId)));
+    const siteIds = Array.from(
+      new Set(articleList.map((article) => article.externalSiteId)),
+    );
     const siteList = siteIds.length
       ? await db
           .select()
@@ -66,6 +93,12 @@ export const ReviewSerializer = serializer({
 
     return Object.fromEntries(
       itemList.map((item) => {
+        const article = articlesById.get(item.articleId!);
+        if (!article) {
+          throw new Error(
+            `Review ${item.id} references missing article ${item.articleId}.`,
+          );
+        }
         const bottle =
           item.bottleId === null
             ? null
@@ -78,8 +111,9 @@ export const ReviewSerializer = serializer({
         return [
           item.id,
           {
+            article,
             bottle,
-            site: sitesByRef[item.externalSiteId],
+            site: sitesByRef[article.externalSiteId],
           },
         ];
       }),
@@ -95,7 +129,7 @@ export const ReviewSerializer = serializer({
       id: item.id,
       name: item.name,
       rating: item.rating,
-      url: item.url,
+      url: attrs.article.canonicalUrl,
       bottle: attrs.bottle,
       site: attrs.site,
       createdAt: item.createdAt.toISOString(),

--- a/apps/server/src/worker/jobs/createMissingBottles.test.ts
+++ b/apps/server/src/worker/jobs/createMissingBottles.test.ts
@@ -75,7 +75,8 @@ describe("createMissingBottles", () => {
   test("uses the classifier to create bottles for unmatched reviews", async ({
     fixtures,
   }) => {
-    const site = await fixtures.ExternalSiteOrExisting();
+    const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
+    const legacySite = await fixtures.ExternalSite({ type: "totalwine" });
     const systemUser = await fixtures.User({
       admin: true,
       username: "dcramer",
@@ -89,6 +90,14 @@ describe("createMissingBottles", () => {
       issue: "Default",
       url: "https://example.com/review",
     });
+    await db
+      .update(reviews)
+      .set({
+        externalSiteId: legacySite.id,
+        issue: "Legacy issue copy",
+        url: "https://example.com/legacy-review-copy",
+      })
+      .where(eq(reviews.id, review.id));
     const price = await fixtures.StorePrice({
       externalSiteId: site.id,
       bottleId: null,
@@ -157,6 +166,8 @@ describe("createMissingBottles", () => {
     expect(decisionLog).toMatchObject({
       sourceKind: "review",
       sourceId: review.id,
+      externalSiteId: site.id,
+      url: review.url,
       decision: "create_bottle",
       actorId: systemActor.id,
       bottleId: updatedReview?.bottleId,

--- a/apps/server/src/worker/jobs/createMissingBottles.ts
+++ b/apps/server/src/worker/jobs/createMissingBottles.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { reviews } from "@peated/server/db/schema";
+import { reviewArticles, reviews } from "@peated/server/db/schema";
 import { getPeatedSystemActor } from "@peated/server/lib/actors";
 import {
   assignBottleAliasInTransaction,
@@ -14,7 +14,7 @@ import {
 } from "@peated/server/lib/incomingBottleDecisionLog";
 import { logInfo, logTelemetryError } from "@peated/server/lib/log";
 import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
-import { and, asc, gt, isNull } from "drizzle-orm";
+import { and, asc, eq, gt, isNull } from "drizzle-orm";
 
 export default async function createMissingBottles() {
   const systemActor = await getPeatedSystemActor();
@@ -25,8 +25,9 @@ export default async function createMissingBottles() {
   let hasMore = true;
   while (hasMore) {
     const missingInReviews = await db
-      .select()
+      .select({ article: reviewArticles, review: reviews })
       .from(reviews)
+      .innerJoin(reviewArticles, eq(reviews.articleId, reviewArticles.id))
       .where(and(isNull(reviews.bottleId), gt(reviews.id, cursor)))
       .orderBy(asc(reviews.id))
       .limit(100);
@@ -34,16 +35,16 @@ export default async function createMissingBottles() {
     hasMore = missingInReviews.length > 0;
     if (!hasMore) break;
 
-    for (const review of missingInReviews) {
+    for (const { article, review } of missingInReviews) {
       cursor = review.id;
       const aliasKey = normalizeBottleAliasKey(review.name);
 
       const resolution = await resolveScrapedBottleReferenceTarget({
         reference: {
           id: review.id,
-          externalSiteId: review.externalSiteId,
+          externalSiteId: article.externalSiteId,
           name: review.name,
-          url: review.url,
+          url: article.canonicalUrl,
           imageUrl: null,
           currentBottleId: review.bottleId,
         },
@@ -104,7 +105,7 @@ export default async function createMissingBottles() {
           const aliasInput = {
             name: aliasKey,
             backfillNames: [review.name],
-            externalSiteId: review.externalSiteId,
+            externalSiteId: article.externalSiteId,
             ...(resolution.source === "exact_alias"
               ? {}
               : { assignmentSource: "classifier_approved" as const }),
@@ -128,9 +129,9 @@ export default async function createMissingBottles() {
             await recordIncomingBottleDecisionInTransaction(tx, {
               sourceKind: "review",
               sourceId: review.id,
-              externalSiteId: review.externalSiteId,
+              externalSiteId: article.externalSiteId,
               name: review.name,
-              url: review.url,
+              url: article.canonicalUrl,
               decision,
               actor: systemActor,
               bottleId,
@@ -145,7 +146,7 @@ export default async function createMissingBottles() {
                       classifierEvidence: resolution.classifierEvidence,
                     }
                   : {}),
-                issue: review.issue,
+                issue: article.issue,
               },
             });
           }
@@ -166,7 +167,7 @@ export default async function createMissingBottles() {
         review: {
           id: review.id,
           name: review.name,
-          url: review.url,
+          url: article.canonicalUrl,
         },
       });
     }

--- a/openspec/changes/pilot-external-review-indexing/tasks.md
+++ b/openspec/changes/pilot-external-review-indexing/tasks.md
@@ -30,7 +30,7 @@
       in the schema migration while preserving source, URL, issue, rating,
       Bottle assignment, and visibility without fetching publisher pages
 - [x] 3.2a Switch review ingestion and fixtures to the article/review model
-- [ ] 3.2b Switch review queries, serializers, and moderation to article-owned
+- [x] 3.2b Switch review queries, serializers, and moderation to article-owned
       metadata
 - [x] 3.3 Migrate the Whisky Advocate job to the shared article ingestion
       boundary without expanding its current collection or summary behavior


### PR DESCRIPTION
Review reads now take publisher identity, canonical URL, and issue from `review_article` across API serialization and filtering, scraper health, moderator updates, Bottle alias propagation, unresolved matching, repair tooling, and mock generation. The public response shape and existing review visibility remain unchanged.

This completes OpenSpec task 3.2b and makes duplicated legacy columns non-authoritative before their separate schema removal. Regression coverage deliberately makes legacy copies disagree and verifies that reads and decisions follow the article. The focused server suite, lint, server typecheck, OpenSpec validation, and full build pass.
