### PR TITLE
feat(reviews): resolve Bottles during article ingestion

### DIFF
--- a/apps/server/src/externalReviews/ingest.test.ts
+++ b/apps/server/src/externalReviews/ingest.test.ts
@@ -1,0 +1,137 @@
+import { db } from "@peated/server/db";
+import { bottleTombstones, reviews } from "@peated/server/db/schema";
+import { ingestReviewArticle } from "@peated/server/externalReviews/ingest";
+import { asc, eq } from "drizzle-orm";
+import { beforeEach, expect, test, vi } from "vitest";
+
+const resolveBottleMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@peated/server/lib/bottleReferenceResolution", () => ({
+  resolveScrapedBottleReferenceTarget: resolveBottleMock,
+}));
+
+function resolution(bottleId: number | null) {
+  return {
+    assignment:
+      bottleId === null ? null : { kind: "direct_bottle" as const, bottleId },
+    source: bottleId === null ? "unresolved" : "classifier_match",
+    error: null,
+    confidence: null,
+    model: null,
+    rationale: null,
+    classifierEvidence: null,
+    createdBottle: false,
+  };
+}
+
+beforeEach(() => {
+  resolveBottleMock.mockReset();
+});
+
+test("rejects a missing source before Bottle resolution", async () => {
+  const externalSiteId = 2_147_483_647;
+
+  await expect(
+    ingestReviewArticle({
+      externalSiteId,
+      fetchedAt: new Date("2026-04-13T12:00:00Z"),
+      article: {
+        canonicalUrl: "https://reviews.example/articles/missing-source",
+        title: "Missing source review",
+        contentHash: "sha256:missing-source",
+        reviews: [{ sourceKey: "review", name: "Review Bottle" }],
+      },
+    }),
+  ).rejects.toThrow(`External site ${externalSiteId} not found.`);
+  expect(resolveBottleMock).not.toHaveBeenCalled();
+});
+
+test("resolves each review and hides unresolved or invalid assignments", async ({
+  fixtures,
+}) => {
+  const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
+  const bottle = await fixtures.Bottle({ name: "Resolved Review Bottle" });
+  const missingBottleId = 2_147_483_647;
+  resolveBottleMock
+    .mockResolvedValueOnce(resolution(bottle.id))
+    .mockResolvedValueOnce(resolution(null))
+    .mockResolvedValueOnce(resolution(missingBottleId));
+
+  await ingestReviewArticle({
+    externalSiteId: site.id,
+    fetchedAt: new Date("2026-04-13T12:00:00Z"),
+    article: {
+      canonicalUrl: "https://reviews.example/articles/spring-releases",
+      title: "Three spring releases reviewed",
+      contentHash: "sha256:first",
+      reviews: [
+        { sourceKey: "resolved", name: bottle.fullName },
+        { sourceKey: "unresolved", name: "Unknown Review Bottle" },
+        { sourceKey: "invalid", name: "Missing Review Bottle" },
+      ],
+    },
+  });
+
+  expect(resolveBottleMock).toHaveBeenCalledTimes(3);
+  expect(
+    await db.select().from(reviews).orderBy(asc(reviews.sourceKey)),
+  ).toMatchObject([
+    {
+      sourceKey: "invalid",
+      bottleId: null,
+      hidden: true,
+    },
+    {
+      sourceKey: "resolved",
+      bottleId: bottle.id,
+      hidden: true,
+    },
+    {
+      sourceKey: "unresolved",
+      bottleId: null,
+      hidden: true,
+    },
+  ]);
+});
+
+test("hides an existing review when its resolved Bottle is retired", async ({
+  fixtures,
+}) => {
+  const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
+  const bottle = await fixtures.Bottle({ name: "Retired Review Bottle" });
+  const replacement = await fixtures.Bottle({
+    name: "Replacement Review Bottle",
+  });
+  resolveBottleMock.mockResolvedValue(resolution(bottle.id));
+  const input = {
+    externalSiteId: site.id,
+    fetchedAt: new Date("2026-04-13T12:00:00Z"),
+    article: {
+      canonicalUrl: "https://reviews.example/articles/retired-bottle",
+      title: "A retired Bottle review",
+      contentHash: "sha256:retired",
+      reviews: [{ sourceKey: "retired", name: bottle.fullName }],
+    },
+  };
+
+  await ingestReviewArticle(input);
+  await db
+    .update(reviews)
+    .set({ hidden: false })
+    .where(eq(reviews.sourceKey, "retired"));
+  await db.insert(bottleTombstones).values({
+    bottleId: bottle.id,
+    newBottleId: replacement.id,
+  });
+
+  await ingestReviewArticle(input);
+
+  expect(
+    await db.query.reviews.findFirst({
+      where: eq(reviews.sourceKey, "retired"),
+    }),
+  ).toMatchObject({
+    bottleId: bottle.id,
+    hidden: true,
+  });
+});

