### PR TITLE
fix(entities): Reconcile SMWS producer collisions

### DIFF
--- a/apps/server/src/worker/jobs/mergeEntity.test.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.test.ts
@@ -584,6 +584,118 @@ test("merges an SMWS collision while replacing a duplicate distiller", async ({
   ).toMatchObject({ newEntityId: destination.id });
 });
 
+test("merges an SMWS collision while replacing a duplicate bottler", async ({
+  fixtures,
+}) => {
+  const brand = await fixtures.Entity({
+    name: "Example Distillery",
+    type: ["brand", "distiller"],
+  });
+  const destination = await fixtures.Entity({
+    name: "SMWS",
+    shortName: "SMWS",
+    type: ["bottler"],
+  });
+  const source = await fixtures.Entity({
+    name: "Scotch Malt Whisky Society",
+    type: ["bottler"],
+  });
+  const canonicalBottle = await fixtures.Bottle({
+    brandId: brand.id,
+    bottlerId: destination.id,
+    name: "1.2 Canonical subtitle",
+    distillerIds: [brand.id],
+  });
+  const duplicateBottle = await fixtures.Bottle({
+    brandId: brand.id,
+    bottlerId: source.id,
+    name: "1.2 Previous subtitle",
+    distillerIds: [brand.id],
+  });
+
+  await mergeEntity({
+    fromEntityIds: [source.id],
+    toEntityId: destination.id,
+  });
+
+  expect(
+    await db.query.bottles.findFirst({
+      where: eq(bottles.id, duplicateBottle.id),
+    }),
+  ).toBeUndefined();
+  expect(
+    await db.query.bottles.findFirst({
+      where: eq(bottles.id, canonicalBottle.id),
+    }),
+  ).toMatchObject({ id: canonicalBottle.id });
+  expect(
+    await db.query.bottleTombstones.findFirst({
+      where: eq(bottleTombstones.bottleId, duplicateBottle.id),
+    }),
+  ).toMatchObject({ newBottleId: canonicalBottle.id });
+  expect(
+    await db.query.entityTombstones.findFirst({
+      where: eq(entityTombstones.entityId, source.id),
+    }),
+  ).toMatchObject({ newEntityId: destination.id });
+});
+
+test("merges an SMWS collision while replacing a duplicate brand", async ({
+  fixtures,
+}) => {
+  const distiller = await fixtures.Entity({
+    name: "Example Producer",
+    type: ["distiller"],
+  });
+  const destination = await fixtures.Entity({
+    name: "SMWS",
+    shortName: "SMWS",
+    type: ["brand", "bottler"],
+  });
+  const source = await fixtures.Entity({
+    name: "The Scotch Malt Whisky Society",
+    type: ["brand", "bottler"],
+  });
+  const canonicalBottle = await fixtures.Bottle({
+    brandId: destination.id,
+    bottlerId: destination.id,
+    name: "2.3 Canonical subtitle",
+    distillerIds: [distiller.id],
+  });
+  const duplicateBottle = await fixtures.Bottle({
+    brandId: source.id,
+    bottlerId: source.id,
+    name: "2.3 Previous subtitle",
+    distillerIds: [distiller.id],
+  });
+
+  await mergeEntity({
+    fromEntityIds: [source.id],
+    toEntityId: destination.id,
+  });
+
+  expect(
+    await db.query.bottles.findFirst({
+      where: eq(bottles.id, duplicateBottle.id),
+    }),
+  ).toBeUndefined();
+  expect(
+    await db.query.bottles.findFirst({
+      where: eq(bottles.id, canonicalBottle.id),
+    }),
+  ).toMatchObject({ id: canonicalBottle.id });
+  expect(
+    await db.query.bottleTombstones.findFirst({
+      where: eq(bottleTombstones.bottleId, duplicateBottle.id),
+    }),
+  ).toMatchObject({ newBottleId: canonicalBottle.id });
+  expect(
+    await db.query.entityTombstones.findFirst({
+      where: eq(entityTombstones.entityId, source.id),
+    }),
+  ).toMatchObject({ newEntityId: destination.id });
+});
+
 test("preserves the source when the locked destination is deleted", async ({
   fixtures,
 }) => {

--- a/apps/server/src/worker/jobs/mergeEntity.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.ts
@@ -408,8 +408,10 @@ async function performEntityMerge({
       // SMWS cask codes own Bottle identity. Merge an existing code collision
       // before changing its producer Entity.
       if (
-        (distillersChange || driftedDistillerGroupIds.has(groupId)) &&
-        !brandChanges
+        brandChanges ||
+        bottlerChanges ||
+        distillersChange ||
+        driftedDistillerGroupIds.has(groupId)
       ) {
         const members = await tx
           .select()
@@ -431,11 +433,15 @@ async function performEntityMerge({
           })
           .from(entities)
           .where(inArray(entities.id, identityEntityIds));
-        const brand = identityEntities.find(({ id }) => id === group.brandId);
+        const brand = brandChanges
+          ? toEntity
+          : identityEntities.find(({ id }) => id === group.brandId);
         const bottler =
           group.bottlerId === null
             ? null
-            : identityEntities.find(({ id }) => id === group.bottlerId);
+            : bottlerChanges
+              ? toEntity
+              : identityEntities.find(({ id }) => id === group.bottlerId);
         if (!brand || (group.bottlerId !== null && !bottler)) {
           throw new Error(
             `BottleGroup ${groupId} has an invalid brand or bottler Entity.`,
@@ -457,14 +463,19 @@ async function performEntityMerge({
           const [destinationOwnedDuplicate] = await tx
             .select({ id: bottles.id })
             .from(bottles)
-            .innerJoin(
+            .innerJoin(bottleGroups, eq(bottleGroups.id, bottles.groupId))
+            .leftJoin(
               bottleGroupDistillers,
               eq(bottleGroupDistillers.groupId, bottles.groupId),
             )
             .where(
               and(
                 eq(bottles.id, duplicateBottleId),
-                eq(bottleGroupDistillers.distillerId, toEntityId),
+                or(
+                  eq(bottleGroups.brandId, toEntityId),
+                  eq(bottleGroups.bottlerId, toEntityId),
+                  eq(bottleGroupDistillers.distillerId, toEntityId),
+                ),
               ),
             )
             .limit(1);


### PR DESCRIPTION
Entity merges now reconcile destination-owned SMWS Bottle collisions before
replacing any producer role: brand, bottler, or distiller. The worker builds
the post-merge identity, finds the matching cask-code owner, and consolidates
through the existing Bottle merge transaction so consumers and tombstones
follow the canonical Bottle.

The destination ownership check still refuses collisions outside the merge
target, and exact-name handling remains in place for non-SMWS brand duplicates.
Integration coverage includes brand and bottler collisions with differing
subtitles.

Fixes PEATED-4D7
