### PR TITLE
feat(api): Expand mock data variety

### DIFF
--- a/apps/server/src/orpc/mock/fixtures.ts
+++ b/apps/server/src/orpc/mock/fixtures.ts
@@ -1,6 +1,7 @@
 import type { MockOutputs } from "./contract";
 
 type Bottle = MockOutputs["bottles"]["list"]["results"][number];
+type BottleDetails = MockOutputs["bottles"]["details"];
 type BadgeAward = MockOutputs["users"]["badgeList"]["results"][number];
 type Comment = MockOutputs["comments"]["list"]["results"][number];
 type CollectionBottle =
@@ -12,9 +13,13 @@ type Region = MockOutputs["regions"]["details"];
 type Review = MockOutputs["reviews"]["list"]["results"][number];
 type Tasting = MockOutputs["tastings"]["details"];
 type User = MockOutputs["auth"]["login"]["user"];
+type ActivityEntry = MockOutputs["activity"]["list"]["results"][number];
 
 const timestamp = "2026-08-26T12:00:00.000Z";
 
+// Keep records connected so each list result can open its detail route.
+
+// Users
 export const mockAccessToken = "peated-mock-access-token";
 
 export const mockUser = {
@@ -56,21 +61,72 @@ export const mockPublicUser = {
   friendStatus: mockUser.friendStatus,
 } satisfies User;
 
+export const mockFriends = [
+  {
+    id: 9102,
+    username: "islay-dreamer",
+    pictureUrl: null,
+    private: false,
+    friendStatus: "friends",
+  },
+  {
+    id: 9103,
+    username: "bourbon-notes",
+    pictureUrl: null,
+    private: false,
+    friendStatus: "friends",
+  },
+] satisfies User[];
+
 export const mockPublicUserDetails = {
   ...mockPublicUser,
   stats: mockUserDetails.stats,
 } satisfies MockOutputs["users"]["details"];
 
-export function mockUserDetailsFor(user: User | null) {
-  return user ? mockUserDetails : mockPublicUserDetails;
+export const mockFriendDetails = [
+  {
+    ...mockFriends[0]!,
+    stats: {
+      tastings: 128,
+      bottles: 82,
+      collected: 64,
+      library: { total: 20, open: 7, sealed: 13 },
+      contributions: 18,
+    },
+  },
+  {
+    ...mockFriends[1]!,
+    stats: {
+      tastings: 86,
+      bottles: 65,
+      collected: 40,
+      library: { total: 9, open: 3, sealed: 6 },
+      contributions: 5,
+    },
+  },
+] satisfies MockOutputs["users"]["details"][];
+
+export const mockPublicUserDetailsList = [
+  mockPublicUserDetails,
+  ...mockFriendDetails,
+];
+
+export function mockUserDetailsFor(
+  user: User | null,
+  profile: MockOutputs["users"]["details"] = mockPublicUserDetails,
+) {
+  return user?.id === profile.id ? mockUserDetails : profile;
 }
 
 export function matchesMockUser(value: string | number, user: User | null) {
   return value === "me"
     ? Boolean(user)
-    : value === mockUser.id || value === mockUser.username;
+    : mockPublicUserDetailsList.some(
+        (profile) => value === profile.id || value === profile.username,
+      );
 }
 
+// Places
 export const mockCountry = {
   id: 9401,
   name: "Scotland",
@@ -81,6 +137,54 @@ export const mockCountry = {
   totalBottles: 8200,
   totalDistillers: 150,
 } satisfies Country;
+
+export const mockCountries: Country[] = [
+  mockCountry,
+  {
+    id: 9402,
+    name: "Ireland",
+    slug: "ireland",
+    description:
+      "Known for blended whiskey and single pot still whiskey made from malted and unmalted barley.",
+    summary: "The home of Irish whiskey and the single pot still style.",
+    location: [-8, 53.4],
+    totalBottles: 1100,
+    totalDistillers: 42,
+  },
+  {
+    id: 9403,
+    name: "United States of America",
+    slug: "united-states",
+    description:
+      "A large whiskey-producing country best known for bourbon and rye.",
+    summary: "Bourbon, rye, and a growing range of regional whiskey styles.",
+    location: [-98.6, 39.8],
+    totalBottles: 6100,
+    totalDistillers: 2100,
+  },
+  {
+    id: 9404,
+    name: "Japan",
+    slug: "japan",
+    description:
+      "Produces precise blends and single malts influenced by Scottish methods.",
+    summary: "Elegant blends and single malts from a varied climate.",
+    location: [138.3, 36.2],
+    totalBottles: 760,
+    totalDistillers: 90,
+  },
+  {
+    id: 9405,
+    name: "India",
+    slug: "india",
+    description:
+      "Warm maturation conditions produce bold single malts at a fast pace.",
+    summary: "Rich single malts shaped by a warm climate.",
+    location: [78.9, 20.6],
+    totalBottles: 420,
+    totalDistillers: 35,
+  },
+];
 
 export const mockRegion = {
   id: 9501,
@@ -93,6 +197,55 @@ export const mockRegion = {
   totalDistillers: 10,
 } satisfies Region;
 
+export const mockRegions: Region[] = [
+  mockRegion,
+  {
+    id: 9502,
+    name: "Speyside",
+    slug: "speyside",
+    country: mockCountry,
+    description:
+      "A dense center of Scotch whisky production known for fruit-forward single malts.",
+    location: [-3.3, 57.5],
+    totalBottles: 2500,
+    totalDistillers: 50,
+  },
+  {
+    id: 9503,
+    name: "Highlands",
+    slug: "highlands",
+    country: mockCountry,
+    description:
+      "A broad Scotch whisky region with coastal, fruity, and rich styles.",
+    location: [-4.7, 57.1],
+    totalBottles: 2200,
+    totalDistillers: 47,
+  },
+  {
+    id: 9504,
+    name: "Campbeltown",
+    slug: "campbeltown",
+    country: mockCountry,
+    description:
+      "A small coastal Scotch whisky region known for oily and lightly smoky malts.",
+    location: [-5.6, 55.4],
+    totalBottles: 310,
+    totalDistillers: 3,
+  },
+  {
+    id: 9505,
+    name: "Kentucky",
+    slug: "kentucky",
+    country: mockCountries[2],
+    description:
+      "The center of American bourbon production, with limestone water and hot summers.",
+    location: [-84.9, 37.8],
+    totalBottles: 3400,
+    totalDistillers: 130,
+  },
+];
+
+// Producers and bottles
 export const mockEntity = {
   id: 9201,
   peatedId: "E9201",
@@ -114,6 +267,151 @@ export const mockEntity = {
   createdAt: timestamp,
   updatedAt: timestamp,
 } satisfies Entity;
+
+export const mockEntities: Entity[] = [
+  mockEntity,
+  {
+    ...mockEntity,
+    id: 9202,
+    peatedId: "E9202",
+    name: "The Macallan",
+    shortName: "Macallan",
+    description:
+      "A Speyside distillery known for sherry-seasoned oak maturation.",
+    yearEstablished: 1824,
+    website: "https://www.themacallan.com",
+    region: mockRegions[1],
+    totalTastings: 2100,
+    totalBottles: 190,
+  },
+  {
+    ...mockEntity,
+    id: 9203,
+    peatedId: "E9203",
+    name: "Springbank",
+    shortName: null,
+    description:
+      "A Campbeltown distillery that malts, distills, matures, and bottles whisky on site.",
+    yearEstablished: 1828,
+    website: "https://www.springbank.scot",
+    region: mockRegions[3],
+    totalTastings: 980,
+    totalBottles: 120,
+  },
+  {
+    ...mockEntity,
+    id: 9204,
+    peatedId: "E9204",
+    name: "Buffalo Trace",
+    shortName: null,
+    description: "A Kentucky distillery that produces bourbon and rye whiskey.",
+    yearEstablished: 1775,
+    website: "https://www.buffalotracedistillery.com",
+    country: mockCountries[2],
+    region: mockRegions[4],
+    totalTastings: 1750,
+    totalBottles: 95,
+  },
+  {
+    ...mockEntity,
+    id: 9205,
+    peatedId: "E9205",
+    name: "Yamazaki",
+    shortName: null,
+    description: "Japan's first malt whisky distillery, founded near Kyoto.",
+    yearEstablished: 1923,
+    website: "https://house.suntory.com/yamazaki-whisky",
+    country: mockCountries[3],
+    region: null,
+    totalTastings: 1300,
+    totalBottles: 72,
+  },
+  {
+    ...mockEntity,
+    id: 9206,
+    peatedId: "E9206",
+    name: "Midleton",
+    shortName: null,
+    type: ["distiller"],
+    description:
+      "An Irish distillery that produces pot still and grain whiskey.",
+    yearEstablished: 1975,
+    website: "https://www.midletondistillerycollection.com",
+    country: mockCountries[1],
+    region: null,
+    totalTastings: 1500,
+    totalBottles: 160,
+  },
+  {
+    ...mockEntity,
+    id: 9207,
+    peatedId: "E9207",
+    name: "Redbreast",
+    shortName: null,
+    type: ["brand"],
+    kind: "brand",
+    description: "A range of Irish single pot still whiskey made at Midleton.",
+    yearEstablished: 1903,
+    website: "https://www.redbreastwhiskey.com",
+    country: mockCountries[1],
+    region: null,
+    totalTastings: 1100,
+    totalBottles: 34,
+  },
+  {
+    ...mockEntity,
+    id: 9208,
+    peatedId: "E9208",
+    name: "Gordon & MacPhail",
+    shortName: "G&M",
+    type: ["bottler"],
+    kind: "bottler",
+    description:
+      "An independent Scotch whisky bottler and maturation specialist.",
+    yearEstablished: 1895,
+    website: "https://www.gordonandmacphail.com",
+    region: mockRegions[1],
+    totalTastings: 760,
+    totalBottles: 1400,
+  },
+  {
+    ...mockEntity,
+    id: 9209,
+    peatedId: "E9209",
+    name: "Compass Box",
+    shortName: null,
+    type: ["brand", "bottler"],
+    kind: "blender",
+    description: "A Scotch whisky blending house founded in London.",
+    yearEstablished: 2000,
+    website: "https://www.compassboxwhisky.com",
+    region: null,
+    totalTastings: 890,
+    totalBottles: 75,
+  },
+  {
+    ...mockEntity,
+    id: 9210,
+    peatedId: "E9210",
+    name: "Diageo",
+    shortName: null,
+    type: [],
+    kind: "company",
+    description: "A global drinks company that owns several whisky brands.",
+    yearEstablished: 1997,
+    website: "https://www.diageo.com",
+    region: null,
+    totalTastings: 5200,
+    totalBottles: 620,
+  },
+];
+
+export const mockMacallanEntity = mockEntities[1]!;
+export const mockSpringbankEntity = mockEntities[2]!;
+export const mockBuffaloTraceEntity = mockEntities[3]!;
+export const mockYamazakiEntity = mockEntities[4]!;
+export const mockMidletonEntity = mockEntities[5]!;
+export const mockRedbreastEntity = mockEntities[6]!;
 
 export const mockBottle = {
   id: 9301,
@@ -174,15 +472,236 @@ export const mockBottle = {
   hasTasted: false,
 } satisfies Bottle;
 
-export function mockBottleFor(user: User | null): Bottle {
+function ratingStats(pass: number, sip: number, savor: number) {
+  const total = pass + sip + savor;
+  const percentage = (count: number) =>
+    Number(((count / total) * 100).toFixed(1));
+
+  return {
+    pass,
+    sip,
+    savor,
+    total,
+    avg: Number(((-pass + sip + savor * 2) / total).toFixed(1)),
+    percentage: {
+      pass: percentage(pass),
+      sip: percentage(sip),
+      savor: percentage(savor),
+    },
+  } satisfies Bottle["ratingStats"];
+}
+
+export const mockBottles: Bottle[] = [
+  mockBottle,
+  {
+    ...mockBottle,
+    id: 9302,
+    peatedId: "B9302",
+    fullName: "The Macallan 12-year-old Sherry Oak",
+    name: "12-year-old Sherry Oak",
+    category: "single_malt",
+    statedAge: 12,
+    abv: 43,
+    brand: mockMacallanEntity,
+    distillers: [mockMacallanEntity],
+    description: "A Speyside single malt matured in sherry-seasoned oak casks.",
+    flavorProfile: "deep_rich_dried_fruit",
+    tastingNotes: {
+      nose: "Dried fruit, vanilla, and ginger",
+      palate: "Raisins, oak spice, and orange peel",
+      finish: "Long, sweet, and gently spiced",
+    },
+    suggestedTags: ["raisin", "orange peel", "oak", "ginger"],
+    avgRating: 1.5,
+    avgScore: 87,
+    totalScores: 36,
+    ratingStats: ratingStats(5, 30, 65),
+    totalTastings: 180,
+    createdAt: "2026-08-24T10:30:00.000Z",
+    updatedAt: "2026-08-25T18:10:00.000Z",
+  },
+  {
+    ...mockBottle,
+    id: 9303,
+    peatedId: "B9303",
+    fullName: "Springbank 10-year-old",
+    name: "10-year-old",
+    statedAge: 10,
+    naturalColor: true,
+    nonChillFiltered: true,
+    abv: 46,
+    brand: mockSpringbankEntity,
+    distillers: [mockSpringbankEntity],
+    description:
+      "A lightly peated Campbeltown single malt with coastal and orchard fruit notes.",
+    flavorProfile: "oily_coastal",
+    tastingNotes: {
+      nose: "Pear, brine, and light peat",
+      palate: "Malt, citrus, mineral oil, and pepper",
+      finish: "Dry, coastal, and lightly smoky",
+    },
+    suggestedTags: ["brine", "pear", "mineral", "light smoke"],
+    avgRating: 1.6,
+    avgScore: 90,
+    totalScores: 31,
+    ratingStats: ratingStats(3, 20, 47),
+    totalTastings: 142,
+    createdAt: "2026-08-21T09:00:00.000Z",
+    updatedAt: "2026-08-23T16:45:00.000Z",
+  },
+  {
+    ...mockBottle,
+    id: 9304,
+    peatedId: "B9304",
+    fullName: "Buffalo Trace Kentucky Straight Bourbon",
+    name: "Kentucky Straight Bourbon",
+    category: "bourbon",
+    statedAge: null,
+    noAgeStatement: true,
+    abv: 45,
+    brand: mockBuffaloTraceEntity,
+    distillers: [mockBuffaloTraceEntity],
+    description:
+      "A Kentucky straight bourbon with caramel, vanilla, and baking spice.",
+    flavorProfile: "juicy_oak_vanilla",
+    tastingNotes: {
+      nose: "Caramel, vanilla, and mint",
+      palate: "Brown sugar, oak, and baking spice",
+      finish: "Medium, sweet, and gently dry",
+    },
+    suggestedTags: ["caramel", "vanilla", "oak", "cinnamon"],
+    avgRating: 1.2,
+    avgScore: 84,
+    totalScores: 44,
+    ratingStats: ratingStats(10, 55, 35),
+    totalTastings: 230,
+    createdAt: "2026-08-18T14:20:00.000Z",
+    updatedAt: "2026-08-22T11:05:00.000Z",
+  },
+  {
+    ...mockBottle,
+    id: 9305,
+    peatedId: "B9305",
+    fullName: "Yamazaki 12-year-old",
+    name: "12-year-old",
+    statedAge: 12,
+    abv: 43,
+    brand: mockYamazakiEntity,
+    distillers: [mockYamazakiEntity],
+    description:
+      "A Japanese single malt with orchard fruit, incense, and gentle oak.",
+    flavorProfile: "light_delicate",
+    tastingNotes: {
+      nose: "Peach, pineapple, and clove",
+      palate: "Coconut, cranberry, and soft oak",
+      finish: "Long, fruity, and lightly spicy",
+    },
+    suggestedTags: ["peach", "incense", "coconut", "soft oak"],
+    avgRating: 1.6,
+    avgScore: 91,
+    totalScores: 28,
+    ratingStats: ratingStats(4, 24, 52),
+    totalTastings: 155,
+    createdAt: "2026-08-15T08:15:00.000Z",
+    updatedAt: "2026-08-20T19:30:00.000Z",
+  },
+  {
+    ...mockBottle,
+    id: 9306,
+    peatedId: "B9306",
+    fullName: "Redbreast 12-year-old",
+    name: "12-year-old",
+    category: "single_pot_still",
+    statedAge: 12,
+    abv: 40,
+    brand: mockRedbreastEntity,
+    distillers: [mockMidletonEntity],
+    description:
+      "An Irish single pot still whiskey with orchard fruit and toasted spice.",
+    flavorProfile: "spicy_sweet",
+    tastingNotes: {
+      nose: "Apple, toasted nuts, and honey",
+      palate: "Dried fruit, baking spice, and vanilla",
+      finish: "Rich, warming, and softly sweet",
+    },
+    suggestedTags: ["apple", "walnut", "honey", "allspice"],
+    avgRating: 1.6,
+    avgScore: 89,
+    totalScores: 26,
+    ratingStats: ratingStats(2, 18, 40),
+    totalTastings: 168,
+    createdAt: "2026-08-12T17:40:00.000Z",
+    updatedAt: "2026-08-19T12:00:00.000Z",
+  },
+  {
+    ...mockBottle,
+    id: 9307,
+    peatedId: "B9307",
+    fullName: "Lagavulin 8-year-old",
+    name: "8-year-old",
+    statedAge: 8,
+    abv: 48,
+    description:
+      "A younger Lagavulin with bright citrus, dry smoke, and maritime notes.",
+    flavorProfile: "heavily_peated",
+    tastingNotes: {
+      nose: "Lemon peel, ash, and sea air",
+      palate: "Dry smoke, pepper, and malt",
+      finish: "Clean, smoky, and mineral",
+    },
+    suggestedTags: ["ash", "lemon", "pepper", "sea air"],
+    avgRating: 1.4,
+    avgScore: 86,
+    totalScores: 17,
+    ratingStats: ratingStats(4, 25, 41),
+    totalTastings: 92,
+    createdAt: "2026-08-09T13:25:00.000Z",
+    updatedAt: "2026-08-17T09:40:00.000Z",
+  },
+  {
+    ...mockBottle,
+    id: 9308,
+    peatedId: "B9308",
+    fullName: "Lagavulin Offerman Edition 11-year-old Charred Oak Cask",
+    name: "Offerman Edition 11-year-old Charred Oak Cask",
+    edition: "Charred Oak Cask",
+    statedAge: 11,
+    abv: 46,
+    description:
+      "A limited Lagavulin edition finished with charred oak influence.",
+    flavorProfile: "peated",
+    tastingNotes: {
+      nose: "Campfire smoke, vanilla, and red fruit",
+      palate: "Charred oak, dark chocolate, and spice",
+      finish: "Smoky, sweet, and warming",
+    },
+    suggestedTags: ["charred oak", "vanilla", "dark chocolate", "smoke"],
+    avgRating: 1.5,
+    avgScore: 88,
+    totalScores: 12,
+    ratingStats: ratingStats(3, 17, 30),
+    totalTastings: 64,
+    createdAt: "2026-08-06T11:10:00.000Z",
+    updatedAt: "2026-08-16T15:20:00.000Z",
+  },
+];
+
+const favoriteBottleIds = new Set([9301, 9305]);
+const libraryBottleIds = new Set([9301, 9303, 9306]);
+const tastedBottleIds = new Set([9301, 9302, 9303, 9304]);
+
+export function mockBottleFor(
+  user: User | null,
+  bottle: Bottle = mockBottle,
+): Bottle {
   return user
     ? {
-        ...mockBottle,
-        isFavorite: true,
-        isLibrary: true,
-        hasTasted: true,
+        ...bottle,
+        isFavorite: favoriteBottleIds.has(bottle.id),
+        isLibrary: libraryBottleIds.has(bottle.id),
+        hasTasted: tastedBottleIds.has(bottle.id),
       }
-    : mockBottle;
+    : bottle;
 }
 
 export const mockBottleDetails = {
@@ -192,12 +711,23 @@ export const mockBottleDetails = {
   lastPrice: null,
 } satisfies MockOutputs["bottles"]["details"];
 
+export const mockBottleDetailsList = mockBottles.map(
+  (bottle, index) =>
+    ({
+      ...bottle,
+      barcodes: index === 0 ? mockBottleDetails.barcodes : [],
+      people: Math.max(24, Math.round(bottle.totalTastings * 0.8)),
+      lastPrice: null,
+    }) satisfies BottleDetails,
+);
+
 export function mockBottleDetailsFor(
   user: User | null,
+  bottle: BottleDetails = mockBottleDetails,
 ): MockOutputs["bottles"]["details"] {
   return {
-    ...mockBottleDetails,
-    ...mockBottleFor(user),
+    ...bottle,
+    ...mockBottleFor(user, bottle),
   };
 }
 
@@ -209,6 +739,20 @@ export const mockBottleTags = {
   ],
   totalCount: 120,
 } satisfies MockOutputs["bottles"]["tags"];
+
+export function mockBottleTagsFor(
+  bottle: Bottle,
+): MockOutputs["bottles"]["tags"] {
+  if (bottle.id === mockBottle.id) return mockBottleTags;
+
+  return {
+    results: (bottle.suggestedTags ?? []).map((tag, index) => ({
+      tag,
+      count: Math.max(4, Math.round(bottle.totalTastings / (index + 3))),
+    })),
+    totalCount: bottle.totalTastings,
+  };
+}
 
 export const mockEntityCatalog = {
   totalBottles: mockEntity.totalBottles,
@@ -237,6 +781,100 @@ export const mockEntityCatalog = {
   ],
 } satisfies MockOutputs["entities"]["catalog"];
 
+export function mockEntityCatalogFor(
+  entity: Entity,
+): MockOutputs["entities"]["catalog"] {
+  if (entity.id === mockEntity.id) {
+    const lagavulinBottles = mockBottles.filter(
+      (bottle) => bottle.brand.id === entity.id,
+    );
+    return {
+      ...mockEntityCatalog,
+      notableBottles: lagavulinBottles.map((bottle) => ({
+        id: bottle.id,
+        fullName: bottle.fullName,
+        totalTastings: bottle.totalTastings,
+        avgRating: bottle.avgRating,
+      })),
+    };
+  }
+
+  const relatedBottles = mockBottles.filter(
+    (bottle) =>
+      bottle.brand.id === entity.id ||
+      bottle.bottler?.id === entity.id ||
+      bottle.distillers.some((distiller) => distiller.id === entity.id),
+  );
+  const categoryCounts = new Map<Bottle["category"], number>();
+  for (const bottle of relatedBottles) {
+    categoryCounts.set(
+      bottle.category,
+      (categoryCounts.get(bottle.category) ?? 0) + 1,
+    );
+  }
+  const relatedEntities = (
+    values: Entity[],
+  ): MockOutputs["entities"]["catalog"]["related"]["brands"] =>
+    values
+      .filter(
+        (value, index) =>
+          value.id !== entity.id &&
+          values.findIndex((candidate) => candidate.id === value.id) === index,
+      )
+      .map((value) => ({
+        id: value.id,
+        name: value.name,
+        shortName: value.shortName,
+        count: relatedBottles.filter(
+          (bottle) =>
+            bottle.brand.id === value.id ||
+            bottle.bottler?.id === value.id ||
+            bottle.distillers.some((distiller) => distiller.id === value.id),
+        ).length,
+      }));
+
+  return {
+    totalBottles: entity.totalBottles,
+    relationships: {
+      brand: entity.type.includes("brand") ? entity.totalBottles : 0,
+      bottler: entity.type.includes("bottler") ? entity.totalBottles : 0,
+      distiller: entity.type.includes("distiller") ? entity.totalBottles : 0,
+    },
+    distilleryCoverage: {
+      documented:
+        entity.type.includes("distiller") ||
+        relatedBottles.some((bottle) => bottle.distillers.length > 0)
+          ? entity.totalBottles
+          : 0,
+      total: entity.totalBottles,
+    },
+    categories: [...categoryCounts].map(([category, count]) => ({
+      category,
+      count: Math.round(
+        entity.totalBottles * (count / Math.max(relatedBottles.length, 1)),
+      ),
+    })),
+    related: {
+      brands: relatedEntities(relatedBottles.map((bottle) => bottle.brand)),
+      bottlers: relatedEntities(
+        relatedBottles.flatMap((bottle) =>
+          bottle.bottler ? [bottle.bottler] : [],
+        ),
+      ),
+      distillers: relatedEntities(
+        relatedBottles.flatMap((bottle) => bottle.distillers),
+      ),
+    },
+    notableBottles: relatedBottles.map((bottle) => ({
+      id: bottle.id,
+      fullName: bottle.fullName,
+      totalTastings: bottle.totalTastings,
+      avgRating: bottle.avgRating,
+    })),
+  };
+}
+
+// Reviews, comments, and profile insights
 export const mockReview = {
   id: 9801,
   name: mockBottle.fullName,
@@ -266,12 +904,199 @@ export const mockReview = {
   updatedAt: timestamp,
 } satisfies Review;
 
+export const mockReviews = [
+  mockReview,
+  {
+    ...mockReview,
+    id: 9810,
+    rating: 88,
+    url: "https://example.com/reviews/lagavulin-8",
+    site: {
+      ...mockReview.site!,
+      id: 9811,
+      type: "whiskyfun",
+      name: "Whiskyfun",
+      runEvery: 1440,
+    },
+    article: {
+      title: "Lagavulin 8-year-old",
+      publishedAt: "2026-08-20T09:00:00.000Z",
+    },
+    reviewerName: "Serge Sample",
+    nativeScore: { value: 88, scale: 100, display: "88 points" },
+    summary: "Bright citrus and dry peat make this younger release lively.",
+    bottle: mockBottles[6],
+    createdAt: "2026-08-20T10:00:00.000Z",
+    updatedAt: "2026-08-20T10:00:00.000Z",
+  },
+  {
+    ...mockReview,
+    id: 9812,
+    name: mockBottles[1]!.fullName,
+    rating: 87,
+    url: "https://example.com/reviews/macallan-12-sherry-oak",
+    site: {
+      ...mockReview.site!,
+      id: 9813,
+      type: "whiskynotes",
+      name: "WhiskyNotes",
+      runEvery: 1440,
+    },
+    article: {
+      title: "Macallan 12 Sherry Oak Review",
+      publishedAt: "2026-08-18T14:00:00.000Z",
+    },
+    reviewerName: "Ruben Sample",
+    nativeScore: { value: 87, scale: 100, display: "87/100" },
+    summary: "Classic dried fruit and orange peel with polished oak.",
+    bottle: mockBottles[1],
+    createdAt: "2026-08-18T15:00:00.000Z",
+    updatedAt: "2026-08-18T15:00:00.000Z",
+  },
+  {
+    ...mockReview,
+    id: 9814,
+    name: mockBottles[3]!.fullName,
+    rating: 84,
+    url: "https://example.com/reviews/buffalo-trace-bourbon",
+    site: {
+      ...mockReview.site!,
+      id: 9815,
+      type: "bourbonculture",
+      name: "Bourbon Culture",
+      runEvery: 1440,
+    },
+    article: {
+      title: "Buffalo Trace Bourbon Review",
+      publishedAt: "2026-08-15T16:00:00.000Z",
+    },
+    reviewerName: "Bourbon Sample",
+    nativeScore: { value: 84, scale: 100, display: "84" },
+    summary: "An approachable bourbon with caramel, vanilla, and mild oak.",
+    bottle: mockBottles[3],
+    createdAt: "2026-08-15T17:00:00.000Z",
+    updatedAt: "2026-08-15T17:00:00.000Z",
+  },
+  {
+    ...mockReview,
+    id: 9816,
+    name: mockBottles[4]!.fullName,
+    rating: 91,
+    url: "https://example.com/reviews/yamazaki-12",
+    article: {
+      title: "Yamazaki 12-year-old Review",
+      publishedAt: "2026-08-12T11:00:00.000Z",
+    },
+    reviewerName: "Editorial Sample",
+    nativeScore: { value: 91, scale: 100, display: "91" },
+    summary: "Layered orchard fruit, incense, and restrained oak.",
+    bottle: mockBottles[4],
+    createdAt: "2026-08-12T12:00:00.000Z",
+    updatedAt: "2026-08-12T12:00:00.000Z",
+  },
+  {
+    ...mockReview,
+    id: 9817,
+    name: "Mystery Islay Malt 18-year-old",
+    rating: 90,
+    url: "https://example.com/reviews/mystery-islay-18",
+    article: {
+      title: "Mystery Islay Malt Review",
+      publishedAt: "2026-08-10T12:00:00.000Z",
+    },
+    reviewerName: "Editorial Sample",
+    nativeScore: { value: 90, scale: 100, display: "90" },
+    summary: "A mature smoky malt that has not yet been matched to a bottle.",
+    bottle: null,
+    createdAt: "2026-08-10T13:00:00.000Z",
+    updatedAt: "2026-08-10T13:00:00.000Z",
+  },
+  {
+    ...mockReview,
+    id: 9818,
+    rating: 89,
+    url: "https://example.com/reviews/lagavulin-16-dramface",
+    site: {
+      ...mockReview.site!,
+      id: 9819,
+      type: "dramface",
+      name: "Dramface",
+      runEvery: 1440,
+    },
+    article: {
+      title: "Lagavulin 16: The Islay Benchmark",
+      publishedAt: "2026-08-08T12:00:00.000Z",
+    },
+    reviewerName: "Dramface Sample",
+    nativeScore: { value: 8.9, scale: 10, display: "8.9/10" },
+    summary: "Balanced peat, fruit, and oak with an easy maritime character.",
+    createdAt: "2026-08-08T13:00:00.000Z",
+    updatedAt: "2026-08-08T13:00:00.000Z",
+  },
+  {
+    ...mockReview,
+    id: 9830,
+    rating: 90,
+    url: "https://example.com/reviews/lagavulin-16-words",
+    site: {
+      ...mockReview.site!,
+      id: 9831,
+      type: "wordsofwhisky",
+      name: "Words of Whisky",
+      runEvery: 1440,
+    },
+    article: {
+      title: "Revisiting Lagavulin 16-year-old",
+      publishedAt: "2026-08-05T12:00:00.000Z",
+    },
+    reviewerName: "Words Sample",
+    nativeScore: { value: 90, scale: 100, display: "90 points" },
+    summary: "Mature smoke, dried fruit, and sea salt remain well integrated.",
+    createdAt: "2026-08-05T13:00:00.000Z",
+    updatedAt: "2026-08-05T13:00:00.000Z",
+  },
+] satisfies Review[];
+
 export const mockComment = {
   id: 9803,
   comment: "The smoke opens up after a few minutes in the glass.",
   createdAt: timestamp,
   createdBy: mockPublicUser,
 } satisfies Comment;
+
+export const mockComments = [
+  mockComment,
+  {
+    id: 9820,
+    comment: "I get grilled pineapple behind the peat on this one.",
+    createdAt: "2026-08-25T18:20:00.000Z",
+    createdBy: mockFriends[0]!,
+  },
+  {
+    id: 9821,
+    comment: "A small splash of water brings out more citrus.",
+    createdAt: "2026-08-25T18:35:00.000Z",
+    createdBy: mockFriends[1]!,
+  },
+  {
+    id: 9822,
+    comment: "The sherry oak feels drier than I expected.",
+    createdAt: "2026-08-22T20:15:00.000Z",
+    createdBy: mockPublicUser,
+  },
+  {
+    id: 9823,
+    comment: "Great contrast between the caramel and mint notes.",
+    createdAt: "2026-08-19T19:45:00.000Z",
+    createdBy: mockFriends[0]!,
+  },
+] satisfies Comment[];
+
+export const mockCommentsByTasting = new Map<number, Comment[]>([
+  [9601, mockComments.slice(0, 3)],
+  [9602, [mockComments[3]!]],
+  [9604, [mockComments[4]!]],
+]);
 
 export const mockBadgeAward = {
   id: 9804,
@@ -286,20 +1111,104 @@ export const mockBadgeAward = {
   createdAt: timestamp,
 } satisfies BadgeAward;
 
+export const mockBadgeAwards = [
+  mockBadgeAward,
+  {
+    id: 9824,
+    xp: 25,
+    level: 5,
+    badge: {
+      id: 9825,
+      name: "World Tour",
+      maxLevel: 25,
+      imageUrl: null,
+    },
+    createdAt: "2026-08-10T12:00:00.000Z",
+    prevLevel: 4,
+  },
+  {
+    id: 9826,
+    xp: 8,
+    level: 1,
+    badge: {
+      id: 9827,
+      name: "Bourbon Trail",
+      maxLevel: 25,
+      imageUrl: null,
+    },
+    createdAt: "2026-07-28T12:00:00.000Z",
+  },
+  {
+    id: 9828,
+    xp: 40,
+    level: 8,
+    badge: {
+      id: 9829,
+      name: "Tasting Streak",
+      maxLevel: 25,
+      imageUrl: null,
+    },
+    createdAt: "2026-07-12T12:00:00.000Z",
+    prevLevel: 7,
+  },
+] satisfies BadgeAward[];
+
 export const mockUserRegionList = {
   results: [
     {
       country: { name: mockCountry.name, slug: mockCountry.slug },
       region: { name: mockRegion.name, slug: mockRegion.slug },
-      count: 42,
+      count: 15,
+    },
+    {
+      country: { name: mockCountry.name, slug: mockCountry.slug },
+      region: {
+        name: mockRegions[1]!.name,
+        slug: mockRegions[1]!.slug,
+      },
+      count: 8,
+    },
+    {
+      country: { name: mockCountry.name, slug: mockCountry.slug },
+      region: {
+        name: mockRegions[3]!.name,
+        slug: mockRegions[3]!.slug,
+      },
+      count: 6,
+    },
+    {
+      country: {
+        name: mockCountries[2]!.name,
+        slug: mockCountries[2]!.slug,
+      },
+      region: {
+        name: mockRegions[4]!.name,
+        slug: mockRegions[4]!.slug,
+      },
+      count: 7,
+    },
+    {
+      country: {
+        name: mockCountries[3]!.name,
+        slug: mockCountries[3]!.slug,
+      },
+      region: null,
+      count: 4,
     },
   ],
   totalCount: 42,
 } satisfies MockOutputs["users"]["regionList"];
 
 export const mockUserFlavorList = {
-  results: [{ flavorProfile: "peated", count: 42, score: 60 }],
-  totalScore: 60,
+  results: [
+    { flavorProfile: "peated", count: 11, score: 19 },
+    { flavorProfile: "deep_rich_dried_fruit", count: 8, score: 13 },
+    { flavorProfile: "oily_coastal", count: 6, score: 11 },
+    { flavorProfile: "juicy_oak_vanilla", count: 6, score: 7 },
+    { flavorProfile: "spicy_sweet", count: 5, score: 7 },
+    { flavorProfile: "light_delicate", count: 3, score: 4 },
+  ],
+  totalScore: 61,
   totalCount: 42,
 } satisfies MockOutputs["users"]["flavorList"];
 
@@ -341,8 +1250,42 @@ export const mockUserLibraryStats = {
     sealed: 8,
     unspecified: 0,
   },
-  brands: [{ id: mockEntity.id, name: mockEntity.name, count: 12 }],
-  distillers: [{ id: mockEntity.id, name: mockEntity.name, count: 12 }],
+  brands: [
+    { id: mockEntity.id, name: mockEntity.name, count: 3 },
+    { id: mockMacallanEntity.id, name: mockMacallanEntity.name, count: 2 },
+    {
+      id: mockSpringbankEntity.id,
+      name: mockSpringbankEntity.name,
+      count: 2,
+    },
+    {
+      id: mockRedbreastEntity.id,
+      name: mockRedbreastEntity.name,
+      count: 2,
+    },
+    {
+      id: mockBuffaloTraceEntity.id,
+      name: mockBuffaloTraceEntity.name,
+      count: 1,
+    },
+    { id: mockYamazakiEntity.id, name: mockYamazakiEntity.name, count: 2 },
+  ],
+  distillers: [
+    { id: mockEntity.id, name: mockEntity.name, count: 3 },
+    { id: mockMacallanEntity.id, name: mockMacallanEntity.name, count: 2 },
+    {
+      id: mockSpringbankEntity.id,
+      name: mockSpringbankEntity.name,
+      count: 2,
+    },
+    { id: mockMidletonEntity.id, name: mockMidletonEntity.name, count: 2 },
+    {
+      id: mockBuffaloTraceEntity.id,
+      name: mockBuffaloTraceEntity.name,
+      count: 1,
+    },
+    { id: mockYamazakiEntity.id, name: mockYamazakiEntity.name, count: 2 },
+  ],
   age: {
     ...mockAgeStats,
     knownCount: 12,
@@ -355,9 +1298,15 @@ export const mockUserLibraryStats = {
       { id: "unstated", label: "Unstated", count: 0 },
     ],
   },
-  categories: [{ category: "single_malt", count: 12 }],
+  categories: [
+    { category: "single_malt", count: 8 },
+    { category: "single_pot_still", count: 2 },
+    { category: "bourbon", count: 1 },
+    { category: "blend", count: 1 },
+  ],
 } satisfies MockOutputs["users"]["libraryStats"];
 
+// Flights, tastings, and collections
 export const mockFlight = {
   id: "mock-islay-flight",
   name: "Islay Smoke",
@@ -367,29 +1316,58 @@ export const mockFlight = {
   createdBy: mockPublicUser,
 } satisfies Flight;
 
-export const mockFlightDetails = {
-  ...mockFlight,
-  bottles: [
-    {
-      bottle: mockBottle,
-      hasTasted: false,
-      isLibrary: false,
-    },
-  ],
-} satisfies MockOutputs["flights"]["details"];
+export const mockFlights = [
+  mockFlight,
+  {
+    id: "mock-world-flight",
+    name: "Whisky Around the World",
+    description:
+      "Compare Scotch, bourbon, Japanese whisky, and Irish pot still whiskey.",
+    public: true,
+    createdAt: "2026-08-18T12:00:00.000Z",
+    createdBy: mockFriends[0],
+  },
+  {
+    id: "mock-sherry-flight",
+    name: "Fruit and Sherry",
+    description: "Rich whiskies with dried fruit and cask spice.",
+    public: true,
+    createdAt: "2026-08-12T12:00:00.000Z",
+    createdBy: mockFriends[1],
+  },
+  {
+    id: "mock-cabinet-flight",
+    name: "Open Cabinet",
+    description: "A private flight from the signed-in user's open bottles.",
+    public: false,
+    createdAt: "2026-08-08T12:00:00.000Z",
+    createdBy: mockPublicUser,
+  },
+] satisfies Flight[];
+
+export const mockFlightBottleIds = new Map<string, number[]>([
+  [mockFlight.id, [9301, 9307, 9308]],
+  ["mock-world-flight", [9302, 9304, 9305, 9306]],
+  ["mock-sherry-flight", [9302, 9306]],
+  ["mock-cabinet-flight", [9301, 9303, 9306]],
+]);
 
 export function mockFlightDetailsFor(
   user: User | null,
+  flight: Flight = mockFlight,
 ): MockOutputs["flights"]["details"] {
+  const bottles = (mockFlightBottleIds.get(flight.id) ?? []).flatMap((id) => {
+    const bottle = mockBottles.find((candidate) => candidate.id === id);
+    return bottle ? [mockBottleFor(user, bottle)] : [];
+  });
+
   return {
-    ...mockFlightDetails,
-    bottles: [
-      {
-        bottle: mockBottleFor(user),
-        hasTasted: Boolean(user),
-        isLibrary: Boolean(user),
-      },
-    ],
+    ...flight,
+    bottles: bottles.map((bottle) => ({
+      bottle,
+      hasTasted: bottle.hasTasted,
+      isLibrary: bottle.isLibrary,
+    })),
   };
 }
 
@@ -412,11 +1390,94 @@ export const mockTasting = {
   createdBy: mockPublicUser,
 } satisfies Tasting;
 
-export function mockTastingFor(user: User | null): Tasting {
-  return {
+export const mockTastings = [
+  mockTasting,
+  {
     ...mockTasting,
-    bottle: mockBottleFor(user),
-    hasToasted: Boolean(user),
+    id: 9602,
+    notes:
+      "Dried apricot, orange peel, and ginger. The oak turns pleasantly dry.",
+    bottle: mockBottles[1]!,
+    rating: 1,
+    tags: ["dried fruit", "orange peel", "ginger", "oak"],
+    color: 16,
+    servingStyle: "splash",
+    friends: [mockFriends[0]!],
+    comments: 1,
+    toasts: 3,
+    createdAt: "2026-08-22T20:00:00.000Z",
+  },
+  {
+    ...mockTasting,
+    id: 9603,
+    notes: "Pear, machine oil, lemon, and a little coastal smoke.",
+    bottle: mockBottles[2]!,
+    rating: 2,
+    tags: ["pear", "mineral", "lemon", "smoke"],
+    color: 9,
+    servingStyle: "neat",
+    friends: [],
+    comments: 0,
+    toasts: 7,
+    createdAt: "2026-08-21T19:10:00.000Z",
+    createdBy: mockFriends[0]!,
+  },
+  {
+    ...mockTasting,
+    id: 9604,
+    notes: "Caramel and vanilla first, then mint and dry oak.",
+    bottle: mockBottles[3]!,
+    rating: 1,
+    tags: ["caramel", "vanilla", "mint", "oak"],
+    color: 12,
+    servingStyle: "rocks",
+    friends: [mockFriends[1]!],
+    comments: 1,
+    toasts: 2,
+    createdAt: "2026-08-19T19:30:00.000Z",
+    createdBy: mockFriends[1]!,
+  },
+  {
+    ...mockTasting,
+    id: 9605,
+    notes: "Peach, incense, and coconut with a very composed finish.",
+    bottle: mockBottles[4]!,
+    rating: null,
+    score: 92,
+    tags: ["peach", "incense", "coconut"],
+    color: 10,
+    servingStyle: "neat",
+    friends: [],
+    comments: 0,
+    toasts: 9,
+    createdAt: "2026-08-17T21:00:00.000Z",
+    createdBy: mockFriends[0]!,
+  },
+  {
+    ...mockTasting,
+    id: 9606,
+    notes: "Baked apple, walnut, honey, and a warming pot still spice.",
+    bottle: mockBottles[5]!,
+    rating: 2,
+    score: null,
+    tags: ["apple", "walnut", "honey", "allspice"],
+    color: 13,
+    servingStyle: "splash",
+    friends: [mockFriends[0]!, mockFriends[1]!],
+    comments: 0,
+    toasts: 6,
+    createdAt: "2026-08-14T18:00:00.000Z",
+  },
+] satisfies Tasting[];
+
+export function mockTastingFor(
+  user: User | null,
+  tasting: Tasting = mockTasting,
+): Tasting {
+  return {
+    ...tasting,
+    bottle: mockBottleFor(user, tasting.bottle),
+    hasToasted: Boolean(user && tasting.id % 2 === 1),
   };
 }
 
@@ -428,10 +1489,110 @@ export const mockCollectionBottle = {
   hasTasted: true,
 } satisfies CollectionBottle;
 
-export const noMorePages = {
-  nextCursor: null,
-  prevCursor: null,
-} as const;
+export const mockCollectionBottles = [
+  mockCollectionBottle,
+  {
+    id: 9702,
+    imageUrl: null,
+    status: "sealed",
+    bottle: mockBottles[1]!,
+    hasTasted: true,
+  },
+  {
+    id: 9703,
+    imageUrl: null,
+    status: "open",
+    bottle: mockBottles[2]!,
+    hasTasted: false,
+  },
+  {
+    id: 9704,
+    imageUrl: null,
+    status: "empty",
+    bottle: mockBottles[3]!,
+    hasTasted: true,
+  },
+  {
+    id: 9705,
+    imageUrl: null,
+    status: "sealed",
+    bottle: mockBottles[4]!,
+    hasTasted: false,
+  },
+  {
+    id: 9706,
+    imageUrl: null,
+    status: null,
+    bottle: mockBottles[5]!,
+    hasTasted: true,
+  },
+] satisfies CollectionBottle[];
+
+export const mockActivity = [
+  {
+    id: "tasting-session-9601",
+    type: "tasting_session",
+    priority: "primary",
+    startedAt: "2026-08-26T11:30:00.000Z",
+    lastActivityAt: timestamp,
+    createdBy: mockPublicUser,
+    tastings: [mockTasting, mockTastings[1]!],
+  },
+  {
+    id: "tasting-session-9603",
+    type: "tasting_session",
+    priority: "primary",
+    startedAt: "2026-08-21T19:10:00.000Z",
+    lastActivityAt: "2026-08-21T19:10:00.000Z",
+    createdBy: mockFriends[0]!,
+    tastings: [mockTastings[2]!],
+  },
+  {
+    id: "collection-add-9701",
+    type: "collection_add",
+    priority: "secondary",
+    createdAt: "2026-08-20T17:00:00.000Z",
+    windowStart: "2026-08-20T16:30:00.000Z",
+    windowEnd: "2026-08-20T17:00:00.000Z",
+    createdBy: mockPublicUser,
+    collection: {
+      id: 9801,
+      name: "Islay Favorites",
+      totalBottles: 3,
+      createdAt: "2026-07-01T12:00:00.000Z",
+      createdBy: mockPublicUser,
+      href: `/users/${mockPublicUser.username}/collections/9801`,
+    },
+    items: [
+      mockCollectionBottle,
+      {
+        ...mockCollectionBottles[2]!,
+        bottle: mockBottles[6]!,
+        status: null,
+      },
+      {
+        ...mockCollectionBottles[4]!,
+        bottle: mockBottles[7]!,
+        status: null,
+      },
+    ],
+    totalItems: 3,
+  },
+] satisfies ActivityEntry[];
+
+// List helpers
+export function mockPage<T>(items: T[], cursor: number, limit: number) {
+  const offset = (cursor - 1) * limit;
+  const results = items.slice(offset, offset + limit);
+
+  return {
+    results,
+    rel: {
+      nextCursor: offset + limit < items.length ? cursor + 1 : null,
+      prevCursor: cursor > 1 ? cursor - 1 : null,
+    },
+  };
+}
 
 export function includesQuery(query: string, ...values: (string | null)[]) {
   const normalizedQuery = query.trim().toLowerCase();

--- a/apps/server/src/orpc/mock/fixtures.ts
+++ b/apps/server/src/orpc/mock/fixtures.ts
@@ -115,7 +115,7 @@ export function mockUserDetailsFor(
   user: User | null,
   profile: MockOutputs["users"]["details"] = mockPublicUserDetails,
 ) {
-  return user?.id === profile.id ? mockUserDetails : profile;
+  return user?.id === profile.id ? { ...profile, ...user } : profile;
 }
 
 export function matchesMockUser(value: string | number, user: User | null) {
@@ -988,6 +988,7 @@ export const mockReviews = [
       publishedAt: "2026-08-12T11:00:00.000Z",
     },
     reviewerName: "Editorial Sample",
+    site: undefined,
     nativeScore: { value: 91, scale: 100, display: "91" },
     summary: "Layered orchard fruit, incense, and restrained oak.",
     bottle: mockBottles[4],
@@ -1005,6 +1006,7 @@ export const mockReviews = [
       publishedAt: "2026-08-10T12:00:00.000Z",
     },
     reviewerName: "Editorial Sample",
+    site: undefined,
     nativeScore: { value: 90, scale: 100, display: "90" },
     summary: "A mature smoky malt that has not yet been matched to a bottle.",
     bottle: null,

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -37,6 +37,9 @@ const anonymousClient = createRouterClient(mockRouter, {
 const authenticatedClient = createRouterClient(mockRouter, {
   context: { user: mockUser },
 });
+const friendClient = createRouterClient(mockRouter, {
+  context: { user: mockFriends[0]! },
+});
 
 describe("mock oRPC router", () => {
   it("returns fixed data from supported routes", async () => {
@@ -288,6 +291,14 @@ describe("mock oRPC router", () => {
       code: "BAD_REQUEST",
       message: "Must be a moderator to list all reviews.",
     });
+
+    const whiskyAdvocateReviews = await anonymousClient.reviews.list({
+      site: "whiskyadvocate",
+      sort: "recent",
+    });
+    expect(whiskyAdvocateReviews.results.map((review) => review.id)).toEqual([
+      mockReview.id,
+    ]);
   });
 
   it("applies read-only filters without saving state", async () => {
@@ -459,6 +470,10 @@ describe("mock oRPC router", () => {
     await expect(
       authenticatedClient.users.details({ user: "me" }),
     ).resolves.toEqual(expect.objectContaining({ email: mockUser.email }));
+
+    await expect(friendClient.users.details({ user: "me" })).resolves.toEqual(
+      mockFriendDetails[0],
+    );
   });
 
   it("returns the route's not-found error for unknown records", async () => {

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -1,17 +1,25 @@
 import { createRouterClient } from "@orpc/server";
 import {
   mockAccessToken,
-  mockBadgeAward,
+  mockActivity,
+  mockBadgeAwards,
   mockBottle,
+  mockBottles,
   mockBottleTags,
-  mockCollectionBottle,
-  mockComment,
+  mockCollectionBottles,
+  mockCommentsByTasting,
+  mockCountries,
   mockCountry,
+  mockEntities,
   mockEntity,
   mockEntityCatalog,
   mockFlight,
+  mockFlights,
+  mockFriendDetails,
+  mockFriends,
   mockPublicUserDetails,
   mockRegion,
+  mockRegions,
   mockReview,
   mockTasting,
   mockUser,
@@ -35,12 +43,17 @@ describe("mock oRPC router", () => {
     await expect(anonymousClient.root()).resolves.toEqual({ version: "mock" });
 
     await expect(anonymousClient.activity.list({})).resolves.toEqual({
-      results: [],
+      results: mockActivity,
       rel: { nextCursor: null, prevCursor: null },
     });
 
     const bottles = await anonymousClient.bottles.list({ query: "Lagavulin" });
-    expect(bottles.results).toEqual([mockBottle]);
+    expect(bottles.results).toHaveLength(3);
+    expect(bottles.results.map((bottle) => bottle.brand.name)).toEqual([
+      "Lagavulin",
+      "Lagavulin",
+      "Lagavulin",
+    ]);
 
     const search = await anonymousClient.search({
       query: "Lagavulin",
@@ -48,7 +61,7 @@ describe("mock oRPC router", () => {
     });
     expect(search.exact).toEqual({ type: "entity", ref: mockEntity });
     expect(search.groups).toMatchObject([
-      { type: "bottles", total: 1, results: [mockBottle] },
+      { type: "bottles", total: 3 },
       { type: "distillers", total: 1, results: [mockEntity] },
     ]);
 
@@ -74,12 +87,24 @@ describe("mock oRPC router", () => {
     ).resolves.toEqual(mockTasting);
 
     const countries = await anonymousClient.countries.list({});
-    expect(countries.results).toEqual([mockCountry]);
+    expect(countries.results).toHaveLength(mockCountries.length);
+    expect(countries.results.map((country) => country.slug)).toEqual([
+      "india",
+      "ireland",
+      "japan",
+      "scotland",
+      "united-states",
+    ]);
 
     const regions = await anonymousClient.regions.list({
       country: mockCountry.slug,
     });
-    expect(regions.results).toEqual([mockRegion]);
+    expect(regions.results).toHaveLength(4);
+    expect(regions.results).toEqual(
+      expect.arrayContaining(
+        mockRegions.filter((region) => region.country.id === mockCountry.id),
+      ),
+    );
 
     const tastings = await anonymousClient.tastings.list({
       bottle: mockBottle.id,
@@ -90,22 +115,90 @@ describe("mock oRPC router", () => {
       collection: "library",
       user: mockUser.username,
     });
-    expect(collection.results).toEqual([
-      {
-        ...mockCollectionBottle,
-        bottle: mockBottle,
-        hasTasted: false,
-      },
-    ]);
+    expect(collection.results).toHaveLength(mockCollectionBottles.length);
+    expect(new Set(collection.results.map((item) => item.status))).toEqual(
+      new Set(["open", "sealed", "empty", null]),
+    );
+  });
+
+  it("returns varied samples with stable pages", async () => {
+    const bottles = await anonymousClient.bottles.list({
+      sort: "name",
+      limit: 100,
+    });
+    expect(bottles.results).toHaveLength(mockBottles.length);
+    expect(new Set(bottles.results.map((bottle) => bottle.category)).size).toBe(
+      3,
+    );
+    expect(
+      new Set(bottles.results.map((bottle) => bottle.flavorProfile)).size,
+    ).toBeGreaterThan(4);
+    expect(
+      new Set(bottles.results.map((bottle) => bottle.avgScore)).size,
+    ).toBeGreaterThan(4);
+
+    const firstPage = await anonymousClient.countries.list({ limit: 2 });
+    expect(firstPage.results).toHaveLength(2);
+    expect(firstPage.rel.nextCursor).toBe(2);
+
+    const secondPage = await anonymousClient.countries.list({
+      cursor: firstPage.rel.nextCursor!,
+      limit: 2,
+    });
+    expect(secondPage.results).toHaveLength(2);
+    expect(secondPage.rel.prevCursor).toBe(1);
+    expect(secondPage.results).not.toEqual(firstPage.results);
+  });
+
+  it("opens detail routes for varied list results", async () => {
+    const japan = mockCountries.find((country) => country.slug === "japan")!;
+    const kentucky = mockRegions.find((region) => region.slug === "kentucky")!;
+    const yamazaki = mockBottles.find(
+      (bottle) => bottle.brand.name === "Yamazaki",
+    )!;
+
+    await expect(
+      anonymousClient.countries.details({ country: japan.slug }),
+    ).resolves.toEqual(japan);
+    await expect(
+      anonymousClient.regions.details({
+        country: kentucky.country.slug,
+        region: kentucky.slug,
+      }),
+    ).resolves.toEqual(kentucky);
+    await expect(
+      anonymousClient.entities.details({ entity: yamazaki.brand.id }),
+    ).resolves.toEqual(yamazaki.brand);
+    await expect(
+      anonymousClient.bottles.details({ bottle: yamazaki.id }),
+    ).resolves.toMatchObject({ id: yamazaki.id, fullName: yamazaki.fullName });
+    await expect(
+      anonymousClient.users.details({ user: mockFriends[0]!.username }),
+    ).resolves.toEqual(mockFriendDetails[0]);
+    await expect(
+      anonymousClient.flights.details({ flight: mockFlights[1]!.id }),
+    ).resolves.toMatchObject({
+      id: mockFlights[1]!.id,
+      bottles: expect.arrayContaining([
+        expect.objectContaining({
+          bottle: expect.objectContaining({ id: yamazaki.id }),
+        }),
+      ]),
+    });
   });
 
   it("completes bottle, entity, and tasting detail pages", async () => {
-    await expect(
-      anonymousClient.reviews.list({
-        bottle: mockBottle.id,
-        sort: "name",
-      }),
-    ).resolves.toMatchObject({ results: [mockReview] });
+    const reviews = await anonymousClient.reviews.list({
+      bottle: mockBottle.id,
+      sort: "name",
+    });
+    expect(reviews.results).toHaveLength(3);
+    expect(reviews.results).toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: mockReview.id })]),
+    );
+    expect(
+      new Set(reviews.results.map((review) => review.site?.type)).size,
+    ).toBe(3);
 
     await expect(
       anonymousClient.bottles.tags({ bottle: mockBottle.id }),
@@ -113,11 +206,18 @@ describe("mock oRPC router", () => {
 
     await expect(
       anonymousClient.entities.catalog({ entity: mockEntity.id }),
-    ).resolves.toEqual(mockEntityCatalog);
+    ).resolves.toMatchObject({
+      ...mockEntityCatalog,
+      notableBottles: expect.arrayContaining([
+        expect.objectContaining({ id: mockBottle.id }),
+      ]),
+    });
 
     await expect(
       anonymousClient.comments.list({ tasting: mockTasting.id }),
-    ).resolves.toMatchObject({ results: [mockComment] });
+    ).resolves.toMatchObject({
+      results: mockCommentsByTasting.get(mockTasting.id),
+    });
   });
 
   it("returns fixed user profile insights", async () => {
@@ -125,7 +225,7 @@ describe("mock oRPC router", () => {
 
     await expect(anonymousClient.users.badgeList(input)).resolves.toMatchObject(
       {
-        results: [mockBadgeAward],
+        results: mockBadgeAwards,
       },
     );
     await expect(anonymousClient.users.regionList(input)).resolves.toEqual(
@@ -144,7 +244,11 @@ describe("mock oRPC router", () => {
 
   it("supports fixed tasting flights", async () => {
     await expect(anonymousClient.flights.list({})).resolves.toMatchObject({
-      results: [mockFlight],
+      results: expect.arrayContaining(
+        mockFlights
+          .filter((flight) => flight.public)
+          .map((flight) => expect.objectContaining({ id: flight.id })),
+      ),
     });
     await expect(
       anonymousClient.flights.list({ query: "Speyside" }),
@@ -153,12 +257,20 @@ describe("mock oRPC router", () => {
     await expect(
       anonymousClient.flights.details({ flight: mockFlight.id }),
     ).resolves.toMatchObject({
-      bottles: [{ hasTasted: false, isLibrary: false }],
+      bottles: [
+        { hasTasted: false, isLibrary: false },
+        { hasTasted: false, isLibrary: false },
+        { hasTasted: false, isLibrary: false },
+      ],
     });
     await expect(
       authenticatedClient.flights.details({ flight: mockFlight.id }),
     ).resolves.toMatchObject({
-      bottles: [{ hasTasted: true, isLibrary: true }],
+      bottles: [
+        { hasTasted: true, isLibrary: true },
+        { hasTasted: false, isLibrary: false },
+        { hasTasted: false, isLibrary: false },
+      ],
     });
   });
 
@@ -180,12 +292,12 @@ describe("mock oRPC router", () => {
 
   it("applies read-only filters without saving state", async () => {
     await expect(
-      anonymousClient.countries.list({ query: "Japan" }),
+      anonymousClient.countries.list({ query: "New Zealand" }),
     ).resolves.toMatchObject({ results: [] });
     await expect(
       anonymousClient.regions.list({
         country: mockCountry.slug,
-        query: "Speyside",
+        query: "Lowlands",
       }),
     ).resolves.toMatchObject({ results: [] });
     await expect(
@@ -195,7 +307,7 @@ describe("mock oRPC router", () => {
       anonymousClient.collections.bottles.list({
         collection: "library",
         user: mockUser.username,
-        status: "sealed",
+        query: "Ardbeg",
       }),
     ).resolves.toMatchObject({ results: [] });
   });
@@ -217,16 +329,26 @@ describe("mock oRPC router", () => {
         user: "me",
       }),
     ).resolves.toMatchObject({
-      results: [
-        {
-          bottle: {
+      results: expect.arrayContaining([
+        expect.objectContaining({
+          bottle: expect.objectContaining({
+            id: mockBottle.id,
             isFavorite: true,
             isLibrary: true,
             hasTasted: true,
-          },
+          }),
           hasTasted: true,
-        },
-      ],
+        }),
+        expect.objectContaining({
+          bottle: expect.objectContaining({
+            id: mockBottles[4]!.id,
+            isFavorite: true,
+            isLibrary: false,
+            hasTasted: false,
+          }),
+          hasTasted: false,
+        }),
+      ]),
     });
   });
 
@@ -244,13 +366,20 @@ describe("mock oRPC router", () => {
         { type: "distillers", total: 0, results: [] },
       ],
       scopeTotals: {
-        bottles: 1,
-        distillers: 1,
-        brands: 1,
-        bottlers: 0,
-        blenders: 0,
-        companies: 0,
-        regions: 0,
+        bottles: mockBottles.length,
+        distillers: mockEntities.filter((entity) =>
+          entity.type.includes("distiller"),
+        ).length,
+        brands: mockEntities.filter((entity) => entity.type.includes("brand"))
+          .length,
+        bottlers: mockEntities.filter((entity) =>
+          entity.type.includes("bottler"),
+        ).length,
+        blenders: mockEntities.filter((entity) => entity.kind === "blender")
+          .length,
+        companies: mockEntities.filter((entity) => entity.kind === "company")
+          .length,
+        regions: mockRegions.length,
       },
       nearest: [],
     });
@@ -283,7 +412,7 @@ describe("mock oRPC router", () => {
         },
       ],
       scopeTotals: {
-        members: 1,
+        members: 3,
       },
     });
   });
@@ -318,7 +447,7 @@ describe("mock oRPC router", () => {
     await expect(
       authenticatedClient.bottles.list({ filter: "following" }),
     ).resolves.toMatchObject({
-      followedDistillerCount: 1,
+      followedDistillerCount: 2,
     });
   });
 

--- a/apps/server/src/orpc/mock/routes/activity/list.ts
+++ b/apps/server/src/orpc/mock/routes/activity/list.ts
@@ -1,9 +1,25 @@
+import { mockActivity } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
-export default mockOS.activity.list.handler(async () => ({
-  results: [],
-  rel: {
-    nextCursor: null,
-    prevCursor: null,
+export default mockOS.activity.list.handler(
+  async ({ input, context, errors }) => {
+    if (input.filter === "friends" && !context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+
+    const activity =
+      input.filter === "friends"
+        ? mockActivity.filter(
+            (entry) => entry.createdBy.id !== context.user?.id,
+          )
+        : mockActivity;
+
+    return {
+      results: activity.slice(0, input.limit),
+      rel: {
+        nextCursor: null,
+        prevCursor: null,
+      },
+    };
   },
-}));
+);

--- a/apps/server/src/orpc/mock/routes/bottles/details.ts
+++ b/apps/server/src/orpc/mock/routes/bottles/details.ts
@@ -1,15 +1,18 @@
 import {
-  mockBottleDetails,
   mockBottleDetailsFor,
+  mockBottleDetailsList,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.bottles.details.handler(
   async ({ input, context, errors }) => {
-    if (input.bottle !== mockBottleDetails.id) {
+    const bottle = mockBottleDetailsList.find(
+      (candidate) => candidate.id === input.bottle,
+    );
+    if (!bottle) {
       throw errors.NOT_FOUND({ message: "Mock bottle not found." });
     }
 
-    return mockBottleDetailsFor(context.user);
+    return mockBottleDetailsFor(context.user, bottle);
   },
 );

--- a/apps/server/src/orpc/mock/routes/bottles/list.ts
+++ b/apps/server/src/orpc/mock/routes/bottles/list.ts
@@ -1,7 +1,9 @@
 import {
   includesQuery,
   mockBottleFor,
-  noMorePages,
+  mockBottles,
+  mockFlightBottleIds,
+  mockPage,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
@@ -11,13 +13,74 @@ export default mockOS.bottles.list.handler(
       throw errors.UNAUTHORIZED();
     }
 
-    const bottle = mockBottleFor(context.user);
+    const flightBottleIds = input.flight
+      ? mockFlightBottleIds.get(input.flight)
+      : undefined;
+    let bottles = mockBottles.filter(
+      (bottle) =>
+        includesQuery(
+          input.query,
+          bottle.fullName,
+          bottle.name,
+          bottle.brand.name,
+        ) &&
+        (input.brand == null || bottle.brand.id === input.brand) &&
+        (input.distiller == null ||
+          bottle.distillers.some((entity) => entity.id === input.distiller)) &&
+        (input.bottler == null || bottle.bottler?.id === input.bottler) &&
+        (input.entity == null ||
+          bottle.brand.id === input.entity ||
+          bottle.bottler?.id === input.entity ||
+          bottle.distillers.some((entity) => entity.id === input.entity)) &&
+        (input.series == null || bottle.series?.id === input.series) &&
+        (input.tag == null || bottle.suggestedTags?.includes(input.tag)) &&
+        (input.flavorProfile == null ||
+          bottle.flavorProfile === input.flavorProfile) &&
+        (input.category == null || bottle.category === input.category) &&
+        (input.age == null || bottle.statedAge === input.age) &&
+        (input.minRating == null ||
+          (bottle.avgRating ?? -1) >= input.minRating) &&
+        (input.minScore == null || (bottle.avgScore ?? 0) >= input.minScore) &&
+        (flightBottleIds === undefined ||
+          flightBottleIds.includes(bottle.id)) &&
+        (input.filter !== "following" ||
+          bottle.brand.id === 9201 ||
+          bottle.brand.id === 9202),
+    );
+
+    const direction = input.sort.startsWith("-") ? -1 : 1;
+    const sort = input.sort.replace(/^-/, "");
+    bottles = bottles.toSorted((left, right) => {
+      switch (sort) {
+        case "name":
+          return direction * left.fullName.localeCompare(right.fullName);
+        case "brand":
+          return direction * left.brand.name.localeCompare(right.brand.name);
+        case "age":
+          return direction * ((left.statedAge ?? 0) - (right.statedAge ?? 0));
+        case "rating":
+          return direction * ((left.avgRating ?? -1) - (right.avgRating ?? -1));
+        case "score":
+          return direction * ((left.avgScore ?? 0) - (right.avgScore ?? 0));
+        case "tastings":
+          return direction * (left.totalTastings - right.totalTastings);
+        case "rank":
+          return 0;
+        case "created":
+        case "release":
+          return direction * left.createdAt.localeCompare(right.createdAt);
+        default:
+          return 0;
+      }
+    });
+
     return {
-      results: includesQuery(input.query, bottle.fullName, bottle.name)
-        ? [bottle]
-        : [],
-      rel: noMorePages,
-      followedDistillerCount: input.filter === "following" ? 1 : null,
+      ...mockPage(
+        bottles.map((bottle) => mockBottleFor(context.user, bottle)),
+        input.cursor,
+        input.limit,
+      ),
+      followedDistillerCount: input.filter === "following" ? 2 : null,
     };
   },
 );

--- a/apps/server/src/orpc/mock/routes/bottles/tags.ts
+++ b/apps/server/src/orpc/mock/routes/bottles/tags.ts
@@ -1,13 +1,19 @@
-import { mockBottle, mockBottleTags } from "@peated/server/orpc/mock/fixtures";
+import {
+  mockBottles,
+  mockBottleTagsFor,
+} from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.bottles.tags.handler(async ({ input, errors }) => {
-  if (input.bottle !== mockBottle.id) {
+  const bottle = mockBottles.find((candidate) => candidate.id === input.bottle);
+  if (!bottle) {
     throw errors.NOT_FOUND({ message: "Mock bottle not found." });
   }
 
+  const tags = mockBottleTagsFor(bottle);
+
   return {
-    results: mockBottleTags.results.slice(0, input.limit),
-    totalCount: mockBottleTags.totalCount,
+    results: tags.results.slice(0, input.limit),
+    totalCount: tags.totalCount,
   };
 });

--- a/apps/server/src/orpc/mock/routes/collections/bottles/list.ts
+++ b/apps/server/src/orpc/mock/routes/collections/bottles/list.ts
@@ -1,11 +1,9 @@
 import {
   includesQuery,
-  mockBottle,
   mockBottleFor,
-  mockCollectionBottle,
-  mockEntity,
+  mockCollectionBottles,
+  mockPage,
   mockUser,
-  noMorePages,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
@@ -45,34 +43,37 @@ export default mockOS.collections.bottles.list.handler(
       });
     }
 
-    const statusMatches =
-      input.status === undefined ||
-      input.status === mockCollectionBottle.status ||
-      (input.status === "unset" && mockCollectionBottle.status === null);
-    const matches =
-      includesQuery(
-        input.query,
-        mockBottle.fullName,
-        mockBottle.name,
-        mockEntity.name,
-      ) &&
-      (input.brand == null || input.brand === mockEntity.id) &&
-      (input.distiller == null || input.distiller === mockEntity.id) &&
-      (input.bottle === undefined || input.bottle === mockBottle.id) &&
-      statusMatches;
+    const collectionBottles = mockCollectionBottles.filter(
+      (item) =>
+        includesQuery(
+          input.query,
+          item.bottle.fullName,
+          item.bottle.name,
+          item.bottle.brand.name,
+        ) &&
+        (input.brand == null || item.bottle.brand.id === input.brand) &&
+        (input.distiller == null ||
+          item.bottle.distillers.some(
+            (entity) => entity.id === input.distiller,
+          )) &&
+        (input.bottle === undefined || item.bottle.id === input.bottle) &&
+        (input.status === undefined ||
+          input.status === item.status ||
+          (input.status === "unset" && item.status === null)),
+    );
 
-    return {
-      results: matches
-        ? [
-            {
-              ...mockCollectionBottle,
-              status: isLibrary ? mockCollectionBottle.status : null,
-              bottle: mockBottleFor(context.user),
-              hasTasted: Boolean(context.user),
-            },
-          ]
-        : [],
-      rel: noMorePages,
-    };
+    return mockPage(
+      collectionBottles.map((item) => {
+        const bottle = mockBottleFor(context.user, item.bottle);
+        return {
+          ...item,
+          status: isLibrary ? item.status : null,
+          bottle,
+          hasTasted: bottle.hasTasted,
+        };
+      }),
+      input.cursor,
+      input.limit,
+    );
   },
 );

--- a/apps/server/src/orpc/mock/routes/comments/list.ts
+++ b/apps/server/src/orpc/mock/routes/comments/list.ts
@@ -1,8 +1,8 @@
 import {
-  mockComment,
-  mockTasting,
+  mockComments,
+  mockCommentsByTasting,
+  mockPage,
   mockUser,
-  noMorePages,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
@@ -13,19 +13,17 @@ export default mockOS.comments.list.handler(
     }
 
     if (!context.user?.admin && !input.tasting && !input.user) {
-      return { results: [], rel: noMorePages };
+      return mockPage([], input.cursor, input.limit);
     }
 
-    const userMatches =
-      input.user === undefined ||
-      input.user === "me" ||
-      input.user === mockUser.id;
-    const tastingMatches =
-      input.tasting === undefined || input.tasting === mockTasting.id;
+    const comments = input.tasting
+      ? (mockCommentsByTasting.get(input.tasting) ?? [])
+      : mockComments;
+    const userId = input.user === "me" ? mockUser.id : input.user;
+    const results = comments.filter(
+      (comment) => userId === undefined || comment.createdBy.id === userId,
+    );
 
-    return {
-      results: userMatches && tastingMatches ? [mockComment] : [],
-      rel: noMorePages,
-    };
+    return mockPage(results, input.cursor, input.limit);
   },
 );

--- a/apps/server/src/orpc/mock/routes/countries/details.ts
+++ b/apps/server/src/orpc/mock/routes/countries/details.ts
@@ -1,10 +1,13 @@
-import { mockCountry } from "@peated/server/orpc/mock/fixtures";
+import { mockCountries } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.countries.details.handler(async ({ input, errors }) => {
-  if (input.country.toLowerCase() !== mockCountry.slug) {
+  const country = mockCountries.find(
+    (candidate) => candidate.slug === input.country.toLowerCase(),
+  );
+  if (!country) {
     throw errors.NOT_FOUND({ message: "Mock country not found." });
   }
 
-  return mockCountry;
+  return country;
 });

--- a/apps/server/src/orpc/mock/routes/countries/list.ts
+++ b/apps/server/src/orpc/mock/routes/countries/list.ts
@@ -1,17 +1,24 @@
 import {
   includesQuery,
-  mockCountry,
-  noMorePages,
+  mockCountries,
+  mockPage,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.countries.list.handler(async ({ input }) => {
-  const matches =
-    includesQuery(input.query, mockCountry.name, mockCountry.slug) &&
-    (!input.hasBottles || mockCountry.totalBottles > 0);
+  const direction = input.sort.startsWith("-") ? -1 : 1;
+  const sort = input.sort.replace(/^-/, "");
+  const countries = mockCountries
+    .filter(
+      (country) =>
+        includesQuery(input.query, country.name, country.slug) &&
+        (!input.hasBottles || country.totalBottles > 0),
+    )
+    .toSorted((left, right) =>
+      sort === "bottles"
+        ? direction * (left.totalBottles - right.totalBottles)
+        : direction * left.name.localeCompare(right.name),
+    );
 
-  return {
-    results: matches ? [mockCountry] : [],
-    rel: noMorePages,
-  };
+  return mockPage(countries, input.cursor, input.limit);
 });

--- a/apps/server/src/orpc/mock/routes/entities/catalog.ts
+++ b/apps/server/src/orpc/mock/routes/entities/catalog.ts
@@ -1,13 +1,16 @@
 import {
-  mockEntity,
-  mockEntityCatalog,
+  mockEntities,
+  mockEntityCatalogFor,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.entities.catalog.handler(async ({ input, errors }) => {
-  if (input.entity !== mockEntity.id) {
+  const entity = mockEntities.find(
+    (candidate) => candidate.id === input.entity,
+  );
+  if (!entity) {
     throw errors.NOT_FOUND({ message: "Mock entity not found." });
   }
 
-  return mockEntityCatalog;
+  return mockEntityCatalogFor(entity);
 });

--- a/apps/server/src/orpc/mock/routes/entities/details.ts
+++ b/apps/server/src/orpc/mock/routes/entities/details.ts
@@ -1,10 +1,13 @@
-import { mockEntity } from "@peated/server/orpc/mock/fixtures";
+import { mockEntities } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.entities.details.handler(async ({ input, errors }) => {
-  if (input.entity !== mockEntity.id) {
+  const entity = mockEntities.find(
+    (candidate) => candidate.id === input.entity,
+  );
+  if (!entity) {
     throw errors.NOT_FOUND({ message: "Mock entity not found." });
   }
 
-  return mockEntity;
+  return entity;
 });

--- a/apps/server/src/orpc/mock/routes/entities/list.ts
+++ b/apps/server/src/orpc/mock/routes/entities/list.ts
@@ -1,13 +1,44 @@
 import {
   includesQuery,
-  mockEntity,
-  noMorePages,
+  mockEntities,
+  mockPage,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
-export default mockOS.entities.list.handler(async ({ input }) => ({
-  results: includesQuery(input.query, mockEntity.name, mockEntity.shortName)
-    ? [mockEntity]
-    : [],
-  rel: noMorePages,
-}));
+export default mockOS.entities.list.handler(async ({ input }) => {
+  const type = input.type ?? input.searchContext?.type;
+  const direction = input.sort.startsWith("-") ? -1 : 1;
+  const sort = input.sort.replace(/^-/, "");
+  const entities = mockEntities
+    .filter(
+      (entity) =>
+        includesQuery(input.query, entity.name, entity.shortName) &&
+        (input.name == null || entity.name === input.name) &&
+        (input.country == null ||
+          entity.country?.slug === input.country.toLowerCase() ||
+          entity.country?.id === Number(input.country)) &&
+        (input.region == null ||
+          entity.region?.slug === input.region.toLowerCase() ||
+          entity.region?.id === Number(input.region)) &&
+        (type == null || entity.type.includes(type)) &&
+        input.bottler == null,
+    )
+    .toSorted((left, right) => {
+      switch (sort) {
+        case "name":
+          return direction * left.name.localeCompare(right.name);
+        case "created":
+          return direction * left.createdAt.localeCompare(right.createdAt);
+        case "tastings":
+          return direction * (left.totalTastings - right.totalTastings);
+        case "rank":
+          return 0;
+        case "bottles":
+          return direction * (left.totalBottles - right.totalBottles);
+        default:
+          return 0;
+      }
+    });
+
+  return mockPage(entities, input.cursor, input.limit);
+});

--- a/apps/server/src/orpc/mock/routes/flights/details.ts
+++ b/apps/server/src/orpc/mock/routes/flights/details.ts
@@ -1,15 +1,21 @@
 import {
-  mockFlight,
   mockFlightDetailsFor,
+  mockFlights,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.flights.details.handler(
   async ({ input, context, errors }) => {
-    if (input.flight !== mockFlight.id) {
+    const flight = mockFlights.find(
+      (candidate) => candidate.id === input.flight,
+    );
+    if (
+      !flight ||
+      (!flight.public && flight.createdBy?.id !== context.user?.id)
+    ) {
       throw errors.NOT_FOUND({ message: "Mock flight not found." });
     }
 
-    return mockFlightDetailsFor(context.user);
+    return mockFlightDetailsFor(context.user, flight);
   },
 );

--- a/apps/server/src/orpc/mock/routes/flights/list.ts
+++ b/apps/server/src/orpc/mock/routes/flights/list.ts
@@ -1,17 +1,26 @@
 import {
   includesQuery,
-  mockFlight,
-  noMorePages,
+  mockFlights,
+  mockPage,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
-export default mockOS.flights.list.handler(async ({ input }) => {
-  const matches =
-    includesQuery(input.query, mockFlight.name, mockFlight.description) &&
-    input.filter !== "private";
+export default mockOS.flights.list.handler(async ({ input, context }) => {
+  const flights = mockFlights
+    .filter(
+      (flight) =>
+        includesQuery(input.query, flight.name, flight.description) &&
+        (flight.public || flight.createdBy?.id === context.user?.id) &&
+        (input.filter === undefined ||
+          input.filter === "none" ||
+          (input.filter === "public" && flight.public) ||
+          (input.filter === "private" && !flight.public)),
+    )
+    .toSorted((left, right) =>
+      input.sort === "-name"
+        ? right.name.localeCompare(left.name)
+        : left.name.localeCompare(right.name),
+    );
 
-  return {
-    results: matches ? [mockFlight] : [],
-    rel: noMorePages,
-  };
+  return mockPage(flights, input.cursor, input.limit);
 });

--- a/apps/server/src/orpc/mock/routes/regions/details.ts
+++ b/apps/server/src/orpc/mock/routes/regions/details.ts
@@ -1,17 +1,24 @@
-import { mockCountry, mockRegion } from "@peated/server/orpc/mock/fixtures";
+import { mockCountries, mockRegions } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.regions.details.handler(async ({ input, errors }) => {
-  const countryMatches =
-    input.country.toLowerCase() === mockCountry.slug ||
-    Number(input.country) === mockCountry.id;
-  if (!countryMatches) {
+  const country = mockCountries.find(
+    (candidate) =>
+      candidate.slug === input.country.toLowerCase() ||
+      candidate.id === Number(input.country),
+  );
+  if (!country) {
     throw errors.BAD_REQUEST({ message: "Invalid mock country." });
   }
 
-  if (input.region.toLowerCase() !== mockRegion.slug) {
+  const region = mockRegions.find(
+    (candidate) =>
+      candidate.country.id === country.id &&
+      candidate.slug === input.region.toLowerCase(),
+  );
+  if (!region) {
     throw errors.NOT_FOUND({ message: "Mock region not found." });
   }
 
-  return mockRegion;
+  return region;
 });

--- a/apps/server/src/orpc/mock/routes/regions/list.ts
+++ b/apps/server/src/orpc/mock/routes/regions/list.ts
@@ -1,28 +1,35 @@
 import {
   includesQuery,
-  mockCountry,
-  mockRegion,
-  noMorePages,
+  mockCountries,
+  mockPage,
+  mockRegions,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
-function matchesCountry(value: string) {
-  return (
-    value.toLowerCase() === mockCountry.slug || Number(value) === mockCountry.id
-  );
-}
-
 export default mockOS.regions.list.handler(async ({ input, errors }) => {
-  if (!matchesCountry(input.country)) {
+  const country = mockCountries.find(
+    (candidate) =>
+      candidate.slug === input.country.toLowerCase() ||
+      candidate.id === Number(input.country),
+  );
+  if (!country) {
     throw errors.BAD_REQUEST({ message: "Invalid mock country." });
   }
 
-  const matches =
-    includesQuery(input.query, mockRegion.name, mockRegion.slug) &&
-    (!input.hasBottles || mockRegion.totalBottles > 0);
+  const direction = input.sort.startsWith("-") ? -1 : 1;
+  const sort = input.sort.replace(/^-/, "");
+  const regions = mockRegions
+    .filter(
+      (region) =>
+        region.country.id === country.id &&
+        includesQuery(input.query, region.name, region.slug) &&
+        (!input.hasBottles || region.totalBottles > 0),
+    )
+    .toSorted((left, right) =>
+      sort === "bottles"
+        ? direction * (left.totalBottles - right.totalBottles)
+        : direction * left.name.localeCompare(right.name),
+    );
 
-  return {
-    results: matches ? [mockRegion] : [],
-    rel: noMorePages,
-  };
+  return mockPage(regions, input.cursor, input.limit);
 });

--- a/apps/server/src/orpc/mock/routes/reviews/list.ts
+++ b/apps/server/src/orpc/mock/routes/reviews/list.ts
@@ -1,14 +1,17 @@
 import {
   includesQuery,
   mockBottleFor,
-  mockReview,
-  noMorePages,
+  mockPage,
+  mockReviews,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.reviews.list.handler(
   async ({ input, context, errors }) => {
-    if (input.site && input.site !== mockReview.site?.type) {
+    if (
+      input.site &&
+      !mockReviews.some((review) => review.site?.type === input.site)
+    ) {
       throw errors.NOT_FOUND({ message: "Mock review site not found." });
     }
 
@@ -21,18 +24,26 @@ export default mockOS.reviews.list.handler(
       });
     }
 
-    const review = {
-      ...mockReview,
-      bottle: mockBottleFor(context.user),
-    };
-    const matches =
-      !input.onlyUnknown &&
-      (input.bottle === undefined || input.bottle === review.bottle.id) &&
-      includesQuery(input.query, review.name);
+    const reviews = mockReviews
+      .filter(
+        (review) =>
+          (input.site === undefined || review.site?.type === input.site) &&
+          (input.bottle === undefined || review.bottle?.id === input.bottle) &&
+          (!input.onlyUnknown || review.bottle === null) &&
+          includesQuery(input.query, review.name),
+      )
+      .toSorted((left, right) =>
+        input.sort === "name"
+          ? left.name.localeCompare(right.name)
+          : right.createdAt.localeCompare(left.createdAt),
+      )
+      .map((review) => ({
+        ...review,
+        bottle: review.bottle
+          ? mockBottleFor(context.user, review.bottle)
+          : null,
+      }));
 
-    return {
-      results: matches ? [review] : [],
-      rel: noMorePages,
-    };
+    return mockPage(reviews, input.cursor, input.limit);
   },
 );

--- a/apps/server/src/orpc/mock/routes/search.ts
+++ b/apps/server/src/orpc/mock/routes/search.ts
@@ -2,106 +2,159 @@ import type { MockOutputs } from "@peated/server/orpc/mock/contract";
 import {
   includesQuery,
   mockBottleFor,
-  mockEntity,
+  mockBottles,
+  mockEntities,
+  mockFriendDetails,
+  mockFriends,
+  mockRegions,
   mockUser,
   mockUserDetails,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
-const scopeTotals = {
-  bottles: 1,
-  distillers: 1,
-  brands: 1,
-  bottlers: 0,
-  blenders: 0,
-  companies: 0,
-  regions: 0,
-} satisfies MockOutputs["search"]["scopeTotals"];
-
 export default mockOS.search.handler(async ({ input, context }) => {
   const groups: MockOutputs["search"]["groups"] = [];
-  const bottle = mockBottleFor(context.user);
-  const bottleMatches = includesQuery(
-    input.query,
-    bottle.fullName,
-    bottle.name,
+  const bottles = mockBottles
+    .filter((bottle) =>
+      includesQuery(
+        input.query,
+        bottle.fullName,
+        bottle.name,
+        bottle.brand.name,
+      ),
+    )
+    .map((bottle) => mockBottleFor(context.user, bottle));
+  const matchingEntities = (
+    predicate: (entity: (typeof mockEntities)[number]) => boolean,
+  ) =>
+    mockEntities.filter(
+      (entity) =>
+        predicate(entity) &&
+        includesQuery(input.query, entity.name, entity.shortName),
+    );
+  const entitiesByScope = {
+    distillers: matchingEntities((entity) => entity.type.includes("distiller")),
+    brands: matchingEntities((entity) => entity.type.includes("brand")),
+    bottlers: matchingEntities((entity) => entity.type.includes("bottler")),
+    blenders: matchingEntities((entity) => entity.kind === "blender"),
+    companies: matchingEntities((entity) => entity.kind === "company"),
+  } as const;
+  const regions = mockRegions.filter((region) =>
+    includesQuery(input.query, region.name, region.slug, region.country.name),
   );
-  const entityMatches = includesQuery(
-    input.query,
-    mockEntity.name,
-    mockEntity.shortName,
-  );
-  const memberMatches = includesQuery(input.query, mockUser.username);
 
   if (input.scopes.includes("bottles")) {
     groups.push({
       type: "bottles",
-      total: bottleMatches ? 1 : 0,
-      results: bottleMatches ? [bottle] : [],
+      total: bottles.length,
+      results: bottles.slice(0, input.limit),
     });
   }
-  if (input.scopes.includes("distillers")) {
-    groups.push({
-      type: "distillers",
-      total: entityMatches ? 1 : 0,
-      results: entityMatches ? [mockEntity] : [],
-    });
-  }
-  if (input.scopes.includes("brands")) {
-    groups.push({
-      type: "brands",
-      total: entityMatches ? 1 : 0,
-      results: entityMatches ? [mockEntity] : [],
-    });
-  }
-  if (input.scopes.includes("bottlers")) {
-    groups.push({ type: "bottlers", total: 0, results: [] });
-  }
-  if (input.scopes.includes("blenders")) {
-    groups.push({ type: "blenders", total: 0, results: [] });
-  }
-  if (input.scopes.includes("companies")) {
-    groups.push({ type: "companies", total: 0, results: [] });
+  for (const scope of [
+    "distillers",
+    "brands",
+    "bottlers",
+    "blenders",
+    "companies",
+  ] as const) {
+    if (input.scopes.includes(scope)) {
+      const results = entitiesByScope[scope];
+      groups.push({
+        type: scope,
+        total: results.length,
+        results: results.slice(0, input.limit),
+      });
+    }
   }
   if (input.scopes.includes("regions")) {
-    groups.push({ type: "regions", total: 0, results: [] });
+    groups.push({
+      type: "regions",
+      total: regions.length,
+      results: regions.slice(0, input.limit),
+    });
   }
+
+  const members = [
+    {
+      member: mockUser,
+      totalTastings: mockUserDetails.stats.tastings,
+    },
+    {
+      member: mockFriends[0]!,
+      totalTastings: mockFriendDetails[0]!.stats.tastings,
+    },
+    {
+      member: mockFriends[1]!,
+      totalTastings: mockFriendDetails[1]!.stats.tastings,
+    },
+  ].filter(({ member }) => includesQuery(input.query, member.username));
   if (context.user && input.scopes.includes("members")) {
     groups.push({
       type: "members",
-      total: memberMatches ? 1 : 0,
-      results: memberMatches
-        ? [
-            {
-              member: mockUser,
-              totalTastings: mockUserDetails.stats.tastings,
-            },
-          ]
-        : [],
+      total: members.length,
+      results: members.slice(0, input.limit),
     });
   }
 
   const exactQuery = input.query.trim().toLowerCase();
-  const exact =
-    input.scopes.includes("bottles") &&
+  const exactBottle = bottles.find((bottle) =>
     [bottle.peatedId, bottle.fullName, bottle.name].some(
       (value) => value.toLowerCase() === exactQuery,
-    )
-      ? { type: "bottle" as const, ref: bottle }
-      : input.scopes.some((scope) =>
-            ["distillers", "brands"].includes(scope),
-          ) &&
-          [mockEntity.peatedId, mockEntity.name].some(
-            (value) => value.toLowerCase() === exactQuery,
-          )
-        ? { type: "entity" as const, ref: mockEntity }
-        : null;
+    ),
+  );
+  const entityMatchesSelectedScope = (entity: (typeof mockEntities)[number]) =>
+    input.scopes.some((scope) => {
+      switch (scope) {
+        case "distillers":
+          return entity.type.includes("distiller");
+        case "brands":
+          return entity.type.includes("brand");
+        case "bottlers":
+          return entity.type.includes("bottler");
+        case "blenders":
+          return entity.kind === "blender";
+        case "companies":
+          return entity.kind === "company";
+        case "bottles":
+        case "members":
+        case "regions":
+          return false;
+      }
+    });
+  const exactEntity = mockEntities.find(
+    (entity) =>
+      entityMatchesSelectedScope(entity) &&
+      [entity.peatedId, entity.name, entity.shortName].some(
+        (value) => value?.toLowerCase() === exactQuery,
+      ),
+  );
+
+  const scopeTotals: MockOutputs["search"]["scopeTotals"] = {
+    bottles: mockBottles.length,
+    distillers: mockEntities.filter((entity) =>
+      entity.type.includes("distiller"),
+    ).length,
+    brands: mockEntities.filter((entity) => entity.type.includes("brand"))
+      .length,
+    bottlers: mockEntities.filter((entity) => entity.type.includes("bottler"))
+      .length,
+    blenders: mockEntities.filter((entity) => entity.kind === "blender").length,
+    companies: mockEntities.filter((entity) => entity.kind === "company")
+      .length,
+    regions: mockRegions.length,
+  };
+  if (context.user) scopeTotals.members = 3;
 
   return {
     query: input.query,
-    exact,
+    exact:
+      input.scopes.includes("bottles") && exactBottle
+        ? { type: "bottle", ref: exactBottle }
+        : exactEntity
+          ? { type: "entity", ref: exactEntity }
+          : null,
     groups,
-    scopeTotals: context.user ? { ...scopeTotals, members: 1 } : scopeTotals,
+    scopeTotals,
     nearest: [],
   };
 });

--- a/apps/server/src/orpc/mock/routes/tastings/details.ts
+++ b/apps/server/src/orpc/mock/routes/tastings/details.ts
@@ -1,12 +1,18 @@
-import { mockTasting, mockTastingFor } from "@peated/server/orpc/mock/fixtures";
+import {
+  mockTastingFor,
+  mockTastings,
+} from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.tastings.details.handler(
   async ({ input, context, errors }) => {
-    if (input.tasting !== mockTasting.id) {
+    const tasting = mockTastings.find(
+      (candidate) => candidate.id === input.tasting,
+    );
+    if (!tasting) {
       throw errors.NOT_FOUND({ message: "Mock tasting not found." });
     }
 
-    return mockTastingFor(context.user);
+    return mockTastingFor(context.user, tasting);
   },
 );

--- a/apps/server/src/orpc/mock/routes/tastings/list.ts
+++ b/apps/server/src/orpc/mock/routes/tastings/list.ts
@@ -1,9 +1,9 @@
 import {
-  mockBottle,
-  mockEntity,
+  mockFriends,
+  mockPage,
   mockTastingFor,
+  mockTastings,
   mockUser,
-  noMorePages,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
@@ -17,23 +17,37 @@ export default mockOS.tastings.list.handler(
       throw errors.UNAUTHORIZED();
     }
 
-    const userMatches =
-      input.user === undefined ||
-      input.user === "me" ||
-      input.user === mockUser.id ||
-      input.user === mockUser.username;
-    if (input.user !== undefined && !userMatches) {
+    const requestedUserId =
+      input.user === "me"
+        ? mockUser.id
+        : [mockUser, ...mockFriends].find(
+            (user) => user.id === input.user || user.username === input.user,
+          )?.id;
+    const knownUserIds = new Set([
+      mockUser.id,
+      ...mockTastings.map((tasting) => tasting.createdBy.id),
+    ]);
+    if (input.user !== undefined && !knownUserIds.has(requestedUserId ?? -1)) {
       throw errors.NOT_FOUND({ message: "Mock user not found." });
     }
 
-    const matches =
-      userMatches &&
-      (input.bottle === undefined || input.bottle === mockBottle.id) &&
-      (input.entity === undefined || input.entity === mockEntity.id);
+    const tastings = mockTastings.filter(
+      (tasting) =>
+        (requestedUserId === undefined ||
+          tasting.createdBy.id === requestedUserId) &&
+        (input.filter !== "friends" || tasting.createdBy.id !== mockUser.id) &&
+        (input.bottle === undefined || tasting.bottle.id === input.bottle) &&
+        (input.entity === undefined ||
+          tasting.bottle.brand.id === input.entity ||
+          tasting.bottle.distillers.some(
+            (entity) => entity.id === input.entity,
+          )),
+    );
 
-    return {
-      results: matches ? [mockTastingFor(context.user)] : [],
-      rel: noMorePages,
-    };
+    return mockPage(
+      tastings.map((tasting) => mockTastingFor(context.user, tasting)),
+      input.cursor,
+      input.limit,
+    );
   },
 );

--- a/apps/server/src/orpc/mock/routes/users/badge-list.ts
+++ b/apps/server/src/orpc/mock/routes/users/badge-list.ts
@@ -1,7 +1,7 @@
 import {
   matchesMockUser,
-  mockBadgeAward,
-  noMorePages,
+  mockBadgeAwards,
+  mockPage,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
@@ -11,6 +11,6 @@ export default mockOS.users.badgeList.handler(
       throw errors.NOT_FOUND({ message: "Mock user not found." });
     }
 
-    return { results: [mockBadgeAward], rel: noMorePages };
+    return mockPage(mockBadgeAwards, input.cursor, input.limit);
   },
 );

--- a/apps/server/src/orpc/mock/routes/users/details.ts
+++ b/apps/server/src/orpc/mock/routes/users/details.ts
@@ -1,5 +1,5 @@
 import {
-  mockUserDetails,
+  mockPublicUserDetailsList,
   mockUserDetailsFor,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
@@ -10,15 +10,19 @@ export default mockOS.users.details.handler(
       throw errors.UNAUTHORIZED();
     }
 
-    const matches =
-      input.user === "me" ||
-      input.user === mockUserDetails.id ||
-      input.user === mockUserDetails.username;
-
-    if (!matches) {
+    const profile =
+      input.user === "me"
+        ? mockPublicUserDetailsList.find(
+            (candidate) => candidate.id === context.user?.id,
+          )
+        : mockPublicUserDetailsList.find(
+            (candidate) =>
+              candidate.id === input.user || candidate.username === input.user,
+          );
+    if (!profile) {
       throw errors.NOT_FOUND({ message: "Mock user not found." });
     }
 
-    return mockUserDetailsFor(context.user);
+    return mockUserDetailsFor(context.user, profile);
   },
 );


### PR DESCRIPTION
The mock API now returns diverse, connected samples across bottles, producers, places, tastings, collections, reviews, comments, badges, flights, activity, and search. QA can exercise populated lists, mixed values, viewer-specific states, and follow a result into its detail page without using a live API.

The data remains stateless and is checked against the existing oRPC contracts. Review the shared fixture graph first; the route changes only filter, sort, and page that graph while preserving authentication and visibility behavior.
