### PR TITLE
fix(prices): converge legacy listing duplicates

### DIFF
--- a/apps/server/src/lib/createStorePrices.ts
+++ b/apps/server/src/lib/createStorePrices.ts
@@ -7,6 +7,7 @@ import {
   externalSites,
   storePriceHistories,
   storePrices,
+  type StorePrice,
 } from "@peated/server/db/schema";
 import { getPeatedSystemActor } from "@peated/server/lib/actors";
 import {
@@ -25,7 +26,7 @@ import {
   StorePriceInputSchema,
 } from "@peated/server/schemas";
 import { pushJob, pushUniqueJob } from "@peated/server/worker/client";
-import { and, eq, or, sql } from "drizzle-orm";
+import { and, eq, inArray, or, sql } from "drizzle-orm";
 import { z } from "zod";
 
 /**
@@ -46,15 +47,17 @@ export type CreateStorePricesInput = z.input<
 
 type ParsedStorePrice = z.output<typeof StorePriceInputSchema>;
 
+type StorePriceIdentity = {
+  externalProductId?: string;
+  externalSiteId: number;
+  url: string;
+};
+
 function getStorePriceIdentityCondition({
   externalProductId,
   externalSiteId,
   url,
-}: {
-  externalProductId?: string;
-  externalSiteId: number;
-  url: string;
-}) {
+}: StorePriceIdentity) {
   const urlCondition = eq(storePrices.url, url);
   return externalProductId
     ? or(
@@ -67,38 +70,87 @@ function getStorePriceIdentityCondition({
     : urlCondition;
 }
 
+function selectStorePrice(
+  rows: StorePrice[],
+  input: StorePriceIdentity,
+): StorePrice {
+  if (rows.some((row) => row.externalSiteId !== input.externalSiteId)) {
+    throw new Error(
+      `Store URL is already assigned to another source (${input.externalSiteId}, ${input.url}).`,
+    );
+  }
+
+  const productIds = new Set(
+    rows.flatMap((row) =>
+      row.externalProductId === null ? [] : [row.externalProductId],
+    ),
+  );
+  if (
+    productIds.size > 1 ||
+    (input.externalProductId &&
+      [...productIds].some((id) => id !== input.externalProductId))
+  ) {
+    throw new Error(
+      `Store URL is already assigned to another source product (${input.externalSiteId}, ${input.url}).`,
+    );
+  }
+
+  const bottleIds = new Set(
+    rows.flatMap((row) => (row.bottleId === null ? [] : [row.bottleId])),
+  );
+  if (bottleIds.size > 1) {
+    throw new Error(
+      `Store product duplicates have conflicting Bottle assignments (${input.externalSiteId}, ${input.externalProductId ?? input.url}).`,
+    );
+  }
+
+  return rows.toSorted((a, b) => {
+    const productIdMatch =
+      Number(b.externalProductId === input.externalProductId) -
+      Number(a.externalProductId === input.externalProductId);
+    if (productIdMatch) return productIdMatch;
+
+    const visible = Number(!b.hidden) - Number(!a.hidden);
+    if (visible) return visible;
+
+    const bottleAssignment =
+      Number(b.bottleId !== null) - Number(a.bottleId !== null);
+    if (bottleAssignment) return bottleAssignment;
+
+    const recency = b.updatedAt.getTime() - a.updatedAt.getTime();
+    return recency || a.id - b.id;
+  })[0];
+}
+
 async function findStorePriceForUpdate(
   tx: AnyTransaction,
-  input: {
-    externalProductId?: string;
-    externalSiteId: number;
-    url: string;
-  },
+  input: StorePriceIdentity,
 ) {
   const rows = await tx
     .select()
     .from(storePrices)
     .where(getStorePriceIdentityCondition(input))
     .for("update");
-  if (rows.length > 1) {
-    throw new Error(
-      `Store product identity resolves to multiple price rows (${input.externalSiteId}, ${input.externalProductId ?? input.url}).`,
-    );
+  if (rows.length === 0) return null;
+
+  const existing = selectStorePrice(rows, input);
+  const duplicateIds = rows
+    .filter((row) => row.id !== existing.id)
+    .map((row) => row.id);
+  if (duplicateIds.length > 0) {
+    // Exact source identity can converge legacy duplicate rows. Conflicting
+    // source products and Bottle assignments fail in selectStorePrice.
+    await tx
+      .update(storePrices)
+      .set({ hidden: true })
+      .where(inArray(storePrices.id, duplicateIds));
   }
-  return rows[0] ?? null;
+  return existing;
 }
 
 async function lockStorePriceIdentity(
   tx: AnyTransaction,
-  {
-    externalProductId,
-    externalSiteId,
-    url,
-  }: {
-    externalProductId?: string;
-    externalSiteId: number;
-    url: string;
-  },
+  { externalProductId, externalSiteId, url }: StorePriceIdentity,
 ) {
   const keys = [
     `store-price-url:${url}`,

--- a/apps/server/src/orpc/routes/prices/create-batch.test.ts
+++ b/apps/server/src/orpc/routes/prices/create-batch.test.ts
@@ -331,6 +331,98 @@ describe("POST /external-sites/:site/prices", () => {
     });
   });
 
+  test("converges compatible legacy rows that share a retailer URL", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const bottle = await fixtures.Bottle({ name: "Legacy Price Bottle" });
+    const url = "https://example.com/products/legacy-duplicate";
+    const canonical = await fixtures.StorePrice({
+      bottleId: bottle.id,
+      externalSiteId: site.id,
+      name: bottle.fullName,
+      url,
+    });
+    const duplicate = await fixtures.StorePrice({
+      bottleId: null,
+      externalSiteId: site.id,
+      name: "Legacy Duplicate",
+      url,
+    });
+
+    await createStorePricesAsPeated({
+      site: site.type,
+      prices: [
+        {
+          externalProductId: "retailer-sku-duplicate",
+          name: bottle.fullName,
+          price: 7_500,
+          currency: "usd",
+          volume: 750,
+          url,
+        },
+      ],
+    });
+
+    expect(
+      await db.query.storePrices.findFirst({
+        where: eq(storePrices.id, canonical.id),
+      }),
+    ).toMatchObject({
+      bottleId: bottle.id,
+      externalProductId: "retailer-sku-duplicate",
+      hidden: false,
+      price: 7_500,
+    });
+    expect(
+      await db.query.storePrices.findFirst({
+        where: eq(storePrices.id, duplicate.id),
+      }),
+    ).toMatchObject({
+      externalProductId: null,
+      hidden: true,
+    });
+  });
+
+  test("does not converge conflicting retailer product IDs", async ({
+    fixtures,
+  }) => {
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const url = "https://example.com/products/reused-url";
+    await fixtures.StorePrice({
+      externalProductId: "retailer-sku-1",
+      externalSiteId: site.id,
+      url,
+    });
+    await fixtures.StorePrice({
+      externalProductId: "retailer-sku-2",
+      externalSiteId: site.id,
+      url,
+    });
+
+    await expect(
+      createStorePricesAsPeated({
+        site: site.type,
+        prices: [
+          {
+            externalProductId: "retailer-sku-1",
+            name: "Reused Retailer URL",
+            price: 7_500,
+            currency: "usd",
+            volume: 750,
+            url,
+          },
+        ],
+      }),
+    ).rejects.toThrow("already assigned to another source product");
+
+    const prices = await db.query.storePrices.findMany({
+      where: eq(storePrices.externalSiteId, site.id),
+    });
+    expect(prices).toHaveLength(2);
+    expect(prices.every((price) => price.hidden === false)).toBe(true);
+  });
+
   test("keeps distinct generic listings instead of merging by title and volume", async ({
     fixtures,
   }) => {


### PR DESCRIPTION
Price ingestion now converges compatible legacy rows that share an exact retailer URL. It keeps the stable product row active, hides extra rows, and continues to reject conflicting retailer product IDs or Bottle assignments.

This prevents scraper runs from failing on pre-existing duplicate URLs without deleting related history or moderation records and without adding a data migration. Refs PEATED-4D3.
