### PR TITLE
feat(catalog): add public Peated IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ in that area.
 | Catalog classifier behavior               | `docs/architecture/whisky-identity-model.md`, `docs/architecture/bottle-classifier.md`, `docs/architecture/entity-classifier.md`, `packages/bottle-classifier/AGENTS.md` |
 | oRPC routes and clients                   | `docs/development/orpc-routes.md`, `docs/development/orpc-client.md`                                                                                                     |
 | Bottle entry and photo resolution         | `docs/features/bottle-entry-workflow.md`, `docs/features/photo-tasting-entry.md`                                                                                         |
+| Public catalog identifiers                | `docs/architecture/peated-ids.md`                                                                                                                                        |
 | Ratings and aggregates                    | `docs/architecture/rating-systems.md`                                                                                                                                    |
 | Web components, layouts, and caching      | `docs/policies/frontend-components.md`, `docs/policies/web-route-layouts.md`, `docs/development/web-caching.md`                                                          |
 | Local UI verification                     | `docs/development/local-ui-verification.md`                                                                                                                              |

--- a/apps/server/src/lib/peatedId.test.ts
+++ b/apps/server/src/lib/peatedId.test.ts
@@ -2,8 +2,8 @@ import { formatPeatedId, isCanonicalPeatedId, parsePeatedId } from "./peatedId";
 
 describe("Peated IDs", () => {
   test("formats bottle and entity IDs", () => {
-    expect(formatPeatedId("bottle", 123)).toBe("B000123");
-    expect(formatPeatedId("entity", 123)).toBe("E000123");
+    expect(formatPeatedId("bottle", 123)).toBe("B0123");
+    expect(formatPeatedId("entity", 123)).toBe("E0123");
     expect(formatPeatedId("bottle", 1234567)).toBe("B1234567");
   });
 
@@ -11,22 +11,23 @@ describe("Peated IDs", () => {
     expect(parsePeatedId("b123")).toEqual({
       type: "bottle",
       id: 123,
-      peatedId: "B000123",
+      peatedId: "B0123",
     });
     expect(parsePeatedId(" E456 ")).toEqual({
       type: "entity",
       id: 456,
-      peatedId: "E000456",
+      peatedId: "E0456",
     });
   });
 
   test("recognizes only canonical output", () => {
-    expect(isCanonicalPeatedId("B000123", "bottle")).toBe(true);
+    expect(isCanonicalPeatedId("B0123", "bottle")).toBe(true);
     expect(isCanonicalPeatedId("B123", "bottle")).toBe(false);
-    expect(isCanonicalPeatedId("b000123", "bottle")).toBe(false);
+    expect(isCanonicalPeatedId("B000123", "bottle")).toBe(false);
+    expect(isCanonicalPeatedId("b0123", "bottle")).toBe(false);
   });
 
-  test.each(["", "B0", "B000000", "B-1", "B1.5", "X123", "BB123", "123"])(
+  test.each(["", "B0", "B0000", "B-1", "B1.5", "X123", "BB123", "123"])(
     "rejects invalid value %j",
     (value) => {
       expect(parsePeatedId(value)).toBeNull();

--- a/apps/server/src/lib/peatedId.test.ts
+++ b/apps/server/src/lib/peatedId.test.ts
@@ -1,0 +1,42 @@
+import { formatPeatedId, isCanonicalPeatedId, parsePeatedId } from "./peatedId";
+
+describe("Peated IDs", () => {
+  test("formats bottle and entity IDs", () => {
+    expect(formatPeatedId("bottle", 123)).toBe("B000123");
+    expect(formatPeatedId("entity", 123)).toBe("E000123");
+    expect(formatPeatedId("bottle", 1234567)).toBe("B1234567");
+  });
+
+  test("parses IDs case-insensitively", () => {
+    expect(parsePeatedId("b123")).toEqual({
+      type: "bottle",
+      id: 123,
+      peatedId: "B000123",
+    });
+    expect(parsePeatedId(" E456 ")).toEqual({
+      type: "entity",
+      id: 456,
+      peatedId: "E000456",
+    });
+  });
+
+  test("recognizes only canonical output", () => {
+    expect(isCanonicalPeatedId("B000123", "bottle")).toBe(true);
+    expect(isCanonicalPeatedId("B123", "bottle")).toBe(false);
+    expect(isCanonicalPeatedId("b000123", "bottle")).toBe(false);
+  });
+
+  test.each(["", "B0", "B000000", "B-1", "B1.5", "X123", "BB123", "123"])(
+    "rejects invalid value %j",
+    (value) => {
+      expect(parsePeatedId(value)).toBeNull();
+    },
+  );
+
+  test.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects invalid numeric ID %s",
+    (id) => {
+      expect(() => formatPeatedId("bottle", id)).toThrow(RangeError);
+    },
+  );
+});

--- a/apps/server/src/lib/peatedId.ts
+++ b/apps/server/src/lib/peatedId.ts
@@ -12,7 +12,7 @@ export type ParsedPeatedId = {
 };
 
 const PEATED_ID_PATTERN = /^([BE])(\d+)$/i;
-const MINIMUM_DIGITS = 6;
+const MINIMUM_DIGITS = 4;
 
 export function formatPeatedId(type: PeatedIdType, id: number): string {
   if (!Number.isSafeInteger(id) || id < 1) {

--- a/apps/server/src/lib/peatedId.ts
+++ b/apps/server/src/lib/peatedId.ts
@@ -1,0 +1,46 @@
+export const PEATED_ID_PREFIXES = {
+  bottle: "B",
+  entity: "E",
+} as const;
+
+export type PeatedIdType = keyof typeof PEATED_ID_PREFIXES;
+
+export type ParsedPeatedId = {
+  type: PeatedIdType;
+  id: number;
+  peatedId: string;
+};
+
+const PEATED_ID_PATTERN = /^([BE])(\d+)$/i;
+const MINIMUM_DIGITS = 6;
+
+export function formatPeatedId(type: PeatedIdType, id: number): string {
+  if (!Number.isSafeInteger(id) || id < 1) {
+    throw new RangeError("Peated IDs require a positive safe integer.");
+  }
+
+  return `${PEATED_ID_PREFIXES[type]}${String(id).padStart(MINIMUM_DIGITS, "0")}`;
+}
+
+export function parsePeatedId(value: string): ParsedPeatedId | null {
+  const match = PEATED_ID_PATTERN.exec(value.trim());
+  if (!match) return null;
+
+  const type = match[1].toUpperCase() === "B" ? "bottle" : "entity";
+  const id = Number(match[2]);
+  if (!Number.isSafeInteger(id) || id < 1) return null;
+
+  return {
+    type,
+    id,
+    peatedId: formatPeatedId(type, id),
+  };
+}
+
+export function isCanonicalPeatedId(
+  value: string,
+  type: PeatedIdType,
+): boolean {
+  const parsed = parsePeatedId(value);
+  return parsed?.type === type && parsed.peatedId === value;
+}

--- a/apps/server/src/orpc/routes/bottles/details.test.ts
+++ b/apps/server/src/orpc/routes/bottles/details.test.ts
@@ -1,5 +1,6 @@
 import { db } from "@peated/server/db";
 import { bottleTombstones } from "@peated/server/db/schema";
+import { formatPeatedId } from "@peated/server/lib/peatedId";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq } from "drizzle-orm";
@@ -13,6 +14,7 @@ describe("GET /bottles/:bottle", () => {
     });
     expect(data.id).toEqual(bottle.id);
     expect(data.group?.id).toEqual(bottle.groupId);
+    expect(data.peatedId).toEqual(formatPeatedId("bottle", bottle.id));
     expect("createdBy" in data).toBe(false);
   });
 

--- a/apps/server/src/orpc/routes/bottles/validation.ts
+++ b/apps/server/src/orpc/routes/bottles/validation.ts
@@ -8,6 +8,7 @@ import { parseDetailsFromName } from "@peated/bottle-classifier/smws";
 import { db, type AnyDatabase } from "@peated/server/db";
 import { entities, entityTombstones } from "@peated/server/db/schema";
 import { findEntityByExactNameOrAlias } from "@peated/server/lib/db";
+import { formatPeatedId } from "@peated/server/lib/peatedId";
 import { procedure } from "@peated/server/orpc";
 import { requireAuth } from "@peated/server/orpc/middleware";
 import {
@@ -41,6 +42,7 @@ async function getEntityById(entityId: number, entityDb: AnyDatabase) {
 
   return EntitySchema.parse({
     id: entity.id,
+    peatedId: formatPeatedId("entity", entity.id),
     name: entity.name,
     shortName: entity.shortName,
     type: entity.type,
@@ -86,6 +88,7 @@ async function getEntity(
 
   return EntitySchema.parse({
     id: existingEntity.id,
+    peatedId: formatPeatedId("entity", existingEntity.id),
     name: existingEntity.name,
     shortName: existingEntity.shortName,
     type: existingEntity.type,

--- a/apps/server/src/orpc/routes/entities/details.test.ts
+++ b/apps/server/src/orpc/routes/entities/details.test.ts
@@ -1,5 +1,6 @@
 import { db } from "@peated/server/db";
 import { entityTombstones } from "@peated/server/db/schema";
+import { formatPeatedId } from "@peated/server/lib/peatedId";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 
@@ -11,6 +12,7 @@ describe("GET /entities/:entity", () => {
       entity: brand.id,
     });
     expect(data.id).toEqual(brand.id);
+    expect(data.peatedId).toEqual(formatPeatedId("entity", brand.id));
     expect("createdBy" in data).toBe(false);
   });
 

--- a/apps/server/src/orpc/routes/search.test.ts
+++ b/apps/server/src/orpc/routes/search.test.ts
@@ -1,5 +1,6 @@
 import { db } from "@peated/server/db";
-import { bottleAliases } from "@peated/server/db/schema";
+import { bottleAliases, bottleTombstones } from "@peated/server/db/schema";
+import { formatPeatedId } from "@peated/server/lib/peatedId";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq } from "drizzle-orm";
@@ -155,6 +156,81 @@ describe("GET /search", () => {
 
     expect(results[0].type).toBe("bottle");
     expect(results[0].ref.id).toBe(exactMatch.id);
+  });
+
+  test("finds a bottle by Peated ID", async ({ fixtures }) => {
+    const bottle = await fixtures.Bottle();
+
+    const { results } = await routerClient.search({
+      query: formatPeatedId("bottle", bottle.id),
+      limit: 10,
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        type: "bottle",
+        ref: expect.objectContaining({
+          id: bottle.id,
+          peatedId: formatPeatedId("bottle", bottle.id),
+        }),
+      }),
+    ]);
+  });
+
+  test("finds an entity by lowercase Peated ID", async ({ fixtures }) => {
+    const entity = await fixtures.Entity();
+
+    const { results } = await routerClient.search({
+      query: `e${entity.id}`,
+      limit: 10,
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        type: "entity",
+        ref: expect.objectContaining({
+          id: entity.id,
+          peatedId: formatPeatedId("entity", entity.id),
+        }),
+      }),
+    ]);
+  });
+
+  test("respects included types for Peated ID lookup", async ({ fixtures }) => {
+    const bottle = await fixtures.Bottle();
+
+    const { results } = await routerClient.search({
+      query: `B${bottle.id}`,
+      include: ["entities"],
+      limit: 10,
+    });
+
+    expect(results).toEqual([]);
+  });
+
+  test("resolves a merged Peated ID to the surviving bottle", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    await db.insert(bottleTombstones).values({
+      bottleId: 999,
+      newBottleId: bottle.id,
+    });
+
+    const { results } = await routerClient.search({
+      query: "B999",
+      limit: 10,
+    });
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        type: "bottle",
+        ref: expect.objectContaining({
+          id: bottle.id,
+          peatedId: formatPeatedId("bottle", bottle.id),
+        }),
+      }),
+    ]);
   });
 
   test("returns empty results with no query", async () => {

--- a/apps/server/src/orpc/routes/search.ts
+++ b/apps/server/src/orpc/routes/search.ts
@@ -1,7 +1,19 @@
+import { db } from "@peated/server/db";
+import {
+  bottleTombstones,
+  bottles,
+  entities,
+  entityTombstones,
+} from "@peated/server/db/schema";
+import { parsePeatedId } from "@peated/server/lib/peatedId";
 import { procedure } from "@peated/server/orpc";
 import type { Context } from "@peated/server/orpc/context";
 import { BottleSchema, EntitySchema, UserSchema } from "@peated/server/schemas";
+import { serialize } from "@peated/server/serializers";
+import { BottleSerializer } from "@peated/server/serializers/bottle";
+import { EntitySerializer } from "@peated/server/serializers/entity";
 import type { Bottle, Entity, User } from "@peated/server/types";
+import { eq, getTableColumns } from "drizzle-orm";
 import { z } from "zod";
 
 export type BottleResult = {
@@ -121,6 +133,30 @@ export function blendResults(
   return results;
 }
 
+async function findBottleById(id: number, context: Context) {
+  let [bottle] = await db.select().from(bottles).where(eq(bottles.id, id));
+  if (!bottle) {
+    [bottle] = await db
+      .select({ ...getTableColumns(bottles) })
+      .from(bottleTombstones)
+      .innerJoin(bottles, eq(bottleTombstones.newBottleId, bottles.id))
+      .where(eq(bottleTombstones.bottleId, id));
+  }
+  return bottle ? serialize(BottleSerializer, bottle, context.user) : null;
+}
+
+async function findEntityById(id: number, context: Context) {
+  let [entity] = await db.select().from(entities).where(eq(entities.id, id));
+  if (!entity) {
+    [entity] = await db
+      .select({ ...getTableColumns(entities) })
+      .from(entityTombstones)
+      .innerJoin(entities, eq(entityTombstones.newEntityId, entities.id))
+      .where(eq(entityTombstones.entityId, id));
+  }
+  return entity ? serialize(EntitySerializer, entity, context.user) : null;
+}
+
 export function createSearchProcedure(sources: SearchSourceClient) {
   return procedure
     .route({
@@ -164,8 +200,27 @@ export function createSearchProcedure(sources: SearchSourceClient) {
         ),
       }),
     )
-    .handler(async function ({ input, context }) {
+    .handler(async function ({
+      input,
+      context,
+    }): Promise<{ query: string; results: Result[] }> {
       const { query, include, limit } = input;
+      const peatedId = parsePeatedId(query);
+
+      if (peatedId) {
+        if (peatedId.type === "bottle" && include.includes("bottles")) {
+          const ref = await findBottleById(peatedId.id, context);
+          return { query, results: ref ? [{ type: "bottle", ref }] : [] };
+        }
+
+        if (peatedId.type === "entity" && include.includes("entities")) {
+          const ref = await findEntityById(peatedId.id, context);
+          return { query, results: ref ? [{ type: "entity", ref }] : [] };
+        }
+
+        return { query, results: [] };
+      }
+
       const promises: Promise<Result[]>[] = [];
 
       if (include.includes("bottles")) {

--- a/apps/server/src/schemas/bottles.ts
+++ b/apps/server/src/schemas/bottles.ts
@@ -1,3 +1,4 @@
+import { isCanonicalPeatedId } from "@peated/server/lib/peatedId";
 import { z } from "zod";
 import { BottleSeriesInputSchema, BottleSeriesSchema } from "./bottleSeries";
 import { BottleGroupV1Schema } from "./catalogIdentity";
@@ -104,6 +105,12 @@ const BottleTastingNotesSchema = z
 
 export const BottleSchema = z.object({
   id: z.number().readonly().describe("Unique identifier for the bottle"),
+  peatedId: z
+    .string()
+    .regex(/^B\d{6,}$/)
+    .refine((value) => isCanonicalPeatedId(value, "bottle"))
+    .readonly()
+    .describe("Permanent Peated ID for the bottle"),
   fullName: z
     .string()
     .readonly()

--- a/apps/server/src/schemas/bottles.ts
+++ b/apps/server/src/schemas/bottles.ts
@@ -107,7 +107,7 @@ export const BottleSchema = z.object({
   id: z.number().readonly().describe("Unique identifier for the bottle"),
   peatedId: z
     .string()
-    .regex(/^B\d{6,}$/)
+    .regex(/^B\d{4,}$/)
     .refine((value) => isCanonicalPeatedId(value, "bottle"))
     .readonly()
     .describe("Permanent Peated ID for the bottle"),

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -1,3 +1,4 @@
+import { isCanonicalPeatedId } from "@peated/server/lib/peatedId";
 import { z } from "zod";
 
 import { ContentSourceEnum, EntityTypeEnum } from "./common";
@@ -53,6 +54,12 @@ const EntityLocationSchema = PointSchema.nullable()
 
 export const EntitySchema = z.object({
   id: z.number().readonly().describe("Unique identifier for the entity"),
+  peatedId: z
+    .string()
+    .regex(/^E\d{6,}$/)
+    .refine((value) => isCanonicalPeatedId(value, "entity"))
+    .readonly()
+    .describe("Permanent Peated ID for the entity"),
   name: EntityNameSchema,
   shortName: EntityShortNameSchema,
   type: EntityTypesSchema,

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -56,7 +56,7 @@ export const EntitySchema = z.object({
   id: z.number().readonly().describe("Unique identifier for the entity"),
   peatedId: z
     .string()
-    .regex(/^E\d{6,}$/)
+    .regex(/^E\d{4,}$/)
     .refine((value) => isCanonicalPeatedId(value, "entity"))
     .readonly()
     .describe("Permanent Peated ID for the entity"),

--- a/apps/server/src/serializers/bottle.ts
+++ b/apps/server/src/serializers/bottle.ts
@@ -15,6 +15,7 @@ import {
 } from "../db/schema";
 import { getReservedCollection, type ReservedCollectionSlug } from "../lib/db";
 import { notEmpty } from "../lib/filter";
+import { formatPeatedId } from "../lib/peatedId";
 import { absoluteUrl } from "../lib/urls";
 import { type BottleSchema } from "../schemas";
 import type { BottleGroupV1 } from "../schemas/catalogIdentity";
@@ -223,6 +224,7 @@ export const BottleSerializer = serializer({
   item: (item: Bottle, attrs: Attrs): z.infer<typeof BottleSchema> => {
     const bottle: z.infer<typeof BottleSchema> = {
       id: item.id,
+      peatedId: formatPeatedId("bottle", item.id),
 
       // fullName is brand + name
       fullName: item.fullName,

--- a/apps/server/src/serializers/entity.ts
+++ b/apps/server/src/serializers/entity.ts
@@ -4,6 +4,7 @@ import { serialize, serializer } from ".";
 import { db } from "../db";
 import { countries, regions, type Entity, type User } from "../db/schema";
 import { notEmpty } from "../lib/filter";
+import { formatPeatedId } from "../lib/peatedId";
 import { type EntitySchema } from "../schemas";
 import { CountrySerializer } from "./country";
 import { RegionSerializer } from "./region";
@@ -60,6 +61,7 @@ export const EntitySerializer = serializer({
   item: (item: Entity, attrs: EntityAttrs): z.infer<typeof EntitySchema> => {
     return {
       id: item.id,
+      peatedId: formatPeatedId("entity", item.id),
       name: item.name,
       shortName: item.shortName,
       type: item.type,

--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -15,7 +15,7 @@ declare global {
   }
 }
 
-import { expectNoHorizontalOverflow } from "./assertions";
+import { bottlePeatedIdPath, expectNoHorizontalOverflow } from "./assertions";
 import {
   addAnotherReleaseSourceBottle,
   createdBottleId,
@@ -201,7 +201,7 @@ test.describe("create bottle", () => {
     );
     await submitCreateBottle(page);
 
-    await expect(page).toHaveURL(new RegExp(`/bottles/${createdBottleId}$`));
+    await expect(page).toHaveURL(bottlePeatedIdPath(createdBottleId));
     await expect(
       page.getByRole("heading", {
         name: `${testBrand.name} ${createdBottleName}`,
@@ -454,7 +454,7 @@ test.describe("create bottle", () => {
     expect(createInput).not.toHaveProperty("sourceBottleId");
     expect(createInput).not.toHaveProperty("release");
     expect(createInput).not.toHaveProperty("releaseId");
-    await expect(page).toHaveURL(new RegExp(`/bottles/${createdBottleId}$`));
+    await expect(page).toHaveURL(bottlePeatedIdPath(createdBottleId));
     await expectNoHorizontalOverflow(page);
   });
 
@@ -878,7 +878,7 @@ test.describe("add bottle flow", () => {
       "playwright-create-token:create_bottle:suitable",
     );
     expect(input).not.toHaveProperty("catalogImageApproval");
-    await expect(page).toHaveURL(new RegExp(`/bottles/${createdBottleId}$`));
+    await expect(page).toHaveURL(bottlePeatedIdPath(createdBottleId));
     await expect(
       page.getByRole("heading", {
         name: `${testBrand.name} ${createdBottleName}`,
@@ -906,7 +906,7 @@ test.describe("add bottle flow", () => {
       "playwright-create-token:create_bottle:suitable",
     );
     expect(input).not.toHaveProperty("catalogImageApproval");
-    await expect(page).toHaveURL(new RegExp(`/bottles/${createdBottleId}$`));
+    await expect(page).toHaveURL(bottlePeatedIdPath(createdBottleId));
     await expect(
       page.getByRole("heading", {
         name: `${testBrand.name} ${createdBottleName}`,
@@ -947,7 +947,7 @@ test.describe("add bottle flow", () => {
     expect(input.createToken).toBe(
       "playwright-create-token:create_bottle:suitable",
     );
-    await expect(page).toHaveURL(new RegExp(`/bottles/${createdBottleId}$`));
+    await expect(page).toHaveURL(bottlePeatedIdPath(createdBottleId));
     await expect(
       page.getByRole("heading", {
         name: `${testBrand.name} ${createdBottleName}`,
@@ -978,7 +978,7 @@ test.describe("add bottle flow", () => {
       "playwright-create-token:create_bottle:unsuitable",
     );
     expect(input).not.toHaveProperty("catalogImageApproval");
-    await expect(page).toHaveURL(new RegExp(`/bottles/${createdBottleId}$`));
+    await expect(page).toHaveURL(bottlePeatedIdPath(createdBottleId));
     await expect(
       page.getByRole("heading", {
         name: `${testBrand.name} ${createdBottleName}`,
@@ -1005,7 +1005,7 @@ test.describe("add bottle flow", () => {
         "The bottle was created, but the public image was not saved.",
       ),
     ).toBeVisible();
-    await expect(page).toHaveURL(new RegExp(`/bottles/${createdBottleId}$`));
+    await expect(page).toHaveURL(bottlePeatedIdPath(createdBottleId));
     await expect(
       page.getByRole("heading", {
         name: `${testBrand.name} ${createdBottleName}`,
@@ -1141,7 +1141,7 @@ test.describe("add bottle flow", () => {
     expect(input.createToken).toBe(
       "playwright-create-token:create_bottle:suitable",
     );
-    await expect(page).toHaveURL(new RegExp(`/bottles/${existingBottle.id}$`));
+    await expect(page).toHaveURL(bottlePeatedIdPath(existingBottle.id));
     await expect(
       page.getByRole("heading", {
         name: `${testBrand.name} ${destinationBottleGroup.name}`,

--- a/apps/web/e2e/assertions.ts
+++ b/apps/web/e2e/assertions.ts
@@ -1,5 +1,9 @@
 import { expect, type Page } from "@playwright/test";
 
+export function bottlePeatedIdPath(id: number) {
+  return `/B${String(id).padStart(4, "0")}`;
+}
+
 /** Asserts that the rendered page does not create horizontal overflow. */
 export async function expectNoHorizontalOverflow(page: Page) {
   await expect

--- a/apps/web/e2e/bottle-checks.spec.ts
+++ b/apps/web/e2e/bottle-checks.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type TestInfo } from "@playwright/test";
 
-import { expectNoHorizontalOverflow } from "./assertions";
+import { bottlePeatedIdPath, expectNoHorizontalOverflow } from "./assertions";
 import {
   existingBottle,
   existingBottleId,
@@ -122,7 +122,7 @@ test("runs a clean moderator Bottle audit inline and returns to the Bottle", asy
   await expectNoHorizontalOverflow(page);
 
   await page.getByRole("button", { name: "Return to Bottle" }).click();
-  await expect(page).toHaveURL(`/bottles/${existingBottleId}`);
+  await expect(page).toHaveURL(bottlePeatedIdPath(existingBottleId));
 });
 
 test("opens an actionable admin audit in its focused Moderation task", async ({

--- a/apps/web/e2e/bottle-page-redirects.spec.ts
+++ b/apps/web/e2e/bottle-page-redirects.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { bottlePeatedIdPath } from "./assertions";
 import {
   destinationBottleGroup,
   exactMatchedBottleId,
@@ -46,9 +47,8 @@ test.describe("Bottle page redirects", () => {
   test("renders not found for a missing Bottle without redirecting", async ({
     page,
   }) => {
-    const missingPath = `/bottles/${missingBottleId}`;
-    await page.goto(missingPath);
-    await expect(page).toHaveURL(missingPath);
+    await page.goto(`/bottles/${missingBottleId}`);
+    await expect(page).toHaveURL(bottlePeatedIdPath(missingBottleId));
     await expect(
       page.getByRole("heading", { name: "Not Found" }),
     ).toBeVisible();

--- a/apps/web/e2e/bottle-prices.spec.ts
+++ b/apps/web/e2e/bottle-prices.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 
+import { bottlePeatedIdPath } from "./assertions";
 import {
   firstStorePriceName,
   priceChangeFirstBottle,
@@ -35,7 +36,7 @@ test.describe("Bottle prices", () => {
       })
       .click();
 
-    await expect(page).toHaveURL(`/bottles/${priceChangeFirstBottle.id}`);
+    await expect(page).toHaveURL(bottlePeatedIdPath(priceChangeFirstBottle.id));
   });
 
   test("links resolved admin prices while leaving unresolved prices unlinked", async ({
@@ -58,7 +59,7 @@ test.describe("Bottle prices", () => {
         exact: true,
       })
       .click();
-    await expect(page).toHaveURL(`/bottles/${priceChangeFirstBottle.id}`);
+    await expect(page).toHaveURL(bottlePeatedIdPath(priceChangeFirstBottle.id));
 
     await page.goto(`/admin/sites/${priceSite.type}`, { waitUntil: "commit" });
 

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -91,7 +91,7 @@ export const testAccessToken = "peated-playwright-access-token";
 
 export const testBrand = {
   id: 9201,
-  peatedId: "E009201",
+  peatedId: "E9201",
   name: "Lagavulin",
   shortName: null,
   type: ["brand", "distiller"],
@@ -131,7 +131,7 @@ export function buildBottle({
 } = {}) {
   return {
     id,
-    peatedId: `B${String(id).padStart(6, "0")}`,
+    peatedId: `B${String(id).padStart(4, "0")}`,
     fullName: `${brand.name} ${name}`,
     name,
     series: null,
@@ -263,7 +263,7 @@ export const unifiedBottleEditContext = {
 export const exactMatchedBottle = {
   ...existingBottle,
   id: exactMatchedBottleId,
-  peatedId: `B${String(exactMatchedBottleId).padStart(6, "0")}`,
+  peatedId: `B${String(exactMatchedBottleId).padStart(4, "0")}`,
   fullName: `${existingBottle.fullName} Distillers Edition`,
   name: "Distillers Edition",
   edition: "Distillers Edition",

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -91,6 +91,7 @@ export const testAccessToken = "peated-playwright-access-token";
 
 export const testBrand = {
   id: 9201,
+  peatedId: "E009201",
   name: "Lagavulin",
   shortName: null,
   type: ["brand", "distiller"],
@@ -130,6 +131,7 @@ export function buildBottle({
 } = {}) {
   return {
     id,
+    peatedId: `B${String(id).padStart(6, "0")}`,
     fullName: `${brand.name} ${name}`,
     name,
     series: null,
@@ -261,6 +263,7 @@ export const unifiedBottleEditContext = {
 export const exactMatchedBottle = {
   ...existingBottle,
   id: exactMatchedBottleId,
+  peatedId: `B${String(exactMatchedBottleId).padStart(6, "0")}`,
   fullName: `${existingBottle.fullName} Distillers Edition`,
   name: "Distillers Edition",
   edition: "Distillers Edition",

--- a/apps/web/e2e/unified-bottle-workflows.spec.ts
+++ b/apps/web/e2e/unified-bottle-workflows.spec.ts
@@ -1,7 +1,7 @@
 import { expect, type Request, test, type TestInfo } from "@playwright/test";
 import { z } from "zod";
 
-import { expectNoHorizontalOverflow } from "./assertions";
+import { bottlePeatedIdPath, expectNoHorizontalOverflow } from "./assertions";
 import {
   anotherReleaseSourceBottle,
   createdBottleName,
@@ -212,7 +212,7 @@ test.describe("unified Bottle workflows", () => {
       expect(input).not.toHaveProperty(legacyField);
       expect(independentBottle).not.toHaveProperty(legacyField);
     }
-    await expect(page).toHaveURL(new RegExp(`${returnTo}$`));
+    await expect(page).toHaveURL(bottlePeatedIdPath(existingBottleId));
   });
 
   test("keeps exact age ownership behind the unified Bottle form", async ({
@@ -314,9 +314,7 @@ test.describe("unified Bottle workflows", () => {
       other: exactMergeOtherBottleId,
       direction: "mergeInto",
     });
-    await expect(page).toHaveURL(
-      new RegExp(`/bottles/${exactMergeOtherBottleId}$`),
-    );
+    await expect(page).toHaveURL(bottlePeatedIdPath(exactMergeOtherBottleId));
   });
 });
 

--- a/apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/releases/releaseFamilyView.test.tsx
+++ b/apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/releases/releaseFamilyView.test.tsx
@@ -39,7 +39,7 @@ const group = {
 
 const brand = {
   id: group.brandId,
-  peatedId: "E000007",
+  peatedId: "E0007",
   name: "Lagavulin",
   shortName: null,
   type: ["brand", "distiller"],
@@ -59,7 +59,7 @@ const brand = {
 
 const bottle = {
   id: 42,
-  peatedId: "B000042",
+  peatedId: "B0042",
   fullName: "Lagavulin 21 Cask 42",
   name: "21-year-old",
   group,

--- a/apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/releases/releaseFamilyView.test.tsx
+++ b/apps/web/src/app/(default)/bottles/[bottleId]/(tabs)/releases/releaseFamilyView.test.tsx
@@ -39,6 +39,7 @@ const group = {
 
 const brand = {
   id: group.brandId,
+  peatedId: "E000007",
   name: "Lagavulin",
   shortName: null,
   type: ["brand", "distiller"],
@@ -58,6 +59,7 @@ const brand = {
 
 const bottle = {
   id: 42,
+  peatedId: "B000042",
   fullName: "Lagavulin 21 Cask 42",
   name: "21-year-old",
   group,

--- a/apps/web/src/app/(default)/bottles/[bottleId]/bottleFullHeader.tsx
+++ b/apps/web/src/app/(default)/bottles/[bottleId]/bottleFullHeader.tsx
@@ -38,7 +38,7 @@ export default function BottleFullHeader({
             <PeatedGlyph className="h-4 w-4" /> Log Tasting
           </Button>
 
-          <ShareButton title={bottleIdentity} url={`/bottles/${bottle.id}`} />
+          <ShareButton title={bottleIdentity} url={`/${bottle.peatedId}`} />
 
           <BottleActions bottle={bottle} />
         </div>

--- a/apps/web/src/app/(default)/entities/[entityId]/layout.tsx
+++ b/apps/web/src/app/(default)/entities/[entityId]/layout.tsx
@@ -113,7 +113,7 @@ export default async function Layout(props: {
                 Create Bottle
               </Button>
 
-              <ShareButton title={entity.name} url={`/entities/${entity.id}`} />
+              <ShareButton title={entity.name} url={`/${entity.peatedId}`} />
 
               <ModActions entity={entity} />
             </div>

--- a/apps/web/src/app/sitemaps/bottles/[id]/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemaps/bottles/[id]/sitemap.xml/route.ts
@@ -32,7 +32,7 @@ export async function GET(
 
     pages.push(
       ...results.map((bottle) => ({
-        url: `/bottles/${bottle.id}`,
+        url: `/${bottle.peatedId}`,
         lastModified: bottle.updatedAt,
       })),
     );

--- a/apps/web/src/app/sitemaps/entities/[id]/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemaps/entities/[id]/sitemap.xml/route.ts
@@ -30,7 +30,7 @@ export async function GET(
 
     pages.push(
       ...results.map((entity) => ({
-        url: `/entities/${entity.id}`,
+        url: `/${entity.peatedId}`,
         lastModified: entity.updatedAt,
       })),
     );

--- a/apps/web/src/components/admin/moderation/llmExport.test.ts
+++ b/apps/web/src/components/admin/moderation/llmExport.test.ts
@@ -9,7 +9,7 @@ type QueueBottle = NonNullable<QueueItem["suggestedBottle"]>;
 const timestamp = "2026-07-21T00:00:00.000Z";
 const brand = {
   id: 1,
-  peatedId: "E000001",
+  peatedId: "E0001",
   name: "Springbank",
   shortName: null,
   type: ["brand"],
@@ -29,7 +29,7 @@ const brand = {
 
 const suggestedBottle = {
   id: 19,
-  peatedId: "B000019",
+  peatedId: "B0019",
   fullName: "Springbank 12 Cask Strength Batch 24",
   name: "12 Cask Strength Batch 24",
   brand,

--- a/apps/web/src/components/admin/moderation/llmExport.test.ts
+++ b/apps/web/src/components/admin/moderation/llmExport.test.ts
@@ -9,6 +9,7 @@ type QueueBottle = NonNullable<QueueItem["suggestedBottle"]>;
 const timestamp = "2026-07-21T00:00:00.000Z";
 const brand = {
   id: 1,
+  peatedId: "E000001",
   name: "Springbank",
   shortName: null,
   type: ["brand"],
@@ -28,6 +29,7 @@ const brand = {
 
 const suggestedBottle = {
   id: 19,
+  peatedId: "B000019",
   fullName: "Springbank 12 Cask Strength Batch 24",
   name: "12 Cask Strength Batch 24",
   brand,

--- a/apps/web/src/components/admin/reviewTable.test.tsx
+++ b/apps/web/src/components/admin/reviewTable.test.tsx
@@ -8,6 +8,7 @@ const timestamp = "2026-07-22T12:00:00.000Z";
 
 const brand = {
   id: 7,
+  peatedId: "E000007",
   name: "Springbank",
   shortName: null,
   type: ["brand"],
@@ -27,6 +28,7 @@ const brand = {
 
 const bottle = {
   id: 19,
+  peatedId: "B000019",
   fullName: "Springbank 12 Cask Strength Batch 24",
   name: "12 Cask Strength Batch 24",
   series: null,

--- a/apps/web/src/components/admin/reviewTable.test.tsx
+++ b/apps/web/src/components/admin/reviewTable.test.tsx
@@ -8,7 +8,7 @@ const timestamp = "2026-07-22T12:00:00.000Z";
 
 const brand = {
   id: 7,
-  peatedId: "E000007",
+  peatedId: "E0007",
   name: "Springbank",
   shortName: null,
   type: ["brand"],
@@ -28,7 +28,7 @@ const brand = {
 
 const bottle = {
   id: 19,
-  peatedId: "B000019",
+  peatedId: "B0019",
   fullName: "Springbank 12 Cask Strength Batch 24",
   name: "12 Cask Strength Batch 24",
   series: null,

--- a/apps/web/src/components/admin/storePriceTable.test.tsx
+++ b/apps/web/src/components/admin/storePriceTable.test.tsx
@@ -8,6 +8,7 @@ const timestamp = "2026-07-22T12:00:00.000Z";
 
 const brand = {
   id: 7,
+  peatedId: "E000007",
   name: "Springbank",
   shortName: null,
   type: ["brand"],
@@ -27,6 +28,7 @@ const brand = {
 
 const bottle = {
   id: 19,
+  peatedId: "B000019",
   fullName: "Springbank 12 Cask Strength Batch 24",
   name: "12 Cask Strength Batch 24",
   series: null,

--- a/apps/web/src/components/admin/storePriceTable.test.tsx
+++ b/apps/web/src/components/admin/storePriceTable.test.tsx
@@ -8,7 +8,7 @@ const timestamp = "2026-07-22T12:00:00.000Z";
 
 const brand = {
   id: 7,
-  peatedId: "E000007",
+  peatedId: "E0007",
   name: "Springbank",
   shortName: null,
   type: ["brand"],
@@ -28,7 +28,7 @@ const brand = {
 
 const bottle = {
   id: 19,
-  peatedId: "B000019",
+  peatedId: "B0019",
   fullName: "Springbank 12 Cask Strength Batch 24",
   name: "12 Cask Strength Batch 24",
   series: null,

--- a/apps/web/src/components/bottleHeader.test.tsx
+++ b/apps/web/src/components/bottleHeader.test.tsx
@@ -9,7 +9,7 @@ describe("BottleHeader", () => {
   it("separates the shared label from exact Bottle metadata", () => {
     const bottle = {
       id: 42,
-      peatedId: "B000042",
+      peatedId: "B0042",
       fullName: "Lagavulin 21 - Distillers Edition - 2025 Release - 55.1% ABV",
       name: "21 - Distillers Edition - 2025 Release - 55.1% ABV",
       group: {
@@ -51,7 +51,7 @@ describe("BottleHeader", () => {
   it("does not repeat an edition already expressed by the title", () => {
     const bottle = {
       id: 42,
-      peatedId: "B000042",
+      peatedId: "B0042",
       fullName: "Lagavulin Distillers Edition - 2025 Release",
       name: "Distillers Edition - 2025 Release",
       group: { name: "Distillers Edition" },
@@ -83,7 +83,7 @@ describe("BottleHeader", () => {
   it("keeps repeated identity fields out of a single-cask header", () => {
     const bottle = {
       id: 42,
-      peatedId: "B000042",
+      peatedId: "B0042",
       fullName: "Pōkeno Double Bourbon Cask 3-year-old",
       name: "Double Bourbon Cask 3-year-old",
       group: { name: "Double Bourbon Cask 3-year-old" },
@@ -120,7 +120,7 @@ describe("BottleHeader", () => {
   it("uses production wording for a non-blend distiller", () => {
     const bottle = {
       id: 42,
-      peatedId: "B000042",
+      peatedId: "B0042",
       fullName: "Compass Box Orchard House",
       name: "Orchard House",
       group: { name: "Orchard House" },
@@ -151,7 +151,7 @@ describe("BottleHeader", () => {
   it("uses provenance wording for a blend with one known distillery", () => {
     const bottle = {
       id: 42,
-      peatedId: "B000042",
+      peatedId: "B0042",
       fullName: "Compass Box Orchard House",
       name: "Orchard House",
       group: { name: "Orchard House" },
@@ -183,7 +183,7 @@ describe("BottleHeader", () => {
   it("shows every distiller name in the multi-distiller tooltip", () => {
     const bottle = {
       id: 42,
-      peatedId: "B000042",
+      peatedId: "B0042",
       fullName: "Compass Box Seven Distilleries",
       name: "Seven Distilleries",
       group: { name: "Seven Distilleries" },
@@ -225,7 +225,7 @@ describe("BottleHeader", () => {
   it("does not add a chip when Single Cask is already in the title", () => {
     const bottle = {
       id: 42,
-      peatedId: "B000042",
+      peatedId: "B0042",
       fullName: "Pōkeno Single Cask 4-year-old",
       name: "Single Cask 4-year-old",
       group: { name: "Single Cask 4-year-old" },
@@ -257,7 +257,7 @@ describe("BottleHeader", () => {
   it("promotes a nonduplicative series into the header context", () => {
     const bottle = {
       id: 42,
-      peatedId: "B000042",
+      peatedId: "B0042",
       fullName: "Decadent Drinks Glenburgie 38-year-old - Chapter Thirty Two",
       name: "Glenburgie 38-year-old - Chapter Thirty Two",
       group: { name: "Glenburgie 38-year-old" },

--- a/apps/web/src/components/bottleHeader.test.tsx
+++ b/apps/web/src/components/bottleHeader.test.tsx
@@ -9,6 +9,7 @@ describe("BottleHeader", () => {
   it("separates the shared label from exact Bottle metadata", () => {
     const bottle = {
       id: 42,
+      peatedId: "B000042",
       fullName: "Lagavulin 21 - Distillers Edition - 2025 Release - 55.1% ABV",
       name: "21 - Distillers Edition - 2025 Release - 55.1% ABV",
       group: {
@@ -50,6 +51,7 @@ describe("BottleHeader", () => {
   it("does not repeat an edition already expressed by the title", () => {
     const bottle = {
       id: 42,
+      peatedId: "B000042",
       fullName: "Lagavulin Distillers Edition - 2025 Release",
       name: "Distillers Edition - 2025 Release",
       group: { name: "Distillers Edition" },
@@ -81,6 +83,7 @@ describe("BottleHeader", () => {
   it("keeps repeated identity fields out of a single-cask header", () => {
     const bottle = {
       id: 42,
+      peatedId: "B000042",
       fullName: "Pōkeno Double Bourbon Cask 3-year-old",
       name: "Double Bourbon Cask 3-year-old",
       group: { name: "Double Bourbon Cask 3-year-old" },
@@ -117,6 +120,7 @@ describe("BottleHeader", () => {
   it("uses production wording for a non-blend distiller", () => {
     const bottle = {
       id: 42,
+      peatedId: "B000042",
       fullName: "Compass Box Orchard House",
       name: "Orchard House",
       group: { name: "Orchard House" },
@@ -147,6 +151,7 @@ describe("BottleHeader", () => {
   it("uses provenance wording for a blend with one known distillery", () => {
     const bottle = {
       id: 42,
+      peatedId: "B000042",
       fullName: "Compass Box Orchard House",
       name: "Orchard House",
       group: { name: "Orchard House" },
@@ -178,6 +183,7 @@ describe("BottleHeader", () => {
   it("shows every distiller name in the multi-distiller tooltip", () => {
     const bottle = {
       id: 42,
+      peatedId: "B000042",
       fullName: "Compass Box Seven Distilleries",
       name: "Seven Distilleries",
       group: { name: "Seven Distilleries" },
@@ -219,6 +225,7 @@ describe("BottleHeader", () => {
   it("does not add a chip when Single Cask is already in the title", () => {
     const bottle = {
       id: 42,
+      peatedId: "B000042",
       fullName: "Pōkeno Single Cask 4-year-old",
       name: "Single Cask 4-year-old",
       group: { name: "Single Cask 4-year-old" },
@@ -250,6 +257,7 @@ describe("BottleHeader", () => {
   it("promotes a nonduplicative series into the header context", () => {
     const bottle = {
       id: 42,
+      peatedId: "B000042",
       fullName: "Decadent Drinks Glenburgie 38-year-old - Chapter Thirty Two",
       name: "Glenburgie 38-year-old - Chapter Thirty Two",
       group: { name: "Glenburgie 38-year-old" },

--- a/apps/web/src/components/bottleHeader.tsx
+++ b/apps/web/src/components/bottleHeader.tsx
@@ -15,8 +15,10 @@ import Link from "@peated/web/components/link";
 import type { ElementType } from "react";
 import { Distillers } from "./bottleMetadata";
 import PageHeader from "./pageHeader";
+import PeatedId from "./peatedId";
 
 export type BottleHeaderBottle = BottleIdentitySource & {
+  peatedId: string;
   distillers: Array<Pick<Bottle["distillers"][number], "id" | "name">>;
 };
 
@@ -91,23 +93,26 @@ export default function BottleHeader({
         </div>
       }
       titleExtra={
-        hasIdentityDetails ? (
-          <div className="flex max-w-full flex-col items-center lg:items-start">
-            <BottleExactMetadata
-              bottle={bottle}
-              exclude={metadataKeys}
-              className="justify-center lg:justify-start"
-            />
-            {distinctDistillers.length ? (
-              <div className="text-muted mt-1 text-sm">
-                <Distillers
-                  distillers={distinctDistillers}
-                  isBlend={bottle.category === "blend"}
-                />
-              </div>
-            ) : null}
-          </div>
-        ) : null
+        <div className="flex max-w-full flex-col items-center gap-1 lg:items-start">
+          <PeatedId value={bottle.peatedId} />
+          {hasIdentityDetails ? (
+            <>
+              <BottleExactMetadata
+                bottle={bottle}
+                exclude={metadataKeys}
+                className="justify-center lg:justify-start"
+              />
+              {distinctDistillers.length ? (
+                <div className="text-muted mt-1 text-sm">
+                  <Distillers
+                    distillers={distinctDistillers}
+                    isBlend={bottle.category === "blend"}
+                  />
+                </div>
+              ) : null}
+            </>
+          ) : null}
+        </div>
       }
     />
   );

--- a/apps/web/src/components/bottleResolver/states.test.tsx
+++ b/apps/web/src/components/bottleResolver/states.test.tsx
@@ -9,13 +9,13 @@ function makeBottle(overrides: Partial<Bottle> = {}): Bottle {
   const timestamp = "2026-08-23T00:00:00.000Z";
   return {
     id: 42,
-    peatedId: "B000042",
+    peatedId: "B0042",
     fullName: "Springbank 12-year-old Cask Strength Batch 24",
     name: "12-year-old Cask Strength Batch 24",
     group: undefined,
     brand: {
       id: 1,
-      peatedId: "E000001",
+      peatedId: "E0001",
       name: "Springbank",
       shortName: null,
       type: ["brand"],

--- a/apps/web/src/components/bottleResolver/states.test.tsx
+++ b/apps/web/src/components/bottleResolver/states.test.tsx
@@ -9,11 +9,13 @@ function makeBottle(overrides: Partial<Bottle> = {}): Bottle {
   const timestamp = "2026-08-23T00:00:00.000Z";
   return {
     id: 42,
+    peatedId: "B000042",
     fullName: "Springbank 12-year-old Cask Strength Batch 24",
     name: "12-year-old Cask Strength Batch 24",
     group: undefined,
     brand: {
       id: 1,
+      peatedId: "E000001",
       name: "Springbank",
       shortName: null,
       type: ["brand"],

--- a/apps/web/src/components/bottleTable.test.tsx
+++ b/apps/web/src/components/bottleTable.test.tsx
@@ -8,6 +8,7 @@ function makeCollectionBottle(): CollectionBottle {
   const timestamp = "2026-08-23T00:00:00.000Z";
   const brand = {
     id: 2,
+    peatedId: "E000002",
     name: "Compass Box",
     shortName: null,
     type: ["brand" as const],
@@ -30,6 +31,7 @@ function makeCollectionBottle(): CollectionBottle {
     status: null,
     bottle: {
       id: 42,
+      peatedId: "B000042",
       fullName: "Compass Box No Name No. 1",
       name: "No Name No. 1",
       brand,
@@ -128,6 +130,7 @@ describe("BottleTable", () => {
     const brand = {
       ...collectionBottle.bottle.brand,
       id: 3,
+      peatedId: "E000003",
       name: "Woodford Reserve",
     };
     const bottle = {

--- a/apps/web/src/components/bottleTable.test.tsx
+++ b/apps/web/src/components/bottleTable.test.tsx
@@ -8,7 +8,7 @@ function makeCollectionBottle(): CollectionBottle {
   const timestamp = "2026-08-23T00:00:00.000Z";
   const brand = {
     id: 2,
-    peatedId: "E000002",
+    peatedId: "E0002",
     name: "Compass Box",
     shortName: null,
     type: ["brand" as const],
@@ -31,7 +31,7 @@ function makeCollectionBottle(): CollectionBottle {
     status: null,
     bottle: {
       id: 42,
-      peatedId: "B000042",
+      peatedId: "B0042",
       fullName: "Compass Box No Name No. 1",
       name: "No Name No. 1",
       brand,
@@ -130,7 +130,7 @@ describe("BottleTable", () => {
     const brand = {
       ...collectionBottle.bottle.brand,
       id: 3,
-      peatedId: "E000003",
+      peatedId: "E0003",
       name: "Woodford Reserve",
     };
     const bottle = {

--- a/apps/web/src/components/entityHeader.tsx
+++ b/apps/web/src/components/entityHeader.tsx
@@ -4,6 +4,7 @@ import Link from "@peated/web/components/link";
 import { getEntityTypeSearchUrl } from "../lib/urls";
 import Chip from "./chip";
 import PageHeader from "./pageHeader";
+import PeatedId from "./peatedId";
 
 export default function EntityHeader({
   entity,
@@ -17,30 +18,33 @@ export default function EntityHeader({
       icon={EntityIcon}
       title={entity.name}
       titleExtra={
-        <div className="text-muted max-w-full text-center lg:text-left">
-          {!!entity.country && (
-            <>
-              Located in{" "}
-              <Link
-                href={`/locations/${entity.country.slug}`}
-                className="truncate hover:underline"
-              >
-                {entity.country.name}
-              </Link>
-            </>
-          )}
-          {!!entity.country && !!entity.region && (
-            <span>
-              {" "}
-              &middot;{" "}
-              <Link
-                href={`/locations/${entity.country.slug}/regions/${entity.region.slug}`}
-                className="truncate hover:underline"
-              >
-                {entity.region.name}
-              </Link>
-            </span>
-          )}
+        <div className="flex max-w-full flex-col items-center lg:items-start">
+          <PeatedId value={entity.peatedId} />
+          <div className="text-muted max-w-full text-center lg:text-left">
+            {!!entity.country && (
+              <>
+                Located in{" "}
+                <Link
+                  href={`/locations/${entity.country.slug}`}
+                  className="truncate hover:underline"
+                >
+                  {entity.country.name}
+                </Link>
+              </>
+            )}
+            {!!entity.country && !!entity.region && (
+              <span>
+                {" "}
+                &middot;{" "}
+                <Link
+                  href={`/locations/${entity.country.slug}/regions/${entity.region.slug}`}
+                  className="truncate hover:underline"
+                >
+                  {entity.region.name}
+                </Link>
+              </span>
+            )}
+          </div>
         </div>
       }
       metadata={

--- a/apps/web/src/components/libraryEntryActions.test.ts
+++ b/apps/web/src/components/libraryEntryActions.test.ts
@@ -81,7 +81,7 @@ function makeCollectionBottle(id: number): CollectionBottle {
     status: "sealed",
     bottle: {
       id: id + 100,
-      peatedId: `B${String(id + 100).padStart(6, "0")}`,
+      peatedId: `B${String(id + 100).padStart(4, "0")}`,
       fullName: `Bottle ${id}`,
       name: `Bottle ${id}`,
       series: null,
@@ -98,7 +98,7 @@ function makeCollectionBottle(id: number): CollectionBottle {
       caskFill: null,
       brand: {
         id: 1,
-        peatedId: "E000001",
+        peatedId: "E0001",
         name: "Test Brand",
         shortName: null,
         type: ["brand"],

--- a/apps/web/src/components/libraryEntryActions.test.ts
+++ b/apps/web/src/components/libraryEntryActions.test.ts
@@ -81,6 +81,7 @@ function makeCollectionBottle(id: number): CollectionBottle {
     status: "sealed",
     bottle: {
       id: id + 100,
+      peatedId: `B${String(id + 100).padStart(6, "0")}`,
       fullName: `Bottle ${id}`,
       name: `Bottle ${id}`,
       series: null,
@@ -97,6 +98,7 @@ function makeCollectionBottle(id: number): CollectionBottle {
       caskFill: null,
       brand: {
         id: 1,
+        peatedId: "E000001",
         name: "Test Brand",
         shortName: null,
         type: ["brand"],

--- a/apps/web/src/components/notifications/entry.test.tsx
+++ b/apps/web/src/components/notifications/entry.test.tsx
@@ -9,6 +9,7 @@ const timestamp = "2026-07-21T00:00:00.000Z";
 
 const brand = {
   id: 8,
+  peatedId: "E000008",
   name: "Springbank",
   shortName: null,
   type: ["brand"],
@@ -28,6 +29,7 @@ const brand = {
 
 const bottle = {
   id: 19,
+  peatedId: "B000019",
   fullName: "Springbank 12 Cask Strength Batch 24",
   name: "12 Cask Strength Batch 24",
   series: null,

--- a/apps/web/src/components/notifications/entry.test.tsx
+++ b/apps/web/src/components/notifications/entry.test.tsx
@@ -9,7 +9,7 @@ const timestamp = "2026-07-21T00:00:00.000Z";
 
 const brand = {
   id: 8,
-  peatedId: "E000008",
+  peatedId: "E0008",
   name: "Springbank",
   shortName: null,
   type: ["brand"],
@@ -29,7 +29,7 @@ const brand = {
 
 const bottle = {
   id: 19,
-  peatedId: "B000019",
+  peatedId: "B0019",
   fullName: "Springbank 12 Cask Strength Batch 24",
   name: "12 Cask Strength Batch 24",
   series: null,

--- a/apps/web/src/components/peatedId.test.tsx
+++ b/apps/web/src/components/peatedId.test.tsx
@@ -1,0 +1,14 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import PeatedId from "./peatedId";
+
+describe("PeatedId", () => {
+  it("renders the labeled ID, permanent path, and copy action", () => {
+    const html = renderToStaticMarkup(<PeatedId value="B000123" />);
+
+    expect(html).toContain(">ID<");
+    expect(html).toContain("B000123");
+    expect(html).toContain('href="/B000123"');
+    expect(html).toContain('aria-label="Copy B000123 link"');
+  });
+});

--- a/apps/web/src/components/peatedId.test.tsx
+++ b/apps/web/src/components/peatedId.test.tsx
@@ -4,11 +4,11 @@ import PeatedId from "./peatedId";
 
 describe("PeatedId", () => {
   it("renders the labeled ID, permanent path, and copy action", () => {
-    const html = renderToStaticMarkup(<PeatedId value="B000123" />);
+    const html = renderToStaticMarkup(<PeatedId value="B0123" />);
 
     expect(html).toContain(">ID<");
-    expect(html).toContain("B000123");
-    expect(html).toContain('href="/B000123"');
-    expect(html).toContain('aria-label="Copy B000123 link"');
+    expect(html).toContain("B0123");
+    expect(html).toContain('href="/B0123"');
+    expect(html).toContain('aria-label="Copy B0123 link"');
   });
 });

--- a/apps/web/src/components/peatedId.tsx
+++ b/apps/web/src/components/peatedId.tsx
@@ -29,6 +29,7 @@ export default function PeatedId({ value }: { value: string }) {
               new URL(pathname, window.location.origin).toString(),
             );
             setCopied(true);
+            window.setTimeout(() => setCopied(false), 1800);
           } catch {
             setCopied(false);
           }

--- a/apps/web/src/components/peatedId.tsx
+++ b/apps/web/src/components/peatedId.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { CheckIcon, ClipboardDocumentIcon } from "@heroicons/react/20/solid";
+import { copyTextToClipboard } from "@peated/web/lib/clipboard";
+import { useState } from "react";
+import Link from "./link";
+
+export default function PeatedId({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+  const pathname = `/${value}`;
+
+  return (
+    <div className="text-muted inline-flex items-center gap-1 text-xs">
+      <span>ID</span>
+      <Link
+        href={pathname}
+        className="focus-visible:ring-highlight rounded font-mono font-semibold text-white hover:underline focus-visible:outline-none focus-visible:ring-2"
+      >
+        {value}
+      </Link>
+      <button
+        type="button"
+        className="hover:text-highlight focus-visible:ring-highlight inline-flex h-6 w-6 items-center justify-center rounded text-white focus-visible:outline-none focus-visible:ring-2"
+        aria-label={`Copy ${value} link`}
+        title={copied ? "Copied" : "Copy Peated ID link"}
+        onClick={async () => {
+          try {
+            await copyTextToClipboard(
+              new URL(pathname, window.location.origin).toString(),
+            );
+            setCopied(true);
+          } catch {
+            setCopied(false);
+          }
+        }}
+      >
+        {copied ? (
+          <CheckIcon className="h-3.5 w-3.5" aria-hidden="true" />
+        ) : (
+          <ClipboardDocumentIcon className="h-3.5 w-3.5" aria-hidden="true" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/search/bottleResult.test.tsx
+++ b/apps/web/src/components/search/bottleResult.test.tsx
@@ -10,6 +10,7 @@ const timestamp = "2026-07-22T12:00:00.000Z";
 
 const distiller = {
   id: 7,
+  peatedId: "E000007",
   name: "Lagavulin",
   shortName: null,
   type: ["brand", "distiller"],
@@ -58,6 +59,7 @@ const group = {
 
 const exactBottle = {
   id: 42,
+  peatedId: "B000042",
   fullName: "Lagavulin 16-year-old Distillers Edition",
   name: "16-year-old",
   group,

--- a/apps/web/src/components/search/bottleResult.test.tsx
+++ b/apps/web/src/components/search/bottleResult.test.tsx
@@ -10,7 +10,7 @@ const timestamp = "2026-07-22T12:00:00.000Z";
 
 const distiller = {
   id: 7,
-  peatedId: "E000007",
+  peatedId: "E0007",
   name: "Lagavulin",
   shortName: null,
   type: ["brand", "distiller"],
@@ -59,7 +59,7 @@ const group = {
 
 const exactBottle = {
   id: 42,
-  peatedId: "B000042",
+  peatedId: "B0042",
   fullName: "Lagavulin 16-year-old Distillers Edition",
   name: "16-year-old",
   group,

--- a/apps/web/src/lib/peatedIdRoutes.test.ts
+++ b/apps/web/src/lib/peatedIdRoutes.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { resolvePeatedIdRoute } from "./peatedIdRoutes";
+
+describe("Peated ID routes", () => {
+  it("rewrites canonical Peated ID paths to existing detail routes", () => {
+    expect(resolvePeatedIdRoute("/B000123")).toEqual({
+      action: "rewrite",
+      pathname: "/bottles/123",
+    });
+    expect(resolvePeatedIdRoute("/E000456")).toEqual({
+      action: "rewrite",
+      pathname: "/entities/456",
+    });
+  });
+
+  it("redirects short, lowercase, and trailing-slash IDs", () => {
+    expect(resolvePeatedIdRoute("/b123")).toEqual({
+      action: "redirect",
+      pathname: "/B000123",
+    });
+    expect(resolvePeatedIdRoute("/B123")).toEqual({
+      action: "redirect",
+      pathname: "/B000123",
+    });
+    expect(resolvePeatedIdRoute("/E000456/")).toEqual({
+      action: "redirect",
+      pathname: "/E000456",
+    });
+  });
+
+  it("redirects exact legacy detail paths", () => {
+    expect(resolvePeatedIdRoute("/bottles/123")).toEqual({
+      action: "redirect",
+      pathname: "/B000123",
+    });
+    expect(resolvePeatedIdRoute("/entities/456")).toEqual({
+      action: "redirect",
+      pathname: "/E000456",
+    });
+  });
+
+  it("does not claim collections, nested routes, or unsupported IDs", () => {
+    expect(resolvePeatedIdRoute("/bottles")).toBeNull();
+    expect(resolvePeatedIdRoute("/bottles/123/edit")).toBeNull();
+    expect(resolvePeatedIdRoute("/entities/456/aliases")).toBeNull();
+    expect(resolvePeatedIdRoute("/B0")).toBeNull();
+    expect(resolvePeatedIdRoute("/B000000")).toBeNull();
+    expect(resolvePeatedIdRoute("/T123")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/peatedIdRoutes.test.ts
+++ b/apps/web/src/lib/peatedIdRoutes.test.ts
@@ -3,39 +3,43 @@ import { resolvePeatedIdRoute } from "./peatedIdRoutes";
 
 describe("Peated ID routes", () => {
   it("rewrites canonical Peated ID paths to existing detail routes", () => {
-    expect(resolvePeatedIdRoute("/B000123")).toEqual({
+    expect(resolvePeatedIdRoute("/B0123")).toEqual({
       action: "rewrite",
       pathname: "/bottles/123",
     });
-    expect(resolvePeatedIdRoute("/E000456")).toEqual({
+    expect(resolvePeatedIdRoute("/E0456")).toEqual({
       action: "rewrite",
       pathname: "/entities/456",
     });
   });
 
-  it("redirects short, lowercase, and trailing-slash IDs", () => {
+  it("redirects short, overpadded, lowercase, and trailing-slash IDs", () => {
     expect(resolvePeatedIdRoute("/b123")).toEqual({
       action: "redirect",
-      pathname: "/B000123",
+      pathname: "/B0123",
     });
     expect(resolvePeatedIdRoute("/B123")).toEqual({
       action: "redirect",
-      pathname: "/B000123",
+      pathname: "/B0123",
     });
-    expect(resolvePeatedIdRoute("/E000456/")).toEqual({
+    expect(resolvePeatedIdRoute("/B000123")).toEqual({
       action: "redirect",
-      pathname: "/E000456",
+      pathname: "/B0123",
+    });
+    expect(resolvePeatedIdRoute("/E0456/")).toEqual({
+      action: "redirect",
+      pathname: "/E0456",
     });
   });
 
   it("redirects exact legacy detail paths", () => {
     expect(resolvePeatedIdRoute("/bottles/123")).toEqual({
       action: "redirect",
-      pathname: "/B000123",
+      pathname: "/B0123",
     });
     expect(resolvePeatedIdRoute("/entities/456")).toEqual({
       action: "redirect",
-      pathname: "/E000456",
+      pathname: "/E0456",
     });
   });
 
@@ -44,7 +48,7 @@ describe("Peated ID routes", () => {
     expect(resolvePeatedIdRoute("/bottles/123/edit")).toBeNull();
     expect(resolvePeatedIdRoute("/entities/456/aliases")).toBeNull();
     expect(resolvePeatedIdRoute("/B0")).toBeNull();
-    expect(resolvePeatedIdRoute("/B000000")).toBeNull();
+    expect(resolvePeatedIdRoute("/B0000")).toBeNull();
     expect(resolvePeatedIdRoute("/T123")).toBeNull();
   });
 });

--- a/apps/web/src/lib/peatedIdRoutes.ts
+++ b/apps/web/src/lib/peatedIdRoutes.ts
@@ -1,0 +1,55 @@
+import { parsePeatedId } from "@peated/server/lib/peatedId";
+
+export type PeatedIdRouteResolution = {
+  action: "redirect" | "rewrite";
+  pathname: string;
+};
+
+const ROOT_PEATED_ID_PATTERN = /^\/([BE]\d+)\/?$/i;
+const LEGACY_BOTTLE_PATTERN = /^\/bottles\/([1-9]\d*)\/?$/;
+const LEGACY_ENTITY_PATTERN = /^\/entities\/([1-9]\d*)\/?$/;
+
+export function resolvePeatedIdRoute(
+  pathname: string,
+): PeatedIdRouteResolution | null {
+  const rootMatch = ROOT_PEATED_ID_PATTERN.exec(pathname);
+  if (rootMatch) {
+    const parsed = parsePeatedId(rootMatch[1]);
+    if (!parsed) return null;
+
+    const canonicalPath = `/${parsed.peatedId}`;
+    if (pathname !== canonicalPath) {
+      return { action: "redirect", pathname: canonicalPath };
+    }
+
+    return {
+      action: "rewrite",
+      pathname:
+        parsed.type === "bottle"
+          ? `/bottles/${parsed.id}`
+          : `/entities/${parsed.id}`,
+    };
+  }
+
+  const bottleMatch = LEGACY_BOTTLE_PATTERN.exec(pathname);
+  if (bottleMatch) {
+    const parsed = parsePeatedId(`B${bottleMatch[1]}`);
+    if (!parsed) return null;
+    return {
+      action: "redirect",
+      pathname: `/${parsed.peatedId}`,
+    };
+  }
+
+  const entityMatch = LEGACY_ENTITY_PATTERN.exec(pathname);
+  if (entityMatch) {
+    const parsed = parsePeatedId(`E${entityMatch[1]}`);
+    if (!parsed) return null;
+    return {
+      action: "redirect",
+      pathname: `/${parsed.peatedId}`,
+    };
+  }
+
+  return null;
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,3 +1,4 @@
+import { resolvePeatedIdRoute } from "@peated/web/lib/peatedIdRoutes";
 import { type NextRequest, NextResponse } from "next/server";
 
 const PRIVATE_CACHE_CONTROL =
@@ -10,9 +11,23 @@ export function proxy(request: NextRequest) {
     "x-peated-request-path",
     `${request.nextUrl.pathname}${request.nextUrl.search}`,
   );
-  const response = NextResponse.next({
-    request: { headers: requestHeaders },
-  });
+  const resolution = resolvePeatedIdRoute(request.nextUrl.pathname);
+  let response: NextResponse;
+
+  if (resolution) {
+    const destination = request.nextUrl.clone();
+    destination.pathname = resolution.pathname;
+    response =
+      resolution.action === "redirect"
+        ? NextResponse.redirect(destination, 308)
+        : NextResponse.rewrite(destination, {
+            request: { headers: requestHeaders },
+          });
+  } else {
+    response = NextResponse.next({
+      request: { headers: requestHeaders },
+    });
+  }
 
   if (request.cookies.has("_session")) {
     response.headers.set("Cache-Control", PRIVATE_CACHE_CONTROL);

--- a/docs/architecture/peated-ids.md
+++ b/docs/architecture/peated-ids.md
@@ -4,19 +4,19 @@ Peated IDs are short, permanent references for public catalog objects. They are 
 
 ## Supported Objects
 
-| Object | Format               | Example   | Permanent URL                |
-| ------ | -------------------- | --------- | ---------------------------- |
-| Bottle | `B` plus six+ digits | `B000123` | `https://peated.com/B000123` |
-| Entity | `E` plus six+ digits | `E000123` | `https://peated.com/E000123` |
+| Object | Format                | Example | Permanent URL              |
+| ------ | --------------------- | ------- | -------------------------- |
+| Bottle | `B` plus four+ digits | `B0123` | `https://peated.com/B0123` |
+| Entity | `E` plus four+ digits | `E0123` | `https://peated.com/E0123` |
 
-The number is the object's existing positive database ID. Numbers shorter than six digits use leading zeroes. The prefix identifies the type, so `B000123` and `E000123` are different Peated IDs.
+The number is the object's existing positive database ID. Numbers shorter than four digits use leading zeroes. The prefix identifies the type, so `B0123` and `E0123` are different Peated IDs.
 
-Peated IDs are serialized in uppercase with at least six digits. Input and search are case-insensitive and accept omitted leading zeroes, so `b123` is normalized to `B000123`.
+Peated IDs are serialized in uppercase with at least four digits. Input and search are case-insensitive and accept omitted leading zeroes, so `b123` is normalized to `B0123`.
 
 ## Public Behavior
 
-- Root URLs such as `/B000123` and `/E000123` are the permanent public links.
-- Short forms such as `/B123` redirect permanently to the canonical six-digit form.
+- Root URLs such as `/B0123` and `/E0123` are the permanent public links.
+- Short forms such as `/B123` redirect permanently to the canonical four-digit form.
 - Exact legacy detail URLs such as `/bottles/123` and `/entities/123` redirect permanently to the corresponding Peated ID URL.
 - Nested routes keep their existing paths.
 - Bottle and entity API responses include `peatedId` alongside the existing numeric `id`.

--- a/docs/architecture/peated-ids.md
+++ b/docs/architecture/peated-ids.md
@@ -26,6 +26,6 @@ Peated IDs are serialized in uppercase with at least four digits. Input and sear
 
 ## Scope
 
-Peated IDs are for objects people or integrations need to reference directly. They do not apply to bottle groups, flights, tastings, prices, aliases, observations, join rows, or other internal records unless those objects later gain a clear external-reference requirement.
+Peated IDs are for objects people or integrations need to reference directly. They do not apply to BottleGroups, flights, tastings, prices, aliases, observations, join rows, or other internal records unless those objects later gain a clear external-reference requirement.
 
 Peated IDs do not replace numeric database primary keys, foreign keys, or existing numeric mutation inputs. They are a stable public identity layered on top of the existing data model.

--- a/docs/architecture/peated-ids.md
+++ b/docs/architecture/peated-ids.md
@@ -1,0 +1,31 @@
+# Peated IDs
+
+Peated IDs are short, permanent references for public catalog objects. They are designed to be easy to read, type, copy, share, and search.
+
+## Supported Objects
+
+| Object | Format               | Example   | Permanent URL                |
+| ------ | -------------------- | --------- | ---------------------------- |
+| Bottle | `B` plus six+ digits | `B000123` | `https://peated.com/B000123` |
+| Entity | `E` plus six+ digits | `E000123` | `https://peated.com/E000123` |
+
+The number is the object's existing positive database ID. Numbers shorter than six digits use leading zeroes. The prefix identifies the type, so `B000123` and `E000123` are different Peated IDs.
+
+Peated IDs are serialized in uppercase with at least six digits. Input and search are case-insensitive and accept omitted leading zeroes, so `b123` is normalized to `B000123`.
+
+## Public Behavior
+
+- Root URLs such as `/B000123` and `/E000123` are the permanent public links.
+- Short forms such as `/B123` redirect permanently to the canonical six-digit form.
+- Exact legacy detail URLs such as `/bottles/123` and `/entities/123` redirect permanently to the corresponding Peated ID URL.
+- Nested routes keep their existing paths.
+- Bottle and entity API responses include `peatedId` alongside the existing numeric `id`.
+- Global search recognizes an exact Peated ID and returns that object when its type is included in the search.
+- Bottle and entity pages display the compact label `ID` and provide a way to copy the permanent URL.
+- IDs for merged bottles and entities continue to resolve through the existing tombstones to the surviving object.
+
+## Scope
+
+Peated IDs are for objects people or integrations need to reference directly. They do not apply to bottle groups, flights, tastings, prices, aliases, observations, join rows, or other internal records unless those objects later gain a clear external-reference requirement.
+
+Peated IDs do not replace numeric database primary keys, foreign keys, or existing numeric mutation inputs. They are a stable public identity layered on top of the existing data model.

--- a/openspec/changes/add-peated-ids/.openspec.yaml
+++ b/openspec/changes/add-peated-ids/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-25

--- a/openspec/changes/add-peated-ids/design.md
+++ b/openspec/changes/add-peated-ids/design.md
@@ -1,0 +1,82 @@
+## Context
+
+Bottles and entities already use stable auto-incrementing numeric primary keys. Those numbers appear in API responses and resource-specific URLs such as `/bottles/123` and `/entities/123`. The type-specific paths prevent ambiguity, but the references are not compact or recognizable outside a URL.
+
+Peated IDs provide a human-facing public reference without replacing the numeric keys used by the database and existing API inputs. The complete value is unique because its prefix identifies the object type. A bottle and entity may both have numeric ID `123` while their Peated IDs remain distinct as `B000123` and `E000123`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give every bottle and entity a permanent, compact Peated ID.
+- Make `https://peated.com/B000123` and `https://peated.com/E000123` stable public URLs.
+- Keep IDs easy to read, type, copy, paste, and search.
+- Preserve current numeric database relationships and API compatibility.
+- Keep old and merged-object links resolving to the current object.
+
+**Non-Goals:**
+
+- Add Peated IDs to bottle groups, flights, tastings, prices, aliases, observations, join rows, or other internal records.
+- Replace numeric database primary keys or foreign keys.
+- Change existing mutation inputs from numbers to Peated ID strings.
+- Hide catalog growth or make public catalog identifiers unguessable.
+- Add punctuation, checksums, random strings, or title slugs to Peated IDs.
+
+## Decisions
+
+### Derive Peated IDs from existing numeric IDs
+
+The formatted value is `B` plus `bottle.id` or `E` plus `entity.id`. The numeric part uses leading zeroes until it contains six digits. Larger numbers keep their full length. No new sequence or database column is needed. The prefix makes the complete reference unique across supported object types, even when their numeric portions match.
+
+Alternative considered: allocate numbers from a new shared sequence. This adds schema and creation-path complexity without improving the uniqueness or usability of the complete prefixed value.
+
+### Use the product term “Peated ID”
+
+Documentation will call the value a Peated ID. Page headers will use the compact label `ID`, and API responses will expose it as `peatedId`. Internal code may use parsing and formatting terminology, but the product will not introduce specialized identifier jargon.
+
+### Reserve prefixed numeric IDs at the root URL
+
+The web layer will recognize root paths matching the supported Peated ID forms and internally route them through the existing bottle and entity pages. This preserves their layouts and behavior while keeping the short URL visible. Input is case-insensitive and may omit leading zeroes. Non-canonical forms redirect to uppercase IDs with at least six digits.
+
+Exact legacy detail paths `/bottles/<number>` and `/entities/<number>` redirect permanently to their Peated ID URLs. Collection and nested workflow routes retain their existing paths.
+
+Alternative considered: make Peated ID URLs redirect to existing resource paths. That would make them useful as short links but would discard the compact URL after navigation.
+
+### Keep numeric `id` and add `peatedId` to API output
+
+Bottle and entity response schemas will retain numeric `id` and add readonly `peatedId`. Existing consumers continue to work, while new consumers can use the stable public reference. A future versioned API may choose Peated IDs as its primary external identifier, but this change does not require that migration.
+
+### Recognize exact Peated IDs in global search
+
+An exact, case-insensitive Peated ID query will directly load the corresponding bottle or entity when that result type is included. Normal text search remains unchanged. This makes copied IDs useful without teaching users a separate lookup workflow.
+
+### Preserve merged-object resolution
+
+Peated IDs use the same numeric value already handled by bottle and entity tombstones. Looking up an ID for a merged object will follow the existing tombstone behavior and resolve to the surviving object's Peated ID.
+
+### Display the ID as quiet primary metadata
+
+Bottle and entity headers will show `ID` and the formatted value near the title. The value links to its permanent URL and provides a copy action for the full URL. It should be easy to find without competing with the object's name.
+
+## Risks / Trade-offs
+
+- Sequential IDs reveal approximate catalog growth → Bottles and entities are public catalog objects whose numeric IDs are already exposed.
+- A mistyped number may identify a different object → Keep copy actions prominent and use strict prefix-plus-positive-integer parsing.
+- Root paths constrain future routing → Reserve only exact bottle and entity ID patterns; normal named routes remain unaffected.
+- Existing links may cause an extra redirect → Permanently redirect exact legacy detail URLs and update prominent sharing and sitemap outputs immediately.
+- Prefix meanings become durable public behavior → Limit the initial namespace to the two object types known to need external references.
+
+## Migration Plan
+
+1. Add and test shared Peated ID format and parse helpers.
+2. Add `peatedId` to bottle and entity API outputs.
+3. Add exact Peated ID search lookup.
+4. Add root URL routing and legacy detail redirects.
+5. Display and share Peated IDs from bottle and entity pages.
+6. Publish Peated ID URLs in bottle and entity sitemaps.
+
+Rollback is low risk because there is no database migration. The additive API fields may remain even if short URL promotion is temporarily removed.
+
+## Open Questions
+
+None.

--- a/openspec/changes/add-peated-ids/design.md
+++ b/openspec/changes/add-peated-ids/design.md
@@ -2,14 +2,14 @@
 
 Bottles and entities already use stable auto-incrementing numeric primary keys. Those numbers appear in API responses and resource-specific URLs such as `/bottles/123` and `/entities/123`. The type-specific paths prevent ambiguity, but the references are not compact or recognizable outside a URL.
 
-Peated IDs provide a human-facing public reference without replacing the numeric keys used by the database and existing API inputs. The complete value is unique because its prefix identifies the object type. A bottle and entity may both have numeric ID `123` while their Peated IDs remain distinct as `B000123` and `E000123`.
+Peated IDs provide a human-facing public reference without replacing the numeric keys used by the database and existing API inputs. The complete value is unique because its prefix identifies the object type. A bottle and entity may both have numeric ID `123` while their Peated IDs remain distinct as `B0123` and `E0123`.
 
 ## Goals / Non-Goals
 
 **Goals:**
 
 - Give every bottle and entity a permanent, compact Peated ID.
-- Make `https://peated.com/B000123` and `https://peated.com/E000123` stable public URLs.
+- Make `https://peated.com/B0123` and `https://peated.com/E0123` stable public URLs.
 - Keep IDs easy to read, type, copy, paste, and search.
 - Preserve current numeric database relationships and API compatibility.
 - Keep old and merged-object links resolving to the current object.
@@ -26,7 +26,7 @@ Peated IDs provide a human-facing public reference without replacing the numeric
 
 ### Derive Peated IDs from existing numeric IDs
 
-The formatted value is `B` plus `bottle.id` or `E` plus `entity.id`. The numeric part uses leading zeroes until it contains six digits. Larger numbers keep their full length. No new sequence or database column is needed. The prefix makes the complete reference unique across supported object types, even when their numeric portions match.
+The formatted value is `B` plus `bottle.id` or `E` plus `entity.id`. The numeric part uses leading zeroes until it contains four digits. Larger numbers keep their full length. No new sequence or database column is needed. The prefix makes the complete reference unique across supported object types, even when their numeric portions match.
 
 Alternative considered: allocate numbers from a new shared sequence. This adds schema and creation-path complexity without improving the uniqueness or usability of the complete prefixed value.
 
@@ -36,7 +36,7 @@ Documentation will call the value a Peated ID. Page headers will use the compact
 
 ### Reserve prefixed numeric IDs at the root URL
 
-The web layer will recognize root paths matching the supported Peated ID forms and internally route them through the existing bottle and entity pages. This preserves their layouts and behavior while keeping the short URL visible. Input is case-insensitive and may omit leading zeroes. Non-canonical forms redirect to uppercase IDs with at least six digits.
+The web layer will recognize root paths matching the supported Peated ID forms and internally route them through the existing bottle and entity pages. This preserves their layouts and behavior while keeping the short URL visible. Input is case-insensitive and may omit leading zeroes. Non-canonical forms redirect to uppercase IDs with at least four digits.
 
 Exact legacy detail paths `/bottles/<number>` and `/entities/<number>` redirect permanently to their Peated ID URLs. Collection and nested workflow routes retain their existing paths.
 

--- a/openspec/changes/add-peated-ids/proposal.md
+++ b/openspec/changes/add-peated-ids/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Bottle and entity links currently expose untyped database numbers inside resource-specific paths. Peated needs a short, memorable way for people and integrations to identify a catalog object, share it, and find it again without relying on its name.
+
+## What Changes
+
+- Introduce permanent Peated IDs for externally referenced bottles and entities.
+- Format bottle IDs as `B` plus at least six digits and entity IDs as `E` plus at least six digits, using each record's existing numeric ID.
+- Serve permanent short URLs such as `https://peated.com/B000123` and `https://peated.com/E000123`.
+- Show the Peated ID on bottle and entity pages with a copyable link.
+- Expose Peated IDs in API responses and recognize exact Peated IDs in global search.
+- Preserve existing bottle and entity detail URLs as compatibility redirects.
+
+## Capabilities
+
+### New Capabilities
+
+- `peated-ids`: Stable, typed public references, short URLs, display, and lookup for bottles and entities.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Shared server code: add Peated ID formatting and parsing helpers.
+- API: add `peatedId` to bottle and entity response schemas and serializers; support exact Peated ID lookup in global search.
+- Web routing: resolve root-level Peated ID URLs while retaining the existing route layouts and redirect old detail URLs.
+- Web UI: display a copyable Peated ID on bottle and entity headers and use Peated ID URLs for sharing and sitemaps.
+- Documentation and tests: define the public contract and add focused helper, API, route, and component coverage.

--- a/openspec/changes/add-peated-ids/proposal.md
+++ b/openspec/changes/add-peated-ids/proposal.md
@@ -5,8 +5,8 @@ Bottle and entity links currently expose untyped database numbers inside resourc
 ## What Changes
 
 - Introduce permanent Peated IDs for externally referenced bottles and entities.
-- Format bottle IDs as `B` plus at least six digits and entity IDs as `E` plus at least six digits, using each record's existing numeric ID.
-- Serve permanent short URLs such as `https://peated.com/B000123` and `https://peated.com/E000123`.
+- Format bottle IDs as `B` plus at least four digits and entity IDs as `E` plus at least four digits, using each record's existing numeric ID.
+- Serve permanent short URLs such as `https://peated.com/B0123` and `https://peated.com/E0123`.
 - Show the Peated ID on bottle and entity pages with a copyable link.
 - Expose Peated IDs in API responses and recognize exact Peated IDs in global search.
 - Preserve existing bottle and entity detail URLs as compatibility redirects.

--- a/openspec/changes/add-peated-ids/specs/peated-ids/spec.md
+++ b/openspec/changes/add-peated-ids/specs/peated-ids/spec.md
@@ -2,22 +2,22 @@
 
 ### Requirement: Bottles and entities have permanent Peated IDs
 
-The system SHALL expose a Peated ID for every bottle and entity by combining its object prefix with its existing positive numeric ID and adding leading zeroes until the numeric part has at least six digits.
+The system SHALL expose a Peated ID for every bottle and entity by combining its object prefix with its existing positive numeric ID and adding leading zeroes until the numeric part has at least four digits.
 
 #### Scenario: Bottle Peated ID
 
 - **WHEN** a bottle has numeric ID `123`
-- **THEN** its Peated ID is `B000123`
+- **THEN** its Peated ID is `B0123`
 
 #### Scenario: Entity Peated ID
 
 - **WHEN** an entity has numeric ID `123`
-- **THEN** its Peated ID is `E000123`
+- **THEN** its Peated ID is `E0123`
 
 #### Scenario: Matching numeric portions remain distinct
 
 - **WHEN** a bottle and an entity both have numeric ID `123`
-- **THEN** `B000123` identifies the bottle and `E000123` identifies the entity without ambiguity
+- **THEN** `B0123` identifies the bottle and `E0123` identifies the entity without ambiguity
 
 ### Requirement: Peated IDs have permanent short URLs
 
@@ -25,23 +25,23 @@ The system SHALL resolve bottle and entity Peated IDs from root-level URLs while
 
 #### Scenario: Bottle short URL
 
-- **WHEN** a visitor opens `/B000123`
+- **WHEN** a visitor opens `/B0123`
 - **THEN** the system displays bottle `123` using the normal bottle page and layout
 
 #### Scenario: Entity short URL
 
-- **WHEN** a visitor opens `/E000123`
+- **WHEN** a visitor opens `/E0123`
 - **THEN** the system displays entity `123` using the normal entity page and layout
 
 #### Scenario: Lowercase URL
 
 - **WHEN** a visitor opens `/b123`
-- **THEN** the system permanently redirects to `/B000123`
+- **THEN** the system permanently redirects to `/B0123`
 
 #### Scenario: Unpadded URL
 
 - **WHEN** a visitor opens `/B123`
-- **THEN** the system permanently redirects to `/B000123`
+- **THEN** the system permanently redirects to `/B0123`
 
 #### Scenario: Unsupported root path
 
@@ -55,12 +55,12 @@ The system SHALL preserve existing numeric bottle and entity detail links by red
 #### Scenario: Existing bottle URL
 
 - **WHEN** a visitor opens `/bottles/123`
-- **THEN** the system permanently redirects to `/B000123`
+- **THEN** the system permanently redirects to `/B0123`
 
 #### Scenario: Existing entity URL
 
 - **WHEN** a visitor opens `/entities/123`
-- **THEN** the system permanently redirects to `/E000123`
+- **THEN** the system permanently redirects to `/E0123`
 
 #### Scenario: Nested route
 
@@ -74,12 +74,12 @@ The system SHALL include a readonly `peatedId` string in serialized bottle and e
 #### Scenario: Serialized bottle
 
 - **WHEN** bottle `123` is returned by the API
-- **THEN** the response includes `id: 123` and `peatedId: "B000123"`
+- **THEN** the response includes `id: 123` and `peatedId: "B0123"`
 
 #### Scenario: Serialized entity
 
 - **WHEN** entity `123` is returned by the API
-- **THEN** the response includes `id: 123` and `peatedId: "E000123"`
+- **THEN** the response includes `id: 123` and `peatedId: "E0123"`
 
 ### Requirement: Global search recognizes Peated IDs
 
@@ -87,7 +87,7 @@ The system SHALL recognize an exact Peated ID query case-insensitively and retur
 
 #### Scenario: Search for bottle Peated ID
 
-- **WHEN** global search receives `B000123` or `B123` and bottle results are included
+- **WHEN** global search receives `B0123` or `B123` and bottle results are included
 - **THEN** bottle `123` is returned as the exact result
 
 #### Scenario: Search for lowercase entity Peated ID
@@ -97,7 +97,7 @@ The system SHALL recognize an exact Peated ID query case-insensitively and retur
 
 #### Scenario: Excluded result type
 
-- **WHEN** global search receives `B000123` and bottle results are excluded
+- **WHEN** global search receives `B0123` and bottle results are excluded
 - **THEN** bottle `123` is not returned
 
 ### Requirement: Peated IDs are visible and copyable
@@ -120,10 +120,10 @@ The system SHALL resolve a Peated ID for a merged bottle or entity through the e
 
 #### Scenario: Merged bottle
 
-- **WHEN** `B000123` identifies a bottle that was merged into bottle `456`
-- **THEN** the visitor is redirected to `B000456`
+- **WHEN** `B0123` identifies a bottle that was merged into bottle `456`
+- **THEN** the visitor is redirected to `B0456`
 
 #### Scenario: Merged entity
 
-- **WHEN** `E000123` identifies an entity that was merged into entity `456`
-- **THEN** the visitor is redirected to `E000456`
+- **WHEN** `E0123` identifies an entity that was merged into entity `456`
+- **THEN** the visitor is redirected to `E0456`

--- a/openspec/changes/add-peated-ids/specs/peated-ids/spec.md
+++ b/openspec/changes/add-peated-ids/specs/peated-ids/spec.md
@@ -1,0 +1,129 @@
+## ADDED Requirements
+
+### Requirement: Bottles and entities have permanent Peated IDs
+
+The system SHALL expose a Peated ID for every bottle and entity by combining its object prefix with its existing positive numeric ID and adding leading zeroes until the numeric part has at least six digits.
+
+#### Scenario: Bottle Peated ID
+
+- **WHEN** a bottle has numeric ID `123`
+- **THEN** its Peated ID is `B000123`
+
+#### Scenario: Entity Peated ID
+
+- **WHEN** an entity has numeric ID `123`
+- **THEN** its Peated ID is `E000123`
+
+#### Scenario: Matching numeric portions remain distinct
+
+- **WHEN** a bottle and an entity both have numeric ID `123`
+- **THEN** `B000123` identifies the bottle and `E000123` identifies the entity without ambiguity
+
+### Requirement: Peated IDs have permanent short URLs
+
+The system SHALL resolve bottle and entity Peated IDs from root-level URLs while preserving the Peated ID in the public URL.
+
+#### Scenario: Bottle short URL
+
+- **WHEN** a visitor opens `/B000123`
+- **THEN** the system displays bottle `123` using the normal bottle page and layout
+
+#### Scenario: Entity short URL
+
+- **WHEN** a visitor opens `/E000123`
+- **THEN** the system displays entity `123` using the normal entity page and layout
+
+#### Scenario: Lowercase URL
+
+- **WHEN** a visitor opens `/b123`
+- **THEN** the system permanently redirects to `/B000123`
+
+#### Scenario: Unpadded URL
+
+- **WHEN** a visitor opens `/B123`
+- **THEN** the system permanently redirects to `/B000123`
+
+#### Scenario: Unsupported root path
+
+- **WHEN** a root path does not exactly match a supported Peated ID
+- **THEN** Peated ID routing does not claim that path
+
+### Requirement: Existing detail URLs remain compatible
+
+The system SHALL preserve existing numeric bottle and entity detail links by redirecting them to Peated ID URLs.
+
+#### Scenario: Existing bottle URL
+
+- **WHEN** a visitor opens `/bottles/123`
+- **THEN** the system permanently redirects to `/B000123`
+
+#### Scenario: Existing entity URL
+
+- **WHEN** a visitor opens `/entities/123`
+- **THEN** the system permanently redirects to `/E000123`
+
+#### Scenario: Nested route
+
+- **WHEN** a visitor opens a nested bottle or entity workflow route
+- **THEN** the route retains its existing resource-specific path
+
+### Requirement: API responses expose Peated IDs
+
+The system SHALL include a readonly `peatedId` string in serialized bottle and entity responses while retaining the existing numeric `id`.
+
+#### Scenario: Serialized bottle
+
+- **WHEN** bottle `123` is returned by the API
+- **THEN** the response includes `id: 123` and `peatedId: "B000123"`
+
+#### Scenario: Serialized entity
+
+- **WHEN** entity `123` is returned by the API
+- **THEN** the response includes `id: 123` and `peatedId: "E000123"`
+
+### Requirement: Global search recognizes Peated IDs
+
+The system SHALL recognize an exact Peated ID query case-insensitively and return the identified object when its result type is included.
+
+#### Scenario: Search for bottle Peated ID
+
+- **WHEN** global search receives `B000123` or `B123` and bottle results are included
+- **THEN** bottle `123` is returned as the exact result
+
+#### Scenario: Search for lowercase entity Peated ID
+
+- **WHEN** global search receives `e123` and entity results are included
+- **THEN** entity `123` is returned as the exact result
+
+#### Scenario: Excluded result type
+
+- **WHEN** global search receives `B000123` and bottle results are excluded
+- **THEN** bottle `123` is not returned
+
+### Requirement: Peated IDs are visible and copyable
+
+The system SHALL show the Peated ID on bottle and entity detail pages and provide a way to copy its permanent URL.
+
+#### Scenario: Bottle header
+
+- **WHEN** a visitor views a bottle page
+- **THEN** the header shows its Peated ID near the bottle name
+
+#### Scenario: Copy Peated ID link
+
+- **WHEN** a visitor activates the Peated ID copy action
+- **THEN** the full permanent Peated ID URL is copied
+
+### Requirement: Merged object IDs continue to resolve
+
+The system SHALL resolve a Peated ID for a merged bottle or entity through the existing tombstone to the surviving object.
+
+#### Scenario: Merged bottle
+
+- **WHEN** `B000123` identifies a bottle that was merged into bottle `456`
+- **THEN** the visitor is redirected to `B000456`
+
+#### Scenario: Merged entity
+
+- **WHEN** `E000123` identifies an entity that was merged into entity `456`
+- **THEN** the visitor is redirected to `E000456`

--- a/openspec/changes/add-peated-ids/tasks.md
+++ b/openspec/changes/add-peated-ids/tasks.md
@@ -1,0 +1,26 @@
+## 1. Documentation and Shared Contract
+
+- [x] 1.1 Document Peated IDs, supported object types, formatting, URL behavior, search behavior, compatibility, and scope in the main architecture documentation.
+- [x] 1.2 Add shared, deterministic Peated ID formatting and parsing helpers with focused tests.
+
+## 2. API
+
+- [x] 2.1 Add readonly `peatedId` fields to bottle and entity response schemas.
+- [x] 2.2 Serialize bottle and entity Peated IDs with their type prefix and at least six numeric digits.
+- [x] 2.3 Recognize exact, case-insensitive Peated IDs in global search while respecting included result types and tombstones.
+- [x] 2.4 Add route coverage for serialized Peated IDs and exact Peated ID search.
+
+## 3. Web URLs and Display
+
+- [x] 3.1 Route uppercase bottle and entity Peated ID root URLs through the existing detail page layouts.
+- [x] 3.2 Permanently redirect lowercase Peated ID URLs and exact legacy numeric detail URLs to uppercase Peated ID URLs without claiming nested routes.
+- [x] 3.3 Add a reusable Peated ID display with a permanent link and accessible copy action.
+- [x] 3.4 Show Peated IDs on bottle and entity headers and use Peated ID URLs for share actions.
+- [x] 3.5 Publish Peated ID URLs in bottle and entity sitemaps.
+- [x] 3.6 Add focused route and component coverage for URL normalization and Peated ID display behavior.
+
+## 4. Verification
+
+- [x] 4.1 Run targeted server tests for Peated ID helpers, bottle/entity details, and global search.
+- [x] 4.2 Run targeted web tests for routing and Peated ID display behavior.
+- [x] 4.3 Run formatting, lint, and server/web typechecks for the touched surface.

--- a/openspec/changes/add-peated-ids/tasks.md
+++ b/openspec/changes/add-peated-ids/tasks.md
@@ -6,7 +6,7 @@
 ## 2. API
 
 - [x] 2.1 Add readonly `peatedId` fields to bottle and entity response schemas.
-- [x] 2.2 Serialize bottle and entity Peated IDs with their type prefix and at least six numeric digits.
+- [x] 2.2 Serialize bottle and entity Peated IDs with their type prefix and at least four numeric digits.
 - [x] 2.3 Recognize exact, case-insensitive Peated IDs in global search while respecting included result types and tombstones.
 - [x] 2.4 Add route coverage for serialized Peated IDs and exact Peated ID search.
 


### PR DESCRIPTION
Peated now gives every bottle and entity a permanent, human-readable ID such as `B0123` or `E0123`. The ID is exposed in API responses, displayed in detail headers with a copy action, recognized by global search, and used by shares and sitemaps.

Root paths such as `/B0123` and `/E0123` render the existing detail pages. Lowercase, unpadded, over-padded, and legacy numeric detail URLs redirect to the canonical four-digit form, while nested routes remain unchanged.

The IDs derive from existing numeric primary keys, so this requires no migration and keeps numeric API inputs compatible. Bottle groups and other internal records remain out of scope, and merged references continue to resolve through existing tombstones.
