### PR TITLE
fix(reviews): preserve source bottle names

### DIFF
--- a/apps/server/src/externalReviews/ingest.test.ts
+++ b/apps/server/src/externalReviews/ingest.test.ts
@@ -69,6 +69,8 @@ test("resolves each review and hides unresolved or invalid assignments", async (
   const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
   const bottle = await fixtures.Bottle({ name: "Resolved Review Bottle" });
   const missingBottleId = 2_147_483_647;
+  const unresolvedName =
+    "Mister Sam Tribute Whiskey (66,9%, OB 2019 (Batch 1), 1200 btl.)";
   resolveBottleMock
     .mockResolvedValueOnce(resolution(bottle.id))
     .mockResolvedValueOnce(resolution(null))
@@ -83,7 +85,7 @@ test("resolves each review and hides unresolved or invalid assignments", async (
       contentHash: "sha256:first",
       reviews: [
         { sourceKey: "resolved", name: bottle.fullName },
-        { sourceKey: "unresolved", name: "Unknown Review Bottle" },
+        { sourceKey: "unresolved", name: unresolvedName },
         { sourceKey: "invalid", name: "Missing Review Bottle" },
       ],
     },
@@ -106,6 +108,7 @@ test("resolves each review and hides unresolved or invalid assignments", async (
     },
     {
       sourceKey: "unresolved",
+      name: unresolvedName,
       bottleId: null,
       hidden: true,
     },

--- a/apps/server/src/externalReviews/ingest.ts
+++ b/apps/server/src/externalReviews/ingest.ts
@@ -51,7 +51,7 @@ export async function ingestReviewArticle(rawInput: unknown) {
 
   for (const review of input.article.reviews) {
     const rawName = review.name;
-    const { name } = normalizeBottle({ name: rawName });
+    const { name: normalizedName } = normalizeBottle({ name: rawName });
     const aliasKey = normalizeBottleAliasKey(rawName);
     const resolution = await resolveScrapedBottleReferenceTarget({
       reference: {
@@ -80,7 +80,7 @@ export async function ingestReviewArticle(rawInput: unknown) {
         summary = await generateExternalReviewSummary({
           externalSiteId: input.externalSiteId,
           sourceKey: review.sourceKey,
-          bottleName: name,
+          bottleName: normalizedName,
           sourceText,
           contentHash: input.article.contentHash,
         });
@@ -98,7 +98,6 @@ export async function ingestReviewArticle(rawInput: unknown) {
     }
     resolvedReviews.push({
       ...review,
-      name,
       bottleId: resolution.assignment?.bottleId ?? null,
       summary,
     });


### PR DESCRIPTION
External review ingestion now stores the publisher's Bottle name unchanged while using the normalized form only as summary context. This prevents nested identity details from being reordered into malformed admin text, while Bottle resolution continues to receive the complete source evidence.

The ingestion regression test uses the production-shaped nested name that exposed the problem.
