### PR TITLE
fix(scrapers): retain retailer product identifiers

### DIFF
--- a/apps/server/__fixtures__/bruichladdich/bottle-list.json
+++ b/apps/server/__fixtures__/bruichladdich/bottle-list.json
@@ -1,12 +1,13 @@
 {
   "products": [
     {
+      "id": 7287951261869,
       "title": "Bruichladdich Bere Barley 2013",
       "handle": "bruichladdich-bere-barley-2013",
       "product_type": "Unpeated Islay Single Malt Scotch Whisky",
       "vendor": "Bruichladdich Distillery",
       "tags": ["Bruichladdich", "Single Malt"],
-      "variants": [{"available": true, "price": "100.00", "title": "70cl"}],
+      "variants": [{"id": 42022881722541, "available": true, "barcode": "036602301979", "price": "100.00", "title": "70cl"}],
       "images": [{"src": "https://cdn.shopify.com/s/files/bruichladdich-bere-barley.png"}]
     },
     {

--- a/apps/server/__fixtures__/cadenheads/bottle-list.json
+++ b/apps/server/__fixtures__/cadenheads/bottle-list.json
@@ -1,5 +1,7 @@
 [
   {
+    "id": 21771,
+    "gtin": "036602301979",
     "name": "Cadenhead&#8217;s Glen Spey-Glenlivet 16yo 54.7% abv 70cl Single Malt Whisky",
     "permalink": "https://www.cadenhead.shop/product/glen-spey-glenlivet-16yo/",
     "prices": {

--- a/apps/server/__fixtures__/douglaslaing/bottle-list.json
+++ b/apps/server/__fixtures__/douglaslaing/bottle-list.json
@@ -1,6 +1,7 @@
 {
   "products": [
     {
+      "id": 6714331496619,
       "title": "Big Peat The World Football Edition 2026",
       "handle": "big-peat-the-world-football-edition-2026",
       "vendor": "Big Peat",
@@ -13,7 +14,9 @@
       ],
       "variants": [
         {
+          "id": 39952360276139,
           "available": true,
+          "barcode": "036602301979",
           "price": "65.00"
         }
       ]

--- a/apps/server/__fixtures__/dramfool/bottle-list.json
+++ b/apps/server/__fixtures__/dramfool/bottle-list.json
@@ -1,12 +1,15 @@
 {
   "items": [
     {
+      "id": "6a46b08a4dafad0f5168d302",
       "title": "Dramfool Glenallachie 11",
       "fullUrl": "/shop/glenallachie-11",
       "assetUrl": "https://images.squarespace-cdn.com/glenallachie-11.png",
       "productType": 1,
       "variants": [
         {
+          "id": "6baddfdf-bfb4-4355-bb4d-c98bb7132588",
+          "barcode": "036602301979",
           "attributes": { "Size": "70cl" },
           "priceMoney": { "currency": "GBP", "value": "100.00" },
           "salePriceMoney": { "currency": "GBP", "value": "0.00" },

--- a/apps/server/__fixtures__/glenallachie/bottle-list.json
+++ b/apps/server/__fixtures__/glenallachie/bottle-list.json
@@ -1,13 +1,14 @@
 {
   "products": [
     {
+      "id": 15633852137812,
       "title": "The GlenAllachie 12 Year Old",
       "handle": "the-glenallachie-12-year-old",
       "body_html": "<p>Our flagship single malt.</p>",
       "product_type": "Single Malt Scotch Whisky",
       "tags": ["glenallachie"],
       "images": [{"src": "https://cdn.shopify.com/s/files/glenallachie-12.png"}],
-      "variants": [{"available": true, "price": "54.99"}]
+      "variants": [{"id": 56545593229652, "available": true, "barcode": "036602301979", "price": "54.99"}]
     },
     {
       "title": "Online-Exclusive 3.0 2021 Chinquapin Virgin Oak Barrel #2300",

--- a/apps/server/__fixtures__/gordonmacphail/bottle-list.json
+++ b/apps/server/__fixtures__/gordonmacphail/bottle-list.json
@@ -12,7 +12,9 @@
       ],
       "variants": [
         {
+          "id": 39677108224067,
           "available": true,
+          "barcode": "036602301979",
           "price": "90.00"
         }
       ]

--- a/apps/server/__fixtures__/healthyspirits/bottle-list.json
+++ b/apps/server/__fixtures__/healthyspirits/bottle-list.json
@@ -40,6 +40,31 @@
           }
         },
         {
+          "identifier": {
+            "productId": 740590997
+          },
+          "externalReferenceId": "26084",
+          "defaultOptionsOverrides": {
+            "pricesOverrides": {
+              "basePrice": 59.99
+            },
+            "variationOverrides": {
+              "isSoldOut": false,
+              "productGridMediaItems": [
+                {
+                  "image800pxUrl": "https://d2j6dbq0eux0bg.cloudfront.net/images/115311147/5577358773.png",
+                  "isMain": true
+                }
+              ]
+            }
+          },
+          "name": "1792 FULL PROOF HEALTHY SPIRITS SINGLE BARREL BOURBON 750ML",
+          "seo": {
+            "canonicalUrl": "https://www.healthyspirits.com/products/1792-full-proof-healthy-spirits-single-barrel-bourbon-750ml",
+            "jsonLD": "{\"@context\":\"http://schema.org/\",\"@type\":\"Product\",\"gtin12\":\"080660001159\",\"sku\":\"26084_sku\"}"
+          }
+        },
+        {
           "defaultOptionsOverrides": {
             "pricesOverrides": {
               "basePrice": 899.99

--- a/apps/server/__fixtures__/missionliquor/bottle-list.json
+++ b/apps/server/__fixtures__/missionliquor/bottle-list.json
@@ -1,12 +1,13 @@
 {
   "products": [
     {
+      "id": 4364171083887,
       "title": "E.H. Taylor Small Batch Bottled In Bond Kentucky Straight Bourbon Whiskey 750ml",
       "handle": "eh-taylor-small-batch",
       "product_type": "WHISKEY",
       "tags": ["country-USA", "size-750ML", "varietal-BOURBON"],
       "images": [{ "src": "https://cdn.shopify.com/s/files/eh-taylor.png" }],
-      "variants": [{ "available": true, "price": "49.99" }]
+      "variants": [{ "id": 31235135012975, "available": true, "barcode": "036602301979", "price": "49.99" }]
     },
     {
       "title": "The Macallan Sherry Oak Single Malt Scotch Whisky 12 Year Old 700ml",

--- a/apps/server/__fixtures__/ncnean/bottle-list.json
+++ b/apps/server/__fixtures__/ncnean/bottle-list.json
@@ -1,13 +1,14 @@
 {
   "products": [
     {
+      "id": 15761596776830,
       "title": "AON 17-163 MADEIRA CASK (SINGLE CASK)",
       "handle": "aon-17-163-madeira-single-cask",
       "body_html": "<p>Unpeated single malt / 57.1% abv / 70cl / natural colour</p>",
       "tags": ["All Products", "Limited Edition Whiskies", "Whiskies"],
       "vendor": "Nc'nean Distillery ",
       "images": [{ "src": "https://cdn.shopify.com/s/files/ncnean-aon.png" }],
-      "variants": [{ "available": true, "price": "94.95", "title": "Default Title" }]
+      "variants": [{ "id": 56862151704958, "available": true, "barcode": "036602301979", "price": "94.95", "title": "Default Title" }]
     },
     {
       "title": "ORGANIC SINGLE MALT SCOTCH WHISKY",

--- a/apps/server/__fixtures__/northstarspirits/bottle-list.json
+++ b/apps/server/__fixtures__/northstarspirits/bottle-list.json
@@ -1,6 +1,7 @@
 {
   "products": [
     {
+      "id": 11503750447445,
       "title": "The Speyside Connection",
       "handle": "speyside-connection",
       "body_html": "<p>A North Star vatting of Speyside malts.</p>",
@@ -11,7 +12,9 @@
       ],
       "variants": [
         {
+          "id": 54618069893461,
           "available": true,
+          "barcode": "036602301979",
           "price": "69.99"
         }
       ]

--- a/apps/server/__fixtures__/singlecasknation/bottle-list.json
+++ b/apps/server/__fixtures__/singlecasknation/bottle-list.json
@@ -1,6 +1,7 @@
 {
   "products": [
     {
+      "id": 9031243464902,
       "title": "Rock Town 10 Year Old",
       "handle": "rock-town-10-year-old",
       "product_type": "Bourbon Whisky",
@@ -11,7 +12,9 @@
       ],
       "variants": [
         {
+          "id": 46957921599686,
           "available": true,
+          "barcode": "036602301979",
           "price": "90.00"
         }
       ]

--- a/apps/server/__fixtures__/thompsonbros/bottle-list.json
+++ b/apps/server/__fixtures__/thompsonbros/bottle-list.json
@@ -1,5 +1,7 @@
 [
   {
+    "id": 109292,
+    "gtin": "036602301979",
     "name": "Glen Scotia Single Malt Scotch Whisky, 2013, 12 Year Old, 70CL, 56.7%ABV",
     "permalink": "https://www.thompsonbrosdistillers.com/product/glen-scotia-2013/",
     "prices": {

--- a/apps/server/src/scraper/adapters/legacy/scrapeBerryBrosRudd.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeBerryBrosRudd.test.ts
@@ -24,6 +24,7 @@ test("scrapes purchasable own-selection bottles and excludes ineligible cards", 
   expect(items).toEqual([
     {
       currency: "gbp",
+      externalProductId: "20188403652",
       imageUrl:
         "https://media.bbr.com/s/bbr/20188403652-ms?fmt=auto&qlt=default",
       name: "2018 Berry Bros. & Rudd The Auld & The Bold Glen Wyvis, Cask Ref. 157, Highland, Single Malt Scotch Whisky (58.1%)",
@@ -33,6 +34,7 @@ test("scrapes purchasable own-selection bottles and excludes ineligible cards", 
     },
     {
       currency: "gbp",
+      externalProductId: "19798075646",
       imageUrl: "https://www.bbr.com/images/benrinnes.png",
       name: "1979 Berry Bros. & Rudd Exceptional Casks, Benrinnes, Cask Ref. 62, Speyside, Single Malt Scotch Whisky (42.1%)",
       price: 180000,

--- a/apps/server/src/scraper/adapters/legacy/scrapeBerryBrosRudd.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeBerryBrosRudd.ts
@@ -35,6 +35,11 @@ function parseVolume(value: string): number | null {
   return Number.isInteger(volume) ? volume : null;
 }
 
+function getExternalProductId(productUrl: string): string | undefined {
+  const match = new URL(productUrl).pathname.match(/^\/products-(\d+)(?:-|$)/);
+  return match?.[1];
+}
+
 export function parseBerryBrosRuddPage(
   html: string,
   sourceUrl: string,
@@ -93,13 +98,16 @@ export function parseBerryBrosRuddPage(
       .find('[data-testid="image-wrapper"] img.sf-image')
       .first();
     const imageUrl = image.attr("src") ?? image.attr("data-src");
+    const url = absoluteUrl(sourceUrl, productUrl);
+    const externalProductId = getExternalProductId(url);
     const { name } = normalizeBottle({ name: rawName });
     const listing = {
+      ...(externalProductId ? { externalProductId } : {}),
       name,
       price,
       currency: "gbp" as const,
       volume,
-      url: absoluteUrl(sourceUrl, productUrl),
+      url,
       imageUrl: imageUrl ? absoluteUrl(sourceUrl, imageUrl) : null,
     };
 

--- a/apps/server/src/scraper/adapters/legacy/scrapeBruichladdich.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeBruichladdich.test.ts
@@ -22,7 +22,9 @@ test("scrapes available full-size whisky and excludes unsupported products", asy
 
   expect(items).toEqual([
     {
+      barcode: "036602301979",
       currency: "gbp",
+      externalProductId: "7287951261869",
       imageUrl: "https://cdn.shopify.com/s/files/bruichladdich-bere-barley.png",
       name: "Bruichladdich Bere Barley 2013",
       price: 10000,

--- a/apps/server/src/scraper/adapters/legacy/scrapeBruichladdich.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeBruichladdich.ts
@@ -5,6 +5,7 @@ import scrapePrices from "../../legacy/scraper";
 import {
   getShopifyImageUrl,
   getShopifyProductTitle,
+  getShopifyStorePriceIdentity,
   parseShopifyPrice,
   scrapeShopifyProducts,
   ShopifyCatalogSchema,
@@ -147,6 +148,7 @@ export function parseBruichladdichProducts(input: unknown): StorePrice[] {
     }
 
     const listing = {
+      ...getShopifyStorePriceIdentity(product, variant),
       name,
       price,
       currency: "gbp" as const,

--- a/apps/server/src/scraper/adapters/legacy/scrapeCadenheads.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeCadenheads.test.ts
@@ -24,7 +24,9 @@ test("scrapes purchasable bottles and excludes unsupported products", async ({
 
   expect(items).toEqual([
     {
+      barcode: "036602301979",
       currency: "gbp",
+      externalProductId: "21771",
       imageUrl: "https://www.cadenhead.shop/wp-content/uploads/glen-spey.png",
       name: "Cadenhead's Glen Spey-Glenlivet 16-year-old 54.7% abv 70cl Single Malt Whisky",
       price: 7500,

--- a/apps/server/src/scraper/adapters/legacy/scrapeCadenheads.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeCadenheads.ts
@@ -5,6 +5,7 @@ import type { ScrapePricesCallback, StorePrice } from "../../legacy/scraper";
 import scrapePrices from "../../legacy/scraper";
 import {
   decodeWooCommerceText,
+  getWooCommerceStorePriceIdentity,
   parseWooCommercePrice,
   scrapeWooCommerceProducts,
   WooCommerceImageSchema,
@@ -90,6 +91,7 @@ export function parseCadenheadsProducts(input: unknown): StorePrice[] {
 
     const { name } = normalizeBottle({ name: rawName });
     const listing = {
+      ...getWooCommerceStorePriceIdentity(product),
       name,
       price,
       currency: "gbp" as const,

--- a/apps/server/src/scraper/adapters/legacy/scrapeDouglasLaing.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeDouglasLaing.test.ts
@@ -23,7 +23,9 @@ test("scrapes supported bottles and excludes non-bottle records", async ({
 
   expect(items).toEqual([
     expect.objectContaining({
+      barcode: "036602301979",
       currency: "usd",
+      externalProductId: "6714331496619",
       imageUrl: "https://cdn.shopify.com/s/files/big-peat-football.png",
       name: "Big Peat The World Football Edition 2026",
       price: 6500,

--- a/apps/server/src/scraper/adapters/legacy/scrapeDouglasLaing.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeDouglasLaing.ts
@@ -11,6 +11,7 @@ import { z } from "zod";
 import type { ScrapePricesCallback, StorePrice } from "../../legacy/scraper";
 import scrapePrices from "../../legacy/scraper";
 import {
+  getShopifyStorePriceIdentity,
   parseShopifyPrice,
   scrapeShopifyProducts,
   ShopifyCatalogSchema,
@@ -136,6 +137,7 @@ export function parseDouglasLaingProducts(
 
     const { name } = normalizeBottle({ name: product.title });
     const listing = {
+      ...getShopifyStorePriceIdentity(product, pricedVariant),
       name,
       price: pricedVariant.parsedPrice,
       currency: "usd" as const,

--- a/apps/server/src/scraper/adapters/legacy/scrapeDramfool.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeDramfool.test.ts
@@ -19,7 +19,9 @@ test("scrapes in-stock full bottles and excludes unsupported variants", async ({
 
   expect(items).toEqual([
     {
+      barcode: "036602301979",
       currency: "gbp",
+      externalProductId: "6baddfdf-bfb4-4355-bb4d-c98bb7132588",
       imageUrl: "https://images.squarespace-cdn.com/glenallachie-11.png",
       name: "Dramfool Glenallachie 11",
       price: 10000,

--- a/apps/server/src/scraper/adapters/legacy/scrapeDramfool.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeDramfool.ts
@@ -1,6 +1,7 @@
 import { normalizeBottle } from "@peated/bottle-classifier/normalize";
 import { ALLOWED_VOLUMES } from "@peated/server/constants";
 import { absoluteUrl } from "@peated/server/lib/urls";
+import { GtinSchema } from "@peated/server/schemas";
 import { z } from "zod";
 import type { ScrapePricesCallback, StorePrice } from "../../legacy/scraper";
 import scrapePrices, { getUrl } from "../../legacy/scraper";
@@ -18,6 +19,7 @@ const DramfoolCatalogSchema = z
 
 const DramfoolProductSchema = z
   .object({
+    id: z.string().trim().min(1).optional(),
     title: z.string().trim().min(1),
     fullUrl: z.string().trim().min(1),
     assetUrl: z.string().nullish(),
@@ -35,6 +37,8 @@ const MoneySchema = z
 
 const DramfoolVariantSchema = z
   .object({
+    id: z.string().trim().min(1).optional(),
+    barcode: z.string().trim().min(1).nullish(),
     attributes: z.record(z.string(), z.string()),
     priceMoney: MoneySchema,
     salePriceMoney: MoneySchema.optional(),
@@ -164,7 +168,13 @@ export function parseDramfoolProducts(input: unknown): StorePrice[] {
         ? product.title
         : `Dramfool ${product.title}`;
       const { name } = normalizeBottle({ name: rawName });
+      const externalProductId = variant.id ?? product.id;
+      const barcode = GtinSchema.safeParse(variant.barcode);
       const listing = {
+        ...(externalProductId
+          ? { externalProductId: String(externalProductId) }
+          : {}),
+        ...(barcode.success ? { barcode: barcode.data } : {}),
         name,
         price,
         currency: "gbp" as const,

--- a/apps/server/src/scraper/adapters/legacy/scrapeGlenAllachie.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeGlenAllachie.test.ts
@@ -22,7 +22,9 @@ test("scrapes available full-size whisky and excludes unsupported products", asy
 
   expect(items).toEqual([
     {
+      barcode: "036602301979",
       currency: "gbp",
+      externalProductId: "15633852137812",
       imageUrl: "https://cdn.shopify.com/s/files/glenallachie-12.png",
       name: "The GlenAllachie 12-year-old",
       price: 5499,

--- a/apps/server/src/scraper/adapters/legacy/scrapeGlenAllachie.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeGlenAllachie.ts
@@ -5,6 +5,7 @@ import scrapePrices from "../../legacy/scraper";
 import {
   getShopifyImageUrl,
   getShopifyProductTitle,
+  getShopifyStorePriceIdentity,
   parseShopifyPrice,
   scrapeShopifyProducts,
   ShopifyCatalogSchema,
@@ -139,6 +140,7 @@ export function parseGlenAllachieProducts(input: unknown): StorePrice[] {
     }
 
     const listing = {
+      ...getShopifyStorePriceIdentity(product, variant),
       name,
       price,
       currency: "gbp" as const,

--- a/apps/server/src/scraper/adapters/legacy/scrapeGordonMacphail.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeGordonMacphail.test.ts
@@ -20,6 +20,7 @@ test("scrapes available bottles and excludes unsupported products", async ({
 
   expect(items).toEqual([
     {
+      barcode: "036602301979",
       currency: "gbp",
       externalProductId: "6631010533443",
       imageUrl:

--- a/apps/server/src/scraper/adapters/legacy/scrapeGordonMacphail.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeGordonMacphail.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { ScrapePricesCallback, StorePrice } from "../../legacy/scraper";
 import scrapePrices from "../../legacy/scraper";
 import {
+  getShopifyStorePriceIdentity,
   parseShopifyPrice,
   scrapeShopifyProducts,
   ShopifyCatalogSchema,
@@ -96,6 +97,7 @@ export function parseGordonMacphailProducts(
 
     const { name } = normalizeBottle({ name: product.title });
     const listing = {
+      ...getShopifyStorePriceIdentity(product, pricedVariant),
       name,
       price: pricedVariant.parsedPrice,
       currency: "gbp" as const,
@@ -105,7 +107,6 @@ export function parseGordonMacphailProducts(
         `/products/${encodeURIComponent(product.handle)}`,
       ),
       imageUrl: product.images[0]?.src ?? null,
-      ...(product.id ? { externalProductId: String(product.id) } : {}),
     };
 
     logScrapedProduct(SITE, listing);

--- a/apps/server/src/scraper/adapters/legacy/scrapeHealthySpirits.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeHealthySpirits.test.ts
@@ -34,6 +34,16 @@ test("parses in-stock bottles from the catalog response", async () => {
           "url": "https://www.healthyspirits.com/products/fuji-japanese-whisky-blend-700ml",
           "volume": 700,
         },
+        {
+          "barcode": "080660001159",
+          "currency": "usd",
+          "externalProductId": "740590997",
+          "imageUrl": "https://d2j6dbq0eux0bg.cloudfront.net/images/115311147/5577358773.png",
+          "name": "1792 Full Proof Healthy Spirits Single Barrel Bourbon",
+          "price": 5999,
+          "url": "https://www.healthyspirits.com/products/1792-full-proof-healthy-spirits-single-barrel-bourbon-750ml",
+          "volume": 750,
+        },
       ]
     `);
 });
@@ -101,7 +111,7 @@ test("follows the catalog total without persisting a dry run", async ({
       ];
     });
 
-  await expect(scrapeHealthySpirits({ dryRun: true })).resolves.toBe(3);
+  await expect(scrapeHealthySpirits({ dryRun: true })).resolves.toBe(4);
   expect(axiosMock.history.post).toHaveLength(2);
   expect(JSON.parse(axiosMock.history.post[0].data)).toMatchObject({
     parentCategoryId: 179389817,

--- a/apps/server/src/scraper/adapters/legacy/scrapeHealthySpirits.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeHealthySpirits.ts
@@ -4,6 +4,7 @@ import {
 } from "@peated/bottle-classifier/normalize";
 import { ALLOWED_VOLUMES } from "@peated/server/constants";
 import { toTitleCase } from "@peated/server/lib/strings";
+import { GtinSchema } from "@peated/server/schemas";
 import { z } from "zod";
 import type { ScrapePricesCallback, StorePrice } from "../../legacy/scraper";
 import scrapePrices, { requestUrl } from "../../legacy/scraper";
@@ -29,6 +30,15 @@ const CatalogResponseSchema = z.object({
 
 const ProductSchema = z
   .object({
+    externalReferenceId: z.string().trim().min(1).optional(),
+    identifier: z
+      .object({
+        productId: z.union([
+          z.number().int().positive(),
+          z.string().trim().min(1),
+        ]),
+      })
+      .optional(),
     defaultOptionsOverrides: z.object({
       pricesOverrides: z.object({
         basePrice: z.number().positive(),
@@ -48,7 +58,18 @@ const ProductSchema = z
     name: z.string().trim().min(1),
     seo: z.object({
       canonicalUrl: z.string().trim().min(1),
+      jsonLD: z.string().optional(),
     }),
+  })
+  .passthrough();
+
+const StructuredProductSchema = z
+  .object({
+    gtin: z.string().optional(),
+    gtin8: z.string().optional(),
+    gtin12: z.string().optional(),
+    gtin13: z.string().optional(),
+    gtin14: z.string().optional(),
   })
   .passthrough();
 
@@ -96,6 +117,31 @@ function getImageUrl(
     return url.protocol === "https:" ? url.toString() : undefined;
   } catch {
     return;
+  }
+}
+
+function getProductBarcode(jsonLD: string | undefined): string | undefined {
+  if (!jsonLD) return;
+
+  let input: unknown;
+  try {
+    input = JSON.parse(jsonLD);
+  } catch {
+    return;
+  }
+
+  const result = StructuredProductSchema.safeParse(input);
+  if (!result.success) return;
+
+  for (const value of [
+    result.data.gtin,
+    result.data.gtin8,
+    result.data.gtin12,
+    result.data.gtin13,
+    result.data.gtin14,
+  ]) {
+    const barcode = GtinSchema.safeParse(value);
+    if (barcode.success) return barcode.data;
   }
 }
 
@@ -156,7 +202,14 @@ export function parseHealthySpiritsProducts(
     }
 
     const { name } = normalizeBottle({ name: toTitleCase(nameRaw) });
+    const externalProductId =
+      product.identifier?.productId ?? product.externalReferenceId;
+    const barcode = getProductBarcode(product.seo.jsonLD);
     const listing = {
+      ...(externalProductId !== undefined
+        ? { externalProductId: String(externalProductId) }
+        : {}),
+      ...(barcode ? { barcode } : {}),
       currency: "usd" as const,
       imageUrl: getImageUrl(
         product.defaultOptionsOverrides.variationOverrides

--- a/apps/server/src/scraper/adapters/legacy/scrapeMissionLiquor.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeMissionLiquor.test.ts
@@ -22,7 +22,9 @@ test("scrapes available single bottles and excludes unsupported products", async
 
   expect(items).toEqual([
     {
+      barcode: "036602301979",
       currency: "usd",
+      externalProductId: "4364171083887",
       imageUrl: "https://cdn.shopify.com/s/files/eh-taylor.png",
       name: "E.H. Taylor Small Batch Bottled In Bond Kentucky Straight Bourbon Whiskey",
       price: 4999,

--- a/apps/server/src/scraper/adapters/legacy/scrapeMissionLiquor.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeMissionLiquor.ts
@@ -6,6 +6,7 @@ import scrapePrices from "../../legacy/scraper";
 import {
   getShopifyImageUrl,
   getShopifyProductTitle,
+  getShopifyStorePriceIdentity,
   parseShopifyPrice,
   scrapeShopifyProducts,
   ShopifyCatalogSchema,
@@ -123,11 +124,14 @@ export function parseMissionLiquorProducts(input: unknown): StorePrice[] {
       continue;
     }
 
-    const price = parseShopifyPrice(availableVariants[0].price);
+    const variant = availableVariants[0];
+    if (!variant) continue;
+
+    const price = parseShopifyPrice(variant.price);
     if (price === null) {
       logScrapeWarning(SITE, "Invalid product price", {
         rawName: product.title,
-        price: availableVariants[0].price,
+        price: variant.price,
       });
       continue;
     }
@@ -151,6 +155,7 @@ export function parseMissionLiquorProducts(input: unknown): StorePrice[] {
     }
 
     const listing = {
+      ...getShopifyStorePriceIdentity(product, variant),
       name,
       price,
       currency: "usd" as const,

--- a/apps/server/src/scraper/adapters/legacy/scrapeNcnean.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeNcnean.test.ts
@@ -22,7 +22,9 @@ test("scrapes available full-size whisky and excludes unsupported products", asy
 
   expect(items).toEqual([
     {
+      barcode: "036602301979",
       currency: "gbp",
+      externalProductId: "15761596776830",
       imageUrl: "https://cdn.shopify.com/s/files/ncnean-aon.png",
       name: "Nc'nean Aon 17-163 Madeira Cask (Single Cask)",
       price: 9495,

--- a/apps/server/src/scraper/adapters/legacy/scrapeNcnean.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeNcnean.ts
@@ -5,6 +5,7 @@ import scrapePrices from "../../legacy/scraper";
 import {
   getShopifyImageUrl,
   getShopifyProductTitle,
+  getShopifyStorePriceIdentity,
   parseShopifyPrice,
   scrapeShopifyProducts,
   ShopifyCatalogSchema,
@@ -153,6 +154,7 @@ export function parseNcneanProducts(input: unknown): StorePrice[] {
     }
 
     const listing = {
+      ...getShopifyStorePriceIdentity(product, variant),
       name,
       price,
       currency: "gbp" as const,

--- a/apps/server/src/scraper/adapters/legacy/scrapeNorthStarSpirits.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeNorthStarSpirits.test.ts
@@ -22,7 +22,9 @@ test("scrapes live whisky listings and excludes unsupported products", async ({
 
   expect(items).toEqual([
     {
+      barcode: "036602301979",
       currency: "gbp",
+      externalProductId: "11503750447445",
       imageUrl: "https://cdn.shopify.com/s/files/speyside-connection.png",
       name: "The Speyside Connection",
       price: 6999,

--- a/apps/server/src/scraper/adapters/legacy/scrapeNorthStarSpirits.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeNorthStarSpirits.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import type { ScrapePricesCallback, StorePrice } from "../../legacy/scraper";
 import scrapePrices from "../../legacy/scraper";
 import {
+  getShopifyStorePriceIdentity,
   parseShopifyPrice,
   scrapeShopifyProducts,
   ShopifyCatalogSchema,
@@ -81,6 +82,7 @@ export function parseNorthStarProducts(
 
     const { name } = normalizeBottle({ name: product.title });
     const listing = {
+      ...getShopifyStorePriceIdentity(product, pricedVariant),
       name,
       price: pricedVariant.parsedPrice,
       currency: "gbp" as const,

--- a/apps/server/src/scraper/adapters/legacy/scrapeReserveBar.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeReserveBar.test.ts
@@ -18,6 +18,7 @@ test("parses supported bottles from the catalog response", async () => {
       [
         {
           "currency": "usd",
+          "externalProductId": "GROUPING-1234",
           "imageUrl": "https://assets.liquidcommerce.co/catalog/macallan.png",
           "name": "The Macallan Double Cask 12-year-old",
           "price": 9289,
@@ -26,6 +27,7 @@ test("parses supported bottles from the catalog response", async () => {
         },
         {
           "currency": "usd",
+          "externalProductId": "GROUPING-38632",
           "imageUrl": null,
           "name": "Gentleman Jack Tennessee Whiskey",
           "price": 2839,

--- a/apps/server/src/scraper/adapters/legacy/scrapeReserveBar.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeReserveBar.ts
@@ -112,6 +112,7 @@ export function parseReserveBarProducts(input: unknown): {
         : product.name;
     const { name } = normalizeBottle({ name: rawName });
     const listing = {
+      externalProductId: product.salsifyGrouping,
       currency: "usd" as const,
       imageUrl: getImageUrl(product.images),
       name,

--- a/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.test.ts
@@ -22,7 +22,9 @@ test("scrapes every supported whisky type and excludes ineligible records", asyn
 
   expect(items).toEqual([
     {
+      barcode: "036602301979",
       currency: "usd",
+      externalProductId: "9031243464902",
       imageUrl: "https://cdn.shopify.com/s/files/rock-town-10.png",
       name: "Single Cask Nation Rock Town 10-year-old",
       price: 9000,

--- a/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { ScrapePricesCallback, StorePrice } from "../../legacy/scraper";
 import scrapePrices from "../../legacy/scraper";
 import {
+  getShopifyStorePriceIdentity,
   parseShopifyPrice,
   scrapeShopifyProducts,
   ShopifyCatalogSchema,
@@ -55,6 +56,7 @@ export function parseSingleCaskNationProducts(
       name: `Single Cask Nation ${product.title}`,
     });
     const listing = {
+      ...getShopifyStorePriceIdentity(product, pricedVariant),
       name,
       price: pricedVariant.parsedPrice,
       currency: "usd" as const,

--- a/apps/server/src/scraper/adapters/legacy/scrapeThompsonBros.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeThompsonBros.test.ts
@@ -20,7 +20,9 @@ test("scrapes purchasable whisky bottles and excludes unsupported products", asy
 
   expect(items).toEqual([
     {
+      barcode: "036602301979",
       currency: "gbp",
+      externalProductId: "109292",
       imageUrl:
         "https://www.thompsonbrosdistillers.com/wp-content/uploads/glen-scotia.png",
       name: "Thompson Bros Glen Scotia Single Malt Scotch Whisky, 2013, 12-year-old, 70CL, 56.7%ABV",

--- a/apps/server/src/scraper/adapters/legacy/scrapeThompsonBros.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeThompsonBros.ts
@@ -5,6 +5,7 @@ import scrapePrices from "../../legacy/scraper";
 import {
   decodeWooCommerceText,
   getWooCommerceProductName,
+  getWooCommerceStorePriceIdentity,
   parseWooCommercePrice,
   scrapeWooCommerceProducts,
   WooCommerceCatalogSchema,
@@ -101,6 +102,7 @@ export function parseThompsonBrosProducts(input: unknown): StorePrice[] {
       : `Thompson Bros ${rawName}`;
     const { name } = normalizeBottle({ name: prefixedName });
     const listing = {
+      ...getWooCommerceStorePriceIdentity(product),
       name,
       price,
       currency: "gbp" as const,

--- a/apps/server/src/scraper/legacy/shopify.test.ts
+++ b/apps/server/src/scraper/legacy/shopify.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test, vi } from "vitest";
 import {
   getShopifyImageUrl,
+  getShopifyStorePriceIdentity,
   parseShopifyPrice,
   scrapeShopifyProducts,
+  ShopifyProductSchema,
 } from "./shopify";
 
 process.env.DISABLE_HTTP_CACHE = "1";
@@ -67,4 +69,44 @@ test("rejects malformed catalog payloads", async ({ axiosMock }) => {
       () => [],
     ),
   ).rejects.toThrow();
+});
+
+test("returns the stable product id and a valid variant barcode", () => {
+  const product = ShopifyProductSchema.parse({
+    id: 123,
+    title: "Example Whisky",
+    handle: "example-whisky",
+    images: [],
+    variants: [
+      {
+        available: true,
+        barcode: "036602301979",
+        price: "50.00",
+      },
+    ],
+  });
+
+  expect(getShopifyStorePriceIdentity(product, product.variants[0]!)).toEqual({
+    barcode: "036602301979",
+    externalProductId: "123",
+  });
+});
+
+test("omits unsupported identity claims", () => {
+  const product = ShopifyProductSchema.parse({
+    title: "Example Whisky",
+    handle: "example-whisky",
+    images: [],
+    variants: [
+      {
+        available: true,
+        barcode: "not-a-gtin",
+        price: "50.00",
+      },
+    ],
+  });
+
+  expect(getShopifyStorePriceIdentity(product, product.variants[0]!)).toEqual(
+    {},
+  );
 });

--- a/apps/server/src/scraper/legacy/shopify.ts
+++ b/apps/server/src/scraper/legacy/shopify.ts
@@ -1,3 +1,4 @@
+import { GtinSchema } from "@peated/server/schemas";
 import { z } from "zod";
 import type {
   ScrapePricesCallback,
@@ -14,7 +15,11 @@ export const ShopifyCatalogSchema = z
 
 export const ShopifyVariantSchema = z
   .object({
+    id: z
+      .union([z.number().int().positive(), z.string().trim().min(1)])
+      .optional(),
     available: z.boolean(),
+    barcode: z.string().trim().min(1).nullish(),
     price: z.string(),
   })
   .passthrough();
@@ -27,12 +32,28 @@ export const ShopifyImageSchema = z
 
 export const ShopifyProductSchema = z
   .object({
+    id: z
+      .union([z.number().int().positive(), z.string().trim().min(1)])
+      .optional(),
     title: z.string().trim().min(1),
     handle: z.string().trim().min(1),
     images: z.array(z.unknown()),
     variants: z.array(ShopifyVariantSchema),
   })
   .passthrough();
+
+export function getShopifyStorePriceIdentity(
+  product: Pick<z.infer<typeof ShopifyProductSchema>, "id">,
+  variant: Pick<z.infer<typeof ShopifyVariantSchema>, "barcode">,
+) {
+  const barcode = GtinSchema.safeParse(variant.barcode);
+  return {
+    ...(product.id !== undefined
+      ? { externalProductId: String(product.id) }
+      : {}),
+    ...(barcode.success ? { barcode: barcode.data } : {}),
+  };
+}
 
 export function getShopifyProductTitle(input: unknown): string | null {
   if (!input || typeof input !== "object" || !("title" in input)) return null;

--- a/apps/server/src/scraper/legacy/woocommerce.test.ts
+++ b/apps/server/src/scraper/legacy/woocommerce.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test, vi } from "vitest";
 import {
   decodeWooCommerceText,
+  getWooCommerceStorePriceIdentity,
   parseWooCommercePrice,
   scrapeWooCommerceProducts,
+  WooCommerceProductSchema,
 } from "./woocommerce";
 
 process.env.DISABLE_HTTP_CACHE = "1";
@@ -49,4 +51,39 @@ test("rejects malformed catalog payloads", async ({ axiosMock }) => {
       () => [],
     ),
   ).rejects.toThrow();
+});
+
+function productWithIdentity(input: { id?: number; gtin?: string | null }) {
+  return WooCommerceProductSchema.parse({
+    ...input,
+    name: "Example Whisky",
+    permalink: "https://example.com/example-whisky",
+    prices: {
+      price: "5000",
+      currency_code: "GBP",
+      currency_minor_unit: 2,
+    },
+    images: [],
+    is_in_stock: true,
+    is_purchasable: true,
+  });
+}
+
+test("returns the stable product id and a valid GTIN", () => {
+  expect(
+    getWooCommerceStorePriceIdentity(
+      productWithIdentity({ id: 123, gtin: "036602301979" }),
+    ),
+  ).toEqual({
+    barcode: "036602301979",
+    externalProductId: "123",
+  });
+});
+
+test("omits unsupported identity claims", () => {
+  expect(
+    getWooCommerceStorePriceIdentity(
+      productWithIdentity({ gtin: "not-a-gtin" }),
+    ),
+  ).toEqual({});
 });

--- a/apps/server/src/scraper/legacy/woocommerce.ts
+++ b/apps/server/src/scraper/legacy/woocommerce.ts
@@ -1,3 +1,4 @@
+import { GtinSchema } from "@peated/server/schemas";
 import { load as cheerio } from "cheerio";
 import { z } from "zod";
 import type {
@@ -25,6 +26,10 @@ export const WooCommerceImageSchema = z
 
 export const WooCommerceProductSchema = z
   .object({
+    id: z
+      .union([z.number().int().positive(), z.string().trim().min(1)])
+      .optional(),
+    gtin: z.string().trim().min(1).nullish(),
     name: z.string().trim().min(1),
     permalink: z.string().trim().min(1),
     prices: WooCommercePriceSchema,
@@ -33,6 +38,18 @@ export const WooCommerceProductSchema = z
     is_purchasable: z.boolean(),
   })
   .passthrough();
+
+export function getWooCommerceStorePriceIdentity(
+  product: z.infer<typeof WooCommerceProductSchema>,
+) {
+  const barcode = GtinSchema.safeParse(product.gtin);
+  return {
+    ...(product.id !== undefined
+      ? { externalProductId: String(product.id) }
+      : {}),
+    ...(barcode.success ? { barcode: barcode.data } : {}),
+  };
+}
 
 export function getWooCommerceProductName(input: unknown): string | null {
   if (!input || typeof input !== "object" || !("name" in input)) return null;


### PR DESCRIPTION
Retailer scrapers now retain stable external product IDs and valid GTIN claims whenever their current catalog response exposes them. Shared Shopify and WooCommerce parsing covers every adapter on those platforms, while Healthy Spirits, Dramfool, ReserveBar, and Berry Bros. & Rudd use their source-specific identifiers.

Canonical product URLs remain the fallback for sources without an identifier, and this adds no per-product requests. Retailer GTINs remain source claims and are not promoted to canonical Bottle barcodes. Existing price rows receive the richer identity after their next normal scrape, so any later proposal reprocessing can stay small and bounded.

Regression coverage includes the Healthy Spirits private-barrel case that exposed the gap, platform-level valid and invalid barcode handling, and each affected adapter's output contract.
