### PR TITLE
feat(scraper): backfill Whisky Saga history

### DIFF
--- a/apps/server/src/scraper/adapters/whiskySaga.test.ts
+++ b/apps/server/src/scraper/adapters/whiskySaga.test.ts
@@ -2,15 +2,38 @@ import { loadFixture } from "@peated/server/lib/test/fixtures";
 import { vi } from "vitest";
 import type { ScraperSession } from "../types";
 import {
+  discoverOlderWhiskySagaPage,
   discoverWhiskySagaArticles,
   parseWhiskySagaArticle,
   whiskySagaAdapter,
+  WhiskySagaCursorSchema,
   type WhiskySagaCursor,
   type WhiskySagaObservation,
 } from "./whiskySaga";
 
 const FIRST_URL = "https://www.whiskysaga.com/blog/example-scotch";
 const SECOND_URL = "https://www.whiskysaga.com/blog/second-scotch";
+const HISTORY_URL =
+  "https://www.whiskysaga.com/blog?offset=1775418696457&category=Scotland";
+const OLDER_HISTORY_URL =
+  "https://www.whiskysaga.com/blog?offset=1772902711929&category=Scotland";
+const COMPLETED_HISTORY: Pick<
+  WhiskySagaCursor,
+  "nextHistoryUrl" | "processedHistoryArticleUrls" | "historyComplete"
+> = {
+  nextHistoryUrl: null,
+  processedHistoryArticleUrls: [],
+  historyComplete: true,
+};
+
+function historyPage({ older = true }: { older?: boolean } = {}) {
+  return `<main><article class="blog-item"><a href="${FIRST_URL}">Review</a></article></main>
+    ${
+      older
+        ? `<div class="older"><a rel="next" href="${OLDER_HISTORY_URL}">Older Posts</a></div>`
+        : ""
+    }`;
+}
 
 test("discovers only 20 current Scotland article cards", async () => {
   const index = await loadFixture("whiskysaga", "index.html");
@@ -31,6 +54,33 @@ test("discovers only 20 current Scotland article cards", async () => {
   expect(discoverWhiskySagaArticles(expandedIndex).at(-1)?.pathname).toBe(
     "/blog/generated-17",
   );
+});
+
+test("accepts only the public Scotland older-page link", () => {
+  expect(discoverOlderWhiskySagaPage(historyPage())?.href).toBe(
+    OLDER_HISTORY_URL,
+  );
+  expect(
+    discoverOlderWhiskySagaPage(
+      '<div class="older"><a rel="next" href="/blog?offset=1772902711929&category=World">Older</a></div>',
+    ),
+  ).toBeNull();
+  expect(
+    discoverOlderWhiskySagaPage(
+      '<div class="older"><a rel="next" href="/blog?offset=1772902711929&category=Scotland&format=json">Older</a></div>',
+    ),
+  ).toBeNull();
+});
+
+test("accepts the current-only cursor and adds history defaults", () => {
+  expect(
+    WhiskySagaCursorSchema.parse({ processedArticleUrls: [FIRST_URL] }),
+  ).toEqual({
+    processedArticleUrls: [FIRST_URL],
+    nextHistoryUrl: null,
+    processedHistoryArticleUrls: [],
+    historyComplete: false,
+  });
 });
 
 test("extracts source facts and only direct tasting paragraphs", async () => {
@@ -119,7 +169,10 @@ test("resumes without requesting a completed current article", async () => {
   };
 
   await whiskySagaAdapter({
-    cursor: { processedArticleUrls: [FIRST_URL] },
+    cursor: {
+      processedArticleUrls: [FIRST_URL],
+      ...COMPLETED_HISTORY,
+    },
     session,
   });
 
@@ -132,5 +185,86 @@ test("resumes without requesting a completed current article", async () => {
   );
   expect(checkpoint).toHaveBeenCalledWith({
     processedArticleUrls: [FIRST_URL, SECOND_URL],
+    ...COMPLETED_HISTORY,
+  });
+});
+
+test("imports one older Scotland page and advances the history cursor", async () => {
+  const article = await loadFixture("whiskysaga", "review.html");
+  const emit = vi.fn();
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body:
+      url.pathname === "/blog/category/Scotland"
+        ? `<main></main><div class="older"><a rel="next" href="${HISTORY_URL}">Older Posts</a></div>`
+        : url.href === HISTORY_URL
+          ? historyPage()
+          : article,
+  }));
+  const session: ScraperSession<WhiskySagaCursor, WhiskySagaObservation> = {
+    request,
+    emit,
+    checkpoint,
+    remainingRequests: () => 22,
+  };
+
+  await whiskySagaAdapter({ cursor: null, session });
+
+  expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
+    "https://www.whiskysaga.com/blog/category/Scotland",
+    HISTORY_URL,
+    FIRST_URL,
+  ]);
+  expect(emit).toHaveBeenCalledWith(
+    expect.objectContaining({ sourceKey: FIRST_URL, itemCount: 1 }),
+  );
+  expect(checkpoint.mock.calls.at(-1)?.[0]).toEqual({
+    processedArticleUrls: [],
+    nextHistoryUrl: OLDER_HISTORY_URL,
+    processedHistoryArticleUrls: [],
+    historyComplete: false,
+  });
+});
+
+test("resumes within an older page and records the history end", async () => {
+  const checkpoint = vi.fn();
+  const request = vi.fn(async ({ url }: { url: URL }) => ({
+    url,
+    status: 200,
+    headers: {},
+    body:
+      url.pathname === "/blog/category/Scotland"
+        ? "<main></main>"
+        : historyPage({ older: false }),
+  }));
+  const session: ScraperSession<WhiskySagaCursor, WhiskySagaObservation> = {
+    request,
+    emit: vi.fn(),
+    checkpoint,
+    remainingRequests: () => 22,
+  };
+
+  await whiskySagaAdapter({
+    cursor: {
+      processedArticleUrls: [],
+      nextHistoryUrl: HISTORY_URL,
+      processedHistoryArticleUrls: [FIRST_URL],
+      historyComplete: false,
+    },
+    session,
+  });
+
+  expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
+    "https://www.whiskysaga.com/blog/category/Scotland",
+    HISTORY_URL,
+  ]);
+  expect(checkpoint.mock.calls.at(-1)?.[0]).toEqual({
+    processedArticleUrls: [],
+    nextHistoryUrl: null,
+    processedHistoryArticleUrls: [],
+    historyComplete: true,
   });
 });

