### PR TITLE
feat(scraper): add The Whiskey Reviewer feed

### DIFF
--- a/apps/server/__fixtures__/whiskeyreviewer/index.html
+++ b/apps/server/__fixtures__/whiskeyreviewer/index.html
@@ -1,0 +1,15 @@
+<main>
+  <div class="widget posts-list">
+    <div class="widget-title"><div class="the-subtitle">Features</div></div>
+    <a class="post-title" href="/2026/08/not-a-review-082126/">News</a>
+  </div>
+  <div class="widget posts-list">
+    <div class="widget-title">
+      <div class="the-subtitle">Recent Reviews</div>
+    </div>
+    <a class="post-title" href="/2026/08/example-bourbon-review-081026/">Example Bourbon Review</a>
+    <a class="post-title" href="/2026/08/example-scotch-review-080626/">Example Scotch Review</a>
+    <a class="post-title" href="/2026/08/example-bourbon-review-081026/?ref=home">Duplicate</a>
+    <a class="post-title" href="https://example.com/foreign-review/">Foreign</a>
+  </div>
+</main>

--- a/apps/server/__fixtures__/whiskeyreviewer/review.html
+++ b/apps/server/__fixtures__/whiskeyreviewer/review.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+  <head>
+    <link rel="canonical" href="https://whiskeyreviewer.com/2026/08/example-bourbon-review-081026/" />
+  </head>
+  <body>
+    <article id="the-post">
+      <h1 class="post-title entry-title">Example 8 Year Old Bourbon Review</h1>
+      <div class="entry-content entry clearfix">
+        <p><em><strong>By Rowan Hill</strong></em></p>
+        <p><strong>Rating: B+</strong></p>
+        <p>Article introduction with production background.</p>
+        <p><strong>The Bourbon</strong><br />The nose has orange peel and vanilla.</p>
+        <p>The palate adds oak spice. The finish is long and dry.</p>
+        <p>Publisher conclusion and recommendation.</p>
+        <p><strong>The Price</strong><br />The suggested price is $70.</p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -59,6 +59,11 @@ export const EXTERNAL_SITE_DEFINITIONS = {
     runEvery: 1440,
     content: "reviews",
   },
