### PR TITLE
fix(prices): Align listing validity and history

### DIFF
--- a/apps/server/src/lib/storePriceValidity.ts
+++ b/apps/server/src/lib/storePriceValidity.ts
@@ -1,0 +1,18 @@
+import { storePrices } from "@peated/server/db/schema";
+import { sql } from "drizzle-orm";
+
+export const STORE_PRICE_VALIDITY_DAYS = 7;
+
+export function isStorePriceValid(
+  updatedAt: Date,
+  now: Date = new Date(),
+): boolean {
+  const cutoff = new Date(
+    now.getTime() - STORE_PRICE_VALIDITY_DAYS * 24 * 60 * 60 * 1000,
+  );
+  return updatedAt > cutoff;
+}
+
+export function currentStorePriceCondition() {
+  return sql`${storePrices.updatedAt} > NOW() - make_interval(days => ${STORE_PRICE_VALIDITY_DAYS})`;
+}

--- a/apps/server/src/orpc/routes/bottles/details.test.ts
+++ b/apps/server/src/orpc/routes/bottles/details.test.ts
@@ -109,4 +109,23 @@ describe("GET /bottles/:bottle", () => {
     expect(data.lastPrice?.id).toBe(directPrice.id);
     expect(data.lastPrice?.bottle?.id).toBe(bottle.id);
   });
+
+  test("does not expose hidden prices as lastPrice", async ({ fixtures }) => {
+    const bottle = await fixtures.Bottle();
+    const visiblePrice = await fixtures.StorePrice({
+      bottleId: bottle.id,
+      name: "Visible detail price",
+      updatedAt: new Date(Date.now() - 2_000),
+    });
+    await fixtures.StorePrice({
+      bottleId: bottle.id,
+      hidden: true,
+      name: "Hidden newer detail price",
+      updatedAt: new Date(Date.now() - 1_000),
+    });
+
+    const data = await routerClient.bottles.details({ bottle: bottle.id });
+
+    expect(data.lastPrice?.id).toBe(visiblePrice.id);
+  });
 });

--- a/apps/server/src/orpc/routes/bottles/details.ts
+++ b/apps/server/src/orpc/routes/bottles/details.ts
@@ -14,7 +14,7 @@ import {
 import { serialize } from "@peated/server/serializers";
 import { BottleSerializer } from "@peated/server/serializers/bottle";
 import { StorePriceSerializer } from "@peated/server/serializers/storePrice";
-import { desc, eq, getTableColumns, sql } from "drizzle-orm";
+import { and, desc, eq, getTableColumns, sql } from "drizzle-orm";
 import { z } from "zod";
 
 // Compose details as Bottle schema + extra fields to allow OpenAPI $ref via allOf
@@ -69,7 +69,9 @@ export default procedure
     const [lastPrice] = await db
       .select()
       .from(storePrices)
-      .where(eq(storePrices.bottleId, bottle.id))
+      .where(
+        and(eq(storePrices.bottleId, bottle.id), eq(storePrices.hidden, false)),
+      )
       .orderBy(desc(storePrices.updatedAt), desc(storePrices.id))
       .limit(1);
 

--- a/apps/server/src/orpc/routes/bottles/prices/history.test.ts
+++ b/apps/server/src/orpc/routes/bottles/prices/history.test.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { storePrices } from "@peated/server/db/schema";
+import { storePriceHistories, storePrices } from "@peated/server/db/schema";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq } from "drizzle-orm";
 
@@ -84,6 +84,24 @@ describe("GET /bottles/:bottle/price-history", () => {
     });
 
     expect(results.map(({ avgPrice }) => avgPrice)).toEqual([17]);
