### PR TITLE
feat(api): Add SMWS distillers to mock API

### DIFF
--- a/apps/server/src/orpc/contracts/smws/distiller-list.ts
+++ b/apps/server/src/orpc/contracts/smws/distiller-list.ts
@@ -1,0 +1,14 @@
+import { EntitySchema, listResponse } from "@peated/server/schemas";
+
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/smws/distillers",
+    summary: "List SMWS distillers",
+    description:
+      "Retrieve distillers that are part of the Scotch Malt Whisky Society (SMWS) system",
+    spec: (spec) => ({ ...spec, operationId: "listSmwsDistillers" }),
+  })
+  .output(listResponse(EntitySchema));

--- a/apps/server/src/orpc/mock/contract.ts
+++ b/apps/server/src/orpc/mock/contract.ts
@@ -29,6 +29,7 @@ import regionList from "@peated/server/orpc/contracts/regions/list";
 import reviewList from "@peated/server/orpc/contracts/reviews/list";
 import root from "@peated/server/orpc/contracts/root";
 import search from "@peated/server/orpc/contracts/search";
+import smwsDistillerList from "@peated/server/orpc/contracts/smws/distiller-list";
 import stats from "@peated/server/orpc/contracts/stats";
 import tastingDetails from "@peated/server/orpc/contracts/tastings/details";
 import tastingList from "@peated/server/orpc/contracts/tastings/list";
@@ -110,6 +111,9 @@ export const mockContract = {
   },
   reviews: {
     list: reviewList,
+  },
+  smws: {
+    distillerList: smwsDistillerList,
   },
   tastings: {
     details: tastingDetails,

--- a/apps/server/src/orpc/mock/fixtures/entities.ts
+++ b/apps/server/src/orpc/mock/fixtures/entities.ts
@@ -175,6 +175,35 @@ export const mockEntities: Entity[] = [
     totalTastings: 1850,
     totalBottles: 130,
   },
+  {
+    ...mockEntity,
+    id: 9212,
+    peatedId: "E9212",
+    name: "The Scotch Malt Whisky Society",
+    shortName: "SMWS",
+    type: ["brand", "bottler"],
+    kind: "bottler",
+    description:
+      "An independent bottler known for identifying single-cask releases with distillery codes.",
+    yearEstablished: 1983,
+    website: "https://smws.com",
+    region: null,
+    totalTastings: 0,
+    totalBottles: 0,
+  },
+  {
+    ...mockEntity,
+    id: 9213,
+    peatedId: "E9213",
+    name: "Highland Park",
+    shortName: null,
+    description: "An island single malt distillery in Orkney.",
+    yearEstablished: 1798,
+    website: "https://www.highlandparkwhisky.com",
+    region: null,
+    totalTastings: 640,
+    totalBottles: 68,
+  },
 ];
 
 export const mockMacallanEntity = mockEntities[1]!;

--- a/apps/server/src/orpc/mock/router.ts
+++ b/apps/server/src/orpc/mock/router.ts
@@ -29,6 +29,7 @@ import regionList from "./routes/regions/list";
 import reviewList from "./routes/reviews/list";
 import root from "./routes/root";
 import search from "./routes/search";
+import smwsDistillerList from "./routes/smws/distiller-list";
 import stats from "./routes/stats";
 import tastingDetails from "./routes/tastings/details";
 import tastingList from "./routes/tastings/list";
@@ -110,6 +111,9 @@ export const mockRouter = mockOS.router({
   },
   reviews: {
     list: reviewList,
+  },
+  smws: {
+    distillerList: smwsDistillerList,
   },
   tastings: {
     details: tastingDetails,

--- a/apps/server/src/orpc/mock/routes/smws/distiller-list.ts
+++ b/apps/server/src/orpc/mock/routes/smws/distiller-list.ts
@@ -1,0 +1,7 @@
+import { mockEntities } from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.smws.distillerList.handler(async () => ({
+  results: mockEntities.filter((entity) => entity.kind === "distillery"),
+  rel: { nextCursor: null, prevCursor: null },
+}));

--- a/apps/server/src/orpc/routes/smws/distiller-list.ts
+++ b/apps/server/src/orpc/routes/smws/distiller-list.ts
@@ -1,41 +1,30 @@
 import { SMWS_DISTILLERY_CODES } from "@peated/bottle-classifier/smws";
 import { db } from "@peated/server/db";
 import { entities, entityAliases } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
-import { EntitySchema, listResponse } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import smwsDistillerListContract from "@peated/server/orpc/contracts/smws/distiller-list";
 import { serialize } from "@peated/server/serializers";
 import { EntitySerializer } from "@peated/server/serializers/entity";
 import { sql } from "drizzle-orm";
-import { z } from "zod";
 
-const OutputSchema = listResponse(EntitySchema);
-
-export default procedure
-  .route({
-    method: "GET",
-    path: "/smws/distillers",
-    summary: "List SMWS distillers",
-    description:
-      "Retrieve distillers that are part of the Scotch Malt Whisky Society (SMWS) system",
-    operationId: "listSmwsDistillers",
-  })
-  .output(OutputSchema)
-  .handler(async function ({ context }) {
-    const results = await db
-      .select()
-      .from(entities)
-      .where(
-        sql`${entities.id} IN (
+export default implement(smwsDistillerListContract).handler(async function ({
+  context,
+}) {
+  const results = await db
+    .select()
+    .from(entities)
+    .where(
+      sql`${entities.id} IN (
           SELECT ${entityAliases.entityId} FROM ${entityAliases}
           WHERE LOWER(${entityAliases.name}) IN ${Object.values(SMWS_DISTILLERY_CODES).map((s) => s.toLowerCase())}
         )`,
-      );
+    );
 
-    return {
-      results: await serialize(EntitySerializer, results, context.user),
-      rel: {
-        nextCursor: null,
-        prevCursor: null,
-      },
-    };
-  });
+  return {
+    results: await serialize(EntitySerializer, results, context.user),
+    rel: {
+      nextCursor: null,
+      prevCursor: null,
+    },
+  };
+});


### PR DESCRIPTION
The SMWS distiller list now uses a shared oRPC contract and is available through the mock API. The production route and response shape stay unchanged. Mock data includes SMWS and Highland Park records so local entity and SMWS surfaces can render without a live database.