--- a/apps/server/src/scraper/adapters/whiskySaga.ts
+++ b/apps/server/src/scraper/adapters/whiskySaga.ts
@@ -5,8 +5,8 @@ import {
 } from "@peated/server/externalReviews/observation";
 import { load as cheerio } from "cheerio";
 import { createHash } from "node:crypto";
-import type { z } from "zod";
-import type { ScraperAdapter } from "../types";
+import { z } from "zod";
+import type { ScraperAdapter, ScraperSession } from "../types";
 import { parseArticleMetadata } from "./articleMetadata";
 import {
   currentReviewCursorSchema,
@@ -19,12 +19,22 @@ import { parseDate } from "./dates";
 const ORIGIN = "https://www.whiskysaga.com";
 const TARGET = "whiskysaga";
 const MAX_CURRENT_ARTICLES = 20;
+const MAX_HISTORY_ARTICLES = 20;
 const ARTICLE_PATH = /^\/blog\/[a-z0-9][a-z0-9-]*$/u;
+const HISTORY_OFFSET = /^\d{10,16}$/u;
 const TASTING_PARAGRAPH = /^(?:Nose|Palate|Taste|Finish)\s*:/iu;
 const SCORE = /^Score\s*:?\s*(?<value>\d{1,3}(?:[.,]\d+)?)\s*\/\s*100\s*$/iu;
 
-export const WhiskySagaCursorSchema =
-  currentReviewCursorSchema(MAX_CURRENT_ARTICLES);
+export const WhiskySagaCursorSchema = currentReviewCursorSchema(
+  MAX_CURRENT_ARTICLES,
+).extend({
+  nextHistoryUrl: z.url().nullable().default(null),
+  processedHistoryArticleUrls: z
+    .array(z.url())
+    .max(MAX_HISTORY_ARTICLES)
+    .default([]),
+  historyComplete: z.boolean().default(false),
+});
 
 export const WhiskySagaObservationSchema = ReviewArticleIngestionSchema;
 
@@ -58,6 +68,32 @@ export function discoverWhiskySagaArticles(data: string): URL[] {
   });
 
   return [...articles.values()].slice(0, MAX_CURRENT_ARTICLES);