+  });
+
+  test("excludes history with an invalid volume", async ({ fixtures }) => {
+    const bottle = await fixtures.Bottle();
+    const price = await fixtures.StorePrice({
+      bottleId: bottle.id,
+      name: "Invalid volume history",
+    });
+    await db
+      .update(storePriceHistories)
+      .set({ volume: 0 })
+      .where(eq(storePriceHistories.priceId, price.id));
+
+    const { results } = await routerClient.bottles.prices.history({
+      bottle: bottle.id,
+    });
+
+    expect(results).toEqual([]);
   });
 
   test("filters by the currency recorded on each history row", async ({

--- a/apps/server/src/orpc/routes/bottles/prices/history.test.ts
+++ b/apps/server/src/orpc/routes/bottles/prices/history.test.ts
@@ -67,4 +67,73 @@ describe("GET /bottles/:bottle/price-history", () => {
 
     expect(results.map(({ avgPrice }) => avgPrice)).toEqual([20]);
   });
+
+  test("rounds after calculating the precise per-milliliter price", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    await fixtures.StorePrice({
+      bottleId: bottle.id,
+      name: "Fractional per-milliliter history",
+      price: 12_450,
+      volume: 750,
+    });
+
+    const { results } = await routerClient.bottles.prices.history({
+      bottle: bottle.id,
+    });
+
+    expect(results.map(({ avgPrice }) => avgPrice)).toEqual([17]);
+  });
+
+  test("filters by the currency recorded on each history row", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const price = await fixtures.StorePrice({
+      bottleId: bottle.id,
+      currency: "usd",
+      name: "Listing with mixed-currency history",
+    });
+    await fixtures.StorePriceHistory({
+      priceId: price.id,
+      currency: "eur",
+      date: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      price: 15_000,
+    });
+
+    const { results } = await routerClient.bottles.prices.history({
+      bottle: bottle.id,
+      currency: "eur",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].avgPrice).toBe(20);
+  });
+
+  test("excludes hidden and older-than-one-year history", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const visiblePrice = await fixtures.StorePrice({
+      bottleId: bottle.id,
+      name: "Visible current history",
+    });
+    await fixtures.StorePriceHistory({
+      priceId: visiblePrice.id,
+      date: "2020-01-01",
+    });
+    await fixtures.StorePrice({
+      bottleId: bottle.id,
+      hidden: true,
+      name: "Hidden current history",
+    });
+
+    const { results } = await routerClient.bottles.prices.history({
+      bottle: bottle.id,
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].date).not.toBe("2020-01-01");
+  });
 });

--- a/apps/server/src/orpc/routes/bottles/prices/history.ts
+++ b/apps/server/src/orpc/routes/bottles/prices/history.ts
@@ -15,7 +15,7 @@ export default procedure
     path: "/bottles/{bottle}/price-history",
     summary: "Get bottle price history",
     description:
-      "Retrieve historical price data for a bottle including average, minimum, and maximum prices over time",
+      "Retrieve one year of historical prices normalized by listed volume. Values use the currency's smallest unit per milliliter (for example, cents per mL)",
     spec: (spec) => ({
       ...spec,
       operationId: "getBottlePriceHistory",
@@ -32,9 +32,21 @@ export default procedure
       results: z.array(
         z.object({
           date: z.string(),
-          avgPrice: z.number(),
-          minPrice: z.number(),
-          maxPrice: z.number(),
+          avgPrice: z
+            .number()
+            .describe(
+              "Average price in the currency's smallest unit per milliliter",
+            ),
+          minPrice: z
+            .number()
+            .describe(
+              "Minimum price in the currency's smallest unit per milliliter",
+            ),
+          maxPrice: z
+            .number()
+            .describe(
+              "Maximum price in the currency's smallest unit per milliliter",
+            ),
         }),
       ),
     }),
@@ -53,16 +65,17 @@ export default procedure
 
     const baseWhere = [
       eq(storePrices.bottleId, bottle.id),
-      eq(storePrices.currency, input.currency),
-      sql`${storePrices.updatedAt} > NOW() - interval '1 year'`,
+      eq(storePrices.hidden, false),
+      eq(storePriceHistories.currency, input.currency),
+      sql`${storePriceHistories.date} >= CURRENT_DATE - interval '1 year'`,
     ];
 
     const results = await db
       .select({
         date: storePriceHistories.date,
-        avgPrice: sql<string>`ROUND(AVG(${storePriceHistories.price} / ${storePriceHistories.volume}))`,
-        minPrice: sql<string>`ROUND(MIN(${storePriceHistories.price} / ${storePriceHistories.volume}))`,
-        maxPrice: sql<string>`ROUND(MAX(${storePriceHistories.price} / ${storePriceHistories.volume}))`,
+        avgPrice: sql<string>`ROUND(AVG(${storePriceHistories.price}::numeric / NULLIF(${storePriceHistories.volume}, 0)))`,
+        minPrice: sql<string>`ROUND(MIN(${storePriceHistories.price}::numeric / NULLIF(${storePriceHistories.volume}, 0)))`,
+        maxPrice: sql<string>`ROUND(MAX(${storePriceHistories.price}::numeric / NULLIF(${storePriceHistories.volume}, 0)))`,
       })
       .from(storePriceHistories)
       .innerJoin(storePrices, eq(storePriceHistories.priceId, storePrices.id))

