### PR TITLE
feat(api)!: expand public stats

### DIFF
--- a/apps/server/src/externalReviews/visibility.ts
+++ b/apps/server/src/externalReviews/visibility.ts
@@ -1,0 +1,17 @@
+import {
+  externalReviewArticles,
+  externalReviews,
+  externalReviewSourcePolicies,
+} from "@peated/server/db/schema";
+import { and, eq, isNull, or } from "drizzle-orm";
+
+/** Owns anonymous visibility for external review records. */
+export function visibleExternalReviewWhere() {
+  return and(
+    eq(externalReviews.hidden, false),
+    or(
+      isNull(externalReviewArticles.contentHash),
+      eq(externalReviewSourcePolicies.publicationMode, "automatic"),
+    ),
+  );
+}

--- a/apps/server/src/orpc/contracts/stats.ts
+++ b/apps/server/src/orpc/contracts/stats.ts
@@ -5,19 +5,37 @@ export default contract
   .route({
     method: "GET",
     path: "/stats",
-    summary: "Get total counts",
-    description: "Get total counts for tastings, Bottles, and entities",
+    summary: "Get public statistics",
+    description: "Get current catalog, tasting, and review counts",
     operationId: "getStats",
   })
   .output(
     z.object({
-      totalTastings: z.number(),
-      totalBottles: z.number(),
-      totalEntities: z.number(),
-      totalBrands: z.number(),
-      totalDistilleries: z.number(),
-      totalBottlers: z.number(),
-      totalBlenders: z.number(),
-      totalCompanies: z.number(),
+      asOf: z.string().datetime().describe("Time when the counts were read"),
+      bottles: z
+        .number()
+        .int()
+        .nonnegative()
+        .describe("Active independently complete Bottles"),
+      brands: z.number().int().nonnegative().describe("Brands"),
+      distilleries: z.number().int().nonnegative().describe("Distilleries"),
+      bottlers: z.number().int().nonnegative().describe("Bottlers"),
+      blenders: z.number().int().nonnegative().describe("Blenders"),
+      companies: z.number().int().nonnegative().describe("Companies"),
+      tastings: z
+        .number()
+        .int()
+        .nonnegative()
+        .describe("User-authored tasting records"),
+      memberReviews: z
+        .number()
+        .int()
+        .nonnegative()
+        .describe("Member reviews contributing to active Bottle summaries"),
+      externalReviews: z
+        .number()
+        .int()
+        .nonnegative()
+        .describe("Public external reviews attached to active Bottles"),
     }),
   );

--- a/apps/server/src/orpc/mock/fixtures/stats.ts
+++ b/apps/server/src/orpc/mock/fixtures/stats.ts
@@ -1,12 +1,14 @@
 import type { MockOutputs } from "../contract";
 
 export const mockStats = {
-  totalTastings: 142_580,
-  totalBottles: 28_430,
-  totalEntities: 9_215,
-  totalBrands: 3_980,
-  totalDistilleries: 2_410,
-  totalBottlers: 1_125,
-  totalBlenders: 420,
-  totalCompanies: 1_280,
+  asOf: "2026-08-28T15:00:00.000Z",
+  bottles: 28_430,
+  brands: 3_980,
+  distilleries: 2_410,
+  bottlers: 1_125,
+  blenders: 420,
+  companies: 1_280,
+  tastings: 142_580,
+  memberReviews: 8_420,
+  externalReviews: 56_730,
 } satisfies MockOutputs["stats"];

--- a/apps/server/src/orpc/routes/externalReviews/list.ts
+++ b/apps/server/src/orpc/routes/externalReviews/list.ts
@@ -5,13 +5,14 @@ import {
   externalReviewSourcePolicies,
   externalSites,
 } from "@peated/server/db/schema";
+import { visibleExternalReviewWhere } from "@peated/server/externalReviews/visibility";
 import { logWarn } from "@peated/server/lib/log";
 import { implement } from "@peated/server/orpc";
 import externalReviewListContract from "@peated/server/orpc/contracts/externalReviews/list";
 import { serialize } from "@peated/server/serializers";
 import { ExternalReviewSerializer } from "@peated/server/serializers/externalReview";
 import type { SQL } from "drizzle-orm";
