### PR TITLE
feat(bottles): Expose and manage product barcodes

### DIFF
--- a/apps/server/src/orpc/routes/bottleBarcodes/delete.ts
+++ b/apps/server/src/orpc/routes/bottleBarcodes/delete.ts
@@ -12,9 +12,9 @@ export default procedure
   .route({
     method: "DELETE",
     path: "/bottle-barcodes/{barcode}",
-    summary: "Delete bottle barcode",
+    summary: "Delete a Bottle barcode",
     description:
-      "Remove a canonical GTIN barcode mapping. Requires moderator privileges",
+      "Remove an approved product barcode from a Bottle. Requires moderator privileges",
     operationId: "deleteBottleBarcode",
   })
   .input(z.object({ barcode: GtinSchema }).strict())

--- a/apps/server/src/orpc/routes/bottleBarcodes/delete.ts
+++ b/apps/server/src/orpc/routes/bottleBarcodes/delete.ts
@@ -14,7 +14,7 @@ export default procedure
     path: "/bottle-barcodes/{barcode}",
     summary: "Delete a Bottle barcode",
     description:
-      "Remove an approved product barcode from a Bottle. Requires moderator privileges",
+      "Remove a product barcode from a Bottle. Requires moderator privileges",
     operationId: "deleteBottleBarcode",
   })
   .input(z.object({ barcode: GtinSchema }).strict())

--- a/apps/server/src/orpc/routes/bottleBarcodes/details.ts
+++ b/apps/server/src/orpc/routes/bottleBarcodes/details.ts
@@ -13,8 +13,8 @@ export default procedure
   .route({
     method: "GET",
     path: "/bottle-barcodes/{barcode}",
-    summary: "Look up bottle by barcode",
-    description: "Resolve a canonical GTIN barcode to an exact Bottle",
+    summary: "Look up a Bottle by barcode",
+    description: "Find the Bottle assigned to an approved product barcode",
     operationId: "getBottleBarcode",
   })
   .input(z.object({ barcode: GtinSchema }).strict())

--- a/apps/server/src/orpc/routes/bottleBarcodes/details.ts
+++ b/apps/server/src/orpc/routes/bottleBarcodes/details.ts
@@ -14,7 +14,7 @@ export default procedure
     method: "GET",
     path: "/bottle-barcodes/{barcode}",
     summary: "Look up a Bottle by barcode",
-    description: "Find the Bottle assigned to an approved product barcode",
+    description: "Find the Bottle that has this product barcode",
     operationId: "getBottleBarcode",
   })
   .input(z.object({ barcode: GtinSchema }).strict())

--- a/apps/server/src/orpc/routes/bottleBarcodes/list.ts
+++ b/apps/server/src/orpc/routes/bottleBarcodes/list.ts
@@ -11,7 +11,7 @@ export default procedure
     method: "GET",
     path: "/bottle-barcodes",
     summary: "List bottle barcodes",
-    description: "List approved product barcodes assigned to a Bottle",
+    description: "List product barcodes for a Bottle",
     operationId: "listBottleBarcodes",
   })
   .input(z.object({ bottle: z.coerce.number() }).strict())

--- a/apps/server/src/orpc/routes/bottleBarcodes/list.ts
+++ b/apps/server/src/orpc/routes/bottleBarcodes/list.ts
@@ -11,7 +11,7 @@ export default procedure
     method: "GET",
     path: "/bottle-barcodes",
     summary: "List bottle barcodes",
-    description: "List canonical GTIN barcodes assigned to an exact Bottle",
+    description: "List approved product barcodes assigned to a Bottle",
     operationId: "listBottleBarcodes",
   })
   .input(z.object({ bottle: z.coerce.number() }).strict())

--- a/apps/server/src/orpc/routes/bottleBarcodes/upsert.ts
+++ b/apps/server/src/orpc/routes/bottleBarcodes/upsert.ts
@@ -16,7 +16,7 @@ export default procedure
     path: "/bottle-barcodes",
     summary: "Add a Bottle barcode",
     description:
