### PR TITLE
ref(web): centralize list row dividers

### DIFF
--- a/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
@@ -2,6 +2,8 @@ import {
   BottleIdentityRow,
   CursorPager,
   EmptyState,
+  ItemList,
+  ItemListItem,
 } from "@peated/web/components/designSystem/components";
 import { getBottleExpressionName } from "@peated/web/lib/bottleLabel";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
@@ -53,24 +55,25 @@ export default async function BottleReleasesPage(props: {
   return (
     <BottleSection count={bottleList.results.length} heading="Releases">
       {bottleList.results.length ? (
-        <div>
+        <ItemList ariaLabel="Bottle releases">
           {bottleList.results.map((bottle) => (
-            <BottleIdentityRow
-              brand={bottle.brand.name}
-              brandHref={`/entities/${bottle.brand.id}`}
-              end={
-                bottle.medianScore !== null && bottle.scoreCount >= 20
-                  ? `${bottle.medianScore} / 100`
-                  : undefined
-              }
-              href={`/bottles/${bottle.id}`}
-              imageUrl={bottle.imageUrl}
-              key={bottle.id}
-              metadata={getBottleMetadata(bottle).split(" · ")}
-              name={getBottleExpressionName(bottle)}
-            />
+            <ItemListItem key={bottle.id}>
+              <BottleIdentityRow
+                brand={bottle.brand.name}
+                brandHref={`/entities/${bottle.brand.id}`}
+                end={
+                  bottle.medianScore !== null && bottle.scoreCount >= 20
+                    ? `${bottle.medianScore} / 100`
+                    : undefined
+                }
+                href={`/bottles/${bottle.id}`}
+                imageUrl={bottle.imageUrl}
+                metadata={getBottleMetadata(bottle).split(" · ")}
+                name={getBottleExpressionName(bottle)}
+              />
+            </ItemListItem>
           ))}
-        </div>
+        </ItemList>
       ) : (
         <EmptyState heading="No releases found">
           This release family has no visible bottles.

--- a/apps/web/src/app/(app)/bottles/[bottleId]/tastings/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/tastings/page.tsx
@@ -2,6 +2,8 @@ import {
   ButtonLink,
   CursorPager,
   EmptyState,
+  ItemList,
+  ItemListItem,
 } from "@peated/web/components/designSystem/components";
 import { TastingRecordEntry } from "@peated/web/components/tastingRecordEntry";
 import { getAddBottleHref } from "@peated/web/lib/addBottle";
@@ -32,11 +34,13 @@ export default async function BottleTastingsPage(props: {
   return (
     <BottleSection count={tastingList.results.length} heading="Tastings">
       {tastingList.results.length ? (
-        <div>
+        <ItemList ariaLabel="Bottle tasting records">
           {tastingList.results.map((tasting) => (
-            <TastingRecordEntry key={tasting.id} tasting={tasting} />
+            <ItemListItem key={tasting.id}>
+              <TastingRecordEntry tasting={tasting} />
+            </ItemListItem>
           ))}
-        </div>
+        </ItemList>
       ) : (
         <EmptyState
           action={

--- a/apps/web/src/app/(app)/entities/[entityId]/tastings/entityTastingListClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/tastings/entityTastingListClient.stylex.tsx
@@ -9,6 +9,8 @@ import {
   ButtonLink,
   CursorPager,
   EmptyState,
+  ItemList,
+  ItemListItem,
 } from "@peated/web/components/designSystem/components";
 import { TastingRecordEntry } from "@peated/web/components/tastingRecordEntry";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
@@ -43,11 +45,13 @@ export function EntityTastingListClient({
       {...stylex.props(styles.content)}
     >
       {tastingList.results.length ? (
-        <div {...stylex.props(styles.list)}>
+        <ItemList ariaLabel={`${entityName} tasting records`}>
           {tastingList.results.map((tasting) => (
-            <TastingRecordEntry key={tasting.id} tasting={tasting} />
+            <ItemListItem key={tasting.id}>
+              <TastingRecordEntry tasting={tasting} />
+            </ItemListItem>
           ))}
-        </div>
+        </ItemList>
       ) : (
         <EmptyState
           action={
@@ -86,10 +90,5 @@ const styles = stylex.create({
   content: {
     minWidth: 0,
     paddingTop: space.x6,
-  },
-  list: {
-    display: "flex",
-    minWidth: 0,
-    flexDirection: "column",
   },
 });

--- a/apps/web/src/app/(app)/flights/[flightId]/page.tsx
+++ b/apps/web/src/app/(app)/flights/[flightId]/page.tsx
@@ -2,6 +2,8 @@ import {
   BottleIdentityRow,
   ButtonLink,
   EmptyState,
+  ItemList,
+  ItemListItem,
 } from "@peated/web/components/designSystem/components";
 import {
   PageHeader,
@@ -59,34 +61,35 @@ export default async function FlightPage(props: {
       />
       <PageSection count={flight.bottles.length} heading="Bottles">
         {flight.bottles.length ? (
-          <div>
+          <ItemList ariaLabel="Flight bottles">
             {flight.bottles.map(({ bottle, hasTasted, isLibrary }) => (
-              <BottleIdentityRow
-                brand={bottle.brand.name}
-                brandHref={`/entities/${bottle.brand.id}`}
-                end={
-                  <ButtonLink
-                    href={getAddBottleHref({
-                      bottleId: bottle.id,
-                      flightId: flight.id,
-                      intent: "tasting",
-                    })}
-                    size="sm"
-                    variant={hasTasted ? "tonal" : "accent"}
-                  >
-                    Log tasting
-                  </ButtonLink>
-                }
-                hasTasted={hasTasted}
-                href={`/bottles/${bottle.id}`}
-                imageUrl={bottle.imageUrl}
-                isLibrary={isLibrary}
-                key={bottle.id}
-                metadata={getBottleMetadata(bottle).split(" · ")}
-                name={getBottleExpressionName(bottle)}
-              />
+              <ItemListItem key={bottle.id}>
+                <BottleIdentityRow
+                  brand={bottle.brand.name}
+                  brandHref={`/entities/${bottle.brand.id}`}
+                  end={
+                    <ButtonLink
+                      href={getAddBottleHref({
+                        bottleId: bottle.id,
+                        flightId: flight.id,
+                        intent: "tasting",
+                      })}
+                      size="sm"
+                      variant={hasTasted ? "tonal" : "accent"}
+                    >
+                      Log tasting
+                    </ButtonLink>
+                  }
+                  hasTasted={hasTasted}
+                  href={`/bottles/${bottle.id}`}
+                  imageUrl={bottle.imageUrl}
+                  isLibrary={isLibrary}
+                  metadata={getBottleMetadata(bottle).split(" · ")}
+                  name={getBottleExpressionName(bottle)}
+                />
+              </ItemListItem>
             ))}
-          </div>
+          </ItemList>
         ) : (
           <EmptyState heading="No bottles yet">
             Edit this flight to add bottles.

--- a/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
+++ b/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
@@ -11,6 +11,8 @@ import {
   CursorPager,
   EmptyState,
   IconButton,
+  ItemList,
+  ItemListItem,
 } from "@peated/web/components/designSystem/components";
 import { Avatar } from "@peated/web/components/designSystem/components/avatar.stylex";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
@@ -123,84 +125,91 @@ export function NotificationList({
 
   return (
     <>
-      <ul aria-label="Notifications" {...stylex.props(styles.list)}>
+      <ItemList ariaLabel="Notifications">
         {notifications.map((notification) => {
           const href = getNotificationHref(notification);
           const from = notification.fromUser;
           return (
-            <li
-              key={notification.id}
-              {...stylex.props(styles.row, !notification.read && styles.unread)}
-            >
-              <Avatar
-                imageUrl={from?.pictureUrl}
-                initials={from?.username.slice(0, 2).toLocaleUpperCase() ?? "P"}
-              />
-              <div {...stylex.props(styles.copy)}>
-                <div {...stylex.props(styles.message)}>
-                  {from ? (
-                    <a
-                      href={`/users/${from.username}`}
-                      {...stylex.props(styles.author)}
-                    >
-                      {from.username}
-                    </a>
-                  ) : null}{" "}
-                  {href ? (
-                    <a
-                      href={href}
-                      onClick={() => markRead(notification.id)}
-                      {...stylex.props(styles.target)}
-                    >
-                      {getNotificationMessage(notification)}
-                    </a>
-                  ) : (
-                    getNotificationMessage(notification)
-                  )}
-                </div>
-                <span {...stylex.props(styles.date)}>
-                  <TimeSince date={notification.createdAt} />
-                </span>
-                {notification.type === "friend_request" && notification.ref ? (
-                  <div {...stylex.props(styles.friendActions)}>
-                    {notification.ref.status === "friends" ? (
-                      <span {...stylex.props(styles.friendStatus)}>
-                        Friends
-                      </span>
-                    ) : (
-                      <Button
-                        disabled={acceptingNotificationId !== undefined}
-                        loading={acceptingNotificationId === notification.id}
-                        onClick={() =>
-                          void acceptFriend(
-                            notification.id,
-                            notification.ref!.userId,
-                          )
-                        }
-                        size="sm"
-                        variant="accent"
+            <ItemListItem key={notification.id}>
+              <div
+                {...stylex.props(
+                  styles.row,
+                  !notification.read && styles.unread,
+                )}
+              >
+                <Avatar
+                  imageUrl={from?.pictureUrl}
+                  initials={
+                    from?.username.slice(0, 2).toLocaleUpperCase() ?? "P"
+                  }
+                />
+                <div {...stylex.props(styles.copy)}>
+                  <div {...stylex.props(styles.message)}>
+                    {from ? (
+                      <a
+                        href={`/users/${from.username}`}
+                        {...stylex.props(styles.author)}
                       >
-                        Add friend
-                      </Button>
+                        {from.username}
+                      </a>
+                    ) : null}{" "}
+                    {href ? (
+                      <a
+                        href={href}
+                        onClick={() => markRead(notification.id)}
+                        {...stylex.props(styles.target)}
+                      >
+                        {getNotificationMessage(notification)}
+                      </a>
+                    ) : (
+                      getNotificationMessage(notification)
                     )}
                   </div>
-                ) : null}
+                  <span {...stylex.props(styles.date)}>
+                    <TimeSince date={notification.createdAt} />
+                  </span>
+                  {notification.type === "friend_request" &&
+                  notification.ref ? (
+                    <div {...stylex.props(styles.friendActions)}>
+                      {notification.ref.status === "friends" ? (
+                        <span {...stylex.props(styles.friendStatus)}>
+                          Friends
+                        </span>
+                      ) : (
+                        <Button
+                          disabled={acceptingNotificationId !== undefined}
+                          loading={acceptingNotificationId === notification.id}
+                          onClick={() =>
+                            void acceptFriend(
+                              notification.id,
+                              notification.ref!.userId,
+                            )
+                          }
+                          size="sm"
+                          variant="accent"
+                        >
+                          Add friend
+                        </Button>
+                      )}
+                    </div>
+                  ) : null}
+                </div>
+                <IconButton
+                  disabled={
+                    deleteNotification.isPending ||
+                    acceptingNotificationId === notification.id
+                  }
+                  icon={<X aria-hidden="true" size={16} />}
+                  label="Dismiss notification"
+                  onClick={() => void dismiss(notification.id)}
+                  size="sm"
+                  variant="text"
+                />
               </div>
-              <IconButton
-                disabled={
-                  deleteNotification.isPending ||
-                  acceptingNotificationId === notification.id
-                }
-                icon={<X aria-hidden="true" size={16} />}
-                label="Dismiss notification"
-                onClick={() => void dismiss(notification.id)}
-                size="sm"
-                variant="text"
-              />
-            </li>
+            </ItemListItem>
           );
         })}
-      </ul>
+      </ItemList>
       <CursorPager
         ariaLabel="Notification pages"
         nextHref={nextHref}
@@ -239,7 +248,6 @@ function getNotificationMessage(notification: Notification) {
 }
 
 const styles = stylex.create({
-  list: { margin: 0, padding: 0, listStyle: "none" },
   row: {
     display: "flex",
     minWidth: 0,
@@ -249,15 +257,7 @@ const styles = stylex.create({
     paddingRight: space.x3,
     paddingBottom: space.x4,
     paddingLeft: space.x3,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
     backgroundColor: "transparent",
-    ":first-child": {
-      borderTopWidth: "1px",
-      borderTopStyle: "solid",
-      borderTopColor: colors.hairline,
-    },
   },
   unread: { backgroundColor: colors.surface },
   copy: { minWidth: 0, flex: 1 },

--- a/apps/web/src/app/(app)/users/[username]/profileTastingsPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileTastingsPageClient.stylex.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import type { Outputs } from "@peated/server/orpc/router";
-import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { usePathname, useSearchParams } from "next/navigation";
 
@@ -9,6 +8,8 @@ import {
   ButtonLink,
   CursorPager,
   EmptyState,
+  ItemList,
+  ItemListItem,
   LoadingList,
   RailList,
   RailListItem,
@@ -63,15 +64,13 @@ export function ProfileTastingsPageClient({
             again.
           </SectionError>
         ) : tastingQuery.data.results.length ? (
-          <div {...stylex.props(styles.tastingList)}>
+          <ItemList ariaLabel={`${user.username}'s tasting records`}>
             {tastingQuery.data.results.map((tasting) => (
-              <TastingRecordEntry
-                key={tasting.id}
-                showAvatar={false}
-                tasting={tasting}
-              />
+              <ItemListItem key={tasting.id}>
+                <TastingRecordEntry showAvatar={false} tasting={tasting} />
+              </ItemListItem>
             ))}
-          </div>
+          </ItemList>
         ) : (
           <EmptyState
             action={
@@ -153,7 +152,3 @@ function getRegionRail(
     </RailSection>
   );
 }
-
-const styles = stylex.create({
-  tastingList: { display: "flex", minWidth: 0, flexDirection: "column" },
-});

--- a/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
+++ b/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
@@ -5,6 +5,8 @@ import { ClientOnly } from "@peated/web/components/clientOnly";
 import {
   BottleIdentityRow,
   Card,
+  ItemList,
+  ItemListItem,
 } from "@peated/web/components/designSystem/components";
 import QRCodeClient from "@peated/web/components/qrcode.client.stylex";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
@@ -42,19 +44,21 @@ export function FlightOverlay({
           ) : null}
         </header>
         <div {...stylex.props(styles.layout)}>
-          <Card>
-            <div {...stylex.props(styles.list)}>
+          <Card padding="none">
+            <ItemList ariaLabel="Flight bottles" variant="surface">
               {bottles.map(({ bottle }) => (
-                <BottleIdentityRow
-                  brand={bottle.brand.name}
-                  href={getBottleUrl(bottle)}
-                  imageUrl={bottle.imageUrl}
-                  key={bottle.id}
-                  metadata={getBottleMetadata(bottle).split(" · ")}
-                  name={bottle.fullName}
-                />
+                <ItemListItem key={bottle.id}>
+                  <BottleIdentityRow
+                    brand={bottle.brand.name}
+                    href={getBottleUrl(bottle)}
+                    imageUrl={bottle.imageUrl}
+                    metadata={getBottleMetadata(bottle).split(" · ")}
+                    name={bottle.fullName}
+                    variant="surface"
+                  />
+                </ItemListItem>
               ))}
-            </div>
+            </ItemList>
           </Card>
           <aside {...stylex.props(styles.qr)}>
             <Card>
@@ -108,6 +112,5 @@ const styles = stylex.create({
     alignItems: "start",
     gap: space.x6,
   },
-  list: { display: "flex", minWidth: 0, flexDirection: "column" },
   qr: { "@media (max-width: 759px)": { display: "none" } },
 });

--- a/apps/web/src/components/designSystem/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/designSystem/components/bottleIdentityRow.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import BottleImage from "../../../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
 import { StoryCanvas, StoryStack } from "../storyFixtures.stylex";
 import { BottleIdentityRow } from "./bottleIdentityRow.stylex";
+import { ItemList, ItemListItem } from "./itemList.stylex";
 
 const meta = {
   title: "Components/Data Display/Bottle Identity Row",
@@ -29,54 +30,86 @@ type Story = StoryObj<typeof meta>;
 
 export const Overview: Story = {
   render: (args) => (
-    <StoryStack>
-      <BottleIdentityRow {...args} />
-      <BottleIdentityRow
-        brand="Lagavulin"
-        brandHref="/entities/245"
-        href="/bottles/42"
-        imageUrl={null}
-        metadata={["16 years", "43.0% ABV", "Distillers Edition"]}
-        name="Lagavulin 16-year-old"
-        relatedReleases={{ count: 3, href: "/bottles/42/releases" }}
-      />
-      <BottleIdentityRow {...args} hasTasted isLibrary />
-      <BottleIdentityRow {...args} isLibrary />
-      <BottleIdentityRow {...args} hasTasted />
-      <BottleIdentityRow
-        brand="Bruichladdich"
-        brandHref="/entities/213"
-        href="/bottles/18481"
-        imageUrl={null}
-        metadata={["61.5% ABV", "2024 release", "Islay barley"]}
-        name="Octomore Edition 15.3 Islay Barley Super Heavily Peated"
-      />
-    </StoryStack>
+    <ItemList ariaLabel="Bottle identity examples">
+      <ItemListItem>
+        <BottleIdentityRow {...args} />
+      </ItemListItem>
+      <ItemListItem>
+        <BottleIdentityRow
+          brand="Lagavulin"
+          brandHref="/entities/245"
+          href="/bottles/42"
+          imageUrl={null}
+          metadata={["16 years", "43.0% ABV", "Distillers Edition"]}
+          name="Lagavulin 16-year-old"
+          relatedReleases={{ count: 3, href: "/bottles/42/releases" }}
+        />
+      </ItemListItem>
+      <ItemListItem>
+        <BottleIdentityRow {...args} hasTasted isLibrary />
+      </ItemListItem>
+      <ItemListItem>
+        <BottleIdentityRow {...args} isLibrary />
+      </ItemListItem>
+      <ItemListItem>
+        <BottleIdentityRow {...args} hasTasted />
+      </ItemListItem>
+      <ItemListItem>
+        <BottleIdentityRow
+          brand="Bruichladdich"
+          brandHref="/entities/213"
+          href="/bottles/18481"
+          imageUrl={null}
+          metadata={["61.5% ABV", "2024 release", "Islay barley"]}
+          name="Octomore Edition 15.3 Islay Barley Super Heavily Peated"
+        />
+      </ItemListItem>
+    </ItemList>
+  ),
+};
+
+export const Surface: Story = {
+  render: (args) => (
+    <ItemList ariaLabel="Bottle identity surface examples" variant="surface">
+      <ItemListItem>
+        <BottleIdentityRow {...args} variant="surface" />
+      </ItemListItem>
+      <ItemListItem>
+        <BottleIdentityRow
+          {...args}
+          imageUrl={null}
+          name="Lagavulin 16-year-old"
+          variant="surface"
+        />
+      </ItemListItem>
+    </ItemList>
   ),
 };
 
 export const InteractionStates: Story = {
   render: (args) => (
     <StoryStack>
-      <div id="bottle-row-default">
-        <BottleIdentityRow {...args} name="Default" />
-      </div>
-      <div id="bottle-row-hovered">
-        <BottleIdentityRow {...args} name="Hovered" />
-      </div>
-      <div id="bottle-row-focused">
-        <BottleIdentityRow {...args} name="Keyboard focused" />
-      </div>
-      <div id="bottle-row-nested">
-        <BottleIdentityRow
-          {...args}
-          name="Primary bottle with brand and release links"
-          relatedReleases={{ count: 3, href: "#releases" }}
-        />
-      </div>
-      <div id="bottle-row-pressed">
-        <BottleIdentityRow {...args} name="Pressed" />
-      </div>
+      <ItemList ariaLabel="Bottle row interaction states">
+        <ItemListItem id="bottle-row-default">
+          <BottleIdentityRow {...args} name="Default" />
+        </ItemListItem>
+        <ItemListItem id="bottle-row-hovered">
+          <BottleIdentityRow {...args} name="Hovered" />
+        </ItemListItem>
+        <ItemListItem id="bottle-row-focused">
+          <BottleIdentityRow {...args} name="Keyboard focused" />
+        </ItemListItem>
+        <ItemListItem id="bottle-row-nested">
+          <BottleIdentityRow
+            {...args}
+            name="Primary bottle with brand and release links"
+            relatedReleases={{ count: 3, href: "#releases" }}
+          />
+        </ItemListItem>
+        <ItemListItem id="bottle-row-pressed">
+          <BottleIdentityRow {...args} name="Pressed" />
+        </ItemListItem>
+      </ItemList>
     </StoryStack>
   ),
   parameters: {

--- a/apps/web/src/components/designSystem/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/bottleIdentityRow.stylex.tsx
@@ -8,6 +8,7 @@ import {
   fonts,
   space,
 } from "../../../styles/tokens.stylex";
+import type { ItemListVariant } from "./itemList.stylex";
 import { linkedRowStyles } from "./linkedRow.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
@@ -63,6 +64,7 @@ export type BottleIdentityRowProps = {
     count: number;
     href: string;
   };
+  variant?: ItemListVariant;
 };
 
 function LibraryStatusMark() {
@@ -120,6 +122,7 @@ export function BottleIdentityRow({
   metadata = [],
   name,
   relatedReleases,
+  variant = "plain",
 }: BottleIdentityRowProps) {
   const Name = href ? "a" : "span";
   const Brand = brandHref ? "a" : "span";
@@ -128,8 +131,12 @@ export function BottleIdentityRow({
     <div
       {...stylex.props(
         styles.row,
+        variant === "surface" && styles.surfaceRow,
         Boolean(href) && linkedRowStyles.container,
-        Boolean(href) && linkedRowStyles.onGround,
+        Boolean(href) &&
+          (variant === "plain"
+            ? linkedRowStyles.onGround
+            : linkedRowStyles.onSurface),
       )}
     >
       <BottleVisual imageUrl={imageUrl} />
@@ -263,9 +270,13 @@ const styles = stylex.create({
     paddingRight: "12px",
     paddingBottom: space.x3,
     paddingLeft: "12px",
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
+  },
+  surfaceRow: {
+    width: "100%",
+    marginRight: 0,
+    marginLeft: 0,
+    paddingRight: "18px",
+    paddingLeft: "18px",
   },
   copy: {
     display: "flex",

--- a/apps/web/src/components/designSystem/components/criticReview.stories.tsx
+++ b/apps/web/src/components/designSystem/components/criticReview.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-import { StoryCanvas, StoryStack } from "../storyFixtures.stylex";
+import { StoryCanvas } from "../storyFixtures.stylex";
 import { CriticReview } from "./criticReview.stylex";
+import { ItemList, ItemListItem } from "./itemList.stylex";
 
 const meta = {
   title: "Components/Data Display/Critic Review",
@@ -29,14 +30,20 @@ type Story = StoryObj<typeof meta>;
 
 export const Overview: Story = {
   render: (args) => (
-    <StoryStack>
-      <CriticReview {...args} />
-      <CriticReview
-        publication="Malt Review"
-        publishedAt="2 Sep 2024"
-        rating={80}
-      />
-      <CriticReview publication="Whisky Notes" rating={null} />
-    </StoryStack>
+    <ItemList ariaLabel="Critic review examples">
+      <ItemListItem>
+        <CriticReview {...args} />
+      </ItemListItem>
+      <ItemListItem>
+        <CriticReview
+          publication="Malt Review"
+          publishedAt="2 Sep 2024"
+          rating={80}
+        />
+      </ItemListItem>
+      <ItemListItem>
+        <CriticReview publication="Whisky Notes" rating={null} />
+      </ItemListItem>
+    </ItemList>
   ),
 };

--- a/apps/web/src/components/designSystem/components/criticReview.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/criticReview.stylex.tsx
@@ -58,9 +58,6 @@ const styles = stylex.create({
     width: "100%",
     paddingTop: "14px",
     paddingBottom: "14px",
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
   },
   heading: {
     display: "flex",

--- a/apps/web/src/components/designSystem/components/index.ts
+++ b/apps/web/src/components/designSystem/components/index.ts
@@ -131,8 +131,9 @@ export type {
   FormSectionProps,
   FormStepsProps,
 } from "./formLayout.stylex";
-export { ItemList, ItemRow } from "./itemList.stylex";
+export { ItemList, ItemListItem, ItemRow } from "./itemList.stylex";
 export type {
+  ItemListItemProps,
   ItemListProps,
   ItemListVariant,
   ItemRowProps,

--- a/apps/web/src/components/designSystem/components/itemList.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/itemList.stylex.tsx
@@ -18,6 +18,7 @@ export type ItemRowSize = "sm" | "md";
 export type ItemListProps = {
   ariaLabel: string;
   children: ReactNode;
+  showTopDivider?: boolean;
   variant?: ItemListVariant;
 };
 
@@ -25,6 +26,7 @@ export type ItemListProps = {
 export function ItemList({
   ariaLabel,
   children,
+  showTopDivider = true,
   variant = "plain",
 }: ItemListProps) {
   return (
@@ -32,11 +34,27 @@ export function ItemList({
       aria-label={ariaLabel}
       {...stylex.props(
         styles.list,
-        variant === "plain" ? styles.plainList : styles.surfaceList,
+        variant === "plain" && styles.plainList,
+        variant === "plain" && !showTopDivider && styles.withoutTopDivider,
+        variant === "surface" && styles.surfaceList,
       )}
     >
       {children}
     </ul>
+  );
+}
+
+export type ItemListItemProps = {
+  children: ReactNode;
+  id?: string;
+};
+
+/** Owns the divider for one custom row inside an ItemList. */
+export function ItemListItem({ children, id }: ItemListItemProps) {
+  return (
+    <li id={id} {...stylex.props(styles.row)}>
+      {children}
+    </li>
   );
 }
 
@@ -69,7 +87,7 @@ export function ItemRow({
   const hasLinkedContent = Boolean(href);
 
   return (
-    <li id={id} {...stylex.props(styles.row)}>
+    <ItemListItem id={id}>
       <div
         {...stylex.props(
           styles.content,
@@ -127,7 +145,7 @@ export function ItemRow({
         {end ? <div {...stylex.props(styles.end)}>{end}</div> : null}
         {action ? <div {...stylex.props(styles.action)}>{action}</div> : null}
       </div>
-    </li>
+    </ItemListItem>
   );
 }
 
@@ -141,6 +159,9 @@ const styles = stylex.create({
     borderTopWidth: "1px",
     borderTopStyle: "solid",
     borderTopColor: colors.hairline,
+  },
+  withoutTopDivider: {
+    borderTopWidth: 0,
   },
   surfaceList: {
     overflow: "hidden",

--- a/apps/web/src/components/designSystem/components/lists.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/lists.stylex.tsx
@@ -10,6 +10,7 @@ import {
   space,
 } from "../../../styles/tokens.stylex";
 import { ButtonLink, IconButton } from "./button.stylex";
+import { ItemList, ItemListItem } from "./itemList.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
 
@@ -148,9 +149,11 @@ export function RailList({
   children: ReactNode;
 }) {
   return (
-    <ul aria-label={ariaLabel} {...stylex.props(styles.railList)}>
-      {children}
-    </ul>
+    <div {...stylex.props(styles.railList)}>
+      <ItemList ariaLabel={ariaLabel} showTopDivider={false}>
+        {children}
+      </ItemList>
+    </div>
   );
 }
 
@@ -168,24 +171,26 @@ export function RailListItem({
   title,
 }: RailListItemProps) {
   return (
-    <li {...stylex.props(styles.railRow)}>
-      <div {...stylex.props(styles.railCopy)}>
-        {href ? (
-          <a
-            href={href}
-            {...stylex.props(styles.railTitle, styles.railTitleLink)}
-          >
-            {title}
-          </a>
-        ) : (
-          <span {...stylex.props(styles.railTitle)}>{title}</span>
-        )}
-        {metadata ? (
-          <span {...stylex.props(styles.railMetadata)}>{metadata}</span>
-        ) : null}
+    <ItemListItem>
+      <div {...stylex.props(styles.railRow)}>
+        <div {...stylex.props(styles.railCopy)}>
+          {href ? (
+            <a
+              href={href}
+              {...stylex.props(styles.railTitle, styles.railTitleLink)}
+            >
+              {title}
+            </a>
+          ) : (
+            <span {...stylex.props(styles.railTitle)}>{title}</span>
+          )}
+          {metadata ? (
+            <span {...stylex.props(styles.railMetadata)}>{metadata}</span>
+          ) : null}
+        </div>
+        {end ? <span {...stylex.props(styles.railEnd)}>{end}</span> : null}
       </div>
-      {end ? <span {...stylex.props(styles.railEnd)}>{end}</span> : null}
-    </li>
+    </ItemListItem>
   );
 }
 
@@ -303,14 +308,12 @@ const styles = stylex.create({
     lineHeight: 1.4,
   },
   railList: {
-    margin: 0,
     paddingTop: space.x1,
     paddingRight: space.x4,
     paddingBottom: space.x1,
     paddingLeft: space.x4,
     borderRadius: controlMetrics.radius,
     backgroundColor: colors.surface,
-    listStyle: "none",
   },
   railRow: {
     display: "flex",
@@ -319,12 +322,6 @@ const styles = stylex.create({
     gap: space.x3,
     paddingTop: "10px",
     paddingBottom: "10px",
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
-    ":last-child": {
-      borderBottomWidth: 0,
-    },
   },
   railCopy: {
     minWidth: 0,

--- a/apps/web/src/components/designSystem/components/tastingEntry.stories.tsx
+++ b/apps/web/src/components/designSystem/components/tastingEntry.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import { StoryCanvas, StoryStack } from "../storyFixtures.stylex";
+import { ItemList, ItemListItem } from "./itemList.stylex";
 import { RowMenu } from "./rowMenu.stylex";
 import { TastingEntry } from "./tastingEntry.stylex";
 
@@ -49,20 +50,26 @@ type Story = StoryObj<typeof meta>;
 export const Overview: Story = {
   render: (args) => (
     <StoryStack>
-      <TastingEntry {...args} />
-      <TastingEntry
-        {...args}
-        comment="A classic benchmark. The smoke never crowds out the fruit."
-        context={undefined}
-        members={[
-          {
-            href: "/bottles/lagavulin-16",
-            metadata: "Islay · 16 years · 43% ABV",
-            name: "Lagavulin 16-year-old",
-            ratingBand: "outstanding",
-          },
-        ]}
-      />
+      <ItemList ariaLabel="Tasting entry examples">
+        <ItemListItem>
+          <TastingEntry {...args} />
+        </ItemListItem>
+        <ItemListItem>
+          <TastingEntry
+            {...args}
+            comment="A classic benchmark. The smoke never crowds out the fruit."
+            context={undefined}
+            members={[
+              {
+                href: "/bottles/lagavulin-16",
+                metadata: "Islay · 16 years · 43% ABV",
+                name: "Lagavulin 16-year-old",
+                ratingBand: "outstanding",
+              },
+            ]}
+          />
+        </ItemListItem>
+      </ItemList>
       <TastingEntry {...args} surface />
     </StoryStack>
   ),

--- a/apps/web/src/components/designSystem/components/tastingEntry.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/tastingEntry.stylex.tsx
@@ -156,16 +156,12 @@ const styles = stylex.create({
   entry: {
     paddingTop: space.x4,
     paddingBottom: space.x4,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
   },
   surfaceEntry: {
     paddingTop: "22px",
     paddingRight: space.x6,
     paddingBottom: "22px",
     paddingLeft: space.x6,
-    borderBottomWidth: 0,
     borderRadius: controlMetrics.radius,
     backgroundColor: colors.surface,
   },

--- a/apps/web/src/components/designSystem/patterns/bottleCatalog.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/bottleCatalog.stylex.tsx
@@ -15,6 +15,8 @@ import {
   FacetGroup,
   FilterPanel,
   FilterQuery,
+  ItemList,
+  ItemListItem,
   ListToolbar,
   LoadingList,
   RatingMeasure,
@@ -89,9 +91,9 @@ export function BottleCatalogList({
         total={total}
       />
       {items.length ? (
-        <ul {...stylex.props(styles.list)}>
+        <ItemList ariaLabel="Bottle records" showTopDivider={false}>
           {items.map((item) => (
-            <li key={item.id} {...stylex.props(styles.listItem)}>
+            <ItemListItem key={item.id}>
               <BottleIdentityRow
                 brand={item.brand}
                 brandHref={item.brandHref}
@@ -104,9 +106,9 @@ export function BottleCatalogList({
                 name={item.name}
                 relatedReleases={item.relatedReleases}
               />
-            </li>
+            </ItemListItem>
           ))}
-        </ul>
+        </ItemList>
       ) : (
         <EmptyState
           action={
@@ -306,16 +308,6 @@ export function BottleCatalogLoading() {
 
 const styles = stylex.create({
   catalog: {
-    minWidth: 0,
-  },
-  list: {
-    display: "flex",
-    margin: 0,
-    padding: 0,
-    flexDirection: "column",
-    listStyle: "none",
-  },
-  listItem: {
     minWidth: 0,
   },
   measures: {

--- a/apps/web/src/components/designSystem/patterns/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/bottleOverview.stylex.tsx
@@ -17,6 +17,8 @@ import {
   CriticReview,
   FactList,
   hasVisibleFacts,
+  ItemList,
+  ItemListItem,
   RailList,
   RailListItem,
   SectionHeading,
@@ -80,14 +82,15 @@ export function BottleOverview({
                 </span>
               ) : null}
             </div>
-            <div>
+            <ItemList ariaLabel="Critic reviews">
               {criticReviews.map((review, index) => (
-                <CriticReview
-                  {...review}
+                <ItemListItem
                   key={`${review.publication}-${review.publishedAt ?? index}`}
-                />
+                >
+                  <CriticReview {...review} />
+                </ItemListItem>
               ))}
-            </div>
+            </ItemList>
           </section>
         ) : null}
 
@@ -96,11 +99,13 @@ export function BottleOverview({
             <SectionHeading count={tastingCount ?? tastings.length}>
               Tastings
             </SectionHeading>
-            <div>
+            <ItemList ariaLabel="Bottle tastings">
               {tastings.map((tasting, index) => (
-                <TastingEntry {...tasting} key={`${tasting.author}-${index}`} />
+                <ItemListItem key={`${tasting.author}-${index}`}>
+                  <TastingEntry {...tasting} />
+                </ItemListItem>
               ))}
-            </div>
+            </ItemList>
             {moreTastingsHref &&
             tastingCount !== undefined &&
             tastingCount > tastings.length ? (

--- a/apps/web/src/components/designSystem/patterns/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/entityCatalog.stylex.tsx
@@ -66,7 +66,7 @@ export function EntityCatalogList({
         sortOptions={sortOptions}
       />
       {items.length ? (
-        <ItemList ariaLabel={`${noun} records`}>
+        <ItemList ariaLabel={`${noun} records`} showTopDivider={false}>
           {items.map((item) => (
             <ItemRow
               end={<EntityMeasures item={item} />}

--- a/apps/web/src/components/designSystem/patterns/memberProfileContent.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/memberProfileContent.stylex.tsx
@@ -17,6 +17,8 @@ import {
   EmptyState,
   FacetGroup,
   FilterQuery,
+  ItemList,
+  ItemListItem,
   RowMenu,
   TastingEntry,
   type BottleIdentityRowProps,
@@ -66,9 +68,9 @@ export function MemberLibraryList({
         ) : null}
       </div>
       {items.length ? (
-        <ul {...stylex.props(styles.libraryList)}>
+        <ItemList ariaLabel="Library bottles" showTopDivider={false}>
           {items.map(({ actions, id, status, ...identity }) => (
-            <li key={id} {...stylex.props(styles.libraryRow)}>
+            <ItemListItem key={id}>
               <BottleIdentityRow
                 {...identity}
                 end={
@@ -82,9 +84,9 @@ export function MemberLibraryList({
                   ) : undefined
                 }
               />
-            </li>
+            </ItemListItem>
           ))}
-        </ul>
+        </ItemList>
       ) : (
         <EmptyState action={emptyAction} heading={emptyHeading}>
           {emptyDescription}
@@ -200,15 +202,19 @@ export function MemberActivityList({
   }
 
   return (
-    <div aria-label="Member activity" {...stylex.props(styles.activityList)}>
+    <ItemList ariaLabel="Member activity">
       {items.map((item) =>
         item.kind === "tasting" ? (
-          <TastingEntry key={item.id} {...item.tasting} />
+          <ItemListItem key={item.id}>
+            <TastingEntry {...item.tasting} />
+          </ItemListItem>
         ) : (
-          <CollectionActivity key={item.id} activity={item.activity} />
+          <ItemListItem key={item.id}>
+            <CollectionActivity activity={item.activity} />
+          </ItemListItem>
         ),
       )}
-    </div>
+    </ItemList>
   );
 }
 
@@ -235,18 +241,25 @@ function CollectionActivity({
         </div>
       </header>
       {activity.items.length ? (
-        <ul {...stylex.props(styles.collectionItems)}>
-          {activity.items.map(({ id, ...identity }) => (
-            <li key={id} {...stylex.props(styles.collectionItem)}>
-              <BottleIdentityRow {...identity} />
-            </li>
-          ))}
-          {hiddenCount ? (
-            <li {...stylex.props(styles.moreItems)}>
-              +{hiddenCount.toLocaleString("en-US")} more
-            </li>
-          ) : null}
-        </ul>
+        <div {...stylex.props(styles.collectionItems)}>
+          <ItemList
+            ariaLabel={`${activity.collectionName} additions`}
+            variant="surface"
+          >
+            {activity.items.map(({ id, ...identity }) => (
+              <ItemListItem key={id}>
+                <BottleIdentityRow {...identity} variant="surface" />
+              </ItemListItem>
+            ))}
+            {hiddenCount ? (
+              <ItemListItem>
+                <div {...stylex.props(styles.moreItems)}>
+                  +{hiddenCount.toLocaleString("en-US")} more
+                </div>
+              </ItemListItem>
+            ) : null}
+          </ItemList>
+        </div>
       ) : null}
     </article>
   );
@@ -272,14 +285,6 @@ const styles = stylex.create({
     letterSpacing: "-0.02em",
     lineHeight: 1.2,
   },
-  libraryList: { margin: 0, padding: 0, listStyle: "none" },
-  libraryRow: {
-    paddingTop: "14px",
-    paddingBottom: "14px",
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
-  },
   libraryEnd: { display: "flex", alignItems: "center", gap: space.x2 },
   filterContent: { display: "flex", flexDirection: "column", gap: space.x6 },
   railFilters: { display: "block", [NARROW]: { display: "none" } },
@@ -298,13 +303,9 @@ const styles = stylex.create({
     fontWeight: 600,
     cursor: "pointer",
   },
-  activityList: { display: "flex", minWidth: 0, flexDirection: "column" },
   collectionActivity: {
     paddingTop: space.x4,
     paddingBottom: space.x4,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
   },
   activityHeader: { display: "flex", minWidth: 0 },
   activityCopy: {
@@ -327,24 +328,13 @@ const styles = stylex.create({
     lineHeight: 1.35,
   },
   collectionItems: {
-    margin: 0,
     marginTop: space.x3,
-    paddingRight: space.x4,
-    paddingLeft: space.x4,
-    borderRadius: controlMetrics.radius,
-    backgroundColor: colors.surface,
-    listStyle: "none",
-  },
-  collectionItem: {
-    paddingTop: space.x3,
-    paddingBottom: space.x3,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
   },
   moreItems: {
     paddingTop: space.x2,
+    paddingRight: "18px",
     paddingBottom: space.x2,
+    paddingLeft: "18px",
     color: colors.inkMuted,
     fontFamily: fonts.data,
     fontSize: "10px",


### PR DESCRIPTION
List separators now come from `ItemList` and `ItemListItem` across libraries, catalogs, tastings, critic reviews, notifications, activity feeds, flights, release lists, and rail lists. This removes doubled borders and gives custom domain rows the same first, middle, and final-row behavior as standard `ItemRow` records.

`BottleIdentityRow`, `TastingEntry`, `CriticReview`, notification rows, collection activity, and rail rows now own only their content and surface treatment. `showTopDivider` lets a list join an existing toolbar or count divider without rendering a second line. Nested tasting-member dividers stay local because `TastingEntry` owns that inner collection.

Review starts in `itemList.stylex.tsx`; the wider call-site diff is the hard cutover to that shared boundary. The local database schema is inconsistent, so route-level local QA was unavailable. The equivalent plain and surface states were checked in Storybook at desktop and mobile widths.
