### PR TITLE
feat(scraper): add Bourbon Culture review feed

### DIFF
--- a/apps/server/__fixtures__/bourbonculture/index.html
+++ b/apps/server/__fixtures__/bourbonculture/index.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html>
+  <body>
+    <main>
+      <h2>Latest Whiskey Reviews</h2>
+      <ul class="wp-block-latest-posts">
+        <li>
+          <a
+            class="wp-block-latest-posts__post-title"
+            href="https://thebourbonculture.com/whiskey-reviews/example-bourbon-review/"
+            >Example Bourbon Review</a
+          >
+        </li>
+        <li>
+          <a
+            class="wp-block-latest-posts__post-title"
+            href="/whiskey-reviews/example-rye-review/"
+            >Example Rye Review</a
+          >
+        </li>
+      </ul>
+      <h2>Popular Reviews</h2>
+      <ul class="wp-block-latest-posts">
+        <li>
+          <a
+            class="wp-block-latest-posts__post-title"
+            href="/whiskey-reviews/popular-review/"
+            >Popular Review</a
+          >
+        </li>
+      </ul>
+    </main>
+  </body>
+</html>

--- a/apps/server/__fixtures__/bourbonculture/review.html
+++ b/apps/server/__fixtures__/bourbonculture/review.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <head>
+    <link
+      rel="canonical"
+      href="https://thebourbonculture.com/whiskey-reviews/example-bourbon-review/"
+    />
+    <meta name="author" content="Mike &amp; Mike" />
+  </head>
+  <body>
+    <article>
+      <h1 class="entry-title">Example 10 Year Old Bourbon Review</h1>
+      <time class="entry-date" datetime="2026-07-25T17:19:59-04:00"
+        >July 25, 2026</time
+      >
+      <div class="entry-content">
+        <p>Article introduction that must stay out of summary input.</p>
+        <h2>Tasting Notes</h2>
+        <p><strong>Nose:</strong> Cherry, vanilla, and mature oak.</p>
+        <p><strong>Palate:</strong> Caramel and baking spice.</p>
+        <p><strong>Finish:</strong> Long, dry, and balanced.</p>
+        <h2>Score: 9.5/10</h2>
+        <h2>Final Thoughts</h2>
+        <p>Publisher conclusion that must stay out of summary input.</p>
+      </div>
+    </article>
+  </body>
+</html>

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -56,6 +56,11 @@ export const EXTERNAL_SITE_DEFINITIONS = {
   // traffic target remains disabled while existing data stays visible.
   totalwine: { name: "Total Wines", runEvery: null },
   woodencork: { name: "Wooden Cork", runEvery: 10080 },
+  bourbonculture: {
+    name: "Bourbon Culture",
+    runEvery: 1440,
+    content: "reviews",
+  },
   dramface: {
     name: "Dramface",
     runEvery: 1440,

--- a/apps/server/src/lib/externalSites.test.ts
+++ b/apps/server/src/lib/externalSites.test.ts
@@ -43,10 +43,11 @@ test("syncs code-owned external-site definitions", async () => {
   expect(fineDrams).toMatchObject(EXTERNAL_SITE_DEFINITIONS.finedrams);
 
   const policies = await db.select().from(externalReviewSourcePolicies);
-  expect(policies).toHaveLength(6);
+  expect(policies).toHaveLength(7);
   expect(policies).toEqual(
     expect.arrayContaining(
       [
+        "bourbonculture",
         "dramface",
         "whiskeyreviewer",
         "whiskyadvocate",

--- a/apps/server/src/scraper/adapters/bourbonCulture.test.ts
+++ b/apps/server/src/scraper/adapters/bourbonCulture.test.ts
@@ -1,0 +1,111 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { vi } from "vitest";
+import type { ScraperSession } from "../types";
+import {
+  bourbonCultureAdapter,
+  discoverBourbonCultureArticles,
+  parseBourbonCultureArticle,
+  type BourbonCultureCursor,
+  type BourbonCultureObservation,
+} from "./bourbonCulture";
+
+const BOURBON_URL =
+  "https://thebourbonculture.com/whiskey-reviews/example-bourbon-review/";
+const RYE_URL =
+  "https://thebourbonculture.com/whiskey-reviews/example-rye-review/";
+
+test("discovers only six links from Latest Whiskey Reviews", async () => {
+  const homepage = await loadFixture("bourbonculture", "index.html");
+  const expandedHomepage = homepage.replace(
+    "</ul>\n      <h2>Popular Reviews</h2>",
+    `${Array.from(
+      { length: 6 },
+      (_, index) =>
+        `<li><a class="wp-block-latest-posts__post-title" href="/whiskey-reviews/generated-${index}-review/">Generated ${index}</a></li>`,
+    ).join("")}</ul>\n      <h2>Popular Reviews</h2>`,
+  );
+
+  expect(
+    discoverBourbonCultureArticles(homepage).map((url) => url.href),
+  ).toEqual([BOURBON_URL, RYE_URL]);
+  expect(discoverBourbonCultureArticles(expandedHomepage)).toHaveLength(6);
+  expect(
+    discoverBourbonCultureArticles(expandedHomepage).at(-1)?.pathname,
+  ).toBe("/whiskey-reviews/generated-3-review/");
+});
+
+test("extracts publisher facts and only tasting notes", async () => {
+  const html = await loadFixture("bourbonculture", "review.html");
+  const parsed = parseBourbonCultureArticle(html, new URL(BOURBON_URL));
+  const reparsed = parseBourbonCultureArticle(
+    html.replace(
+      "Example 10 Year Old Bourbon",
+      "Example   10 Year Old Bourbon",
+    ),
+    new URL(BOURBON_URL),
+  );
+
+  expect(parsed.article).toMatchObject({
+    canonicalUrl: BOURBON_URL,
+    title: "Example 10 Year Old Bourbon Review",
+    publishedAt: new Date("2026-07-25T21:19:59.000Z"),
+    contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    reviews: [
+      {
+        name: "Example 10 Year Old Bourbon",
+        reviewerName: "Mike & Mike",
+        nativeScore: { value: 9.5, scale: 10, display: "9.5/10" },
+        normalizedRating: 95,
+      },
+    ],
+  });
+  expect(parsed.article.reviews[0]?.sourceKey).toBe(
+    reparsed.article.reviews[0]?.sourceKey,
+  );
+  expect(Object.values(parsed.reviewTexts)).toEqual([
+    "Nose: Cherry, vanilla, and mature oak. Palate: Caramel and baking spice. Finish: Long, dry, and balanced.",
+  ]);
+  expect(Object.values(parsed.reviewTexts).join(" ")).not.toMatch(
+    /introduction|conclusion/iu,
+  );
+});
+
+test("resumes without requesting a completed current article", async () => {
+  const homepage = await loadFixture("bourbonculture", "index.html");
+  const article = (
+    await loadFixture("bourbonculture", "review.html")
+  ).replaceAll("example-bourbon-review", "example-rye-review");
+  const emit = vi.fn();
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body: url.pathname === "/" ? homepage : article,
+  }));
+  const session: ScraperSession<
+    BourbonCultureCursor,
+    BourbonCultureObservation
+  > = {
+    request,
+    emit,
+    checkpoint,
+    remainingRequests: () => 7,
+  };
+
+  await bourbonCultureAdapter({
+    cursor: { processedArticleUrls: [BOURBON_URL] },
+    session,
+  });
+
+  expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
+    "https://thebourbonculture.com/",
+    RYE_URL,
+  ]);
+  expect(emit).toHaveBeenCalledWith(
+    expect.objectContaining({ sourceKey: RYE_URL, itemCount: 1 }),
+  );
+  expect(checkpoint).toHaveBeenCalledWith({
+    processedArticleUrls: [BOURBON_URL, RYE_URL],
+  });
+});

--- a/apps/server/src/scraper/adapters/bourbonCulture.ts
+++ b/apps/server/src/scraper/adapters/bourbonCulture.ts
@@ -1,0 +1,194 @@
+import {
+  normalizeReviewRating,
+  type ReviewArticleIngestion,
+  ReviewArticleIngestionSchema,
+} from "@peated/server/externalReviews/observation";
+import { load as cheerio } from "cheerio";
+import { createHash } from "node:crypto";
+import type { z } from "zod";
+import type { ScraperAdapter } from "../types";
+import {
+  currentReviewCursorSchema,
+  processCurrentReviews,
+} from "./currentReviews";
+import { parseDate } from "./dates";
+
+// This adapter owns Bourbon Culture parsing. The shared scraper runtime owns
+// every remote request and the shared review sink owns storage.
+const ORIGIN = "https://thebourbonculture.com";
+const TARGET = "bourbonculture";
+const MAX_CURRENT_ARTICLES = 6;
+const ARTICLE_PATH = /^\/whiskey-reviews\/[a-z0-9][a-z0-9-]*\/$/u;
+const TASTING_NOTE = /^(?:Nose|Palate|Finish)\s*:/iu;
+
+export const BourbonCultureCursorSchema =
+  currentReviewCursorSchema(MAX_CURRENT_ARTICLES);
+
+export const BourbonCultureObservationSchema = ReviewArticleIngestionSchema;
+
+export type BourbonCultureCursor = z.infer<typeof BourbonCultureCursorSchema>;
+export type BourbonCultureObservation = ReviewArticleIngestion;
+
+function normalizeText(value: string): string {
+  return value.replaceAll(/\s+/g, " ").trim();
+}
+
+function articleUrl(value: string): URL | null {
+  try {
+    const url = new URL(value, ORIGIN);
+    url.hash = "";
+    url.search = "";
+    if (!url.pathname.endsWith("/")) url.pathname += "/";
+    if (url.origin !== ORIGIN || !ARTICLE_PATH.test(url.pathname)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+export function discoverBourbonCultureArticles(data: string): URL[] {
+  const $ = cheerio(data);
+  const articles = new Map<string, URL>();
+  const heading = $("h2")
+    .filter((_, element) =>
+      /^Latest Whiskey Reviews$/iu.test(normalizeText($(element).text())),
+    )
+    .first();
+  const list = heading.nextAll("ul.wp-block-latest-posts").first();
+
+  list.find("a.wp-block-latest-posts__post-title[href]").each((_, element) => {
+    const url = articleUrl($(element).attr("href") ?? "");
+    if (url) articles.set(url.href, url);
+  });
+
+  return [...articles.values()].slice(0, MAX_CURRENT_ARTICLES);
+}
+
+function score(value: string) {
+  const match = /^Score:\s*(?<value>\d{1,2}(?:[.,]\d+)?)\s*\/\s*10$/iu.exec(
+    normalizeText(value),
+  );
+  const nativeValue = match?.groups?.value
+    ? Number(match.groups.value.replace(",", "."))
+    : Number.NaN;
+  if (!Number.isFinite(nativeValue) || nativeValue < 0 || nativeValue > 10) {
+    return null;
+  }
+  const nativeScore = {
+    value: nativeValue,
+    scale: 10,
+    display: `${match?.groups?.value}/10`,
+  };
+  return {
+    nativeScore,
+    normalizedRating: normalizeReviewRating(nativeScore),
+  };
+}
+
+function bottleName(title: string): string | null {
+  const name = normalizeText(title.replace(/\s+Review$/iu, ""));
+  return name === title ? null : name;
+}
+
+function sourceKey(canonicalUrl: string): string {
+  const digest = createHash("sha256").update(canonicalUrl).digest("hex");
+  return `bourbonculture:${digest}`;
+}
+
+export function parseBourbonCultureArticle(
+  data: string,
+  rawCanonicalUrl: URL,
+): BourbonCultureObservation {
+  const $ = cheerio(data);
+  const canonicalUrl = articleUrl(
+    $('link[rel="canonical"]').first().attr("href") ?? rawCanonicalUrl.href,
+  );
+  if (!canonicalUrl) throw new Error("Invalid Bourbon Culture article URL.");
+
+  const article = $("article").first();
+  const title = normalizeText(article.find("h1.entry-title").first().text());
+  const name = bottleName(title);
+  const reviewerName = normalizeText(
+    $('meta[name="author"]').first().attr("content") ?? "",
+  );
+  const rawPublishedAt =
+    article.find("time.entry-date").first().attr("datetime") ?? "";
+  const publishedAt = parseDate(rawPublishedAt);
+  const content = article.find(".entry-content").first();
+  const elements = content.children("h2,p").toArray();
+  const tastingIndex = elements.findIndex(
+    (element) =>
+      element.tagName === "h2" &&
+      /^Tasting Notes$/iu.test(normalizeText($(element).text())),
+  );
+  const scoreIndex = elements.findIndex(
+    (element, index) => index > tastingIndex && score($(element).text()),
+  );
+  const reviewScore =
+    scoreIndex < 0 ? null : score($(elements[scoreIndex]).text());
+  if (!title) throw new Error("Bourbon Culture article title is missing.");
+  if (!name) throw new Error("Bourbon Culture Bottle name is missing.");
+  if (!reviewerName) throw new Error("Bourbon Culture writer is missing.");
+  if (!rawPublishedAt || !publishedAt) {
+    throw new Error("Bourbon Culture article date is missing or invalid.");
+  }
+  if (tastingIndex < 0) {
+    throw new Error("Bourbon Culture tasting notes are missing.");
+  }
+  if (!reviewScore) {
+    throw new Error("Bourbon Culture score is missing or invalid.");
+  }
+
+  const reviewText = normalizeText(
+    elements
+      .slice(tastingIndex + 1, scoreIndex)
+      .filter((element) => TASTING_NOTE.test(normalizeText($(element).text())))
+      .map((element) => normalizeText($(element).text()))
+      .join(" "),
+  );
+  const reviewSourceKey = sourceKey(canonicalUrl.href);
+  const review = {
+    sourceKey: reviewSourceKey,
+    name,
+    category: null,
+    reviewerName,
+    nativeScore: reviewScore.nativeScore,
+    normalizedRating: reviewScore.normalizedRating,
+  };
+  const contentText = JSON.stringify({
+    review,
+    reviewText: reviewText || null,
+  });
+
+  return BourbonCultureObservationSchema.parse({
+    article: {
+      canonicalUrl: canonicalUrl.href,
+      title,
+      issue: null,
+      publishedAt,
+      contentHash: createHash("sha256").update(contentText).digest("hex"),
+      reviews: [review],
+    },
+    reviewTexts: reviewText ? { [reviewSourceKey]: reviewText } : {},
+  });
+}
+
+export const bourbonCultureAdapter: ScraperAdapter<
+  BourbonCultureCursor,
+  BourbonCultureObservation
+> = async ({ cursor, session }) => {
+  const homepageResponse = await session.request({
+    target: TARGET,
+    url: new URL("/", ORIGIN),
+  });
+  const articleUrls = discoverBourbonCultureArticles(homepageResponse.body);
+  await processCurrentReviews({
+    target: TARGET,
+    articles: articleUrls,
+    articleUrl: (url) => url,
+    cursor,
+    session,
+    parse: (response) =>
+      parseBourbonCultureArticle(response.body, response.url),
+  });
+};

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -22,6 +22,7 @@ const migratedSources = [
   "astorwines",
   "berrybrosrudd",
   "bruichladdich",
+  "bourbonculture",
   "cadenheads",
   "compassbox",
   "decadentdrinks",
@@ -82,6 +83,13 @@ test("registers every scraper source with explicit target ownership", () => {
   expect(EXTERNAL_SITE_DEFINITIONS.dramfool.runEvery).toBeNull();
   expect(scraperRegistry.targets.get("dramfool")?.enabled).toBe(true);
   expect(scraperRegistry.targets.get("totalwine")?.enabled).toBe(false);
+  expect(EXTERNAL_SITE_DEFINITIONS.bourbonculture.runEvery).toBe(1440);
+  expect(scraperRegistry.targets.get("bourbonculture")).toMatchObject({
+    minimumSpacingMs: 5_000,
+    requestsPerWindow: 10,
+    windowMs: 3_600_000,
+  });
+  expect(scraperRegistry.sources.get("bourbonculture")?.requestLimit).toBe(7);
   expect(EXTERNAL_SITE_DEFINITIONS.dramface.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("dramface")).toMatchObject({
     minimumSpacingMs: 2_500,
@@ -133,6 +141,9 @@ test("registers every scraper source with explicit target ownership", () => {
   expect(scraperRegistry.sources.get("dramface")?.observationSchema).toBe(
     scraperRegistry.sources.get("whiskynotes")?.observationSchema,
   );
+  expect(scraperRegistry.sources.get("bourbonculture")?.observationSchema).toBe(
+    scraperRegistry.sources.get("whiskynotes")?.observationSchema,
+  );
   expect(
     scraperRegistry.sources.get("whiskeyreviewer")?.observationSchema,
   ).toBe(scraperRegistry.sources.get("whiskynotes")?.observationSchema);
@@ -146,6 +157,9 @@ test("registers every scraper source with explicit target ownership", () => {
     scraperRegistry.sources.get("whiskynotes")?.sink,
   );
   expect(scraperRegistry.sources.get("dramface")?.sink).toBe(
+    scraperRegistry.sources.get("whiskynotes")?.sink,
+  );
+  expect(scraperRegistry.sources.get("bourbonculture")?.sink).toBe(
     scraperRegistry.sources.get("whiskynotes")?.sink,
   );
   expect(scraperRegistry.sources.get("whiskeyreviewer")?.sink).toBe(

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -1,5 +1,10 @@
 import { z } from "zod";
 import {
+  bourbonCultureAdapter,
+  BourbonCultureCursorSchema,
+  BourbonCultureObservationSchema,
+} from "./adapters/bourbonCulture";
+import {
   dramfaceAdapter,
   DramfaceCursorSchema,
   DramfaceObservationSchema,
@@ -230,6 +235,17 @@ export const scraperRegistry = createScraperRegistry({
       }),
     ),
     defineScrapeTarget({
+      key: "bourbonculture",
+      minimumSpacingMs: 5_000,
+      requestsPerWindow: 10,
+      origins: [
+        {
+          origin: "https://thebourbonculture.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
+    defineScrapeTarget({
       key: "dramface",
       minimumSpacingMs: 2_500,
       requestsPerWindow: 25,
@@ -319,6 +335,16 @@ export const scraperRegistry = createScraperRegistry({
         sink: bottleObservationSink,
       }),
     ),
+    defineScraperSource({
+      key: "bourbonculture",
+      externalSiteType: "bourbonculture",
+      targetKeys: ["bourbonculture"],
+      requestLimit: 7,
+      cursorSchema: BourbonCultureCursorSchema,
+      observationSchema: BourbonCultureObservationSchema,
+      adapter: bourbonCultureAdapter,
+      sink: externalReviewSink,
+    }),
     defineScraperSource({
       key: "dramface",
       externalSiteType: "dramface",

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -177,6 +177,15 @@ canonical link, displayed letter grade, and URL date when valid. Only direct
 tasting-note paragraphs stay transient for summary generation. Introductions,
 prices, and publisher conclusions are excluded.
 
+Bourbon Culture runs once per day. It reads only the six links under Latest
+Whiskey Reviews on the public homepage. It does not request archives, ratings
+pages, sitemaps, feeds, search, or WordPress APIs. Requests are at least five
+seconds apart. The target allows 10 requests per hour, and each worker pass
+stops after seven requests. The adapter stores the writer, exact publication
+timestamp, canonical link, and native 10-point score. Only direct tasting-note
+paragraphs stay transient for summary generation. Introductions and publisher
+conclusions are excluded.
+
 Enable automatic publication only after the reviewed sample passes the gate.
 Use the same source-specific process for each later publisher. Do not add a
 generic crawler only because several sources use RSS or HTML.

--- a/docs/research/external-review-content-supply.md
+++ b/docs/research/external-review-content-supply.md
@@ -55,7 +55,7 @@ site-specific search; it does not mean unrestricted use is allowed.
 | P1         | [Words of Whisky](https://wordsofwhisky.com/)                 | Active scored reviews, including multi-bottle articles                            | Public pages allowed; WordPress administration restricted                                          | No dedicated terms page located; footer reserves rights                                                                                           | `public_index`                                |
 | P2         | [The Whiskey Reviewer](https://whiskeyreviewer.com/)          | Long-running American and world whiskey review archive                            | Public pages allowed; WordPress administration restricted                                          | No dedicated reuse terms located                                                                                                                  | `public_index`                                |
 | P2         | [Fred Minnick](https://www.fredminnick.com/)                  | Reviews, rankings, and American whiskey news                                      | Public content not disallowed; 30-second crawl delay; calendar implementation paths restricted     | No reuse restriction located                                                                                                                      | `public_index`; enforce 30-second delay       |
-| P2         | [The Bourbon Culture](https://thebourbonculture.com/)         | Bourbon reviews and comparisons                                                   | File defines Cloudflare content-signal semantics but publishes no actual allow/deny signal         | No reuse restriction located                                                                                                                      | `public_index`                                |
+| P2         | [Bourbon Culture](https://thebourbonculture.com/)             | Active scored bourbon and American whiskey reviews                                | File defines Cloudflare content-signal semantics but publishes no actual allow/deny signal         | Public privacy page contains no automated-access or content-reuse restriction; no dedicated terms page located                                    | `public_index`, daily feed                    |
 | P3         | [The Scotch Noob](https://scotchnoob.com/)                    | Useful historical backfill through 2023; little current supply                    | Explicitly allows all pages and publishes a sitemap                                                | No dedicated reuse terms located                                                                                                                  | `public_index`, low priority because inactive |
 | Restricted | [Whiskybase](https://www.whiskybase.com/)                     | Millions of community ratings plus bottle identity data                           | robots request returned HTTP 403 during the audit                                                  | Terms prohibit collection, copying, public display, commercial reuse, archiving, and derivative works; copyright and database rights are asserted | `licensed_only`; do not crawl                 |
 | Restricted | [Distiller](https://distiller.com/)                           | Large editorial and community review database                                     | Only `/data-admin` is disallowed and a sitemap is published                                        | Terms prohibit scraping, indexing, database building, permanent copies, and commercial exploitation                                               | `licensed_only`; do not crawl                 |
@@ -161,6 +161,22 @@ podcast transcripts need a separate platform-terms and creator-rights review.
   sitemaps, feeds, search, or WordPress APIs. It excludes introductions, price
   text, and publisher conclusions from transient summary input.
 
+### Bourbon Culture
+
+- Evidence: [homepage and latest reviews](https://thebourbonculture.com/),
+  [privacy policy](https://thebourbonculture.com/privacy-policy/), and
+  [robots.txt](https://thebourbonculture.com/robots.txt).
+- Rechecked on 2026-08-21. The robots file describes Cloudflare content signals
+  but publishes no allow or deny signal and no path rule. The public privacy
+  page contains no automated-access or content-reuse restriction. No dedicated
+  terms page is linked from the public site.
+- Current article pages expose a canonical link, writer, exact publication
+  timestamp, Bottle title, tasting-note section, and 10-point score.
+- The implemented daily feed reads only the six links under Latest Whiskey
+  Reviews on the homepage. It does not use archives, ratings pages, sitemaps,
+  feeds, search, or WordPress APIs. It excludes introductions and publisher
+  conclusions from transient summary input.
+
 ### Explicitly Restricted Sources
 
 - [Breaking Bourbon terms](https://www.breakingbourbon.com/site/breaking-bourbon-terms-of-use-agreement)
@@ -227,7 +243,8 @@ boundary.
 4. Dramface supplies the next daily multi-bottle and multi-writer feed.
 5. Words of Whisky supplies the next daily multi-bottle feed.
 6. The Whiskey Reviewer supplies the next daily American whiskey feed.
-7. Continue through the reviewed public-index candidates until Peated has at
+7. Bourbon Culture supplies the next daily American whiskey feed.
+8. Continue through the reviewed public-index candidates until Peated has at
    least 12 reliable feeds.
 
 The pilot is successful with at least 90% article extraction accuracy on a

--- a/docs/research/scraper-source-inventory.md
+++ b/docs/research/scraper-source-inventory.md
@@ -31,6 +31,7 @@ estimate of current live inventory.
 | SMWSA              | `https://newmake.smwsa.com`                | One GET HTML collection                                                    | 35 bottles                                                          |
 | Thompson Bros.     | `https://www.thompsonbrosdistillers.com`   | GET WooCommerce JSON pages                                                 | 2 items                                                             |
 | Total Wine         | `https://www.totalwine.com`                | GET HTML, two paginated categories                                         | 112 items on listing fixture; target disabled pending policy review |
+| Bourbon Culture    | `https://thebourbonculture.com`            | Daily GET of homepage plus up to six current review pages                  | 2 review links and 1 article review in parser fixtures              |
 | Whisky Advocate    | `https://whiskyadvocate.com`               | Manual-only GET of the issue index, newest issue, and listed review pages  | 106 issues and 166 reviews in parser fixtures                       |
 | Whiskyfun          | `https://www.whiskyfun.com`                | Daily GET of RSS plus up to 20 current article pages                       | 2 accepted feed items and 2 article reviews in parser fixtures      |
 | The Whisky World   | `https://www.thewhiskyworld.com`           | GET HTML pages                                                             | 5 items                                                             |


### PR DESCRIPTION
Bourbon Culture now supplies a daily external-review feed from the six latest review links on its public homepage. The adapter stores canonical article facts, author, exact date, Bottle name, and native 10-point score while keeping only direct tasting notes available for the existing summary boundary.

The source uses the shared current-review cursor, date parser, classifier-backed review sink, robots enforcement, and request coordinator. It is limited to seven requests per run, five-second spacing, and 10 requests per hour; archives, ratings pages, feeds, search, sitemaps, WordPress APIs, images, and full article prose remain out of scope.
