### PR TITLE
feat(api): Expose entity totals by kind

### DIFF
--- a/apps/server/src/orpc/routes/stats.test.ts
+++ b/apps/server/src/orpc/routes/stats.test.ts
@@ -20,6 +20,26 @@ describe("GET /stats", () => {
     expect(data.totalEntities).toBe(Number(totalEntities));
   });
 
+  test("returns entity totals by kind", async ({ fixtures }) => {
+    await fixtures.Entity({ name: "Stats Brand", kind: "brand" });
+    await fixtures.Entity({ name: "Stats Distillery", kind: "distillery" });
+    await fixtures.Entity({ name: "Stats Bottler", kind: "bottler" });
+    await fixtures.Entity({ name: "Stats Blender", kind: "blender" });
+    await fixtures.Entity({ name: "Stats Company", kind: "company" });
+    await fixtures.Entity({ name: "Stats Unclassified", kind: null });
+
+    const data = await routerClient.stats();
+
+    expect(data).toMatchObject({
+      totalEntities: 6,
+      totalBrands: 1,
+      totalDistilleries: 1,
+      totalBottlers: 1,
+      totalBlenders: 1,
+      totalCompanies: 1,
+    });
+  });
+
   test("counts each active independently complete Bottle", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/stats.ts
+++ b/apps/server/src/orpc/routes/stats.ts
@@ -26,6 +26,11 @@ export default procedure
       totalTastings: z.number(),
       totalBottles: z.number(),
       totalEntities: z.number(),
+      totalBrands: z.number(),
+      totalDistilleries: z.number(),
+      totalBottlers: z.number(),
+      totalBlenders: z.number(),
+      totalCompanies: z.number(),
     }),
   )
   .handler(async function () {
@@ -47,15 +52,25 @@ export default procedure
         ),
       );
 
-    const [{ totalEntities }] = await db
+    const [entityTotals] = await db
       .select({
         totalEntities: sql<string>`COUNT(${entities.id})`,
+        totalBrands: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'brand')`,
+        totalDistilleries: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'distillery')`,
+        totalBottlers: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'bottler')`,
+        totalBlenders: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'blender')`,
+        totalCompanies: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'company')`,
       })
       .from(entities);
 
     return {
       totalTastings: Number(totalTastings),
       totalBottles: Number(totalBottles),
-      totalEntities: Number(totalEntities),
+      totalEntities: Number(entityTotals.totalEntities),
+      totalBrands: Number(entityTotals.totalBrands),
+      totalDistilleries: Number(entityTotals.totalDistilleries),
+      totalBottlers: Number(entityTotals.totalBottlers),
+      totalBlenders: Number(entityTotals.totalBlenders),
+      totalCompanies: Number(entityTotals.totalCompanies),
     };
   });


### PR DESCRIPTION
The `/stats` response now includes totals for brands, distilleries, bottlers,
blenders, and companies. Each total uses the entity `kind`, while the existing
`totalEntities` field continues to include unclassified entities.

Route coverage verifies every supported kind and the unchanged handling of an
entity with a null kind.
