### PR TITLE
fix(scraper): parse Whiskyfun colon scores

### DIFF
--- a/apps/server/__fixtures__/whiskyfun/article.html
+++ b/apps/server/__fixtures__/whiskyfun/article.html
@@ -10,7 +10,7 @@
         <td class="TextenormalNEW">
           <span class="textegrandfoncegras">Dailuaine 5 yo 2020/2025 (61%, Sample Bottler, cask #1)</span>
           <p>A short fixture review.</p>
-          <strong>SGP:562 - 87 points.</strong>
+          <strong>SGP:562: 87 points.</strong>
         </td>
       </tr>
       <tr>

--- a/apps/server/src/scraper/adapters/whiskyfun.ts
+++ b/apps/server/src/scraper/adapters/whiskyfun.ts
@@ -271,7 +271,7 @@ function bottleName(value: string): string | null {
 
 function score(value: string) {
   const match =
-    /\bSGP:\s*\d{3}\s*[-\u2012-\u2015]\s*(\d{1,3})\s+points?\b/iu.exec(value);
+    /\bSGP:\s*\d{3}\s*[:\u2012-\u2015-]\s*(\d{1,3})\s+points?\b/iu.exec(value);
   const nativeValue = match?.[1] ? Number(match[1]) : Number.NaN;
   if (!Number.isFinite(nativeValue) || nativeValue < 0 || nativeValue > 100) {
     return null;


### PR DESCRIPTION
Whiskyfun score parsing now accepts the colon separator used by current articles in addition to the existing dash forms. This prevents scored articles from failing the full scraper run as unscored; the production article that exposed the issue now parses both Glenfiddich reviews.