+  whiskeyreviewer: {
+    name: "The Whiskey Reviewer",
+    runEvery: 1440,
+    content: "reviews",
+  },
   whiskyadvocate: {
     name: "Whisky Advocate",
     runEvery: null,

--- a/apps/server/src/lib/externalSites.test.ts
+++ b/apps/server/src/lib/externalSites.test.ts
@@ -43,11 +43,12 @@ test("syncs code-owned external-site definitions", async () => {
   expect(fineDrams).toMatchObject(EXTERNAL_SITE_DEFINITIONS.finedrams);
 
   const policies = await db.select().from(externalReviewSourcePolicies);
-  expect(policies).toHaveLength(5);
+  expect(policies).toHaveLength(6);
   expect(policies).toEqual(
     expect.arrayContaining(
       [
         "dramface",
+        "whiskeyreviewer",
         "whiskyadvocate",
         "whiskyfun",
         "whiskynotes",

--- a/apps/server/src/scraper/adapters/whiskeyReviewer.test.ts
+++ b/apps/server/src/scraper/adapters/whiskeyReviewer.test.ts
@@ -1,0 +1,174 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { vi } from "vitest";
+import type { ScraperObservation, ScraperSession } from "../types";
+import {
+  discoverWhiskeyReviewerArticles,
+  parseWhiskeyReviewerArticle,
+  whiskeyReviewerAdapter,
+  type WhiskeyReviewerCursor,
+  type WhiskeyReviewerObservation,
+} from "./whiskeyReviewer";
+
+const BOURBON_URL =
+  "https://whiskeyreviewer.com/2026/08/example-bourbon-review-081026";
+const SCOTCH_URL =
+  "https://whiskeyreviewer.com/2026/08/example-scotch-review-080626";
+
+test("discovers only five links from the Recent Reviews widget", async () => {
+  const homepage = await loadFixture("whiskeyreviewer", "index.html");
+  const expandedHomepage = homepage.replace(
+    "  </div>\n</main>",
+    `${Array.from(
+      { length: 6 },
+      (_, index) =>
+        `<a class="post-title" href="/2026/08/generated-${index}-review-080126/">Generated ${index}</a>`,
+    ).join("")}  </div>\n</main>`,
+  );
+
+  expect(
+    discoverWhiskeyReviewerArticles(homepage).map((url) => url.href),
+  ).toEqual([BOURBON_URL, SCOTCH_URL]);
+  expect(discoverWhiskeyReviewerArticles(expandedHomepage)).toHaveLength(5);
+  expect(
+    discoverWhiskeyReviewerArticles(expandedHomepage).at(-1)?.pathname,
+  ).toBe("/2026/08/generated-2-review-080126");
+});
+
+test("extracts the grade and only tasting-note paragraphs", async () => {
+  const html = await loadFixture("whiskeyreviewer", "review.html");
+  const parsed = parseWhiskeyReviewerArticle(html, new URL(BOURBON_URL));
+  const reparsed = parseWhiskeyReviewerArticle(
+    html.replace("Example 8 Year Old Bourbon", "Example   8 Year Old Bourbon"),
+    new URL(BOURBON_URL),
+  );
+
+  expect(parsed.article).toMatchObject({
+    canonicalUrl: BOURBON_URL,
+    title: "Example 8 Year Old Bourbon Review",
+    publishedAt: new Date("2026-08-10T00:00:00.000Z"),
+    contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    reviews: [
+      {
+        name: "Example 8 Year Old Bourbon",
+        reviewerName: "Rowan Hill",
+        nativeScore: { value: 87, scale: 100, display: "B+" },
+        normalizedRating: 87,
+      },
+    ],
+  });
+  expect(parsed.article.reviews[0]?.sourceKey).toBe(
+    reparsed.article.reviews[0]?.sourceKey,
+  );
+  expect(Object.values(parsed.reviewTexts)).toEqual([
+    "The Bourbon The nose has orange peel and vanilla. The palate adds oak spice. The finish is long and dry.",
+  ]);
+  expect(Object.values(parsed.reviewTexts).join(" ")).not.toMatch(
+    /introduction|conclusion|suggested price/iu,
+  );
+});
+
+test("maps another grade and allows an article without an encoded date", async () => {
+  const html = await loadFixture("whiskeyreviewer", "review.html");
+  const undatedUrl =
+    "https://whiskeyreviewer.com/2026/08/example-bourbon-review";
+  const parsed = parseWhiskeyReviewerArticle(
+    html
+      .replace("example-bourbon-review-081026", "example-bourbon-review")
+      .replace("Rating: B+", "Rating: A-"),
+    new URL(undatedUrl),
+  );
+
+  expect(parsed.article.publishedAt).toBeNull();
+  expect(parsed.article.reviews[0]).toMatchObject({
+    nativeScore: { value: 90, scale: 100, display: "A-" },
+    normalizedRating: 90,
+  });
+});
+
+test("resumes without requesting a completed current article", async () => {
+  const homepage = await loadFixture("whiskeyreviewer", "index.html");
+  const article = (
+    await loadFixture("whiskeyreviewer", "review.html")
+  ).replaceAll("example-bourbon-review-081026", "example-scotch-review-080626");
+  const observations: ScraperObservation<WhiskeyReviewerObservation>[] = [];
+  const checkpoints: WhiskeyReviewerCursor[] = [];
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body: url.pathname === "/" ? homepage : article,
+  }));
+  const session: ScraperSession<
+    WhiskeyReviewerCursor,
+    WhiskeyReviewerObservation
+  > = {
+    request,
+    emit: async (observation) => {
+      observations.push(observation);
+    },
+    checkpoint: async (cursor) => {
+      checkpoints.push(cursor);
+    },
+    remainingRequests: () => 6,
+  };
+
+  await whiskeyReviewerAdapter({
+    cursor: { processedArticleUrls: [BOURBON_URL] },
+    session,
+  });
+
+  expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
+    "https://whiskeyreviewer.com/",
+    SCOTCH_URL,
+  ]);
+  expect(observations).toHaveLength(1);
+  expect(observations[0]).toMatchObject({
+    sourceKey: SCOTCH_URL,
+    itemCount: 1,
+  });
+  expect(checkpoints).toEqual([
+    { processedArticleUrls: [BOURBON_URL, SCOTCH_URL] },
+  ]);
+});
+
+test("drops completed URLs that leave the current homepage window", async () => {
+  const priorUrls = Array.from(
+    { length: 5 },
+    (_, index) =>
+      `https://whiskeyreviewer.com/2026/08/prior-${index}-review-080126`,
+  );
+  const currentUrls = [
+    "https://whiskeyreviewer.com/2026/08/new-review-080226",
+    ...priorUrls.slice(0, -1),
+  ];
+  const homepage = `<div class="widget posts-list"><div class="widget-title">Recent Reviews</div>${currentUrls
+    .map((url) => `<a class="post-title" href="${url}">Current review</a>`)
+    .join("")}</div>`;
+  const article = await loadFixture("whiskeyreviewer", "review.html");
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body: url.pathname === "/" ? homepage : article,
+  }));
+  const session: ScraperSession<
+    WhiskeyReviewerCursor,
+    WhiskeyReviewerObservation
+  > = {
+    request,
+    emit: vi.fn(),
+    checkpoint,
+    remainingRequests: () => 6,
+  };
+
+  await whiskeyReviewerAdapter({
+    cursor: { processedArticleUrls: priorUrls },
+    session,
+  });
+
+  expect(request).toHaveBeenCalledTimes(2);
+  const completedUrls = checkpoint.mock.calls.at(-1)?.[0].processedArticleUrls;
+  expect(completedUrls).toHaveLength(5);
+  expect(new Set(completedUrls)).toEqual(new Set(currentUrls));
+});

