### PR TITLE
fix(web): remove common questions from homepage

### DIFF
--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -15,7 +15,6 @@ import {
   HomeDistilleries,
   HomeHighestRated,
   HomeOrigins,
-  HomeQuestions,
   HomeRecentBottles,
   HomeRecentReviews,
 } from "@peated/web/components/designSystem/patterns/homeBrowse.stylex";
@@ -30,29 +29,6 @@ import { getEntityUrl } from "@peated/web/lib/urls";
 import { space } from "../../../../styles/tokens.stylex";
 
 type Bottle = Outputs["bottles"]["list"]["results"][number];
-
-const questions = [
-  {
-    question: "How is a score calculated?",
-    answer:
-      "It's the median of member scores and published scores that use a 100-point scale. Each score counts once. The number appears after 20 scores.",
-  },
-  {
-    question: "Why do some bottles have no score?",
-    answer:
-      "Some records are single casks that only a few people have tasted. We show what people said and leave the number blank until 20 scores.",
-  },
-  {
-    question: "Do I need an account?",
-    answer:
-      "Only to log a tasting, keep your Library, or add a bottle. Every record page is readable without one.",
-  },
-  {
-    question: "Where do critic reviews come from?",
-    answer:
-      "Each review names its publication and links to the original article.",
-  },
-] as const;
 
 export function PublicHome() {
   const orpc = useORPC();
@@ -96,7 +72,6 @@ export function PublicHome() {
               totalDistilleries={stats.data?.distilleries}
             />
           </PageColumns>
-          <HomeQuestions questions={questions} />
         </>
       }
       description="Browse whisky bottlings, including single casks, with critic scores and tasting notes. No account needed."

--- a/apps/web/src/components/designSystem/patterns/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/homeBrowse.stylex.tsx
@@ -426,33 +426,6 @@ export function HomeContributionPrompt({
   );
 }
 
-export type HomeQuestion = {
-  answer: ReactNode;
-  question: string;
-};
-
-export function HomeQuestions({
-  questions,
-}: {
-  questions: readonly HomeQuestion[];
-}) {
-  return (
-    <section {...stylex.props(styles.section)}>
-      <HomeModuleHeading title="Common questions" />
-      <div {...stylex.props(styles.questionGrid)}>
-        {questions.map((question) => (
-          <article key={question.question} {...stylex.props(styles.question)}>
-            <h3 {...stylex.props(styles.questionTitle)}>{question.question}</h3>
-            <div {...stylex.props(styles.questionAnswer)}>
-              {question.answer}
-            </div>
-          </article>
-        ))}
-      </div>
-    </section>
-  );
-}
-
 const styles = stylex.create({
   section: {
     minWidth: 0,
@@ -774,39 +747,5 @@ const styles = stylex.create({
     gap: "6px",
     marginTop: space.x3,
     flexWrap: "wrap",
-  },
-  questionGrid: {
-    display: "grid",
-    gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
-    gap: "6px",
-    marginTop: "14px",
-    [COMPACT]: {
-      gridTemplateColumns: "minmax(0, 1fr)",
-    },
-  },
-  question: {
-    paddingTop: "18px",
-    paddingRight: "20px",
-    paddingBottom: "18px",
-    paddingLeft: "20px",
-    borderRadius: controlMetrics.radius,
-    backgroundColor: colors.surface,
-  },
-  questionTitle: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "15px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.25,
-  },
-  questionAnswer: {
-    marginTop: "6px",
-    color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
-    textWrap: "pretty",
   },
 });


### PR DESCRIPTION
The public homepage no longer shows the Common questions section. This also removes the unused question component and its styles from the homepage design pattern.
