### PR TITLE
feat(entities): expose distillery follow action

### DIFF
--- a/apps/server/src/orpc/contracts/entities/details.ts
+++ b/apps/server/src/orpc/contracts/entities/details.ts
@@ -1,4 +1,4 @@
-import { detailsResponse, EntitySchema } from "@peated/server/schemas";
+import { detailsResponse, EntityDetailsSchema } from "@peated/server/schemas";
 import { z } from "zod";
 import { contract } from "../base";
 
@@ -13,4 +13,4 @@ export default contract
   .input(z.object({ entity: z.coerce.number() }))
   // TODO(response-envelope): Return { data: ... } when all detail routes use the
   // same wrapper.
-  .output(detailsResponse(EntitySchema));
+  .output(detailsResponse(EntityDetailsSchema));

--- a/apps/server/src/orpc/mock/fixtures/catalog.ts
+++ b/apps/server/src/orpc/mock/fixtures/catalog.ts
@@ -3,7 +3,7 @@ import { mockBottle, mockBottles } from "./bottles";
 import { mockEntity } from "./entities";
 
 type Bottle = MockOutputs["bottles"]["list"]["results"][number];
-type Entity = MockOutputs["entities"]["details"];
+type Entity = MockOutputs["entities"]["list"]["results"][number];
 
 export const mockEntityCatalog = {
   totalBottles: mockEntity.totalBottles,

--- a/apps/server/src/orpc/mock/fixtures/entities.ts
+++ b/apps/server/src/orpc/mock/fixtures/entities.ts
@@ -22,6 +22,7 @@ export const mockEntity = {
   location: [-6.126, 55.635],
   totalTastings: 1200,
   totalBottles: 84,
+  isFollowing: false,
   createdAt: timestamp,
   updatedAt: timestamp,
 } satisfies Entity;

--- a/apps/server/src/orpc/mock/fixtures/entities.ts
+++ b/apps/server/src/orpc/mock/fixtures/entities.ts
@@ -2,7 +2,7 @@ import type { MockOutputs } from "../contract";
 import { timestamp } from "./constants";
 import { mockCountries, mockCountry, mockRegion, mockRegions } from "./places";
 
-type Entity = MockOutputs["entities"]["details"];
+type Entity = MockOutputs["entities"]["list"]["results"][number];
 
 // Producers and bottles
 export const mockEntity = {
@@ -22,7 +22,6 @@ export const mockEntity = {
   location: [-6.126, 55.635],
   totalTastings: 1200,
   totalBottles: 84,
-  isFollowing: false,
   createdAt: timestamp,
   updatedAt: timestamp,
 } satisfies Entity;

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -84,7 +84,7 @@ describe("mock oRPC router", () => {
   it("returns data used by the main pages", async () => {
     await expect(
       anonymousClient.entities.details({ entity: mockEntity.id }),
-    ).resolves.toEqual(mockEntity);
+    ).resolves.toEqual({ ...mockEntity, isFollowing: false });
     const entities = await anonymousClient.entities.list({ limit: 100 });
     expect(entities.results).toHaveLength(mockEntities.length);
     expect(entities.results.every((entity) => entity.kind)).toBe(true);
@@ -195,7 +195,7 @@ describe("mock oRPC router", () => {
     ).resolves.toEqual(kentucky);
     await expect(
       anonymousClient.entities.details({ entity: yamazaki.brand.id }),
-    ).resolves.toEqual(yamazaki.brand);
+    ).resolves.toEqual({ ...yamazaki.brand, isFollowing: false });
     await expect(
       anonymousClient.bottles.details({ bottle: yamazaki.id }),
     ).resolves.toMatchObject({ id: yamazaki.id, fullName: yamazaki.fullName });

--- a/apps/server/src/orpc/mock/routes/entities/details.ts
+++ b/apps/server/src/orpc/mock/routes/entities/details.ts
@@ -9,5 +9,5 @@ export default mockOS.entities.details.handler(async ({ input, errors }) => {
     throw errors.NOT_FOUND({ message: "Mock entity not found." });
   }
 
-  return entity;
+  return { ...entity, isFollowing: false };
 });

--- a/apps/server/src/orpc/routes/entities/details.test.ts
+++ b/apps/server/src/orpc/routes/entities/details.test.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { entityTombstones } from "@peated/server/db/schema";
+import { entityFollows, entityTombstones } from "@peated/server/db/schema";
 import { formatPeatedId } from "@peated/server/lib/peatedId";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
@@ -38,6 +38,28 @@ describe("GET /entities/:entity", () => {
       peatedId: formatPeatedId("entity", owner.id),
       name: owner.name,
     });
+  });
+
+  test("returns whether the current user follows the entity", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const entity = await fixtures.Entity({ kind: "distillery" });
+    await db.insert(entityFollows).values({
+      entityId: entity.id,
+      userId: defaults.user.id,
+    });
+
+    const anonymousData = await routerClient.entities.details({
+      entity: entity.id,
+    });
+    const userData = await routerClient.entities.details(
+      { entity: entity.id },
+      { context: { user: defaults.user } },
+    );
+
+    expect(anonymousData.isFollowing).toBe(false);
+    expect(userData.isFollowing).toBe(true);
   });
 
   test("errors on invalid entity", async () => {

--- a/apps/server/src/orpc/routes/entities/details.ts
+++ b/apps/server/src/orpc/routes/entities/details.ts
@@ -1,10 +1,14 @@
 import { db } from "@peated/server/db";
-import { entities, entityTombstones } from "@peated/server/db/schema";
+import {
+  entities,
+  entityFollows,
+  entityTombstones,
+} from "@peated/server/db/schema";
 import { implement } from "@peated/server/orpc";
 import entityDetailsContract from "@peated/server/orpc/contracts/entities/details";
 import { serialize } from "@peated/server/serializers";
 import { EntitySerializer } from "@peated/server/serializers/entity";
-import { eq, getTableColumns } from "drizzle-orm";
+import { and, eq, getTableColumns } from "drizzle-orm";
 
 export default implement(entityDetailsContract).handler(async function ({
   input,
@@ -33,5 +37,23 @@ export default implement(entityDetailsContract).handler(async function ({
     }
   }
 
-  return await serialize(EntitySerializer, entity, context.user);
+  let isFollowing = false;
+  if (context.user) {
+    const [follow] = await db
+      .select({ entityId: entityFollows.entityId })
+      .from(entityFollows)
+      .where(
+        and(
+          eq(entityFollows.userId, context.user.id),
+          eq(entityFollows.entityId, entity.id),
+        ),
+      )
+      .limit(1);
+    isFollowing = Boolean(follow);
+  }
+
+  return {
+    ...(await serialize(EntitySerializer, entity, context.user)),
+    isFollowing,
+  };
 });

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -112,6 +112,13 @@ export const EntitySchema = z.object({
     .describe("Timestamp when the entity was last updated"),
 });
 
+export const EntityDetailsSchema = EntitySchema.extend({
+  isFollowing: z
+    .boolean()
+    .readonly()
+    .describe("Whether the current user follows this entity"),
+});
+
 export const EntityInputFields = {
   name: EntityNameSchema,
   shortName: EntityShortNameSchema,

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -106,6 +106,7 @@ export const testBrand = {
   location: null,
   totalTastings: 0,
   totalBottles: 1,
+  isFollowing: false,
   createdAt: timestamp,
   updatedAt: timestamp,
 };

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import {
+  Button,
   ButtonLink,
   PageTabs,
   RowMenu,
@@ -27,6 +28,73 @@ import {
   getEntityTabs,
   type Entity,
 } from "./entityPageData";
+
+function DistilleryFollowAction({ entity }: { entity: Entity }) {
+  const { user } = useAuth();
+  const orpc = useORPC();
+  const queryClient = useQueryClient();
+  const { flash } = useFlashMessages();
+  const [followingOverride, setFollowingOverride] = useState<boolean | null>(
+    null,
+  );
+  const followMutation = useMutation(orpc.entities.follow.mutationOptions());
+  const unfollowMutation = useMutation(
+    orpc.entities.unfollow.mutationOptions(),
+  );
+
+  if (!user) {
+    return (
+      <ButtonLink
+        aria-label={`Follow ${entity.name}`}
+        href={`/login?redirectTo=${encodeURIComponent(`/distillers/${entity.id}`)}`}
+        size="lg"
+        variant="tonal"
+      >
+        Follow
+      </ButtonLink>
+    );
+  }
+
+  const isFollowing = followingOverride ?? entity.isFollowing;
+  const pending = followMutation.isPending || unfollowMutation.isPending;
+
+  return (
+    <Button
+      aria-label={
+        isFollowing ? `Unfollow ${entity.name}` : `Follow ${entity.name}`
+      }
+      aria-pressed={isFollowing}
+      loading={pending}
+      loadingLabel={isFollowing ? "Unfollowing…" : "Following…"}
+      onClick={async () => {
+        try {
+          if (isFollowing) {
+            await unfollowMutation.mutateAsync({ entity: entity.id });
+          } else {
+            await followMutation.mutateAsync({ entity: entity.id });
+          }
+          setFollowingOverride(!isFollowing);
+          await queryClient.invalidateQueries({
+            queryKey: orpc.entities.details.key({
+              input: { entity: entity.id },
+            }),
+          });
+        } catch (error) {
+          flash(
+            error instanceof Error
+              ? error.message
+              : "We couldn't update the distilleries you follow. Try again.",
+            "error",
+          );
+        }
+      }}
+      size="lg"
+      variant="tonal"
+    >
+      {isFollowing ? "Unfollow" : "Follow"}
+    </Button>
+  );
+}
 
 function EntityActions({ entity }: { entity: Entity }) {
   const { user } = useAuth();
@@ -136,12 +204,19 @@ export function EntityPageFrameClient({
     <div {...stylex.props(styles.page)}>
       <EntityPageHeader
         actions={
-          createBottleHref ? (
-            <ButtonLink href={createBottleHref} size="lg" variant="accent">
-              {presentation.bottleSectionLabel === "Bottlings"
-                ? "Record a bottling"
-                : "Record a bottle"}
-            </ButtonLink>
+          createBottleHref || entity.kind === "distillery" ? (
+            <>
+              {createBottleHref ? (
+                <ButtonLink href={createBottleHref} size="lg" variant="accent">
+                  {presentation.bottleSectionLabel === "Bottlings"
+                    ? "Record a bottling"
+                    : "Record a bottle"}
+                </ButtonLink>
+              ) : null}
+              {entity.kind === "distillery" ? (
+                <DistilleryFollowAction key={entity.id} entity={entity} />
+              ) : null}
+            </>
           ) : undefined
         }
         description={

--- a/apps/web/src/app/(app)/entities/[entityId]/layout.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/layout.tsx
@@ -1,6 +1,6 @@
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { summarize } from "@peated/web/lib/markdown";
-import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
+import { getServerClient } from "@peated/web/lib/orpc/client.server";
 import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
 import type { ReactNode } from "react";
 import type { Organization, WithContext } from "schema-dts";
@@ -27,8 +27,9 @@ export default async function EntityLayout(props: {
   params: Promise<{ entityId: string }>;
 }) {
   const { entityId } = await props.params;
-  const { client } = await getAnonymousServerClient();
-  const entity = await getEntityPage(Number(entityId));
+  const canonicalEntity = await getEntityPage(Number(entityId));
+  const { client } = await getServerClient();
+  const entity = await client.entities.details({ entity: canonicalEntity.id });
 
   const owner = entity.ownerId
     ? await resolveOrNotFound(

--- a/apps/web/src/components/designSystem/patterns/pageLayout.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/pageLayout.stylex.tsx
@@ -288,7 +288,7 @@ const styles = stylex.create({
     display: "flex",
     flexShrink: 0,
     alignItems: "center",
-    gap: space.x2,
+    gap: { default: space.x2, [MOBILE]: space.x1 },
     flexWrap: "wrap",
   },
   tabbedPage: {


### PR DESCRIPTION
Distillery pages now expose a Follow/Unfollow control beside Record a bottling. Signed-out members return to the distillery after login, while signed-in members get immediate state updates that persist after reload. The mobile header keeps all three actions on one row.

Entity details now returns viewer-scoped follow state without expanding every embedded entity payload. The existing follow mutations and storage model remain unchanged, and focused route coverage verifies anonymous and authenticated states.
