### PR TITLE
feat(scraper): add Words of Whisky review feed

### DIFF
--- a/apps/server/__fixtures__/wordsofwhisky/index.html
+++ b/apps/server/__fixtures__/wordsofwhisky/index.html
@@ -1,0 +1,12 @@
+<main>
+  <article class="category-tastingnotes">
+    <a href="/bruichladdich-greener-still-review/">Image</a>
+    <a href="/bruichladdich-greener-still-review/">Bruichladdich</a>
+  </article>
+  <article class="category-tastingnotes">
+    <a href="/kanosuke-dingle-meikle-toir-the-whisky-exchange/">Three reviews</a>
+  </article>
+  <article class="category-news">
+    <a href="/production-restarts-at-example-distillery/">News</a>
+  </article>
+</main>

--- a/apps/server/__fixtures__/wordsofwhisky/multi-review.html
+++ b/apps/server/__fixtures__/wordsofwhisky/multi-review.html
@@ -1,0 +1,36 @@
+<html>
+  <head>
+    <link
+      rel="canonical"
+      href="https://wordsofwhisky.com/kanosuke-dingle-meikle-toir-the-whisky-exchange/"
+    />
+  </head>
+  <body>
+    <div class="post-wrap">
+      <h1 class="entry-title">
+        Kanosuke / Dingle / Meikle Tòir (The Whisky Exchange)
+      </h1>
+      <time class="entry-date" datetime="2026-08-19T08:00:00+02:00">
+        19 August 2026
+      </time>
+      <div class="side-author__wrap">Thijs Klaverstijn</div>
+      <div class="entry-content">
+        <p>Article introduction.</p>
+        <h2>Dingle 2020 5 Years Palo Cortado (59.6%, OB, 330 bts.)</h2>
+        <p>Nose: Red apple. Taste: Dark fruit. Finish: Medium.</p>
+        <div class="lets-review-block__wrap">
+          <div class="lets-review-block__conclusion">First conclusion.</div>
+          <div class="lets-review-block__final-score">8.7</div>
+        </div>
+        <script type="application/ld+json">{"name":"article title"}</script>
+        <h2>Kanosuke 2018 (57%, OB ‘Brush Stroke’, C#19044)</h2>
+        <p>Nose: Citrus. Taste: Tropical fruit. Finish: Long.</p>
+        <div class="lets-review-block__wrap">
+          <div class="lets-review-block__conclusion">Second conclusion.</div>
+          <div class="lets-review-block__final-score">9</div>
+        </div>
+        <p>Samples provided by a retailer.</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/apps/server/__fixtures__/wordsofwhisky/single-review.html
+++ b/apps/server/__fixtures__/wordsofwhisky/single-review.html
@@ -1,0 +1,33 @@
+<html>
+  <head>
+    <link
+      rel="canonical"
+      href="https://wordsofwhisky.com/bruichladdich-greener-still-review/"
+    />
+  </head>
+  <body>
+    <div class="post-wrap">
+      <h1 class="entry-title">Bruichladdich Greener Still (2026)</h1>
+      <time class="entry-date" datetime="2026-08-21T08:00:00+02:00">
+        21 August 2026
+      </time>
+      <div class="side-author__wrap">Thijs Klaverstijn</div>
+      <div class="entry-content">
+        <p>Article introduction that must not enter summary input.</p>
+        <h2>Bruichladdich Greener Still 15 Years (51.6%, OB, 2026)</h2>
+        <p>
+          <strong>Nose:</strong> Fresh barley and lemon oil.<br />
+          <strong>Taste:</strong> Mineral malt and gentle spice.<br />
+          <strong>Finish:</strong> Long, bright, and coastal.
+        </p>
+        <div class="lets-review-block__wrap">
+          <div class="lets-review-block__conclusion">
+            Publisher conclusion that must not enter summary input.
+          </div>
+          <div class="lets-review-block__final-score">9</div>
+        </div>
+      </div>
+    </div>
+    <footer>Footer content that must not enter summary input.</footer>
+  </body>
+</html>

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -74,6 +74,11 @@ export const EXTERNAL_SITE_DEFINITIONS = {
     runEvery: null,
     content: "reviews",
   },
+  wordsofwhisky: {
+    name: "Words of Whisky",
+    runEvery: 1440,
+    content: "reviews",
+  },
   whiskyworld: { name: "The Whisky World", runEvery: 10080 },
 } as const;
 