--- a/apps/server/src/externalReviews/ingest.ts
+++ b/apps/server/src/externalReviews/ingest.ts
@@ -1,0 +1,73 @@
+import {
+  normalizeBottle,
+  normalizeBottleAliasKey,
+} from "@peated/bottle-classifier/normalize";
+import { db } from "@peated/server/db";
+import { externalSites } from "@peated/server/db/schema";
+import { ReviewArticleObservationSchema } from "@peated/server/externalReviews/observation";
+import { storeReviewArticle } from "@peated/server/externalReviews/store";
+import { getPeatedSystemActor } from "@peated/server/lib/actors";
+import { resolveScrapedBottleReferenceTarget } from "@peated/server/lib/bottleReferenceResolution";
+import { logError } from "@peated/server/lib/log";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+
+const InputSchema = z
+  .object({
+    externalSiteId: z.number().int().positive(),
+    fetchedAt: z.date(),
+    article: ReviewArticleObservationSchema,
+  })
+  .strict();
+
+/** Resolves each review to a Bottle, then stores the article with hidden reviews. */
+export async function ingestReviewArticle(rawInput: unknown) {
+  const input = InputSchema.parse(rawInput);
+  const site = await db.query.externalSites.findFirst({
+    columns: { id: true },
+    where: eq(externalSites.id, input.externalSiteId),
+  });
+  if (!site)
+    throw new Error(`External site ${input.externalSiteId} not found.`);
+
+  const actor = await getPeatedSystemActor();
+  const resolvedReviews = [];
+
+  for (const review of input.article.reviews) {
+    const rawName = review.name;
+    const { name } = normalizeBottle({ name: rawName });
+    const aliasKey = normalizeBottleAliasKey(rawName);
+    const resolution = await resolveScrapedBottleReferenceTarget({
+      reference: {
+        externalSiteId: input.externalSiteId,
+        name: rawName,
+        url: input.article.canonicalUrl,
+        imageUrl: null,
+        currentBottleId: null,
+      },
+      aliasLookupNames: [aliasKey, rawName],
+      createdByActorId: actor.id,
+    });
+    if (resolution.error) {
+      logError(resolution.error, {
+        review: {
+          externalSiteId: input.externalSiteId,
+          name: rawName,
+          url: input.article.canonicalUrl,
+        },
+      });
+    }
+    resolvedReviews.push({
+      ...review,
+      name,
+      bottleId: resolution.assignment?.bottleId ?? null,
+    });
+  }
+
+  return await storeReviewArticle({
+    externalSiteId: input.externalSiteId,
+    fetchedAt: input.fetchedAt,
+    ...input.article,
+    reviews: resolvedReviews,
+  });
+}

--- a/apps/server/src/externalReviews/observation.ts
+++ b/apps/server/src/externalReviews/observation.ts
@@ -1,7 +1,7 @@
 import { NativeScoreSchema } from "@peated/server/schemas";
 import { z } from "zod";
 
