### PR TITLE
feat(api): Add read-only page mocks

### DIFF
--- a/apps/server/src/orpc/contracts/bottles/tags.ts
+++ b/apps/server/src/orpc/contracts/bottles/tags.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/bottles/{bottle}/tags",
+    summary: "Get bottle tags",
+    description: "Get common tasting tags for a bottle",
+    spec: (spec) => ({ ...spec, operationId: "getBottleTags" }),
+  })
+  .input(
+    z.object({
+      bottle: z.coerce.number(),
+      limit: z.coerce.number().gte(1).lte(100).default(25),
+    }),
+  )
+  .output(
+    z.object({
+      results: z.array(
+        z.object({
+          tag: z.string(),
+          count: z.number(),
+        }),
+      ),
+      totalCount: z.number(),
+    }),
+  );

--- a/apps/server/src/orpc/contracts/comments/list.ts
+++ b/apps/server/src/orpc/contracts/comments/list.ts
@@ -1,0 +1,23 @@
+import { CommentSchema, listResponse } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/comments",
+    summary: "List comments",
+    description: "Find comments by user or tasting",
+    spec: (spec) => ({ ...spec, operationId: "listComments" }),
+  })
+  .input(
+    z.object({
+      user: z.union([z.literal("me"), z.coerce.number()]).optional(),
+      tasting: z.coerce.number().optional(),
+      cursor: z.coerce.number().gte(1).default(1),
+      limit: z.coerce.number().gte(1).lte(100).default(100),
+    }),
+  )
+  // TODO(response-envelope): Return { data, meta } when all list routes use the
+  // same wrapper.
+  .output(listResponse(CommentSchema));

--- a/apps/server/src/orpc/contracts/entities/catalog.ts
+++ b/apps/server/src/orpc/contracts/entities/catalog.ts
@@ -1,0 +1,53 @@
+import { CategoryEnum } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+const RelatedEntitySchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  shortName: z.string().nullable(),
+  count: z.number(),
+});
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/entities/{entity}/catalog",
+    summary: "Get an entity catalog summary",
+    description: "Summarize bottles and related producers for an entity",
+    spec: (spec) => ({ ...spec, operationId: "getEntityCatalog" }),
+  })
+  .input(z.object({ entity: z.coerce.number() }))
+  .output(
+    z.object({
+      totalBottles: z.number(),
+      relationships: z.object({
+        brand: z.number(),
+        bottler: z.number(),
+        distiller: z.number(),
+      }),
+      distilleryCoverage: z.object({
+        documented: z.number(),
+        total: z.number(),
+      }),
+      categories: z.array(
+        z.object({
+          category: CategoryEnum.nullable(),
+          count: z.number(),
+        }),
+      ),
+      related: z.object({
+        brands: z.array(RelatedEntitySchema),
+        bottlers: z.array(RelatedEntitySchema),
+        distillers: z.array(RelatedEntitySchema),
+      }),
+      notableBottles: z.array(
+        z.object({
+          id: z.number(),
+          fullName: z.string(),
+          totalTastings: z.number(),
+          avgRating: z.number().nullable(),
+        }),
+      ),
+    }),
+  );

--- a/apps/server/src/orpc/contracts/flights/details.ts
+++ b/apps/server/src/orpc/contracts/flights/details.ts
@@ -1,0 +1,16 @@
+import { detailsResponse, FlightDetailsSchema } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/flights/{flight}",
+    summary: "Get flight details",
+    description: "Get a tasting flight by its public ID",
+    operationId: "getFlight",
+  })
+  .input(z.object({ flight: z.string() }))
+  // TODO(response-envelope): Return { data: ... } when all detail routes use the
+  // same wrapper.
+  .output(detailsResponse(FlightDetailsSchema));

--- a/apps/server/src/orpc/contracts/flights/list.ts
+++ b/apps/server/src/orpc/contracts/flights/list.ts
@@ -1,0 +1,32 @@
+import { FlightSchema, listResponse } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+const DEFAULT_SORT = "name";
+const SORT_OPTIONS = ["name", "-name"] as const;
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/flights",
+    summary: "List flights",
+    description: "Find tasting flights by name and visibility",
+    operationId: "listFlights",
+  })
+  .input(
+    z
+      .object({
+        query: z.string().default(""),
+        filter: z.enum(["public", "private", "none"]).optional(),
+        sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
+        cursor: z.coerce.number().gte(1).default(1),
+        limit: z.coerce.number().gte(1).lte(100).default(100),
+      })
+      .default({
+        query: "",
+        sort: DEFAULT_SORT,
+        cursor: 1,
+        limit: 100,
+      }),
+  )
+  .output(listResponse(FlightSchema));

--- a/apps/server/src/orpc/contracts/notifications/count.ts
+++ b/apps/server/src/orpc/contracts/notifications/count.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/notifications/count",
+    summary: "Count notifications",
+    description: "Count all or unread notifications for the current user",
+    operationId: "countNotifications",
+  })
+  .input(
+    z
+      .object({
+        filter: z.enum(["unread", "all"]).nullish(),
+      })
+      .default({}),
+  )
+  .output(z.object({ count: z.number() }));

--- a/apps/server/src/orpc/contracts/reviews/list.ts
+++ b/apps/server/src/orpc/contracts/reviews/list.ts
@@ -1,0 +1,41 @@
+import {
+  ExternalSiteTypeEnum,
+  listResponse,
+  ReviewSchema,
+} from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+const DEFAULT_SORT = "recent";
+const SORT_OPTIONS = ["recent", "name"] as const;
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/reviews",
+    summary: "List reviews",
+    description: "Find reviews by bottle, site, or name",
+    operationId: "listReviews",
+  })
+  .input(
+    z
+      .object({
+        site: ExternalSiteTypeEnum.optional(),
+        bottle: z.coerce.number().gte(1).optional(),
+        query: z.string().default(""),
+        onlyUnknown: z.coerce.boolean().optional(),
+        sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
+        cursor: z.coerce.number().gte(1).default(1),
+        limit: z.coerce.number().gte(1).lte(100).default(100),
+      })
+      .strict()
+      .default({
+        query: "",
+        sort: DEFAULT_SORT,
+        cursor: 1,
+        limit: 100,
+      }),
+  )
+  // TODO(response-envelope): Return { data, meta } when all list routes use the
+  // same wrapper.
+  .output(listResponse(ReviewSchema));

--- a/apps/server/src/orpc/contracts/users/badge-list.ts
+++ b/apps/server/src/orpc/contracts/users/badge-list.ts
@@ -1,0 +1,22 @@
+import { BadgeAwardSchema, listResponse } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/users/{user}/badges",
+    summary: "List user badges",
+    description: "Get badges earned by a user",
+    operationId: "listUserBadges",
+  })
+  .input(
+    z.object({
+      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
+      cursor: z.coerce.number().gte(1).default(1),
+      limit: z.coerce.number().gte(1).lte(100).default(25),
+    }),
+  )
+  // TODO(response-envelope): Return { data, meta } when all list routes use the
+  // same wrapper.
+  .output(listResponse(BadgeAwardSchema));

--- a/apps/server/src/orpc/contracts/users/flavor-list.ts
+++ b/apps/server/src/orpc/contracts/users/flavor-list.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/users/{user}/flavors",
+    summary: "List user flavor profiles",
+    description: "Count and score the flavor profiles a user has tasted",
+    operationId: "listUserFlavors",
+  })
+  .input(
+    z.object({
+      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
+    }),
+  )
+  .output(
+    z.object({
+      results: z.array(
+        z.object({
+          flavorProfile: z.string(),
+          count: z.number(),
+          score: z.number(),
+        }),
+      ),
+      totalScore: z.number(),
+      totalCount: z.number(),
+    }),
+  );

--- a/apps/server/src/orpc/contracts/users/library-stats.ts
+++ b/apps/server/src/orpc/contracts/users/library-stats.ts
@@ -1,0 +1,35 @@
+import { AgeStatsSchema, CategoryEnum } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export const LibraryStatsSchema = z.object({
+  total: z.number(),
+  status: z.object({
+    open: z.number(),
+    sealed: z.number(),
+    unspecified: z.number(),
+  }),
+  brands: z.array(
+    z.object({ id: z.number(), name: z.string(), count: z.number() }),
+  ),
+  distillers: z.array(
+    z.object({ id: z.number(), name: z.string(), count: z.number() }),
+  ),
+  age: AgeStatsSchema,
+  categories: z.array(z.object({ category: CategoryEnum, count: z.number() })),
+});
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/users/{user}/library/stats",
+    summary: "Get user Library statistics",
+    description: "Get producer, status, age, and category totals for a Library",
+    operationId: "getUserLibraryStats",
+  })
+  .input(
+    z.object({
+      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
+    }),
+  )
+  .output(LibraryStatsSchema);

--- a/apps/server/src/orpc/contracts/users/region-list.ts
+++ b/apps/server/src/orpc/contracts/users/region-list.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/users/{user}/regions",
+    summary: "List user regions",
+    description: "Count a user's tastings by country and region",
+    operationId: "listUserRegions",
+  })
+  .input(
+    z.object({
+      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
+    }),
+  )
+  .output(
+    z.object({
+      results: z.array(
+        z.object({
+          country: z.object({ name: z.string(), slug: z.string() }),
+          region: z.object({ name: z.string(), slug: z.string() }).nullable(),
+          count: z.number(),
+        }),
+      ),
+      totalCount: z.number(),
+    }),
+  );

--- a/apps/server/src/orpc/contracts/users/tasting-stats.ts
+++ b/apps/server/src/orpc/contracts/users/tasting-stats.ts
@@ -1,0 +1,37 @@
+import { AgeStatsSchema } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/users/{user}/tasting-stats",
+    summary: "Get user tasting statistics",
+    description: "Get rating, bottle, and age totals for a user's tastings",
+    operationId: "getUserTastingStats",
+  })
+  .input(
+    z.object({
+      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
+    }),
+  )
+  .output(
+    z.object({
+      total: z.number(),
+      uniqueBottles: z.number(),
+      ratings: z.object({
+        total: z.number(),
+        pass: z.number(),
+        sip: z.number(),
+        savor: z.number(),
+      }),
+      mostTastedBottle: z
+        .object({
+          id: z.number(),
+          name: z.string(),
+          count: z.number(),
+        })
+        .nullable(),
+      age: AgeStatsSchema,
+    }),
+  );

--- a/apps/server/src/orpc/mock/contract.ts
+++ b/apps/server/src/orpc/mock/contract.ts
@@ -3,18 +3,30 @@ import activityList from "@peated/server/orpc/contracts/activity/list";
 import login from "@peated/server/orpc/contracts/auth/login";
 import bottleDetails from "@peated/server/orpc/contracts/bottles/details";
 import bottleList from "@peated/server/orpc/contracts/bottles/list";
+import bottleTags from "@peated/server/orpc/contracts/bottles/tags";
 import collectionBottleList from "@peated/server/orpc/contracts/collections/bottles/list";
+import commentList from "@peated/server/orpc/contracts/comments/list";
 import countryDetails from "@peated/server/orpc/contracts/countries/details";
 import countryList from "@peated/server/orpc/contracts/countries/list";
+import entityCatalog from "@peated/server/orpc/contracts/entities/catalog";
 import entityDetails from "@peated/server/orpc/contracts/entities/details";
 import entityList from "@peated/server/orpc/contracts/entities/list";
+import flightDetails from "@peated/server/orpc/contracts/flights/details";
+import flightList from "@peated/server/orpc/contracts/flights/list";
+import notificationCount from "@peated/server/orpc/contracts/notifications/count";
 import regionDetails from "@peated/server/orpc/contracts/regions/details";
 import regionList from "@peated/server/orpc/contracts/regions/list";
+import reviewList from "@peated/server/orpc/contracts/reviews/list";
 import root from "@peated/server/orpc/contracts/root";
 import search from "@peated/server/orpc/contracts/search";
 import tastingDetails from "@peated/server/orpc/contracts/tastings/details";
 import tastingList from "@peated/server/orpc/contracts/tastings/list";
+import userBadgeList from "@peated/server/orpc/contracts/users/badge-list";
 import userDetails from "@peated/server/orpc/contracts/users/details";