+}
+
+function historyPageUrl(value: string): URL | null {
+  try {
+    const url = new URL(value, ORIGIN);
+    if (
+      url.origin !== ORIGIN ||
+      url.pathname !== "/blog" ||
+      url.hash ||
+      url.searchParams.size !== 2 ||
+      url.searchParams.get("category") !== "Scotland" ||
+      !HISTORY_OFFSET.test(url.searchParams.get("offset") ?? "")
+    ) {
+      return null;
+    }
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+export function discoverOlderWhiskySagaPage(data: string): URL | null {
+  const $ = cheerio(data);
+  return historyPageUrl(
+    $(".older a[rel='next'][href]").first().attr("href") ?? "",
+  );
 }
 
 function reviewScore(value: string) {
@@ -144,17 +180,91 @@ export const whiskySagaAdapter: ScraperAdapter<
   WhiskySagaCursor,
   WhiskySagaObservation
 > = async ({ cursor, session }) => {
+  let nextCursor = WhiskySagaCursorSchema.parse(
+    cursor ?? { processedArticleUrls: [] },
+  );
   const indexResponse = await session.request({
     target: TARGET,
     url: new URL("/blog/category/Scotland", ORIGIN),
   });
   const articleUrls = discoverWhiskySagaArticles(indexResponse.body);
+  const currentSession: ScraperSession<
+    { processedArticleUrls: string[] },
+    WhiskySagaObservation
+  > = {
+    request: (request) => session.request(request),
+    emit: (observation) => session.emit(observation),
+    remainingRequests: () => session.remainingRequests(),
+    checkpoint: async ({ processedArticleUrls }) => {
+      nextCursor = { ...nextCursor, processedArticleUrls };
+      await session.checkpoint(nextCursor);
+    },
+  };
   await processCurrentReviews({
     target: TARGET,
     articles: articleUrls,
     articleUrl: (url) => url,
-    cursor,
-    session,
+    cursor: nextCursor,
+    session: currentSession,
     parse: (response) => parseWhiskySagaArticle(response.body, response.url),
   });
+
+  if (nextCursor.historyComplete) return;
+
+  if (!nextCursor.nextHistoryUrl) {
+    const olderPage = discoverOlderWhiskySagaPage(indexResponse.body);
+    nextCursor = {
+      ...nextCursor,
+      nextHistoryUrl: olderPage?.href ?? null,
+      processedHistoryArticleUrls: [],
+      historyComplete: olderPage === null,
+    };
+    await session.checkpoint(nextCursor);
+    if (!olderPage) return;
+  }
+
+  const historyUrl = historyPageUrl(nextCursor.nextHistoryUrl ?? "");
+  if (!historyUrl) throw new Error("Invalid Whisky Saga history cursor URL.");
+  const historyResponse = await session.request({
+    target: TARGET,
+    url: historyUrl,
+  });
+  const historyArticles = discoverWhiskySagaArticles(historyResponse.body);
+  if (historyArticles.length === 0) {
+    throw new Error("Whisky Saga history page contains no article cards.");
+  }
+
+  const historyArticleUrls = new Set(historyArticles.map((url) => url.href));
+  const processedHistoryArticleUrls = new Set(
+    nextCursor.processedHistoryArticleUrls.filter((url) =>
+      historyArticleUrls.has(url),
+    ),
+  );
+  for (const url of historyArticles) {
+    if (processedHistoryArticleUrls.has(url.href)) continue;
+    const response = await session.request({ target: TARGET, url });
+    const observation = parseWhiskySagaArticle(response.body, response.url);
+    if (observation) {
+      await session.emit({
+        sourceKey: observation.article.canonicalUrl,
+        itemCount: observation.article.reviews.length,
+        value: observation,
+      });
+    }
+    processedHistoryArticleUrls.add(url.href);
+    nextCursor = {
+      ...nextCursor,
+      processedHistoryArticleUrls: [...processedHistoryArticleUrls],
+    };
+    await session.checkpoint(nextCursor);
+  }
+
+  const olderPage = discoverOlderWhiskySagaPage(historyResponse.body);
+  nextCursor = {
+    ...nextCursor,
+    nextHistoryUrl: olderPage?.href ?? null,
+    processedHistoryArticleUrls: [],
+    historyComplete: olderPage === null,
+  };
+  await session.checkpoint(nextCursor);
 };

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -154,6 +154,9 @@ test("registers every scraper source with explicit target ownership", () => {
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("whiskysaga")?.requestLimit).toBe(22);
+  expect(scraperRegistry.sources.get("whiskysaga")?.resumeFromLastRun).toBe(
+    true,
+  );
   expect(EXTERNAL_SITE_DEFINITIONS.whiskystudy.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskystudy")).toMatchObject({
     minimumSpacingMs: 2_500,

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -462,6 +462,7 @@ export const scraperRegistry = createScraperRegistry({
       externalSiteType: "whiskysaga",
       targetKeys: ["whiskysaga"],
       requestLimit: 22,
+      resumeFromLastRun: true,
       cursorSchema: WhiskySagaCursorSchema,
       observationSchema: WhiskySagaObservationSchema,
       adapter: whiskySagaAdapter,

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -247,14 +247,16 @@ Minnick reviewer attribution. Native and normalized scores stay absent. Only
 direct tasting paragraphs stay transient for summary generation; comparisons,
 introductions, prices, related links, and site furniture are excluded.
 
-Whisky Saga runs once per day. It reads only the 20 current article cards on
-the public Scotland category page. It does not request the full sitemap,
-archive pagination, search, query filters, or Squarespace APIs. Requests are at
+Whisky Saga runs once per day. It reads the 20 current article cards on the
+public Scotland category page, then advances one public Older Posts page from
+its last successful cursor. It follows only the publisher's Scotland category
+links with `offset` and `category` parameters. It does not request the full
+sitemap, search, other query filters, or Squarespace APIs. Requests are at
 least 2.5 seconds apart. The target allows 25 requests per hour, and each worker
-pass stops after 21 source requests plus the governed robots request when its
-cache is stale. The adapter stores the exact publication timestamp, author,
-canonical link, and native 100-point score. Only direct nose, taste, palate,
-and finish paragraphs stay transient for summary generation.
+pass stops after 22 requests. The adapter stores the exact publication
+timestamp, author, canonical link, and native 100-point score. Only direct
+nose, taste, palate, and finish paragraphs stay transient for summary
+generation.
 
 The Whisky Study runs once per day. It reads only the 20 article cards on the
 first public Scotch review index page. It does not request older pagination,

--- a/docs/research/external-review-content-supply.md
+++ b/docs/research/external-review-content-supply.md
@@ -107,17 +107,19 @@ a separate platform-terms and creator-rights review.
   [editorial standards](https://www.whiskysaga.com/editorial-standards),
   [privacy policy](https://www.whiskysaga.com/privacy), and
   [robots.txt](https://www.whiskysaga.com/robots.txt).
-- Rechecked on 2026-08-21. Robots allow the public Scotland category and
-  article paths. They block Squarespace APIs, search, query filters, and
-  internal formats. The public privacy and editorial pages contain no
-  automated-access restriction.
+- Rechecked on 2026-08-22. Robots allow the public Scotland category, its
+  `offset` pagination, and article paths. They block Squarespace APIs, search,
+  author, tag, month, view, and internal-format filters. The public privacy and
+  editorial pages contain no automated-access restriction.
 - The Scotland category contains more than 2,000 articles and displays 20
   current posts. Review articles expose an exact timestamp, author, Bottle
   title, direct tasting sections, and a 100-point score.
-- The implemented daily feed reads only the 20 current Scotland article cards.
-  It does not use the full sitemap, archive pagination, search, query filters,
-  or Squarespace APIs. Only direct nose, taste, palate, and finish paragraphs
-  stay transient for summary generation.
+- The daily importer reads the 20 current Scotland article cards and advances
+  one public Older Posts page from its last successful cursor. It follows only
+  the publisher's Scotland category links with `offset` and `category`
+  parameters. It does not use the full sitemap, search, other query filters, or
+  Squarespace APIs. Only direct nose, taste, palate, and finish paragraphs stay
+  transient for summary generation.
 
 ### The Whisky Study
 


### PR DESCRIPTION
Whisky Saga now keeps its daily current-review check and also advances one older Scotland category page from its last successful cursor. The adapter accepts only the publisher's public `offset` and `category=Scotland` links, checkpoints each completed article, and resumes without repeating stored work.

This keeps the backfill inside the existing scraper runtime, request limits, robots checks, review schema, matcher, and sink. Existing current-only cursors receive safe history defaults. The live parser check confirmed an older page and article still match the source contract.