--- a/apps/server/src/scraper/adapters/whiskeyReviewer.ts
+++ b/apps/server/src/scraper/adapters/whiskeyReviewer.ts
@@ -1,0 +1,246 @@
+import {
+  normalizeReviewRating,
+  type ReviewArticleIngestion,
+  ReviewArticleIngestionSchema,
+} from "@peated/server/externalReviews/observation";
+import { load as cheerio } from "cheerio";
+import { createHash } from "node:crypto";
+import { z } from "zod";
+import type { ScraperAdapter } from "../types";
+
+// This adapter owns The Whiskey Reviewer parsing. The shared scraper runtime
+// owns every remote request and the shared review sink owns storage.
+const ORIGIN = "https://whiskeyreviewer.com";
+const TARGET = "whiskeyreviewer";
+const MAX_CURRENT_ARTICLES = 5;
+const ARTICLE_PATH = /^\/(?<year>\d{4})\/(?<month>\d{2})\/[a-z0-9][a-z0-9-]*$/u;
+const TASTING_TEXT = /\b(?:nose|palate|finish)\b/iu;
+const GRADE_VALUES = {
+  "A+": 100,
+  A: 95,
+  "A-": 90,
+  "B+": 87,
+  B: 83,
+  "B-": 80,
+  "C+": 77,
+  C: 73,
+  "C-": 70,
+  "D+": 67,
+  D: 63,
+  "D-": 60,
+  F: 0,
+} as const;
+
+export const WhiskeyReviewerCursorSchema = z
+  .object({
+    processedArticleUrls: z.array(z.url()).max(MAX_CURRENT_ARTICLES),
+  })
+  .strict();
+
+export const WhiskeyReviewerObservationSchema = ReviewArticleIngestionSchema;
+
+export type WhiskeyReviewerCursor = z.infer<typeof WhiskeyReviewerCursorSchema>;
+export type WhiskeyReviewerObservation = ReviewArticleIngestion;
+
+function normalizeText(value: string): string {
+  return value.replaceAll(/\s+/g, " ").trim();
+}
+
+function articleUrl(value: string): URL | null {
+  try {
+    const url = new URL(value, ORIGIN);
+    url.hash = "";
+    url.search = "";
+    url.pathname = url.pathname.replace(/\/$/u, "");
+    if (url.origin !== ORIGIN || !ARTICLE_PATH.test(url.pathname)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+export function discoverWhiskeyReviewerArticles(data: string): URL[] {
+  const $ = cheerio(data);
+  const articles = new Map<string, URL>();
+  const reviewWidget = $(".widget.posts-list")
+    .filter((_, element) =>
+      /^Recent Reviews$/iu.test(
+        normalizeText($(element).find(".widget-title").first().text()),
+      ),
+    )
+    .first();
+
+  reviewWidget.find("a.post-title[href]").each((_, element) => {
+    const url = articleUrl($(element).attr("href") ?? "");
+    if (url) articles.set(url.href, url);
+  });
+
+  return [...articles.values()].slice(0, MAX_CURRENT_ARTICLES);
+}
+
+function publishedAt(url: URL): Date | null {
+  const pathMatch = ARTICLE_PATH.exec(url.pathname);
+  const slug = url.pathname.split("/").at(-1) ?? "";
+  const dateMatch = /(?<month>\d{2})(?<day>\d{2})(?<year>\d{2})$/u.exec(slug);
+  if (!pathMatch?.groups || !dateMatch?.groups) return null;
+
+  const year = Number(pathMatch.groups.year);
+  const pathMonth = Number(pathMatch.groups.month);
+  const month = Number(dateMatch.groups.month);
+  const day = Number(dateMatch.groups.day);
+  const shortYear = Number(dateMatch.groups.year);
+  if (year % 100 !== shortYear || pathMonth !== month) return null;
+
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  return date;
+}
+
+function reviewGrade(value: string) {
+  const match =
+    /^Rating:\s*(?<grade>A\+|A-|A|B\+|B-|B|C\+|C-|C|D\+|D-|D|F)$/iu.exec(
+      normalizeText(value),
+    );
+  const grade = match?.groups?.grade?.toLocaleUpperCase("en") as
+    | keyof typeof GRADE_VALUES
+    | undefined;
+  if (!grade || !(grade in GRADE_VALUES)) return null;
+
+  const nativeScore = {
+    value: GRADE_VALUES[grade],
+    scale: 100,
+    display: grade,
+  };
+  return {
+    nativeScore,
+    normalizedRating: normalizeReviewRating(nativeScore),
+  };
+}
+
+function bottleName(title: string): string | null {
+  const name = normalizeText(title.replace(/\s+Review$/iu, ""));
+  return name === title ? null : name;
+}
+
+function sourceKey(canonicalUrl: string): string {
+  const digest = createHash("sha256").update(canonicalUrl).digest("hex");
+  return `whiskeyreviewer:${digest}`;
+}
+
+export function parseWhiskeyReviewerArticle(
+  data: string,
+  rawCanonicalUrl: URL,
+): WhiskeyReviewerObservation {
+  const $ = cheerio(data);
+  const canonicalUrl = articleUrl(
+    $('link[rel="canonical"]').first().attr("href") ?? rawCanonicalUrl.href,
+  );
+  if (!canonicalUrl) throw new Error("Invalid Whiskey Reviewer article URL.");
+
+  const article = $("#the-post").first();
+  const title = normalizeText(article.find("h1.entry-title").first().text());
+  const name = bottleName(title);
+  const paragraphs = article
+    .find(".entry-content")
+    .first()
+    .children("p")
+    .toArray();
+  const reviewerMatch = paragraphs
+    .map((element) =>
+      /^By\s+(?<name>.+)$/iu.exec(normalizeText($(element).text())),
+    )
+    .find((match) => match?.groups?.name);
+  const reviewerName = normalizeText(reviewerMatch?.groups?.name ?? "");
+  const ratingIndex = paragraphs.findIndex((element) =>
+    reviewGrade($(element).text()),
+  );
+  const grade =
+    ratingIndex < 0 ? null : reviewGrade($(paragraphs[ratingIndex]).text());
+  if (!title) throw new Error("Whiskey Reviewer article title is missing.");
+  if (!name) throw new Error("Whiskey Reviewer Bottle name is missing.");
+  if (!reviewerName) throw new Error("Whiskey Reviewer writer is missing.");
+  if (!grade) throw new Error("Whiskey Reviewer grade is missing or invalid.");
+
+  const priceIndex = paragraphs.findIndex(
+    (element, index) =>
+      index > ratingIndex &&
+      /^The Price\b/iu.test(normalizeText($(element).text())),
+  );
+  const reviewText = normalizeText(
+    paragraphs
+      .slice(ratingIndex + 1, priceIndex < 0 ? paragraphs.length : priceIndex)
+      .map((element) => {
+        const paragraph = $(element).clone();
+        paragraph.find("br").replaceWith(" ");
+        return normalizeText(paragraph.text());
+      })
+      .filter((text) => TASTING_TEXT.test(text))
+      .join(" "),
+  );
+  const reviewSourceKey = sourceKey(canonicalUrl.href);
+  const review = {
+    sourceKey: reviewSourceKey,
+    name,
+    category: null,
+    reviewerName,
+    nativeScore: grade.nativeScore,
+    normalizedRating: grade.normalizedRating,
+  };
+  const contentText = JSON.stringify({
+    review,
+    reviewText: reviewText || null,
+  });
+
+  return WhiskeyReviewerObservationSchema.parse({
+    article: {
+      canonicalUrl: canonicalUrl.href,
+      title,
+      issue: null,
+      publishedAt: publishedAt(canonicalUrl),
+      contentHash: createHash("sha256").update(contentText).digest("hex"),
+      reviews: [review],
+    },
+    reviewTexts: reviewText ? { [reviewSourceKey]: reviewText } : {},
+  });
+}
+
+export const whiskeyReviewerAdapter: ScraperAdapter<
+  WhiskeyReviewerCursor,
+  WhiskeyReviewerObservation
+> = async ({ cursor, session }) => {
+  const homepageResponse = await session.request({
+    target: TARGET,
+    url: new URL("/", ORIGIN),
+  });
+  const articleUrls = discoverWhiskeyReviewerArticles(homepageResponse.body);
+  const currentArticleUrls = new Set(articleUrls.map((url) => url.href));
+  const processedArticleUrls = new Set(
+    (cursor?.processedArticleUrls ?? []).filter((url) =>
+      currentArticleUrls.has(url),
+    ),
+  );
+
+  for (const url of articleUrls) {
+    if (processedArticleUrls.has(url.href)) continue;
+    const articleResponse = await session.request({ target: TARGET, url });
+    const observation = parseWhiskeyReviewerArticle(
+      articleResponse.body,
+      articleResponse.url,
+    );
+    await session.emit({
+      sourceKey: observation.article.canonicalUrl,
+      itemCount: 1,
+      value: observation,
+    });
+    processedArticleUrls.add(url.href);
+    await session.checkpoint({
+      processedArticleUrls: [...processedArticleUrls],
+    });
+  }
+};

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -44,6 +44,7 @@ const migratedSources = [
   "singlecasknation",
   "thompsonbros",
   "totalwine",
+  "whiskeyreviewer",
   "whiskyadvocate",
   "whiskyfun",
   "whiskynotes",
@@ -86,6 +87,13 @@ test("registers every scraper source with explicit target ownership", () => {
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("dramface")?.requestLimit).toBe(30);
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskeyreviewer.runEvery).toBe(1440);
+  expect(scraperRegistry.targets.get("whiskeyreviewer")).toMatchObject({
+    minimumSpacingMs: 5_000,
+    requestsPerWindow: 10,
+    windowMs: 3_600_000,
+  });
+  expect(scraperRegistry.sources.get("whiskeyreviewer")?.requestLimit).toBe(6);
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyadvocate.runEvery).toBeNull();
   expect(scraperRegistry.targets.get("whiskyadvocate")).toMatchObject({
     minimumSpacingMs: 2_500,
@@ -123,6 +131,9 @@ test("registers every scraper source with explicit target ownership", () => {
   expect(scraperRegistry.sources.get("dramface")?.observationSchema).toBe(
     scraperRegistry.sources.get("whiskynotes")?.observationSchema,
   );
+  expect(
+    scraperRegistry.sources.get("whiskeyreviewer")?.observationSchema,
+  ).toBe(scraperRegistry.sources.get("whiskynotes")?.observationSchema);
   expect(scraperRegistry.sources.get("wordsofwhisky")?.observationSchema).toBe(
     scraperRegistry.sources.get("whiskynotes")?.observationSchema,
   );
@@ -133,6 +144,9 @@ test("registers every scraper source with explicit target ownership", () => {
     scraperRegistry.sources.get("whiskynotes")?.sink,
   );
   expect(scraperRegistry.sources.get("dramface")?.sink).toBe(
+    scraperRegistry.sources.get("whiskynotes")?.sink,
+  );
+  expect(scraperRegistry.sources.get("whiskeyreviewer")?.sink).toBe(
     scraperRegistry.sources.get("whiskynotes")?.sink,
   );
   expect(scraperRegistry.sources.get("wordsofwhisky")?.sink).toBe(

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -40,6 +40,11 @@ import {
   StorePriceBatchSchema,
 } from "./adapters/legacyPrice";
 import {
+  whiskeyReviewerAdapter,
+  WhiskeyReviewerCursorSchema,
+  WhiskeyReviewerObservationSchema,
+} from "./adapters/whiskeyReviewer";
+import {
   whiskyAdvocateAdapter,
   WhiskyAdvocateCursorSchema,
   WhiskyAdvocateObservationSchema,
@@ -236,6 +241,17 @@ export const scraperRegistry = createScraperRegistry({
       ],
     }),
     defineScrapeTarget({
+      key: "whiskeyreviewer",
+      minimumSpacingMs: 5_000,
+      requestsPerWindow: 10,
+      origins: [
+        {
+          origin: "https://whiskeyreviewer.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
+    defineScrapeTarget({
       key: "whiskyadvocate",
       minimumSpacingMs: 2_500,
       requestsPerWindow: 20,
@@ -311,6 +327,16 @@ export const scraperRegistry = createScraperRegistry({
       cursorSchema: DramfaceCursorSchema,
       observationSchema: DramfaceObservationSchema,
       adapter: dramfaceAdapter,
+      sink: externalReviewSink,
+    }),
+    defineScraperSource({
+      key: "whiskeyreviewer",
+      externalSiteType: "whiskeyreviewer",
+      targetKeys: ["whiskeyreviewer"],
+      requestLimit: 6,
+      cursorSchema: WhiskeyReviewerCursorSchema,
+      observationSchema: WhiskeyReviewerObservationSchema,
+      adapter: whiskeyReviewerAdapter,
       sink: externalReviewSink,
     }),
     defineScraperSource({

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -157,6 +157,15 @@ into scored reviews. It stores exact timestamps, the published writer, native
 scores, and canonical links. Tasting notes stay transient. Article
 introductions and publisher conclusions are excluded from summary input.
 
+The Whiskey Reviewer runs once per day. It reads only the five links in the
+public homepage Recent Reviews list. It does not request the alphabetical
+archive, category pages, sitemaps, feeds, search, or WordPress APIs. Requests
+are at least five seconds apart. The target allows 10 requests per hour, and
+each worker pass stops after six requests. The adapter stores the writer,
+canonical link, displayed letter grade, and URL date when valid. Only direct
+tasting-note paragraphs stay transient for summary generation. Introductions,
+prices, and publisher conclusions are excluded.
+
 Enable automatic publication only after the reviewed sample passes the gate.
 Use the same source-specific process for each later publisher. Do not add a
 generic crawler only because several sources use RSS or HTML.

--- a/docs/research/external-review-content-supply.md
+++ b/docs/research/external-review-content-supply.md
@@ -144,6 +144,23 @@ podcast transcripts need a separate platform-terms and creator-rights review.
   excludes article introductions and publisher conclusions from transient
   summary input.
 
+### The Whiskey Reviewer
+
+- Evidence: [homepage and current reviews](https://whiskeyreviewer.com/),
+  [review archive](https://whiskeyreviewer.com/whiskey-reviews/),
+  [privacy policy](https://whiskeyreviewer.com/privacy-policy/), and
+  [robots.txt](https://whiskeyreviewer.com/robots.txt).
+- Rechecked on 2026-08-21. Robots rules block WordPress administration and
+  allow the public homepage and article paths. The public privacy page contains
+  no automated-access or content-reuse restriction. No dedicated terms page is
+  linked from the public site. The footer reserves rights.
+- Current article pages expose a canonical link, writer, Bottle title, and
+  letter grade. Current URLs usually encode the publication date.
+- The implemented daily feed reads only the five links in the homepage Recent
+  Reviews list. It does not use the alphabetical archive, category pages,
+  sitemaps, feeds, search, or WordPress APIs. It excludes introductions, price
+  text, and publisher conclusions from transient summary input.
+
 ### Explicitly Restricted Sources
 
 - [Breaking Bourbon terms](https://www.breakingbourbon.com/site/breaking-bourbon-terms-of-use-agreement)
@@ -209,7 +226,8 @@ boundary.
    archive as a later bounded change.
 4. Dramface supplies the next daily multi-bottle and multi-writer feed.
 5. Words of Whisky supplies the next daily multi-bottle feed.
-6. Continue through the reviewed public-index candidates until Peated has at
+6. The Whiskey Reviewer supplies the next daily American whiskey feed.
+7. Continue through the reviewed public-index candidates until Peated has at
    least 12 reliable feeds.
 
 The pilot is successful with at least 90% article extraction accuracy on a

--- a/openspec/changes/add-whiskey-reviewer-review-feed/.openspec.yaml
+++ b/openspec/changes/add-whiskey-reviewer-review-feed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/add-whiskey-reviewer-review-feed/design.md
+++ b/openspec/changes/add-whiskey-reviewer-review-feed/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The Whiskey Reviewer publishes a dedicated Recent Reviews list on its public
+homepage. The list currently contains five article links. Each current article
+has a canonical URL, title, writer, one Bottle review, and a letter grade. The
+article URL usually encodes the publication date. Peated already owns the
+shared review schema, Bottle matcher, sink, summary policy, robots enforcement,
+and request controls.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add current The Whiskey Reviewer articles without a schema or API change.
+- Preserve canonical links, dates when available, writers, Bottle names, and
+  displayed letter grades.
+- Run daily with six or fewer spaced requests.
+
+**Non-Goals:**
+
+- Backfill the alphabetical review archive.
+- Request category pages, sitemaps, feeds, search, or WordPress APIs.
+- Build a generic WordPress review crawler.
+- Store article HTML, images, full prose, prices, or publisher conclusions.
+
+## Decisions
+
+### Use the homepage Recent Reviews list
+
+The adapter reads at most five unique article links from the widget whose title
+is Recent Reviews. It accepts only same-origin article paths with year and month
+segments. A run checkpoints each emitted article URL so a deferred run does not
+repeat completed requests.
+
+The alphabetical review page was rejected for this slice because it exposes the
+full archive. The general homepage article list was rejected because it mixes
+reviews, news, interviews, and features.
+
+### Keep article parsing specific to the publisher
+
+The adapter reads the title and canonical URL from the main post. It reads the
+writer from the direct `By` paragraph and the letter grade from the direct
+`Rating` paragraph. It removes the final `Review` label from the title to form
+the Bottle name. It reads a publication date from the current URL suffix when
+that suffix is valid.
+
+Only direct article paragraphs after the rating and before the price section
+are eligible for summary input. Eligible paragraphs must contain tasting terms
+such as nose, palate, or finish. This excludes the introduction, price, and
+general conclusion in the current article form.
+
+### Preserve letter grades with a deterministic numeric mapping
+
+The shared score contract requires a numeric value and scale. The adapter keeps
+the publisher's letter as the displayed score and maps grades to a 100-point
+value for Peated's normalized field: A+ 100, A 95, A- 90, B+ 87, B 83, B- 80,
+C+ 77, C 73, C- 70, D+ 67, D 63, D- 60, and F 0. The mapping is local to this
+source and does not change shared schemas.
+
+### Reuse the existing external-review boundary
+
+The adapter emits the shared article ingestion schema. Review prose remains
+transient. The shared runtime owns all network requests, and the shared sink
+owns matching and storage. Source policy controls display and model use, but it
+does not disable manual or scheduled fetching.
+
+## Risks / Trade-offs
+
+- **The widget title or markup changes** → Require the exact Recent Reviews
+  widget and cover its current markup with a fixture.
+- **The article form changes** → Require a title, writer, and recognized grade
+  before emitting an observation.
+- **A date is not encoded in a future URL** → Store a null publication date
+  instead of inventing one or failing the article.
+- **Letter grades are not numeric percentages** → Preserve the letter for
+  display and keep the explicit conversion local to this adapter.

--- a/openspec/changes/add-whiskey-reviewer-review-feed/proposal.md
+++ b/openspec/changes/add-whiskey-reviewer-review-feed/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Peated needs broader American whiskey coverage on Bottle pages. The Whiskey
+Reviewer publishes frequent scored reviews and exposes a small current-review
+list on its public homepage.
+
+## What Changes
+
+- Add The Whiskey Reviewer as a scheduled external-review source.
+- Discover only the five current articles in the homepage Recent Reviews list.
+- Extract canonical links, writers, dates, Bottle names, and letter grades with
+  source-specific code.
+- Send only tasting-note paragraphs through the existing transient summary
+  boundary.
+- Use the shared Bottle matcher, review sink, request controls, robots
+  enforcement, and publication policy.
+
+## Capabilities
+
+### New Capabilities
+
+- `external-review-feeds`: Bounded ingestion of current editorial review feeds
+  through source-specific adapters and the shared external-review boundary.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds one external-site definition and one native scraper adapter.
+- Adds fixture-backed parser and runtime registration tests.
+- Adds no database schema, API, model, or UI changes.

--- a/openspec/changes/add-whiskey-reviewer-review-feed/specs/external-review-feeds/spec.md
+++ b/openspec/changes/add-whiskey-reviewer-review-feed/specs/external-review-feeds/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Current review pages use bounded discovery
+
+The system SHALL discover at most five current The Whiskey Reviewer articles
+from the Recent Reviews list on its public homepage and SHALL fetch them through
+the shared scraper runtime.
+
+#### Scenario: Scheduled current-review run
+
+- **WHEN** the daily source run reads The Whiskey Reviewer homepage
+- **THEN** it considers only the five current links in the Recent Reviews list
+- **AND** all requests use the registered origin, robots rules, spacing, quota,
+  retry, and backoff controls
+
+#### Scenario: Deferred run resumes
+
+- **WHEN** a run is deferred after it stores an article
+- **THEN** the resumed run does not request that completed current article
+  again
+
+### Requirement: Article facts preserve the publisher grade
+
+The system SHALL store each complete current article by canonical URL with its
+title, writer, Bottle name, displayed letter grade, and publication date when
+the current article URL supplies a valid date.
+
+#### Scenario: Article has a recognized grade
+
+- **WHEN** a current article contains one Bottle review with a supported letter
+  grade
+- **THEN** the system stores one review with the publisher letter as its native
+  score display
+- **AND** it derives the normalized rating from the source-owned grade mapping
+
+#### Scenario: Article URL has no valid date
+
+- **WHEN** a complete current article does not encode a valid publication date
+- **THEN** the system stores the article with a null publication date
+
+### Requirement: Publisher content remains transient
+
+The system MUST NOT persist The Whiskey Reviewer HTML, full review prose,
+publisher images, price text, or publisher conclusions as source content.
+
+#### Scenario: Review text is processed
+
+- **WHEN** source policy permits Peated to generate a review summary
+- **THEN** the adapter passes only tasting-note paragraphs through the existing
+  transient summary boundary
+- **AND** stored output contains only permitted structured facts, derived
+  summary data, content hash, and canonical link

--- a/openspec/changes/add-whiskey-reviewer-review-feed/tasks.md
+++ b/openspec/changes/add-whiskey-reviewer-review-feed/tasks.md
@@ -1,0 +1,14 @@
+## 1. Source Adapter
+
+- [x] 1.1 Add fixture-backed current-review discovery and article parsing
+- [x] 1.2 Add resumable adapter execution with a five-article window
+
+## 2. Runtime Registration
+
+- [x] 2.1 Register The Whiskey Reviewer as a daily source with polite limits
+- [x] 2.2 Prove registration and shared review boundaries in tests
+
+## 3. Documentation And Verification
+
+- [x] 3.1 Update source research and operating documentation
+- [x] 3.2 Run focused tests, typecheck, lint, format, and strict OpenSpec validation


### PR DESCRIPTION
Adds The Whiskey Reviewer as a daily external review source. The adapter reads only the five current links in the homepage Recent Reviews list, preserves each writer, valid URL date, native letter grade, and canonical link, and sends only tasting-note paragraphs through the existing transient summary boundary.

All requests use the shared governed runtime with robots enforcement, five-second spacing, a 10-request hourly quota, and a six-request run limit. Manual fetching remains available. The source starts with the existing disabled display and model-use policy.
