### PR TITLE
fix(db): parse geometry from relational queries

### DIFF
--- a/apps/server/src/db/columns/geometry.test.ts
+++ b/apps/server/src/db/columns/geometry.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+import { parseGeometryPoint } from "./geometry";
+
+describe("parseGeometryPoint", () => {
+  test("parses hexadecimal point geometry", () => {
+    expect(
+      parseGeometryPoint("0101000020E6100000CDCCCCCCCC0C4C409A999999999909C0"),
+    ).toEqual([56.1, -3.2]);
+  });
+
+  test("parses point geometry from relational JSON", () => {
+    expect(
+      parseGeometryPoint({
+        type: "Point",
+        coordinates: [56.1, -3.2],
+      }),
+    ).toEqual([56.1, -3.2]);
+  });
+
+  test.each([
+    "not-geometry",
+    "010200000002000000000000000000F03F000000000000004000000000000008400000000000001040",
+    { type: "LineString", coordinates: [56.1, -3.2] },
+    { type: "Point", coordinates: [56.1] },
+    { coordinates: { lat: 56.1, lng: -3.2 } },
+  ])("rejects malformed geometry %#", (value) => {
+    expect(() => parseGeometryPoint(value)).toThrow();
+  });
+});

--- a/apps/server/src/db/columns/geometry.ts
+++ b/apps/server/src/db/columns/geometry.ts
@@ -9,11 +9,36 @@ type GeometryPointType = Point | LatLng | string;
 
 type GeometryPointGeoJson = {
   type: "Point";
-  coordinates: {
-    lat: number;
-    lng: number;
-  };
+  coordinates: LatLng;
 };
+
+type GeometryPointJsonValue = {
+  type?: string;
+  coordinates?: number[] | { lat?: number; lng?: number };
+};
+
+const CoordinatesSchema = z.tuple([z.number(), z.number()]);
+const GeometryPointGeoJsonSchema = z
+  .object({
+    type: z.literal("Point"),
+    coordinates: CoordinatesSchema,
+  })
+  .strict();
+
+export function parseGeometryPoint(
+  value: string | GeometryPointJsonValue,
+): LatLng {
+  const encodedGeometry = z.string().safeParse(value);
+  if (encodedGeometry.success) {
+    const parsed = wkx.Geometry.parse(Buffer.from(encodedGeometry.data, "hex"));
+    if (!(parsed instanceof wkx.Point)) {
+      throw new TypeError("Expected point geometry from database.");
+    }
+    return CoordinatesSchema.parse([parsed.x, parsed.y]);
+  }
+
+  return GeometryPointGeoJsonSchema.parse(value).coordinates;
+}
 
 export class Point {
   lat: number;
@@ -52,23 +77,7 @@ export function geometry_point(name: string) {
     },
 
     fromDriver(value: string | GeometryPointGeoJson): LatLng {
-      const encodedGeometry = z.string().safeParse(value);
-      if (encodedGeometry.success) {
-        const parsed = wkx.Geometry.parse(
-          Buffer.from(encodedGeometry.data, "hex"),
-        );
-        if (!(parsed instanceof wkx.Point)) {
-          throw new TypeError("Expected point geometry from database.");
-        }
-        return [parsed.x, parsed.y];
-      }
-
-      const geometry = z
-        .object({
-          coordinates: z.object({ lat: z.number(), lng: z.number() }),
-        })
-        .parse(value);
-      return [geometry.coordinates.lat, geometry.coordinates.lng];
+      return parseGeometryPoint(value);
     },
 
     toDriver(value: GeometryPointType) {

--- a/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/index.test.ts
@@ -214,6 +214,53 @@ describe("price match queue", () => {
     expect(queueItem).not.toHaveProperty("proposedRelease");
   });
 
+  test("serializes Entity locations in relational Bottle queries", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const bottler = await fixtures.Entity({
+      type: ["bottler"],
+      location: [56.1, -3.2],
+    });
+    const bottle = await fixtures.Bottle({ bottlerId: bottler.id });
+    const price = await fixtures.StorePrice({
+      bottleId: bottle.id,
+      name: "Relational Geometry Candidate",
+    });
+    const [proposal] = await db
+      .insert(storePriceMatchProposals)
+      .values({
+        priceId: price.id,
+        status: "pending_review",
+        proposalType: "correction",
+        currentBottleId: bottle.id,
+      })
+      .returning();
+
+    const list = await routerClient.prices.matchQueue.list(
+      {},
+      { context: { user } },
+    );
+    const details = await routerClient.prices.matchQueue.details(
+      { proposal: proposal.id },
+      { context: { user } },
+    );
+
+    expect(list.results).toHaveLength(1);
+    expect(list.results[0]).toMatchObject({
+      id: proposal.id,
+      currentBottle: {
+        bottler: { id: bottler.id, location: [56.1, -3.2] },
+      },
+    });
+    expect(details).toMatchObject({
+      id: proposal.id,
+      currentBottle: {
+        bottler: { id: bottler.id, location: [56.1, -3.2] },
+      },
+    });
+  });
+
   test("keeps a pending primary decision in Incoming Listings only", async ({
     fixtures,
   }) => {


### PR DESCRIPTION
Geometry point columns now decode both EWKB values returned by direct selects and the strict GeoJSON point shape emitted inside Drizzle relational JSON. This restores price match queue list and detail reads when a related brand or bottler has a location while continuing to reject malformed and non-point geometry.

Regression coverage exercises both database representations and the queue hydration path for an Entity location.

Fixes #726
