### PR TITLE
feat(scraper): add Dramface review feed

### DIFF
--- a/apps/server/__fixtures__/dramface/index.html
+++ b/apps/server/__fixtures__/dramface/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <body>
+    <main>
+      <a href="/all-reviews/2026/springbank-12-cask-strength-2026">Springbank</a>
+      <a href="/all-reviews/category/Scotch+Whisky">Scotch Whisky</a>
+      <a href="/all-reviews/2026/impex-duo-isle-of-raasay-ardmore">Impex Duo</a>
+      <a href="/all-reviews/2026/springbank-12-cask-strength-2026">Read more</a>
+      <a href="/features/2026/example">Feature</a>
+    </main>
+  </body>
+</html>

--- a/apps/server/__fixtures__/dramface/multi-bottle.html
+++ b/apps/server/__fixtures__/dramface/multi-bottle.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+  <head>
+    <link
+      rel="canonical"
+      href="https://www.dramface.com/all-reviews/2026/impex-duo-isle-of-raasay-ardmore"
+    />
+  </head>
+  <body>
+    <article>
+      <h1 class="blog-item-title">Impex Duo - Isle of Raasay &amp; Ardmore</h1>
+      <time class="dt-published">11 Aug, 2026</time>
+      <a class="blog-author-name">Archie Dunlop</a>
+      <h3>Review 1/2</h3>
+      <p class="sqsrte-large">
+        Isle of Raasay 4yo, Impex Collection, Manzanilla cask, 60.3% ABV
+      </p>
+      <h2>Score: 6/10</h2>
+      <p>TL;DR<br />Punchy but pricey.</p>
+      <h3>Nose</h3>
+      <p>Young smoke and dry orchard fruit.</p>
+      <h3>Palate</h3>
+      <p>Strong peat with a saline edge.</p>
+      <p>Score: 6/10</p>
+      <h3>Review 2/2</h3>
+      <p class="sqsrte-large">
+        Ardmore 14yo, Impex Collection, ex-bourbon hogshead, 59.2% ABV
+      </p>
+      <h2>Score: 7.5/10</h2>
+      <p>TL;DR<br />A sweet Ardmore.</p>
+      <h3>Nose</h3>
+      <p>Vanilla and soft heath smoke.</p>
+      <h3>Palate</h3>
+      <p>Sweet malt and pepper.</p>
+      <p>Score: 7.5/10</p>
+    </article>
+  </body>
+</html>

--- a/apps/server/__fixtures__/dramface/multi-writer.html
+++ b/apps/server/__fixtures__/dramface/multi-writer.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+  <head>
+    <link
+      rel="canonical"
+      href="https://www.dramface.com/all-reviews/2026/ben-nevis-7yo-bedford-park"
+    />
+  </head>
+  <body>
+    <article>
+      <h1 class="blog-item-title">Ben Nevis 7yo Bedford Park</h1>
+      <time class="dt-published">20 Aug, 2026</time>
+      <a class="blog-author-name">Ogilvie Shaw</a>
+      <h3>Review 1/2 - Ogilvie</h3>
+      <p class="sqsrte-large">
+        Ben Nevis 7yo, Bedford Park, Oloroso hogshead, 58.7% ABV
+      </p>
+      <h2>Score: 8/10</h2>
+      <h3>Nose</h3>
+      <p>Dark fruit and brown sugar.</p>
+      <h3>Palate</h3>
+      <p>Rich fruit and tobacco.</p>
+      <p>Score: 8/10 OS</p>
+      <h3>Review 2/2 - Broddy</h3>
+      <p class="sqsrte-large">
+        Ben Nevis 7yo, Bedford Park, Oloroso hogshead, 58.7% ABV
+      </p>
+      <h2>Score: 8/10</h2>
+      <h3>Nose</h3>
+      <p>Candied walnut and orange oil.</p>
+      <h3>Palate</h3>
+      <p>Toffee and dark chocolate.</p>
+      <p>Score: 8/10 BB</p>
+    </article>
+  </body>
+</html>

