### PR TITLE
fix(scraper): complete and verify review runs

### DIFF
--- a/apps/server/src/orpc/routes/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/list.test.ts
@@ -32,8 +32,12 @@ describe("GET /bottles", () => {
   });
 
   test("treats search text as words, not operators", async ({ fixtures }) => {
-    const bottle = await fixtures.Bottle({ name: "Triple Distilled" });
-    await fixtures.Bottle({ name: "Triple Reserve" });
+    const brand = await fixtures.Entity({ name: "Search Test Brand" });
+    const bottle = await fixtures.Bottle({
+      name: "Triple Distilled",
+      brandId: brand.id,
+    });
+    await fixtures.Bottle({ name: "Triple Reserve", brandId: brand.id });
 
     const searches = await Promise.all(
       ["Triple - Distilled", "Triple OR Distilled"].map((query) =>

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -65,6 +65,28 @@ this grouping from a registrable domain. Stricter limits need no exception;
 less restrictive spacing, window, or quota requires a reviewed rationale in
 the code-owned definition.
 
+## Source acceptance rules
+
+Every new or changed source must satisfy this contract. Prove a rule at the
+listed owner. Do not repeat a runtime test in every adapter.
+
+| Rule                                                                                                                                                                                            | Owner and proof                                                                                                                                                              |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The source requests only its declared targets and exact origins.                                                                                                                                | The registry owns the declaration. Definition and boundary tests prove it.                                                                                                   |
+| Discovery is bounded. The adapter does not become a generic crawler.                                                                                                                            | The adapter owns its exact entry points and maximum pages or items. A fixture test proves the bound.                                                                         |
+| Every request uses the injected session. Robots, spacing, quotas, retries, response limits, and `429` cooldowns stay active.                                                                    | The runtime owns request control. Boundary and HTTP tests prove it.                                                                                                          |
+| The configured limits let a run complete or make durable progress. Discovery plus the first work request must fit before a quota or slice boundary. Request spacing must not restart discovery. | The registry owns limits. A registered runtime test proves completion or a cursor advance.                                                                                   |
+| A cursor is strict and describes the next safe work. The adapter emits before it checkpoints. A replay is safe.                                                                                 | The adapter owns progress. Fixture tests prove resume, replay, and failed emit or parse behavior.                                                                            |
+| Observation keys are stable across runs. They are unique within their storage scope.                                                                                                            | The adapter owns source identity. Parser tests prove stable keys, multi-item keys, and known collision cases.                                                                |
+| Parsed output uses the registered strict schema. Product writes happen only in the registered sink.                                                                                             | The session and registry own validation and sink selection. Registry and sink tests prove it.                                                                                |
+| Expected remote deferrals remain non-terminal. Unexpected markup, validation, and persistence failures fail the run.                                                                            | The runtime owns deferrals. The adapter owns the difference between an expected non-item and malformed source data.                                                          |
+| A source change passes deterministic fixtures and one local acceptance run against the current public source.                                                                                   | The source author runs the registered adapter through the local runtime and inspects the run, cursor, request count, and emitted observations. Live checks do not run in CI. |
+| The first production run is checked in Admin → Scrapers and Sentry.                                                                                                                             | The source author confirms status, counts, cursor progress, robots state, and any terminal error.                                                                            |
+
+Keep source-specific facts in the adapter tests and the owning feature or
+research document. Update a fixture when the publisher changes markup. Do not
+weaken a shared schema or runtime rule to accept one malformed page.
+
 ## Run outcomes
 
 - `succeeded` means the adapter returned after validated observations and its

--- a/apps/server/src/scraper/adapters/dramface.test.ts
+++ b/apps/server/src/scraper/adapters/dramface.test.ts
@@ -62,6 +62,9 @@ test("extracts one scored review and only its tasting prose", async () => {
   expect(parsed.article.reviews[0]?.sourceKey).toBe(
     reparsed.article.reviews[0]?.sourceKey,
   );
+  expect(parsed.article.reviews[0]?.sourceKey).toBe(
+    "dramface:a376fb89d0ea5fe526068a1200d1482ec4ab6c6400e43ecfa9b44d65c932fffd",
+  );
   expect(Object.values(parsed.reviewTexts)).toEqual([
     "Lemon oil and coastal peat. Dense malt with mineral smoke. A balanced and characterful release.",
   ]);
@@ -112,6 +115,23 @@ test("keeps separate reviewers for the same bottle", async () => {
   expect(
     parsed.article.reviews.map(({ reviewerName }) => reviewerName),
   ).toEqual(["Ogilvie", "Broddy"]);
+  expect(
+    new Set(parsed.article.reviews.map(({ sourceKey }) => sourceKey)),
+  ).toHaveLength(2);
+});
+
+test("keeps separate sections for the same bottle and reviewer", async () => {
+  const html = await loadFixture("dramface", "multi-bottle.html");
+  const repeatedBottle = html.replace(
+    "Ardmore 14yo, Impex Collection, ex-bourbon hogshead, 59.2% ABV",
+    "Isle of Raasay 4yo, Impex Collection, Manzanilla cask, 60.3% ABV",
+  );
+  const parsed = parseDramfaceArticle(repeatedBottle, new URL(MULTI_URL));
+
+  expect(parsed.article.reviews.map(({ name }) => name)).toEqual([
+    "Isle of Raasay 4yo, Impex Collection, Manzanilla cask, 60.3% ABV",
+    "Isle of Raasay 4yo, Impex Collection, Manzanilla cask, 60.3% ABV",
+  ]);
   expect(
     new Set(parsed.article.reviews.map(({ sourceKey }) => sourceKey)),
   ).toHaveLength(2);

--- a/apps/server/src/scraper/adapters/dramface.ts
+++ b/apps/server/src/scraper/adapters/dramface.ts
@@ -100,10 +100,13 @@ function reviewSourceKey(
   canonicalUrl: string,
   name: string,
   reviewerName: string | null,
+  discriminator?: string,
 ): string {
+  const parts = [canonicalUrl, name, reviewerName ?? ""];
+  if (discriminator) parts.push(discriminator);
   const digest = createHash("sha256")
     .update(
-      [canonicalUrl, name, reviewerName ?? ""]
+      parts
         .map((value) => normalizeText(value).toLocaleLowerCase("en"))
         .join("\n"),
     )
@@ -160,7 +163,16 @@ export function parseDramfaceArticle(
       .find((value) => value !== null);
     if (!name || !reviewScore) continue;
 
-    const sourceKey = reviewSourceKey(canonicalUrl.href, name, reviewerName);
+    const baseSourceKey = reviewSourceKey(
+      canonicalUrl.href,
+      name,
+      reviewerName,
+    );
+    const sourceKey = reviews.some(
+      (review) => review.sourceKey === baseSourceKey,
+    )
+      ? reviewSourceKey(canonicalUrl.href, name, reviewerName, heading)
+      : baseSourceKey;
     reviews.push({
       sourceKey,
       name,

--- a/apps/server/src/scraper/http.test.ts
+++ b/apps/server/src/scraper/http.test.ts
@@ -35,25 +35,28 @@ function requestScraperUrl(
 
 function clockAt(value = "2026-08-18T12:00:00Z") {
   let now = new Date(value);
+  const sleepSpy = vi.fn(async (milliseconds: number) => {
+    now = new Date(now.getTime() + milliseconds);
+  });
   const clock: ScraperHttpClock = {
     now: () => now,
-    sleep: vi.fn(async (milliseconds: number) => {
-      now = new Date(now.getTime() + milliseconds);
-    }),
+    sleep: sleepSpy,
     random: () => 0,
   };
-  return clock;
+  return { ...clock, sleepSpy };
 }
 
 async function setupRuntime({
   origins = ["https://example.com"],
   requestLimit = 20,
+  minimumSpacingMs,
   maxRetries = 2,
   maxResponseBytes = 10 * 1024 * 1024,
   allowedRequestHeaders = [],
 }: {
   origins?: [string, ...string[]];
   requestLimit?: number;
+  minimumSpacingMs?: number;
   maxRetries?: number;
   maxResponseBytes?: number;
   allowedRequestHeaders?: string[];
@@ -62,6 +65,7 @@ async function setupRuntime({
     targets: [
       defineScrapeTarget({
         key: "operator",
+        minimumSpacingMs,
         maxRetries,
         maxResponseBytes,
         allowedRequestHeaders,
@@ -107,6 +111,31 @@ async function setupRuntime({
   if (!run) throw new Error("Expected run.");
   return { registry, run };
 }
+
+test("waits for the target spacing before the next request", async () => {
+  const { registry, run } = await setupRuntime({ minimumSpacingMs: 5_000 });
+  const clock = clockAt();
+  const fetchImpl = vi
+    .fn<typeof fetch>()
+    .mockImplementation(async () => new Response("catalog"));
+  const input = {
+    runId: run.id,
+    sourceKey: "finedrams",
+    request: {
+      target: "operator",
+      url: new URL("https://example.com/catalog"),
+    },
+    registry,
+    fetchImpl,
+    clock,
+  };
+
+  await requestScraperUrl(input);
+  await requestScraperUrl(input);
+
+  expect(clock.sleepSpy).toHaveBeenCalledWith(5_000);
+  expect(fetchImpl).toHaveBeenCalledTimes(2);
+});
 
 test("sends an identified bounded GET and exposes only safe response headers", async () => {
   const { registry, run } = await setupRuntime();

--- a/apps/server/src/scraper/http.ts
+++ b/apps/server/src/scraper/http.ts
@@ -9,7 +9,6 @@ import { resolveScraperOrigin } from "./definitions";
 import type { ScraperRegistry, ScraperRequest, ScraperResponse } from "./types";
 
 const MAX_REDIRECTS = 5;
-const SHORT_WAIT_THRESHOLD_MS = 2_500;
 const RETRY_BASE_DELAY_MS = 250;
 const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
 const SAFE_REQUEST_HEADERS = new Set([
@@ -221,13 +220,8 @@ async function acquireOrDefer({
     const delay = result.nextEligibleAt
       ? result.nextEligibleAt.getTime() - clock.now().getTime()
       : null;
-    if (
-      result.reason === "target_spacing" &&
-      delay !== null &&
-      delay > 0 &&
-      delay <= SHORT_WAIT_THRESHOLD_MS
-    ) {
-      await clock.sleep(delay);
+    if (result.reason === "target_spacing" && delay !== null) {
+      if (delay > 0) await clock.sleep(delay);
       continue;
     }
     if (

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -1,4 +1,8 @@
-import { EXTERNAL_SITE_DEFINITIONS } from "@peated/server/constants";
+import {
+  EXTERNAL_SITE_DEFINITIONS,
+  EXTERNAL_SITE_TYPE_LIST,
+  isExternalReviewSiteType,
+} from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import {
   externalReviewSourcePolicies,
@@ -8,6 +12,7 @@ import {
   reviews,
   storePrices,
 } from "@peated/server/db/schema";
+import { ReviewArticleIngestionSchema } from "@peated/server/externalReviews/observation";
 import { syncExternalSites } from "@peated/server/lib/externalSites";
 import { loadFixture } from "@peated/server/lib/test/fixtures";
 import { eq } from "drizzle-orm";
@@ -16,6 +21,7 @@ import type { ScraperHttpClock } from "./http";
 import { createScraperLifecycle } from "./lifecycle";
 import { scraperRegistry } from "./registry";
 import { executeScraperRun } from "./runs";
+import { externalReviewSink } from "./sinks/externalReviews";
 import { syncScraperDefinitions } from "./syncDefinitions";
 
 const migratedSources = [
@@ -132,42 +138,12 @@ test("registers every scraper source with explicit target ownership", () => {
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("wordsofwhisky")?.requestLimit).toBe(25);
-  expect(scraperRegistry.sources.get("whiskyadvocate")?.observationSchema).toBe(
-    scraperRegistry.sources.get("whiskynotes")?.observationSchema,
-  );
-  expect(scraperRegistry.sources.get("whiskyfun")?.observationSchema).toBe(
-    scraperRegistry.sources.get("whiskynotes")?.observationSchema,
-  );
-  expect(scraperRegistry.sources.get("dramface")?.observationSchema).toBe(
-    scraperRegistry.sources.get("whiskynotes")?.observationSchema,
-  );
-  expect(scraperRegistry.sources.get("bourbonculture")?.observationSchema).toBe(
-    scraperRegistry.sources.get("whiskynotes")?.observationSchema,
-  );
-  expect(
-    scraperRegistry.sources.get("whiskeyreviewer")?.observationSchema,
-  ).toBe(scraperRegistry.sources.get("whiskynotes")?.observationSchema);
-  expect(scraperRegistry.sources.get("wordsofwhisky")?.observationSchema).toBe(
-    scraperRegistry.sources.get("whiskynotes")?.observationSchema,
-  );
-  expect(scraperRegistry.sources.get("whiskyadvocate")?.sink).toBe(
-    scraperRegistry.sources.get("whiskynotes")?.sink,
-  );
-  expect(scraperRegistry.sources.get("whiskyfun")?.sink).toBe(
-    scraperRegistry.sources.get("whiskynotes")?.sink,
-  );
-  expect(scraperRegistry.sources.get("dramface")?.sink).toBe(
-    scraperRegistry.sources.get("whiskynotes")?.sink,
-  );
-  expect(scraperRegistry.sources.get("bourbonculture")?.sink).toBe(
-    scraperRegistry.sources.get("whiskynotes")?.sink,
-  );
-  expect(scraperRegistry.sources.get("whiskeyreviewer")?.sink).toBe(
-    scraperRegistry.sources.get("whiskynotes")?.sink,
-  );
-  expect(scraperRegistry.sources.get("wordsofwhisky")?.sink).toBe(
-    scraperRegistry.sources.get("whiskynotes")?.sink,
-  );
+  for (const type of EXTERNAL_SITE_TYPE_LIST.filter(isExternalReviewSiteType)) {
+    const source = scraperRegistry.sources.get(type);
+    expect(source, `${type} is not registered`).toBeDefined();
+    expect(source?.observationSchema).toBe(ReviewArticleIngestionSchema);
+    expect(source?.sink).toBe(externalReviewSink);
+  }
 });
 
 test("runs Bruichladdich through the production runtime with fixture parity", async () => {

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -87,6 +87,49 @@ position is not a stable key. One article can own several reviews.
 All review adapters emit `ReviewArticleIngestionSchema` and use the shared
 review sink. Do not translate a source-specific review shape in the sink.
 
+### Review source acceptance rules
+
+Apply these rules to each review publisher. Shared runtime rules are tested
+once in the scraper module. Each adapter test owns only publisher behavior.
+
+1. Name the exact discovery page or feed and its maximum result count. Exclude
+   archives, search, APIs, feeds, or pagination that are outside the source
+   plan.
+2. Set a request limit and target quota that allow discovery plus at least one
+   article request. A normal run must complete or save cursor progress under
+   those limits.
+3. Test discovery with current publisher markup and unrelated links. The
+   adapter must select only planned review URLs.
+4. Test one normal article. Verify its canonical URL, title, publication date,
+   writer, Bottle name, native score, normalized rating, and permitted summary
+   text.
+5. Test every source shape that can contain several reviews. Include repeated
+   Bottle names or writers when the publisher can show them. Review keys must
+   stay stable and unique without using array position alone.
+6. Use the shared date and rating parsers when they cover the publisher value.
+   Test the publisher's short, full, decimal, or missing values. Do not make the
+   shared observation schema accept invalid output.
+7. Return `null` only for an item that is clearly not a review. A review-shaped
+   page with missing required facts must throw and must not checkpoint.
+8. Test resume behavior. A completed article must not be requested again while
+   it remains in the current discovery window. A failed parse or sink call must
+   remain eligible for replay.
+9. Keep publisher prose transient. Assert that summary input contains only the
+   planned review section and excludes introductions, prices, navigation,
+   conclusions, fallback markup, and scripts.
+10. Before merge, run the registered source through the local scraper runtime
+    against the current public pages. Inspect the terminal status, request
+    count, emitted article and review counts, cursor, and observations. Replace
+    only the sink with an in-memory collector when model or product writes are
+    not part of the check.
+11. After deployment, inspect the first run in Admin → Scrapers and Sentry. A
+    successful parser test is not enough if the run defers without progress or
+    fails after partial ingestion.
+
+The production registry test automatically requires every external site marked
+as review content to use `ReviewArticleIngestionSchema` and the shared review
+sink.
+
 The adapter does not access the database, select a Peated Bottle, decide public
 visibility, call a model, or store records. The sink and external-review
 ingestion boundary own those actions. Unresolved or invalid Bottle matches stay


### PR DESCRIPTION
Review scrapers now wait for their configured request spacing within the active execution. Bourbon Culture and The Whiskey Reviewer no longer refetch their listing page until the run reaches its attempt limit. Quotas, cooldowns, and remote rate limits still use durable deferrals.

Dramface now adds a stable section discriminator only when an article contains the same bottle and reviewer more than once. Existing review keys stay unchanged, while pages with two scores for the same bottle pass shared observation validation.

The scraper module now defines one acceptance contract for target scope, bounded discovery, request control, durable progress, stable keys, strict schemas, local live checks, and production verification. Review adapters have a specific checklist, and the registry test automatically requires every review source to use the shared observation schema and sink.
