### PR TITLE
fix(server): enforce generated bottle tag contract

### DIFF
--- a/apps/server/src/lib/bottleSchemas.ts
+++ b/apps/server/src/lib/bottleSchemas.ts
@@ -5,6 +5,8 @@
 import { BottleInputSchema } from "@peated/server/schemas";
 import { z } from "zod";
 
+export const MAX_BOTTLE_SUGGESTED_TAGS = 5;
+
 const BottleGroupFieldsSchema = BottleInputSchema.pick({
   name: true,
   statedAge: true,
@@ -165,7 +167,10 @@ const BottlePatchFieldsSchema = z
       .optional(),
     image: BottleInputSchema.shape.image.optional(),
     tastingNotes: BottleInputSchema.shape.tastingNotes.optional(),
-    suggestedTags: z.array(z.string().max(64)).max(5).optional(),
+    suggestedTags: z
+      .array(z.string().max(64))
+      .max(MAX_BOTTLE_SUGGESTED_TAGS)
+      .optional(),
   })
   .strict();
 

--- a/apps/server/src/lib/openai.test.ts
+++ b/apps/server/src/lib/openai.test.ts
@@ -5,6 +5,7 @@ import { OpenAIBottleDetailsValidationSchema } from "../worker/jobs/generateBott
 import { OpenAICountryDetailsSchema } from "../worker/jobs/generateCountryDetails";
 import { OpenAIEntityDetailsValidationSchema } from "../worker/jobs/generateEntityDetails";
 import { OpenAIRegionDetailsSchema } from "../worker/jobs/generateRegionDetails";
+import { MAX_BOTTLE_SUGGESTED_TAGS } from "./bottleSchemas";
 import { buildStructuredResponseSpanContext } from "./openai";
 
 test("uses GenAI workflow semantics for structured responses", () => {
@@ -64,5 +65,19 @@ describe("openai structured output schemas", () => {
         (schema) => schema.format === "uri",
       ),
     ).toBe(false);
+  });
+
+  test("limits generated bottle tags to the storage contract", () => {
+    const jsonSchema = z.toJSONSchema(
+      OpenAIBottleDetailsValidationSchema,
+    ) as unknown as {
+      properties?: {
+        suggestedTags?: { maxItems?: number };
+      };
+    };
+
+    expect(jsonSchema.properties?.suggestedTags?.maxItems).toBe(
+      MAX_BOTTLE_SUGGESTED_TAGS,
+    );
   });
 });

--- a/apps/server/src/orpc/routes/ai/bottle-lookup.test.ts
+++ b/apps/server/src/orpc/routes/ai/bottle-lookup.test.ts
@@ -1,0 +1,35 @@
+import { getStructuredResponse } from "@peated/server/lib/openai";
+import { routerClient } from "@peated/server/orpc/router";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+vi.mock("@peated/server/lib/openai", () => ({
+  getStructuredResponse: vi.fn(),
+}));
+
+describe("POST /ai/bottle-lookup", () => {
+  beforeEach(() => {
+    vi.mocked(getStructuredResponse).mockReset();
+  });
+
+  test("returns only generated tags from the allowed tag list", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const smoke = await fixtures.Tag({ name: "smoke" });
+    const fruit = await fixtures.Tag({ name: "fruit" });
+    vi.mocked(getStructuredResponse).mockResolvedValue({
+      description: "Generated description",
+      tastingNotes: null,
+      category: "single_malt",
+      suggestedTags: [smoke.name, "unsupported", fruit.name],
+      flavorProfile: "peated",
+    });
+
+    const result = await routerClient.ai.bottleLookup(
+      { name: "Generated Tag Example" },
+      { context: { user } },
+    );
+
+    expect(result.suggestedTags).toEqual(["smoke", "fruit"]);
+  });
+});

