### PR TITLE
ref(reviews): unify external review persistence

### DIFF
--- a/apps/server/src/externalReviews/ingest.ts
+++ b/apps/server/src/externalReviews/ingest.ts
@@ -62,6 +62,8 @@ export async function ingestReviewArticle(rawInput: unknown) {
         currentBottleId: null,
       },
       aliasLookupNames: [aliasKey, rawName],
+      extractedIdentity:
+        review.category === null ? null : { category: review.category },
       createdByActorId: actor.id,
     });
     if (resolution.error) {

--- a/apps/server/src/externalReviews/observation.ts
+++ b/apps/server/src/externalReviews/observation.ts
@@ -1,10 +1,11 @@
-import { NativeScoreSchema } from "@peated/server/schemas";
+import { CategoryEnum, NativeScoreSchema } from "@peated/server/schemas";
 import { z } from "zod";
 
 export const ReviewArticleReviewSchema = z
   .object({
     sourceKey: z.string().trim().min(1).max(255),
     name: z.string().trim().min(1).max(500),
+    category: CategoryEnum.nullable().default(null),
     reviewerName: z.string().trim().min(1).max(255).nullable().default(null),
     nativeScore: NativeScoreSchema.nullable().default(null),
     normalizedRating: z.number().int().min(0).max(100).nullable().default(null),

--- a/apps/server/src/externalReviews/store.test.ts
+++ b/apps/server/src/externalReviews/store.test.ts
@@ -1,9 +1,34 @@
 import { db } from "@peated/server/db";
+import { getPostgresConnectionConfig } from "@peated/server/db/connection";
 import { reviewArticles, reviews } from "@peated/server/db/schema";
 import { storeReviewArticle } from "@peated/server/externalReviews/store";
 import waitError from "@peated/server/lib/test/waitError";
 import { asc, eq } from "drizzle-orm";
+import pg from "pg";
 import { describe, expect, test } from "vitest";
+
+const { Client } = pg;
+type NodePgClient = InstanceType<typeof Client>;
+
+async function waitForSessionBlockedBy(
+  client: NodePgClient,
+  blockerPid: number,
+): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    const result = await client.query<{ blocked: boolean }>(
+      `SELECT EXISTS (
+        SELECT 1
+        FROM pg_stat_activity
+        WHERE $1 = ANY(pg_blocking_pids(pid))
+      ) AS blocked`,
+      [blockerPid],
+    );
+    if (result.rows[0]?.blocked) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Timed out waiting for external review source lock.");
+}
 
 function inputFor(externalSiteId: number) {
   return {
@@ -115,6 +140,105 @@ describe("storeReviewArticle", () => {
       { sourceKey: "ardbeg-ten", hidden: false },
       { sourceKey: "lagavulin-special", hidden: true },
     ]);
+  });
+
+  test("publishes a newly resolved review but preserves a moderator hide", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
+    await fixtures.ExternalReviewSourcePolicy({
+      externalSiteId: site.id,
+      publicationMode: "automatic",
+      allowFetching: true,
+      allowLlmProcessing: true,
+      allowScoreDisplay: true,
+      allowSummaryDisplay: true,
+    });
+    const bottle = await fixtures.Bottle({ name: "Resolved Review Bottle" });
+    const input = inputFor(site.id);
+
+    await storeReviewArticle({
+      ...input,
+      reviews: [{ ...input.reviews[0], bottleId: null }],
+    });
+    await storeReviewArticle({
+      ...input,
+      reviews: [{ ...input.reviews[0], bottleId: bottle.id }],
+    });
+    const review = await db.query.reviews.findFirst({
+      where: eq(reviews.sourceKey, "ardbeg-ten"),
+    });
+    expect(review).toMatchObject({ bottleId: bottle.id, hidden: false });
+
+    await db
+      .update(reviews)
+      .set({ hidden: true })
+      .where(eq(reviews.id, review!.id));
+    await storeReviewArticle({
+      ...input,
+      reviews: [{ ...input.reviews[0], bottleId: bottle.id }],
+    });
+
+    expect(
+      await db.query.reviews.findFirst({
+        where: eq(reviews.id, review!.id),
+      }),
+    ).toMatchObject({ bottleId: bottle.id, hidden: true });
+  });
+
+  test("serializes publication policy changes with article ingestion", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
+    await fixtures.ExternalReviewSourcePolicy({
+      externalSiteId: site.id,
+      publicationMode: "review_only",
+      allowFetching: true,
+      allowLlmProcessing: true,
+      allowScoreDisplay: true,
+      allowSummaryDisplay: true,
+    });
+    const bottle = await fixtures.Bottle({ name: "Concurrent Review Bottle" });
+    const input = inputFor(site.id);
+    const client = new Client(getPostgresConnectionConfig());
+    let committed = false;
+    let ingestion: ReturnType<typeof storeReviewArticle> | undefined;
+
+    await client.connect();
+    try {
+      await client.query("BEGIN");
+      const blockerPid = (
+        await client.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")
+      ).rows[0]!.pid;
+      await client.query(
+        `SELECT "id" FROM "external_site" WHERE "id" = $1 FOR UPDATE`,
+        [site.id],
+      );
+      ingestion = storeReviewArticle({
+        ...input,
+        reviews: [{ ...input.reviews[0], bottleId: bottle.id }],
+      });
+      await waitForSessionBlockedBy(client, blockerPid);
+      await client.query(
+        `UPDATE "external_review_source_policy"
+         SET "publication_mode" = 'automatic'
+         WHERE "external_site_id" = $1`,
+        [site.id],
+      );
+      await client.query("COMMIT");
+      committed = true;
+      await ingestion;
+
+      expect(
+        await db.query.reviews.findFirst({
+          where: eq(reviews.sourceKey, "ardbeg-ten"),
+        }),
+      ).toMatchObject({ bottleId: bottle.id, hidden: false });
+    } finally {
+      if (!committed) await client.query("ROLLBACK");
+      await client.end();
+      await ingestion?.catch(() => undefined);
+    }
   });
 
   test("updates the same article and stable reviews idempotently", async ({

--- a/apps/server/src/externalReviews/store.ts
+++ b/apps/server/src/externalReviews/store.ts
@@ -1,8 +1,10 @@
-import { db } from "@peated/server/db";
+import { db, type AnyTransaction } from "@peated/server/db";
 import {
   externalReviewSourcePolicies,
+  externalSites,
   reviewArticles,
   reviews,
+  storePrices,
 } from "@peated/server/db/schema";
 import {
   ReviewArticleObservationSchema,
@@ -12,7 +14,7 @@ import {
   ActiveBottleSelectionError,
   resolveActiveBottleIds,
 } from "@peated/server/lib/resolveActiveBottleIds";
-import { and, eq, isNotNull, ne, sql } from "drizzle-orm";
+import { and, eq, isNotNull, ne, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 const StoredSummarySchema = z
@@ -47,68 +49,120 @@ export const ReviewArticleInputSchema =
     }
   });
 
-/**
- * Stores external review metadata. The input excludes full review text, HTML,
- * tasting notes, conclusions, and images. Callers must discard those values
- * before they call this function.
- */
-export async function storeReviewArticle(rawInput: unknown) {
-  const input = ReviewArticleInputSchema.parse(rawInput);
+type SourceReviewArticleInput = z.infer<typeof ReviewArticleInputSchema>;
+type ReviewArticleInput = Omit<
+  SourceReviewArticleInput,
+  "contentHash" | "fetchedAt" | "title"
+> & {
+  contentHash: string | null;
+  fetchedAt: Date | null;
+  title: string | null;
+};
+type ReviewOrigin = "manual" | "source";
+type InvalidBottleAction = "reject" | "stage";
 
-  return await db.transaction(async (tx) => {
-    const policy = await tx.query.externalReviewSourcePolicies.findFirst({
-      columns: { publicationMode: true },
-      where: eq(
-        externalReviewSourcePolicies.externalSiteId,
-        input.externalSiteId,
-      ),
-    });
-    const publishesAutomatically = policy?.publicationMode === "automatic";
+/** Stores one article after locking its source, Bottles, and alias consumers. */
+export async function storeReviewArticleInTransaction(
+  tx: AnyTransaction,
+  input: ReviewArticleInput,
+  {
+    origin,
+    invalidBottleAction,
+    aliasLookupNames = [],
+  }: {
+    origin: ReviewOrigin;
+    invalidBottleAction: InvalidBottleAction;
+    aliasLookupNames?: string[];
+  },
+) {
+  // The source row serializes ingestion with moderator policy updates.
+  const [site] = await tx
+    .select({ id: externalSites.id })
+    .from(externalSites)
+    .where(eq(externalSites.id, input.externalSiteId))
+    .limit(1)
+    .for("share");
+  if (!site) {
+    throw new Error(`External site ${input.externalSiteId} not found.`);
+  }
 
-    const [article] = await tx
-      .insert(reviewArticles)
-      .values({
-        externalSiteId: input.externalSiteId,
-        canonicalUrl: input.canonicalUrl,
-        title: input.title,
-        issue: input.issue,
-        publishedAt: input.publishedAt,
-        contentHash: input.contentHash,
-        fetchedAt: input.fetchedAt,
-      })
-      .onConflictDoUpdate({
-        target: [reviewArticles.externalSiteId, reviewArticles.canonicalUrl],
-        set: {
+  const policy =
+    origin === "source"
+      ? await tx.query.externalReviewSourcePolicies.findFirst({
+          columns: { publicationMode: true },
+          where: eq(
+            externalReviewSourcePolicies.externalSiteId,
+            input.externalSiteId,
+          ),
+        })
+      : null;
+  const publishesAutomatically = policy?.publicationMode === "automatic";
+
+  const articleUpdate =
+    origin === "manual"
+      ? { issue: input.issue, updatedAt: sql`NOW()` }
+      : {
           title: input.title,
           issue: input.issue,
           publishedAt: input.publishedAt,
           contentHash: input.contentHash,
           fetchedAt: input.fetchedAt,
           updatedAt: sql`NOW()`,
-        },
-      })
-      .returning({ id: reviewArticles.id });
+        };
+  const [article] = await tx
+    .insert(reviewArticles)
+    .values({
+      externalSiteId: input.externalSiteId,
+      canonicalUrl: input.canonicalUrl,
+      title: input.title,
+      issue: input.issue,
+      publishedAt: input.publishedAt,
+      contentHash: input.contentHash,
+      fetchedAt: input.fetchedAt,
+    })
+    .onConflictDoUpdate({
+      target: [reviewArticles.externalSiteId, reviewArticles.canonicalUrl],
+      set: articleUpdate,
+    })
+    .returning({ id: reviewArticles.id });
+  if (!article) throw new Error("Unable to store review article.");
 
-    if (!article) throw new Error("Unable to store review article.");
-
-    // Match createExternalReview lock order: article, Bottles, then reviews.
-    const invalidBottleIds = new Set<number>();
-    const bottleIds = [
-      ...new Set(
-        input.reviews.flatMap(({ bottleId }) =>
-          bottleId === null ? [] : [bottleId],
-        ),
+  const invalidBottleIds = new Set<number>();
+  const bottleIds = [
+    ...new Set(
+      input.reviews.flatMap(({ bottleId }) =>
+        bottleId === null ? [] : [bottleId],
       ),
-    ].sort((left, right) => left - right);
-    for (const bottleId of bottleIds) {
-      try {
-        await resolveActiveBottleIds(tx, [bottleId], { lock: "update" });
-      } catch (error) {
-        if (!(error instanceof ActiveBottleSelectionError)) throw error;
-        invalidBottleIds.add(bottleId);
-      }
+    ),
+  ].sort((left, right) => left - right);
+  for (const bottleId of bottleIds) {
+    try {
+      await resolveActiveBottleIds(tx, [bottleId], { lock: "update" });
+    } catch (error) {
+      if (!(error instanceof ActiveBottleSelectionError)) throw error;
+      if (invalidBottleAction === "reject") throw error;
+      invalidBottleIds.add(bottleId);
     }
+  }
 
+  if (aliasLookupNames.length) {
+    await tx
+      .select({ id: storePrices.id })
+      .from(storePrices)
+      .where(
+        and(
+          eq(storePrices.externalSiteId, input.externalSiteId),
+          or(
+            ...aliasLookupNames.map((name) =>
+              eq(sql`LOWER(${storePrices.name})`, name.toLowerCase()),
+            ),
+          ),
+        ),
+      )
+      .for("update");
+  }
+
+  if (origin === "source" && input.contentHash !== null) {
     await tx
       .update(reviews)
       .set({
@@ -126,85 +180,111 @@ export async function storeReviewArticle(rawInput: unknown) {
           ne(reviews.summaryContentHash, input.contentHash),
         ),
       );
+  }
 
-    const reviewIds: number[] = [];
-    for (const review of input.reviews) {
-      const hasInvalidBottle =
-        review.bottleId !== null && invalidBottleIds.has(review.bottleId);
-      const bottleId =
-        review.bottleId !== null && !hasInvalidBottle ? review.bottleId : null;
-      const publish = publishesAutomatically && bottleId !== null;
-      const [stored] = await tx
-        .insert(reviews)
-        .values({
-          articleId: article.id,
-          bottleId,
-          sourceKey: review.sourceKey,
-          name: review.name,
-          reviewerName: review.reviewerName,
-          nativeScoreValue: review.nativeScore?.value ?? null,
-          nativeScoreScale: review.nativeScore?.scale ?? null,
-          nativeScoreDisplay: review.nativeScore?.display ?? null,
-          rating: review.normalizedRating,
-          summary: review.summary?.text ?? null,
-          summaryContentHash: review.summary?.contentHash ?? null,
-          summaryModel: review.summary?.model ?? null,
-          summaryPromptVersion: review.summary?.promptVersion ?? null,
-          summaryGeneratedAt: review.summary?.generatedAt ?? null,
-          hidden: !publish,
-        })
-        .onConflictDoUpdate({
-          target: [reviews.articleId, reviews.sourceKey],
-          set: {
-            bottleId: sql`CASE
-              WHEN excluded.bottle_id IS NOT NULL
-                AND (${reviews.bottleId} IS NULL OR ${reviews.bottleId} = excluded.bottle_id)
-              THEN excluded.bottle_id
-              ELSE ${reviews.bottleId}
-            END`,
-            name: review.name,
+  const storedReviews = [];
+
+  for (const review of input.reviews) {
+    const [existing] = await tx
+      .select()
+      .from(reviews)
+      .where(
+        and(
+          eq(reviews.articleId, article.id),
+          eq(reviews.sourceKey, review.sourceKey),
+        ),
+      )
+      .limit(1)
+      .for("update");
+    const hasInvalidBottle =
+      review.bottleId !== null && invalidBottleIds.has(review.bottleId);
+    const incomingBottleId = hasInvalidBottle ? null : review.bottleId;
+    const bottleId =
+      incomingBottleId !== null &&
+      (existing?.bottleId == null || existing.bottleId === incomingBottleId)
+        ? incomingBottleId
+        : (existing?.bottleId ?? null);
+    const hidden = existing
+      ? hasInvalidBottle &&
+        (existing.bottleId === null || existing.bottleId === review.bottleId)
+        ? true
+        : origin === "source" &&
+            publishesAutomatically &&
+            existing.bottleId === null &&
+            bottleId !== null
+          ? false
+          : (existing.hidden ?? false)
+      : origin === "source"
+        ? !(publishesAutomatically && bottleId !== null)
+        : false;
+    const values = {
+      bottleId,
+      name: review.name,
+      rating: review.normalizedRating,
+      ...(origin === "source"
+        ? {
             reviewerName: review.reviewerName,
             nativeScoreValue: review.nativeScore?.value ?? null,
             nativeScoreScale: review.nativeScore?.scale ?? null,
             nativeScoreDisplay: review.nativeScore?.display ?? null,
-            rating: review.normalizedRating,
-            ...(review.summary
-              ? {
-                  summary: review.summary.text,
-                  summaryContentHash: review.summary.contentHash,
-                  summaryModel: review.summary.model,
-                  summaryPromptVersion: review.summary.promptVersion,
-                  summaryGeneratedAt: review.summary.generatedAt,
-                }
-              : {}),
-            ...(hasInvalidBottle
-              ? {
-                  hidden: sql`CASE
-                    WHEN ${reviews.bottleId} IS NULL
-                      OR ${reviews.bottleId} = ${review.bottleId}
-                    THEN TRUE
-                    ELSE ${reviews.hidden}
-                  END`,
-                }
-              : publish
-                ? {
-                    hidden: sql`CASE
-                      WHEN ${reviews.bottleId} IS NULL
-                        OR ${reviews.bottleId} = ${bottleId}
-                      THEN FALSE
-                      ELSE ${reviews.hidden}
-                    END`,
-                  }
-                : {}),
-            updatedAt: sql`NOW()`,
-          },
-        })
-        .returning({ id: reviews.id });
+          }
+        : {}),
+      ...(review.summary
+        ? {
+            summary: review.summary.text,
+            summaryContentHash: review.summary.contentHash,
+            summaryModel: review.summary.model,
+            summaryPromptVersion: review.summary.promptVersion,
+            summaryGeneratedAt: review.summary.generatedAt,
+          }
+        : {}),
+      hidden,
+      updatedAt: sql`NOW()`,
+    };
+    const [stored] = existing
+      ? await tx
+          .update(reviews)
+          .set(values)
+          .where(eq(reviews.id, existing.id))
+          .returning()
+      : await tx
+          .insert(reviews)
+          .values({
+            articleId: article.id,
+            sourceKey: review.sourceKey,
+            ...values,
+          })
+          .returning();
+    if (!stored) throw new Error("Unable to store review.");
+    storedReviews.push({
+      review: stored,
+      previousBottleId: existing?.bottleId,
+    });
+  }
 
-      if (!stored) throw new Error("Unable to store review.");
-      reviewIds.push(stored.id);
-    }
+  return { articleId: article.id, storedReviews };
+}
 
-    return { articleId: article.id, reviewIds };
+/**
+ * Stores external review metadata. The input excludes full review text, HTML,
+ * tasting notes, conclusions, and images. Callers must discard those values
+ * before they call this function.
+ */
+export async function storeReviewArticle(rawInput: unknown) {
+  const input = ReviewArticleInputSchema.parse(rawInput);
+
+  return await db.transaction(async (tx) => {
+    const { articleId, storedReviews } = await storeReviewArticleInTransaction(
+      tx,
+      input,
+      {
+        origin: "source",
+        invalidBottleAction: "stage",
+      },
+    );
+    return {
+      articleId,
+      reviewIds: storedReviews.map(({ review }) => review.id),
+    };
   });
 }

--- a/apps/server/src/lib/createExternalReview.ts
+++ b/apps/server/src/lib/createExternalReview.ts
@@ -3,12 +3,8 @@ import {
   normalizeBottleAliasKey,
 } from "@peated/bottle-classifier/normalize";
 import { db } from "@peated/server/db";
-import {
-  externalSites,
-  reviewArticles,
-  reviews,
-  storePrices,
-} from "@peated/server/db/schema";
+import { externalSites } from "@peated/server/db/schema";
+import { storeReviewArticleInTransaction } from "@peated/server/externalReviews/store";
 import { getPeatedSystemActor } from "@peated/server/lib/actors";
 import {
   assignBottleAliasInTransaction,
@@ -30,7 +26,7 @@ import {
   resolveActiveBottleIds,
 } from "@peated/server/lib/resolveActiveBottleIds";
 import { ReviewInputSchema } from "@peated/server/schemas";
-import { and, eq, or, sql } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 /**
  * Owns external-review ingestion and Bottle identity assignment. Both API and
@@ -111,150 +107,111 @@ export async function createExternalReview(
   const bottleId = resolution.assignment?.bottleId ?? null;
   const reviewName = normalizedName;
 
-  const { review, aliasAssignment } = await db.transaction(async (tx) => {
-    const [article] = await tx
-      .insert(reviewArticles)
-      .values({
-        externalSiteId: site.id,
-        canonicalUrl: input.url,
-        issue: input.issue,
-      })
-      .onConflictDoUpdate({
-        target: [reviewArticles.externalSiteId, reviewArticles.canonicalUrl],
-        set: {
+  let stored;
+  try {
+    stored = await db.transaction(async (tx) => {
+      const result = await storeReviewArticleInTransaction(
+        tx,
+        {
+          externalSiteId: site.id,
+          canonicalUrl: input.url,
+          title: null,
           issue: input.issue,
-          updatedAt: sql`NOW()`,
+          publishedAt: null,
+          contentHash: null,
+          fetchedAt: null,
+          reviews: [
+            {
+              sourceKey,
+              name: reviewName,
+              category: input.category,
+              reviewerName: null,
+              nativeScore: null,
+              normalizedRating: input.rating,
+              bottleId,
+              summary: null,
+            },
+          ],
         },
-      })
-      .returning({ id: reviewArticles.id });
-    if (!article) throw new Error("Unable to store review article.");
-
-    if (bottleId !== null) {
-      try {
-        await resolveActiveBottleIds(tx, [bottleId], { lock: "update" });
-      } catch (error) {
-        if (!(error instanceof ActiveBottleSelectionError)) throw error;
-        throw new ExternalReviewBottleStateError(error);
-      }
-      const aliasLookupNames = Array.from(
-        new Set(
-          [aliasKey, reviewName, rawName].map((name) => name.toLowerCase()),
-        ),
+        {
+          origin: "manual",
+          invalidBottleAction: "reject",
+          aliasLookupNames:
+            bottleId === null ? [] : [aliasKey, reviewName, rawName],
+        },
       );
-      await tx
-        .select({ id: storePrices.id })
-        .from(storePrices)
-        .where(
-          and(
-            eq(storePrices.externalSiteId, site.id),
-            or(
-              ...aliasLookupNames.map((name) =>
-                eq(sql`LOWER(${storePrices.name})`, name),
-              ),
-            ),
-          ),
-        )
-        .for("update");
-    }
+      const storedReview = result.storedReviews[0];
+      if (!storedReview) throw new Error("Unable to store review.");
+      const { previousBottleId, review } = storedReview;
 
-    const [existingReview] = await tx
-      .select()
-      .from(reviews)
-      .where(
-        and(
-          eq(reviews.articleId, article.id),
-          eq(reviews.sourceKey, sourceKey),
-        ),
-      )
-      .limit(1)
-      .for("update");
+      const appliedIncomingIdentity = review.bottleId === bottleId;
+      if (!bottleId || !appliedIncomingIdentity) {
+        return { review, aliasAssignment: null };
+      }
 
-    const [review] = await tx
-      .insert(reviews)
-      .values({
-        articleId: article.id,
+      const aliasAssignment = await assignBottleAliasInTransaction(tx, {
         bottleId,
-        name: reviewName,
-        rating: input.rating,
-        sourceKey,
-      })
-      .onConflictDoUpdate({
-        target: [reviews.articleId, reviews.sourceKey],
-        set: {
-          bottleId: sql`CASE
-            WHEN excluded.bottle_id IS NOT NULL
-              AND (${reviews.bottleId} IS NULL OR ${reviews.bottleId} = excluded.bottle_id)
-            THEN excluded.bottle_id
-            ELSE ${reviews.bottleId}
-          END`,
-          name: reviewName,
-          rating: input.rating,
-          updatedAt: sql`NOW()`,
-        },
-      })
-      .returning();
-    if (!review) throw new Error("Unable to store review.");
-
-    const appliedIncomingIdentity = review.bottleId === bottleId;
-    if (!bottleId || !appliedIncomingIdentity) {
-      return { review, aliasAssignment: null };
-    }
-
-    const aliasAssignment = await assignBottleAliasInTransaction(tx, {
-      bottleId,
-      name: aliasKey,
-      backfillNames: [reviewName, rawName],
-      externalSiteId: site.id,
-      assignmentSource:
-        resolution.source === "exact_alias" ? undefined : "classifier_approved",
-      assignedByActorId: systemActor.id,
-      sourceAliasIdentity: resolution.sourceAliasIdentity,
-    });
-
-    const decision = getIncomingBottleDecisionFromResolutionSource(
-      resolution.source,
-      { createdBottle: resolution.createdBottle },
-    );
-    if (
-      decision !== null &&
-      shouldRecordIncomingBottleDecision({
-        previousBottleId: existingReview?.bottleId,
-        bottleId,
-        decision,
-      })
-    ) {
-      await recordIncomingBottleDecisionInTransaction(tx, {
-        sourceKind: "review",
-        sourceId: review.id,
+        name: aliasKey,
+        backfillNames: [reviewName, rawName],
         externalSiteId: site.id,
-        name: reviewName,
-        url: input.url,
-        decision,
-        actor: systemActor,
-        bottleId,
-        createdBottle: resolution.createdBottle,
-        confidence: resolution.confidence,
-        model: resolution.model,
-        rationale: resolution.rationale,
-        metadata: {
-          resolutionSource: resolution.source,
-          ...(resolution.classifierEvidence
-            ? { classifierEvidence: resolution.classifierEvidence }
-            : {}),
-          issue: input.issue,
-          ...(initiatedByUserId === undefined ? {} : { initiatedByUserId }),
-        },
+        assignmentSource:
+          resolution.source === "exact_alias"
+            ? undefined
+            : "classifier_approved",
+        assignedByActorId: systemActor.id,
+        sourceAliasIdentity: resolution.sourceAliasIdentity,
       });
+
+      const decision = getIncomingBottleDecisionFromResolutionSource(
+        resolution.source,
+        { createdBottle: resolution.createdBottle },
+      );
+      if (
+        decision !== null &&
+        shouldRecordIncomingBottleDecision({
+          previousBottleId,
+          bottleId,
+          decision,
+        })
+      ) {
+        await recordIncomingBottleDecisionInTransaction(tx, {
+          sourceKind: "review",
+          sourceId: review.id,
+          externalSiteId: site.id,
+          name: reviewName,
+          url: input.url,
+          decision,
+          actor: systemActor,
+          bottleId,
+          createdBottle: resolution.createdBottle,
+          confidence: resolution.confidence,
+          model: resolution.model,
+          rationale: resolution.rationale,
+          metadata: {
+            resolutionSource: resolution.source,
+            ...(resolution.classifierEvidence
+              ? { classifierEvidence: resolution.classifierEvidence }
+              : {}),
+            issue: input.issue,
+            ...(initiatedByUserId === undefined ? {} : { initiatedByUserId }),
+          },
+        });
+      }
+
+      return { review, aliasAssignment };
+    });
+  } catch (error) {
+    if (error instanceof ActiveBottleSelectionError) {
+      throw new ExternalReviewBottleStateError(error);
     }
+    throw error;
+  }
 
-    return { review, aliasAssignment };
-  });
-
-  if (aliasAssignment) {
-    await finalizeBottleAliasAssignment(aliasAssignment, {
+  if (stored.aliasAssignment) {
+    await finalizeBottleAliasAssignment(stored.aliasAssignment, {
       review: { site: input.site, name: reviewName, url: input.url },
     });
   }
 
-  return review;
+  return stored.review;
 }

--- a/apps/server/src/orpc/routes/reviews/create.test.ts
+++ b/apps/server/src/orpc/routes/reviews/create.test.ts
@@ -7,6 +7,7 @@ import {
   reviewArticles,
   reviews,
 } from "@peated/server/db/schema";
+import { storeReviewArticle } from "@peated/server/externalReviews/store";
 import { getPeatedSystemActor } from "@peated/server/lib/actors";
 import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
 import waitError from "@peated/server/lib/test/waitError";
@@ -194,6 +195,71 @@ describe("POST /reviews", () => {
         where: eq(bottleAliases.name, "Unresolved Review Bottle"),
       }),
     ).toBeUndefined();
+  });
+
+  test("preserves fetched article and review metadata on a manual update", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting({
+      type: "whiskyadvocate",
+    });
+    const admin = await fixtures.User({ admin: true });
+    const url = "https://example.com/reviews/fetched-review";
+    const generatedAt = new Date("2026-08-20T12:00:00Z");
+    await storeReviewArticle({
+      externalSiteId: site.id,
+      canonicalUrl: url,
+      title: "Fetched review title",
+      issue: "Original issue",
+      publishedAt: new Date("2026-08-19T12:00:00Z"),
+      contentHash: "sha256:fetched",
+      fetchedAt: new Date("2026-08-20T11:00:00Z"),
+      reviews: [
+        {
+          sourceKey: url,
+          name: "Fetched Review Bottle",
+          reviewerName: "Source Reviewer",
+          nativeScore: { value: 8.8, scale: 10, display: "8.8/10" },
+          normalizedRating: 88,
+          summary: {
+            text: "The review describes a bright whisky. It notes a dry finish.",
+            contentHash: "sha256:fetched",
+            model: "summary-model",
+            promptVersion: "summary-v1",
+            generatedAt,
+          },
+        },
+      ],
+    });
+
+    await routerClient.reviews.create(
+      {
+        site: site.type,
+        name: "Fetched Review Bottle",
+        issue: "Manual correction",
+        rating: 90,
+        url,
+        category: "single_malt",
+      },
+      { context: { user: admin } },
+    );
+
+    expect(
+      await db.query.reviewArticles.findFirst({
+        where: eq(reviewArticles.canonicalUrl, url),
+      }),
+    ).toMatchObject({
+      title: "Fetched review title",
+      issue: "Manual correction",
+      contentHash: "sha256:fetched",
+    });
+    expect(await findReviewByUrl(url)).toMatchObject({
+      rating: 90,
+      reviewerName: "Source Reviewer",
+      nativeScoreDisplay: "8.8/10",
+      summaryContentHash: "sha256:fetched",
+      summaryGeneratedAt: generatedAt,
+    });
   });
 
   test("writes an exact alias match directly to reviews.bottleId", async ({

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -35,9 +35,14 @@ The runtime checks source policy at each owning boundary:
 | Return a native score or summary       | The review serializer checks the matching display capability.                   |
 | Return a fetched review to the public  | The review must be visible and the source must use `automatic` mode.            |
 
-The moderator policy API accepts only `disabled` and `review_only` during the
-pilot. The policy update is moderator-only and audit logged. Automatic
-publication needs a later reviewed change after the pilot gate passes.
+The moderator policy API accepts `disabled`, `review_only`, and `automatic`.
+The policy update is moderator-only and audit logged. A transition to
+`automatic` publishes staged reviews only when they have an active resolved
+Bottle. Unresolved and retired Bottle assignments remain hidden.
+
+Article ingestion and policy updates serialize on the source record. A refresh
+can publish a review when it gains its first active Bottle assignment. A refresh
+does not make an already matched review visible after a moderator hides it.
 
 ## Source Adapter Contract
 
@@ -112,15 +117,15 @@ Use this sequence for each publisher:
    Review the agreed hidden sample for extraction, multi-bottle splitting,
    Bottle matches, and any enabled summaries.
 7. Require at least 90% extraction accuracy and acceptable Bottle-match
-   precision. Record the result before proposing automatic publication.
+   precision. Record the result before setting the source to `automatic`.
 
 The WhiskyNotes pilot is manual-only. It checks at most five archive pages and
 20 article links on each page. Requests are at least 2.5 seconds apart. The
 target allows 30 requests per hour. Each worker pass stops after 30 requests.
 
-Keep automatic publication unavailable until a reviewed code and policy change
-implements that decision. Repeat the robots, terms, and review-only process for
-the second publisher before adding shared adapter behavior.
+Enable automatic publication only after the reviewed sample passes the gate.
+Repeat the robots, terms, and review-only process for the second publisher
+before adding shared adapter behavior.
 
 ## Stop And Roll Back
 

--- a/openspec/changes/pilot-external-review-indexing/design.md
+++ b/openspec/changes/pilot-external-review-indexing/design.md
@@ -145,6 +145,18 @@ invalid Bottle assignments always remain hidden.
 Disabling a source stops fetching immediately and hides source reviews when the
 current policy no longer permits display.
 
+Policy updates and article ingestion serialize on the source record. This keeps
+the publication mode used by an ingestion transaction consistent with a
+concurrent moderator update. A refresh can publish a previously unresolved
+review after it gains its first active Bottle assignment. It does not make an
+already matched review visible after a moderator hides it.
+
+Native article scrapers use the article ingestion boundary. The legacy
+single-review source and the moderator API retain their existing entry point
+because they have different source metadata and failure behavior. Both entry
+points use the same persistence helpers for source locking, article identity,
+Bottle validation, and review conflict behavior.
+
 ## Risks / Trade-offs
 
 - **Robots rules or public terms prohibit the planned requests** → Keep the

--- a/openspec/changes/pilot-external-review-indexing/specs/external-review-indexing/spec.md
+++ b/openspec/changes/pilot-external-review-indexing/specs/external-review-indexing/spec.md
@@ -139,6 +139,17 @@ without one active resolved Bottle.
 - **THEN** the review is not made visible and no partial identity update is
   committed
 
+#### Scenario: Moderator hides an automatically published review
+
+- **WHEN** a moderator hides a matched review and the source later refreshes it
+- **THEN** the refresh preserves the hidden state
+
+#### Scenario: Source policy changes during ingestion
+
+- **WHEN** article ingestion and a publication-mode update run concurrently
+- **THEN** they serialize so the stored visibility uses one committed policy
+  state
+
 ### Requirement: Bottle pages send readers to publishers
 
 The Bottle page SHALL present a visible external review with its publisher,

--- a/openspec/changes/pilot-external-review-indexing/tasks.md
+++ b/openspec/changes/pilot-external-review-indexing/tasks.md
@@ -93,3 +93,14 @@
 - [x] 7.4 Validate the OpenSpec change and record remaining source-pilot
       tasks without weakening the disabled-by-default boundary. The second
       publisher and post-deploy manual QA remain.
+
+## 8. Post-Pilot Cleanup
+
+- [x] 8.1 Share article and review persistence between the article ingestion
+      path and the legacy moderator entry point without changing either API
+- [x] 8.2 Serialize source policy updates with article ingestion and add a
+      deterministic concurrency test
+- [x] 8.3 Preserve a moderator-hidden matched review during automatic refresh
+      while still publishing a newly resolved review
+- [x] 8.4 Update the operating document for automatic publication and validate
+      the completed cleanup


### PR DESCRIPTION
External review imports now share one persistence boundary for source locking, article identity, Bottle validation, conflict handling, and review writes. Automatic ingestion serializes with publication-policy changes, publishes a review when it gains its first valid Bottle assignment, and preserves an explicit moderator hide on later refreshes.

The moderator endpoint keeps its existing classifier attribution and invalid-Bottle errors. Source ingestion keeps staged unresolved reviews and the scraper classifier credential. This changes no database schema or HTTP contract. The operating document now describes the available automatic mode.
