### PR TITLE
feat(api): Add library mutations to mock API

### DIFF
--- a/apps/server/src/orpc/contracts/collections/bottles/delete.ts
+++ b/apps/server/src/orpc/contracts/collections/bottles/delete.ts
@@ -1,0 +1,25 @@
+import { RESERVED_COLLECTION_SLUGS } from "@peated/server/constants";
+import { CollectionBottleInputSchema } from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../../base";
+
+const fields = {
+  collection: z.union([z.enum(RESERVED_COLLECTION_SLUGS), z.coerce.number()]),
+  user: z.union([z.literal("me"), z.coerce.number(), z.string()]),
+} as const;
+
+export default contract
+  .route({
+    method: "DELETE",
+    path: "/users/{user}/collections/{collection}/bottles",
+    summary: "Remove a Bottle from a collection",
+    description:
+      "Remove one Bottle membership from a user's collection. Requires authentication and ownership.",
+    operationId: "removeBottleFromCollection",
+  })
+  .input(
+    CollectionBottleInputSchema.pick({ bottle: true })
+      .safeExtend(fields)
+      .strict(),
+  )
+  .output(z.object({}));

--- a/apps/server/src/orpc/contracts/collections/bottles/update.ts
+++ b/apps/server/src/orpc/contracts/collections/bottles/update.ts
@@ -1,0 +1,29 @@
+import { RESERVED_COLLECTION_SLUGS } from "@peated/server/constants";
+import {
+  CollectionBottleSchema,
+  CollectionBottleStatusSchema,
+} from "@peated/server/schemas";
+import { z } from "zod";
+import { contract } from "../../base";
+
+export default contract
+  .route({
+    method: "PATCH",
+    path: "/users/{user}/collections/{collection}/bottles/{collectionBottle}",
+    summary: "Update collection bottle entry",
+    description:
+      "Update collection bottle entry fields. Requires authentication and ownership",
+    operationId: "updateCollectionBottle",
+  })
+  .input(
+    z.object({
+      collection: z.union([
+        z.enum(RESERVED_COLLECTION_SLUGS),
+        z.coerce.number(),
+      ]),
+      collectionBottle: z.coerce.number(),
+      status: CollectionBottleStatusSchema.nullable(),
+      user: z.union([z.literal("me"), z.coerce.number(), z.string()]),
+    }),
+  )
+  .output(CollectionBottleSchema);

--- a/apps/server/src/orpc/mock/contract.ts
+++ b/apps/server/src/orpc/mock/contract.ts
@@ -10,7 +10,9 @@ import bottleList from "@peated/server/orpc/contracts/bottles/list";
 import bottlePriceList from "@peated/server/orpc/contracts/bottles/prices/list";
 import bottleTags from "@peated/server/orpc/contracts/bottles/tags";
 import changeList from "@peated/server/orpc/contracts/changes/list";
+import collectionBottleDelete from "@peated/server/orpc/contracts/collections/bottles/delete";
 import collectionBottleList from "@peated/server/orpc/contracts/collections/bottles/list";
+import collectionBottleUpdate from "@peated/server/orpc/contracts/collections/bottles/update";
 import commentList from "@peated/server/orpc/contracts/comments/list";
 import countryDetails from "@peated/server/orpc/contracts/countries/details";
 import countryList from "@peated/server/orpc/contracts/countries/list";