--- a/apps/server/__fixtures__/dramface/single-review.html
+++ b/apps/server/__fixtures__/dramface/single-review.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+  <head>
+    <link
+      rel="canonical"
+      href="https://www.dramface.com/all-reviews/2026/springbank-12-cask-strength-2026"
+    />
+  </head>
+  <body>
+    <article>
+      <h1 class="blog-item-title">Springbank 12yo Cask Strength 2026</h1>
+      <time class="dt-published">18 Aug, 2026</time>
+      <a class="blog-author-name">Drummond Dunbar</a>
+      <h2>Score: 8/10</h2>
+      <p>TL;DR<br />Publisher summary must stay out of Peated.</p>
+      <p>Article introduction must stay out of the review text.</p>
+      <h3>Review</h3>
+      <p class="sqsrte-large">
+        Springbank 12yo Cask Strength, 2026 release, Batch 29, 56.6% ABV<br />
+        £74, sparse availability
+      </p>
+      <h2>Score: 8/10</h2>
+      <p>TL;DR<br />Publisher summary must stay out of Peated.</p>
+      <h3>Nose</h3>
+      <p>Lemon oil and coastal peat.</p>
+      <h3>Palate</h3>
+      <p>Dense malt with mineral smoke.</p>
+      <h3>The Dregs</h3>
+      <p>A balanced and characterful release.</p>
+      <p>Score: 8/10</p>
+      <h3>Latest Reviews</h3>
+      <p>Footer content must stay out of the review text.</p>
+    </article>
+  </body>
+</html>

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -54,6 +54,11 @@ export const EXTERNAL_SITE_DEFINITIONS = {
   // traffic target remains disabled while existing data stays visible.
   totalwine: { name: "Total Wines", runEvery: null },
   woodencork: { name: "Wooden Cork", runEvery: 10080 },
+  dramface: {
+    name: "Dramface",
+    runEvery: 1440,
+    content: "reviews",
+  },
   whiskyadvocate: {
     name: "Whisky Advocate",
     runEvery: null,

--- a/apps/server/src/lib/externalSites.test.ts
+++ b/apps/server/src/lib/externalSites.test.ts
@@ -43,10 +43,10 @@ test("syncs code-owned external-site definitions", async () => {
   expect(fineDrams).toMatchObject(EXTERNAL_SITE_DEFINITIONS.finedrams);
 
   const policies = await db.select().from(externalReviewSourcePolicies);
-  expect(policies).toHaveLength(3);
+  expect(policies).toHaveLength(4);
   expect(policies).toEqual(
     expect.arrayContaining(
-      ["whiskyadvocate", "whiskyfun", "whiskynotes"].map((type) =>
+      ["dramface", "whiskyadvocate", "whiskyfun", "whiskynotes"].map((type) =>
         expect.objectContaining({
           externalSiteId: sites.find((site) => site.type === type)?.id,
           publicationMode: "disabled",

--- a/apps/server/src/scraper/adapters/dramface.test.ts
+++ b/apps/server/src/scraper/adapters/dramface.test.ts
@@ -1,0 +1,185 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { vi } from "vitest";
+import type { ScraperObservation, ScraperSession } from "../types";
+import {
+  discoverDramfaceArticles,
+  dramfaceAdapter,
+  parseDramfaceArticle,
+  type DramfaceCursor,
+  type DramfaceObservation,
+} from "./dramface";
+
+const SINGLE_URL =
+  "https://www.dramface.com/all-reviews/2026/springbank-12-cask-strength-2026";
+const MULTI_URL =
+  "https://www.dramface.com/all-reviews/2026/impex-duo-isle-of-raasay-ardmore";
+const WRITERS_URL =
+  "https://www.dramface.com/all-reviews/2026/ben-nevis-7yo-bedford-park";
+
+test("discovers at most twenty current review articles", async () => {
+  const index = await loadFixture("dramface", "index.html");
+  const expandedIndex = index.replace(
+    "</main>",
+    `${Array.from(
+      { length: 25 },
+      (_, index) =>
+        `<a href="/all-reviews/2026/generated-${index}">Generated ${index}</a>`,
+    ).join("")}</main>`,
+  );
+
+  expect(discoverDramfaceArticles(index).map((url) => url.href)).toEqual([
+    SINGLE_URL,
+    MULTI_URL,
+  ]);
+  expect(discoverDramfaceArticles(expandedIndex)).toHaveLength(20);
+  expect(discoverDramfaceArticles(expandedIndex).at(-1)?.pathname).toBe(
+    "/all-reviews/2026/generated-17",
+  );
+});
+
+test("extracts one scored review and only its tasting prose", async () => {
+  const html = await loadFixture("dramface", "single-review.html");
+  const parsed = parseDramfaceArticle(html, new URL(SINGLE_URL));
+  const reparsed = parseDramfaceArticle(
+    html.replaceAll("Springbank 12yo", "Springbank   12yo"),
+    new URL(SINGLE_URL),
+  );
+
+  expect(parsed.article).toMatchObject({
+    canonicalUrl: SINGLE_URL,
+    title: "Springbank 12yo Cask Strength 2026",
+    publishedAt: new Date("2026-08-18T00:00:00.000Z"),
+    contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    reviews: [
+      {
+        name: "Springbank 12yo Cask Strength, 2026 release, Batch 29, 56.6% ABV",
+        reviewerName: "Drummond Dunbar",
+        nativeScore: { value: 8, scale: 10, display: "8/10" },
+        normalizedRating: 80,
+      },
+    ],
+  });
+  expect(parsed.article.reviews[0]?.sourceKey).toBe(
+    reparsed.article.reviews[0]?.sourceKey,
+  );
+  expect(Object.values(parsed.reviewTexts)).toEqual([
+    "Lemon oil and coastal peat. Dense malt with mineral smoke. A balanced and characterful release.",
+  ]);
+  expect(Object.values(parsed.reviewTexts).join(" ")).not.toMatch(
+    /TL;DR|Publisher summary|Article introduction|Footer content/u,
+  );
+});
+
+test("extracts each bottle and normalizes decimal scores", async () => {
+  const html = await loadFixture("dramface", "multi-bottle.html");
+  const parsed = parseDramfaceArticle(html, new URL(MULTI_URL));
+
+  expect(parsed.article.reviews).toMatchObject([
+    {
+      name: "Isle of Raasay 4yo, Impex Collection, Manzanilla cask, 60.3% ABV",
+      reviewerName: "Archie Dunlop",
+      nativeScore: { value: 6, scale: 10, display: "6/10" },
+      normalizedRating: 60,
+    },
+    {
+      name: "Ardmore 14yo, Impex Collection, ex-bourbon hogshead, 59.2% ABV",
+      reviewerName: "Archie Dunlop",
+      nativeScore: { value: 7.5, scale: 10, display: "7.5/10" },
+      normalizedRating: 75,
+    },
+  ]);
+  expect(Object.keys(parsed.reviewTexts)).toEqual(
+    parsed.article.reviews.map(({ sourceKey }) => sourceKey),
+  );
+});
+
+test("keeps separate reviewers for the same bottle", async () => {
+  const html = await loadFixture("dramface", "multi-writer.html");
+  const parsed = parseDramfaceArticle(html, new URL(WRITERS_URL));
+
+  expect(
+    parsed.article.reviews.map(({ reviewerName }) => reviewerName),
+  ).toEqual(["Ogilvie", "Broddy"]);
+  expect(
+    new Set(parsed.article.reviews.map(({ sourceKey }) => sourceKey)),
+  ).toHaveLength(2);
+});
+
+test("resumes without requesting a completed current article", async () => {
+  const index = await loadFixture("dramface", "index.html");
+  const multi = await loadFixture("dramface", "multi-bottle.html");
+  const observations: ScraperObservation<DramfaceObservation>[] = [];
+  const checkpoints: DramfaceCursor[] = [];
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body: url.pathname === "/all-reviews" ? index : multi,
+  }));
+  const session: ScraperSession<DramfaceCursor, DramfaceObservation> = {
+    request,
+    emit: async (observation) => {
+      observations.push(observation);
+    },
+    checkpoint: async (cursor) => {
+      checkpoints.push(cursor);
+    },
+    remainingRequests: () => 30,
+  };
+
+  await dramfaceAdapter({
+    cursor: { processedArticleUrls: [SINGLE_URL] },
+    session,
+  });
+
+  expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
+    "https://www.dramface.com/all-reviews",
+    MULTI_URL,
+  ]);
+  expect(observations).toHaveLength(1);
+  expect(observations[0]).toMatchObject({ sourceKey: MULTI_URL, itemCount: 2 });
+  expect(checkpoints).toEqual([
+    { processedArticleUrls: [SINGLE_URL, MULTI_URL] },
+  ]);
+});
+
+test("drops completed URLs that leave the current index window", async () => {
+  const priorUrls = Array.from(
+    { length: 20 },
+    (_, index) => `https://www.dramface.com/all-reviews/2026/prior-${index}`,
+  );
+  const currentUrls = [
+    "https://www.dramface.com/all-reviews/2026/new-review",
+    ...priorUrls.slice(0, -1),
+  ];
+  const index = `<main>${currentUrls
+    .map((url) => `<a href="${url}">Review</a>`)
+    .join("")}</main>`;
+  const article = (await loadFixture("dramface", "single-review.html")).replace(
+    /<link[\s\S]+?\/>/u,
+    "",
+  );
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body: url.pathname === "/all-reviews" ? index : article,
+  }));
+  const session: ScraperSession<DramfaceCursor, DramfaceObservation> = {
+    request,
+    emit: vi.fn(),
+    checkpoint,
+    remainingRequests: () => 30,
+  };
+
+  await dramfaceAdapter({
+    cursor: { processedArticleUrls: priorUrls },
+    session,
+  });
+
+  expect(request).toHaveBeenCalledTimes(2);
+  const completedUrls = checkpoint.mock.calls.at(-1)?.[0].processedArticleUrls;
+  expect(completedUrls).toHaveLength(20);
+  expect(new Set(completedUrls)).toEqual(new Set(currentUrls));
+});

--- a/apps/server/src/scraper/adapters/dramface.ts
+++ b/apps/server/src/scraper/adapters/dramface.ts
@@ -1,0 +1,282 @@
+import {
+  normalizeReviewRating,
+  type ReviewArticleIngestion,
+  ReviewArticleIngestionSchema,
+  type ReviewArticleObservation,
+} from "@peated/server/externalReviews/observation";
+import { load as cheerio } from "cheerio";
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import type { ScraperAdapter } from "../types";
+
+// This adapter owns Dramface-specific discovery and parsing. The shared
+// scraper runtime owns every remote request and the shared sink owns storage.
+const ORIGIN = "https://www.dramface.com";
+const TARGET = "dramface";
+const MAX_INDEX_ARTICLES = 20;
+const ARTICLE_PATH = /^\/all-reviews\/\d{4}\/[^/]+$/;
+const REVIEW_HEADING =
+  /^Review(?:\s+\d+\s*\/\s*\d+)?(?:\s*-\s*(?<reviewer>.+))?$/iu;
+const TASTING_HEADING = /^(?:Nose|Palate|Finish|The Dregs)\s*:?$/iu;
+const MONTHS = new Map(
+  [
+    "jan",
+    "feb",
+    "mar",
+    "apr",
+    "may",
+    "jun",
+    "jul",
+    "aug",
+    "sep",
+    "oct",
+    "nov",
+    "dec",
+  ].map((month, index) => [month, index]),
+);
+
+export const DramfaceCursorSchema = z
+  .object({
+    processedArticleUrls: z.array(z.url()).max(MAX_INDEX_ARTICLES),
+  })
+  .strict();
+
+export const DramfaceObservationSchema = ReviewArticleIngestionSchema;
+
+export type DramfaceCursor = z.infer<typeof DramfaceCursorSchema>;
+export type DramfaceObservation = ReviewArticleIngestion;
+
+function normalizeText(value: string): string {
+  return value.replaceAll(/\s+/g, " ").trim();
+}
+
+function articleUrl(value: string): URL | null {
+  try {
+    const url = new URL(value, ORIGIN);
+    url.hash = "";
+    url.search = "";
+    url.pathname = url.pathname.replace(/\/$/u, "");
+    if (url.origin !== ORIGIN || !ARTICLE_PATH.test(url.pathname)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+export function discoverDramfaceArticles(data: string): URL[] {
+  const $ = cheerio(data);
+  const articles = new Map<string, URL>();
+
+  $("main a[href]").each((_, element) => {
+    const url = articleUrl($(element).attr("href") ?? "");
+    if (url) articles.set(url.href, url);
+  });
+
+  return [...articles.values()].slice(0, MAX_INDEX_ARTICLES);
+}
+
+function publishedAt(value: string): Date {
+  const match =
+    /^(?<day>\d{1,2})\s+(?<month>[A-Z][a-z]{2}),?\s+(?<year>\d{4})$/u.exec(
+      normalizeText(value),
+    );
+  const month = match?.groups?.month
+    ? MONTHS.get(match.groups.month.toLocaleLowerCase("en"))
+    : undefined;
+  const day = match?.groups?.day ? Number(match.groups.day) : Number.NaN;
+  const year = match?.groups?.year ? Number(match.groups.year) : Number.NaN;
+  if (
+    month === undefined ||
+    !Number.isInteger(day) ||
+    !Number.isInteger(year)
+  ) {
+    throw new Error("Dramface article date is invalid.");
+  }
+
+  const date = new Date(Date.UTC(year, month, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month ||
+    date.getUTCDate() !== day
+  ) {
+    throw new Error("Dramface article date is invalid.");
+  }
+  return date;
+}
+
+function score(value: string) {
+  const match = /^Score:\s*(?<value>\d{1,2}(?:[.,]\d+)?)\s*\/\s*10\b/iu.exec(
+    normalizeText(value),
+  );
+  const nativeValue = match?.groups?.value
+    ? Number(match.groups.value.replace(",", "."))
+    : Number.NaN;
+  if (!Number.isFinite(nativeValue) || nativeValue < 0 || nativeValue > 10) {
+    return null;
+  }
+  const nativeScore = {
+    value: nativeValue,
+    scale: 10,
+    display: `${match?.groups?.value}/10`,
+  };
+  return {
+    nativeScore,
+    normalizedRating: normalizeReviewRating(nativeScore),
+  };
+}
+
+function bottleName(value: string): string | null {
+  return value.split("\n").map(normalizeText).find(Boolean) ?? null;
+}
+
+function reviewSourceKey(
+  canonicalUrl: string,
+  name: string,
+  reviewerName: string | null,
+): string {
+  const digest = createHash("sha256")
+    .update(
+      [canonicalUrl, name, reviewerName ?? ""]
+        .map((value) => normalizeText(value).toLocaleLowerCase("en"))
+        .join("\n"),
+    )
+    .digest("hex");
+  return `dramface:${digest}`;
+}
+
+export function parseDramfaceArticle(
+  data: string,
+  rawCanonicalUrl: URL,
+): DramfaceObservation {
+  const $ = cheerio(data);
+  const canonicalUrl = articleUrl(
+    $('link[rel="canonical"]').first().attr("href") ?? rawCanonicalUrl.href,
+  );
+  if (!canonicalUrl) throw new Error("Invalid Dramface article URL.");
+
+  const article = $("article").first();
+  const title = normalizeText(article.find(".blog-item-title").first().text());
+  const articleReviewerName =
+    normalizeText(article.find(".blog-author-name").first().text()) || null;
+  const dateText = article.find("time.dt-published").first().text();
+  if (!title) throw new Error("Dramface article title is missing.");
+  if (!dateText) throw new Error("Dramface article date is missing.");
+
+  const elements = article.find("h1,h2,h3,h4,p").toArray();
+  const reviewStarts = elements.flatMap((element, index) =>
+    element.tagName === "h3" &&
+    REVIEW_HEADING.test(normalizeText($(element).text()))
+      ? [index]
+      : [],
+  );
+  const reviews: ReviewArticleObservation["reviews"] = [];
+  const reviewTexts: Record<string, string> = {};
+
+  for (const [reviewIndex, start] of reviewStarts.entries()) {
+    const end = reviewStarts[reviewIndex + 1] ?? elements.length;
+    const section = elements.slice(start, end);
+    const heading = normalizeText($(section[0]).text());
+    const reviewerMatch = REVIEW_HEADING.exec(heading);
+    const reviewerName =
+      normalizeText(reviewerMatch?.groups?.reviewer ?? "") ||
+      articleReviewerName;
+    const bottleElement = section.find(
+      (element) =>
+        element.tagName === "p" && $(element).hasClass("sqsrte-large"),
+    );
+    const bottleContent = bottleElement ? $(bottleElement).clone() : null;
+    bottleContent?.find("br").replaceWith("\n");
+    const name = bottleContent ? bottleName(bottleContent.text()) : null;
+    const reviewScore = section
+      .map((element) => score($(element).text()))
+      .find((value) => value !== null);
+    if (!name || !reviewScore) continue;
+
+    const sourceKey = reviewSourceKey(canonicalUrl.href, name, reviewerName);
+    reviews.push({
+      sourceKey,
+      name,
+      category: null,
+      reviewerName,
+      nativeScore: reviewScore.nativeScore,
+      normalizedRating: reviewScore.normalizedRating,
+    });
+
+    const tastingStart = section.findIndex((element) =>
+      TASTING_HEADING.test(normalizeText($(element).text())),
+    );
+    const finalScore = section.findLastIndex((element) =>
+      score($(element).text()),
+    );
+    const reviewText = normalizeText(
+      tastingStart < 0
+        ? ""
+        : section
+            .slice(
+              tastingStart + 1,
+              finalScore > tastingStart ? finalScore : section.length,
+            )
+            .filter((element) => element.tagName === "p")
+            .map((element) => $(element).text())
+            .join(" "),
+    );
+    if (reviewText) reviewTexts[sourceKey] = reviewText;
+  }
+
+  if (reviews.length === 0) {
+    throw new Error("Dramface article contains no scored review sections.");
+  }
+
+  const contentText = JSON.stringify(
+    reviews.map((review) => ({
+      ...review,
+      reviewText: reviewTexts[review.sourceKey] ?? null,
+    })),
+  );
+  return DramfaceObservationSchema.parse({
+    article: {
+      canonicalUrl: canonicalUrl.href,
+      title,
+      issue: null,
+      publishedAt: publishedAt(dateText),
+      contentHash: createHash("sha256").update(contentText).digest("hex"),
+      reviews,
+    },
+    reviewTexts,
+  });
+}
+
+export const dramfaceAdapter: ScraperAdapter<
+  DramfaceCursor,
+  DramfaceObservation
+> = async ({ cursor, session }) => {
+  const indexResponse = await session.request({
+    target: TARGET,
+    url: new URL("/all-reviews", ORIGIN),
+  });
+  const articleUrls = discoverDramfaceArticles(indexResponse.body);
+  const currentArticleUrls = new Set(articleUrls.map((url) => url.href));
+  const processedArticleUrls = new Set(
+    (cursor?.processedArticleUrls ?? []).filter((url) =>
+      currentArticleUrls.has(url),
+    ),
+  );
+
+  for (const url of articleUrls) {
+    if (processedArticleUrls.has(url.href)) continue;
+    const articleResponse = await session.request({ target: TARGET, url });
+    const observation = parseDramfaceArticle(
+      articleResponse.body,
+      articleResponse.url,
+    );
+    await session.emit({
+      sourceKey: observation.article.canonicalUrl,
+      itemCount: observation.article.reviews.length,
+      value: observation,
+    });
+    processedArticleUrls.add(url.href);
+    await session.checkpoint({
+      processedArticleUrls: [...processedArticleUrls],
+    });
+  }
+};

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -26,6 +26,7 @@ const migratedSources = [
   "compassbox",
   "decadentdrinks",
   "douglaslaing",
+  "dramface",
   "dramfool",
   "edradour",
   "finedrams",
@@ -77,6 +78,13 @@ test("registers every scraper source with explicit target ownership", () => {
   expect(scraperRegistry.targets.get("astorwines")?.enabled).toBe(true);
   expect(EXTERNAL_SITE_DEFINITIONS.astorwines.runEvery).toBeNull();
   expect(scraperRegistry.targets.get("totalwine")?.enabled).toBe(false);
+  expect(EXTERNAL_SITE_DEFINITIONS.dramface.runEvery).toBe(1440);
+  expect(scraperRegistry.targets.get("dramface")).toMatchObject({
+    minimumSpacingMs: 2_500,
+    requestsPerWindow: 25,
+    windowMs: 3_600_000,
+  });
+  expect(scraperRegistry.sources.get("dramface")?.requestLimit).toBe(30);
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyadvocate.runEvery).toBeNull();
   expect(scraperRegistry.targets.get("whiskyadvocate")).toMatchObject({
     minimumSpacingMs: 2_500,
@@ -104,10 +112,16 @@ test("registers every scraper source with explicit target ownership", () => {
   expect(scraperRegistry.sources.get("whiskyfun")?.observationSchema).toBe(
     scraperRegistry.sources.get("whiskynotes")?.observationSchema,
   );
+  expect(scraperRegistry.sources.get("dramface")?.observationSchema).toBe(
+    scraperRegistry.sources.get("whiskynotes")?.observationSchema,
+  );
   expect(scraperRegistry.sources.get("whiskyadvocate")?.sink).toBe(
     scraperRegistry.sources.get("whiskynotes")?.sink,
   );
   expect(scraperRegistry.sources.get("whiskyfun")?.sink).toBe(
+    scraperRegistry.sources.get("whiskynotes")?.sink,
+  );
+  expect(scraperRegistry.sources.get("dramface")?.sink).toBe(
     scraperRegistry.sources.get("whiskynotes")?.sink,
   );
 });

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -1,4 +1,9 @@
 import { z } from "zod";
+import {
+  dramfaceAdapter,
+  DramfaceCursorSchema,
+  DramfaceObservationSchema,
+} from "./adapters/dramface";
 import scrapeAstorWines from "./adapters/legacy/scrapeAstorWines";
 import scrapeBerryBrosRudd from "./adapters/legacy/scrapeBerryBrosRudd";
 import scrapeBruichladdich from "./adapters/legacy/scrapeBruichladdich";
@@ -215,6 +220,17 @@ export const scraperRegistry = createScraperRegistry({
       }),
     ),
     defineScrapeTarget({
+      key: "dramface",
+      minimumSpacingMs: 2_500,
+      requestsPerWindow: 25,
+      origins: [
+        {
+          origin: "https://www.dramface.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
+    defineScrapeTarget({
       key: "whiskyadvocate",
       minimumSpacingMs: 2_500,
       requestsPerWindow: 20,
@@ -271,6 +287,16 @@ export const scraperRegistry = createScraperRegistry({
         sink: bottleObservationSink,
       }),
     ),
+    defineScraperSource({
+      key: "dramface",
+      externalSiteType: "dramface",
+      targetKeys: ["dramface"],
+      requestLimit: 30,
+      cursorSchema: DramfaceCursorSchema,
+      observationSchema: DramfaceObservationSchema,
+      adapter: dramfaceAdapter,
+      sink: externalReviewSink,
+    }),
     defineScraperSource({
       key: "whiskyadvocate",
       externalSiteType: "whiskyadvocate",

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -140,6 +140,14 @@ least 2.5 seconds apart. The target allows 25 requests per hour, and each worker
 pass stops after 30 requests. The adapter stores explicit feed dates, reviewer
 metadata, native scores, and canonical links. Review prose stays transient.
 
+Dramface runs once per day. It reads at most 20 current links from the public
+review index. It does not request Squarespace feeds, JSON views, APIs, search,
+or author query pages. Requests are at least 2.5 seconds apart. The target
+allows 25 requests per hour, and each worker pass stops after 30 requests. The
+adapter splits multi-bottle and multi-writer articles into scored reviews. It
+stores exact dates, published reviewer names, native scores, and canonical
+links. Review prose stays transient, and Dramface's TL;DR text is excluded.
+
 Enable automatic publication only after the reviewed sample passes the gate.
 Use the same source-specific process for each later publisher. Do not add a
 generic crawler only because several sources use RSS or HTML.

--- a/docs/research/external-review-content-supply.md
+++ b/docs/research/external-review-content-supply.md
@@ -103,6 +103,10 @@ podcast transcripts need a separate platform-terms and creator-rights review.
   `TL;DR`, but Peated should not assume that the existing summary is reusable.
 - Multi-bottle and multi-author articles make it a good test for the required
   review-article model.
+- The implemented daily feed reads at most 20 links from the public review
+  index. It uses only allowed article paths through the governed runtime. It
+  keeps each Bottle and reviewer section separate and excludes Dramface's
+  `TL;DR` text from transient summary input.
 - Dramface also republishes press releases in a clearly labeled news section.
   Use that as discovery; release facts should link to the original producer or
   issuer when available.
@@ -187,8 +191,9 @@ boundary.
    issue.
 3. Whiskyfun supplies the next daily multi-bottle feed. Keep its historical
    archive as a later bounded change.
-4. Add Dramface next, then continue through the reviewed public-index
-   candidates until Peated has at least 12 reliable feeds.
+4. Dramface supplies the next daily multi-bottle and multi-writer feed.
+5. Continue through the reviewed public-index candidates until Peated has at
+   least 12 reliable feeds.
 
 The pilot is successful with at least 90% article extraction accuracy on a
 reviewed sample, reliable splitting of multi-bottle articles, measurable

--- a/openspec/changes/add-dramface-review-feed/.openspec.yaml
+++ b/openspec/changes/add-dramface-review-feed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/add-dramface-review-feed/design.md
+++ b/openspec/changes/add-dramface-review-feed/design.md
@@ -1,0 +1,70 @@
+## Context
+
+Dramface publishes a public review index with 20 current article links. Each
+article has a canonical URL, title, publication date, and writer. Review
+sections contain Bottle details, a 10-point score, and review prose. One article
+can contain several bottles or several reviews of one Bottle. Peated already
+owns shared ingestion, Bottle matching, summary, policy, robots, and request
+control boundaries.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add current Dramface reviews without a schema or API change.
+- Preserve each article's canonical URL, date, writer, Bottle facts, and native
+  score.
+- Preserve review section boundaries for multi-bottle and multi-writer pages.
+- Run on a daily schedule with bounded and spaced requests.
+
+**Non-Goals:**
+
+- Backfill the full Dramface archive.
+- Fetch Squarespace APIs, JSON views, search pages, or author query pages.
+- Build a generic Squarespace or HTML review crawler.
+- Ingest Dramface news or features.
+- Store article HTML, publisher images, full review prose, or publisher TL;DR
+  text.
+
+## Decisions
+
+### Use the public review index for bounded discovery
+
+The adapter reads at most 20 current article links from `/all-reviews`. It
+requests only canonical `/all-reviews/<year>/<slug>` pages. A run checkpoints
+each emitted article URL so a deferred run does not repeat completed requests.
+
+The Squarespace RSS and JSON views were rejected because Dramface's robots
+rules block format query parameters. Sitemap discovery was rejected because it
+would mix current reviews with the full archive.
+
+### Keep parsing specific to Dramface
+
+The adapter starts each review at a `Review` heading. The next large paragraph
+supplies the Bottle text. The adapter reads the score within that section. It
+uses a reviewer named in the section heading when present and otherwise uses
+the article writer. It derives a stable review key from the canonical URL,
+Bottle text, and reviewer.
+
+A configurable parser was rejected because Dramface's review boundaries and
+duplicate article summary fields are source-specific.
+
+### Reuse the existing external-review boundary
+
+The adapter emits the shared article ingestion schema. Only tasting prose from
+the matching review section enters the policy-gated summary path. The adapter
+excludes Dramface's TL;DR text. The scraper runtime enforces robots rules, exact
+origins, request spacing, hourly quota, response limits, retries, and backoff.
+Source policy controls visibility and model use, but it does not disable
+fetching.
+
+## Risks / Trade-offs
+
+- **Article markup varies** → Accept only complete review sections and cover the
+  current one-review, multi-bottle, and multi-writer forms with small fixtures.
+- **The index contains category links and repeated links** → Require the
+  canonical year-and-slug path and remove duplicates before applying the limit.
+- **A review heading uses a short writer name** → Preserve that published name;
+  use the article writer only when the section does not name a reviewer.
+- **Page parsing changes** → Fail the article without deleting prior reviews.
+  Fixture tests make the expected structure explicit.

--- a/openspec/changes/add-dramface-review-feed/proposal.md
+++ b/openspec/changes/add-dramface-review-feed/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Peated needs more current critic reviews to make Bottle pages useful. Dramface
+publishes frequent public reviews with exact dates, scores, writers, and
+multi-bottle or multi-writer articles.
+
+## What Changes
+
+- Add Dramface as a scheduled external-review source.
+- Discover only the latest bounded set of articles from its public review page.
+- Extract article metadata and each scored Bottle review with source-specific
+  code.
+- Send review prose only through the existing transient summary boundary.
+- Use the shared Bottle matcher, review storage, request controls, robots
+  enforcement, and publication policy.
+
+## Capabilities
+
+### New Capabilities
+
+- `external-review-feeds`: Bounded ingestion of current editorial review feeds
+  through source-specific adapters and the shared external-review boundary.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds one external-site definition and one native scraper adapter.
+- Adds fixture-backed parser and runtime registration tests.
+- Adds no database schema, API, model, or UI changes.

--- a/openspec/changes/add-dramface-review-feed/specs/external-review-feeds/spec.md
+++ b/openspec/changes/add-dramface-review-feed/specs/external-review-feeds/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Current editorial indexes use bounded discovery
+
+The system SHALL discover a fixed maximum number of current articles from a
+registered publisher review index and SHALL fetch them through the shared
+scraper runtime.
+
+#### Scenario: Scheduled Dramface run
+
+- **WHEN** the daily Dramface run reads its public review index
+- **THEN** it considers at most 20 current review articles
+- **AND** all requests use the registered origin, robots rules, spacing, quota,
+  retry, and backoff controls
+
+#### Scenario: Deferred run resumes
+
+- **WHEN** a Dramface run is deferred after it stores an article
+- **THEN** the resumed run does not request that completed article again
+
+### Requirement: Review sections preserve publisher facts
+
+The system SHALL store each review article by canonical URL with its explicit
+publisher date, title, writer, Bottle text, and native review scores.
+
+#### Scenario: Article contains several bottles
+
+- **WHEN** one Dramface article contains several scored Bottle review sections
+- **THEN** the system stores one review article with one independently matched
+  review for each valid section
+
+#### Scenario: Article contains several reviewers
+
+- **WHEN** Dramface names a reviewer in a review section heading
+- **THEN** the system preserves that reviewer on the matching review
+- **AND** reviews without a section reviewer use the article writer
+
+#### Scenario: Article supplies a publication date
+
+- **WHEN** a Dramface article supplies a valid publication date
+- **THEN** the system stores that exact date as the article publication date
+
+### Requirement: Publisher content remains transient
+
+The system MUST NOT persist Dramface HTML, full review prose, publisher images,
+or publisher TL;DR text as source content.
+
+#### Scenario: Review text is processed
+
+- **WHEN** the source policy permits Peated to generate a review summary
+- **THEN** the adapter passes only that review section's tasting prose through
+  the existing transient summary boundary
+- **AND** stored output contains only permitted structured facts, derived
+  summary data, content hash, and canonical link

--- a/openspec/changes/add-dramface-review-feed/tasks.md
+++ b/openspec/changes/add-dramface-review-feed/tasks.md
@@ -1,0 +1,14 @@
+## 1. Source Adapter
+
+- [x] 1.1 Add fixture-backed index discovery and review section parsing
+- [x] 1.2 Add resumable adapter execution with bounded current-item discovery
+
+## 2. Runtime Registration
+
+- [x] 2.1 Register Dramface as a daily review source with polite request limits
+- [x] 2.2 Prove source registration and shared review boundaries in tests
+
+## 3. Documentation And Verification
+
+- [x] 3.1 Update source research and operating documentation with the live path
+- [x] 3.2 Run focused tests, typecheck, lint, format, and strict OpenSpec validation


### PR DESCRIPTION
Peated now imports the 20 current reviews from Dramface each day. The source adapter preserves article dates, writers, native scores, and canonical links. It also separates multi-bottle and multi-writer articles before the shared Bottle matcher and review sink process them.

Discovery stays on the public review index and canonical article paths. The shared scraper runtime enforces robots rules, 2.5-second spacing, and a 25-request hourly limit. Review prose remains transient, and the adapter excludes publisher TL;DR text from summary input. This adds no database, API, model, or UI changes, and source content policy does not disable fetching.

Fixture coverage includes one-review, multi-bottle, multi-writer, decimal-score, resume, and rolling-index cases. The full repository test gate and server typecheck pass.
