### PR TITLE
fix(catalog): enforce entity and bottle integrity

### DIFF
--- a/apps/server/src/db/schema/entities.test.ts
+++ b/apps/server/src/db/schema/entities.test.ts
@@ -1,0 +1,27 @@
+import { eq } from "drizzle-orm";
+import { db } from "../index";
+import { entities } from "./entities";
+
+describe("Entity relations", () => {
+  test("loads region through regionId", async ({ fixtures }) => {
+    const country = await fixtures.Country();
+    const firstRegion = await fixtures.Region({ countryId: country.id });
+    const region =
+      firstRegion.id === country.id
+        ? await fixtures.Region({ countryId: country.id })
+        : firstRegion;
+    const entity = await fixtures.Entity({
+      countryId: country.id,
+      regionId: region.id,
+    });
+
+    expect(region.id).not.toBe(country.id);
+
+    const loaded = await db.query.entities.findFirst({
+      where: eq(entities.id, entity.id),
+      with: { region: true },
+    });
+
+    expect(loaded?.region?.id).toBe(region.id);
+  });
+});

--- a/apps/server/src/db/schema/entities.ts
+++ b/apps/server/src/db/schema/entities.ts
@@ -94,7 +94,7 @@ export const entitiesRelations = relations(entities, ({ one, many }) => ({
     references: [countries.id],
   }),
   region: one(regions, {
-    fields: [entities.countryId],
+    fields: [entities.regionId],
     references: [regions.id],
   }),
   createdByActor: one(actors, {

--- a/apps/server/src/lib/resolveActiveBottleIds.test.ts
+++ b/apps/server/src/lib/resolveActiveBottleIds.test.ts
@@ -2,6 +2,7 @@ import { db } from "@peated/server/db";
 import { bottleTombstones } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { expect, test } from "vitest";
+import { mergeBottlesInTransaction } from "./mergeBottles";
 import {
   ActiveBottleSelectionError,
   resolveActiveBottleIds,
@@ -59,4 +60,30 @@ test("rejects every inactive Bottle state", async ({ fixtures }) => {
       bottleId: scenario.bottleId,
     });
   }
+});
+
+test("returns the replacement for a merged Bottle whose source row was deleted", async ({
+  fixtures,
+}) => {
+  const source = await fixtures.Bottle({ name: "Retired Source" });
+  const destination = await fixtures.Bottle({ name: "Active Destination" });
+
+  await db.transaction((tx) =>
+    mergeBottlesInTransaction(tx, {
+      sourceBottleId: source.id,
+      destinationBottleId: destination.id,
+      actorId: source.createdByActorId,
+    }),
+  );
+
+  const error = await waitError(() =>
+    db.transaction((tx) => resolveActiveBottleIds(tx, [source.id])),
+  );
+
+  expect(error).toBeInstanceOf(ActiveBottleSelectionError);
+  expect(error).toMatchObject({
+    reason: "bottle_retired",
+    bottleId: source.id,
+    replacementBottleId: destination.id,
+  });
 });

--- a/apps/server/src/lib/resolveActiveBottleIds.ts
+++ b/apps/server/src/lib/resolveActiveBottleIds.ts
@@ -36,19 +36,6 @@ export async function resolveActiveBottleIds(
     .where(inArray(bottles.id, ids))
     .orderBy(asc(bottles.id))
     .for(lock);
-  if (selectedBottles.length !== ids.length) {
-    const selectedIds = new Set(selectedBottles.map(({ id }) => id));
-    throw new ActiveBottleSelectionError(
-      "missing",
-      ids.find((id) => !selectedIds.has(id))!,
-    );
-  }
-  for (const { id, groupId } of selectedBottles) {
-    if (groupId === null) {
-      throw new ActiveBottleSelectionError("unassigned", id);
-    }
-  }
-
   const retiredBottles = await tx
     .select({
       bottleId: bottleTombstones.bottleId,
@@ -56,14 +43,32 @@ export async function resolveActiveBottleIds(
     })
     .from(bottleTombstones)
     .where(inArray(bottleTombstones.bottleId, ids))
-    .limit(1);
-  const retiredBottle = retiredBottles[0];
-  if (retiredBottle) {
-    throw new ActiveBottleSelectionError(
-      "bottle_retired",
-      retiredBottle.bottleId,
-      retiredBottle.replacementBottleId,
-    );
+    .orderBy(asc(bottleTombstones.bottleId))
+    .for(lock);
+
+  const selectedById = new Map(
+    selectedBottles.map((bottle) => [bottle.id, bottle]),
+  );
+  const retiredById = new Map(
+    retiredBottles.map((bottle) => [bottle.bottleId, bottle]),
+  );
+  for (const id of ids) {
+    const retiredBottle = retiredById.get(id);
+    if (retiredBottle) {
+      throw new ActiveBottleSelectionError(
+        "bottle_retired",
+        id,
+        retiredBottle.replacementBottleId,
+      );
+    }
+
+    const selectedBottle = selectedById.get(id);
+    if (!selectedBottle) {
+      throw new ActiveBottleSelectionError("missing", id);
+    }
+    if (selectedBottle.groupId === null) {
+      throw new ActiveBottleSelectionError("unassigned", id);
+    }
   }
 
   return selectedBottles.map(({ id }) => id);

--- a/apps/server/src/lib/updateEntity.test.ts
+++ b/apps/server/src/lib/updateEntity.test.ts
@@ -151,4 +151,56 @@ describe("updateEntity", () => {
       }),
     ).rejects.toBeInstanceOf(EntityUpdateAuthorizationError);
   });
+
+  test("rejects removing Entity roles that active Bottle identity references", async ({
+    fixtures,
+  }) => {
+    const entity = await fixtures.Entity({
+      name: "All Roles",
+      type: ["brand", "bottler", "distiller"],
+    });
+    await fixtures.Bottle({
+      brandId: entity.id,
+      bottlerId: entity.id,
+      distillerIds: [entity.id],
+    });
+    const moderator = await fixtures.User({ mod: true });
+    const scenarios = [
+      {
+        role: "brand" as const,
+        message:
+          "Cannot remove the brand role while the Entity is referenced as a brand.",
+      },
+      {
+        role: "bottler" as const,
+        message:
+          "Cannot remove the bottler role while the Entity is referenced as a bottler.",
+      },
+      {
+        role: "distiller" as const,
+        message:
+          "Cannot remove the distiller role while the Entity is referenced as a distiller.",
+      },
+    ];
+
+    for (const { role, message } of scenarios) {
+      await expect(
+        updateEntity({
+          entityId: entity.id,
+          input: {
+            type: entity.type.filter((candidate) => candidate !== role),
+          },
+          user: moderator,
+        }),
+      ).rejects.toMatchObject({
+        name: EntityUpdateConflictError.name,
+        message,
+      });
+    }
+
+    const unchanged = await db.query.entities.findFirst({
+      where: eq(entities.id, entity.id),
+    });
+    expect(unchanged?.type).toEqual(entity.type);
+  });
 });

