### PR TITLE
feat(prices): add per-site identity coverage

### DIFF
--- a/apps/server/src/orpc/routes/prices/identity-coverage.test.ts
+++ b/apps/server/src/orpc/routes/prices/identity-coverage.test.ts
@@ -1,0 +1,116 @@
+import { db } from "@peated/server/db";
+import { storePrices } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+describe("GET /external-sites/:site/prices/identity-coverage", () => {
+  test("requires authentication", async () => {
+    const error = await waitError(() =>
+      routerClient.prices.identityCoverage({ site: "totalwine" }),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("requires admin", async ({ fixtures }) => {
+    const moderator = await fixtures.User({ mod: true });
+
+    const error = await waitError(() =>
+      routerClient.prices.identityCoverage(
+        { site: "totalwine" },
+        { context: { user: moderator } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("returns not found for an unconfigured site", async ({ fixtures }) => {
+    const admin = await fixtures.User({ admin: true });
+
+    const error = await waitError(() =>
+      routerClient.prices.identityCoverage(
+        { site: "totalwine" },
+        { context: { user: admin } },
+      ),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Site not found.]`);
+  });
+
+  test("counts visible identity coverage for only the requested site", async ({
+    fixtures,
+  }) => {
+    const admin = await fixtures.User({ admin: true });
+    const site = await fixtures.ExternalSiteOrExisting({ type: "totalwine" });
+    const otherSite = await fixtures.ExternalSiteOrExisting({
+      type: "healthyspirits",
+    });
+    const bottle = await fixtures.Bottle({ name: "Coverage Bottle" });
+
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      bottleId: bottle.id,
+      externalProductId: "matched-source-id",
+      sourceFingerprint: "matched-fingerprint",
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      bottleId: null,
+      externalProductId: "unmatched-source-id",
+      sourceFingerprint: null,
+    });
+    const unresolved = await fixtures.StorePrice({
+      externalSiteId: site.id,
+      bottleId: null,
+      externalProductId: null,
+      sourceFingerprint: "url-fallback-fingerprint",
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      bottleId: bottle.id,
+      externalProductId: "hidden-source-id",
+      sourceFingerprint: "hidden-fingerprint",
+      hidden: true,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: otherSite.id,
+      bottleId: bottle.id,
+      externalProductId: "other-site-source-id",
+      sourceFingerprint: "other-site-fingerprint",
+    });
+
+    await expect(
+      routerClient.prices.identityCoverage(
+        { site: site.type },
+        { context: { user: admin } },
+      ),
+    ).resolves.toEqual({
+      total: 3,
+      matched: 1,
+      unmatched: 2,
+      withSourceId: 2,
+      withFingerprint: 2,
+    });
+
+    await db
+      .update(storePrices)
+      .set({ bottleId: bottle.id, externalProductId: "resolved-source-id" })
+      .where(eq(storePrices.id, unresolved.id));
+
+    await expect(
+      routerClient.prices.identityCoverage(
+        { site: site.type },
+        { context: { user: admin } },
+      ),
+    ).resolves.toEqual({
+      total: 3,
+      matched: 2,
+      unmatched: 1,
+      withSourceId: 3,
+      withFingerprint: 2,
+    });
+  });
+});

--- a/apps/server/src/orpc/routes/prices/identity-coverage.ts
+++ b/apps/server/src/orpc/routes/prices/identity-coverage.ts
@@ -1,0 +1,57 @@
+import { db } from "@peated/server/db";
+import { externalSites, storePrices } from "@peated/server/db/schema";
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import { ExternalSiteTypeEnum } from "@peated/server/schemas";
+import { and, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+
+const SitePriceIdentityCoverageSchema = z
+  .object({
+    total: z.number().int().nonnegative(),
+    matched: z.number().int().nonnegative(),
+    unmatched: z.number().int().nonnegative(),
+    withSourceId: z.number().int().nonnegative(),
+    withFingerprint: z.number().int().nonnegative(),
+  })
+  .strict();
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "GET",
+    path: "/external-sites/{site}/prices/identity-coverage",
+    summary: "Get external-site price identity coverage",
+    description:
+      "Retrieve current StorePrice identity coverage for one external site. Requires admin privileges",
+    operationId: "getExternalSitePriceIdentityCoverage",
+  })
+  .input(z.object({ site: ExternalSiteTypeEnum }).strict())
+  .output(SitePriceIdentityCoverageSchema)
+  .handler(async ({ input, errors }) => {
+    const site = await db.query.externalSites.findFirst({
+      where: eq(externalSites.type, input.site),
+      columns: { id: true },
+    });
+    if (!site) {
+      throw errors.NOT_FOUND({ message: "Site not found." });
+    }
+
+    const [coverage] = await db
+      .select({
+        total: sql<number>`count(*)::int`,
+        matched: sql<number>`count(*) filter (where ${storePrices.bottleId} is not null)::int`,
+        unmatched: sql<number>`count(*) filter (where ${storePrices.bottleId} is null)::int`,
+        withSourceId: sql<number>`count(*) filter (where ${storePrices.externalProductId} is not null)::int`,
+        withFingerprint: sql<number>`count(*) filter (where ${storePrices.sourceFingerprint} is not null)::int`,
+      })
+      .from(storePrices)
+      .where(
+        and(
+          eq(storePrices.externalSiteId, site.id),
+          eq(storePrices.hidden, false),
+        ),
+      );
+
+    return coverage!;
+  });

--- a/apps/server/src/orpc/routes/prices/index.ts
+++ b/apps/server/src/orpc/routes/prices/index.ts
@@ -1,6 +1,7 @@
 import { base } from "@peated/server/orpc";
 import changeList from "./change-list";
 import createBatch from "./create-batch";
+import identityCoverage from "./identity-coverage";
 import list from "./list";
 import matchQueue from "./matchQueue";
 import update from "./update";
@@ -9,6 +10,7 @@ export default base.tag("prices").router({
   list,
   update,
   createBatch,
+  identityCoverage,
   changeList,
   matchQueue,
 });

--- a/openspec/changes/add-site-price-identity-coverage/.openspec.yaml
+++ b/openspec/changes/add-site-price-identity-coverage/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-24

--- a/openspec/changes/add-site-price-identity-coverage/design.md
+++ b/openspec/changes/add-site-price-identity-coverage/design.md
@@ -1,0 +1,29 @@
+## Context
+
+StorePrice rows already hold the current exact Bottle assignment, external product id, source fingerprint, visibility, and owning external site. The API already supports listing unresolved prices by site, but it does not expose per-site identity coverage counts.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let an administrator query current identity coverage for one external site.
+- Keep the response small, stable, and directly derived from StorePrice state.
+- Reuse existing authentication, site identifiers, and price-list drill-down.
+
+**Non-Goals:**
+
+- No global rollup, percentages, samples, history, event tracking, persistence, background job, or UI.
+- No classifier or matching behavior changes.
+
+## Decisions
+
+Add `GET /external-sites/{site}/prices/identity-coverage` beside the existing external-site price ingestion route. The route requires administrator access and returns `total`, `matched`, `unmatched`, `withSourceId`, and `withFingerprint`.
+
+Resolve `{site}` through the existing external-site type and database row. Return not found when the configured site does not exist. Count only visible StorePrice rows owned by that site in one aggregate query. `matched` means `bottleId` is non-null; `unmatched` means it is null. Source coverage uses non-null `externalProductId` and `sourceFingerprint`.
+
+Keep row inspection on `GET /prices` with its existing `site` and `onlyUnknown` filters. This avoids duplicating pagination and serialization.
+
+## Risks / Trade-offs
+
+- Current-state counts do not explain historical reuse or invalidation events. This is intentional; event storage can be justified separately if current coverage proves insufficient.
+- Old rows can lack fingerprints until they are ingested again. The endpoint reports that gap rather than inferring coverage.

--- a/openspec/changes/add-site-price-identity-coverage/proposal.md
+++ b/openspec/changes/add-site-price-identity-coverage/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Source-identity quality differs by retailer, so a global catalog total can hide a broken or incomplete scraper. Administrators and API clients need one small read-only endpoint that reports the current identity coverage for a specific external site.
+
+## What Changes
+
+- Add an administrator-only API endpoint for one external site's StorePrice identity coverage.
+- Return live counts for visible listings, exact Bottle assignments, unresolved listings, stable source product ids, and source fingerprints.
+- Keep row inspection on the existing StorePrice list API.
+- Add no persistence, background work, UI, percentages, or historical event tracking.
+
+## Capabilities
+
+### New Capabilities
+
+- `site-price-identity-coverage`: Per-site, API-driven StorePrice identity coverage for administrators.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds one oRPC route under the external-site price API.
+- Reads `external_site` and `store_price` only.
+- Adds focused server integration coverage and route registration.

--- a/openspec/changes/add-site-price-identity-coverage/specs/site-price-identity-coverage/spec.md
+++ b/openspec/changes/add-site-price-identity-coverage/specs/site-price-identity-coverage/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Administrators can query one site's price identity coverage
+
+The system SHALL expose a read-only administrator API for the current StorePrice identity coverage of one configured external site.
+
+#### Scenario: Coverage is returned
+
+- **WHEN** an administrator requests identity coverage for a configured external site
+- **THEN** the response SHALL contain visible-listing counts for total, exact Bottle matches, unresolved listings, stable source product ids, and source fingerprints
+
+#### Scenario: Hidden listings are excluded
+
+- **WHEN** a site has hidden StorePrice rows
+- **THEN** those rows SHALL NOT contribute to any coverage count
+
+#### Scenario: Site does not exist
+
+- **WHEN** an administrator requests coverage for an external-site type without a configured site row
+- **THEN** the API SHALL return not found
+
+#### Scenario: Caller is not an administrator
+
+- **WHEN** an unauthenticated or non-administrator caller requests site identity coverage
+- **THEN** the API SHALL reject the request
+
+### Requirement: Coverage remains a live aggregate
+
+The system SHALL derive site identity coverage from current StorePrice rows without new reporting persistence or background work.
+
+#### Scenario: Current assignments are counted
+
+- **WHEN** a visible StorePrice gains or loses an exact Bottle assignment, source product id, or source fingerprint
+- **THEN** the next coverage request SHALL reflect the current value
+
+#### Scenario: Individual rows need inspection
+
+- **WHEN** an administrator needs to inspect unresolved StorePrice rows
+- **THEN** the existing StorePrice list API SHALL remain the drill-down interface

--- a/openspec/changes/add-site-price-identity-coverage/tasks.md
+++ b/openspec/changes/add-site-price-identity-coverage/tasks.md
@@ -1,0 +1,14 @@
+## 1. API
+
+- [x] 1.1 Add the strict per-site price identity coverage response schema and administrator route.
+- [x] 1.2 Register the endpoint beside the existing price routes.
+
+## 2. Coverage Query
+
+- [x] 2.1 Resolve the configured external site and compute the five visible StorePrice counts in one aggregate query.
+- [x] 2.2 Keep hidden rows excluded and return not found for an unconfigured site.
+
+## 3. Verification
+
+- [x] 3.1 Add integration tests for authorization, site isolation, count semantics, hidden-row exclusion, and missing sites.
+- [x] 3.2 Run the focused route test, server typecheck, touched-file lint and format checks, and strict OpenSpec validation.


### PR DESCRIPTION
Adds an admin-only `GET /external-sites/{site}/prices/identity-coverage` endpoint that reports `total`, `matched`, `unmatched`, `withSourceId`, and `withFingerprint` for the selected retailer's visible StorePrice rows. Counts come from one live aggregate query, remain isolated by site, and return not found for an unconfigured source.

This deliberately adds no reporting persistence, background work, global rollup, percentages, or UI. Administrators can continue using the existing filtered StorePrice list API to inspect individual unresolved rows; focused integration coverage verifies authorization, site isolation, hidden-row exclusion, count semantics, and live updates.
