### PR TITLE
fix(prices): allow concurrent alias assignments to converge

### DIFF
--- a/apps/server/src/lib/bottleAliases.test.ts
+++ b/apps/server/src/lib/bottleAliases.test.ts
@@ -320,10 +320,16 @@ describe("assignBottleAliasInTransaction", () => {
     ).toBeUndefined();
   });
 
-  test("rolls back when source alias Bottle, name, or ignored state changes", async ({
+  test("rolls back when a distinct source alias identity changes", async ({
     fixtures,
   }) => {
-    for (const field of ["bottleId", "name", "ignored"] as const) {
+    for (const field of [
+      "bottleId",
+      "name",
+      "ignored",
+      "assignmentSource",
+      "assignedByActorId",
+    ] as const) {
       const bottle = await fixtures.Bottle();
       const concurrent = await fixtures.Bottle();
       const source = await fixtures.BottleAlias({
@@ -340,10 +346,20 @@ describe("assignBottleAliasInTransaction", () => {
           .update(bottleAliases)
           .set({ name: `${source.name} changed` })
           .where(eq(bottleAliases.name, source.name));
-      } else {
+      } else if (field === "ignored") {
         await db
           .update(bottleAliases)
           .set({ ignored: !source.ignored })
+          .where(eq(bottleAliases.name, source.name));
+      } else if (field === "assignmentSource") {
+        await db
+          .update(bottleAliases)
+          .set({ assignmentSource: "human_approved" })
+          .where(eq(bottleAliases.name, source.name));
+      } else {
+        await db
+          .update(bottleAliases)
+          .set({ assignedByActorId: concurrent.createdByActorId })
           .where(eq(bottleAliases.name, source.name));
       }
 
@@ -364,6 +380,39 @@ describe("assignBottleAliasInTransaction", () => {
         }),
       ).toBeUndefined();
     }
+  });
+
+  test("allows concurrent assignments that converge on the same alias identity", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const source = await fixtures.BottleAlias({
+      name: "Concurrent Source Alias",
+      bottleId: bottle.id,
+      assignmentSource: "source_approved",
+    });
+    expect(source.assignedByActorId).not.toBe(bottle.createdByActorId);
+
+    const results = await Promise.all(
+      [1, 2].map(() =>
+        db.transaction((tx) =>
+          assignBottleAliasInTransaction(tx, {
+            bottleId: bottle.id,
+            name: source.name,
+            assignmentSource: "source_approved",
+            assignedByActorId: bottle.createdByActorId,
+            sourceAliasIdentity: source,
+          }),
+        ),
+      ),
+    );
+
+    expect(results).toHaveLength(2);
+    expect(await getAlias(source.name)).toMatchObject({
+      bottleId: bottle.id,
+      assignmentSource: "source_approved",
+      assignedByActorId: bottle.createdByActorId,
+    });
   });
 
   test("allows one winner when Bottles race to claim the same alias", async ({

--- a/apps/server/src/lib/bottleAliases.ts
+++ b/apps/server/src/lib/bottleAliases.ts
@@ -189,18 +189,30 @@ function getAssignmentUpdateValues(options: BottleAliasAssignmentValues) {
   };
 }
 
-/** Rejects a stale lookup precondition against an alias locked by its caller. */
+function bottleAliasIdentityMatches(
+  alias: BottleAliasIdentitySnapshot,
+  snapshot: BottleAliasIdentitySnapshot,
+) {
+  return (
+    alias.name === snapshot.name &&
+    alias.bottleId === snapshot.bottleId &&
+    alias.ignored === snapshot.ignored &&
+    alias.assignmentSource === snapshot.assignmentSource &&
+    alias.assignedByActorId === snapshot.assignedByActorId
+  );
+}
+
+/** Rejects a stale lookup unless a concurrent assignment already converged. */
 function assertBottleAliasIdentitySnapshot(
   lockedAlias: BottleAliasIdentitySnapshot | undefined,
   snapshot: BottleAliasIdentitySnapshot,
+  convergedSnapshot?: BottleAliasIdentitySnapshot,
 ): asserts lockedAlias is BottleAliasIdentitySnapshot {
   if (
     !lockedAlias ||
-    lockedAlias.name !== snapshot.name ||
-    lockedAlias.bottleId !== snapshot.bottleId ||
-    lockedAlias.ignored !== snapshot.ignored ||
-    lockedAlias.assignmentSource !== snapshot.assignmentSource ||
-    lockedAlias.assignedByActorId !== snapshot.assignedByActorId
+    (!bottleAliasIdentityMatches(lockedAlias, snapshot) &&
+      (!convergedSnapshot ||
+        !bottleAliasIdentityMatches(lockedAlias, convergedSnapshot)))
   ) {
     throw new BottleAliasIdentityChangedError(snapshot.name);
   }
@@ -300,7 +312,21 @@ async function claimBottleAliasNameInTransaction(
       .for("update");
 
     if (expectedIdentity) {
-      assertBottleAliasIdentitySnapshot(existingAlias, expectedIdentity);
+      const convergedIdentity: BottleAliasIdentitySnapshot = {
+        name,
+        bottleId,
+        ignored:
+          reservation || expectedIdentity.bottleId === null
+            ? (ignored ?? false)
+            : expectedIdentity.ignored,
+        assignmentSource: assignmentSource ?? expectedIdentity.assignmentSource,
+        assignedByActorId,
+      };
+      assertBottleAliasIdentitySnapshot(
+        existingAlias,
+        expectedIdentity,
+        convergedIdentity,
+      );
     }
 
     if (!existingAlias) {


### PR DESCRIPTION
Concurrent scraper listings can now reuse an alias when another transaction already wrote the exact Bottle identity, provenance, and actor that the current transaction intended to write. This prevents repeated listings in one scrape batch from raising a stale alias error while preserving rejection for conflicting Bottle, name, ignored-state, provenance, or actor changes.

The regression coverage reproduces the same-Bottle assignment race and verifies that unrelated source alias identity changes still roll back.

Fixes PEATED-4CW.