@@ -75,7 +77,9 @@ export const mockContract = {
   },
   collections: {
     bottles: {
+      delete: collectionBottleDelete,
       list: collectionBottleList,
+      update: collectionBottleUpdate,
     },
   },
   countries: {

--- a/apps/server/src/orpc/mock/router.ts
+++ b/apps/server/src/orpc/mock/router.ts
@@ -10,7 +10,9 @@ import bottleList from "./routes/bottles/list";
 import bottlePriceList from "./routes/bottles/prices/list";
 import bottleTags from "./routes/bottles/tags";
 import changeList from "./routes/changes/list";
+import collectionBottleDelete from "./routes/collections/bottles/delete";
 import collectionBottleList from "./routes/collections/bottles/list";
+import collectionBottleUpdate from "./routes/collections/bottles/update";
 import commentList from "./routes/comments/list";
 import countryDetails from "./routes/countries/details";
 import countryList from "./routes/countries/list";
@@ -75,7 +77,9 @@ export const mockRouter = mockOS.router({
   },
   collections: {
     bottles: {
+      delete: collectionBottleDelete,
       list: collectionBottleList,
+      update: collectionBottleUpdate,
     },
   },
   countries: {

--- a/apps/server/src/orpc/mock/routes/collections/bottles/delete.ts
+++ b/apps/server/src/orpc/mock/routes/collections/bottles/delete.ts
@@ -1,0 +1,26 @@
+import { mockCollectionBottles } from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.collections.bottles.delete.handler(
+  async ({ input, context, errors }) => {
+    if (!context.user) throw errors.UNAUTHORIZED();
+    if (
+      input.user !== "me" &&
+      input.user !== context.user.id &&
+      input.user !== context.user.username
+    ) {
+      throw errors.FORBIDDEN({
+        message: "Cannot modify another user's collection.",
+      });
+    }
+    if (input.collection !== "library") {
+      throw errors.NOT_FOUND({ message: "Mock collection not found." });
+    }
+    if (
+      !mockCollectionBottles.some((entry) => entry.bottle.id === input.bottle)
+    ) {
+      return {};
+    }
+    return {};
+  },
+);

--- a/apps/server/src/orpc/mock/routes/collections/bottles/list.ts
+++ b/apps/server/src/orpc/mock/routes/collections/bottles/list.ts
@@ -1,9 +1,9 @@
 import {
   includesQuery,
+  matchesMockUser,
   mockBottleFor,
   mockCollectionBottles,
   mockPage,
-  mockUser,
 } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
@@ -11,11 +11,7 @@ const mockCollectionId = 9801;
 
 export default mockOS.collections.bottles.list.handler(
   async ({ input, context, errors }) => {
-    const userMatches =
-      input.user === "me"
-        ? Boolean(context.user)
-        : input.user === mockUser.id || input.user === mockUser.username;
-    if (!userMatches) {
+    if (!matchesMockUser(input.user, context.user)) {
       throw errors.NOT_FOUND({ message: "Mock user not found." });
     }
 

--- a/apps/server/src/orpc/mock/routes/collections/bottles/update.ts
+++ b/apps/server/src/orpc/mock/routes/collections/bottles/update.ts
@@ -1,0 +1,36 @@
+import {
+  mockBottleFor,
+  mockCollectionBottles,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.collections.bottles.update.handler(
+  async ({ input, context, errors }) => {
+    if (!context.user) throw errors.UNAUTHORIZED();
+    if (
+      input.user !== "me" &&
+      input.user !== context.user.id &&
+      input.user !== context.user.username
+    ) {
+      throw errors.FORBIDDEN({
+        message: "Cannot modify another user's collection.",
+      });
+    }
+    if (input.collection !== "library") {
+      throw errors.BAD_REQUEST({
+        message: "Bottle status is only supported for Library entries.",
+      });
+    }
+    const entry = mockCollectionBottles.find(
+      (candidate) => candidate.id === input.collectionBottle,
+    );
+    if (!entry) {
+      throw errors.NOT_FOUND({ message: "Mock collection bottle not found." });
+    }
+    return {
+      ...entry,
+      bottle: mockBottleFor(context.user, entry.bottle),
+      status: input.status,
+    };
+  },
+);

--- a/apps/server/src/orpc/routes/collections/bottles/delete.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/delete.ts
@@ -1,4 +1,3 @@
-import { RESERVED_COLLECTION_SLUGS } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import { collectionBottles, collections } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
@@ -6,39 +5,18 @@ import {
   getReservedCollection,
   isReservedCollectionSlug,
 } from "@peated/server/lib/db";
-import { procedure } from "@peated/server/orpc";
+import { implement } from "@peated/server/orpc";
+import collectionBottleDeleteContract from "@peated/server/orpc/contracts/collections/bottles/delete";
 import {
   requireAuth,
   requireTosAccepted,
 } from "@peated/server/orpc/middleware";
-import { CollectionBottleInputSchema } from "@peated/server/schemas";
 import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
-const CollectionBottleDeleteFields = {
-  collection: z.union([z.enum(RESERVED_COLLECTION_SLUGS), z.coerce.number()]),
-  user: z.union([z.literal("me"), z.coerce.number(), z.string()]),
-} as const;
-
-const CollectionBottleDeleteInputSchema = CollectionBottleInputSchema.pick({
-  bottle: true,
-})
-  .safeExtend(CollectionBottleDeleteFields)
-  .strict();
-
-export default procedure
+export default implement(collectionBottleDeleteContract)
   .use(requireAuth)
   .use(requireTosAccepted)
-  .route({
-    method: "DELETE",
-    path: "/users/{user}/collections/{collection}/bottles",
-    summary: "Remove a Bottle from a collection",
-    description:
-      "Remove one Bottle membership from a user's collection. Requires authentication and ownership.",
-    operationId: "removeBottleFromCollection",
-  })
-  .input(CollectionBottleDeleteInputSchema)
-  .output(z.object({}))
   .handler(async function ({ input, context, errors }) {
     const user = await getUserFromId(db, input.user, context.user);
     if (!user) {

--- a/apps/server/src/orpc/routes/collections/bottles/update.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/update.ts
@@ -1,4 +1,3 @@
-import { RESERVED_COLLECTION_SLUGS } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import { collectionBottles } from "@peated/server/db/schema";
 import { getUserFromId } from "@peated/server/lib/api";
@@ -6,17 +5,13 @@ import {
   getReservedCollection,
   isReservedCollectionSlug,
 } from "@peated/server/lib/db";
-import { procedure } from "@peated/server/orpc";
+import { implement } from "@peated/server/orpc";
+import collectionBottleUpdateContract from "@peated/server/orpc/contracts/collections/bottles/update";
 import {
   requireAuth,
   requireTosAccepted,
 } from "@peated/server/orpc/middleware";
-import {
-  CollectionBottleSchema,
-  CollectionBottleStatusSchema,
-} from "@peated/server/schemas";
 import { eq } from "drizzle-orm";
-import { z } from "zod";
 import {
   findCollectionBottleEntry,
   isLibraryCollection,
@@ -29,29 +24,9 @@ async function findCollectionById(collectionId: number) {
   });
 }
 
-export default procedure
+export default implement(collectionBottleUpdateContract)
   .use(requireAuth)
   .use(requireTosAccepted)
-  .route({
-    method: "PATCH",
-    path: "/users/{user}/collections/{collection}/bottles/{collectionBottle}",
-    summary: "Update collection bottle entry",
-    description:
-      "Update collection bottle entry fields. Requires authentication and ownership",
-    operationId: "updateCollectionBottle",
-  })
-  .input(
-    z.object({
-      collection: z.union([
-        z.enum(RESERVED_COLLECTION_SLUGS),
-        z.coerce.number(),
-      ]),
-      collectionBottle: z.coerce.number(),
-      status: CollectionBottleStatusSchema.nullable(),
-      user: z.union([z.literal("me"), z.coerce.number(), z.string()]),
-    }),
-  )
-  .output(CollectionBottleSchema)
   .handler(async function ({ input, context, errors }) {
     const user = await getUserFromId(db, input.user, context.user);
     if (!user) {


### PR DESCRIPTION
Library status updates and removals now use shared oRPC contracts and are available through the mock API. Production paths and ownership rules stay unchanged. Mock collection lists also accept any known mock profile, so public and signed-in profile libraries use the same contract.
