### PR TITLE
fix(search): show complete bottle display names

### DIFF
--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -127,7 +127,6 @@ function bottleItem(
   },
 ) {
   const metadata = [
-    bottle.brand.name,
     bottle.category ? formatCategoryName(bottle.category) : null,
     bottle.statedAge === null ? null : `${bottle.statedAge} years`,
     bottle.abv === null ? null : `${bottle.abv.toFixed(1)}% ABV`,
@@ -146,7 +145,7 @@ function bottleItem(
         }
       : undefined,
     metadata: metadata.join(" · "),
-    title: formatBottleDisplayName(bottle, { includeBrand: false }),
+    title: formatBottleDisplayName(bottle),
     visual: {
       fallback: "B",
       imageUrl: bottle.imageUrl,


### PR DESCRIPTION
Bottle search results now use the complete simplified display name, so entries read like `Lagavulin 16-year-old` instead of `16-year-old`. The metadata row no longer repeats the brand that is present in the title.
