### PR TITLE
fix(entities): reconcile SMWS collisions during merge

### DIFF
--- a/apps/server/src/worker/jobs/mergeEntity.test.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.test.ts
@@ -9,8 +9,10 @@ import {
   bottleOperations,
   bottles,
   bottleSeries,
+  bottleTombstones,
   changes,
   entities,
+  entityAliases,
   entityTombstones,
   storePriceMatchAttempts,
   storePriceMatchProposals,
@@ -345,6 +347,82 @@ test("merge A into B", async ({ fixtures }) => {
     .from(entityTombstones)
     .where(eq(entityTombstones.entityId, entityA.id));
   expect(tombstone.newEntityId).toEqual(newEntityB.id);
+});
+
+test("merges an SMWS collision while replacing a duplicate distiller", async ({
+  fixtures,
+}) => {
+  const smws = await fixtures.Entity({
+    name: "SMWS",
+    shortName: "SMWS",
+    type: ["brand", "bottler"],
+  });
+  const destination = await fixtures.Entity({
+    name: "Balcones Distilling",
+    shortName: "Balcones",
+    type: ["distiller"],
+  });
+  const source = await fixtures.Entity({
+    name: "Balcones",
+    type: ["distiller"],
+  });
+  const canonicalBottle = await fixtures.Bottle({
+    brandId: smws.id,
+    bottlerId: smws.id,
+    name: "140.17 Bowled over by something beautiful",
+    distillerIds: [destination.id],
+  });
+  const duplicateBottle = await fixtures.Bottle({
+    brandId: smws.id,
+    bottlerId: smws.id,
+    name: "140.17 Bowled over by cinnamon cola",
+    distillerIds: [source.id],
+  });
+  if (duplicateBottle.groupId === null) {
+    throw new Error("Fixture Bottle must belong to a BottleGroup.");
+  }
+  await db
+    .update(bottleGroupDistillers)
+    .set({ distillerId: destination.id })
+    .where(eq(bottleGroupDistillers.groupId, duplicateBottle.groupId));
+  await db
+    .update(entityAliases)
+    .set({ entityId: destination.id })
+    .where(eq(entityAliases.name, source.name));
+
+  await mergeEntity({
+    fromEntityIds: [source.id],
+    toEntityId: destination.id,
+  });
+
+  expect(
+    await db.query.entities.findFirst({ where: eq(entities.id, source.id) }),
+  ).toBeUndefined();
+  expect(
+    await db.query.bottles.findFirst({
+      where: eq(bottles.id, duplicateBottle.id),
+    }),
+  ).toBeUndefined();
+  expect(
+    await db.query.bottles.findFirst({
+      where: eq(bottles.id, canonicalBottle.id),
+    }),
+  ).toMatchObject({ id: canonicalBottle.id });
+  expect(
+    await db.query.bottleTombstones.findFirst({
+      where: eq(bottleTombstones.bottleId, duplicateBottle.id),
+    }),
+  ).toMatchObject({ newBottleId: canonicalBottle.id });
+  expect(
+    await db.query.entityAliases.findFirst({
+      where: eq(entityAliases.name, source.name),
+    }),
+  ).toMatchObject({ entityId: destination.id });
+  expect(
+    await db.query.entityTombstones.findFirst({
+      where: eq(entityTombstones.entityId, source.id),
+    }),
+  ).toMatchObject({ newEntityId: destination.id });
 });
 
 test("preserves the source when the locked destination is deleted", async ({

--- a/apps/server/src/worker/jobs/mergeEntity.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.ts
@@ -14,6 +14,7 @@ import {
   getPeatedSystemActorForDatabase,
   getUserActorForDatabase,
 } from "@peated/server/lib/actors";
+import { findConflictingSmwsBottleId } from "@peated/server/lib/bottleConflicts";
 import {
   getBottleExactIdentity,
   materializeBottleForGroup,
@@ -283,6 +284,25 @@ async function performEntityMerge({
           ),
         ),
       );
+    const driftedDistillerGroupIds = new Set(
+      (
+        await tx
+          .selectDistinct({ id: bottles.groupId })
+          .from(bottles)
+          .innerJoin(
+            bottlesToDistillers,
+            eq(bottlesToDistillers.bottleId, bottles.id),
+          )
+          .where(
+            and(
+              sql`${bottles.groupId} IS NOT NULL`,
+              inArray(bottlesToDistillers.distillerId, fromEntityIds),
+            ),
+          )
+      )
+        .map(({ id }) => id)
+        .filter((id): id is number => id !== null),
+    );
     const affectedGroupIds = Array.from(
       new Set(
         [
@@ -336,6 +356,89 @@ async function performEntityMerge({
         ) {
           seriesInput = { name: series.name, description: series.description };
         }
+      }
+
+      // SMWS cask codes own Bottle identity. Merge an existing code collision
+      // before changing its producer Entity.
+      if (
+        (distillersChange || driftedDistillerGroupIds.has(groupId)) &&
+        !brandChanges
+      ) {
+        const members = await tx
+          .select()
+          .from(bottles)
+          .where(eq(bottles.groupId, groupId))
+          .orderBy(asc(bottles.id));
+        const identityEntityIds = Array.from(
+          new Set(
+            [group.brandId, group.bottlerId].filter(
+              (id): id is number => id !== null,
+            ),
+          ),
+        );
+        const identityEntities = await tx
+          .select({
+            id: entities.id,
+            name: entities.name,
+            shortName: entities.shortName,
+          })
+          .from(entities)
+          .where(inArray(entities.id, identityEntityIds));
+        const brand = identityEntities.find(({ id }) => id === group.brandId);
+        const bottler =
+          group.bottlerId === null
+            ? null
+            : identityEntities.find(({ id }) => id === group.bottlerId);
+        if (!brand || (group.bottlerId !== null && !bottler)) {
+          throw new Error(
+            `BottleGroup ${groupId} has an invalid brand or bottler Entity.`,
+          );
+        }
+
+        for (const member of members) {
+          const duplicateBottleId = await findConflictingSmwsBottleId(
+            tx,
+            {
+              name: member.name,
+              fullName: member.fullName,
+              brand,
+              bottler: bottler ?? null,
+            },
+            { excludeBottleIds: members.map(({ id }) => id) },
+          );
+          if (duplicateBottleId === null) continue;
+          const [destinationOwnedDuplicate] = await tx
+            .select({ id: bottles.id })
+            .from(bottles)
+            .innerJoin(
+              bottleGroupDistillers,
+              eq(bottleGroupDistillers.groupId, bottles.groupId),
+            )
+            .where(
+              and(
+                eq(bottles.id, duplicateBottleId),
+                eq(bottleGroupDistillers.distillerId, toEntityId),
+              ),
+            )
+            .limit(1);
+          // The merge direction only identifies a safe survivor when the
+          // conflicting Bottle already belongs to the destination producer.
+          if (!destinationOwnedDuplicate) continue;
+          bottleMergeManifests.push(
+            await mergeBottlesInTransaction(tx, {
+              sourceBottleId: member.id,
+              destinationBottleId: duplicateBottleId,
+              actorId: actor.id,
+            }),
+          );
+        }
+
+        [group] = await tx
+          .select()
+          .from(bottleGroups)
+          .where(eq(bottleGroups.id, groupId))
+          .limit(1);
+        if (!group) continue;
       }
 
       if (brandChanges) {


### PR DESCRIPTION
Entity merges now recover when a drifted SMWS Bottle collides with an existing Bottle for the same cask code already owned by the destination distiller. The worker consolidates that duplicate through the existing Bottle merge path before completing the Entity merge; collisions outside the destination still fail instead of choosing a survivor automatically.

The regression models the production graph where BottleGroup authority was already canonical but one Bottle member still referenced the duplicate Entity. It verifies both Bottle and Entity redirects. Fixes #708.
