### PR TITLE
feat(scraper): add Whisky Study review feed

### DIFF
--- a/apps/server/__fixtures__/whiskystudy/index.html
+++ b/apps/server/__fixtures__/whiskystudy/index.html
@@ -1,0 +1,13 @@
+<main>
+  <article class="blog-item entry">
+    <a href="/reviews-3/example-scotch-review">Example Scotch Review</a>
+    <a href="/reviews-3/example-scotch-review">Read More</a>
+  </article>
+  <article class="blog-item entry">
+    <a href="https://thewhiskystudy.com/reviews-3/second-scotch-review">Second Scotch Review</a>
+  </article>
+  <article class="blog-item entry">
+    <a href="https://example.com/reviews-3/offsite-review">Offsite</a>
+  </article>
+  <a href="/reviews-3?offset=123">Older Posts</a>
+</main>

--- a/apps/server/__fixtures__/whiskystudy/review.html
+++ b/apps/server/__fixtures__/whiskystudy/review.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+  <head>
+    <link rel="canonical" href="https://thewhiskystudy.com/reviews-3/example-scotch-review" />
+    <script type="application/ld+json">
+      {
+        "@type": "Article",
+        "headline": "Example Scotch 18 Year Shelf Review",
+        "datePublished": "2026-07-04T12:03:15-0700",
+        "author": "Chris Ellis",
+        "publisher": { "name": "The Whisky Study" }
+      }
+    </script>
+  </head>
+  <body>
+    <article class="h-entry entry hentry">
+      <h1 class="entry-title">Example Scotch 18 Year Shelf Review</h1>
+      <div class="blog-item-content e-content">
+        <p>This introduction includes a price of $120.</p>
+        <p>Age: 18 Years</p>
+        <p>Review Date: 7/1/26</p>
+        <p>Nose: Orchard fruit and soft wax.</p>
+        <p>Palate: Malt, citrus, and gentle oak.</p>
+        <p>Finish: Long and lightly spiced.</p>
+        <p>Final Thoughts: A balanced release.</p>
+        <h4>Score: 92</h4>
+      </div>
+    </article>
+  </body>
+</html>

--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -91,6 +91,11 @@ export const EXTERNAL_SITE_DEFINITIONS = {
     runEvery: 1440,
     content: "reviews",
   },
