### PR TITLE
feat(api): Add collaborative bottle recommendations

### DIFF
--- a/apps/server/src/orpc/routes/bottles/index.ts
+++ b/apps/server/src/orpc/routes/bottles/index.ts
@@ -11,6 +11,7 @@ import imageUpdate from "./image-update";
 import list from "./list";
 import merge from "./merge";
 import prices from "./prices";
+import recommendations from "./recommendations";
 import similar from "./similar";
 import suggestedTags from "./suggested-tags";
 import tags from "./tags";
@@ -31,6 +32,7 @@ export default base.tag("bottles").router({
   delete: delete_,
   merge,
   validation,
+  recommendations,
   similar,
   tags,
   suggestedTags,

--- a/apps/server/src/orpc/routes/bottles/recommendations.test.ts
+++ b/apps/server/src/orpc/routes/bottles/recommendations.test.ts
@@ -1,0 +1,181 @@
+import { SIMPLE_RATING_VALUES } from "@peated/server/constants";
+import { db } from "@peated/server/db";
+import { bottleTombstones } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { describe, expect, test } from "vitest";
+
+const communityVerdict = {
+  pass: 1,
+  sip: 2,
+  savor: 3,
+  total: 6,
+  avg: 1,
+  percentage: { pass: 16.67, sip: 33.33, savor: 50 },
+};
+
+describe("GET /bottles/:bottle/recommendations", () => {
+  test("orders Savor overlap and excludes the source and retired duplicates", async ({
+    fixtures,
+  }) => {
+    const source = await fixtures.Bottle({ name: "Recommendation Source" });
+    const first = await fixtures.Bottle({
+      name: "First Recommendation",
+      ratingStats: communityVerdict,
+    });
+    const second = await fixtures.Bottle({ name: "Second Recommendation" });
+    const tied = await fixtures.Bottle({ name: "Tied Recommendation" });
+    const retiredDuplicate = await fixtures.Bottle({
+      name: "Retired Duplicate",
+    });
+    await db.insert(bottleTombstones).values({
+      bottleId: retiredDuplicate.id,
+      newBottleId: first.id,
+    });
+
+    const members = await Promise.all([
+      fixtures.User(),
+      fixtures.User(),
+      fixtures.User(),
+    ]);
+    for (const member of members) {
+      await fixtures.Tasting({
+        bottleId: source.id,
+        createdById: member.id,
+        rating: SIMPLE_RATING_VALUES.SAVOR,
+      });
+      await fixtures.Tasting({
+        bottleId: first.id,
+        createdById: member.id,
+        rating: SIMPLE_RATING_VALUES.SAVOR,
+      });
+      await fixtures.Tasting({
+        bottleId: retiredDuplicate.id,
+        createdById: member.id,
+        rating: SIMPLE_RATING_VALUES.SAVOR,
+      });
+    }
+    for (const member of members.slice(0, 2)) {
+      await fixtures.Tasting({
+        bottleId: second.id,
+        createdById: member.id,
+        rating: SIMPLE_RATING_VALUES.SAVOR,
+      });
+      await fixtures.Tasting({
+        bottleId: tied.id,
+        createdById: member.id,
+        rating: SIMPLE_RATING_VALUES.SAVOR,
+      });
+    }
+
+    const result = await routerClient.bottles.recommendations({
+      bottle: source.id,
+    });
+
+    expect(result.reason).toBe(
+      "People who liked this bottle also liked these bottles.",
+    );
+    expect(result.results.map(({ id }) => id)).toEqual([
+      first.id,
+      second.id,
+      tied.id,
+    ]);
+    expect(result.results[0]).toMatchObject({
+      id: first.id,
+      fullName: first.fullName,
+      ratingStats: communityVerdict,
+    });
+    expect(result.results.map(({ id }) => id)).not.toContain(source.id);
+    expect(result.results.map(({ id }) => id)).not.toContain(
+      retiredDuplicate.id,
+    );
+  });
+
+  test("counts each member once when ranking", async ({ fixtures }) => {
+    const source = await fixtures.Bottle({ name: "Distinct Member Source" });
+    const broad = await fixtures.Bottle({ name: "Broad Support" });
+    const repeated = await fixtures.Bottle({ name: "Repeated Support" });
+    const members = await Promise.all([
+      fixtures.User(),
+      fixtures.User(),
+      fixtures.User(),
+    ]);
+
+    for (const member of members) {
+      await fixtures.Tasting({
+        bottleId: source.id,
+        createdById: member.id,
+        rating: SIMPLE_RATING_VALUES.SAVOR,
+      });
+      await fixtures.Tasting({
+        bottleId: broad.id,
+        createdById: member.id,
+        rating: SIMPLE_RATING_VALUES.SAVOR,
+      });
+    }
+    for (let day = 1; day <= 3; day += 1) {
+      await fixtures.Tasting({
+        bottleId: repeated.id,
+        createdById: members[0].id,
+        createdAt: new Date(2026, 0, day),
+        rating: SIMPLE_RATING_VALUES.SAVOR,
+      });
+    }
+    await fixtures.Tasting({
+      bottleId: repeated.id,
+      createdById: members[1].id,
+      rating: SIMPLE_RATING_VALUES.SAVOR,
+    });
+
+    const result = await routerClient.bottles.recommendations({
+      bottle: source.id,
+    });
+
+    expect(result.results.map(({ id }) => id)).toEqual([broad.id, repeated.id]);
+  });
+
+  test("returns an empty set when fewer than three members Savor the source", async ({
+    fixtures,
+  }) => {
+    const source = await fixtures.Bottle({ name: "Sparse Source" });
+    const candidate = await fixtures.Bottle({ name: "Sparse Candidate" });
+    const members = await Promise.all([fixtures.User(), fixtures.User()]);
+    for (const member of members) {
+      await fixtures.Tasting({
+        bottleId: source.id,
+        createdById: member.id,
+        rating: SIMPLE_RATING_VALUES.SAVOR,
+      });
+      await fixtures.Tasting({
+        bottleId: candidate.id,
+        createdById: member.id,
+        rating: SIMPLE_RATING_VALUES.SAVOR,
+      });
+    }
+
+    const result = await routerClient.bottles.recommendations({
+      bottle: source.id,
+    });
+
+    expect(result).toEqual({
+      reason: "People who liked this bottle also liked these bottles.",
+      results: [],
+    });
+  });
+
+  test("returns not found for a retired source Bottle", async ({
+    fixtures,
+  }) => {
+    const source = await fixtures.Bottle({ name: "Retired Source" });
+    await db.insert(bottleTombstones).values({ bottleId: source.id });
+
+    const error = await waitError(
+      routerClient.bottles.recommendations({ bottle: source.id }),
+    );
+
+    expect(error).toMatchObject({
+      status: 404,
+      message: "Bottle not found.",
+    });
+  });
+});

--- a/apps/server/src/orpc/routes/bottles/recommendations.ts
+++ b/apps/server/src/orpc/routes/bottles/recommendations.ts
@@ -1,0 +1,134 @@
+import { SIMPLE_RATING_VALUES } from "@peated/server/constants";
+import { db } from "@peated/server/db";
+import { bottles, bottleTombstones, tastings } from "@peated/server/db/schema";
+import { procedure } from "@peated/server/orpc";
+import {
+  BOTTLE_RECOMMENDATION_REASON,
+  BottleRecommendationsSchema,
+} from "@peated/server/schemas";
+import { serialize } from "@peated/server/serializers";
+import { BottleSerializer } from "@peated/server/serializers/bottle";
+import { and, asc, desc, eq, inArray, isNotNull, ne, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
+import { z } from "zod";
+
+const MIN_SOURCE_MEMBERS = 3;
+const MIN_SHARED_MEMBERS = 2;
+
+const activeBottleConditions = and(
+  isNotNull(bottles.groupId),
+  sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
+);
+
+export default procedure
+  .route({
+    method: "GET",
+    path: "/bottles/{bottle}/recommendations",
+    summary: "Get bottle recommendations",
+    description:
+      "Recommend bottles based on preferences from the Peated community",
+    spec: (spec) => ({
+      ...spec,
+      operationId: "listBottleRecommendations",
+    }),
+  })
+  .input(
+    z.object({
+      bottle: z.coerce.number(),
+      limit: z.coerce.number().gte(1).lte(12).default(6),
+    }),
+  )
+  .output(BottleRecommendationsSchema)
+  .handler(async function ({ input, context, errors }) {
+    const [source] = await db
+      .select({ id: bottles.id })
+      .from(bottles)
+      .where(and(eq(bottles.id, input.bottle), activeBottleConditions));
+
+    if (!source) {
+      throw errors.NOT_FOUND({
+        message: "Bottle not found.",
+      });
+    }
+
+    const [{ memberCount }] = await db
+      .select({
+        memberCount: sql<string>`COUNT(DISTINCT ${tastings.createdById})`,
+      })
+      .from(tastings)
+      .where(
+        and(
+          eq(tastings.bottleId, source.id),
+          eq(tastings.rating, SIMPLE_RATING_VALUES.SAVOR),
+        ),
+      );
+
+    // This route owns its sample policy. Sparse data must not become a fallback.
+    if (Number(memberCount) < MIN_SOURCE_MEMBERS) {
+      return {
+        reason: BOTTLE_RECOMMENDATION_REASON,
+        results: [],
+      };
+    }
+
+    const sourceRatings = alias(tastings, "source_ratings");
+    const candidateRatings = alias(tastings, "candidate_ratings");
+    const overlap = sql<string>`COUNT(DISTINCT ${candidateRatings.createdById})`;
+    const ranked = await db
+      .select({ bottleId: candidateRatings.bottleId, overlap })
+      .from(sourceRatings)
+      .innerJoin(
+        candidateRatings,
+        eq(candidateRatings.createdById, sourceRatings.createdById),
+      )
+      .innerJoin(bottles, eq(bottles.id, candidateRatings.bottleId))
+      .where(
+        and(
+          eq(sourceRatings.bottleId, source.id),
+          eq(sourceRatings.rating, SIMPLE_RATING_VALUES.SAVOR),
+          eq(candidateRatings.rating, SIMPLE_RATING_VALUES.SAVOR),
+          ne(candidateRatings.bottleId, source.id),
+          activeBottleConditions,
+        ),
+      )
+      .groupBy(candidateRatings.bottleId)
+      .having(sql`${overlap} >= ${MIN_SHARED_MEMBERS}`)
+      .orderBy(desc(overlap), asc(candidateRatings.bottleId))
+      .limit(input.limit);
+
+    if (!ranked.length) {
+      return {
+        reason: BOTTLE_RECOMMENDATION_REASON,
+        results: [],
+      };
+    }
+
+    const resultById = new Map(
+      (
+        await db
+          .select()
+          .from(bottles)
+          .where(
+            inArray(
+              bottles.id,
+              ranked.map(({ bottleId }) => bottleId),
+            ),
+          )
+      ).map((bottle) => [bottle.id, bottle] as const),
+    );
+    const results = ranked.map(({ bottleId }) => {
+      const bottle = resultById.get(bottleId);
+      if (!bottle) {
+        throw new Error(`Ranked Bottle ${bottleId} was not found.`);
+      }
+      return bottle;
+    });
+
+    return {
+      reason: BOTTLE_RECOMMENDATION_REASON,
+      results: await serialize(BottleSerializer, results, context.user, [
+        "description",
+        "tastingNotes",
+      ]),
+    };
+  });

--- a/apps/server/src/schemas/bottles.ts
+++ b/apps/server/src/schemas/bottles.ts
@@ -284,6 +284,22 @@ export const BottleSchema = z.object({
     .describe("Whether the current user has recorded a tasting this bottle"),
 });
 
+export const BOTTLE_RECOMMENDATION_REASON =
+  "People who liked this bottle also liked these bottles." as const;
+
+export const BottleRecommendationsSchema = z.object({
+  reason: z
+    .literal(BOTTLE_RECOMMENDATION_REASON)
+    .readonly()
+    .describe("Text that explains why these bottles are shown"),
+  results: z
+    .array(BottleSchema)
+    .readonly()
+    .describe(
+      "Recommended Bottles in display order, including community rating counts",
+    ),
+});
+
 export const EntityChoiceInputSchema = EntityInputSchema.extend({
   id: z.number().nullish().describe("Optional ID for the entity"),
 });


### PR DESCRIPTION
Adds a bottle recommendations read for the bottle overview. Results are ordered
from shared community preferences, include the standard Bottle preview and
community rating counts, and carry display-ready explanation copy.

The server owns ranking and the minimum sample size. Sparse samples return no
recommendations, and the source Bottle and retired duplicates are excluded.

Fixes #758
