### PR TITLE
fix(db): accept geometry metadata

### DIFF
--- a/apps/server/src/db/columns/geometry.test.ts
+++ b/apps/server/src/db/columns/geometry.test.ts
@@ -13,6 +13,10 @@ describe("parseGeometryPoint", () => {
       parseGeometryPoint({
         type: "Point",
         coordinates: [56.1, -3.2],
+        crs: {
+          type: "name",
+          properties: { name: "EPSG:4326" },
+        },
       }),
     ).toEqual([56.1, -3.2]);
   });

--- a/apps/server/src/db/columns/geometry.ts
+++ b/apps/server/src/db/columns/geometry.ts
@@ -15,15 +15,14 @@ type GeometryPointGeoJson = {
 type GeometryPointJsonValue = {
   type?: string;
   coordinates?: number[] | { lat?: number; lng?: number };
+  crs?: unknown;
 };
 
 const CoordinatesSchema = z.tuple([z.number(), z.number()]);
-const GeometryPointGeoJsonSchema = z
-  .object({
-    type: z.literal("Point"),
-    coordinates: CoordinatesSchema,
-  })
-  .strict();
+const GeometryPointGeoJsonSchema = z.object({
+  type: z.literal("Point"),
+  coordinates: CoordinatesSchema,
+});
 
 export function parseGeometryPoint(
   value: string | GeometryPointJsonValue,


### PR DESCRIPTION
Relational Bottle queries now accept GeoJSON Point values that include valid top-level metadata such as `crs`. This restores correction queue list and detail reads after #727 while preserving validation of the `Point` type and two-number coordinate tuple.

The parser selects the required fields through Zod's default object behavior. Regression coverage uses a production-shaped `crs` member and keeps the existing malformed and non-Point rejection cases.

Fixes #726
Fixes PEATED-4DE
