### PR TITLE
fix(admin): simplify scraper settings

### DIFF
--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { ExternalSiteKeySchema } from "@peated/server/schemas";
-import { AdminPage } from "@peated/web/components/admin/adminContent.stylex";
+import {
+  AdminPage,
+  AdminSection,
+} from "@peated/web/components/admin/adminContent.stylex";
 import ScraperAdapterStatus from "@peated/web/components/admin/scraperAdapterStatus";
 import ScraperIconSettings from "@peated/web/components/admin/scraperIconSettings";
 import { ScraperParsingEditor } from "@peated/web/components/admin/scraperParsingEditor.stylex";
@@ -10,6 +13,8 @@ import ScraperPublicationSettings from "@peated/web/components/admin/scraperPubl
 import ScraperReadiness from "@peated/web/components/admin/scraperReadiness";
 import ScraperScheduleSettings from "@peated/web/components/admin/scraperScheduleSettings.stylex";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { colors, space } from "@peated/web/styles/tokens.stylex";
+import * as stylex from "@stylexjs/stylex";
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { use } from "react";
 
@@ -42,11 +47,25 @@ export default function Page(props: { params: Promise<{ siteId: string }> }) {
 
   return (
     <AdminPage>
-      <ScraperScheduleSettings key={site.runEvery ?? "manual"} site={site} />
-      <ScraperIconSettings site={site} />
-      {site.reviewPublication ? (
-        <ScraperPublicationSettings site={site} />
-      ) : null}
+      <AdminSection
+        title="Site settings"
+        description="Set the schedule, update the site icon, and choose whether reviews linked to bottles are public."
+      >
+        <div {...stylex.props(styles.settings)}>
+          <ScraperScheduleSettings
+            key={site.runEvery ?? "manual"}
+            site={site}
+          />
+          <div {...stylex.props(styles.dividedSetting)}>
+            <ScraperIconSettings site={site} />
+          </div>
+          {site.reviewPublication ? (
+            <div {...stylex.props(styles.dividedSetting)}>
+              <ScraperPublicationSettings site={site} />
+            </div>
+          ) : null}
+        </div>
+      </AdminSection>
       <ScraperReadiness site={site} />
       {source ? (
         <ScraperParsingEditor
@@ -64,3 +83,19 @@ export default function Page(props: { params: Promise<{ siteId: string }> }) {
     </AdminPage>
   );
 }
+
+const styles = stylex.create({
+  settings: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+  },
+  dividedSetting: {
+    minWidth: 0,
+    marginTop: space.x6,
+    paddingTop: space.x6,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.hairline,
+  },
+});

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
@@ -113,7 +113,7 @@ export default function Layout({
       />
       <AdminStatGrid>
         <AdminStat
-          label="External reviews"
+          label="Reviews"
           value={`${site.externalReviews.matched.toLocaleString("en-US")} / ${site.externalReviews.total.toLocaleString("en-US")}`}
         />
         <AdminStat
@@ -125,10 +125,10 @@ export default function Layout({
         ariaLabel="Scraper"
         currentHref={pathname}
         items={[
-          { href: root, label: "Setup" },
+          { href: root, label: "Settings" },
           { href: `${root}/runs`, label: "Runs" },
           { href: `${root}/prices`, label: "Prices" },
-          { href: `${root}/external-reviews`, label: "External reviews" },
+          { href: `${root}/external-reviews`, label: "Reviews" },
         ]}
       />
       {children}

--- a/apps/web/src/components/admin/externalReviewTable.test.tsx
+++ b/apps/web/src/components/admin/externalReviewTable.test.tsx
@@ -88,7 +88,7 @@ function makeExternalReview(
     id,
     name: "Springbank review",
     url: `https://example.com/reviews/${id}`,
-    article: { title: null, publishedAt: null },
+    article: { title: null, publishedAt: "2026-07-21T00:00:00.000Z" },
     reviewerName: null,
     nativeScore: { value: 91, scale: 100, display: "91/100" },
     bottle: reviewBottle,
@@ -107,6 +107,8 @@ describe("ExternalReviewTable", () => {
 
     expect(html).toContain('href="/bottles/19"');
     expect(html).toContain("Springbank 12 Cask Strength Batch 24");
+    expect(html).toContain("Published Jul 21, 2026");
+    expect(html).toContain('dateTime="2026-07-21T00:00:00.000Z"');
   });
 
   it("renders unresolved review identity without a catalog link", () => {

--- a/apps/web/src/components/admin/externalReviewTable.tsx
+++ b/apps/web/src/components/admin/externalReviewTable.tsx
@@ -1,8 +1,17 @@
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { ExternalReview, PagingRel } from "@peated/server/types";
+import * as stylex from "@stylexjs/stylex";
 
+import { colors, fonts, space } from "../../styles/tokens.stylex";
 import { AdminTextLink } from "./adminContent.stylex";
 import { AdminTable } from "./adminTable.stylex";
+
+const publishedDateFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+});
 
 export default function ExternalReviewTable({
   externalReviewList,
@@ -29,18 +38,30 @@ export function ExternalReviewRows({
         {
           name: "review",
           value: (review) => (
-            <span>
-              <AdminTextLink href={review.url}>{review.name}</AdminTextLink>
-              {review.bottle ? (
-                <>
-                  {" · "}
+            <span {...stylex.props(styles.review)}>
+              <span>
+                <AdminTextLink href={review.url}>{review.name}</AdminTextLink>
+              </span>
+              <span {...stylex.props(styles.metadata)}>
+                {review.bottle ? (
                   <AdminTextLink href={`/bottles/${review.bottle.id}`}>
                     {formatBottleDisplayName(review.bottle)}
                   </AdminTextLink>
-                </>
-              ) : (
-                " · No bottle"
-              )}
+                ) : (
+                  "No bottle"
+                )}
+                {" · "}
+                {review.article.publishedAt ? (
+                  <time dateTime={review.article.publishedAt}>
+                    Published{" "}
+                    {publishedDateFormatter.format(
+                      new Date(review.article.publishedAt),
+                    )}
+                  </time>
+                ) : (
+                  "Publish date unknown"
+                )}
+              </span>
             </span>
           ),
         },
@@ -55,3 +76,17 @@ export function ExternalReviewRows({
     />
   );
 }
+
+const styles = stylex.create({
+  review: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x1,
+  },
+  metadata: {
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "11px",
+  },
+});

--- a/apps/web/src/components/admin/scraperIconSettings.tsx
+++ b/apps/web/src/components/admin/scraperIconSettings.tsx
@@ -6,9 +6,9 @@ import { useState } from "react";
 import { getFormErrorMessage } from "../../lib/formHelpers";
 import { useORPC } from "../../lib/orpc/context";
 import { AdminButton } from "./adminButton.stylex";
-import { AdminSection } from "./adminContent.stylex";
 import { AdminFormError } from "./adminForm.stylex";
 import { ExternalSiteIdentity } from "./externalSiteIcon.stylex";
+import ScraperSetting from "./scraperSetting.stylex";
 
 type Site = Outputs["externalSites"]["healthDetails"];
 
@@ -43,7 +43,7 @@ export default function ScraperIconSettings({ site }: { site: Site }) {
   }
 
   return (
-    <AdminSection
+    <ScraperSetting
       title="Site icon"
       description={
         hasWebsite
@@ -65,6 +65,6 @@ export default function ScraperIconSettings({ site }: { site: Site }) {
       <ExternalSiteIdentity imageUrl={site.imageUrl} name={site.name} size="lg">
         {site.imageUrl ? "Saved icon" : "No icon saved"}
       </ExternalSiteIdentity>
-    </AdminSection>
+    </ScraperSetting>
   );
 }

--- a/apps/web/src/components/admin/scraperPublicationSettings.tsx
+++ b/apps/web/src/components/admin/scraperPublicationSettings.tsx
@@ -7,9 +7,10 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { getFormErrorMessage } from "../../lib/formHelpers";
 import { useORPC } from "../../lib/orpc/context";
 import { AdminButton } from "./adminButton.stylex";
-import { AdminSection, AdminStatus } from "./adminContent.stylex";
+import { AdminStatus } from "./adminContent.stylex";
 import { AdminFormError } from "./adminForm.stylex";
 import { AdminDefinitionList as DefinitionList } from "./adminUtility.stylex";
+import ScraperSetting from "./scraperSetting.stylex";
 
 type Site = Outputs["externalSites"]["healthDetails"];
 
@@ -87,12 +88,12 @@ export default function ScraperPublicationSettings({ site }: { site: Site }) {
   }
 
   return (
-    <AdminSection
+    <ScraperSetting
       title="Public reviews"
       description={
         approved
-          ? "Matched reviews are public. New matches will be public too."
-          : "Publish matched reviews. New matches will be public too."
+          ? "Reviews linked to bottles are public. Reviews linked later will be public too."
+          : "Publish reviews linked to bottles. Reviews linked later will be public too."
       }
       action={
         <ReviewPublishingAction
@@ -105,6 +106,6 @@ export default function ScraperPublicationSettings({ site }: { site: Site }) {
     >
       {error ? <AdminFormError values={[error]} /> : null}
       <ReviewPublishingState site={site} />
-    </AdminSection>
+    </ScraperSetting>
   );
 }

--- a/apps/web/src/components/admin/scraperScheduleSettings.stylex.tsx
+++ b/apps/web/src/components/admin/scraperScheduleSettings.stylex.tsx
@@ -8,10 +8,9 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { formatDuration } from "../../lib/format";
 import { getFormErrorMessage } from "../../lib/formHelpers";
 import { useORPC } from "../../lib/orpc/context";
-import { space } from "../../styles/tokens.stylex";
+import { colors, fonts, space } from "../../styles/tokens.stylex";
 import TimeSince from "../timeSince";
 import { AdminButton } from "./adminButton.stylex";
-import { AdminSection } from "./adminContent.stylex";
 import {
   AdminFormError,
   AdminFormGrid,
@@ -19,6 +18,7 @@ import {
   AdminTextField,
 } from "./adminForm.stylex";
 import { AdminDefinitionList as DefinitionList } from "./adminUtility.stylex";
+import ScraperSetting from "./scraperSetting.stylex";
 
 type Site = Outputs["externalSites"]["healthDetails"];
 export type ScheduleChoice = "manual" | "daily" | "weekly" | "custom";
@@ -98,7 +98,7 @@ export default function ScraperScheduleSettings({ site }: { site: Site }) {
   }
 
   return (
-    <AdminSection
+    <ScraperSetting
       title="Schedule"
       description="Choose when this scraper runs. You can still run it manually."
       action={
@@ -117,72 +117,69 @@ export default function ScraperScheduleSettings({ site }: { site: Site }) {
         </AdminButton>
       }
     >
-      <div {...stylex.props(styles.stack)}>
-        {error ? <AdminFormError values={[error]} /> : null}
-        <DefinitionList>
-          <DefinitionList.Term>Current</DefinitionList.Term>
-          <DefinitionList.Details>
-            {site.runEvery === null
-              ? "Manual"
-              : `Every ${formatDuration(site.runEvery * 60_000)}`}
-          </DefinitionList.Details>
-          <DefinitionList.Term>Next run</DefinitionList.Term>
-          <DefinitionList.Details>
-            {site.nextRunAt ? (
-              <TimeSince date={site.nextRunAt} />
-            ) : site.runEvery === null ? (
-              "Not scheduled"
-            ) : (
-              "Due now"
-            )}
-          </DefinitionList.Details>
-        </DefinitionList>
-        <AdminFormGrid>
-          <AdminSelectField
-            label="Run schedule"
-            name="schedule"
-            value={choice}
-            onChange={(event) =>
-              setChoice(parseScheduleChoice(event.target.value))
-            }
-            options={[
-              { label: "Manual only", value: "manual" },
-              { label: "Every day", value: "daily" },
-              { label: "Every week", value: "weekly" },
-              { label: "Custom", value: "custom" },
-            ]}
+      {error ? <AdminFormError values={[error]} /> : null}
+      <DefinitionList>
+        <DefinitionList.Term>Current</DefinitionList.Term>
+        <DefinitionList.Details>
+          {site.runEvery === null
+            ? "Manual"
+            : `Every ${formatDuration(site.runEvery * 60_000)}`}
+        </DefinitionList.Details>
+        <DefinitionList.Term>Next run</DefinitionList.Term>
+        <DefinitionList.Details>
+          {site.nextRunAt ? (
+            <TimeSince date={site.nextRunAt} />
+          ) : site.runEvery === null ? (
+            "Not scheduled"
+          ) : (
+            "Due now"
+          )}
+        </DefinitionList.Details>
+      </DefinitionList>
+      <AdminFormGrid>
+        <AdminSelectField
+          label="Run schedule"
+          name="schedule"
+          value={choice}
+          onChange={(event) =>
+            setChoice(parseScheduleChoice(event.target.value))
+          }
+          options={[
+            { label: "Manual only", value: "manual" },
+            { label: "Every day", value: "daily" },
+            { label: "Every week", value: "weekly" },
+            { label: "Custom", value: "custom" },
+          ]}
+          required
+        />
+        {choice === "custom" ? (
+          <AdminTextField
+            label="Run every"
+            name="customMinutes"
+            type="number"
+            min={1}
+            step={1}
+            value={customMinutes}
+            suffixLabel="minutes"
+            onChange={(event) => setCustomMinutes(event.target.value)}
             required
           />
-          {choice === "custom" ? (
-            <AdminTextField
-              label="Run every"
-              name="customMinutes"
-              type="number"
-              min={1}
-              step={1}
-              value={customMinutes}
-              suffixLabel="minutes"
-              onChange={(event) => setCustomMinutes(event.target.value)}
-              required
-            />
-          ) : null}
-        </AdminFormGrid>
-        {automaticUnavailable ? (
-          <p {...stylex.props(styles.help)}>
-            Set up this scraper before you schedule automatic runs.
-          </p>
         ) : null}
-      </div>
-    </AdminSection>
+      </AdminFormGrid>
+      {automaticUnavailable ? (
+        <p {...stylex.props(styles.help)}>
+          Set up this scraper before you schedule automatic runs.
+        </p>
+      ) : null}
+    </ScraperSetting>
   );
 }
 
 const styles = stylex.create({
-  stack: {
-    display: "flex",
-    minWidth: 0,
-    flexDirection: "column",
-    gap: space.x4,
+  help: {
+    margin: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
   },
-  help: { margin: 0 },
 });

--- a/apps/web/src/components/admin/scraperSetting.stylex.tsx
+++ b/apps/web/src/components/admin/scraperSetting.stylex.tsx
@@ -1,0 +1,58 @@
+import * as stylex from "@stylexjs/stylex";
+import type { ReactNode } from "react";
+
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, fonts, space } from "../../styles/tokens.stylex";
+
+export default function ScraperSetting({
+  action,
+  children,
+  description,
+  title,
+}: {
+  action: ReactNode;
+  children: ReactNode;
+  description: ReactNode;
+  title: ReactNode;
+}) {
+  return (
+    <div {...stylex.props(styles.stack)}>
+      <div {...stylex.props(styles.header)}>
+        <div {...stylex.props(styles.copy)}>
+          <h3 {...stylex.props(foundationStyles.sectionHeading)}>{title}</h3>
+          <p {...stylex.props(styles.description)}>{description}</p>
+        </div>
+        {action}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  stack: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x4,
+  },
+  header: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    flexWrap: "wrap",
+    gap: space.x4,
+  },
+  copy: { minWidth: 0 },
+  description: {
+    marginTop: space.x2,
+    marginRight: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "14px",
+    lineHeight: 1.5,
+  },
+});


### PR DESCRIPTION
Scraper details now use the plain “Settings” and “Reviews” labels, show each review’s publication date, and group the schedule, site icon, and public-review controls into one settings card. Connection diagnostics and parsing-version workflows remain separate.

A small scraper-specific wrapper keeps the three settings consistent without changing their mutations or any API contracts. Reviews without a source date show “Publish date unknown.”