+  whiskystudy: {
+    name: "The Whisky Study",
+    runEvery: 1440,
+    content: "reviews",
+  },
   whiskynotes: {
     name: "WhiskyNotes",
     runEvery: null,

--- a/apps/server/src/lib/externalSites.test.ts
+++ b/apps/server/src/lib/externalSites.test.ts
@@ -43,7 +43,7 @@ test("syncs code-owned external-site definitions", async () => {
   expect(fineDrams).toMatchObject(EXTERNAL_SITE_DEFINITIONS.finedrams);
 
   const policies = await db.select().from(externalReviewSourcePolicies);
-  expect(policies).toHaveLength(9);
+  expect(policies).toHaveLength(10);
   expect(policies).toEqual(
     expect.arrayContaining(
       [
@@ -55,6 +55,7 @@ test("syncs code-owned external-site definitions", async () => {
         "whiskyfun",
         "whiskynotes",
         "whiskysaga",
+        "whiskystudy",
         "wordsofwhisky",
       ].map((type) =>
         expect.objectContaining({

--- a/apps/server/src/scraper/adapters/articleMetadata.ts
+++ b/apps/server/src/scraper/adapters/articleMetadata.ts
@@ -1,0 +1,48 @@
+import { load as cheerio } from "cheerio";
+import { z } from "zod";
+
+const ArticleMetadataSchema = z
+  .object({
+    type: z.literal("Article"),
+    datePublished: z.string().trim().min(1),
+    author: z.string().trim().min(1),
+  })
+  .strict();
+
+type ArticleMetadata = z.infer<typeof ArticleMetadataSchema>;
+
+function objectValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/** Reads the common article facts that Squarespace publishes as JSON-LD. */
+export function parseArticleMetadata(data: string): ArticleMetadata | null {
+  const $ = cheerio(data);
+  for (const script of $('script[type="application/ld+json"]').toArray()) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse($(script).text());
+    } catch {
+      continue;
+    }
+
+    const values = Array.isArray(parsed) ? parsed : [parsed];
+    for (const value of values) {
+      const metadata = objectValue(value);
+      const rawAuthor = metadata?.author;
+      const author =
+        typeof rawAuthor === "string"
+          ? rawAuthor
+          : objectValue(rawAuthor)?.name;
+      const result = ArticleMetadataSchema.safeParse({
+        type: metadata?.["@type"],
+        datePublished: metadata?.datePublished,
+        author,
+      });
+      if (result.success) return result.data;
+    }
+  }
+  return null;
+}

--- a/apps/server/src/scraper/adapters/whiskyStudy.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyStudy.test.ts
@@ -1,0 +1,123 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
+import { vi } from "vitest";
+import type { ScraperSession } from "../types";
+import {
+  discoverWhiskyStudyArticles,
+  parseWhiskyStudyArticle,
+  whiskyStudyAdapter,
+  type WhiskyStudyCursor,
+  type WhiskyStudyObservation,
+} from "./whiskyStudy";
+
+const FIRST_URL = "https://thewhiskystudy.com/reviews-3/example-scotch-review";
+const SECOND_URL = "https://thewhiskystudy.com/reviews-3/second-scotch-review";
+
+test("discovers only 20 current Scotch article cards", async () => {
+  const index = await loadFixture("whiskystudy", "index.html");
+  const expandedIndex = index.replace(
+    "</main>",
+    `${Array.from(
+      { length: 20 },
+      (_, index) =>
+        `<article class="blog-item"><a href="/reviews-3/generated-${index}">Generated ${index}</a></article>`,
+    ).join("")}</main>`,
+  );
+
+  expect(discoverWhiskyStudyArticles(index).map((url) => url.href)).toEqual([
+    FIRST_URL,
+    SECOND_URL,
+  ]);
+  expect(discoverWhiskyStudyArticles(expandedIndex)).toHaveLength(20);
+  expect(discoverWhiskyStudyArticles(expandedIndex).at(-1)?.pathname).toBe(
+    "/reviews-3/generated-17",
+  );
+});
+
+test("extracts source facts and only direct tasting paragraphs", async () => {
+  const html = await loadFixture("whiskystudy", "review.html");
+  const parsed = parseWhiskyStudyArticle(html, new URL(FIRST_URL));
+  const decimalScore = parseWhiskyStudyArticle(
+    html.replace("Score: 92", "Score: 92,5 / 100"),
+    new URL(FIRST_URL),
+  );
+
+  expect(parsed?.article).toMatchObject({
+    canonicalUrl: FIRST_URL,
+    title: "Example Scotch 18 Year Shelf Review",
+    publishedAt: new Date("2026-07-04T19:03:15.000Z"),
+    contentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+    reviews: [
+      {
+        name: "Example Scotch 18 Year",
+        reviewerName: "Chris Ellis",
+        nativeScore: { value: 92, scale: 100, display: "92/100" },
+        normalizedRating: 92,
+      },
+    ],
+  });
+  expect(decimalScore?.article.reviews[0]).toMatchObject({
+    nativeScore: { value: 92.5, scale: 100, display: "92,5/100" },
+    normalizedRating: 93,
+  });
+  expect(Object.values(parsed?.reviewTexts ?? {})).toEqual([
+    "Nose: Orchard fruit and soft wax. Palate: Malt, citrus, and gentle oak. Finish: Long and lightly spiced.",
+  ]);
+  expect(Object.values(parsed?.reviewTexts ?? {}).join(" ")).not.toMatch(
+    /introduction|price|age:|review date|final thoughts/iu,
+  );
+});
+
+test("skips a clear non-review but rejects an incomplete review", async () => {
+  const html = await loadFixture("whiskystudy", "review.html");
+
+  expect(
+    parseWhiskyStudyArticle(
+      html.replaceAll(/(?:Nose|Palate|Finish):/gu, "Background:"),
+      new URL(FIRST_URL),
+    ),
+  ).toBeNull();
+  expect(() =>
+    parseWhiskyStudyArticle(
+      html.replace("Score: 92", "Score unavailable"),
+      new URL(FIRST_URL),
+    ),
+  ).toThrow("The Whisky Study score is missing or invalid.");
+});
+
+test("resumes without requesting a completed current article", async () => {
+  const index = await loadFixture("whiskystudy", "index.html");
+  const article = (await loadFixture("whiskystudy", "review.html")).replaceAll(
+    "example-scotch-review",
+    "second-scotch-review",
+  );
+  const emit = vi.fn();
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body: url.pathname === "/reviews-3" ? index : article,
+  }));
+  const session: ScraperSession<WhiskyStudyCursor, WhiskyStudyObservation> = {
+    request,
+    emit,
+    checkpoint,
+    remainingRequests: () => 22,
+  };
+
+  await whiskyStudyAdapter({
+    cursor: { processedArticleUrls: [FIRST_URL] },
+    session,
+  });
+
+  expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
+    "https://thewhiskystudy.com/reviews-3",
+    SECOND_URL,
+  ]);
+  expect(emit).toHaveBeenCalledWith(
+    expect.objectContaining({ sourceKey: SECOND_URL, itemCount: 1 }),
+  );
+  expect(checkpoint).toHaveBeenCalledWith({
+    processedArticleUrls: [FIRST_URL, SECOND_URL],
+  });
+});

--- a/apps/server/src/scraper/adapters/whiskyStudy.ts
+++ b/apps/server/src/scraper/adapters/whiskyStudy.ts
@@ -14,22 +14,23 @@ import {
 } from "./currentReviews";
 import { parseDate } from "./dates";
 
-// This adapter owns Whisky Saga parsing. The shared scraper runtime owns every
-// remote request and the shared review sink owns storage.
-const ORIGIN = "https://www.whiskysaga.com";
-const TARGET = "whiskysaga";
+// This adapter owns The Whisky Study parsing. The shared scraper runtime owns
+// every remote request and the shared review sink owns storage.
+const ORIGIN = "https://thewhiskystudy.com";
+const TARGET = "whiskystudy";
 const MAX_CURRENT_ARTICLES = 20;
-const ARTICLE_PATH = /^\/blog\/[a-z0-9][a-z0-9-]*$/u;
+const ARTICLE_PATH = /^\/reviews-3\/[a-z0-9][a-z0-9-]*$/u;
 const TASTING_PARAGRAPH = /^(?:Nose|Palate|Taste|Finish)\s*:/iu;
-const SCORE = /^Score\s*:?\s*(?<value>\d{1,3}(?:[.,]\d+)?)\s*\/\s*100\s*$/iu;
+const SCORE =
+  /^Score\s*:\s*(?<value>\d{1,3}(?:[.,]\d+)?)(?:\s*\/\s*100)?\s*$/iu;
 
-export const WhiskySagaCursorSchema =
+export const WhiskyStudyCursorSchema =
   currentReviewCursorSchema(MAX_CURRENT_ARTICLES);
 
-export const WhiskySagaObservationSchema = ReviewArticleIngestionSchema;
+export const WhiskyStudyObservationSchema = ReviewArticleIngestionSchema;
 
-export type WhiskySagaCursor = z.infer<typeof WhiskySagaCursorSchema>;
-export type WhiskySagaObservation = ReviewArticleIngestion;
+export type WhiskyStudyCursor = z.infer<typeof WhiskyStudyCursorSchema>;
+export type WhiskyStudyObservation = ReviewArticleIngestion;
 
 function normalizeText(value: string): string {
   return value.replaceAll(/\s+/g, " ").trim();
@@ -48,7 +49,7 @@ function articleUrl(value: string): URL | null {
   }
 }
 
-export function discoverWhiskySagaArticles(data: string): URL[] {
+export function discoverWhiskyStudyArticles(data: string): URL[] {
   const $ = cheerio(data);
   const articles = new Map<string, URL>();
 
@@ -58,6 +59,11 @@ export function discoverWhiskySagaArticles(data: string): URL[] {
   });
 
   return [...articles.values()].slice(0, MAX_CURRENT_ARTICLES);
+}
+
+function bottleName(title: string): string | null {
+  const name = normalizeText(title.replace(/\s+(?:Shelf\s+)?Review$/iu, ""));
+  return name || null;
 }
 
 function reviewScore(value: string) {
@@ -81,16 +87,16 @@ function reviewScore(value: string) {
 
 function sourceKey(canonicalUrl: string): string {
   const digest = createHash("sha256").update(canonicalUrl).digest("hex");
-  return `whiskysaga:${digest}`;
+  return `whiskystudy:${digest}`;
 }
 
-export function parseWhiskySagaArticle(
+export function parseWhiskyStudyArticle(
   data: string,
   rawCanonicalUrl: URL,
-): WhiskySagaObservation | null {
+): WhiskyStudyObservation | null {
   const $ = cheerio(data);
   const article = $("article.h-entry").first();
-  const paragraphs = article.find(".blog-item-content p").toArray();
+  const paragraphs = article.find("p").toArray();
   const reviewText = normalizeText(
     paragraphs
       .map((element) => normalizeText($(element).text()))
@@ -102,24 +108,29 @@ export function parseWhiskySagaArticle(
   const canonicalUrl = articleUrl(
     $('link[rel="canonical"]').first().attr("href") ?? rawCanonicalUrl.href,
   );
-  if (!canonicalUrl) throw new Error("Invalid Whisky Saga article URL.");
+  if (!canonicalUrl) throw new Error("Invalid The Whisky Study article URL.");
 
   const title = normalizeText(article.find("h1.entry-title").first().text());
+  const name = bottleName(title);
   const metadata = parseArticleMetadata(data);
-  const score = paragraphs
+  const score = article
+    .find("h1,h2,h3,h4,p")
+    .toArray()
     .map((element) => reviewScore($(element).text()))
     .find((value) => value !== null);
   const publishedAt = metadata ? parseDate(metadata.datePublished) : null;
-  if (!title) throw new Error("Whisky Saga article title is missing.");
-  if (!metadata?.author) throw new Error("Whisky Saga reviewer is missing.");
+  if (!title) throw new Error("The Whisky Study article title is missing.");
+  if (!name) throw new Error("The Whisky Study Bottle name is missing.");
+  if (!metadata?.author)
+    throw new Error("The Whisky Study reviewer is missing.");
   if (!publishedAt)
-    throw new Error("Whisky Saga article date is missing or invalid.");
-  if (!score) throw new Error("Whisky Saga score is missing or invalid.");
+    throw new Error("The Whisky Study article date is missing or invalid.");
+  if (!score) throw new Error("The Whisky Study score is missing or invalid.");
 
   const reviewSourceKey = sourceKey(canonicalUrl.href);
   const review = {
     sourceKey: reviewSourceKey,
-    name: title,
+    name,
     category: null,
     reviewerName: metadata.author,
     nativeScore: score.nativeScore,
@@ -127,7 +138,7 @@ export function parseWhiskySagaArticle(
   };
   const contentText = JSON.stringify({ review, reviewText });
 
-  return WhiskySagaObservationSchema.parse({
+  return WhiskyStudyObservationSchema.parse({
     article: {
       canonicalUrl: canonicalUrl.href,
       title,
@@ -140,21 +151,21 @@ export function parseWhiskySagaArticle(
   });
 }
 
-export const whiskySagaAdapter: ScraperAdapter<
-  WhiskySagaCursor,
-  WhiskySagaObservation
+export const whiskyStudyAdapter: ScraperAdapter<
+  WhiskyStudyCursor,
+  WhiskyStudyObservation
 > = async ({ cursor, session }) => {
   const indexResponse = await session.request({
     target: TARGET,
-    url: new URL("/blog/category/Scotland", ORIGIN),
+    url: new URL("/reviews-3", ORIGIN),
   });
-  const articleUrls = discoverWhiskySagaArticles(indexResponse.body);
+  const articleUrls = discoverWhiskyStudyArticles(indexResponse.body);
   await processCurrentReviews({
     target: TARGET,
     articles: articleUrls,
     articleUrl: (url) => url,
     cursor,
     session,
-    parse: (response) => parseWhiskySagaArticle(response.body, response.url),
+    parse: (response) => parseWhiskyStudyArticle(response.body, response.url),
   });
 };

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -57,6 +57,7 @@ const migratedSources = [
   "whiskyfun",
   "whiskynotes",
   "whiskysaga",
+  "whiskystudy",
   "whiskyworld",
   "woodencork",
   "wordsofwhisky",
@@ -147,6 +148,13 @@ test("registers every scraper source with explicit target ownership", () => {
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("whiskysaga")?.requestLimit).toBe(22);
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskystudy.runEvery).toBe(1440);
+  expect(scraperRegistry.targets.get("whiskystudy")).toMatchObject({
+    minimumSpacingMs: 2_500,
+    requestsPerWindow: 25,
+    windowMs: 3_600_000,
+  });
+  expect(scraperRegistry.sources.get("whiskystudy")?.requestLimit).toBe(22);
   expect(EXTERNAL_SITE_DEFINITIONS.wordsofwhisky.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("wordsofwhisky")).toMatchObject({
     minimumSpacingMs: 2_500,

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -75,6 +75,11 @@ import {
   WhiskySagaObservationSchema,
 } from "./adapters/whiskySaga";
 import {
+  whiskyStudyAdapter,
+  WhiskyStudyCursorSchema,
+  WhiskyStudyObservationSchema,
+} from "./adapters/whiskyStudy";
+import {
   wordsOfWhiskyAdapter,
   WordsOfWhiskyCursorSchema,
   WordsOfWhiskyObservationSchema,
@@ -333,6 +338,17 @@ export const scraperRegistry = createScraperRegistry({
       ],
     }),
     defineScrapeTarget({
+      key: "whiskystudy",
+      minimumSpacingMs: 2_500,
+      requestsPerWindow: 25,
+      origins: [
+        {
+          origin: "https://thewhiskystudy.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
+    defineScrapeTarget({
       key: "wordsofwhisky",
       minimumSpacingMs: 2_500,
       requestsPerWindow: 25,
@@ -447,6 +463,16 @@ export const scraperRegistry = createScraperRegistry({
       cursorSchema: WhiskySagaCursorSchema,
       observationSchema: WhiskySagaObservationSchema,
       adapter: whiskySagaAdapter,
+      sink: externalReviewSink,
+    }),
+    defineScraperSource({
+      key: "whiskystudy",
+      externalSiteType: "whiskystudy",
+      targetKeys: ["whiskystudy"],
+      requestLimit: 22,
+      cursorSchema: WhiskyStudyCursorSchema,
+      observationSchema: WhiskyStudyObservationSchema,
+      adapter: whiskyStudyAdapter,
       sink: externalReviewSink,
     }),
     defineScraperSource({

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -249,6 +249,15 @@ cache is stale. The adapter stores the exact publication timestamp, author,
 canonical link, and native 100-point score. Only direct nose, taste, palate,
 and finish paragraphs stay transient for summary generation.
 
+The Whisky Study runs once per day. It reads only the 20 article cards on the
+first public Scotch review index page. It does not request older pagination,
+the sitemap, search, query filters, or Squarespace APIs. Requests are at least
+2.5 seconds apart. The target allows 25 requests per hour, and each worker pass
+stops after 21 source requests plus the governed robots request when its cache
+is stale. The adapter stores the exact publication timestamp, author, canonical
+link, and native 100-point score. Only direct nose, taste, palate, and finish
+paragraphs stay transient for summary generation.
+
 Enable automatic publication only after the reviewed sample passes the gate.
 Use the same source-specific process for each later publisher. Do not add a
 generic crawler only because several sources use RSS or HTML.

--- a/docs/research/external-review-content-supply.md
+++ b/docs/research/external-review-content-supply.md
@@ -49,6 +49,7 @@ site-specific search; it does not mean unrestricted use is allowed.
 | P0         | [Dramface](https://www.dramface.com/)                         | Reviews most weekdays, multiple writers, frequent multi-bottle articles           | Public pages allowed; Squarespace rules block API, JSON, search, account, and other internal paths         | No dedicated terms page linked in the public footer                                                                                               | `public_index`, ongoing-feed pilot            |
 | P0         | [Whisky Advocate](https://whiskyadvocate.com/ratings-reviews) | Existing Peated source; publisher describes an archive of more than 6,000 reviews | Ratings paths allowed for general crawlers; GPTBot, ChatGPT-User, and CCBot are blocked                    | Privacy policy references general terms, but no public general terms page or review-reuse restriction was located                                 | `public_index`, second bounded pilot          |
 | P0         | [Whisky Saga](https://www.whiskysaga.com/)                    | Active scored reviews; the Scotland category contains more than 2,000 articles    | Public category and article paths allowed; Squarespace APIs, search, filters, and internal formats blocked | Privacy and editorial pages contain no automated-access restriction                                                                               | `public_index`, daily Scotch feed             |
+| P1         | [The Whisky Study](https://thewhiskystudy.com/reviews-3)      | Active single-Bottle Scotch reviews with explicit dates and 100-point scores      | Public index and article paths allowed; Squarespace APIs, search, filters, and internal formats blocked    | No dedicated terms or privacy page is linked in the public navigation                                                                             | `public_index`, daily Scotch feed             |
 | P1         | [Whisky Magazine](https://www.whiskymag.com/search/tastings/) | Structured tasting archive spanning more than 200 magazine issues                 | Verification failed because the server reset the automated request                                         | Terms prohibit automated access, aggregation, and commercial reuse without written permission                                                     | `licensed_only`                               |
 | P1         | [Malt](https://malt-review.com/)                              | Large historical review archive with multiple contributors                        | Automated requests returned HTTP 429 during the audit                                                      | No current terms page verified because automated access was rate-limited                                                                          | `do_not_ingest`; do not work around the block |
 | P1         | [Breaking Bourbon](https://www.breakingbourbon.com/)          | Deep American whiskey archive with structured ratings and reviewers               | robots file exposes a sitemap and no reviewed article-path restriction                                     | Terms prohibit robots, spiders, retrieval/indexing applications, and reuse without written consent                                                | `licensed_only`                               |
@@ -111,6 +112,24 @@ a separate platform-terms and creator-rights review.
   It does not use the full sitemap, archive pagination, search, query filters,
   or Squarespace APIs. Only direct nose, taste, palate, and finish paragraphs
   stay transient for summary generation.
+
+### The Whisky Study
+
+- Evidence: [Scotch reviews](https://thewhiskystudy.com/reviews-3),
+  [scoring method](https://thewhiskystudy.com/scoring),
+  [about](https://thewhiskystudy.com/about), and
+  [robots.txt](https://thewhiskystudy.com/robots.txt).
+- Rechecked on 2026-08-21. Robots allow the public Scotch index and article
+  paths. They block Squarespace APIs, search, query filters, and internal
+  formats. No dedicated terms or privacy page is linked in the public
+  navigation.
+- The first Scotch index page displays 20 current posts. Review articles expose
+  an exact timestamp, author, Bottle title, direct tasting sections, and a
+  100-point score.
+- The implemented daily feed reads only those 20 current article cards. It does
+  not follow older pagination or use the sitemap, search, query filters, or
+  Squarespace APIs. Only direct nose, taste, palate, and finish paragraphs stay
+  transient for summary generation.
 
 ### Dramface
 
@@ -283,7 +302,8 @@ boundary.
 7. Bourbon Culture supplies the next daily American whiskey feed.
 8. Fred Minnick supplies a low-cadence daily American whiskey review feed.
 9. Whisky Saga supplies the next daily Scotch review feed.
-10. Continue through the reviewed public-index candidates until Peated has at
+10. The Whisky Study supplies the next daily Scotch review feed.
+11. Continue through the reviewed public-index candidates until Peated has at
     least 12 reliable feeds.
 
 The pilot is successful with at least 90% article extraction accuracy on a

--- a/openspec/changes/add-whisky-study-review-feed/.openspec.yaml
+++ b/openspec/changes/add-whisky-study-review-feed/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/add-whisky-study-review-feed/design.md
+++ b/openspec/changes/add-whisky-study-review-feed/design.md
@@ -1,0 +1,67 @@
+## Context
+
+The Whisky Study publishes current Scotch reviews on a public Squarespace
+index. The first page shows 20 articles. Each article exposes a canonical URL,
+publication timestamp, author, Bottle title, direct tasting sections, and a
+100-point score. Robots allow the public index and article paths. They block
+Squarespace APIs, search, query filters, and internal formats.
+
+Peated already owns the shared review schema, current-window lifecycle, Bottle
+matcher, sink, publication policy, robots enforcement, and request controls.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add up to 20 current scored Scotch reviews without a schema or API change.
+- Preserve canonical links, publication dates, Bottle names, reviewer
+  attribution, and native 100-point scores.
+- Run daily through the shared governed runtime.
+
+**Non-Goals:**
+
+- Backfill older index pages or the full sitemap.
+- Read search, query filters, or Squarespace APIs.
+- Index non-Scotch categories or build a generic Squarespace crawler.
+- Persist publisher HTML, images, introductions, conclusions, or full prose.
+
+## Decisions
+
+### Use the first Scotch review index page
+
+The adapter reads `/reviews-3` and accepts at most 20 unique same-origin
+`/reviews-3/<slug>` article links from its article cards. It does not follow the
+Older Posts link. This gives a bounded current feed with one discovery request.
+
+The homepage mixes several whisky regions. Pagination and the sitemap expose
+older content that is outside this change.
+
+### Read article facts from their owning elements
+
+The adapter reads the canonical link and article title from the page. It reads
+the publication timestamp and author from public structured metadata. It
+removes a trailing `Review` or `Shelf Review` label from the title for the
+Bottle name. It parses the published 100-point score with the shared rating
+normalizer.
+
+The adapter sends only paragraphs labeled nose, taste, palate, or finish to the
+transient summary boundary. It excludes product background, specifications,
+images, final thoughts, scores, purchase links, and comments.
+
+### Reuse the shared current-review lifecycle
+
+The adapter emits the shared article ingestion schema. The shared lifecycle
+checkpoints each completed article and keeps only URLs in the current discovery
+window. The shared runtime owns every request, and the shared sink owns matching
+and storage.
+
+## Risks / Trade-offs
+
+- **A non-review enters the Scotch index** → Checkpoint a page only when it has
+  no direct tasting section. Fail a review-shaped page that lacks required
+  facts.
+- **More than 20 new articles arrive between runs** → The daily 20-item window
+  matches the publisher page size and bounds traffic. Older stored reviews
+  remain.
+- **Squarespace markup changes** → Keep parsing source-specific and cover the
+  current index and article shapes with fixtures and a governed live check.

--- a/openspec/changes/add-whisky-study-review-feed/proposal.md
+++ b/openspec/changes/add-whisky-study-review-feed/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Peated needs more current, independent Scotch coverage. The Whisky Study
+publishes structured single-Bottle Scotch reviews with dates and scores, but
+Peated does not index them.
+
+## What Changes
+
+- Add The Whisky Study as a scheduled external-review source.
+- Read at most 20 current articles from its public Scotch review index.
+- Store each article's canonical link, publication date, Bottle name, reviewer,
+  and native 100-point score.
+- Send only direct nose, palate, taste, and finish sections through the existing
+  transient summary boundary.
+- Reuse the shared review sink, Bottle matcher, request controls, robots
+  enforcement, and publication policy.
+
+## Capabilities
+
+### New Capabilities
+
+- `external-review-feeds`: Bounded ingestion of current The Whisky Study Scotch
+  reviews through the shared external-review boundary.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds one external-site definition and one source-specific scraper adapter.
+- Adds fixture-backed parser and runtime registration tests.
+- Adds no database schema, API, model, or UI changes.

--- a/openspec/changes/add-whisky-study-review-feed/specs/external-review-feeds/spec.md
+++ b/openspec/changes/add-whisky-study-review-feed/specs/external-review-feeds/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: The Whisky Study discovery is bounded to current Scotch reviews
+
+The system SHALL discover at most 20 current The Whisky Study articles from the
+public Scotch review index and SHALL fetch them through the shared scraper
+runtime.
+
+#### Scenario: Scheduled current-review run
+
+- **WHEN** the daily source run reads the Scotch review index
+- **THEN** it considers only 20 unique same-origin article URLs from current
+  article cards
+- **AND** all requests use the registered origin, robots rules, spacing, quota,
+  retry, and backoff controls
+
+#### Scenario: Deferred run resumes
+
+- **WHEN** a run is deferred after it stores an article
+- **THEN** the resumed run does not request that completed current article
+  again
+
+### Requirement: The Whisky Study article facts remain source-accurate
+
+The system SHALL store each complete current article by canonical URL with its
+title, explicit publication date, Bottle name, reviewer, native 100-point
+score, and normalized compatibility rating.
+
+#### Scenario: Complete single-Bottle review
+
+- **WHEN** a current article has a canonical URL, title, author, explicit date,
+  direct tasting section, and valid 100-point score
+- **THEN** the system stores one scored review for that Bottle
+
+#### Scenario: Clear non-review article
+
+- **WHEN** a selected article has no direct tasting section
+- **THEN** the adapter skips and checkpoints it
+
+#### Scenario: Review-shaped article is incomplete
+
+- **WHEN** a selected article has tasting text but lacks a required fact or a
+  valid score
+- **THEN** the adapter fails without checkpointing that article
+
+### Requirement: The Whisky Study prose remains transient
+
+The system MUST NOT persist The Whisky Study HTML, full review prose,
+publisher images, product background, final thoughts, or comments as source
+content.
+
+#### Scenario: Review text is processed
+
+- **WHEN** source policy permits Peated to generate a review summary
+- **THEN** the adapter passes only direct nose, taste, palate, and finish
+  paragraphs through the existing transient summary boundary
+- **AND** stored output contains only permitted structured facts, derived
+  summary data, content hash, and canonical link

--- a/openspec/changes/add-whisky-study-review-feed/tasks.md
+++ b/openspec/changes/add-whisky-study-review-feed/tasks.md
@@ -1,0 +1,14 @@
+## 1. Source Adapter
+
+- [x] 1.1 Add fixture-backed bounded Scotch discovery and article parsing
+- [x] 1.2 Add resumable execution for the 20-article current window
+
+## 2. Runtime Registration
+
+- [x] 2.1 Register The Whisky Study as a governed daily review source
+- [x] 2.2 Prove registry ownership and shared review boundaries in tests
+
+## 3. Documentation And Verification
+
+- [x] 3.1 Update source research and operating documentation
+- [x] 3.2 Run focused tests, typecheck, lint, format, a governed live acceptance run, and strict OpenSpec validation


### PR DESCRIPTION
Adds The Whisky Study as a daily external-review source for current Scotch coverage. It reads at most 20 articles from the first public Scotch review index page and records each canonical link, exact publication timestamp, Bottle name, reviewer, native 100-point score, and normalized rating. Only direct nose, taste, palate, and finish paragraphs enter the existing transient summary path.

The source reuses the shared current-review lifecycle, Bottle matcher, review sink, and policy controls. The common Squarespace JSON-LD article parser is now shared with Whisky Saga, while discovery and content selectors remain source-specific. The governed runtime enforces robots rules, 2.5-second spacing, a 25-request hourly quota, and a 22-request run limit. A live governed run completed with 20 reviews and 22 total requests. This adds no database, API, model, or UI changes.
