### PR TITLE
fix(web): correct photo processing time copy

### DIFF
--- a/apps/web/src/components/bottleResolver/states.tsx
+++ b/apps/web/src/components/bottleResolver/states.tsx
@@ -119,7 +119,7 @@ export function PhotoLoadingState({
       {previewUrl ? (
         <PhotoPreview
           loading
-          metadata="Usually about 10 seconds"
+          metadata="Usually about a minute"
           src={previewUrl}
           title="Reading the label"
         />


### PR DESCRIPTION
The add-bottle photo loading state now says processing usually takes about a minute. This replaces the inaccurate 10-second estimate and sets a more realistic expectation while the label is read.
