### PR TITLE
feat(api): Expand typed read-only mocks

### DIFF
--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -22,6 +22,9 @@ export const CATEGORY_LIST = [
 
 export const SERVING_STYLE_LIST = ["neat", "rocks", "splash"] as const;
 
+export const RESERVED_COLLECTION_SLUGS = ["default", "library"] as const;
+export type ReservedCollectionSlug = (typeof RESERVED_COLLECTION_SLUGS)[number];
+
 export const EXTERNAL_SITE_DEFINITIONS = {
   // Astor stays manual-only while its non-browser catalog behavior is checked.
   astorwines: { name: "Astor Wines", runEvery: null },

--- a/apps/server/src/lib/db.ts
+++ b/apps/server/src/lib/db.ts
@@ -4,6 +4,7 @@ import type { InferSelectModel, Table } from "drizzle-orm";
 import { and, eq, getTableColumns, inArray, ne, sql } from "drizzle-orm";
 import type { PgTableWithColumns, TableConfig } from "drizzle-orm/pg-core";
 import { z } from "zod";
+import type { ReservedCollectionSlug } from "../constants";
 import type { AnyDatabase } from "../db";
 import type { Collection, Entity, EntityType } from "../db/schema";
 import { changes, collections, entities, entityAliases } from "../db/schema";
@@ -31,9 +32,6 @@ const EntityInsertDataSchema = EntityUpsertDataSchema.omit({ id: true });
 type EntityUpsertData = z.input<typeof EntityUpsertDataSchema>;
 type EntityUpsertInput = number | EntityUpsertData;
 
-export const reservedCollectionSlugs = ["default", "library"] as const;
-
-export type ReservedCollectionSlug = (typeof reservedCollectionSlugs)[number];
 export type ReservedCollection = Pick<
   Collection,
   "id" | "createdById" | "name"

--- a/apps/server/src/orpc/contracts/collections/bottles/list.ts
+++ b/apps/server/src/orpc/contracts/collections/bottles/list.ts
@@ -1,0 +1,43 @@
+import { RESERVED_COLLECTION_SLUGS } from "@peated/server/constants";
+import {
+  CollectionBottleSchema,
+  CollectionBottleStatusSchema,
+  listResponse,
+} from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/users/{user}/collections/{collection}/bottles",
+    summary: "List collection bottles",
+    description: "Get bottles in a user's collection",
+    operationId: "listCollectionBottles",
+  })
+  .input(
+    z
+      .object({
+        collection: z.union([
+          z.enum(RESERVED_COLLECTION_SLUGS),
+          z.coerce.number(),
+        ]),
+        user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
+        query: z.coerce
+          .string()
+          .default("")
+          .describe("Search text only. Search operators are not supported."),
+        brand: z.coerce.number().nullish(),
+        distiller: z.coerce.number().nullish(),
+        bottle: z.number().int().positive().optional(),
+        status: z
+          .union([CollectionBottleStatusSchema, z.literal("unset")])
+          .optional(),
+        cursor: z.coerce.number().gte(1).default(1),
+        limit: z.coerce.number().gte(1).lte(100).default(25),
+      })
+      .strict(),
+  )
+  // TODO(response-envelope): Return { data, meta } when all list routes use the
+  // same wrapper.
+  .output(listResponse(CollectionBottleSchema));

--- a/apps/server/src/orpc/contracts/countries/details.ts
+++ b/apps/server/src/orpc/contracts/countries/details.ts
@@ -1,0 +1,16 @@
+import { CountrySchema, detailsResponse } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/countries/{country}",
+    summary: "Get country details",
+    description: "Get a country by its URL name",
+    operationId: "getCountry",
+  })
+  .input(z.object({ country: z.string() }))
+  // TODO(response-envelope): Return { data: ... } when all detail routes use the
+  // same wrapper.
+  .output(detailsResponse(CountrySchema));

--- a/apps/server/src/orpc/contracts/countries/list.ts
+++ b/apps/server/src/orpc/contracts/countries/list.ts
@@ -1,0 +1,37 @@
+import { CountrySchema, listResponse } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+const DEFAULT_SORT = "name";
+const SORT_OPTIONS = ["name", "bottles", "-name", "-bottles"] as const;
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/countries",
+    summary: "List countries",
+    description: "Find countries by name or bottle availability",
+    operationId: "listCountries",
+  })
+  .input(
+    z
+      .object({
+        query: z.string().default(""),
+        cursor: z.coerce.number().gte(1).default(1),
+        limit: z.coerce.number().gte(1).lte(100).default(100),
+        sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
+        onlyMajor: z.coerce.boolean().default(false),
+        hasBottles: z.coerce.boolean().default(false),
+      })
+      .default({
+        query: "",
+        cursor: 1,
+        limit: 100,
+        sort: DEFAULT_SORT,
+        onlyMajor: false,
+        hasBottles: false,
+      }),
+  )
+  // TODO(response-envelope): Return { data, meta } when all list routes use the
+  // same wrapper.
+  .output(listResponse(CountrySchema));

--- a/apps/server/src/orpc/contracts/entities/details.ts
+++ b/apps/server/src/orpc/contracts/entities/details.ts
@@ -1,0 +1,16 @@
+import { detailsResponse, EntitySchema } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/entities/{entity}",
+    summary: "Get entity details",
+    description: "Get a brand, distillery, or bottler",
+    operationId: "getEntity",
+  })
+  .input(z.object({ entity: z.coerce.number() }))
+  // TODO(response-envelope): Return { data: ... } when all detail routes use the
+  // same wrapper.
+  .output(detailsResponse(EntitySchema));

--- a/apps/server/src/orpc/contracts/regions/details.ts
+++ b/apps/server/src/orpc/contracts/regions/details.ts
@@ -1,0 +1,21 @@
+import { detailsResponse, RegionSchema } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/countries/{country}/regions/{region}",
+    summary: "Get region details",
+    description: "Get a region by its country and URL name",
+    operationId: "getRegion",
+  })
+  .input(
+    z.object({
+      region: z.string(),
+      country: z.string(),
+    }),
+  )
+  // TODO(response-envelope): Return { data: ... } when all detail routes use the
+  // same wrapper.
+  .output(detailsResponse(RegionSchema));

--- a/apps/server/src/orpc/contracts/regions/list.ts
+++ b/apps/server/src/orpc/contracts/regions/list.ts
@@ -1,0 +1,26 @@
+import { RegionSchema, listResponse } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+const DEFAULT_SORT = "name";
+const SORT_OPTIONS = ["name", "bottles", "-name", "-bottles"] as const;
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/countries/{country}/regions",
+    summary: "List regions",
+    description: "Find regions in a country by name or bottle availability",
+    operationId: "listRegions",
+  })
+  .input(
+    z.object({
+      country: z.string(),
+      query: z.string().default(""),
+      cursor: z.coerce.number().gte(1).default(1),
+      limit: z.coerce.number().gte(1).lte(100).default(100),
+      sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
+      hasBottles: z.coerce.boolean().default(false),
+    }),
+  )
+  .output(listResponse(RegionSchema));

--- a/apps/server/src/orpc/contracts/tastings/details.ts
+++ b/apps/server/src/orpc/contracts/tastings/details.ts
@@ -1,0 +1,16 @@
+import { detailsResponse, TastingSchema } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/tastings/{tasting}",
+    summary: "Get tasting details",
+    description: "Get one tasting",
+    operationId: "getTasting",
+  })
+  .input(z.object({ tasting: z.coerce.number() }))
+  // TODO(response-envelope): Return { data: ... } when all detail routes use the
+  // same wrapper.
+  .output(detailsResponse(TastingSchema));

--- a/apps/server/src/orpc/contracts/tastings/list.ts
+++ b/apps/server/src/orpc/contracts/tastings/list.ts
@@ -1,0 +1,34 @@
+import { listResponse, TastingSchema } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/tastings",
+    summary: "List tastings",
+    description: "Find tastings by bottle, entity, user, or feed",
+    operationId: "listTastings",
+  })
+  .input(
+    z
+      .object({
+        bottle: z.coerce.number().int().positive().optional(),
+        entity: z.coerce.number().optional(),
+        user: z
+          .union([z.coerce.number(), z.literal("me"), z.string()])
+          .optional(),
+        filter: z.enum(["global", "friends", "local"]).default("global"),
+        cursor: z.coerce.number().gte(1).default(1),
+        limit: z.coerce.number().gte(1).lte(100).default(25),
+      })
+      .strict()
+      .default({
+        filter: "global",
+        cursor: 1,
+        limit: 25,
+      }),
+  )
+  // TODO(response-envelope): Return { data, meta } when all list routes use the
+  // same wrapper.
+  .output(listResponse(TastingSchema));

