### PR TITLE
fix(reviews): preserve WhiskyNotes bottle identity

### DIFF
--- a/apps/server/__fixtures__/whiskynotes/multi-review.html
+++ b/apps/server/__fixtures__/whiskynotes/multi-review.html
@@ -14,6 +14,8 @@
         </header>
         <div class="entry-content">
           <p>An introduction to three releases.</p>
+          <h2>Three independent releases</h2>
+          <p>This heading describes the article and is not a Bottle review.</p>
           <h2>
             Ben Nevis 30 yo 1996 (43,4%, The Whisky Agency 2026, sherry butt)
           </h2>

--- a/apps/server/src/scraper/adapters/whiskyNotes.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyNotes.test.ts
@@ -38,23 +38,29 @@ test("extracts multi-bottle reviews with stable source keys", async () => {
     contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
     reviews: [
       {
-        name: "Ben Nevis 30 yo 1996",
+        name: "Ben Nevis 30 yo 1996 (43,4%, The Whisky Agency 2026, sherry butt)",
         reviewerName: "Ruben",
         nativeScore: { value: 91, scale: 100, display: "91/100" },
         normalizedRating: 91,
       },
       {
-        name: "Ben Nevis 30 yo 1996",
+        name: "Ben Nevis 30 yo 1996 (45,3%, The Whisky Agency & Sansibar 2026, hogshead)",
         nativeScore: { value: 90, scale: 100, display: "90/100" },
         normalizedRating: 90,
       },
       {
-        name: "Bowmore 20 yo 2005",
+        name: "Bowmore 20 yo 2005 (48,8%, The Whisky Agency 2026, refill sherry hogshead)",
         nativeScore: { value: 91, scale: 100, display: "91/100" },
         normalizedRating: 91,
       },
     ],
   });
+  expect(parsed.article.reviews.map(({ name }) => name)).not.toContain(
+    "Three independent releases",
+  );
+  expect(new Set(parsed.article.reviews.map(({ name }) => name))).toHaveLength(
+    3,
+  );
   expect(parsed.article.reviews.map(({ sourceKey }) => sourceKey)).toEqual(
     reparsed.article.reviews.map(({ sourceKey }) => sourceKey),
   );

--- a/apps/server/src/scraper/adapters/whiskyNotes.ts
+++ b/apps/server/src/scraper/adapters/whiskyNotes.ts
@@ -97,11 +97,11 @@ function score(value: string) {
   };
 }
 
-function bottleName(heading: string): string {
-  const details = heading.match(
-    /^(.+)\s+\((?=[^)]*\d{1,3}(?:[.,]\d+)?\s*%)[^)]*\)\s*$/u,
-  );
-  return normalizeText(details?.[1] ?? heading);
+function bottleName(heading: string): string | null {
+  const name = normalizeText(heading);
+  return /^.+\s+\((?=[^)]*\d{1,3}(?:[.,]\d+)?\s*%)[^)]*\)\s*$/u.test(name)
+    ? name
+    : null;
 }
 
 function reviewSourceKey(canonicalUrl: string, heading: string): string {
@@ -147,7 +147,7 @@ export function parseWhiskyNotesArticle(
   const headings = content
     .find("h2")
     .toArray()
-    .filter((heading) => normalizeText($(heading).text()).length > 0);
+    .filter((heading) => bottleName($(heading).text()) !== null);
   const rawPageScore = normalizeText(
     article.find(".entry-score").first().text(),
   );
@@ -157,6 +157,8 @@ export function parseWhiskyNotesArticle(
 
   for (const [index, heading] of headings.entries()) {
     const headingText = normalizeText($(heading).text());
+    const name = bottleName(headingText);
+    if (name === null) continue;
     const sectionText = normalizeText(
       [
         headingText,
@@ -170,7 +172,7 @@ export function parseWhiskyNotesArticle(
     const reviewScore = score(sectionText) ?? (index === 0 ? pageScore : null);
     reviewList.push({
       sourceKey,
-      name: bottleName(headingText),
+      name,
       reviewerName,
       nativeScore: reviewScore?.nativeScore ?? null,
       normalizedRating: reviewScore?.normalizedRating ?? null,

--- a/openspec/changes/pilot-external-review-indexing/tasks.md
+++ b/openspec/changes/pilot-external-review-indexing/tasks.md
@@ -69,8 +69,9 @@
       planned WhiskyNotes requests
 - [x] 6.2 Implement and fixture-test the first source adapter with
       bounded discovery and stable source keys
-- [ ] 6.3 Run the first backfill in review-only mode and capture article,
-      review, extraction, matched, and unresolved counts
+- [x] 6.3 Run the first backfill in review-only mode and capture article,
+      review, extraction, matched, and unresolved counts. Production run 239
+      stored 42 articles and 80 extracted reviews: 67 matched and 13 unresolved.
 - [ ] 6.4 Review the selected sample for at least 90% extraction accuracy,
       multi-bottle splitting, summary quality, and Bottle-match precision
 - [ ] 6.5 Explicitly enable or reject automatic publication based on the recorded


### PR DESCRIPTION
WhiskyNotes now accepts only product headings with the source's parenthesized ABV details and keeps the complete heading as Bottle reference evidence. This prevents article section headings from becoming reviews and preserves bottler, release, and cask identity when same-name bottles are matched.

The regression fixture covers both production failure patterns. Existing staged production rows are intentionally not deleted or reassigned by replay; they need targeted cleanup after deployment.
