### PR TITLE
feat(api): Add friend mutations to mock API

### DIFF
--- a/apps/server/src/orpc/contracts/friends/create.ts
+++ b/apps/server/src/orpc/contracts/friends/create.ts
@@ -1,0 +1,23 @@
+import { FriendStatusEnum } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "PUT",
+    path: "/friends/{user}",
+    summary: "Send friend request",
+    description:
+      "Send a friend request to another user or accept a pending request. Creates mutual following relationship when accepted",
+    operationId: "addFriend",
+  })
+  .input(
+    z.object({
+      user: z.coerce.number(),
+    }),
+  )
+  .output(
+    z.object({
+      status: FriendStatusEnum,
+    }),
+  );

--- a/apps/server/src/orpc/contracts/friends/delete.ts
+++ b/apps/server/src/orpc/contracts/friends/delete.ts
@@ -1,0 +1,19 @@
+import { FriendStatusEnum } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "DELETE",
+    path: "/friends/{user}",
+    summary: "Remove friend",
+    description:
+      "Remove a friend relationship and cancel any pending friend requests. Requires authentication",
+    operationId: "removeFriend",
+  })
+  .input(z.object({ user: z.coerce.number() }))
+  .output(
+    z.object({
+      status: FriendStatusEnum,
+    }),
+  );

--- a/apps/server/src/orpc/mock/contract.ts
+++ b/apps/server/src/orpc/mock/contract.ts
@@ -20,6 +20,8 @@ import entityList from "@peated/server/orpc/contracts/entities/list";
 import eventList from "@peated/server/orpc/contracts/events/list";
 import flightDetails from "@peated/server/orpc/contracts/flights/details";
 import flightList from "@peated/server/orpc/contracts/flights/list";
+import friendCreate from "@peated/server/orpc/contracts/friends/create";
+import friendDelete from "@peated/server/orpc/contracts/friends/delete";
 import friendList from "@peated/server/orpc/contracts/friends/list";
 import notificationCount from "@peated/server/orpc/contracts/notifications/count";
 import notificationList from "@peated/server/orpc/contracts/notifications/list";
@@ -95,6 +97,8 @@ export const mockContract = {
     list: flightList,
   },
   friends: {
+    create: friendCreate,
+    delete: friendDelete,
     list: friendList,
   },
   notifications: {

--- a/apps/server/src/orpc/mock/router.ts
+++ b/apps/server/src/orpc/mock/router.ts
@@ -20,6 +20,8 @@ import entityList from "./routes/entities/list";
 import eventList from "./routes/events/list";
 import flightDetails from "./routes/flights/details";
 import flightList from "./routes/flights/list";
+import friendCreate from "./routes/friends/create";
+import friendDelete from "./routes/friends/delete";
 import friendList from "./routes/friends/list";
 import notificationCount from "./routes/notifications/count";
 import notificationList from "./routes/notifications/list";
@@ -95,6 +97,8 @@ export const mockRouter = mockOS.router({
     list: flightList,
   },
   friends: {
+    create: friendCreate,
+    delete: friendDelete,
     list: friendList,
   },
   notifications: {

--- a/apps/server/src/orpc/mock/routes/friends/create.ts
+++ b/apps/server/src/orpc/mock/routes/friends/create.ts
@@ -1,0 +1,18 @@
+import { mockPublicUserDetailsList } from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.friends.create.handler(
+  async ({ input, context, errors }) => {
+    if (!context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+    if (context.user.id === input.user) {
+      throw errors.BAD_REQUEST({ message: "Cannot friend yourself." });
+    }
+    if (!mockPublicUserDetailsList.some((user) => user.id === input.user)) {
+      throw errors.NOT_FOUND({ message: "Mock user not found." });
+    }
+
+    return { status: "pending" };
+  },
+);

--- a/apps/server/src/orpc/mock/routes/friends/delete.ts
+++ b/apps/server/src/orpc/mock/routes/friends/delete.ts
@@ -1,0 +1,18 @@
+import { mockPublicUserDetailsList } from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.friends.delete.handler(
+  async ({ input, context, errors }) => {
+    if (!context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+    if (context.user.id === input.user) {
+      throw errors.BAD_REQUEST({ message: "Cannot unfriend yourself." });
+    }
+    if (!mockPublicUserDetailsList.some((user) => user.id === input.user)) {
+      throw errors.NOT_FOUND({ message: "Mock user not found." });
+    }
+
+    return { status: "none" };
+  },
+);

--- a/apps/server/src/orpc/routes/friends/create.ts
+++ b/apps/server/src/orpc/routes/friends/create.ts
@@ -1,38 +1,18 @@
 import { db } from "@peated/server/db";
 import { follows, users } from "@peated/server/db/schema";
 import { createNotification } from "@peated/server/lib/notifications";
-import { procedure } from "@peated/server/orpc";
+import { implement } from "@peated/server/orpc";
+import friendCreateContract from "@peated/server/orpc/contracts/friends/create";
 import {
   requireAuth,
   requireTosAccepted,
 } from "@peated/server/orpc/middleware/auth";
-import { FriendStatusEnum } from "@peated/server/schemas";
 import type { FriendStatus } from "@peated/server/types";
 import { and, eq, inArray } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
+export default implement(friendCreateContract)
   .use(requireAuth)
   .use(requireTosAccepted)
-  // TODO: better path
-  .route({
-    method: "PUT",
-    path: "/friends/{user}",
-    summary: "Send friend request",
-    description:
-      "Send a friend request to another user or accept a pending request. Creates mutual following relationship when accepted",
-    operationId: "addFriend",
-  })
-  .input(
-    z.object({
-      user: z.coerce.number(),
-    }),
-  )
-  .output(
-    z.object({
-      status: FriendStatusEnum,
-    }),
-  )
   .handler(async function ({ input, context, errors }) {
     const { user: userId } = input;
 

--- a/apps/server/src/orpc/routes/friends/delete.ts
+++ b/apps/server/src/orpc/routes/friends/delete.ts
@@ -1,34 +1,18 @@
 import { db } from "@peated/server/db";
 import { follows, users } from "@peated/server/db/schema";
 import { deleteNotification } from "@peated/server/lib/notifications";
-import { procedure } from "@peated/server/orpc";
+import { implement } from "@peated/server/orpc";
+import friendDeleteContract from "@peated/server/orpc/contracts/friends/delete";
 import {
   requireAuth,
   requireTosAccepted,
 } from "@peated/server/orpc/middleware/auth";
-import { FriendStatusEnum } from "@peated/server/schemas";
 import type { FriendStatus } from "@peated/server/types";
 import { and, eq } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
+export default implement(friendDeleteContract)
   .use(requireAuth)
   .use(requireTosAccepted)
-  // TODO: better path
-  .route({
-    method: "DELETE",
-    path: "/friends/{user}",
-    summary: "Remove friend",
-    description:
-      "Remove a friend relationship and cancel any pending friend requests. Requires authentication",
-    operationId: "removeFriend",
-  })
-  .input(z.object({ user: z.coerce.number() }))
-  .output(
-    z.object({
-      status: FriendStatusEnum,
-    }),
-  )
   .handler(async function ({ input, context, errors }) {
     const { user: userId } = input;
 


### PR DESCRIPTION
Friend create and delete now use shared oRPC contracts and are available through the mock API. The production paths, payloads, and permission behavior stay unchanged; local profile flows can now exercise request, cancel, and remove actions against authenticated mock users.
