### PR TITLE
feat(api): Add public recent critic reviews feed

### DIFF
--- a/apps/server/src/orpc/routes/reviews/list.test.ts
+++ b/apps/server/src/orpc/routes/reviews/list.test.ts
@@ -117,6 +117,148 @@ describe("GET /reviews", () => {
     expect(publicResults.results.map(({ id }) => id)).not.toContain(review.id);
   });
 
+  test("lists recent public reviews by publication date", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle({
+      imageUrl: "/media/springbank-12.jpg",
+      releaseYear: 2026,
+      statedAge: 12,
+    });
+    const site = await fixtures.ExternalSite({
+      name: "Whisky Advocate",
+      type: "whiskyadvocate",
+    });
+    await fixtures.EnabledExternalReviewSourcePolicy({
+      externalSiteId: site.id,
+      publicationMode: "automatic",
+    });
+    const older = await fixtures.Review({
+      bottleId: bottle.id,
+      externalSiteId: site.id,
+      url: "https://example.com/older-review",
+    });
+    const firstAtLatestDate = await fixtures.Review({
+      bottleId: bottle.id,
+      externalSiteId: site.id,
+      url: "https://example.com/first-latest-review",
+    });
+    const latest = await fixtures.Review({
+      bottleId: bottle.id,
+      externalSiteId: site.id,
+      url: "https://example.com/latest-review",
+      rating: 84,
+      reviewerName: "A. Critic",
+      nativeScoreValue: 8.4,
+      nativeScoreScale: 10,
+      nativeScoreDisplay: "8.4/10",
+      summary: "A balanced whisky with coastal smoke and a long finish.",
+      summaryContentHash: "latest-content",
+      summaryModel: "summary-model",
+      summaryPromptVersion: "v1",
+      summaryGeneratedAt: new Date("2026-08-24T00:00:00.000Z"),
+    });
+    await Promise.all([
+      db
+        .update(reviewArticles)
+        .set({
+          contentHash: "older-content",
+          publishedAt: new Date("2026-08-22T00:00:00.000Z"),
+        })
+        .where(eq(reviewArticles.id, older.articleId!)),
+      db
+        .update(reviewArticles)
+        .set({
+          contentHash: "first-latest-content",
+          publishedAt: new Date("2026-08-23T00:00:00.000Z"),
+        })
+        .where(eq(reviewArticles.id, firstAtLatestDate.articleId!)),
+      db
+        .update(reviewArticles)
+        .set({
+          title: "Springbank 12 Year Old Cask Strength review",
+          contentHash: "latest-content",
+          publishedAt: new Date("2026-08-23T00:00:00.000Z"),
+        })
+        .where(eq(reviewArticles.id, latest.articleId!)),
+    ]);
+
+    const hidden = await fixtures.Review({
+      bottleId: bottle.id,
+      externalSiteId: site.id,
+      hidden: true,
+    });
+    const unresolved = await fixtures.Review({
+      bottleId: null,
+      externalSiteId: site.id,
+      name: "Unresolved review",
+    });
+    const unpublished = await fixtures.Review({
+      bottleId: bottle.id,
+      externalSiteId: site.id,
+    });
+    const reviewOnlySite = await fixtures.ExternalSite({ type: "dramface" });
+    await fixtures.EnabledExternalReviewSourcePolicy({
+      externalSiteId: reviewOnlySite.id,
+    });
+    const reviewOnly = await fixtures.Review({
+      bottleId: bottle.id,
+      externalSiteId: reviewOnlySite.id,
+    });
+    await Promise.all(
+      [hidden, unresolved, reviewOnly].map((review) =>
+        db
+          .update(reviewArticles)
+          .set({
+            contentHash: `content-${review.id}`,
+            publishedAt: new Date("2026-08-24T00:00:00.000Z"),
+          })
+          .where(eq(reviewArticles.id, review.articleId!)),
+      ),
+    );
+    await db
+      .update(reviewArticles)
+      .set({ contentHash: `content-${unpublished.id}` })
+      .where(eq(reviewArticles.id, unpublished.articleId!));
+
+    const firstPage = await routerClient.reviews.list({
+      recent: true,
+      limit: 2,
+    });
+    const secondPage = await routerClient.reviews.list({
+      recent: true,
+      cursor: 2,
+      limit: 2,
+    });
+
+    expect(firstPage.results.map(({ id }) => id)).toEqual([
+      latest.id,
+      firstAtLatestDate.id,
+    ]);
+    expect(firstPage.results[0]).toMatchObject({
+      url: "https://example.com/latest-review",
+      rating: 84,
+      site: { id: site.id, name: "Whisky Advocate" },
+      reviewerName: "A. Critic",
+      article: {
+        title: "Springbank 12 Year Old Cask Strength review",
+        publishedAt: "2026-08-23T00:00:00.000Z",
+      },
+      nativeScore: { value: 8.4, scale: 10, display: "8.4/10" },
+      summary: "A balanced whisky with coastal smoke and a long finish.",
+      bottle: {
+        id: bottle.id,
+        fullName: bottle.fullName,
+        imageUrl: expect.stringContaining("/media/springbank-12.jpg"),
+        releaseYear: 2026,
+        statedAge: 12,
+      },
+    });
+    expect(firstPage.rel).toEqual({ nextCursor: 2, prevCursor: null });
+    expect(secondPage.results.map(({ id }) => id)).toEqual([older.id]);
+    expect(secondPage.rel).toEqual({ nextCursor: null, prevCursor: 1 });
+  });
+
   test("uses article-owned source and URL metadata", async ({ fixtures }) => {
     const user = await fixtures.User({ mod: true });
     const articleSite = await fixtures.ExternalSite({

--- a/apps/server/src/orpc/routes/reviews/list.test.ts
+++ b/apps/server/src/orpc/routes/reviews/list.test.ts
@@ -17,7 +17,7 @@ describe("GET /reviews", () => {
     await fixtures.Review({ externalSiteId: site.id });
 
     const { results } = await routerClient.reviews.list(
-      {},
+      { sort: "name" },
       { context: { user } },
     );
 
@@ -46,7 +46,10 @@ describe("GET /reviews", () => {
       .select({ count: sql<number>`COUNT(*)::int` })
       .from(actors);
 
-    await routerClient.reviews.list({}, { context: { user: currentUser } });
+    await routerClient.reviews.list(
+      { sort: "name" },
+      { context: { user: currentUser } },
+    );
 
     const [{ count: after }] = await db
       .select({ count: sql<number>`COUNT(*)::int` })
@@ -63,7 +66,7 @@ describe("GET /reviews", () => {
     const user = await fixtures.User();
 
     const err = await waitError(
-      routerClient.reviews.list({}, { context: { user } }),
+      routerClient.reviews.list({ sort: "name" }, { context: { user } }),
     );
     expect(err).toMatchInlineSnapshot(
       `[Error: Must be a moderator to list all reviews.]`,
@@ -85,6 +88,7 @@ describe("GET /reviews", () => {
     const { results } = await routerClient.reviews.list(
       {
         site: astorwine.type,
+        sort: "name",
       },
       { context: { user } },
     );
@@ -106,11 +110,12 @@ describe("GET /reviews", () => {
     });
 
     const moderatorResults = await routerClient.reviews.list(
-      { site: site.type },
+      { site: site.type, sort: "name" },
       { context: { user } },
     );
     const publicResults = await routerClient.reviews.list({
       bottle: bottle.id,
+      sort: "name",
     });
 
     expect(moderatorResults.results.map(({ id }) => id)).toContain(review.id);
@@ -222,11 +227,10 @@ describe("GET /reviews", () => {
       .where(eq(reviewArticles.id, unpublished.articleId!));
 
     const firstPage = await routerClient.reviews.list({
-      recent: true,
       limit: 2,
     });
     const secondPage = await routerClient.reviews.list({
-      recent: true,
+      sort: "recent",
       cursor: 2,
       limit: 2,
     });
@@ -270,15 +274,15 @@ describe("GET /reviews", () => {
       url: "https://example.com/article-owned-review",
     });
     const articleResults = await routerClient.reviews.list(
-      { site: articleSite.type },
+      { site: articleSite.type, sort: "name" },
       { context: { user } },
     );
     const otherResults = await routerClient.reviews.list(
-      { site: otherSite.type },
+      { site: otherSite.type, sort: "name" },
       { context: { user } },
     );
     const allResults = await routerClient.reviews.list(
-      {},
+      { sort: "name" },
       { context: { user } },
     );
 
@@ -332,6 +336,7 @@ describe("GET /reviews", () => {
 
     const { results } = await routerClient.reviews.list({
       bottle: bottle.id,
+      sort: "name",
     });
 
     expect(results).toMatchObject([
@@ -362,6 +367,7 @@ describe("GET /reviews", () => {
 
     const { results } = await routerClient.reviews.list({
       bottle: bottle.id,
+      sort: "name",
     });
 
     expect(results.map(({ id }) => id)).toContain(review.id);
@@ -405,6 +411,7 @@ describe("GET /reviews", () => {
 
     const contentRevoked = await routerClient.reviews.list({
       bottle: bottle.id,
+      sort: "name",
     });
     expect(contentRevoked.results).toMatchObject([
       { id: review.id, nativeScore: null, summary: null },
@@ -416,7 +423,7 @@ describe("GET /reviews", () => {
       .where(eq(externalReviewSourcePolicies.externalSiteId, site.id));
 
     await expect(
-      routerClient.reviews.list({ bottle: bottle.id }),
+      routerClient.reviews.list({ bottle: bottle.id, sort: "name" }),
     ).resolves.toMatchObject({ results: [] });
   });
 
@@ -440,7 +447,10 @@ describe("GET /reviews", () => {
       issue: "Other Bottle review",
     });
 
-    const { results } = await routerClient.reviews.list({ bottle: bottle.id });
+    const { results } = await routerClient.reviews.list({
+      bottle: bottle.id,
+      sort: "name",
+    });
 
     expect(results.map(({ id }) => id)).toEqual(
       expect.arrayContaining([firstDirect.id, secondDirect.id]),
@@ -487,15 +497,18 @@ describe("GET /reviews", () => {
 
     const firstPage = await routerClient.reviews.list({
       bottle: bottle.id,
+      sort: "name",
       limit: 1,
     });
     const secondPage = await routerClient.reviews.list({
       bottle: bottle.id,
+      sort: "name",
       cursor: 2,
       limit: 1,
     });
     const thirdPage = await routerClient.reviews.list({
       bottle: bottle.id,
+      sort: "name",
       cursor: 3,
       limit: 1,
     });
@@ -513,7 +526,7 @@ describe("GET /reviews", () => {
 
   test("preserves empty Bottle-filter misses", async () => {
     await expect(
-      routerClient.reviews.list({ bottle: 999_999 }),
+      routerClient.reviews.list({ bottle: 999_999, sort: "name" }),
     ).resolves.toMatchObject({ results: [] });
   });
 
@@ -539,11 +552,11 @@ describe("GET /reviews", () => {
     });
 
     const unknownResults = await routerClient.reviews.list(
-      { onlyUnknown: true },
+      { onlyUnknown: true, sort: "name" },
       { context: { user } },
     );
     const allResults = await routerClient.reviews.list(
-      {},
+      { sort: "name" },
       { context: { user } },
     );
 
@@ -575,6 +588,7 @@ describe("GET /reviews", () => {
       routerClient.reviews.list({
         bottle: bottle.id,
         onlyUnknown: true,
+        sort: "name",
       }),
     );
     expect(err).toMatchInlineSnapshot(
@@ -590,6 +604,7 @@ describe("GET /reviews", () => {
       routerClient.reviews.list(
         {
           site: site.type,
+          sort: "name",
         },
         { context: { user } },
       ),

--- a/apps/server/src/orpc/routes/reviews/list.ts
+++ b/apps/server/src/orpc/routes/reviews/list.ts
@@ -18,23 +18,23 @@ import type { SQL } from "drizzle-orm";
 import { and, asc, desc, eq, ilike, isNotNull, isNull, or } from "drizzle-orm";
 import { z } from "zod";
 
+const DEFAULT_SORT = "recent";
+const SORT_OPTIONS = ["recent", "name"] as const;
+
 const InputSchema = z
   .object({
     site: ExternalSiteTypeEnum.optional(),
     bottle: z.coerce.number().gte(1).optional(),
-    recent: z.coerce
-      .boolean()
-      .default(false)
-      .describe("Return public reviews ordered by publication date"),
     query: z.string().default(""),
     onlyUnknown: z.coerce.boolean().optional(),
+    sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
     cursor: z.coerce.number().gte(1).default(1),
     limit: z.coerce.number().gte(1).lte(100).default(100),
   })
   .strict()
   .default({
     query: "",
-    recent: false,
+    sort: DEFAULT_SORT,
     cursor: 1,
     limit: 100,
   });
@@ -52,11 +52,11 @@ export default procedure
   // TODO(response-envelope): use helper to enable later switch to { data, meta }
   .output(listResponse(ReviewSchema))
   .handler(async function ({
-    input: { cursor, query, limit, ...input },
+    input: { cursor, query, limit, sort, ...input },
     context,
     errors,
   }) {
-    const hasPublicScope = input.bottle !== undefined || input.recent;
+    const hasPublicScope = input.bottle !== undefined || sort === "recent";
     const requiresModerator = input.onlyUnknown || !hasPublicScope;
     // This route owns review visibility. Public Bottle and recent queries
     // exclude staged reviews. Moderator queries include them for review and matching.
@@ -89,7 +89,7 @@ export default procedure
       );
     }
 
-    if (input.recent) {
+    if (sort === "recent") {
       baseWhere.push(
         isNotNull(reviews.bottleId),
         isNotNull(reviewArticles.publishedAt),
@@ -135,7 +135,7 @@ export default procedure
       .limit(limit + 1)
       .offset(offset)
       .orderBy(
-        ...(input.recent
+        ...(sort === "recent"
           ? [desc(reviewArticles.publishedAt), desc(reviews.id)]
           : [asc(reviews.name), asc(reviews.id)]),
       );
@@ -146,7 +146,7 @@ export default procedure
         ReviewSerializer,
         results.slice(0, limit),
         context.user,
-        input.site && !input.recent ? ["site"] : [],
+        input.site && sort !== "recent" ? ["site"] : [],
       ),
       rel: {
         nextCursor: results.length > limit ? cursor + 1 : null,

--- a/apps/server/src/orpc/routes/reviews/list.ts
+++ b/apps/server/src/orpc/routes/reviews/list.ts
@@ -15,13 +15,17 @@ import {
 import { serialize } from "@peated/server/serializers";
 import { ReviewSerializer } from "@peated/server/serializers/review";
 import type { SQL } from "drizzle-orm";
-import { and, asc, eq, ilike, isNull, or } from "drizzle-orm";
+import { and, asc, desc, eq, ilike, isNotNull, isNull, or } from "drizzle-orm";
 import { z } from "zod";
 
 const InputSchema = z
   .object({
     site: ExternalSiteTypeEnum.optional(),
     bottle: z.coerce.number().gte(1).optional(),
+    recent: z.coerce
+      .boolean()
+      .default(false)
+      .describe("Return public reviews ordered by publication date"),
     query: z.string().default(""),
     onlyUnknown: z.coerce.boolean().optional(),
     cursor: z.coerce.number().gte(1).default(1),
@@ -30,6 +34,7 @@ const InputSchema = z
   .strict()
   .default({
     query: "",
+    recent: false,
     cursor: 1,
     limit: 100,
   });
@@ -40,7 +45,7 @@ export default procedure
     path: "/reviews",
     summary: "List reviews",
     description:
-      "Retrieve reviews with filtering by site, bottle, and unknown status. Requires moderator privileges for full access",
+      "Retrieve reviews with filtering by site, Bottle, recent publication, and unknown status. Requires moderator privileges for full access",
     operationId: "listReviews",
   })
   .input(InputSchema)
@@ -51,10 +56,10 @@ export default procedure
     context,
     errors,
   }) {
-    const hasPublicScope = input.bottle !== undefined;
+    const hasPublicScope = input.bottle !== undefined || input.recent;
     const requiresModerator = input.onlyUnknown || !hasPublicScope;
-    // This route owns review visibility. Public Bottle queries exclude staged
-    // reviews. Moderator queries include them for review and matching.
+    // This route owns review visibility. Public Bottle and recent queries
+    // exclude staged reviews. Moderator queries include them for review and matching.
     const baseWhere: (SQL<unknown> | undefined)[] = requiresModerator
       ? []
       : [eq(reviews.hidden, false)];
@@ -81,6 +86,13 @@ export default procedure
           isNull(reviewArticles.contentHash),
           eq(externalReviewSourcePolicies.publicationMode, "automatic"),
         ),
+      );
+    }
+
+    if (input.recent) {
+      baseWhere.push(
+        isNotNull(reviews.bottleId),
+        isNotNull(reviewArticles.publishedAt),
       );
     }
 
@@ -122,7 +134,11 @@ export default procedure
       .where(and(...baseWhere, ...identityWhere))
       .limit(limit + 1)
       .offset(offset)
-      .orderBy(asc(reviews.name));
+      .orderBy(
+        ...(input.recent
+          ? [desc(reviewArticles.publishedAt), desc(reviews.id)]
+          : [asc(reviews.name), asc(reviews.id)]),
+      );
     const results = rows.map(({ review }) => review);
 
     return {
@@ -130,7 +146,7 @@ export default procedure
         ReviewSerializer,
         results.slice(0, limit),
         context.user,
-        input.site ? ["site"] : [],
+        input.site && !input.recent ? ["site"] : [],
       ),
       rel: {
         nextCursor: results.length > limit ? cursor + 1 : null,

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/reviews/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/reviews/page.tsx
@@ -16,6 +16,9 @@ export default function Page(props: {
   const { siteId } = params;
 
   const queryParams = useApiQueryParams({
+    defaults: {
+      sort: "name",
+    },
     overrides: {
       site: siteId,
     },

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/reviews/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/reviews/page.tsx
@@ -16,11 +16,9 @@ export default function Page(props: {
   const { siteId } = params;
 
   const queryParams = useApiQueryParams({
-    defaults: {
-      sort: "name",
-    },
     overrides: {
       site: siteId,
+      sort: "name",
     },
   });
 

--- a/apps/web/src/components/bottleReviews.tsx
+++ b/apps/web/src/components/bottleReviews.tsx
@@ -20,6 +20,7 @@ export default function BottleReviews({ bottleId }: { bottleId: number }) {
     orpc.reviews.list.queryOptions({
       input: {
         bottle: bottleId,
+        sort: "name",
       },
     }),
   );


### PR DESCRIPTION
`reviews.list` now defaults to `sort: "recent"` as the public Home critic-review feed. It returns only visible reviews from publicly enabled sources with a resolved Bottle and publication date, then orders them by publication date and review ID for deterministic pagination.

Callers can request `sort: "name"` for the existing moderator list or Bottle-scoped read. The Admin review page and Bottle review component set that sort explicitly, so their behavior is unchanged. Both sorts continue to use the existing review serializer and source-policy display checks for publication, Bottle release metadata, reviewer, native score, summary, and canonical article URL.

Fixes #751
