### PR TITLE
fix(api): paginate source alias repair audit

### DIFF
--- a/apps/server/src/lib/repairInvalidSourceBottleAliases.test.ts
+++ b/apps/server/src/lib/repairInvalidSourceBottleAliases.test.ts
@@ -173,3 +173,77 @@ test("requires explicit BottleAlias names before execution", async ({
     repairInvalidSourceBottleAliases({ dryRun: false, user }),
   ).rejects.toThrow("explicit BottleAlias names");
 });
+
+test("continues a broad preview after a page of report-only aliases", async ({
+  fixtures,
+}) => {
+  const user = await fixtures.User({ mod: true });
+  const actor = await getUserActor(user);
+  const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+  const activeBottle = await fixtures.Bottle({ name: "Cursor Active Bottle" });
+  for (const name of ["Cursor Active A", "Cursor Active B"]) {
+    await fixtures.BottleAlias({
+      bottleId: activeBottle.id,
+      name,
+      ignored: false,
+      assignmentSource: "source_approved",
+      assignedByActorId: actor.id,
+    });
+  }
+
+  const repairBottle = await fixtures.Bottle({ name: "Cursor Repair Bottle" });
+  const price = await fixtures.StorePrice({
+    externalSiteId: site.id,
+    name: "Cursor Repair C",
+    bottleId: repairBottle.id,
+  });
+  const [proposal] = await db
+    .insert(storePriceMatchProposals)
+    .values({
+      priceId: price.id,
+      status: "approved",
+      proposalType: "match_existing",
+      aliasScope: "none",
+      currentBottleId: repairBottle.id,
+      suggestedBottleId: repairBottle.id,
+      reviewedById: user.id,
+    })
+    .returning();
+  await db.insert(incomingBottleDecisionLogs).values({
+    sourceKind: "store_price",
+    sourceId: price.id,
+    proposalId: proposal.id,
+    externalSiteId: site.id,
+    name: price.name,
+    decision: "match_existing",
+    actorId: actor.id,
+    bottleId: repairBottle.id,
+  });
+  await fixtures.BottleAlias({
+    bottleId: repairBottle.id,
+    name: price.name,
+    ignored: true,
+    assignmentSource: "source_approved",
+    assignedByActorId: actor.id,
+  });
+
+  const firstPage = await repairInvalidSourceBottleAliases({ limit: 2 });
+  expect(firstPage.items.map(({ aliasName }) => aliasName)).toEqual([
+    "Cursor Active A",
+    "Cursor Active B",
+  ]);
+  expect(firstPage.nextAliasName).toBe("Cursor Active B");
+
+  const secondPage = await repairInvalidSourceBottleAliases({
+    afterAliasName: firstPage.nextAliasName!,
+    limit: 2,
+  });
+  expect(secondPage.items).toEqual([
+    expect.objectContaining({
+      aliasName: price.name,
+      evidenceProposalIds: [proposal.id],
+      status: "planned",
+    }),
+  ]);
+  expect(secondPage.nextAliasName).toBeNull();
+});

