### PR TITLE
feat(scraper): backfill Whiskyfun review history

### DIFF
--- a/apps/server/src/scraper/adapters/whiskyfun.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyfun.test.ts
@@ -2,9 +2,13 @@ import { loadFixture } from "@peated/server/lib/test/fixtures";
 import { vi } from "vitest";
 import type { ScraperObservation, ScraperSession } from "../types";
 import {
+  discoverLatestWhiskyfunArchive,
+  discoverOlderWhiskyfunArchive,
+  discoverWhiskyfunArchiveArticles,
   discoverWhiskyfunArticles,
   parseWhiskyfunArticle,
   whiskyfunAdapter,
+  WhiskyfunCursorSchema,
   type WhiskyfunCursor,
   type WhiskyfunObservation,
 } from "./whiskyfun";
@@ -12,6 +16,31 @@ import {
 const FIRST_URL =
   "https://www.whiskyfun.com/2026/A-wee-trainload-of-a-dozen-secret-Speysiders.html";
 const SECOND_URL = "https://www.whiskyfun.com/2026/A-trio-of-Dailuaine.html";
+const ARCHIVE_URL =
+  "https://www.whiskyfun.com/archivejanuary25-1-Longmorn-Linkwood.html";
+const OLDER_ARCHIVE_URL =
+  "https://www.whiskyfun.com/archivedecember24-2-Lagavulin-Brora.html";
+const COMPLETED_HISTORY: Pick<
+  WhiskyfunCursor,
+  "nextArchiveUrl" | "processedArchiveArticleUrls" | "historyComplete"
+> = {
+  nextArchiveUrl: null,
+  processedArchiveArticleUrls: [],
+  historyComplete: true,
+};
+
+function archivePage({ older = true }: { older?: boolean } = {}) {
+  return `<html><head><meta name="author" content="Archive Reviewer"></head><body>
+    <a name="020125"></a><font>January 2, 2025</font>
+    <p class="textetresgrandfoncegrasCopie">Two archive whiskies</p>
+    <table><tr><td class="TextenormalNEW"><span class="textegrandfoncegras">Archive Malt 10 yo (46%, Sample Bottler)</span> Notes. SGP: 551 – 88 points.</td></tr></table>
+    <a name="010125"></a><font>January 1, 2025</font>
+    <p class="textetresgrandfoncegrasCopie">First rum session</p>
+    <table><tr><td class="TextenormalNEW"><span class="textegrandfoncegras">Archive Rum 10 yo (46%, Sample Bottler)</span> Notes. SGP: 551 - 85 points.</td></tr></table>
+    ${older ? `<a href="${OLDER_ARCHIVE_URL}">December 2024 - part 2</a>` : ""}
+    <a href="https://www.whiskyfun.com/archivejanuary25-2-Caperdonich-Mortlach.html">January 2025 - part 2</a>
+  </body></html>`;
+}
 
 test("discovers at most twenty current whisky articles", async () => {
   const feed = await loadFixture("whiskyfun", "feed.xml");
@@ -87,6 +116,76 @@ test("extracts scored reviews with stable source keys", async () => {
   );
 });
 
+test("discovers the newest archive and the next older linked page", () => {
+  const index = `<a href="archiveapril25-2-Aberlour.html">April part 2</a>
+    <a href="archivemay25-1-Linkwood.html">May part 1</a>
+    <a href="archiveavril25-1-Benrinnes.html">April part 1</a>
+    <a href="https://example.com/archivejune25-1-Other.html">Other site</a>`;
+
+  expect(discoverLatestWhiskyfunArchive(index)?.href).toBe(
+    "https://www.whiskyfun.com/archivemay25-1-Linkwood.html",
+  );
+  expect(
+    discoverOlderWhiskyfunArchive(archivePage(), new URL(ARCHIVE_URL))?.href,
+  ).toBe(OLDER_ARCHIVE_URL);
+});
+
+test("splits archive dates and excludes a non-whisky session", () => {
+  const discovered = discoverWhiskyfunArchiveArticles(
+    archivePage(),
+    new URL(ARCHIVE_URL),
+  );
+
+  expect(
+    discovered.map(({ article }) => ({
+      canonicalUrl: article.canonicalUrl,
+      title: article.title,
+      publishedAt: article.publishedAt,
+      reviewerName: article.reviewerName,
+    })),
+  ).toEqual([
+    {
+      canonicalUrl: `${ARCHIVE_URL}#020125`,
+      title: "Two archive whiskies",
+      publishedAt: new Date("2025-01-02T00:00:00.000Z"),
+      reviewerName: "Archive Reviewer",
+    },
+    {
+      canonicalUrl: `${ARCHIVE_URL}#010125`,
+      title: "First rum session",
+      publishedAt: new Date("2025-01-01T00:00:00.000Z"),
+      reviewerName: "Archive Reviewer",
+    },
+  ]);
+
+  const whisky = parseWhiskyfunArticle(
+    discovered[0]!.body,
+    discovered[0]!.article,
+  );
+  expect(whisky?.article.reviews).toEqual([
+    expect.objectContaining({
+      name: "Archive Malt 10 yo (46%, Sample Bottler)",
+      reviewerName: "Archive Reviewer",
+      nativeScore: { value: 88, scale: 100, display: "88 points" },
+      normalizedRating: 88,
+    }),
+  ]);
+  expect(
+    parseWhiskyfunArticle(discovered[1]!.body, discovered[1]!.article),
+  ).toBeNull();
+});
+
+test("accepts a current-only cursor and adds history defaults", () => {
+  expect(
+    WhiskyfunCursorSchema.parse({ processedArticleUrls: [FIRST_URL] }),
+  ).toEqual({
+    processedArticleUrls: [FIRST_URL],
+    nextArchiveUrl: null,
+    processedArchiveArticleUrls: [],
+    historyComplete: false,
+  });
+});
+
 test("returns no observation for an editorial feed item", () => {
   expect(
     parseWhiskyfunArticle(
@@ -142,13 +241,15 @@ test("checkpoints an editorial item and continues to reviews", async () => {
     remainingRequests: () => 30,
   };
 
-  await whiskyfunAdapter({ cursor: null, session });
+  await whiskyfunAdapter({
+    cursor: { processedArticleUrls: [], ...COMPLETED_HISTORY },
+    session,
+  });
 
   expect(emit).toHaveBeenCalledTimes(1);
-  expect(checkpoint.mock.calls.map(([cursor]) => cursor)).toEqual([
-    { processedArticleUrls: [editorialUrl] },
-    { processedArticleUrls: [editorialUrl, SECOND_URL] },
-  ]);
+  expect(
+    checkpoint.mock.calls.map(([cursor]) => cursor.processedArticleUrls),
+  ).toEqual([[editorialUrl], [editorialUrl, SECOND_URL]]);
 });
 
 test("resumes without requesting a completed article", async () => {
@@ -174,7 +275,10 @@ test("resumes without requesting a completed article", async () => {
   };
 
   await whiskyfunAdapter({
-    cursor: { processedArticleUrls: [FIRST_URL] },
+    cursor: {
+      processedArticleUrls: [FIRST_URL],
+      ...COMPLETED_HISTORY,
+    },
     session,
   });
 
@@ -188,9 +292,9 @@ test("resumes without requesting a completed article", async () => {
     sourceKey: SECOND_URL,
     itemCount: 2,
   });
-  expect(checkpoints).toEqual([
-    { processedArticleUrls: [FIRST_URL, SECOND_URL] },
-  ]);
+  expect(
+    checkpoints.map(({ processedArticleUrls }) => processedArticleUrls),
+  ).toEqual([[FIRST_URL, SECOND_URL]]);
 });
 
 test("drops completed URLs that leave the current feed window", async () => {
@@ -224,7 +328,7 @@ test("drops completed URLs that leave the current feed window", async () => {
   };
 
   await whiskyfunAdapter({
-    cursor: { processedArticleUrls: priorUrls },
+    cursor: { processedArticleUrls: priorUrls, ...COMPLETED_HISTORY },
     session,
   });
 
@@ -232,4 +336,87 @@ test("drops completed URLs that leave the current feed window", async () => {
   const completedUrls = checkpoint.mock.calls.at(-1)?.[0].processedArticleUrls;
   expect(completedUrls).toHaveLength(20);
   expect(new Set(completedUrls)).toEqual(new Set(currentUrls));
+});
+
+test("checks current reviews, imports one archive page, and advances", async () => {
+  const emit = vi.fn();
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body:
+      url.pathname === "/whatsnew.xml"
+        ? '<?xml version="1.0"?><rss><channel></channel></rss>'
+        : url.pathname === "/"
+          ? `<a href="${ARCHIVE_URL}">January 2025 - part 1</a>`
+          : archivePage(),
+  }));
+  const session: ScraperSession<WhiskyfunCursor, WhiskyfunObservation> = {
+    request,
+    emit,
+    checkpoint,
+    remainingRequests: () => 30,
+  };
+
+  await whiskyfunAdapter({ cursor: null, session });
+
+  expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
+    "https://www.whiskyfun.com/whatsnew.xml",
+    "https://www.whiskyfun.com/",
+    ARCHIVE_URL,
+  ]);
+  expect(emit).toHaveBeenCalledTimes(1);
+  expect(emit).toHaveBeenCalledWith(
+    expect.objectContaining({
+      sourceKey: `${ARCHIVE_URL}#020125`,
+      itemCount: 1,
+    }),
+  );
+  expect(checkpoint.mock.calls.at(-1)?.[0]).toEqual({
+    processedArticleUrls: [],
+    nextArchiveUrl: OLDER_ARCHIVE_URL,
+    processedArchiveArticleUrls: [],
+    historyComplete: false,
+  });
+});
+
+test("resumes within an archive page and records the archive end", async () => {
+  const completedUrl = `${ARCHIVE_URL}#020125`;
+  const emit = vi.fn();
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body:
+      url.pathname === "/whatsnew.xml"
+        ? '<?xml version="1.0"?><rss><channel></channel></rss>'
+        : archivePage({ older: false }),
+  }));
+  const session: ScraperSession<WhiskyfunCursor, WhiskyfunObservation> = {
+    request,
+    emit,
+    checkpoint,
+    remainingRequests: () => 30,
+  };
+
+  await whiskyfunAdapter({
+    cursor: {
+      processedArticleUrls: [],
+      nextArchiveUrl: ARCHIVE_URL,
+      processedArchiveArticleUrls: [completedUrl],
+      historyComplete: false,
+    },
+    session,
+  });
+
+  expect(request).toHaveBeenCalledTimes(2);
+  expect(emit).not.toHaveBeenCalled();
+  expect(checkpoint.mock.calls.at(-1)?.[0]).toEqual({
+    processedArticleUrls: [],
+    nextArchiveUrl: null,
+    processedArchiveArticleUrls: [],
+    historyComplete: true,
+  });
 });

--- a/apps/server/src/scraper/adapters/whiskyfun.ts
+++ b/apps/server/src/scraper/adapters/whiskyfun.ts
@@ -7,7 +7,7 @@ import {
 import { load as cheerio } from "cheerio";
 import { createHash } from "node:crypto";
 import { z } from "zod";
-import type { ScraperAdapter } from "../types";
+import type { ScraperAdapter, ScraperSession } from "../types";
 import {
   currentReviewCursorSchema,
   processCurrentReviews,
@@ -17,7 +17,13 @@ import { parseDate } from "./dates";
 const ORIGIN = "https://www.whiskyfun.com";
 const TARGET = "whiskyfun";
 const MAX_FEED_ITEMS = 20;
+const MAX_ARCHIVE_ARTICLES = 40;
 const ARTICLE_PATH = /^\/\d{4}\/[^/]+\.html$/;
+const ARCHIVE_PATH =
+  /^\/archive(january|february|march|april|avril|may|june|july|august|september|october|november|december)(\d{2})-([12])(?:-[^/]+)?\.html$/i;
+const DATE_ANCHOR = /^\d{6}$/;
+const DATE_ANCHOR_TAG = /<a\b[^>]*\bname\s*=\s*["'](\d{6})["'][^>]*>/giu;
+const SESSION_TITLE_SELECTOR = ".textetresgrandfoncegrasCopie";
 const NON_WHISKY_TITLE =
   /\b(?:armagnacs?|brand(?:y|ies)|calvados|cognacs?|mezcal|rums?|tequilas?)\b/iu;
 
@@ -26,10 +32,20 @@ const WhiskyfunFeedArticleSchema = z
     canonicalUrl: z.url(),
     title: z.string().trim().min(1).max(1000),
     publishedAt: z.date(),
+    reviewerName: z.string().trim().min(1).max(255).nullable().optional(),
   })
   .strict();
 
-export const WhiskyfunCursorSchema = currentReviewCursorSchema(MAX_FEED_ITEMS);
+export const WhiskyfunCursorSchema = currentReviewCursorSchema(
+  MAX_FEED_ITEMS,
+).extend({
+  nextArchiveUrl: z.url().nullable().default(null),
+  processedArchiveArticleUrls: z
+    .array(z.url())
+    .max(MAX_ARCHIVE_ARTICLES)
+    .default([]),
+  historyComplete: z.boolean().default(false),
+});
 
 export const WhiskyfunObservationSchema = ReviewArticleIngestionSchema;
 
@@ -44,13 +60,169 @@ function normalizeText(value: string): string {
 function articleUrl(value: string): URL | null {
   try {
     const url = new URL(value, ORIGIN);
+    url.search = "";
+    if (url.origin !== ORIGIN) return null;
+    if (ARTICLE_PATH.test(url.pathname)) {
+      url.hash = "";
+      return url;
+    }
+    if (
+      ARCHIVE_PATH.test(url.pathname) &&
+      DATE_ANCHOR.test(url.hash.slice(1))
+    ) {
+      return url;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function archivePageUrl(value: string): URL | null {
+  try {
+    const url = new URL(value, ORIGIN);
     url.hash = "";
     url.search = "";
-    if (url.origin !== ORIGIN || !ARTICLE_PATH.test(url.pathname)) return null;
+    if (url.origin !== ORIGIN || !ARCHIVE_PATH.test(url.pathname)) return null;
     return url;
   } catch {
     return null;
   }
+}
+
+type ArchivePeriod = {
+  year: number;
+  month: number;
+  part: number;
+};
+
+const ARCHIVE_MONTHS: Record<string, number> = {
+  january: 1,
+  february: 2,
+  march: 3,
+  april: 4,
+  avril: 4,
+  may: 5,
+  june: 6,
+  july: 7,
+  august: 8,
+  september: 9,
+  october: 10,
+  november: 11,
+  december: 12,
+};
+
+function archivePeriod(url: URL): ArchivePeriod {
+  const match = ARCHIVE_PATH.exec(url.pathname);
+  if (!match?.[1] || !match[2] || !match[3]) {
+    throw new Error("Invalid Whiskyfun archive URL.");
+  }
+  return {
+    year: 2000 + Number(match[2]),
+    month: ARCHIVE_MONTHS[match[1].toLocaleLowerCase("en")] ?? 0,
+    part: Number(match[3]),
+  };
+}
+
+function compareArchivePeriods(left: URL, right: URL): number {
+  const a = archivePeriod(left);
+  const b = archivePeriod(right);
+  return a.year - b.year || a.month - b.month || a.part - b.part;
+}
+
+function discoverArchiveLinks(data: string): URL[] {
+  const $ = cheerio(data);
+  const links = new Map<string, URL>();
+  $("a[href]").each((_, element) => {
+    const url = archivePageUrl($(element).attr("href") ?? "");
+    if (url) links.set(url.href, url);
+  });
+  return [...links.values()];
+}
+
+export function discoverLatestWhiskyfunArchive(data: string): URL | null {
+  return discoverArchiveLinks(data).sort(compareArchivePeriods).at(-1) ?? null;
+}
+
+export function discoverOlderWhiskyfunArchive(
+  data: string,
+  rawCurrentUrl: URL,
+): URL | null {
+  const currentUrl = archivePageUrl(rawCurrentUrl.href);
+  if (!currentUrl) throw new Error("Invalid current Whiskyfun archive URL.");
+  return (
+    discoverArchiveLinks(data)
+      .filter((url) => compareArchivePeriods(url, currentUrl) < 0)
+      .sort(compareArchivePeriods)
+      .at(-1) ?? null
+  );
+}
+
+function publishedAtFromAnchor(anchor: string): Date | null {
+  if (!DATE_ANCHOR.test(anchor)) return null;
+  const day = Number(anchor.slice(0, 2));
+  const month = Number(anchor.slice(2, 4));
+  const year = 2000 + Number(anchor.slice(4, 6));
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+    ? date
+    : null;
+}
+
+type WhiskyfunArchiveArticle = {
+  article: WhiskyfunFeedArticle;
+  body: string;
+};
+
+export function discoverWhiskyfunArchiveArticles(
+  data: string,
+  rawArchiveUrl: URL,
+): WhiskyfunArchiveArticle[] {
+  const archiveUrl = archivePageUrl(rawArchiveUrl.href);
+  if (!archiveUrl) throw new Error("Invalid Whiskyfun archive URL.");
+
+  const page = cheerio(data);
+  const reviewerName =
+    normalizeText(page('meta[name="author"]').first().attr("content") ?? "") ||
+    null;
+  const matches = [...data.matchAll(DATE_ANCHOR_TAG)];
+  const articles: WhiskyfunArchiveArticle[] = [];
+
+  for (const [index, match] of matches.entries()) {
+    const anchor = match[1];
+    const start = match.index;
+    if (!anchor || start === undefined) continue;
+    const publishedAt = publishedAtFromAnchor(anchor);
+    if (!publishedAt) {
+      throw new Error("Whiskyfun archive date anchor is invalid.");
+    }
+
+    const end = matches[index + 1]?.index ?? data.length;
+    const body = data.slice(start, end);
+    const section = cheerio(body);
+    const title =
+      section(SESSION_TITLE_SELECTOR)
+        .toArray()
+        .map((element) => normalizeText(section(element).text()))
+        .find(Boolean) ||
+      `Whiskyfun reviews for ${publishedAt.toISOString().slice(0, 10)}`;
+    const canonicalUrl = new URL(archiveUrl);
+    canonicalUrl.hash = anchor;
+
+    articles.push({
+      article: WhiskyfunFeedArticleSchema.parse({
+        canonicalUrl: canonicalUrl.href,
+        title,
+        publishedAt,
+        reviewerName,
+      }),
+      body,
+    });
+  }
+
+  return articles;
 }
 
 export function discoverWhiskyfunArticles(
@@ -98,7 +270,8 @@ function bottleName(value: string): string | null {
 }
 
 function score(value: string) {
-  const match = /\bSGP:\s*\d{3}\s*-\s*(\d{1,3})\s+points?\b/iu.exec(value);
+  const match =
+    /\bSGP:\s*\d{3}\s*[-\u2012-\u2015]\s*(\d{1,3})\s+points?\b/iu.exec(value);
   const nativeValue = match?.[1] ? Number(match[1]) : Number.NaN;
   if (!Number.isFinite(nativeValue) || nativeValue < 0 || nativeValue > 100) {
     return null;
@@ -133,13 +306,22 @@ export function parseWhiskyfunArticle(
 
   const $ = cheerio(data);
   const reviewerName =
-    normalizeText($('meta[name="author"]').first().attr("content") ?? "") ||
-    null;
+    article.reviewerName ??
+    (normalizeText($('meta[name="author"]').first().attr("content") ?? "") ||
+      null);
   const reviews: ReviewArticleObservation["reviews"] = [];
   const reviewTexts: Record<string, string> = {};
   let hasReviewCandidate = false;
+  let sessionTitle = article.title;
 
-  $("td.TextenormalNEW").each((_, element) => {
+  $("*").each((_, element) => {
+    if ($(element).is(SESSION_TITLE_SELECTOR)) {
+      sessionTitle = normalizeText($(element).text()) || sessionTitle;
+      return;
+    }
+    if (!$(element).is("td.TextenormalNEW")) return;
+    if (NON_WHISKY_TITLE.test(sessionTitle)) return;
+
     const heading = $(element)
       .find(".textegrandfoncegras")
       .toArray()
@@ -187,17 +369,107 @@ export const whiskyfunAdapter: ScraperAdapter<
   WhiskyfunCursor,
   WhiskyfunObservation
 > = async ({ cursor, session }) => {
+  let nextCursor = WhiskyfunCursorSchema.parse(
+    cursor ?? { processedArticleUrls: [] },
+  );
   const feedResponse = await session.request({
     target: TARGET,
     url: new URL("/whatsnew.xml", ORIGIN),
   });
   const articles = discoverWhiskyfunArticles(feedResponse.body);
+  const currentSession: ScraperSession<
+    { processedArticleUrls: string[] },
+    WhiskyfunObservation
+  > = {
+    request: (request) => session.request(request),
+    emit: (observation) => session.emit(observation),
+    remainingRequests: () => session.remainingRequests(),
+    checkpoint: async ({ processedArticleUrls }) => {
+      nextCursor = { ...nextCursor, processedArticleUrls };
+      await session.checkpoint(nextCursor);
+    },
+  };
   await processCurrentReviews({
     target: TARGET,
     articles,
     articleUrl: (article) => new URL(article.canonicalUrl),
-    cursor,
-    session,
+    cursor: nextCursor,
+    session: currentSession,
     parse: (response, article) => parseWhiskyfunArticle(response.body, article),
   });
+
+  if (nextCursor.historyComplete) return;
+
+  if (!nextCursor.nextArchiveUrl) {
+    const indexResponse = await session.request({
+      target: TARGET,
+      url: new URL("/", ORIGIN),
+    });
+    const latestArchive = discoverLatestWhiskyfunArchive(indexResponse.body);
+    if (!latestArchive) {
+      throw new Error("Whiskyfun archive index contains no archive pages.");
+    }
+    nextCursor = {
+      ...nextCursor,
+      nextArchiveUrl: latestArchive.href,
+      processedArchiveArticleUrls: [],
+    };
+    await session.checkpoint(nextCursor);
+  }
+
+  const archiveCursorUrl = nextCursor.nextArchiveUrl;
+  if (!archiveCursorUrl) {
+    throw new Error("Whiskyfun archive cursor URL is missing.");
+  }
+  const archiveUrl = archivePageUrl(archiveCursorUrl);
+  if (!archiveUrl) throw new Error("Invalid Whiskyfun archive cursor URL.");
+  const archiveResponse = await session.request({
+    target: TARGET,
+    url: archiveUrl,
+  });
+  const archiveArticles = discoverWhiskyfunArchiveArticles(
+    archiveResponse.body,
+    archiveUrl,
+  );
+  if (archiveArticles.length === 0) {
+    throw new Error("Whiskyfun archive contains no dated articles.");
+  }
+
+  const archiveArticleUrls = new Set(
+    archiveArticles.map(({ article }) => article.canonicalUrl),
+  );
+  const processedArchiveArticleUrls = new Set(
+    nextCursor.processedArchiveArticleUrls.filter((url) =>
+      archiveArticleUrls.has(url),
+    ),
+  );
+  for (const { article, body } of archiveArticles) {
+    if (processedArchiveArticleUrls.has(article.canonicalUrl)) continue;
+    const observation = parseWhiskyfunArticle(body, article);
+    if (observation) {
+      await session.emit({
+        sourceKey: observation.article.canonicalUrl,
+        itemCount: observation.article.reviews.length,
+        value: observation,
+      });
+    }
+    processedArchiveArticleUrls.add(article.canonicalUrl);
+    nextCursor = {
+      ...nextCursor,
+      processedArchiveArticleUrls: [...processedArchiveArticleUrls],
+    };
+    await session.checkpoint(nextCursor);
+  }
+
+  const olderArchive = discoverOlderWhiskyfunArchive(
+    archiveResponse.body,
+    archiveUrl,
+  );
+  nextCursor = {
+    ...nextCursor,
+    nextArchiveUrl: olderArchive?.href ?? null,
+    processedArchiveArticleUrls: [],
+    historyComplete: olderArchive === null,
+  };
+  await session.checkpoint(nextCursor);
 };

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -143,6 +143,9 @@ test("registers every scraper source with explicit target ownership", () => {
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("whiskyfun")?.requestLimit).toBe(30);
+  expect(scraperRegistry.sources.get("whiskyfun")?.resumeFromLastRun).toBe(
+    true,
+  );
   expect(EXTERNAL_SITE_DEFINITIONS.whiskysaga.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskysaga")).toMatchObject({
     minimumSpacingMs: 2_500,

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -435,6 +435,7 @@ export const scraperRegistry = createScraperRegistry({
       externalSiteType: "whiskyfun",
       targetKeys: ["whiskyfun"],
       requestLimit: 30,
+      resumeFromLastRun: true,
       cursorSchema: WhiskyfunCursorSchema,
       observationSchema: WhiskyfunObservationSchema,
       adapter: whiskyfunAdapter,

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -192,9 +192,13 @@ the complete source Bottle title for classification and reads the category
 before the separate price line. It does not persist review prose.
 
 Whiskyfun runs once per day. It reads at most 20 current RSS items and skips
-clear non-whisky articles before it requests article pages. Requests are at
-least 2.5 seconds apart. The target allows 25 requests per hour, and each worker
-pass stops after 30 requests. The adapter stores explicit feed dates, reviewer
+clear non-whisky articles before it requests article pages. It then advances
+one historical archive page from its last successful cursor. The first history
+run discovers the newest archive from the homepage. Each later page supplies
+the next older link. Historical articles keep the publisher's daily date anchor
+and date. When the archive ends, later runs check only the current feed.
+Requests are at least 2.5 seconds apart. The target allows 25 requests per hour,
+and each worker pass stops after 30 requests. The adapter stores dates, reviewer
 metadata, native scores, and canonical links. Review prose stays transient.
 
 Dramface runs once per day. It reads at most 20 current links from the public

--- a/docs/research/external-review-content-supply.md
+++ b/docs/research/external-review-content-supply.md
@@ -45,7 +45,7 @@ site-specific search; it does not mean unrestricted use is allowed.
 | Priority   | Source                                                        | Supply opportunity                                                                | robots.txt observation                                                                                     | Terms/reuse observation                                                                                                                           | Recommended mode                              |
 | ---------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
 | P0         | [WhiskyNotes](https://www.whiskynotes.be/)                    | About 6,600 reviews across 4,985 articles; new tasting notes every weekday        | Public article paths allowed; feed, search, downloads, and WordPress internals disallowed                  | No dedicated terms page located                                                                                                                   | `public_index`, daily archive import          |
-| P0         | [Whiskyfun](https://www.whiskyfun.com/)                       | About 22,700 whisky reviews dating to 2002                                        | No `Disallow` rule observed; unusual single `Allow` entry                                                  | No formal terms located; FAQ and disclosure discuss free commercial use                                                                           | `public_index`, later archive candidate       |
+| P0         | [Whiskyfun](https://www.whiskyfun.com/)                       | About 22,800 whisky reviews dating to 2002                                        | No `Disallow` rule observed; unusual single `Allow` entry                                                  | No formal terms located; FAQ and disclosure discuss free commercial use                                                                           | `public_index`, daily archive import          |
 | P0         | [Dramface](https://www.dramface.com/)                         | Reviews most weekdays, multiple writers, frequent multi-bottle articles           | Public pages allowed; Squarespace rules block API, JSON, search, account, and other internal paths         | No dedicated terms page linked in the public footer                                                                                               | `public_index`, ongoing-feed pilot            |
 | P0         | [Whisky Advocate](https://whiskyadvocate.com/ratings-reviews) | Existing Peated source; publisher describes an archive of more than 6,000 reviews | Ratings paths allowed for general crawlers; GPTBot, ChatGPT-User, and CCBot are blocked                    | Privacy policy references general terms, but no public general terms page or review-reuse restriction was located                                 | `public_index`, second bounded pilot          |
 | P0         | [Whisky Saga](https://www.whiskysaga.com/)                    | Active scored reviews; the Scotland category contains more than 2,000 articles    | Public category and article paths allowed; Squarespace APIs, search, filters, and internal formats blocked | Privacy and editorial pages contain no automated-access restriction                                                                               | `public_index`, daily Scotch feed             |
@@ -93,9 +93,12 @@ a separate platform-terms and creator-rights review.
 - The current RSS feed supplies canonical article URLs, titles, exact dates,
   and Bottle names. Article pages supply the reviewer and native 100-point
   scores.
-- The implemented daily feed checks at most 20 items and uses the governed
-  runtime for article requests. The two-decade archive remains a separate
-  future backfill.
+- Archive pages provide stable daily date anchors and links to their older and
+  newer neighbors. One page can contain several daily entries and can mix
+  whisky with other spirits.
+- The daily importer checks at most 20 current RSS items before it advances one
+  older archive page from its last successful cursor. It excludes clear
+  non-whisky sessions and stops older-page requests when the archive ends.
 
 ### Whisky Saga
 

--- a/openspec/changes/backfill-whiskyfun-review-history/.openspec.yaml
+++ b/openspec/changes/backfill-whiskyfun-review-history/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-22

--- a/openspec/changes/backfill-whiskyfun-review-history/design.md
+++ b/openspec/changes/backfill-whiskyfun-review-history/design.md
@@ -1,0 +1,94 @@
+## Context
+
+The Whiskyfun adapter reads at most 20 current articles from RSS. Whiskyfun
+also publishes half-month archive pages. Each archive page contains several
+daily entries. The entries have stable date anchors, titles, review text, and
+scores. Each archive page links to the older and newer neighboring pages.
+
+The source allows 25 requests per hour and spaces requests by 2.5 seconds. A
+full current run can use 21 requests: one feed and 20 articles. Historical work
+must fit in the same source policy.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Import Whiskyfun history over several successful daily runs.
+- Keep the current RSS import unchanged and first in each run.
+- Preserve the public daily anchor, title, and publication date.
+- Reuse the existing request runtime, review parser, sink, and Bottle matcher.
+- Accept cursors written by the current adapter.
+
+**Non-Goals:**
+
+- A general archive crawler or a second cursor continuation mechanism.
+- New database tables, admin controls, or request policy settings.
+- Faster source request rates or a full archive import in one run.
+- Import of rum, brandy, or other non-whisky sessions.
+
+## Decisions
+
+### Traverse one archive page per run
+
+The first historical run reads the public homepage and selects the newest valid
+archive page. Each archive page then provides the link to the next older page.
+Later runs request that saved page directly. This avoids downloading the large
+homepage on every run.
+
+Each run processes one archive page after current RSS work. A first run uses at
+most 23 content requests. Later runs use at most 22. Both fit the existing
+25-request hourly target quota.
+
+The alternative was to save the full archive index or add a configurable page
+count. The full index makes the cursor large, and a page count adds no value
+under the current quota.
+
+### Store progress in the compatible source cursor
+
+The Whiskyfun cursor keeps its current article URLs and adds the next archive
+URL, processed daily entry URLs for the active archive page, and a completion
+flag. New fields have defaults so stored current-only cursors remain valid.
+Whiskyfun enables the existing successful-run cursor continuation option.
+
+The adapter checkpoints each stored daily entry. A retry can then skip entries
+whose sink work completed. After a page completes, the cursor advances to the
+older linked page and clears its per-page entry list.
+
+### Treat each date anchor as one historical article
+
+The adapter splits an archive page at publisher-provided six-digit date
+anchors. It uses the archive URL plus that anchor as the canonical link and
+derives the publication date from the anchor. It uses the first suitable daily
+heading as the title and a date-based title when the page has no heading.
+
+This preserves stable public links and dates. Treating a half-month page as one
+article would lose daily dates and create an unusually large record.
+
+### Keep non-whisky filtering beside the Whiskyfun parser
+
+Archive days can contain several sessions. The parser tracks the current
+session heading and ignores review candidates under a non-whisky heading. The
+same existing category terms used for RSS titles apply here. The score parser
+accepts the hyphen and dash characters found across old and current pages.
+
+## Risks / Trade-offs
+
+- **Old markup can differ from current samples** → The adapter validates date
+  anchors and archive links. Unexpected review-shaped content fails the run and
+  preserves the last successful cursor.
+- **One old page contains many reviews** → The source makes one historical
+  request per run. Sink checkpoints prevent completed daily entries from being
+  repeated after a retry.
+- **The oldest page has no older link** → The cursor records completion.
+  Later runs continue only the current RSS check.
+
+## Migration Plan
+
+Deploy the compatible cursor schema, adapter change, and registry opt-in
+together. Existing active cursors receive defaults when parsed. To stop the
+history import, remove the continuation opt-in or set the completion cursor;
+stored review data remains valid.
+
+## Open Questions
+
+None.

--- a/openspec/changes/backfill-whiskyfun-review-history/proposal.md
+++ b/openspec/changes/backfill-whiskyfun-review-history/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Peated only indexes the newest Whiskyfun articles from its RSS feed. Whiskyfun
+has more than 22,000 reviews in public archive pages dating to 2002, so most of
+its useful review history is absent.
+
+## What Changes
+
+- Continue Whiskyfun archive discovery across successful daily runs.
+- Keep the current RSS check on every run so new reviews still arrive.
+- Import one historical archive page per run and preserve each daily entry's
+  public anchor, title, and publication date.
+- Keep existing request spacing, quotas, robots checks, parsing, matching, and
+  ingestion.
+- Stop historical discovery when the public archive ends.
+
+## Capabilities
+
+### New Capabilities
+
+- `whiskyfun-review-history`: Bounded, resumable collection of older Whiskyfun
+  reviews without delaying current review collection.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Changes the Whiskyfun cursor and adapter behavior.
+- Enables the existing cursor continuation option for Whiskyfun.
+- Adds focused adapter, registry, and operating-document coverage.

--- a/openspec/changes/backfill-whiskyfun-review-history/specs/whiskyfun-review-history/spec.md
+++ b/openspec/changes/backfill-whiskyfun-review-history/specs/whiskyfun-review-history/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Current Whiskyfun reviews remain current
+
+The system MUST check Whiskyfun's bounded current RSS feed before historical
+work on every run.
+
+#### Scenario: New review appears during history import
+
+- **WHEN** a new RSS article appears while the historical cursor points to an older archive page
+- **THEN** the run ingests the new article before it advances the historical cursor
+
+### Requirement: Historical Whiskyfun work remains bounded
+
+The system MUST request at most one Whiskyfun archive page per run and MUST use
+the existing target spacing, quota, retry, robots, and run limits.
+
+#### Scenario: More archive pages remain
+
+- **WHEN** a run completes one archive page and an older linked page exists
+- **THEN** it checkpoints the older page without requesting it
+
+#### Scenario: Run resumes within an archive page
+
+- **WHEN** a run stops after it stores part of one archive page
+- **THEN** its next attempt skips stored daily entries and retries the first unstored entry
+
+### Requirement: Historical articles preserve public identity
+
+The system SHALL store each valid daily archive entry as a separate article
+with its publisher-provided anchor, title, and publication date. It SHALL
+exclude review candidates in sessions identified as non-whisky content.
+
+#### Scenario: Archive page contains several daily entries
+
+- **WHEN** the adapter reads an archive page with several valid date anchors
+- **THEN** it emits each scored whisky entry with its archive fragment and date
+
+#### Scenario: Archive day contains a rum session
+
+- **WHEN** a daily entry contains review-shaped content under a rum heading
+- **THEN** the adapter does not include those reviews in the observation
+
+### Requirement: Completed Whiskyfun history does not restart
+
+The system SHALL record when an archive page has no older linked page and SHALL
+continue only the bounded current RSS check on later runs.
+
+#### Scenario: Oldest archive page is reached
+
+- **WHEN** the adapter completes an archive page with no older link
+- **THEN** it records that the history import is complete
+- **AND** a later run does not request the homepage or an archive page

--- a/openspec/changes/backfill-whiskyfun-review-history/tasks.md
+++ b/openspec/changes/backfill-whiskyfun-review-history/tasks.md
@@ -1,0 +1,18 @@
+## 1. Archive Discovery And Parsing
+
+- [x] 1.1 Add compatible Whiskyfun cursor state and archive URL discovery
+- [x] 1.2 Split archive pages into daily articles with stable anchors and dates
+- [x] 1.3 Parse historical score punctuation and exclude non-whisky sessions
+
+## 2. Bounded Import
+
+- [x] 2.1 Keep current RSS processing first and preserve history cursor fields
+- [x] 2.2 Process one resumable archive page per run and record completion
+- [x] 2.3 Enable successful-run cursor continuation for Whiskyfun
+
+## 3. Documentation And Verification
+
+- [x] 3.1 Update external review operating and source research documents
+- [x] 3.2 Add focused discovery, parsing, resume, completion, and compatibility tests
+- [x] 3.3 Run focused tests, server typecheck, lint, format, and OpenSpec validation
+- [x] 3.4 Run the registered adapter against current public pages without product writes and inspect requests, observations, and cursor progress


### PR DESCRIPTION
Whiskyfun now checks its current RSS feed first, then advances through one public archive page per successful daily run. Historical entries keep the publisher's daily anchor, title, date, reviewer, and score, while clear non-whisky sessions are excluded. When the archive ends, later runs continue the current feed only.

The adapter uses the existing successful-run cursor continuation and accepts deployed current-only cursors. A full first run remains below the source's existing 25-request hourly quota, including a robots refresh. A live no-write acceptance run used five governed requests, parsed 55 review items, and advanced the archive cursor from July 2026 part 2 to part 1.
