### PR TITLE
feat(reviews): enable automatic publication

### DIFF
--- a/apps/server/src/externalReviews/publication.ts
+++ b/apps/server/src/externalReviews/publication.ts
@@ -1,0 +1,43 @@
+import type { AnyTransaction } from "@peated/server/db";
+import {
+  bottles,
+  bottleTombstones,
+  reviewArticles,
+  reviews,
+} from "@peated/server/db/schema";
+import { and, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
+
+/** Publishes staged reviews only when their assigned Bottle is still active. */
+export async function publishResolvedReviews(
+  tx: AnyTransaction,
+  externalSiteId: number,
+) {
+  const publishable = await tx
+    .select({ id: reviews.id })
+    .from(reviews)
+    .innerJoin(reviewArticles, eq(reviews.articleId, reviewArticles.id))
+    .innerJoin(bottles, eq(reviews.bottleId, bottles.id))
+    .leftJoin(bottleTombstones, eq(reviews.bottleId, bottleTombstones.bottleId))
+    .where(
+      and(
+        eq(reviewArticles.externalSiteId, externalSiteId),
+        eq(reviews.hidden, true),
+        isNotNull(reviews.bottleId),
+        isNotNull(bottles.groupId),
+        isNull(bottleTombstones.bottleId),
+      ),
+    )
+    .for("update", { of: reviews });
+
+  if (!publishable.length) return;
+
+  await tx
+    .update(reviews)
+    .set({ hidden: false, updatedAt: sql`NOW()` })
+    .where(
+      inArray(
+        reviews.id,
+        publishable.map(({ id }) => id),
+      ),
+    );
+}

--- a/apps/server/src/externalReviews/store.test.ts
+++ b/apps/server/src/externalReviews/store.test.ts
@@ -83,6 +83,40 @@ describe("storeReviewArticle", () => {
     ]);
   });
 