--- a/apps/server/src/orpc/routes/ai/bottle-lookup.ts
+++ b/apps/server/src/orpc/routes/ai/bottle-lookup.ts
@@ -1,4 +1,4 @@
-import { db } from "@peated/server/db";
+import { MAX_BOTTLE_SUGGESTED_TAGS } from "@peated/server/lib/bottleSchemas";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
 import { BottleInputSchema } from "@peated/server/schemas";
@@ -18,7 +18,7 @@ const OutputSchema = z.object({
       finish: z.string().nullish(),
     })
     .nullish(),
-  suggestedTags: z.array(z.string()).nullish(),
+  suggestedTags: z.array(z.string()).max(MAX_BOTTLE_SUGGESTED_TAGS).nullish(),
 });
 
 export default procedure
@@ -34,10 +34,7 @@ export default procedure
   .input(InputSchema)
   .output(OutputSchema)
   .handler(async function ({ input }) {
-    const tagList = (
-      await db.query.tags.findMany({ columns: { name: true } })
-    ).map(({ name }) => name);
-    const result = await getGeneratedBottleDetails(input, tagList);
+    const result = await getGeneratedBottleDetails(input);
     return {
       description: result?.description,
       category: result?.category,

--- a/apps/server/src/orpc/routes/ai/bottle-lookup.ts
+++ b/apps/server/src/orpc/routes/ai/bottle-lookup.ts
@@ -1,5 +1,5 @@
+import { db } from "@peated/server/db";
 import { procedure } from "@peated/server/orpc";
-import type { Context } from "@peated/server/orpc/context";
 import { requireMod } from "@peated/server/orpc/middleware";
 import { BottleInputSchema } from "@peated/server/schemas";
 import { getGeneratedBottleDetails } from "@peated/server/worker/jobs/generateBottleDetails";
@@ -34,7 +34,10 @@ export default procedure
   .input(InputSchema)
   .output(OutputSchema)
   .handler(async function ({ input }) {
-    const result = await getGeneratedBottleDetails(input, []);
+    const tagList = (
+      await db.query.tags.findMany({ columns: { name: true } })
+    ).map(({ name }) => name);
+    const result = await getGeneratedBottleDetails(input, tagList);
     return {
       description: result?.description,
       category: result?.category,

--- a/apps/server/src/worker/jobs/generateBottleDetails.test.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.test.ts
@@ -94,18 +94,42 @@ beforeEach(() => {
   vi.mocked(workerClient.pushUniqueJob).mockClear();
 });
 
-test("filters generated tags to the allowed tag list", async () => {
+test("normalizes generated tags to the catalog and storage limit", async ({
+  fixtures,
+}) => {
+  for (const name of ["smoke", "fruit", "oak", "vanilla", "citrus", "malt"]) {
+    await fixtures.Tag({ name });
+  }
   vi.mocked(getStructuredResponse).mockResolvedValue({
     ...generatedDetails(),
-    suggestedTags: ["smoke", "unsupported", "fruit"],
+    suggestedTags: [
+      "smoke",
+      "unsupported",
+      "smoke",
+      "fruit",
+      "oak",
+      "vanilla",
+      "citrus",
+      "malt",
+    ],
   });
 
   await expect(
-    getGeneratedBottleDetails({ id: 1, fullName: "Generated Tag Example" }, [
-      "smoke",
-      "fruit",
-    ]),
-  ).resolves.toMatchObject({ suggestedTags: ["smoke", "fruit"] });
+    getGeneratedBottleDetails({ id: 1, fullName: "Generated Tag Example" }),
+  ).resolves.toMatchObject({
+    suggestedTags: ["smoke", "fruit", "oak", "vanilla", "citrus"],
+  });
+});
+
+test("returns no generated tags when the catalog is empty", async () => {
+  vi.mocked(getStructuredResponse).mockResolvedValue({
+    ...generatedDetails(),
+    suggestedTags: ["unsupported"],
+  });
+
+  await expect(
+    getGeneratedBottleDetails({ id: 1, fullName: "Generated Tag Example" }),
+  ).resolves.toMatchObject({ suggestedTags: [] });
 });
 
 test("rejects an unassigned Bottle before invoking AI", async ({

--- a/apps/server/src/worker/jobs/generateBottleDetails.test.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.test.ts
@@ -16,6 +16,7 @@ import { and, asc, eq } from "drizzle-orm";
 import { beforeEach, expect, test, vi } from "vitest";
 import generateBottleDetails, {
   type GeneratedBottleDetails,
+  getGeneratedBottleDetails,
 } from "./generateBottleDetails";
 
 vi.mock("@peated/server/config", async (importOriginal) => {
@@ -91,6 +92,20 @@ async function createTwoMemberGroup(user: User, brandId: number) {
 beforeEach(() => {
   vi.mocked(getStructuredResponse).mockReset();
   vi.mocked(workerClient.pushUniqueJob).mockClear();
+});
+
+test("filters generated tags to the allowed tag list", async () => {
+  vi.mocked(getStructuredResponse).mockResolvedValue({
+    ...generatedDetails(),
+    suggestedTags: ["smoke", "unsupported", "fruit"],
+  });
+
+  await expect(
+    getGeneratedBottleDetails({ id: 1, fullName: "Generated Tag Example" }, [
+      "smoke",
+      "fruit",
+    ]),
+  ).resolves.toMatchObject({ suggestedTags: ["smoke", "fruit"] });
 });
 
 test("rejects an unassigned Bottle before invoking AI", async ({

--- a/apps/server/src/worker/jobs/generateBottleDetails.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.ts
@@ -16,7 +16,7 @@ import {
 } from "@peated/server/lib/bottleSchemas";
 import { arraysEqual, objectsShallowEqual } from "@peated/server/lib/equals";
 import { notesForProfile } from "@peated/server/lib/format";
-import { logError, logWarn } from "@peated/server/lib/log";
+import { logWarn } from "@peated/server/lib/log";
 import { getStructuredResponse } from "@peated/server/lib/openai";
 import { withSentryConversation } from "@peated/server/lib/openaiClient";
 import {
@@ -121,7 +121,7 @@ export async function getGeneratedBottleDetails(
     ? `bottle_details:${bottle.id}`
     : `ai:bottle_lookup:${bottle.fullName ?? bottle.name ?? "draft"}`;
 
-  return await withSentryConversation(
+  const result = await withSentryConversation(
     conversationId,
     async () =>
       await getStructuredResponse(
@@ -138,6 +138,14 @@ export async function getGeneratedBottleDetails(
         },
       ),
   );
+
+  if (!result) return null;
+
+  const allowedTags = new Set(tagList);
+  return {
+    ...result,
+    suggestedTags: result.suggestedTags.filter((tag) => allowedTags.has(tag)),
+  };
 }
 
 export default async function generateBottleDetails(rawJobArgs: unknown) {
@@ -227,19 +235,7 @@ export default async function generateBottleDetails(rawJobArgs: unknown) {
     result.suggestedTags?.length &&
     !arraysEqual(result.suggestedTags, bottle.suggestedTags)
   ) {
-    if (!result.suggestedTags.find((t) => !tagList.includes(t))) {
-      patch.suggestedTags = result.suggestedTags;
-    } else {
-      logError(`Invalid value for suggestedTags`, {
-        tag: {
-          values: result.suggestedTags.filter((t) => !tagList.includes(t)),
-        },
-        bottle: {
-          id: bottle.id,
-          fullName: bottle.fullName,
-        },
-      });
-    }
+    patch.suggestedTags = result.suggestedTags;
   }
 
   if (!bottle.flavorProfile) {

--- a/apps/server/src/worker/jobs/generateBottleDetails.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.ts
@@ -11,6 +11,7 @@ import {
 } from "@peated/server/db/schema";
 import { getPeatedSystemActorForDatabase } from "@peated/server/lib/actors";
 import {
+  MAX_BOTTLE_SUGGESTED_TAGS,
   SystemBottlePatchSchema,
   type SystemBottlePatch,
 } from "@peated/server/lib/bottleSchemas";
@@ -74,7 +75,7 @@ function generatePrompt(bottle: Partial<Bottle>, tagList: string[]) {
     ].join("\n"),
     tagList.length
       ? [
-          "'suggestedTags' may contain up to five items when they are strongly supported by the bottle's style or profile.",
+          `'suggestedTags' may contain up to ${MAX_BOTTLE_SUGGESTED_TAGS} items when they are strongly supported by the bottle's style or profile.`,
           "If no tags are well supported, return an empty array.",
           "Values must come from this list:",
           `- ${tagList.join("\n- ")}`,
@@ -96,17 +97,14 @@ export const OpenAIBottleDetailsSchema = z.object({
     .nullable()
     .default(null),
   category: z.string().nullable().default(null),
-  suggestedTags: z.array(z.string()).default([]),
+  suggestedTags: z.array(z.string()).max(MAX_BOTTLE_SUGGESTED_TAGS).default([]),
   flavorProfile: z.string().nullable().default(null),
 });
 
-// we dont send enums to openai as they dont get used
 export const OpenAIBottleDetailsValidationSchema =
   OpenAIBottleDetailsSchema.extend({
     category: CategoryEnum.nullable().default(null),
     flavorProfile: FlavorProfileEnum.nullable().default(null),
-    // TODO: ChatGPT is ignoring this shit, so lets validate later and throw away if invalid
-    // suggestedTags: z.array(DefaultTagEnum).default([]),
   });
 
 export type GeneratedBottleDetails = z.infer<
@@ -115,8 +113,10 @@ export type GeneratedBottleDetails = z.infer<
 
 export async function getGeneratedBottleDetails(
   bottle: Partial<Bottle>,
-  tagList: string[],
 ): Promise<GeneratedBottleDetails | null> {
+  const tagList = (
+    await db.query.tags.findMany({ columns: { name: true } })
+  ).map(({ name }) => name);
   const conversationId = bottle.id
     ? `bottle_details:${bottle.id}`
     : `ai:bottle_lookup:${bottle.fullName ?? bottle.name ?? "draft"}`;
@@ -141,10 +141,13 @@ export async function getGeneratedBottleDetails(
 
   if (!result) return null;
 
+  // The database catalog owns tag identity; model output is only a proposal.
   const allowedTags = new Set(tagList);
   return {
     ...result,
-    suggestedTags: result.suggestedTags.filter((tag) => allowedTags.has(tag)),
+    suggestedTags: Array.from(
+      new Set(result.suggestedTags.filter((tag) => allowedTags.has(tag))),
+    ).slice(0, MAX_BOTTLE_SUGGESTED_TAGS),
   };
 }
 
@@ -205,8 +208,7 @@ export default async function generateBottleDetails(rawJobArgs: unknown) {
     return;
   }
 
-  const tagList = (await db.query.tags.findMany()).map((r) => r.name);
-  const result = await getGeneratedBottleDetails(bottle, tagList);
+  const result = await getGeneratedBottleDetails(bottle);
 
   if (!result) {
     throw new Error(`Failed to generate details for bottle: ${bottleId}`);


### PR DESCRIPTION
Generated bottle details now treat AI tag suggestions as proposals against the canonical database catalog. The shared generation boundary loads that catalog, preserves supported suggestions, removes invalid and duplicate values, and enforces the same five-tag limit across structured output, the moderator lookup API, and bottle persistence.

This keeps normal model misses from opening Sentry issues or crashing the worker, while both consumers use one contract. Regression coverage includes mixed valid and invalid output, duplicates, excessive suggestions, and an empty catalog. Fixes PEATED-GK.