--- a/apps/server/src/lib/repairInvalidSourceBottleAliases.ts
+++ b/apps/server/src/lib/repairInvalidSourceBottleAliases.ts
@@ -11,7 +11,17 @@ import {
 import { getUserActorByIdForDatabase } from "@peated/server/lib/actors";
 import { logError } from "@peated/server/lib/log";
 import { normalizeBottleAliasKey } from "@peated/server/lib/normalize";
-import { and, asc, eq, inArray, isNotNull, isNull, or, sql } from "drizzle-orm";
+import {
+  and,
+  asc,
+  eq,
+  gt,
+  inArray,
+  isNotNull,
+  isNull,
+  or,
+  sql,
+} from "drizzle-orm";
 
 type RepairStatus = "applied" | "failed" | "planned" | "review_required";
 
@@ -25,10 +35,12 @@ export type InvalidSourceBottleAliasRepairItem = {
 
 export type InvalidSourceBottleAliasRepairResult = {
   items: InvalidSourceBottleAliasRepairItem[];
+  nextAliasName: string | null;
   summary: Record<RepairStatus | "total", number>;
 };
 
 type RepairOptions = {
+  afterAliasName?: string;
   aliasNames?: string[];
   db?: AnyDatabase;
   dryRun?: boolean;
@@ -136,6 +148,7 @@ function buildSummary(items: InvalidSourceBottleAliasRepairItem[]) {
  * matching approved proposal evidence.
  */
 export async function repairInvalidSourceBottleAliases({
+  afterAliasName,
   aliasNames = [],
   db = defaultDb,
   dryRun = true,
@@ -168,6 +181,8 @@ export async function repairInvalidSourceBottleAliases({
       aliasNames.map((name) => name.trim().toLowerCase()).filter(Boolean),
     ),
   );
+  const normalizedCursor = afterAliasName?.trim().toLowerCase() || null;
+  const isNamedRequest = requestedNames.length > 0;
   const rows = await db
     .select({
       name: bottleAliases.name,
@@ -182,16 +197,26 @@ export async function repairInvalidSourceBottleAliases({
     .where(
       and(
         isNotNull(bottleAliases.bottleId),
-        requestedNames.length
+        isNamedRequest
           ? inArray(sql`LOWER(${bottleAliases.name})`, requestedNames)
-          : eq(bottleAliases.assignmentSource, "source_approved"),
+          : and(
+              eq(bottleAliases.assignmentSource, "source_approved"),
+              normalizedCursor
+                ? gt(sql`LOWER(${bottleAliases.name})`, normalizedCursor)
+                : undefined,
+            ),
       ),
     )
-    .orderBy(asc(bottleAliases.name))
-    .limit(requestedNames.length || limit);
-  const candidates: Candidate[] = rows.flatMap((row) =>
+    .orderBy(asc(sql`LOWER(${bottleAliases.name})`))
+    .limit(isNamedRequest ? requestedNames.length : limit + 1);
+  const pageRows = isNamedRequest ? rows : rows.slice(0, limit);
+  const candidates: Candidate[] = pageRows.flatMap((row) =>
     row.bottleId === null ? [] : [{ ...row, bottleId: row.bottleId }],
   );
+  const nextAliasName =
+    !isNamedRequest && rows.length > limit
+      ? (pageRows.at(-1)?.name ?? null)
+      : null;
   const items: InvalidSourceBottleAliasRepairItem[] = [];
 
   for (const candidate of candidates) {
@@ -318,5 +343,5 @@ export async function repairInvalidSourceBottleAliases({
     }
   }
 
-  return { items, summary: buildSummary(items) };
+  return { items, nextAliasName, summary: buildSummary(items) };
 }

--- a/apps/server/src/orpc/routes/bottleAliases/repair-source-approvals.test.ts
+++ b/apps/server/src/orpc/routes/bottleAliases/repair-source-approvals.test.ts
@@ -81,6 +81,7 @@ describe("POST /bottle-aliases/repair-source-approvals", () => {
           status: "planned",
         },
       ],
+      nextAliasName: null,
       summary: { applied: 0, planned: 1, reviewRequired: 0, total: 1 },
     });
     expect(
@@ -128,5 +129,55 @@ describe("POST /bottle-aliases/repair-source-approvals", () => {
     );
 
     expect(error).toMatchInlineSnapshot(`[Error: Input validation failed]`);
+  });
+
+  test("rejects a preview cursor combined with explicit names", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+
+    const error = await waitError(
+      routerClient.bottleAliases.repairSourceApprovals(
+        { afterAliasName: "Cursor", aliasNames: ["Named Alias"] },
+        { context: { user } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Input validation failed]`);
+  });
+
+  test("continues a broad preview from the returned alias cursor", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const actor = await getUserActor(user);
+    const bottle = await fixtures.Bottle({ name: "API Cursor Bottle" });
+    for (const name of ["API Cursor A", "API Cursor B"]) {
+      await fixtures.BottleAlias({
+        bottleId: bottle.id,
+        name,
+        ignored: false,
+        assignmentSource: "source_approved",
+        assignedByActorId: actor.id,
+      });
+    }
+
+    const firstPage = await routerClient.bottleAliases.repairSourceApprovals(
+      { limit: 1 },
+      { context: { user } },
+    );
+    expect(firstPage.items.map(({ aliasName }) => aliasName)).toEqual([
+      "API Cursor A",
+    ]);
+    expect(firstPage.nextAliasName).toBe("API Cursor A");
+
+    const secondPage = await routerClient.bottleAliases.repairSourceApprovals(
+      { afterAliasName: firstPage.nextAliasName!, limit: 1 },
+      { context: { user } },
+    );
+    expect(secondPage.items.map(({ aliasName }) => aliasName)).toEqual([
+      "API Cursor B",
+    ]);
+    expect(secondPage.nextAliasName).toBeNull();
   });
 });

--- a/apps/server/src/orpc/routes/bottleAliases/repair-source-approvals.ts
+++ b/apps/server/src/orpc/routes/bottleAliases/repair-source-approvals.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 
 const InputSchema = z
   .object({
+    afterAliasName: z.string().trim().min(1).optional(),
     aliasNames: z.array(z.string().trim().min(1)).max(100).default([]),
     execute: z.boolean().default(false),
     limit: z.number().int().gte(1).lte(100).default(100),
@@ -16,6 +17,13 @@ const InputSchema = z
         code: "custom",
         message: "Execution requires one or more explicit BottleAlias names.",
         path: ["aliasNames"],
+      });
+    }
+    if (input.afterAliasName && input.aliasNames.length > 0) {
+      context.addIssue({
+        code: "custom",
+        message: "A preview cursor cannot be combined with explicit names.",
+        path: ["afterAliasName"],
       });
     }
   });
@@ -52,6 +60,7 @@ export default procedure
           status: RepairStatusSchema,
         }),
       ),
+      nextAliasName: z.string().nullable(),
       summary: z.object({
         applied: z.number(),
         failed: z.number(),
@@ -63,6 +72,7 @@ export default procedure
   )
   .handler(async ({ input, context }) => {
     const result = await repairInvalidSourceBottleAliases({
+      afterAliasName: input.afterAliasName,
       aliasNames: input.aliasNames,
       dryRun: !input.execute,
       limit: input.limit,
@@ -71,6 +81,7 @@ export default procedure
 
     return {
       items: result.items,
+      nextAliasName: result.nextAliasName,
       summary: {
         applied: result.summary.applied,
         failed: result.summary.failed,

--- a/docs/features/store-price-matching.md
+++ b/docs/features/store-price-matching.md
@@ -153,7 +153,9 @@ changing them by default. The OAuth `cli api` client can call this endpoint
 against production. Execution requires `execute: true` and one or more explicit
 BottleAlias names. The repair only unassigns ignored rows when an approved
 source-only proposal and decision provide matching evidence. Active rows are
-report-only and require manual review.
+report-only and require manual review. A full audit follows `nextAliasName` with
+the next request's `afterAliasName` so report-only rows cannot hide later repair
+candidates.
 
 ## Image Promotion
 

--- a/openspec/changes/add-source-scoped-store-price-identity/tasks.md
+++ b/openspec/changes/add-source-scoped-store-price-identity/tasks.md
@@ -36,6 +36,7 @@
 - [x] 5.4 Keep missing alias-safety metadata conservative.
 - [x] 5.5 Keep current BottleAlias behavior for explicit reusable approvals when the moderator accepts the suggested Bottle.
 - [x] 5.6 Add a moderator API for preview-first repair of proven ignored BottleAlias rows from old source-only approvals. Require explicit names for execution and leave active rows for manual review.
+- [x] 5.7 Add stable cursor pagination so report-only BottleAlias rows cannot hide later repair candidates.
 
 ## 6. Scraper Reuse
 


### PR DESCRIPTION
The source-approval BottleAlias repair API now returns a stable `nextAliasName` cursor and accepts it as `afterAliasName` on the next preview. This lets an operator scan past active or manual-review rows instead of silently stopping at the first 100 aliases.

Cursor ordering uses the existing case-insensitive unique BottleAlias name. Explicit-name execution remains unchanged and cannot be combined with a preview cursor, so repairs still require reviewed names and revalidate each row under lock. No schema change is required.

This is a follow-up to #723. It unblocks the exhaustive production audit after 70 eligible rows were safely repaired and verified.

Validated with the focused server tests (9 tests), Oxlint, Prettier, and the server typecheck.
