### PR TITLE
fix(prices): prevent source-only approvals from changing BottleAlias

### DIFF
--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -10,6 +10,7 @@ import {
 import { findEntityByExactNameOrAlias } from "@peated/server/lib/db";
 import { fixBadReviewEntities } from "@peated/server/lib/fixBadReviewEntities";
 import { repairBottleBrandDistilleryAssignments } from "@peated/server/lib/repairBottleBrandDistilleryAssignments";
+import { repairInvalidSourceBottleAliases } from "@peated/server/lib/repairInvalidSourceBottleAliases";
 import { getAutomationModeratorUser } from "@peated/server/lib/systemUser";
 import { routerClient } from "@peated/server/orpc/router";
 import { runJob } from "@peated/server/worker/client";
@@ -270,6 +271,60 @@ subcommand
     if (options.execute && result.summary.failed > 0) {
       throw new Error(
         `${result.summary.failed} bottle repair(s) failed during execution.`,
+      );
+    }
+  });
+
+subcommand
+  .command("repair-source-aliases")
+  .description(
+    "Preview or unassign invalid BottleAlias rows from source-only price approvals",
+  )
+  .option(
+    "--limit <number>",
+    "Maximum number of BottleAlias rows to scan",
+    "100",
+  )
+  .option("--execute", "Apply repairs to the explicitly named BottleAlias rows")
+  .argument("[aliasNames...]")
+  .action(async (aliasNames: string[], options) => {
+    const limit = Number.parseInt(options.limit, 10);
+    if (!Number.isSafeInteger(limit) || limit <= 0) {
+      throw new Error(`Invalid limit: ${options.limit}`);
+    }
+    if (options.execute && aliasNames.length === 0) {
+      throw new Error(
+        "--execute requires one or more explicit BottleAlias names.",
+      );
+    }
+
+    const result = await repairInvalidSourceBottleAliases({
+      aliasNames,
+      dryRun: !options.execute,
+      limit,
+      user: options.execute ? await getAutomationModeratorUser() : undefined,
+    });
+    console.log(
+      `${options.execute ? "Processed" : "Previewed"} BottleAlias rows: ${result.summary.total}`,
+    );
+    console.log(
+      `planned=${result.summary.planned} applied=${result.summary.applied} reviewRequired=${result.summary.review_required} failed=${result.summary.failed}`,
+    );
+    for (const item of result.items) {
+      const evidence = item.evidenceProposalIds.length
+        ? ` proposals=${item.evidenceProposalIds.join(",")}`
+        : "";
+      console.log(
+        `[${item.status}] ${item.aliasName} bottle=${item.bottleId ?? "none"}${evidence}`,
+      );
+      console.log(`  ${item.message}`);
+    }
+    if (
+      options.execute &&
+      result.summary.failed + result.summary.review_required > 0
+    ) {
+      throw new Error(
+        `${result.summary.failed + result.summary.review_required} requested BottleAlias repair(s) were not applied.`,
       );
     }
   });

--- a/apps/cli/src/commands/bottles.ts
+++ b/apps/cli/src/commands/bottles.ts
@@ -10,7 +10,6 @@ import {
 import { findEntityByExactNameOrAlias } from "@peated/server/lib/db";
 import { fixBadReviewEntities } from "@peated/server/lib/fixBadReviewEntities";
 import { repairBottleBrandDistilleryAssignments } from "@peated/server/lib/repairBottleBrandDistilleryAssignments";
-import { repairInvalidSourceBottleAliases } from "@peated/server/lib/repairInvalidSourceBottleAliases";
 import { getAutomationModeratorUser } from "@peated/server/lib/systemUser";
 import { routerClient } from "@peated/server/orpc/router";
 import { runJob } from "@peated/server/worker/client";
@@ -271,60 +270,6 @@ subcommand
     if (options.execute && result.summary.failed > 0) {
       throw new Error(
         `${result.summary.failed} bottle repair(s) failed during execution.`,
-      );
-    }
-  });
-
-subcommand
-  .command("repair-source-aliases")
-  .description(
-    "Preview or unassign invalid BottleAlias rows from source-only price approvals",
-  )
-  .option(
-    "--limit <number>",
-    "Maximum number of BottleAlias rows to scan",
-    "100",
-  )
-  .option("--execute", "Apply repairs to the explicitly named BottleAlias rows")
-  .argument("[aliasNames...]")
-  .action(async (aliasNames: string[], options) => {
-    const limit = Number.parseInt(options.limit, 10);
-    if (!Number.isSafeInteger(limit) || limit <= 0) {
-      throw new Error(`Invalid limit: ${options.limit}`);
-    }
-    if (options.execute && aliasNames.length === 0) {
-      throw new Error(
-        "--execute requires one or more explicit BottleAlias names.",
-      );
-    }
-
-    const result = await repairInvalidSourceBottleAliases({
-      aliasNames,
-      dryRun: !options.execute,
-      limit,
-      user: options.execute ? await getAutomationModeratorUser() : undefined,
-    });
-    console.log(
-      `${options.execute ? "Processed" : "Previewed"} BottleAlias rows: ${result.summary.total}`,
-    );
-    console.log(
-      `planned=${result.summary.planned} applied=${result.summary.applied} reviewRequired=${result.summary.review_required} failed=${result.summary.failed}`,
-    );
-    for (const item of result.items) {
-      const evidence = item.evidenceProposalIds.length
-        ? ` proposals=${item.evidenceProposalIds.join(",")}`
-        : "";
-      console.log(
-        `[${item.status}] ${item.aliasName} bottle=${item.bottleId ?? "none"}${evidence}`,
-      );
-      console.log(`  ${item.message}`);
-    }
-    if (
-      options.execute &&
-      result.summary.failed + result.summary.review_required > 0
-    ) {
-      throw new Error(
-        `${result.summary.failed + result.summary.review_required} requested BottleAlias repair(s) were not applied.`,
       );
     }
   });

--- a/apps/server/src/lib/bottleAliases.ts
+++ b/apps/server/src/lib/bottleAliases.ts
@@ -156,7 +156,7 @@ export type BottleAliasAssignmentOptions = Pick<
   "assignmentSource" | "assignedByActorId"
 >;
 