--- a/apps/server/src/lib/externalSites.test.ts
+++ b/apps/server/src/lib/externalSites.test.ts
@@ -43,10 +43,16 @@ test("syncs code-owned external-site definitions", async () => {
   expect(fineDrams).toMatchObject(EXTERNAL_SITE_DEFINITIONS.finedrams);
 
   const policies = await db.select().from(externalReviewSourcePolicies);
-  expect(policies).toHaveLength(4);
+  expect(policies).toHaveLength(5);
   expect(policies).toEqual(
     expect.arrayContaining(
-      ["dramface", "whiskyadvocate", "whiskyfun", "whiskynotes"].map((type) =>
+      [
+        "dramface",
+        "whiskyadvocate",
+        "whiskyfun",
+        "whiskynotes",
+        "wordsofwhisky",
+      ].map((type) =>
         expect.objectContaining({
           externalSiteId: sites.find((site) => site.type === type)?.id,
           publicationMode: "disabled",

--- a/apps/server/src/scraper/adapters/wordsOfWhisky.test.ts
+++ b/apps/server/src/scraper/adapters/wordsOfWhisky.test.ts
@@ -1,0 +1,180 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { vi } from "vitest";
+import type { ScraperObservation, ScraperSession } from "../types";
+import {
+  discoverWordsOfWhiskyArticles,
+  parseWordsOfWhiskyArticle,
+  wordsOfWhiskyAdapter,
+  type WordsOfWhiskyCursor,
+  type WordsOfWhiskyObservation,
+} from "./wordsOfWhisky";
+
+const SINGLE_URL =
+  "https://wordsofwhisky.com/bruichladdich-greener-still-review";
+const MULTI_URL =
+  "https://wordsofwhisky.com/kanosuke-dingle-meikle-toir-the-whisky-exchange";
+
+test("discovers at most twenty current tasting-note articles", async () => {
+  const homepage = await loadFixture("wordsofwhisky", "index.html");
+  const expandedHomepage = homepage.replace(
+    "</main>",
+    `${Array.from(
+      { length: 25 },
+      (_, index) =>
+        `<article class="category-tastingnotes"><a href="/generated-${index}/">Generated ${index}</a></article>`,
+    ).join("")}</main>`,
+  );
+
+  expect(
+    discoverWordsOfWhiskyArticles(homepage).map((url) => url.href),
+  ).toEqual([SINGLE_URL, MULTI_URL]);
+  expect(discoverWordsOfWhiskyArticles(expandedHomepage)).toHaveLength(20);
+  expect(discoverWordsOfWhiskyArticles(expandedHomepage).at(-1)?.pathname).toBe(
+    "/generated-17",
+  );
+});
+
+test("extracts one scored review and only its tasting notes", async () => {
+  const html = await loadFixture("wordsofwhisky", "single-review.html");
+  const parsed = parseWordsOfWhiskyArticle(html, new URL(SINGLE_URL));
+  const reparsed = parseWordsOfWhiskyArticle(
+    html.replaceAll(
+      "Bruichladdich Greener Still 15 Years",
+      "Bruichladdich   Greener Still 15 Years",
+    ),
+    new URL(SINGLE_URL),
+  );
+
+  expect(parsed.article).toMatchObject({
+    canonicalUrl: SINGLE_URL,
+    title: "Bruichladdich Greener Still (2026)",
+    publishedAt: new Date("2026-08-21T06:00:00.000Z"),
+    contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    reviews: [
+      {
+        name: "Bruichladdich Greener Still 15 Years (51.6%, OB, 2026)",
+        reviewerName: "Thijs Klaverstijn",
+        nativeScore: { value: 9, scale: 10, display: "9/10" },
+        normalizedRating: 90,
+      },
+    ],
+  });
+  expect(parsed.article.reviews[0]?.sourceKey).toBe(
+    reparsed.article.reviews[0]?.sourceKey,
+  );
+  expect(Object.values(parsed.reviewTexts)).toEqual([
+    "Nose: Fresh barley and lemon oil. Taste: Mineral malt and gentle spice. Finish: Long, bright, and coastal.",
+  ]);
+  expect(Object.values(parsed.reviewTexts).join(" ")).not.toMatch(
+    /Article introduction|Publisher conclusion|Footer content/u,
+  );
+});
+
+test("extracts each Bottle and normalizes decimal scores", async () => {
+  const html = await loadFixture("wordsofwhisky", "multi-review.html");
+  const parsed = parseWordsOfWhiskyArticle(html, new URL(MULTI_URL));
+
+  expect(parsed.article.reviews).toMatchObject([
+    {
+      name: "Dingle 2020 5 Years Palo Cortado (59.6%, OB, 330 bts.)",
+      reviewerName: "Thijs Klaverstijn",
+      nativeScore: { value: 8.7, scale: 10, display: "8.7/10" },
+      normalizedRating: 87,
+    },
+    {
+      name: "Kanosuke 2018 (57%, OB ‘Brush Stroke’, C#19044)",
+      reviewerName: "Thijs Klaverstijn",
+      nativeScore: { value: 9, scale: 10, display: "9/10" },
+      normalizedRating: 90,
+    },
+  ]);
+  expect(Object.keys(parsed.reviewTexts)).toEqual(
+    parsed.article.reviews.map(({ sourceKey }) => sourceKey),
+  );
+  expect(Object.values(parsed.reviewTexts).join(" ")).not.toMatch(
+    /conclusion|Samples provided|Article introduction/iu,
+  );
+});
+
+test("resumes without requesting a completed current article", async () => {
+  const homepage = await loadFixture("wordsofwhisky", "index.html");
+  const multi = await loadFixture("wordsofwhisky", "multi-review.html");
+  const observations: ScraperObservation<WordsOfWhiskyObservation>[] = [];
+  const checkpoints: WordsOfWhiskyCursor[] = [];
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body: url.pathname === "/" ? homepage : multi,
+  }));
+  const session: ScraperSession<WordsOfWhiskyCursor, WordsOfWhiskyObservation> =
+    {
+      request,
+      emit: async (observation) => {
+        observations.push(observation);
+      },
+      checkpoint: async (cursor) => {
+        checkpoints.push(cursor);
+      },
+      remainingRequests: () => 25,
+    };
+
+  await wordsOfWhiskyAdapter({
+    cursor: { processedArticleUrls: [SINGLE_URL] },
+    session,
+  });
+
+  expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
+    "https://wordsofwhisky.com/",
+    MULTI_URL,
+  ]);
+  expect(observations).toHaveLength(1);
+  expect(observations[0]).toMatchObject({ sourceKey: MULTI_URL, itemCount: 2 });
+  expect(checkpoints).toEqual([
+    { processedArticleUrls: [SINGLE_URL, MULTI_URL] },
+  ]);
+});
+
+test("drops completed URLs that leave the current homepage window", async () => {
+  const priorUrls = Array.from(
+    { length: 20 },
+    (_, index) => `https://wordsofwhisky.com/prior-${index}`,
+  );
+  const currentUrls = [
+    "https://wordsofwhisky.com/new-review",
+    ...priorUrls.slice(0, -1),
+  ];
+  const homepage = `<main>${currentUrls
+    .map(
+      (url) =>
+        `<article class="category-tastingnotes"><a href="${url}">Review</a></article>`,
+    )
+    .join("")}</main>`;
+  const article = (
+    await loadFixture("wordsofwhisky", "single-review.html")
+  ).replace(/<link[\s\S]+?\/>/u, "");
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body: url.pathname === "/" ? homepage : article,
+  }));
+  const session: ScraperSession<WordsOfWhiskyCursor, WordsOfWhiskyObservation> =
+    {
+      request,
+      emit: vi.fn(),
+      checkpoint,
+      remainingRequests: () => 25,
+    };
+
+  await wordsOfWhiskyAdapter({
+    cursor: { processedArticleUrls: priorUrls },
+    session,
+  });
+
+  expect(request).toHaveBeenCalledTimes(2);
+  const completedUrls = checkpoint.mock.calls.at(-1)?.[0].processedArticleUrls;
+  expect(completedUrls).toHaveLength(20);
+  expect(new Set(completedUrls)).toEqual(new Set(currentUrls));
+});

