### PR TITLE
fix(classifier): review image-only ABV conflicts

### DIFF
--- a/apps/server/src/agents/bottleClassifier/classifyBottleReference.test.ts
+++ b/apps/server/src/agents/bottleClassifier/classifyBottleReference.test.ts
@@ -15,6 +15,7 @@ describe("server bottleClassifier wrapper", () => {
       reason: "ignored",
       artifacts: {
         extractedIdentity: null,
+        extractedIdentitySource: null,
         candidates: [],
         searchEvidence: [],
         resolvedEntities: [],
@@ -44,6 +45,7 @@ describe("server bottleClassifier wrapper", () => {
         reason: "ignored",
         artifacts: {
           extractedIdentity: null,
+          extractedIdentitySource: null,
           imageEvidence: null,
           candidates: [],
           searchEvidence: [],

--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -454,7 +454,10 @@ describe("priceMatching", () => {
     await resolveStorePriceMatchProposal(price.id);
 
     expect(runScrapedBottleReference).toHaveBeenCalledWith(
-      expect.objectContaining({ extractedIdentity: sourceIdentity }),
+      expect.objectContaining({
+        extractedIdentity: sourceIdentity,
+        extractedIdentitySource: "structured",
+      }),
     );
   });
 

--- a/apps/server/src/lib/priceMatching.test.ts
+++ b/apps/server/src/lib/priceMatching.test.ts
@@ -461,6 +461,57 @@ describe("priceMatching", () => {
     );
   });
 
+  test("does not guess the source of a reused extraction", async ({
+    fixtures,
+  }) => {
+    const extractedIdentity: BottleExtractedDetails = {
+      brand: "Example",
+      bottler: null,
+      expression: "Single Malt",
+      series: null,
+      distillery: [],
+      category: "single_malt",
+      stated_age: null,
+      abv: 46,
+      release_year: null,
+      vintage_year: null,
+      cask_strength: null,
+      single_cask: null,
+      cask_type: null,
+      cask_size: null,
+      cask_fill: null,
+      edition: null,
+    };
+    const price = await fixtures.StorePrice({
+      bottleId: null,
+      name: "Example Single Malt",
+      imageUrl: "/media/example.png",
+    });
+    classifyBottleReference.mockResolvedValue(
+      buildMockBottleReferenceClassification({
+        decision: {
+          action: "no_match",
+          rationale: "No safe local match.",
+          candidateBottleIds: [],
+          matchedBottleId: null,
+          proposedBottle: null,
+        },
+        extractedLabel: extractedIdentity,
+      }),
+    );
+
+    await resolveStorePriceMatchProposal(price.id);
+    runScrapedBottleReference.mockClear();
+    await resolveStorePriceMatchProposal(price.id, {
+      force: true,
+      reuseExistingExtraction: true,
+    });
+
+    const retryInput = runScrapedBottleReference.mock.calls[0]?.[0];
+    expect(retryInput).toMatchObject({ extractedIdentity });
+    expect(retryInput).not.toHaveProperty("extractedIdentitySource");
+  });
+
   test("auto creates a Bottle from complete structured scraper facts without web evidence", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -1269,9 +1269,13 @@ export function createStorePriceMatchResolver({
       if (price.sourceBottleIdentity) {
         classificationInput.extractedIdentity =
           BottleExtractedDetailsSchema.parse(price.sourceBottleIdentity);
+        classificationInput.extractedIdentitySource = "structured";
       } else if (reuseExistingExtraction) {
         classificationInput.extractedIdentity =
           parseStoredExtractedLabel(existingProposal);
+        classificationInput.extractedIdentitySource = price.imageUrl
+          ? "image"
+          : "text";
       }
 
       const classificationRun = await runReference(classificationInput);

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -1273,9 +1273,6 @@ export function createStorePriceMatchResolver({
       } else if (reuseExistingExtraction) {
         classificationInput.extractedIdentity =
           parseStoredExtractedLabel(existingProposal);
-        classificationInput.extractedIdentitySource = price.imageUrl
-          ? "image"
-          : "text";
       }
 
       const classificationRun = await runReference(classificationInput);

--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -366,6 +366,11 @@ If behavior depends on brand context, marketed family meaning, source quality,
 or whether a fact is canonical versus observational, it belongs to the agent and
 review policy.
 
+An ABV conflict from image extraction alone is not a hard contradiction. Keep
+the agent's Match and add a trait-conflict risk so automated consumers require
+review. Supportive independent web evidence clears that risk. Conflicting web
+evidence or a structured source ABV conflict remains a hard contradiction.
+
 ### SMWS Deterministic Exception
 
 SMWS is the narrow whisky-domain exception because its cask-code syntax is a

--- a/docs/architecture/bottle-classifier.md
+++ b/docs/architecture/bottle-classifier.md
@@ -368,8 +368,10 @@ review policy.
 
 An ABV conflict from image extraction alone is not a hard contradiction. Keep
 the agent's Match and add a trait-conflict risk so automated consumers require
-review. Supportive independent web evidence clears that risk. Conflicting web
-evidence or a structured source ABV conflict remains a hard contradiction.
+review. A broad web-evidence judgment cannot clear this field-level risk.
+Conflicting web evidence or a known text or structured source ABV conflict
+remains a hard contradiction. Treat an unknown extraction source as a hard
+contradiction.
 
 ### SMWS Deterministic Exception
 

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -2079,6 +2079,27 @@ describe("createBottleClassifier", () => {
     expect(result.artifacts.extractedIdentitySource).toBe("image");
   });
 
+  test("keeps supplied extraction provenance unknown when omitted", async () => {
+    const { classifier } = createTestClassifier({
+      runBottleClassifierAgent: async ({ extractedIdentity }) => ({
+        decision: noMatchAgentDecision(),
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [],
+          candidates: [],
+          resolvedEntities: [],
+        },
+      }),
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: { name: "Wild Turkey Rare Breed Rye" },
+      extractedIdentity: wildTurkeyRareBreedRyeIdentity,
+    });
+
+    expect(result.artifacts.extractedIdentitySource).toBeNull();
+  });
+
   test("falls back to text extraction when image extraction returns null", async () => {
     const runBottleClassifierAgent = vi.fn(
       async ({ extractedIdentity }): Promise<ReasoningResult> => ({

--- a/packages/bottle-classifier/src/classifier.test.ts
+++ b/packages/bottle-classifier/src/classifier.test.ts
@@ -2055,6 +2055,30 @@ describe("createBottleClassifier", () => {
     expect(run.modelMetadata).toBeNull();
   });
 
+  test("records image extraction provenance in classification artifacts", async () => {
+    const { classifier } = createTestClassifier({
+      extractedIdentityFromImage: wildTurkeyRareBreedRyeIdentity,
+      runBottleClassifierAgent: async ({ extractedIdentity }) => ({
+        decision: noMatchAgentDecision(),
+        artifacts: {
+          extractedIdentity,
+          searchEvidence: [],
+          candidates: [],
+          resolvedEntities: [],
+        },
+      }),
+    });
+
+    const result = await classifier.classifyBottleReference({
+      reference: {
+        name: "Wild Turkey Rare Breed Rye",
+        imageUrl: "https://example.com/wild-turkey.png",
+      },
+    });
+
+    expect(result.artifacts.extractedIdentitySource).toBe("image");
+  });
+
   test("falls back to text extraction when image extraction returns null", async () => {
     const runBottleClassifierAgent = vi.fn(
       async ({ extractedIdentity }): Promise<ReasoningResult> => ({
@@ -2139,6 +2163,7 @@ describe("createBottleClassifier", () => {
       brand: "Springbank",
       stated_age: 10,
     });
+    expect(result.artifacts.extractedIdentitySource).toBe("text");
     expect(runBottleClassifierAgent).toHaveBeenCalledOnce();
   });
 
@@ -2201,6 +2226,7 @@ describe("createBottleClassifier", () => {
       brand: "Ardbeg",
       expression: "Uigeadail",
     });
+    expect(result.artifacts.extractedIdentitySource).toBe("text");
     expect(runBottleClassifierAgent).toHaveBeenCalledOnce();
   });
 

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -906,16 +906,19 @@ export function createBottleClassifier(
       ? await options.overrides.extractFromText(label)
       : await extractor.extractFromText(label);
 
-  const extractBottleReferenceIdentity = async (
+  const extractBottleReferenceIdentityWithSource = async (
     reference: Pick<BottleReference, "name" | "imageUrl">,
-  ): Promise<BottleExtractedDetails | null> => {
+  ): Promise<{
+    identity: BottleExtractedDetails | null;
+    source: "image" | "text";
+  }> => {
     let imageExtractionError: Error | null = null;
 
     if (reference.imageUrl) {
       try {
         const extractedFromImage = await extractFromImage(reference.imageUrl);
         if (extractedFromImage) {
-          return extractedFromImage;
+          return { identity: extractedFromImage, source: "image" };
         }
       } catch (error) {
         imageExtractionError =
@@ -924,7 +927,10 @@ export function createBottleClassifier(
     }
 
     try {
-      return await extractFromText(reference.name);
+      return {
+        identity: await extractFromText(reference.name),
+        source: "text",
+      };
     } catch (error) {
       if (imageExtractionError) {
         throw imageExtractionError;
@@ -932,6 +938,11 @@ export function createBottleClassifier(
       throw error;
     }
   };
+
+  const extractBottleReferenceIdentity = async (
+    reference: Pick<BottleReference, "name" | "imageUrl">,
+  ): Promise<BottleExtractedDetails | null> =>
+    (await extractBottleReferenceIdentityWithSource(reference)).identity;
 
   const resolveInitialCandidates = async ({
     reference,
@@ -963,29 +974,43 @@ export function createBottleClassifier(
   const prepareBottleReferenceEvidence = async ({
     reference,
     extractedIdentity: suppliedExtractedIdentity,
+    extractedIdentitySource: suppliedExtractedIdentitySource,
     imageEvidence,
     initialCandidates,
     candidateExpansion,
     allowAutoIgnore = true,
   }: Pick<
     ClassifyBottleReferenceInput,
-    "reference" | "extractedIdentity" | "imageEvidence" | "initialCandidates"
+    | "reference"
+    | "extractedIdentity"
+    | "extractedIdentitySource"
+    | "imageEvidence"
+    | "initialCandidates"
   > & {
     candidateExpansion: CandidateExpansionMode;
     allowAutoIgnore?: boolean;
   }) => {
     const deterministicIdentitySeed = getDeterministicIdentitySeed(reference);
-    const rawExtractedIdentity =
+    // Supplied identities come from reviewed adapters unless the caller marks
+    // reused model extraction explicitly.
+    const extractedReference =
       suppliedExtractedIdentity !== undefined
-        ? suppliedExtractedIdentity
-        : (deterministicIdentitySeed ??
-          (await extractBottleReferenceIdentity(reference)));
+        ? {
+            identity: suppliedExtractedIdentity,
+            source: suppliedExtractedIdentitySource ?? "structured",
+          }
+        : deterministicIdentitySeed
+          ? { identity: deterministicIdentitySeed, source: "text" as const }
+          : await extractBottleReferenceIdentityWithSource(reference);
+    const rawExtractedIdentity = extractedReference.identity;
+    const extractedIdentitySource = extractedReference.source;
     const extractedIdentity = applyDeterministicIdentitySeed({
       reference,
       extractedIdentity: rawExtractedIdentity,
     });
     let preparedArtifacts = buildBottleClassificationArtifacts({
       extractedIdentity,
+      extractedIdentitySource,
       imageEvidence: imageEvidence ?? null,
     });
     const autoIgnoreReason = getAutoIgnoreBottleReferenceReason(
@@ -1339,6 +1364,7 @@ export function createBottleClassifier(
       const preparedEvidence = await prepareBottleReferenceEvidence({
         reference: parsedInput.reference,
         extractedIdentity: parsedInput.extractedIdentity,
+        extractedIdentitySource: parsedInput.extractedIdentitySource,
         imageEvidence: parsedInput.imageEvidence,
         initialCandidates: parsedInput.initialCandidates,
         candidateExpansion: parsedInput.candidateExpansion,
@@ -1368,9 +1394,17 @@ export function createBottleClassifier(
         identityAnchor: preparedEvidence.deterministicDecision,
         webSearchBudget: preparedEvidence.webSearchBudget,
       });
+      const agentResult = {
+        ...agentRun.agentResult,
+        // Extraction provenance is runtime-owned. Agent output cannot replace it.
+        artifacts: buildBottleClassificationArtifacts({
+          ...agentRun.agentResult.artifacts,
+          extractedIdentitySource: artifacts.extractedIdentitySource,
+        }),
+      };
       const finalized = await finalizeBottleClassifierAgentResult({
         reference: parsedInput.reference,
-        agentResult: agentRun.agentResult,
+        agentResult,
       });
       artifacts = finalized.artifacts;
 

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -991,19 +991,18 @@ export function createBottleClassifier(
     allowAutoIgnore?: boolean;
   }) => {
     const deterministicIdentitySeed = getDeterministicIdentitySeed(reference);
-    // Supplied identities come from reviewed adapters unless the caller marks
-    // reused model extraction explicitly.
     const extractedReference =
       suppliedExtractedIdentity !== undefined
         ? {
             identity: suppliedExtractedIdentity,
-            source: suppliedExtractedIdentitySource ?? "structured",
+            source: suppliedExtractedIdentitySource ?? null,
           }
         : deterministicIdentitySeed
           ? { identity: deterministicIdentitySeed, source: "text" as const }
           : await extractBottleReferenceIdentityWithSource(reference);
     const rawExtractedIdentity = extractedReference.identity;
-    const extractedIdentitySource = extractedReference.source;
+    const extractedIdentitySource: "image" | "text" | "structured" | null =
+      extractedReference.source;
     const extractedIdentity = applyDeterministicIdentitySeed({
       reference,
       extractedIdentity: rawExtractedIdentity,

--- a/packages/bottle-classifier/src/contract.ts
+++ b/packages/bottle-classifier/src/contract.ts
@@ -193,6 +193,11 @@ export const BottleReferenceSchema = z
 export const BottleClassificationArtifactsSchema = z
   .object({
     extractedIdentity: BottleExtractedDetailsSchema.nullable().default(null),
+    extractedIdentitySource: z
+      .enum(["image", "text", "structured"])
+      .nullable()
+      .default(null)
+      .describe("Origin of the complete extracted identity."),
     // Direct artifact fixtures may omit image evidence; the builder normalizes
     // that compatibility path to null for runtime consumers.
     imageEvidence: ImageBottleEvidenceSchema.nullable().optional(),
@@ -211,6 +216,10 @@ export const ClassifyBottleReferenceInputSchema = z
     reference: BottleReferenceSchema,
     conversationId: z.string().trim().min(1).optional(),
     extractedIdentity: BottleExtractedDetailsSchema.nullable().optional(),
+    extractedIdentitySource: z
+      .enum(["image", "text", "structured"])
+      .optional()
+      .describe("Origin of a supplied extracted identity."),
     imageEvidence: ImageBottleEvidenceSchema.nullable().optional(),
     initialCandidates: z.array(BottleCandidateSchema).optional(),
     candidateExpansion: CandidateExpansionModeSchema.default("open"),
@@ -317,6 +326,8 @@ export type ClassifyBottleReferenceInput = {
   reference: BottleReference;
   conversationId?: string;
   extractedIdentity?: null | z.infer<typeof BottleExtractedDetailsSchema>;
+  /** Origin of a supplied extracted identity. Defaults to structured. */
+  extractedIdentitySource?: "image" | "text" | "structured";
   imageEvidence?: null | z.infer<typeof ImageBottleEvidenceSchema>;
   initialCandidates?: z.infer<typeof BottleCandidateSchema>[];
   candidateExpansion?: CandidateExpansionMode;
@@ -337,6 +348,7 @@ export function buildBottleClassificationArtifacts(
 ): BottleClassificationArtifacts {
   return BottleClassificationArtifactsSchema.parse({
     extractedIdentity: null,
+    extractedIdentitySource: null,
     imageEvidence: null,
     candidates: [],
     searchEvidence: [],

--- a/packages/bottle-classifier/src/contract.ts
+++ b/packages/bottle-classifier/src/contract.ts
@@ -219,7 +219,9 @@ export const ClassifyBottleReferenceInputSchema = z
     extractedIdentitySource: z
       .enum(["image", "text", "structured"])
       .optional()
-      .describe("Origin of a supplied extracted identity."),
+      .describe(
+        "Known origin of a supplied extracted identity. Omit when unknown.",
+      ),
     imageEvidence: ImageBottleEvidenceSchema.nullable().optional(),
     initialCandidates: z.array(BottleCandidateSchema).optional(),
     candidateExpansion: CandidateExpansionModeSchema.default("open"),
@@ -326,7 +328,7 @@ export type ClassifyBottleReferenceInput = {
   reference: BottleReference;
   conversationId?: string;
   extractedIdentity?: null | z.infer<typeof BottleExtractedDetailsSchema>;
-  /** Origin of a supplied extracted identity. Defaults to structured. */
+  /** Known origin of a supplied extracted identity. Omit when unknown. */
   extractedIdentitySource?: "image" | "text" | "structured";
   imageEvidence?: null | z.infer<typeof ImageBottleEvidenceSchema>;
   initialCandidates?: z.infer<typeof BottleCandidateSchema>[];

--- a/packages/bottle-classifier/src/reviewPolicy.test.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.test.ts
@@ -260,6 +260,73 @@ function classifyStructuredExactName({
   });
 }
 
+function buildAbvMatchInput({
+  brand = "Example",
+  candidateAbv,
+  extractedAbv,
+  source,
+  webEvidence = "not_needed",
+}: {
+  brand?: string;
+  candidateAbv: number;
+  extractedAbv: number;
+  source: "image" | "structured";
+  webEvidence?: "supportive" | "conflicting" | "not_needed";
+}) {
+  const targetCandidate: BottleCandidate = {
+    ...existingPrivateCask,
+    bottleId: 9901,
+    fullName: `${brand} Single Malt`,
+    brand,
+    singleCask: null,
+    abv: candidateAbv,
+  };
+
+  return {
+    reference: {
+      name: `${brand} Single Malt`,
+      imageUrl:
+        source === "image" ? "https://example.com/bottle.jpg" : undefined,
+    },
+    decision: {
+      action: "match" as const,
+      rationale: "The Bottle identity matches the candidate.",
+      candidateBottleIds: [targetCandidate.bottleId],
+      identityScope: "product" as const,
+      aliasScope: "none" as const,
+      observation: null,
+      confidenceBasis: {
+        unresolvedRisks: [],
+        webEvidence,
+      },
+      matchedBottleId: targetCandidate.bottleId,
+      proposedBottle: null,
+    },
+    artifacts: buildBottleClassificationArtifacts({
+      candidates: [targetCandidate],
+      extractedIdentitySource: source,
+      extractedIdentity: {
+        brand,
+        bottler: null,
+        expression: "Single Malt",
+        series: null,
+        distillery: [],
+        category: "single_malt",
+        stated_age: null,
+        abv: extractedAbv,
+        release_year: null,
+        vintage_year: null,
+        cask_strength: null,
+        single_cask: null,
+        cask_type: null,
+        cask_size: null,
+        cask_fill: null,
+        edition: null,
+      },
+    }),
+  };
+}
+
 describe("finalizeBottleReferenceClassification", () => {
   test("rejects a proposed series that repeats the Brand", () => {
     const result = finalizeBottleReferenceClassification({
@@ -1373,6 +1440,95 @@ describe("finalizeBottleReferenceClassification", () => {
         artifacts,
       }),
     ).toMatchObject({ action: "no_match", matchedBottleId: null });
+  });
+
+  test.each([
+    ["John Crabbie", 46, 40],
+    ["Beauchamp", 40, 46],
+  ])(
+    "routes an image-only ABV conflict to review: %s",
+    (brand, extractedAbv, candidateAbv) => {
+      const result = finalizeBottleReferenceClassification(
+        buildAbvMatchInput({
+          brand,
+          extractedAbv,
+          candidateAbv,
+          source: "image",
+        }),
+      );
+
+      expect(result).toMatchObject({
+        action: "match",
+        matchedBottleId: 9901,
+        confidenceBasis: {
+          unresolvedRisks: [
+            {
+              category: "trait_conflict",
+              note: "Image-extracted ABV conflicts with the matched Bottle and needs review.",
+            },
+          ],
+          webEvidence: "not_needed",
+        },
+      });
+    },
+  );
+
+  test("keeps a structured ABV conflict as a hard failure", () => {
+    expect(
+      finalizeBottleReferenceClassification(
+        buildAbvMatchInput({
+          extractedAbv: 46,
+          candidateAbv: 40,
+          source: "structured",
+        }),
+      ),
+    ).toMatchObject({ action: "no_match", matchedBottleId: null });
+  });
+
+  test("keeps a matching image-derived ABV without adding a risk", () => {
+    const result = finalizeBottleReferenceClassification(
+      buildAbvMatchInput({
+        extractedAbv: 46,
+        candidateAbv: 46,
+        source: "image",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      action: "match",
+      matchedBottleId: 9901,
+      confidenceBasis: { unresolvedRisks: [] },
+    });
+  });
+
+  test("accepts independent web evidence that supports the candidate ABV", () => {
+    const result = finalizeBottleReferenceClassification(
+      buildAbvMatchInput({
+        extractedAbv: 46,
+        candidateAbv: 40,
+        source: "image",
+        webEvidence: "supportive",
+      }),
+    );
+
+    expect(result).toMatchObject({
+      action: "match",
+      matchedBottleId: 9901,
+      confidenceBasis: { unresolvedRisks: [] },
+    });
+  });
+
+  test("rejects a candidate when web evidence supports the image ABV conflict", () => {
+    const result = finalizeBottleReferenceClassification(
+      buildAbvMatchInput({
+        extractedAbv: 46,
+        candidateAbv: 40,
+        source: "image",
+        webEvidence: "conflicting",
+      }),
+    );
+
+    expect(result).toMatchObject({ action: "no_match", matchedBottleId: null });
   });
 
   test("keeps the extracted SMWS title in exact-cask create proposals", () => {

--- a/packages/bottle-classifier/src/reviewPolicy.test.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.test.ts
@@ -270,7 +270,7 @@ function buildAbvMatchInput({
   brand?: string;
   candidateAbv: number;
   extractedAbv: number;
-  source: "image" | "structured";
+  source: "image" | "text" | "structured" | null;
   webEvidence?: "supportive" | "conflicting" | "not_needed";
 }) {
   const targetCandidate: BottleCandidate = {
@@ -1473,18 +1473,6 @@ describe("finalizeBottleReferenceClassification", () => {
     },
   );
 
-  test("keeps a structured ABV conflict as a hard failure", () => {
-    expect(
-      finalizeBottleReferenceClassification(
-        buildAbvMatchInput({
-          extractedAbv: 46,
-          candidateAbv: 40,
-          source: "structured",
-        }),
-      ),
-    ).toMatchObject({ action: "no_match", matchedBottleId: null });
-  });
-
   test("keeps a matching image-derived ABV without adding a risk", () => {
     const result = finalizeBottleReferenceClassification(
       buildAbvMatchInput({
@@ -1501,7 +1489,7 @@ describe("finalizeBottleReferenceClassification", () => {
     });
   });
 
-  test("accepts independent web evidence that supports the candidate ABV", () => {
+  test("keeps an image ABV conflict in review with supportive web evidence", () => {
     const result = finalizeBottleReferenceClassification(
       buildAbvMatchInput({
         extractedAbv: 46,
@@ -1514,9 +1502,31 @@ describe("finalizeBottleReferenceClassification", () => {
     expect(result).toMatchObject({
       action: "match",
       matchedBottleId: 9901,
-      confidenceBasis: { unresolvedRisks: [] },
+      confidenceBasis: {
+        unresolvedRisks: [
+          {
+            category: "trait_conflict",
+            note: "Image-extracted ABV conflicts with the matched Bottle and needs review.",
+          },
+        ],
+      },
     });
   });
+
+  test.each(["text", "structured", null] as const)(
+    "keeps a %s-source ABV conflict as a hard failure",
+    (source) => {
+      expect(
+        finalizeBottleReferenceClassification(
+          buildAbvMatchInput({
+            extractedAbv: 46,
+            candidateAbv: 40,
+            source,
+          }),
+        ),
+      ).toMatchObject({ action: "no_match", matchedBottleId: null });
+    },
+  );
 
   test("rejects a candidate when web evidence supports the image ABV conflict", () => {
     const result = finalizeBottleReferenceClassification(

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -498,6 +498,39 @@ function createNoMatchDecision({
   });
 }
 
+const IMAGE_ABV_CONFLICT_RISK_NOTE =
+  "Image-extracted ABV conflicts with the matched Bottle and needs review.";
+
+function addImageAbvConflictRisk(
+  decision: BottleClassificationDecision,
+): BottleClassificationDecision {
+  const confidenceBasis = decision.confidenceBasis ?? {
+    unresolvedRisks: [],
+    webEvidence: "not_used" as const,
+  };
+  if (
+    confidenceBasis.unresolvedRisks.some(
+      ({ note }) => note === IMAGE_ABV_CONFLICT_RISK_NOTE,
+    )
+  ) {
+    return decision;
+  }
+
+  return {
+    ...decision,
+    confidenceBasis: {
+      ...confidenceBasis,
+      unresolvedRisks: [
+        ...confidenceBasis.unresolvedRisks,
+        {
+          category: "trait_conflict",
+          note: IMAGE_ABV_CONFLICT_RISK_NOTE,
+        },
+      ],
+    },
+  };
+}
+
 function rejectInvalidExistingMatch({
   reference,
   decision,
@@ -530,17 +563,31 @@ function rejectInvalidExistingMatch({
     targetCandidate: target,
     extractedLabel: artifacts.extractedIdentity,
   });
+  const hasImageAbvConflict =
+    artifacts.extractedIdentitySource === "image" &&
+    identityConflicts.includes("abv");
+  // One image read cannot erase a Match. Independent evidence decides whether
+  // the conflict is resolved or remains unsafe.
+  const imageAbvNeedsReview =
+    hasImageAbvConflict &&
+    decision.confidenceBasis?.webEvidence !== "supportive" &&
+    decision.confidenceBasis?.webEvidence !== "conflicting";
+  const hardIdentityConflicts =
+    hasImageAbvConflict &&
+    decision.confidenceBasis?.webEvidence !== "conflicting"
+      ? identityConflicts.filter((field) => field !== "abv")
+      : identityConflicts;
 
   const smwsCode = getSmwsCodeAnchor({ reference, decision, artifacts });
   const materialIdentityConflicts =
     smwsCode &&
     candidateLooksSmws(target) &&
     candidateHasExactCaskCodeAnchor(target, smwsCode)
-      ? identityConflicts.filter((field) => field !== "brand")
-      : identityConflicts;
+      ? hardIdentityConflicts.filter((field) => field !== "brand")
+      : hardIdentityConflicts;
 
   if (!materialIdentityConflicts.length) {
-    return decision;
+    return imageAbvNeedsReview ? addImageAbvConflictRisk(decision) : decision;
   }
 
   const downgradedRationale = appendRationale(

--- a/packages/bottle-classifier/src/reviewPolicy.ts
+++ b/packages/bottle-classifier/src/reviewPolicy.ts
@@ -566,11 +566,10 @@ function rejectInvalidExistingMatch({
   const hasImageAbvConflict =
     artifacts.extractedIdentitySource === "image" &&
     identityConflicts.includes("abv");
-  // One image read cannot erase a Match. Independent evidence decides whether
-  // the conflict is resolved or remains unsafe.
+  // One image read cannot erase a Match. The conflict still needs review until
+  // the runtime carries independent evidence for this exact field and value.
   const imageAbvNeedsReview =
     hasImageAbvConflict &&
-    decision.confidenceBasis?.webEvidence !== "supportive" &&
     decision.confidenceBasis?.webEvidence !== "conflicting";
   const hardIdentityConflicts =
     hasImageAbvConflict &&


### PR DESCRIPTION
A known image-extracted ABV conflict no longer erases an otherwise valid Match. The classifier keeps the Match and adds an unresolved trait-conflict risk, so automated consumers send it to review. A broad web-evidence judgment cannot clear that exact-field risk. Conflicting web evidence and ABV conflicts from known text, structured data, or unknown provenance still produce No Match.

The runtime records whether extraction actually used an image or text. Normalized scraper facts are marked as structured. Legacy retry data remains unknown instead of inferring its source from the presence of an image URL. This leaves non-ABV conflicts unchanged and adds no model calls.
