### PR TITLE
fix(web): hide empty detail fields

### DIFF
--- a/apps/web/src/app/(redesign)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(redesign)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -338,6 +338,7 @@ export function BottlePageFrameClient({
   children: ReactNode;
   initialBottle: Bottle;
 }) {
+  const { user } = useAuth();
   const orpc = useORPC();
   const pathname = usePathname();
   const bottleQuery = useQuery({
@@ -391,10 +392,14 @@ export function BottlePageFrameClient({
           detail={getBottleDetail(bottle)}
           id={bottle.peatedId}
           imageUrl={bottle.imageUrl}
-          memberStatus={{
-            hasTasted: bottle.hasTasted,
-            isLibrary: bottle.isLibrary,
-          }}
+          memberStatus={
+            user
+              ? {
+                  hasTasted: bottle.hasTasted,
+                  isLibrary: bottle.isLibrary,
+                }
+              : undefined
+          }
           menu={<BottleActions bottle={bottle} />}
           name={getBottleExpressionName(bottle)}
           notes={getBottleNotes(bottle)}
@@ -542,8 +547,8 @@ export function BottleOverviewClient({
       {recommendationsQuery.error ||
       (!mainFailed && (externalReviewsQuery.error || tastingsQuery.error)) ? (
         <p role="status" {...stylex.props(styles.partialError)}>
-          Some bottle details could not be loaded. The rest of this page is
-          still available.
+          Some reviews, tastings, or recommendations could not be loaded. The
+          rest of this page is still available.
         </p>
       ) : null}
     </>

--- a/apps/web/src/app/(redesign)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(redesign)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -11,6 +11,7 @@ import {
   Card,
   EmptyState,
   FactList,
+  hasVisibleFacts,
   LoadingList,
   RatingMeasure,
   SectionError,
@@ -266,16 +267,25 @@ export function EntityOverviewClient({
 
   const entity = entityQuery.data;
   const createBottleHref = getEntityBottleCreateHref(entity);
+  const entityFacts = getEntityFacts(entity);
+  const hasDetails = hasVisibleFacts(entityFacts);
 
   return (
-    <div {...stylex.props(styles.overviewGrid)}>
-      <aside {...stylex.props(styles.details)}>
-        <PageSection heading="Details">
-          <Card appearance="surface" padding="sm">
-            <FactList facts={getEntityFacts(entity)} />
-          </Card>
-        </PageSection>
-      </aside>
+    <div
+      {...stylex.props(
+        styles.overviewGrid,
+        !hasDetails && styles.overviewGridWithoutDetails,
+      )}
+    >
+      {hasDetails ? (
+        <aside {...stylex.props(styles.details)}>
+          <PageSection heading="Details">
+            <Card appearance="surface" padding="sm">
+              <FactList facts={entityFacts} />
+            </Card>
+          </PageSection>
+        </aside>
+      ) : null}
 
       <div {...stylex.props(styles.catalog)}>
         <EntityBottleOverview
@@ -304,6 +314,10 @@ const styles = stylex.create({
       [NARROW]: "minmax(0, 1fr)",
     },
     columnGap: space.x12,
+  },
+  overviewGridWithoutDetails: {
+    gridTemplateAreas: '"catalog"',
+    gridTemplateColumns: "minmax(0, 1fr)",
   },
   catalog: {
     gridArea: "catalog",

--- a/apps/web/src/components/designSystem/components/dataDevices.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/dataDevices.stylex.tsx
@@ -36,21 +36,34 @@ export type SpecStripCells =
   | readonly [SpecStripCell, SpecStripCell, SpecStripCell]
   | readonly [SpecStripCell, SpecStripCell, SpecStripCell, SpecStripCell];
 
+function hasSpecStripValue(cell: SpecStripCell) {
+  return cell.value !== null && cell.value !== undefined && cell.value !== "";
+}
+
+export function hasVisibleSpecStripCells(cells: SpecStripCells) {
+  return cells.some(hasSpecStripValue);
+}
+
 export function SpecStrip({ cells }: { cells: SpecStripCells }) {
+  const visibleCells = cells.filter(hasSpecStripValue);
+
+  if (!visibleCells.length) return null;
+
   return (
     <dl
-      {...stylex.props(styles.specStrip, specStripColumnStyles[cells.length])}
+      {...stylex.props(
+        styles.specStrip,
+        getSpecStripColumnStyle(visibleCells.length),
+      )}
     >
-      {cells.map((cell, index) => (
+      {visibleCells.map((cell, index) => (
         <div
           data-spec-cell={index + 1}
           key={`${cell.label}-${index}`}
           {...stylex.props(styles.specCell)}
         >
           <dt {...stylex.props(styles.specLabel)}>{cell.label}</dt>
-          <dd {...stylex.props(styles.specValue)}>
-            {cell.value === null || cell.value === undefined ? "–" : cell.value}
-          </dd>
+          <dd {...stylex.props(styles.specValue)}>{cell.value}</dd>
         </div>
       ))}
     </dl>
@@ -158,3 +171,10 @@ const specStripColumnStyles = {
   3: styles.specStripThree,
   4: styles.specStripFour,
 } satisfies Record<SpecStripCells["length"], stylex.StyleXStyles>;
+
+function getSpecStripColumnStyle(cellCount: number) {
+  if (cellCount === 1) return specStripColumnStyles[1];
+  if (cellCount === 2) return specStripColumnStyles[2];
+  if (cellCount === 3) return specStripColumnStyles[3];
+  return specStripColumnStyles[4];
+}

--- a/apps/web/src/components/designSystem/components/detailValues.test.tsx
+++ b/apps/web/src/components/designSystem/components/detailValues.test.tsx
@@ -1,0 +1,49 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { SpecStrip } from "./dataDevices.stylex";
+import { FactList } from "./factList.stylex";
+
+describe("detail values", () => {
+  it("omits facts without values and keeps zero", () => {
+    const html = renderToStaticMarkup(
+      <FactList
+        facts={[
+          { label: "Also known as", value: null },
+          { label: "Website", value: "" },
+          { label: "Bottles", value: 0 },
+        ]}
+      />,
+    );
+
+    expect(html).not.toContain("Also known as");
+    expect(html).not.toContain("Website");
+    expect(html).toContain("Bottles");
+    expect(html).toContain(">0<");
+  });
+
+  it("does not render a fact list when every value is missing", () => {
+    expect(
+      renderToStaticMarkup(
+        <FactList facts={[{ label: "Also known as", value: null }]} />,
+      ),
+    ).toBe("");
+  });
+
+  it("omits empty specs and keeps zero", () => {
+    const html = renderToStaticMarkup(
+      <SpecStrip
+        cells={[
+          { label: "Founded", value: null },
+          { label: "Country", value: "" },
+          { label: "Bottles", value: 0 },
+        ]}
+      />,
+    );
+
+    expect(html).not.toContain("Founded");
+    expect(html).not.toContain("Country");
+    expect(html).toContain("Bottles");
+    expect(html).toContain(">0<");
+  });
+});

--- a/apps/web/src/components/designSystem/components/factList.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/factList.stylex.tsx
@@ -12,14 +12,32 @@ export type FactListProps = {
   facts: readonly [FactListItem, ...FactListItem[]];
 };
 
-/** Presents supplied label facts without inferring values for missing data. */
+function hasFactValue(value: ReactNode) {
+  return (
+    value !== null &&
+    value !== undefined &&
+    value !== "" &&
+    value !== false &&
+    value !== true
+  );
+}
+
+export function hasVisibleFacts(facts: readonly FactListItem[]) {
+  return facts.some((fact) => hasFactValue(fact.value));
+}
+
+/** Presents supplied facts and omits facts that have no value. */
 export function FactList({ facts }: FactListProps) {
+  const visibleFacts = facts.filter((fact) => hasFactValue(fact.value));
+
+  if (!visibleFacts.length) return null;
+
   return (
     <dl {...stylex.props(styles.list)}>
-      {facts.map((fact) => (
+      {visibleFacts.map((fact) => (
         <div key={fact.label} {...stylex.props(styles.row)}>
           <dt {...stylex.props(styles.label)}>{fact.label}</dt>
-          <dd {...stylex.props(styles.value)}>{fact.value ?? "Not stated"}</dd>
+          <dd {...stylex.props(styles.value)}>{fact.value}</dd>
         </div>
       ))}
     </dl>

--- a/apps/web/src/components/designSystem/components/index.ts
+++ b/apps/web/src/components/designSystem/components/index.ts
@@ -55,7 +55,11 @@ export type {
 } from "./collectionBottleStatus.stylex";
 export { CriticReview } from "./criticReview.stylex";
 export type { CriticReviewProps } from "./criticReview.stylex";
-export { RecordId, SpecStrip } from "./dataDevices.stylex";
+export {
+  RecordId,
+  SpecStrip,
+  hasVisibleSpecStripCells,
+} from "./dataDevices.stylex";
 export type {
   RecordIdProps,
   SpecStripCell,
@@ -71,7 +75,7 @@ export type {
 } from "./entityPicker.stylex";
 export { FacetRow } from "./facetRow.stylex";
 export type { FacetRowProps } from "./facetRow.stylex";
-export { FactList } from "./factList.stylex";
+export { FactList, hasVisibleFacts } from "./factList.stylex";
 export type { FactListItem, FactListProps } from "./factList.stylex";
 export {
   EmptyState,

--- a/apps/web/src/components/designSystem/patterns/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/bottleOverview.stylex.tsx
@@ -16,6 +16,7 @@ import type {
 import {
   CriticReview,
   FactList,
+  hasVisibleFacts,
   RailList,
   RailListItem,
   SectionHeading,
@@ -61,8 +62,11 @@ export function BottleOverview({
   tastingCount,
   tastings = [],
 }: BottleOverviewProps) {
+  const hasDeclaredFacts = hasVisibleFacts(declaredFacts);
+  const hasRail = hasDeclaredFacts || recommendations.length > 0;
+
   return (
-    <div {...stylex.props(styles.layout)}>
+    <div {...stylex.props(styles.layout, !hasRail && styles.layoutWithoutRail)}>
       <div {...stylex.props(styles.main)}>
         {criticReviews.length ? (
           <section {...stylex.props(styles.section)}>
@@ -110,36 +114,42 @@ export function BottleOverview({
         {!criticReviews.length && !tastings.length ? mainState : null}
       </div>
 
-      <aside aria-label="Bottle details" {...stylex.props(styles.rail)}>
-        <section {...stylex.props(styles.railSection)}>
-          <h2 {...stylex.props(styles.railHeading)}>Declared on the label</h2>
-          <div {...stylex.props(styles.panel)}>
-            <FactList facts={declaredFacts} />
-          </div>
-        </section>
+      {hasRail ? (
+        <aside aria-label="Bottle details" {...stylex.props(styles.rail)}>
+          {hasDeclaredFacts ? (
+            <section {...stylex.props(styles.railSection)}>
+              <h2 {...stylex.props(styles.railHeading)}>
+                Declared on the label
+              </h2>
+              <div {...stylex.props(styles.panel)}>
+                <FactList facts={declaredFacts} />
+              </div>
+            </section>
+          ) : null}
 
-        {recommendations.length ? (
-          <section {...stylex.props(styles.railSection)}>
-            <h2 {...stylex.props(styles.railHeading)}>
-              {recommendationHeading}
-            </h2>
-            {recommendationIntro ? (
-              <p {...stylex.props(styles.railIntro)}>{recommendationIntro}</p>
-            ) : null}
-            <RailList ariaLabel={recommendationHeading}>
-              {recommendations.map((recommendation) => (
-                <RailListItem
-                  end={recommendation.end}
-                  href={recommendation.href}
-                  key={recommendation.href}
-                  metadata={recommendation.metadata}
-                  title={recommendation.name}
-                />
-              ))}
-            </RailList>
-          </section>
-        ) : null}
-      </aside>
+          {recommendations.length ? (
+            <section {...stylex.props(styles.railSection)}>
+              <h2 {...stylex.props(styles.railHeading)}>
+                {recommendationHeading}
+              </h2>
+              {recommendationIntro ? (
+                <p {...stylex.props(styles.railIntro)}>{recommendationIntro}</p>
+              ) : null}
+              <RailList ariaLabel={recommendationHeading}>
+                {recommendations.map((recommendation) => (
+                  <RailListItem
+                    end={recommendation.end}
+                    href={recommendation.href}
+                    key={recommendation.href}
+                    metadata={recommendation.metadata}
+                    title={recommendation.name}
+                  />
+                ))}
+              </RailList>
+            </section>
+          ) : null}
+        </aside>
+      ) : null}
     </div>
   );
 }
@@ -156,6 +166,9 @@ const styles = stylex.create({
     alignItems: "start",
     columnGap: space.x8,
     rowGap: space.x8,
+  },
+  layoutWithoutRail: {
+    gridTemplateColumns: "minmax(0, 1fr)",
   },
   main: {
     display: "flex",

--- a/apps/web/src/components/designSystem/patterns/bottlePageHeader.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/bottlePageHeader.stylex.tsx
@@ -14,6 +14,7 @@ import {
   BandStack,
   BottleVisual,
   Chip,
+  hasVisibleSpecStripCells,
   RecordId,
   Score,
   SpecStrip,
@@ -115,9 +116,11 @@ export function BottlePageHeader({
           </div>
         </div>
       </div>
-      <div {...stylex.props(styles.specs)}>
-        <SpecStrip cells={specs} />
-      </div>
+      {hasVisibleSpecStripCells(specs) ? (
+        <div {...stylex.props(styles.specs)}>
+          <SpecStrip cells={specs} />
+        </div>
+      ) : null}
       {hasMeasures ? (
         <div aria-label="Community measures" {...stylex.props(styles.measures)}>
           {score ? (

--- a/apps/web/src/components/designSystem/patterns/entityPageHeader.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/entityPageHeader.stylex.tsx
@@ -2,7 +2,12 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import { space } from "../../../styles/tokens.stylex";
-import { RecordId, SpecStrip, type SpecStripCells } from "../components";
+import {
+  hasVisibleSpecStripCells,
+  RecordId,
+  SpecStrip,
+  type SpecStripCells,
+} from "../components";
 import { PageHeader } from "./pageLayout.stylex";
 
 export type EntityPageHeaderProps = {
@@ -40,9 +45,11 @@ export function EntityPageHeader({
         parent={parent}
         title={title}
       />
-      <div {...stylex.props(styles.specs)}>
-        <SpecStrip cells={specs} />
-      </div>
+      {hasVisibleSpecStripCells(specs) ? (
+        <div {...stylex.props(styles.specs)}>
+          <SpecStrip cells={specs} />
+        </div>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Entity and bottle detail pages now omit facts and header specs when the source value is absent instead of showing empty labels, “Not stated,” or dash placeholders. Empty detail and declared-fact shells collapse, while meaningful zero counts stay visible.

The bottle header also hides member-only status from signed-out visitors, and partial-load copy names the affected reviews, tastings, and recommendations. Shared fact and spec components own the filtering, with regression coverage for missing values and zeroes.
