### PR TITLE
perf(prices): skip duplicate creation audits

### DIFF
--- a/apps/server/src/worker/jobs/verifyBottleCreation.test.ts
+++ b/apps/server/src/worker/jobs/verifyBottleCreation.test.ts
@@ -1,14 +1,5 @@
-import {
-  buildBottleClassificationArtifacts,
-  createAuditBottleResult,
-} from "@peated/bottle-classifier/contract";
 import { db } from "@peated/server/db";
-import {
-  bottleChecks,
-  bottleOperations,
-  bottles,
-  changes,
-} from "@peated/server/db/schema";
+import { bottleChecks, changes } from "@peated/server/db/schema";
 import { and, eq } from "drizzle-orm";
 import { beforeEach, vi } from "vitest";
 import type { JobPayload } from "../types";
@@ -57,81 +48,24 @@ describe("verifyBottleCreation", () => {
     expect(runAudit).not.toHaveBeenCalled();
   });
 
-  test("audits automated price-match Bottles with one review-only check", async ({
+  test("skips a second audit for automated price-match Bottles", async ({
     fixtures,
   }) => {
-    const bottle = await fixtures.Bottle({ edition: null });
-    const { getBottleClassifierContext } =
-      await import("@peated/server/agents/bottleClassifier/contextAdapters");
-    const bottleContext = await getBottleClassifierContext(bottle.id);
-    if (!bottleContext) {
-      throw new Error(`Bottle ${bottle.id} context was not found.`);
-    }
-    const { imageSources: _imageSources, ...contextFields } = bottleContext;
-
-    runAudit.mockResolvedValue({
-      result: createAuditBottleResult({
-        summary: "The edition should be corrected.",
-        proposedOperations: [
-          {
-            type: "update_bottle",
-            input: {
-              bottleId: bottle.id,
-              patch: { edition: "Audited Edition" },
-            },
-            rationale: "The inspected Bottle has a missing edition.",
-            evidenceRefs: [{ kind: "bottle", bottleId: bottle.id }],
-          },
-        ],
-        findings: [],
-        artifacts: buildBottleClassificationArtifacts({
-          bottleContexts: [{ ...contextFields, publicImages: [] }],
-        }),
-      }),
-      modelMetadata: null,
-    });
-
-    const input = {
+    const bottle = await fixtures.Bottle();
+    await verifyBottleCreation({
       bottleId: bottle.id,
       creationSource: "price_match_automation" as const,
-    };
-    await verifyBottleCreation(input);
-    await verifyBottleCreation(input);
-
-    expect(runAudit).toHaveBeenCalledTimes(1);
-    expect(runAudit).toHaveBeenCalledWith({
-      bottleId: bottle.id,
-      origin: "post_user_creation",
     });
 
-    const checks = await db
-      .select()
-      .from(bottleChecks)
-      .where(
-        eq(bottleChecks.backgroundEventKey, `bottle_created:${bottle.id}`),
-      );
-    expect(checks).toHaveLength(1);
-    expect(checks[0]).toMatchObject({
-      intent: "audit_bottle",
-      origin: "post_user_creation",
-      bottleId: bottle.id,
-    });
-
-    const operations = await db
-      .select()
-      .from(bottleOperations)
-      .where(eq(bottleOperations.checkId, checks[0]!.id));
-    expect(operations).toHaveLength(1);
-    expect(operations[0]).toMatchObject({
-      status: "pending_review",
-      proposal: { type: "update_bottle" },
-    });
+    expect(runAudit).not.toHaveBeenCalled();
     expect(
-      await db.query.bottles.findFirst({
-        where: eq(bottles.id, bottle.id),
-        columns: { edition: true },
-      }),
-    ).toEqual({ edition: null });
+      await db
+        .select()
+        .from(bottleChecks)
+        .where(
+          eq(bottleChecks.backgroundEventKey, `bottle_created:${bottle.id}`),
+        ),
+    ).toEqual([]);
 
     const bottleChanges = await db
       .select()
@@ -139,11 +73,13 @@ describe("verifyBottleCreation", () => {
       .where(
         and(eq(changes.objectType, "bottle"), eq(changes.objectId, bottle.id)),
       );
-    expect(
-      bottleChanges.some(
-        (change) => change.data?.catalogVerification?.phase === "result",
-      ),
-    ).toBe(false);
+    const verificationChange = bottleChanges.find(
+      (change) => change.data?.catalogVerification?.phase === "result",
+    );
+    expect(verificationChange?.data.catalogVerification).toMatchObject({
+      source: "price_match_automation",
+      status: "skipped",
+    });
   });
 
   test("fails for retry without falling back to the old heuristic conclusion", async ({

--- a/apps/server/src/worker/jobs/verifyBottleCreation.ts
+++ b/apps/server/src/worker/jobs/verifyBottleCreation.ts
@@ -35,7 +35,9 @@ export async function verifyBottleCreation(
   const { bottleId, creationSource } =
     VerifyBottleCreationJobArgsSchema.parse(input);
 
-  if (!shouldRunCatalogVerification(creationSource)) {
+  const policyInput = { objectType: "bottle", source: creationSource } as const;
+
+  if (!shouldRunCatalogVerification(policyInput)) {
     const displayName = await getCatalogVerificationDisplayName({
       objectId: bottleId,
       objectType: "bottle",
@@ -47,7 +49,7 @@ export async function verifyBottleCreation(
       result: {
         source: creationSource,
         status: "skipped",
-        reason: getCatalogVerificationSkipReason(creationSource),
+        reason: getCatalogVerificationSkipReason(policyInput),
         findings: [],
       },
     });

--- a/apps/server/src/worker/jobs/verifyEntityCreation.ts
+++ b/apps/server/src/worker/jobs/verifyEntityCreation.ts
@@ -21,7 +21,9 @@ export default async function ({
     objectType: "entity",
   });
 
-  if (!shouldRunCatalogVerification(creationSource)) {
+  const policyInput = { objectType: "entity", source: creationSource } as const;
+
+  if (!shouldRunCatalogVerification(policyInput)) {
     await recordCatalogVerificationResult({
       displayName,
       objectId: entityId,
@@ -29,7 +31,7 @@ export default async function ({
       result: {
         source: creationSource,
         status: "skipped",
-        reason: getCatalogVerificationSkipReason(creationSource),
+        reason: getCatalogVerificationSkipReason(policyInput),
         findings: [],
       },
     });

--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -148,9 +148,10 @@ also removes older terminal manual reviews; pending, applying, blocked, stale,
 and failed work remains durable.
 
 Post-user-creation audits run after the Bottle save commits and never delay or
-roll back that save. The job audits every eligible `manual_entry` and
-`price_match_automation` Bottle. Background checks retain their event-key
-receipt for retry safety.
+roll back that save. The job audits every eligible `manual_entry` Bottle.
+`price_match_automation` Bottles skip this audit because price matching already
+checked their Bottle details before creation. Background checks retain their
+event-key receipt for retry safety.
 
 ### BottleGroup Findings
 

--- a/packages/catalog-verifier/src/verification.test.ts
+++ b/packages/catalog-verifier/src/verification.test.ts
@@ -22,24 +22,64 @@ describe("catalog verifier policy", () => {
   });
 
   test("runs verification for manual entries", () => {
-    expect(shouldRunCatalogVerification("manual_entry")).toBe(true);
-    expect(getCatalogVerificationSkipReason("manual_entry")).toBeNull();
+    const input = { objectType: "bottle", source: "manual_entry" } as const;
+
+    expect(shouldRunCatalogVerification(input)).toBe(true);
+    expect(getCatalogVerificationSkipReason(input)).toBeNull();
   });
 
-  test("runs verification for automated price matches", () => {
-    expect(shouldRunCatalogVerification("price_match_automation")).toBe(true);
-    expect(
-      getCatalogVerificationSkipReason("price_match_automation"),
-    ).toBeNull();
+  test("skips automated Bottle audits but checks automated entities", () => {
+    const bottleInput = {
+      objectType: "bottle",
+      source: "price_match_automation",
+    } as const;
+    const entityInput = {
+      objectType: "entity",
+      source: "price_match_automation",
+    } as const;
+
+    expect(shouldRunCatalogVerification(bottleInput)).toBe(false);
+    expect(getCatalogVerificationSkipReason(bottleInput)).toContain(
+      "already checked",
+    );
+    expect(shouldRunCatalogVerification(entityInput)).toBe(true);
+    expect(getCatalogVerificationSkipReason(entityInput)).toBeNull();
   });
 
   test("skips reviewed and repair creation flows", () => {
-    expect(shouldRunCatalogVerification("bottle_classifier")).toBe(false);
-    expect(shouldRunCatalogVerification("price_match_review")).toBe(false);
-    expect(shouldRunCatalogVerification("repair_workflow")).toBe(false);
-    expect(getCatalogVerificationSkipReason("bottle_classifier")).toContain(
-      "classifier",
-    );
+    expect(
+      shouldRunCatalogVerification({
+        objectType: "bottle",
+        source: "bottle_classifier",
+      }),
+    ).toBe(false);
+    expect(
+      shouldRunCatalogVerification({
+        objectType: "bottle",
+        source: "price_match_review",
+      }),
+    ).toBe(false);
+    expect(
+      shouldRunCatalogVerification({
+        objectType: "entity",
+        source: "repair_workflow",
+      }),
+    ).toBe(false);
+    expect(
+      getCatalogVerificationSkipReason({
+        objectType: "bottle",
+        source: "bottle_classifier",
+      }),
+    ).toContain("classifier");
+  });
+
+  test("runs verification for manual entities", () => {
+    expect(
+      shouldRunCatalogVerification({
+        objectType: "entity",
+        source: "manual_entry",
+      }),
+    ).toBe(true);
   });
 
   test("builds parsed creation metadata and results", () => {

--- a/packages/catalog-verifier/src/verification.ts
+++ b/packages/catalog-verifier/src/verification.ts
@@ -99,22 +99,36 @@ export type PersistedCatalogVerificationResult = z.infer<
   typeof CatalogVerificationResultSchema
 >;
 
-export function shouldRunCatalogVerification(
-  source: CatalogVerificationCreationSource,
-) {
-  return source === "manual_entry" || source === "price_match_automation";
+type CatalogVerificationPolicyInput = {
+  objectType: "bottle" | "entity";
+  source: CatalogVerificationCreationSource;
+};
+
+export function shouldRunCatalogVerification({
+  objectType,
+  source,
+}: CatalogVerificationPolicyInput) {
+  return (
+    source === "manual_entry" ||
+    (objectType === "entity" && source === "price_match_automation")
+  );
 }
 
 export function getCatalogVerificationSkipReason(
-  source: CatalogVerificationCreationSource,
+  input: CatalogVerificationPolicyInput,
 ) {
+  if (shouldRunCatalogVerification(input)) {
+    return null;
+  }
+
+  const { source } = input;
   switch (source) {
     case "bottle_classifier":
       return "Created through the reviewed bottle classifier flow.";
     case "price_match_review":
       return "Created through the moderator-reviewed price match workflow.";
     case "price_match_automation":
-      return null;
+      return "Bottle details were already checked before automatic price matching created it.";
     case "repair_workflow":
       return "Created through a dedicated repair workflow.";
     case "manual_entry":


### PR DESCRIPTION
Bottles created by automatic price matching no longer run a second full Bottle audit. Price matching already checks the Bottle details before creation, so the follow-up job records a skipped result instead of starting another model run.

Manual Bottle entries keep the existing post-creation audit. Focused policy and worker tests cover the skipped result and confirm that no Bottle check is created.