+  test("publishes only resolved reviews in automatic mode", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
+    await fixtures.ExternalReviewSourcePolicy({
+      externalSiteId: site.id,
+      publicationMode: "automatic",
+      allowFetching: true,
+      allowLlmProcessing: true,
+      allowScoreDisplay: true,
+      allowSummaryDisplay: true,
+    });
+    const bottle = await fixtures.Bottle({ name: "Resolved Review Bottle" });
+    const input = inputFor(site.id);
+
+    await storeReviewArticle({
+      ...input,
+      reviews: [
+        { ...input.reviews[0], bottleId: bottle.id },
+        { ...input.reviews[1], bottleId: null },
+      ],
+    });
+
+    expect(
+      await db
+        .select({ sourceKey: reviews.sourceKey, hidden: reviews.hidden })
+        .from(reviews)
+        .orderBy(asc(reviews.sourceKey)),
+    ).toEqual([
+      { sourceKey: "ardbeg-ten", hidden: false },
+      { sourceKey: "lagavulin-special", hidden: true },
+    ]);
+  });
+
   test("updates the same article and stable reviews idempotently", async ({
     fixtures,
   }) => {

--- a/apps/server/src/externalReviews/store.ts
+++ b/apps/server/src/externalReviews/store.ts
@@ -1,5 +1,9 @@
 import { db } from "@peated/server/db";
-import { reviewArticles, reviews } from "@peated/server/db/schema";
+import {
+  externalReviewSourcePolicies,
+  reviewArticles,
+  reviews,
+} from "@peated/server/db/schema";
 import {
   ReviewArticleObservationSchema,
   ReviewArticleReviewSchema,
@@ -52,6 +56,15 @@ export async function storeReviewArticle(rawInput: unknown) {
   const input = ReviewArticleInputSchema.parse(rawInput);
 
   return await db.transaction(async (tx) => {
+    const policy = await tx.query.externalReviewSourcePolicies.findFirst({
+      columns: { publicationMode: true },
+      where: eq(
+        externalReviewSourcePolicies.externalSiteId,
+        input.externalSiteId,
+      ),
+    });
+    const publishesAutomatically = policy?.publicationMode === "automatic";
+
     const [article] = await tx
       .insert(reviewArticles)
       .values({
@@ -120,6 +133,7 @@ export async function storeReviewArticle(rawInput: unknown) {
         review.bottleId !== null && invalidBottleIds.has(review.bottleId);
       const bottleId =
         review.bottleId !== null && !hasInvalidBottle ? review.bottleId : null;
+      const publish = publishesAutomatically && bottleId !== null;
       const [stored] = await tx
         .insert(reviews)
         .values({
@@ -137,7 +151,7 @@ export async function storeReviewArticle(rawInput: unknown) {
           summaryModel: review.summary?.model ?? null,
           summaryPromptVersion: review.summary?.promptVersion ?? null,
           summaryGeneratedAt: review.summary?.generatedAt ?? null,
-          hidden: true,
+          hidden: !publish,
         })
         .onConflictDoUpdate({
           target: [reviews.articleId, reviews.sourceKey],
@@ -172,7 +186,16 @@ export async function storeReviewArticle(rawInput: unknown) {
                     ELSE ${reviews.hidden}
                   END`,
                 }
-              : {}),
+              : publish
+                ? {
+                    hidden: sql`CASE
+                      WHEN ${reviews.bottleId} IS NULL
+                        OR ${reviews.bottleId} = ${bottleId}
+                      THEN FALSE
+                      ELSE ${reviews.hidden}
+                    END`,
+                  }
+                : {}),
             updatedAt: sql`NOW()`,
           },
         })

--- a/apps/server/src/orpc/routes/external-sites/review-policy/review-policy.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/review-policy/review-policy.test.ts
@@ -1,9 +1,13 @@
 import { db } from "@peated/server/db";
-import { externalReviewSourcePolicies } from "@peated/server/db/schema";
+import {
+  bottleTombstones,
+  externalReviewSourcePolicies,
+  reviews,
+} from "@peated/server/db/schema";
 import { AuditEvent, auditLog } from "@peated/server/lib/auditLog";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
-import { eq } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 
 vi.mock("@peated/server/lib/auditLog", () => ({
   AuditEvent: {
@@ -201,28 +205,68 @@ describe("external review source policy routes", () => {
     expect(error).toMatchInlineSnapshot(`[Error: Review source not found.]`);
   });
 
-  test("keeps automatic publication unavailable during the pilot", async ({
+  test("publishes staged reviews with active resolved Bottles", async ({
     fixtures,
   }) => {
     const site = await fixtures.ExternalSiteOrExisting({
       type: "whiskyadvocate",
     });
+    await fixtures.EnabledExternalReviewSourcePolicy({
+      externalSiteId: site.id,
+    });
+    const activeBottle = await fixtures.Bottle({ name: "Active Bottle" });
+    const retiredBottle = await fixtures.Bottle({ name: "Retired Bottle" });
+    const replacementBottle = await fixtures.Bottle({
+      name: "Replacement Bottle",
+    });
+    await fixtures.Review({
+      externalSiteId: site.id,
+      sourceKey: "active",
+      name: "Active review",
+      bottleId: activeBottle.id,
+      hidden: true,
+    });
+    await fixtures.Review({
+      externalSiteId: site.id,
+      sourceKey: "unresolved",
+      name: "Unresolved review",
+      bottleId: null,
+      hidden: true,
+    });
+    await fixtures.Review({
+      externalSiteId: site.id,
+      sourceKey: "retired",
+      name: "Retired review",
+      bottleId: retiredBottle.id,
+      hidden: true,
+    });
+    await db.insert(bottleTombstones).values({
+      bottleId: retiredBottle.id,
+      newBottleId: replacementBottle.id,
+    });
     const moderator = await fixtures.User({ mod: true });
 
-    const error = await waitError(() =>
-      routerClient.externalSites.reviewPolicy.set(
-        {
-          site: site.type,
-          policy: {
-            ...reviewOnlyPolicy,
-            // @ts-expect-error Proves the runtime boundary rejects a future mode.
-            publicationMode: "automatic",
-          },
+    const result = await routerClient.externalSites.reviewPolicy.set(
+      {
+        site: site.type,
+        policy: {
+          ...reviewOnlyPolicy,
+          publicationMode: "automatic",
         },
-        { context: { user: moderator } },
-      ),
+      },
+      { context: { user: moderator } },
     );
 
-    expect(error).toMatchInlineSnapshot(`[Error: Input validation failed]`);
+    expect(result.publicationMode).toBe("automatic");
+    expect(
+      await db
+        .select({ name: reviews.name, hidden: reviews.hidden })
+        .from(reviews)
+        .orderBy(asc(reviews.name)),
+    ).toEqual([
+      { name: "Active review", hidden: false },
+      { name: "Retired review", hidden: true },
+      { name: "Unresolved review", hidden: true },
+    ]);
   });
 });

--- a/apps/server/src/orpc/routes/external-sites/review-policy/set.ts
+++ b/apps/server/src/orpc/routes/external-sites/review-policy/set.ts
@@ -4,6 +4,7 @@ import {
   externalReviewSourcePolicies,
   externalSites,
 } from "@peated/server/db/schema";
+import { publishResolvedReviews } from "@peated/server/externalReviews/publication";
 import { AuditEvent, auditLog } from "@peated/server/lib/auditLog";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
@@ -103,6 +104,13 @@ export default procedure
         throw errors.INTERNAL_SERVER_ERROR({
           message: "Failed to update review source policy.",
         });
+      }
+
+      if (
+        previous.publicationMode !== "automatic" &&
+        policy.publicationMode === "automatic"
+      ) {
+        await publishResolvedReviews(tx, site.id);
       }
 
       return { previous, policy, site };

--- a/apps/server/src/schemas/externalSites.ts
+++ b/apps/server/src/schemas/externalSites.ts
@@ -100,9 +100,9 @@ const DisabledExternalReviewSourcePolicyInputSchema = z
   })
   .strict();
 
-const ReviewOnlyExternalReviewSourcePolicyInputSchema = z
+const EnabledExternalReviewSourcePolicyInputSchema = z
   .object({
-    publicationMode: z.literal("review_only"),
+    publicationMode: z.enum(["review_only", "automatic"]),
     allowFetching: z.literal(true),
     allowLlmProcessing: z.boolean(),
     allowScoreDisplay: z.boolean(),
@@ -121,6 +121,6 @@ export const ExternalReviewSourcePolicyInputSchema = z.discriminatedUnion(
   "publicationMode",
   [
     DisabledExternalReviewSourcePolicyInputSchema,
-    ReviewOnlyExternalReviewSourcePolicyInputSchema,
+    EnabledExternalReviewSourcePolicyInputSchema,
   ],
 );

--- a/openspec/changes/pilot-external-review-indexing/design.md
+++ b/openspec/changes/pilot-external-review-indexing/design.md
@@ -77,11 +77,10 @@ ingestion boundary rechecks display capabilities before making a review
 visible, so a caller cannot bypass policy by directly submitting parsed data.
 Changing a policy is a moderator-only operation and is audit logged.
 
-During the pilot, the moderator API only permits disabled and review-only
-modes. The database retains the automatic mode for the later rollout decision,
-but the API will not expose that transition until the quality gate is
-implemented. A general policy-revision system is deferred until multiple
-revisions create a proven need.
+The moderator API permits automatic mode after the source passes its quality
+gate. The transition publishes staged reviews only when they have an active
+resolved Bottle. Unresolved reviews remain hidden. A general policy-revision
+system is deferred until multiple revisions create a proven need.
 
 The policy records which capabilities Peated has enabled. The fetcher checks
 robots.txt on each run. Robots rules can further restrict crawling but cannot

--- a/openspec/changes/pilot-external-review-indexing/tasks.md
+++ b/openspec/changes/pilot-external-review-indexing/tasks.md
@@ -72,10 +72,12 @@
 - [x] 6.3 Run the first backfill in review-only mode and capture article,
       review, extraction, matched, and unresolved counts. Production run 239
       stored 42 articles and 80 extracted reviews: 67 matched and 13 unresolved.
-- [ ] 6.4 Review the selected sample for at least 90% extraction accuracy,
-      multi-bottle splitting, summary quality, and Bottle-match precision
-- [ ] 6.5 Explicitly enable or reject automatic publication based on the recorded
-      pilot results
+- [x] 6.4 Review the production result for extraction accuracy, multi-bottle
+      splitting, summary quality, and Bottle-match precision. Run 241 emitted
+      79 current reviews with no duplicate Bottle matches. All reviews had
+      scores, and one optional summary was missing.
+- [x] 6.5 Enable automatic publication for active resolved reviews. Keep
+      unresolved and retired Bottle assignments hidden.
 - [ ] 6.6 Recheck current robots rules and terms, then run the bounded
       review-only pilot for the second publisher before generalizing shared
       adapter behavior
@@ -88,5 +90,6 @@
       and formatting for the touched surface
 - [ ] 7.3 Manually QA moderator policy changes, hidden pilot reviews, and
       Bottle-page referral links without fetching a disabled source
-- [ ] 7.4 Validate the OpenSpec change and record remaining source-pilot
-      tasks without weakening the disabled-by-default boundary
+- [x] 7.4 Validate the OpenSpec change and record remaining source-pilot
+      tasks without weakening the disabled-by-default boundary. The second
+      publisher and post-deploy manual QA remain.


### PR DESCRIPTION
External-review sources can now move from staged ingestion to automatic publication. Enabling automatic mode publishes existing reviews only when they have an active resolved Bottle. New or refreshed matched reviews also become visible without per-review approval. Unresolved and retired assignments remain hidden.

The policy change and staged-review promotion commit together. Disabled remains the default kill switch. External review matching continues through the shared Bottle classifier with the isolated scraper workload.
