### PR TITLE
fix(classifier): keep merged candidates JSON-safe

### DIFF
--- a/packages/bottle-classifier/src/candidateFamilyContext.ts
+++ b/packages/bottle-classifier/src/candidateFamilyContext.ts
@@ -7,7 +7,7 @@ export function mergeBottleCandidateFamilyContext(
   candidate: BottleCandidateFamilyContext,
 ): BottleCandidateFamilyContext {
   if (!existing) {
-    return candidate;
+    return candidate ?? null;
   }
   if (!candidate) {
     return existing;

--- a/packages/bottle-classifier/src/runtime/candidates.test.ts
+++ b/packages/bottle-classifier/src/runtime/candidates.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+import { z } from "zod";
+import {
+  BottleCandidateSchema,
+  type BottleCandidate,
+} from "../classifierTypes";
+import { mergeBottleCandidate } from "./candidates";
+
+describe("mergeBottleCandidate", () => {
+  test("keeps candidates JSON-safe when duplicate results have no family context", () => {
+    const first = BottleCandidateSchema.parse({
+      bottleId: 1,
+      fullName: "Example Small Batch",
+      source: ["exact"],
+    });
+    const second = BottleCandidateSchema.parse({
+      bottleId: 1,
+      fullName: "Example Small Batch",
+      source: ["search"],
+    });
+    const candidates = new Map<number, BottleCandidate>();
+
+    mergeBottleCandidate(candidates, first);
+    mergeBottleCandidate(candidates, second);
+
+    const merged = candidates.get(1);
+    expect(merged?.familyContext).toBeNull();
+    expect(z.json().safeParse(merged).success).toBe(true);
+  });
+});


### PR DESCRIPTION
Candidate result merging now normalizes missing family context to `null` before artifacts are persisted. This keeps duplicate candidate results JSON-safe and prevents otherwise valid classifier runs from becoming errored while saving their Bottle check receipt.

The regression recreates duplicate candidates with no family context and verifies that the merged output passes JSON validation. Classifier identity decisions are unchanged.
