### PR TITLE
fix(reviews): show staged imports in admin

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/health.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.test.ts
@@ -180,7 +180,7 @@ test("health details show review inventory and blocked review policy", async ({
   const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
   await fixtures.Review({
     externalSiteId: site.id,
-    hidden: false,
+    hidden: true,
   });
   await fixtures.Review({
     externalSiteId: site.id,

--- a/apps/server/src/orpc/routes/external-sites/health.ts
+++ b/apps/server/src/orpc/routes/external-sites/health.ts
@@ -55,12 +55,9 @@ async function getHealthForSites(
       })
       .from(reviews)
       .innerJoin(reviewArticles, eq(reviews.articleId, reviewArticles.id))
-      .where(
-        and(
-          inArray(reviewArticles.externalSiteId, siteIds),
-          eq(reviews.hidden, false),
-        ),
-      )
+      // Admin health includes staged reviews so operators can verify imports
+      // before publication.
+      .where(inArray(reviewArticles.externalSiteId, siteIds))
       .groupBy(reviewArticles.externalSiteId),
     db
       .select({

--- a/apps/server/src/orpc/routes/reviews/list.test.ts
+++ b/apps/server/src/orpc/routes/reviews/list.test.ts
@@ -93,6 +93,30 @@ describe("GET /reviews", () => {
     expect(results[0].id).toEqual(review.id);
   });
 
+  test("shows staged reviews to moderators but not on public Bottle pages", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const bottle = await fixtures.Bottle();
+    const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
+    const review = await fixtures.Review({
+      bottleId: bottle.id,
+      externalSiteId: site.id,
+      hidden: true,
+    });
+
+    const moderatorResults = await routerClient.reviews.list(
+      { site: site.type },
+      { context: { user } },
+    );
+    const publicResults = await routerClient.reviews.list({
+      bottle: bottle.id,
+    });
+
+    expect(moderatorResults.results.map(({ id }) => id)).toContain(review.id);
+    expect(publicResults.results.map(({ id }) => id)).not.toContain(review.id);
+  });
+
   test("uses article-owned source and URL metadata", async ({ fixtures }) => {
     const user = await fixtures.User({ mod: true });
     const articleSite = await fixtures.ExternalSite({

--- a/apps/server/src/orpc/routes/reviews/list.ts
+++ b/apps/server/src/orpc/routes/reviews/list.ts
@@ -51,7 +51,13 @@ export default procedure
     context,
     errors,
   }) {
-    const baseWhere: (SQL<unknown> | undefined)[] = [eq(reviews.hidden, false)];
+    const hasPublicScope = input.bottle !== undefined;
+    const requiresModerator = input.onlyUnknown || !hasPublicScope;
+    // This route owns review visibility. Public Bottle queries exclude staged
+    // reviews. Moderator queries include them for review and matching.
+    const baseWhere: (SQL<unknown> | undefined)[] = requiresModerator
+      ? []
+      : [eq(reviews.hidden, false)];
     const identityWhere: SQL<unknown>[] = [];
 
     if (input.site) {
@@ -66,9 +72,6 @@ export default procedure
       }
       baseWhere.push(eq(reviewArticles.externalSiteId, site.id));
     }
-
-    const hasPublicScope = input.bottle !== undefined;
-    const requiresModerator = input.onlyUnknown || !hasPublicScope;
 
     if (hasPublicScope) {
       // No-fetch migration articles have no content hash and preserve their


### PR DESCRIPTION
Admin review pages and scraper health now include staged review imports, so completed review-only scraper runs are visible and counted. Public Bottle review queries still exclude staged reviews; only moderator-scoped queries changed.

Regression coverage verifies both visibility boundaries and confirms that health totals include staged reviews.