-import { and, asc, desc, eq, ilike, isNotNull, isNull, or } from "drizzle-orm";
+import { and, asc, desc, eq, ilike, isNotNull, isNull } from "drizzle-orm";
 export default implement(externalReviewListContract).handler(async function ({
   input: { cursor, query, limit, sort, ...input },
   context,
@@ -19,11 +20,10 @@ export default implement(externalReviewListContract).handler(async function ({
 }) {
   const hasPublicScope = input.bottle !== undefined || sort === "recent";
   const requiresModerator = input.onlyUnknown || !hasPublicScope;
-  // This route owns external review visibility. Public Bottle and recent
-  // queries exclude staged records. Moderator queries include them for matching.
+  // Moderator queries include staged records for matching.
   const baseWhere: (SQL<unknown> | undefined)[] = requiresModerator
     ? []
-    : [eq(externalReviews.hidden, false)];
+    : [visibleExternalReviewWhere()];
   const identityWhere: SQL<unknown>[] = [];
 
   if (input.site) {
@@ -37,17 +37,6 @@ export default implement(externalReviewListContract).handler(async function ({
       });
     }
     baseWhere.push(eq(externalReviewArticles.externalSiteId, site.id));
-  }
-
-  if (hasPublicScope) {
-    // No-fetch migration articles have no content hash and preserve their
-    // legacy visibility. Newly fetched articles require automatic mode.
-    baseWhere.push(
-      or(
-        isNull(externalReviewArticles.contentHash),
-        eq(externalReviewSourcePolicies.publicationMode, "automatic"),
-      ),
-    );
   }
 
   if (sort === "recent") {

--- a/apps/server/src/orpc/routes/stats.test.ts
+++ b/apps/server/src/orpc/routes/stats.test.ts
@@ -1,23 +1,24 @@
 import { db } from "@peated/server/db";
-import { bottleTombstones, entities, tastings } from "@peated/server/db/schema";
+import {
+  bottleTombstones,
+  externalReviewArticles,
+  memberReviews,
+  tastings,
+} from "@peated/server/db/schema";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq, sql } from "drizzle-orm";
 
 describe("GET /stats", () => {
-  test("returns raw tasting and entity totals", async ({ fixtures }) => {
+  test("returns the current tasting count", async ({ fixtures }) => {
     await fixtures.Tasting();
-    await fixtures.Entity();
 
     const data = await routerClient.stats();
-    const [{ totalTastings }] = await db
-      .select({ totalTastings: sql<string>`COUNT(${tastings.id})` })
+    const [{ count }] = await db
+      .select({ count: sql<string>`COUNT(${tastings.id})` })
       .from(tastings);
-    const [{ totalEntities }] = await db
-      .select({ totalEntities: sql<string>`COUNT(${entities.id})` })
-      .from(entities);
 
-    expect(data.totalTastings).toBe(Number(totalTastings));
-    expect(data.totalEntities).toBe(Number(totalEntities));
+    expect(data.tastings).toBe(Number(count));
+    expect(data.asOf).toMatch(/^\d{4}-\d{2}-\d{2}T/);
   });
 
   test("returns entity totals by kind", async ({ fixtures }) => {
@@ -30,12 +31,11 @@ describe("GET /stats", () => {
     const data = await routerClient.stats();
 
     expect(data).toMatchObject({
-      totalEntities: 5,
-      totalBrands: 1,
-      totalDistilleries: 1,
-      totalBottlers: 1,
-      totalBlenders: 1,
-      totalCompanies: 1,
+      brands: 1,
+      distilleries: 1,
+      bottlers: 1,
+      blenders: 1,
+      companies: 1,
     });
   });
 
@@ -61,7 +61,83 @@ describe("GET /stats", () => {
 
     const data = await routerClient.stats();
 
-    expect(data.totalBottles).toBe(4);
+    expect(data.bottles).toBe(4);
     expect(legacyBottle.groupId).toBeNull();
+  });
+
+  test("counts reviews attached to active Bottles", async ({ fixtures }) => {
+    const activeBottle = await fixtures.Bottle();
+    const retiredBottle = await fixtures.Bottle();
+    const privateMember = await fixtures.User({ private: true });
+    await db.insert(memberReviews).values([
+      {
+        bottleId: activeBottle.id,
+        createdById: privateMember.id,
+        score: 90,
+      },
+      {
+        bottleId: retiredBottle.id,
+        createdById: privateMember.id,
+        score: 85,
+      },
+    ]);
+
+    const automaticSite = await fixtures.ExternalSite({ type: "dramface" });
+    await fixtures.ExternalReviewSourcePolicy({
+      externalSiteId: automaticSite.id,
+      publicationMode: "automatic",
+    });
+    await fixtures.ExternalReview({
+      bottleId: activeBottle.id,
+      externalSiteId: automaticSite.id,
+      name: "Legacy public review",
+    });
+    const automaticReview = await fixtures.ExternalReview({
+      bottleId: activeBottle.id,
+      externalSiteId: automaticSite.id,
+      name: "Automatic public review",
+    });
+    await db
+      .update(externalReviewArticles)
+      .set({ contentHash: "automatic-public-review" })
+      .where(eq(externalReviewArticles.id, automaticReview.articleId));
+
+    await fixtures.ExternalReview({
+      bottleId: activeBottle.id,
+      externalSiteId: automaticSite.id,
+      hidden: true,
+      name: "Hidden review",
+    });
+    await fixtures.ExternalReview({
+      bottleId: null,
+      externalSiteId: automaticSite.id,
+      name: "Unmatched review",
+    });
+    await fixtures.ExternalReview({
+      bottleId: retiredBottle.id,
+      externalSiteId: automaticSite.id,
+      name: "Retired Bottle review",
+    });
+
+    const disabledSite = await fixtures.ExternalSite({ type: "fredminnick" });
+    const stagedReview = await fixtures.ExternalReview({
+      bottleId: activeBottle.id,
+      externalSiteId: disabledSite.id,
+      name: "Staged review",
+    });
+    await db
+      .update(externalReviewArticles)
+      .set({ contentHash: "staged-review" })
+      .where(eq(externalReviewArticles.id, stagedReview.articleId));
+
+    await db.insert(bottleTombstones).values({
+      bottleId: retiredBottle.id,
+      newBottleId: activeBottle.id,
+    });
+
+    const data = await routerClient.stats();
+
+    expect(data.memberReviews).toBe(1);
+    expect(data.externalReviews).toBe(2);
   });
 });

--- a/apps/server/src/orpc/routes/stats.ts
+++ b/apps/server/src/orpc/routes/stats.ts
@@ -1,52 +1,93 @@
 import { db } from "@peated/server/db";
 import {
-  bottleTombstones,
   bottles,
+  bottleTombstones,
   entities,
+  externalReviewArticles,
+  externalReviews,
+  externalReviewSourcePolicies,
+  memberReviews,
   tastings,
 } from "@peated/server/db/schema";
+import { visibleExternalReviewWhere } from "@peated/server/externalReviews/visibility";
 import { implement } from "@peated/server/orpc";
 import statsContract from "@peated/server/orpc/contracts/stats";
-import { and, isNotNull, sql } from "drizzle-orm";
+import { and, eq, isNotNull, sql } from "drizzle-orm";
+
+// This route counts only current public Bottle identities.
+function activeBottleWhere() {
+  return and(
+    isNotNull(bottles.groupId),
+    sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
+  );
+}
 
 export default implement(statsContract).handler(async function () {
-  const [{ totalTastings }] = await db
-    .select({
-      totalTastings: sql<string>`COUNT(${tastings.id})`,
-    })
-    .from(tastings);
+  const asOf = new Date().toISOString();
+  const [
+    tastingTotals,
+    bottleTotals,
+    entityTotals,
+    memberReviewTotals,
+    externalReviewTotals,
+  ] = await Promise.all([
+    db.select({ tastings: sql<string>`COUNT(${tastings.id})` }).from(tastings),
+    db
+      .select({ bottles: sql<string>`COUNT(${bottles.id})` })
+      .from(bottles)
+      .where(activeBottleWhere()),
+    db
+      .select({
+        brands: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'brand')`,
+        distilleries: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'distillery')`,
+        bottlers: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'bottler')`,
+        blenders: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'blender')`,
+        companies: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'company')`,
+      })
+      .from(entities),
+    db
+      .select({
+        memberReviews: sql<string>`COUNT(${memberReviews.id})`,
+      })
+      .from(memberReviews)
+      .innerJoin(bottles, eq(memberReviews.bottleId, bottles.id))
+      .where(activeBottleWhere()),
+    db
+      .select({
+        externalReviews: sql<string>`COUNT(${externalReviews.id})`,
+      })
+      .from(externalReviews)
+      .innerJoin(
+        externalReviewArticles,
+        eq(externalReviews.articleId, externalReviewArticles.id),
+      )
+      .leftJoin(
+        externalReviewSourcePolicies,
+        eq(
+          externalReviewArticles.externalSiteId,
+          externalReviewSourcePolicies.externalSiteId,
+        ),
+      )
+      .innerJoin(bottles, eq(externalReviews.bottleId, bottles.id))
+      .where(and(activeBottleWhere(), visibleExternalReviewWhere())),
+  ]);
 
-  const [{ totalBottles }] = await db
-    .select({
-      totalBottles: sql<string>`COUNT(${bottles.id})`,
-    })
-    .from(bottles)
-    .where(
-      and(
-        isNotNull(bottles.groupId),
-        sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
-      ),
-    );
-
-  const [entityTotals] = await db
-    .select({
-      totalEntities: sql<string>`COUNT(${entities.id})`,
-      totalBrands: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'brand')`,
-      totalDistilleries: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'distillery')`,
-      totalBottlers: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'bottler')`,
-      totalBlenders: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'blender')`,
-      totalCompanies: sql<string>`COUNT(${entities.id}) FILTER (WHERE ${entities.kind} = 'company')`,
-    })
-    .from(entities);
+  const tastingTotal = tastingTotals[0]!;
+  const bottleTotal = bottleTotals[0]!;
+  const entityTotal = entityTotals[0]!;
+  const memberReviewTotal = memberReviewTotals[0]!;
+  const externalReviewTotal = externalReviewTotals[0]!;
 
   return {
-    totalTastings: Number(totalTastings),
-    totalBottles: Number(totalBottles),
-    totalEntities: Number(entityTotals.totalEntities),
-    totalBrands: Number(entityTotals.totalBrands),
-    totalDistilleries: Number(entityTotals.totalDistilleries),
-    totalBottlers: Number(entityTotals.totalBottlers),
-    totalBlenders: Number(entityTotals.totalBlenders),
-    totalCompanies: Number(entityTotals.totalCompanies),
+    asOf,
+    bottles: Number(bottleTotal.bottles),
+    brands: Number(entityTotal.brands),
+    distilleries: Number(entityTotal.distilleries),
+    bottlers: Number(entityTotal.bottlers),
+    blenders: Number(entityTotal.blenders),
+    companies: Number(entityTotal.companies),
+    tastings: Number(tastingTotal.tastings),
+    memberReviews: Number(memberReviewTotal.memberReviews),
+    externalReviews: Number(externalReviewTotal.externalReviews),
   };
 });

--- a/apps/web/src/app/(default)/about/stats.tsx
+++ b/apps/web/src/app/(default)/about/stats.tsx
@@ -32,10 +32,16 @@ export default function Stats() {
     return <div>{"Oops, maybe you're offline?"}</div>;
   }
 
+  const entities =
+    data.brands +
+    data.distilleries +
+    data.bottlers +
+    data.blenders +
+    data.companies;
   const stats = [
-    { name: "Tastings", value: data.totalTastings.toLocaleString() },
-    { name: "Bottles", value: data.totalBottles.toLocaleString() },
-    { name: "Entities", value: data.totalEntities.toLocaleString() },
+    { name: "Tastings", value: data.tastings.toLocaleString() },
+    { name: "Bottles", value: data.bottles.toLocaleString() },
+    { name: "Entities", value: entities.toLocaleString() },
   ];
 
   return (

--- a/apps/web/src/app/sitemaps/bottles/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemaps/bottles/sitemap.xml/route.ts
@@ -23,9 +23,9 @@ function range(start: number, end?: number): number[] {
 
 export async function GET() {
   const { client } = await createAnonymousServerClient();
-  const { totalBottles } = await client.stats();
+  const { bottles } = await client.stats();
   const sitemapIndexXML = await buildSitemapIndex(
-    range(1, Math.ceil(totalBottles / PAGE_LIMIT)).map(
+    range(1, Math.ceil(bottles / PAGE_LIMIT)).map(
       (i) => `/sitemaps/bottles/${i}/sitemap.xml`,
     ),
   );

--- a/apps/web/src/lib/entitySitemaps.test.ts
+++ b/apps/web/src/lib/entitySitemaps.test.ts
@@ -13,31 +13,31 @@ describe("Entity sitemaps", () => {
         clientKey: "brands",
         collection: "brands",
         kind: "brand",
-        statsKey: "totalBrands",
+        statsKey: "brands",
       },
       {
         clientKey: "distilleries",
         collection: "distillers",
         kind: "distillery",
-        statsKey: "totalDistilleries",
+        statsKey: "distilleries",
       },
       {
         clientKey: "bottlers",
         collection: "bottlers",
         kind: "bottler",
-        statsKey: "totalBottlers",
+        statsKey: "bottlers",
       },
       {
         clientKey: "blenders",
         collection: "blenders",
         kind: "blender",
-        statsKey: "totalBlenders",
+        statsKey: "blenders",
       },
       {
         clientKey: "companies",
         collection: "companies",
         kind: "company",
-        statsKey: "totalCompanies",
+        statsKey: "companies",
       },
     ]);
     expect(getEntitySitemapCollection("entities")).toBeUndefined();

--- a/apps/web/src/lib/entitySitemaps.ts
+++ b/apps/web/src/lib/entitySitemaps.ts
@@ -6,42 +6,42 @@ export const ENTITY_SITEMAP_PAGE_LIMIT = 1000;
 const API_PAGE_LIMIT = 500;
 
 type EntitySitemapStatsKey =
-  | "totalBlenders"
-  | "totalBottlers"
-  | "totalBrands"
-  | "totalCompanies"
-  | "totalDistilleries";
+  | "blenders"
+  | "bottlers"
+  | "brands"
+  | "companies"
+  | "distilleries";
 
 export const ENTITY_SITEMAP_COLLECTIONS = [
   {
     clientKey: "brands",
     collection: "brands",
     kind: "brand",
-    statsKey: "totalBrands",
+    statsKey: "brands",
   },
   {
     clientKey: "distilleries",
     collection: "distillers",
     kind: "distillery",
-    statsKey: "totalDistilleries",
+    statsKey: "distilleries",
   },
   {
     clientKey: "bottlers",
     collection: "bottlers",
     kind: "bottler",
-    statsKey: "totalBottlers",
+    statsKey: "bottlers",
   },
   {
     clientKey: "blenders",
     collection: "blenders",
     kind: "blender",
-    statsKey: "totalBlenders",
+    statsKey: "blenders",
   },
   {
     clientKey: "companies",
     collection: "companies",
     kind: "company",
-    statsKey: "totalCompanies",
+    statsKey: "companies",
   },
 ] as const satisfies readonly {
   clientKey: string;

--- a/docs/development/orpc-client.md
+++ b/docs/development/orpc-client.md
@@ -39,7 +39,7 @@ import { getServerClient } from "@peated/web/lib/orpc/client.server";
 
 export async function GET() {
   const { client } = await getServerClient();
-  const { totalBottles } = await client.stats();
+  const { bottles } = await client.stats();
   // ...
 }
 ```


### PR DESCRIPTION
`GET /v1/stats` now returns a flat, timestamped public snapshot with active Bottle and entity-kind counts plus tasting, member-review, and public external-review totals. Public external reviews reuse the anonymous visibility rule, so hidden, staged, unmatched, and retired-Bottle records do not enter the count; private-member reviews remain included because they contribute to public Bottle summaries.

This is a breaking response-contract change. Consumers must replace the former `total*` fields with `bottles`, `brands`, `distilleries`, `bottlers`, `blenders`, `companies`, and `tastings`; `totalEntities` is removed and consumers can sum the five entity-kind fields when needed. The About page, sitemaps, mocks, and client documentation have been migrated without changing their presentation.
