### PR TITLE
fix(worker): Skip stale derived jobs

### DIFF
--- a/apps/server/src/agents/bottleClassifier/auditBottle.test.ts
+++ b/apps/server/src/agents/bottleClassifier/auditBottle.test.ts
@@ -5,6 +5,7 @@ import {
 import config from "@peated/server/config";
 import { db } from "@peated/server/db";
 import {
+  bottleAliases,
   bottleChecks,
   bottleOperations,
   bottles,
@@ -409,6 +410,50 @@ describe("server-owned Bottle audit workflows", () => {
     ).toHaveLength(1);
   });
 
+  test("discards a post-user-creation audit after its Bottle is deleted", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.LegacyBottle();
+    const deferred =
+      Promise.withResolvers<
+        Awaited<ReturnType<typeof auditBottleWithServerAdapters>>
+      >();
+    auditBottleWithServerAdapters.mockImplementation(
+      async () => await deferred.promise,
+    );
+    const input = {
+      bottleId: bottle.id,
+      backgroundEventKey: `deleted_bottle_created:${bottle.id}`,
+    };
+
+    const work = runPostUserCreationBottleAudit(input);
+    await vi.waitFor(() =>
+      expect(auditBottleWithServerAdapters).toHaveBeenCalledOnce(),
+    );
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(bottleAliases)
+        .where(eq(bottleAliases.bottleId, bottle.id));
+      await tx.delete(bottles).where(eq(bottles.id, bottle.id));
+    });
+    deferred.resolve({
+      result: createAuditBottleResult({
+        summary: "The deleted Bottle has no remaining verification work.",
+        proposedOperations: [],
+        findings: [],
+        artifacts: buildBottleClassificationArtifacts({}),
+      }),
+      modelMetadata: null,
+    });
+
+    await expect(work).resolves.toBeNull();
+    expect(
+      await db.query.bottleChecks.findMany({
+        where: eq(bottleChecks.backgroundEventKey, input.backgroundEventKey),
+      }),
+    ).toEqual([]);
+  });
+
   test("keeps concurrent post-user-creation retries race-safe at persistence", async ({
     fixtures,
   }) => {
@@ -437,10 +482,11 @@ describe("server-owned Bottle audit workflows", () => {
       runPostUserCreationBottleAudit(input),
     ]);
 
-    expect(results.map((entry) => entry?.created).sort()).toEqual([
-      false,
-      true,
-    ]);
+    expect(
+      results
+        .map((entry) => entry?.created)
+        .sort((left, right) => String(left).localeCompare(String(right))),
+    ).toEqual([false, true]);
     expect(results[0]?.check.id).toBe(results[1]?.check.id);
     expect(auditBottleWithServerAdapters).toHaveBeenCalledTimes(2);
     expect(

--- a/apps/server/src/agents/bottleClassifier/auditBottle.ts
+++ b/apps/server/src/agents/bottleClassifier/auditBottle.ts
@@ -7,7 +7,6 @@ import {
   deleteTerminalModeratorBottleAudits,
   getCurrentModeratorBottleAudit,
   type BottleCheckWithOperations,
-  type CreateBottleCheckInput,
   type CreateBottleCheckResult,
 } from "@peated/server/lib/bottleChecks";
 import { eq } from "drizzle-orm";
@@ -41,28 +40,6 @@ export type PostUserCreationBottleAuditInput = z.input<
 export type ModeratorBottleAuditResult =
   | { status: "clean"; summary: string }
   | { status: "needs_review"; check: BottleCheckWithOperations };
-
-async function runAndPersistBottleAudit({
-  input,
-  backgroundEventKey,
-  runAudit,
-}: {
-  input: AuditBottleInput;
-  backgroundEventKey?: string;
-  runAudit: typeof auditBottleWithServerAdapters;
-}): Promise<CreateBottleCheckResult> {
-  const { result, modelMetadata } = await runAudit(input);
-
-  const checkInput: CreateBottleCheckInput = {
-    intent: "audit_bottle",
-    input,
-    result,
-    model: config.BOTTLE_CLASSIFIER_MODEL,
-    modelMetadata,
-  };
-  if (backgroundEventKey) checkInput.backgroundEventKey = backgroundEventKey;
-  return await createBottleCheck(checkInput);
-}
 
 export async function runModeratorBottleAudit(
   rawInput: ModeratorBottleAuditInput,
@@ -110,7 +87,7 @@ export async function runModeratorBottleAudit(
 export async function runPostUserCreationBottleAudit(
   rawInput: PostUserCreationBottleAuditInput,
   runAudit: typeof auditBottleWithServerAdapters = auditBottleWithServerAdapters,
-): Promise<CreateBottleCheckResult> {
+): Promise<CreateBottleCheckResult | null> {
   const input = PostUserCreationBottleAuditInputSchema.parse(rawInput);
   const existing = await db.query.bottleChecks.findFirst({
     where: eq(bottleChecks.backgroundEventKey, input.backgroundEventKey),
@@ -129,14 +106,30 @@ export async function runPostUserCreationBottleAudit(
     return { check: existing, created: false };
   }
 
+  const bottle = await db.query.bottles.findFirst({
+    columns: { id: true },
+    where: (bottles, { eq }) => eq(bottles.id, input.bottleId),
+  });
+  if (!bottle) return null;
+
   const auditInput: AuditBottleInput = {
     bottleId: input.bottleId,
     origin: "post_user_creation",
   };
   if (input.note) auditInput.note = input.note;
-  return await runAndPersistBottleAudit({
+  const { result, modelMetadata } = await runAudit(auditInput);
+  const activeBottle = await db.query.bottles.findFirst({
+    columns: { id: true },
+    where: (bottles, { eq }) => eq(bottles.id, input.bottleId),
+  });
+  if (!activeBottle) return null;
+
+  return await createBottleCheck({
+    intent: "audit_bottle",
     input: auditInput,
+    result,
+    model: config.BOTTLE_CLASSIFIER_MODEL,
+    modelMetadata,
     backgroundEventKey: input.backgroundEventKey,
-    runAudit,
   });
 }

--- a/apps/server/src/lib/catalogVerificationFindings.ts
+++ b/apps/server/src/lib/catalogVerificationFindings.ts
@@ -100,9 +100,7 @@ export async function getCatalogVerificationDisplayName({
       .where(eq(bottles.id, objectId))
       .limit(1);
 
-    if (!bottle) {
-      throw new Error(`Unknown bottle: ${objectId}`);
-    }
+    if (!bottle) return null;
 
     return bottle.displayName;
   }
@@ -115,9 +113,7 @@ export async function getCatalogVerificationDisplayName({
     .where(eq(entities.id, objectId))
     .limit(1);
 
-  if (!entity) {
-    throw new Error(`Unknown entity: ${objectId}`);
-  }
+  if (!entity) return null;
 
   return entity.displayName;
 }

--- a/apps/server/src/worker/jobs/entityDerivedJobs.test.ts
+++ b/apps/server/src/worker/jobs/entityDerivedJobs.test.ts
@@ -1,0 +1,26 @@
+import config from "@peated/server/config";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import generateEntityDetails from "./generateEntityDetails";
+import geocodeEntityLocation from "./geocodeEntityLocation";
+import indexEntitySearchVectors from "./indexEntitySearchVectors";
+
+const originalAiGatewayApiKey = config.AI_GATEWAY_API_KEY;
+const originalGoogleMapsApiKey = config.GOOGLE_MAPS_API_KEY;
+
+beforeEach(() => {
+  config.AI_GATEWAY_API_KEY = "test-api-key";
+  config.GOOGLE_MAPS_API_KEY = "test-api-key";
+});
+
+afterEach(() => {
+  config.AI_GATEWAY_API_KEY = originalAiGatewayApiKey;
+  config.GOOGLE_MAPS_API_KEY = originalGoogleMapsApiKey;
+});
+
+test("skips stale derived work for a deleted Entity", async () => {
+  const entityId = 2_147_483_647;
+
+  await expect(generateEntityDetails({ entityId })).resolves.toBeUndefined();
+  await expect(indexEntitySearchVectors({ entityId })).resolves.toBeUndefined();
+  await expect(geocodeEntityLocation({ entityId })).resolves.toBeUndefined();
+});

--- a/apps/server/src/worker/jobs/generateBottleDetails.test.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.test.ts
@@ -142,6 +142,13 @@ test("rejects an unassigned Bottle before invoking AI", async ({
   expect(bottleDetailsModel).not.toHaveBeenCalled();
 });
 
+test("skips stale work for a deleted Bottle before invoking AI", async () => {
+  await expect(
+    generateBottleDetails({ bottleId: 2_147_483_647 }),
+  ).resolves.toBeUndefined();
+  expect(bottleDetailsModel).not.toHaveBeenCalled();
+});
+
 test("rejects a Bottle tombstone before invoking AI", async ({ fixtures }) => {
   const retiredBottle = await fixtures.Bottle();
   const bottleDestination = await fixtures.Bottle();

--- a/apps/server/src/worker/jobs/generateBottleDetails.ts
+++ b/apps/server/src/worker/jobs/generateBottleDetails.ts
@@ -25,6 +25,7 @@ import {
   bottleUpdateExpectedSelectedBottleState,
   bottleUpdateExpectedSharedState,
   BottleUpdateExpectedStateError,
+  BottleUpdateGraphError,
   finalizeBottleUpdate,
   updateBottleInTransaction,
 } from "@peated/server/lib/updateBottle";
@@ -201,6 +202,11 @@ export async function generateBottleDetails(
     .where(and(eq(bottles.id, bottleId), isNull(bottleTombstones.bottleId)))
     .limit(1);
   if (!owned) {
+    const bottle = await db.query.bottles.findFirst({
+      columns: { id: true },
+      where: eq(bottles.id, bottleId),
+    });
+    if (!bottle) return;
     throw new Error(
       `Bottle ${bottleId} does not belong to an active BottleGroup.`,
     );
@@ -301,7 +307,9 @@ export async function generateBottleDetails(
     // authoritative edit supersedes them, so the stale result is discarded.
     if (
       error instanceof BottleUpdateExpectedBottleStateError ||
-      error instanceof BottleUpdateExpectedStateError
+      error instanceof BottleUpdateExpectedStateError ||
+      (error instanceof BottleUpdateGraphError &&
+        (error.code === "not_found" || error.code === "retired"))
     ) {
       return;
     }

--- a/apps/server/src/worker/jobs/generateEntityDetails.ts
+++ b/apps/server/src/worker/jobs/generateEntityDetails.ts
@@ -128,9 +128,7 @@ export default async ({
       region: true,
     },
   });
-  if (!entity) {
-    throw new Error(`Unknown entity: ${entityId}`);
-  }
+  if (!entity) return;
 
   const generateDesc =
     (!entity.descriptionSrc || entity.descriptionSrc === "generated") &&
@@ -187,7 +185,12 @@ export default async ({
   const actor = await getPeatedSystemActor();
 
   await db.transaction(async (tx) => {
-    await tx.update(entities).set(data).where(eq(entities.id, entity.id));
+    const [updated] = await tx
+      .update(entities)
+      .set(data)
+      .where(eq(entities.id, entity.id))
+      .returning({ id: entities.id });
+    if (!updated) return;
 
     await tx.insert(changes).values({
       objectType: "entity",

--- a/apps/server/src/worker/jobs/geocodeEntityLocation.ts
+++ b/apps/server/src/worker/jobs/geocodeEntityLocation.ts
@@ -86,9 +86,7 @@ export default async ({
     },
   });
 
-  if (!entity) {
-    throw new Error(`Unknown entity: ${entityId}`);
-  }
+  if (!entity) return;
 
   if (!entity.country) {
     // cant geocode if we dont know the country
@@ -138,7 +136,12 @@ export default async ({
   const actor = await getPeatedSystemActor();
 
   await db.transaction(async (tx) => {
-    await tx.update(entities).set(data).where(eq(entities.id, entity.id));
+    const [updated] = await tx
+      .update(entities)
+      .set(data)
+      .where(eq(entities.id, entity.id))
+      .returning({ id: entities.id });
+    if (!updated) return;
 
     await tx.insert(changes).values({
       objectType: "entity",

--- a/apps/server/src/worker/jobs/indexBottleSearchVectors.test.ts
+++ b/apps/server/src/worker/jobs/indexBottleSearchVectors.test.ts
@@ -117,9 +117,9 @@ describe("indexBottleSearchVectors", () => {
     );
   });
 
-  test("rejects an unknown Bottle", async () => {
+  test("skips stale work for a deleted Bottle", async () => {
     await expect(
       indexBottleSearchVectors({ bottleId: 2_147_483_647 }),
-    ).rejects.toThrow("Unknown bottle: 2147483647");
+    ).resolves.toBeUndefined();
   });
 });

--- a/apps/server/src/worker/jobs/indexBottleSearchVectors.ts
+++ b/apps/server/src/worker/jobs/indexBottleSearchVectors.ts
@@ -24,9 +24,7 @@ export default async function indexBottleSearchVectors(input: JobPayload) {
   const bottle = await db.query.bottles.findFirst({
     where: (bottles, { eq }) => eq(bottles.id, bottleId),
   });
-  if (!bottle) {
-    throw new Error(`Unknown bottle: ${bottleId}`);
-  }
+  if (!bottle) return;
 
   const aliasList = await db
     .select({
@@ -55,6 +53,7 @@ export default async function indexBottleSearchVectors(input: JobPayload) {
     .select()
     .from(entities)
     .where(eq(entities.id, bottle.brandId));
+  if (!brand) return;
 
   const [bottler] = bottle.bottlerId
     ? await db.select().from(entities).where(eq(entities.id, bottle.bottlerId))
@@ -70,7 +69,7 @@ export default async function indexBottleSearchVectors(input: JobPayload) {
   const searchVector =
     buildBottleSearchVector(
       bottle,
-      brand!,
+      brand,
       aliasList,
       bottler,
       distillerList,

--- a/apps/server/src/worker/jobs/indexBottleSeriesSearchVectors.test.ts
+++ b/apps/server/src/worker/jobs/indexBottleSeriesSearchVectors.test.ts
@@ -1,0 +1,14 @@
+import * as workerClient from "@peated/server/lib/test/workerDispatch";
+import { beforeEach, expect, test, vi } from "vitest";
+import indexBottleSeriesSearchVectors from "./indexBottleSeriesSearchVectors";
+
+beforeEach(() => {
+  vi.mocked(workerClient.pushUniqueJob).mockClear();
+});
+
+test("skips stale work for a deleted BottleSeries", async () => {
+  await expect(
+    indexBottleSeriesSearchVectors({ seriesId: 2_147_483_647 }),
+  ).resolves.toBeUndefined();
+  expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
+});

--- a/apps/server/src/worker/jobs/indexBottleSeriesSearchVectors.ts
+++ b/apps/server/src/worker/jobs/indexBottleSeriesSearchVectors.ts
@@ -9,16 +9,15 @@ export default async ({ seriesId }: { seriesId: number }) => {
   const series = await db.query.bottleSeries.findFirst({
     where: (bottleSeries, { eq }) => eq(bottleSeries.id, seriesId),
   });
-  if (!series) {
-    throw new Error(`Unknown series: ${seriesId}`);
-  }
+  if (!series) return;
 
   const [brand] = await db
     .select()
     .from(entities)
     .where(eq(entities.id, series.brandId));
+  if (!brand) return;
 
-  const searchVector = buildBottleSeriesSearchVector(series, brand!) || null;
+  const searchVector = buildBottleSeriesSearchVector(series, brand) || null;
 
   logInfo("Updating search vector for series {seriesId}", {
     extra: {

--- a/apps/server/src/worker/jobs/indexEntitySearchVectors.ts
+++ b/apps/server/src/worker/jobs/indexEntitySearchVectors.ts
@@ -8,9 +8,7 @@ export default async ({ entityId }: { entityId: number }) => {
   const entity = await db.query.entities.findFirst({
     where: (entities, { eq }) => eq(entities.id, entityId),
   });
-  if (!entity) {
-    throw new Error(`Unknown entity: ${entityId}`);
-  }
+  if (!entity) return;
 
   const aliasList = await db
     .select()

--- a/apps/server/src/worker/jobs/notifyDiscordOnTasting.test.ts
+++ b/apps/server/src/worker/jobs/notifyDiscordOnTasting.test.ts
@@ -76,6 +76,13 @@ test("uses the referenced Bottle label", async ({ fixtures }) => {
   });
 });
 
+test("skips stale work for a deleted Tasting", async () => {
+  await expect(
+    notifyDiscordOnTasting({ tastingId: 2_147_483_647 }),
+  ).resolves.toBeUndefined();
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
 test("rejects a retired Bottle without sending a webhook", async ({
   fixtures,
 }) => {

--- a/apps/server/src/worker/jobs/notifyDiscordOnTasting.ts
+++ b/apps/server/src/worker/jobs/notifyDiscordOnTasting.ts
@@ -32,7 +32,7 @@ export default async function notifyDiscordOnTasting(input: JobPayload) {
       },
     });
     if (!selected) {
-      throw new Error(`Unknown tasting: ${tastingId}`);
+      return null;
     }
     const bottleId = selected.bottleId;
     if (bottleId === null) {
@@ -50,6 +50,7 @@ export default async function notifyDiscordOnTasting(input: JobPayload) {
     }
     return { ...selected, bottle };
   });
+  if (!tasting) return;
 
   // TODO: pretty sure we're mismatched timezones on db + server, and need normalization
   // move db to UTC (if its not, or if its not storing tzinfo), and then run all these checks

--- a/apps/server/src/worker/jobs/onBottleChange.test.ts
+++ b/apps/server/src/worker/jobs/onBottleChange.test.ts
@@ -55,6 +55,13 @@ test("generates details only when explicitly requested", async ({
   );
 });
 
+test("skips stale work for a deleted Bottle", async () => {
+  await onBottleChange({ bottleId: 2_147_483_647 });
+
+  expect(workerClient.runJob).not.toHaveBeenCalled();
+  expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
+});
+
 test.each([
   undefined,
   {},

--- a/apps/server/src/worker/jobs/onBottleChange.ts
+++ b/apps/server/src/worker/jobs/onBottleChange.ts
@@ -1,3 +1,4 @@
+import { db } from "@peated/server/db";
 import { pushUniqueJob, runJob } from "@peated/server/worker/client";
 import { z } from "zod";
 import type { JobPayload } from "../types";
@@ -34,6 +35,14 @@ export function buildBottleChangeStatsJob(
 export default async (input: JobPayload) => {
   const { bottleId, generateDetails } =
     OnBottleChangeJobArgsSchema.parse(input);
+
+  const bottle = await db.query.bottles.findFirst({
+    columns: { id: true },
+    where: (bottles, { eq }) => eq(bottles.id, bottleId),
+  });
+  // Bottle change jobs can outlive a delete or merge. Missing rows mean that
+  // this queued work is stale, so no derived Bottle state remains to update.
+  if (!bottle) return;
 
   if (generateDetails) {
     await runJob("GenerateBottleDetails", { bottleId });

--- a/apps/server/src/worker/jobs/onEntityChange.test.ts
+++ b/apps/server/src/worker/jobs/onEntityChange.test.ts
@@ -1,0 +1,42 @@
+import * as workerClient from "@peated/server/lib/test/workerDispatch";
+import { beforeEach, expect, test, vi } from "vitest";
+import onEntityChange from "./onEntityChange";
+
+beforeEach(() => {
+  vi.mocked(workerClient.runJob).mockClear();
+  vi.mocked(workerClient.pushUniqueJob).mockClear();
+});
+
+test("dispatches derived work for an existing Entity", async ({ fixtures }) => {
+  const entity = await fixtures.Entity();
+
+  await onEntityChange({ entityId: entity.id });
+
+  expect(workerClient.runJob).toHaveBeenNthCalledWith(
+    1,
+    "GenerateEntityDetails",
+    { entityId: entity.id },
+  );
+  expect(workerClient.runJob).toHaveBeenNthCalledWith(
+    2,
+    "IndexEntitySearchVectors",
+    { entityId: entity.id },
+  );
+  expect(workerClient.runJob).toHaveBeenNthCalledWith(
+    3,
+    "GeocodeEntityLocation",
+    { entityId: entity.id },
+  );
+  expect(workerClient.pushUniqueJob).toHaveBeenCalledWith(
+    "UpdateEntityStats",
+    { entityId: entity.id },
+    { delay: 5000 },
+  );
+});
+
+test("skips stale work for a deleted Entity", async () => {
+  await onEntityChange({ entityId: 2_147_483_647 });
+
+  expect(workerClient.runJob).not.toHaveBeenCalled();
+  expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
+});

--- a/apps/server/src/worker/jobs/onEntityChange.ts
+++ b/apps/server/src/worker/jobs/onEntityChange.ts
@@ -1,6 +1,15 @@
+import { db } from "@peated/server/db";
 import { pushUniqueJob, runJob } from "@peated/server/worker/client";
 
 export default async ({ entityId }: { entityId: number }) => {
+  const entity = await db.query.entities.findFirst({
+    columns: { id: true },
+    where: (entities, { eq }) => eq(entities.id, entityId),
+  });
+  // Entity change jobs can outlive a delete or merge. Missing rows mean that
+  // this queued work is stale, so no derived entity state remains to update.
+  if (!entity) return;
+
   await runJob("GenerateEntityDetails", { entityId });
   await runJob("IndexEntitySearchVectors", { entityId });
   await runJob("GeocodeEntityLocation", { entityId });

--- a/apps/server/src/worker/jobs/processNotification.test.ts
+++ b/apps/server/src/worker/jobs/processNotification.test.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "vitest";
+import processNotification from "./processNotification";
+
+test("skips stale work for a deleted Notification", async () => {
+  await expect(
+    processNotification({ notificationId: 2_147_483_647 }),
+  ).resolves.toBeUndefined();
+});

--- a/apps/server/src/worker/jobs/processNotification.ts
+++ b/apps/server/src/worker/jobs/processNotification.ts
@@ -9,9 +9,7 @@ export default async function processNotification({
   const notif = await db.query.notifications.findFirst({
     where: (notifications, { eq }) => eq(notifications.id, notificationId),
   });
-  if (!notif) {
-    throw new Error(`Unknown notifification: ${notificationId}`);
-  }
+  if (!notif) return;
 
   if (notif.type === "comment") {
     const comment = await db.query.comments.findFirst({
@@ -26,11 +24,7 @@ export default async function processNotification({
       },
     });
 
-    if (!comment) {
-      throw new Error(
-        `Unable to find comment for notification: ${notificationId}`,
-      );
-    }
+    if (!comment) return;
 
     await notifyComment({
       comment,

--- a/apps/server/src/worker/jobs/queueBottleEntityStats.ts
+++ b/apps/server/src/worker/jobs/queueBottleEntityStats.ts
@@ -31,9 +31,7 @@ export async function queueBottleEntityStats(bottleId: number): Promise<void> {
       },
     },
   });
-  if (!bottle) {
-    throw new Error(`Bottle ${bottleId} is not active.`);
-  }
+  if (!bottle) return;
 
   await queueEntityStats({
     brandId: bottle.brandId,

--- a/apps/server/src/worker/jobs/updateBottleStats.test.ts
+++ b/apps/server/src/worker/jobs/updateBottleStats.test.ts
@@ -3,6 +3,7 @@ import { db } from "@peated/server/db";
 import {
   bottleGroupDistillers,
   bottleGroups,
+  bottleTombstones,
   bottles,
 } from "@peated/server/db/schema";
 import { pushJob } from "@peated/server/lib/test/workerDispatch";
@@ -123,8 +124,23 @@ test.each([
   await expect(updateBottleStats(input)).rejects.toThrow();
 });
 
-test("rejects a missing Bottle", async () => {
-  await expect(updateBottleStats({ bottleId: 2_000_000_000 })).rejects.toThrow(
-    "Cannot recompute Bottle 2000000000 statistics: not_found",
-  );
+test("skips stale work for a deleted Bottle", async () => {
+  await expect(
+    updateBottleStats({ bottleId: 2_000_000_000 }),
+  ).resolves.toBeUndefined();
+  expect(pushJob).not.toHaveBeenCalled();
+});
+
+test("skips stale work for a retired Bottle", async ({ fixtures }) => {
+  const bottle = await fixtures.Bottle();
+  const destination = await fixtures.Bottle();
+  await db.insert(bottleTombstones).values({
+    bottleId: bottle.id,
+    newBottleId: destination.id,
+  });
+
+  await expect(
+    updateBottleStats({ bottleId: bottle.id }),
+  ).resolves.toBeUndefined();
+  expect(pushJob).not.toHaveBeenCalled();
 });

--- a/apps/server/src/worker/jobs/updateBottleStats.ts
+++ b/apps/server/src/worker/jobs/updateBottleStats.ts
@@ -1,6 +1,9 @@
 import { logError } from "@peated/server/lib/log";
 import { recomputeBottleGroupStats } from "@peated/server/lib/recomputeBottleGroupStats";
-import { recomputeBottleStats } from "@peated/server/lib/recomputeBottleStats";
+import {
+  BottleStatsIntegrityError,
+  recomputeBottleStats,
+} from "@peated/server/lib/recomputeBottleStats";
 import { z } from "zod";
 import type { JobPayload } from "../types";
 import { queueBottleEntityStats } from "./queueBottleEntityStats";
@@ -26,6 +29,12 @@ export default async function updateBottleStats(
     await recomputeBottleGroupStats(bottle.groupId);
     await queueBottleEntityStats(bottleId);
   } catch (error) {
+    if (
+      error instanceof BottleStatsIntegrityError &&
+      (error.code === "not_found" || error.code === "retired")
+    ) {
+      return;
+    }
     logError(error, {
       job: { name: "UpdateBottleStats" },
       extra: { bottleId },

--- a/apps/server/src/worker/jobs/updateEntityStats.test.ts
+++ b/apps/server/src/worker/jobs/updateEntityStats.test.ts
@@ -131,6 +131,12 @@ test("excludes Bottle-tombstoned members and their tastings", async ({
   });
 });
 
+test("skips stale work for a deleted Entity", async () => {
+  await expect(
+    updateEntityStats({ entityId: 2_147_483_647 }),
+  ).resolves.toBeUndefined();
+});
+
 test.each([
   undefined,
   {},

--- a/apps/server/src/worker/jobs/updateEntityStats.ts
+++ b/apps/server/src/worker/jobs/updateEntityStats.ts
@@ -25,9 +25,7 @@ export default async (input: JobPayload) => {
   const entity = await db.query.entities.findFirst({
     where: (entities, { eq }) => eq(entities.id, entityId),
   });
-  if (!entity) {
-    throw new Error(`Unknown entity: ${entityId}`);
-  }
+  if (!entity) return;
 
   await db.transaction(async (tx) => {
     await tx

--- a/apps/server/src/worker/jobs/verifyBottleCreation.test.ts
+++ b/apps/server/src/worker/jobs/verifyBottleCreation.test.ts
@@ -82,6 +82,16 @@ describe("verifyBottleCreation", () => {
     });
   });
 
+  test("skips stale verification for a deleted Bottle", async () => {
+    await expect(
+      verifyBottleCreation({
+        bottleId: 2_147_483_647,
+        creationSource: "manual_entry",
+      }),
+    ).resolves.toBeUndefined();
+    expect(runAudit).not.toHaveBeenCalled();
+  });
+
   test("fails for retry without falling back to the old heuristic conclusion", async ({
     fixtures,
   }) => {

--- a/apps/server/src/worker/jobs/verifyBottleCreation.ts
+++ b/apps/server/src/worker/jobs/verifyBottleCreation.ts
@@ -37,11 +37,13 @@ export async function verifyBottleCreation(
 
   const policyInput = { objectType: "bottle", source: creationSource } as const;
 
+  const displayName = await getCatalogVerificationDisplayName({
+    objectId: bottleId,
+    objectType: "bottle",
+  });
+  if (!displayName) return;
+
   if (!shouldRunCatalogVerification(policyInput)) {
-    const displayName = await getCatalogVerificationDisplayName({
-      objectId: bottleId,
-      objectType: "bottle",
-    });
     await recordCatalogVerificationResult({
       displayName,
       objectId: bottleId,

--- a/apps/server/src/worker/jobs/verifyEntityCreation.test.ts
+++ b/apps/server/src/worker/jobs/verifyEntityCreation.test.ts
@@ -70,4 +70,13 @@ describe("verifyEntityCreation", () => {
       status: "skipped",
     });
   });
+
+  test("skips stale verification for a deleted Entity", async () => {
+    await expect(
+      verifyEntityCreation({
+        entityId: 2_147_483_647,
+        creationSource: "repair_workflow",
+      }),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/server/src/worker/jobs/verifyEntityCreation.ts
+++ b/apps/server/src/worker/jobs/verifyEntityCreation.ts
@@ -20,6 +20,7 @@ export default async function ({
     objectId: entityId,
     objectType: "entity",
   });
+  if (!displayName) return;
 
   const policyInput = { objectType: "entity", source: creationSource } as const;
 


### PR DESCRIPTION
Derived worker jobs now treat records removed by a delete or merge as completed stale work. This covers entity, Bottle, and BottleSeries indexing, generated details, statistics, creation verification, and one-shot notification delivery.

Long-running generation, geocoding, and Bottle-audit paths also recheck ownership before persistence. Invalid payloads, active-record catalog corruption, and authoritative merge failures still fail normally.

Fixes PEATED-4D0
Fixes PEATED-4D9
