### PR TITLE
feat(scraper): backfill WhiskyNotes review history

### DIFF
--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -93,7 +93,7 @@ export const EXTERNAL_SITE_DEFINITIONS = {
   },
   whiskynotes: {
     name: "WhiskyNotes",
-    runEvery: null,
+    runEvery: 1440,
     content: "reviews",
   },
   wordsofwhisky: {

--- a/apps/server/src/scraper/adapters/whiskyNotes.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyNotes.test.ts
@@ -5,6 +5,7 @@ import {
   discoverWhiskyNotesArticles,
   parseWhiskyNotesArticle,
   whiskyNotesAdapter,
+  WhiskyNotesCursorSchema,
   type WhiskyNotesCursor,
   type WhiskyNotesObservation,
 } from "./whiskyNotes";
@@ -72,7 +73,13 @@ test("extracts multi-bottle reviews with stable source keys", async () => {
   );
 });
 
-test("limits discovery to five archive pages", async () => {
+async function runAdapter(
+  cursor: WhiskyNotesCursor | null,
+  {
+    emptyCurrent = false,
+    endPage,
+  }: { emptyCurrent?: boolean; endPage?: number } = {},
+) {
   const archive = await loadFixture("whiskynotes", "archive.html");
   const singleReview = await loadFixture("whiskynotes", "single-review.html");
   const multiReview = await loadFixture("whiskynotes", "multi-review.html");
@@ -82,16 +89,23 @@ test("limits discovery to five archive pages", async () => {
     if (url.pathname === "/" || url.pathname.startsWith("/page/")) {
       const page =
         url.pathname === "/" ? 1 : Number(url.pathname.split("/")[2]);
+      let body = archive
+        .replaceAll("kanekou-okinawa-whisky", `single-review-${page}`)
+        .replaceAll(
+          "bowmore-2005-ben-nevis-1996-whisky-agency",
+          `multi-review-${page}`,
+        );
+      if (endPage !== undefined && page >= endPage) {
+        body = body.replace(/<link rel="next"[^>]+>/, "");
+      }
+      if (emptyCurrent && page === 1) {
+        body = '<html><head><link rel="next"></head><body></body></html>';
+      }
       return {
         url,
         status: 200,
         headers: {},
-        body: archive
-          .replaceAll("kanekou-okinawa-whisky", `single-review-${page}`)
-          .replaceAll(
-            "bowmore-2005-ben-nevis-1996-whisky-agency",
-            `multi-review-${page}`,
-          ),
+        body,
       };
     }
     return {
@@ -112,21 +126,137 @@ test("limits discovery to five archive pages", async () => {
     remainingRequests: () => 100,
   };
 
-  await whiskyNotesAdapter({ cursor: null, session });
+  await whiskyNotesAdapter({ cursor, session });
 
-  expect(observations).toHaveLength(10);
-  expect(new Set(observations.map(({ sourceKey }) => sourceKey))).toHaveLength(
-    10,
-  );
-  expect(request).toHaveBeenCalledTimes(15);
-  expect(
-    request.mock.calls.some(([{ url }]) => url.pathname === "/page/6/"),
-  ).toBe(false);
-  expect(checkpoints.at(-1)).toMatchObject({
+  return { checkpoints, observations, request };
+}
+
+test("continues four archive pages per run and refreshes the current page", async () => {
+  const first = await runAdapter(null);
+
+  expect(first.observations).toHaveLength(8);
+  expect(first.request).toHaveBeenCalledTimes(12);
+  expect(first.checkpoints.at(-1)).toEqual({
     page: 5,
-    processedArticleUrls: expect.arrayContaining([
-      "https://www.whiskynotes.be/2026/world/single-review-5/",
-      "https://www.whiskynotes.be/2026/bowmore/multi-review-5/",
-    ]),
+    processedArticleUrls: [],
+    currentArticleUrls: [
+      "https://www.whiskynotes.be/2026/world/single-review-1/",
+      "https://www.whiskynotes.be/2026/bowmore/multi-review-1/",
+    ],
+    historyComplete: false,
   });
+
+  const second = await runAdapter(first.checkpoints.at(-1)!);
+
+  expect(second.observations).toHaveLength(8);
+  expect(second.request).toHaveBeenCalledTimes(13);
+  expect(
+    second.request.mock.calls.some(([{ url }]) => url.pathname === "/page/9/"),
+  ).toBe(false);
+  expect(second.checkpoints.at(-1)).toMatchObject({
+    page: 9,
+    processedArticleUrls: [],
+    historyComplete: false,
+  });
+});
+
+test("resumes within a history page without requesting stored articles", async () => {
+  const cursor = WhiskyNotesCursorSchema.parse({
+    page: 3,
+    processedArticleUrls: [
+      "https://www.whiskynotes.be/2026/world/single-review-3/",
+    ],
+    currentArticleUrls: [
+      "https://www.whiskynotes.be/2026/world/single-review-1/",
+      "https://www.whiskynotes.be/2026/bowmore/multi-review-1/",
+    ],
+    historyComplete: false,
+  });
+
+  const result = await runAdapter(cursor);
+
+  expect(result.observations).toHaveLength(7);
+  expect(
+    result.request.mock.calls.some(([{ url }]) =>
+      url.pathname.includes("single-review-3"),
+    ),
+  ).toBe(false);
+  expect(
+    result.request.mock.calls.some(([{ url }]) =>
+      url.pathname.includes("multi-review-3"),
+    ),
+  ).toBe(true);
+  expect(result.checkpoints.at(-1)).toMatchObject({
+    page: 7,
+    processedArticleUrls: [],
+  });
+});
+
+test("ingests a new current review while history points to an older page", async () => {
+  const cursor = WhiskyNotesCursorSchema.parse({
+    page: 5,
+    processedArticleUrls: [],
+    currentArticleUrls: [
+      "https://www.whiskynotes.be/2026/world/single-review-1/",
+    ],
+    historyComplete: false,
+  });
+
+  const result = await runAdapter(cursor);
+
+  expect(result.observations.at(0)?.sourceKey).toBe(
+    "https://www.whiskynotes.be/2026/bowmore/multi-review-1/",
+  );
+  expect(
+    result.request.mock.calls.some(([{ url }]) =>
+      url.pathname.includes("single-review-1"),
+    ),
+  ).toBe(false);
+});
+
+test("stops history at the archive end but keeps checking current reviews", async () => {
+  const cursor = WhiskyNotesCursorSchema.parse({
+    page: 3,
+    processedArticleUrls: [],
+    currentArticleUrls: [
+      "https://www.whiskynotes.be/2026/world/single-review-1/",
+      "https://www.whiskynotes.be/2026/bowmore/multi-review-1/",
+    ],
+    historyComplete: false,
+  });
+
+  const completed = await runAdapter(cursor, { endPage: 3 });
+  const completedCursor = completed.checkpoints.at(-1)!;
+  expect(completedCursor).toMatchObject({
+    page: 3,
+    historyComplete: true,
+  });
+
+  const currentOnly = await runAdapter(completedCursor, { endPage: 3 });
+  expect(currentOnly.observations).toHaveLength(0);
+  expect(currentOnly.request).toHaveBeenCalledTimes(1);
+  expect(currentOnly.request).toHaveBeenCalledWith({
+    target: "whiskynotes",
+    url: new URL("https://www.whiskynotes.be/"),
+  });
+});
+
+test("accepts cursors stored by the bounded pilot adapter", () => {
+  expect(
+    WhiskyNotesCursorSchema.parse({
+      page: 5,
+      processedArticleUrls: ["https://www.whiskynotes.be/2026/world/example/"],
+    }),
+  ).toEqual({
+    page: 5,
+    processedArticleUrls: ["https://www.whiskynotes.be/2026/world/example/"],
+    currentArticleUrls: [],
+    historyComplete: false,
+  });
+});
+
+test("does not treat an empty current listing as completed history", async () => {
+  await expect(runAdapter(null, { emptyCurrent: true })).rejects.toThrow(
+    "WhiskyNotes current archive contains no review articles.",
+  );
 });

--- a/apps/server/src/scraper/adapters/whiskyNotes.ts
+++ b/apps/server/src/scraper/adapters/whiskyNotes.ts
@@ -10,7 +10,7 @@ import { parseDate } from "./dates";
 
 const ORIGIN = "https://www.whiskynotes.be";
 const TARGET = "whiskynotes";
-const MAX_DISCOVERY_PAGES = 5;
+const MAX_HISTORY_PAGES_PER_RUN = 4;
 const MAX_ARTICLES_PER_PAGE = 20;
 const ARTICLE_PATH = /^\/\d{4}\/[^/]+\/[^/]+\/$/;
 const EXCLUDED_CATEGORIES = new Set([
@@ -25,8 +25,10 @@ const EXCLUDED_CATEGORIES = new Set([
 
 export const WhiskyNotesCursorSchema = z
   .object({
-    page: z.number().int().min(1).max(MAX_DISCOVERY_PAGES),
+    page: z.number().int().min(1),
     processedArticleUrls: z.array(z.url()).max(MAX_ARTICLES_PER_PAGE),
+    currentArticleUrls: z.array(z.url()).max(MAX_ARTICLES_PER_PAGE).default([]),
+    historyComplete: z.boolean().default(false),
   })
   .strict();
 
@@ -203,40 +205,92 @@ export const whiskyNotesAdapter: ScraperAdapter<
 > = async ({ cursor, session }) => {
   let page = cursor?.page ?? 1;
   let processedArticleUrls = new Set(cursor?.processedArticleUrls ?? []);
+  let currentArticleUrls = new Set(cursor?.currentArticleUrls ?? []);
+  let historyComplete = cursor?.historyComplete ?? false;
 
-  while (page <= MAX_DISCOVERY_PAGES) {
-    const listingResponse = await session.request({
-      target: TARGET,
-      url: archiveUrl(page),
+  const checkpoint = async () => {
+    await session.checkpoint({
+      page,
+      processedArticleUrls: [...processedArticleUrls],
+      currentArticleUrls: [...currentArticleUrls],
+      historyComplete,
     });
+  };
+
+  const emitArticle = async (discoveredUrl: URL) => {
+    const articleResponse = await session.request({
+      target: TARGET,
+      url: discoveredUrl,
+    });
+    const observation = parseWhiskyNotesArticle(
+      articleResponse.body,
+      articleResponse.url,
+    );
+    await session.emit({
+      sourceKey: observation.article.canonicalUrl,
+      itemCount: observation.article.reviews.length,
+      value: observation,
+    });
+  };
+
+  const currentResponse = await session.request({
+    target: TARGET,
+    url: archiveUrl(1),
+  });
+  const currentUrls = discoverWhiskyNotesArticles(currentResponse.body);
+  if (currentUrls.length === 0) {
+    throw new Error("WhiskyNotes current archive contains no review articles.");
+  }
+  const currentUrlSet = new Set(currentUrls.map((url) => url.href));
+  currentArticleUrls = new Set(
+    [...currentArticleUrls].filter((url) => currentUrlSet.has(url)),
+  );
+
+  for (const discoveredUrl of currentUrls) {
+    const isHistoryPage = page === 1 && !historyComplete;
+    if (
+      currentArticleUrls.has(discoveredUrl.href) ||
+      (isHistoryPage && processedArticleUrls.has(discoveredUrl.href))
+    ) {
+      currentArticleUrls.add(discoveredUrl.href);
+      if (isHistoryPage) processedArticleUrls.add(discoveredUrl.href);
+      continue;
+    }
+    await emitArticle(discoveredUrl);
+    currentArticleUrls.add(discoveredUrl.href);
+    if (isHistoryPage) processedArticleUrls.add(discoveredUrl.href);
+    await checkpoint();
+  }
+  await checkpoint();
+
+  if (historyComplete) return;
+
+  let completedPages = 0;
+  while (completedPages < MAX_HISTORY_PAGES_PER_RUN) {
+    const listingResponse =
+      page === 1
+        ? currentResponse
+        : await session.request({
+            target: TARGET,
+            url: archiveUrl(page),
+          });
     const articleUrls = discoverWhiskyNotesArticles(listingResponse.body);
 
     for (const discoveredUrl of articleUrls) {
       if (processedArticleUrls.has(discoveredUrl.href)) continue;
-      const articleResponse = await session.request({
-        target: TARGET,
-        url: discoveredUrl,
-      });
-      const observation = parseWhiskyNotesArticle(
-        articleResponse.body,
-        articleResponse.url,
-      );
-      await session.emit({
-        sourceKey: observation.article.canonicalUrl,
-        itemCount: observation.article.reviews.length,
-        value: observation,
-      });
+      await emitArticle(discoveredUrl);
       processedArticleUrls.add(discoveredUrl.href);
-      await session.checkpoint({
-        page,
-        processedArticleUrls: [...processedArticleUrls],
-      });
+      await checkpoint();
     }
 
-    if (page === MAX_DISCOVERY_PAGES) return;
-    if (!hasNextArchivePage(cheerio(listingResponse.body))) return;
+    completedPages += 1;
+    if (!hasNextArchivePage(cheerio(listingResponse.body))) {
+      historyComplete = true;
+      await checkpoint();
+      return;
+    }
     page += 1;
     processedArticleUrls = new Set();
-    await session.checkpoint({ page, processedArticleUrls: [] });
+    await checkpoint();
   }
 };

--- a/apps/server/src/scraper/definitions.test.ts
+++ b/apps/server/src/scraper/definitions.test.ts
@@ -41,6 +41,7 @@ test("applies conservative target and run defaults", () => {
     maxRetries: 2,
   });
   expect(definition.requestLimit).toBe(100);
+  expect(definition.resumeFromLastRun).toBe(false);
 });
 
 test("allows sources to share one target and a target to declare several origins", () => {

--- a/apps/server/src/scraper/definitions.ts
+++ b/apps/server/src/scraper/definitions.ts
@@ -164,6 +164,7 @@ const SourceDefinitionSchema = z
       .positive()
       .max(DEFAULT_SCRAPER_REQUEST_POLICY.requestLimit)
       .default(DEFAULT_SCRAPER_REQUEST_POLICY.requestLimit),
+    resumeFromLastRun: z.boolean().default(false),
     cursorSchema: ZodSchemaSchema,
     observationSchema: ZodSchemaSchema,
     adapter: FunctionSchema,
@@ -203,9 +204,10 @@ export function defineScrapeTarget(
 export function defineScraperSource<TCursor, TObservation>(
   input: Omit<
     ScraperSourceDefinition<TCursor, TObservation>,
-    "requestLimit"
+    "requestLimit" | "resumeFromLastRun"
   > & {
     requestLimit?: number;
+    resumeFromLastRun?: boolean;
   },
 ): ScraperSourceDefinition<TCursor, TObservation> {
   return SourceDefinitionSchema.parse(

--- a/apps/server/src/scraper/lifecycle.test.ts
+++ b/apps/server/src/scraper/lifecycle.test.ts
@@ -95,6 +95,45 @@ test("manual review runs do not require a publication policy", async ({
   expect(enqueue).toHaveBeenCalledOnce();
 });
 
+test("opted-in source resumes the last successful run cursor", async ({
+  fixtures,
+}) => {
+  const requestedBy = await fixtures.User({ admin: true });
+  const site = await fixtures.ExternalSite({ type: "whiskynotes" });
+  const successfulCursor = {
+    page: 5,
+    processedArticleUrls: ["https://www.whiskynotes.be/2026/world/example/"],
+  };
+  await db.insert(externalSiteRuns).values([
+    {
+      externalSiteId: site.id,
+      trigger: "scheduled",
+      status: "succeeded",
+      cursor: successfulCursor,
+      completedAt: new Date("2026-08-20T00:00:00Z"),
+    },
+    {
+      externalSiteId: site.id,
+      trigger: "scheduled",
+      status: "failed",
+      cursor: { page: 8, processedArticleUrls: [] },
+      completedAt: new Date("2026-08-21T00:00:00Z"),
+    },
+  ]);
+
+  const run = await queueManualExternalSiteRun({
+    site,
+    requestedById: requestedBy.id,
+    enqueue: async () => undefined,
+  });
+
+  expect(run.cursor).toEqual({
+    ...successfulCursor,
+    currentArticleUrls: [],
+    historyComplete: false,
+  });
+});
+
 test("active run prevents overlap", async ({ fixtures }) => {
   const requestedBy = await fixtures.User({ admin: true });
   const site = await fixtures.ExternalSite({ type: "decadentdrinks" });

--- a/apps/server/src/scraper/lifecycle.ts
+++ b/apps/server/src/scraper/lifecycle.ts
@@ -5,7 +5,17 @@ import {
   type ExternalSite,
   type ExternalSiteRun,
 } from "@peated/server/db/schema";
-import { and, asc, eq, inArray, isNotNull, isNull, lte, or } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  isNotNull,
+  isNull,
+  lte,
+  or,
+} from "drizzle-orm";
 import {
   findScraperSourceBySiteType,
   requireEnabledScraperTargets,
@@ -68,6 +78,22 @@ async function insertRun(
     );
   }
   requireEnabledScraperTargets(registry, source);
+  let cursor = null;
+  if (source.resumeFromLastRun) {
+    const [priorRun] = await connection
+      .select({ cursor: externalSiteRuns.cursor })
+      .from(externalSiteRuns)
+      .where(
+        and(
+          eq(externalSiteRuns.externalSiteId, site.id),
+          eq(externalSiteRuns.status, "succeeded"),
+          isNotNull(externalSiteRuns.cursor),
+        ),
+      )
+      .orderBy(desc(externalSiteRuns.completedAt), desc(externalSiteRuns.id))
+      .limit(1);
+    cursor = priorRun ? source.cursorSchema.parse(priorRun.cursor) : null;
+  }
   const [run] = await connection
     .insert(externalSiteRuns)
     .values({
@@ -75,6 +101,7 @@ async function insertRun(
       trigger,
       requestedById,
       requestLimit: source.requestLimit,
+      cursor,
     })
     .returning();
   if (!run) throw new Error("Failed to create external site run.");

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -126,13 +126,16 @@ test("registers every scraper source with explicit target ownership", () => {
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("whiskyadvocate")?.requestLimit).toBe(30);
-  expect(EXTERNAL_SITE_DEFINITIONS.whiskynotes.runEvery).toBeNull();
+  expect(EXTERNAL_SITE_DEFINITIONS.whiskynotes.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskynotes")).toMatchObject({
     minimumSpacingMs: 2_500,
     requestsPerWindow: 30,
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("whiskynotes")?.requestLimit).toBe(30);
+  expect(scraperRegistry.sources.get("whiskynotes")?.resumeFromLastRun).toBe(
+    true,
+  );
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyfun.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskyfun")).toMatchObject({
     minimumSpacingMs: 2_500,

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -424,6 +424,7 @@ export const scraperRegistry = createScraperRegistry({
       externalSiteType: "whiskynotes",
       targetKeys: ["whiskynotes"],
       requestLimit: 30,
+      resumeFromLastRun: true,
       cursorSchema: WhiskyNotesCursorSchema,
       observationSchema: WhiskyNotesObservationSchema,
       adapter: whiskyNotesAdapter,

--- a/apps/server/src/scraper/types.ts
+++ b/apps/server/src/scraper/types.ts
@@ -48,6 +48,7 @@ export type ScraperSourceDefinition<TCursor = any, TObservation = any> = {
   externalSiteType: ExternalSiteType;
   targetKeys: readonly [string, ...string[]];
   requestLimit: number;
+  resumeFromLastRun: boolean;
   cursorSchema: z.ZodType<TCursor>;
   observationSchema: z.ZodType<TObservation>;
   adapter: ScraperAdapter<TCursor, TObservation>;

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -176,9 +176,12 @@ Use this sequence for each publisher:
 7. Require at least 90% extraction accuracy and acceptable Bottle-match
    precision. Record the result before setting the source to `automatic`.
 
-The WhiskyNotes pilot is manual-only. It checks at most five archive pages and
-20 article links on each page. Requests are at least 2.5 seconds apart. The
-target allows 30 requests per hour. Each worker pass stops after 30 requests.
+WhiskyNotes runs once per day. It checks the current archive page and advances
+at most four historical archive pages. Each page supplies at most 20 article
+links. A new run continues from the last successful run cursor. When the
+archive ends, later runs check only the current page. Requests are at least 2.5
+seconds apart. The target allows 30 requests per hour, and each worker pass
+stops after 30 requests.
 
 The Whisky Advocate pilot is also manual-only. It requests the issue index, the
 newest issue, and each listed review page to collect its explicit publication

--- a/docs/research/external-review-content-supply.md
+++ b/docs/research/external-review-content-supply.md
@@ -44,7 +44,7 @@ site-specific search; it does not mean unrestricted use is allowed.
 
 | Priority   | Source                                                        | Supply opportunity                                                                | robots.txt observation                                                                                     | Terms/reuse observation                                                                                                                           | Recommended mode                              |
 | ---------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
-| P0         | [WhiskyNotes](https://www.whiskynotes.be/)                    | About 6,600 reviews across 4,985 articles; new tasting notes every weekday        | Public article paths allowed; feed, search, downloads, and WordPress internals disallowed                  | No dedicated terms page located                                                                                                                   | `public_index`, first archive pilot           |
+| P0         | [WhiskyNotes](https://www.whiskynotes.be/)                    | About 6,600 reviews across 4,985 articles; new tasting notes every weekday        | Public article paths allowed; feed, search, downloads, and WordPress internals disallowed                  | No dedicated terms page located                                                                                                                   | `public_index`, daily archive import          |
 | P0         | [Whiskyfun](https://www.whiskyfun.com/)                       | About 22,700 whisky reviews dating to 2002                                        | No `Disallow` rule observed; unusual single `Allow` entry                                                  | No formal terms located; FAQ and disclosure discuss free commercial use                                                                           | `public_index`, later archive candidate       |
 | P0         | [Dramface](https://www.dramface.com/)                         | Reviews most weekdays, multiple writers, frequent multi-bottle articles           | Public pages allowed; Squarespace rules block API, JSON, search, account, and other internal paths         | No dedicated terms page linked in the public footer                                                                                               | `public_index`, ongoing-feed pilot            |
 | P0         | [Whisky Advocate](https://whiskyadvocate.com/ratings-reviews) | Existing Peated source; publisher describes an archive of more than 6,000 reviews | Ratings paths allowed for general crawlers; GPTBot, ChatGPT-User, and CCBot are blocked                    | Privacy policy references general terms, but no public general terms page or review-reuse restriction was located                                 | `public_index`, second bounded pilot          |
@@ -76,6 +76,9 @@ a separate platform-terms and creator-rights review.
   sections, and score. One document may review several bottles.
 - The feed is explicitly disallowed in robots.txt, so do not treat WordPress
   feed discovery as an ingestion path. Use only allowed article pages.
+- The daily importer checks the current page and advances at most four older
+  archive pages from its last successful cursor. It stops older-page requests
+  when the public archive ends.
 
 ### Whiskyfun
 
@@ -272,7 +275,8 @@ boundary.
 
 ## Source Sequence
 
-1. WhiskyNotes supplies the first current archive feed.
+1. WhiskyNotes supplies the first resumable historical archive import and a
+   daily current feed.
 2. Whisky Advocate supplies the existing large scored archive and current
    issue.
 3. Whiskyfun supplies the next daily multi-bottle feed. Keep its historical

--- a/openspec/changes/backfill-whiskynotes-review-history/.openspec.yaml
+++ b/openspec/changes/backfill-whiskynotes-review-history/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/backfill-whiskynotes-review-history/design.md
+++ b/openspec/changes/backfill-whiskynotes-review-history/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The WhiskyNotes adapter currently scans pages 1 through 5 in one manual run.
+Its run cursor supports retries and worker deferrals, but a later run starts
+with an empty cursor. The scraper runtime limits each run to ten worker attempts
+and 24 hours. A full archive crawl cannot fit inside one run under the source's
+30-request hourly quota.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Collect the WhiskyNotes archive over several bounded daily runs.
+- Continue current review collection while the history import runs.
+- Reuse existing request controls, parser, sink, and Bottle matching.
+- Accept cursors written by the current adapter during a deployment.
+
+**Non-Goals:**
+
+- A general backfill framework or a second historical source.
+- New database tables, admin controls, or request policy settings.
+- Faster source request rates or a full archive import in one run.
+
+## Decisions
+
+### Opt one source into cursor continuation
+
+Add one optional source-definition flag that seeds a new run from the last
+successful run's cursor. Only WhiskyNotes enables it. Failed runs do not become
+the starting point for new work. The existing run cursor remains the durable
+state, so this change needs no schema migration.
+
+The alternative was a new backfill table or source-specific state in the run
+lifecycle. Both add more storage and ownership rules for the same cursor.
+
+### Refresh current reviews before advancing history
+
+The WhiskyNotes cursor tracks the current page URLs separately from the active
+historical page. Each run first reads page 1 and emits new current articles.
+It then resumes the historical page and processes at most four pages. Page 1
+can serve both roles on the first run without a second request.
+
+Four history pages plus the current page fit within the existing run-attempt
+limit under normal hourly quota deferrals. This keeps the maximum daily request
+volume close to the existing five-page pilot.
+
+### Mark the archive end in the cursor
+
+When an archive page has no next-page link, the cursor records that history is
+complete. Later runs still refresh page 1 but do not request older pages.
+Article checkpoints remain after successful sink storage, so a failed item is
+eligible for replay.
+
+The cursor keeps the current `page` and `processedArticleUrls` fields and adds
+fields with defaults. This lets the new schema parse stored cursors from the
+deployed adapter.
+
+## Risks / Trade-offs
+
+- **Archive markup changes during the import** → The existing strict parser
+  fails the owning run and preserves the last successful cursor.
+- **A run receives extra quota deferrals** → The run can fail at its execution
+  limit. A later daily run restarts from the last successful run.
+- **Historical progress is gradual** → Four pages per day favors stable,
+  friendly collection over a burst crawl.
+
+## Migration Plan
+
+Deploy the compatible cursor schema, continuation flag, adapter change, and
+daily schedule together. Existing active WhiskyNotes runs can resume with the
+new cursor defaults. To stop the import, restore the source to manual scheduling
+or remove cursor continuation; stored review data remains valid.
+
+## Open Questions
+
+None.

--- a/openspec/changes/backfill-whiskynotes-review-history/proposal.md
+++ b/openspec/changes/backfill-whiskynotes-review-history/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+Peated only indexes the newest WhiskyNotes archive pages. WhiskyNotes has about
+4,985 review articles, so most of its useful review history is absent.
+
+## What Changes
+
+- Continue WhiskyNotes archive discovery across successful daily runs.
+- Refresh the current archive page on every run so new reviews still arrive.
+- Limit each run to a small number of historical pages and keep existing
+  request spacing, quotas, robots checks, parsing, matching, and ingestion.
+- Stop historical discovery when the public archive ends.
+
+## Capabilities
+
+### New Capabilities
+
+- `historical-review-imports`: Bounded, resumable collection of older review
+  articles without delaying current review collection.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Changes the scraper source definition and run creation lifecycle so an
+  opted-in source can continue from its last successful cursor.
+- Changes the WhiskyNotes cursor and adapter behavior.
+- Enables the existing WhiskyNotes source to run once per day.
+- Adds focused lifecycle, adapter, registry, and operating-document coverage.

--- a/openspec/changes/backfill-whiskynotes-review-history/specs/historical-review-imports/spec.md
+++ b/openspec/changes/backfill-whiskynotes-review-history/specs/historical-review-imports/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Historical review progress survives successful runs
+
+The system SHALL let an explicitly configured review source continue its
+historical import from the cursor of its last successful run.
+
+#### Scenario: Next run starts after stored progress
+
+- **WHEN** a configured source starts after a successful historical import run
+- **THEN** the new run starts from that successful run's stored cursor
+
+#### Scenario: Prior run failed
+
+- **WHEN** the most recent run failed after partial historical work
+- **THEN** a new run starts from the most recent successful run instead
+
+### Requirement: Current reviews remain current during history import
+
+The system MUST check the source's bounded current-review page on every
+historical import run.
+
+#### Scenario: New review appears during backfill
+
+- **WHEN** a new review appears while the historical cursor points to an older page
+- **THEN** the next run ingests the new review before it advances the historical cursor
+
+### Requirement: Historical work remains bounded
+
+The system MUST limit each WhiskyNotes run to at most four historical archive
+pages and MUST use the existing target spacing, quota, retry, robots, and run
+limits for all requests.
+
+#### Scenario: More archive pages remain
+
+- **WHEN** a run completes four historical archive pages and another page exists
+- **THEN** it checkpoints the next page and completes without requesting it
+
+#### Scenario: Run resumes within a page
+
+- **WHEN** a run stops after it stores part of one archive page
+- **THEN** its next attempt skips stored articles and retries the first unstored article
+
+### Requirement: Completed history does not restart
+
+The system SHALL record when the public archive ends and SHALL continue only
+the bounded current-review check on later runs.
+
+#### Scenario: Last archive page is reached
+
+- **WHEN** a historical listing has no next-page link
+- **THEN** the run records the history import as complete
+- **AND** a later run does not request historical archive pages

--- a/openspec/changes/backfill-whiskynotes-review-history/tasks.md
+++ b/openspec/changes/backfill-whiskynotes-review-history/tasks.md
@@ -1,0 +1,22 @@
+## 1. Run Continuation
+
+- [x] 1.1 Add an opt-in source definition flag that seeds a new run from the
+      last successful run cursor
+- [x] 1.2 Add lifecycle tests for successful cursor continuation and failed-run
+      exclusion
+
+## 2. WhiskyNotes History
+
+- [x] 2.1 Update the compatible WhiskyNotes cursor and adapter to refresh
+      current reviews and advance at most four historical pages per run
+- [x] 2.2 Add adapter tests for cross-run progress, current review refresh,
+      within-page resume, archive completion, and prior cursor compatibility
+- [x] 2.3 Enable daily WhiskyNotes runs and update registry coverage
+
+## 3. Documentation And Verification
+
+- [x] 3.1 Update the external review operating and source research documents
+- [x] 3.2 Run focused tests, server typecheck, lint, format, and OpenSpec
+      validation
+- [x] 3.3 Run the registered adapter against current public pages without
+      product writes and inspect requests, observations, and cursor progress


### PR DESCRIPTION
WhiskyNotes now runs daily, ingests new reviews from its current archive page, and advances through four older pages per run. Each run resumes from the last successful cursor, failed runs do not advance durable progress, and older-page requests stop when the public archive ends. Existing WhiskyNotes cursors remain valid, and all requests keep the current robots, spacing, quota, retry, and run limits.

Cursor continuation is opt-in and enabled only for WhiskyNotes. Other scraper sources still start each run with an empty cursor, and this change adds no database table or migration. A live current-page check parsed 9 articles into 11 reviews, including one three-bottle article, without product writes.
