### PR TITLE
fix(web): truncate tasting note previews

### DIFF
--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -153,6 +153,7 @@ function getCriticReview(
 function getTasting(tasting: Tasting, bottle: Bottle): TastingEntryProps {
   const member = {
     description: tasting.notes ?? undefined,
+    descriptionHref: `/tastings/${tasting.id}`,
     name: bottle.fullName,
     notes: tasting.tags,
     ratingBand: tasting.ratingBand ?? undefined,

--- a/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
@@ -58,7 +58,7 @@ export default async function TastingPage(props: {
         title={getBottlePlainTextIdentity(tasting.bottle)}
       />
       <PageSection heading="Tasting">
-        <TastingRecordEntry tasting={tasting} />
+        <TastingRecordEntry showFullNotes tasting={tasting} />
       </PageSection>
       <PageSection count={commentList.results.length} heading="Comments">
         <TastingComments

--- a/apps/web/src/components/designSystem/components/tastingEntry.stories.tsx
+++ b/apps/web/src/components/designSystem/components/tastingEntry.stories.tsx
@@ -67,3 +67,20 @@ export const Overview: Story = {
     </StoryStack>
   ),
 };
+
+export const LongDescription: Story = {
+  args: {
+    members: [
+      {
+        description:
+          "The nose starts with wood smoke, dried orange, and old leather before moving into dark chocolate and sea salt. The palate adds roasted coffee, black pepper, and a little raisin sweetness. With time, the smoke softens and more fruit comes through. The finish is long, dry, and smoky, with espresso and orange peel lingering after the last sip.",
+        descriptionHref: "/tastings/42",
+        href: "/bottles/lagavulin-16",
+        metadata: "Islay · 16 years · 43% ABV",
+        name: "Lagavulin 16-year-old",
+        notes: ["Smoke", "Dried fruit", "Sea salt"],
+        ratingBand: "outstanding",
+      },
+    ],
+  },
+};

--- a/apps/web/src/components/designSystem/components/tastingEntry.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/tastingEntry.stylex.tsx
@@ -11,7 +11,8 @@ import {
 import { BandMark, type RatingBand } from "./scoring.stylex";
 
 export type TastingEntryMember = {
-  description?: ReactNode;
+  description?: string;
+  descriptionHref?: string;
   href?: string;
   metadata?: string;
   name: string;
@@ -99,7 +100,7 @@ export function TastingEntry({
               ) : null}
               {member.description ? (
                 <span {...stylex.props(styles.description)}>
-                  {member.description}
+                  <TastingDescription member={member} />
                 </span>
               ) : null}
             </div>
@@ -115,6 +116,39 @@ export function TastingEntry({
       </ul>
       {comment ? <p {...stylex.props(styles.comment)}>{comment}</p> : null}
     </article>
+  );
+}
+
+const DESCRIPTION_PREVIEW_LENGTH = 60;
+
+function TastingDescription({ member }: { member: TastingEntryMember }) {
+  const description = member.description?.trim().replace(/\s+/g, " ");
+
+  if (
+    !member.descriptionHref ||
+    !description ||
+    description.length <= DESCRIPTION_PREVIEW_LENGTH
+  ) {
+    return member.description;
+  }
+
+  const wordBoundary = description
+    .slice(0, DESCRIPTION_PREVIEW_LENGTH + 1)
+    .lastIndexOf(" ");
+  const cutoff = wordBoundary > 0 ? wordBoundary : DESCRIPTION_PREVIEW_LENGTH;
+  const preview = `${description.slice(0, cutoff).trimEnd()}…`;
+
+  return (
+    <>
+      <span {...stylex.props(styles.descriptionPreview)}>{preview}</span>
+      <a
+        aria-label={`Read the full tasting notes for ${member.name}`}
+        href={member.descriptionHref}
+        {...stylex.props(styles.descriptionLink)}
+      >
+        Read more <span aria-hidden="true">→</span>
+      </a>
+    </>
   );
 }
 
@@ -259,6 +293,25 @@ const styles = stylex.create({
     fontSize: "13px",
     lineHeight: 1.5,
     whiteSpace: "pre-wrap",
+  },
+  descriptionLink: {
+    display: "inline-block",
+    marginTop: space.x2,
+    color: colors.accentDeep,
+    fontWeight: 600,
+    textDecoration: {
+      default: "none",
+      ":hover": "underline",
+    },
+    outline: "none",
+    boxShadow: {
+      default: "none",
+      ":focus-visible": effects.focusRing,
+    },
+    whiteSpace: "nowrap",
+  },
+  descriptionPreview: {
+    display: "block",
   },
   measure: {
     display: "flex",

--- a/apps/web/src/components/designSystem/components/tastingEntry.test.tsx
+++ b/apps/web/src/components/designSystem/components/tastingEntry.test.tsx
@@ -1,0 +1,54 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { TastingEntry } from "./tastingEntry.stylex";
+
+function renderDescription(description: string, descriptionHref?: string) {
+  return renderToStaticMarkup(
+    <TastingEntry
+      author="peatfan"
+      date="Today"
+      members={[
+        {
+          description,
+          descriptionHref,
+          name: "Lagavulin 16-year-old",
+        },
+      ]}
+    />,
+  );
+}
+
+describe("TastingEntry descriptions", () => {
+  it("shows short tasting notes without a details link", () => {
+    const html = renderDescription(
+      "Smoke, fruit, and sea salt.",
+      "/tastings/1",
+    );
+
+    expect(html).toContain("Smoke, fruit, and sea salt.");
+    expect(html).not.toContain("Read more");
+  });
+
+  it("shortens long tasting notes and links to the tasting details", () => {
+    const html = renderDescription(
+      `${"Smoke, fruit, and sea salt. ".repeat(12)}The final sentence.`,
+      "/tastings/42",
+    );
+
+    expect(html).toContain("Read more");
+    expect(html).toContain('href="/tastings/42"');
+    expect(html).toContain(
+      'aria-label="Read the full tasting notes for Lagavulin 16-year-old"',
+    );
+    expect(html).not.toContain("The final sentence.");
+  });
+
+  it("shows the full tasting notes when no details link is provided", () => {
+    const description = `${"Smoke, fruit, and sea salt. ".repeat(12)}The final sentence.`;
+    const html = renderDescription(description);
+
+    expect(html).toContain("The final sentence.");
+    expect(html).not.toContain("Read more");
+  });
+});

--- a/apps/web/src/components/tastingRecordEntry.tsx
+++ b/apps/web/src/components/tastingRecordEntry.tsx
@@ -15,6 +15,7 @@ type Tasting = Outputs["tastings"]["list"]["results"][number];
 
 type TastingEntryRecord = {
   bottle: BottleMetadata & { fullName: string; id: number };
+  id: number;
   notes?: string | null;
   ratingBand?: TastingEntryMember["ratingBand"] | null;
   tags?: readonly string[] | null;
@@ -24,7 +25,8 @@ export function getTastingEntryMember(
   tasting: TastingEntryRecord,
 ): TastingEntryMember {
   return {
-    description: tasting.notes,
+    description: tasting.notes ?? undefined,
+    descriptionHref: `/tastings/${tasting.id}`,
     href: `/bottles/${tasting.bottle.id}`,
     metadata: getBottleMetadata(tasting.bottle),
     name: tasting.bottle.fullName,
@@ -35,11 +37,15 @@ export function getTastingEntryMember(
 
 export function TastingRecordEntry({
   showAvatar = true,
+  showFullNotes = false,
   tasting,
 }: {
   showAvatar?: boolean;
+  showFullNotes?: boolean;
   tasting: Tasting;
 }) {
+  const member = getTastingEntryMember(tasting);
+
   return (
     <TastingEntry
       author={tasting.createdBy.username}
@@ -53,7 +59,9 @@ export function TastingRecordEntry({
           />
         ) : undefined
       }
-      members={[getTastingEntryMember(tasting)]}
+      members={[
+        showFullNotes ? { ...member, descriptionHref: undefined } : member,
+      ]}
     />
   );
 }


### PR DESCRIPTION
Long tasting notes in feeds, member profiles, and bottle overviews now use a compact word-boundary preview with a separate “Read more →” link to the tasting details page. Short notes remain unchanged, and the details page continues to show the complete note.

The preview follows the same bounded-copy pattern as homepage region descriptions, with a Storybook state for visual review and focused coverage for short, truncated, and full-detail behavior.
