### PR TITLE
feat(scraper): collect Whisky Advocate review dates

### DIFF
--- a/apps/server/__fixtures__/whiskyadvocate/review-page.html
+++ b/apps/server/__fixtures__/whiskyadvocate/review-page.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <script type="application/ld json">
+      {
+        "@context": "https://schema.org",
+        "@type": "NewsArticle",
+        "datePublished": "{{ December 19, 2023 | iso8601 }}"
+      }
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/apps/server/src/scraper/adapters/whiskyAdvocate.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyAdvocate.test.ts
@@ -5,6 +5,8 @@ import type { ScraperObservation, ScraperSession } from "../types";
 import {
   type WhiskyAdvocateCursor,
   type WhiskyAdvocateObservation,
+  parseReviewPublishedAt,
+  parseReviews,
   whiskyAdvocateAdapter,
   WhiskyAdvocateCursorSchema,
 } from "./whiskyAdvocate";
@@ -13,11 +15,33 @@ test("accepts a cursor stored by the previous adapter", () => {
   expect(
     WhiskyAdvocateCursorSchema.parse({ processedIssues: ["Winter 2023"] }),
   ).toEqual({ processedIssues: ["Winter 2023"] });
+  expect(
+    WhiskyAdvocateCursorSchema.parse({
+      issue: "Winter 2023",
+      processedReviewUrls: ["https://whiskyadvocate.com/example-review"],
+    }),
+  ).toEqual({
+    issue: "Winter 2023",
+    processedReviewUrls: ["https://whiskyadvocate.com/example-review"],
+  });
 });
 
