### PR TITLE
feat(scraper): add Fred Minnick review feed

### DIFF
--- a/apps/server/__fixtures__/fredminnick/post-sitemap2.xml
+++ b/apps/server/__fixtures__/fredminnick/post-sitemap2.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://www.fredminnick.com/2025/09/24/review-2025-parkers-heritage-11-year-american-whiskey/</loc></url>
+  <url><loc>https://www.fredminnick.com/2025/12/03/review-barrell-20-year-toasted-bourbon-single-barrel/</loc></url>
+  <url><loc>https://www.fredminnick.com/2025/12/29/review-btac-e-h-taylor-bottled-in-bond-15-year/</loc></url>
+  <url><loc>https://www.fredminnick.com/2025/12/31/year-in-review/</loc></url>
+</urlset>

--- a/apps/server/__fixtures__/fredminnick/post-sitemap3.xml
+++ b/apps/server/__fixtures__/fredminnick/post-sitemap3.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://www.fredminnick.com/2026/01/06/review-2025-btac-george-t-stagg/</loc></url>
+  <url><loc>https://www.fredminnick.com/2026/01/08/bourbon-review-2025-btac-william-larue-weller/</loc></url>
+  <url><loc>https://www.fredminnick.com/2026/01/13/whiskey-review-2025-btac-thomas-h-handy-sazerac-rye/</loc></url>
+  <url><loc>https://www.fredminnick.com/2026/05/12/fred-minnick-reviews-eagle-rare-25-30-year/</loc></url>
+  <url><loc>https://www.fredminnick.com/2026/08/21/new-bourbon-release/</loc></url>
+</urlset>

--- a/apps/server/__fixtures__/fredminnick/review.html
+++ b/apps/server/__fixtures__/fredminnick/review.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+  <head>
+    <link
+      rel="canonical"
+      href="https://www.fredminnick.com/2026/01/06/review-2025-btac-george-t-stagg/"
+    />
+  </head>
+  <body>
+    <main>
+      <p class="text__paragraph m-t m-b">Review: 2025 BTAC George T. Stagg</p>
+      <p class="date-label">January 6, 2026</p>
+      <div class="rich-text-block-4 w-richtext">
+        <p class="has-drop-cap wp-block-paragraph">
+          This introduction describes the series and its release history.
+        </p>
+        <p class="wp-block-paragraph">
+          The nose has caramel and peach. The first sip adds brown sugar.
+        </p>
+        <p class="wp-block-paragraph">
+          On the palate, spice develops before a long fruit finish.
+        </p>
+        <p class="wp-block-paragraph">
+          The final conclusion recommends watching the complete video.
+        </p>
+        <p class="wp-block-paragraph">Read more: An unrelated review</p>
+      </div>
+    </main>
+    <aside><p>Navigation and price text must stay out.</p></aside>
+  </body>
+</html>

--- a/apps/server/__fixtures__/fredminnick/sitemap-index.xml
+++ b/apps/server/__fixtures__/fredminnick/sitemap-index.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://www.fredminnick.com/post-sitemap.xml</loc></sitemap>
+  <sitemap><loc>https://www.fredminnick.com/post-sitemap2.xml</loc></sitemap>
+  <sitemap><loc>https://www.fredminnick.com/post-sitemap3.xml</loc></sitemap>
+  <sitemap><loc>https://other.example/post-sitemap4.xml</loc></sitemap>
+  <sitemap><loc>https://www.fredminnick.com/page-sitemap.xml</loc></sitemap>
+</sitemapindex>

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -66,6 +66,11 @@ export const EXTERNAL_SITE_DEFINITIONS = {
     runEvery: 1440,
     content: "reviews",
   },