--- a/apps/server/src/orpc/routes/bottles/prices/history.ts
+++ b/apps/server/src/orpc/routes/bottles/prices/history.ts
@@ -6,7 +6,7 @@ import {
 } from "@peated/server/db/schema";
 import { procedure } from "@peated/server/orpc";
 import { CurrencyEnum } from "@peated/server/schemas";
-import { and, desc, eq, sql } from "drizzle-orm";
+import { and, desc, eq, gt, sql } from "drizzle-orm";
 import { z } from "zod";
 
 export default procedure
@@ -67,6 +67,7 @@ export default procedure
       eq(storePrices.bottleId, bottle.id),
       eq(storePrices.hidden, false),
       eq(storePriceHistories.currency, input.currency),
+      gt(storePriceHistories.volume, 0),
       sql`${storePriceHistories.date} >= CURRENT_DATE - interval '1 year'`,
     ];
 

--- a/apps/server/src/orpc/routes/bottles/prices/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/prices/list.test.ts
@@ -116,4 +116,23 @@ describe("GET /bottles/:bottle/prices", () => {
 
     expect(result.results.map(({ id }) => id)).toEqual([current.id]);
   });
+
+  test("reports validity using the same seven-day window as filtering", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const current = await fixtures.StorePrice({
+      bottleId: bottle.id,
+      name: "Two-day-old listing",
+      updatedAt: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+    });
+
+    const result = await routerClient.bottles.prices.list({
+      bottle: bottle.id,
+      onlyValid: true,
+    });
+
+    expect(result.results).toHaveLength(1);
+    expect(result.results[0]).toMatchObject({ id: current.id, isValid: true });
+  });
 });

--- a/apps/server/src/orpc/routes/bottles/prices/list.ts
+++ b/apps/server/src/orpc/routes/bottles/prices/list.ts
@@ -1,5 +1,6 @@
 import { db } from "@peated/server/db";
 import { bottles, externalSites, storePrices } from "@peated/server/db/schema";
+import { currentStorePriceCondition } from "@peated/server/lib/storePriceValidity";
 import { procedure } from "@peated/server/orpc";
 import { ExternalSiteSchema, StorePriceSchema } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
@@ -60,7 +61,7 @@ export default procedure
     ];
 
     if (input.onlyValid) {
-      baseWhere.push(sql`${storePrices.updatedAt} > NOW() - interval '1 week'`);
+      baseWhere.push(currentStorePriceCondition());
     }
 
     const results = await db
@@ -74,10 +75,7 @@ export default procedure
         eq(storePrices.externalSiteId, externalSites.id),
       )
       .where(and(...baseWhere))