-test("fetches the latest issue and preserves Bottle identity facts", async () => {
+test("parses the publisher date template", async () => {
+  const html = await loadFixture("whiskyadvocate", "review-page.html");
+
+  expect(parseReviewPublishedAt(html)).toEqual(
+    new Date("2023-12-19T00:00:00.000Z"),
+  );
+  expect(parseReviewPublishedAt("<html></html>")).toBeNull();
+  expect(() =>
+    parseReviewPublishedAt('<script>"datePublished": "not-a-date"</script>'),
+  ).toThrow("Whisky Advocate review date is invalid.");
+});
+
+test("fetches dates for the latest issue and checkpoints each review", async () => {
   const issueHtml = await loadFixture("whiskyadvocate", "empty-search.html");
   const reviewHtml = await loadFixture("whiskyadvocate", "bottle-list.html");
+  const articleHtml = await loadFixture("whiskyadvocate", "review-page.html");
   const $ = cheerio(issueHtml);
   const issueNames = $("select")
     .filter(
@@ -35,8 +59,14 @@ test("fetches the latest issue and preserves Bottle identity facts", async () =>
     url,
     status: 200,
     headers: {},
-    body: url.search.includes("custom_rating_issue") ? reviewHtml : issueHtml,
+    body:
+      url.pathname !== "/ratings-reviews"
+        ? articleHtml
+        : url.search.includes("custom_rating_issue")
+          ? reviewHtml
+          : issueHtml,
   }));
+  const checkpoint = vi.fn();
   const session: ScraperSession<
     WhiskyAdvocateCursor,
     WhiskyAdvocateObservation
@@ -45,13 +75,13 @@ test("fetches the latest issue and preserves Bottle identity facts", async () =>
     emit: async (observation) => {
       observations.push(observation);
     },
-    checkpoint: vi.fn(),
-    remainingRequests: () => 2,
+    checkpoint,
+    remainingRequests: () => 200,
   };
 
   await whiskyAdvocateAdapter({ cursor: null, session });
 
-  expect(request).toHaveBeenCalledTimes(2);
+  expect(request).toHaveBeenCalledTimes(168);
   expect(
     request.mock.calls[1]?.[0].url.searchParams.get("custom_rating_issue[0]"),
   ).toBe(issueNames[0]);
@@ -66,6 +96,7 @@ test("fetches the latest issue and preserves Bottle identity facts", async () =>
         title:
           "Angel’s Envy Cask Strength Sauternes and Toasted Oak Barrel Finished (Batch RC1), 57.2%",
         issue: "Winter 2023",
+        publishedAt: new Date("2023-12-19T00:00:00.000Z"),
         contentHash: expect.any(String),
         reviews: [
           {
@@ -81,12 +112,59 @@ test("fetches the latest issue and preserves Bottle identity facts", async () =>
       reviewTexts: {},
     },
   });
+  expect(checkpoint).toHaveBeenCalledTimes(166);
+  expect(checkpoint).toHaveBeenLastCalledWith({
+    issue: "Winter 2023",
+    processedReviewUrls: observations.map(({ sourceKey }) => sourceKey),
+  });
+});
+
+test("resumes the same issue after the last stored review", async () => {
+  const reviewHtml = await loadFixture("whiskyadvocate", "bottle-list.html");
+  const articleHtml = await loadFixture("whiskyadvocate", "review-page.html");
+  const reviews = parseReviews(
+    reviewHtml,
+    "https://whiskyadvocate.com/ratings-reviews",
+  );
+  const processedReviewUrls = reviews.slice(0, -1).map((review) => review.url);
+  const emit = vi.fn();
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body: url.pathname === "/ratings-reviews" ? reviewHtml : articleHtml,
+  }));
+  const session: ScraperSession<
+    WhiskyAdvocateCursor,
+    WhiskyAdvocateObservation
+  > = {
+    request,
+    emit,
+    checkpoint,
+    remainingRequests: () => 20,
+  };
+
+  await whiskyAdvocateAdapter({
+    cursor: { issue: "Winter 2023", processedReviewUrls },
+    session,
+  });
+
+  expect(request).toHaveBeenCalledTimes(2);
+  expect(emit).toHaveBeenCalledOnce();
+  expect(emit).toHaveBeenCalledWith(
+    expect.objectContaining({ sourceKey: reviews.at(-1)?.url }),
+  );
+  expect(checkpoint).toHaveBeenCalledWith({
+    issue: "Winter 2023",
+    processedReviewUrls: reviews.map((review) => review.url),
+  });
 });
 
 test("fails when the newest issue has no review results", async () => {
   const issueHtml = await loadFixture("whiskyadvocate", "empty-search.html");
-  const request = vi.fn(async ({ url }: { url: URL }) => ({
-    url,
+  const request = vi.fn(async () => ({
+    url: new URL("https://whiskyadvocate.com/ratings-reviews"),
     status: 200,
     headers: {},
     body: issueHtml,

--- a/apps/server/src/scraper/adapters/whiskyAdvocate.ts
+++ b/apps/server/src/scraper/adapters/whiskyAdvocate.ts
@@ -15,11 +15,23 @@ import type { ScraperAdapter } from "../types";
 const ORIGIN = "https://whiskyadvocate.com";
 const TARGET = "whiskyadvocate";
 
-// Active runs can resume across deploys.
-// Accept cursors written by the prior adapter.
-export const WhiskyAdvocateCursorSchema = z
+const LegacyWhiskyAdvocateCursorSchema = z
   .object({ processedIssues: z.array(z.string().min(1)) })
   .strict();
+
+const CurrentWhiskyAdvocateCursorSchema = z
+  .object({
+    issue: z.string().min(1),
+    processedReviewUrls: z.array(z.url()).max(500),
+  })
+  .strict();
+
+// Active runs can resume across deploys.
+// Accept cursors written by the prior adapter.
+export const WhiskyAdvocateCursorSchema = z.union([
+  LegacyWhiskyAdvocateCursorSchema,
+  CurrentWhiskyAdvocateCursorSchema,
+]);
 
 export type WhiskyAdvocateCursor = z.infer<typeof WhiskyAdvocateCursorSchema>;
 
@@ -42,6 +54,28 @@ function normalizeText(value: string): string {
   return value.replaceAll(/\s+/g, " ").trim();
 }
 
+export function parseReviewPublishedAt(data: string): Date | null {
+  const $ = cheerio(data);
+  const metadata = $("script")
+    .toArray()
+    .map((element) => $(element).text())
+    .find((value) => /"datePublished"\s*:/iu.test(value));
+  const rawValue = metadata?.match(/"datePublished"\s*:\s*"(?<value>[^"]+)"/iu)
+    ?.groups?.value;
+  if (!rawValue) return null;
+
+  const templateValue = rawValue.match(
+    /^\{\{\s*(?<value>.+?)\s*\|\s*iso8601\s*\}\}$/iu,
+  )?.groups?.value;
+  const publishedAt = new Date(
+    templateValue ? `${templateValue} UTC` : rawValue,
+  );
+  if (Number.isNaN(publishedAt.getTime())) {
+    throw new Error("Whisky Advocate review date is invalid.");
+  }
+  return publishedAt;
+}
+
 export function parseIssueList(data: string) {
   const $ = cheerio(data);
   const results: string[] = [];
@@ -58,13 +92,9 @@ export function parseIssueList(data: string) {
   return results;
 }
 
-export async function parseReviews(
-  data: string,
-  url: string,
-  callback: (review: WhiskyAdvocateReview) => Promise<void>,
-) {
+export function parseReviews(data: string, url: string) {
   const $ = cheerio(data);
-  let parsed = 0;
+  const reviews: WhiskyAdvocateReview[] = [];
 
   for (const element of $("#directoryResults .postsItem")) {
     const name = normalizeText(
@@ -107,30 +137,34 @@ export async function parseReviews(
       .contents()
       .first()
       .text();
-    await callback({
+    reviews.push({
       name,
       category: normalizeCategory(normalizeText(rawCategory)),
       rating: Number(rawRating),
       issue,
       url: absoluteUrl(url, reviewUrl),
     });
-    parsed += 1;
   }
 
-  return parsed;
+  return reviews;
 }
 
 export const whiskyAdvocateAdapter: ScraperAdapter<
   WhiskyAdvocateCursor,
   WhiskyAdvocateObservation
-> = async ({ session }) => {
-  const issueListUrl = new URL("/ratings-reviews", ORIGIN);
-  const issueListResponse = await session.request({
-    target: TARGET,
-    url: issueListUrl,
-  });
-  const issue = parseIssueList(issueListResponse.body)[0];
+> = async ({ cursor, session }) => {
+  const activeCursor =
+    cursor && "processedReviewUrls" in cursor ? cursor : null;
+  let issue = activeCursor?.issue;
+  if (!issue) {
+    const issueListResponse = await session.request({
+      target: TARGET,
+      url: new URL("/ratings-reviews", ORIGIN),
+    });
+    issue = parseIssueList(issueListResponse.body)[0];
+  }
   if (!issue) throw new Error("Whisky Advocate issue list is empty.");
+  const processedReviewUrls = new Set(activeCursor?.processedReviewUrls ?? []);
 
   const reviewUrl = new URL("/ratings-reviews", ORIGIN);
   reviewUrl.searchParams.set("custom_rating_issue[0]", issue);
@@ -139,49 +173,58 @@ export const whiskyAdvocateAdapter: ScraperAdapter<
     target: TARGET,
     url: reviewUrl,
   });
-  const parsed = await parseReviews(
-    reviewResponse.body,
-    reviewResponse.url.href,
-    async (review) => {
-      const nativeScore = {
-        value: review.rating,
-        scale: 100,
-        display: `${review.rating}/100`,
-      };
-      const value = WhiskyAdvocateObservationSchema.parse({
-        article: {
-          canonicalUrl: review.url,
-          title: review.name,
-          issue: review.issue,
-          publishedAt: null,
-          contentHash: createHash("sha256")
-            .update(
-              JSON.stringify({
-                name: review.name,
-                category: review.category,
-                rating: review.rating,
-                url: review.url,
-                issue: review.issue,
-              }),
-            )
-            .digest("hex"),
-          reviews: [
-            {
-              sourceKey: review.url,
+  const reviews = parseReviews(reviewResponse.body, reviewResponse.url.href);
+  if (reviews.length === 0) {
+    throw new Error("Whisky Advocate issue contains no reviews.");
+  }
+
+  for (const review of reviews) {
+    if (processedReviewUrls.has(review.url)) continue;
+    const articleResponse = await session.request({
+      target: TARGET,
+      url: new URL(review.url),
+    });
+    const publishedAt = parseReviewPublishedAt(articleResponse.body);
+    const nativeScore = {
+      value: review.rating,
+      scale: 100,
+      display: `${review.rating}/100`,
+    };
+    const value = WhiskyAdvocateObservationSchema.parse({
+      article: {
+        canonicalUrl: review.url,
+        title: review.name,
+        issue: review.issue,
+        publishedAt,
+        contentHash: createHash("sha256")
+          .update(
+            JSON.stringify({
               name: review.name,
               category: review.category,
-              reviewerName: null,
-              nativeScore,
-              normalizedRating: normalizeReviewRating(nativeScore),
-            },
-          ],
-        },
-        reviewTexts: {},
-      });
-      await session.emit({ sourceKey: review.url, value });
-    },
-  );
-  if (parsed === 0) {
-    throw new Error("Whisky Advocate issue contains no reviews.");
+              rating: review.rating,
+              url: review.url,
+              issue: review.issue,
+            }),
+          )
+          .digest("hex"),
+        reviews: [
+          {
+            sourceKey: review.url,
+            name: review.name,
+            category: review.category,
+            reviewerName: null,
+            nativeScore,
+            normalizedRating: normalizeReviewRating(nativeScore),
+          },
+        ],
+      },
+      reviewTexts: {},
+    });
+    await session.emit({ sourceKey: review.url, value });
+    processedReviewUrls.add(review.url);
+    await session.checkpoint({
+      issue,
+      processedReviewUrls: [...processedReviewUrls],
+    });
   }
 };

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -79,10 +79,10 @@ test("registers every scraper source with explicit target ownership", () => {
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyadvocate.runEvery).toBeNull();
   expect(scraperRegistry.targets.get("whiskyadvocate")).toMatchObject({
     minimumSpacingMs: 2_500,
-    requestsPerWindow: 10,
+    requestsPerWindow: 20,
     windowMs: 3_600_000,
   });
-  expect(scraperRegistry.sources.get("whiskyadvocate")?.requestLimit).toBe(2);
+  expect(scraperRegistry.sources.get("whiskyadvocate")?.requestLimit).toBe(30);
   expect(EXTERNAL_SITE_DEFINITIONS.whiskynotes.runEvery).toBeNull();
   expect(scraperRegistry.targets.get("whiskynotes")).toMatchObject({
     minimumSpacingMs: 2_500,

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -212,7 +212,7 @@ export const scraperRegistry = createScraperRegistry({
     defineScrapeTarget({
       key: "whiskyadvocate",
       minimumSpacingMs: 2_500,
-      requestsPerWindow: 10,
+      requestsPerWindow: 20,
       origins: [
         {
           origin: "https://whiskyadvocate.com",
@@ -259,7 +259,9 @@ export const scraperRegistry = createScraperRegistry({
       key: "whiskyadvocate",
       externalSiteType: "whiskyadvocate",
       targetKeys: ["whiskyadvocate"],
-      requestLimit: 2,
+      // Keep the slice budget above the target quota so one hourly deferral
+      // consumes one execution attempt.
+      requestLimit: 30,
       cursorSchema: WhiskyAdvocateCursorSchema,
       observationSchema: WhiskyAdvocateObservationSchema,
       adapter: whiskyAdvocateAdapter,

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -126,11 +126,13 @@ The WhiskyNotes pilot is manual-only. It checks at most five archive pages and
 20 article links on each page. Requests are at least 2.5 seconds apart. The
 target allows 30 requests per hour. Each worker pass stops after 30 requests.
 
-The Whisky Advocate pilot is also manual-only. It requests the issue index and
-the newest issue, with at least 2.5 seconds between requests. Each run stops
-after two requests, and the target allows at most 10 requests per hour. The
-adapter keeps the complete source Bottle title for classification and reads the
-category before the separate price line. It does not fetch review prose.
+The Whisky Advocate pilot is also manual-only. It requests the issue index, the
+newest issue, and each listed review page to collect its explicit publication
+date. Requests are at least 2.5 seconds apart. Each worker pass has a 30-request
+budget, and the target allows at most 20 requests per hour. The run checkpoints
+each stored review and can resume for up to ten worker passes. The adapter keeps
+the complete source Bottle title for classification and reads the category
+before the separate price line. It does not persist review prose.
 
 Enable automatic publication only after the reviewed sample passes the gate.
 Repeat the robots, terms, and review-only process for the second publisher

--- a/docs/research/external-review-content-supply.md
+++ b/docs/research/external-review-content-supply.md
@@ -116,8 +116,9 @@ podcast transcripts need a separate platform-terms and creator-rights review.
   Terms of Service, but no public general terms page was linked or found. No
   reviewed page prohibited the planned metadata indexing and canonical links.
 - Peated already has more than 7,000 stored review rows. The second pilot reads
-  only the issue index and newest issue. It does not fetch review prose or
-  generate summaries.
+  the issue index, newest issue, and listed review pages. Review pages provide
+  explicit publication dates. Peated does not persist review prose or generate
+  summaries from it.
 
 ### Explicitly Restricted Sources
 

--- a/docs/research/scraper-source-inventory.md
+++ b/docs/research/scraper-source-inventory.md
@@ -31,7 +31,7 @@ estimate of current live inventory.
 | SMWSA              | `https://newmake.smwsa.com`                | One GET HTML collection                                                    | 35 bottles                                                          |
 | Thompson Bros.     | `https://www.thompsonbrosdistillers.com`   | GET WooCommerce JSON pages                                                 | 2 items                                                             |
 | Total Wine         | `https://www.totalwine.com`                | GET HTML, two paginated categories                                         | 112 items on listing fixture; target disabled pending policy review |
-| Whisky Advocate    | `https://whiskyadvocate.com`               | Manual-only GET of the issue index and newest issue; two requests per run  | 106 issues and 166 reviews in parser fixtures                       |
+| Whisky Advocate    | `https://whiskyadvocate.com`               | Manual-only GET of the issue index, newest issue, and listed review pages  | 106 issues and 166 reviews in parser fixtures                       |
 | The Whisky World   | `https://www.thewhiskyworld.com`           | GET HTML pages                                                             | 5 items                                                             |
 | Wooden Cork        | `https://woodencork.com`                   | GET cursor-style collection pages                                          | 38 items                                                            |
 

--- a/openspec/changes/pilot-external-review-indexing/design.md
+++ b/openspec/changes/pilot-external-review-indexing/design.md
@@ -103,6 +103,13 @@ through the governed runtime. Dramface remains a later multi-bottle candidate.
 Each source remains disabled until its current robots rules and public terms
 are checked.
 
+The Whisky Advocate listing does not expose publication dates. Its review
+pages contain an explicit publisher date in article metadata. The adapter may
+request those pages through the same bounded runtime, store only the date, and
+checkpoint each review so a deferred run resumes without repeating completed
+article requests. Sitemap modification dates and issue seasons are not treated
+as publication dates.
+
 Alternative considered: build a configurable LLM-only arbitrary-page crawler.
 This was rejected because discovery, rate limits, identity keys, score scales,
 and site rules are source-specific and deserve code review during the pilot.

--- a/openspec/changes/pilot-external-review-indexing/specs/external-review-indexing/spec.md
+++ b/openspec/changes/pilot-external-review-indexing/specs/external-review-indexing/spec.md
@@ -170,6 +170,13 @@ review.
 - **THEN** the Bottle page omits that field without inventing a value and still
   provides the publisher link
 
+#### Scenario: Publisher supplies an article date
+
+- **WHEN** a review page provides an explicit publication date
+- **THEN** the source adapter stores that date with the review article
+- **AND** it does not substitute a sitemap modification date or approximate
+  issue season
+
 #### Scenario: Publisher content is rendered
 
 - **WHEN** Peated renders an external review

--- a/openspec/changes/pilot-external-review-indexing/tasks.md
+++ b/openspec/changes/pilot-external-review-indexing/tasks.md
@@ -81,6 +81,8 @@
 - [ ] 6.6 Recheck current robots rules and terms, then run the bounded
       review-only pilot for the second publisher before generalizing shared
       adapter behavior
+- [x] 6.7 Collect explicit publisher dates for the newest Whisky Advocate issue
+      through bounded article-page requests with resumable checkpoints
 
 ## 7. Verification And Documentation
 


### PR DESCRIPTION
Whisky Advocate reviews now capture the exact publication date exposed on each review page. The scraper keeps article bodies transient, stores only the parsed date and existing review metadata, and never substitutes sitemap modification dates or issue-season estimates.

The adapter checkpoints each stored review and resumes the same issue without repeating completed article pages. It remains manual-only, keeps 2.5-second request spacing, and permits at most 20 requests per hour. Existing in-flight cursor data remains valid across the deployment.
