### PR TITLE
fix(classifier): Validate strict OpenAI output schemas

### DIFF
--- a/packages/bottle-classifier/src/classifierOutputBoundary.test.ts
+++ b/packages/bottle-classifier/src/classifierOutputBoundary.test.ts
@@ -158,6 +158,22 @@ describe("classifier output boundary", () => {
     );
     expect(outputType.schema.properties).not.toHaveProperty("identityBasis");
     expect(outputType.schema.properties).not.toHaveProperty("findings");
+    expect(outputType.schema).toMatchObject({
+      properties: {
+        proposedBottle: {
+          anyOf: expect.arrayContaining([
+            expect.objectContaining({
+              type: "object",
+              properties: expect.objectContaining({
+                bottlingYear: expect.any(Object),
+              }),
+              required: expect.arrayContaining(["bottlingYear"]),
+              additionalProperties: false,
+            }),
+          ]),
+        },
+      },
+    });
     expect(hasFormatAnnotation(outputType.schema)).toBe(false);
     expect(prepared.agent.tools.map((tool) => tool.name)).not.toEqual(
       expect.arrayContaining([

--- a/packages/bottle-classifier/src/classifierRuntime.ts
+++ b/packages/bottle-classifier/src/classifierRuntime.ts
@@ -7,6 +7,7 @@ import {
 } from "@openai/agents";
 import { randomUUID } from "node:crypto";
 import type OpenAI from "openai";
+import { zodTextFormat } from "openai/helpers/zod";
 import { z } from "zod";
 import { normalizePotentialProofLikeDecision } from "./abv";
 import type { BottleContext, EntityContext } from "./bottleContextContract";
@@ -165,11 +166,10 @@ function stripProviderUnsupportedFormats(value: JsonValue): JsonValue {
 function createAgentOutputType(
   name: string,
   schema: z.ZodObject,
-  strict = false,
 ): JsonSchemaDefinition {
-  const generatedSchema = z.toJSONSchema(schema, {
-    target: "draft-7",
-  });
+  // The OpenAI helper makes nullable optional fields required on the wire and
+  // rejects optional non-nullable fields before the provider request.
+  const generatedSchema = zodTextFormat(schema, name).schema;
   // Zod attaches non-JSON Standard Schema metadata to the generated object.
   // The provider contract owns only its serialized JSON representation.
   const providerSchema = JsonObjectSchema.parse(
@@ -178,7 +178,7 @@ function createAgentOutputType(
   return {
     type: "json_schema",
     name,
-    strict,
+    strict: true,
     schema: AgentOutputJsonSchema.parse(
       stripProviderUnsupportedFormats(providerSchema),
     ),
@@ -188,13 +188,11 @@ function createAgentOutputType(
 const BottleReferenceAgentOutputType = createAgentOutputType(
   "bottle_reference_output",
   BottleReferenceAgentOutputSchema,
-  true,
 );
 
 const BottleAuditAgentOutputType = createAgentOutputType(
   "bottle_audit_output",
   BottleAuditAgentOutputSchema,
-  true,
 );
 
 export type BottleAuditAgentOutput = z.infer<

--- a/packages/bottle-classifier/src/classifierTypes.ts
+++ b/packages/bottle-classifier/src/classifierTypes.ts
@@ -549,10 +549,6 @@ export const BottleClassificationDecisionSchema = z.discriminatedUnion(
   [MatchDecisionSchema, CreateBottleDecisionSchema, NoMatchDecisionSchema],
 );
 
-const AgentProposedBottleSchema = ProposedBottleSchema.extend({
-  abv: z.number().nullable().default(null),
-});
-
 export const BottleClassifierActionSchema = z.enum([
   "match",
   "create_bottle",
@@ -581,7 +577,7 @@ export const BottleClassifierAgentDecisionSchema = z
       .max(MAX_BOTTLE_CANDIDATES)
       .default([]),
     matchedBottleId: z.number().int().nullable().default(null),
-    proposedBottle: AgentProposedBottleSchema.nullable()
+    proposedBottle: ProposedBottleSchema.nullable()
       .default(null)
       .describe(
         "Required for create_bottle. A create draft describes one independently complete Bottle, including every supported marketed release trait; unknown optional fields may remain null.",

--- a/packages/bottle-classifier/src/extractor.test.ts
+++ b/packages/bottle-classifier/src/extractor.test.ts
@@ -40,6 +40,31 @@ describe("createWhiskyLabelExtractor", () => {
       expect.objectContaining({
         model: "gpt-5.6-luna",
         reasoning: { effort: "high" },
+        text: {
+          format: expect.objectContaining({
+            type: "json_schema",
+            strict: true,
+            schema: expect.objectContaining({
+              properties: expect.objectContaining({
+                result: expect.objectContaining({
+                  anyOf: expect.arrayContaining([
+                    expect.objectContaining({
+                      type: "object",
+                      properties: expect.objectContaining({
+                        bottling_year: expect.any(Object),
+                      }),
+                      required: expect.arrayContaining(["bottling_year"]),
+                      additionalProperties: false,
+                    }),
+                  ]),
+                }),
+                rawLabelText: expect.any(Object),
+              }),
+              required: expect.arrayContaining(["result", "rawLabelText"]),
+              additionalProperties: false,
+            }),
+          }),
+        },
       }),
     );
     expect(extraction).toMatchObject({

--- a/packages/bottle-classifier/src/extractor.ts
+++ b/packages/bottle-classifier/src/extractor.ts
@@ -1,4 +1,5 @@
 import type OpenAI from "openai";
+import { zodTextFormat } from "openai/helpers/zod";
 import { z } from "zod";
 import { BottleExtractedDetailsSchema } from "./classifierTypes";
 import { buildWhiskyLabelExtractorInstructions } from "./extractorInstructions";
@@ -11,6 +12,7 @@ const ResponseSchema = z.object({
   result: BottleExtractedDetailsSchema.nullable(),
   rawLabelText: z.string().trim().min(1).max(4000).nullable().default(null),
 });
+const ResponseFormat = zodTextFormat(ResponseSchema, "ExtractedBottleDetails");
 
 interface WhiskyLabelProviderResponse {
   id: string;
@@ -149,11 +151,7 @@ export async function extractFromImageWithMetadata({
       },
     ],
     text: {
-      format: {
-        type: "json_schema",
-        name: "ExtractedBottleDetails",
-        schema: z.toJSONSchema(ResponseSchema),
-      },
+      format: ResponseFormat,
     },
     ...getStableOpenAISettings(model, reasoningEffort),
   });
@@ -214,11 +212,7 @@ export async function extractFromText({
       },
     ],
     text: {
-      format: {
-        type: "json_schema",
-        name: "ExtractedBottleDetails",
-        schema: z.toJSONSchema(ResponseSchema),
-      },
+      format: ResponseFormat,
     },
     ...getStableOpenAISettings(model, reasoningEffort),
   });


### PR DESCRIPTION
Bottle classification and label extraction now use the OpenAI SDK's strict Zod conversion at the provider boundary. Nullable optional fields become required nullable fields in the wire schema, while stored replays and partial inputs can still omit fields added later.

The boundary tests verify that both bottling-year fields appear in their nested `required` lists and that objects reject additional properties. The SDK conversion also rejects non-nullable optional fields before a provider request.

Fixes PEATED-4DM
Fixes PEATED-4DV
Fixes PEATED-4DR
Fixes PEATED-4DS
Fixes PEATED-4DT
