### PR TITLE
feat(scraper): add Whiskyfun review feed

### DIFF
--- a/apps/server/__fixtures__/whiskyfun/article.html
+++ b/apps/server/__fixtures__/whiskyfun/article.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+  <head>
+    <meta name="author" content="Serge Valentin" />
+    <title>A trio of Dailuaine</title>
+  </head>
+  <body>
+    <table>
+      <tr>
+        <td class="TextenormalNEW">
+          <span class="textegrandfoncegras">Dailuaine 5 yo 2020/2025 (61%, Sample Bottler, cask #1)</span>
+          <p>A short fixture review.</p>
+          <strong>SGP:562 - 87 points.</strong>
+        </td>
+      </tr>
+      <tr>
+        <td class="TextenormalNEW">
+          <span class="textegrandfoncegras"></span>
+          <span class="textegrandfoncegras">Dailuaine 23 yo 2002/2025 (57%, Sample Bottler, cask #2)</span>
+          <p>Another short fixture review.</p>
+          <strong>SGP:561 - 89 points.</strong>
+        </td>
+      </tr>
+      <tr>
+        <td class="TextenormalNEW">
+          <span class="textegrandfoncegras">Unscored introduction</span>
+          <p>This is not a Bottle review.</p>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>

--- a/apps/server/__fixtures__/whiskyfun/feed.xml
+++ b/apps/server/__fixtures__/whiskyfun/feed.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Whiskyfun</title>
+    <item>
+      <title>A wee trainload of a dozen secret Speysiders</title>
+      <link>https://www.whiskyfun.com/2026/A-wee-trainload-of-a-dozen-secret-Speysiders.html</link>
+      <pubDate>Thu, 20 Aug 2026 08:21:00 +0200</pubDate>
+    </item>
+    <item>
+      <title>A trio of Dailuaine</title>
+      <link>https://www.whiskyfun.com/2026/A-trio-of-Dailuaine.html</link>
+      <pubDate>Wed, 19 Aug 2026 08:49:00 +0200</pubDate>
+    </item>
+    <item>
+      <title>Another little bag of Armagnacs</title>
+      <link>https://www.whiskyfun.com/2026/Another-little-bag-of-Armagnacs.html</link>
+      <pubDate>Sun, 16 Aug 2026 09:19:00 +0200</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -59,6 +59,11 @@ export const EXTERNAL_SITE_DEFINITIONS = {
     runEvery: null,
     content: "reviews",
   },
+  whiskyfun: {
+    name: "Whiskyfun",
+    runEvery: 1440,
+    content: "reviews",
+  },
   whiskynotes: {
     name: "WhiskyNotes",
     runEvery: null,

--- a/apps/server/src/lib/externalSites.test.ts
+++ b/apps/server/src/lib/externalSites.test.ts
@@ -43,10 +43,10 @@ test("syncs code-owned external-site definitions", async () => {
   expect(fineDrams).toMatchObject(EXTERNAL_SITE_DEFINITIONS.finedrams);
 
   const policies = await db.select().from(externalReviewSourcePolicies);
-  expect(policies).toHaveLength(2);
+  expect(policies).toHaveLength(3);
   expect(policies).toEqual(
     expect.arrayContaining(
-      ["whiskyadvocate", "whiskynotes"].map((type) =>
+      ["whiskyadvocate", "whiskyfun", "whiskynotes"].map((type) =>
         expect.objectContaining({
           externalSiteId: sites.find((site) => site.type === type)?.id,
           publicationMode: "disabled",

--- a/apps/server/src/scraper/adapters/whiskyfun.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyfun.test.ts
@@ -1,0 +1,129 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { vi } from "vitest";
+import type { ScraperObservation, ScraperSession } from "../types";
+import {
+  discoverWhiskyfunArticles,
+  parseWhiskyfunArticle,
+  whiskyfunAdapter,
+  type WhiskyfunCursor,
+  type WhiskyfunObservation,
+} from "./whiskyfun";
+
+const FIRST_URL =
+  "https://www.whiskyfun.com/2026/A-wee-trainload-of-a-dozen-secret-Speysiders.html";
+const SECOND_URL = "https://www.whiskyfun.com/2026/A-trio-of-Dailuaine.html";
+
+test("discovers at most twenty current whisky articles", async () => {
+  const feed = await loadFixture("whiskyfun", "feed.xml");
+  const expandedFeed = feed.replace(
+    "</channel>",
+    Array.from(
+      { length: 20 },
+      (_, index) =>
+        `<item><title>Whisky article ${index}</title><link>https://www.whiskyfun.com/2026/Whisky-article-${index}.html</link><pubDate>Wed, 19 Aug 2026 08:49:00 +0200</pubDate></item>`,
+    ).join("") + "</channel>",
+  );
+
+  expect(discoverWhiskyfunArticles(feed)).toEqual([
+    {
+      canonicalUrl: FIRST_URL,
+      title: "A wee trainload of a dozen secret Speysiders",
+      publishedAt: new Date("2026-08-20T06:21:00.000Z"),
+    },
+    {
+      canonicalUrl: SECOND_URL,
+      title: "A trio of Dailuaine",
+      publishedAt: new Date("2026-08-19T06:49:00.000Z"),
+    },
+  ]);
+  expect(discoverWhiskyfunArticles(expandedFeed)).toHaveLength(19);
+  expect(discoverWhiskyfunArticles(expandedFeed).at(-1)?.title).toBe(
+    "Whisky article 16",
+  );
+});
+
+test("extracts scored reviews with stable source keys", async () => {
+  const html = await loadFixture("whiskyfun", "article.html");
+  const article = {
+    canonicalUrl: SECOND_URL,
+    title: "A trio of Dailuaine",
+    publishedAt: new Date("2026-08-19T06:49:00.000Z"),
+  };
+  const parsed = parseWhiskyfunArticle(html, article);
+  const reparsed = parseWhiskyfunArticle(
+    html.replaceAll("Dailuaine 5 yo", "Dailuaine   5 yo"),
+    article,
+  );
+
+  expect(parsed.article).toMatchObject({
+    canonicalUrl: SECOND_URL,
+    title: "A trio of Dailuaine",
+    publishedAt: new Date("2026-08-19T06:49:00.000Z"),
+    contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    reviews: [
+      {
+        name: "Dailuaine 5 yo 2020/2025 (61%, Sample Bottler, cask #1)",
+        reviewerName: "Serge Valentin",
+        nativeScore: { value: 87, scale: 100, display: "87 points" },
+        normalizedRating: 87,
+      },
+      {
+        name: "Dailuaine 23 yo 2002/2025 (57%, Sample Bottler, cask #2)",
+        reviewerName: "Serge Valentin",
+        nativeScore: { value: 89, scale: 100, display: "89 points" },
+        normalizedRating: 89,
+      },
+    ],
+  });
+  expect(parsed.article.reviews.map(({ sourceKey }) => sourceKey)).toEqual(
+    reparsed.article.reviews.map(({ sourceKey }) => sourceKey),
+  );
+  expect(Object.keys(parsed.reviewTexts)).toEqual(
+    parsed.article.reviews.map(({ sourceKey }) => sourceKey),
+  );
+  expect(Object.values(parsed.reviewTexts).join(" ")).not.toContain(
+    "Unscored introduction",
+  );
+});
+
+test("resumes without requesting a completed article", async () => {
+  const feed = await loadFixture("whiskyfun", "feed.xml");
+  const html = await loadFixture("whiskyfun", "article.html");
+  const observations: ScraperObservation<WhiskyfunObservation>[] = [];
+  const checkpoints: WhiskyfunCursor[] = [];
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body: url.pathname === "/whatsnew.xml" ? feed : html,
+  }));
+  const session: ScraperSession<WhiskyfunCursor, WhiskyfunObservation> = {
+    request,
+    emit: async (observation) => {
+      observations.push(observation);
+    },
+    checkpoint: async (nextCursor) => {
+      checkpoints.push(nextCursor);
+    },
+    remainingRequests: () => 30,
+  };
+
+  await whiskyfunAdapter({
+    cursor: { processedArticleUrls: [FIRST_URL] },
+    session,
+  });
+
+  expect(request).toHaveBeenCalledTimes(2);
+  expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
+    "https://www.whiskyfun.com/whatsnew.xml",
+    SECOND_URL,
+  ]);
+  expect(observations).toHaveLength(1);
+  expect(observations[0]).toMatchObject({
+    sourceKey: SECOND_URL,
+    itemCount: 2,
+  });
+  expect(checkpoints).toEqual([
+    { processedArticleUrls: [FIRST_URL, SECOND_URL] },
+  ]);
+});

--- a/apps/server/src/scraper/adapters/whiskyfun.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyfun.test.ts
@@ -127,3 +127,44 @@ test("resumes without requesting a completed article", async () => {
     { processedArticleUrls: [FIRST_URL, SECOND_URL] },
   ]);
 });
+
+test("drops completed URLs that leave the current feed window", async () => {
+  const html = await loadFixture("whiskyfun", "article.html");
+  const priorUrls = Array.from(
+    { length: 20 },
+    (_, index) => `https://www.whiskyfun.com/2026/Prior-${index}.html`,
+  );
+  const currentUrls = [
+    "https://www.whiskyfun.com/2026/New-review.html",
+    ...priorUrls.slice(0, -1),
+  ];
+  const feed = `<?xml version="1.0"?><rss><channel>${currentUrls
+    .map(
+      (url, index) =>
+        `<item><title>Review ${index}</title><link>${url}</link><pubDate>Wed, 19 Aug 2026 08:49:00 +0200</pubDate></item>`,
+    )
+    .join("")}</channel></rss>`;
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body: url.pathname === "/whatsnew.xml" ? feed : html,
+  }));
+  const session: ScraperSession<WhiskyfunCursor, WhiskyfunObservation> = {
+    request,
+    emit: vi.fn(),
+    checkpoint,
+    remainingRequests: () => 30,
+  };
+
+  await whiskyfunAdapter({
+    cursor: { processedArticleUrls: priorUrls },
+    session,
+  });
+
+  expect(request).toHaveBeenCalledTimes(2);
+  const completedUrls = checkpoint.mock.calls.at(-1)?.[0].processedArticleUrls;
+  expect(completedUrls).toHaveLength(20);
+  expect(new Set(completedUrls)).toEqual(new Set(currentUrls));
+});

--- a/apps/server/src/scraper/adapters/whiskyfun.ts
+++ b/apps/server/src/scraper/adapters/whiskyfun.ts
@@ -183,12 +183,19 @@ export const whiskyfunAdapter: ScraperAdapter<
   WhiskyfunCursor,
   WhiskyfunObservation
 > = async ({ cursor, session }) => {
-  const processedArticleUrls = new Set(cursor?.processedArticleUrls ?? []);
   const feedResponse = await session.request({
     target: TARGET,
     url: new URL("/whatsnew.xml", ORIGIN),
   });
   const articles = discoverWhiskyfunArticles(feedResponse.body);
+  const currentArticleUrls = new Set(
+    articles.map(({ canonicalUrl }) => canonicalUrl),
+  );
+  const processedArticleUrls = new Set(
+    (cursor?.processedArticleUrls ?? []).filter((url) =>
+      currentArticleUrls.has(url),
+    ),
+  );
 
   for (const article of articles) {
     if (processedArticleUrls.has(article.canonicalUrl)) continue;

--- a/apps/server/src/scraper/adapters/whiskyfun.ts
+++ b/apps/server/src/scraper/adapters/whiskyfun.ts
@@ -1,0 +1,210 @@
+import {
+  normalizeReviewRating,
+  type ReviewArticleIngestion,
+  ReviewArticleIngestionSchema,
+  type ReviewArticleObservation,
+} from "@peated/server/externalReviews/observation";
+import { load as cheerio } from "cheerio";
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import type { ScraperAdapter } from "../types";
+
+const ORIGIN = "https://www.whiskyfun.com";
+const TARGET = "whiskyfun";
+const MAX_FEED_ITEMS = 20;
+const ARTICLE_PATH = /^\/\d{4}\/[^/]+\.html$/;
+const NON_WHISKY_TITLE =
+  /\b(?:armagnacs?|brand(?:y|ies)|calvados|cognacs?|mezcal|rums?|tequilas?)\b/iu;
+
+const WhiskyfunFeedArticleSchema = z
+  .object({
+    canonicalUrl: z.url(),
+    title: z.string().trim().min(1).max(1000),
+    publishedAt: z.date(),
+  })
+  .strict();
+
+export const WhiskyfunCursorSchema = z
+  .object({
+    processedArticleUrls: z.array(z.url()).max(MAX_FEED_ITEMS),
+  })
+  .strict();
+
+export const WhiskyfunObservationSchema = ReviewArticleIngestionSchema;
+
+export type WhiskyfunCursor = z.infer<typeof WhiskyfunCursorSchema>;
+export type WhiskyfunObservation = ReviewArticleIngestion;
+type WhiskyfunFeedArticle = z.infer<typeof WhiskyfunFeedArticleSchema>;
+
+function normalizeText(value: string): string {
+  return value.replaceAll(/\s+/g, " ").trim();
+}
+
+function articleUrl(value: string): URL | null {
+  try {
+    const url = new URL(value, ORIGIN);
+    url.hash = "";
+    url.search = "";
+    if (url.origin !== ORIGIN || !ARTICLE_PATH.test(url.pathname)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+export function discoverWhiskyfunArticles(
+  data: string,
+): WhiskyfunFeedArticle[] {
+  const $ = cheerio(data, { xmlMode: true });
+  const articles: WhiskyfunFeedArticle[] = [];
+
+  for (const item of $("channel > item").slice(0, MAX_FEED_ITEMS)) {
+    const title = normalizeText($(item).find("title").first().text());
+    if (!title || NON_WHISKY_TITLE.test(title)) continue;
+
+    const canonicalUrl = articleUrl($(item).find("link").first().text().trim());
+    if (!canonicalUrl) {
+      throw new Error("Whiskyfun feed article URL is invalid.");
+    }
+
+    const rawPublishedAt = normalizeText(
+      $(item).find("pubDate").first().text(),
+    );
+    const publishedAt = new Date(rawPublishedAt);
+    if (!rawPublishedAt || Number.isNaN(publishedAt.getTime())) {
+      throw new Error("Whiskyfun feed article date is invalid.");
+    }
+
+    articles.push(
+      WhiskyfunFeedArticleSchema.parse({
+        canonicalUrl: canonicalUrl.href,
+        title,
+        publishedAt,
+      }),
+    );
+  }
+
+  return articles;
+}
+
+function bottleName(value: string): string | null {
+  const name = normalizeText(value);
+  return /^.+\s+\((?=[^)]*\d{1,3}(?:[.,]\d+)?\s*(?:%|proof))[^)]*\)\s*$/iu.test(
+    name,
+  )
+    ? name
+    : null;
+}
+
+function score(value: string) {
+  const match = /\bSGP:\s*\d{3}\s*-\s*(\d{1,3})\s+points?\b/iu.exec(value);
+  const nativeValue = match?.[1] ? Number(match[1]) : Number.NaN;
+  if (!Number.isFinite(nativeValue) || nativeValue < 0 || nativeValue > 100) {
+    return null;
+  }
+  const nativeScore = {
+    value: nativeValue,
+    scale: 100,
+    display: `${nativeValue} points`,
+  };
+  return {
+    nativeScore,
+    normalizedRating: normalizeReviewRating(nativeScore),
+  };
+}
+
+function reviewSourceKey(canonicalUrl: string, heading: string): string {
+  const digest = createHash("sha256")
+    .update(
+      `${canonicalUrl}\n${normalizeText(heading).toLocaleLowerCase("en")}`,
+    )
+    .digest("hex");
+  return `whiskyfun:${digest}`;
+}
+
+export function parseWhiskyfunArticle(
+  data: string,
+  feedArticle: WhiskyfunFeedArticle,
+): WhiskyfunObservation {
+  const article = WhiskyfunFeedArticleSchema.parse(feedArticle);
+  const canonicalUrl = articleUrl(article.canonicalUrl);
+  if (!canonicalUrl) throw new Error("Invalid Whiskyfun article URL.");
+
+  const $ = cheerio(data);
+  const reviewerName =
+    normalizeText($('meta[name="author"]').first().attr("content") ?? "") ||
+    null;
+  const reviews: ReviewArticleObservation["reviews"] = [];
+  const reviewTexts: Record<string, string> = {};
+
+  $("td.TextenormalNEW").each((_, element) => {
+    const heading = $(element)
+      .find(".textegrandfoncegras")
+      .toArray()
+      .map((candidate) => bottleName($(candidate).text()))
+      .find((candidate) => candidate !== null);
+    if (!heading) return;
+
+    const reviewText = normalizeText($(element).text());
+    const reviewScore = score(reviewText);
+    if (!reviewScore) return;
+
+    const sourceKey = reviewSourceKey(canonicalUrl.href, heading);
+    reviews.push({
+      sourceKey,
+      name: heading,
+      category: null,
+      reviewerName,
+      nativeScore: reviewScore.nativeScore,
+      normalizedRating: reviewScore.normalizedRating,
+    });
+    reviewTexts[sourceKey] = reviewText;
+  });
+
+  if (reviews.length === 0) {
+    throw new Error("Whiskyfun article contains no scored reviews.");
+  }
+
+  const contentText = Object.values(reviewTexts).join("\n");
+  return WhiskyfunObservationSchema.parse({
+    article: {
+      canonicalUrl: canonicalUrl.href,
+      title: article.title,
+      issue: null,
+      publishedAt: article.publishedAt,
+      contentHash: createHash("sha256").update(contentText).digest("hex"),
+      reviews,
+    },
+    reviewTexts,
+  });
+}
+
+export const whiskyfunAdapter: ScraperAdapter<
+  WhiskyfunCursor,
+  WhiskyfunObservation
+> = async ({ cursor, session }) => {
+  const processedArticleUrls = new Set(cursor?.processedArticleUrls ?? []);
+  const feedResponse = await session.request({
+    target: TARGET,
+    url: new URL("/whatsnew.xml", ORIGIN),
+  });
+  const articles = discoverWhiskyfunArticles(feedResponse.body);
+
+  for (const article of articles) {
+    if (processedArticleUrls.has(article.canonicalUrl)) continue;
+    const articleResponse = await session.request({
+      target: TARGET,
+      url: new URL(article.canonicalUrl),
+    });
+    const observation = parseWhiskyfunArticle(articleResponse.body, article);
+    await session.emit({
+      sourceKey: observation.article.canonicalUrl,
+      itemCount: observation.article.reviews.length,
+      value: observation,
+    });
+    processedArticleUrls.add(article.canonicalUrl);
+    await session.checkpoint({
+      processedArticleUrls: [...processedArticleUrls],
+    });
+  }
+};

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -44,6 +44,7 @@ const migratedSources = [
   "thompsonbros",
   "totalwine",
   "whiskyadvocate",
+  "whiskyfun",
   "whiskynotes",
   "whiskyworld",
   "woodencork",
@@ -90,10 +91,23 @@ test("registers every scraper source with explicit target ownership", () => {
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("whiskynotes")?.requestLimit).toBe(30);
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskyfun.runEvery).toBe(1440);
+  expect(scraperRegistry.targets.get("whiskyfun")).toMatchObject({
+    minimumSpacingMs: 2_500,
+    requestsPerWindow: 25,
+    windowMs: 3_600_000,
+  });
+  expect(scraperRegistry.sources.get("whiskyfun")?.requestLimit).toBe(30);
   expect(scraperRegistry.sources.get("whiskyadvocate")?.observationSchema).toBe(
     scraperRegistry.sources.get("whiskynotes")?.observationSchema,
   );
+  expect(scraperRegistry.sources.get("whiskyfun")?.observationSchema).toBe(
+    scraperRegistry.sources.get("whiskynotes")?.observationSchema,
+  );
   expect(scraperRegistry.sources.get("whiskyadvocate")?.sink).toBe(
+    scraperRegistry.sources.get("whiskynotes")?.sink,
+  );
+  expect(scraperRegistry.sources.get("whiskyfun")?.sink).toBe(
     scraperRegistry.sources.get("whiskynotes")?.sink,
   );
 });

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -18,9 +18,9 @@ import scrapeMissionLiquor from "./adapters/legacy/scrapeMissionLiquor";
 import scrapeNcnean from "./adapters/legacy/scrapeNcnean";
 import scrapeNorthStarSpirits from "./adapters/legacy/scrapeNorthStarSpirits";
 import scrapeReserveBar from "./adapters/legacy/scrapeReserveBar";
+import scrapeSingleCaskNation from "./adapters/legacy/scrapeSingleCaskNation";
 import scrapeSMWS from "./adapters/legacy/scrapeSMWS";
 import scrapeSMWSA from "./adapters/legacy/scrapeSMWSA";
-import scrapeSingleCaskNation from "./adapters/legacy/scrapeSingleCaskNation";
 import scrapeThompsonBros from "./adapters/legacy/scrapeThompsonBros";
 import scrapeTotalWine from "./adapters/legacy/scrapeTotalWine";
 import scrapeWhiskyWorld from "./adapters/legacy/scrapeWhiskyWorld";
@@ -39,6 +39,11 @@ import {
   WhiskyAdvocateCursorSchema,
   WhiskyAdvocateObservationSchema,
 } from "./adapters/whiskyAdvocate";
+import {
+  whiskyfunAdapter,
+  WhiskyfunCursorSchema,
+  WhiskyfunObservationSchema,
+} from "./adapters/whiskyfun";
 import {
   whiskyNotesAdapter,
   WhiskyNotesCursorSchema,
@@ -231,6 +236,17 @@ export const scraperRegistry = createScraperRegistry({
         },
       ],
     }),
+    defineScrapeTarget({
+      key: "whiskyfun",
+      minimumSpacingMs: 2_500,
+      requestsPerWindow: 25,
+      origins: [
+        {
+          origin: "https://www.whiskyfun.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
   ],
   sources: [
     ...legacyPriceSources.map((source) =>
@@ -275,6 +291,16 @@ export const scraperRegistry = createScraperRegistry({
       cursorSchema: WhiskyNotesCursorSchema,
       observationSchema: WhiskyNotesObservationSchema,
       adapter: whiskyNotesAdapter,
+      sink: externalReviewSink,
+    }),
+    defineScraperSource({
+      key: "whiskyfun",
+      externalSiteType: "whiskyfun",
+      targetKeys: ["whiskyfun"],
+      requestLimit: 30,
+      cursorSchema: WhiskyfunCursorSchema,
+      observationSchema: WhiskyfunObservationSchema,
+      adapter: whiskyfunAdapter,
       sink: externalReviewSink,
     }),
   ],

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -113,9 +113,9 @@ Use this sequence for each publisher:
 3. Synchronize scraper definitions. In **Admin → Scrapers**, confirm that the
    source is registered, its targets are enabled, and its robots state is safe.
 4. Use the moderator review-policy API to set `review_only` with the exact
-   capability flags.
-5. Trigger one bounded manual run from the source page. Do not enable a
-   schedule for the first sample.
+   capability flags when a hidden sample is needed.
+5. Trigger one bounded manual run or let the registered bounded schedule run.
+   A schedule does not bypass source policy or publish hidden reviews.
 6. Record article, review, extracted-item, matched, and unresolved counts.
    Review the agreed hidden sample for extraction, multi-bottle splitting,
    Bottle matches, and any enabled summaries.
@@ -134,9 +134,15 @@ each stored review and can resume for up to ten worker passes. The adapter keeps
 the complete source Bottle title for classification and reads the category
 before the separate price line. It does not persist review prose.
 
+Whiskyfun runs once per day. It reads at most 20 current RSS items and skips
+clear non-whisky articles before it requests article pages. Requests are at
+least 2.5 seconds apart. The target allows 25 requests per hour, and each worker
+pass stops after 30 requests. The adapter stores explicit feed dates, reviewer
+metadata, native scores, and canonical links. Review prose stays transient.
+
 Enable automatic publication only after the reviewed sample passes the gate.
-Repeat the robots, terms, and review-only process for the second publisher
-before adding shared adapter behavior.
+Use the same source-specific process for each later publisher. Do not add a
+generic crawler only because several sources use RSS or HTML.
 
 ## Stop And Roll Back
 

--- a/docs/research/external-review-content-supply.md
+++ b/docs/research/external-review-content-supply.md
@@ -86,8 +86,12 @@ podcast transcripts need a separate platform-terms and creator-rights review.
   Sessions frequently contain several reviews on one legacy HTML page.
 - The FAQ says the author is comfortable with some free use of notes and scores
   by commercial entities.
-- Treat the two-decade archive as a later bounded backfill. Start with a small
-  current sample.
+- The current RSS feed supplies canonical article URLs, titles, exact dates,
+  and Bottle names. Article pages supply the reviewer and native 100-point
+  scores.
+- The implemented daily feed checks at most 20 items and uses the governed
+  runtime for article requests. The two-decade archive remains a separate
+  future backfill.
 
 ### Dramface
 
@@ -172,18 +176,19 @@ The current model separates:
 - zero or more scored or unscored Bottle reviews from that article; and
 - a short generated summary with model provenance and source evidence.
 
-Do not design the full generalized pipeline until two source pilots validate
-the content and source-policy model.
+Add later publishers through source-specific adapters. Do not replace them
+with a generalized crawler unless repeated source work proves a smaller shared
+boundary.
 
-## Recommended First Pilot
+## Source Sequence
 
-1. Use WhiskyNotes as the preferred archive pilot because it combines
-   meaningful volume, current cadence, and clear bottle specifications.
-2. Use the existing Whisky Advocate source as the second bounded pilot. Keep
-   Dramface as a later multi-bottle candidate.
-3. Treat Whiskyfun as a later high-volume backfill target.
-4. Do not add Whisky Advocate summaries or a full backfill in the bounded
-   pilot.
+1. WhiskyNotes supplies the first current archive feed.
+2. Whisky Advocate supplies the existing large scored archive and current
+   issue.
+3. Whiskyfun supplies the next daily multi-bottle feed. Keep its historical
+   archive as a later bounded change.
+4. Add Dramface next, then continue through the reviewed public-index
+   candidates until Peated has at least 12 reliable feeds.
 
 The pilot is successful with at least 90% article extraction accuracy on a
 reviewed sample, reliable splitting of multi-bottle articles, measurable

--- a/docs/research/scraper-source-inventory.md
+++ b/docs/research/scraper-source-inventory.md
@@ -32,6 +32,7 @@ estimate of current live inventory.
 | Thompson Bros.     | `https://www.thompsonbrosdistillers.com`   | GET WooCommerce JSON pages                                                 | 2 items                                                             |
 | Total Wine         | `https://www.totalwine.com`                | GET HTML, two paginated categories                                         | 112 items on listing fixture; target disabled pending policy review |
 | Whisky Advocate    | `https://whiskyadvocate.com`               | Manual-only GET of the issue index, newest issue, and listed review pages  | 106 issues and 166 reviews in parser fixtures                       |
+| Whiskyfun          | `https://www.whiskyfun.com`                | Daily GET of RSS plus up to 20 current article pages                       | 2 accepted feed items and 2 article reviews in parser fixtures      |
 | The Whisky World   | `https://www.thewhiskyworld.com`           | GET HTML pages                                                             | 5 items                                                             |
 | Wooden Cork        | `https://woodencork.com`                   | GET cursor-style collection pages                                          | 38 items                                                            |
 
@@ -41,8 +42,8 @@ All scheduled and manual external-site runs now dispatch only `RunScraper` with
 a durable run id. Retailer GETs use the runtime-backed legacy request bridge;
 Healthy Spirits, Master of Malt, and ReserveBar use its governed POST support.
 SMWS and SMWSA emit bottle observations through runtime sinks. Whisky Advocate
-uses a review sink and independently rechecks its approved fetch capability
-before every request.
+and Whiskyfun use the shared external-review sink. The runtime enforces robots
+rules before remote requests.
 
 The previous response-body disk cache is removed. Production use of the legacy
 request helper without an active runtime session fails before network access;

--- a/openspec/changes/add-whiskyfun-review-feed/.openspec.yaml
+++ b/openspec/changes/add-whiskyfun-review-feed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/add-whiskyfun-review-feed/design.md
+++ b/openspec/changes/add-whiskyfun-review-feed/design.md
@@ -1,0 +1,64 @@
+## Context
+
+Whiskyfun publishes an RSS feed with current article URLs, titles, dates, and
+bottle names. Each article can contain several reviews. The article HTML uses
+a repeated review cell with a bottle heading and a 100-point score. Peated
+already has shared review ingestion, Bottle matching, summary, policy, robots,
+and request-control boundaries.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add current Whiskyfun reviews without a schema or API change.
+- Preserve the publisher's canonical URL, date, reviewer, and native score.
+- Support multi-bottle articles and safe resume after request deferral.
+- Run on a daily schedule with bounded and spaced requests.
+
+**Non-Goals:**
+
+- Backfill the full Whiskyfun archive.
+- Build a generic RSS or HTML review crawler.
+- Store article HTML, publisher images, or full review prose.
+- Add consensus scores or new Bottle-page presentation.
+
+## Decisions
+
+### Use the public RSS feed for bounded discovery
+
+The adapter reads at most 20 current feed items. It skips clear non-whisky
+article titles, then requests each remaining canonical article. The feed date
+is the publisher date. A run checkpoints each emitted article URL so a deferred
+run does not repeat completed article requests.
+
+Direct archive discovery was rejected for this slice. It would add historical
+pagination and a much larger request budget before current supply is proven.
+
+### Keep parsing specific to Whiskyfun
+
+The adapter reads review cells that contain one non-empty bottle heading and
+one `SGP` score. It derives a stable review key from the canonical article URL
+and normalized heading. It uses the page author metadata for the reviewer.
+
+A configurable parser was rejected because Whiskyfun's legacy markup and
+review boundaries are source-specific.
+
+### Reuse the existing external-review boundary
+
+The adapter emits the shared article ingestion schema. Review text exists only
+in the observation passed to the policy-gated summary path. The scraper runtime
+enforces robots rules, exact origins, request spacing, hourly quota, response
+limits, retries, and backoff. Source policy controls visibility and model use,
+but it does not disable fetching.
+
+## Risks / Trade-offs
+
+- **Legacy markup varies between articles** → Accept only complete review cells
+  and fail an article that contains no valid reviews. Cover current variants
+  with small fixtures.
+- **The feed includes other spirits** → Skip titles with clear non-whisky
+  spirit terms. Bottle matching remains the final publication boundary.
+- **A daily feed item contains many reviews** → Emit one article observation
+  with all valid reviews. The request count stays bounded by article count.
+- **Feed or article parsing changes** → Fail the run without deleting prior
+  reviews. Fixture tests make the expected structure explicit.

--- a/openspec/changes/add-whiskyfun-review-feed/proposal.md
+++ b/openspec/changes/add-whiskyfun-review-feed/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Peated needs more current critic reviews to make Bottle pages useful. Whiskyfun
+publishes a high-volume public feed with exact dates, scores, reviewers, and
+multi-bottle articles.
+
+## What Changes
+
+- Add Whiskyfun as a scheduled external-review source.
+- Discover only the latest bounded set of articles from its public RSS feed.
+- Extract article metadata and scored Bottle reviews with source-specific code.
+- Send review prose only through the existing transient summary boundary.
+- Use the shared Bottle matcher, review storage, request controls, robots
+  enforcement, and publication policy.
+
+## Capabilities
+
+### New Capabilities
+
+- `external-review-feeds`: Bounded ingestion of current editorial review feeds
+  through source-specific adapters and the shared external-review boundary.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds one external-site definition and one native scraper adapter.
+- Adds fixture-backed parser and runtime registration tests.
+- Adds no database schema, API, model, or UI changes.

--- a/openspec/changes/add-whiskyfun-review-feed/specs/external-review-feeds/spec.md
+++ b/openspec/changes/add-whiskyfun-review-feed/specs/external-review-feeds/spec.md
@@ -1,0 +1,48 @@
+## ADDED Requirements
+
+### Requirement: Current editorial feeds use bounded discovery
+
+The system SHALL discover a fixed maximum number of current articles from a
+registered publisher feed and SHALL fetch them through the shared scraper
+runtime.
+
+#### Scenario: Scheduled Whiskyfun run
+
+- **WHEN** the daily Whiskyfun run reads its public feed
+- **THEN** it considers at most 20 current feed items
+- **AND** all requests use the registered origin, robots rules, spacing, quota,
+  retry, and backoff controls
+
+#### Scenario: Deferred run resumes
+
+- **WHEN** a Whiskyfun run is deferred after it stores an article
+- **THEN** the resumed run does not request that completed article again
+
+### Requirement: Feed articles preserve publisher facts
+
+The system SHALL store each feed article by canonical URL with its explicit
+publisher date, title, reviewer when supplied, and native review scores.
+
+#### Scenario: Article contains several reviews
+
+- **WHEN** one Whiskyfun article contains several scored whisky reviews
+- **THEN** the system stores one review article with one independently matched
+  review for each valid bottle heading and score
+
+#### Scenario: Feed supplies a publication date
+
+- **WHEN** the Whiskyfun feed supplies a valid publication date for an article
+- **THEN** the system stores that exact date as the article publication date
+
+### Requirement: Publisher content remains transient
+
+The system MUST NOT persist Whiskyfun HTML, full review prose, or publisher
+images as source content.
+
+#### Scenario: Review text is processed
+
+- **WHEN** the source policy permits Peated to generate a review summary
+- **THEN** the adapter passes only that review's text through the existing
+  transient summary boundary
+- **AND** stored output contains only permitted structured facts, derived
+  summary data, content hash, and canonical link

--- a/openspec/changes/add-whiskyfun-review-feed/tasks.md
+++ b/openspec/changes/add-whiskyfun-review-feed/tasks.md
@@ -1,0 +1,14 @@
+## 1. Source Adapter
+
+- [x] 1.1 Add fixture-backed RSS discovery and multi-review article parsing
+- [x] 1.2 Add resumable adapter execution with bounded current-item discovery
+
+## 2. Runtime Registration
+
+- [x] 2.1 Register Whiskyfun as a daily review source with polite request limits
+- [x] 2.2 Prove source registration and shared review boundaries in tests
+
+## 3. Documentation And Verification
+
+- [x] 3.1 Update source research and operating documentation with the live path
+- [x] 3.2 Run focused tests, typecheck, lint, format, and strict OpenSpec validation


### PR DESCRIPTION
Peated now ingests current Whiskyfun reviews once per day. The source reads at
most 20 RSS items, skips clear non-whisky articles, splits multi-bottle pages
into independently matched reviews, and preserves the canonical link, explicit
feed date, reviewer, and native score.

Requests stay inside the shared scraper runtime with 2.5-second spacing, a
25-request hourly quota, and resumable article checkpoints. Review prose stays
transient and only enters the existing policy-gated summary path. The historical
Whiskyfun archive and a generalized feed crawler remain out of scope.
