### PR TITLE
feat(api): Expose bottle catalog facets

### DIFF
--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -20,6 +20,14 @@ export const CATEGORY_LIST = [
   "spirit",
 ] as const;
 
+export const BOTTLE_AGE_BAND_LIST = [
+  "nas",
+  "under_12",
+  "12_17",
+  "18_24",
+  "25_plus",
+] as const;
+
 export const SERVING_STYLE_LIST = ["neat", "rocks", "splash"] as const;
 
 export const RESERVED_COLLECTION_SLUGS = ["default", "library"] as const;

--- a/apps/server/src/orpc/contracts/bottles/list.ts
+++ b/apps/server/src/orpc/contracts/bottles/list.ts
@@ -1,4 +1,8 @@
-import { CATEGORY_LIST, FLAVOR_PROFILES } from "@peated/server/constants";
+import {
+  BOTTLE_AGE_BAND_LIST,
+  CATEGORY_LIST,
+  FLAVOR_PROFILES,
+} from "@peated/server/constants";
 import { BottleSchema, listResponse } from "@peated/server/schemas";
 import { z } from "zod";
 import { contract } from "../base";
@@ -24,6 +28,21 @@ const SORT_OPTIONS = [
 ] as const;
 
 const OutputSchema = listResponse(BottleSchema).extend({
+  total: z.number().int().nonnegative(),
+  facets: z.object({
+    category: z.array(
+      z.object({
+        value: z.enum(CATEGORY_LIST),
+        count: z.number().int().positive(),
+      }),
+    ),
+    ageBand: z.array(
+      z.object({
+        value: z.enum(BOTTLE_AGE_BAND_LIST),
+        count: z.number().int().positive(),
+      }),
+    ),
+  }),
   followedDistillerCount: z.number().int().nonnegative().nullable(),
 });
 
@@ -55,6 +74,7 @@ export default contract
       flight: z.string().nullish(),
       category: z.enum(CATEGORY_LIST).nullish(),
       age: z.coerce.number().nullish(),
+      ageBand: z.enum(BOTTLE_AGE_BAND_LIST).nullish(),
       minRating: z.coerce.number().min(-1).max(2).nullish(),
       minScore: z.coerce.number().int().min(0).max(100).nullish(),
       cursor: z.coerce.number().gte(1).default(1),