+  fredminnick: {
+    name: "Fred Minnick",
+    runEvery: 1440,
+    content: "reviews",
+  },
   whiskeyreviewer: {
     name: "The Whiskey Reviewer",
     runEvery: 1440,

--- a/apps/server/src/lib/externalSites.test.ts
+++ b/apps/server/src/lib/externalSites.test.ts
@@ -43,12 +43,13 @@ test("syncs code-owned external-site definitions", async () => {
   expect(fineDrams).toMatchObject(EXTERNAL_SITE_DEFINITIONS.finedrams);
 
   const policies = await db.select().from(externalReviewSourcePolicies);
-  expect(policies).toHaveLength(7);
+  expect(policies).toHaveLength(8);
   expect(policies).toEqual(
     expect.arrayContaining(
       [
         "bourbonculture",
         "dramface",
+        "fredminnick",
         "whiskeyreviewer",
         "whiskyadvocate",
         "whiskyfun",

--- a/apps/server/src/scraper/adapters/fredMinnick.test.ts
+++ b/apps/server/src/scraper/adapters/fredMinnick.test.ts
@@ -1,0 +1,147 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { vi } from "vitest";
+import type { ScraperSession } from "../types";
+import {
+  discoverFredMinnickArticles,
+  discoverFredMinnickPostSitemaps,
+  fredMinnickAdapter,
+  parseFredMinnickArticle,
+  type FredMinnickCursor,
+  type FredMinnickObservation,
+} from "./fredMinnick";
+
+const STAGG_URL =
+  "https://www.fredminnick.com/2026/01/06/review-2025-btac-george-t-stagg/";
+const WELLER_URL =
+  "https://www.fredminnick.com/2026/01/08/bourbon-review-2025-btac-william-larue-weller/";
+const HANDY_URL =
+  "https://www.fredminnick.com/2026/01/13/whiskey-review-2025-btac-thomas-h-handy-sazerac-rye/";
+
+test("selects only the newest two same-origin post sitemaps", async () => {
+  const index = await loadFixture("fredminnick", "sitemap-index.xml");
+
+  expect(discoverFredMinnickPostSitemaps(index).map((url) => url.href)).toEqual(
+    [
+      "https://www.fredminnick.com/post-sitemap2.xml",
+      "https://www.fredminnick.com/post-sitemap3.xml",
+    ],
+  );
+});
+
+test("discovers only supported current review URLs", async () => {
+  const older = await loadFixture("fredminnick", "post-sitemap2.xml");
+  const newer = await loadFixture("fredminnick", "post-sitemap3.xml");
+
+  expect(
+    discoverFredMinnickArticles([older, newer]).map((url) => url.href),
+  ).toEqual([
+    HANDY_URL,
+    WELLER_URL,
+    STAGG_URL,
+    "https://www.fredminnick.com/2025/12/29/review-btac-e-h-taylor-bottled-in-bond-15-year/",
+    "https://www.fredminnick.com/2025/12/03/review-barrell-20-year-toasted-bourbon-single-barrel/",
+  ]);
+});
+
+test("extracts an unscored review and only direct tasting text", async () => {
+  const html = await loadFixture("fredminnick", "review.html");
+  const parsed = parseFredMinnickArticle(html, new URL(STAGG_URL));
+  const reparsed = parseFredMinnickArticle(
+    html.replace("2025 BTAC George T. Stagg", "2025   BTAC George T. Stagg"),
+    new URL(STAGG_URL),
+  );
+  if (!parsed || !reparsed) throw new Error("Expected one parsed review.");
+
+  expect(parsed.article).toMatchObject({
+    canonicalUrl: STAGG_URL,
+    title: "Review: 2025 BTAC George T. Stagg",
+    publishedAt: new Date("2026-01-06T00:00:00.000Z"),
+    contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    reviews: [
+      {
+        name: "2025 BTAC George T. Stagg",
+        reviewerName: "Fred Minnick",
+        nativeScore: null,
+        normalizedRating: null,
+      },
+    ],
+  });
+  expect(parsed.article.reviews[0]?.sourceKey).toBe(
+    reparsed.article.reviews[0]?.sourceKey,
+  );
+  expect(Object.values(parsed.reviewTexts)).toEqual([
+    "The nose has caramel and peach. The first sip adds brown sugar. On the palate, spice develops before a long fruit finish.",
+  ]);
+  expect(Object.values(parsed.reviewTexts).join(" ")).not.toMatch(
+    /introduction|conclusion|navigation|price|read more/iu,
+  );
+});
+
+test("skips a selected comparison article", async () => {
+  const html = (await loadFixture("fredminnick", "review.html")).replace(
+    "Review: 2025 BTAC George T. Stagg",
+    "Whiskey Review: Thomas H. Handy, Sazerac 18 Year",
+  );
+
+  expect(parseFredMinnickArticle(html, new URL(HANDY_URL))).toBeNull();
+});
+
+test("fails a selected review with an unsupported title", async () => {
+  const html = (await loadFixture("fredminnick", "review.html")).replace(
+    "Review: 2025 BTAC George T. Stagg",
+    "2025 BTAC George T. Stagg",
+  );
+
+  expect(() => parseFredMinnickArticle(html, new URL(STAGG_URL))).toThrow(
+    "Bottle name is missing or ambiguous",
+  );
+});
+
+test("resumes without requesting a completed current article", async () => {
+  const index = await loadFixture("fredminnick", "sitemap-index.xml");
+  const older = await loadFixture("fredminnick", "post-sitemap2.xml");
+  const newer = await loadFixture("fredminnick", "post-sitemap3.xml");
+  const article = await loadFixture("fredminnick", "review.html");
+  const emit = vi.fn();
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body:
+      url.pathname === "/sitemap_index.xml"
+        ? index
+        : url.pathname === "/post-sitemap2.xml"
+          ? older
+          : url.pathname === "/post-sitemap3.xml"
+            ? newer.replaceAll(HANDY_URL, STAGG_URL)
+            : article,
+  }));
+  const session: ScraperSession<FredMinnickCursor, FredMinnickObservation> = {
+    request,
+    emit,
+    checkpoint,
+    remainingRequests: () => 9,
+  };
+
+  await fredMinnickAdapter({
+    cursor: {
+      processedArticleUrls: [
+        WELLER_URL,
+        STAGG_URL,
+        "https://www.fredminnick.com/2025/12/29/review-btac-e-h-taylor-bottled-in-bond-15-year/",
+        "https://www.fredminnick.com/2025/12/03/review-barrell-20-year-toasted-bourbon-single-barrel/",
+        "https://www.fredminnick.com/2025/09/24/review-2025-parkers-heritage-11-year-american-whiskey/",
+      ],
+    },
+    session,
+  });
+
+  expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
+    "https://www.fredminnick.com/sitemap_index.xml",
+    "https://www.fredminnick.com/post-sitemap2.xml",
+    "https://www.fredminnick.com/post-sitemap3.xml",
+  ]);
+  expect(emit).not.toHaveBeenCalled();
+  expect(checkpoint).not.toHaveBeenCalled();
+});

--- a/apps/server/src/scraper/adapters/fredMinnick.ts
+++ b/apps/server/src/scraper/adapters/fredMinnick.ts
@@ -1,0 +1,187 @@
+import {
+  type ReviewArticleIngestion,
+  ReviewArticleIngestionSchema,
+} from "@peated/server/externalReviews/observation";
+import { load as cheerio } from "cheerio";
+import { createHash } from "node:crypto";
+import type { z } from "zod";
+import type { ScraperAdapter } from "../types";
+import {
+  currentReviewCursorSchema,
+  processCurrentReviews,
+} from "./currentReviews";
+import { parseDate } from "./dates";
+
+// This adapter owns Fred Minnick parsing. The shared scraper runtime owns
+// every remote request and the shared review sink owns storage.
+const ORIGIN = "https://www.fredminnick.com";
+const TARGET = "fredminnick";
+const MAX_CURRENT_ARTICLES = 5;
+const MAX_CURRENT_SITEMAPS = 2;
+const POST_SITEMAP_PATH = /^\/post-sitemap(?<page>\d*)\.xml$/u;
+const ARTICLE_PATH =
+  /^\/(?<year>\d{4})\/(?<month>\d{2})\/(?<day>\d{2})\/(?<slug>(?:review|bourbon-review|whiskey-review)-[a-z0-9][a-z0-9-]*)\/$/u;
+const REVIEW_TITLE =
+  /^(?:Review|Bourbon Review|Whiskey Review):\s*(?<name>[^,]+)$/iu;
+const TASTING_TEXT =
+  /\b(?:aroma|finish|flavou?r|nose|nosing|notes?|palate|sip|taste|tasting notes?)\b/iu;
+
+export const FredMinnickCursorSchema =
+  currentReviewCursorSchema(MAX_CURRENT_ARTICLES);
+
+export const FredMinnickObservationSchema = ReviewArticleIngestionSchema;
+
+export type FredMinnickCursor = z.infer<typeof FredMinnickCursorSchema>;
+export type FredMinnickObservation = ReviewArticleIngestion;
+
+function normalizeText(value: string): string {
+  return value.replaceAll(/\s+/g, " ").trim();
+}
+
+function sourceUrl(value: string, pattern: RegExp): URL | null {
+  try {
+    const url = new URL(value, ORIGIN);
+    url.hash = "";
+    url.search = "";
+    if (!url.pathname.endsWith("/") && !url.pathname.endsWith(".xml")) {
+      url.pathname += "/";
+    }
+    if (url.origin !== ORIGIN || !pattern.test(url.pathname)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function sitemapPage(url: URL): number {
+  const page = POST_SITEMAP_PATH.exec(url.pathname)?.groups?.page;
+  return page ? Number(page) : 1;
+}
+
+export function discoverFredMinnickPostSitemaps(data: string): URL[] {
+  const $ = cheerio(data, { xmlMode: true });
+  const sitemaps = new Map<string, URL>();
+
+  $("sitemap > loc").each((_, element) => {
+    const url = sourceUrl($(element).text(), POST_SITEMAP_PATH);
+    if (url) sitemaps.set(url.href, url);
+  });
+
+  return [...sitemaps.values()]
+    .sort((left, right) => sitemapPage(left) - sitemapPage(right))
+    .slice(-MAX_CURRENT_SITEMAPS);
+}
+
+export function discoverFredMinnickArticles(
+  sitemaps: readonly string[],
+): URL[] {
+  const articles = new Map<string, URL>();
+
+  for (const data of sitemaps) {
+    const $ = cheerio(data, { xmlMode: true });
+    $("url > loc").each((_, element) => {
+      const url = sourceUrl($(element).text(), ARTICLE_PATH);
+      if (url) articles.set(url.href, url);
+    });
+  }
+
+  return [...articles.values()]
+    .sort((left, right) => right.pathname.localeCompare(left.pathname))
+    .slice(0, MAX_CURRENT_ARTICLES);
+}
+
+function bottleName(title: string): string | null {
+  const match = REVIEW_TITLE.exec(normalizeText(title));
+  const name = normalizeText(match?.groups?.name ?? "");
+  return name || null;
+}
+
+function sourceKey(canonicalUrl: string): string {
+  const digest = createHash("sha256").update(canonicalUrl).digest("hex");
+  return `fredminnick:${digest}`;
+}
+
+export function parseFredMinnickArticle(
+  data: string,
+  rawCanonicalUrl: URL,
+): FredMinnickObservation | null {
+  const $ = cheerio(data);
+  const canonicalUrl = sourceUrl(
+    $('link[rel="canonical"]').first().attr("href") ?? rawCanonicalUrl.href,
+    ARTICLE_PATH,
+  );
+  if (!canonicalUrl) throw new Error("Invalid Fred Minnick article URL.");
+
+  const title = normalizeText($("p.text__paragraph.m-t.m-b").first().text());
+  const name = bottleName(title);
+  const rawPublishedAt = normalizeText($("p.date-label").first().text());
+  const publishedAt = parseDate(rawPublishedAt);
+  if (!title) throw new Error("Fred Minnick article title is missing.");
+  if (title.includes(",")) return null;
+  if (!name)
+    throw new Error("Fred Minnick Bottle name is missing or ambiguous.");
+  if (!rawPublishedAt || !publishedAt) {
+    throw new Error("Fred Minnick article date is missing or invalid.");
+  }
+
+  const reviewText = normalizeText(
+    $(".rich-text-block-4")
+      .first()
+      .children("p.wp-block-paragraph")
+      .toArray()
+      .map((element) => normalizeText($(element).text()))
+      .filter((text) => TASTING_TEXT.test(text) && !/^Read more:/iu.test(text))
+      .join(" "),
+  );
+  const reviewSourceKey = sourceKey(canonicalUrl.href);
+  const review = {
+    sourceKey: reviewSourceKey,
+    name,
+    category: null,
+    reviewerName: "Fred Minnick",
+    nativeScore: null,
+    normalizedRating: null,
+  };
+  const contentText = JSON.stringify({
+    review,
+    reviewText: reviewText || null,
+  });
+
+  return FredMinnickObservationSchema.parse({
+    article: {
+      canonicalUrl: canonicalUrl.href,
+      title,
+      issue: null,
+      publishedAt,
+      contentHash: createHash("sha256").update(contentText).digest("hex"),
+      reviews: [review],
+    },
+    reviewTexts: reviewText ? { [reviewSourceKey]: reviewText } : {},
+  });
+}
+
+export const fredMinnickAdapter: ScraperAdapter<
+  FredMinnickCursor,
+  FredMinnickObservation
+> = async ({ cursor, session }) => {
+  const indexResponse = await session.request({
+    target: TARGET,
+    url: new URL("/sitemap_index.xml", ORIGIN),
+  });
+  const sitemapUrls = discoverFredMinnickPostSitemaps(indexResponse.body);
+  const sitemapBodies: string[] = [];
+  for (const url of sitemapUrls) {
+    const response = await session.request({ target: TARGET, url });
+    sitemapBodies.push(response.body);
+  }
+  const articleUrls = discoverFredMinnickArticles(sitemapBodies);
+
+  await processCurrentReviews({
+    target: TARGET,
+    articles: articleUrls,
+    articleUrl: (url) => url,
+    cursor,
+    session,
+    parse: (response) => parseFredMinnickArticle(response.body, response.url),
+  });
+};

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -37,6 +37,7 @@ const migratedSources = [
   "dramfool",
   "edradour",
   "finedrams",
+  "fredminnick",
   "glenallachie",
   "gordonmacphail",
   "healthyspirits",
@@ -103,6 +104,13 @@ test("registers every scraper source with explicit target ownership", () => {
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("dramface")?.requestLimit).toBe(30);
+  expect(EXTERNAL_SITE_DEFINITIONS.fredminnick.runEvery).toBe(1440);
+  expect(scraperRegistry.targets.get("fredminnick")).toMatchObject({
+    minimumSpacingMs: 30_000,
+    requestsPerWindow: 10,
+    windowMs: 3_600_000,
+  });
+  expect(scraperRegistry.sources.get("fredminnick")?.requestLimit).toBe(9);
   expect(EXTERNAL_SITE_DEFINITIONS.whiskeyreviewer.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskeyreviewer")).toMatchObject({
     minimumSpacingMs: 5_000,

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -9,6 +9,11 @@ import {
   DramfaceCursorSchema,
   DramfaceObservationSchema,
 } from "./adapters/dramface";
+import {
+  fredMinnickAdapter,
+  FredMinnickCursorSchema,
+  FredMinnickObservationSchema,
+} from "./adapters/fredMinnick";
 import scrapeAstorWines from "./adapters/legacy/scrapeAstorWines";
 import scrapeBerryBrosRudd from "./adapters/legacy/scrapeBerryBrosRudd";
 import scrapeBruichladdich from "./adapters/legacy/scrapeBruichladdich";
@@ -257,6 +262,17 @@ export const scraperRegistry = createScraperRegistry({
       ],
     }),
     defineScrapeTarget({
+      key: "fredminnick",
+      minimumSpacingMs: 30_000,
+      requestsPerWindow: 10,
+      origins: [
+        {
+          origin: "https://www.fredminnick.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
+    defineScrapeTarget({
       key: "whiskeyreviewer",
       minimumSpacingMs: 5_000,
       requestsPerWindow: 10,
@@ -353,6 +369,16 @@ export const scraperRegistry = createScraperRegistry({
       cursorSchema: DramfaceCursorSchema,
       observationSchema: DramfaceObservationSchema,
       adapter: dramfaceAdapter,
+      sink: externalReviewSink,
+    }),
+    defineScraperSource({
+      key: "fredminnick",
+      externalSiteType: "fredminnick",
+      targetKeys: ["fredminnick"],
+      requestLimit: 9,
+      cursorSchema: FredMinnickCursorSchema,
+      observationSchema: FredMinnickObservationSchema,
+      adapter: fredMinnickAdapter,
       sink: externalReviewSink,
     }),
     defineScraperSource({

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -229,6 +229,17 @@ timestamp, canonical link, and native 10-point score. Only direct tasting-note
 paragraphs stay transient for summary generation. Introductions and publisher
 conclusions are excluded.
 
+Fred Minnick runs once per day. It reads the public sitemap index and only the
+newest two post sitemaps. It does not request the empty Reviews page, the main
+news feed, older sitemaps, search, pagination, or WordPress APIs. It selects at
+most five single-Bottle review URLs. Requests are at least 30 seconds apart.
+The target allows 10 requests per hour, and each worker pass stops after eight
+source requests plus the governed robots request when its cache is stale. The
+adapter stores the explicit date, canonical link, and Fred
+Minnick reviewer attribution. Native and normalized scores stay absent. Only
+direct tasting paragraphs stay transient for summary generation; comparisons,
+introductions, prices, related links, and site furniture are excluded.
+
 Enable automatic publication only after the reviewed sample passes the gate.
 Use the same source-specific process for each later publisher. Do not add a
 generic crawler only because several sources use RSS or HTML.

--- a/docs/research/external-review-content-supply.md
+++ b/docs/research/external-review-content-supply.md
@@ -54,7 +54,7 @@ site-specific search; it does not mean unrestricted use is allowed.
 | P1         | [The Whiskey Wash](https://thewhiskeywash.com/)               | High-cadence reviews and release news                                             | Public articles allowed; administrative, search, feed, and implementation paths restricted         | Terms prohibit unauthorized robots, spiders, scrapers, and derivative works                                                                       | `licensed_only`                               |
 | P1         | [Words of Whisky](https://wordsofwhisky.com/)                 | Active scored reviews, including multi-bottle articles                            | Public pages allowed; WordPress administration restricted                                          | No dedicated terms page located; footer reserves rights                                                                                           | `public_index`                                |
 | P2         | [The Whiskey Reviewer](https://whiskeyreviewer.com/)          | Long-running American and world whiskey review archive                            | Public pages allowed; WordPress administration restricted                                          | No dedicated reuse terms located                                                                                                                  | `public_index`                                |
-| P2         | [Fred Minnick](https://www.fredminnick.com/)                  | Reviews, rankings, and American whiskey news                                      | Public content not disallowed; 30-second crawl delay; calendar implementation paths restricted     | No reuse restriction located                                                                                                                      | `public_index`; enforce 30-second delay       |
+| P2         | [Fred Minnick](https://www.fredminnick.com/)                  | Infrequent current American whiskey reviews among a high-volume news stream       | Public content allowed with a 30-second crawl delay; calendar implementation paths restricted      | No dedicated terms page located; the linked privacy page contains placeholder text                                                                | `public_index`; bounded review feed           |
 | P2         | [Bourbon Culture](https://thebourbonculture.com/)             | Active scored bourbon and American whiskey reviews                                | File defines Cloudflare content-signal semantics but publishes no actual allow/deny signal         | Public privacy page contains no automated-access or content-reuse restriction; no dedicated terms page located                                    | `public_index`, daily feed                    |
 | P3         | [The Scotch Noob](https://scotchnoob.com/)                    | Useful historical backfill through 2023; little current supply                    | Explicitly allows all pages and publishes a sitemap                                                | No dedicated reuse terms located                                                                                                                  | `public_index`, low priority because inactive |
 | Restricted | [Whiskybase](https://www.whiskybase.com/)                     | Millions of community ratings plus bottle identity data                           | robots request returned HTTP 403 during the audit                                                  | Terms prohibit collection, copying, public display, commercial reuse, archiving, and derivative works; copyright and database rights are asserted | `licensed_only`; do not crawl                 |
@@ -177,6 +177,24 @@ podcast transcripts need a separate platform-terms and creator-rights review.
   feeds, search, or WordPress APIs. It excludes introductions and publisher
   conclusions from transient summary input.
 
+### Fred Minnick
+
+- Evidence: [homepage and public sitemap](https://www.fredminnick.com/),
+  [disclosures](https://www.fredminnick.com/elementor-9293/), and
+  [robots.txt](https://www.fredminnick.com/robots.txt).
+- Rechecked on 2026-08-21. Robots allows public posts and sitemaps, requires a
+  30-second crawl delay, and restricts calendar implementation paths. No
+  dedicated terms page was linked or located. The linked privacy page contains
+  placeholder text and states no automated-access or reuse restriction.
+- The public Reviews page is empty. The main RSS feed is limited and usually
+  contains news rather than reviews. Current review articles appear as normal
+  posts and do not publish a stable numeric or letter score.
+- The implemented daily feed reads the sitemap index and only the newest two
+  post sitemaps. It selects at most five single-Bottle review URLs and skips
+  comparisons. It stores explicit dates, canonical links, and Fred Minnick as
+  the reviewer. Native scores stay absent. Only direct tasting paragraphs stay
+  transient for summary generation.
+
 ### Explicitly Restricted Sources
 
 - [Breaking Bourbon terms](https://www.breakingbourbon.com/site/breaking-bourbon-terms-of-use-agreement)
@@ -244,7 +262,8 @@ boundary.
 5. Words of Whisky supplies the next daily multi-bottle feed.
 6. The Whiskey Reviewer supplies the next daily American whiskey feed.
 7. Bourbon Culture supplies the next daily American whiskey feed.
-8. Continue through the reviewed public-index candidates until Peated has at
+8. Fred Minnick supplies a low-cadence daily American whiskey review feed.
+9. Continue through the reviewed public-index candidates until Peated has at
    least 12 reliable feeds.
 
 The pilot is successful with at least 90% article extraction accuracy on a

--- a/openspec/changes/add-fred-minnick-review-feed/.openspec.yaml
+++ b/openspec/changes/add-fred-minnick-review-feed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-21

--- a/openspec/changes/add-fred-minnick-review-feed/design.md
+++ b/openspec/changes/add-fred-minnick-review-feed/design.md
@@ -1,0 +1,75 @@
+## Context
+
+Fred Minnick publishes current review articles as normal WordPress posts. The
+public `/reviews/` page is empty, and the main RSS feed is limited to a small
+news-heavy window. The public sitemap index lists bounded post sitemaps and is
+allowed by the site's robots rules. Robots also specify a 30-second crawl
+delay. Current review articles identify one Bottle in the title and publish an
+explicit date, but they do not publish a stable numeric or letter score.
+
+Peated already owns the shared review schema, current-window lifecycle, Bottle
+matcher, sink, publication policy, robots enforcement, and request controls.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add up to five recent single-Bottle Fred Minnick reviews without a schema or
+  API change.
+- Preserve canonical links, explicit dates, Bottle names, and reviewer
+  attribution.
+- Run daily with a bounded discovery window and a 30-second request delay.
+
+**Non-Goals:**
+
+- Backfill the full site or its older review custom-post archive.
+- Parse rankings, awards, comparison articles, or multi-Bottle videos.
+- Request WordPress APIs, search pages, or pagination.
+- Invent a score when the publisher does not provide one.
+- Build a generic sitemap or WordPress crawler.
+
+## Decisions
+
+### Use the newest two post sitemaps
+
+The adapter reads the public sitemap index and only the newest two post
+sitemaps. It accepts up to five same-origin article URLs whose slug begins with
+`review`, `bourbon-review`, or `whiskey-review`. It rejects plural comparison
+titles and unrelated URLs. This window includes recent reviews even when the
+main feed is filled by news.
+
+Using the empty Reviews page cannot discover work. Using the short main feed
+would often return no reviews. Reading every sitemap would turn this slice into
+an archive crawl.
+
+### Keep article parsing source-specific
+
+The adapter reads the canonical URL, title, and explicit article date from the
+main article. It removes the supported review prefix from the title to form the
+Bottle name. It attributes the review to Fred Minnick because the indexed
+article summarizes his published tasting, even when another site contributor
+prepared the post.
+
+The adapter keeps the native score and normalized rating null. It sends only
+paragraphs that describe nose, palate, taste, or finish through the existing
+transient summary boundary. It excludes introductions, prices, navigation,
+related links, and site furniture.
+
+### Reuse the shared current-review lifecycle
+
+The adapter emits the shared article ingestion schema. The shared lifecycle
+checkpoints each completed article and keeps only URLs in the current discovery
+window. The shared runtime owns every request, including the 30-second spacing,
+and the shared sink owns matching and storage.
+
+## Risks / Trade-offs
+
+- **A new post sitemap pushes an older review outside the two-map window** → A
+  completed review already remains stored; the bounded feed only needs current
+  discovery.
+- **A comparison article uses a singular review slug** → Require a single
+  supported review title and one derived Bottle name before emission.
+- **Current review markup changes** → Fail the review-shaped article without a
+  checkpoint and cover the verified markup with a fixture.
+- **The source publishes reviews infrequently** → A successful zero-item run is
+  expected; the feed adds new reviews when they appear without crawling news.

--- a/openspec/changes/add-fred-minnick-review-feed/proposal.md
+++ b/openspec/changes/add-fred-minnick-review-feed/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Peated needs more independent American whiskey coverage on Bottle pages. Fred
+Minnick publishes current editorial reviews, but his public reviews page is
+empty and his main feed mixes reviews with a much larger news stream.
+
+## What Changes
+
+- Add Fred Minnick as a scheduled external-review source.
+- Discover at most five recent single-Bottle reviews from the newest bounded
+  public post sitemaps.
+- Extract canonical links, explicit dates, Bottle names, and Fred Minnick as
+  the reviewer with source-specific code.
+- Keep native scores absent because current articles do not publish a stable
+  score.
+- Use the shared review sink, Bottle matcher, request controls, robots
+  enforcement, and publication policy.
+
+## Capabilities
+
+### New Capabilities
+
+- `external-review-feeds`: Bounded ingestion of current editorial review feeds
+  through source-specific adapters and the shared external-review boundary.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds one external-site definition and one native scraper adapter.
+- Adds fixture-backed parser and runtime registration tests.
+- Adds no database schema, API, model, or UI changes.

--- a/openspec/changes/add-fred-minnick-review-feed/specs/external-review-feeds/spec.md
+++ b/openspec/changes/add-fred-minnick-review-feed/specs/external-review-feeds/spec.md
@@ -1,0 +1,54 @@
+## ADDED Requirements
+
+### Requirement: Fred Minnick discovery is bounded
+
+The system SHALL discover at most five recent single-Bottle Fred Minnick review
+articles from the newest two public post sitemaps and SHALL fetch them through
+the shared scraper runtime.
+
+#### Scenario: Scheduled current-review run
+
+- **WHEN** the daily source run reads the Fred Minnick sitemap index
+- **THEN** it requests only the newest two post sitemaps
+- **AND** it considers only five same-origin URLs with a supported review slug
+- **AND** all requests use the registered origin, robots rules, 30-second
+  spacing, quota, retry, and backoff controls
+
+#### Scenario: Deferred run resumes
+
+- **WHEN** a run is deferred after it stores an article
+- **THEN** the resumed run does not request that completed current article
+  again
+
+### Requirement: Fred Minnick article facts remain source-accurate
+
+The system SHALL store each complete current article by canonical URL with its
+title, explicit publication date, Bottle name, and Fred Minnick reviewer
+attribution. The system MUST keep native and normalized scores absent when the
+article does not publish a stable score.
+
+#### Scenario: Complete single-Bottle review
+
+- **WHEN** a current article has a supported review title, canonical URL, and
+  explicit publication date
+- **THEN** the system stores one unscored review for the derived Bottle name
+- **AND** it attributes the review to Fred Minnick
+
+#### Scenario: Review-shaped article is incomplete
+
+- **WHEN** a selected article lacks a supported title, canonical URL, or valid
+  publication date
+- **THEN** the adapter fails without checkpointing that article
+
+### Requirement: Fred Minnick prose remains transient
+
+The system MUST NOT persist Fred Minnick HTML, full review prose, publisher
+images, price text, related links, or site furniture as source content.
+
+#### Scenario: Review text is processed
+
+- **WHEN** source policy permits Peated to generate a review summary
+- **THEN** the adapter passes only direct tasting paragraphs through the
+  existing transient summary boundary
+- **AND** stored output contains only permitted structured facts, derived
+  summary data, content hash, and canonical link

--- a/openspec/changes/add-fred-minnick-review-feed/tasks.md
+++ b/openspec/changes/add-fred-minnick-review-feed/tasks.md
@@ -1,0 +1,14 @@
+## 1. Source Adapter
+
+- [x] 1.1 Add fixture-backed bounded sitemap discovery and article parsing
+- [x] 1.2 Add resumable execution for the five-article current window
+
+## 2. Runtime Registration
+
+- [x] 2.1 Register Fred Minnick as a daily source with the 30-second crawl delay
+- [x] 2.2 Prove registry ownership and shared review boundaries in tests
+
+## 3. Documentation And Verification
+
+- [x] 3.1 Update source research and operating documentation
+- [x] 3.2 Run focused tests, typecheck, lint, format, a live acceptance run, and strict OpenSpec validation


### PR DESCRIPTION
Adds Fred Minnick as a daily external-review source. It discovers at most five recent single-Bottle reviews from the newest two public post sitemaps, records the canonical link, publication date, Bottle name, and reviewer, and leaves scores empty when the source does not publish one.

The adapter reuses the shared current-review lifecycle, Bottle matcher, review sink, and policy controls. The governed runtime enforces robots rules, 30-second request spacing, and a nine-request run limit that includes the robots request. A live governed run confirmed the bounded flow. This adds no database, API, model, or UI changes.
