### PR TITLE
fix: stop Bottle updates from rewriting generated details

### DIFF
--- a/apps/server/src/lib/createBottle.ts
+++ b/apps/server/src/lib/createBottle.ts
@@ -718,7 +718,10 @@ export async function finalizeCreatedBottle(
   } = {},
 ) {
   try {
-    await pushUniqueJob("OnBottleChange", { bottleId: bottle.id });
+    await pushUniqueJob("OnBottleChange", {
+      bottleId: bottle.id,
+      generateDetails: true,
+    });
   } catch (err) {
     logError(err, {
       bottle: {

--- a/apps/server/src/lib/updateBottle.test.ts
+++ b/apps/server/src/lib/updateBottle.test.ts
@@ -1049,6 +1049,85 @@ describe("Bottle updates", () => {
     expect((await loadGroupMembers(groupBefore.id))[1]).toEqual(siblingBefore);
   });
 
+  test("invalidates only generated content after a semantic identity change", async ({
+    fixtures,
+  }) => {
+    const mod = await fixtures.User({ mod: true });
+    const brand = await fixtures.Entity({ name: "Generated Content Brand" });
+    const originalNotes = {
+      nose: "Original nose",
+      palate: "Original palate",
+      finish: "Original finish",
+    };
+    const updatedNotes = {
+      nose: "Moderator nose",
+      palate: "Moderator palate",
+      finish: "Moderator finish",
+    };
+    const { first } = await createGroup({
+      user: mod,
+      stable: { name: "Generated Content", brand: brand.id },
+      exacts: [
+        {
+          abv: 46,
+          description: "Generated description",
+          descriptionSrc: "generated",
+          tastingNotes: originalNotes,
+        },
+      ],
+    });
+    await db
+      .update(bottles)
+      .set({ suggestedTags: ["smoke", "fruit"] })
+      .where(eq(bottles.id, first.bottle.id));
+
+    const contentResult = await updateBottle({
+      bottleId: first.bottle.id,
+      input: { tastingNotes: updatedNotes },
+      context: contextFor(mod),
+    });
+    expect(contentResult.bottle).toMatchObject({
+      description: "Generated description",
+      descriptionSrc: "generated",
+      suggestedTags: ["smoke", "fruit"],
+      tastingNotes: updatedNotes,
+    });
+
+    const identityResult = await updateBottle({
+      bottleId: first.bottle.id,
+      input: { abv: 48 },
+      context: contextFor(mod),
+    });
+    expect(identityResult.bottle).toMatchObject({
+      abv: 48,
+      description: null,
+      descriptionSrc: null,
+      suggestedTags: [],
+      tastingNotes: updatedNotes,
+    });
+
+    await db
+      .update(bottles)
+      .set({
+        description: "Moderator description",
+        descriptionSrc: "user",
+        suggestedTags: ["oak"],
+      })
+      .where(eq(bottles.id, first.bottle.id));
+    const moderatorContentResult = await updateBottle({
+      bottleId: first.bottle.id,
+      input: { abv: 50 },
+      context: contextFor(mod),
+    });
+    expect(moderatorContentResult.bottle).toMatchObject({
+      abv: 50,
+      description: "Moderator description",
+      descriptionSrc: "user",
+      suggestedTags: [],
+      tastingNotes: updatedNotes,
+    });
+  });
+
   test("updates direct Bottle identity and owns aliases directly", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/updateBottle.test.ts
+++ b/apps/server/src/lib/updateBottle.test.ts
@@ -1049,7 +1049,7 @@ describe("Bottle updates", () => {
     expect((await loadGroupMembers(groupBefore.id))[1]).toEqual(siblingBefore);
   });
 
-  test("invalidates only generated content after a semantic identity change", async ({
+  test("clears generated content for Bottle changes but not cask details", async ({
     fixtures,
   }) => {
     const mod = await fixtures.User({ mod: true });
@@ -1087,6 +1087,25 @@ describe("Bottle updates", () => {
       context: contextFor(mod),
     });
     expect(contentResult.bottle).toMatchObject({
+      description: "Generated description",
+      descriptionSrc: "generated",
+      suggestedTags: ["smoke", "fruit"],
+      tastingNotes: updatedNotes,
+    });
+
+    const caskResult = await updateBottle({
+      bottleId: first.bottle.id,
+      input: {
+        caskType: "bourbon",
+        caskSize: "barrel",
+        caskFill: "1st_fill",
+      },
+      context: contextFor(mod),
+    });
+    expect(caskResult.bottle).toMatchObject({
+      caskType: "bourbon",
+      caskSize: "barrel",
+      caskFill: "1st_fill",
       description: "Generated description",
       descriptionSrc: "generated",
       suggestedTags: ["smoke", "fruit"],

--- a/apps/server/src/lib/updateBottle.ts
+++ b/apps/server/src/lib/updateBottle.ts
@@ -445,6 +445,25 @@ const exactIdentityKeys: ReadonlyArray<keyof ExactPatch> = [
   "caskFill",
 ];
 
+const generatedDetailsIdentityKeys = [
+  "name",
+  "fullName",
+  "statedAge",
+  "brandId",
+  "bottlerId",
+  "seriesId",
+  "category",
+  "edition",
+  "abv",
+  "singleCask",
+  "caskStrength",
+  "vintageYear",
+  "releaseYear",
+  "caskSize",
+  "caskType",
+  "caskFill",
+] as const satisfies ReadonlyArray<keyof DesiredBottle>;
+
 function hasExactIdentityFields(patch: ExactPatch | undefined): boolean {
   return patch !== undefined && exactIdentityKeys.some((key) => key in patch);
 }
@@ -453,6 +472,24 @@ function sameValues(left: readonly number[], right: readonly number[]) {
   return (
     left.length === right.length &&
     left.every((value, index) => value === right[index])
+  );
+}
+
+function generatedDetailsIdentityChanged({
+  bottle,
+  desired,
+  currentDistillerIds,
+  desiredDistillerIds,
+}: {
+  bottle: Bottle;
+  desired: DesiredBottle;
+  currentDistillerIds: readonly number[];
+  desiredDistillerIds: readonly number[];
+}) {
+  return (
+    generatedDetailsIdentityKeys.some(
+      (key) => JSON.stringify(bottle[key]) !== JSON.stringify(desired[key]),
+    ) || !sameValues(currentDistillerIds, desiredDistillerIds)
   );
 }
 
@@ -1069,6 +1106,7 @@ export async function updateBottleInTransaction(
     expectedSharedState,
     actorId,
     creationSource,
+    invalidateGeneratedDetails = true,
   }: {
     bottleId: number;
     input: SystemBottlePatch;
@@ -1076,6 +1114,7 @@ export async function updateBottleInTransaction(
     expectedSharedState?: BottleUpdateExpectedSharedState;
     actorId: number;
     creationSource: CatalogVerificationCreationSource;
+    invalidateGeneratedDetails?: boolean;
   },
 ): Promise<BottleUpdateFinalizationManifest> {
   const expectedReferencedEntityIds =
@@ -1326,6 +1365,50 @@ export async function updateBottleInTransaction(
     ? members
     : members.filter(({ id }) => id === bottleId);
   const affectedIds = affectedMembers.map(({ id }) => id).sort((a, b) => a - b);
+
+  if (invalidateGeneratedDetails) {
+    for (const member of affectedMembers) {
+      const desired = desiredByBottleId.get(member.id)!;
+      if (
+        !generatedDetailsIdentityChanged({
+          bottle: member,
+          desired,
+          currentDistillerIds: bottleDistillers.get(member.id) ?? [],
+          desiredDistillerIds: sharedChanged
+            ? stable.distillerIds
+            : (bottleDistillers.get(member.id) ?? []),
+        })
+      ) {
+        continue;
+      }
+
+      const selectedExactPatch =
+        exactIntent && member.id === bottleId ? storage.exact : undefined;
+      const descriptionWasExplicitlyPatched =
+        selectedExactPatch !== undefined &&
+        ("description" in selectedExactPatch ||
+          "descriptionSrc" in selectedExactPatch);
+      const suggestedTagsWereExplicitlyPatched =
+        selectedExactPatch !== undefined &&
+        "suggestedTags" in selectedExactPatch;
+
+      const invalidated = { ...desired };
+      if (
+        member.descriptionSrc === "generated" &&
+        !descriptionWasExplicitlyPatched
+      ) {
+        invalidated.description = null;
+        invalidated.descriptionSrc = null;
+      }
+      if (
+        !suggestedTagsWereExplicitlyPatched &&
+        member.suggestedTags.length > 0
+      ) {
+        invalidated.suggestedTags = [];
+      }
+      desiredByBottleId.set(member.id, invalidated);
+    }
+  }
 
   const currentBrand =
     stable.brandId === group.brandId

--- a/apps/server/src/lib/updateBottle.ts
+++ b/apps/server/src/lib/updateBottle.ts
@@ -446,8 +446,6 @@ const exactIdentityKeys: ReadonlyArray<keyof ExactPatch> = [
 ];
 
 const generatedDetailsIdentityKeys = [
-  "name",
-  "fullName",
   "statedAge",
   "brandId",
   "bottlerId",
@@ -459,9 +457,6 @@ const generatedDetailsIdentityKeys = [
   "caskStrength",
   "vintageYear",
   "releaseYear",
-  "caskSize",
-  "caskType",
-  "caskFill",
 ] as const satisfies ReadonlyArray<keyof DesiredBottle>;
 
 function hasExactIdentityFields(patch: ExactPatch | undefined): boolean {
@@ -478,18 +473,23 @@ function sameValues(left: readonly number[], right: readonly number[]) {
 function generatedDetailsIdentityChanged({
   bottle,
   desired,
+  includeNameChange,
   currentDistillerIds,
   desiredDistillerIds,
 }: {
   bottle: Bottle;
   desired: DesiredBottle;
+  includeNameChange: boolean;
   currentDistillerIds: readonly number[];
   desiredDistillerIds: readonly number[];
 }) {
   return (
+    (includeNameChange &&
+      (bottle.name !== desired.name || bottle.fullName !== desired.fullName)) ||
     generatedDetailsIdentityKeys.some(
       (key) => JSON.stringify(bottle[key]) !== JSON.stringify(desired[key]),
-    ) || !sameValues(currentDistillerIds, desiredDistillerIds)
+    ) ||
+    !sameValues(currentDistillerIds, desiredDistillerIds)
   );
 }
 
@@ -1373,6 +1373,7 @@ export async function updateBottleInTransaction(
         !generatedDetailsIdentityChanged({
           bottle: member,
           desired,
+          includeNameChange: sharedIntent,
           currentDistillerIds: bottleDistillers.get(member.id) ?? [],
           desiredDistillerIds: sharedChanged
             ? stable.distillerIds

--- a/apps/server/src/orpc/routes/bottles/create.test.ts
+++ b/apps/server/src/orpc/routes/bottles/create.test.ts
@@ -212,6 +212,7 @@ describe("POST /bottles", () => {
     expect(distillers.length).toBe(0);
     expect(workerClient.pushUniqueJob).toHaveBeenCalledWith("OnBottleChange", {
       bottleId: bottle.id,
+      generateDetails: true,
     });
     expect(workerClient.pushUniqueJob).toHaveBeenCalledWith(
       "OnBottleAliasChange",

--- a/apps/server/src/worker/jobs/mergeEntity.test.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.test.ts
@@ -355,6 +355,53 @@ test("merge A into B", async ({ fixtures }) => {
   expect(tombstone.newEntityId).toEqual(newEntityB.id);
 });
 
+test("preserves generated Bottle content during an equivalent Entity merge", async ({
+  fixtures,
+}) => {
+  const source = await fixtures.Entity({
+    name: "Legacy Bottler Name",
+    type: ["bottler"],
+  });
+  const destination = await fixtures.Entity({
+    name: "Canonical Bottler Name",
+    type: ["bottler"],
+  });
+  const bottle = await fixtures.Bottle({ bottlerId: source.id });
+  const tastingNotes = {
+    nose: "Preserved nose",
+    palate: "Preserved palate",
+    finish: "Preserved finish",
+  };
+  await db
+    .update(bottles)
+    .set({
+      description: "Preserved generated description",
+      descriptionSrc: "generated",
+      suggestedTags: ["smoke"],
+      tastingNotes,
+    })
+    .where(eq(bottles.id, bottle.id));
+  vi.mocked(pushUniqueJob).mockClear();
+
+  await mergeEntity({
+    fromEntityIds: [source.id],
+    toEntityId: destination.id,
+  });
+
+  expect(
+    await db.query.bottles.findFirst({ where: eq(bottles.id, bottle.id) }),
+  ).toMatchObject({
+    bottlerId: destination.id,
+    description: "Preserved generated description",
+    descriptionSrc: "generated",
+    suggestedTags: ["smoke"],
+    tastingNotes,
+  });
+  expect(pushUniqueJob).toHaveBeenCalledWith("OnBottleChange", {
+    bottleId: bottle.id,
+  });
+});
+
 test("merges an SMWS collision while replacing a duplicate distiller", async ({
   fixtures,
 }) => {

--- a/apps/server/src/worker/jobs/mergeEntity.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.ts
@@ -524,6 +524,9 @@ async function performEntityMerge({
           input,
           actorId: actor.id,
           creationSource: "repair_workflow",
+          // An Entity merge changes the record ID, not the Bottle itself.
+          // Keep the Bottle's existing generated content.
+          invalidateGeneratedDetails: false,
         }),
       );
     }

--- a/apps/server/src/worker/jobs/onBottleChange.test.ts
+++ b/apps/server/src/worker/jobs/onBottleChange.test.ts
@@ -22,9 +22,10 @@ test("dispatches derived work for the supplied Bottle", async ({
 
   await onBottleChange({ bottleId: bottle.id });
 
-  expect(workerClient.runJob).toHaveBeenCalledWith("GenerateBottleDetails", {
-    bottleId: bottle.id,
-  });
+  expect(workerClient.runJob).not.toHaveBeenCalledWith(
+    "GenerateBottleDetails",
+    expect.anything(),
+  );
   expect(workerClient.runJob).toHaveBeenCalledWith("IndexBottleSearchVectors", {
     bottleId: bottle.id,
   });
@@ -35,6 +36,25 @@ test("dispatches derived work for the supplied Bottle", async ({
   );
 });
 
+test("generates details only when explicitly requested", async ({
+  fixtures,
+}) => {
+  const bottle = await fixtures.Bottle();
+
+  await onBottleChange({ bottleId: bottle.id, generateDetails: true });
+
+  expect(workerClient.runJob).toHaveBeenNthCalledWith(
+    1,
+    "GenerateBottleDetails",
+    { bottleId: bottle.id },
+  );
+  expect(workerClient.runJob).toHaveBeenNthCalledWith(
+    2,
+    "IndexBottleSearchVectors",
+    { bottleId: bottle.id },
+  );
+});
+
 test.each([
   undefined,
   {},
@@ -42,6 +62,7 @@ test.each([
   { bottleId: -1 },
   { bottleId: 1.5 },
   { bottleId: "1" },
+  { bottleId: 1, generateDetails: "true" },
   { bottleId: 1, unexpected: true },
   { legacyId: 1 },
 ])("rejects malformed job input %#", async (input) => {

--- a/apps/server/src/worker/jobs/onBottleChange.ts
+++ b/apps/server/src/worker/jobs/onBottleChange.ts
@@ -6,6 +6,7 @@ import type { UpdateBottleStatsJobArgs } from "./updateBottleStats";
 export const OnBottleChangeJobArgsSchema = z
   .object({
     bottleId: z.number().int().positive(),
+    generateDetails: z.boolean().default(false),
   })
   .strict();
 export type OnBottleChangeJobArgs = z.infer<typeof OnBottleChangeJobArgsSchema>;
@@ -31,9 +32,12 @@ export function buildBottleChangeStatsJob(
 }
 
 export default async (input: JobPayload) => {
-  const { bottleId } = OnBottleChangeJobArgsSchema.parse(input);
+  const { bottleId, generateDetails } =
+    OnBottleChangeJobArgsSchema.parse(input);
 
-  await runJob("GenerateBottleDetails", { bottleId });
+  if (generateDetails) {
+    await runJob("GenerateBottleDetails", { bottleId });
+  }
   await runJob("IndexBottleSearchVectors", { bottleId });
   const statsJob = buildBottleChangeStatsJob(bottleId);
   await pushUniqueJob(statsJob.name, statsJob.args, statsJob.opts);


### PR DESCRIPTION
New Bottles still get generated descriptions and tags. Routine Bottle updates and Entity merges no longer run generation, so they cannot silently rewrite existing details or make unnecessary AI calls.

When core Bottle details such as its name, age, ABV, brand, or year change, the save clears only the generated description and suggested tags. Cask type, size, and fill do not clear content. The save also keeps moderator-written descriptions, tasting notes, and flavor data. Entity merges keep existing content because they change the Entity record, not the Bottle itself.
