### PR TITLE
fix(bottles): clear inherited stated ages

### DIFF
--- a/apps/server/src/lib/bottleOperationReview.test.ts
+++ b/apps/server/src/lib/bottleOperationReview.test.ts
@@ -3,6 +3,7 @@ import { db } from "@peated/server/db";
 import {
   bottleAliases,
   bottleGroups,
+  bottles,
   collectionBottles,
   entities,
 } from "@peated/server/db/schema";
@@ -1516,6 +1517,77 @@ describe("Bottle operation review preparation", () => {
       });
       expect(after.stateToken).not.toEqual(before.stateToken);
     }
+  });
+
+  test("previews inherited age clears as shared and override clears as exact", async ({
+    fixtures,
+  }) => {
+    const inherited = await fixtures.Bottle({
+      name: "Inherited Age Review",
+      statedAge: null,
+    });
+    const override = await fixtures.BottleGroupMember({
+      groupId: inherited.groupId as number,
+      edition: "Override",
+      statedAge: 14,
+    });
+    await db
+      .update(bottleGroups)
+      .set({ statedAge: 12 })
+      .where(eq(bottleGroups.id, inherited.groupId as number));
+    await db
+      .update(bottles)
+      .set({ statedAge: 12 })
+      .where(eq(bottles.id, inherited.id));
+
+    const operation = (bottleId: number, id: number) =>
+      ({
+        id,
+        proposal: {
+          type: "update_bottle",
+          input: { bottleId, patch: { statedAge: null } },
+          rationale: "The inspected label has no age statement.",
+          evidenceRefs: [{ kind: "bottle", bottleId }],
+        },
+      }) as const;
+    const [sharedClear, exactClear] = await Promise.all([
+      prepareOperation({
+        operation: operation(inherited.id, 67),
+        artifacts: artifacts({
+          bottleContexts: [await bottleContext(inherited.id)],
+        }),
+      }),
+      prepareOperation({
+        operation: operation(override.id, 68),
+        artifacts: artifacts({
+          bottleContexts: [await bottleContext(override.id)],
+        }),
+      }),
+    ]);
+
+    expect(sharedClear).toMatchObject({
+      status: "pending_review",
+      type: "update_bottle",
+      preview: {
+        changedFields: ["shared.statedAge"],
+        after: { shared: { statedAge: null }, exact: { statedAge: null } },
+        affectedBottles: { total: 2 },
+        warnings: [{ code: "shared_group_fan_out" }],
+      },
+      stateToken: { shared: { statedAge: 12 } },
+    });
+    expect(sharedClear).not.toHaveProperty("stateToken.exact.statedAge");
+    expect(exactClear).toMatchObject({
+      status: "pending_review",
+      type: "update_bottle",
+      preview: {
+        changedFields: ["exact.statedAge"],
+        after: { shared: { statedAge: 12 }, exact: { statedAge: null } },
+        affectedBottles: { total: 1 },
+        warnings: [],
+      },
+      stateToken: { exact: { statedAge: 14 } },
+    });
   });
 
   test("relationship digests change for affected membership drift", async ({

--- a/apps/server/src/lib/bottleOperationReview/bottleUpdate.ts
+++ b/apps/server/src/lib/bottleOperationReview/bottleUpdate.ts
@@ -244,12 +244,14 @@ function collectChangedBottleFields(
 function relevantBottleUpdateToken({
   resource,
   proposal,
+  sharedStatedAgeIntent,
   referencedEntities,
   referencedSeries,
   relationshipDigest: relatedMemberships,
 }: {
   resource: BottleResource;
   proposal: Extract<ProposedOperation, { type: "update_bottle" }>;
+  sharedStatedAgeIntent: boolean;
   referencedEntities: Array<{
     entityId: number;
     name: string;
@@ -273,6 +275,10 @@ function relevantBottleUpdateToken({
     ),
   );
   const sharedFields = new Set(requestedSharedFields);
+  if (sharedStatedAgeIntent) {
+    sharedFields.add("statedAge");
+    requestedSharedFields.add("statedAge");
+  }
   if (sharedFields.has("name")) {
     sharedFields.add("statedAge");
   }
@@ -561,20 +567,30 @@ export async function prepareBottleUpdate(
       ? { distillers: distillers.map(({ canonical }) => canonical) }
       : {}),
   });
-  const storage = bottleStoragePatch(canonicalInput);
+  const storage = bottleStoragePatch(canonicalInput, {
+    bottleStatedAge: resource.bottle.statedAge,
+    groupStatedAge: resource.group.statedAge,
+  });
+  const sharedStatedAgeIntent =
+    storage.shared !== undefined && "statedAge" in storage.shared;
 
   let sharedName =
     storage.shared?.name === undefined
       ? resource.group.name
       : storage.shared.name;
-  let sharedStatedAge = resource.group.statedAge;
+  let sharedStatedAge =
+    storage.shared?.statedAge === undefined
+      ? resource.group.statedAge
+      : storage.shared.statedAge;
   if (storage.shared?.name !== undefined) {
     const normalized = normalizeBottleAge({
       name: normalizeBottleAliasKey(storage.shared.name),
       statedAge: sharedStatedAge,
     });
     sharedName = normalized.name;
-    sharedStatedAge = normalized.statedAge;
+    if (storage.shared.statedAge === undefined) {
+      sharedStatedAge = normalized.statedAge;
+    }
   }
   const brandName =
     brand.preview.kind === "existing"
@@ -701,6 +717,7 @@ export async function prepareBottleUpdate(
   const stateToken = relevantBottleUpdateToken({
     resource,
     proposal,
+    sharedStatedAgeIntent,
     referencedEntities,
     referencedSeries,
     relationshipDigest: storage.shared

--- a/apps/server/src/lib/updateBottle.test.ts
+++ b/apps/server/src/lib/updateBottle.test.ts
@@ -1657,6 +1657,26 @@ describe("Bottle updates", () => {
     });
     persisted = await loadGroupMembers(first.group.id);
     expect(persisted.map(({ statedAge }) => statedAge)).toEqual([15, 12, 18]);
+
+    resetQueueMock();
+    const clearedSharedAge = await updateBottle({
+      bottleId: members[1].bottle.id,
+      input: { statedAge: null },
+      context: contextFor(mod),
+    });
+    expect(clearedSharedAge).toMatchObject({
+      bottle: { id: members[1].bottle.id, statedAge: null },
+      group: { id: first.group.id, statedAge: null },
+      changed: true,
+    });
+    persisted = await loadGroupMembers(first.group.id);
+    expect(persisted.map(({ statedAge }) => statedAge)).toEqual([15, null, 18]);
+    expect(
+      vi
+        .mocked(workerClient.pushUniqueJob)
+        .mock.calls.filter(([jobName]) => jobName === "OnBottleChange")
+        .map(([, payload]) => payload),
+    ).toEqual(members.map(({ bottle }) => ({ bottleId: bottle.id })));
   });
 
   test("rolls back a shared update on Bottle or exact-alias collisions", async ({

--- a/apps/server/src/lib/updateBottle.ts
+++ b/apps/server/src/lib/updateBottle.ts
@@ -37,6 +37,7 @@ import {
 import { processSeries } from "@peated/server/lib/bottleHelpers";
 import {
   getBottleExactIdentity,
+  getBottleExactStatedAge,
   materializeBottleForGroup,
 } from "@peated/server/lib/bottleIdentity";
 import {
@@ -59,6 +60,7 @@ type SharedPatch = Partial<
   Pick<
     SystemBottlePatch,
     | "name"
+    | "statedAge"
     | "series"
     | "category"
     | "brand"
@@ -316,6 +318,13 @@ function hasFields(value: object | undefined): boolean {
  */
 export function bottleStoragePatch(
   input: SystemBottlePatch,
+  {
+    bottleStatedAge,
+    groupStatedAge,
+  }: {
+    bottleStatedAge: Bottle["statedAge"];
+    groupStatedAge: BottleGroup["statedAge"];
+  },
 ): BottleStoragePatch {
   const shared: SharedPatch = {};
   const exact: ExactPatch = {};
@@ -329,7 +338,22 @@ export function bottleStoragePatch(
   if ("flavorProfile" in input) shared.flavorProfile = input.flavorProfile;
 
   if ("edition" in input) exact.edition = input.edition;
-  if ("statedAge" in input) exact.statedAge = input.statedAge;
+  if ("statedAge" in input) {
+    // Null must clear the effective age. With no exact override, the group is
+    // the storage owner and the clear must fan out to every member.
+    const clearsSharedAge =
+      input.statedAge === null &&
+      groupStatedAge !== null &&
+      getBottleExactStatedAge({
+        bottleStatedAge,
+        stableStatedAge: groupStatedAge,
+      }) === null;
+    if (clearsSharedAge) {
+      shared.statedAge = null;
+    } else {
+      exact.statedAge = input.statedAge;
+    }
+  }
   if ("abv" in input) exact.abv = input.abv;
   if ("singleCask" in input) exact.singleCask = input.singleCask;
   if ("caskStrength" in input) exact.caskStrength = input.caskStrength;
@@ -716,7 +740,7 @@ async function resolveStableState(
     (left, right) => left - right,
   );
 
-  let statedAge = group.statedAge;
+  let statedAge = valueOrCurrent(patch?.statedAge, group.statedAge);
   let name = patch?.name ?? group.name;
   if (patch?.name !== undefined) {
     const normalized = normalizeBottleAge({
@@ -724,7 +748,7 @@ async function resolveStableState(
       statedAge,
     });
     name = normalized.name;
-    statedAge = normalized.statedAge;
+    if (patch.statedAge === undefined) statedAge = normalized.statedAge;
   }
   name = stripDuplicateBrandPrefixFromBottleName(name, brand.name);
   if (!name || bottleNameDuplicatesBrand(name, brand.name)) {
@@ -1023,7 +1047,10 @@ export async function updateBottleInTransaction(
     ...existingEntityIdsForUpdate(input),
   ]);
   const groupId = group.id;
-  const storage = bottleStoragePatch(input);
+  const storage = bottleStoragePatch(input, {
+    bottleStatedAge: lockedBottle.statedAge,
+    groupStatedAge: group.statedAge,
+  });
   if (
     expectedSelectedBottleState &&
     expectedSelectedBottleKeys.some(

--- a/apps/server/src/orpc/routes/bottles/update.test.ts
+++ b/apps/server/src/orpc/routes/bottles/update.test.ts
@@ -158,6 +158,37 @@ describe("PATCH /bottles/{bottle}", () => {
     ).toHaveLength(1);
   });
 
+  test("clears an inherited stated age from a singleton group", async ({
+    fixtures,
+  }) => {
+    const mod = await fixtures.User({ mod: true });
+    const brand = await fixtures.Entity({ name: "Clear Route Age Brand" });
+    const { first } = await createGroup(
+      mod,
+      { name: "Clear Route Age", statedAge: 10, brand: brand.id },
+      [{}],
+    );
+
+    const result = await routerClient.bottles.update(
+      { bottle: first.bottle.id, statedAge: null },
+      { context: { user: mod } },
+    );
+    const fresh = await routerClient.bottles.details({
+      bottle: first.bottle.id,
+    });
+
+    expect(result).toMatchObject({
+      id: first.bottle.id,
+      statedAge: null,
+      group: { id: first.group.id, statedAge: null },
+    });
+    expect(fresh).toMatchObject({
+      id: first.bottle.id,
+      statedAge: null,
+      group: { id: first.group.id, statedAge: null },
+    });
+  });
+
   test("isolates exact edits to the selected Bottle", async ({ fixtures }) => {
     const mod = await fixtures.User({ mod: true });
     const brand = await fixtures.Entity({ name: "Exact Route Brand" });

--- a/docs/architecture/whisky-identity-model.md
+++ b/docs/architecture/whisky-identity-model.md
@@ -48,8 +48,9 @@ does not create another catalog identity layer.
   the age is invariant across a future group.
 - Updates accept one flat `BottlePatch`. The server assigns storage ownership.
   Name, brand, bottler, distillers, category, series, and flavor profile changes
-  use shared editing semantics. A `statedAge` change belongs to the selected
-  Bottle.
+  use shared editing semantics. A non-null `statedAge` change belongs to the
+  selected Bottle. A null age clears a differing exact override, or clears and
+  fans out the shared age when the selected Bottle has no exact override.
 - Semantic grouping happens outside ordinary creation. Similar names, a shared
   brand, or a shared BottleSeries may suggest a relationship but do not prove
   same-expression identity. This release does not ship an automatic regrouping


### PR DESCRIPTION
`PATCH /bottles/{bottle}` now clears the visible age when `statedAge: null`: it removes a differing Bottle override when one exists, or clears the group-owned inherited age and rematerializes every group member while preserving valid overrides. Moderator review previews use the same state-aware storage decision and surface shared fan-out without exposing BottleGroup storage in public input.

Fixes #687
