### PR TITLE
fix(scrapers): distinguish disabled and manual-only runs

### DIFF
--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -23,9 +23,7 @@ export const CATEGORY_LIST = [
 export const SERVING_STYLE_LIST = ["neat", "rocks", "splash"] as const;
 
 export const EXTERNAL_SITE_DEFINITIONS = {
-  // Disabled: Astor rejects non-browser clients, while Total Wine requires an
-  // interactive human-verification challenge. Keep both registered so their
-  // existing data and scraper implementations remain available for a future fix.
+  // Astor stays manual-only while its non-browser catalog behavior is checked.
   astorwines: { name: "Astor Wines", runEvery: null },
   berrybrosrudd: { name: "Berry Bros. & Rudd", runEvery: 10080 },
   bruichladdich: { name: "Bruichladdich", runEvery: 10080 },
@@ -52,6 +50,8 @@ export const EXTERNAL_SITE_DEFINITIONS = {
     runEvery: 10080,
   },
   thompsonbros: { name: "Thompson Bros.", runEvery: 10080 },
+  // Total Wine requires an interactive human-verification challenge. Its
+  // traffic target remains disabled while existing data stays visible.
   totalwine: { name: "Total Wines", runEvery: null },
   woodencork: { name: "Wooden Cork", runEvery: 10080 },
   whiskyadvocate: {

--- a/apps/server/src/orpc/routes/external-sites/trigger-job.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/trigger-job.test.ts
@@ -71,7 +71,7 @@ describe("POST /external-sites/:site/trigger", () => {
   test("refuses a disabled scraper before creating durable work", async ({
     fixtures,
   }) => {
-    const site = await fixtures.ExternalSiteOrExisting({ type: "astorwines" });
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
     const adminUser = await fixtures.User({ admin: true });
 
     const err = await waitError(
@@ -82,7 +82,7 @@ describe("POST /external-sites/:site/trigger", () => {
     );
 
     expect(err).toMatchInlineSnapshot(
-      `[Error: Scraper target astorwines is disabled.]`,
+      `[Error: Scraper target totalwine is disabled.]`,
     );
     expect(pushJob).not.toHaveBeenCalled();
     await expect(

--- a/apps/server/src/orpc/routes/external-sites/trigger-job.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/trigger-job.test.ts
@@ -1,6 +1,9 @@
+import { db } from "@peated/server/db";
+import { externalSiteRuns } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { pushJob } from "@peated/server/worker/client";
+import { eq } from "drizzle-orm";
 
 vi.mock("@peated/server/worker/client");
 
@@ -63,5 +66,30 @@ describe("POST /external-sites/:site/trigger", () => {
       `[Error: External review source whiskyadvocate is not approved for allowFetching.]`,
     );
     expect(pushJob).not.toHaveBeenCalled();
+  });
+
+  test("refuses a disabled scraper before creating durable work", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting({ type: "astorwines" });
+    const adminUser = await fixtures.User({ admin: true });
+
+    const err = await waitError(
+      routerClient.externalSites.triggerJob(
+        { site: site.type },
+        { context: { user: adminUser } },
+      ),
+    );
+
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Scraper target astorwines is disabled.]`,
+    );
+    expect(pushJob).not.toHaveBeenCalled();
+    await expect(
+      db
+        .select()
+        .from(externalSiteRuns)
+        .where(eq(externalSiteRuns.externalSiteId, site.id)),
+    ).resolves.toHaveLength(0);
   });
 });

--- a/apps/server/src/orpc/routes/external-sites/trigger-job.ts
+++ b/apps/server/src/orpc/routes/external-sites/trigger-job.ts
@@ -10,6 +10,7 @@ import {
   ExternalReviewSourcePolicyError,
   ExternalSiteRunActiveError,
   queueManualExternalSiteRun,
+  ScraperTargetDisabledError,
 } from "@peated/server/scraper";
 import { serialize } from "@peated/server/serializers";
 import { ExternalSiteRunSerializer } from "@peated/server/serializers/externalSite";
@@ -52,7 +53,10 @@ export default procedure
       });
       return serialize(ExternalSiteRunSerializer, run, context.user);
     } catch (error) {
-      if (error instanceof ExternalSiteRunActiveError) {
+      if (
+        error instanceof ExternalSiteRunActiveError ||
+        error instanceof ScraperTargetDisabledError
+      ) {
         throw errors.CONFLICT({ message: error.message, cause: error });
       }
       if (error instanceof ExternalReviewSourcePolicyError) {

--- a/apps/server/src/scraper/definitions.ts
+++ b/apps/server/src/scraper/definitions.ts
@@ -8,6 +8,14 @@ import type {
   ScrapeTargetDefinition,
 } from "./types";
 
+export class ScraperTargetDisabledError extends Error {
+  override name = "ScraperTargetDisabledError";
+
+  constructor(readonly targetKey: string) {
+    super(`Scraper target ${targetKey} is disabled.`);
+  }
+}
+
 export const DEFAULT_SCRAPER_REQUEST_POLICY = Object.freeze({
   minimumSpacingMs: 2_000,
   requestsPerWindow: 300,
@@ -287,4 +295,15 @@ export function findScraperSourceBySiteType(
   return [...registry.sources.values()].find(
     (source) => source.externalSiteType === externalSiteType,
   );
+}
+
+/** Disabled code-owned targets cannot create or execute durable scraper work. */
+export function requireEnabledScraperTargets(
+  registry: ScraperRegistry,
+  source: ScraperSourceDefinition,
+) {
+  for (const targetKey of source.targetKeys) {
+    const target = registry.targets.get(targetKey);
+    if (!target?.enabled) throw new ScraperTargetDisabledError(targetKey);
+  }
 }

--- a/apps/server/src/scraper/index.ts
+++ b/apps/server/src/scraper/index.ts
@@ -6,7 +6,10 @@
  */
 import type { ExternalSite } from "@peated/server/db/schema";
 import type { ExternalSiteType } from "@peated/server/types";
-import { findScraperSourceBySiteType } from "./definitions";
+import {
+  findScraperSourceBySiteType,
+  ScraperTargetDisabledError,
+} from "./definitions";
 import {
   createScraperLifecycle,
   ExternalSiteRunActiveError,
@@ -30,7 +33,11 @@ const lifecycle = createScraperLifecycle({
   enqueue: enqueueScraperRun,
 });
 
-export { ExternalReviewSourcePolicyError, ExternalSiteRunActiveError };
+export {
+  ExternalReviewSourcePolicyError,
+  ExternalSiteRunActiveError,
+  ScraperTargetDisabledError,
+};
 export type { ScraperRunExecutionResult };
 
 export function getScraperRegistration(siteType: ExternalSiteType) {

--- a/apps/server/src/scraper/lifecycle.ts
+++ b/apps/server/src/scraper/lifecycle.ts
@@ -6,7 +6,10 @@ import {
   type ExternalSiteRun,
 } from "@peated/server/db/schema";
 import { and, asc, eq, inArray, isNotNull, isNull, lte, or } from "drizzle-orm";
-import { findScraperSourceBySiteType } from "./definitions";
+import {
+  findScraperSourceBySiteType,
+  requireEnabledScraperTargets,
+} from "./definitions";
 import { requireExternalReviewFetchBeforeQueue } from "./sourcePolicy";
 import type { ScraperRegistry } from "./types";
 
@@ -65,6 +68,7 @@ async function insertRun(
       `External site ${site.type} is not registered with the scraper runtime.`,
     );
   }
+  requireEnabledScraperTargets(registry, source);
   const [run] = await connection
     .insert(externalSiteRuns)
     .values({

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -1,3 +1,4 @@
+import { EXTERNAL_SITE_DEFINITIONS } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import {
   externalSiteRuns,
@@ -63,7 +64,8 @@ test("registers every scraper source with explicit target ownership", () => {
     expect(source.targetKeys).toEqual([source.externalSiteType]);
     expect(scraperRegistry.targets.get(source.targetKeys[0])).toBeDefined();
   }
-  expect(scraperRegistry.targets.get("astorwines")?.enabled).toBe(false);
+  expect(scraperRegistry.targets.get("astorwines")?.enabled).toBe(true);
+  expect(EXTERNAL_SITE_DEFINITIONS.astorwines.runEvery).toBeNull();
   expect(scraperRegistry.targets.get("totalwine")?.enabled).toBe(false);
 });
 

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -54,7 +54,6 @@ const legacyPriceSources = [
   {
     type: "astorwines",
     origin: "https://www.astorwines.com",
-    enabled: false,
     scrape: scrapeAstorWines,
   },
   {

--- a/apps/server/src/scraper/robots.test.ts
+++ b/apps/server/src/scraper/robots.test.ts
@@ -45,9 +45,11 @@ function fixedClock(value = "2026-08-18T12:00:00Z"): ScraperHttpClock {
 async function setupRobotsRuntime({
   mode = "enforce",
   maxRetries = 0,
+  targetEnabled = true,
 }: {
   mode?: "enforce" | "not_applicable";
   maxRetries?: number;
+  targetEnabled?: boolean;
 } = {}) {
   const robots =
     mode === "enforce"
@@ -60,6 +62,7 @@ async function setupRobotsRuntime({
     targets: [
       defineScrapeTarget({
         key: "operator",
+        enabled: targetEnabled,
         maxRetries,
         origins: [{ origin: "https://example.com", robots }],
       }),
@@ -197,6 +200,28 @@ test("defers when robots is unavailable without a fresh decision", async () => {
   });
   const [origin] = await db.select().from(scrapeOrigins);
   expect(origin?.robotsState).toBeNull();
+});
+
+test("does not report a disabled target as unavailable robots", async () => {
+  const { registry, run } = await setupRobotsRuntime({
+    targetEnabled: false,
+  });
+  const fetchImpl = vi.fn<typeof fetch>();
+
+  await expect(
+    ensureRobotsAllowed({
+      runId: run.id,
+      sourceKey: "finedrams",
+      targetKey: "operator",
+      url: new URL("https://example.com/catalog"),
+      registry,
+      fetchImpl,
+      clock: fixedClock(),
+    }),
+  ).rejects.toMatchObject({
+    category: "invalid_request",
+  });
+  expect(fetchImpl).not.toHaveBeenCalled();
 });
 
 test("refreshes expired rules and persists parsed rules rather than content", async () => {

--- a/apps/server/src/scraper/robots.ts
+++ b/apps/server/src/scraper/robots.ts
@@ -12,6 +12,7 @@ import {
   type ScraperHttpClock,
   ScraperHttpStatusError,
   ScraperRequestDeferredError,
+  ScraperRequestError,
 } from "./http";
 import type { ScraperRegistry } from "./types";
 
@@ -215,6 +216,11 @@ export async function ensureRobotsAllowed({
         await writeRobotsCache(url.origin, missing, now);
         state = CachedRobotsRulesSchema.safeParse(missing);
       } else if (error instanceof ScraperRequestDeferredError) {
+        throw error;
+      } else if (
+        error instanceof ScraperRequestError &&
+        error.category === "invalid_request"
+      ) {
         throw error;
       } else {
         throw new ScraperRequestDeferredError(

--- a/apps/server/src/scraper/runs.test.ts
+++ b/apps/server/src/scraper/runs.test.ts
@@ -13,6 +13,7 @@ import {
   createScraperRegistry,
   defineScraperSource,
   defineScrapeTarget,
+  ScraperTargetDisabledError,
 } from "./definitions";
 import type { ScraperHttpClock } from "./http";
 import { ScraperRequestDeferredError } from "./http";
@@ -45,12 +46,14 @@ async function setupRun({
   sink,
   authorize,
   cursor,
+  targetEnabled = true,
 }: {
   requestLimit?: number;
   adapter?: ScraperAdapter<FixtureCursor, FixtureObservation>;
   sink?: ScraperSink<FixtureObservation>;
   authorize?: ScraperAuthorization;
   cursor?: unknown;
+  targetEnabled?: boolean;
 } = {}) {
   const observations = new Map<string, FixtureObservation>();
   const sourceSink: ScraperSink<FixtureObservation> =
@@ -62,6 +65,7 @@ async function setupRun({
     targets: [
       defineScrapeTarget({
         key: "fixture-target",
+        enabled: targetEnabled,
         origins: [
           {
             origin: "https://fixture.invalid",
@@ -147,6 +151,35 @@ test("executes the fixture adapter through request, emit, checkpoint, and comple
     itemCount: 2,
     cursor: { page: 2 },
     executionToken: null,
+  });
+});
+
+test("fails a queued run before adapter execution when its target is disabled", async () => {
+  const adapter = vi.fn<ScraperAdapter<FixtureCursor, FixtureObservation>>();
+  const { registry, run } = await setupRun({
+    adapter,
+    targetEnabled: false,
+  });
+  const fetchImpl = vi.fn<typeof fetch>();
+
+  await expect(
+    executeScraperRun(
+      { runId: run.id },
+      { registry, fetchImpl, clock: fixedClock(), executionToken: "owner" },
+    ),
+  ).rejects.toBeInstanceOf(ScraperTargetDisabledError);
+  expect(adapter).not.toHaveBeenCalled();
+  expect(fetchImpl).not.toHaveBeenCalled();
+
+  const [stored] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, run.id));
+  expect(stored).toMatchObject({
+    status: "failed",
+    attemptCount: 1,
+    requestCount: 0,
+    error: "Scraper target fixture-target is disabled.",
   });
 });
 

--- a/apps/server/src/scraper/runs.ts
+++ b/apps/server/src/scraper/runs.ts
@@ -10,7 +10,11 @@ import { and, eq, inArray, sql } from "drizzle-orm";
 import { randomUUID } from "node:crypto";
 import { z } from "zod";
 import { ScraperCoordinationError } from "./coordinator";
-import { findScraperSourceBySiteType } from "./definitions";
+import {
+  findScraperSourceBySiteType,
+  requireEnabledScraperTargets,
+  ScraperTargetDisabledError,
+} from "./definitions";
 import {
   ScraperHttpStatusError,
   ScraperRequestDeferredError,
@@ -46,6 +50,7 @@ export type ScraperRunExecutionResult =
   | { status: "deferred"; nextAttemptAt: Date };
 
 function safeRunError(error: unknown) {
+  if (error instanceof ScraperTargetDisabledError) return error.message;
   if (error instanceof z.ZodError) return "Scraper data failed validation.";
   if (error instanceof ScraperRobotsDeniedError) {
     return "Robots policy disallows this scraper path.";
@@ -284,6 +289,7 @@ export async function executeScraperRun(
   });
 
   try {
+    requireEnabledScraperTargets(registry, claimed.source);
     const cursor =
       claimed.run.cursor === null
         ? null

--- a/apps/server/src/worker/jobs/scheduleScrapers.test.ts
+++ b/apps/server/src/worker/jobs/scheduleScrapers.test.ts
@@ -1,0 +1,37 @@
+import { db } from "@peated/server/db";
+import { externalSiteRuns } from "@peated/server/db/schema";
+import { pushJob } from "@peated/server/worker/client";
+import { asc } from "drizzle-orm";
+import scheduleScrapers from "./scheduleScrapers";
+
+vi.mock("@peated/server/worker/client");
+
+test("skips disabled targets and schedules other due scrapers", async ({
+  fixtures,
+}) => {
+  const disabledSite = await fixtures.ExternalSite({
+    type: "astorwines",
+    runEvery: 60,
+    nextRunAt: null,
+  });
+  const enabledSite = await fixtures.ExternalSite({
+    type: "decadentdrinks",
+    runEvery: 60,
+    nextRunAt: null,
+  });
+
+  await scheduleScrapers();
+
+  const runs = await db
+    .select()
+    .from(externalSiteRuns)
+    .orderBy(asc(externalSiteRuns.id));
+  expect(runs).toHaveLength(1);
+  expect(runs[0]).toMatchObject({
+    externalSiteId: enabledSite.id,
+    status: "queued",
+    trigger: "scheduled",
+  });
+  expect(runs[0]?.externalSiteId).not.toBe(disabledSite.id);
+  expect(pushJob).toHaveBeenCalledOnce();
+});

--- a/apps/server/src/worker/jobs/scheduleScrapers.test.ts
+++ b/apps/server/src/worker/jobs/scheduleScrapers.test.ts
@@ -10,7 +10,7 @@ test("skips disabled targets and schedules other due scrapers", async ({
   fixtures,
 }) => {
   const disabledSite = await fixtures.ExternalSite({
-    type: "astorwines",
+    type: "totalwine",
     runEvery: 60,
     nextRunAt: null,
   });

--- a/apps/server/src/worker/jobs/scheduleScrapers.ts
+++ b/apps/server/src/worker/jobs/scheduleScrapers.ts
@@ -5,6 +5,7 @@ import {
   ExternalSiteRunActiveError,
   queueScheduledExternalSiteRun,
   redispatchStaleExternalSiteRuns,
+  ScraperTargetDisabledError,
 } from "@peated/server/scraper";
 import { and, isNotNull, isNull, lte, or, sql } from "drizzle-orm";
 
@@ -29,7 +30,8 @@ export default async function scheduleScrapers() {
     } catch (error) {
       if (
         !(error instanceof ExternalSiteRunActiveError) &&
-        !(error instanceof ExternalReviewSourcePolicyError)
+        !(error instanceof ExternalReviewSourcePolicyError) &&
+        !(error instanceof ScraperTargetDisabledError)
       ) {
         throw error;
       }

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
@@ -4,6 +4,7 @@ import type { Outputs } from "@peated/server/orpc/router";
 import { type ExternalSiteType } from "@peated/server/types";
 import ExternalSiteRunStatus from "@peated/web/components/admin/externalSiteRunStatus";
 import ScraperReadiness from "@peated/web/components/admin/scraperReadiness";
+import { getScraperRunAvailability } from "@peated/web/components/admin/scraperRunAvailability";
 import { Breadcrumbs } from "@peated/web/components/breadcrumbs";
 import Button from "@peated/web/components/button";
 import Link from "@peated/web/components/link";
@@ -22,11 +23,7 @@ type Site = Outputs["externalSites"]["healthDetails"];
 
 function TriggerJobButton({ site }: { site: Site }) {
   const [isLoading, setLoading] = useState(false);
-  const unavailableReason = !site.runtime.registered
-    ? "This scraper is not registered with the runtime."
-    : site.reviewPolicy?.allowFetching === false
-      ? "Fetching is blocked by review policy."
-      : null;
+  const availability = getScraperRunAvailability(site);
   const orpc = useORPC();
   const queryClient = useQueryClient();
   const triggerJobMutation = useMutation(
@@ -35,9 +32,9 @@ function TriggerJobButton({ site }: { site: Site }) {
 
   return (
     <Button
-      disabled={isLoading || unavailableReason !== null}
+      disabled={isLoading || availability !== null}
       loading={isLoading}
-      title={unavailableReason ?? undefined}
+      title={availability?.reason}
       onClick={async () => {
         setLoading(true);
         try {
@@ -60,7 +57,7 @@ function TriggerJobButton({ site }: { site: Site }) {
         }
       }}
     >
-      {unavailableReason ? "Run unavailable" : "Run Scraper Now"}
+      {availability?.label ?? "Run Scraper Now"}
     </Button>
   );
 }

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
@@ -144,6 +144,8 @@ export default function Layout(props: {
               <dd className="order-1 text-sm font-bold text-white sm:text-base">
                 {site.nextRunAt ? (
                   <TimeSince date={site.nextRunAt} />
+                ) : site.runEvery !== null ? (
+                  "Due now"
                 ) : (
                   "Not scheduled"
                 )}

--- a/apps/web/src/app/(admin)/admin/(default)/sites/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/page.tsx
@@ -106,8 +106,10 @@ export default function Page() {
               value: (site) =>
                 site.nextRunAt ? (
                   <TimeSince date={site.nextRunAt} />
+                ) : site.runEvery === null ? (
+                  "Manual only"
                 ) : (
-                  <>&mdash;</>
+                  "Due now"
                 ),
             },
           ]}

--- a/apps/web/src/components/admin/externalSiteRunStatus.tsx
+++ b/apps/web/src/components/admin/externalSiteRunStatus.tsx
@@ -13,10 +13,8 @@ export default function ExternalSiteRunStatus({
   compact?: boolean;
 }) {
   const run = site.latestRun;
-  const disabled = site.runEvery === null && run === null;
-  const status = disabled ? "disabled" : (run?.status ?? "never");
+  const status = run?.status ?? "never";
   const labels = {
-    disabled: "Disabled",
     never: "Never recorded",
     queued: "Queued",
     running: "Running",
@@ -24,7 +22,6 @@ export default function ExternalSiteRunStatus({
     failed: "Failed",
   } as const;
   const colors = {
-    disabled: "bg-slate-500",
     never: "bg-slate-500",
     queued: "bg-sky-400",
     running: "bg-amber-400",
@@ -46,7 +43,7 @@ export default function ExternalSiteRunStatus({
           className={classNames("h-2 w-2 rounded-full", colors[status])}
         />
         {labels[status]}
-        {timestamp && !disabled ? (
+        {timestamp ? (
           <span className="text-muted font-normal">
             · <TimeSince date={timestamp} />
           </span>

--- a/apps/web/src/components/admin/scraperObservability.test.tsx
+++ b/apps/web/src/components/admin/scraperObservability.test.tsx
@@ -1,6 +1,7 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
+import ExternalSiteRunStatus from "./externalSiteRunStatus";
 import ExternalSiteRunTelemetry from "./externalSiteRunTelemetry";
 import ScraperCatalogCoverage from "./scraperCatalogCoverage";
 import ScraperReadiness from "./scraperReadiness";
@@ -86,20 +87,27 @@ describe("scraper observability", () => {
     });
   });
 
-  it("allows a synchronized enabled scraper", () => {
-    expect(
-      getScraperRunAvailability({
-        ...site,
-        runtime: {
-          ...site.runtime,
-          targets: site.runtime.targets.map((target) => ({
-            ...target,
-            enabled: true,
-          })),
-        },
-        reviewPolicy: { ...site.reviewPolicy, allowFetching: true },
-      }),
-    ).toBeNull();
+  it("allows a synchronized enabled manual-only scraper", () => {
+    const manualOnlySite = {
+      ...site,
+      runEvery: null,
+      runtime: {
+        ...site.runtime,
+        targets: site.runtime.targets.map((target) => ({
+          ...target,
+          enabled: true,
+        })),
+      },
+      reviewPolicy: { ...site.reviewPolicy, allowFetching: true },
+    };
+
+    expect(getScraperRunAvailability(manualOnlySite)).toBeNull();
+
+    const html = renderToStaticMarkup(
+      <ExternalSiteRunStatus site={manualOnlySite} />,
+    );
+    expect(html).toContain("Never recorded");
+    expect(html).not.toContain("Disabled");
   });
 
   it("shows runtime, robots, and review-policy readiness", () => {

--- a/apps/web/src/components/admin/scraperObservability.test.tsx
+++ b/apps/web/src/components/admin/scraperObservability.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import ExternalSiteRunTelemetry from "./externalSiteRunTelemetry";
 import ScraperCatalogCoverage from "./scraperCatalogCoverage";
 import ScraperReadiness from "./scraperReadiness";
+import { getScraperRunAvailability } from "./scraperRunAvailability";
 
 const timestamp = "2026-08-18T12:00:00.000Z";
 
@@ -78,6 +79,29 @@ const run = {
 } satisfies Outputs["externalSites"]["runs"]["results"][number];
 
 describe("scraper observability", () => {
+  it("explains why a disabled scraper cannot run", () => {
+    expect(getScraperRunAvailability(site)).toEqual({
+      label: "Scraper disabled",
+      reason: "Scraper target whiskyadvocate is disabled.",
+    });
+  });
+
+  it("allows a synchronized enabled scraper", () => {
+    expect(
+      getScraperRunAvailability({
+        ...site,
+        runtime: {
+          ...site.runtime,
+          targets: site.runtime.targets.map((target) => ({
+            ...target,
+            enabled: true,
+          })),
+        },
+        reviewPolicy: { ...site.reviewPolicy, allowFetching: true },
+      }),
+    ).toBeNull();
+  });
+
   it("shows runtime, robots, and review-policy readiness", () => {
     const html = renderToStaticMarkup(<ScraperReadiness site={site} />);
 

--- a/apps/web/src/components/admin/scraperRunAvailability.ts
+++ b/apps/web/src/components/admin/scraperRunAvailability.ts
@@ -1,0 +1,48 @@
+import type { Outputs } from "@peated/server/orpc/router";
+
+type Site = Outputs["externalSites"]["healthDetails"];
+
+type ScraperRunAvailability = {
+  label: string;
+  reason: string;
+};
+
+export function getScraperRunAvailability(
+  site: Site,
+): ScraperRunAvailability | null {
+  if (!site.runtime.registered) {
+    return {
+      label: "Run unavailable",
+      reason: "This scraper is not registered with the runtime.",
+    };
+  }
+
+  const missingTarget = site.runtime.targetKeys.find(
+    (key) => !site.runtime.targets.some((target) => target.key === key),
+  );
+  if (missingTarget) {
+    return {
+      label: "Run unavailable",
+      reason: `Scraper target ${missingTarget} is not synchronized.`,
+    };
+  }
+
+  const disabledTarget = site.runtime.targets.find(
+    (target) => site.runtime.targetKeys.includes(target.key) && !target.enabled,
+  );
+  if (disabledTarget) {
+    return {
+      label: "Scraper disabled",
+      reason: `Scraper target ${disabledTarget.key} is disabled.`,
+    };
+  }
+
+  if (site.reviewPolicy?.allowFetching === false) {
+    return {
+      label: "Run unavailable",
+      reason: "Fetching is blocked by review policy.",
+    };
+  }
+
+  return null;
+}

--- a/docs/research/scraper-source-inventory.md
+++ b/docs/research/scraper-source-inventory.md
@@ -7,7 +7,7 @@ estimate of current live inventory.
 
 | Source             | Exact origin                               | Request and continuation shape                                                                     | Fixture baseline                                                    |
 | ------------------ | ------------------------------------------ | -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
-| Astor Wines        | `https://www.astorwines.com`               | GET HTML, two paginated categories                                                                 | 12 items on listing fixture; target disabled pending policy review  |
+| Astor Wines        | `https://www.astorwines.com`               | GET HTML, two paginated categories                                                                 | 12 items on listing fixture; manual-only                            |
 | Berry Bros. & Rudd | `https://www.bbr.com`                      | GET HTML pages                                                                                     | 3 items                                                             |
 | Bruichladdich      | `https://www.bruichladdich.com`            | GET JSON pages                                                                                     | 4 items; runtime integration persists 4                             |
 | Cadenhead's        | `https://www.cadenhead.shop`               | GET WooCommerce JSON pages                                                                         | 2 items                                                             |

--- a/openspec/changes/fix-disabled-scraper-runs/.openspec.yaml
+++ b/openspec/changes/fix-disabled-scraper-runs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-19

--- a/openspec/changes/fix-disabled-scraper-runs/design.md
+++ b/openspec/changes/fix-disabled-scraper-runs/design.md
@@ -10,10 +10,11 @@ Scraper target enablement is code-owned and synchronized to SQL. Run admission c
 - Refuse new durable work before insertion or queue dispatch.
 - Recheck the policy during execution so queued work cannot bypass a later change.
 - Make the admin action match the factual runtime state.
+- Keep automatic scheduling, run history, and traffic readiness as separate operator concerns.
 
 **Non-Goals:**
 
-- Enabling Astor Wines or bypassing its Cloudflare response.
+- Bypassing Astor Wines' non-browser catalog response.
 - Adding runtime-editable scraper policy.
 - Adding new logging, cancellation, or database fields.
 
@@ -37,8 +38,15 @@ The web client will use the existing registration, synchronized target, target e
 
 Alternative: return a new server-computed availability field. The existing health response already contains the small set of facts needed by this one component.
 
+### Represent Astor Wines as manual-only
+
+Astor Wines will keep its null schedule so the scheduler never creates work for it. Its traffic target will be enabled so an explicit administrator run can acquire a permit, refresh unknown or expired robots rules, and attempt the catalog. The admin run-status label will describe only recorded runs; schedule and traffic readiness remain separate fields.
+
+Alternative: let manual runs bypass disabled targets. That weakens the code-owned no-network guard and adds a second permit policy when the existing schedule field already represents manual-only operation.
+
 ## Risks / Trade-offs
 
 - **A source later treats a declared target as optional** → Current source definitions describe required traffic targets. Introduce optionality only with a proven source requirement.
 - **The UI health snapshot becomes stale after a deploy** → The server-side admission check remains authoritative and returns a conflict.
 - **An existing queued run is delivered after the change** → Worker execution rechecks enablement and stores a terminal disabled-target error before adapter or network work.
+- **Astor still rejects the catalog request** → The manual run reports the remote failure after robots evaluation instead of appearing disabled or waiting on a false robots deferral.

--- a/openspec/changes/fix-disabled-scraper-runs/design.md
+++ b/openspec/changes/fix-disabled-scraper-runs/design.md
@@ -1,0 +1,44 @@
+## Context
+
+Scraper target enablement is code-owned and synchronized to SQL. Run admission currently verifies source registration and review-source authorization, but it does not verify target enablement. A worker discovers the disabled target only while acquiring the first request permit. When that first request is a robots refresh, the robots boundary converts the permanent local denial into a transient `robots_unavailable` deferral.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep disabled-target policy inside the scraper module.
+- Refuse new durable work before insertion or queue dispatch.
+- Recheck the policy during execution so queued work cannot bypass a later change.
+- Make the admin action match the factual runtime state.
+
+**Non-Goals:**
+
+- Enabling Astor Wines or bypassing its Cloudflare response.
+- Adding runtime-editable scraper policy.
+- Adding new logging, cancellation, or database fields.
+
+## Decisions
+
+### Use one typed disabled-target error at scraper boundaries
+
+The definition boundary will validate every target required by a source and raise a typed error containing the target key. Run insertion and worker execution will call the same capability. The API will translate admission failure to a conflict, while worker execution will store the bounded error and fail the run.
+
+Alternative: rely only on the request coordinator. That creates durable work known to be invalid and makes the result depend on which request happens first.
+
+### Preserve permanent request-policy errors during robots refresh
+
+The robots boundary will continue to defer transport and remote failures when it cannot establish fresh rules. It will rethrow an `invalid_request` because that result means the runtime cannot legally issue the request and waiting cannot change it.
+
+Alternative: preflight only target enablement. That fixes the current registry state but leaves synchronization and other permanent request-policy failures mislabeled.
+
+### Derive the admin action from existing health facts
+
+The web client will use the existing registration, synchronized target, target enablement, and review policy fields. It will not add a second API contract or mutable control.
+
+Alternative: return a new server-computed availability field. The existing health response already contains the small set of facts needed by this one component.
+
+## Risks / Trade-offs
+
+- **A source later treats a declared target as optional** → Current source definitions describe required traffic targets. Introduce optionality only with a proven source requirement.
+- **The UI health snapshot becomes stale after a deploy** → The server-side admission check remains authoritative and returns a conflict.
+- **An existing queued run is delivered after the change** → Worker execution rechecks enablement and stores a terminal disabled-target error before adapter or network work.

--- a/openspec/changes/fix-disabled-scraper-runs/proposal.md
+++ b/openspec/changes/fix-disabled-scraper-runs/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The admin action can queue a scraper run whose code-owned traffic target is disabled. The worker then misreports the local denial as unavailable robots rules and silently defers the run without making a request.
+
+## What Changes
+
+- Reject manual and scheduled runs before creating durable work when a required scraper target is disabled.
+- Recheck target enablement in the worker so already-queued runs fail before adapter or network execution.
+- Preserve permanent request-policy failures during robots evaluation instead of converting them to transient robots failures.
+- Disable the admin run action and explain the disabled or unsynchronized target state.
+
+## Capabilities
+
+### New Capabilities
+
+- `scraper-run-availability`: Defines when scraper runs can be admitted or executed and how the admin action presents unavailable runtime state.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Changes scraper lifecycle admission, worker execution, and robots error translation.
+- Changes the administrator scraper detail action.
+- Adds focused server and web regression coverage without changing storage schemas or traffic policy configuration.

--- a/openspec/changes/fix-disabled-scraper-runs/proposal.md
+++ b/openspec/changes/fix-disabled-scraper-runs/proposal.md
@@ -8,6 +8,7 @@ The admin action can queue a scraper run whose code-owned traffic target is disa
 - Recheck target enablement in the worker so already-queued runs fail before adapter or network execution.
 - Preserve permanent request-policy failures during robots evaluation instead of converting them to transient robots failures.
 - Disable the admin run action and explain the disabled or unsynchronized target state.
+- Keep manual-only scheduling distinct from disabled traffic, and allow Astor Wines manual runs to refresh robots state and attempt the scraper.
 
 ## Capabilities
 
@@ -22,5 +23,5 @@ None.
 ## Impact
 
 - Changes scraper lifecycle admission, worker execution, and robots error translation.
-- Changes the administrator scraper detail action.
+- Changes administrator scraper status, schedule, readiness, and run-action presentation.
 - Adds focused server and web regression coverage without changing storage schemas or traffic policy configuration.

--- a/openspec/changes/fix-disabled-scraper-runs/specs/scraper-run-availability/spec.md
+++ b/openspec/changes/fix-disabled-scraper-runs/specs/scraper-run-availability/spec.md
@@ -45,3 +45,22 @@ The administrator scraper detail SHALL make the manual action unavailable when s
 
 - **WHEN** an administrator views a registered source whose required target is absent from synchronized runtime state
 - **THEN** the run action SHALL be disabled and explain that the target is not synchronized
+
+### Requirement: Manual-only scheduling remains runnable
+
+The system MUST treat a null schedule as disabled automatic scheduling, not as disabled scraper traffic or run history.
+
+#### Scenario: Administrator views a manual-only source
+
+- **WHEN** a source has no automatic schedule, has an enabled synchronized target, and has no recorded run
+- **THEN** the admin UI SHALL show a manual-only schedule, show that no run is recorded, and allow the administrator to start a run
+
+#### Scenario: Manual-only run needs robots rules
+
+- **WHEN** an administrator starts a manual-only source with unknown or expired robots state
+- **THEN** the runtime SHALL refresh robots rules through the governed request path before attempting public catalog traffic
+
+#### Scenario: Scheduled source has no next-run timestamp
+
+- **WHEN** a source has an automatic schedule and no next-run timestamp
+- **THEN** the admin UI SHALL identify the source as due now rather than not scheduled

--- a/openspec/changes/fix-disabled-scraper-runs/specs/scraper-run-availability/spec.md
+++ b/openspec/changes/fix-disabled-scraper-runs/specs/scraper-run-availability/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Disabled targets cannot create scraper runs
+
+The system MUST reject a manual or scheduled scraper run before creating durable work when any traffic target required by its source is disabled.
+
+#### Scenario: Administrator triggers a disabled scraper
+
+- **WHEN** an administrator requests a manual run for a source with a disabled target
+- **THEN** the system SHALL return a conflict that identifies the disabled target and SHALL create no run or queue job
+
+#### Scenario: Scheduler finds a disabled scraper due
+
+- **WHEN** scheduling evaluates a source with a disabled target
+- **THEN** the system SHALL create no run or queue job and SHALL continue evaluating other sources
+
+### Requirement: Workers recheck scraper availability
+
+The system MUST recheck code-owned target enablement before adapter or network execution for every claimed run.
+
+#### Scenario: Queued run has a disabled target
+
+- **WHEN** a worker claims an existing run whose required target is disabled
+- **THEN** the run SHALL fail with a bounded disabled-target error without executing the adapter or making a network request
+
+### Requirement: Permanent policy failures are not robots deferrals
+
+The system MUST preserve permanent local request-policy failures encountered while refreshing robots rules.
+
+#### Scenario: Robots refresh cannot obtain a request permit
+
+- **WHEN** a robots refresh is refused because the request is invalid under local runtime policy
+- **THEN** the system SHALL propagate the permanent failure instead of recording `robots_unavailable` or scheduling a retry
+
+### Requirement: Admin run action reflects scraper availability
+
+The administrator scraper detail SHALL make the manual action unavailable when source registration, synchronized target state, target enablement, or required review authorization prevents a run.
+
+#### Scenario: Target is disabled
+
+- **WHEN** an administrator views a source whose required target is disabled
+- **THEN** the run action SHALL be disabled and identify the disabled target
+
+#### Scenario: Target is not synchronized
+
+- **WHEN** an administrator views a registered source whose required target is absent from synchronized runtime state
+- **THEN** the run action SHALL be disabled and explain that the target is not synchronized

--- a/openspec/changes/fix-disabled-scraper-runs/tasks.md
+++ b/openspec/changes/fix-disabled-scraper-runs/tasks.md
@@ -7,8 +7,10 @@
 ## 2. Administrator experience
 
 - [x] 2.1 Disable the manual run action for disabled or unsynchronized targets with a specific explanation
+- [x] 2.2 Configure Astor Wines as manual-only and separate run, schedule, and traffic-readiness labels
 
 ## 3. Regression coverage
 
 - [x] 3.1 Add focused route, scheduler, worker, robots, and web availability tests
 - [x] 3.2 Run targeted tests, typechecks, lint, formatting, and OpenSpec validation
+- [x] 3.3 Add manual-only regression coverage and validate the updated admin behavior

--- a/openspec/changes/fix-disabled-scraper-runs/tasks.md
+++ b/openspec/changes/fix-disabled-scraper-runs/tasks.md
@@ -1,0 +1,14 @@
+## 1. Runtime availability
+
+- [x] 1.1 Reject disabled targets before manual or scheduled run insertion and translate manual rejection at the API boundary
+- [x] 1.2 Recheck target enablement before worker adapter execution and store a bounded terminal error
+- [x] 1.3 Preserve permanent invalid-request failures during robots refresh
+
+## 2. Administrator experience
+
+- [x] 2.1 Disable the manual run action for disabled or unsynchronized targets with a specific explanation
+
+## 3. Regression coverage
+
+- [x] 3.1 Add focused route, scheduler, worker, robots, and web availability tests
+- [x] 3.2 Run targeted tests, typechecks, lint, formatting, and OpenSpec validation


### PR DESCRIPTION
Scraper runs now reject genuinely disabled traffic targets before durable work is created, and workers recheck target availability so older queued work fails without adapter or network execution. Astor Wines is instead configured as manual-only: its automatic schedule remains off, its target is enabled, and an explicit admin run can refresh unknown or expired robots rules before attempting the catalog.

The admin UI now keeps three concerns separate: run history (`Never recorded` or the latest outcome), scheduling (`Manual only`, `Due now`, or the next timestamp), and traffic readiness (`Enabled` or `Disabled`). The root bug was a disabled-target permit failure during robots refresh being converted into a transient robots-unavailable deferral; permanent invalid-request failures now surface while genuine robots transport failures still defer. Focused server and web tests, both typechecks, policy checks, strict OpenSpec validation, and desktop and mobile admin QA pass.