--- a/apps/server/src/lib/updateEntity.ts
+++ b/apps/server/src/lib/updateEntity.ts
@@ -2,7 +2,9 @@ import { normalizeEntityName } from "@peated/bottle-classifier/normalize";
 import { db, type AnyTransaction } from "@peated/server/db";
 import type { Entity, User } from "@peated/server/db/schema";
 import {
+  bottleGroupDistillers,
   bottleGroups,
+  bottleSeries,
   bottles,
   bottlesToDistillers,
   changes,
@@ -124,6 +126,75 @@ export type EntityUpdateExpectedState = {
   referencedCountry: { id: number; name: string } | null;
   referencedRegion: { id: number; countryId: number; name: string } | null;
 };
+
+async function assertRemovedRolesAreUnreferenced(
+  transaction: AnyTransaction,
+  entity: Entity,
+  nextRoles: Entity["type"],
+) {
+  const removesRole = (role: Entity["type"][number]) =>
+    entity.type.includes(role) && !nextRoles.includes(role);
+  const hasReference = async (
+    table:
+      | typeof bottles
+      | typeof bottleGroups
+      | typeof bottleSeries
+      | typeof bottlesToDistillers
+      | typeof bottleGroupDistillers,
+    field:
+      | typeof bottles.brandId
+      | typeof bottles.bottlerId
+      | typeof bottleGroups.brandId
+      | typeof bottleGroups.bottlerId
+      | typeof bottleSeries.brandId
+      | typeof bottlesToDistillers.distillerId
+      | typeof bottleGroupDistillers.distillerId,
+  ) =>
+    Boolean(
+      (
+        await transaction
+          .select({ id: sql`1` })
+          .from(table)
+          .where(eq(field, entity.id))
+          .limit(1)
+      )[0],
+    );
+
+  if (
+    removesRole("brand") &&
+    ((await hasReference(bottles, bottles.brandId)) ||
+      (await hasReference(bottleGroups, bottleGroups.brandId)) ||
+      (await hasReference(bottleSeries, bottleSeries.brandId)))
+  ) {
+    throw new EntityUpdateConflictError(
+      "Cannot remove the brand role while the Entity is referenced as a brand.",
+    );
+  }
+  if (
+    removesRole("bottler") &&
+    ((await hasReference(bottles, bottles.bottlerId)) ||
+      (await hasReference(bottleGroups, bottleGroups.bottlerId)))
+  ) {
+    throw new EntityUpdateConflictError(
+      "Cannot remove the bottler role while the Entity is referenced as a bottler.",
+    );
+  }
+  if (
+    removesRole("distiller") &&
+    ((await hasReference(
+      bottlesToDistillers,
+      bottlesToDistillers.distillerId,
+    )) ||
+      (await hasReference(
+        bottleGroupDistillers,
+        bottleGroupDistillers.distillerId,
+      )))
+  ) {
+    throw new EntityUpdateConflictError(
+      "Cannot remove the distiller role while the Entity is referenced as a distiller.",
+    );
+  }
+}
 
 /**
  * Applies the durable part of an Entity update inside a caller-owned
@@ -257,6 +328,7 @@ export async function updateEntityInTransaction(
   }
 
   if (input.type !== undefined && !arraysEqual(input.type, entity.type)) {
+    await assertRemovedRolesAreUnreferenced(transaction, entity, input.type);
     data.type = input.type;
   }
   if (

--- a/apps/server/src/orpc/routes/entities/details.test.ts
+++ b/apps/server/src/orpc/routes/entities/details.test.ts
@@ -14,6 +14,17 @@ describe("GET /entities/:entity", () => {
     expect("createdBy" in data).toBe(false);
   });
 
+  test("returns the Entity update timestamp", async ({ fixtures }) => {
+    const createdAt = new Date("2020-01-01T00:00:00.000Z");
+    const updatedAt = new Date("2025-06-01T00:00:00.000Z");
+    const entity = await fixtures.Entity({ createdAt, updatedAt });
+
+    const data = await routerClient.entities.details({ entity: entity.id });
+
+    expect(data.createdAt).toBe(createdAt.toISOString());
+    expect(data.updatedAt).toBe(updatedAt.toISOString());
+  });
+
   test("errors on invalid entity", async () => {
     const err = await waitError(
       routerClient.entities.details({

--- a/apps/server/src/serializers/entity.ts
+++ b/apps/server/src/serializers/entity.ts
@@ -71,7 +71,7 @@ export const EntitySerializer = serializer({
       address: item.address,
       location: item.location,
       createdAt: item.createdAt.toISOString(),
-      updatedAt: item.createdAt.toISOString(),
+      updatedAt: item.updatedAt.toISOString(),
 
       totalTastings: item.totalTastings,
       totalBottles: item.totalBottles,


### PR DESCRIPTION
Catalog identity now rejects removal of Entity roles that are still referenced by Bottles, BottleGroups, or BottleSeries, and merged Bottle selection reports the surviving replacement instead of treating the deleted source as missing. Entity reads also load regions through `regionId` and serialize the actual update timestamp.

Focused database and service coverage exercises each corrected boundary, including replacement resolution after a real exact-Bottle merge.