--- a/apps/server/src/orpc/mock/contract.ts
+++ b/apps/server/src/orpc/mock/contract.ts
@@ -3,9 +3,17 @@ import activityList from "@peated/server/orpc/contracts/activity/list";
 import login from "@peated/server/orpc/contracts/auth/login";
 import bottleDetails from "@peated/server/orpc/contracts/bottles/details";
 import bottleList from "@peated/server/orpc/contracts/bottles/list";
+import collectionBottleList from "@peated/server/orpc/contracts/collections/bottles/list";
+import countryDetails from "@peated/server/orpc/contracts/countries/details";
+import countryList from "@peated/server/orpc/contracts/countries/list";
+import entityDetails from "@peated/server/orpc/contracts/entities/details";
 import entityList from "@peated/server/orpc/contracts/entities/list";
+import regionDetails from "@peated/server/orpc/contracts/regions/details";
+import regionList from "@peated/server/orpc/contracts/regions/list";
 import root from "@peated/server/orpc/contracts/root";
 import search from "@peated/server/orpc/contracts/search";
+import tastingDetails from "@peated/server/orpc/contracts/tastings/details";
+import tastingList from "@peated/server/orpc/contracts/tastings/list";
 import userDetails from "@peated/server/orpc/contracts/users/details";
 
 // The mock API supports only the routes listed here.
@@ -22,8 +30,26 @@ export const mockContract = {
     details: bottleDetails,
     list: bottleList,
   },