-type BottleImageCandidate = {
+export type BottleImageCandidate = {
   bottleId: number;
   imageUrl: string;
 };
@@ -722,73 +722,7 @@ export async function finalizeBottleAliasAssignment(
   }: BottleAliasAssignmentResult,
   contexts?: SentryLogContexts,
 ) {
-  if (bottleImageCandidate) {
-    try {
-      const [updatedOriginal] = await db
-        .update(bottles)
-        .set({ imageUrl: bottleImageCandidate.imageUrl })
-        .where(
-          and(
-            eq(bottles.id, bottleImageCandidate.bottleId),
-            or(isNull(bottles.imageUrl), eq(bottles.imageUrl, "")),
-            sql`${bottleImageCandidate.imageUrl} <> ALL(${bottles.rejectedImageUrls})`,
-          ),
-        )
-        .returning({ id: bottles.id });
-      if (!updatedOriginal) {
-        const original = await db.query.bottles.findFirst({
-          where: eq(bottles.id, bottleImageCandidate.bottleId),
-          columns: { id: true },
-        });
-        if (!original) {
-          const tombstone = await db.query.bottleTombstones.findFirst({
-            where: eq(bottleTombstones.bottleId, bottleImageCandidate.bottleId),
-            columns: { newBottleId: true },
-          });
-          if (!tombstone) {
-            recordUnresolvedBottleImageCandidate(
-              bottleImageCandidate,
-              "missing_tombstone",
-            );
-          } else if (tombstone.newBottleId) {
-            const [updatedReplacement] = await db
-              .update(bottles)
-              .set({ imageUrl: bottleImageCandidate.imageUrl })
-              .where(
-                and(
-                  eq(bottles.id, tombstone.newBottleId),
-                  or(isNull(bottles.imageUrl), eq(bottles.imageUrl, "")),
-                  sql`${bottleImageCandidate.imageUrl} <> ALL(${bottles.rejectedImageUrls})`,
-                ),
-              )
-              .returning({ id: bottles.id });
-            if (!updatedReplacement) {
-              const replacement = await db.query.bottles.findFirst({
-                where: eq(bottles.id, tombstone.newBottleId),
-                columns: { id: true },
-              });
-              if (!replacement) {
-                recordUnresolvedBottleImageCandidate(
-                  bottleImageCandidate,
-                  "missing_replacement_bottle",
-                );
-              }
-            }
-          } else {
-            recordUnresolvedBottleImageCandidate(
-              bottleImageCandidate,
-              "missing_replacement_mapping",
-            );
-          }
-        }
-      }
-    } catch (err) {
-      logError(err, {
-        ...contexts,
-        bottleImageCandidate,
-      });
-    }
-  }
+  await fillMissingBottleImage(bottleImageCandidate, contexts);
 
   if (aliasChanged) {
     try {
@@ -802,6 +736,83 @@ export async function finalizeBottleAliasAssignment(
     await pushUniqueJob("IndexBottleSearchVectors", { bottleId });
   } catch (err) {
     logError(err, contexts);
+  }
+}
+
+/** Fills only a missing Bottle image and respects rejected image URLs. */
+export async function fillMissingBottleImage(
+  bottleImageCandidate: BottleImageCandidate | null,
+  contexts?: SentryLogContexts,
+) {
+  if (!bottleImageCandidate) return;
+
+  try {
+    const [updatedOriginal] = await db
+      .update(bottles)
+      .set({ imageUrl: bottleImageCandidate.imageUrl })
+      .where(
+        and(
+          eq(bottles.id, bottleImageCandidate.bottleId),
+          or(isNull(bottles.imageUrl), eq(bottles.imageUrl, "")),
+          sql`${bottleImageCandidate.imageUrl} <> ALL(${bottles.rejectedImageUrls})`,
+        ),
+      )
+      .returning({ id: bottles.id });
+    if (updatedOriginal) return;
+
+    const original = await db.query.bottles.findFirst({
+      where: eq(bottles.id, bottleImageCandidate.bottleId),
+      columns: { id: true },
+    });
+    if (original) return;
+
+    const tombstone = await db.query.bottleTombstones.findFirst({
+      where: eq(bottleTombstones.bottleId, bottleImageCandidate.bottleId),
+      columns: { newBottleId: true },
+    });
+    if (!tombstone) {
+      recordUnresolvedBottleImageCandidate(
+        bottleImageCandidate,
+        "missing_tombstone",
+      );
+      return;
+    }
+    if (!tombstone.newBottleId) {
+      recordUnresolvedBottleImageCandidate(
+        bottleImageCandidate,
+        "missing_replacement_mapping",
+      );
+      return;
+    }
+
+    const [updatedReplacement] = await db
+      .update(bottles)
+      .set({ imageUrl: bottleImageCandidate.imageUrl })
+      .where(
+        and(
+          eq(bottles.id, tombstone.newBottleId),
+          or(isNull(bottles.imageUrl), eq(bottles.imageUrl, "")),
+          sql`${bottleImageCandidate.imageUrl} <> ALL(${bottles.rejectedImageUrls})`,
+        ),
+      )
+      .returning({ id: bottles.id });
+    if (updatedReplacement) return;
+
+    const replacement = await db.query.bottles.findFirst({
+      where: eq(bottles.id, tombstone.newBottleId),
+      columns: { id: true },
+    });
+    if (!replacement) {
+      recordUnresolvedBottleImageCandidate(
+        bottleImageCandidate,
+        "missing_replacement_bottle",
+      );
+    }
+  } catch (err) {
+    logError(err, {
+      ...contexts,
+      bottleImageCandidate,
+    });
   }
 }
 

--- a/apps/server/src/lib/incomingBottleDecisionLog.ts
+++ b/apps/server/src/lib/incomingBottleDecisionLog.ts
@@ -15,6 +15,7 @@ export type IncomingBottleDecisionSourceKind =
 export type IncomingBottleDecisionActor = Pick<Actor, "id" | "type" | "userId">;
 
 export interface IncomingBottleDecisionMetadata {
+  aliasScope?: "global_alias" | "none";
   classifierEvidence?: unknown;
   creationSource?: string;
   gtin14?: string;

--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -1003,6 +1003,7 @@ describe("priceMatching", () => {
         priceId: price.id,
         status: "pending_review",
         proposalType: "create_new",
+        aliasScope: "global_alias",
         extractedLabel: {
           brand: "SMWS",
           bottler: "SMWS",
@@ -1591,6 +1592,7 @@ describe("priceMatching", () => {
           action: "match_existing",
           confidence: 80,
           rationale: "The current bottle identity already matches cleanly.",
+          aliasScope: "global_alias",
           suggestedBottleId: bottle.id,
           candidateBottleIds: [bottle.id],
           proposedBottle: null,
@@ -3232,6 +3234,7 @@ describe("priceMatching", () => {
           confidence: 100,
           rationale: "Classifier matched the SMWS exact-cask code.",
           identityScope: "exact_cask",
+          aliasScope: "global_alias",
           confidenceBasis: autoVerificationConfidenceBasis,
           suggestedBottleId: bottle.id,
           candidateBottleIds: [bottle.id],
@@ -3346,6 +3349,7 @@ describe("priceMatching", () => {
           confidence: 100,
           rationale: "Classifier matched the SMWS exact-cask code.",
           identityScope: "exact_cask",
+          aliasScope: "global_alias",
           confidenceBasis: autoVerificationConfidenceBasis,
           suggestedBottleId: bottle.id,
           candidateBottleIds: [bottle.id],
@@ -3451,6 +3455,7 @@ describe("priceMatching", () => {
           action: "create_new",
           confidence: 95,
           rationale: "Classifier created the SMWS exact-cask bottle.",
+          aliasScope: "global_alias",
           candidateBottleIds: [],
           proposedBottle: {
             name: "RW6.5 Sauna Smoke",
@@ -4049,6 +4054,7 @@ describe("priceMatching", () => {
           action: "create_new",
           confidence: 92,
           rationale: "Web evidence confirms a distinct release.",
+          aliasScope: "global_alias",
           confidenceBasis: supportiveWebEvidenceConfidenceBasis,
           suggestedBottleId: null,
           candidateBottleIds: [],
@@ -6817,9 +6823,7 @@ describe("priceMatching", () => {
     const updatedPrice = await db.query.storePrices.findFirst({
       where: eq(storePrices.id, price.id),
     });
-    expect(listingAlias).toMatchObject({
-      bottleId: promotedBottle.id,
-    });
+    expect(listingAlias).toBeUndefined();
     expect(updatedPrice).toMatchObject({
       bottleId: promotedBottle.id,
     });
@@ -7060,7 +7064,7 @@ describe("priceMatching", () => {
       suggestedBottleId: suggestedParent.id,
       reviewedById: reviewer.id,
     });
-    expect(alias).toMatchObject({ bottleId: suggestedParent.id });
+    expect(alias).toBeUndefined();
     expect(observation).toMatchObject({
       bottleId: suggestedParent.id,
     });
@@ -7174,6 +7178,7 @@ describe("priceMatching", () => {
         status: "pending_review",
         proposalType: "match_existing",
         aliasScope: "global_alias",
+        suggestedBottleId: bottle.id,
       })
       .returning();
 
@@ -7240,10 +7245,46 @@ describe("priceMatching", () => {
     });
 
     expect(updatedPrice?.bottleId).toBe(bottle.id);
-    expect(listingAlias).toMatchObject({
-      bottleId: bottle.id,
-      ignored: true,
+    expect(listingAlias).toBeUndefined();
+  });
+
+  test("does not create a BottleAlias when a match proposal has no suggested Bottle", async ({
+    fixtures,
+  }) => {
+    const reviewer = await fixtures.User();
+    const bottle = await fixtures.Bottle();
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      name: "Missing Suggested Bottle",
     });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "match_existing",
+        aliasScope: "global_alias",
+        suggestedBottleId: null,
+      })
+      .returning();
+
+    await applyApprovedStorePriceMatch({
+      proposalId: proposal.id,
+      bottleId: bottle.id,
+      reviewedById: reviewer.id,
+      actor: await getUserActor(reviewer),
+    });
+
+    expect(
+      await db.query.storePrices.findFirst({
+        where: eq(storePrices.id, price.id),
+      }),
+    ).toMatchObject({ bottleId: bottle.id });
+    expect(
+      await db.query.bottleAliases.findFirst({
+        where: eq(bottleAliases.name, normalizeBottleAliasKey(price.name)),
+      }),
+    ).toBeUndefined();
   });
 
   test("treats missing alias scope conservatively and keeps the listing title source-scoped", async ({
@@ -7278,8 +7319,7 @@ describe("priceMatching", () => {
       where: eq(bottleAliases.name, normalizeBottleAliasKey(price.name)),
     });
 
-    expect(listingAlias?.bottleId).toBe(bottle.id);
-    expect(listingAlias?.ignored).toBe(true);
+    expect(listingAlias).toBeUndefined();
   });
 
   test("leaves other aliases reusable when a none-scope listing is approved", async ({
@@ -7334,7 +7374,7 @@ describe("priceMatching", () => {
       name: "Existing Active Alias Listing",
       volume: 750,
     });
-    await fixtures.BottleAlias({
+    const existingAlias = await fixtures.BottleAlias({
       bottleId: bottle.id,
       name: normalizeBottleAliasKey(price.name),
       assignmentSource: "human_approved",
@@ -7366,6 +7406,8 @@ describe("priceMatching", () => {
     expect(listingAlias).toMatchObject({
       bottleId: bottle.id,
       ignored: false,
+      assignmentSource: "human_approved",
+      assignedByActorId: existingAlias.assignedByActorId,
     });
   });
 
@@ -7394,6 +7436,7 @@ describe("priceMatching", () => {
         status: "pending_review",
         proposalType: "match_existing",
         aliasScope: "global_alias",
+        suggestedBottleId: bottle.id,
       })
       .returning();
 

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -35,6 +35,7 @@ import {
 import { getPeatedSystemActor } from "@peated/server/lib/actors";
 import {
   assignBottleAliasInTransaction,
+  fillMissingBottleImage,
   finalizeBottleAliasAssignment,
 } from "@peated/server/lib/bottleAliases";
 import { createBottleCheck } from "@peated/server/lib/bottleChecks";
@@ -706,10 +707,11 @@ function getStorePriceBottleRepairDraft(
 function buildStorePriceObservationFacts(
   proposal: Pick<
     StorePriceMatchProposalForReview,
-    "proposalType" | "proposedBottle"
+    "aliasScope" | "proposalType" | "proposedBottle"
   >,
 ) {
   return {
+    aliasScope: proposal.aliasScope ?? "none",
     proposalType: proposal.proposalType,
     proposedBottle: proposal.proposedBottle ?? null,
   };
@@ -954,28 +956,25 @@ async function createBottleFromStorePriceMatchProposalInTransaction(
     throw new StorePriceMatchProposalIdentityChangedError(proposalId);
   }
 
-  const aliasResult = await applyApprovedStorePriceMatchProposalInTransaction(
-    tx,
-    {
-      proposal,
-      reviewedById: user.id,
-      allowSystemActor: creationSource === "price_match_automation",
-      decisionLog: {
-        actor: writeActor,
-        decision: createResult ? "create_bottle" : "match_existing",
-        createdBottle: !!createResult,
-        metadata: {
-          creationSource,
-          reusedExistingBottle: !createResult,
-        },
+  const approval = await applyApprovedStorePriceMatchProposalInTransaction(tx, {
+    proposal,
+    reviewedById: user.id,
+    allowSystemActor: creationSource === "price_match_automation",
+    decisionLog: {
+      actor: writeActor,
+      decision: createResult ? "create_bottle" : "match_existing",
+      createdBottle: !!createResult,
+      metadata: {
+        creationSource,
+        reusedExistingBottle: !createResult,
       },
-      bottleId: resolvedBottle.id,
     },
-  );
+    bottleId: resolvedBottle.id,
+  });
 
   return {
     createResult,
-    aliasResult,
+    approval,
     bottle: resolvedBottle,
   };
 }
@@ -1014,9 +1013,7 @@ export async function createBottleFromStorePriceMatchProposal(
       creationSource,
     });
   }
-  await finalizeBottleAliasAssignment(result.aliasResult, {
-    bottle: { id: result.bottle.id },
-  });
+  await finalizeStorePriceApproval(result.approval, result.bottle.id);
 
   return {
     bottle: result.bottle,
@@ -1713,8 +1710,9 @@ async function persistApprovedStorePriceMatchInTransaction(
   // The decision writer is idempotent by source. Always offer a completed
   // moderation decision so legacy or preassigned prices still gain history.
   const metadata: IncomingBottleDecisionMetadata = {
-    proposalType: proposal.proposalType,
     ...decisionLog.metadata,
+    proposalType: proposal.proposalType,
+    aliasScope: proposal.aliasScope ?? "none",
   };
   if (decisionLog.actor.type === "system") {
     metadata.initiatedByUserId = reviewedById;
@@ -1770,22 +1768,25 @@ export async function applyApprovedStorePriceMatchProposalInTransaction(
     },
   );
 
-  const aliasKey = normalizeBottleAliasKey(proposal.price.name);
-  // Only `global_alias` lets this store title match future listings. Other
-  // approvals still link this listing to the bottle, but keep its title out of
-  // automatic matching. Existing aliases keep their current setting.
-  const mayReuseAlias = proposal.aliasScope === "global_alias";
-  const aliasInput = {
-    bottleId,
-    externalSiteId: proposal.price.externalSiteId,
-    name: aliasKey,
-    backfillNames: [proposal.price.name],
-    volume: proposal.price.volume,
-    ignored: !mayReuseAlias,
-    assignmentSource: "source_approved",
-    assignedByActorId: actor.id,
-  } satisfies Parameters<typeof assignBottleAliasInTransaction>[1];
-  const aliasResult = await assignBottleAliasInTransaction(tx, aliasInput);
+  // A BottleAlias affects other listings and reviews. Create it only when the
+  // proposal explicitly allows that reuse and the moderator accepted the
+  // suggested Bottle. The exact StorePrice assignment below is independent.
+  const shouldAssignAlias =
+    proposal.aliasScope === "global_alias" &&
+    (proposal.proposalType === "create_new" ||
+      proposal.suggestedBottleId === bottleId);
+  const aliasResult = shouldAssignAlias
+    ? await assignBottleAliasInTransaction(tx, {
+        bottleId,
+        externalSiteId: proposal.price.externalSiteId,
+        name: normalizeBottleAliasKey(proposal.price.name),
+        backfillNames: [proposal.price.name],
+        volume: proposal.price.volume,
+        ignored: false,
+        assignmentSource: "source_approved",
+        assignedByActorId: actor.id,
+      })
+    : null;
 
   await persistApprovedStorePriceMatchInTransaction(tx, {
     proposal,
@@ -1797,7 +1798,30 @@ export async function applyApprovedStorePriceMatchProposalInTransaction(
     },
   });
 
-  return aliasResult;
+  return {
+    aliasResult,
+    bottleImageCandidate:
+      aliasResult === null && proposal.price.imageUrl
+        ? { bottleId, imageUrl: proposal.price.imageUrl }
+        : null,
+  };
+}
+
+async function finalizeStorePriceApproval(
+  approval: Awaited<
+    ReturnType<typeof applyApprovedStorePriceMatchProposalInTransaction>
+  >,
+  bottleId: number,
+) {
+  if (approval.aliasResult) {
+    await finalizeBottleAliasAssignment(approval.aliasResult, {
+      bottle: { id: bottleId },
+    });
+    return;
+  }
+  await fillMissingBottleImage(approval.bottleImageCandidate, {
+    bottle: { id: bottleId },
+  });
 }
 
 export async function applyApprovedStorePriceMatchInTransaction(
@@ -1826,7 +1850,7 @@ export async function applyApprovedStorePriceMatchInTransaction(
   });
 
   return {
-    aliasResult: await applyApprovedStorePriceMatchProposalInTransaction(tx, {
+    approval: await applyApprovedStorePriceMatchProposalInTransaction(tx, {
       proposal,
       reviewedById,
       allowSystemActor,
@@ -1855,7 +1879,7 @@ export async function applyApprovedStorePriceMatch({
   allowSystemActor?: boolean;
   expectedProcessingToken?: string;
 }) {
-  const { aliasResult } = await db.transaction(async (tx) =>
+  const { approval } = await db.transaction(async (tx) =>
     applyApprovedStorePriceMatchInTransaction(tx, {
       proposalId,
       bottleId,
@@ -1866,9 +1890,7 @@ export async function applyApprovedStorePriceMatch({
     }),
   );
 
-  await finalizeBottleAliasAssignment(aliasResult, {
-    bottle: { id: bottleId },
-  });
+  await finalizeStorePriceApproval(approval, bottleId);
 }
 
 /**
@@ -1886,7 +1908,7 @@ export async function applyStorePriceBottleRepairFromProposal({
   actor: IncomingBottleDecisionActor;
   expectedProcessingToken?: string;
 }) {
-  const { updateManifest, aliasResult } = await db.transaction(async (tx) => {
+  const { updateManifest, approval } = await db.transaction(async (tx) => {
     const preflight = await getStorePriceMatchProposalPreflight(tx, proposalId);
     if (
       preflight.proposalType !== "correction" ||
@@ -1932,8 +1954,9 @@ export async function applyStorePriceBottleRepairFromProposal({
     ) {
       throw new StorePriceMatchProposalIdentityChangedError(proposalId);
     }
-    const approvedAliasResult =
-      await applyApprovedStorePriceMatchProposalInTransaction(tx, {
+    const approval = await applyApprovedStorePriceMatchProposalInTransaction(
+      tx,
+      {
         proposal,
         reviewedById: user.id,
         bottleId: updateManifest.bottle.id,
@@ -1941,19 +1964,16 @@ export async function applyStorePriceBottleRepairFromProposal({
           actor,
           decision: "match_existing",
         },
-      });
+      },
+    );
 
     return {
       updateManifest,
-      aliasResult: approvedAliasResult,
+      approval,
     };
   });
 
-  await finalizeBottleAliasAssignment(aliasResult, {
-    bottle: {
-      id: updateManifest.bottle.id,
-    },
-  });
+  await finalizeStorePriceApproval(approval, updateManifest.bottle.id);
   await finalizeBottleUpdate(updateManifest);
 
   return updateManifest.bottle;

--- a/apps/server/src/lib/repairInvalidSourceBottleAliases.test.ts
+++ b/apps/server/src/lib/repairInvalidSourceBottleAliases.test.ts
@@ -1,0 +1,175 @@
+import { db } from "@peated/server/db";
+import {
+  bottleAliases,
+  changes,
+  incomingBottleDecisionLogs,
+  storePriceMatchProposals,
+} from "@peated/server/db/schema";
+import { getUserActor } from "@peated/server/lib/actors";
+import { repairInvalidSourceBottleAliases } from "@peated/server/lib/repairInvalidSourceBottleAliases";
+import { and, eq } from "drizzle-orm";
+import { expect, test } from "vitest";
+
+test("previews and explicitly unassigns a proven ignored source-only BottleAlias", async ({
+  fixtures,
+}) => {
+  const user = await fixtures.User({ mod: true });
+  const actor = await getUserActor(user);
+  const bottle = await fixtures.Bottle({ name: "Specific Cleanup Bottle" });
+  const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+  const price = await fixtures.StorePrice({
+    externalSiteId: site.id,
+    name: "Generic Cleanup Listing",
+    bottleId: bottle.id,
+  });
+  const [proposal] = await db
+    .insert(storePriceMatchProposals)
+    .values({
+      priceId: price.id,
+      status: "approved",
+      proposalType: "match_existing",
+      aliasScope: "none",
+      currentBottleId: bottle.id,
+      suggestedBottleId: bottle.id,
+      reviewedById: user.id,
+    })
+    .returning();
+  await db.insert(incomingBottleDecisionLogs).values({
+    sourceKind: "store_price",
+    sourceId: price.id,
+    proposalId: proposal.id,
+    externalSiteId: site.id,
+    name: price.name,
+    decision: "match_existing",
+    actorId: actor.id,
+    bottleId: bottle.id,
+  });
+  await fixtures.BottleAlias({
+    bottleId: bottle.id,
+    name: price.name,
+    ignored: true,
+    assignmentSource: "source_approved",
+    assignedByActorId: actor.id,
+  });
+
+  const preview = await repairInvalidSourceBottleAliases({
+    aliasNames: [price.name],
+  });
+
+  expect(preview.items).toEqual([
+    expect.objectContaining({
+      aliasName: price.name,
+      bottleId: bottle.id,
+      evidenceProposalIds: [proposal.id],
+      status: "planned",
+    }),
+  ]);
+  expect(
+    await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, price.name),
+    }),
+  ).toMatchObject({ bottleId: bottle.id });
+
+  const applied = await repairInvalidSourceBottleAliases({
+    aliasNames: [price.name],
+    dryRun: false,
+    user,
+  });
+
+  expect(applied.summary).toMatchObject({ applied: 1, failed: 0 });
+  expect(
+    await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, price.name),
+    }),
+  ).toMatchObject({
+    bottleId: null,
+    ignored: true,
+    assignmentSource: "source_approved",
+  });
+  expect(
+    await db.query.changes.findFirst({
+      where: and(
+        eq(changes.objectType, "bottle"),
+        eq(changes.objectId, bottle.id),
+      ),
+      orderBy: (table, { desc }) => desc(table.id),
+    }),
+  ).toMatchObject({
+    actorId: actor.id,
+    data: expect.objectContaining({
+      updateScope: "bottle_alias_repair",
+      aliasName: price.name,
+      evidenceProposalIds: [proposal.id],
+    }),
+  });
+});
+
+test("does not automatically repair an active BottleAlias", async ({
+  fixtures,
+}) => {
+  const user = await fixtures.User({ mod: true });
+  const actor = await getUserActor(user);
+  const bottle = await fixtures.Bottle({ name: "Active Alias Bottle" });
+  const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+  const price = await fixtures.StorePrice({
+    externalSiteId: site.id,
+    name: "Active Source Alias",
+    bottleId: bottle.id,
+  });
+  const [proposal] = await db
+    .insert(storePriceMatchProposals)
+    .values({
+      priceId: price.id,
+      status: "approved",
+      proposalType: "match_existing",
+      aliasScope: "none",
+      currentBottleId: bottle.id,
+      suggestedBottleId: bottle.id,
+      reviewedById: user.id,
+    })
+    .returning();
+  await db.insert(incomingBottleDecisionLogs).values({
+    sourceKind: "store_price",
+    sourceId: price.id,
+    proposalId: proposal.id,
+    externalSiteId: site.id,
+    name: price.name,
+    decision: "match_existing",
+    actorId: actor.id,
+    bottleId: bottle.id,
+  });
+  await fixtures.BottleAlias({
+    bottleId: bottle.id,
+    name: price.name,
+    ignored: false,
+    assignmentSource: "source_approved",
+    assignedByActorId: actor.id,
+  });
+
+  const result = await repairInvalidSourceBottleAliases({
+    aliasNames: [price.name],
+  });
+
+  expect(result.items).toEqual([
+    expect.objectContaining({
+      aliasName: price.name,
+      status: "review_required",
+      message: "Active BottleAlias requires manual review.",
+    }),
+  ]);
+  expect(
+    await db.query.bottleAliases.findFirst({
+      where: eq(bottleAliases.name, price.name),
+    }),
+  ).toMatchObject({ bottleId: bottle.id });
+});
+
+test("requires explicit BottleAlias names before execution", async ({
+  fixtures,
+}) => {
+  const user = await fixtures.User({ mod: true });
+
+  await expect(
+    repairInvalidSourceBottleAliases({ dryRun: false, user }),
+  ).rejects.toThrow("explicit BottleAlias names");
+});

--- a/apps/server/src/lib/repairInvalidSourceBottleAliases.ts
+++ b/apps/server/src/lib/repairInvalidSourceBottleAliases.ts
@@ -1,0 +1,322 @@
+import { db as defaultDb, type AnyDatabase } from "@peated/server/db";
+import type { User } from "@peated/server/db/schema";
+import {
+  bottleAliases,
+  bottles,
+  changes,
+  incomingBottleDecisionLogs,
+  storePriceMatchProposals,
+  users,
+} from "@peated/server/db/schema";
+import { getUserActorByIdForDatabase } from "@peated/server/lib/actors";
+import { logError } from "@peated/server/lib/log";
+import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
+import { and, asc, eq, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
+
+type RepairStatus = "applied" | "failed" | "planned" | "review_required";
+
+export type InvalidSourceBottleAliasRepairItem = {
+  aliasName: string;
+  bottleId: number | null;
+  evidenceProposalIds: number[];
+  message: string;
+  status: RepairStatus;
+};
+
+export type InvalidSourceBottleAliasRepairResult = {
+  items: InvalidSourceBottleAliasRepairItem[];
+  summary: Record<RepairStatus | "total", number>;
+};
+
+type RepairOptions = {
+  aliasNames?: string[];
+  db?: AnyDatabase;
+  dryRun?: boolean;
+  limit?: number;
+  user?: Pick<User, "id">;
+};
+
+type Candidate = {
+  name: string;
+  bottleId: number;
+  ignored: boolean | null;
+  assignmentSource: typeof bottleAliases.$inferSelect.assignmentSource;
+  assignedByActorId: number;
+  bottleFullName: string;
+};
+
+async function inspectCandidate(database: AnyDatabase, candidate: Candidate) {
+  const evidence = await database
+    .select({
+      decisionName: incomingBottleDecisionLogs.name,
+      proposalId: storePriceMatchProposals.id,
+    })
+    .from(incomingBottleDecisionLogs)
+    .innerJoin(
+      storePriceMatchProposals,
+      eq(storePriceMatchProposals.id, incomingBottleDecisionLogs.proposalId),
+    )
+    .where(
+      and(
+        eq(incomingBottleDecisionLogs.sourceKind, "store_price"),
+        eq(incomingBottleDecisionLogs.bottleId, candidate.bottleId),
+        eq(storePriceMatchProposals.status, "approved"),
+        eq(storePriceMatchProposals.currentBottleId, candidate.bottleId),
+        or(
+          isNull(storePriceMatchProposals.aliasScope),
+          eq(storePriceMatchProposals.aliasScope, "none"),
+        ),
+      ),
+    )
+    .orderBy(asc(storePriceMatchProposals.id));
+  const evidenceProposalIds = evidence
+    .filter(
+      ({ decisionName }) =>
+        normalizeBottleAliasKey(decisionName).toLowerCase() ===
+        candidate.name.toLowerCase(),
+    )
+    .map(({ proposalId }) => proposalId);
+
+  if (candidate.assignmentSource !== "source_approved") {
+    return {
+      eligible: false,
+      evidenceProposalIds,
+      message: "BottleAlias was not assigned by a StorePrice approval.",
+    };
+  }
+  if (!candidate.ignored) {
+    return {
+      eligible: false,
+      evidenceProposalIds,
+      message: "Active BottleAlias requires manual review.",
+    };
+  }
+  const canonicalNames = new Set([
+    candidate.bottleFullName.trim().toLowerCase(),
+    normalizeBottleAliasKey(candidate.bottleFullName).toLowerCase(),
+  ]);
+  if (canonicalNames.has(candidate.name.toLowerCase())) {
+    return {
+      eligible: false,
+      evidenceProposalIds,
+      message:
+        "BottleAlias matches the Bottle name and requires manual review.",
+    };
+  }
+  if (evidenceProposalIds.length === 0) {
+    return {
+      eligible: false,
+      evidenceProposalIds,
+      message:
+        "No approved source-only StorePrice decision proves this repair.",
+    };
+  }
+  return {
+    eligible: true,
+    evidenceProposalIds,
+    message:
+      "Unassign ignored BottleAlias so it no longer blocks a later valid assignment.",
+  };
+}
+
+function buildSummary(items: InvalidSourceBottleAliasRepairItem[]) {
+  return items.reduce<InvalidSourceBottleAliasRepairResult["summary"]>(
+    (summary, item) => {
+      summary.total += 1;
+      summary[item.status] += 1;
+      return summary;
+    },
+    { applied: 0, failed: 0, planned: 0, review_required: 0, total: 0 },
+  );
+}
+
+/**
+ * Audits legacy BottleAlias rows touched by source-only StorePrice approvals.
+ * Execution requires explicit alias names and only unassigns ignored rows with
+ * matching approved proposal evidence.
+ */
+export async function repairInvalidSourceBottleAliases({
+  aliasNames = [],
+  db = defaultDb,
+  dryRun = true,
+  limit = 100,
+  user,
+}: RepairOptions): Promise<InvalidSourceBottleAliasRepairResult> {
+  if (!dryRun && aliasNames.length === 0) {
+    throw new Error(
+      "Execution requires one or more explicit BottleAlias names.",
+    );
+  }
+  if (!dryRun && !user) {
+    throw new Error("A user is required to repair BottleAlias rows.");
+  }
+
+  let repairActorId: number | null = null;
+  if (!dryRun) {
+    const persistedUser = await db.query.users.findFirst({
+      where: eq(users.id, user!.id),
+    });
+    if (!persistedUser) {
+      throw new Error(`Repair user ${user!.id} no longer exists.`);
+    }
+    repairActorId = (await getUserActorByIdForDatabase(db, persistedUser.id))
+      .id;
+  }
+
+  const requestedNames = Array.from(
+    new Set(
+      aliasNames.map((name) => name.trim().toLowerCase()).filter(Boolean),
+    ),
+  );
+  const rows = await db
+    .select({
+      name: bottleAliases.name,
+      bottleId: bottleAliases.bottleId,
+      ignored: bottleAliases.ignored,
+      assignmentSource: bottleAliases.assignmentSource,
+      assignedByActorId: bottleAliases.assignedByActorId,
+      bottleFullName: bottles.fullName,
+    })
+    .from(bottleAliases)
+    .innerJoin(bottles, eq(bottles.id, bottleAliases.bottleId))
+    .where(
+      and(
+        isNotNull(bottleAliases.bottleId),
+        requestedNames.length
+          ? inArray(sql`LOWER(${bottleAliases.name})`, requestedNames)
+          : eq(bottleAliases.assignmentSource, "source_approved"),
+      ),
+    )
+    .orderBy(asc(bottleAliases.name))
+    .limit(requestedNames.length || limit);
+  const candidates: Candidate[] = rows.flatMap((row) =>
+    row.bottleId === null ? [] : [{ ...row, bottleId: row.bottleId }],
+  );
+  const items: InvalidSourceBottleAliasRepairItem[] = [];
+
+  for (const candidate of candidates) {
+    const inspection = await inspectCandidate(db, candidate);
+    if (!inspection.eligible) {
+      items.push({
+        aliasName: candidate.name,
+        bottleId: candidate.bottleId,
+        evidenceProposalIds: inspection.evidenceProposalIds,
+        message: inspection.message,
+        status: "review_required",
+      });
+      continue;
+    }
+    if (dryRun) {
+      items.push({
+        aliasName: candidate.name,
+        bottleId: candidate.bottleId,
+        evidenceProposalIds: inspection.evidenceProposalIds,
+        message: inspection.message,
+        status: "planned",
+      });
+      continue;
+    }
+
+    try {
+      const item = await db.transaction(async (tx) => {
+        const [locked] = await tx
+          .select({
+            name: bottleAliases.name,
+            bottleId: bottleAliases.bottleId,
+            ignored: bottleAliases.ignored,
+            assignmentSource: bottleAliases.assignmentSource,
+            assignedByActorId: bottleAliases.assignedByActorId,
+            bottleFullName: bottles.fullName,
+          })
+          .from(bottleAliases)
+          .innerJoin(bottles, eq(bottles.id, bottleAliases.bottleId))
+          .where(
+            eq(sql`LOWER(${bottleAliases.name})`, candidate.name.toLowerCase()),
+          )
+          .limit(1)
+          .for("update");
+        if (!locked || locked.bottleId === null) {
+          throw new Error("BottleAlias changed after preview.");
+        }
+        const current: Candidate = {
+          ...locked,
+          bottleId: locked.bottleId,
+        };
+        const currentInspection = await inspectCandidate(tx, current);
+        if (!currentInspection.eligible) {
+          throw new Error(currentInspection.message);
+        }
+        const [updated] = await tx
+          .update(bottleAliases)
+          .set({ bottleId: null, embedding: null })
+          .where(
+            and(
+              eq(bottleAliases.name, current.name),
+              eq(bottleAliases.bottleId, current.bottleId),
+              eq(bottleAliases.ignored, true),
+              eq(bottleAliases.assignmentSource, "source_approved"),
+            ),
+          )
+          .returning({ name: bottleAliases.name });
+        if (!updated) {
+          throw new Error("BottleAlias changed during repair.");
+        }
+        await tx.insert(changes).values({
+          objectType: "bottle",
+          objectId: current.bottleId,
+          actorId: repairActorId!,
+          displayName: current.bottleFullName,
+          type: "update",
+          data: {
+            updateScope: "bottle_alias_repair",
+            aliasName: current.name,
+            evidenceProposalIds: currentInspection.evidenceProposalIds,
+            before: {
+              bottleId: current.bottleId,
+              ignored: current.ignored,
+              assignmentSource: current.assignmentSource,
+              assignedByActorId: current.assignedByActorId,
+            },
+            after: { bottleId: null },
+          },
+        });
+        return {
+          aliasName: current.name,
+          bottleId: current.bottleId,
+          evidenceProposalIds: currentInspection.evidenceProposalIds,
+          message: currentInspection.message,
+          status: "applied" as const,
+        };
+      });
+      items.push(item);
+    } catch (error) {
+      logError(error, { bottleAlias: { name: candidate.name } });
+      items.push({
+        aliasName: candidate.name,
+        bottleId: candidate.bottleId,
+        evidenceProposalIds: inspection.evidenceProposalIds,
+        message:
+          error instanceof Error ? error.message : "Unknown repair failure.",
+        status: "failed",
+      });
+    }
+  }
+
+  for (const requestedName of requestedNames) {
+    if (
+      !candidates.some(
+        (candidate) => candidate.name.toLowerCase() === requestedName,
+      )
+    ) {
+      items.push({
+        aliasName: requestedName,
+        bottleId: null,
+        evidenceProposalIds: [],
+        message: "Assigned BottleAlias was not found.",
+        status: "review_required",
+      });
+    }
+  }
+
+  return { items, summary: buildSummary(items) };
+}

--- a/apps/server/src/orpc/routes/bottleAliases/index.ts
+++ b/apps/server/src/orpc/routes/bottleAliases/index.ts
@@ -1,11 +1,13 @@
 import { base } from "@peated/server/orpc";
 import delete_ from "./delete";
 import list from "./list";
+import repairSourceApprovals from "./repair-source-approvals";
 import update from "./update";
 import upsert from "./upsert";
 
 export default base.tag("bottleAliases").router({
   list,
+  repairSourceApprovals,
   update,
   delete: delete_,
   upsert,

--- a/apps/server/src/orpc/routes/bottleAliases/repair-source-approvals.test.ts
+++ b/apps/server/src/orpc/routes/bottleAliases/repair-source-approvals.test.ts
@@ -1,0 +1,132 @@
+import { db } from "@peated/server/db";
+import {
+  bottleAliases,
+  changes,
+  incomingBottleDecisionLogs,
+  storePriceMatchProposals,
+} from "@peated/server/db/schema";
+import { getUserActor } from "@peated/server/lib/actors";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { and, eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+describe("POST /bottle-aliases/repair-source-approvals", () => {
+  test("requires moderator access", async ({ fixtures }) => {
+    const user = await fixtures.User({ mod: false });
+
+    const error = await waitError(
+      routerClient.bottleAliases.repairSourceApprovals(
+        {},
+        { context: { user } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("previews by default and applies only an explicitly named repair", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const actor = await getUserActor(user);
+    const bottle = await fixtures.Bottle({ name: "API Cleanup Bottle" });
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const price = await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "API Cleanup Listing",
+      bottleId: bottle.id,
+    });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "approved",
+        proposalType: "match_existing",
+        aliasScope: "none",
+        currentBottleId: bottle.id,
+        suggestedBottleId: bottle.id,
+        reviewedById: user.id,
+      })
+      .returning();
+    await db.insert(incomingBottleDecisionLogs).values({
+      sourceKind: "store_price",
+      sourceId: price.id,
+      proposalId: proposal.id,
+      externalSiteId: site.id,
+      name: price.name,
+      decision: "match_existing",
+      actorId: actor.id,
+      bottleId: bottle.id,
+    });
+    await fixtures.BottleAlias({
+      bottleId: bottle.id,
+      name: price.name,
+      ignored: true,
+      assignmentSource: "source_approved",
+      assignedByActorId: actor.id,
+    });
+
+    const preview = await routerClient.bottleAliases.repairSourceApprovals(
+      { aliasNames: [price.name] },
+      { context: { user } },
+    );
+
+    expect(preview).toMatchObject({
+      items: [
+        {
+          aliasName: price.name,
+          bottleId: bottle.id,
+          evidenceProposalIds: [proposal.id],
+          status: "planned",
+        },
+      ],
+      summary: { applied: 0, planned: 1, reviewRequired: 0, total: 1 },
+    });
+    expect(
+      await db.query.bottleAliases.findFirst({
+        where: eq(bottleAliases.name, price.name),
+      }),
+    ).toMatchObject({ bottleId: bottle.id });
+
+    const applied = await routerClient.bottleAliases.repairSourceApprovals(
+      { aliasNames: [price.name], execute: true },
+      { context: { user } },
+    );
+
+    expect(applied.summary).toMatchObject({ applied: 1, failed: 0 });
+    expect(
+      await db.query.bottleAliases.findFirst({
+        where: eq(bottleAliases.name, price.name),
+      }),
+    ).toMatchObject({ bottleId: null });
+    expect(
+      await db.query.changes.findFirst({
+        where: and(
+          eq(changes.objectType, "bottle"),
+          eq(changes.objectId, bottle.id),
+        ),
+        orderBy: (table, { desc }) => desc(table.id),
+      }),
+    ).toMatchObject({
+      actorId: actor.id,
+      data: expect.objectContaining({
+        updateScope: "bottle_alias_repair",
+        aliasName: price.name,
+      }),
+    });
+  });
+
+  test("requires explicit names for execution", async ({ fixtures }) => {
+    const user = await fixtures.User({ mod: true });
+
+    const error = await waitError(
+      routerClient.bottleAliases.repairSourceApprovals(
+        { execute: true },
+        { context: { user } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Input validation failed]`);
+  });
+});

--- a/apps/server/src/orpc/routes/bottleAliases/repair-source-approvals.ts
+++ b/apps/server/src/orpc/routes/bottleAliases/repair-source-approvals.ts
@@ -1,0 +1,82 @@
+import { repairInvalidSourceBottleAliases } from "@peated/server/lib/repairInvalidSourceBottleAliases";
+import { procedure } from "@peated/server/orpc";
+import { requireMod } from "@peated/server/orpc/middleware";
+import { z } from "zod";
+
+const InputSchema = z
+  .object({
+    aliasNames: z.array(z.string().trim().min(1)).max(100).default([]),
+    execute: z.boolean().default(false),
+    limit: z.number().int().gte(1).lte(100).default(100),
+  })
+  .strict()
+  .superRefine((input, context) => {
+    if (input.execute && input.aliasNames.length === 0) {
+      context.addIssue({
+        code: "custom",
+        message: "Execution requires one or more explicit BottleAlias names.",
+        path: ["aliasNames"],
+      });
+    }
+  });
+
+const RepairStatusSchema = z.enum([
+  "applied",
+  "failed",
+  "planned",
+  "review_required",
+]);
+
+export default procedure
+  .use(requireMod)
+  .route({
+    method: "POST",
+    path: "/bottle-aliases/repair-source-approvals",
+    summary: "Preview or repair invalid source-approval BottleAlias rows",
+    description:
+      "Preview is the default. Execution requires explicit BottleAlias names and moderator privileges.",
+    spec: (spec) => ({
+      ...spec,
+      operationId: "repairSourceBottleAliases",
+    }),
+  })
+  .input(InputSchema)
+  .output(
+    z.object({
+      items: z.array(
+        z.object({
+          aliasName: z.string(),
+          bottleId: z.number().nullable(),
+          evidenceProposalIds: z.array(z.number()),
+          message: z.string(),
+          status: RepairStatusSchema,
+        }),
+      ),
+      summary: z.object({
+        applied: z.number(),
+        failed: z.number(),
+        planned: z.number(),
+        reviewRequired: z.number(),
+        total: z.number(),
+      }),
+    }),
+  )
+  .handler(async ({ input, context }) => {
+    const result = await repairInvalidSourceBottleAliases({
+      aliasNames: input.aliasNames,
+      dryRun: !input.execute,
+      limit: input.limit,
+      user: context.user,
+    });
+
+    return {
+      items: result.items,
+      summary: {
+        applied: result.summary.applied,
+        failed: result.summary.failed,
+        planned: result.summary.planned,
+        reviewRequired: result.summary.review_required,
+        total: result.summary.total,
+      },
+    };
+  });

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -1088,6 +1088,7 @@ describe("price match queue", () => {
         confidence: 92,
         currentBottleId: currentBottle.id,
         suggestedBottleId: currentBottle.id,
+        aliasScope: "global_alias",
         candidateBottles: [
           {
             bottleId: currentBottle.id,
@@ -2029,10 +2030,7 @@ describe("price match queue", () => {
     });
     const userActor = await getUserActor(user);
 
-    expect(alias).toMatchObject({
-      bottleId: bottle.id,
-    });
-    expect(alias?.assignedByActorId).toBe(userActor.id);
+    expect(alias).toBeUndefined();
     expect(decisionLog).toMatchObject({
       actorId: userActor.id,
       decision: "match_existing",
@@ -2042,7 +2040,7 @@ describe("price match queue", () => {
       bottleId: bottle.id,
     });
     expect(updatedSiblingPrice?.bottleId).toBeNull();
-    expect(updatedReview?.bottleId).toBe(bottle.id);
+    expect(updatedReview?.bottleId).toBeNull();
     expect(updatedBottle?.imageUrl).toBe("https://example.com/price.jpg");
     expect(updatedBottle?.rejectedImageUrls).toEqual([
       "https://example.com/other-price.jpg",
@@ -2070,19 +2068,123 @@ describe("price match queue", () => {
       currentBottleId: null,
       suggestedBottleId: null,
     });
-    expect(workerClient.pushJob).toHaveBeenCalledWith("IndexBottleAlias", {
-      name: "Queue Approval",
-    });
+    expect(workerClient.pushJob).not.toHaveBeenCalledWith(
+      "IndexBottleAlias",
+      expect.anything(),
+    );
     expect(workerClient.pushJob).not.toHaveBeenCalledWith(
       "OnBottleAliasChange",
       expect.anything(),
     );
-    expect(workerClient.pushUniqueJob).toHaveBeenCalledWith(
+    expect(workerClient.pushUniqueJob).not.toHaveBeenCalledWith(
       "IndexBottleSearchVectors",
-      {
-        bottleId: bottle.id,
-      },
+      expect.anything(),
     );
+  });
+
+  test("approves one StorePrice when its title is a BottleAlias for another Bottle", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const generalBottle = await fixtures.Bottle({ name: "General Edition" });
+    const exactBottle = await fixtures.Bottle({ name: "Exact Edition" });
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const price = await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Shared Store Title",
+      bottleId: null,
+    });
+    const siblingPrice = await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: price.name,
+      bottleId: null,
+    });
+    const review = await fixtures.Review({
+      externalSiteId: site.id,
+      name: price.name,
+      bottleId: null,
+    });
+    const existingAlias = await fixtures.BottleAlias({
+      bottleId: generalBottle.id,
+      name: price.name,
+      assignmentSource: "human_approved",
+      ignored: false,
+    });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "match_existing",
+        aliasScope: "none",
+        suggestedBottleId: exactBottle.id,
+      })
+      .returning();
+
+    await routerClient.prices.matchQueue.resolve(
+      {
+        proposal: proposal.id,
+        action: "match",
+        bottle: exactBottle.id,
+      },
+      { context: { user } },
+    );
+
+    const [
+      updatedPrice,
+      updatedSiblingPrice,
+      updatedReview,
+      unchangedAlias,
+      updatedProposal,
+      observation,
+      decisionLog,
+    ] = await Promise.all([
+      db.query.storePrices.findFirst({ where: eq(storePrices.id, price.id) }),
+      db.query.storePrices.findFirst({
+        where: eq(storePrices.id, siblingPrice.id),
+      }),
+      db.query.reviews.findFirst({ where: eq(reviews.id, review.id) }),
+      db.query.bottleAliases.findFirst({
+        where: eq(bottleAliases.name, price.name),
+      }),
+      db.query.storePriceMatchProposals.findFirst({
+        where: eq(storePriceMatchProposals.id, proposal.id),
+      }),
+      db.query.bottleObservations.findFirst({
+        where: eq(bottleObservations.sourceKey, `store_price:${price.id}`),
+      }),
+      db.query.incomingBottleDecisionLogs.findFirst({
+        where: and(
+          eq(incomingBottleDecisionLogs.sourceKind, "store_price"),
+          eq(incomingBottleDecisionLogs.sourceId, price.id),
+        ),
+      }),
+    ]);
+
+    expect(updatedPrice?.bottleId).toBe(exactBottle.id);
+    expect(updatedSiblingPrice?.bottleId).toBeNull();
+    expect(updatedReview?.bottleId).toBeNull();
+    expect(unchangedAlias).toMatchObject({
+      bottleId: generalBottle.id,
+      ignored: false,
+      assignmentSource: "human_approved",
+      assignedByActorId: existingAlias.assignedByActorId,
+    });
+    expect(updatedProposal).toMatchObject({
+      status: "approved",
+      currentBottleId: exactBottle.id,
+      suggestedBottleId: exactBottle.id,
+    });
+    expect(observation).toMatchObject({
+      bottleId: exactBottle.id,
+      facts: expect.objectContaining({ aliasScope: "none" }),
+    });
+    expect(decisionLog).toMatchObject({
+      proposalId: proposal.id,
+      bottleId: exactBottle.id,
+      decision: "match_existing",
+      metadata: expect.objectContaining({ aliasScope: "none" }),
+    });
   });
 
   test("does not restore an image removed before approval", async ({
@@ -2143,7 +2245,7 @@ describe("price match queue", () => {
       await db.query.reviews.findFirst({
         where: eq(reviews.id, review.id),
       }),
-    ).toMatchObject({ bottleId: bottle.id });
+    ).toMatchObject({ bottleId: null });
     expect(
       await db.query.storePriceMatchProposals.findFirst({
         where: eq(storePriceMatchProposals.id, proposal.id),
@@ -2153,7 +2255,7 @@ describe("price match queue", () => {
       await db.query.bottleAliases.findFirst({
         where: eq(bottleAliases.name, "Removed Image Approval"),
       }),
-    ).toMatchObject({ bottleId: bottle.id });
+    ).toBeUndefined();
   });
 
   test("records moderation history when approving the current Bottle", async ({
@@ -2280,9 +2382,7 @@ describe("price match queue", () => {
     expect(updatedPrice).toMatchObject({
       bottleId: sourceBottle.id,
     });
-    expect(alias).toMatchObject({
-      bottleId: sourceBottle.id,
-    });
+    expect(alias).toBeUndefined();
     expect(updatedProposal).toMatchObject({
       currentBottleId: sourceBottle.id,
       suggestedBottleId: sourceBottle.id,
@@ -2314,6 +2414,7 @@ describe("price match queue", () => {
         priceId: price.id,
         status: "pending_review",
         proposalType: "match_existing",
+        aliasScope: "global_alias",
         suggestedBottleId: suggestedBottle.id,
       })
       .returning();
@@ -2334,6 +2435,11 @@ describe("price match queue", () => {
     ).resolves.toMatchObject({
       bottleId: otherBottle.id,
     });
+    await expect(
+      db.query.bottleAliases.findFirst({
+        where: eq(bottleAliases.name, price.name),
+      }),
+    ).resolves.toBeUndefined();
   });
 
   test("creates a bottle from a proposal and approves it atomically", async ({
@@ -2354,6 +2460,7 @@ describe("price match queue", () => {
         priceId: price.id,
         status: "pending_review",
         proposalType: "create_new",
+        aliasScope: "global_alias",
         proposedBottle: completeProposedBottle({
           name: "Single Cask",
           brand: { id: brand.id, name: brand.name },
@@ -2553,6 +2660,7 @@ describe("price match queue", () => {
         priceId: price.id,
         status: "pending_review",
         proposalType: "create_new",
+        aliasScope: "global_alias",
         currentBottleId: previousBottle.id,
         proposedBottle: completeProposedBottle({
           name: "Replacement Decision",
@@ -3263,6 +3371,7 @@ describe("price match queue", () => {
         priceId: price.id,
         status: "pending_review",
         proposalType: "match_existing",
+        aliasScope: "global_alias",
         suggestedBottleId: targetBottle.id,
       })
       .returning();
@@ -3308,6 +3417,7 @@ describe("price match queue", () => {
         priceId: price.id,
         status: "pending_review",
         proposalType: "create_new",
+        aliasScope: "global_alias",
         proposedBottle: completeProposedBottle({
           name: "Fresh Release",
           brand: { id: brand.id, name: brand.name },

--- a/docs/features/store-price-matching.md
+++ b/docs/features/store-price-matching.md
@@ -147,11 +147,13 @@ The approved StorePrice image can still fill an empty Bottle image. The server
 uses only that StorePrice image and continues to respect rejected image URLs.
 
 Legacy ignored BottleAlias rows from old source-only approvals can block later
-valid alias assignment. `pnpm cli bottles repair-source-aliases` audits these
-rows without changing them. Execution requires `--execute` and one or more
-explicit BottleAlias names. The repair only unassigns ignored rows when an
-approved source-only proposal and decision provide matching evidence. Active
-rows are report-only and require manual review.
+valid alias assignment. The moderator-only
+`POST /v1/bottle-aliases/repair-source-approvals` API audits these rows without
+changing them by default. The OAuth `cli api` client can call this endpoint
+against production. Execution requires `execute: true` and one or more explicit
+BottleAlias names. The repair only unassigns ignored rows when an approved
+source-only proposal and decision provide matching evidence. Active rows are
+report-only and require manual review.
 
 ## Image Promotion
 

--- a/docs/features/store-price-matching.md
+++ b/docs/features/store-price-matching.md
@@ -126,6 +126,33 @@ That observation stores:
 This keeps exact source detail without forcing new public fields into the normal
 Bottle entry flow.
 
+## Approval And BottleAlias Safety
+
+An approval always assigns the reviewed `store_price` to the selected Bottle.
+This exact assignment does not require a BottleAlias.
+
+A proposal can also allow the store title to become a reusable BottleAlias.
+The server creates that BottleAlias only when both conditions are true:
+
+- the stored proposal has `aliasScope = global_alias`
+- the moderator accepts the Bottle suggested by that proposal
+
+Missing scope and `aliasScope = none` create no BottleAlias. They also do not
+change an existing BottleAlias with the same name. The approval does not assign
+same-name StorePrices or reviews. A moderator override to a different Bottle
+also creates no BottleAlias, even if the proposal allowed one for its original
+suggestion.
+
+The approved StorePrice image can still fill an empty Bottle image. The server
+uses only that StorePrice image and continues to respect rejected image URLs.
+
+Legacy ignored BottleAlias rows from old source-only approvals can block later
+valid alias assignment. `pnpm cli bottles repair-source-aliases` audits these
+rows without changing them. Execution requires `--execute` and one or more
+explicit BottleAlias names. The repair only unassigns ignored rows when an
+approved source-only proposal and decision provide matching evidence. Active
+rows are report-only and require manual review.
+
 ## Image Promotion
 
 A StorePrice image can fill an empty Bottle image. It cannot use an image link

--- a/openspec/changes/add-source-scoped-store-price-identity/design.md
+++ b/openspec/changes/add-source-scoped-store-price-identity/design.md
@@ -74,7 +74,18 @@ Alternative considered: Create bottle aliases with an `externalSiteId` and rely 
 
 Implementation note: if a title is marked generic or source-scoped, no code path should call the existing global alias assignment helper for that title. A future source-scoped lookup mechanism must be separate from `bottle_alias` unless `bottle_alias` itself gains enforceable source scoping across lookup, assignment, and alias-change jobs.
 
-### Decision: Persist source-scoped verification as durable source identity
+### Decision: Keep the MVP on existing StorePrice evidence
+
+For the MVP, the approved `store_price.bottleId` is the durable identity for
+that exact row. `bottle_observation` and the incoming decision log preserve the
+source evidence and moderation history. The approval does not create a
+BottleAlias when `aliasScope` is `none` or missing.
+
+This does not let a future StorePrice row reuse the decision. Reuse by a future
+row requires a stable source key and remains deferred. The MVP adds no table and
+does not use a display title as that key.
+
+### Future decision: Persist reusable source identity
 
 Use existing `bottle_observation` only if it can support lookup semantics safely. Otherwise add a purpose-built table, likely keyed by:
 

--- a/openspec/changes/add-source-scoped-store-price-identity/proposal.md
+++ b/openspec/changes/add-source-scoped-store-price-identity/proposal.md
@@ -29,6 +29,6 @@ The central invariant is alias safety: a generic listing title MUST NOT become a
 
 - `packages/bottle-classifier`: decision schema, prompts/instructions, review policy, eval fixture schema, production-miss fixtures, and replay recordings.
 - `apps/server/src/lib/priceMatching*`: proposal mapping, automation assessment, approval application, alias assignment behavior, and observation metadata.
-- `apps/server/src/db/schema`: likely migration for source-scoped listing identity or equivalent durable verification metadata if existing `bottle_observation` cannot safely carry it, including internal store listing ids when scrapers can provide them.
+- Existing `store_price`, `bottle_observation`, proposal, and decision-log rows carry the MVP assignment and evidence. Reuse by a future source row is deferred and may require separate schema work later.
 - `docs/features/store-price-matching.md` and `docs/architecture/bottle-classifier.md`: document the distinction between reusable global aliases and source-specific listing identity.
 - Scraper ingestion paths that create `store_price` rows: future matching should be able to use stable source identifiers, URL/product ids, and source fingerprints without globalizing generic titles.

--- a/openspec/changes/add-source-scoped-store-price-identity/tasks.md
+++ b/openspec/changes/add-source-scoped-store-price-identity/tasks.md
@@ -24,17 +24,18 @@
 
 ## 4. Source-Scoped Persistence
 
-- [ ] 4.1 Decide whether `bottle_observation` can safely store reusable source-scoped verification or whether a new indexed table is required.
+- [x] 4.1 Keep the MVP on existing tables: the exact `store_price.bottleId` is durable identity, while observations and decision logs preserve evidence. Defer reuse by a future source row.
 - [ ] 4.2 Implement the selected persistence model with source keys for external site, internal store listing id when available, product id or canonical URL, optional SKU/fingerprint, target bottle/release, scope, evidence hash, confidence, and actor.
 - [ ] 4.3 Add migration and database tests for source-scoped lookup and non-reuse by display title alone.
 
 ## 5. Approval And Alias Safety
 
-- [ ] 5.1 Update store-price approval flow to skip global bottle alias assignment when alias scope is `none` or the title is classified as generic/underspecified.
-- [ ] 5.2 Preserve exact source evidence and source-scope metadata in observations or the new source identity table.
-- [ ] 5.3 Add integration tests proving source-scoped approval assigns the exact store price, creates no `bottle_alias` row for the generic label, and does not update unrelated future listings with the same generic title.
-- [ ] 5.4 Make new classifier decisions default to no global alias when alias-safety metadata is missing.
-- [ ] 5.5 Ensure current global alias behavior remains unchanged for explicit reusable canonical identity approvals.
+- [x] 5.1 Update store-price approval flow to skip BottleAlias assignment when alias scope is `none` or missing.
+- [x] 5.2 Preserve exact source evidence and source-scope metadata in observations and decision logs.
+- [x] 5.3 Add integration tests proving source-only approval assigns the exact StorePrice, creates no BottleAlias, and does not update unrelated same-name listings or reviews.
+- [x] 5.4 Keep missing alias-safety metadata conservative.
+- [x] 5.5 Keep current BottleAlias behavior for explicit reusable approvals when the moderator accepts the suggested Bottle.
+- [x] 5.6 Add a preview-first repair for proven ignored BottleAlias rows from old source-only approvals. Require explicit names for execution and leave active rows for manual review.
 
 ## 6. Scraper Reuse
 
@@ -50,7 +51,7 @@
 
 ## 8. Documentation And Validation
 
-- [ ] 8.1 Update `docs/features/store-price-matching.md` with source-scoped listing identity and alias-safety behavior.
+- [x] 8.1 Update `docs/features/store-price-matching.md` with source-scoped listing identity and BottleAlias safety behavior.
 - [ ] 8.2 Update `docs/architecture/bottle-classifier.md` with the classifier alias-safety contract.
-- [ ] 8.3 Run targeted server tests, classifier tests/evals, lint, and typecheck for touched surfaces.
+- [x] 8.3 Run the full server test suite, repo typecheck, and repo lint for the touched approval, BottleAlias, CLI, and documentation surfaces. Classifier eval behavior did not change.
 - [ ] 8.4 Capture any remaining open questions before enabling broad automation.

--- a/openspec/changes/add-source-scoped-store-price-identity/tasks.md
+++ b/openspec/changes/add-source-scoped-store-price-identity/tasks.md
@@ -35,7 +35,7 @@
 - [x] 5.3 Add integration tests proving source-only approval assigns the exact StorePrice, creates no BottleAlias, and does not update unrelated same-name listings or reviews.
 - [x] 5.4 Keep missing alias-safety metadata conservative.
 - [x] 5.5 Keep current BottleAlias behavior for explicit reusable approvals when the moderator accepts the suggested Bottle.
-- [x] 5.6 Add a preview-first repair for proven ignored BottleAlias rows from old source-only approvals. Require explicit names for execution and leave active rows for manual review.
+- [x] 5.6 Add a moderator API for preview-first repair of proven ignored BottleAlias rows from old source-only approvals. Require explicit names for execution and leave active rows for manual review.
 
 ## 6. Scraper Reuse
 


### PR DESCRIPTION
Approving a source-only StorePrice now assigns only the reviewed listing. It does not create or change a BottleAlias, and it does not assign same-name StorePrices or reviews. The approved listing image can still fill an empty Bottle image and still respects rejected image URLs.

A BottleAlias is created only when the stored proposal explicitly permits reuse and the moderator accepts its suggested Bottle. Missing scope and moderator overrides stay source-only. The proposal observation and decision log now record that scope.

Legacy ignored BottleAlias rows from the old behavior can be audited through a moderator-only API that is callable with the existing OAuth CLI. It previews by default. Execution requires explicit alias names, revalidates proposal and decision evidence under lock, leaves active aliases for manual review, and records each applied repair in the existing Bottle change log. This uses existing tables and requires no migration.

Fixes #720.
