### PR TITLE
fix(api)!: publish multipart photo uploads

### DIFF
--- a/apps/server/src/lib/test/fixtures.ts
+++ b/apps/server/src/lib/test/fixtures.ts
@@ -1272,7 +1272,11 @@ export const AuthenticatedHeaders = async (
 };
 
 export const SampleSquareImage = async () => {
-  return new Blob([await readFile(await SampleSquareImagePath())]);
+  return new File(
+    [await readFile(await SampleSquareImagePath())],
+    "sample-square-image.jpg",
+    { type: "image/jpeg" },
+  );
 };
 
 export const SampleSquareImagePath = async () => {

--- a/apps/server/src/openapi/spec.test.ts
+++ b/apps/server/src/openapi/spec.test.ts
@@ -484,6 +484,30 @@ describe("OpenAPI generation ($ref reuse)", () => {
     >().toEqualTypeOf<number>();
   });
 
+  it("publishes the photo-identification multipart upload contract", async () => {
+    const spec = await generateSpec();
+    const operation = spec.paths?.["/tastings/photo-identification"]?.post;
+    const requestBody = operation?.requestBody;
+    const content =
+      requestBody && "content" in requestBody ? requestBody.content : undefined;
+    const request = content?.["multipart/form-data"]?.schema;
+
+    expect(content?.["application/json"]).toBeUndefined();
+    expect(request).toBeDefined();
+    expect(request).toMatchObject({
+      type: "object",
+      required: expect.arrayContaining(["file", "idempotencyKey"]),
+      properties: {
+        file: expect.objectContaining({
+          type: "string",
+          format: "binary",
+          contentMediaType: "image/*",
+        }),
+        idempotencyKey: expect.objectContaining({ type: "string" }),
+      },
+    });
+  });
+
   it("publishes direct Bottle mutation contracts", async () => {
     const spec = await generateSpec();
     const mergeOperation = spec.paths?.["/bottles/{bottle}/merge"]?.post;

--- a/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.test.ts
@@ -258,7 +258,7 @@ async function identifyCreateProposal({
   candidates = [],
   suitableAsBottleImage = true,
 }: {
-  fixtures: { SampleSquareImage: () => Promise<Blob> };
+  fixtures: { SampleSquareImage: () => Promise<File> };
   user: NonNullable<Context["user"]>;
   idempotencyKey: string;
   decision: MockClassificationDecision;
@@ -565,7 +565,9 @@ describe("POST /tastings/photo-identification", () => {
     const err = await waitError(
       routerClient.tastings.photoIdentification(
         {
-          file: new Blob([new Uint8Array(MAX_FILESIZE + 1)]),
+          file: new File([new Uint8Array(MAX_FILESIZE + 1)], "oversized.jpg", {
+            type: "image/jpeg",
+          }),
           idempotencyKey: "photo-identification-oversized",
         },
         {

--- a/apps/server/src/orpc/routes/tastings/photo-identification.ts
+++ b/apps/server/src/orpc/routes/tastings/photo-identification.ts
@@ -725,6 +725,23 @@ export function createPhotoIdentificationProcedure(
       description:
         "Upload a temporary bottle photo, extract label evidence, and classify the likely bottle without creating a tasting.",
       operationId: "identifyTastingBottleFromPhoto",
+      // Advertise one request format so generated clients send a file upload.
+      spec: (spec) => {
+        const multipart =
+          spec.requestBody && "content" in spec.requestBody
+            ? spec.requestBody.content?.["multipart/form-data"]
+            : undefined;
+
+        return multipart
+          ? {
+              ...spec,
+              requestBody: {
+                ...spec.requestBody,
+                content: { "multipart/form-data": multipart },
+              },
+            }
+          : spec;
+      },
     })
     .input(PhotoIdentificationInputSchema)
     .output(PhotoIdentificationSchema)

--- a/apps/server/src/schemas/tastings.ts
+++ b/apps/server/src/schemas/tastings.ts
@@ -1,3 +1,4 @@
+import { JSON_SCHEMA_INPUT_REGISTRY } from "@orpc/zod/zod4";
 import {
   BottleCandidateSchema,
   ImageBottleEvidenceSchema,
@@ -146,8 +147,17 @@ export const PhotoIdentificationSuggestedNextStepEnum = z.enum([
   "manual_search",
 ]);
 
+const PhotoIdentificationFileSchema = z
+  .file()
+  .describe("Bottle label image to identify");
+
+JSON_SCHEMA_INPUT_REGISTRY.add(PhotoIdentificationFileSchema, {
+  format: "binary",
+  contentMediaType: "image/*",
+});
+
 export const PhotoIdentificationInputSchema = z.object({
-  file: z.instanceof(Blob).describe("Bottle label image to identify"),
+  file: PhotoIdentificationFileSchema,
   idempotencyKey: z
     .string()
     .trim()

--- a/apps/server/src/test/setup-test-env.ts
+++ b/apps/server/src/test/setup-test-env.ts
@@ -146,7 +146,12 @@ beforeEach(async (ctx) => {
     const oJobs = await import("../worker/client");
     const redis = await oJobs.getConnection();
     if (redis) {
-      const rateLimitPrefixes = ["rl:*", "auth:*", "auth-strict:*"];
+      const rateLimitPrefixes = [
+        "rl:*",
+        "auth:*",
+        "auth-strict:*",
+        "photo-identification:*",
+      ];
       for (const prefix of rateLimitPrefixes) {
         const keys = await redis.keys(prefix);
         if (keys.length > 0) {


### PR DESCRIPTION
Photo identification now accepts a real file and publishes only `multipart/form-data`. The generated OpenAPI request marks `file` as a binary image and keeps `idempotencyKey` required, so the regenerated iOS client and the existing web oRPC client both use the same upload format.

This intentionally removes the JSON data-URL request shape. The iOS client must be regenerated from the updated specification before release. Contract coverage asserts that JSON is absent and the multipart fields retain their required binary and string schemas.
