### PR TITLE
fix(web): prevent layout shifts during navigation

### DIFF
--- a/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
@@ -16,6 +16,7 @@ import {
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getEntityUrl } from "@peated/web/lib/urls";
 
 const DEFAULT_SORT = "-tastings";
 
@@ -170,7 +171,7 @@ function toCatalogItem(entity: Entity): EntityCatalogItem {
   ].filter((value): value is string => value !== null);
 
   return {
-    href: `/entities/${entity.id}`,
+    href: getEntityUrl(entity),
     id: entity.peatedId,
     metadata,
     name: entity.name,

--- a/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
@@ -70,7 +70,7 @@ export function ApplicationFooter({ stats }: { stats?: Outputs["stats"] }) {
       provenance="Edited by members · corrections welcome"
       referenceLinks={[
         {
-          href: "/entities/4263/codes",
+          href: "/bottlers/4263/codes",
           label: "SMWS distillery codes",
         },
       ]}

--- a/apps/web/src/app/(app)/_components/home/homeActivity.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/homeActivity.stylex.tsx
@@ -7,6 +7,7 @@ import { Fragment, useEffect } from "react";
 import { useEventListener } from "usehooks-ts";
 
 import {
+  AppLink,
   ButtonLink,
   EmptyState,
   ItemList,
@@ -82,16 +83,18 @@ function CollectionActivityItem({
           username={activity.createdBy.username}
         />
         <div {...stylex.props(styles.collectionCopy)}>
-          <a
+          <AppLink
             href={`/users/${activity.createdBy.username}`}
             {...stylex.props(styles.collectionAuthor)}
           >
             {activity.createdBy.username}
-          </a>
+          </AppLink>
           <span {...stylex.props(styles.collectionContext)}>
             added {formatBottleCount(activity.totalItems)} to{" "}
             {activity.collection.href ? (
-              <a href={activity.collection.href}>{activity.collection.name}</a>
+              <AppLink href={activity.collection.href}>
+                {activity.collection.name}
+              </AppLink>
             ) : (
               activity.collection.name
             )}

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -37,6 +37,7 @@ import {
 import { getBottleExpressionName } from "@peated/web/lib/bottleLabel";
 import { logTelemetryError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getEntityUrl } from "@peated/web/lib/urls";
 import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 type Bottle = Outputs["bottles"]["details"];
@@ -389,7 +390,7 @@ export function BottlePageFrameClient({
               : null
           }
           brand={bottle.brand.shortName || bottle.brand.name}
-          brandHref={`/entities/${bottle.brand.id}`}
+          brandHref={getEntityUrl({ id: bottle.brand.id, kind: "brand" })}
           detail={getBottleDetail(bottle)}
           id={bottle.peatedId}
           imageUrl={bottle.imageUrl}

--- a/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
@@ -16,6 +16,7 @@ import {
   requireReleaseFamilyAnchor,
   requireReleaseFamilyGroup,
 } from "@peated/web/lib/releaseFamily";
+import { getEntityUrl } from "@peated/web/lib/urls";
 
 import { BottleSection } from "../bottleSection.stylex";
 
@@ -60,7 +61,10 @@ export default async function BottleReleasesPage(props: {
             <ItemListItem key={bottle.id}>
               <BottleIdentityRow
                 brand={bottle.brand.name}
-                brandHref={`/entities/${bottle.brand.id}`}
+                brandHref={getEntityUrl({
+                  id: bottle.brand.id,
+                  kind: "brand",
+                })}
                 end={
                   bottle.medianScore !== null && bottle.scoreCount >= 20
                     ? `${bottle.medianScore} / 100`

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/loading.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/loading.tsx
@@ -1,5 +1,5 @@
-import { LoadingList } from "@peated/web/components/designSystem/components";
+import { EntityTabLoading } from "../entityTabLoading.stylex";
 
 export default function EntityBottlesLoading() {
-  return <LoadingList label="Loading entity bottles" rows={4} />;
+  return <EntityTabLoading label="Loading entity bottles" />;
 }

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
@@ -3,6 +3,7 @@ import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getEntityUrl } from "@peated/web/lib/urls";
 
 import { EntityBottleListClient } from "./entityBottleListClient.stylex";
 
@@ -40,7 +41,7 @@ export default async function EntityBottlesPage(props: {
           href={
             createBottleHref ??
             `/bottles/new?${new URLSearchParams({
-              returnTo: `/entities/${entity.id}/bottles`,
+              returnTo: `${getEntityUrl(entity)}/bottles`,
             }).toString()}`
           }
           size="sm"

--- a/apps/web/src/app/(app)/entities/[entityId]/codes/loading.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/codes/loading.tsx
@@ -1,5 +1,5 @@
-import { LoadingList } from "@peated/web/components/designSystem/components";
+import { EntityTabLoading } from "../entityTabLoading.stylex";
 
 export default function EntityCodesLoading() {
-  return <LoadingList label="Loading distillery codes" rows={4} />;
+  return <EntityTabLoading label="Loading distillery codes" section />;
 }

--- a/apps/web/src/app/(app)/entities/[entityId]/codes/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/codes/page.tsx
@@ -5,6 +5,7 @@ import {
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { logError } from "@peated/web/lib/log";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
+import { getEntityUrl } from "@peated/web/lib/urls";
 import { notFound } from "next/navigation";
 
 import { EntityCodes } from "./entityCodes.stylex";
@@ -60,7 +61,9 @@ export default async function EntityCodesPage(props: {
       rows.push({
         code,
         country: distiller?.country?.name ?? null,
-        href: distiller ? `/entities/${distiller.id}` : undefined,
+        href: distiller
+          ? getEntityUrl({ id: distiller.id, kind: "distillery" })
+          : undefined,
         name: distiller?.name ?? distillerName ?? "Unknown",
       });
     }
@@ -74,7 +77,7 @@ export default async function EntityCodesPage(props: {
     <EntityCodes
       entityName={entity.name}
       example={{
-        href: `/entities/${exampleDistiller.id}`,
+        href: getEntityUrl({ id: exampleDistiller.id, kind: "distillery" }),
         name: exampleDistiller.name,
       }}
       groups={groups}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -6,6 +6,7 @@ import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 
 import {
+  AppLink,
   BottleComparisonTable,
   ButtonLink,
   Card,
@@ -22,7 +23,7 @@ import {
 import { PageSection } from "@peated/web/components/designSystem/patterns/pageLayout.stylex";
 import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { parseDomain } from "@peated/web/lib/urls";
+import { getEntityUrl, parseDomain } from "@peated/web/lib/urls";
 import {
   colors,
   effects,
@@ -41,21 +42,21 @@ function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
     <>
       {entity.region ? (
         <>
-          <a
+          <AppLink
             href={`/locations/${entity.country.slug}/regions/${entity.region.slug}`}
             {...stylex.props(styles.factLink)}
           >
             {entity.region.name}
-          </a>
+          </AppLink>
           <span>, </span>
         </>
       ) : null}
-      <a
+      <AppLink
         href={`/locations/${entity.country.slug}`}
         {...stylex.props(styles.factLink)}
       >
         {entity.country.name}
-      </a>
+      </AppLink>
     </>
   ) : null;
 
@@ -150,6 +151,7 @@ function EntityBottleOverview({
   totalBottles: number;
 }) {
   const presentation = getEntityPresentation(entity);
+  const entityHref = getEntityUrl(entity);
   const ownsBottleModule =
     entity.kind === "brand" ||
     entity.kind === "bottler" ||
@@ -185,7 +187,7 @@ function EntityBottleOverview({
     const recordHref =
       createBottleHref ??
       `/bottles/new?${new URLSearchParams({
-        returnTo: `/entities/${entity.id}`,
+        returnTo: entityHref,
       }).toString()}`;
 
     return (
@@ -212,7 +214,7 @@ function EntityBottleOverview({
       count={bottleList.results.length}
       heading={presentation.bottleSectionLabel}
       intro={
-        <TextLink href={`/entities/${entity.id}/bottles?sort=-tastings`}>
+        <TextLink href={`${entityHref}/bottles?sort=-tastings`}>
           View all {totalBottles.toLocaleString("en-US")} bottles
         </TextLink>
       }

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { getEntityCurrentHref, getEntityTabs } from "./entityPageData";
+
+describe("getEntityTabs", () => {
+  it("uses the canonical public Entity route", () => {
+    expect(
+      getEntityTabs({
+        id: 4263,
+        kind: "bottler",
+        shortName: "SMWS",
+        totalBottles: 1_301,
+        totalTastings: 29,
+      }),
+    ).toEqual([
+      { href: "/bottlers/4263", label: "Overview" },
+      { count: 1_301, href: "/bottlers/4263/bottles", label: "Bottles" },
+      { count: 29, href: "/bottlers/4263/tastings", label: "Tastings" },
+      { href: "/bottlers/4263/codes", label: "Distillery codes" },
+    ]);
+  });
+});
+
+describe("getEntityCurrentHref", () => {
+  it("maps a Peated ID route to the canonical public route", () => {
+    expect(
+      getEntityCurrentHref(
+        { id: 4263, kind: "bottler", peatedId: "E4263" },
+        "/E4263",
+      ),
+    ).toBe("/bottlers/4263");
+  });
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -1,7 +1,12 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import type { PageTabItem } from "@peated/web/components/designSystem/components";
+import { getEntityUrl } from "@peated/web/lib/urls";
 
 export type Entity = Outputs["entities"]["details"];
+type EntityTabSource = Pick<
+  Entity,
+  "id" | "kind" | "shortName" | "totalBottles" | "totalTastings"
+>;
 
 const entityKindPresentation = {
   blender: {
@@ -49,8 +54,10 @@ export function getEntityLocationLabel(entity: Entity) {
     .join(" · ");
 }
 
-export function getEntityTabs(entity: Entity): [PageTabItem, ...PageTabItem[]] {
-  const baseUrl = `/entities/${entity.id}`;
+export function getEntityTabs(
+  entity: EntityTabSource,
+): [PageTabItem, ...PageTabItem[]] {
+  const baseUrl = getEntityUrl(entity);
   const tabs: [PageTabItem, ...PageTabItem[]] = [
     { href: baseUrl, label: "Overview" },
     {
@@ -70,4 +77,11 @@ export function getEntityTabs(entity: Entity): [PageTabItem, ...PageTabItem[]] {
   }
 
   return tabs;
+}
+
+export function getEntityCurrentHref(
+  entity: Pick<Entity, "id" | "kind" | "peatedId">,
+  pathname: string,
+) {
+  return pathname === `/${entity.peatedId}` ? getEntityUrl(entity) : pathname;
 }

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useState, type ReactNode } from "react";
 
 import {
+  AppLink,
   Button,
   ButtonLink,
   PageTabs,
@@ -20,9 +21,11 @@ import useAuth from "@peated/web/hooks/useAuth";
 import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";
 import { logTelemetryError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getEntityUrl } from "@peated/web/lib/urls";
 import { effects, space } from "../../../../styles/tokens.stylex";
 
 import {
+  getEntityCurrentHref,
   getEntityLocationLabel,
   getEntityPresentation,
   getEntityTabs,
@@ -196,9 +199,7 @@ export function EntityPageFrameClient({
   const entity = entityQuery.data;
   const createBottleHref = getEntityBottleCreateHref(entity);
   const presentation = getEntityPresentation(entity);
-  const overviewHref = `/entities/${entity.id}`;
-  const currentHref =
-    pathname === `/${entity.peatedId}` ? overviewHref : pathname;
+  const currentHref = getEntityCurrentHref(entity, pathname);
 
   return (
     <div {...stylex.props(styles.page)}>
@@ -230,12 +231,12 @@ export function EntityPageFrameClient({
         menu={<EntityActions entity={entity} />}
         parent={
           owner ? (
-            <a
-              href={`/entities/${owner.id}`}
+            <AppLink
+              href={getEntityUrl(owner)}
               {...stylex.props(styles.ownerLink)}
             >
               Owned by {owner.shortName || owner.name}
-            </a>
+            </AppLink>
           ) : undefined
         }
         specs={[

--- a/apps/web/src/app/(app)/entities/[entityId]/entityTabLoading.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityTabLoading.stylex.tsx
@@ -1,0 +1,42 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { LoadingList } from "@peated/web/components/designSystem/components";
+import { space } from "../../../../styles/tokens.stylex";
+
+export function EntityTabLoading({
+  label,
+  section = false,
+}: {
+  label: string;
+  section?: boolean;
+}) {
+  if (section) {
+    return (
+      <div {...stylex.props(styles.sectionContent)}>
+        <div {...stylex.props(styles.sectionBody)}>
+          <LoadingList label={label} rows={4} />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div {...stylex.props(styles.content)}>
+      <LoadingList label={label} rows={4} />
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  content: {
+    minWidth: 0,
+    paddingTop: space.x6,
+  },
+  sectionContent: {
+    minWidth: 0,
+    paddingTop: space.x2,
+  },
+  sectionBody: {
+    marginTop: space.x8,
+  },
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/tastings/loading.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/tastings/loading.tsx
@@ -1,5 +1,5 @@
-import { LoadingList } from "@peated/web/components/designSystem/components";
+import { EntityTabLoading } from "../entityTabLoading.stylex";
 
 export default function EntityTastingsLoading() {
-  return <LoadingList label="Loading entity tastings" rows={4} />;
+  return <EntityTabLoading label="Loading entity tastings" />;
 }

--- a/apps/web/src/app/(app)/flights/[flightId]/page.tsx
+++ b/apps/web/src/app/(app)/flights/[flightId]/page.tsx
@@ -15,6 +15,7 @@ import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { summarize } from "@peated/web/lib/markdown";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
 import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
+import { getEntityUrl } from "@peated/web/lib/urls";
 import { cache } from "react";
 
 import { FlightActions } from "./flightActions";
@@ -66,7 +67,10 @@ export default async function FlightPage(props: {
               <ItemListItem key={bottle.id}>
                 <BottleIdentityRow
                   brand={bottle.brand.name}
-                  brandHref={`/entities/${bottle.brand.id}`}
+                  brandHref={getEntityUrl({
+                    id: bottle.brand.id,
+                    kind: "brand",
+                  })}
                   end={
                     <ButtonLink
                       href={getAddBottleHref({

--- a/apps/web/src/app/(app)/locations/locationLists.tsx
+++ b/apps/web/src/app/(app)/locations/locationLists.tsx
@@ -6,6 +6,7 @@ import {
   EmptyState,
   type DataTableColumn,
 } from "@peated/web/components/designSystem/components";
+import { getEntityUrl } from "@peated/web/lib/urls";
 
 type LocationListItem = {
   name: string;
@@ -102,7 +103,7 @@ export function LocationDistillerList({
         <DataTable
           caption={`Distillers in ${name}`}
           columns={distillerColumns}
-          getHref={(item) => `/entities/${item.id}`}
+          getHref={(item) => getEntityUrl(item)}
           getKey={(item) => item.id}
           items={items}
         />

--- a/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from "react";
 
 import CountryMapIcon from "@peated/web/components/countryMapIcon";
 import {
+  AppLink,
   PageTabs,
   SpecStrip,
 } from "@peated/web/components/designSystem/components";
@@ -67,7 +68,11 @@ export function LocationPageFrame({
         description={description}
         eyebrow={country ? "Whisky region" : "Whisky country"}
         identity={visual ? <LocationVisual visual={visual} /> : undefined}
-        parent={country ? <a href={country.href}>{country.name}</a> : undefined}
+        parent={
+          country ? (
+            <AppLink href={country.href}>{country.name}</AppLink>
+          ) : undefined
+        }
         title={name}
       />
       <div {...stylex.props(styles.specs)}>

--- a/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
+++ b/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
@@ -7,6 +7,7 @@ import { X } from "lucide-react";
 import { useState } from "react";
 
 import {
+  AppLink,
   Button,
   CursorPager,
   EmptyState,
@@ -146,21 +147,21 @@ export function NotificationList({
                 <div {...stylex.props(styles.copy)}>
                   <div {...stylex.props(styles.message)}>
                     {from ? (
-                      <a
+                      <AppLink
                         href={`/users/${from.username}`}
                         {...stylex.props(styles.author)}
                       >
                         {from.username}
-                      </a>
+                      </AppLink>
                     ) : null}{" "}
                     {href ? (
-                      <a
+                      <AppLink
                         href={href}
                         onClick={() => markRead(notification.id)}
                         {...stylex.props(styles.target)}
                       >
                         {getNotificationMessage(notification)}
-                      </a>
+                      </AppLink>
                     ) : (
                       getNotificationMessage(notification)
                     )}

--- a/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
@@ -1,3 +1,4 @@
+import { AppLink } from "@peated/web/components/designSystem/components";
 import {
   PageHeader,
   PageSection,
@@ -51,9 +52,9 @@ export default async function TastingPage(props: {
       <PageHeader
         eyebrow="Tasting record"
         parent={
-          <a href={`/users/${tasting.createdBy.username}`}>
+          <AppLink href={`/users/${tasting.createdBy.username}`}>
             {tasting.createdBy.username}
-          </a>
+          </AppLink>
         }
         title={getBottlePlainTextIdentity(tasting.bottle)}
       />

--- a/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
@@ -27,6 +27,7 @@ import { getBottleExpressionName } from "@peated/web/lib/bottleLabel";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getEntityUrl } from "@peated/web/lib/urls";
 import { useProfile } from "../profileContext";
 
 type Activity = Outputs["users"]["activity"]["list"]["results"][number];
@@ -150,7 +151,10 @@ function toActivityItem(activity: Activity): MemberActivityItem {
         id: activity.id,
         items: activity.items.map((entry) => ({
           brand: entry.bottle.brand.shortName || entry.bottle.brand.name,
-          brandHref: `/entities/${entry.bottle.brand.id}`,
+          brandHref: getEntityUrl({
+            id: entry.bottle.brand.id,
+            kind: "brand",
+          }),
           href: `/bottles/${entry.bottle.id}`,
           id: String(entry.id),
           imageUrl: entry.imageUrl ?? entry.bottle.imageUrl,

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
@@ -22,6 +22,7 @@ import { PageColumns } from "@peated/web/components/designSystem/patterns/pageLa
 import { getBottleExpressionName } from "@peated/web/lib/bottleLabel";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getEntityUrl } from "@peated/web/lib/urls";
 import { colors, fonts, space } from "../../../../../styles/tokens.stylex";
 import { useProfile } from "../profileContext";
 
@@ -347,7 +348,7 @@ function toLibraryItem(
         ]
       : undefined,
     brand: bottle.brand.shortName || bottle.brand.name,
-    brandHref: `/entities/${bottle.brand.id}`,
+    brandHref: getEntityUrl({ id: bottle.brand.id, kind: "brand" }),
     href: `/bottles/${bottle.id}`,
     id: String(entry.id),
     imageUrl: entry.imageUrl ?? bottle.imageUrl,

--- a/apps/web/src/components/designSystem/components/appLink.test.ts
+++ b/apps/web/src/components/designSystem/components/appLink.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { isInternalAppHref } from "./appLink";
+
+describe("isInternalAppHref", () => {
+  it.each(["/", "/bottles/123", "/users/example?tab=library"])(
+    "recognizes the internal route %s",
+    (href) => {
+      expect(isInternalAppHref(href)).toBe(true);
+    },
+  );
+
+  it.each([
+    "//cdn.example.com/image.jpg",
+    "https://example.com",
+    "mailto:hello@example.com",
+    "#main-content",
+  ])("leaves the non-app target %s to the browser", (href) => {
+    expect(isInternalAppHref(href)).toBe(false);
+  });
+});

--- a/apps/web/src/components/designSystem/components/appLink.tsx
+++ b/apps/web/src/components/designSystem/components/appLink.tsx
@@ -1,0 +1,34 @@
+import NextLink from "next/link";
+import {
+  forwardRef,
+  type AnchorHTMLAttributes,
+  type ForwardedRef,
+} from "react";
+
+export type AppLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+  prefetch?: boolean;
+};
+
+export function isInternalAppHref(href: string) {
+  return href.startsWith("/") && !href.startsWith("//");
+}
+
+/** Uses client navigation for app routes and native anchors for other targets. */
+export const AppLink = forwardRef(function AppLink(
+  { children, download, href, prefetch = false, ...props }: AppLinkProps,
+  ref: ForwardedRef<HTMLAnchorElement>,
+) {
+  if (!href || !isInternalAppHref(href) || download !== undefined) {
+    return (
+      <a {...props} download={download} href={href} ref={ref}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <NextLink {...props} href={href} prefetch={prefetch} ref={ref}>
+      {children}
+    </NextLink>
+  );
+});

--- a/apps/web/src/components/designSystem/components/applicationHeader.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/applicationHeader.stylex.tsx
@@ -11,6 +11,7 @@ import { Menu as MenuIcon, Search, X } from "lucide-react";
 import { Fragment, useEffect, useRef, useState, type ReactNode } from "react";
 
 import { colors, effects, fonts, space } from "../../../styles/tokens.stylex";
+import { AppLink } from "./appLink";
 import { IconButton } from "./button.stylex";
 import {
   isCurrentNavigationHref,
@@ -126,7 +127,7 @@ export function ApplicationHeader({
               variant="text"
             />
           </div>
-          <a
+          <AppLink
             href={brandHref}
             {...stylex.props(
               styles.brand,
@@ -134,7 +135,7 @@ export function ApplicationHeader({
             )}
           >
             {brand}
-          </a>
+          </AppLink>
           {navigationPlacement === "inline" ? (
             <div {...stylex.props(styles.inlineNavigation)}>
               <NavigationTabs
@@ -297,7 +298,7 @@ function AccountMenuItem({
   }
 
   return (
-    <a
+    <AppLink
       aria-current={current ? "page" : undefined}
       href={item.href}
       {...stylex.props(
@@ -307,7 +308,7 @@ function AccountMenuItem({
       )}
     >
       {content}
-    </a>
+    </AppLink>
   );
 }
 
@@ -326,7 +327,7 @@ function HeaderDrawerGroup({
       <ul {...stylex.props(styles.drawerList)}>
         {items.map((item) => (
           <li key={item.href} {...stylex.props(styles.drawerListItem)}>
-            <a
+            <AppLink
               aria-current={
                 isCurrentNavigationHref(currentHref, item.href)
                   ? "page"
@@ -340,7 +341,7 @@ function HeaderDrawerGroup({
               )}
             >
               {item.label}
-            </a>
+            </AppLink>
             {item.count !== undefined ? (
               <span {...stylex.props(styles.drawerCount)}>
                 {item.count.toLocaleString("en-US")}

--- a/apps/web/src/components/designSystem/components/bottleComparisonTable.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/bottleComparisonTable.stylex.tsx
@@ -2,6 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import { type ReactNode, useId } from "react";
 
 import { colors, effects, fonts, space } from "../../../styles/tokens.stylex";
+import { AppLink } from "./appLink";
 import { linkedRowStyles } from "./linkedRow.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
@@ -77,7 +78,7 @@ export function BottleComparisonTable({
             >
               <th scope="row" {...stylex.props(styles.nameCell)}>
                 {row.href ? (
-                  <a
+                  <AppLink
                     href={row.href}
                     {...stylex.props(
                       styles.name,
@@ -86,7 +87,7 @@ export function BottleComparisonTable({
                     )}
                   >
                     {row.name}
-                  </a>
+                  </AppLink>
                 ) : (
                   <span {...stylex.props(styles.name)}>{row.name}</span>
                 )}

--- a/apps/web/src/components/designSystem/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/bottleIdentityRow.stylex.tsx
@@ -8,6 +8,7 @@ import {
   fonts,
   space,
 } from "../../../styles/tokens.stylex";
+import { AppLink } from "./appLink";
 import type { ItemListVariant } from "./itemList.stylex";
 import { linkedRowStyles } from "./linkedRow.stylex";
 
@@ -124,9 +125,6 @@ export function BottleIdentityRow({
   relatedReleases,
   variant = "plain",
 }: BottleIdentityRowProps) {
-  const Name = href ? "a" : "span";
-  const Brand = brandHref ? "a" : "span";
-
   return (
     <div
       {...stylex.props(
@@ -142,28 +140,36 @@ export function BottleIdentityRow({
       <BottleVisual imageUrl={imageUrl} />
       <div {...stylex.props(styles.copy)}>
         {brand ? (
-          <Brand
-            href={brandHref}
-            {...stylex.props(
-              styles.brand,
-              Boolean(brandHref) && styles.brandLink,
-              Boolean(brandHref) && linkedRowStyles.nestedAction,
-            )}
-          >
-            {brand}
-          </Brand>
+          brandHref ? (
+            <AppLink
+              href={brandHref}
+              {...stylex.props(
+                styles.brand,
+                styles.brandLink,
+                linkedRowStyles.nestedAction,
+              )}
+            >
+              {brand}
+            </AppLink>
+          ) : (
+            <span {...stylex.props(styles.brand)}>{brand}</span>
+          )
         ) : null}
         <div {...stylex.props(styles.nameLine)}>
-          <Name
-            href={href}
-            {...stylex.props(
-              styles.name,
-              Boolean(href) && styles.nameLink,
-              Boolean(href) && linkedRowStyles.primaryLink,
-            )}
-          >
-            {name}
-          </Name>
+          {href ? (
+            <AppLink
+              href={href}
+              {...stylex.props(
+                styles.name,
+                styles.nameLink,
+                linkedRowStyles.primaryLink,
+              )}
+            >
+              {name}
+            </AppLink>
+          ) : (
+            <span {...stylex.props(styles.name)}>{name}</span>
+          )}
           {isLibrary ? (
             <span
               aria-label="In Library"
@@ -196,7 +202,7 @@ export function BottleIdentityRow({
           </div>
         ) : null}
         {relatedReleases && relatedReleases.count > 1 ? (
-          <a
+          <AppLink
             href={relatedReleases.href}
             {...stylex.props(
               styles.relatedReleases,
@@ -204,7 +210,7 @@ export function BottleIdentityRow({
             )}
           >
             {relatedReleases.count.toLocaleString("en-US")} related releases
-          </a>
+          </AppLink>
         ) : null}
       </div>
       {end ? <div {...stylex.props(styles.end)}>{end}</div> : null}

--- a/apps/web/src/components/designSystem/components/button.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/button.stylex.tsx
@@ -1,9 +1,5 @@
 import * as stylex from "@stylexjs/stylex";
-import type {
-  AnchorHTMLAttributes,
-  ButtonHTMLAttributes,
-  ReactNode,
-} from "react";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
 import { forwardRef } from "react";
 
 import {
@@ -13,6 +9,7 @@ import {
   fonts,
   space,
 } from "../../../styles/tokens.stylex";
+import { AppLink, type AppLinkProps } from "./appLink";
 
 const REDUCED_MOTION = "@media (prefers-reduced-motion: reduce)";
 
@@ -79,10 +76,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
   },
 );
 
-export type ButtonLinkProps = Omit<
-  AnchorHTMLAttributes<HTMLAnchorElement>,
-  "className" | "style"
-> & {
+export type ButtonLinkProps = Omit<AppLinkProps, "className" | "style"> & {
   align?: "center" | "start";
   fullWidth?: boolean;
   size?: ButtonSize;
@@ -99,7 +93,7 @@ export function ButtonLink({
   ...props
 }: ButtonLinkProps) {
   return (
-    <a
+    <AppLink
       {...props}
       data-size={size}
       data-variant={variant}
@@ -115,7 +109,7 @@ export function ButtonLink({
       )}
     >
       {children}
-    </a>
+    </AppLink>
   );
 }
 

--- a/apps/web/src/components/designSystem/components/card.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/card.stylex.tsx
@@ -1,10 +1,5 @@
 import * as stylex from "@stylexjs/stylex";
-import type {
-  AnchorHTMLAttributes,
-  CSSProperties,
-  HTMLAttributes,
-  ReactNode,
-} from "react";
+import type { CSSProperties, HTMLAttributes, ReactNode } from "react";
 
 import {
   colors,
@@ -12,6 +7,7 @@ import {
   effects,
   space,
 } from "../../../styles/tokens.stylex";
+import { AppLink, type AppLinkProps } from "./appLink";
 
 export type CardProps = HTMLAttributes<HTMLDivElement> & {
   appearance?: "outlined" | "surface";
@@ -49,7 +45,7 @@ export function Card({
   );
 }
 
-export type CardLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
+export type CardLinkProps = AppLinkProps & {
   appearance?: "outlined" | "surface";
   children: ReactNode;
   href: string;
@@ -74,13 +70,13 @@ export function CardLink({
   );
 
   return (
-    <a
+    <AppLink
       {...props}
       className={joinClassNames(cardProps.className, className)}
       style={mergeStyles(cardProps.style, style)}
     >
       {children}
-    </a>
+    </AppLink>
   );
 }
 
@@ -90,20 +86,20 @@ export function CardPrimaryLink({
   className,
   style,
   ...props
-}: AnchorHTMLAttributes<HTMLAnchorElement> & {
+}: AppLinkProps & {
   children: ReactNode;
   href: string;
 }) {
   const linkProps = stylex.props(styles.primaryLink);
 
   return (
-    <a
+    <AppLink
       {...props}
       className={joinClassNames(linkProps.className, className)}
       style={mergeStyles(linkProps.style, style)}
     >
       {children}
-    </a>
+    </AppLink>
   );
 }
 
@@ -113,20 +109,20 @@ export function CardActionLink({
   className,
   style,
   ...props
-}: AnchorHTMLAttributes<HTMLAnchorElement> & {
+}: AppLinkProps & {
   children: ReactNode;
   href: string;
 }) {
   const actionProps = stylex.props(styles.nestedAction);
 
   return (
-    <a
+    <AppLink
       {...props}
       className={joinClassNames(actionProps.className, className)}
       style={mergeStyles(actionProps.style, style)}
     >
       {children}
-    </a>
+    </AppLink>
   );
 }
 

--- a/apps/web/src/components/designSystem/components/dataTable.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/dataTable.stylex.tsx
@@ -2,6 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import { colors, fonts, space } from "../../../styles/tokens.stylex";
+import { AppLink } from "./appLink";
 import { linkedRowStyles } from "./linkedRow.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
@@ -74,7 +75,7 @@ export function DataTable<Item>({
                     )}
                   >
                     {index === 0 && href ? (
-                      <a
+                      <AppLink
                         href={href}
                         {...stylex.props(
                           styles.rowLink,
@@ -82,7 +83,7 @@ export function DataTable<Item>({
                         )}
                       >
                         {column.cell(item)}
-                      </a>
+                      </AppLink>
                     ) : (
                       column.cell(item)
                     )}

--- a/apps/web/src/components/designSystem/components/index.ts
+++ b/apps/web/src/components/designSystem/components/index.ts
@@ -10,6 +10,8 @@ export type {
   HeaderAccountItem,
   HeaderNavigationItem,
 } from "./applicationHeader.stylex";
+export { AppLink, isInternalAppHref } from "./appLink";
+export type { AppLinkProps } from "./appLink";
 export { Avatar } from "./avatar.stylex";
 export type { AvatarProps, AvatarSize } from "./avatar.stylex";
 export { BadgeImage } from "./badgeImage.stylex";

--- a/apps/web/src/components/designSystem/components/itemList.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/itemList.stylex.tsx
@@ -8,6 +8,7 @@ import {
   fonts,
   space,
 } from "../../../styles/tokens.stylex";
+import { AppLink } from "./appLink";
 import { linkedRowStyles } from "./linkedRow.stylex";
 
 const MOBILE = "@media (max-width: 559px)";
@@ -108,7 +109,7 @@ export function ItemRow({
         ) : null}
         <div {...stylex.props(styles.copy)}>
           {href ? (
-            <a
+            <AppLink
               href={href}
               {...stylex.props(
                 styles.title,
@@ -117,7 +118,7 @@ export function ItemRow({
               )}
             >
               {title}
-            </a>
+            </AppLink>
           ) : (
             <span
               {...stylex.props(

--- a/apps/web/src/components/designSystem/components/lists.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/lists.stylex.tsx
@@ -9,6 +9,7 @@ import {
   fonts,
   space,
 } from "../../../styles/tokens.stylex";
+import { AppLink } from "./appLink";
 import { ButtonLink, IconButton } from "./button.stylex";
 import { ItemList, ItemListItem } from "./itemList.stylex";
 
@@ -175,12 +176,12 @@ export function RailListItem({
       <div {...stylex.props(styles.railRow)}>
         <div {...stylex.props(styles.railCopy)}>
           {href ? (
-            <a
+            <AppLink
               href={href}
               {...stylex.props(styles.railTitle, styles.railTitleLink)}
             >
               {title}
-            </a>
+            </AppLink>
           ) : (
             <span {...stylex.props(styles.railTitle)}>{title}</span>
           )}

--- a/apps/web/src/components/designSystem/components/navigation.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/navigation.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
 import { colors, effects, fonts, space } from "../../../styles/tokens.stylex";
+import { AppLink } from "./appLink";
 
 const PERSONAL_FOLDS = "@media (max-width: 959px)";
 const NAV_SCROLLS = "@media (max-width: 759px)";
@@ -65,13 +66,13 @@ function NavigationLink({
   item: NavigationItem;
 }) {
   return (
-    <a
+    <AppLink
       aria-current={current ? "page" : undefined}
       href={item.href}
       {...stylex.props(styles.link, current && styles.currentLink)}
     >
       {item.label}
-    </a>
+    </AppLink>
   );
 }
 

--- a/apps/web/src/components/designSystem/components/pageTabs.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/pageTabs.stylex.tsx
@@ -1,4 +1,5 @@
 import * as stylex from "@stylexjs/stylex";
+import Link from "next/link";
 
 import { colors, effects, fonts, space } from "../../../styles/tokens.stylex";
 
@@ -22,7 +23,7 @@ export function PageTabs({ ariaLabel, currentHref, items }: PageTabsProps) {
         const current = item.href === currentHref;
 
         return (
-          <a
+          <Link
             aria-current={current ? "page" : undefined}
             href={item.href}
             key={item.href}
@@ -34,7 +35,7 @@ export function PageTabs({ ariaLabel, currentHref, items }: PageTabsProps) {
                 {item.count.toLocaleString("en-US")}
               </span>
             ) : null}
-          </a>
+          </Link>
         );
       })}
     </nav>

--- a/apps/web/src/components/designSystem/components/rowMenu.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/rowMenu.stylex.tsx
@@ -10,6 +10,7 @@ import {
   effects,
   fonts,
 } from "../../../styles/tokens.stylex";
+import { AppLink } from "./appLink";
 
 const PHONE = "@media (max-width: 480px)";
 
@@ -93,7 +94,7 @@ export function RowMenu({
                   >
                     {({ disabled, focus }) =>
                       item.href ? (
-                        <a
+                        <AppLink
                           href={item.href}
                           {...stylex.props(
                             styles.item,
@@ -102,7 +103,7 @@ export function RowMenu({
                           )}
                         >
                           {item.label}
-                        </a>
+                        </AppLink>
                       ) : (
                         <button
                           onClick={item.onSelect}

--- a/apps/web/src/components/designSystem/components/searchResults.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/searchResults.stylex.tsx
@@ -8,6 +8,7 @@ import {
   fonts,
   space,
 } from "../../../styles/tokens.stylex";
+import { AppLink } from "./appLink";
 import { Button } from "./button.stylex";
 import { FloatingPanel } from "./feedback.stylex";
 import { RatingMeasure, type BandCounts } from "./scoring.stylex";
@@ -141,7 +142,7 @@ export function SearchResults({
       {visibleContribution ? (
         <>
           <div aria-hidden="true" {...stylex.props(styles.contributionRule)} />
-          <a
+          <AppLink
             href={visibleContribution.href}
             {...stylex.props(styles.contribution)}
           >
@@ -151,7 +152,7 @@ export function SearchResults({
             <strong {...stylex.props(styles.contributionAction)}>
               {visibleContribution.label} →
             </strong>
-          </a>
+          </AppLink>
         </>
       ) : null}
     </div>
@@ -206,7 +207,7 @@ function SearchResultsGroup({
       <ul {...stylex.props(styles.list)}>
         {group.items.map((item) => (
           <li key={item.id} {...stylex.props(styles.listItem)}>
-            <a
+            <AppLink
               href={item.href}
               id={
                 optionIdPrefix
@@ -245,19 +246,19 @@ function SearchResultsGroup({
                   <ResultMeasures measures={item.measures} />
                 </span>
               ) : null}
-            </a>
+            </AppLink>
           </li>
         ))}
       </ul>
       {group.moreHref ? (
-        <a href={group.moreHref} {...stylex.props(styles.more)}>
+        <AppLink href={group.moreHref} {...stylex.props(styles.more)}>
           <span>
             {remaining === undefined || remaining === 0
               ? "More results"
               : `${remaining.toLocaleString("en-US")} more ${group.label.toLowerCase()}`}
           </span>
           <strong>{group.moreLabel ?? "See all"} →</strong>
-        </a>
+        </AppLink>
       ) : null}
     </section>
   );

--- a/apps/web/src/components/designSystem/components/siteFooter.stories.tsx
+++ b/apps/web/src/components/designSystem/components/siteFooter.stories.tsx
@@ -52,7 +52,7 @@ const meta = {
     groups,
     provenance: "Community-edited · corrections welcome",
     referenceLinks: [
-      { href: "/entities/4263/codes", label: "SMWS distillery codes" },
+      { href: "/bottlers/4263/codes", label: "SMWS distillery codes" },
     ],
     statement:
       "A record of every whisky bottling, what the critics said, and what the people who drank it said.",

--- a/apps/web/src/components/designSystem/components/siteFooter.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/siteFooter.stylex.tsx
@@ -2,6 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import { colors, effects, fonts, space } from "../../../styles/tokens.stylex";
+import { AppLink } from "./appLink";
 
 const COMPACT = "@media (max-width: 639px)";
 
@@ -78,9 +79,9 @@ export function SiteFooter({
 
 function FooterAnchor({ link }: { link: FooterLink }) {
   return (
-    <a href={link.href} {...stylex.props(styles.footerLink)}>
+    <AppLink href={link.href} {...stylex.props(styles.footerLink)}>
       {link.label}
-    </a>
+    </AppLink>
   );
 }
 

--- a/apps/web/src/components/designSystem/components/tastingEntry.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/tastingEntry.stylex.tsx
@@ -8,6 +8,7 @@ import {
   fonts,
   space,
 } from "../../../styles/tokens.stylex";
+import { AppLink } from "./appLink";
 import { BandMark, type RatingBand } from "./scoring.stylex";
 
 export type TastingEntryMember = {
@@ -50,12 +51,12 @@ export function TastingEntry({
         {leading}
         <div {...stylex.props(styles.headerCopy)}>
           {authorHref ? (
-            <a
+            <AppLink
               href={authorHref}
               {...stylex.props(styles.author, styles.authorLink)}
             >
               {author}
-            </a>
+            </AppLink>
           ) : (
             <strong {...stylex.props(styles.author)}>{author}</strong>
           )}
@@ -79,12 +80,12 @@ export function TastingEntry({
           >
             <div {...stylex.props(styles.memberCopy)}>
               {member.href ? (
-                <a
+                <AppLink
                   href={member.href}
                   {...stylex.props(styles.name, styles.nameLink)}
                 >
                   {member.name}
-                </a>
+                </AppLink>
               ) : (
                 <span {...stylex.props(styles.name)}>{member.name}</span>
               )}
@@ -141,13 +142,13 @@ function TastingDescription({ member }: { member: TastingEntryMember }) {
   return (
     <>
       <span {...stylex.props(styles.descriptionPreview)}>{preview}</span>
-      <a
+      <AppLink
         aria-label={`Read the full tasting notes for ${member.name}`}
         href={member.descriptionHref}
         {...stylex.props(styles.descriptionLink)}
       >
         Read more <span aria-hidden="true">→</span>
-      </a>
+      </AppLink>
     </>
   );
 }

--- a/apps/web/src/components/designSystem/components/textLink.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/textLink.stylex.tsx
@@ -1,10 +1,10 @@
 import * as stylex from "@stylexjs/stylex";
-import type { AnchorHTMLAttributes } from "react";
 
 import { colors, effects, fonts } from "../../../styles/tokens.stylex";
+import { AppLink, type AppLinkProps } from "./appLink";
 
 export type TextLinkProps = Omit<
-  AnchorHTMLAttributes<HTMLAnchorElement>,
+  AppLinkProps,
   "href" | "className" | "style"
 > & {
   href: string;
@@ -19,13 +19,13 @@ export function TextLink({
   ...props
 }: TextLinkProps) {
   return (
-    <a
+    <AppLink
       href={href}
       {...props}
       {...stylex.props(styles.link, size === "sm" && styles.small)}
     >
       {children}
-    </a>
+    </AppLink>
   );
 }
 

--- a/apps/web/src/components/designSystem/patterns/bottleCatalog.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/bottleCatalog.stylex.tsx
@@ -4,7 +4,6 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 import { useId } from "react";
 
-import { foundationStyles } from "../../../styles/foundations.stylex";
 import { colors, fonts, space } from "../../../styles/tokens.stylex";
 import {
   BottleIdentityRow,
@@ -18,13 +17,13 @@ import {
   ItemList,
   ItemListItem,
   ListToolbar,
-  LoadingList,
   RatingMeasure,
   Select,
   TextInput,
   type BandCounts,
   type ListSortOption,
 } from "../components";
+import { CatalogPageLoading } from "./catalogPage.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
 const NARROW = "@media (max-width: 759px)";
@@ -296,14 +295,7 @@ function FilterSelect({
 }
 
 export function BottleCatalogLoading() {
-  return (
-    <section aria-label="Bottle catalog" {...stylex.props(styles.catalog)}>
-      <h1 {...stylex.props(foundationStyles.pageTitle)}>Bottles</h1>
-      <div {...stylex.props(styles.loading)}>
-        <LoadingList label="Loading bottles" rows={4} />
-      </div>
-    </section>
-  );
+  return <CatalogPageLoading title="Bottles" />;
 }
 
 const styles = stylex.create({
@@ -342,8 +334,5 @@ const styles = stylex.create({
     [NARROW]: {
       gridColumn: "1 / -1",
     },
-  },
-  loading: {
-    marginTop: space.x6,
   },
 });

--- a/apps/web/src/components/designSystem/patterns/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/bottleOverview.stylex.tsx
@@ -14,6 +14,7 @@ import type {
   TastingEntryProps,
 } from "../components";
 import {
+  AppLink,
   CriticReview,
   FactList,
   hasVisibleFacts,
@@ -109,9 +110,12 @@ export function BottleOverview({
             {moreTastingsHref &&
             tastingCount !== undefined &&
             tastingCount > tastings.length ? (
-              <a href={moreTastingsHref} {...stylex.props(styles.moreLink)}>
+              <AppLink
+                href={moreTastingsHref}
+                {...stylex.props(styles.moreLink)}
+              >
                 Show all {tastingCount.toLocaleString("en-US")} tastings →
-              </a>
+              </AppLink>
             ) : null}
           </section>
         ) : null}

--- a/apps/web/src/components/designSystem/patterns/bottlePageHeader.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/bottlePageHeader.stylex.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../../styles/tokens.stylex";
 import type { BandStackProps, ScoreProps, SpecStripCells } from "../components";
 import {
+  AppLink,
   BandStack,
   BottleVisual,
   Chip,
@@ -61,7 +62,6 @@ export function BottlePageHeader({
   score,
   specs,
 }: BottlePageHeaderProps) {
-  const Brand = brandHref ? "a" : "span";
   const hasActions = Boolean(actions || menu);
   const hasMeasures = Boolean(score || bands);
 
@@ -85,9 +85,13 @@ export function BottlePageHeader({
             size="lg"
           />
           <div {...stylex.props(styles.identity)}>
-            <Brand href={brandHref} {...stylex.props(styles.brand)}>
-              {brand}
-            </Brand>
+            {brandHref ? (
+              <AppLink href={brandHref} {...stylex.props(styles.brand)}>
+                {brand}
+              </AppLink>
+            ) : (
+              <span {...stylex.props(styles.brand)}>{brand}</span>
+            )}
             <h1 {...stylex.props(foundationStyles.pageTitle, styles.name)}>
               {name}
             </h1>

--- a/apps/web/src/components/designSystem/patterns/catalogPage.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/catalogPage.stylex.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 
 import { foundationStyles } from "../../../styles/foundations.stylex";
 import { colors, fonts, space } from "../../../styles/tokens.stylex";
+import { LoadingList, LoadingPlaceholder } from "../components";
 
 const NARROW = "@media (max-width: 759px)";
 
@@ -33,6 +34,20 @@ export function CatalogPage({
         <aside {...stylex.props(styles.filters)}>{filters}</aside>
       </div>
     </div>
+  );
+}
+
+export function CatalogPageLoading({ title }: { title: ReactNode }) {
+  return (
+    <CatalogPage
+      filters={<LoadingList label="Loading catalog filters" rows={4} />}
+      title={title}
+    >
+      <div {...stylex.props(styles.loadingResults)}>
+        <LoadingPlaceholder preset="heading" />
+        <LoadingList label="Loading catalog records" rows={4} />
+      </div>
+    </CatalogPage>
   );
 }
 
@@ -71,6 +86,12 @@ const styles = stylex.create({
   },
   results: {
     minWidth: 0,
+  },
+  loadingResults: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x4,
   },
   filters: {
     minWidth: 0,

--- a/apps/web/src/components/designSystem/patterns/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/entityCatalog.stylex.tsx
@@ -2,7 +2,6 @@
 
 import * as stylex from "@stylexjs/stylex";
 
-import { foundationStyles } from "../../../styles/foundations.stylex";
 import { colors, fonts, space } from "../../../styles/tokens.stylex";
 import {
   Button,
@@ -15,9 +14,9 @@ import {
   ItemList,
   ItemRow,
   ListToolbar,
-  LoadingList,
   type ListSortOption,
 } from "../components";
+import { CatalogPageLoading } from "./catalogPage.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
 
@@ -184,14 +183,7 @@ export function EntityCatalogFilters({
 }
 
 export function EntityCatalogLoading({ title }: { title: string }) {
-  return (
-    <section aria-label={`${title} catalog`} {...stylex.props(styles.catalog)}>
-      <h1 {...stylex.props(foundationStyles.pageTitle)}>{title}</h1>
-      <div {...stylex.props(styles.loading)}>
-        <LoadingList label={`Loading ${title.toLowerCase()}`} rows={4} />
-      </div>
-    </section>
-  );
+  return <CatalogPageLoading title={title} />;
 }
 
 const styles = stylex.create({
@@ -242,8 +234,5 @@ const styles = stylex.create({
     [COMPACT]: {
       display: "none",
     },
-  },
-  loading: {
-    marginTop: space.x6,
   },
 });

--- a/apps/web/src/components/designSystem/patterns/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/homeBrowse.stylex.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../../styles/tokens.stylex";
 import CountryMapIcon from "../../countryMapIcon";
 import {
+  AppLink,
   Card,
   CardActionLink,
   CardLink,
@@ -352,9 +353,9 @@ export function HomeDistilleries({
                 ·
               </span>
             ) : null}
-            <a href={link.href} {...stylex.props(styles.moreLink)}>
+            <AppLink href={link.href} {...stylex.props(styles.moreLink)}>
               {link.label} <span aria-hidden="true">→</span>
-            </a>
+            </AppLink>
           </span>
         ))}
       </div>

--- a/apps/web/src/components/designSystem/patterns/homeDiscovery.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/homeDiscovery.stylex.tsx
@@ -9,6 +9,7 @@ import {
   space,
 } from "../../../styles/tokens.stylex";
 import {
+  AppLink,
   BottleVisual,
   Card,
   CardActionLink,
@@ -148,9 +149,9 @@ export function FollowedReleaseList({
           Following {followedDistillerCount.toLocaleString("en-US")} distiller
           {followedDistillerCount === 1 ? "" : "s"}
         </span>
-        <a href={seeAllHref} {...stylex.props(styles.seeAll)}>
+        <AppLink href={seeAllHref} {...stylex.props(styles.seeAll)}>
           See all <span aria-hidden="true">→</span>
-        </a>
+        </AppLink>
       </div>
     </section>
   );

--- a/apps/web/src/components/designSystem/patterns/memberProfileContent.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/memberProfileContent.stylex.tsx
@@ -10,6 +10,7 @@ import {
   space,
 } from "../../../styles/tokens.stylex";
 import {
+  AppLink,
   BottleIdentityRow,
   Button,
   Chip,
@@ -229,10 +230,12 @@ function CollectionActivity({
       <header {...stylex.props(styles.activityHeader)}>
         <div {...stylex.props(styles.activityCopy)}>
           <div {...stylex.props(styles.activitySentence)}>
-            <a href={activity.authorHref}>{activity.author}</a>
+            <AppLink href={activity.authorHref}>{activity.author}</AppLink>
             <span> added {formatBottleCount(activity.totalItems)} to </span>
             {activity.collectionHref ? (
-              <a href={activity.collectionHref}>{activity.collectionName}</a>
+              <AppLink href={activity.collectionHref}>
+                {activity.collectionName}
+              </AppLink>
             ) : (
               <strong>{activity.collectionName}</strong>
             )}

--- a/apps/web/src/components/designSystem/patterns/pageLayout.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/pageLayout.stylex.tsx
@@ -182,6 +182,7 @@ const styles = stylex.create({
   },
   page: {
     boxSizing: "border-box",
+    minHeight: "calc(100dvh - 118px)",
     width: "100%",
     maxWidth: "1320px",
     marginRight: "auto",
@@ -191,6 +192,7 @@ const styles = stylex.create({
     paddingBottom: space.x12,
     paddingLeft: space.x8,
     [NARROW]: {
+      minHeight: "calc(100dvh - 70px)",
       paddingTop: space.x6,
       paddingRight: "20px",
       paddingBottom: space.x8,

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -13,6 +13,7 @@ import {
 import { getCreateBottleHref } from "@peated/web/components/search/createBottleHref";
 import useAuth from "@peated/web/hooks/useAuth";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getEntityUrl } from "@peated/web/lib/urls";
 import * as stylex from "@stylexjs/stylex";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -156,7 +157,7 @@ function bottleItem(
 
 function entityItem(entity: EntitySearchResult) {
   return {
-    href: `/entities/${entity.id}`,
+    href: getEntityUrl(entity),
     id: `entity-${entity.id}`,
     metadata: entity.region?.name,
     title: entity.name,

--- a/apps/web/src/lib/bottleCatalogItem.ts
+++ b/apps/web/src/lib/bottleCatalogItem.ts
@@ -4,6 +4,7 @@ import type { BottleCatalogItem } from "@peated/web/components/designSystem/patt
 
 import { getBottleExpressionName } from "./bottleLabel";
 import { getReleaseFamilyHref } from "./releaseFamily";
+import { getEntityUrl } from "./urls";
 
 type Bottle = Outputs["bottles"]["list"]["results"][number];
 
@@ -23,7 +24,7 @@ export function toBottleCatalogItem(bottle: Bottle): BottleCatalogItem {
   return {
     bandCounts: bottle.tastingBandCounts,
     brand: bottle.brand.name,
-    brandHref: `/entities/${bottle.brand.id}`,
+    brandHref: getEntityUrl({ id: bottle.brand.id, kind: "brand" }),
     hasTasted: bottle.hasTasted,
     href: `/bottles/${bottle.id}`,
     id: bottle.peatedId,

--- a/apps/web/src/lib/entityBottleCreateHref.test.ts
+++ b/apps/web/src/lib/entityBottleCreateHref.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { getEntityBottleCreateHref } from "./entityBottleCreateHref";
+
+describe("getEntityBottleCreateHref", () => {
+  it("returns to the canonical public Entity route", () => {
+    const href = getEntityBottleCreateHref({ id: 4263, kind: "bottler" });
+    const url = new URL(href!, "https://peated.com");
+
+    expect(url.pathname).toBe("/bottles/new");
+    expect(url.searchParams.get("bottler")).toBe("4263");
+    expect(url.searchParams.get("returnTo")).toBe("/bottlers/4263");
+  });
+
+  it("does not offer bottle creation for a company", () => {
+    expect(getEntityBottleCreateHref({ id: 1, kind: "company" })).toBe(
+      undefined,
+    );
+  });
+});

--- a/apps/web/src/lib/entityBottleCreateHref.ts
+++ b/apps/web/src/lib/entityBottleCreateHref.ts
@@ -1,5 +1,7 @@
 import type { EntityKind } from "@peated/server/types";
 
+import { getEntityUrl } from "./urls";
+
 export function getEntityBottleCreateHref({
   id,
   kind,
@@ -7,7 +9,7 @@ export function getEntityBottleCreateHref({
   id: number;
   kind: EntityKind | null;
 }) {
-  const params = new URLSearchParams({ returnTo: `/entities/${id}` });
+  const params = new URLSearchParams({ returnTo: getEntityUrl({ id, kind }) });
 
   switch (kind) {
     case "brand":

--- a/apps/web/src/lib/urls.test.ts
+++ b/apps/web/src/lib/urls.test.ts
@@ -16,6 +16,10 @@ describe("public catalog URLs", () => {
     expect(getEntityUrl({ id: 123, kind })).toBe(expected);
   });
 
+  it("uses the generic Entity route when kind is unavailable", () => {
+    expect(getEntityUrl({ id: 123, kind: null })).toBe("/entities/123");
+  });
+
   it("lists every route prefix that can resolve an Entity", () => {
     expect(getEntityRoutePrefixes(123)).toEqual([
       "/brands/123",

--- a/apps/web/src/lib/urls.ts
+++ b/apps/web/src/lib/urls.ts
@@ -1,4 +1,4 @@
-import type { Entity, EntityKind } from "@peated/server/types";
+import type { EntityKind } from "@peated/server/types";
 
 const ENTITY_COLLECTION_BY_KIND = {
   brand: "/brands",
@@ -23,9 +23,11 @@ export function getBottleUrl(
   return `/bottles/${bottle.id}`;
 }
 
-export function getEntityUrl(
-  entity: Pick<Entity, "id" | "kind">,
-): `/${string}` {
+export function getEntityUrl(entity: {
+  id: number;
+  kind: EntityKind | null;
+}): `/${string}` {
+  if (!entity.kind) return `/entities/${entity.id}`;
   return `${ENTITY_COLLECTION_BY_KIND[entity.kind]}/${entity.id}`;
 }
 


### PR DESCRIPTION
Page and tab links now stay within Next.js navigation, and public entity links use their canonical kind routes instead of redirecting through generic entity URLs. This prevents the header and footer teardown seen on the SMWS codes page and applies the same behavior across shared navigation, cards, lists, search results, profiles, locations, notifications, and bottle links. External, hash, and download links remain native, while repeated list links avoid automatic prefetch request bursts.

Catalog and entity loading states now reserve the geometry of their final content, and the page frame keeps the footer below the viewport during short loads. Local desktop and mobile navigation measured at or below `0.000025` CLS, with `0` CLS on the distillery-codes tab and no horizontal overflow. Route helpers and shared-link behavior have regression coverage; the full web suite passes.
