### PR TITLE
fix(scrapers): reduce hourly request limit

### DIFF
--- a/apps/server/src/scraper/definitions.test.ts
+++ b/apps/server/src/scraper/definitions.test.ts
@@ -34,7 +34,7 @@ test("applies conservative target and run defaults", () => {
   expect(target).toMatchObject({
     enabled: true,
     minimumSpacingMs: 2_000,
-    requestsPerWindow: 300,
+    requestsPerWindow: 60,
     windowMs: 3_600_000,
     timeoutMs: 30_000,
     maxResponseBytes: 10 * 1024 * 1024,

--- a/apps/server/src/scraper/definitions.ts
+++ b/apps/server/src/scraper/definitions.ts
@@ -18,7 +18,7 @@ export class ScraperTargetDisabledError extends Error {
 
 export const DEFAULT_SCRAPER_REQUEST_POLICY = Object.freeze({
   minimumSpacingMs: 2_000,
-  requestsPerWindow: 300,
+  requestsPerWindow: 60,
   windowMs: 60 * 60_000,
   requestLimit: 100,
   timeoutMs: 30_000,

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -552,7 +552,7 @@ export const priceSite = {
         blockedUntil: null,
         coolingDown: false,
         minimumSpacingMs: 2_000,
-        requestsPerWindow: 300,
+        requestsPerWindow: 60,
         windowMs: 3_600_000,
         origins: [
           {


### PR DESCRIPTION
Scraper targets now default to 60 requests per hour instead of 300, reducing the maximum request volume by 80%. Definition coverage and the admin E2E fixture use the same limit, and the existing definition sync will apply it to registered targets while preserving stricter target policies.