-      "Assign an approved product barcode to a Bottle. Requires moderator privileges",
+      "Add a product barcode to a Bottle. Requires moderator privileges",
     operationId: "upsertBottleBarcode",
   })
   .input(

--- a/apps/server/src/orpc/routes/bottleBarcodes/upsert.ts
+++ b/apps/server/src/orpc/routes/bottleBarcodes/upsert.ts
@@ -14,9 +14,9 @@ export default procedure
   .route({
     method: "PUT",
     path: "/bottle-barcodes",
-    summary: "Add bottle barcode",
+    summary: "Add a Bottle barcode",
     description:
-      "Assign a canonical GTIN barcode to an exact Bottle. Requires moderator privileges",
+      "Assign an approved product barcode to a Bottle. Requires moderator privileges",
     operationId: "upsertBottleBarcode",
   })
   .input(

--- a/apps/server/src/orpc/routes/bottles/details.test.ts
+++ b/apps/server/src/orpc/routes/bottles/details.test.ts
@@ -30,6 +30,26 @@ describe("GET /bottles/:bottle", () => {
     expect("displayImageUrl" in data).toBe(false);
   });
 
+  test("includes approved product barcodes", async ({ fixtures }) => {
+    const bottle = await fixtures.Bottle();
+    const moderator = await fixtures.User({ mod: true });
+    await routerClient.bottleBarcodes.upsert(
+      { bottle: bottle.id, barcode: "96385074", volume: 700 },
+      { context: { user: moderator } },
+    );
+    await routerClient.bottleBarcodes.upsert(
+      { bottle: bottle.id, barcode: "4006381333931" },
+      { context: { user: moderator } },
+    );
+
+    const data = await routerClient.bottles.details({ bottle: bottle.id });
+
+    expect(data.barcodes).toEqual([
+      expect.objectContaining({ value: "4006381333931", volume: null }),
+      expect.objectContaining({ value: "96385074", volume: 700 }),
+    ]);
+  });
+
   test("errors on invalid bottle", async () => {
     const err = await waitError(routerClient.bottles.details({ bottle: 1 }));
     expect(err).toMatchInlineSnapshot(`[Error: Bottle not found.]`);

--- a/apps/server/src/orpc/routes/bottles/details.ts
+++ b/apps/server/src/orpc/routes/bottles/details.ts
@@ -1,5 +1,6 @@
 import { db } from "@peated/server/db";
 import {
+  bottleBarcodes,
   bottleTombstones,
   bottles,
   storePrices,
@@ -7,6 +8,7 @@ import {
 } from "@peated/server/db/schema";
 import { procedure } from "@peated/server/orpc";
 import {
+  BottleBarcodeSchema,
   BottleSchema,
   StorePriceSchema,
   detailsResponse,
@@ -14,13 +16,17 @@ import {
 import { serialize } from "@peated/server/serializers";
 import { BottleSerializer } from "@peated/server/serializers/bottle";
 import { StorePriceSerializer } from "@peated/server/serializers/storePrice";
-import { and, desc, eq, getTableColumns, sql } from "drizzle-orm";
+import { and, asc, desc, eq, getTableColumns, sql } from "drizzle-orm";
 import { z } from "zod";
 
 // Compose details as Bottle schema + extra fields to allow OpenAPI $ref via allOf
 const OutputSchema = z.intersection(
   BottleSchema,
   z.object({
+    barcodes: z
+      .array(BottleBarcodeSchema.pick({ value: true, volume: true }))
+      .readonly()
+      .describe("Approved product barcodes assigned to this Bottle"),
     people: z.number(),
     lastPrice: StorePriceSchema.nullable(),
   }),
@@ -32,7 +38,7 @@ export default procedure
     path: "/bottles/{bottle}",
     summary: "Get bottle details",
     description:
-      "Retrieve detailed information about a specific bottle including pricing and tasting statistics",
+      "Retrieve Bottle details, including product barcodes, pricing, and tasting statistics",
     spec: (spec) => ({
       ...spec,
       operationId: "getBottle",
@@ -66,26 +72,37 @@ export default procedure
       }
     }
 
-    const [lastPrice] = await db
-      .select()
-      .from(storePrices)
-      .where(
-        and(eq(storePrices.bottleId, bottle.id), eq(storePrices.hidden, false)),
-      )
-      .orderBy(desc(storePrices.updatedAt), desc(storePrices.id))
-      .limit(1);
-
-    const [{ count: totalPeople }] = await db
-      .select({
-        count: sql<string>`COUNT(DISTINCT ${tastings.createdById})`,
-      })
-      .from(tastings)
-      .where(eq(tastings.bottleId, bottle.id));
+    const [[lastPrice], [{ count: totalPeople }], barcodeList] =
+      await Promise.all([
+        db
+          .select()
+          .from(storePrices)
+          .where(
+            and(
+              eq(storePrices.bottleId, bottle.id),
+              eq(storePrices.hidden, false),
+            ),
+          )
+          .orderBy(desc(storePrices.updatedAt), desc(storePrices.id))
+          .limit(1),
+        db
+          .select({
+            count: sql<string>`COUNT(DISTINCT ${tastings.createdById})`,
+          })
+          .from(tastings)
+          .where(eq(tastings.bottleId, bottle.id)),
+        db
+          .select()
+          .from(bottleBarcodes)
+          .where(eq(bottleBarcodes.bottleId, bottle.id))
+          .orderBy(asc(bottleBarcodes.value), asc(bottleBarcodes.id)),
+      ]);
 
     return {
       ...(await serialize(BottleSerializer, bottle, context.user, [], {
         includeGroupSummary: true,
       })),
+      barcodes: barcodeList.map(({ value, volume }) => ({ value, volume })),
       people: Number(totalPeople),
       lastPrice: lastPrice
         ? await serialize(StorePriceSerializer, lastPrice, context.user)

--- a/apps/server/src/orpc/routes/bottles/details.ts
+++ b/apps/server/src/orpc/routes/bottles/details.ts
@@ -26,7 +26,7 @@ const OutputSchema = z.intersection(
     barcodes: z
       .array(BottleBarcodeSchema.pick({ value: true, volume: true }))
       .readonly()
-      .describe("Approved product barcodes assigned to this Bottle"),
+      .describe("Product barcodes for this Bottle"),
     people: z.number(),
     lastPrice: StorePriceSchema.nullable(),
   }),

--- a/apps/server/src/schemas/bottleBarcodes.ts
+++ b/apps/server/src/schemas/bottleBarcodes.ts
@@ -17,7 +17,7 @@ export const GtinSchema = z
       return z.NEVER;
     }
   })
-  .describe("A valid GTIN-8, GTIN-12, GTIN-13, or GTIN-14 barcode");
+  .describe("Product barcode number (GTIN-8, GTIN-12, GTIN-13, or GTIN-14)");
 
 export const BottleBarcodeSchema = z.object({
   id: z.number().readonly().describe("Unique identifier for this barcode"),

--- a/apps/server/src/schemas/bottleBarcodes.ts
+++ b/apps/server/src/schemas/bottleBarcodes.ts
@@ -20,11 +20,21 @@ export const GtinSchema = z
   .describe("A valid GTIN-8, GTIN-12, GTIN-13, or GTIN-14 barcode");
 
 export const BottleBarcodeSchema = z.object({
-  id: z.number().readonly(),
-  bottle: z.number().readonly(),
-  value: z.string().readonly(),
-  volume: z.number().int().positive().nullable().readonly(),
-  createdAt: z.string().datetime().readonly(),
+  id: z.number().readonly().describe("Unique identifier for this barcode"),
+  bottle: z.number().readonly().describe("Bottle assigned to this barcode"),
+  value: GtinSchema.readonly().describe("Product barcode number"),
+  volume: z
+    .number()
+    .int()
+    .positive()
+    .nullable()
+    .readonly()
+    .describe("Package size in milliliters, when known"),
+  createdAt: z
+    .string()
+    .datetime()
+    .readonly()
+    .describe("Time when this barcode was assigned"),
 });
 
 export const BottleBarcodeLookupSchema = z.object({

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -173,6 +173,7 @@ export function buildBottle({
     totalTastings,
     people,
     lastPrice: null,
+    barcodes: [],
     createdBy: null,
     createdAt: timestamp,
     updatedAt: timestamp,

--- a/apps/web/src/components/bottleBarcodes.test.tsx
+++ b/apps/web/src/components/bottleBarcodes.test.tsx
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+import { BottleBarcodeItems } from "./bottleBarcodes";
+
+describe("BottleBarcodeItems", () => {
+  test("shows barcode numbers and known package sizes", () => {
+    const html = renderToStaticMarkup(
+      <BottleBarcodeItems
+        barcodes={[
+          {
+            value: "96385074",
+            volume: 700,
+          },
+          {
+            value: "4006381333931",
+            volume: null,
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain("96385074");
+    expect(html).toContain("700 mL package");
+    expect(html).toContain("4006381333931");
+    expect(html).not.toContain("Remove");
+  });
+});

--- a/apps/web/src/components/bottleBarcodes.tsx
+++ b/apps/web/src/components/bottleBarcodes.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+import type { Outputs } from "@peated/server/orpc/router";
+import Alert from "@peated/web/components/alert";
+import Button from "@peated/web/components/button";
+import ConfirmationButton from "@peated/web/components/confirmationButton";
+import { useFlashMessages } from "@peated/web/components/flash";
+import Heading from "@peated/web/components/heading";
+import TextField from "@peated/web/components/textField";
+import useAuth from "@peated/web/hooks/useAuth";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState, type FormEvent } from "react";
+
+type Barcode = Outputs["bottles"]["details"]["barcodes"][number];
+
+export function BottleBarcodeItems({
+  barcodes,
+  onRemove,
+  removing = false,
+}: {
+  barcodes: readonly Barcode[];
+  onRemove?: (barcode: Barcode) => void;
+  removing?: boolean;
+}) {
+  return (
+    <ul className="mb-4 space-y-2">
+      {barcodes.map((barcode) => (
+        <li
+          key={barcode.value}
+          className="flex items-center justify-between gap-4 rounded border border-slate-800 bg-slate-900 px-3 py-2"
+        >
+          <div>
+            <div className="font-mono text-sm text-white">{barcode.value}</div>
+            {barcode.volume !== null ? (
+              <div className="text-muted text-sm">
+                {barcode.volume} mL package
+              </div>
+            ) : null}
+          </div>
+          {onRemove ? (
+            <ConfirmationButton
+              className="text-muted text-sm underline hover:text-white"
+              disabled={removing}
+              onContinue={() => onRemove(barcode)}
+              confirmationTitle="Remove barcode"
+              confirmationMessage={`Remove ${barcode.value}? Peated will stop using this barcode to connect store listings to this product.`}
+              continueLabel="Remove barcode"
+            >
+              Remove
+            </ConfirmationButton>
+          ) : null}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function BottleBarcodes({
+  bottleId,
+  barcodes,
+}: {
+  bottleId: number;
+  barcodes: readonly Barcode[];
+}) {
+  const { user } = useAuth();
+  const orpc = useORPC();
+  const queryClient = useQueryClient();
+  const { flash } = useFlashMessages();
+  const [showForm, setShowForm] = useState(false);
+  const [barcode, setBarcode] = useState("");
+  const [packageSize, setPackageSize] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const canEdit = !!(user?.mod || user?.admin);
+
+  const addMutation = useMutation(orpc.bottleBarcodes.upsert.mutationOptions());
+  const removeMutation = useMutation(
+    orpc.bottleBarcodes.delete.mutationOptions(),
+  );
+  const bottleDetailsKey = orpc.bottles.details.key({
+    input: { bottle: bottleId },
+    type: "query",
+  });
+
+  if (!barcodes.length && !canEdit) return null;
+
+  const refreshBottle = () =>
+    queryClient.invalidateQueries({ queryKey: bottleDetailsKey });
+
+  const addBarcode = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+
+    const volume = packageSize ? Number(packageSize) : null;
+    if (volume !== null && (!Number.isInteger(volume) || volume <= 0)) {
+      setError("Package size must be a positive whole number.");
+      return;
+    }
+
+    try {
+      await addMutation.mutateAsync({
+        bottle: bottleId,
+        barcode,
+        volume,
+      });
+      await refreshBottle();
+      setBarcode("");
+      setPackageSize("");
+      setShowForm(false);
+      flash("Barcode added.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to add barcode.");
+    }
+  };
+
+  const removeBarcode = async (item: Barcode) => {
+    setError(null);
+    try {
+      await removeMutation.mutateAsync({ barcode: item.value });
+      await refreshBottle();
+      flash("Barcode removed.");
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Unable to remove barcode.",
+      );
+    }
+  };
+
+  return (
+    <section className="my-6">
+      <Heading as="h3">Product barcodes</Heading>
+      {barcodes.length ? (
+        <BottleBarcodeItems
+          barcodes={barcodes}
+          onRemove={canEdit ? removeBarcode : undefined}
+          removing={removeMutation.isPending}
+        />
+      ) : (
+        <p className="text-muted mb-4">No barcodes have been added.</p>
+      )}
+
+      {error ? (
+        <div className="mb-4">
+          <Alert noMargin>{error}</Alert>
+        </div>
+      ) : null}
+
+      {canEdit && showForm ? (
+        <form
+          className="flex flex-col border border-slate-800 sm:flex-row sm:items-start"
+          onSubmit={addBarcode}
+        >
+          <TextField
+            name="barcode"
+            label="Barcode number"
+            helpText="Enter the number printed below the barcode."
+            inputMode="numeric"
+            autoComplete="off"
+            required
+            value={barcode}
+            onChange={(event) => {
+              if ("value" in event.currentTarget) {
+                setBarcode(String(event.currentTarget.value));
+              }
+            }}
+            className="flex-1"
+          />
+          <TextField
+            name="package-size"
+            label="Package size (mL)"
+            type="number"
+            inputMode="numeric"
+            min="1"
+            step="1"
+            value={packageSize}
+            onChange={(event) => {
+              if ("value" in event.currentTarget) {
+                setPackageSize(String(event.currentTarget.value));
+              }
+            }}
+            className="sm:w-48"
+          />
+          <div className="flex gap-2 p-4 sm:mt-5">
+            <Button
+              type="submit"
+              color="primary"
+              disabled={!barcode.trim() || addMutation.isPending}
+              loading={addMutation.isPending}
+            >
+              Add barcode
+            </Button>
+            <Button
+              onClick={() => {
+                setShowForm(false);
+                setError(null);
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        </form>
+      ) : canEdit ? (
+        <Button onClick={() => setShowForm(true)} size="small">
+          Add barcode
+        </Button>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/bottleOverview.tsx
+++ b/apps/web/src/components/bottleOverview.tsx
@@ -5,6 +5,7 @@ import RobotImage from "@peated/web/assets/robot.png";
 import Link from "@peated/web/components/link";
 import { Suspense } from "react";
 import AdvancedRatingDisplay from "./advancedRatingDisplay";
+import BottleBarcodes from "./bottleBarcodes";
 import BottleReviews from "./bottleReviews";
 import BottleTagDistribution from "./bottleTagDistribution";
 import CaskDetails from "./caskDetails";
@@ -200,6 +201,7 @@ export default function BottleOverview({
                 </>
               )}
             </DefinitionList>
+            <BottleBarcodes bottleId={bottle.id} barcodes={bottle.barcodes} />
           </div>
           <div className="hidden w-64 lg:block">
             {bottle.imageUrl ? (


### PR DESCRIPTION
Bottle detail responses now include product barcodes as narrow `value` and optional `volume` views. Bottle overview pages show these barcodes publicly, and moderators can add or remove them inline with validation and confirmation.

Retailer barcode claims remain separate. Package size stays optional packaging metadata and does not affect Bottle identity. This reuses the existing barcode table, lookup routes, and moderator permissions, so no migration is required.