### PR TITLE
fix(scraper): use original review dates

### DIFF
--- a/apps/server/src/externalReviews/observation.test.ts
+++ b/apps/server/src/externalReviews/observation.test.ts
@@ -53,3 +53,11 @@ test("rejects duplicate review source keys", () => {
     "External review source keys must be unique within an article.",
   );
 });
+
+test("requires scrapers to include the review date", () => {
+  expect(() =>
+    ExternalReviewArticleIngestionSchema.parse({
+      article: { ...observation(), publishedAt: null },
+    }),
+  ).toThrow();
+});

--- a/apps/server/src/externalReviews/observation.ts
+++ b/apps/server/src/externalReviews/observation.ts
@@ -51,10 +51,12 @@ export type ExternalReviewArticleObservation = z.infer<
   typeof ExternalReviewArticleObservationSchema
 >;
 
-/** Shared adapter output. The sink passes this shape to article ingestion. */
+// A scraper must use the date shown by the publisher.
 export const ExternalReviewArticleIngestionSchema = z
   .object({
-    article: ExternalReviewArticleObservationSchema,
+    article: ExternalReviewArticleObservationSchema.safeExtend({
+      publishedAt: z.date(),
+    }),
   })
   .strict();
 

--- a/apps/server/src/scraper/adapters/currentReviews.test.ts
+++ b/apps/server/src/scraper/adapters/currentReviews.test.ts
@@ -35,7 +35,7 @@ function observation(canonicalUrl: string): ExternalReviewArticleIngestion {
       canonicalUrl,
       title: "Example review",
       issue: null,
-      publishedAt: null,
+      publishedAt: new Date("2026-08-20T00:00:00.000Z"),
       contentHash: "content-hash",
       externalReviews: [
         {

--- a/apps/server/src/scraper/adapters/whiskeyReviewer.test.ts
+++ b/apps/server/src/scraper/adapters/whiskeyReviewer.test.ts
@@ -60,21 +60,18 @@ test("extracts the grade and only tasting-note paragraphs", async () => {
   );
 });
 
-test("maps another grade and allows an article without an encoded date", async () => {
+test("rejects an article without an encoded date", async () => {
   const html = await loadFixture("whiskeyreviewer", "review.html");
   const undatedUrl =
     "https://whiskeyreviewer.com/2026/08/example-bourbon-review";
-  const parsed = parseWhiskeyReviewerArticle(
-    html
-      .replace("example-bourbon-review-081026", "example-bourbon-review")
-      .replace("Rating: B+", "Rating: A-"),
-    new URL(undatedUrl),
-  );
-
-  expect(parsed.article.publishedAt).toBeNull();
-  expect(parsed.article.externalReviews[0]).toMatchObject({
-    nativeScore: { value: 90, scale: 100, display: "A-" },
-  });
+  expect(() =>
+    parseWhiskeyReviewerArticle(
+      html
+        .replace("example-bourbon-review-081026", "example-bourbon-review")
+        .replace("Rating: B+", "Rating: A-"),
+      new URL(undatedUrl),
+    ),
+  ).toThrow("Whiskey Reviewer article date is missing.");
 });
 
 test("resumes without requesting a completed current article", async () => {

--- a/apps/server/src/scraper/adapters/whiskeyReviewer.ts
+++ b/apps/server/src/scraper/adapters/whiskeyReviewer.ts
@@ -84,19 +84,27 @@ export function discoverWhiskeyReviewerArticles(data: string): URL[] {
   return [...articles.values()].slice(0, MAX_CURRENT_ARTICLES);
 }
 
-function publishedAt(url: URL): Date | null {
+function publishedAt(url: URL): Date {
   const pathMatch = ARTICLE_PATH.exec(url.pathname);
   const slug = url.pathname.split("/").at(-1) ?? "";
   const dateMatch = /(?<month>\d{2})(?<day>\d{2})(?<year>\d{2})$/u.exec(slug);
-  if (!pathMatch?.groups || !dateMatch?.groups) return null;
+  if (!pathMatch?.groups || !dateMatch?.groups) {
+    throw new Error("Whiskey Reviewer article date is missing.");
+  }
 
   const year = Number(pathMatch.groups.year);
   const pathMonth = Number(pathMatch.groups.month);
   const month = Number(dateMatch.groups.month);
   const shortYear = Number(dateMatch.groups.year);
-  if (year % 100 !== shortYear || pathMonth !== month) return null;
+  if (year % 100 !== shortYear || pathMonth !== month) {
+    throw new Error("Whiskey Reviewer article date conflicts with its URL.");
+  }
 
-  return parseDate(`${year}-${dateMatch.groups.month}-${dateMatch.groups.day}`);
+  const date = parseDate(
+    `${year}-${dateMatch.groups.month}-${dateMatch.groups.day}`,
+  );
+  if (!date) throw new Error("Whiskey Reviewer article date is invalid.");
+  return date;
 }
 
 function reviewGrade(value: string) {

--- a/apps/server/src/scraper/adapters/whiskyAdvocate.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyAdvocate.test.ts
@@ -5,6 +5,7 @@ import type { ScraperObservation, ScraperSession } from "../types";
 import {
   type WhiskyAdvocateCursor,
   type WhiskyAdvocateObservation,
+  parseIssueList,
   parseReviewPublishedAt,
   parseReviews,
   whiskyAdvocateAdapter,
@@ -26,13 +27,72 @@ test("accepts a cursor stored by the previous adapter", () => {
   });
 });
 
+test("starts old saved progress again and checks older issues later", async () => {
+  const issueHtml = await loadFixture("whiskyadvocate", "empty-search.html");
+  const reviewHtml = await loadFixture("whiskyadvocate", "bottle-list.html");
+  const articleHtml = await loadFixture("whiskyadvocate", "review-page.html");
+  const issueNames = parseIssueList(issueHtml);
+  const $ = cheerio(reviewHtml);
+  $("#directoryResults .postsItem").slice(1).remove();
+  const oneReviewHtml = $.html();
+
+  const run = async (cursor: WhiskyAdvocateCursor) => {
+    const checkpoint = vi.fn();
+    const request = vi.fn(async ({ url }: { url: URL }) => ({
+      url,
+      status: 200,
+      headers: {},
+      body:
+        url.pathname !== "/ratings-reviews"
+          ? articleHtml
+          : url.search.includes("custom_rating_issue")
+            ? oneReviewHtml
+            : issueHtml,
+    }));
+    await whiskyAdvocateAdapter({
+      cursor,
+      session: {
+        request,
+        emit: vi.fn(),
+        checkpoint,
+        remainingRequests: () => 30,
+      },
+    });
+    return { checkpoint, request };
+  };
+
+  const oldRun = await run({ processedIssues: [issueNames[0]!] });
+  expect(
+    oldRun.request.mock.calls[1]?.[0].url.searchParams.get(
+      "custom_rating_issue[0]",
+    ),
+  ).toBe(issueNames[0]);
+
+  const nextRun = await run({
+    checksReviewDates: true,
+    completedIssues: [issueNames[0]!],
+    issue: null,
+    completedReviewUrls: [],
+  });
+  expect(
+    nextRun.request.mock.calls[1]?.[0].url.searchParams.get(
+      "custom_rating_issue[0]",
+    ),
+  ).toBe(issueNames[1]);
+  expect(nextRun.checkpoint).toHaveBeenLastCalledWith(
+    expect.objectContaining({ completedIssues: issueNames.slice(0, 2) }),
+  );
+});
+
 test("parses the publisher date template", async () => {
   const html = await loadFixture("whiskyadvocate", "review-page.html");
 
   expect(parseReviewPublishedAt(html)).toEqual(
     new Date("2023-12-19T00:00:00.000Z"),
   );
-  expect(parseReviewPublishedAt("<html></html>")).toBeNull();
+  expect(() => parseReviewPublishedAt("<html></html>")).toThrow(
+    "Whisky Advocate review date is missing.",
+  );
   expect(() =>
     parseReviewPublishedAt('<script>"datePublished": "not-a-date"</script>'),
   ).toThrow("Whisky Advocate review date is invalid.");
@@ -110,54 +170,84 @@ test("fetches dates for the latest issue and checkpoints each review", async () 
       },
     },
   });
-  expect(checkpoint).toHaveBeenCalledTimes(166);
+  expect(checkpoint).toHaveBeenCalledTimes(167);
   expect(checkpoint).toHaveBeenLastCalledWith({
-    issue: "Winter 2023",
-    processedReviewUrls: observations.map(({ sourceKey }) => sourceKey),
+    checksReviewDates: true,
+    completedIssues: ["Winter 2023"],
+    issue: null,
+    completedReviewUrls: [],
   });
 });
 
-test("resumes the same issue after the last stored review", async () => {
+test("rechecks old saved reviews and resumes reviews checked for dates", async () => {
+  const issueHtml = await loadFixture("whiskyadvocate", "empty-search.html");
   const reviewHtml = await loadFixture("whiskyadvocate", "bottle-list.html");
   const articleHtml = await loadFixture("whiskyadvocate", "review-page.html");
+  const $ = cheerio(reviewHtml);
+  $("#directoryResults .postsItem").slice(2).remove();
+  const twoReviewHtml = $.html();
   const externalReviews = parseReviews(
-    reviewHtml,
+    twoReviewHtml,
     "https://whiskyadvocate.com/ratings-reviews",
   );
-  const processedReviewUrls = externalReviews
-    .slice(0, -1)
-    .map((review) => review.url);
-  const emit = vi.fn();
-  const checkpoint = vi.fn();
-  const request = vi.fn(async ({ url }: { url: URL }) => ({
-    url,
-    status: 200,
-    headers: {},
-    body: url.pathname === "/ratings-reviews" ? reviewHtml : articleHtml,
-  }));
-  const session: ScraperSession<
-    WhiskyAdvocateCursor,
-    WhiskyAdvocateObservation
-  > = {
-    request,
-    emit,
-    checkpoint,
-    remainingRequests: () => 20,
+  const firstReviewUrl = externalReviews[0]!.url;
+
+  const run = async (cursor: WhiskyAdvocateCursor) => {
+    const emit = vi.fn();
+    const checkpoint = vi.fn();
+    const request = vi.fn(async ({ url }: { url: URL }) => ({
+      url,
+      status: 200,
+      headers: {},
+      body:
+        url.pathname !== "/ratings-reviews"
+          ? articleHtml
+          : url.search.includes("custom_rating_issue")
+            ? twoReviewHtml
+            : issueHtml,
+    }));
+    const session: ScraperSession<
+      WhiskyAdvocateCursor,
+      WhiskyAdvocateObservation
+    > = {
+      request,
+      emit,
+      checkpoint,
+      remainingRequests: () => 20,
+    };
+    await whiskyAdvocateAdapter({ cursor, session });
+    return { checkpoint, emit, request };
   };
 
-  await whiskyAdvocateAdapter({
-    cursor: { issue: "Winter 2023", processedReviewUrls },
-    session,
+  const oldRun = await run({
+    issue: "Winter 2023",
+    processedReviewUrls: [firstReviewUrl],
   });
+  expect(oldRun.request).toHaveBeenCalledTimes(4);
+  expect(oldRun.emit).toHaveBeenCalledTimes(2);
 
-  expect(request).toHaveBeenCalledTimes(2);
-  expect(emit).toHaveBeenCalledOnce();
-  expect(emit).toHaveBeenCalledWith(
+  const datedRun = await run({
+    checksReviewDates: true,
+    completedIssues: [],
+    issue: "Winter 2023",
+    completedReviewUrls: [firstReviewUrl],
+  });
+  expect(datedRun.request).toHaveBeenCalledTimes(3);
+  expect(datedRun.emit).toHaveBeenCalledOnce();
+  expect(datedRun.emit).toHaveBeenCalledWith(
     expect.objectContaining({ sourceKey: externalReviews.at(-1)?.url }),
   );
-  expect(checkpoint).toHaveBeenCalledWith({
+  expect(datedRun.checkpoint).toHaveBeenCalledWith({
+    checksReviewDates: true,
+    completedIssues: [],
     issue: "Winter 2023",
-    processedReviewUrls: externalReviews.map((review) => review.url),
+    completedReviewUrls: externalReviews.map((review) => review.url),
+  });
+  expect(datedRun.checkpoint).toHaveBeenLastCalledWith({
+    checksReviewDates: true,
+    completedIssues: ["Winter 2023"],
+    issue: null,
+    completedReviewUrls: [],
   });
 });
 

--- a/apps/server/src/scraper/adapters/whiskyAdvocate.ts
+++ b/apps/server/src/scraper/adapters/whiskyAdvocate.ts
@@ -26,9 +26,19 @@ const CurrentWhiskyAdvocateCursorSchema = z
   })
   .strict();
 
+const DatedWhiskyAdvocateCursorSchema = z
+  .object({
+    checksReviewDates: z.literal(true),
+    completedIssues: z.array(z.string().min(1)).max(500),
+    issue: z.string().min(1).nullable(),
+    completedReviewUrls: z.array(z.url()).max(500),
+  })
+  .strict();
+
 // Active runs can resume across deploys.
 // Accept cursors written by the prior adapter.
 export const WhiskyAdvocateCursorSchema = z.union([
+  DatedWhiskyAdvocateCursorSchema,
   LegacyWhiskyAdvocateCursorSchema,
   CurrentWhiskyAdvocateCursorSchema,
 ]);
@@ -55,7 +65,7 @@ function normalizeText(value: string): string {
   return value.replaceAll(/\s+/g, " ").trim();
 }
 
-export function parseReviewPublishedAt(data: string): Date | null {
+export function parseReviewPublishedAt(data: string): Date {
   const $ = cheerio(data);
   const metadata = $("script")
     .toArray()
@@ -63,7 +73,7 @@ export function parseReviewPublishedAt(data: string): Date | null {
     .find((value) => /"datePublished"\s*:/iu.test(value));
   const rawValue = metadata?.match(/"datePublished"\s*:\s*"(?<value>[^"]+)"/iu)
     ?.groups?.value;
-  if (!rawValue) return null;
+  if (!rawValue) throw new Error("Whisky Advocate review date is missing.");
 
   const templateValue = rawValue.match(
     /^\{\{\s*(?<value>.+?)\s*\|\s*iso8601\s*\}\}$/iu,
@@ -75,7 +85,7 @@ export function parseReviewPublishedAt(data: string): Date | null {
   return publishedAt;
 }
 
-function parseIssueList(data: string) {
+export function parseIssueList(data: string) {
   const $ = cheerio(data);
   const results: string[] = [];
   $("select")
@@ -152,18 +162,25 @@ export const whiskyAdvocateAdapter: ScraperAdapter<
   WhiskyAdvocateCursor,
   WhiskyAdvocateObservation
 > = async ({ cursor, session }) => {
-  const activeCursor =
-    cursor && "processedReviewUrls" in cursor ? cursor : null;
-  let issue = activeCursor?.issue;
-  if (!issue) {
-    const issueListResponse = await session.request({
-      target: TARGET,
-      url: new URL("/ratings-reviews", ORIGIN),
-    });
-    issue = parseIssueList(issueListResponse.body)[0];
+  const issueListResponse = await session.request({
+    target: TARGET,
+    url: new URL("/ratings-reviews", ORIGIN),
+  });
+  const issueList = parseIssueList(issueListResponse.body);
+  if (issueList.length === 0) {
+    throw new Error("Whisky Advocate issue list is empty.");
   }
-  if (!issue) throw new Error("Whisky Advocate issue list is empty.");
-  const processedReviewUrls = new Set(activeCursor?.processedReviewUrls ?? []);
+  // Old saved progress skipped dates, so start again from the newest issue.
+  const completedIssues = new Set(
+    cursor && "checksReviewDates" in cursor ? cursor.completedIssues : [],
+  );
+  const activeIssue = cursor && "issue" in cursor ? cursor.issue : null;
+  const issue =
+    activeIssue ?? issueList.find((value) => !completedIssues.has(value));
+  if (!issue) return;
+  const completedReviewUrls = new Set(
+    cursor && "completedReviewUrls" in cursor ? cursor.completedReviewUrls : [],
+  );
 
   const reviewUrl = new URL("/ratings-reviews", ORIGIN);
   reviewUrl.searchParams.set("custom_rating_issue[0]", issue);
@@ -181,7 +198,7 @@ export const whiskyAdvocateAdapter: ScraperAdapter<
   }
 
   for (const review of externalReviews) {
-    if (processedReviewUrls.has(review.url)) continue;
+    if (completedReviewUrls.has(review.url)) continue;
     const articleResponse = await session.request({
       target: TARGET,
       url: new URL(review.url),
@@ -221,10 +238,20 @@ export const whiskyAdvocateAdapter: ScraperAdapter<
       },
     });
     await session.emit({ sourceKey: review.url, value });
-    processedReviewUrls.add(review.url);
+    completedReviewUrls.add(review.url);
     await session.checkpoint({
+      checksReviewDates: true,
+      completedIssues: [...completedIssues],
       issue,
-      processedReviewUrls: [...processedReviewUrls],
+      completedReviewUrls: [...completedReviewUrls],
     });
   }
+
+  completedIssues.add(issue);
+  await session.checkpoint({
+    checksReviewDates: true,
+    completedIssues: [...completedIssues],
+    issue: null,
+    completedReviewUrls: [],
+  });
 };

--- a/apps/server/src/scraper/adapters/whiskyNotes.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyNotes.test.ts
@@ -122,12 +122,20 @@ async function runAdapter(
   return { checkpoints, observations, request };
 }
 
-test("continues four archive pages per run and refreshes the current page", async () => {
-  const first = await runAdapter(null);
+test("starts old saved progress again and checks four older pages", async () => {
+  const first = await runAdapter(
+    WhiskyNotesCursorSchema.parse({
+      page: 99,
+      processedArticleUrls: [],
+      currentArticleUrls: [],
+      historyComplete: true,
+    }),
+  );
 
   expect(first.observations).toHaveLength(8);
   expect(first.request).toHaveBeenCalledTimes(12);
   expect(first.checkpoints.at(-1)).toEqual({
+    checksReviewDates: true,
     page: 5,
     processedArticleUrls: [],
     currentArticleUrls: [
@@ -153,6 +161,7 @@ test("continues four archive pages per run and refreshes the current page", asyn
 
 test("resumes within a history page without requesting stored articles", async () => {
   const cursor = WhiskyNotesCursorSchema.parse({
+    checksReviewDates: true,
     page: 3,
     processedArticleUrls: [
       "https://www.whiskynotes.be/2026/world/single-review-3/",
@@ -185,6 +194,7 @@ test("resumes within a history page without requesting stored articles", async (
 
 test("ingests a new current review while history points to an older page", async () => {
   const cursor = WhiskyNotesCursorSchema.parse({
+    checksReviewDates: true,
     page: 5,
     processedArticleUrls: [],
     currentArticleUrls: [
@@ -207,6 +217,7 @@ test("ingests a new current review while history points to an older page", async
 
 test("stops history at the archive end but keeps checking current reviews", async () => {
   const cursor = WhiskyNotesCursorSchema.parse({
+    checksReviewDates: true,
     page: 3,
     processedArticleUrls: [],
     currentArticleUrls: [
@@ -239,6 +250,7 @@ test("accepts cursors stored by the bounded pilot adapter", () => {
       processedArticleUrls: ["https://www.whiskynotes.be/2026/world/example/"],
     }),
   ).toEqual({
+    checksReviewDates: false,
     page: 5,
     processedArticleUrls: ["https://www.whiskynotes.be/2026/world/example/"],
     currentArticleUrls: [],

--- a/apps/server/src/scraper/adapters/whiskyNotes.ts
+++ b/apps/server/src/scraper/adapters/whiskyNotes.ts
@@ -22,6 +22,8 @@ const EXCLUDED_CATEGORIES = new Set([
 
 export const WhiskyNotesCursorSchema = z
   .object({
+    // Old saved progress skipped some dates. Start from page 1 once.
+    checksReviewDates: z.boolean().default(false),
     page: z.number().int().min(1),
     processedArticleUrls: z.array(z.url()).max(MAX_ARTICLES_PER_PAGE),
     currentArticleUrls: z.array(z.url()).max(MAX_ARTICLES_PER_PAGE).default([]),
@@ -126,8 +128,8 @@ export function parseWhiskyNotesArticle(
     .attr("datetime");
   const publishedAt = publishedValue ? parseDate(publishedValue) : null;
   if (!title) throw new Error("WhiskyNotes article title is missing.");
-  if (publishedValue && !publishedAt) {
-    throw new Error("WhiskyNotes article date is invalid.");
+  if (!publishedAt) {
+    throw new Error("WhiskyNotes article date is missing or invalid.");
   }
 
   const content = article.find(".entry-content").first().clone();
@@ -196,13 +198,15 @@ export const whiskyNotesAdapter: ScraperAdapter<
   WhiskyNotesCursor,
   WhiskyNotesObservation
 > = async ({ cursor, session }) => {
-  let page = cursor?.page ?? 1;
-  let processedArticleUrls = new Set(cursor?.processedArticleUrls ?? []);
-  let currentArticleUrls = new Set(cursor?.currentArticleUrls ?? []);
-  let historyComplete = cursor?.historyComplete ?? false;
+  const savedProgress = cursor?.checksReviewDates ? cursor : null;
+  let page = savedProgress?.page ?? 1;
+  let processedArticleUrls = new Set(savedProgress?.processedArticleUrls ?? []);
+  let currentArticleUrls = new Set(savedProgress?.currentArticleUrls ?? []);
+  let historyComplete = savedProgress?.historyComplete ?? false;
 
   const checkpoint = async () => {
     await session.checkpoint({
+      checksReviewDates: true,
       page,
       processedArticleUrls: [...processedArticleUrls],
       currentArticleUrls: [...currentArticleUrls],

--- a/apps/server/src/scraper/adapters/whiskySaga.test.ts
+++ b/apps/server/src/scraper/adapters/whiskySaga.test.ts
@@ -19,8 +19,12 @@ const OLDER_HISTORY_URL =
   "https://www.whiskysaga.com/blog?offset=1772902711929&category=Scotland";
 const COMPLETED_HISTORY: Pick<
   WhiskySagaCursor,
-  "nextHistoryUrl" | "processedHistoryArticleUrls" | "historyComplete"
+  | "checksReviewDates"
+  | "nextHistoryUrl"
+  | "processedHistoryArticleUrls"
+  | "historyComplete"
 > = {
+  checksReviewDates: true,
   nextHistoryUrl: null,
   processedHistoryArticleUrls: [],
   historyComplete: true,
@@ -76,6 +80,7 @@ test("accepts the current-only cursor and adds history defaults", () => {
   expect(
     WhiskySagaCursorSchema.parse({ processedArticleUrls: [FIRST_URL] }),
   ).toEqual({
+    checksReviewDates: false,
     processedArticleUrls: [FIRST_URL],
     nextHistoryUrl: null,
     processedHistoryArticleUrls: [],
@@ -183,7 +188,7 @@ test("resumes without requesting a completed current article", async () => {
   });
 });
 
-test("imports one older Scotland page and advances the history cursor", async () => {
+test("starts old saved progress again and checks one older page", async () => {
   const article = await loadFixture("whiskysaga", "review.html");
   const emit = vi.fn();
   const checkpoint = vi.fn();
@@ -205,7 +210,15 @@ test("imports one older Scotland page and advances the history cursor", async ()
     remainingRequests: () => 22,
   };
 
-  await whiskySagaAdapter({ cursor: null, session });
+  await whiskySagaAdapter({
+    cursor: WhiskySagaCursorSchema.parse({
+      processedArticleUrls: [],
+      nextHistoryUrl: null,
+      processedHistoryArticleUrls: [],
+      historyComplete: true,
+    }),
+    session,
+  });
 
   expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
     "https://www.whiskysaga.com/blog/category/Scotland",
@@ -216,6 +229,7 @@ test("imports one older Scotland page and advances the history cursor", async ()
     expect.objectContaining({ sourceKey: FIRST_URL, itemCount: 1 }),
   );
   expect(checkpoint.mock.calls.at(-1)?.[0]).toEqual({
+    checksReviewDates: true,
     processedArticleUrls: [],
     nextHistoryUrl: OLDER_HISTORY_URL,
     processedHistoryArticleUrls: [],
@@ -243,6 +257,7 @@ test("resumes within an older page and records the history end", async () => {
 
   await whiskySagaAdapter({
     cursor: {
+      checksReviewDates: true,
       processedArticleUrls: [],
       nextHistoryUrl: HISTORY_URL,
       processedHistoryArticleUrls: [FIRST_URL],
@@ -256,6 +271,7 @@ test("resumes within an older page and records the history end", async () => {
     HISTORY_URL,
   ]);
   expect(checkpoint.mock.calls.at(-1)?.[0]).toEqual({
+    checksReviewDates: true,
     processedArticleUrls: [],
     nextHistoryUrl: null,
     processedHistoryArticleUrls: [],

--- a/apps/server/src/scraper/adapters/whiskySaga.ts
+++ b/apps/server/src/scraper/adapters/whiskySaga.ts
@@ -27,6 +27,8 @@ const SCORE = /^Score\s*:?\s*(?<value>\d{1,3}(?:[.,]\d+)?)\s*\/\s*100\s*$/iu;
 export const WhiskySagaCursorSchema = currentReviewCursorSchema(
   MAX_CURRENT_ARTICLES,
 ).extend({
+  // Old saved progress skipped some dates. Start from the oldest list once.
+  checksReviewDates: z.boolean().default(false),
   nextHistoryUrl: z.url().nullable().default(null),
   processedHistoryArticleUrls: z
     .array(z.url())
@@ -176,8 +178,9 @@ export const whiskySagaAdapter: ScraperAdapter<
   WhiskySagaCursor,
   WhiskySagaObservation
 > = async ({ cursor, session }) => {
+  const savedProgress = cursor?.checksReviewDates ? cursor : null;
   let nextCursor = WhiskySagaCursorSchema.parse(
-    cursor ?? { processedArticleUrls: [] },
+    savedProgress ?? { checksReviewDates: true, processedArticleUrls: [] },
   );
   const indexResponse = await session.request({
     target: TARGET,

--- a/apps/server/src/scraper/adapters/whiskyfun.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyfun.test.ts
@@ -22,8 +22,12 @@ const OLDER_ARCHIVE_URL =
   "https://www.whiskyfun.com/archivedecember24-2-Lagavulin-Brora.html";
 const COMPLETED_HISTORY: Pick<
   WhiskyfunCursor,
-  "nextArchiveUrl" | "processedArchiveArticleUrls" | "historyComplete"
+  | "checksReviewDates"
+  | "nextArchiveUrl"
+  | "processedArchiveArticleUrls"
+  | "historyComplete"
 > = {
+  checksReviewDates: true,
   nextArchiveUrl: null,
   processedArchiveArticleUrls: [],
   historyComplete: true,
@@ -171,6 +175,7 @@ test("accepts a current-only cursor and adds history defaults", () => {
   expect(
     WhiskyfunCursorSchema.parse({ processedArticleUrls: [FIRST_URL] }),
   ).toEqual({
+    checksReviewDates: false,
     processedArticleUrls: [FIRST_URL],
     nextArchiveUrl: null,
     processedArchiveArticleUrls: [],
@@ -330,7 +335,7 @@ test("drops completed URLs that leave the current feed window", async () => {
   expect(new Set(completedUrls)).toEqual(new Set(currentUrls));
 });
 
-test("checks current externalReviews, imports one archive page, and advances", async () => {
+test("starts old saved progress again and checks one older page", async () => {
   const emit = vi.fn();
   const checkpoint = vi.fn();
   const request = vi.fn(async ({ url }: { url: URL }) => ({
@@ -351,7 +356,15 @@ test("checks current externalReviews, imports one archive page, and advances", a
     remainingRequests: () => 30,
   };
 
-  await whiskyfunAdapter({ cursor: null, session });
+  await whiskyfunAdapter({
+    cursor: WhiskyfunCursorSchema.parse({
+      processedArticleUrls: [],
+      nextArchiveUrl: null,
+      processedArchiveArticleUrls: [],
+      historyComplete: true,
+    }),
+    session,
+  });
 
   expect(request.mock.calls.map(([input]) => input.url.href)).toEqual([
     "https://www.whiskyfun.com/whatsnew.xml",
@@ -366,6 +379,7 @@ test("checks current externalReviews, imports one archive page, and advances", a
     }),
   );
   expect(checkpoint.mock.calls.at(-1)?.[0]).toEqual({
+    checksReviewDates: true,
     processedArticleUrls: [],
     nextArchiveUrl: OLDER_ARCHIVE_URL,
     processedArchiveArticleUrls: [],
@@ -395,6 +409,7 @@ test("resumes within an archive page and records the archive end", async () => {
 
   await whiskyfunAdapter({
     cursor: {
+      checksReviewDates: true,
       processedArticleUrls: [],
       nextArchiveUrl: ARCHIVE_URL,
       processedArchiveArticleUrls: [completedUrl],
@@ -406,6 +421,7 @@ test("resumes within an archive page and records the archive end", async () => {
   expect(request).toHaveBeenCalledTimes(2);
   expect(emit).not.toHaveBeenCalled();
   expect(checkpoint.mock.calls.at(-1)?.[0]).toEqual({
+    checksReviewDates: true,
     processedArticleUrls: [],
     nextArchiveUrl: null,
     processedArchiveArticleUrls: [],

--- a/apps/server/src/scraper/adapters/whiskyfun.ts
+++ b/apps/server/src/scraper/adapters/whiskyfun.ts
@@ -38,6 +38,8 @@ const WhiskyfunFeedArticleSchema = z
 export const WhiskyfunCursorSchema = currentReviewCursorSchema(
   MAX_FEED_ITEMS,
 ).extend({
+  // Old saved progress skipped some dates. Start from the oldest list once.
+  checksReviewDates: z.boolean().default(false),
   nextArchiveUrl: z.url().nullable().default(null),
   processedArchiveArticleUrls: z
     .array(z.url())
@@ -370,8 +372,9 @@ export const whiskyfunAdapter: ScraperAdapter<
   WhiskyfunCursor,
   WhiskyfunObservation
 > = async ({ cursor, session }) => {
+  const savedProgress = cursor?.checksReviewDates ? cursor : null;
   let nextCursor = WhiskyfunCursorSchema.parse(
-    cursor ?? { processedArticleUrls: [] },
+    savedProgress ?? { checksReviewDates: true, processedArticleUrls: [] },
   );
   const feedResponse = await session.request({
     target: TARGET,

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -101,7 +101,7 @@ describe("scrape source parser", () => {
   it("reads page fields for a single review", () => {
     const result = parseScrapeDetail(
       reviewConfig,
-      '<h1>Spring reviews</h1><h2>Example 12 Year</h2><article class="review"><span class="author">Ada</span><div class="body">Rich and balanced.</div></article>',
+      '<h1>Spring reviews</h1><time datetime="2026-04-02"></time><h2>Example 12 Year</h2><article class="review"><span class="author">Ada</span><div class="body">Rich and balanced.</div></article>',
       new URL("https://reviews.test/spring"),
     );
 
@@ -138,7 +138,7 @@ describe("scrape source parser", () => {
     );
     expect(result.kind).toBe("review");
     if (result.kind !== "review") throw new Error("Wrong kind");
-    expect(result.value?.article.externalReviews).toHaveLength(2);
+    expect(result.value).toBeNull();
     expect(result.issues).toEqual([
       { field: "detail.publishedAt", message: "Date is not valid." },
       {
@@ -158,6 +158,7 @@ describe("scrape source parser", () => {
     if (result.kind !== "review") throw new Error("Wrong kind");
     expect(result.value).toBeNull();
     expect(result.issues.map(({ field }) => field)).toEqual([
+      "detail.publishedAt",
       "detail.title",
       "detail.reviewItem",
     ]);

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -195,7 +195,12 @@ function parseReviewDetail(
     ? readValue($, rules.detail.publishedAt)
     : null;
   const publishedAt = parseDate(publishedAtText);
-  if (publishedAtText && !publishedAt) {
+  if (!publishedAtText) {
+    issues.push({
+      field: "detail.publishedAt",
+      message: "Required value was not found.",
+    });
+  } else if (!publishedAt) {
     issues.push({ field: "detail.publishedAt", message: "Date is not valid." });
   }
   const externalReviews: Array<{
@@ -277,7 +282,11 @@ function parseReviewDetail(
     },
   });
   if (!result.success) {
-    issues.push(...validationIssues(result.error, reviewField));
+    issues.push(
+      ...validationIssues(result.error, reviewField).filter(
+        ({ field }) => field !== "detail.publishedAt",
+      ),
+    );
     return { kind: "review", value: null, issues };
   }
   return {

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -63,6 +63,7 @@ async function setupSource(titleSelector = "h1", paginate = false) {
       list,
       detail: {
         title: { selector: titleSelector },
+        publishedAt: { selector: "time", attribute: "datetime" },
         reviewItem: "article.review",
         name: { selector: "h2" },
         reviewText: { selector: ".body" },
@@ -104,12 +105,12 @@ function previewFetch(paginate = false) {
     }
     if (url.pathname === "/one") {
       return new Response(
-        '<h1>August reviews</h1><article class="review"><h2>Example Whisky</h2><div class="body">Publisher prose must not be stored in preview.</div></article>',
+        '<h1>August reviews</h1><time datetime="2026-08-12"></time><article class="review"><h2>Example Whisky</h2><div class="body">Publisher prose must not be stored in preview.</div></article>',
       );
     }
     if (url.pathname === "/two") {
       return new Response(
-        '<h1>Earlier reviews</h1><article class="review"><h2>Second Whisky</h2><div class="body">Another review.</div></article>',
+        '<h1>Earlier reviews</h1><time datetime="2026-07-30"></time><article class="review"><h2>Second Whisky</h2><div class="body">Another review.</div></article>',
       );
     }
     throw new Error(`Unexpected URL: ${url.toString()}`);

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -17,7 +17,7 @@ function reviewCandidate(nameSelector: string) {
       },
       detail: {
         title: { selector: "h1", attribute: null },
-        publishedAt: null,
+        publishedAt: { selector: "time", attribute: "datetime" },
         reviewItem: "article.review",
         name: { selector: nameSelector, attribute: null },
         reviewerName: null,

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -74,7 +74,7 @@ const SuggestedReviewRulesSchema = z
     detail: z
       .object({
         title: SuggestedValueSelectorSchema,
-        publishedAt: SuggestedValueSelectorSchema.nullable(),
+        publishedAt: SuggestedValueSelectorSchema,
         reviewItem: ScrapeSelectorSchema,
         name: SuggestedValueSelectorSchema,
         reviewerName: SuggestedValueSelectorSchema.nullable(),
@@ -162,6 +162,7 @@ const RULE_INSTRUCTIONS = [
   "<success_criteria>",
   "Identify the content and attributes that represent each output field.",
   "Selectors must match the same field across the supplied detail pages.",
+  "Review rules must read the publisher's publication date.",
   "Include an optional field when the supplied pages clearly and consistently provide it.",
   "Pagination must add new detail-page links when the website has a next page.",
   "</success_criteria>",
@@ -192,6 +193,7 @@ function toScrapeValueSelector(
 function toReviewRules(input: SuggestedReviewRules): ScrapeRules {
   const detail: ReviewRules["detail"] = {
     title: toScrapeValueSelector(input.detail.title),
+    publishedAt: toScrapeValueSelector(input.detail.publishedAt),
     reviewItem: input.detail.reviewItem,
     name: toScrapeValueSelector(input.detail.name),
   };
@@ -201,9 +203,6 @@ function toReviewRules(input: SuggestedReviewRules): ScrapeRules {
   };
   if (input.list.nextPage !== null) {
     list.nextPage = toScrapeValueSelector(input.list.nextPage);
-  }
-  if (input.detail.publishedAt !== null) {
-    detail.publishedAt = toScrapeValueSelector(input.detail.publishedAt);
   }
   if (input.detail.reviewerName !== null) {
     detail.reviewerName = toScrapeValueSelector(input.detail.reviewerName);

--- a/apps/server/src/scraper/configured/suggestion.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.test.ts
@@ -13,6 +13,7 @@ const reviewRules = {
   },
   detail: {
     title: { selector: "h1" },
+    publishedAt: { selector: "time", attribute: "datetime" },
     reviewItem: "article.review",
     name: { selector: "h2" },
     reviewText: { selector: ".body" },
@@ -104,7 +105,7 @@ test("parses supplied detail pages with the production parser", async () => {
     suppliedPages: [
       {
         url: "https://example.test/reviews/one",
-        html: '<h1>Autumn reviews</h1><article class="review"><h2>North Coast 12</h2><p class="body">Orange and oak.</p></article>',
+        html: '<h1>Autumn reviews</h1><time datetime="2026-08-12"></time><article class="review"><h2>North Coast 12</h2><p class="body">Orange and oak.</p></article>',
       },
     ],
     loadPage: async () => {
@@ -139,7 +140,7 @@ test("keeps complete review text in the checked output", async () => {
     suppliedPages: [
       {
         url: "https://example.test/reviews/one",
-        html: `<h1>Autumn reviews</h1><article class="review"><h2>North Coast 12</h2><p class="body">${reviewText}</p></article>`,
+        html: `<h1>Autumn reviews</h1><time datetime="2026-08-12"></time><article class="review"><h2>North Coast 12</h2><p class="body">${reviewText}</p></article>`,
       },
     ],
     loadPage: async () => {

--- a/apps/server/src/scraper/lifecycle.test.ts
+++ b/apps/server/src/scraper/lifecycle.test.ts
@@ -129,6 +129,7 @@ test("opted-in source resumes the last successful run cursor", async ({
 
   expect(run.cursor).toEqual({
     ...successfulCursor,
+    checksReviewDates: false,
     currentArticleUrls: [],
     historyComplete: false,
   });

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -127,6 +127,9 @@ test("registers every scraper source with explicit target ownership", () => {
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("whiskyadvocate")?.requestLimit).toBe(30);
+  expect(scraperRegistry.sources.get("whiskyadvocate")?.resumeFromLastRun).toBe(
+    true,
+  );
   expect(EXTERNAL_SITE_DEFINITIONS.whiskynotes.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskynotes")).toMatchObject({
     minimumSpacingMs: 2_500,

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -438,6 +438,7 @@ export const scraperRegistry = createScraperRegistry({
       // Keep the slice budget above the target quota so one hourly deferral
       // consumes one execution attempt.
       requestLimit: 30,
+      resumeFromLastRun: true,
       cursorSchema: WhiskyAdvocateCursorSchema,
       observationSchema: WhiskyAdvocateObservationSchema,
       adapter: whiskyAdvocateAdapter,

--- a/apps/server/src/scraper/sinks/externalReviews.test.ts
+++ b/apps/server/src/scraper/sinks/externalReviews.test.ts
@@ -24,7 +24,7 @@ test("Whisky Advocate observations use article and source identity", async ({
         canonicalUrl: url,
         title: bottle.fullName,
         issue: "Fall 2026",
-        publishedAt: null,
+        publishedAt: new Date("2026-08-20T00:00:00.000Z"),
         contentHash: "first",
         externalReviews: [
           {
@@ -48,6 +48,7 @@ test("Whisky Advocate observations use article and source identity", async ({
         ...observation.value,
         article: {
           ...observation.value.article,
+          publishedAt: new Date("2026-08-19T00:00:00.000Z"),
           contentHash: "second",
           externalReviews: [
             {
@@ -102,6 +103,7 @@ test("Whisky Advocate observations use article and source identity", async ({
       id: storedExternalReviews[0]!.externalReview.articleId,
       issue: "Fall 2026",
       title: bottle.fullName,
+      publishedAt: new Date("2026-08-19T00:00:00.000Z"),
       contentHash: expect.any(String),
       fetchedAt: expect.any(Date),
     },

--- a/docs/features/external-review-indexing.md
+++ b/docs/features/external-review-indexing.md
@@ -59,7 +59,7 @@ extracts the publisher value and any fallback year.
 
 The adapter emits one strict article observation with:
 
-- canonical URL, title, optional issue, optional publication date, and content
+- review URL, title, optional issue, required publication date, and content
   hash;
 - one or more Bottle review observations;
 - a stable key, Bottle name, optional reviewer, optional native score, and
@@ -151,15 +151,18 @@ at most four historical archive pages. Each page supplies at most 20 article
 links. A new run continues from the last successful run cursor. When the
 archive ends, later runs check only the current page. Requests are at least 2.5
 seconds apart. The target allows 30 requests per hour, and each worker pass
-stops after 30 requests.
+stops after 30 requests. After this date fix, the scraper starts the archive
+from the beginning once so it can correct dates already in Peated.
 
-The Whisky Advocate pilot is also manual-only. It requests the issue index, the
-newest issue, and each listed review page to collect its explicit publication
-date. Requests are at least 2.5 seconds apart. Each worker pass has a 30-request
-budget, and the target allows at most 20 requests per hour. The run checkpoints
-each stored review and can resume for up to ten worker passes. The adapter keeps
-the complete source Bottle title for classification and reads the category
-before the separate price line. It does not persist review prose.
+The Whisky Advocate pilot is also manual-only. It checks one magazine issue at
+a time and reads the date from each review page. Later manual runs continue
+with older issues. This corrects reviews that were saved without their original
+date. Requests are at
+least 2.5 seconds apart. Each worker pass has a 30-request budget, and the
+target allows at most 20 requests per hour. The run checkpoints each stored
+review and can resume for up to ten worker passes. The adapter keeps the
+complete source Bottle title for classification and reads the category before
+the separate price line. It does not persist review prose.
 
 Whiskyfun runs once per day. It reads at most 20 current RSS items and skips
 clear non-whisky articles before it requests article pages. It then advances
@@ -168,8 +171,9 @@ run discovers the newest archive from the homepage. Each later page supplies
 the next older link. Historical articles keep the publisher's daily date anchor
 and date. When the archive ends, later runs check only the current feed.
 Requests are at least 2.5 seconds apart. The target allows 25 requests per hour,
-and each worker pass stops after 30 requests. The adapter stores dates, reviewer
-metadata, native scores, and canonical links. Review prose stays transient.
+and each worker pass stops after 30 requests. The scraper saves dates, reviewer
+names, scores, and review links. It does not save review text. After this date
+fix, the scraper starts the old archive from the beginning once.
 
 Dramface runs once per day. It reads at most 20 current links from the public
 review index. It does not request Squarespace feeds, JSON views, APIs, search,
@@ -193,7 +197,7 @@ public homepage Recent Reviews list. It does not request the alphabetical
 archive, category pages, sitemaps, feeds, search, or WordPress APIs. Requests
 are at least five seconds apart. The target allows 10 requests per hour, and
 each worker pass stops after six requests. The adapter stores the writer,
-canonical link, displayed letter grade, and URL date when valid. Tasting-note
+canonical link, displayed letter grade, and required URL date. Tasting-note
 paragraphs stay transient and are discarded after parsing.
 
 Bourbon Culture runs once per day. It reads only the six links under Latest
@@ -220,9 +224,9 @@ its last successful cursor. It follows only the publisher's Scotland category
 links with `offset` and `category` parameters. It does not request the full
 sitemap, search, other query filters, or Squarespace APIs. Requests are at
 least 2.5 seconds apart. The target allows 25 requests per hour, and each worker
-pass stops after 22 requests. The adapter stores the exact publication
-timestamp, author, canonical link, and native 100-point score. Review text
-stays transient and is discarded after parsing.
+pass stops after 22 requests. The scraper saves the exact date and time, author,
+review link, and 100-point score. It does not save review text. After this date
+fix, the scraper starts the old pages from the beginning once.
 
 The Whisky Study runs once per day. It reads only the 20 article cards on the
 first public Scotch review index page. It does not request older pagination,


### PR DESCRIPTION
Review scrapers now save the date shown on the original review. They no longer use the day Peated found the review. This also applies to scrapers we generate.

The next runs will go back through older reviews and correct dates already in Peated. Whisky Advocate will recheck reviews listed in progress saved by the old code because those reviews might not have dates. If a scraper cannot find a valid date, it will stop instead of saving a wrong one. Existing generated scraper setups that do not collect a date must be set up again.