+  collections: {
+    bottles: {
+      list: collectionBottleList,
+    },
+  },
+  countries: {
+    details: countryDetails,
+    list: countryList,
+  },
   entities: {
+    details: entityDetails,
     list: entityList,
+  },
+  regions: {
+    details: regionDetails,
+    list: regionList,
+  },
+  tastings: {
+    details: tastingDetails,
+    list: tastingList,
   },
   users: {
     details: userDetails,

--- a/apps/server/src/orpc/mock/fixtures.ts
+++ b/apps/server/src/orpc/mock/fixtures.ts
@@ -1,7 +1,12 @@
 import type { MockOutputs } from "./contract";
 
 type Bottle = MockOutputs["bottles"]["list"]["results"][number];
+type CollectionBottle =
+  MockOutputs["collections"]["bottles"]["list"]["results"][number];
+type Country = MockOutputs["countries"]["details"];
 type Entity = MockOutputs["entities"]["list"]["results"][number];
+type Region = MockOutputs["regions"]["details"];
+type Tasting = MockOutputs["tastings"]["details"];
 type User = MockOutputs["auth"]["login"]["user"];
 
 const timestamp = "2026-08-26T12:00:00.000Z";
@@ -56,6 +61,28 @@ export function mockUserDetailsFor(user: User | null) {
   return user ? mockUserDetails : mockPublicUserDetails;
 }
 
+export const mockCountry = {
+  id: 9401,
+  name: "Scotland",
+  slug: "scotland",
+  description: "A major whisky-producing country.",
+  summary: "Home to distinct whisky regions and styles.",
+  location: [-4.2, 56.5],
+  totalBottles: 8200,
+  totalDistillers: 150,
+} satisfies Country;
+
+export const mockRegion = {
+  id: 9501,
+  name: "Islay",
+  slug: "islay",
+  country: mockCountry,
+  description: "An island region known for smoky single malt whisky.",
+  location: [-6.2, 55.8],
+  totalBottles: 680,
+  totalDistillers: 10,
+} satisfies Region;
+
 export const mockEntity = {
   id: 9201,
   peatedId: "E9201",
@@ -68,8 +95,8 @@ export const mockEntity = {
   descriptionSrc: "user",
   yearEstablished: 1816,
   website: "https://www.malts.com/en-row/distilleries/lagavulin",
-  country: null,
-  region: null,
+  country: mockCountry,
+  region: mockRegion,
   address: null,
   location: null,
   totalTastings: 1200,
@@ -163,6 +190,41 @@ export function mockBottleDetailsFor(
     ...mockBottleFor(user),
   };
 }
+
+export const mockTasting = {
+  id: 9601,
+  imageUrl: null,
+  notes: "Smoke, dried fruit, sea salt, and a long finish.",
+  bottle: mockBottle,
+  rating: 2,
+  score: null,
+  tags: ["smoke", "dried fruit", "sea salt"],
+  color: 14,
+  servingStyle: "neat",
+  friends: [],
+  awards: [],
+  comments: 2,
+  toasts: 5,
+  hasToasted: false,
+  createdAt: timestamp,
+  createdBy: mockPublicUser,
+} satisfies Tasting;
+
+export function mockTastingFor(user: User | null): Tasting {
+  return {
+    ...mockTasting,
+    bottle: mockBottleFor(user),
+    hasToasted: Boolean(user),
+  };
+}
+
+export const mockCollectionBottle = {
+  id: 9701,
+  imageUrl: null,
+  status: "open",
+  bottle: mockBottle,
+  hasTasted: true,
+} satisfies CollectionBottle;
 
 export const noMorePages = {
   nextCursor: null,

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -2,8 +2,12 @@ import { createRouterClient } from "@orpc/server";
 import {
   mockAccessToken,
   mockBottle,
+  mockCollectionBottle,
+  mockCountry,
   mockEntity,
   mockPublicUserDetails,
+  mockRegion,
+  mockTasting,
   mockUser,
   mockUserDetails,
 } from "./fixtures";
@@ -40,6 +44,101 @@ describe("mock oRPC router", () => {
 
     const user = await authenticatedClient.users.details({ user: "me" });
     expect(user.id).toBe(mockUser.id);
+  });
+
+  it("covers the main read-only page data", async () => {
+    await expect(
+      anonymousClient.entities.details({ entity: mockEntity.id }),
+    ).resolves.toEqual(mockEntity);
+    await expect(
+      anonymousClient.countries.details({ country: mockCountry.slug }),
+    ).resolves.toEqual(mockCountry);
+    await expect(
+      anonymousClient.regions.details({
+        country: mockCountry.slug,
+        region: mockRegion.slug,
+      }),
+    ).resolves.toEqual(mockRegion);
+    await expect(
+      anonymousClient.tastings.details({ tasting: mockTasting.id }),
+    ).resolves.toEqual(mockTasting);
+
+    const countries = await anonymousClient.countries.list({});
+    expect(countries.results).toEqual([mockCountry]);
+
+    const regions = await anonymousClient.regions.list({
+      country: mockCountry.slug,
+    });
+    expect(regions.results).toEqual([mockRegion]);
+
+    const tastings = await anonymousClient.tastings.list({
+      bottle: mockBottle.id,
+    });
+    expect(tastings.results).toEqual([mockTasting]);
+
+    const collection = await anonymousClient.collections.bottles.list({
+      collection: "library",
+      user: mockUser.username,
+    });
+    expect(collection.results).toEqual([
+      {
+        ...mockCollectionBottle,
+        bottle: mockBottle,
+        hasTasted: false,
+      },
+    ]);
+  });
+
+  it("applies read-only filters without saving state", async () => {
+    await expect(
+      anonymousClient.countries.list({ query: "Japan" }),
+    ).resolves.toMatchObject({ results: [] });
+    await expect(
+      anonymousClient.regions.list({
+        country: mockCountry.slug,
+        query: "Speyside",
+      }),
+    ).resolves.toMatchObject({ results: [] });
+    await expect(
+      anonymousClient.tastings.list({ bottle: 9999 }),
+    ).resolves.toMatchObject({ results: [] });
+    await expect(
+      anonymousClient.collections.bottles.list({
+        collection: "library",
+        user: mockUser.username,
+        status: "sealed",
+      }),
+    ).resolves.toMatchObject({ results: [] });
+  });
+
+  it("keeps signed-in read filters protected", async () => {
+    await expect(
+      anonymousClient.tastings.list({ filter: "friends" }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+    await expect(
+      anonymousClient.collections.bottles.list({
+        collection: "library",
+        user: "me",
+      }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+
+    await expect(
+      authenticatedClient.collections.bottles.list({
+        collection: "library",
+        user: "me",
+      }),
+    ).resolves.toMatchObject({
+      results: [
+        {
+          bottle: {
+            isFavorite: true,
+            isLibrary: true,
+            hasTasted: true,
+          },
+          hasTasted: true,
+        },
+      ],
+    });
   });
 
   it("returns no results when the fixed data does not match", async () => {

--- a/apps/server/src/orpc/mock/router.ts
+++ b/apps/server/src/orpc/mock/router.ts
@@ -3,9 +3,17 @@ import activityList from "./routes/activity/list";
 import login from "./routes/auth/login";
 import bottleDetails from "./routes/bottles/details";
 import bottleList from "./routes/bottles/list";
+import collectionBottleList from "./routes/collections/bottles/list";
+import countryDetails from "./routes/countries/details";
+import countryList from "./routes/countries/list";
+import entityDetails from "./routes/entities/details";
 import entityList from "./routes/entities/list";
+import regionDetails from "./routes/regions/details";
+import regionList from "./routes/regions/list";
 import root from "./routes/root";
 import search from "./routes/search";
+import tastingDetails from "./routes/tastings/details";
+import tastingList from "./routes/tastings/list";
 import userDetails from "./routes/users/details";
 
 // Requests for routes not listed here return 404 from the mock server.
@@ -22,8 +30,26 @@ export const mockRouter = mockOS.router({
     details: bottleDetails,
     list: bottleList,
   },
+  collections: {
+    bottles: {
+      list: collectionBottleList,
+    },
+  },
+  countries: {
+    details: countryDetails,
+    list: countryList,
+  },
   entities: {
+    details: entityDetails,
     list: entityList,
+  },
+  regions: {
+    details: regionDetails,
+    list: regionList,
+  },
+  tastings: {
+    details: tastingDetails,
+    list: tastingList,
   },
   users: {
     details: userDetails,

--- a/apps/server/src/orpc/mock/routes/collections/bottles/list.ts
+++ b/apps/server/src/orpc/mock/routes/collections/bottles/list.ts
@@ -1,0 +1,78 @@
+import {
+  includesQuery,
+  mockBottle,
+  mockBottleFor,
+  mockCollectionBottle,
+  mockEntity,
+  mockUser,
+  noMorePages,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+const mockCollectionId = 9801;
+
+export default mockOS.collections.bottles.list.handler(
+  async ({ input, context, errors }) => {
+    const userMatches =
+      input.user === "me"
+        ? Boolean(context.user)
+        : input.user === mockUser.id || input.user === mockUser.username;
+    if (!userMatches) {
+      throw errors.NOT_FOUND({ message: "Mock user not found." });
+    }
+
+    const isLibrary = input.collection === "library";
+    const isReserved =
+      input.collection === "library" || input.collection === "default";
+    if (!isReserved && input.collection !== mockCollectionId) {
+      throw errors.NOT_FOUND({ message: "Mock collection not found." });
+    }
+
+    if (
+      !isLibrary &&
+      (input.query ||
+        input.brand ||
+        input.distiller ||
+        (isReserved && input.status))
+    ) {
+      throw errors.BAD_REQUEST({
+        message: "Collection filters are only supported for Library.",
+      });
+    }
+    if (input.status && !isLibrary) {
+      throw errors.BAD_REQUEST({
+        message: "Status filtering is only supported for Library.",
+      });
+    }
+
+    const statusMatches =
+      input.status === undefined ||
+      input.status === mockCollectionBottle.status ||
+      (input.status === "unset" && mockCollectionBottle.status === null);
+    const matches =
+      includesQuery(
+        input.query,
+        mockBottle.fullName,
+        mockBottle.name,
+        mockEntity.name,
+      ) &&
+      (input.brand == null || input.brand === mockEntity.id) &&
+      (input.distiller == null || input.distiller === mockEntity.id) &&
+      (input.bottle === undefined || input.bottle === mockBottle.id) &&
+      statusMatches;
+
+    return {
+      results: matches
+        ? [
+            {
+              ...mockCollectionBottle,
+              status: isLibrary ? mockCollectionBottle.status : null,
+              bottle: mockBottleFor(context.user),
+              hasTasted: Boolean(context.user),
+            },
+          ]
+        : [],
+      rel: noMorePages,
+    };
+  },
+);

--- a/apps/server/src/orpc/mock/routes/countries/details.ts
+++ b/apps/server/src/orpc/mock/routes/countries/details.ts
@@ -1,0 +1,10 @@
+import { mockCountry } from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.countries.details.handler(async ({ input, errors }) => {
+  if (input.country.toLowerCase() !== mockCountry.slug) {
+    throw errors.NOT_FOUND({ message: "Mock country not found." });
+  }
+
+  return mockCountry;
+});

--- a/apps/server/src/orpc/mock/routes/countries/list.ts
+++ b/apps/server/src/orpc/mock/routes/countries/list.ts
@@ -1,0 +1,17 @@
+import {
+  includesQuery,
+  mockCountry,
+  noMorePages,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.countries.list.handler(async ({ input }) => {
+  const matches =
+    includesQuery(input.query, mockCountry.name, mockCountry.slug) &&
+    (!input.hasBottles || mockCountry.totalBottles > 0);
+
+  return {
+    results: matches ? [mockCountry] : [],
+    rel: noMorePages,
+  };
+});

--- a/apps/server/src/orpc/mock/routes/entities/details.ts
+++ b/apps/server/src/orpc/mock/routes/entities/details.ts
@@ -1,0 +1,10 @@
+import { mockEntity } from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.entities.details.handler(async ({ input, errors }) => {
+  if (input.entity !== mockEntity.id) {
+    throw errors.NOT_FOUND({ message: "Mock entity not found." });
+  }
+
+  return mockEntity;
+});

--- a/apps/server/src/orpc/mock/routes/regions/details.ts
+++ b/apps/server/src/orpc/mock/routes/regions/details.ts
@@ -1,0 +1,17 @@
+import { mockCountry, mockRegion } from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.regions.details.handler(async ({ input, errors }) => {
+  const countryMatches =
+    input.country.toLowerCase() === mockCountry.slug ||
+    Number(input.country) === mockCountry.id;
+  if (!countryMatches) {
+    throw errors.BAD_REQUEST({ message: "Invalid mock country." });
+  }
+
+  if (input.region.toLowerCase() !== mockRegion.slug) {
+    throw errors.NOT_FOUND({ message: "Mock region not found." });
+  }
+
+  return mockRegion;
+});

--- a/apps/server/src/orpc/mock/routes/regions/list.ts
+++ b/apps/server/src/orpc/mock/routes/regions/list.ts
@@ -1,0 +1,28 @@
+import {
+  includesQuery,
+  mockCountry,
+  mockRegion,
+  noMorePages,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+function matchesCountry(value: string) {
+  return (
+    value.toLowerCase() === mockCountry.slug || Number(value) === mockCountry.id
+  );
+}
+
+export default mockOS.regions.list.handler(async ({ input, errors }) => {
+  if (!matchesCountry(input.country)) {
+    throw errors.BAD_REQUEST({ message: "Invalid mock country." });
+  }
+
+  const matches =
+    includesQuery(input.query, mockRegion.name, mockRegion.slug) &&
+    (!input.hasBottles || mockRegion.totalBottles > 0);
+
+  return {
+    results: matches ? [mockRegion] : [],
+    rel: noMorePages,
+  };
+});

--- a/apps/server/src/orpc/mock/routes/tastings/details.ts
+++ b/apps/server/src/orpc/mock/routes/tastings/details.ts
@@ -1,0 +1,12 @@
+import { mockTasting, mockTastingFor } from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.tastings.details.handler(
+  async ({ input, context, errors }) => {
+    if (input.tasting !== mockTasting.id) {
+      throw errors.NOT_FOUND({ message: "Mock tasting not found." });
+    }
+
+    return mockTastingFor(context.user);
+  },
+);

--- a/apps/server/src/orpc/mock/routes/tastings/list.ts
+++ b/apps/server/src/orpc/mock/routes/tastings/list.ts
@@ -1,0 +1,39 @@
+import {
+  mockBottle,
+  mockEntity,
+  mockTastingFor,
+  mockUser,
+  noMorePages,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.tastings.list.handler(
+  async ({ input, context, errors }) => {
+    if (input.filter === "friends" && !context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+
+    if (input.user === "me" && !context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+
+    const userMatches =
+      input.user === undefined ||
+      input.user === "me" ||
+      input.user === mockUser.id ||
+      input.user === mockUser.username;
+    if (input.user !== undefined && !userMatches) {
+      throw errors.NOT_FOUND({ message: "Mock user not found." });
+    }
+
+    const matches =
+      userMatches &&
+      (input.bottle === undefined || input.bottle === mockBottle.id) &&
+      (input.entity === undefined || input.entity === mockEntity.id);
+
+    return {
+      results: matches ? [mockTastingFor(context.user)] : [],
+      rel: noMorePages,
+    };
+  },
+);

--- a/apps/server/src/orpc/routes/collections/bottles/create.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/create.ts
@@ -1,3 +1,4 @@
+import { RESERVED_COLLECTION_SLUGS } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import type { CollectionBottle } from "@peated/server/db/schema";
 import { collectionBottles, collections } from "@peated/server/db/schema";
@@ -5,7 +6,6 @@ import { getUserFromId } from "@peated/server/lib/api";
 import {
   getReservedCollection,
   isReservedCollectionSlug,
-  reservedCollectionSlugs,
 } from "@peated/server/lib/db";
 import { logError } from "@peated/server/lib/log";
 import { PendingUploadError } from "@peated/server/lib/pendingUploads";
@@ -35,7 +35,7 @@ import {
 } from "./imageHelpers";
 
 const CollectionBottleCreateFields = {
-  collection: z.union([z.enum(reservedCollectionSlugs), z.coerce.number()]),
+  collection: z.union([z.enum(RESERVED_COLLECTION_SLUGS), z.coerce.number()]),
   pendingImageId: z.string().trim().min(1).optional(),
   user: z.union([z.literal("me"), z.coerce.number(), z.string()]),
 } as const;

--- a/apps/server/src/orpc/routes/collections/bottles/delete.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/delete.ts
@@ -1,10 +1,10 @@
+import { RESERVED_COLLECTION_SLUGS } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import { collectionBottles, collections } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
 import {
   getReservedCollection,
   isReservedCollectionSlug,
-  reservedCollectionSlugs,
 } from "@peated/server/lib/db";
 import { procedure } from "@peated/server/orpc";
 import {
@@ -16,7 +16,7 @@ import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
 const CollectionBottleDeleteFields = {
-  collection: z.union([z.enum(reservedCollectionSlugs), z.coerce.number()]),
+  collection: z.union([z.enum(RESERVED_COLLECTION_SLUGS), z.coerce.number()]),
   user: z.union([z.literal("me"), z.coerce.number(), z.string()]),
 } as const;
 

--- a/apps/server/src/orpc/routes/collections/bottles/image-delete.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/image-delete.ts
@@ -1,10 +1,10 @@
+import { RESERVED_COLLECTION_SLUGS } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import { collectionBottles } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
 import {
   getReservedCollection,
   isReservedCollectionSlug,
-  reservedCollectionSlugs,
 } from "@peated/server/lib/db";
 import { procedure } from "@peated/server/orpc";
 import {
@@ -39,7 +39,10 @@ export default procedure
   })
   .input(
     z.object({
-      collection: z.union([z.enum(reservedCollectionSlugs), z.coerce.number()]),
+      collection: z.union([
+        z.enum(RESERVED_COLLECTION_SLUGS),
+        z.coerce.number(),
+      ]),
       collectionBottle: z.coerce.number(),
       user: z.union([z.literal("me"), z.coerce.number(), z.string()]),
     }),

--- a/apps/server/src/orpc/routes/collections/bottles/image-update.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/image-update.ts
@@ -1,10 +1,10 @@
+import { RESERVED_COLLECTION_SLUGS } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import { collectionBottles } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
 import {
   getReservedCollection,
   isReservedCollectionSlug,
-  reservedCollectionSlugs,
 } from "@peated/server/lib/db";
 import { PendingUploadError } from "@peated/server/lib/pendingUploads";
 import { procedure } from "@peated/server/orpc";
@@ -41,7 +41,10 @@ export default procedure
   })
   .input(
     z.object({
-      collection: z.union([z.enum(reservedCollectionSlugs), z.coerce.number()]),
+      collection: z.union([
+        z.enum(RESERVED_COLLECTION_SLUGS),
+        z.coerce.number(),
+      ]),
       collectionBottle: z.coerce.number(),
       pendingImageId: z.string().trim().min(1),
       user: z.union([z.literal("me"), z.coerce.number(), z.string()]),

--- a/apps/server/src/orpc/routes/collections/bottles/list.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/list.ts
@@ -9,15 +9,10 @@ import { getUserFromId, profileVisible } from "@peated/server/lib/api";
 import {
   getReservedCollection,
   isReservedCollectionSlug,
-  reservedCollectionSlugs,
 } from "@peated/server/lib/db";
 import { plainTextSearchQuery } from "@peated/server/lib/search";
-import { procedure } from "@peated/server/orpc";
-import {
-  CollectionBottleSchema,
-  CollectionBottleStatusSchema,
-  listResponse,
-} from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import collectionBottleListContract from "@peated/server/orpc/contracts/collections/bottles/list";
 import { serialize } from "@peated/server/serializers";
 import { CollectionBottleSerializer } from "@peated/server/serializers/collectionBottle";
 import type { SQL } from "drizzle-orm";
@@ -25,155 +20,123 @@ import { and, asc, eq, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
 import { isLibraryCollection } from "./collectionBottleHelpers";
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/users/{user}/collections/{collection}/bottles",
-    summary: "List collection bottles",
-    description:
-      "Retrieve bottles in a user's collection with pagination support. Respects privacy settings",
-    operationId: "listCollectionBottles",
-  })
-  .input(
-    z
-      .object({
-        collection: z.union([
-          z.enum(reservedCollectionSlugs),
-          z.coerce.number(),
-        ]),
-        user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
-        query: z.coerce
-          .string()
-          .default("")
-          .describe("Search text only. Search operators are not supported."),
-        brand: z.coerce.number().nullish(),
-        distiller: z.coerce.number().nullish(),
-        bottle: z.number().int().positive().optional(),
-        status: z
-          .union([CollectionBottleStatusSchema, z.literal("unset")])
-          .optional(),
-        cursor: z.coerce.number().gte(1).default(1),
-        limit: z.coerce.number().gte(1).lte(100).default(25),
-      })
-      .strict(),
-  )
-  // TODO(response-envelope): use helper to enable later switch to { data, meta }
-  .output(listResponse(CollectionBottleSchema))
-  .handler(async function ({ input, context, errors }) {
-    const { cursor, limit } = input;
+export default implement(collectionBottleListContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const { cursor, limit } = input;
 
-    const user = await getUserFromId(db, input.user, context.user);
-    if (!user) {
-      throw errors.NOT_FOUND({
-        message: "User not found.",
+  const user = await getUserFromId(db, input.user, context.user);
+  if (!user) {
+    throw errors.NOT_FOUND({
+      message: "User not found.",
+    });
+  }
+
+  if (!(await profileVisible(db, user, context.user))) {
+    throw errors.BAD_REQUEST({
+      message: "User's profile is private.",
+    });
+  }
+
+  const reservedCollection = isReservedCollectionSlug(input.collection)
+    ? input.collection
+    : null;
+  if (
+    reservedCollection !== "library" &&
+    (input.query ||
+      input.brand ||
+      input.distiller ||
+      (reservedCollection && input.status))
+  ) {
+    throw errors.BAD_REQUEST({
+      message: "Collection filters are only supported for Library.",
+    });
+  }
+  const collection = reservedCollection
+    ? await getReservedCollection(db, user.id, reservedCollection)
+    : await db.query.collections.findFirst({
+        where: (collections, { and, eq }) =>
+          and(
+            eq(collections.createdById, user.id),
+            eq(collections.id, z.number().parse(input.collection)),
+          ),
       });
+
+  if (!collection) {
+    if (reservedCollection) {
+      return {
+        results: [],
+        rel: {
+          nextCursor: null,
+          prevCursor: null,
+        },
+      };
     }
 
-    if (!(await profileVisible(db, user, context.user))) {
-      throw errors.BAD_REQUEST({
-        message: "User's profile is private.",
-      });
-    }
+    throw errors.NOT_FOUND({
+      message: "Collection not found.",
+    });
+  }
+  if (input.status && !isLibraryCollection(collection)) {
+    throw errors.BAD_REQUEST({
+      message: "Status filtering is only supported for Library.",
+    });
+  }
 
-    const reservedCollection = isReservedCollectionSlug(input.collection)
-      ? input.collection
-      : null;
-    if (
-      reservedCollection !== "library" &&
-      (input.query ||
-        input.brand ||
-        input.distiller ||
-        (reservedCollection && input.status))
-    ) {
-      throw errors.BAD_REQUEST({
-        message: "Collection filters are only supported for Library.",
-      });
-    }
-    const collection = reservedCollection
-      ? await getReservedCollection(db, user.id, reservedCollection)
-      : await db.query.collections.findFirst({
-          where: (collections, { and, eq }) =>
-            and(
-              eq(collections.createdById, user.id),
-              eq(collections.id, z.number().parse(input.collection)),
-            ),
-        });
+  const offset = (cursor - 1) * limit;
 
-    if (!collection) {
-      if (reservedCollection) {
-        return {
-          results: [],
-          rel: {
-            nextCursor: null,
-            prevCursor: null,
-          },
-        };
-      }
-
-      throw errors.NOT_FOUND({
-        message: "Collection not found.",
-      });
-    }
-    if (input.status && !isLibraryCollection(collection)) {
-      throw errors.BAD_REQUEST({
-        message: "Status filtering is only supported for Library.",
-      });
-    }
-
-    const offset = (cursor - 1) * limit;
-
-    const baseWhere: (SQL<unknown> | undefined)[] = [
-      eq(collectionBottles.collectionId, collection.id),
-    ];
-    if (input.query) {
-      baseWhere.push(
-        sql`EXISTS(
+  const baseWhere: (SQL<unknown> | undefined)[] = [
+    eq(collectionBottles.collectionId, collection.id),
+  ];
+  if (input.query) {
+    baseWhere.push(
+      sql`EXISTS(
           SELECT FROM ${bottleAliases}
           WHERE ${bottleAliases.bottleId} = ${collectionBottles.bottleId}
             AND LOWER(${bottleAliases.name}) = ${input.query.toLowerCase()}
             AND ${bottleAliases.ignored} IS NOT TRUE
         ) OR ${bottles.searchVector} @@ ${plainTextSearchQuery(input.query)}`,
-      );
-    }
-    if (input.brand) {
-      baseWhere.push(eq(bottles.brandId, input.brand));
-    }
-    if (input.distiller) {
-      baseWhere.push(sql`EXISTS(
+    );
+  }
+  if (input.brand) {
+    baseWhere.push(eq(bottles.brandId, input.brand));
+  }
+  if (input.distiller) {
+    baseWhere.push(sql`EXISTS(
         SELECT FROM ${bottlesToDistillers}
         WHERE ${bottlesToDistillers.distillerId} = ${input.distiller}
           AND ${bottlesToDistillers.bottleId} = ${collectionBottles.bottleId}
       )`);
-    }
-    if (input.bottle !== undefined) {
-      baseWhere.push(eq(collectionBottles.bottleId, input.bottle));
-    }
-    if (input.status === "unset") {
-      baseWhere.push(isNull(collectionBottles.status));
-    } else if (input.status) {
-      baseWhere.push(eq(collectionBottles.status, input.status));
-    }
+  }
+  if (input.bottle !== undefined) {
+    baseWhere.push(eq(collectionBottles.bottleId, input.bottle));
+  }
+  if (input.status === "unset") {
+    baseWhere.push(isNull(collectionBottles.status));
+  } else if (input.status) {
+    baseWhere.push(eq(collectionBottles.status, input.status));
+  }
 
-    const results = await db
-      .select({ collectionBottles })
-      .from(collectionBottles)
-      .leftJoin(bottles, eq(bottles.id, collectionBottles.bottleId))
-      .where(and(...baseWhere))
-      .limit(limit + 1)
-      .offset(offset)
-      .orderBy(asc(bottles.fullName), asc(collectionBottles.id));
+  const results = await db
+    .select({ collectionBottles })
+    .from(collectionBottles)
+    .leftJoin(bottles, eq(bottles.id, collectionBottles.bottleId))
+    .where(and(...baseWhere))
+    .limit(limit + 1)
+    .offset(offset)
+    .orderBy(asc(bottles.fullName), asc(collectionBottles.id));
 
-    return {
-      results: await serialize(
-        CollectionBottleSerializer,
-        results
-          .slice(0, limit)
-          .map(({ collectionBottles }) => collectionBottles),
-        context.user,
-      ),
-      rel: {
-        nextCursor: results.length > limit ? cursor + 1 : null,
-        prevCursor: cursor > 1 ? cursor - 1 : null,
-      },
-    };
-  });
+  return {
+    results: await serialize(
+      CollectionBottleSerializer,
+      results.slice(0, limit).map(({ collectionBottles }) => collectionBottles),
+      context.user,
+    ),
+    rel: {
+      nextCursor: results.length > limit ? cursor + 1 : null,
+      prevCursor: cursor > 1 ? cursor - 1 : null,
+    },
+  };
+});

--- a/apps/server/src/orpc/routes/collections/bottles/update.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/update.ts
@@ -1,10 +1,10 @@
+import { RESERVED_COLLECTION_SLUGS } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import { collectionBottles } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
 import {
   getReservedCollection,
   isReservedCollectionSlug,
-  reservedCollectionSlugs,
 } from "@peated/server/lib/db";
 import { procedure } from "@peated/server/orpc";
 import {
@@ -42,7 +42,10 @@ export default procedure
   })
   .input(
     z.object({
-      collection: z.union([z.enum(reservedCollectionSlugs), z.coerce.number()]),
+      collection: z.union([
+        z.enum(RESERVED_COLLECTION_SLUGS),
+        z.coerce.number(),
+      ]),
       collectionBottle: z.coerce.number(),
       status: CollectionBottleStatusSchema.nullable(),
       user: z.union([z.literal("me"), z.coerce.number(), z.string()]),

--- a/apps/server/src/orpc/routes/countries/details.ts
+++ b/apps/server/src/orpc/routes/countries/details.ts
@@ -1,40 +1,26 @@
-import { ORPCError } from "@orpc/server";
 import { db } from "@peated/server/db";
 import { countries } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
-import { CountrySchema, detailsResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import countryDetailsContract from "@peated/server/orpc/contracts/countries/details";
 import { serialize } from "@peated/server/serializers";
 import { CountrySerializer } from "@peated/server/serializers/country";
 import { eq, sql } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/countries/{country}",
-    summary: "Get country details",
-    description:
-      "Retrieve detailed information about a specific country using its slug",
-    operationId: "getCountry",
-  })
-  .input(
-    z.object({
-      country: z.string(),
-    }),
-  )
-  // TODO(response-envelope): wrap in { data } by updating detailsResponse() at cutover
-  .output(detailsResponse(CountrySchema))
-  .handler(async function ({ input, context, errors }) {
-    const [country] = await db
-      .select()
-      .from(countries)
-      .where(eq(sql`LOWER(${countries.slug})`, input.country.toLowerCase()));
+export default implement(countryDetailsContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const [country] = await db
+    .select()
+    .from(countries)
+    .where(eq(sql`LOWER(${countries.slug})`, input.country.toLowerCase()));
 
-    if (!country) {
-      throw errors.NOT_FOUND({
-        message: "Country not found.",
-      });
-    }
+  if (!country) {
+    throw errors.NOT_FOUND({
+      message: "Country not found.",
+    });
+  }
 
-    return await serialize(CountrySerializer, country, context.user);
-  });
+  return await serialize(CountrySerializer, country, context.user);
+});

--- a/apps/server/src/orpc/routes/countries/list.ts
+++ b/apps/server/src/orpc/routes/countries/list.ts
@@ -1,113 +1,69 @@
 import { MAJOR_COUNTRIES } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import { countries } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
-import { CountrySchema, listResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import countryListContract from "@peated/server/orpc/contracts/countries/list";
 import { serialize } from "@peated/server/serializers";
 import { CountrySerializer } from "@peated/server/serializers/country";
 import { and, asc, desc, ilike, inArray, ne, sql, type SQL } from "drizzle-orm";
-import { z } from "zod";
 
-const DEFAULT_SORT = "name";
+export default implement(countryListContract).handler(async function ({
+  input: { cursor, query, limit, ...input },
+  context,
+}) {
+  const where: (SQL<unknown> | undefined)[] = [];
 
-const SORT_OPTIONS = ["name", "bottles", "-name", "-bottles"] as const;
+  const offset = (cursor - 1) * limit;
+  if (query) {
+    where.push(ilike(countries.name, `%${query}%`));
+  }
 
-// Standardized paginated list response
-const OutputSchema = listResponse(CountrySchema);
+  if (input.hasBottles) {
+    where.push(ne(countries.totalBottles, 0));
+  }
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/countries",
-    summary: "List countries",
-    description:
-      "Retrieve countries with filtering by major whisky regions, bottle counts, and search support",
-    operationId: "listCountries",
-  })
-  .input(
-    z
-      .object({
-        query: z.string().default(""),
-        cursor: z.coerce.number().gte(1).default(1),
-        limit: z.coerce.number().gte(1).lte(100).default(100),
-        sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
-        onlyMajor: z.coerce.boolean().default(false),
-        hasBottles: z.coerce.boolean().default(false),
-      })
-      .default({
-        query: "",
-        cursor: 1,
-        limit: 100,
-        sort: DEFAULT_SORT,
-        onlyMajor: false,
-        hasBottles: false,
-      }),
-  )
-  // TODO(response-envelope): helper enables later switch to { data, meta }
-  .output(OutputSchema)
-  .handler(async function ({
-    input: { cursor, query, limit, ...input },
-    context,
-    errors,
-  }) {
-    const where: (SQL<unknown> | undefined)[] = [];
-
-    const offset = (cursor - 1) * limit;
-    if (query) {
-      where.push(ilike(countries.name, `%${query}%`));
-    }
-
-    if (input.hasBottles) {
-      where.push(ne(countries.totalBottles, 0));
-    }
-
-    if (input.onlyMajor) {
-      where.push(
-        inArray(
-          sql`LOWER(${countries.slug})`,
-          MAJOR_COUNTRIES.map(([, slug]) => slug),
-        ),
-      );
-    }
-
-    let orderBy: SQL<unknown>;
-    switch (input.sort) {
-      case "name":
-        orderBy = asc(countries.name);
-        break;
-      case "-name":
-        orderBy = desc(countries.name);
-        break;
-      case "bottles":
-        orderBy = asc(countries.totalBottles);
-        break;
-      case "-bottles":
-        orderBy = desc(countries.totalBottles);
-        break;
-      default:
-        // TODO: should be a schema validation error
-        throw errors.BAD_REQUEST({
-          message: `Invalid sort: ${input.sort}`,
-        });
-    }
-
-    const results = await db
-      .select()
-      .from(countries)
-      .where(where ? and(...where) : undefined)
-      .limit(limit + 1)
-      .offset(offset)
-      .orderBy(orderBy);
-
-    return {
-      results: await serialize(
-        CountrySerializer,
-        results.slice(0, limit),
-        context.user,
+  if (input.onlyMajor) {
+    where.push(
+      inArray(
+        sql`LOWER(${countries.slug})`,
+        MAJOR_COUNTRIES.map(([, slug]) => slug),
       ),
-      rel: {
-        nextCursor: results.length > limit ? cursor + 1 : null,
-        prevCursor: cursor > 1 ? cursor - 1 : null,
-      },
-    };
-  });
+    );
+  }
+
+  let orderBy: SQL<unknown>;
+  switch (input.sort) {
+    case "name":
+      orderBy = asc(countries.name);
+      break;
+    case "-name":
+      orderBy = desc(countries.name);
+      break;
+    case "bottles":
+      orderBy = asc(countries.totalBottles);
+      break;
+    case "-bottles":
+      orderBy = desc(countries.totalBottles);
+      break;
+  }
+
+  const results = await db
+    .select()
+    .from(countries)
+    .where(where ? and(...where) : undefined)
+    .limit(limit + 1)
+    .offset(offset)
+    .orderBy(orderBy);
+
+  return {
+    results: await serialize(
+      CountrySerializer,
+      results.slice(0, limit),
+      context.user,
+    ),
+    rel: {
+      nextCursor: results.length > limit ? cursor + 1 : null,
+      prevCursor: cursor > 1 ? cursor - 1 : null,
+    },
+  };
+});

--- a/apps/server/src/orpc/routes/entities/details.ts
+++ b/apps/server/src/orpc/routes/entities/details.ts
@@ -1,46 +1,37 @@
 import { db } from "@peated/server/db";
 import { entities, entityTombstones } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
-import { EntitySchema, detailsResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import entityDetailsContract from "@peated/server/orpc/contracts/entities/details";
 import { serialize } from "@peated/server/serializers";
 import { EntitySerializer } from "@peated/server/serializers/entity";
 import { eq, getTableColumns } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/entities/{entity}",
-    summary: "Get entity details",
-    description:
-      "Retrieve detailed information about a specific entity (brand, distillery, or bottler)",
-    operationId: "getEntity",
-  })
-  .input(z.object({ entity: z.coerce.number() }))
-  // TODO(response-envelope): wrap in { data } by updating detailsResponse() at cutover
-  .output(detailsResponse(EntitySchema))
-  .handler(async function ({ input, context, errors }) {
-    const { entity: entityId } = input;
+export default implement(entityDetailsContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const { entity: entityId } = input;
 
-    let [entity] = await db
-      .select()
-      .from(entities)
-      .where(eq(entities.id, entityId));
+  let [entity] = await db
+    .select()
+    .from(entities)
+    .where(eq(entities.id, entityId));
+  if (!entity) {
+    // check for a tombstone
+    [entity] = await db
+      .select({
+        ...getTableColumns(entities),
+      })
+      .from(entityTombstones)
+      .innerJoin(entities, eq(entityTombstones.newEntityId, entities.id))
+      .where(eq(entityTombstones.entityId, entityId));
     if (!entity) {
-      // check for a tombstone
-      [entity] = await db
-        .select({
-          ...getTableColumns(entities),
-        })
-        .from(entityTombstones)
-        .innerJoin(entities, eq(entityTombstones.newEntityId, entities.id))
-        .where(eq(entityTombstones.entityId, entityId));
-      if (!entity) {
-        throw errors.NOT_FOUND({
-          message: "Entity not found.",
-        });
-      }
+      throw errors.NOT_FOUND({
+        message: "Entity not found.",
+      });
     }
+  }
 
-    return await serialize(EntitySerializer, entity, context.user);
-  });
+  return await serialize(EntitySerializer, entity, context.user);
+});

--- a/apps/server/src/orpc/routes/regions/details.ts
+++ b/apps/server/src/orpc/routes/regions/details.ts
@@ -1,63 +1,48 @@
-import { ORPCError } from "@orpc/server";
 import { db } from "@peated/server/db";
 import { countries, regions } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
-import { RegionSchema, detailsResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import regionDetailsContract from "@peated/server/orpc/contracts/regions/details";
 import { serialize } from "@peated/server/serializers";
 import { RegionSerializer } from "@peated/server/serializers/region";
 import { and, eq, sql } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/countries/{country}/regions/{region}",
-    summary: "Get region details",
-    description:
-      "Retrieve detailed information about a specific region within a country using their slugs",
-    operationId: "getRegion",
-  })
-  .input(
-    z.object({
-      region: z.string(),
-      country: z.string(),
-    }),
-  )
-  // TODO(response-envelope): wrap in { data } by updating detailsResponse() at cutover
-  .output(detailsResponse(RegionSchema))
-  .handler(async function ({ input, context, errors }) {
-    let countryId: number;
-    if (Number.isFinite(+input.country)) {
-      countryId = Number(input.country);
-    } else {
-      const [result] = await db
-        .select({ id: countries.id })
-        .from(countries)
-        .where(eq(sql`LOWER(${countries.slug})`, input.country.toLowerCase()))
-        .limit(1);
-      if (!result) {
-        throw errors.BAD_REQUEST({
-          message: "Invalid country.",
-        });
-      }
-      countryId = result.id;
-    }
-
-    const [region] = await db
-      .select()
-      .from(regions)
-      .where(
-        and(
-          eq(regions.countryId, countryId),
-          eq(sql`LOWER(${regions.slug})`, input.region.toLowerCase()),
-        ),
-      );
-
-    if (!region) {
-      throw errors.NOT_FOUND({
-        message: "Region not found.",
+export default implement(regionDetailsContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  let countryId: number;
+  if (Number.isFinite(+input.country)) {
+    countryId = Number(input.country);
+  } else {
+    const [result] = await db
+      .select({ id: countries.id })
+      .from(countries)
+      .where(eq(sql`LOWER(${countries.slug})`, input.country.toLowerCase()))
+      .limit(1);
+    if (!result) {
+      throw errors.BAD_REQUEST({
+        message: "Invalid country.",
       });
     }
+    countryId = result.id;
+  }
 
-    return await serialize(RegionSerializer, region, context.user);
-  });
+  const [region] = await db
+    .select()
+    .from(regions)
+    .where(
+      and(
+        eq(regions.countryId, countryId),
+        eq(sql`LOWER(${regions.slug})`, input.region.toLowerCase()),
+      ),
+    );
+
+  if (!region) {
+    throw errors.NOT_FOUND({
+      message: "Region not found.",
+    });
+  }
+
+  return await serialize(RegionSerializer, region, context.user);
+});

--- a/apps/server/src/orpc/routes/regions/list.ts
+++ b/apps/server/src/orpc/routes/regions/list.ts
@@ -1,111 +1,79 @@
-import { ORPCError } from "@orpc/server";
 import { db } from "@peated/server/db";
 import { countries } from "@peated/server/db/schema";
 import { regions } from "@peated/server/db/schema/regions";
-import { procedure } from "@peated/server/orpc";
-import { RegionSchema, listResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import regionListContract from "@peated/server/orpc/contracts/regions/list";
 import { serialize } from "@peated/server/serializers";
 import { RegionSerializer } from "@peated/server/serializers/region";
 import { and, asc, desc, eq, ilike, ne, sql, type SQL } from "drizzle-orm";
-import { z } from "zod";
 
-const DEFAULT_SORT = "name";
+export default implement(regionListContract).handler(async function ({
+  input: { cursor, query, limit, ...input },
+  context,
+  errors,
+}) {
+  const where: (SQL<unknown> | undefined)[] = [];
 
-const SORT_OPTIONS = ["name", "bottles", "-name", "-bottles"] as const;
+  const offset = (cursor - 1) * limit;
 
-const InputSchema = z.object({
-  country: z.string(),
-  query: z.string().default(""),
-  cursor: z.coerce.number().gte(1).default(1),
-  limit: z.coerce.number().gte(1).lte(100).default(100),
-  sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
-  hasBottles: z.coerce.boolean().default(false),
+  // TODO: switch to tsvector to improve upon unicode
+  if (query) {
+    where.push(ilike(regions.name, `%${query}%`));
+  }
+
+  if (Number.isFinite(+input.country)) {
+    where.push(eq(regions.countryId, Number(input.country)));
+  } else if (input.country) {
+    const [result] = await db
+      .select({ id: countries.id })
+      .from(countries)
+      .where(eq(sql`LOWER(${countries.slug})`, input.country.toLowerCase()))
+      .limit(1);
+    if (!result) {
+      throw errors.BAD_REQUEST({
+        message: "Invalid country.",
+      });
+    }
+    where.push(eq(regions.countryId, result.id));
+  }
+
+  if (input.hasBottles) {
+    where.push(ne(regions.totalBottles, 0));
+  }
+
+  let orderBy: SQL<unknown>;
+  switch (input.sort) {
+    case "name":
+      orderBy = asc(regions.name);
+      break;
+    case "-name":
+      orderBy = desc(regions.name);
+      break;
+    case "bottles":
+      orderBy = asc(regions.totalBottles);
+      break;
+    case "-bottles":
+      orderBy = desc(regions.totalBottles);
+      break;
+  }
+
+  const results = await db
+    .select()
+    .from(regions)
+    .where(where ? and(...where) : undefined)
+    .limit(limit + 1)
+    .offset(offset)
+    .orderBy(orderBy);
+
+  return {
+    results: await serialize(
+      RegionSerializer,
+      results.slice(0, limit),
+      context.user,
+    ),
+    rel: {
+      nextCursor: results.length > limit ? cursor + 1 : null,
+      prevCursor: cursor > 1 ? cursor - 1 : null,
+    },
+  };
 });
-
-const OutputSchema = listResponse(RegionSchema);
-
-export default procedure
-  .route({
-    method: "GET",
-    path: "/countries/{country}/regions",
-    summary: "List regions",
-    description:
-      "Retrieve regions within a specific country with filtering by bottle counts and search support",
-    operationId: "listRegions",
-  })
-  .input(InputSchema)
-  .output(OutputSchema)
-  .handler(async function ({
-    input: { cursor, query, limit, ...input },
-    context,
-    errors,
-  }) {
-    const where: (SQL<unknown> | undefined)[] = [];
-
-    const offset = (cursor - 1) * limit;
-
-    // TODO: switch to tsvector to improve upon unicode
-    if (query) {
-      where.push(ilike(regions.name, `%${query}%`));
-    }
-
-    if (Number.isFinite(+input.country)) {
-      where.push(eq(regions.countryId, Number(input.country)));
-    } else if (input.country) {
-      const [result] = await db
-        .select({ id: countries.id })
-        .from(countries)
-        .where(eq(sql`LOWER(${countries.slug})`, input.country.toLowerCase()))
-        .limit(1);
-      if (!result) {
-        throw errors.BAD_REQUEST({
-          message: "Invalid country.",
-        });
-      }
-      where.push(eq(regions.countryId, result.id));
-    }
-
-    if (input.hasBottles) {
-      where.push(ne(regions.totalBottles, 0));
-    }
-
-    let orderBy: SQL<unknown>;
-    switch (input.sort) {
-      case "name":
-        orderBy = asc(regions.name);
-        break;
-      case "-name":
-        orderBy = desc(regions.name);
-        break;
-      case "bottles":
-        orderBy = asc(regions.totalBottles);
-        break;
-      case "-bottles":
-        orderBy = desc(regions.totalBottles);
-        break;
-      default:
-        throw errors.BAD_REQUEST({
-          message: `Invalid sort: ${input.sort}`,
-        });
-    }
-
-    const results = await db
-      .select()
-      .from(regions)
-      .where(where ? and(...where) : undefined)
-      .limit(limit + 1)
-      .offset(offset)
-      .orderBy(orderBy);
-
-    return {
-      results: await serialize(
-        RegionSerializer,
-        results.slice(0, limit),
-        context.user,
-      ),
-      rel: {
-        nextCursor: results.length > limit ? cursor + 1 : null,
-        prevCursor: cursor > 1 ? cursor - 1 : null,
-      },
-    };
-  });

--- a/apps/server/src/orpc/routes/tastings/details.ts
+++ b/apps/server/src/orpc/routes/tastings/details.ts
@@ -1,38 +1,26 @@
 import { db } from "@peated/server/db";
 import { tastings } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
-import { TastingSchema, detailsResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import tastingDetailsContract from "@peated/server/orpc/contracts/tastings/details";
 import { serialize } from "@peated/server/serializers";
 import { TastingSerializer } from "@peated/server/serializers/tasting";
 import { eq } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/tastings/{tasting}",
-    summary: "Get tasting details",
-    description: "Retrieve detailed information about a specific tasting",
-    operationId: "getTasting",
-  })
-  .input(
-    z.object({
-      tasting: z.coerce.number(),
-    }),
-  )
-  // TODO(response-envelope): wrap in { data } by updating detailsResponse() at cutover
-  .output(detailsResponse(TastingSchema))
-  .handler(async function ({ input, context, errors }) {
-    const [tasting] = await db
-      .select()
-      .from(tastings)
-      .where(eq(tastings.id, input.tasting));
+export default implement(tastingDetailsContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const [tasting] = await db
+    .select()
+    .from(tastings)
+    .where(eq(tastings.id, input.tasting));
 
-    if (!tasting) {
-      throw errors.NOT_FOUND({
-        message: "Tasting not found.",
-      });
-    }
+  if (!tasting) {
+    throw errors.NOT_FOUND({
+      message: "Tasting not found.",
+    });
+  }
 
-    return await serialize(TastingSerializer, tasting, context.user);
-  });
+  return await serialize(TastingSerializer, tasting, context.user);
+});

--- a/apps/server/src/orpc/routes/tastings/list.ts
+++ b/apps/server/src/orpc/routes/tastings/list.ts
@@ -7,58 +7,28 @@ import {
   users,
 } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
-import { procedure } from "@peated/server/orpc";
-import { TastingSchema, listResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import tastingListContract from "@peated/server/orpc/contracts/tastings/list";
 import { serialize } from "@peated/server/serializers";
 import { TastingSerializer } from "@peated/server/serializers/tasting";
 import type { SQL } from "drizzle-orm";
 import { and, desc, eq, or, sql } from "drizzle-orm";
-import { z } from "zod";
+export default implement(tastingListContract).handler(async function ({
+  input: { cursor, limit, ...input },
+  context,
+  errors,
+}) {
+  const offset = (cursor - 1) * limit;
 
-const InputSchema = z
-  .object({
-    bottle: z.coerce.number().int().positive().optional(),
-    entity: z.coerce.number().optional(),
-    user: z.union([z.coerce.number(), z.literal("me"), z.string()]).optional(),
-    filter: z.enum(["global", "friends", "local"]).default("global"),
-    cursor: z.coerce.number().gte(1).default(1),
-    limit: z.coerce.number().gte(1).lte(100).default(25),
-  })
-  .strict()
-  .default({
-    filter: "global",
-    cursor: 1,
-    limit: 25,
-  });
+  const baseWhere: (SQL<unknown> | undefined)[] = [];
+  const bottleWhere: SQL<unknown>[] = [];
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/tastings",
-    summary: "List tastings",
-    description:
-      "Retrieve tastings with filtering by bottle, entity, user, and privacy settings. Supports pagination",
-    operationId: "listTastings",
-  })
-  .input(InputSchema)
-  // TODO(response-envelope): helper enables later switch to { data, meta }
-  .output(listResponse(TastingSchema))
-  .handler(async function ({
-    input: { cursor, limit, ...input },
-    context,
-    errors,
-  }) {
-    const offset = (cursor - 1) * limit;
+  if (input.bottle !== undefined) {
+    bottleWhere.push(eq(tastings.bottleId, input.bottle));
+  }
 
-    const baseWhere: (SQL<unknown> | undefined)[] = [];
-    const bottleWhere: SQL<unknown>[] = [];
-
-    if (input.bottle !== undefined) {
-      bottleWhere.push(eq(tastings.bottleId, input.bottle));
-    }
-
-    if (input.entity) {
-      bottleWhere.push(sql`EXISTS(
+  if (input.entity) {
+    bottleWhere.push(sql`EXISTS(
         SELECT FROM ${bottles}
         WHERE (${bottles.brandId} = ${input.entity}
           OR ${bottles.bottlerId} = ${input.entity}
@@ -68,68 +38,68 @@ export default procedure
               AND ${bottlesToDistillers.distillerId} = ${input.entity}
           )) AND ${bottles.id} = ${tastings.bottleId}
       )`);
-    }
+  }
 
-    if (input.user) {
-      const selectedUser = await getUserFromId(db, input.user, context.user);
+  if (input.user) {
+    const selectedUser = await getUserFromId(db, input.user, context.user);
 
-      if (!selectedUser) {
-        if (input.user === "me") {
-          throw errors.UNAUTHORIZED();
-        } else {
-          throw errors.NOT_FOUND({
-            message: "User not found.",
-          });
-        }
-      }
-
-      baseWhere.push(eq(tastings.createdById, selectedUser.id));
-    }
-
-    const limitPrivate = input.filter !== "friends";
-    if (input.filter === "friends") {
-      if (!context.user) {
+    if (!selectedUser) {
+      if (input.user === "me") {
         throw errors.UNAUTHORIZED();
+      } else {
+        throw errors.NOT_FOUND({
+          message: "User not found.",
+        });
       }
-      baseWhere.push(
-        sql`${tastings.createdById} IN (SELECT ${follows.toUserId} FROM ${follows} WHERE ${follows.fromUserId} = ${context.user.id} AND ${follows.status} = 'following')`,
-      );
     }
 
-    if (limitPrivate) {
-      baseWhere.push(
-        or(
-          eq(users.private, false),
-          ...(context.user
-            ? [
-                eq(tastings.createdById, context.user.id),
-                sql`${tastings.createdById} IN (
+    baseWhere.push(eq(tastings.createdById, selectedUser.id));
+  }
+
+  const limitPrivate = input.filter !== "friends";
+  if (input.filter === "friends") {
+    if (!context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+    baseWhere.push(
+      sql`${tastings.createdById} IN (SELECT ${follows.toUserId} FROM ${follows} WHERE ${follows.fromUserId} = ${context.user.id} AND ${follows.status} = 'following')`,
+    );
+  }
+
+  if (limitPrivate) {
+    baseWhere.push(
+      or(
+        eq(users.private, false),
+        ...(context.user
+          ? [
+              eq(tastings.createdById, context.user.id),
+              sql`${tastings.createdById} IN (
                   SELECT ${follows.toUserId} FROM ${follows} WHERE ${follows.fromUserId} = ${context.user.id} AND ${follows.status} = 'following'
                 )`,
-              ]
-            : []),
-        ),
-      );
-    }
-
-    const results = await db
-      .select({ tastings })
-      .from(tastings)
-      .innerJoin(users, eq(users.id, tastings.createdById))
-      .where(and(...baseWhere, ...bottleWhere))
-      .limit(limit + 1)
-      .offset(offset)
-      .orderBy(desc(tastings.createdAt));
-
-    return {
-      results: await serialize(
-        TastingSerializer,
-        results.map((t) => t.tastings).slice(0, limit),
-        context.user,
+            ]
+          : []),
       ),
-      rel: {
-        nextCursor: results.length > limit ? cursor + 1 : null,
-        prevCursor: cursor > 1 ? cursor - 1 : null,
-      },
-    };
-  });
+    );
+  }
+
+  const results = await db
+    .select({ tastings })
+    .from(tastings)
+    .innerJoin(users, eq(users.id, tastings.createdById))
+    .where(and(...baseWhere, ...bottleWhere))
+    .limit(limit + 1)
+    .offset(offset)
+    .orderBy(desc(tastings.createdAt));
+
+  return {
+    results: await serialize(
+      TastingSerializer,
+      results.map((t) => t.tastings).slice(0, limit),
+      context.user,
+    ),
+    rel: {
+      nextCursor: results.length > limit ? cursor + 1 : null,
+      prevCursor: cursor > 1 ? cursor - 1 : null,
+    },
+  };
+});

--- a/apps/server/src/serializers/bottle.ts
+++ b/apps/server/src/serializers/bottle.ts
@@ -2,6 +2,7 @@ import { and, eq, inArray } from "drizzle-orm";
 import { type z } from "zod";
 import { serialize, serializer } from ".";
 import config from "../config";
+import type { ReservedCollectionSlug } from "../constants";
 import { db } from "../db";
 import type { Bottle, User } from "../db/schema";
 import {
@@ -13,7 +14,7 @@ import {
   entities,
   tastings,
 } from "../db/schema";
-import { getReservedCollection, type ReservedCollectionSlug } from "../lib/db";
+import { getReservedCollection } from "../lib/db";
 import { notEmpty } from "../lib/filter";
 import { formatPeatedId } from "../lib/peatedId";
 import { absoluteUrl } from "../lib/urls";


### PR DESCRIPTION
Mock development mode now covers entity details, country and region lists and details, tasting lists and details, and collection bottle lists. The stateless fixtures let QA exercise entity, location, tasting, library, and favorites views without using the production API.

Each added production route now exposes a reusable oRPC contract that both the live and mock handlers must satisfy. Reserved collection slugs moved to a pure constants module so contracts do not pull database code into mock or web bundles. Existing production handler behavior and global middleware remain unchanged.