--- a/apps/server/src/scraper/adapters/wordsOfWhisky.ts
+++ b/apps/server/src/scraper/adapters/wordsOfWhisky.ts
@@ -1,0 +1,220 @@
+import {
+  normalizeReviewRating,
+  type ReviewArticleIngestion,
+  ReviewArticleIngestionSchema,
+  type ReviewArticleObservation,
+} from "@peated/server/externalReviews/observation";
+import { load as cheerio } from "cheerio";
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import type { ScraperAdapter } from "../types";
+
+// This adapter owns Words of Whisky parsing. The shared scraper runtime owns
+// every remote request and the shared review sink owns storage.
+const ORIGIN = "https://wordsofwhisky.com";
+const TARGET = "wordsofwhisky";
+const MAX_HOMEPAGE_ARTICLES = 20;
+const ARTICLE_PATH = /^\/[a-z0-9][a-z0-9-]*$/u;
+const TASTING_PARAGRAPH = /^(?:Nose|Palate|Taste|Finish)\s*:/iu;
+
+export const WordsOfWhiskyCursorSchema = z
+  .object({
+    processedArticleUrls: z.array(z.url()).max(MAX_HOMEPAGE_ARTICLES),
+  })
+  .strict();
+
+export const WordsOfWhiskyObservationSchema = ReviewArticleIngestionSchema;
+
+export type WordsOfWhiskyCursor = z.infer<typeof WordsOfWhiskyCursorSchema>;
+export type WordsOfWhiskyObservation = ReviewArticleIngestion;
+
+function normalizeText(value: string): string {
+  return value.replaceAll(/\s+/g, " ").trim();
+}
+
+function articleUrl(value: string): URL | null {
+  try {
+    const url = new URL(value, ORIGIN);
+    url.hash = "";
+    url.search = "";
+    url.pathname = url.pathname.replace(/\/$/u, "");
+    if (url.origin !== ORIGIN || !ARTICLE_PATH.test(url.pathname)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+export function discoverWordsOfWhiskyArticles(data: string): URL[] {
+  const $ = cheerio(data);
+  const articles = new Map<string, URL>();
+
+  $("article.category-tastingnotes a[href]").each((_, element) => {
+    const url = articleUrl($(element).attr("href") ?? "");
+    if (url) articles.set(url.href, url);
+  });
+
+  return [...articles.values()].slice(0, MAX_HOMEPAGE_ARTICLES);
+}
+
+function publishedAt(value: string): Date {
+  const date = new Date(value);
+  if (!value.trim() || Number.isNaN(date.getTime())) {
+    throw new Error("Words of Whisky article date is invalid.");
+  }
+  return date;
+}
+
+function score(value: string) {
+  const match = /^(?<value>\d{1,2}(?:[.,]\d+)?)$/u.exec(normalizeText(value));
+  const nativeValue = match?.groups?.value
+    ? Number(match.groups.value.replace(",", "."))
+    : Number.NaN;
+  if (!Number.isFinite(nativeValue) || nativeValue < 0 || nativeValue > 10) {
+    return null;
+  }
+  const nativeScore = {
+    value: nativeValue,
+    scale: 10,
+    display: `${match?.groups?.value}/10`,
+  };
+  return {
+    nativeScore,
+    normalizedRating: normalizeReviewRating(nativeScore),
+  };
+}
+
+function reviewSourceKey(
+  canonicalUrl: string,
+  name: string,
+  reviewerName: string | null,
+): string {
+  const digest = createHash("sha256")
+    .update(
+      [canonicalUrl, name, reviewerName ?? ""]
+        .map((value) => normalizeText(value).toLocaleLowerCase("en"))
+        .join("\n"),
+    )
+    .digest("hex");
+  return `wordsofwhisky:${digest}`;
+}
+
+export function parseWordsOfWhiskyArticle(
+  data: string,
+  rawCanonicalUrl: URL,
+): WordsOfWhiskyObservation {
+  const $ = cheerio(data);
+  const canonicalUrl = articleUrl(
+    $('link[rel="canonical"]').first().attr("href") ?? rawCanonicalUrl.href,
+  );
+  if (!canonicalUrl) throw new Error("Invalid Words of Whisky article URL.");
+
+  const article = $(".post-wrap").first();
+  const title = normalizeText(article.find(".entry-title").first().text());
+  const reviewerName =
+    normalizeText(article.find(".side-author__wrap").first().text()) || null;
+  const dateText =
+    article.find("time.entry-date").first().attr("datetime") ?? "";
+  if (!title) throw new Error("Words of Whisky article title is missing.");
+  if (!dateText) throw new Error("Words of Whisky article date is missing.");
+
+  const elements = article.find(".entry-content").first().children().toArray();
+  const reviewStarts = elements.flatMap((element, index) =>
+    element.tagName === "h2" ? [index] : [],
+  );
+  const reviews: ReviewArticleObservation["reviews"] = [];
+  const reviewTexts: Record<string, string> = {};
+
+  for (const [reviewIndex, start] of reviewStarts.entries()) {
+    const end = reviewStarts[reviewIndex + 1] ?? elements.length;
+    const section = elements.slice(start, end);
+    const name = normalizeText($(section[0]).text());
+    const reviewBlock = section.find((element) =>
+      $(element).hasClass("lets-review-block__wrap"),
+    );
+    const reviewScore = reviewBlock
+      ? score(
+          $(reviewBlock).find(".lets-review-block__final-score").first().text(),
+        )
+      : null;
+    if (!name || !reviewScore) continue;
+
+    const sourceKey = reviewSourceKey(canonicalUrl.href, name, reviewerName);
+    reviews.push({
+      sourceKey,
+      name,
+      category: null,
+      reviewerName,
+      nativeScore: reviewScore.nativeScore,
+      normalizedRating: reviewScore.normalizedRating,
+    });
+
+    const reviewText = normalizeText(
+      section
+        .filter((element) => element.tagName === "p")
+        .map((element) => normalizeText($(element).text()))
+        .filter((text) => TASTING_PARAGRAPH.test(text))
+        .join(" "),
+    );
+    if (reviewText) reviewTexts[sourceKey] = reviewText;
+  }
+
+  if (reviews.length === 0) {
+    throw new Error(
+      "Words of Whisky article contains no scored Bottle sections.",
+    );
+  }
+
+  const contentText = JSON.stringify(
+    reviews.map((review) => ({
+      ...review,
+      reviewText: reviewTexts[review.sourceKey] ?? null,
+    })),
+  );
+  return WordsOfWhiskyObservationSchema.parse({
+    article: {
+      canonicalUrl: canonicalUrl.href,
+      title,
+      issue: null,
+      publishedAt: publishedAt(dateText),
+      contentHash: createHash("sha256").update(contentText).digest("hex"),
+      reviews,
+    },
+    reviewTexts,
+  });
+}
+
+export const wordsOfWhiskyAdapter: ScraperAdapter<
+  WordsOfWhiskyCursor,
+  WordsOfWhiskyObservation
+> = async ({ cursor, session }) => {
+  const homepageResponse = await session.request({
+    target: TARGET,
+    url: new URL("/", ORIGIN),
+  });
+  const articleUrls = discoverWordsOfWhiskyArticles(homepageResponse.body);
+  const currentArticleUrls = new Set(articleUrls.map((url) => url.href));
+  const processedArticleUrls = new Set(
+    (cursor?.processedArticleUrls ?? []).filter((url) =>
+      currentArticleUrls.has(url),
+    ),
+  );
+
+  for (const url of articleUrls) {
+    if (processedArticleUrls.has(url.href)) continue;
+    const articleResponse = await session.request({ target: TARGET, url });
+    const observation = parseWordsOfWhiskyArticle(
+      articleResponse.body,
+      articleResponse.url,
+    );
+    await session.emit({
+      sourceKey: observation.article.canonicalUrl,
+      itemCount: observation.article.reviews.length,
+      value: observation,
+    });
+    processedArticleUrls.add(url.href);
+    await session.checkpoint({
+      processedArticleUrls: [...processedArticleUrls],
+    });
+  }
+};

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -49,6 +49,7 @@ const migratedSources = [
   "whiskynotes",
   "whiskyworld",
   "woodencork",
+  "wordsofwhisky",
 ];
 
 type RuntimeTestClock = ScraperHttpClock & { advanceTo(value: Date): void };
@@ -106,6 +107,13 @@ test("registers every scraper source with explicit target ownership", () => {
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("whiskyfun")?.requestLimit).toBe(30);
+  expect(EXTERNAL_SITE_DEFINITIONS.wordsofwhisky.runEvery).toBe(1440);
+  expect(scraperRegistry.targets.get("wordsofwhisky")).toMatchObject({
+    minimumSpacingMs: 2_500,
+    requestsPerWindow: 25,
+    windowMs: 3_600_000,
+  });
+  expect(scraperRegistry.sources.get("wordsofwhisky")?.requestLimit).toBe(25);
   expect(scraperRegistry.sources.get("whiskyadvocate")?.observationSchema).toBe(
     scraperRegistry.sources.get("whiskynotes")?.observationSchema,
   );
@@ -115,6 +123,9 @@ test("registers every scraper source with explicit target ownership", () => {
   expect(scraperRegistry.sources.get("dramface")?.observationSchema).toBe(
     scraperRegistry.sources.get("whiskynotes")?.observationSchema,
   );
+  expect(scraperRegistry.sources.get("wordsofwhisky")?.observationSchema).toBe(
+    scraperRegistry.sources.get("whiskynotes")?.observationSchema,
+  );
   expect(scraperRegistry.sources.get("whiskyadvocate")?.sink).toBe(
     scraperRegistry.sources.get("whiskynotes")?.sink,
   );
@@ -122,6 +133,9 @@ test("registers every scraper source with explicit target ownership", () => {
     scraperRegistry.sources.get("whiskynotes")?.sink,
   );
   expect(scraperRegistry.sources.get("dramface")?.sink).toBe(
+    scraperRegistry.sources.get("whiskynotes")?.sink,
+  );
+  expect(scraperRegistry.sources.get("wordsofwhisky")?.sink).toBe(
     scraperRegistry.sources.get("whiskynotes")?.sink,
   );
 });

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -55,6 +55,11 @@ import {
   WhiskyNotesObservationSchema,
 } from "./adapters/whiskyNotes";
 import {
+  wordsOfWhiskyAdapter,
+  WordsOfWhiskyCursorSchema,
+  WordsOfWhiskyObservationSchema,
+} from "./adapters/wordsOfWhisky";
+import {
   createScraperRegistry,
   defineScraperSource,
   defineScrapeTarget,
@@ -263,6 +268,17 @@ export const scraperRegistry = createScraperRegistry({
         },
       ],
     }),
+    defineScrapeTarget({
+      key: "wordsofwhisky",
+      minimumSpacingMs: 2_500,
+      requestsPerWindow: 25,
+      origins: [
+        {
+          origin: "https://wordsofwhisky.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
   ],
   sources: [
     ...legacyPriceSources.map((source) =>
@@ -327,6 +343,16 @@ export const scraperRegistry = createScraperRegistry({
       cursorSchema: WhiskyfunCursorSchema,
       observationSchema: WhiskyfunObservationSchema,
       adapter: whiskyfunAdapter,
+      sink: externalReviewSink,
+    }),
+    defineScraperSource({
+      key: "wordsofwhisky",
+      externalSiteType: "wordsofwhisky",
+      targetKeys: ["wordsofwhisky"],
+      requestLimit: 25,
+      cursorSchema: WordsOfWhiskyCursorSchema,
+      observationSchema: WordsOfWhiskyObservationSchema,
+      adapter: wordsOfWhiskyAdapter,
       sink: externalReviewSink,
     }),
   ],

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -148,6 +148,15 @@ adapter splits multi-bottle and multi-writer articles into scored reviews. It
 stores exact dates, published reviewer names, native scores, and canonical
 links. Review prose stays transient, and Dramface's TL;DR text is excluded.
 
+Words of Whisky runs once per day. It reads at most 20 current tasting-note
+articles from the public homepage. It does not request the full tasting-notes
+archive, RSS, WordPress APIs, search, or the load-more endpoint. Requests are
+at least 2.5 seconds apart. The target allows 25 requests per hour, and each
+worker pass stops after 25 requests. The adapter splits multi-bottle articles
+into scored reviews. It stores exact timestamps, the published writer, native
+scores, and canonical links. Tasting notes stay transient. Article
+introductions and publisher conclusions are excluded from summary input.
+
 Enable automatic publication only after the reviewed sample passes the gate.
 Use the same source-specific process for each later publisher. Do not add a
 generic crawler only because several sources use RSS or HTML.

--- a/docs/research/external-review-content-supply.md
+++ b/docs/research/external-review-content-supply.md
@@ -1,6 +1,6 @@
 # External Review Content Supply
 
-Status: research notes, checked 2026-08-20. This is product and technical
+Status: research notes, checked 2026-08-21. This is product and technical
 research, not legal advice. Recheck every source before enabling ingestion.
 
 ## Product Intent
@@ -128,6 +128,22 @@ podcast transcripts need a separate platform-terms and creator-rights review.
   explicit publication dates. Peated does not persist review prose or generate
   summaries from it.
 
+### Words of Whisky
+
+- Evidence: [homepage and current reviews](https://wordsofwhisky.com/),
+  [tasting-notes index](https://wordsofwhisky.com/tasting-notes/), and
+  [robots.txt](https://wordsofwhisky.com/robots.txt).
+- Rechecked on 2026-08-21. Robots rules block WordPress administration and
+  allow the public homepage and article paths. No dedicated terms or privacy
+  page is linked from the public site. The footer reserves rights.
+- Current article pages expose an exact timestamp, writer, Bottle headings,
+  tasting notes, publisher conclusions, and per-Bottle 10-point scores.
+- The implemented daily feed reads at most 20 current tasting-note articles
+  from the homepage. It does not use the full archive, RSS, WordPress APIs,
+  search, or load-more endpoints. It keeps multi-bottle sections separate and
+  excludes article introductions and publisher conclusions from transient
+  summary input.
+
 ### Explicitly Restricted Sources
 
 - [Breaking Bourbon terms](https://www.breakingbourbon.com/site/breaking-bourbon-terms-of-use-agreement)
@@ -192,7 +208,8 @@ boundary.
 3. Whiskyfun supplies the next daily multi-bottle feed. Keep its historical
    archive as a later bounded change.
 4. Dramface supplies the next daily multi-bottle and multi-writer feed.
-5. Continue through the reviewed public-index candidates until Peated has at
+5. Words of Whisky supplies the next daily multi-bottle feed.
+6. Continue through the reviewed public-index candidates until Peated has at
    least 12 reliable feeds.
 
 The pilot is successful with at least 90% article extraction accuracy on a

--- a/openspec/changes/add-words-of-whisky-review-feed/.openspec.yaml
+++ b/openspec/changes/add-words-of-whisky-review-feed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/add-words-of-whisky-review-feed/design.md
+++ b/openspec/changes/add-words-of-whisky-review-feed/design.md
@@ -1,0 +1,65 @@
+## Context
+
+Words of Whisky publishes current scored reviews on its public homepage. The
+homepage marks review cards with the tasting-notes category. Each article has
+a canonical URL, exact publication time, writer, and one or more Bottle review
+sections. Each section has a Bottle heading, tasting notes, conclusion, and
+10-point score. Peated already owns the shared review schema, Bottle matcher,
+sink, summary policy, robots enforcement, and request controls.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add current Words of Whisky reviews without a schema or API change.
+- Preserve canonical links, dates, writer, Bottle headings, and native scores.
+- Preserve Bottle boundaries in multi-bottle articles.
+- Run daily with bounded and spaced requests.
+
+**Non-Goals:**
+
+- Backfill the full tasting-notes archive.
+- Use the WordPress API, RSS, search, or load-more endpoint.
+- Build a generic WordPress review crawler.
+- Store article HTML, images, full prose, or publisher conclusions.
+
+## Decisions
+
+### Use the public homepage for bounded discovery
+
+The adapter reads at most 20 unique links from homepage article cards marked
+with the tasting-notes category. It requests only canonical root-level article
+paths. A run checkpoints each emitted article URL so a deferred run does not
+repeat completed requests.
+
+The full tasting-notes index was rejected because it exposes the complete
+archive. RSS and WordPress endpoints are not needed for the current feed.
+
+### Keep parsing specific to Words of Whisky
+
+The adapter reads article metadata from the main post wrapper. Each level-two
+heading in the entry body starts one Bottle review. The next publisher review
+block supplies that section's score. The adapter derives a stable review key
+from the canonical URL, Bottle heading, and writer.
+
+A generic WordPress parser was rejected because the review headings and score
+blocks come from this site's theme and review plugin.
+
+### Reuse the existing external-review boundary
+
+The adapter emits the shared article ingestion schema. Only the tasting-note
+paragraphs between a Bottle heading and its score block enter the policy-gated
+summary path. Publisher introductions and conclusions stay out of that input.
+The shared runtime owns all network requests. Source policy controls display
+and model use, but it does not disable fetching.
+
+## Risks / Trade-offs
+
+- **Homepage layout changes** → Require tasting-notes article cards and cover
+  the current discovery markup with a small fixture.
+- **Article markup changes** → Accept only complete Bottle sections and cover
+  current single- and multi-bottle forms with fixtures.
+- **A heading is not a Bottle review** → Require a matching 10-point score
+  block before emitting the section.
+- **The homepage window changes during a deferred run** → Keep only cursor URLs
+  that remain in the current bounded window.

--- a/openspec/changes/add-words-of-whisky-review-feed/proposal.md
+++ b/openspec/changes/add-words-of-whisky-review-feed/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Peated needs more current critic reviews to make Bottle pages useful. Words of
+Whisky publishes frequent scored reviews with exact dates and many
+multi-bottle articles.
+
+## What Changes
+
+- Add Words of Whisky as a scheduled external-review source.
+- Discover only the current review articles shown on its public homepage.
+- Extract article metadata and each scored Bottle review with source-specific
+  code.
+- Send only each Bottle's tasting notes through the existing transient summary
+  boundary.
+- Use the shared Bottle matcher, review sink, request controls, robots
+  enforcement, and publication policy.
+
+## Capabilities
+
+### New Capabilities
+
+- `external-review-feeds`: Bounded ingestion of current editorial review feeds
+  through source-specific adapters and the shared external-review boundary.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds one external-site definition and one native scraper adapter.
+- Adds fixture-backed parser and runtime registration tests.
+- Adds no database schema, API, model, or UI changes.

--- a/openspec/changes/add-words-of-whisky-review-feed/specs/external-review-feeds/spec.md
+++ b/openspec/changes/add-words-of-whisky-review-feed/specs/external-review-feeds/spec.md
@@ -1,0 +1,56 @@
+## ADDED Requirements
+
+### Requirement: Current review pages use bounded discovery
+
+The system SHALL discover a fixed maximum number of current Words of Whisky
+articles from its public homepage and SHALL fetch them through the shared
+scraper runtime.
+
+#### Scenario: Scheduled Words of Whisky run
+
+- **WHEN** the daily source run reads the Words of Whisky homepage
+- **THEN** it considers at most 20 current tasting-note articles
+- **AND** all requests use the registered origin, robots rules, spacing, quota,
+  retry, and backoff controls
+
+#### Scenario: Deferred run resumes
+
+- **WHEN** a Words of Whisky run is deferred after it stores an article
+- **THEN** the resumed run does not request that completed current article
+  again
+
+### Requirement: Review sections preserve publisher facts
+
+The system SHALL store each article by canonical URL with its explicit date,
+title, writer, Bottle headings, and native review scores.
+
+#### Scenario: Article contains one Bottle
+
+- **WHEN** a Words of Whisky article contains one complete scored Bottle review
+- **THEN** the system stores one review article with one matched review
+
+#### Scenario: Article contains several Bottles
+
+- **WHEN** one Words of Whisky article contains several complete scored Bottle
+  sections
+- **THEN** the system stores one review article with one independently matched
+  review for each valid section
+
+#### Scenario: Article supplies an exact publication time
+
+- **WHEN** a Words of Whisky article supplies a valid publication timestamp
+- **THEN** the system stores that exact timestamp as the article publication
+  date
+
+### Requirement: Publisher content remains transient
+
+The system MUST NOT persist Words of Whisky HTML, full review prose, publisher
+images, article introductions, or publisher conclusions as source content.
+
+#### Scenario: Review text is processed
+
+- **WHEN** source policy permits Peated to generate a review summary
+- **THEN** the adapter passes only that Bottle section's tasting notes through
+  the existing transient summary boundary
+- **AND** stored output contains only permitted structured facts, derived
+  summary data, content hash, and canonical link

--- a/openspec/changes/add-words-of-whisky-review-feed/tasks.md
+++ b/openspec/changes/add-words-of-whisky-review-feed/tasks.md
@@ -1,0 +1,14 @@
+## 1. Source Adapter
+
+- [x] 1.1 Add fixture-backed homepage discovery and Bottle section parsing
+- [x] 1.2 Add resumable adapter execution with bounded current-item discovery
+
+## 2. Runtime Registration
+
+- [x] 2.1 Register Words of Whisky as a daily review source with polite request limits
+- [x] 2.2 Prove source registration and shared review boundaries in tests
+
+## 3. Documentation And Verification
+
+- [x] 3.1 Update source research and operating documentation with the live path
+- [x] 3.2 Run focused tests, typecheck, lint, format, and strict OpenSpec validation


### PR DESCRIPTION
Adds Words of Whisky as a daily external review source. The adapter reads at most 20 current tasting-note articles from the homepage, splits multi-bottle articles, and sends exact timestamps, writers, native scores, Bottle names, and canonical links through the shared review sink. Tasting-note text is transient summary input; article introductions and publisher conclusions are excluded.

All requests use the governed scraper runtime with robots enforcement, 2.5-second spacing, and a 25-request hourly limit. Manual fetching remains available. New review content keeps the existing disabled publication policy until the source is reviewed in production.
