### PR TITLE
docs(api): define OpenAPI description conventions

### DIFF
--- a/apps/server/src/orpc/contracts/entityKinds/list.ts
+++ b/apps/server/src/orpc/contracts/entityKinds/list.ts
@@ -22,13 +22,42 @@ export const EntityKindListInputSchema = z
       .string()
       .default("")
       .describe("Search text only. Search operators are not supported."),
-    name: z.string().nullish(),
-    owner: z.coerce.number().int().positive().nullish(),
-    country: z.coerce.string().nullish().describe("Country slug or id"),
-    region: z.coerce.string().nullish().describe("Region slug or id"),
-    sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
-    cursor: z.coerce.number().gte(1).default(1),
-    limit: z.coerce.number().lte(500).default(100),
+    name: z
+      .string()
+      .nullish()
+      .describe("Match an Entity name or alias case-insensitively"),
+    owner: z.coerce
+      .number()
+      .int()
+      .positive()
+      .nullish()
+      .describe("Filter by the current owner Entity ID"),
+    country: z.coerce
+      .string()
+      .nullish()
+      .describe("Filter by country slug or numeric ID"),
+    region: z.coerce
+      .string()
+      .nullish()
+      .describe(
+        "Filter by region slug or numeric ID. A slug requires `country`.",
+      ),
+    sort: z
+      .enum(SORT_OPTIONS)
+      .default(DEFAULT_SORT)
+      .describe(
+        "`rank` orders by search relevance, or tasting count when `query` is empty. Prefix another value with `-` for descending order.",
+      ),
+    cursor: z.coerce
+      .number()
+      .gte(1)
+      .default(1)
+      .describe("Page number to return"),
+    limit: z.coerce
+      .number()
+      .lte(500)
+      .default(100)
+      .describe("Maximum number of Entities to return per page"),
   })
   .default({
     query: "",

--- a/apps/server/src/orpc/routes/entities/list.test.ts
+++ b/apps/server/src/orpc/routes/entities/list.test.ts
@@ -42,4 +42,28 @@ describe("GET /entities", () => {
       expect.arrayContaining([brand.id, bottler.id]),
     );
   });
+
+  test("filters Entities across kinds by current owner", async ({
+    fixtures,
+  }) => {
+    const owner = await fixtures.Entity({ kind: "company" });
+    const brand = await fixtures.Entity({
+      name: "A Owned Brand",
+      kind: "brand",
+      ownerId: owner.id,
+    });
+    const distillery = await fixtures.Entity({
+      name: "B Owned Distillery",
+      kind: "distillery",
+      ownerId: owner.id,
+    });
+    await fixtures.Entity({ name: "Unowned Bottler", kind: "bottler" });
+
+    const { results } = await routerClient.entities.list({
+      owner: owner.id,
+      sort: "name",
+    });
+
+    expect(results.map(({ id }) => id)).toEqual([brand.id, distillery.id]);
+  });
 });

--- a/docs/development/orpc-routes.md
+++ b/docs/development/orpc-routes.md
@@ -218,6 +218,39 @@ const Input = z.object({
 });
 ```
 
+### OpenAPI Text
+
+Write OpenAPI text for a developer who cannot see the handler. Use a neutral,
+direct, and factual voice. Use present tense, active verbs, common words, and
+short sentences. Do not use humor, marketing language, or conversational
+filler.
+
+- Start an operation summary with a verb and name the resource, such as
+  `List bottles`.
+- Use the operation description for the endpoint's overall behavior, scope,
+  permission, or important side effect. Keep optional filter details on their
+  parameters.
+- Describe what each field means or changes. Include units, accepted identifier
+  forms, special values, ordering rules, and conditional requirements when
+  they are not clear from the schema.
+- Do not repeat a type, range, enum, or default that the generated schema
+  already shows unless the value needs domain context.
+- Use the canonical domain noun. Put parameter names and literal values in
+  backticks.
+- Start filter descriptions with a direct verb such as `Filter`, `Match`, or
+  `Search`. Use a short noun phrase when it is clearer, such as
+  `Page number to return`.
+- Describe the public contract. Do not mention database columns, framework
+  types, handler names, or other implementation details.
+
+Examples:
+
+| Avoid        | Write                                                           |
+| ------------ | --------------------------------------------------------------- |
+| Owner filter | Filter by the current owner Entity ID                           |
+| Region       | Filter by region slug or numeric ID. A slug requires `country`. |
+| Sort value   | Prefix a value with `-` for descending order.                   |
+
 ## 7. Error Handling
 
 `procedure` injects an `errors` helper with canonical REST errors like `NOT_FOUND`, `CONFLICT`, and `UNAUTHORIZED`. Prefer these over manual `ORPCError` construction.


### PR DESCRIPTION
Entity list query parameters now describe their filter, pagination, and ordering semantics in generated OpenAPI. This includes current-owner filtering, the conditional region slug, and the `rank` fallback. Route coverage confirms that one owner query returns Entities across kinds.

The oRPC route guide now defines a neutral, direct OpenAPI voice. Endpoint-wide behavior stays in operation descriptions, while filter details stay on their parameters.