+import userFlavorList from "@peated/server/orpc/contracts/users/flavor-list";
+import userLibraryStats from "@peated/server/orpc/contracts/users/library-stats";
+import userRegionList from "@peated/server/orpc/contracts/users/region-list";
+import userTastingStats from "@peated/server/orpc/contracts/users/tasting-stats";
 
 // The mock API supports only the routes listed here.
 export const mockContract = {
@@ -29,6 +41,10 @@ export const mockContract = {
   bottles: {
     details: bottleDetails,
     list: bottleList,
+    tags: bottleTags,
+  },
+  comments: {
+    list: commentList,
   },
   collections: {
     bottles: {
@@ -40,19 +56,35 @@ export const mockContract = {
     list: countryList,
   },
   entities: {
+    catalog: entityCatalog,
     details: entityDetails,
     list: entityList,
+  },
+  flights: {
+    details: flightDetails,
+    list: flightList,
+  },
+  notifications: {
+    count: notificationCount,
   },
   regions: {
     details: regionDetails,
     list: regionList,
+  },
+  reviews: {
+    list: reviewList,
   },
   tastings: {
     details: tastingDetails,
     list: tastingList,
   },
   users: {
+    badgeList: userBadgeList,
     details: userDetails,
+    flavorList: userFlavorList,
+    libraryStats: userLibraryStats,
+    regionList: userRegionList,
+    tastingStats: userTastingStats,
   },
 };
 

--- a/apps/server/src/orpc/mock/fixtures.ts
+++ b/apps/server/src/orpc/mock/fixtures.ts
@@ -1,11 +1,15 @@
 import type { MockOutputs } from "./contract";
 
 type Bottle = MockOutputs["bottles"]["list"]["results"][number];
+type BadgeAward = MockOutputs["users"]["badgeList"]["results"][number];
+type Comment = MockOutputs["comments"]["list"]["results"][number];
 type CollectionBottle =
   MockOutputs["collections"]["bottles"]["list"]["results"][number];
 type Country = MockOutputs["countries"]["details"];
 type Entity = MockOutputs["entities"]["list"]["results"][number];
+type Flight = MockOutputs["flights"]["list"]["results"][number];
 type Region = MockOutputs["regions"]["details"];
+type Review = MockOutputs["reviews"]["list"]["results"][number];
 type Tasting = MockOutputs["tastings"]["details"];
 type User = MockOutputs["auth"]["login"]["user"];
 
@@ -59,6 +63,12 @@ export const mockPublicUserDetails = {
 
 export function mockUserDetailsFor(user: User | null) {
   return user ? mockUserDetails : mockPublicUserDetails;
+}
+
+export function matchesMockUser(value: string | number, user: User | null) {
+  return value === "me"
+    ? Boolean(user)
+    : value === mockUser.id || value === mockUser.username;
 }
 
 export const mockCountry = {
@@ -188,6 +198,198 @@ export function mockBottleDetailsFor(
   return {
     ...mockBottleDetails,
     ...mockBottleFor(user),
+  };
+}
+
+export const mockBottleTags = {
+  results: [
+    { tag: "smoke", count: 48 },
+    { tag: "sea salt", count: 31 },
+    { tag: "dried fruit", count: 22 },
+  ],
+  totalCount: 120,
+} satisfies MockOutputs["bottles"]["tags"];
+
+export const mockEntityCatalog = {
+  totalBottles: mockEntity.totalBottles,
+  relationships: {
+    brand: mockEntity.totalBottles,
+    bottler: 0,
+    distiller: mockEntity.totalBottles,
+  },
+  distilleryCoverage: {
+    documented: mockEntity.totalBottles,
+    total: mockEntity.totalBottles,
+  },
+  categories: [{ category: "single_malt", count: mockEntity.totalBottles }],
+  related: {
+    brands: [],
+    bottlers: [],
+    distillers: [],
+  },
+  notableBottles: [
+    {
+      id: mockBottle.id,
+      fullName: mockBottle.fullName,
+      totalTastings: mockBottle.totalTastings,
+      avgRating: mockBottle.avgRating,
+    },
+  ],
+} satisfies MockOutputs["entities"]["catalog"];
+
+export const mockReview = {
+  id: 9801,
+  name: mockBottle.fullName,
+  rating: 92,
+  url: "https://example.com/reviews/lagavulin-16",
+  site: {
+    id: 9802,
+    type: "whiskyadvocate",
+    name: "Whisky Advocate",
+    lastRunAt: timestamp,
+    nextRunAt: null,
+    runEvery: null,
+  },
+  article: {
+    title: "Lagavulin 16 Review",
+    publishedAt: timestamp,
+  },
+  reviewerName: "Mock Reviewer",
+  nativeScore: {
+    value: 92,
+    scale: 100,
+    display: "92",
+  },
+  summary: "Rich smoke, dried fruit, and maritime notes.",
+  bottle: mockBottle,
+  createdAt: timestamp,
+  updatedAt: timestamp,
+} satisfies Review;
+
+export const mockComment = {
+  id: 9803,
+  comment: "The smoke opens up after a few minutes in the glass.",
+  createdAt: timestamp,
+  createdBy: mockPublicUser,
+} satisfies Comment;
+
+export const mockBadgeAward = {
+  id: 9804,
+  xp: 12,
+  level: 2,
+  badge: {
+    id: 9805,
+    name: "Islay Explorer",
+    maxLevel: 25,
+    imageUrl: null,
+  },
+  createdAt: timestamp,
+} satisfies BadgeAward;
+
+export const mockUserRegionList = {
+  results: [
+    {
+      country: { name: mockCountry.name, slug: mockCountry.slug },
+      region: { name: mockRegion.name, slug: mockRegion.slug },
+      count: 42,
+    },
+  ],
+  totalCount: 42,
+} satisfies MockOutputs["users"]["regionList"];
+
+export const mockUserFlavorList = {
+  results: [{ flavorProfile: "peated", count: 42, score: 60 }],
+  totalScore: 60,
+  totalCount: 42,
+} satisfies MockOutputs["users"]["flavorList"];
+
+export const mockAgeStats = {
+  knownCount: 36,
+  median: 16,
+  oldest: 25,
+  buckets: [
+    { id: "under10", label: "Under 10", count: 4 },
+    { id: "from10To12", label: "10–12", count: 8 },
+    { id: "from13To17", label: "13–17", count: 18 },
+    { id: "from18To24", label: "18–24", count: 4 },
+    { id: "atLeast25", label: "25+", count: 2 },
+    { id: "unstated", label: "Unstated", count: 6 },
+  ],
+} satisfies MockOutputs["users"]["tastingStats"]["age"];
+
+export const mockUserTastingStats = {
+  total: 42,
+  uniqueBottles: 31,
+  ratings: {
+    total: 42,
+    pass: 2,
+    sip: 15,
+    savor: 25,
+  },
+  mostTastedBottle: {
+    id: mockBottle.id,
+    name: mockBottle.fullName,
+    count: 3,
+  },
+  age: mockAgeStats,
+} satisfies MockOutputs["users"]["tastingStats"];
+
+export const mockUserLibraryStats = {
+  total: 12,
+  status: {
+    open: 4,
+    sealed: 8,
+    unspecified: 0,
+  },
+  brands: [{ id: mockEntity.id, name: mockEntity.name, count: 12 }],
+  distillers: [{ id: mockEntity.id, name: mockEntity.name, count: 12 }],
+  age: {
+    ...mockAgeStats,
+    knownCount: 12,
+    buckets: [
+      { id: "under10", label: "Under 10", count: 0 },
+      { id: "from10To12", label: "10–12", count: 0 },
+      { id: "from13To17", label: "13–17", count: 12 },
+      { id: "from18To24", label: "18–24", count: 0 },
+      { id: "atLeast25", label: "25+", count: 0 },
+      { id: "unstated", label: "Unstated", count: 0 },
+    ],
+  },
+  categories: [{ category: "single_malt", count: 12 }],
+} satisfies MockOutputs["users"]["libraryStats"];
+
+export const mockFlight = {
+  id: "mock-islay-flight",
+  name: "Islay Smoke",
+  description: "A side-by-side tasting of smoky Islay whisky.",
+  public: true,
+  createdAt: timestamp,
+  createdBy: mockPublicUser,
+} satisfies Flight;
+
+export const mockFlightDetails = {
+  ...mockFlight,
+  bottles: [
+    {
+      bottle: mockBottle,
+      hasTasted: false,
+      isLibrary: false,
+    },
+  ],
+} satisfies MockOutputs["flights"]["details"];
+
+export function mockFlightDetailsFor(
+  user: User | null,
+): MockOutputs["flights"]["details"] {
+  return {
+    ...mockFlightDetails,
+    bottles: [
+      {
+        bottle: mockBottleFor(user),
+        hasTasted: Boolean(user),
+        isLibrary: Boolean(user),
+      },
+    ],
   };
 }
 

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -1,15 +1,25 @@
 import { createRouterClient } from "@orpc/server";
 import {
   mockAccessToken,
+  mockBadgeAward,
   mockBottle,
+  mockBottleTags,
   mockCollectionBottle,
+  mockComment,
   mockCountry,
   mockEntity,
+  mockEntityCatalog,
+  mockFlight,
   mockPublicUserDetails,
   mockRegion,
+  mockReview,
   mockTasting,
   mockUser,
   mockUserDetails,
+  mockUserFlavorList,
+  mockUserLibraryStats,
+  mockUserRegionList,
+  mockUserTastingStats,
 } from "./fixtures";
 import { mockRouter } from "./router";
 
@@ -87,6 +97,85 @@ describe("mock oRPC router", () => {
         hasTasted: false,
       },
     ]);
+  });
+
+  it("completes bottle, entity, and tasting detail pages", async () => {
+    await expect(
+      anonymousClient.reviews.list({
+        bottle: mockBottle.id,
+        sort: "name",
+      }),
+    ).resolves.toMatchObject({ results: [mockReview] });
+
+    await expect(
+      anonymousClient.bottles.tags({ bottle: mockBottle.id }),
+    ).resolves.toEqual(mockBottleTags);
+
+    await expect(
+      anonymousClient.entities.catalog({ entity: mockEntity.id }),
+    ).resolves.toEqual(mockEntityCatalog);
+
+    await expect(
+      anonymousClient.comments.list({ tasting: mockTasting.id }),
+    ).resolves.toMatchObject({ results: [mockComment] });
+  });
+
+  it("returns fixed user profile insights", async () => {
+    const input = { user: mockUser.username };
+
+    await expect(anonymousClient.users.badgeList(input)).resolves.toMatchObject(
+      {
+        results: [mockBadgeAward],
+      },
+    );
+    await expect(anonymousClient.users.regionList(input)).resolves.toEqual(
+      mockUserRegionList,
+    );
+    await expect(anonymousClient.users.flavorList(input)).resolves.toEqual(
+      mockUserFlavorList,
+    );
+    await expect(anonymousClient.users.tastingStats(input)).resolves.toEqual(
+      mockUserTastingStats,
+    );
+    await expect(anonymousClient.users.libraryStats(input)).resolves.toEqual(
+      mockUserLibraryStats,
+    );
+  });
+
+  it("supports fixed tasting flights", async () => {
+    await expect(anonymousClient.flights.list({})).resolves.toMatchObject({
+      results: [mockFlight],
+    });
+    await expect(
+      anonymousClient.flights.list({ query: "Speyside" }),
+    ).resolves.toMatchObject({ results: [] });
+
+    await expect(
+      anonymousClient.flights.details({ flight: mockFlight.id }),
+    ).resolves.toMatchObject({
+      bottles: [{ hasTasted: false, isLibrary: false }],
+    });
+    await expect(
+      authenticatedClient.flights.details({ flight: mockFlight.id }),
+    ).resolves.toMatchObject({
+      bottles: [{ hasTasted: true, isLibrary: true }],
+    });
+  });
+
+  it("keeps notification and review permissions", async () => {
+    await expect(anonymousClient.notifications.count({})).rejects.toMatchObject(
+      { code: "UNAUTHORIZED" },
+    );
+    await expect(
+      authenticatedClient.notifications.count({ filter: "unread" }),
+    ).resolves.toEqual({ count: 3 });
+
+    await expect(
+      anonymousClient.reviews.list({ sort: "name" }),
+    ).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Must be a moderator to list all reviews.",
+    });
   });
 
   it("applies read-only filters without saving state", async () => {

--- a/apps/server/src/orpc/mock/router.ts
+++ b/apps/server/src/orpc/mock/router.ts
@@ -3,18 +3,30 @@ import activityList from "./routes/activity/list";
 import login from "./routes/auth/login";
 import bottleDetails from "./routes/bottles/details";
 import bottleList from "./routes/bottles/list";
+import bottleTags from "./routes/bottles/tags";
 import collectionBottleList from "./routes/collections/bottles/list";
+import commentList from "./routes/comments/list";
 import countryDetails from "./routes/countries/details";
 import countryList from "./routes/countries/list";
+import entityCatalog from "./routes/entities/catalog";
 import entityDetails from "./routes/entities/details";
 import entityList from "./routes/entities/list";
+import flightDetails from "./routes/flights/details";
+import flightList from "./routes/flights/list";
+import notificationCount from "./routes/notifications/count";
 import regionDetails from "./routes/regions/details";
 import regionList from "./routes/regions/list";
+import reviewList from "./routes/reviews/list";
 import root from "./routes/root";
 import search from "./routes/search";
 import tastingDetails from "./routes/tastings/details";
 import tastingList from "./routes/tastings/list";
+import userBadgeList from "./routes/users/badge-list";
 import userDetails from "./routes/users/details";
+import userFlavorList from "./routes/users/flavor-list";
+import userLibraryStats from "./routes/users/library-stats";
+import userRegionList from "./routes/users/region-list";
+import userTastingStats from "./routes/users/tasting-stats";
 
 // Requests for routes not listed here return 404 from the mock server.
 export const mockRouter = mockOS.router({
@@ -29,6 +41,10 @@ export const mockRouter = mockOS.router({
   bottles: {
     details: bottleDetails,
     list: bottleList,
+    tags: bottleTags,
+  },
+  comments: {
+    list: commentList,
   },
   collections: {
     bottles: {
@@ -40,18 +56,34 @@ export const mockRouter = mockOS.router({
     list: countryList,
   },
   entities: {
+    catalog: entityCatalog,
     details: entityDetails,
     list: entityList,
+  },
+  flights: {
+    details: flightDetails,
+    list: flightList,
+  },
+  notifications: {
+    count: notificationCount,
   },
   regions: {
     details: regionDetails,
     list: regionList,
+  },
+  reviews: {
+    list: reviewList,
   },
   tastings: {
     details: tastingDetails,
     list: tastingList,
   },
   users: {
+    badgeList: userBadgeList,
     details: userDetails,
+    flavorList: userFlavorList,
+    libraryStats: userLibraryStats,
+    regionList: userRegionList,
+    tastingStats: userTastingStats,
   },
 });

--- a/apps/server/src/orpc/mock/routes/bottles/tags.ts
+++ b/apps/server/src/orpc/mock/routes/bottles/tags.ts
@@ -1,0 +1,13 @@
+import { mockBottle, mockBottleTags } from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.bottles.tags.handler(async ({ input, errors }) => {
+  if (input.bottle !== mockBottle.id) {
+    throw errors.NOT_FOUND({ message: "Mock bottle not found." });
+  }
+
+  return {
+    results: mockBottleTags.results.slice(0, input.limit),
+    totalCount: mockBottleTags.totalCount,
+  };
+});

--- a/apps/server/src/orpc/mock/routes/comments/list.ts
+++ b/apps/server/src/orpc/mock/routes/comments/list.ts
@@ -1,0 +1,31 @@
+import {
+  mockComment,
+  mockTasting,
+  mockUser,
+  noMorePages,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.comments.list.handler(
+  async ({ input, context, errors }) => {
+    if (input.user === "me" && !context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+
+    if (!context.user?.admin && !input.tasting && !input.user) {
+      return { results: [], rel: noMorePages };
+    }
+
+    const userMatches =
+      input.user === undefined ||
+      input.user === "me" ||
+      input.user === mockUser.id;
+    const tastingMatches =
+      input.tasting === undefined || input.tasting === mockTasting.id;
+
+    return {
+      results: userMatches && tastingMatches ? [mockComment] : [],
+      rel: noMorePages,
+    };
+  },
+);

--- a/apps/server/src/orpc/mock/routes/entities/catalog.ts
+++ b/apps/server/src/orpc/mock/routes/entities/catalog.ts
@@ -1,0 +1,13 @@
+import {
+  mockEntity,
+  mockEntityCatalog,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.entities.catalog.handler(async ({ input, errors }) => {
+  if (input.entity !== mockEntity.id) {
+    throw errors.NOT_FOUND({ message: "Mock entity not found." });
+  }
+
+  return mockEntityCatalog;
+});

--- a/apps/server/src/orpc/mock/routes/flights/details.ts
+++ b/apps/server/src/orpc/mock/routes/flights/details.ts
@@ -1,0 +1,15 @@
+import {
+  mockFlight,
+  mockFlightDetailsFor,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.flights.details.handler(
+  async ({ input, context, errors }) => {
+    if (input.flight !== mockFlight.id) {
+      throw errors.NOT_FOUND({ message: "Mock flight not found." });
+    }
+
+    return mockFlightDetailsFor(context.user);
+  },
+);

--- a/apps/server/src/orpc/mock/routes/flights/list.ts
+++ b/apps/server/src/orpc/mock/routes/flights/list.ts
@@ -1,0 +1,17 @@
+import {
+  includesQuery,
+  mockFlight,
+  noMorePages,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.flights.list.handler(async ({ input }) => {
+  const matches =
+    includesQuery(input.query, mockFlight.name, mockFlight.description) &&
+    input.filter !== "private";
+
+  return {
+    results: matches ? [mockFlight] : [],
+    rel: noMorePages,
+  };
+});

--- a/apps/server/src/orpc/mock/routes/notifications/count.ts
+++ b/apps/server/src/orpc/mock/routes/notifications/count.ts
@@ -1,0 +1,11 @@
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.notifications.count.handler(
+  async ({ input, context, errors }) => {
+    if (!context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+
+    return { count: input.filter === "unread" ? 3 : 5 };
+  },
+);

--- a/apps/server/src/orpc/mock/routes/reviews/list.ts
+++ b/apps/server/src/orpc/mock/routes/reviews/list.ts
@@ -1,0 +1,38 @@
+import {
+  includesQuery,
+  mockBottleFor,
+  mockReview,
+  noMorePages,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.reviews.list.handler(
+  async ({ input, context, errors }) => {
+    if (input.site && input.site !== mockReview.site?.type) {
+      throw errors.NOT_FOUND({ message: "Mock review site not found." });
+    }
+
+    const hasPublicScope =
+      input.bottle !== undefined || input.sort === "recent";
+    const requiresModerator = input.onlyUnknown || !hasPublicScope;
+    if (requiresModerator && !context.user?.admin && !context.user?.mod) {
+      throw errors.BAD_REQUEST({
+        message: "Must be a moderator to list all reviews.",
+      });
+    }
+
+    const review = {
+      ...mockReview,
+      bottle: mockBottleFor(context.user),
+    };
+    const matches =
+      !input.onlyUnknown &&
+      (input.bottle === undefined || input.bottle === review.bottle.id) &&
+      includesQuery(input.query, review.name);
+
+    return {
+      results: matches ? [review] : [],
+      rel: noMorePages,
+    };
+  },
+);

--- a/apps/server/src/orpc/mock/routes/users/badge-list.ts
+++ b/apps/server/src/orpc/mock/routes/users/badge-list.ts
@@ -1,0 +1,16 @@
+import {
+  matchesMockUser,
+  mockBadgeAward,
+  noMorePages,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.users.badgeList.handler(
+  async ({ input, context, errors }) => {
+    if (!matchesMockUser(input.user, context.user)) {
+      throw errors.NOT_FOUND({ message: "Mock user not found." });
+    }
+
+    return { results: [mockBadgeAward], rel: noMorePages };
+  },
+);

--- a/apps/server/src/orpc/mock/routes/users/flavor-list.ts
+++ b/apps/server/src/orpc/mock/routes/users/flavor-list.ts
@@ -1,0 +1,15 @@
+import {
+  matchesMockUser,
+  mockUserFlavorList,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.users.flavorList.handler(
+  async ({ input, context, errors }) => {
+    if (!matchesMockUser(input.user, context.user)) {
+      throw errors.NOT_FOUND({ message: "Mock user not found." });
+    }
+
+    return mockUserFlavorList;
+  },
+);

--- a/apps/server/src/orpc/mock/routes/users/library-stats.ts
+++ b/apps/server/src/orpc/mock/routes/users/library-stats.ts
@@ -1,0 +1,15 @@
+import {
+  matchesMockUser,
+  mockUserLibraryStats,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.users.libraryStats.handler(
+  async ({ input, context, errors }) => {
+    if (!matchesMockUser(input.user, context.user)) {
+      throw errors.NOT_FOUND({ message: "Mock user not found." });
+    }
+
+    return mockUserLibraryStats;
+  },
+);

--- a/apps/server/src/orpc/mock/routes/users/region-list.ts
+++ b/apps/server/src/orpc/mock/routes/users/region-list.ts
@@ -1,0 +1,15 @@
+import {
+  matchesMockUser,
+  mockUserRegionList,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.users.regionList.handler(
+  async ({ input, context, errors }) => {
+    if (!matchesMockUser(input.user, context.user)) {
+      throw errors.NOT_FOUND({ message: "Mock user not found." });
+    }
+
+    return mockUserRegionList;
+  },
+);

--- a/apps/server/src/orpc/mock/routes/users/tasting-stats.ts
+++ b/apps/server/src/orpc/mock/routes/users/tasting-stats.ts
@@ -1,0 +1,15 @@
+import {
+  matchesMockUser,
+  mockUserTastingStats,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.users.tastingStats.handler(
+  async ({ input, context, errors }) => {
+    if (!matchesMockUser(input.user, context.user)) {
+      throw errors.NOT_FOUND({ message: "Mock user not found." });
+    }
+
+    return mockUserTastingStats;
+  },
+);

--- a/apps/server/src/orpc/routes/bottles/tags.ts
+++ b/apps/server/src/orpc/routes/bottles/tags.ts
@@ -4,71 +4,45 @@ import {
   ActiveBottleSelectionError,
   resolveActiveBottleIds,
 } from "@peated/server/lib/resolveActiveBottleIds";
-import { procedure } from "@peated/server/orpc";
+import { implement } from "@peated/server/orpc";
+import bottleTagsContract from "@peated/server/orpc/contracts/bottles/tags";
 import { and, eq, sql } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/bottles/{bottle}/tags",
-    summary: "Get bottle tags",
-    description:
-      "Retrieve tags associated with a bottle and their usage counts from tastings",
-    spec: (spec) => ({
-      ...spec,
-      operationId: "getBottleTags",
-    }),
-  })
-  .input(
-    z.object({
-      bottle: z.coerce.number(),
-      limit: z.coerce.number().gte(1).lte(100).default(25),
-    }),
-  )
-  .output(
-    z.object({
-      results: z.array(
-        z.object({
-          tag: z.string(),
-          count: z.number(),
-        }),
-      ),
-      totalCount: z.number(),
-    }),
-  )
-  .handler(async function ({ input, errors }) {
-    try {
-      return await db.transaction(async (tx) => {
-        await resolveActiveBottleIds(tx, [input.bottle]);
+export default implement(bottleTagsContract).handler(async function ({
+  input,
+  errors,
+}) {
+  try {
+    return await db.transaction(async (tx) => {
+      await resolveActiveBottleIds(tx, [input.bottle]);
 
-        const results = await tx.query.bottleTags.findMany({
-          where: (bottleTags, { eq }) => eq(bottleTags.bottleId, input.bottle),
-          orderBy: (bottleTags, { desc }) => desc(bottleTags.count),
-          limit: input.limit,
-        });
-        const [{ count }] = await tx
-          .select({ count: sql<string>`COUNT(*)` })
-          .from(tastings)
-          .where(
-            and(
-              eq(tastings.bottleId, input.bottle),
-              sql<boolean>`array_length(${tastings.tags}, 1) > 0`,
-            ),
-          );
-
-        return {
-          results: results.map(({ tag, count }) => ({ tag, count })),
-          totalCount: Number(count),
-        };
+      const results = await tx.query.bottleTags.findMany({
+        where: (bottleTags, { eq }) => eq(bottleTags.bottleId, input.bottle),
+        orderBy: (bottleTags, { desc }) => desc(bottleTags.count),
+        limit: input.limit,
       });
-    } catch (error) {
-      if (error instanceof ActiveBottleSelectionError) {
-        if (error.reason === "missing") {
-          throw errors.NOT_FOUND({ message: error.message, cause: error });
-        }
-        throw errors.CONFLICT({ message: error.message, cause: error });
+      const [{ count }] = await tx
+        .select({ count: sql<string>`COUNT(*)` })
+        .from(tastings)
+        .where(
+          and(
+            eq(tastings.bottleId, input.bottle),
+            sql<boolean>`array_length(${tastings.tags}, 1) > 0`,
+          ),
+        );
+
+      return {
+        results: results.map(({ tag, count }) => ({ tag, count })),
+        totalCount: Number(count),
+      };
+    });
+  } catch (error) {
+    if (error instanceof ActiveBottleSelectionError) {
+      if (error.reason === "missing") {
+        throw errors.NOT_FOUND({ message: error.message, cause: error });
       }
-      throw error;
+      throw errors.CONFLICT({ message: error.message, cause: error });
     }
-  });
+    throw error;
+  }
+});

--- a/apps/server/src/orpc/routes/comments/list.ts
+++ b/apps/server/src/orpc/routes/comments/list.ts
@@ -1,88 +1,64 @@
 import { db } from "@peated/server/db";
 import { comments } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
-import { CommentSchema, listResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import commentListContract from "@peated/server/orpc/contracts/comments/list";
 import { serialize } from "@peated/server/serializers";
 import { CommentSerializer } from "@peated/server/serializers/comment";
 import { and, asc, eq } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/comments",
-    summary: "List comments",
-    description: "Retrieve comments with filtering by user and tasting",
-    spec: (spec) => ({
-      ...spec,
-      operationId: "listComments",
-    }),
-  })
-  // .route({
-  //   method: "GET",
-  //   path: "/tastings/{tasting}/comments",
-  //   tags: ["tastings"],
-  // })
-  // .route({ method: "GET", path: "/users/{user}/comments", tags: ["users"] })
-  .input(
-    z.object({
-      user: z.union([z.literal("me"), z.coerce.number()]).optional(),
-      tasting: z.coerce.number().optional(),
-      cursor: z.coerce.number().gte(1).default(1),
-      limit: z.coerce.number().gte(1).lte(100).default(100),
-    }),
-  )
-  // TODO(response-envelope): helper enables later switch to { data, meta }
-  .output(listResponse(CommentSchema))
-  .handler(async function ({ input, context, errors }) {
-    const { cursor, limit, ...rest } = input;
-    const offset = (cursor - 1) * limit;
+export default implement(commentListContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const { cursor, limit, ...rest } = input;
+  const offset = (cursor - 1) * limit;
 
-    // have to specify at least one so folks dont scrape all comments
-    if (!context.user?.admin && !rest.tasting && !rest.user) {
-      return {
-        results: [],
-        rel: {
-          nextCursor: null,
-          prevCursor: null,
-        },
-      };
-    }
-
-    const where = [];
-
-    if (rest.user) {
-      if (rest.user === "me") {
-        if (!context.user) {
-          throw errors.UNAUTHORIZED();
-        }
-        where.push(eq(comments.createdById, context.user.id));
-      } else {
-        where.push(eq(comments.createdById, rest.user));
-      }
-    }
-
-    if (rest.tasting) {
-      where.push(eq(comments.tastingId, rest.tasting));
-    }
-
-    const results = await db
-      .select()
-      .from(comments)
-      .where(and(...where))
-      .limit(limit + 1)
-      .offset(offset)
-      .orderBy(asc(comments.createdAt));
-
+  // have to specify at least one so folks dont scrape all comments
+  if (!context.user?.admin && !rest.tasting && !rest.user) {
     return {
-      results: await serialize(
-        CommentSerializer,
-        results.slice(0, limit),
-        context.user,
-      ),
+      results: [],
       rel: {
-        nextCursor: results.length > limit ? cursor + 1 : null,
-        prevCursor: cursor > 1 ? cursor - 1 : null,
+        nextCursor: null,
+        prevCursor: null,
       },
     };
-  });
+  }
+
+  const where = [];
+
+  if (rest.user) {
+    if (rest.user === "me") {
+      if (!context.user) {
+        throw errors.UNAUTHORIZED();
+      }
+      where.push(eq(comments.createdById, context.user.id));
+    } else {
+      where.push(eq(comments.createdById, rest.user));
+    }
+  }
+
+  if (rest.tasting) {
+    where.push(eq(comments.tastingId, rest.tasting));
+  }
+
+  const results = await db
+    .select()
+    .from(comments)
+    .where(and(...where))
+    .limit(limit + 1)
+    .offset(offset)
+    .orderBy(asc(comments.createdAt));
+
+  return {
+    results: await serialize(
+      CommentSerializer,
+      results.slice(0, limit),
+      context.user,
+    ),
+    rel: {
+      nextCursor: results.length > limit ? cursor + 1 : null,
+      prevCursor: cursor > 1 ? cursor - 1 : null,
+    },
+  };
+});

--- a/apps/server/src/orpc/routes/entities/catalog.ts
+++ b/apps/server/src/orpc/routes/entities/catalog.ts
@@ -5,17 +5,9 @@ import {
   bottlesToDistillers,
   entities,
 } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
-import { CategoryEnum } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import entityCatalogContract from "@peated/server/orpc/contracts/entities/catalog";
 import { and, asc, desc, eq, isNotNull, ne, or, sql } from "drizzle-orm";
-import { z } from "zod";
-
-const RelatedEntitySchema = z.object({
-  id: z.number(),
-  name: z.string(),
-  shortName: z.string().nullable(),
-  count: z.number(),
-});
 
 const activeBottleWhere = (entityId: number) =>
   and(
@@ -32,178 +24,138 @@ const activeBottleWhere = (entityId: number) =>
     ),
   );
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/entities/{entity}/catalog",
-    summary: "Get an entity catalog summary",
-    description:
-      "Summarize bottle roles, categories, and related entities for a brand, bottler, or distiller",
-    spec: (spec) => ({ ...spec, operationId: "getEntityCatalog" }),
-  })
-  .input(z.object({ entity: z.coerce.number() }))
-  .output(
-    z.object({
-      totalBottles: z.number(),
-      relationships: z.object({
-        brand: z.number(),
-        bottler: z.number(),
-        distiller: z.number(),
-      }),
-      distilleryCoverage: z.object({
-        documented: z.number(),
-        total: z.number(),
-      }),
-      categories: z.array(
-        z.object({
-          category: CategoryEnum.nullable(),
-          count: z.number(),
-        }),
-      ),
-      related: z.object({
-        brands: z.array(RelatedEntitySchema),
-        bottlers: z.array(RelatedEntitySchema),
-        distillers: z.array(RelatedEntitySchema),
-      }),
-      notableBottles: z.array(
-        z.object({
-          id: z.number(),
-          fullName: z.string(),
-          totalTastings: z.number(),
-          avgRating: z.number().nullable(),
-        }),
-      ),
-    }),
-  )
-  .handler(async function ({ input, errors }) {
-    const [entity] = await db
-      .select({ id: entities.id })
-      .from(entities)
-      .where(eq(entities.id, input.entity));
-    if (!entity) {
-      throw errors.NOT_FOUND({ message: "Entity not found." });
-    }
+export default implement(entityCatalogContract).handler(async function ({
+  input,
+  errors,
+}) {
+  const [entity] = await db
+    .select({ id: entities.id })
+    .from(entities)
+    .where(eq(entities.id, input.entity));
+  if (!entity) {
+    throw errors.NOT_FOUND({ message: "Entity not found." });
+  }
 
-    const associatedBottle = activeBottleWhere(entity.id);
-    const [
-      counts,
-      categoryRows,
-      brandRows,
-      bottlerRows,
-      distillerRows,
-      notableBottleRows,
-    ] = await Promise.all([
-      db
-        .select({
-          totalBottles: sql<string>`COUNT(*)`,
-          brand: sql<string>`COUNT(*) FILTER (WHERE ${bottles.brandId} = ${entity.id})`,
-          bottler: sql<string>`COUNT(*) FILTER (WHERE ${bottles.bottlerId} = ${entity.id})`,
-          distiller: sql<string>`COUNT(*) FILTER (WHERE EXISTS(
+  const associatedBottle = activeBottleWhere(entity.id);
+  const [
+    counts,
+    categoryRows,
+    brandRows,
+    bottlerRows,
+    distillerRows,
+    notableBottleRows,
+  ] = await Promise.all([
+    db
+      .select({
+        totalBottles: sql<string>`COUNT(*)`,
+        brand: sql<string>`COUNT(*) FILTER (WHERE ${bottles.brandId} = ${entity.id})`,
+        bottler: sql<string>`COUNT(*) FILTER (WHERE ${bottles.bottlerId} = ${entity.id})`,
+        distiller: sql<string>`COUNT(*) FILTER (WHERE EXISTS(
               SELECT FROM ${bottlesToDistillers}
               WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
                 AND ${bottlesToDistillers.distillerId} = ${entity.id}
             ))`,
-          documentedDistillery: sql<string>`COUNT(*) FILTER (WHERE EXISTS(
+        documentedDistillery: sql<string>`COUNT(*) FILTER (WHERE EXISTS(
               SELECT FROM ${bottlesToDistillers}
               WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
             ))`,
-        })
-        .from(bottles)
-        .where(associatedBottle),
-      db
-        .select({
-          category: bottles.category,
-          count: sql<string>`COUNT(*)`,
-        })
-        .from(bottles)
-        .where(associatedBottle)
-        .groupBy(bottles.category)
-        .orderBy(desc(sql`COUNT(*)`), asc(bottles.category)),
-      db
-        .select({
-          id: entities.id,
-          name: entities.name,
-          shortName: entities.shortName,
-          count: sql<string>`COUNT(DISTINCT ${bottles.id})`,
-        })
-        .from(bottles)
-        .innerJoin(entities, eq(entities.id, bottles.brandId))
-        .where(and(associatedBottle, ne(entities.id, entity.id)))
-        .groupBy(entities.id)
-        .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
-        .limit(7),
-      db
-        .select({
-          id: entities.id,
-          name: entities.name,
-          shortName: entities.shortName,
-          count: sql<string>`COUNT(DISTINCT ${bottles.id})`,
-        })
-        .from(bottles)
-        .innerJoin(entities, eq(entities.id, bottles.bottlerId))
-        .where(and(associatedBottle, ne(entities.id, entity.id)))
-        .groupBy(entities.id)
-        .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
-        .limit(7),
-      db
-        .select({
-          id: entities.id,
-          name: entities.name,
-          shortName: entities.shortName,
-          count: sql<string>`COUNT(DISTINCT ${bottles.id})`,
-        })
-        .from(bottles)
-        .innerJoin(
-          bottlesToDistillers,
-          eq(bottlesToDistillers.bottleId, bottles.id),
-        )
-        .innerJoin(entities, eq(entities.id, bottlesToDistillers.distillerId))
-        .where(and(associatedBottle, ne(entities.id, entity.id)))
-        .groupBy(entities.id)
-        .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
-        .limit(7),
-      db
-        .select({
-          id: bottles.id,
-          fullName: bottles.fullName,
-          totalTastings: bottles.totalTastings,
-          avgRating: bottles.avgRating,
-        })
-        .from(bottles)
-        .where(associatedBottle)
-        .orderBy(desc(bottles.totalTastings), asc(bottles.fullName))
-        .limit(4),
-    ]);
+      })
+      .from(bottles)
+      .where(associatedBottle),
+    db
+      .select({
+        category: bottles.category,
+        count: sql<string>`COUNT(*)`,
+      })
+      .from(bottles)
+      .where(associatedBottle)
+      .groupBy(bottles.category)
+      .orderBy(desc(sql`COUNT(*)`), asc(bottles.category)),
+    db
+      .select({
+        id: entities.id,
+        name: entities.name,
+        shortName: entities.shortName,
+        count: sql<string>`COUNT(DISTINCT ${bottles.id})`,
+      })
+      .from(bottles)
+      .innerJoin(entities, eq(entities.id, bottles.brandId))
+      .where(and(associatedBottle, ne(entities.id, entity.id)))
+      .groupBy(entities.id)
+      .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
+      .limit(7),
+    db
+      .select({
+        id: entities.id,
+        name: entities.name,
+        shortName: entities.shortName,
+        count: sql<string>`COUNT(DISTINCT ${bottles.id})`,
+      })
+      .from(bottles)
+      .innerJoin(entities, eq(entities.id, bottles.bottlerId))
+      .where(and(associatedBottle, ne(entities.id, entity.id)))
+      .groupBy(entities.id)
+      .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
+      .limit(7),
+    db
+      .select({
+        id: entities.id,
+        name: entities.name,
+        shortName: entities.shortName,
+        count: sql<string>`COUNT(DISTINCT ${bottles.id})`,
+      })
+      .from(bottles)
+      .innerJoin(
+        bottlesToDistillers,
+        eq(bottlesToDistillers.bottleId, bottles.id),
+      )
+      .innerJoin(entities, eq(entities.id, bottlesToDistillers.distillerId))
+      .where(and(associatedBottle, ne(entities.id, entity.id)))
+      .groupBy(entities.id)
+      .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
+      .limit(7),
+    db
+      .select({
+        id: bottles.id,
+        fullName: bottles.fullName,
+        totalTastings: bottles.totalTastings,
+        avgRating: bottles.avgRating,
+      })
+      .from(bottles)
+      .where(associatedBottle)
+      .orderBy(desc(bottles.totalTastings), asc(bottles.fullName))
+      .limit(4),
+  ]);
 
-    const summary = counts[0];
-    if (!summary) {
-      throw new Error(`Missing catalog summary for Entity ${entity.id}.`);
-    }
+  const summary = counts[0];
+  if (!summary) {
+    throw new Error(`Missing catalog summary for Entity ${entity.id}.`);
+  }
 
-    const related = (rows: typeof brandRows) =>
-      rows.map((row) => ({ ...row, count: Number(row.count) }));
-    const totalBottles = Number(summary.totalBottles);
+  const related = (rows: typeof brandRows) =>
+    rows.map((row) => ({ ...row, count: Number(row.count) }));
+  const totalBottles = Number(summary.totalBottles);
 
-    return {
-      totalBottles,
-      relationships: {
-        brand: Number(summary.brand),
-        bottler: Number(summary.bottler),
-        distiller: Number(summary.distiller),
-      },
-      distilleryCoverage: {
-        documented: Number(summary.documentedDistillery),
-        total: totalBottles,
-      },
-      categories: categoryRows.map((row) => ({
-        category: row.category,
-        count: Number(row.count),
-      })),
-      related: {
-        brands: related(brandRows),
-        bottlers: related(bottlerRows),
-        distillers: related(distillerRows),
-      },
-      notableBottles: notableBottleRows,
-    };
-  });
+  return {
+    totalBottles,
+    relationships: {
+      brand: Number(summary.brand),
+      bottler: Number(summary.bottler),
+      distiller: Number(summary.distiller),
+    },
+    distilleryCoverage: {
+      documented: Number(summary.documentedDistillery),
+      total: totalBottles,
+    },
+    categories: categoryRows.map((row) => ({
+      category: row.category,
+      count: Number(row.count),
+    })),
+    related: {
+      brands: related(brandRows),
+      bottlers: related(bottlerRows),
+      distillers: related(distillerRows),
+    },
+    notableBottles: notableBottleRows,
+  };
+});

--- a/apps/server/src/orpc/routes/flights/details.ts
+++ b/apps/server/src/orpc/routes/flights/details.ts
@@ -1,38 +1,27 @@
 import { db } from "@peated/server/db";
 import { flights } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
-import { FlightDetailsSchema, detailsResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import flightDetailsContract from "@peated/server/orpc/contracts/flights/details";
 import { serialize } from "@peated/server/serializers";
 import { FlightDetailsSerializer } from "@peated/server/serializers/flight";
 import { eq } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
-  // we use the publicId as the route param here as an easy solution
-  // to make the flight private (through obscuring the id)
-  .route({
-    method: "GET",
-    path: "/flights/{flight}",
-    summary: "Get flight details",
-    description:
-      "Retrieve detailed information about a specific tasting flight using its public ID",
-    operationId: "getFlight",
-  })
-  .input(z.object({ flight: z.string() }))
-  // TODO(response-envelope): wrap in { data } by updating detailsResponse() at cutover
-  .output(detailsResponse(FlightDetailsSchema))
-  .handler(async function ({ input, context, errors }) {
-    const { flight: flightId } = input;
+export default implement(flightDetailsContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const { flight: flightId } = input;
 
-    const [flight] = await db
-      .select()
-      .from(flights)
-      .where(eq(flights.publicId, flightId));
-    if (!flight) {
-      throw errors.NOT_FOUND({
-        message: "Flight not found.",
-      });
-    }
+  const [flight] = await db
+    .select()
+    .from(flights)
+    .where(eq(flights.publicId, flightId));
+  if (!flight) {
+    throw errors.NOT_FOUND({
+      message: "Flight not found.",
+    });
+  }
 
-    return await serialize(FlightDetailsSerializer, flight, context.user);
-  });
+  return await serialize(FlightDetailsSerializer, flight, context.user);
+});

--- a/apps/server/src/orpc/routes/flights/list.ts
+++ b/apps/server/src/orpc/routes/flights/list.ts
@@ -1,106 +1,68 @@
 import { db } from "@peated/server/db";
 import { flights } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
-import { FlightSchema, listResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import flightListContract from "@peated/server/orpc/contracts/flights/list";
 import { serialize } from "@peated/server/serializers";
 import { FlightSerializer } from "@peated/server/serializers/flight";
 import type { SQL } from "drizzle-orm";
 import { and, asc, desc, eq, ilike, or } from "drizzle-orm";
-import { z } from "zod";
 
-const DEFAULT_SORT = "name";
+export default implement(flightListContract).handler(async function ({
+  input: { query, cursor, limit, ...input },
+  context,
+}) {
+  const offset = (cursor - 1) * limit;
 
-const SORT_OPTIONS = ["name", "-name"] as const;
+  const where: (SQL<unknown> | undefined)[] = [];
+  if (query) {
+    where.push(ilike(flights.name, `%${query}%`));
+  }
 
-const OutputSchema = listResponse(FlightSchema);
-
-export default procedure
-  .route({
-    method: "GET",
-    path: "/flights",
-    summary: "List flights",
-    description:
-      "Retrieve tasting flights with filtering by visibility and search. Respects user permissions for private flights",
-    operationId: "listFlights",
-  })
-  .input(
-    z
-      .object({
-        query: z.string().default(""),
-        filter: z.enum(["public", "private", "none"]).optional(),
-        sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
-        cursor: z.coerce.number().gte(1).default(1),
-        limit: z.coerce.number().gte(1).lte(100).default(100),
-      })
-      .default({
-        query: "",
-        sort: DEFAULT_SORT,
-        cursor: 1,
-        limit: 100,
-      }),
-  )
-  .output(OutputSchema)
-  .handler(async function ({
-    input: { query, cursor, limit, ...input },
-    context,
-  }) {
-    const offset = (cursor - 1) * limit;
-
-    const where: (SQL<unknown> | undefined)[] = [];
-    if (query) {
-      where.push(ilike(flights.name, `%${query}%`));
-    }
-
-    if (context.user?.mod && input.filter === "none") {
-      // do nothing
+  if (context.user?.mod && input.filter === "none") {
+    // do nothing
+  } else {
+    if (context.user) {
+      where.push(
+        or(eq(flights.public, true), eq(flights.createdById, context.user.id)),
+      );
     } else {
-      if (context.user) {
-        where.push(
-          or(
-            eq(flights.public, true),
-            eq(flights.createdById, context.user.id),
-          ),
-        );
-      } else {
-        where.push(eq(flights.public, true));
-      }
-
-      if (input.filter === "public") {
-        where.push(eq(flights.public, true));
-      } else if (input.filter === "private") {
-        where.push(eq(flights.public, false));
-      }
+      where.push(eq(flights.public, true));
     }
 
-    let orderBy: SQL<unknown>;
-    switch (input.sort) {
-      case "name":
-        orderBy = asc(flights.name);
-        break;
-      case "-name":
-        orderBy = desc(flights.name);
-        break;
-      default:
-        orderBy = asc(flights.name);
+    if (input.filter === "public") {
+      where.push(eq(flights.public, true));
+    } else if (input.filter === "private") {
+      where.push(eq(flights.public, false));
     }
+  }
 
-    const results = await db
-      .select()
-      .from(flights)
-      .where(where ? and(...where) : undefined)
-      .limit(limit + 1)
-      .offset(offset)
-      .orderBy(orderBy);
+  let orderBy: SQL<unknown>;
+  switch (input.sort) {
+    case "name":
+      orderBy = asc(flights.name);
+      break;
+    case "-name":
+      orderBy = desc(flights.name);
+      break;
+  }
 
-    return {
-      results: await serialize(
-        FlightSerializer,
-        results.slice(0, limit),
-        context.user,
-      ),
-      rel: {
-        nextCursor: results.length > limit ? cursor + 1 : null,
-        prevCursor: cursor > 1 ? cursor - 1 : null,
-      },
-    };
-  });
+  const results = await db
+    .select()
+    .from(flights)
+    .where(where ? and(...where) : undefined)
+    .limit(limit + 1)
+    .offset(offset)
+    .orderBy(orderBy);
+
+  return {
+    results: await serialize(
+      FlightSerializer,
+      results.slice(0, limit),
+      context.user,
+    ),
+    rel: {
+      nextCursor: results.length > limit ? cursor + 1 : null,
+      prevCursor: cursor > 1 ? cursor - 1 : null,
+    },
+  };
+});

--- a/apps/server/src/orpc/routes/notifications/count.ts
+++ b/apps/server/src/orpc/routes/notifications/count.ts
@@ -1,29 +1,13 @@
 import { db } from "@peated/server/db";
 import { notifications } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
+import { implement } from "@peated/server/orpc";
+import notificationCountContract from "@peated/server/orpc/contracts/notifications/count";
 import { requireAuth } from "@peated/server/orpc/middleware";
 import type { SQL } from "drizzle-orm";
 import { and, eq, sql } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
+export default implement(notificationCountContract)
   .use(requireAuth)
-  .route({
-    method: "GET",
-    path: "/notifications/count",
-    summary: "Count notifications",
-    description:
-      "Get the count of user notifications with optional filtering by read status",
-    operationId: "countNotifications",
-  })
-  .input(
-    z
-      .object({
-        filter: z.enum(["unread", "all"]).nullish(),
-      })
-      .default({}),
-  )
-  .output(z.object({ count: z.number() }))
   .handler(async function ({ input, context }) {
     const where: (SQL<unknown> | undefined)[] = [
       eq(notifications.userId, context.user.id),

--- a/apps/server/src/orpc/routes/reviews/list.ts
+++ b/apps/server/src/orpc/routes/reviews/list.ts
@@ -6,151 +6,112 @@ import {
   reviews,
 } from "@peated/server/db/schema";
 import { logWarn } from "@peated/server/lib/log";
-import { procedure } from "@peated/server/orpc";
-import {
-  ExternalSiteTypeEnum,
-  ReviewSchema,
-  listResponse,
-} from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import reviewListContract from "@peated/server/orpc/contracts/reviews/list";
 import { serialize } from "@peated/server/serializers";
 import { ReviewSerializer } from "@peated/server/serializers/review";
 import type { SQL } from "drizzle-orm";
 import { and, asc, desc, eq, ilike, isNotNull, isNull, or } from "drizzle-orm";
-import { z } from "zod";
+export default implement(reviewListContract).handler(async function ({
+  input: { cursor, query, limit, sort, ...input },
+  context,
+  errors,
+}) {
+  const hasPublicScope = input.bottle !== undefined || sort === "recent";
+  const requiresModerator = input.onlyUnknown || !hasPublicScope;
+  // This route owns review visibility. Public Bottle and recent queries
+  // exclude staged reviews. Moderator queries include them for review and matching.
+  const baseWhere: (SQL<unknown> | undefined)[] = requiresModerator
+    ? []
+    : [eq(reviews.hidden, false)];
+  const identityWhere: SQL<unknown>[] = [];
 
-const DEFAULT_SORT = "recent";
-const SORT_OPTIONS = ["recent", "name"] as const;
+  if (input.site) {
+    const site = await db.query.externalSites.findFirst({
+      where: eq(externalSites.type, input.site),
+    });
 
-const InputSchema = z
-  .object({
-    site: ExternalSiteTypeEnum.optional(),
-    bottle: z.coerce.number().gte(1).optional(),
-    query: z.string().default(""),
-    onlyUnknown: z.coerce.boolean().optional(),
-    sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
-    cursor: z.coerce.number().gte(1).default(1),
-    limit: z.coerce.number().gte(1).lte(100).default(100),
-  })
-  .strict()
-  .default({
-    query: "",
-    sort: DEFAULT_SORT,
-    cursor: 1,
-    limit: 100,
-  });
-
-export default procedure
-  .route({
-    method: "GET",
-    path: "/reviews",
-    summary: "List reviews",
-    description:
-      "Retrieve reviews with filtering by site, Bottle, recent publication, and unknown status. Requires moderator privileges for full access",
-    operationId: "listReviews",
-  })
-  .input(InputSchema)
-  // TODO(response-envelope): use helper to enable later switch to { data, meta }
-  .output(listResponse(ReviewSchema))
-  .handler(async function ({
-    input: { cursor, query, limit, sort, ...input },
-    context,
-    errors,
-  }) {
-    const hasPublicScope = input.bottle !== undefined || sort === "recent";
-    const requiresModerator = input.onlyUnknown || !hasPublicScope;
-    // This route owns review visibility. Public Bottle and recent queries
-    // exclude staged reviews. Moderator queries include them for review and matching.
-    const baseWhere: (SQL<unknown> | undefined)[] = requiresModerator
-      ? []
-      : [eq(reviews.hidden, false)];
-    const identityWhere: SQL<unknown>[] = [];
-
-    if (input.site) {
-      const site = await db.query.externalSites.findFirst({
-        where: eq(externalSites.type, input.site),
-      });
-
-      if (!site) {
-        throw errors.NOT_FOUND({
-          message: "Site not found.",
-        });
-      }
-      baseWhere.push(eq(reviewArticles.externalSiteId, site.id));
-    }
-
-    if (hasPublicScope) {
-      // No-fetch migration articles have no content hash and preserve their
-      // legacy visibility. Newly fetched articles require automatic mode.
-      baseWhere.push(
-        or(
-          isNull(reviewArticles.contentHash),
-          eq(externalReviewSourcePolicies.publicationMode, "automatic"),
-        ),
-      );
-    }
-
-    if (sort === "recent") {
-      baseWhere.push(
-        isNotNull(reviews.bottleId),
-        isNotNull(reviewArticles.publishedAt),
-      );
-    }
-
-    if (requiresModerator && !context.user?.admin && !context.user?.mod) {
-      logWarn("User requested review list without moderator permissions", {
-        extra: {
-          userId: context.user?.id,
-        },
-      });
-      throw errors.BAD_REQUEST({
-        message: "Must be a moderator to list all reviews.",
+    if (!site) {
+      throw errors.NOT_FOUND({
+        message: "Site not found.",
       });
     }
+    baseWhere.push(eq(reviewArticles.externalSiteId, site.id));
+  }
 
-    if (input.onlyUnknown) {
-      identityWhere.push(isNull(reviews.bottleId));
-    }
-
-    if (input.bottle !== undefined) {
-      identityWhere.push(eq(reviews.bottleId, input.bottle));
-    }
-
-    const offset = (cursor - 1) * limit;
-    if (query) {
-      baseWhere.push(ilike(reviews.name, `%${query}%`));
-    }
-
-    const rows = await db
-      .select({ review: reviews })
-      .from(reviews)
-      .innerJoin(reviewArticles, eq(reviews.articleId, reviewArticles.id))
-      .leftJoin(
-        externalReviewSourcePolicies,
-        eq(
-          reviewArticles.externalSiteId,
-          externalReviewSourcePolicies.externalSiteId,
-        ),
-      )
-      .where(and(...baseWhere, ...identityWhere))
-      .limit(limit + 1)
-      .offset(offset)
-      .orderBy(
-        ...(sort === "recent"
-          ? [desc(reviewArticles.publishedAt), desc(reviews.id)]
-          : [asc(reviews.name), asc(reviews.id)]),
-      );
-    const results = rows.map(({ review }) => review);
-
-    return {
-      results: await serialize(
-        ReviewSerializer,
-        results.slice(0, limit),
-        context.user,
-        input.site && sort !== "recent" ? ["site"] : [],
+  if (hasPublicScope) {
+    // No-fetch migration articles have no content hash and preserve their
+    // legacy visibility. Newly fetched articles require automatic mode.
+    baseWhere.push(
+      or(
+        isNull(reviewArticles.contentHash),
+        eq(externalReviewSourcePolicies.publicationMode, "automatic"),
       ),
-      rel: {
-        nextCursor: results.length > limit ? cursor + 1 : null,
-        prevCursor: cursor > 1 ? cursor - 1 : null,
+    );
+  }
+
+  if (sort === "recent") {
+    baseWhere.push(
+      isNotNull(reviews.bottleId),
+      isNotNull(reviewArticles.publishedAt),
+    );
+  }
+
+  if (requiresModerator && !context.user?.admin && !context.user?.mod) {
+    logWarn("User requested review list without moderator permissions", {
+      extra: {
+        userId: context.user?.id,
       },
-    };
-  });
+    });
+    throw errors.BAD_REQUEST({
+      message: "Must be a moderator to list all reviews.",
+    });
+  }
+
+  if (input.onlyUnknown) {
+    identityWhere.push(isNull(reviews.bottleId));
+  }
+
+  if (input.bottle !== undefined) {
+    identityWhere.push(eq(reviews.bottleId, input.bottle));
+  }
+
+  const offset = (cursor - 1) * limit;
+  if (query) {
+    baseWhere.push(ilike(reviews.name, `%${query}%`));
+  }
+
+  const rows = await db
+    .select({ review: reviews })
+    .from(reviews)
+    .innerJoin(reviewArticles, eq(reviews.articleId, reviewArticles.id))
+    .leftJoin(
+      externalReviewSourcePolicies,
+      eq(
+        reviewArticles.externalSiteId,
+        externalReviewSourcePolicies.externalSiteId,
+      ),
+    )
+    .where(and(...baseWhere, ...identityWhere))
+    .limit(limit + 1)
+    .offset(offset)
+    .orderBy(
+      ...(sort === "recent"
+        ? [desc(reviewArticles.publishedAt), desc(reviews.id)]
+        : [asc(reviews.name), asc(reviews.id)]),
+    );
+  const results = rows.map(({ review }) => review);
+
+  return {
+    results: await serialize(
+      ReviewSerializer,
+      results.slice(0, limit),
+      context.user,
+      input.site && sort !== "recent" ? ["site"] : [],
+    ),
+    rel: {
+      nextCursor: results.length > limit ? cursor + 1 : null,
+      prevCursor: cursor > 1 ? cursor - 1 : null,
+    },
+  };
+});

--- a/apps/server/src/orpc/routes/users/age-stats.ts
+++ b/apps/server/src/orpc/routes/users/age-stats.ts
@@ -1,26 +1,4 @@
-import { z } from "zod";
-
-export const AgeStatsSchema = z.object({
-  knownCount: z.number(),
-  median: z.number().nullable(),
-  oldest: z.number().nullable(),
-  buckets: z.array(
-    z.object({
-      id: z.enum([
-        "under10",
-        "from10To12",
-        "from13To17",
-        "from18To24",
-        "atLeast25",
-        "unstated",
-      ]),
-      label: z.string(),
-      count: z.number(),
-    }),
-  ),
-});
-
-export type AgeStats = z.infer<typeof AgeStatsSchema>;
+import type { AgeStats } from "@peated/server/schemas";
 
 function median(values: number[]): number | null {
   if (values.length === 0) return null;

--- a/apps/server/src/orpc/routes/users/badge-list.ts
+++ b/apps/server/src/orpc/routes/users/badge-list.ts
@@ -1,71 +1,52 @@
 import { db } from "@peated/server/db";
 import { badgeAwards } from "@peated/server/db/schema";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
-import { procedure } from "@peated/server/orpc";
-import { BadgeAwardSchema, listResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import userBadgeListContract from "@peated/server/orpc/contracts/users/badge-list";
 import { serialize } from "@peated/server/serializers";
 import { BadgeAwardSerializer } from "@peated/server/serializers/badgeAward";
 import { and, desc, eq, gte, sql } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/users/{user}/badges",
-    summary: "List user badges",
-    description:
-      "Retrieve badges earned by a user with pagination support. Respects privacy settings",
-    operationId: "listUserBadges",
-  })
-  .input(
-    z.object({
-      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
-      cursor: z.coerce.number().gte(1).default(1),
-      limit: z.coerce.number().gte(1).lte(100).default(25),
-    }),
-  )
-  // TODO(response-envelope): helper enables later switch to { data, meta }
-  .output(listResponse(BadgeAwardSchema))
-  .handler(async function ({
-    input: { cursor, limit, ...input },
-    context,
-    errors,
-  }) {
-    const user = await getUserFromId(db, input.user, context.user);
-    if (!user) {
-      throw errors.NOT_FOUND({
-        message: "User not found.",
-      });
-    }
+export default implement(userBadgeListContract).handler(async function ({
+  input: { cursor, limit, ...input },
+  context,
+  errors,
+}) {
+  const user = await getUserFromId(db, input.user, context.user);
+  if (!user) {
+    throw errors.NOT_FOUND({
+      message: "User not found.",
+    });
+  }
 
-    if (!(await profileVisible(db, user, context.user))) {
-      throw errors.BAD_REQUEST({
-        message: "User's profile is not public.",
-      });
-    }
+  if (!(await profileVisible(db, user, context.user))) {
+    throw errors.BAD_REQUEST({
+      message: "User's profile is not public.",
+    });
+  }
 
-    const offset = (cursor - 1) * limit;
+  const offset = (cursor - 1) * limit;
 
-    const results = await db
-      .select()
-      .from(badgeAwards)
-      .where(and(eq(badgeAwards.userId, user.id), gte(badgeAwards.xp, 0)))
-      .limit(limit + 1)
-      .offset(offset)
-      .orderBy(
-        sql`CASE WHEN ${badgeAwards.level} = 0 THEN 1 ELSE 0 END`,
-        desc(badgeAwards.createdAt),
-      );
+  const results = await db
+    .select()
+    .from(badgeAwards)
+    .where(and(eq(badgeAwards.userId, user.id), gte(badgeAwards.xp, 0)))
+    .limit(limit + 1)
+    .offset(offset)
+    .orderBy(
+      sql`CASE WHEN ${badgeAwards.level} = 0 THEN 1 ELSE 0 END`,
+      desc(badgeAwards.createdAt),
+    );
 
-    return {
-      results: await serialize(
-        BadgeAwardSerializer,
-        results.slice(0, limit),
-        context.user,
-      ),
-      rel: {
-        nextCursor: results.length > limit ? cursor + 1 : null,
-        prevCursor: cursor > 1 ? cursor - 1 : null,
-      },
-    };
-  });
+  return {
+    results: await serialize(
+      BadgeAwardSerializer,
+      results.slice(0, limit),
+      context.user,
+    ),
+    rel: {
+      nextCursor: results.length > limit ? cursor + 1 : null,
+      prevCursor: cursor > 1 ? cursor - 1 : null,
+    },
+  };
+});

--- a/apps/server/src/orpc/routes/users/flavor-list.ts
+++ b/apps/server/src/orpc/routes/users/flavor-list.ts
@@ -1,105 +1,82 @@
 import { db } from "@peated/server/db";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
-import { procedure } from "@peated/server/orpc";
-import { z } from "zod";
+import { implement } from "@peated/server/orpc";
+import userFlavorListContract from "@peated/server/orpc/contracts/users/flavor-list";
 import {
   scanUserTastingBottles,
   UserBottleReadIntegrityError,
 } from "./tasting-bottle-scan";
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/users/{user}/flavors",
-    summary: "List user flavor profiles",
-    description:
-      "Retrieve flavor profiles from bottles tasted by a user with counts and scores. Respects privacy settings",
-    operationId: "listUserFlavors",
-  })
-  .input(
-    z.object({
-      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
-    }),
-  )
-  .output(
-    z.object({
-      results: z.array(
-        z.object({
-          flavorProfile: z.string(),
-          count: z.number(),
-          score: z.number(),
-        }),
-      ),
-      totalScore: z.number(),
-      totalCount: z.number(),
-    }),
-  )
-  .handler(async function ({ input, context, errors }) {
-    const user = await getUserFromId(db, input.user, context.user);
-    if (!user) {
-      throw errors.NOT_FOUND({
-        message: "User not found.",
-      });
-    }
+export default implement(userFlavorListContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const user = await getUserFromId(db, input.user, context.user);
+  if (!user) {
+    throw errors.NOT_FOUND({
+      message: "User not found.",
+    });
+  }
 
-    if (!(await profileVisible(db, user, context.user))) {
-      throw errors.BAD_REQUEST({
-        message: "User's profile is not public.",
-      });
-    }
+  if (!(await profileVisible(db, user, context.user))) {
+    throw errors.BAD_REQUEST({
+      message: "User's profile is not public.",
+    });
+  }
 
-    const byFlavor = new Map<
-      string,
-      { count: number; score: number; hasRating: boolean }
-    >();
-    let totalCount = 0;
-    let totalScore = 0;
+  const byFlavor = new Map<
+    string,
+    { count: number; score: number; hasRating: boolean }
+  >();
+  let totalCount = 0;
+  let totalScore = 0;
 
-    try {
-      for await (const rows of scanUserTastingBottles(user.id)) {
-        for (const { bottle, rating } of rows) {
-          totalCount += 1;
-          totalScore += rating ?? 0;
+  try {
+    for await (const rows of scanUserTastingBottles(user.id)) {
+      for (const { bottle, rating } of rows) {
+        totalCount += 1;
+        totalScore += rating ?? 0;
 
-          if (!bottle?.flavorProfile) continue;
+        if (!bottle?.flavorProfile) continue;
 
-          const current = byFlavor.get(bottle.flavorProfile) ?? {
-            count: 0,
-            score: 0,
-            hasRating: false,
-          };
-          current.count += 1;
-          current.score += rating ?? 0;
-          current.hasRating ||= rating !== null;
-          byFlavor.set(bottle.flavorProfile, current);
-        }
+        const current = byFlavor.get(bottle.flavorProfile) ?? {
+          count: 0,
+          score: 0,
+          hasRating: false,
+        };
+        current.count += 1;
+        current.score += rating ?? 0;
+        current.hasRating ||= rating !== null;
+        byFlavor.set(bottle.flavorProfile, current);
       }
-    } catch (error) {
-      if (error instanceof UserBottleReadIntegrityError) {
-        throw errors.CONFLICT({ message: error.message, cause: error });
-      }
-      throw error;
     }
+  } catch (error) {
+    if (error instanceof UserBottleReadIntegrityError) {
+      throw errors.CONFLICT({ message: error.message, cause: error });
+    }
+    throw error;
+  }
 
-    const results = Array.from(byFlavor, ([flavorProfile, stats]) => ({
-      flavorProfile,
-      count: stats.count,
-      score: stats.score,
-      hasRating: stats.hasRating,
-    }))
-      .sort(
-        (left, right) =>
-          Number(left.hasRating) - Number(right.hasRating) ||
-          right.score - left.score ||
-          right.count - left.count ||
-          left.flavorProfile.localeCompare(right.flavorProfile),
-      )
-      .slice(0, 25)
-      .map(({ hasRating: _, ...result }) => result);
+  const results = Array.from(byFlavor, ([flavorProfile, stats]) => ({
+    flavorProfile,
+    count: stats.count,
+    score: stats.score,
+    hasRating: stats.hasRating,
+  }))
+    .sort(
+      (left, right) =>
+        Number(left.hasRating) - Number(right.hasRating) ||
+        right.score - left.score ||
+        right.count - left.count ||
+        left.flavorProfile.localeCompare(right.flavorProfile),
+    )
+    .slice(0, 25)
+    .map(({ hasRating: _, ...result }) => result);
 
-    return {
-      results,
-      totalScore,
-      totalCount,
-    };
-  });
+  return {
+    results,
+    totalScore,
+    totalCount,
+  };
+});

--- a/apps/server/src/orpc/routes/users/library-stats.ts
+++ b/apps/server/src/orpc/routes/users/library-stats.ts
@@ -8,11 +8,13 @@ import {
 } from "@peated/server/db/schema";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
 import { getReservedCollection } from "@peated/server/lib/db";
-import { procedure } from "@peated/server/orpc";
-import { CategoryEnum } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import type { LibraryStatsSchema } from "@peated/server/orpc/contracts/users/library-stats";
+import libraryStatsContract from "@peated/server/orpc/contracts/users/library-stats";
+import type { CategoryEnum } from "@peated/server/schemas";
 import { and, eq, gt, inArray, sql } from "drizzle-orm";
-import { z } from "zod";
-import { AgeStatsSchema, buildAgeStats } from "./age-stats";
+import type { z } from "zod";
+import { buildAgeStats } from "./age-stats";
 import {
   readJoinedUserBottle,
   type UserBottleRead,
@@ -20,36 +22,6 @@ import {
 } from "./tasting-bottle-scan";
 
 const LIBRARY_STATS_BATCH_SIZE = 200;
-
-const LibraryStatsSchema = z.object({
-  total: z.number(),
-  status: z.object({
-    open: z.number(),
-    sealed: z.number(),
-    unspecified: z.number(),
-  }),
-  brands: z.array(
-    z.object({
-      id: z.number(),
-      name: z.string(),
-      count: z.number(),
-    }),
-  ),
-  distillers: z.array(
-    z.object({
-      id: z.number(),
-      name: z.string(),
-      count: z.number(),
-    }),
-  ),
-  age: AgeStatsSchema,
-  categories: z.array(
-    z.object({
-      category: CategoryEnum,
-      count: z.number(),
-    }),
-  ),
-});
 
 type Category = z.infer<typeof CategoryEnum>;
 type LibraryStats = z.infer<typeof LibraryStatsSchema>;
@@ -199,117 +171,106 @@ async function finalizeLibraryStats(
   };
 }
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/users/{user}/library/stats",
-    summary: "Get user Library statistics",
-    description:
-      "Retrieve producer, status, age, and category insights for non-empty bottles in a visible user's Library",
-    operationId: "getUserLibraryStats",
-  })
-  .input(
-    z.object({
-      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
-    }),
-  )
-  .output(LibraryStatsSchema)
-  .handler(async function ({ input, context, errors }) {
-    const user = await getUserFromId(db, input.user, context.user);
-    if (!user) {
-      throw errors.NOT_FOUND({
-        message: "User not found.",
-      });
-    }
+export default implement(libraryStatsContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const user = await getUserFromId(db, input.user, context.user);
+  if (!user) {
+    throw errors.NOT_FOUND({
+      message: "User not found.",
+    });
+  }
 
-    if (!(await profileVisible(db, user, context.user))) {
-      throw errors.BAD_REQUEST({
-        message: "User's profile is private.",
-      });
-    }
+  if (!(await profileVisible(db, user, context.user))) {
+    throw errors.BAD_REQUEST({
+      message: "User's profile is private.",
+    });
+  }
 
-    const library = await getReservedCollection(db, user.id, "library");
-    if (!library) {
-      return emptyStats;
-    }
+  const library = await getReservedCollection(db, user.id, "library");
+  if (!library) {
+    return emptyStats;
+  }
 
-    try {
-      const accumulator = createLibraryStatsAccumulator();
-      let afterId: number | null = null;
+  try {
+    const accumulator = createLibraryStatsAccumulator();
+    let afterId: number | null = null;
 
-      while (true) {
-        const rows = await db
-          .select({
-            id: collectionBottles.id,
-            storedBottleId: collectionBottles.bottleId,
-            bottle: {
-              id: bottles.id,
-              groupId: bottles.groupId,
-              brandId: bottles.brandId,
-              category: bottles.category,
-              flavorProfile: bottles.flavorProfile,
-              statedAge: bottles.statedAge,
-            },
-            retiredBottleId: bottleTombstones.bottleId,
-            status: collectionBottles.status,
-          })
-          .from(collectionBottles)
-          .leftJoin(bottles, eq(bottles.id, collectionBottles.bottleId))
-          .leftJoin(bottleTombstones, eq(bottleTombstones.bottleId, bottles.id))
-          .where(
-            and(
-              eq(collectionBottles.collectionId, library.id),
-              sql`${collectionBottles.status} IS DISTINCT FROM 'empty'`,
-              afterId === null ? undefined : gt(collectionBottles.id, afterId),
-            ),
-          )
-          .orderBy(collectionBottles.id)
-          .limit(LIBRARY_STATS_BATCH_SIZE);
-
-        if (rows.length === 0) break;
-
-        const directBottles = rows.map(readJoinedUserBottle);
-        const bottleIds = Array.from(
-          new Set(
-            directBottles.flatMap((bottle) =>
-              bottle === null ? [] : [bottle.id],
-            ),
+    while (true) {
+      const rows = await db
+        .select({
+          id: collectionBottles.id,
+          storedBottleId: collectionBottles.bottleId,
+          bottle: {
+            id: bottles.id,
+            groupId: bottles.groupId,
+            brandId: bottles.brandId,
+            category: bottles.category,
+            flavorProfile: bottles.flavorProfile,
+            statedAge: bottles.statedAge,
+          },
+          retiredBottleId: bottleTombstones.bottleId,
+          status: collectionBottles.status,
+        })
+        .from(collectionBottles)
+        .leftJoin(bottles, eq(bottles.id, collectionBottles.bottleId))
+        .leftJoin(bottleTombstones, eq(bottleTombstones.bottleId, bottles.id))
+        .where(
+          and(
+            eq(collectionBottles.collectionId, library.id),
+            sql`${collectionBottles.status} IS DISTINCT FROM 'empty'`,
+            afterId === null ? undefined : gt(collectionBottles.id, afterId),
           ),
-        );
-        const distillerRows = bottleIds.length
-          ? await db
-              .select()
-              .from(bottlesToDistillers)
-              .where(inArray(bottlesToDistillers.bottleId, bottleIds))
-          : [];
-        const distillerIdsByBottleId = new Map<number, number[]>();
-        for (const { bottleId, distillerId } of distillerRows) {
-          const ids = distillerIdsByBottleId.get(bottleId) ?? [];
-          ids.push(distillerId);
-          distillerIdsByBottleId.set(bottleId, ids);
-        }
-        accumulateLibraryStats(
-          accumulator,
-          directBottles.map((bottle, index) =>
-            bottle === null
-              ? null
-              : {
-                  ...bottle,
-                  distillerIds: distillerIdsByBottleId.get(bottle.id) ?? [],
-                  status: rows[index]!.status,
-                },
+        )
+        .orderBy(collectionBottles.id)
+        .limit(LIBRARY_STATS_BATCH_SIZE);
+
+      if (rows.length === 0) break;
+
+      const directBottles = rows.map(readJoinedUserBottle);
+      const bottleIds = Array.from(
+        new Set(
+          directBottles.flatMap((bottle) =>
+            bottle === null ? [] : [bottle.id],
           ),
-        );
-
-        afterId = rows.at(-1)!.id;
-        if (rows.length < LIBRARY_STATS_BATCH_SIZE) break;
+        ),
+      );
+      const distillerRows = bottleIds.length
+        ? await db
+            .select()
+            .from(bottlesToDistillers)
+            .where(inArray(bottlesToDistillers.bottleId, bottleIds))
+        : [];
+      const distillerIdsByBottleId = new Map<number, number[]>();
+      for (const { bottleId, distillerId } of distillerRows) {
+        const ids = distillerIdsByBottleId.get(bottleId) ?? [];
+        ids.push(distillerId);
+        distillerIdsByBottleId.set(bottleId, ids);
       }
+      accumulateLibraryStats(
+        accumulator,
+        directBottles.map((bottle, index) =>
+          bottle === null
+            ? null
+            : {
+                ...bottle,
+                distillerIds: distillerIdsByBottleId.get(bottle.id) ?? [],
+                status: rows[index]!.status,
+              },
+        ),
+      );
 
-      return await finalizeLibraryStats(accumulator);
-    } catch (error) {
-      if (error instanceof UserBottleReadIntegrityError) {
-        throw errors.CONFLICT({ message: error.message, cause: error });
-      }
-      throw error;
+      afterId = rows.at(-1)!.id;
+      if (rows.length < LIBRARY_STATS_BATCH_SIZE) break;
     }
-  });
+
+    return await finalizeLibraryStats(accumulator);
+  } catch (error) {
+    if (error instanceof UserBottleReadIntegrityError) {
+      throw errors.CONFLICT({ message: error.message, cause: error });
+    }
+    throw error;
+  }
+});

--- a/apps/server/src/orpc/routes/users/region-list.ts
+++ b/apps/server/src/orpc/routes/users/region-list.ts
@@ -1,192 +1,159 @@
 import { db } from "@peated/server/db";
 import { countries, entities, regions } from "@peated/server/db/schema";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
-import { procedure } from "@peated/server/orpc";
+import { implement } from "@peated/server/orpc";
+import userRegionListContract from "@peated/server/orpc/contracts/users/region-list";
 import { inArray } from "drizzle-orm";
-import { z } from "zod";
 import {
   scanUserTastingBottles,
   UserBottleReadIntegrityError,
 } from "./tasting-bottle-scan";
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/users/{user}/regions",
-    summary: "List user regions",
-    description:
-      "Retrieve regions from bottles tasted by a user with tasting counts. Respects privacy settings",
-    operationId: "listUserRegions",
-  })
-  .input(
-    z.object({
-      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
-    }),
-  )
-  .output(
-    z.object({
-      results: z.array(
-        z.object({
-          country: z.object({
-            name: z.string(),
-            slug: z.string(),
-          }),
-          region: z
-            .object({
-              name: z.string(),
-              slug: z.string(),
-            })
-            .nullable(),
-          count: z.number(),
-        }),
-      ),
-      totalCount: z.number(),
-    }),
-  )
-  .handler(async function ({ input, context, errors }) {
-    const user = await getUserFromId(db, input.user, context.user);
-    if (!user) {
-      throw errors.NOT_FOUND({
-        message: "User not found.",
-      });
-    }
+export default implement(userRegionListContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const user = await getUserFromId(db, input.user, context.user);
+  if (!user) {
+    throw errors.NOT_FOUND({
+      message: "User not found.",
+    });
+  }
 
-    if (!(await profileVisible(db, user, context.user))) {
-      throw errors.BAD_REQUEST({
-        message: "User's profile is not public.",
-      });
-    }
+  if (!(await profileVisible(db, user, context.user))) {
+    throw errors.BAD_REQUEST({
+      message: "User's profile is not public.",
+    });
+  }
 
-    const geographyByBrand = new Map<
-      number,
-      { countryId: number | null; regionId: number | null } | null
-    >();
-    const grouped = new Map<
-      string,
-      { countryId: number; regionId: number | null; count: number }
-    >();
-    let totalCount = 0;
+  const geographyByBrand = new Map<
+    number,
+    { countryId: number | null; regionId: number | null } | null
+  >();
+  const grouped = new Map<
+    string,
+    { countryId: number; regionId: number | null; count: number }
+  >();
+  let totalCount = 0;
 
-    try {
-      for await (const rows of scanUserTastingBottles(user.id)) {
-        totalCount += rows.length;
-        const tastingCountsByBrand = new Map<number, number>();
-        for (const { bottle } of rows) {
-          if (!bottle) continue;
-          const brandId = bottle.brandId;
-          tastingCountsByBrand.set(
-            brandId,
-            (tastingCountsByBrand.get(brandId) ?? 0) + 1,
-          );
-        }
-
-        const missingBrandIds = Array.from(tastingCountsByBrand.keys()).filter(
-          (brandId) => !geographyByBrand.has(brandId),
+  try {
+    for await (const rows of scanUserTastingBottles(user.id)) {
+      totalCount += rows.length;
+      const tastingCountsByBrand = new Map<number, number>();
+      for (const { bottle } of rows) {
+        if (!bottle) continue;
+        const brandId = bottle.brandId;
+        tastingCountsByBrand.set(
+          brandId,
+          (tastingCountsByBrand.get(brandId) ?? 0) + 1,
         );
-        if (missingBrandIds.length) {
-          const brandRows = await db
-            .select({
-              id: entities.id,
-              countryId: entities.countryId,
-              regionId: entities.regionId,
-            })
-            .from(entities)
-            .where(inArray(entities.id, missingBrandIds));
+      }
 
-          for (const brandId of missingBrandIds) {
-            geographyByBrand.set(brandId, null);
-          }
-          for (const { id, countryId, regionId } of brandRows) {
-            geographyByBrand.set(id, { countryId, regionId });
-          }
+      const missingBrandIds = Array.from(tastingCountsByBrand.keys()).filter(
+        (brandId) => !geographyByBrand.has(brandId),
+      );
+      if (missingBrandIds.length) {
+        const brandRows = await db
+          .select({
+            id: entities.id,
+            countryId: entities.countryId,
+            regionId: entities.regionId,
+          })
+          .from(entities)
+          .where(inArray(entities.id, missingBrandIds));
+
+        for (const brandId of missingBrandIds) {
+          geographyByBrand.set(brandId, null);
         }
-
-        for (const [brandId, count] of tastingCountsByBrand) {
-          const geography = geographyByBrand.get(brandId);
-          if (!geography || geography.countryId === null) continue;
-          const key = `${geography.countryId}:${geography.regionId ?? "null"}`;
-          const current = grouped.get(key);
-          if (current) {
-            current.count += count;
-          } else {
-            grouped.set(key, {
-              countryId: geography.countryId,
-              regionId: geography.regionId,
-              count,
-            });
-          }
+        for (const { id, countryId, regionId } of brandRows) {
+          geographyByBrand.set(id, { countryId, regionId });
         }
       }
-    } catch (error) {
-      if (error instanceof UserBottleReadIntegrityError) {
-        throw errors.CONFLICT({ message: error.message, cause: error });
+
+      for (const [brandId, count] of tastingCountsByBrand) {
+        const geography = geographyByBrand.get(brandId);
+        if (!geography || geography.countryId === null) continue;
+        const key = `${geography.countryId}:${geography.regionId ?? "null"}`;
+        const current = grouped.get(key);
+        if (current) {
+          current.count += count;
+        } else {
+          grouped.set(key, {
+            countryId: geography.countryId,
+            regionId: geography.regionId,
+            count,
+          });
+        }
       }
-      throw error;
     }
+  } catch (error) {
+    if (error instanceof UserBottleReadIntegrityError) {
+      throw errors.CONFLICT({ message: error.message, cause: error });
+    }
+    throw error;
+  }
 
-    const aggregates = Array.from(grouped.values())
-      .sort(
-        (left, right) =>
-          right.count - left.count ||
-          left.countryId - right.countryId ||
-          (left.regionId === null
-            ? 1
-            : right.regionId === null
-              ? -1
-              : left.regionId - right.regionId),
+  const aggregates = Array.from(grouped.values())
+    .sort(
+      (left, right) =>
+        right.count - left.count ||
+        left.countryId - right.countryId ||
+        (left.regionId === null
+          ? 1
+          : right.regionId === null
+            ? -1
+            : left.regionId - right.regionId),
+    )
+    .slice(0, 25);
+
+  const countryIds = Array.from(
+    new Set(aggregates.map(({ countryId }) => countryId)),
+  );
+  const countriesById = countryIds.length
+    ? Object.fromEntries(
+        (
+          await db
+            .select()
+            .from(countries)
+            .where(inArray(countries.id, countryIds))
+        ).map((r) => [
+          r.id,
+          {
+            name: r.name,
+            slug: r.slug,
+          },
+        ]),
       )
-      .slice(0, 25);
+    : {};
 
-    const countryIds = Array.from(
-      new Set(aggregates.map(({ countryId }) => countryId)),
-    );
-    const countriesById = countryIds.length
-      ? Object.fromEntries(
-          (
-            await db
-              .select()
-              .from(countries)
-              .where(inArray(countries.id, countryIds))
-          ).map((r) => [
-            r.id,
-            {
-              name: r.name,
-              slug: r.slug,
-            },
-          ]),
-        )
-      : {};
-
-    const regionIds = Array.from(
-      new Set(
-        aggregates.flatMap(({ regionId }) =>
-          regionId === null ? [] : [regionId],
-        ),
+  const regionIds = Array.from(
+    new Set(
+      aggregates.flatMap(({ regionId }) =>
+        regionId === null ? [] : [regionId],
       ),
-    );
-    const regionsById = regionIds.length
-      ? Object.fromEntries(
-          (
-            await db
-              .select()
-              .from(regions)
-              .where(inArray(regions.id, regionIds))
-          ).map((r) => [
-            r.id,
-            {
-              name: r.name,
-              slug: r.slug,
-            },
-          ]),
-        )
-      : {};
+    ),
+  );
+  const regionsById = regionIds.length
+    ? Object.fromEntries(
+        (
+          await db.select().from(regions).where(inArray(regions.id, regionIds))
+        ).map((r) => [
+          r.id,
+          {
+            name: r.name,
+            slug: r.slug,
+          },
+        ]),
+      )
+    : {};
 
-    return {
-      results: aggregates.map(({ countryId, regionId, count }) => ({
-        country: countriesById[countryId],
-        region: regionId === null ? null : regionsById[regionId],
-        count,
-      })),
-      totalCount,
-    };
-  });
+  return {
+    results: aggregates.map(({ countryId, regionId, count }) => ({
+      country: countriesById[countryId],
+      region: regionId === null ? null : regionsById[regionId],
+      count,
+    })),
+    totalCount,
+  };
+});

--- a/apps/server/src/orpc/routes/users/tasting-stats.ts
+++ b/apps/server/src/orpc/routes/users/tasting-stats.ts
@@ -2,126 +2,96 @@ import { SIMPLE_RATING_VALUES } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import { bottles } from "@peated/server/db/schema";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
-import { procedure } from "@peated/server/orpc";
+import { implement } from "@peated/server/orpc";
+import userTastingStatsContract from "@peated/server/orpc/contracts/users/tasting-stats";
 import { eq } from "drizzle-orm";
-import { z } from "zod";
-import { AgeStatsSchema, buildAgeStats } from "./age-stats";
+import { buildAgeStats } from "./age-stats";
 import {
   scanUserTastingBottles,
   UserBottleReadIntegrityError,
 } from "./tasting-bottle-scan";
 
-const TastingStatsSchema = z.object({
-  total: z.number(),
-  uniqueBottles: z.number(),
-  ratings: z.object({
-    total: z.number(),
-    pass: z.number(),
-    sip: z.number(),
-    savor: z.number(),
-  }),
-  mostTastedBottle: z
-    .object({
-      id: z.number(),
-      name: z.string(),
-      count: z.number(),
-    })
-    .nullable(),
-  age: AgeStatsSchema,
-});
+export default implement(userTastingStatsContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const user = await getUserFromId(db, input.user, context.user);
+  if (!user) {
+    throw errors.NOT_FOUND({
+      message: "User not found.",
+    });
+  }
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/users/{user}/tasting-stats",
-    summary: "Get user tasting statistics",
-    description:
-      "Retrieve rating, exploration, and age insights for bottles tasted by a visible user",
-    operationId: "getUserTastingStats",
-  })
-  .input(
-    z.object({
-      user: z.union([z.literal("me"), z.string(), z.coerce.number()]),
-    }),
-  )
-  .output(TastingStatsSchema)
-  .handler(async function ({ input, context, errors }) {
-    const user = await getUserFromId(db, input.user, context.user);
-    if (!user) {
-      throw errors.NOT_FOUND({
-        message: "User not found.",
-      });
-    }
+  if (!(await profileVisible(db, user, context.user))) {
+    throw errors.BAD_REQUEST({
+      message: "User's profile is private.",
+    });
+  }
 
-    if (!(await profileVisible(db, user, context.user))) {
-      throw errors.BAD_REQUEST({
-        message: "User's profile is private.",
-      });
-    }
+  const ages: number[] = [];
+  const bottleCounts = new Map<number, number>();
+  const ratings = { total: 0, pass: 0, sip: 0, savor: 0 };
+  let total = 0;
+  let unstatedCount = 0;
 
-    const ages: number[] = [];
-    const bottleCounts = new Map<number, number>();
-    const ratings = { total: 0, pass: 0, sip: 0, savor: 0 };
-    let total = 0;
-    let unstatedCount = 0;
+  try {
+    for await (const rows of scanUserTastingBottles(user.id)) {
+      total += rows.length;
+      for (const { bottle, rating } of rows) {
+        if (rating === SIMPLE_RATING_VALUES.PASS) {
+          ratings.pass += 1;
+          ratings.total += 1;
+        } else if (rating === SIMPLE_RATING_VALUES.SIP) {
+          ratings.sip += 1;
+          ratings.total += 1;
+        } else if (rating === SIMPLE_RATING_VALUES.SAVOR) {
+          ratings.savor += 1;
+          ratings.total += 1;
+        }
 
-    try {
-      for await (const rows of scanUserTastingBottles(user.id)) {
-        total += rows.length;
-        for (const { bottle, rating } of rows) {
-          if (rating === SIMPLE_RATING_VALUES.PASS) {
-            ratings.pass += 1;
-            ratings.total += 1;
-          } else if (rating === SIMPLE_RATING_VALUES.SIP) {
-            ratings.sip += 1;
-            ratings.total += 1;
-          } else if (rating === SIMPLE_RATING_VALUES.SAVOR) {
-            ratings.savor += 1;
-            ratings.total += 1;
-          }
-
-          if (bottle) {
-            bottleCounts.set(bottle.id, (bottleCounts.get(bottle.id) ?? 0) + 1);
-          }
-          if (bottle?.statedAge === null || !bottle) {
-            unstatedCount += 1;
-          } else {
-            ages.push(bottle.statedAge);
-          }
+        if (bottle) {
+          bottleCounts.set(bottle.id, (bottleCounts.get(bottle.id) ?? 0) + 1);
+        }
+        if (bottle?.statedAge === null || !bottle) {
+          unstatedCount += 1;
+        } else {
+          ages.push(bottle.statedAge);
         }
       }
-    } catch (error) {
-      if (error instanceof UserBottleReadIntegrityError) {
-        throw errors.CONFLICT({ message: error.message, cause: error });
-      }
-      throw error;
     }
+  } catch (error) {
+    if (error instanceof UserBottleReadIntegrityError) {
+      throw errors.CONFLICT({ message: error.message, cause: error });
+    }
+    throw error;
+  }
 
-    const [mostTastedBottleId, mostTastedCount] = Array.from(bottleCounts)
-      .filter(([, count]) => count > 1)
-      .sort(
-        ([leftId, leftCount], [rightId, rightCount]) =>
-          rightCount - leftCount || leftId - rightId,
-      )[0] ?? [null, 0];
-    const mostTastedBottle =
-      mostTastedBottleId === null
-        ? null
-        : await db.query.bottles.findFirst({
-            where: eq(bottles.id, mostTastedBottleId),
-            columns: { id: true, fullName: true },
-          });
+  const [mostTastedBottleId, mostTastedCount] = Array.from(bottleCounts)
+    .filter(([, count]) => count > 1)
+    .sort(
+      ([leftId, leftCount], [rightId, rightCount]) =>
+        rightCount - leftCount || leftId - rightId,
+    )[0] ?? [null, 0];
+  const mostTastedBottle =
+    mostTastedBottleId === null
+      ? null
+      : await db.query.bottles.findFirst({
+          where: eq(bottles.id, mostTastedBottleId),
+          columns: { id: true, fullName: true },
+        });
 
-    return {
-      total,
-      uniqueBottles: bottleCounts.size,
-      ratings,
-      mostTastedBottle: mostTastedBottle
-        ? {
-            id: mostTastedBottle.id,
-            name: mostTastedBottle.fullName,
-            count: mostTastedCount,
-          }
-        : null,
-      age: buildAgeStats(ages, unstatedCount),
-    };
-  });
+  return {
+    total,
+    uniqueBottles: bottleCounts.size,
+    ratings,
+    mostTastedBottle: mostTastedBottle
+      ? {
+          id: mostTastedBottle.id,
+          name: mostTastedBottle.fullName,
+          count: mostTastedCount,
+        }
+      : null,
+    age: buildAgeStats(ages, unstatedCount),
+  };
+});

--- a/apps/server/src/schemas/users.ts
+++ b/apps/server/src/schemas/users.ts
@@ -80,3 +80,25 @@ export const UserInputSchema = UserSchema.omit({
     .optional()
     .describe("Whether to notify user of comments on their content"),
 });
+
+export const AgeStatsSchema = z.object({
+  knownCount: z.number(),
+  median: z.number().nullable(),
+  oldest: z.number().nullable(),
+  buckets: z.array(
+    z.object({
+      id: z.enum([
+        "under10",
+        "from10To12",
+        "from13To17",
+        "from18To24",
+        "atLeast25",
+        "unstated",
+      ]),
+      label: z.string(),
+      count: z.number(),
+    }),
+  ),
+});
+
+export type AgeStats = z.infer<typeof AgeStatsSchema>;


### PR DESCRIPTION
The mock API now covers the read-only endpoints used by bottle, entity, tasting, user profile, notification, and flight pages. These pages can be checked against deterministic data without connecting the web app to a live API.

Each mock implements the same shared oRPC contract as its production handler, so input and output changes remain type-checked in both paths. The fixtures share one stateless data graph, and focused coverage verifies page data, viewer-specific flight state, notification authentication, and review permissions.