--- a/apps/server/src/orpc/mock/routes/bottles/list.ts
+++ b/apps/server/src/orpc/mock/routes/bottles/list.ts
@@ -1,3 +1,4 @@
+import { BOTTLE_AGE_BAND_LIST, CATEGORY_LIST } from "@peated/server/constants";
 import {
   includesQuery,
   mockBottleFor,
@@ -6,6 +7,32 @@ import {
   mockPage,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+type MockBottle = (typeof mockBottles)[number];
+type BottleAgeBand = (typeof BOTTLE_AGE_BAND_LIST)[number];
+
+function matchesAgeBand(bottle: MockBottle, ageBand: BottleAgeBand) {
+  switch (ageBand) {
+    case "nas":
+      return bottle.noAgeStatement === true;
+    case "under_12":
+      return bottle.statedAge !== null && bottle.statedAge < 12;
+    case "12_17":
+      return (
+        bottle.statedAge !== null &&
+        bottle.statedAge >= 12 &&
+        bottle.statedAge < 18
+      );
+    case "18_24":
+      return (
+        bottle.statedAge !== null &&
+        bottle.statedAge >= 18 &&
+        bottle.statedAge < 25
+      );
+    case "25_plus":
+      return bottle.statedAge !== null && bottle.statedAge >= 25;
+  }
+}
 
 export default mockOS.bottles.list.handler(
   async ({ input, context, errors }) => {
@@ -16,37 +43,61 @@ export default mockOS.bottles.list.handler(
     const flightBottleIds = input.flight
       ? mockFlightBottleIds.get(input.flight)
       : undefined;
-    let bottles = mockBottles.filter(
-      (bottle) =>
-        includesQuery(
-          input.query,
-          bottle.fullName,
-          bottle.name,
-          bottle.brand.name,
-        ) &&
-        (input.brand == null || bottle.brand.id === input.brand) &&
-        (input.distiller == null ||
-          bottle.distillers.some((entity) => entity.id === input.distiller)) &&
-        (input.bottler == null || bottle.bottler?.id === input.bottler) &&
-        (input.entity == null ||
-          bottle.brand.id === input.entity ||
-          bottle.bottler?.id === input.entity ||
-          bottle.distillers.some((entity) => entity.id === input.entity)) &&
-        (input.series == null || bottle.series?.id === input.series) &&
-        (input.tag == null || bottle.suggestedTags?.includes(input.tag)) &&
-        (input.flavorProfile == null ||
-          bottle.flavorProfile === input.flavorProfile) &&
-        (input.category == null || bottle.category === input.category) &&
-        (input.age == null || bottle.statedAge === input.age) &&
-        (input.minRating == null ||
-          (bottle.avgRating ?? -1) >= input.minRating) &&
-        (input.minScore == null || (bottle.avgScore ?? 0) >= input.minScore) &&
-        (flightBottleIds === undefined ||
-          flightBottleIds.includes(bottle.id)) &&
-        (input.filter !== "following" ||
-          bottle.brand.id === 9201 ||
-          bottle.brand.id === 9202),
-    );
+    const matchesBottle = (
+      bottle: MockBottle,
+      omittedFacet?: "category" | "ageBand",
+    ) =>
+      includesQuery(
+        input.query,
+        bottle.fullName,
+        bottle.name,
+        bottle.brand.name,
+      ) &&
+      (input.brand == null || bottle.brand.id === input.brand) &&
+      (input.distiller == null ||
+        bottle.distillers.some((entity) => entity.id === input.distiller)) &&
+      (input.bottler == null || bottle.bottler?.id === input.bottler) &&
+      (input.entity == null ||
+        bottle.brand.id === input.entity ||
+        bottle.bottler?.id === input.entity ||
+        bottle.distillers.some((entity) => entity.id === input.entity)) &&
+      (input.series == null || bottle.series?.id === input.series) &&
+      (input.tag == null || bottle.suggestedTags?.includes(input.tag)) &&
+      (input.flavorProfile == null ||
+        bottle.flavorProfile === input.flavorProfile) &&
+      (omittedFacet === "category" ||
+        input.category == null ||
+        bottle.category === input.category) &&
+      (input.age == null || bottle.statedAge === input.age) &&
+      (omittedFacet === "ageBand" ||
+        input.ageBand == null ||
+        matchesAgeBand(bottle, input.ageBand)) &&
+      (input.minRating == null ||
+        (bottle.avgRating ?? -1) >= input.minRating) &&
+      (input.minScore == null || (bottle.avgScore ?? 0) >= input.minScore) &&
+      (input.flight == null || flightBottleIds?.includes(bottle.id) === true) &&
+      (input.filter !== "following" ||
+        bottle.brand.id === 9201 ||
+        bottle.brand.id === 9202);
+
+    let bottles = mockBottles.filter((bottle) => matchesBottle(bottle));
+    const total = bottles.length;
+    const facets = {
+      category: CATEGORY_LIST.flatMap((value) => {
+        const count = mockBottles.filter(
+          (bottle) =>
+            matchesBottle(bottle, "category") && bottle.category === value,
+        ).length;
+        return count > 0 ? [{ value, count }] : [];
+      }),
+      ageBand: BOTTLE_AGE_BAND_LIST.flatMap((value) => {
+        const count = mockBottles.filter(
+          (bottle) =>
+            matchesBottle(bottle, "ageBand") && matchesAgeBand(bottle, value),
+        ).length;
+        return count > 0 ? [{ value, count }] : [];
+      }),
+    };
 
     const direction = input.sort.startsWith("-") ? -1 : 1;
     const sort = input.sort.replace(/^-/, "");
@@ -80,6 +131,8 @@ export default mockOS.bottles.list.handler(
         input.cursor,
         input.limit,
       ),
+      total,
+      facets,
       followedDistillerCount: input.filter === "following" ? 2 : null,
     };
   },

--- a/apps/server/src/orpc/routes/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/list.test.ts
@@ -346,6 +346,175 @@ describe("GET /bottles", () => {
     expect(results[0].id).toBe(bottle1.id);
   });
 
+  test("returns the unfiltered total and non-empty facet buckets", async ({
+    fixtures,
+  }) => {
+    await fixtures.Bottle({
+      name: "Young Single Malt",
+      category: "single_malt",
+      statedAge: 10,
+    });
+    await fixtures.Bottle({
+      name: "Twelve Year Single Malt",
+      category: "single_malt",
+      statedAge: 12,
+    });
+    await fixtures.Bottle({
+      name: "Mature Bourbon",
+      category: "bourbon",
+      statedAge: 18,
+    });
+    await fixtures.Bottle({
+      name: "Old Rye",
+      category: "rye",
+      statedAge: 25,
+    });
+    await fixtures.Bottle({
+      name: "NAS Blend",
+      category: "blend",
+      noAgeStatement: true,
+    });
+    await fixtures.Bottle({ name: "Unknown Age", category: "spirit" });
+
+    const response = await routerClient.bottles.list({ limit: 2 });
+
+    expect(response.results).toHaveLength(2);
+    expect(response.total).toBe(6);
+    expect(response.facets).toEqual({
+      category: [
+        { value: "blend", count: 1 },
+        { value: "bourbon", count: 1 },
+        { value: "rye", count: 1 },
+        { value: "single_malt", count: 2 },
+        { value: "spirit", count: 1 },
+      ],
+      ageBand: [
+        { value: "nas", count: 1 },
+        { value: "under_12", count: 1 },
+        { value: "12_17", count: 1 },
+        { value: "18_24", count: 1 },
+        { value: "25_plus", count: 1 },
+      ],
+    });
+  });
+
+  test("applies search text to the total and facets", async ({ fixtures }) => {
+    await fixtures.Bottle({
+      name: "Catalog Match Twelve",
+      category: "single_malt",
+      statedAge: 12,
+    });
+    await fixtures.Bottle({
+      name: "Catalog Match NAS",
+      category: "bourbon",
+      noAgeStatement: true,
+    });
+    await fixtures.Bottle({
+      name: "Different Bottle",
+      category: "rye",
+      statedAge: 25,
+    });
+
+    const response = await routerClient.bottles.list({
+      query: "Catalog Match",
+    });
+
+    expect(response.total).toBe(2);
+    expect(response.facets).toEqual({
+      category: [
+        { value: "bourbon", count: 1 },
+        { value: "single_malt", count: 1 },
+      ],
+      ageBand: [
+        { value: "nas", count: 1 },
+        { value: "12_17", count: 1 },
+      ],
+    });
+  });
+
+  test("omits each selected facet from its own buckets while paginating", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Facet Test Brand" });
+    await fixtures.Bottle({
+      name: "Young Single Malt",
+      brandId: brand.id,
+      category: "single_malt",
+      statedAge: 10,
+    });
+    const firstSelected = await fixtures.Bottle({
+      name: "First Selected Single Malt",
+      brandId: brand.id,
+      category: "single_malt",
+      statedAge: 12,
+    });
+    const secondSelected = await fixtures.Bottle({
+      name: "Second Selected Single Malt",
+      brandId: brand.id,
+      category: "single_malt",
+      statedAge: 15,
+    });
+    await fixtures.Bottle({
+      name: "Selected Bourbon",
+      brandId: brand.id,
+      category: "bourbon",
+      statedAge: 12,
+    });
+    await fixtures.Bottle({
+      name: "Mature Rye",
+      brandId: brand.id,
+      category: "rye",
+      statedAge: 18,
+    });
+
+    const page1 = await routerClient.bottles.list({
+      category: "single_malt",
+      ageBand: "12_17",
+      cursor: 1,
+      limit: 1,
+      sort: "name",
+    });
+    const page2 = await routerClient.bottles.list({
+      category: "single_malt",
+      ageBand: "12_17",
+      cursor: 2,
+      limit: 1,
+      sort: "name",
+    });
+
+    expect(page1.results.map(({ id }) => id)).toEqual([firstSelected.id]);
+    expect(page2.results.map(({ id }) => id)).toEqual([secondSelected.id]);
+    expect(page1.total).toBe(2);
+    expect(page2.total).toBe(2);
+    expect(page1.rel).toEqual({ nextCursor: 2, prevCursor: null });
+    expect(page2.rel).toEqual({ nextCursor: null, prevCursor: 1 });
+    expect(page1.facets).toEqual({
+      category: [
+        { value: "bourbon", count: 1 },
+        { value: "single_malt", count: 2 },
+      ],
+      ageBand: [
+        { value: "under_12", count: 1 },
+        { value: "12_17", count: 2 },
+      ],
+    });
+    expect(page2.facets).toEqual(page1.facets);
+  });
+
+  test("returns empty totals and facets for an unmatched query", async ({
+    fixtures,
+  }) => {
+    await fixtures.Bottle({ name: "Available Bottle", statedAge: 12 });
+
+    const response = await routerClient.bottles.list({
+      query: "No Such Catalog Bottle",
+    });
+
+    expect(response.results).toEqual([]);
+    expect(response.total).toBe(0);
+    expect(response.facets).toEqual({ category: [], ageBand: [] });
+  });
+
   test("filters tags by direct Bottle identity", async ({ fixtures }) => {
     const bottle1 = await fixtures.Bottle({ name: "Tagged Bottle" });
     const bottle2 = await fixtures.Bottle({ name: "Other Bottle" });
@@ -402,6 +571,11 @@ describe("GET /bottles", () => {
 
     expect(result).toEqual({
       results: [],
+      total: 0,
+      facets: {
+        category: [],
+        ageBand: [],
+      },
       followedDistillerCount: null,
       rel: {
         nextCursor: null,

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -1,3 +1,4 @@
+import { BOTTLE_AGE_BAND_LIST, CATEGORY_LIST } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import {
   bottleAliases,
@@ -31,12 +32,29 @@ import {
   sql,
 } from "drizzle-orm";
 
+type BottleAgeBand = (typeof BOTTLE_AGE_BAND_LIST)[number];
+
+function ageBandFilter(ageBand: BottleAgeBand): SQL<unknown> {
+  switch (ageBand) {
+    case "nas":
+      return sql`${bottles.noAgeStatement} IS TRUE`;
+    case "under_12":
+      return sql`${bottles.statedAge} < 12`;
+    case "12_17":
+      return sql`${bottles.statedAge} >= 12 AND ${bottles.statedAge} < 18`;
+    case "18_24":
+      return sql`${bottles.statedAge} >= 18 AND ${bottles.statedAge} < 25`;
+    case "25_plus":
+      return sql`${bottles.statedAge} >= 25`;
+  }
+}
+
 export default implement(bottleListContract).handler(async function ({
   input,
   context,
   errors,
 }) {
-  const { query, cursor, limit, filter, ...rest } = input;
+  const { query, cursor, limit, filter, category, ageBand, ...rest } = input;
   const offset = (cursor - 1) * limit;
   const textQuery = plainTextSearchQuery(query);
   const prefixQuery = prefixTextSearchQuery(query);
@@ -60,6 +78,7 @@ export default implement(bottleListContract).handler(async function ({
 
   const where: (SQL<unknown> | undefined)[] = [];
   let followedDistillerIds: number[] | null = null;
+  let hasUnknownFlight = false;
   where.push(isNotNull(bottles.groupId));
   where.push(
     sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
@@ -129,9 +148,6 @@ export default implement(bottleListContract).handler(async function ({
   if (rest.series) {
     where.push(eq(bottles.seriesId, rest.series));
   }
-  if (rest.category) {
-    where.push(eq(bottles.category, rest.category));
-  }
   if (rest.flavorProfile) {
     where.push(eq(bottles.flavorProfile, rest.flavorProfile));
   }
@@ -167,20 +183,17 @@ export default implement(bottleListContract).handler(async function ({
       .select({ id: flights.id })
       .from(flights)
       .where(eq(flights.publicId, rest.flight));
-    if (!flight) {
-      return {
-        results: [],
-        followedDistillerCount: followedDistillerIds?.length ?? null,
-        rel: {
-          nextCursor: null,
-          prevCursor: null,
-        },
-      };
-    }
+    hasUnknownFlight = !flight;
     where.push(
-      sql`EXISTS(SELECT FROM ${flightBottles} WHERE ${flightBottles.flightId} = ${flight.id} AND ${flightBottles.bottleId} = ${bottles.id})`,
+      flight
+        ? sql`EXISTS(SELECT FROM ${flightBottles} WHERE ${flightBottles.flightId} = ${flight.id} AND ${flightBottles.bottleId} = ${bottles.id})`
+        : sql`FALSE`,
     );
   }
+
+  const categoryWhere = category ? eq(bottles.category, category) : undefined;
+  const ageBandWhere = ageBand ? ageBandFilter(ageBand) : undefined;
+  const resultWhere = [...where, categoryWhere, ageBandWhere];
 
   let orderBy: SQL<unknown>;
   switch (rest.sort) {
@@ -248,25 +261,54 @@ export default implement(bottleListContract).handler(async function ({
       orderBy = desc(bottles.totalTastings);
   }
 
-  const results = await db
-    .select({ ...getTableColumns(bottles) })
-    .from(bottles)
-    .innerJoin(entities, eq(entities.id, bottles.brandId))
-    .where(where ? and(...where) : undefined)
-    .limit(limit + 1)
-    .offset(offset)
-    .orderBy(
-      ...(exactAliasBottleIds.length
-        ? [
-            sql`CASE WHEN ${bottles.id} IN (${sql.join(
-              exactAliasBottleIds.map((bottleId) => sql`${bottleId}`),
-              sql`, `,
-            )}) THEN 0 ELSE 1 END`,
-            orderBy,
-            asc(bottles.id),
-          ]
-        : [orderBy, asc(bottles.id)]),
-    );
+  const [results, [totalRow], categoryRows, [ageBandCounts]] =
+    await Promise.all([
+      db
+        .select({ ...getTableColumns(bottles) })
+        .from(bottles)
+        .innerJoin(entities, eq(entities.id, bottles.brandId))
+        .where(and(...resultWhere))
+        .limit(limit + 1)
+        .offset(offset)
+        .orderBy(
+          ...(exactAliasBottleIds.length
+            ? [
+                sql`CASE WHEN ${bottles.id} IN (${sql.join(
+                  exactAliasBottleIds.map((bottleId) => sql`${bottleId}`),
+                  sql`, `,
+                )}) THEN 0 ELSE 1 END`,
+                orderBy,
+                asc(bottles.id),
+              ]
+            : [orderBy, asc(bottles.id)]),
+        ),
+      db
+        .select({ count: sql<string>`COUNT(*)` })
+        .from(bottles)
+        .where(and(...resultWhere)),
+      db
+        .select({
+          value: bottles.category,
+          count: sql<string>`COUNT(*)`,
+        })
+        .from(bottles)
+        .where(and(...where, ageBandWhere, isNotNull(bottles.category)))
+        .groupBy(bottles.category),
+      db
+        .select({
+          nas: sql<string>`COUNT(*) FILTER (WHERE ${bottles.noAgeStatement} IS TRUE)`,
+          under_12: sql<string>`COUNT(*) FILTER (WHERE ${bottles.statedAge} < 12)`,
+          "12_17": sql<string>`COUNT(*) FILTER (WHERE ${bottles.statedAge} >= 12 AND ${bottles.statedAge} < 18)`,
+          "18_24": sql<string>`COUNT(*) FILTER (WHERE ${bottles.statedAge} >= 18 AND ${bottles.statedAge} < 25)`,
+          "25_plus": sql<string>`COUNT(*) FILTER (WHERE ${bottles.statedAge} >= 25)`,
+        })
+        .from(bottles)
+        .where(and(...where, categoryWhere)),
+    ]);
+
+  const categoryCounts = new Map(
+    categoryRows.map(({ value, count }) => [value, Number(count)]),
+  );
 
   return {
     results: await serialize(
@@ -276,10 +318,21 @@ export default implement(bottleListContract).handler(async function ({
       ["description", "tastingNotes"],
       { includeGroupSummary: true },
     ),
+    total: Number(totalRow?.count ?? 0),
+    facets: {
+      category: CATEGORY_LIST.flatMap((value) => {
+        const count = categoryCounts.get(value) ?? 0;
+        return count > 0 ? [{ value, count }] : [];
+      }),
+      ageBand: BOTTLE_AGE_BAND_LIST.flatMap((value) => {
+        const count = Number(ageBandCounts?.[value] ?? 0);
+        return count > 0 ? [{ value, count }] : [];
+      }),
+    },
     followedDistillerCount: followedDistillerIds?.length ?? null,
     rel: {
       nextCursor: results.length > limit ? cursor + 1 : null,
-      prevCursor: cursor > 1 ? cursor - 1 : null,
+      prevCursor: !hasUnknownFlight && cursor > 1 ? cursor - 1 : null,
     },
   };
 });


### PR DESCRIPTION
`GET /v1/bottles` now returns the total matching bottle count and non-zero category and age-band facet buckets for the complete result set. It also accepts the stable `ageBand` values `nas`, `under_12`, `12_17`, `18_24`, and `25_plus` while keeping the existing exact `age` filter.

Each facet applies search and other active filters but omits its own selected value, so clients can show valid alternatives. Cursor pagination, authorization, `filter=following`, and the mock API keep the same behavior.

Fixes #762
