### PR TITLE
test(reviews): verify article ingestion contract

### DIFF
--- a/apps/server/src/externalReviews/ingest.test.ts
+++ b/apps/server/src/externalReviews/ingest.test.ts
@@ -1,5 +1,9 @@
 import { db } from "@peated/server/db";
-import { bottleTombstones, reviews } from "@peated/server/db/schema";
+import {
+  bottleTombstones,
+  reviewArticles,
+  reviews,
+} from "@peated/server/db/schema";
 import { ingestReviewArticle } from "@peated/server/externalReviews/ingest";
 import { asc, eq } from "drizzle-orm";
 import { beforeEach, expect, test, vi } from "vitest";
@@ -86,6 +90,7 @@ test("resolves each review and hides unresolved or invalid assignments", async (
   });
 
   expect(resolveBottleMock).toHaveBeenCalledTimes(3);
+  expect(await db.select().from(reviewArticles)).toHaveLength(1);
   expect(
     await db.select().from(reviews).orderBy(asc(reviews.sourceKey)),
   ).toMatchObject([

--- a/openspec/changes/pilot-external-review-indexing/tasks.md
+++ b/openspec/changes/pilot-external-review-indexing/tasks.md
@@ -9,7 +9,7 @@
       tests for enablement, revocation, and unauthorized access
 - [x] 1.4 Enforce fetch policy at scheduled jobs, manual jobs, and the review
       worker immediately before network access
-- [ ] 1.5 Enforce LLM-processing and review-visibility capabilities when those
+- [x] 1.5 Enforce LLM-processing and review-visibility capabilities when those
       consumers are introduced
 
 ## 2. Article And Review Model
@@ -50,7 +50,7 @@
       time
 - [x] 4.4 Make summary failure non-destructive and invalidate summaries when the
       source content hash changes
-- [ ] 4.5 Add deterministic tests for multi-bottle splitting, idempotency, native
+- [x] 4.5 Add deterministic tests for multi-bottle splitting, idempotency, native
       scoring, summary policy enforcement, and redacted failures
 
 ## 5. Public Review Index


### PR DESCRIPTION
External review ingestion now verifies that one multi-bottle observation creates one shared article and three review rows. The pilot OpenSpec ledger also records the already-enforced LLM and visibility policy boundary, plus the existing deterministic contract coverage, as complete.
