### PR TITLE
ref(reviews): define article observation contract

### DIFF
--- a/apps/server/src/externalReviews/observation.test.ts
+++ b/apps/server/src/externalReviews/observation.test.ts
@@ -1,0 +1,53 @@
+import { ReviewArticleObservationSchema } from "@peated/server/externalReviews/observation";
+
+function observation() {
+  return {
+    canonicalUrl: "https://reviews.example/articles/spring-releases",
+    title: "Three spring releases reviewed",
+    issue: "Spring 2026",
+    publishedAt: new Date("2026-04-12T12:00:00Z"),
+    contentHash: "sha256:first",
+    reviews: [
+      {
+        sourceKey: "ardbeg-ten",
+        name: "Ardbeg 10-year-old",
+        reviewerName: "A. Reviewer",
+        nativeScore: { value: 7.8, scale: 10, display: "7.8/10" },
+        normalizedRating: 78,
+      },
+      {
+        sourceKey: "lagavulin-special",
+        name: "Lagavulin Special Release",
+      },
+    ],
+  };
+}
+
+test("parses one article with stable scored and unscored reviews", () => {
+  expect(ReviewArticleObservationSchema.parse(observation())).toMatchObject({
+    reviews: [
+      {
+        sourceKey: "ardbeg-ten",
+        normalizedRating: 78,
+      },
+      {
+        sourceKey: "lagavulin-special",
+        reviewerName: null,
+        nativeScore: null,
+        normalizedRating: null,
+      },
+    ],
+  });
+});
+
+test("rejects duplicate review source keys", () => {
+  const input = observation();
+  input.reviews[1] = {
+    ...input.reviews[0],
+    name: "Another bottle",
+  };
+
+  expect(() => ReviewArticleObservationSchema.parse(input)).toThrow(
+    "Review source keys must be unique within an article.",
+  );
+});

--- a/apps/server/src/externalReviews/observation.ts
+++ b/apps/server/src/externalReviews/observation.ts
@@ -1,0 +1,49 @@
+import { NativeScoreSchema } from "@peated/server/schemas";
+import { z } from "zod";
+
+const ReviewSchema = z
+  .object({
+    sourceKey: z.string().trim().min(1).max(255),
+    name: z.string().trim().min(1).max(500),
+    reviewerName: z.string().trim().min(1).max(255).nullable().default(null),
+    nativeScore: NativeScoreSchema.nullable().default(null),
+    normalizedRating: z.number().int().min(0).max(100).nullable().default(null),
+  })
+  .strict();
+
+/**
+ * Source adapters emit this strict article shape. Each review source key must
+ * remain stable across runs; array position alone is not a stable key.
+ */
+export const ReviewArticleObservationSchema = z
+  .object({
+    canonicalUrl: z
+      .url()
+      .refine(
+        (value) => ["http:", "https:"].includes(new URL(value).protocol),
+        { message: "Canonical URL must use HTTP or HTTPS." },
+      ),
+    title: z.string().trim().min(1).max(1000),
+    issue: z.string().trim().min(1).max(255).nullable().default(null),
+    publishedAt: z.date().nullable().default(null),
+    contentHash: z.string().trim().min(1).max(128),
+    reviews: z.array(ReviewSchema).min(1),
+  })
+  .strict()
+  .superRefine(({ reviews }, context) => {
+    const sourceKeys = new Set<string>();
+    for (const [index, review] of reviews.entries()) {
+      if (sourceKeys.has(review.sourceKey)) {
+        context.addIssue({
+          code: "custom",
+          message: "Review source keys must be unique within an article.",
+          path: ["reviews", index, "sourceKey"],
+        });
+      }
+      sourceKeys.add(review.sourceKey);
+    }
+  });
+
+export type ReviewArticleObservation = z.infer<
+  typeof ReviewArticleObservationSchema
+>;

--- a/apps/server/src/externalReviews/store.ts
+++ b/apps/server/src/externalReviews/store.ts
@@ -1,50 +1,13 @@
 import { db } from "@peated/server/db";
 import { reviewArticles, reviews } from "@peated/server/db/schema";
-import { NativeScoreSchema } from "@peated/server/schemas";
+import { ReviewArticleObservationSchema } from "@peated/server/externalReviews/observation";
 import { sql } from "drizzle-orm";
 import { z } from "zod";
 
-const ArticleReviewSchema = z
-  .object({
-    sourceKey: z.string().trim().min(1).max(255),
-    name: z.string().trim().min(1).max(500),
-    reviewerName: z.string().trim().min(1).max(255).nullable().default(null),
-    nativeScore: NativeScoreSchema.nullable().default(null),
-    normalizedRating: z.number().int().min(0).max(100).nullable().default(null),
-  })
-  .strict();
-
-export const ReviewArticleInputSchema = z
-  .object({
+export const ReviewArticleInputSchema =
+  ReviewArticleObservationSchema.safeExtend({
     externalSiteId: z.number().int().positive(),
-    canonicalUrl: z
-      .url()
-      .refine(
-        (value) => ["http:", "https:"].includes(new URL(value).protocol),
-        {
-          message: "Canonical URL must use HTTP or HTTPS.",
-        },
-      ),
-    title: z.string().trim().min(1).max(1000),
-    issue: z.string().trim().min(1).max(255).nullable().default(null),
-    publishedAt: z.date().nullable().default(null),
-    contentHash: z.string().trim().min(1).max(128),
     fetchedAt: z.date(),
-    reviews: z.array(ArticleReviewSchema).min(1),
-  })
-  .strict()
-  .superRefine(({ reviews }, context) => {
-    const sourceKeys = new Set<string>();
-    for (const [index, review] of reviews.entries()) {
-      if (sourceKeys.has(review.sourceKey)) {
-        context.addIssue({
-          code: "custom",
-          message: "Review source keys must be unique within an article.",
-          path: ["reviews", index, "sourceKey"],
-        });
-      }
-      sourceKeys.add(review.sourceKey);
-    }
   });
 
 /**

--- a/openspec/changes/pilot-external-review-indexing/tasks.md
+++ b/openspec/changes/pilot-external-review-indexing/tasks.md
@@ -41,7 +41,7 @@
 
 ## 4. Extraction And Summary Boundary
 
-- [ ] 4.1 Define the narrow source-adapter output contract for article metadata
+- [x] 4.1 Define the narrow source-adapter output contract for article metadata
       and stable reviews
 - [ ] 4.2 Reuse external-review Bottle resolution for every review and keep
       unresolved or invalid Bottle assignments hidden


### PR DESCRIPTION
External review sources now share one strict article observation schema for canonical article metadata and independently keyed reviews. The existing review store extends the same schema with runtime-owned site and fetch fields, so adapter output and persistence validation stay aligned while duplicate per-article source keys are rejected before writes.

This is a contract-only change. It does not register a publisher, fetch new content, or change review visibility.
