### PR TITLE
fix(scraper): accept Fine Drams image host

### DIFF
--- a/apps/server/__fixtures__/finedrams/bottle-list.html
+++ b/apps/server/__fixtures__/finedrams/bottle-list.html
@@ -11,11 +11,11 @@
             <div class="image_container">
               <picture>
                 <source
-                  data-src="https://d1wd5rt8ssn8ry.cloudfront.net/image/lagavulin.webp"
+                  srcset="https://images.finedrams.com/image/lagavulin.webp"
                   type="image/webp"
                 />
                 <img
-                  data-src="https://d1wd5rt8ssn8ry.cloudfront.net/image/lagavulin.jpg"
+                  src="https://images.finedrams.com/image/lagavulin.jpg"
                 />
               </picture>
             </div>

--- a/apps/server/src/scraper/adapters/legacy/scrapeFineDrams.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeFineDrams.test.ts
@@ -48,7 +48,7 @@ test("scrapes in-stock single bottles and excludes ineligible cards", async ({
   expect(items).toEqual([
     {
       currency: "eur",
-      imageUrl: "https://d1wd5rt8ssn8ry.cloudfront.net/image/lagavulin.webp",
+      imageUrl: "https://images.finedrams.com/image/lagavulin.webp",
       name: "Lagavulin 12-year-old (2019 Special Release)",
       price: 12880,
       url: "https://www.finedrams.com/lagavulin-12-year-old-cask-strength-2019-special-release-whisky.html",

--- a/apps/server/src/scraper/adapters/legacy/scrapeFineDrams.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeFineDrams.ts
@@ -83,6 +83,7 @@ function getImageUrl(
       if (
         url.protocol === "https:" &&
         (url.origin === STORE_ORIGIN ||
+          url.hostname === "images.finedrams.com" ||
           url.hostname === "d1wd5rt8ssn8ry.cloudfront.net")
       ) {
         return url.toString();


### PR DESCRIPTION
Fine Drams price runs now accept the HTTPS image host returned to PeatedBot, so valid product cards no longer fail as invalid image URLs. The parser keeps its exact-host allowlist and still supports the existing Fine Drams and CloudFront image hosts.

The fixture now matches the bot-specific `srcset` and `src` markup. A live one-page check parsed 54 supported listings from the current PeatedBot response.