-      .orderBy(
-        desc(sql`${storePrices.updatedAt} > NOW() - interval '1 week'`),
-        asc(storePrices.name),
-      );
+      .orderBy(desc(currentStorePriceCondition()), asc(storePrices.name));
 
     return {
       results: await serialize(

--- a/apps/server/src/orpc/routes/countries/categories.test.ts
+++ b/apps/server/src/orpc/routes/countries/categories.test.ts
@@ -126,8 +126,14 @@ describe("GET /countries/categories", () => {
   test("counts active Bottles directly and ignores legacy ungrouped identity", async ({
     fixtures,
   }) => {
-    const country = await fixtures.Country();
-    const otherCountry = await fixtures.Country();
+    const country = await fixtures.Country({
+      name: "Target Country",
+      slug: "target-country",
+    });
+    const otherCountry = await fixtures.Country({
+      name: "Other Country",
+      slug: "other-country",
+    });
     const countryDistiller = await fixtures.Entity({
       countryId: country.id,
       type: ["distiller"],
@@ -203,8 +209,14 @@ describe("GET /countries/categories", () => {
   test("counts each Bottle once and orders nullable category buckets", async ({
     fixtures,
   }) => {
-    const country = await fixtures.Country();
-    const otherCountry = await fixtures.Country();
+    const country = await fixtures.Country({
+      name: "Target Country",
+      slug: "target-country",
+    });
+    const otherCountry = await fixtures.Country({
+      name: "Other Country",
+      slug: "other-country",
+    });
     const firstDistiller = await fixtures.Entity({
       countryId: country.id,
       type: ["distiller"],

--- a/apps/server/src/orpc/routes/prices/list.ts
+++ b/apps/server/src/orpc/routes/prices/list.ts
@@ -1,5 +1,6 @@
 import { db } from "@peated/server/db";
 import { externalSites, storePrices } from "@peated/server/db/schema";
+import { currentStorePriceCondition } from "@peated/server/lib/storePriceValidity";
 import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
 import {
@@ -65,7 +66,7 @@ export default procedure
     }
 
     if (input.onlyValid) {
-      baseWhere.push(sql`${storePrices.updatedAt} > NOW() - interval '1 week'`);
+      baseWhere.push(currentStorePriceCondition());
     }
 
     if (input.onlyUnknown) {
@@ -84,10 +85,7 @@ export default procedure
       .where(and(...baseWhere, ...identityWhere))
       .limit(limit + 1)
       .offset(offset)
-      .orderBy(
-        desc(sql`${storePrices.updatedAt} > NOW() - interval '1 week'`),
-        asc(storePrices.name),
-      );
+      .orderBy(desc(currentStorePriceCondition()), asc(storePrices.name));
 
     return {
       results: await serialize(

--- a/apps/server/src/schemas/stores.ts
+++ b/apps/server/src/schemas/stores.ts
@@ -21,7 +21,11 @@ export const StorePriceSchema = z.object({
     .nullable()
     .readonly()
     .describe("GTIN barcode claimed by the store"),
-  price: z.number().describe("Current price of the listing"),
+  price: z
+    .number()
+    .describe(
+      "Current listing price in the currency's smallest unit (for example, cents)",
+    ),
   currency: CurrencyEnum.describe("Currency of the price"),
   url: z.string().describe("URL to the product page"),
   volume: z.number().describe("Listed volume in milliliters"),
@@ -73,7 +77,11 @@ export const StorePriceInputSchema = z.object({
     .trim()
     .min(1, "Required")
     .describe("Name of the product as listed by the store"),
-  price: z.number().describe("Current price of the listing"),
+  price: z
+    .number()
+    .describe(
+      "Current listing price in the currency's smallest unit (for example, cents)",
+    ),
   currency: CurrencyEnum.describe("Currency of the price"),
   volume: z
     .number()

--- a/apps/server/src/serializers/storePrice.ts
+++ b/apps/server/src/serializers/storePrice.ts
@@ -11,6 +11,7 @@ import { serialize, serializer } from ".";
 import config from "../config";
 import { db } from "../db";
 import type { ExternalSite, StorePrice, User } from "../db/schema";
+import { isStorePriceValid } from "../lib/storePriceValidity";
 import { absoluteUrl } from "../lib/urls";
 import type {
   BottleSchema,
@@ -21,12 +22,6 @@ import type {
 import type { Currency } from "../types";
 import { BottleSerializer } from "./bottle";
 import { ExternalSiteSerializer } from "./externalSite";
-
-const ONE_DAY_MS = 1000 * 60 * 60 * 24;
-
-function priceIsValid(price: StorePrice) {
-  return price.updatedAt > new Date(Date.now() - ONE_DAY_MS);
-}
 
 type StorePriceAttrs = {
   bottle: z.infer<typeof BottleSchema> | null;
@@ -94,7 +89,7 @@ export const StorePriceSerializer = serializer({
       volume: item.volume,
       currency: item.currency,
       url: item.url,
-      isValid: priceIsValid(item),
+      isValid: isStorePriceValid(item.updatedAt),
       imageUrl: item.imageUrl
         ? absoluteUrl(config.API_SERVER, item.imageUrl)
         : null,
@@ -158,7 +153,7 @@ export const StorePriceWithSiteSerializer = serializer({
       volume: item.volume,
       currency: item.currency,
       url: affUrl,
-      isValid: priceIsValid(item),
+      isValid: isStorePriceValid(item.updatedAt),
       imageUrl: item.imageUrl
         ? absoluteUrl(config.API_SERVER, item.imageUrl)
         : null,


### PR DESCRIPTION
Store prices now use one seven-day freshness window across API filtering,
ordering, and `isValid` serialization. Bottle details and price history exclude
hidden listings, preventing moderated or disabled listings from appearing in
public bottle data.

Price history now filters using each history row's currency and date,
calculates per-milliliter aggregates without integer truncation, and documents
the returned price units in OpenAPI. The response shape and existing
volume-normalized pricing behavior remain unchanged.