-const ReviewSchema = z
+export const ReviewArticleReviewSchema = z
   .object({
     sourceKey: z.string().trim().min(1).max(255),
     name: z.string().trim().min(1).max(500),
@@ -27,7 +27,7 @@ export const ReviewArticleObservationSchema = z
     issue: z.string().trim().min(1).max(255).nullable().default(null),
     publishedAt: z.date().nullable().default(null),
     contentHash: z.string().trim().min(1).max(128),
-    reviews: z.array(ReviewSchema).min(1),
+    reviews: z.array(ReviewArticleReviewSchema).min(1),
   })
   .strict()
   .superRefine(({ reviews }, context) => {

--- a/apps/server/src/externalReviews/store.ts
+++ b/apps/server/src/externalReviews/store.ts
@@ -1,19 +1,31 @@
 import { db } from "@peated/server/db";
 import { reviewArticles, reviews } from "@peated/server/db/schema";
-import { ReviewArticleObservationSchema } from "@peated/server/externalReviews/observation";
+import {
+  ReviewArticleObservationSchema,
+  ReviewArticleReviewSchema,
+} from "@peated/server/externalReviews/observation";
+import {
+  ActiveBottleSelectionError,
+  resolveActiveBottleIds,
+} from "@peated/server/lib/resolveActiveBottleIds";
 import { sql } from "drizzle-orm";
 import { z } from "zod";
+
+const StoredReviewSchema = ReviewArticleReviewSchema.safeExtend({
+  bottleId: z.number().int().positive().nullable().default(null),
+});
 
 export const ReviewArticleInputSchema =
   ReviewArticleObservationSchema.safeExtend({
     externalSiteId: z.number().int().positive(),
     fetchedAt: z.date(),
+    reviews: z.array(StoredReviewSchema).min(1),
   });
 
 /**
- * Owns durable external-review metadata. The strict input deliberately excludes
- * publisher bodies, HTML, tasting notes, conclusions, and images; callers must
- * discard those transient values before crossing this boundary.
+ * Stores external review metadata. The input excludes full review text, HTML,
+ * tasting notes, conclusions, and images. Callers must discard those values
+ * before they call this function.
  */
 export async function storeReviewArticle(rawInput: unknown) {
   const input = ReviewArticleInputSchema.parse(rawInput);
@@ -45,12 +57,35 @@ export async function storeReviewArticle(rawInput: unknown) {
 
     if (!article) throw new Error("Unable to store review article.");
 
+    // Match createExternalReview lock order: article, Bottles, then reviews.
+    const invalidBottleIds = new Set<number>();
+    const bottleIds = [
+      ...new Set(
+        input.reviews.flatMap(({ bottleId }) =>
+          bottleId === null ? [] : [bottleId],
+        ),
+      ),
+    ].sort((left, right) => left - right);
+    for (const bottleId of bottleIds) {
+      try {
+        await resolveActiveBottleIds(tx, [bottleId], { lock: "update" });
+      } catch (error) {
+        if (!(error instanceof ActiveBottleSelectionError)) throw error;
+        invalidBottleIds.add(bottleId);
+      }
+    }
+
     const reviewIds: number[] = [];
     for (const review of input.reviews) {
+      const hasInvalidBottle =
+        review.bottleId !== null && invalidBottleIds.has(review.bottleId);
+      const bottleId =
+        review.bottleId !== null && !hasInvalidBottle ? review.bottleId : null;
       const [stored] = await tx
         .insert(reviews)
         .values({
           articleId: article.id,
+          bottleId,
           sourceKey: review.sourceKey,
           name: review.name,
           reviewerName: review.reviewerName,
@@ -63,12 +98,28 @@ export async function storeReviewArticle(rawInput: unknown) {
         .onConflictDoUpdate({
           target: [reviews.articleId, reviews.sourceKey],
           set: {
+            bottleId: sql`CASE
+              WHEN excluded.bottle_id IS NOT NULL
+                AND (${reviews.bottleId} IS NULL OR ${reviews.bottleId} = excluded.bottle_id)
+              THEN excluded.bottle_id
+              ELSE ${reviews.bottleId}
+            END`,
             name: review.name,
             reviewerName: review.reviewerName,
             nativeScoreValue: review.nativeScore?.value ?? null,
             nativeScoreScale: review.nativeScore?.scale ?? null,
             nativeScoreDisplay: review.nativeScore?.display ?? null,
             rating: review.normalizedRating,
+            ...(hasInvalidBottle
+              ? {
+                  hidden: sql`CASE
+                    WHEN ${reviews.bottleId} IS NULL
+                      OR ${reviews.bottleId} = ${review.bottleId}
+                    THEN TRUE
+                    ELSE ${reviews.hidden}
+                  END`,
+                }
+              : {}),
             updatedAt: sql`NOW()`,
           },
         })

--- a/openspec/changes/pilot-external-review-indexing/tasks.md
+++ b/openspec/changes/pilot-external-review-indexing/tasks.md
@@ -43,7 +43,7 @@
 
 - [x] 4.1 Define the narrow source-adapter output contract for article metadata
       and stable reviews
-- [ ] 4.2 Reuse external-review Bottle resolution for every review and keep
+- [x] 4.2 Reuse external-review Bottle resolution for each review and keep
       unresolved or invalid Bottle assignments hidden
 - [ ] 4.3 Add transient summary generation with a constrained two- or
       three-sentence prompt, content hash, model, prompt version, and generation


### PR DESCRIPTION
External review ingestion now resolves each article review through the existing Bottle reference workflow before storage. Resolved reviews keep their active Bottle assignment, while unresolved or invalid assignments stay hidden.

Storage validates Bottle state under the existing lock order. Re-ingestion can fill a missing assignment, preserves a different valid manual assignment, and hides a visible review if its assigned Bottle is later retired.
