### PR TITLE
feat(web): add entity-specific overview modules

### DIFF
--- a/apps/server/src/orpc/mock/fixtures/entities.ts
+++ b/apps/server/src/orpc/mock/fixtures/entities.ts
@@ -219,6 +219,41 @@ export const mockEntities: Entity[] = [
     totalTastings: 640,
     totalBottles: 68,
   },
+  {
+    ...mockEntity,
+    id: 9214,
+    peatedId: "E9214",
+    name: "Caol Ila",
+    shortName: null,
+    ownerId: 9210,
+    owner: { id: 9210, peatedId: "E9210", name: "Diageo" },
+    description:
+      "An Islay distillery known for a lighter, maritime style of peated single malt.",
+    yearEstablished: 1846,
+    website: "https://www.malts.com/en-row/distilleries/caol-ila",
+    address: "Caol Ila Distillery, Port Askaig, Isle of Islay, PA46 7RL, UK",
+    location: [-6.109, 55.8543],
+    totalTastings: 720,
+    totalBottles: 604,
+  },
+  {
+    ...mockEntity,
+    id: 9215,
+    peatedId: "E9215",
+    name: "Talisker",
+    shortName: null,
+    ownerId: 9210,
+    owner: { id: 9210, peatedId: "E9210", name: "Diageo" },
+    description:
+      "An island distillery known for peppery, maritime single malt.",
+    yearEstablished: 1830,
+    website: "https://www.malts.com/en-row/distilleries/talisker",
+    region: null,
+    address: "Talisker Distillery, Carbost, Isle of Skye, IV47 8SR, UK",
+    location: [-6.3552, 57.3026],
+    totalTastings: 860,
+    totalBottles: 188,
+  },
 ];
 
 export const mockMacallanEntity = mockEntities[1]!;
@@ -228,3 +263,6 @@ export const mockYamazakiEntity = mockEntities[4]!;
 export const mockMidletonEntity = mockEntities[5]!;
 export const mockRedbreastEntity = mockEntities[6]!;
 export const mockLaphroaigEntity = mockEntities[10]!;
+export const mockDiageoEntity = mockEntities[9]!;
+export const mockCaolIlaEntity = mockEntities[13]!;
+export const mockTaliskerEntity = mockEntities[14]!;

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -10,6 +10,7 @@ import {
   mockBottlePrices,
   mockBottles,
   mockBottleTags,
+  mockCaolIlaEntity,
   mockChanges,
   mockCollectionBottles,
   mockCommentsByTasting,
@@ -25,11 +26,13 @@ import {
   mockFriendDetails,
   mockFriends,
   mockFriendships,
+  mockLaphroaigEntity,
   mockNotifications,
   mockPublicUserDetails,
   mockRegion,
   mockRegions,
   mockStats,
+  mockTaliskerEntity,
   mockTasting,
   mockUser,
   mockUserDetails,
@@ -88,6 +91,21 @@ describe("mock oRPC router", () => {
     const entities = await anonymousClient.entities.list({ limit: 100 });
     expect(entities.results).toHaveLength(mockEntities.length);
     expect(entities.results.every((entity) => entity.kind)).toBe(true);
+    const diageoEntities = await anonymousClient.entities.list({
+      owner: 9210,
+      sort: "-bottles",
+    });
+    expect(diageoEntities.results).toEqual([
+      mockCaolIlaEntity,
+      mockTaliskerEntity,
+    ]);
+    const laphroaigReleases = await anonymousClient.bottles.list({
+      entity: mockLaphroaigEntity.id,
+      sort: "-release",
+    });
+    expect(
+      laphroaigReleases.results.map((bottle) => bottle.releaseYear),
+    ).toEqual([2023, 2022]);
     await expect(
       authenticatedClient.entities.create({
         name: "New Bottler",

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
@@ -1,0 +1,113 @@
+import type { Outputs } from "@peated/server/orpc/router";
+
+import {
+  BottleComparisonTable,
+  ButtonLink,
+  EmptyState,
+  LoadingList,
+  SectionError,
+  TextLink,
+} from "@peated/web/components/designSystem/components";
+import { PageSection } from "@peated/web/components/designSystem/patterns/pageLayout.stylex";
+import { getEntityUrl } from "@peated/web/lib/urls";
+
+import { toBottleTableRow } from "./entityBottleTableRows";
+import {
+  entityHasBottleCatalog,
+  getEntityPresentation,
+  type Entity,
+} from "./entityPageData";
+
+type BottleList = Outputs["bottles"]["list"];
+
+export function EntityBottleOverview({
+  bottleList,
+  createBottleHref,
+  entity,
+  error,
+  pending,
+  retry,
+  totalBottles,
+}: {
+  bottleList?: BottleList;
+  createBottleHref?: string;
+  entity: Entity;
+  error: boolean;
+  pending: boolean;
+  retry: () => void;
+  totalBottles: number;
+}) {
+  const presentation = getEntityPresentation(entity);
+  const entityHref = getEntityUrl(entity);
+
+  if (!entityHasBottleCatalog(entity)) return null;
+
+  if (pending) {
+    return (
+      <PageSection heading={presentation.bottleSectionLabel}>
+        <LoadingList label="Loading associated bottles" rows={4} />
+      </PageSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageSection heading={presentation.bottleSectionLabel}>
+        <SectionError
+          heading="Associated bottles are unavailable"
+          onRetry={retry}
+        >
+          The entity record is still available. Try loading its bottles again.
+        </SectionError>
+      </PageSection>
+    );
+  }
+
+  if (!bottleList?.results.length) {
+    const isBottling = presentation.bottleSectionLabel === "Bottlings";
+    const addBottleHref =
+      createBottleHref ??
+      `/bottles/new?${new URLSearchParams({
+        returnTo: entityHref,
+      }).toString()}`;
+
+    return (
+      <PageSection heading={presentation.bottleSectionLabel}>
+        <EmptyState
+          action={
+            <ButtonLink href={addBottleHref} size="sm" variant="accent">
+              Add a bottle
+            </ButtonLink>
+          }
+          heading={isBottling ? "No bottlings yet" : "No bottles yet"}
+        >
+          No {presentation.bottleSectionLabel.toLowerCase()} have been added for
+          {entity.name} yet.
+        </EmptyState>
+      </PageSection>
+    );
+  }
+
+  const [firstBottle, ...remainingBottles] = bottleList.results;
+
+  return (
+    <PageSection
+      count={bottleList.results.length}
+      heading={presentation.bottleSectionLabel}
+      intro={
+        <TextLink href={`${entityHref}/bottles?sort=-tastings`}>
+          View all {totalBottles.toLocaleString("en-US")} bottles
+        </TextLink>
+      }
+    >
+      <BottleComparisonTable
+        ariaLabel={`${entity.name} ${presentation.bottleSectionLabel.toLowerCase()}`}
+        columns={["Rating"]}
+        rows={[
+          toBottleTableRow(firstBottle),
+          ...remainingBottles.map((bottle) => toBottleTableRow(bottle)),
+        ]}
+      />
+    </PageSection>
+  );
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleTableRows.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleTableRows.tsx
@@ -1,0 +1,89 @@
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
+import { formatCategoryName } from "@peated/server/lib/format";
+import type { Outputs } from "@peated/server/orpc/router";
+
+import {
+  RatingMeasure,
+  type BottleComparisonRow,
+} from "@peated/web/components/designSystem/components";
+
+type Bottle = Outputs["bottles"]["list"]["results"][number];
+
+const releaseDateFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+});
+
+function formatAbv(abv: number) {
+  return abv.toFixed(1).replace(/\.0$/, "");
+}
+
+function formatBottleMetadata(bottle: Bottle) {
+  const origins = [
+    ...new Set(
+      bottle.distillers
+        .map((distiller) => distiller.region?.name ?? distiller.country?.name)
+        .filter((value): value is string => Boolean(value)),
+    ),
+  ];
+  const origin =
+    origins.length === 1
+      ? origins[0]
+      : bottle.category
+        ? formatCategoryName(bottle.category)
+        : null;
+
+  return [
+    origin,
+    bottle.statedAge !== null
+      ? `${bottle.statedAge} years`
+      : bottle.noAgeStatement
+        ? "NAS"
+        : null,
+    bottle.abv !== null ? `${formatAbv(bottle.abv)}% ABV` : null,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" · ");
+}
+
+function formatReleaseMetadata(bottle: Bottle) {
+  const release = bottle.releaseDate
+    ? `Released ${releaseDateFormatter.format(
+        new Date(`${bottle.releaseDate}T00:00:00Z`),
+      )}`
+    : bottle.releaseYear
+      ? `Released ${bottle.releaseYear}`
+      : null;
+
+  return [release, formatBottleMetadata(bottle)]
+    .filter((value): value is string => Boolean(value))
+    .join(" · ");
+}
+
+export function toBottleTableRow(
+  bottle: Bottle,
+  metadata = formatBottleMetadata(bottle),
+): BottleComparisonRow {
+  return {
+    href: `/bottles/${bottle.id}`,
+    id: bottle.peatedId,
+    metadata,
+    name: formatBottleDisplayName(bottle),
+    values: [
+      <RatingMeasure
+        counts={bottle.tastingBandCounts}
+        high={bottle.maxScore}
+        key={`${bottle.id}-rating`}
+        low={bottle.minScore}
+        median={bottle.medianScore}
+        scoreCount={bottle.scoreCount}
+      />,
+    ],
+  };
+}
+
+export function toReleaseTableRow(bottle: Bottle): BottleComparisonRow {
+  return toBottleTableRow(bottle, formatReleaseMetadata(bottle));
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
@@ -1,0 +1,86 @@
+import * as stylex from "@stylexjs/stylex";
+
+import {
+  AppLink,
+  Card,
+  FactList,
+  hasVisibleFacts,
+  type FactListItem,
+} from "@peated/web/components/designSystem/components";
+import { PageSection } from "@peated/web/components/designSystem/patterns/pageLayout.stylex";
+import { parseDomain } from "@peated/web/lib/urls";
+import { colors, effects } from "../../../../styles/tokens.stylex";
+
+import type { Entity } from "./entityPageData";
+
+function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
+  const location = entity.country ? (
+    <>
+      {entity.region ? (
+        <>
+          <AppLink
+            href={`/locations/${entity.country.slug}/regions/${entity.region.slug}`}
+            {...stylex.props(styles.factLink)}
+          >
+            {entity.region.name}
+          </AppLink>
+          <span>, </span>
+        </>
+      ) : null}
+      <AppLink
+        href={`/locations/${entity.country.slug}`}
+        {...stylex.props(styles.factLink)}
+      >
+        {entity.country.name}
+      </AppLink>
+    </>
+  ) : null;
+
+  return [
+    {
+      label: "Website",
+      value: entity.website ? (
+        <a
+          href={entity.website}
+          rel="noreferrer"
+          target="_blank"
+          {...stylex.props(styles.factLink)}
+        >
+          {parseDomain(entity.website)}
+        </a>
+      ) : null,
+    },
+    { label: "Location", value: location },
+    { label: "Address", value: entity.address },
+    { label: "Also known as", value: entity.shortName },
+  ];
+}
+
+export function hasEntityDetails(entity: Entity) {
+  return hasVisibleFacts(getEntityFacts(entity));
+}
+
+export function EntityDetails({ entity }: { entity: Entity }) {
+  const facts = getEntityFacts(entity);
+  if (!hasVisibleFacts(facts)) return null;
+
+  return (
+    <PageSection heading="Details">
+      <Card appearance="surface" padding="sm">
+        <FactList facts={facts} />
+      </Card>
+    </PageSection>
+  );
+}
+
+const styles = stylex.create({
+  factLink: {
+    color: colors.accentDeep,
+    outline: "none",
+    textDecoration: "none",
+    boxShadow: {
+      default: "none",
+      ":focus-visible": effects.focusRing,
+    },
+  },
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
@@ -1,0 +1,97 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { Card } from "@peated/web/components/designSystem/components";
+import { PageSection } from "@peated/web/components/designSystem/patterns/pageLayout.stylex";
+import {
+  colors,
+  effects,
+  fonts,
+  space,
+} from "../../../../styles/tokens.stylex";
+
+import type { Entity } from "./entityPageData";
+
+function formatCoordinate(value: number, positive: string, negative: string) {
+  return `${Math.abs(value).toFixed(4)}°${value >= 0 ? positive : negative}`;
+}
+
+export function EntityMap({ entity }: { entity: Entity }) {
+  if (!entity.location) return null;
+
+  const [longitude, latitude] = entity.location;
+  const mapBounds = [
+    longitude - 0.025,
+    latitude - 0.015,
+    longitude + 0.025,
+    latitude + 0.015,
+  ].join(",");
+  const embedParams = new URLSearchParams({
+    bbox: mapBounds,
+    layer: "mapnik",
+    marker: `${latitude},${longitude}`,
+  });
+  const mapHref = `https://www.openstreetmap.org/?mlat=${latitude}&mlon=${longitude}#map=15/${latitude}/${longitude}`;
+  const coordinateLabel = `${formatCoordinate(latitude, "N", "S")} ${formatCoordinate(longitude, "E", "W")}`;
+
+  return (
+    <PageSection heading="Where">
+      <Card appearance="surface" padding="sm">
+        <iframe
+          loading="lazy"
+          src={`https://www.openstreetmap.org/export/embed.html?${embedParams.toString()}`}
+          title={`${entity.name} map`}
+          {...stylex.props(styles.mapFrame)}
+        />
+        <div {...stylex.props(styles.mapFooter)}>
+          <span {...stylex.props(styles.coordinates)}>{coordinateLabel}</span>
+          <a
+            href={mapHref}
+            rel="noreferrer"
+            target="_blank"
+            {...stylex.props(styles.mapLink)}
+          >
+            Open in map →
+          </a>
+        </div>
+      </Card>
+    </PageSection>
+  );
+}
+
+const styles = stylex.create({
+  mapFrame: {
+    display: "block",
+    width: "100%",
+    height: "220px",
+    borderWidth: 0,
+    borderRadius: "2px",
+    backgroundColor: colors.inset,
+  },
+  mapFooter: {
+    display: "flex",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: space.x3,
+    paddingTop: space.x3,
+    flexWrap: "wrap",
+  },
+  coordinates: {
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "10px",
+    lineHeight: 1.4,
+  },
+  mapLink: {
+    color: colors.accentDeep,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    fontWeight: 700,
+    lineHeight: 1.3,
+    outline: "none",
+    textDecoration: "none",
+    boxShadow: {
+      default: "none",
+      ":focus-visible": effects.focusRing,
+    },
+  },
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -1,243 +1,39 @@
 "use client";
 
-import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
-import {
-  AppLink,
-  BottleComparisonTable,
-  ButtonLink,
-  Card,
-  EmptyState,
-  FactList,
-  hasVisibleFacts,
-  LoadingList,
-  RatingMeasure,
-  SectionError,
-  TextLink,
-  type BottleComparisonRow,
-  type FactListItem,
-} from "@peated/web/components/designSystem/components";
-import { PageSection } from "@peated/web/components/designSystem/patterns/pageLayout.stylex";
+import { SectionError } from "@peated/web/components/designSystem/components";
 import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { getEntityUrl, parseDomain } from "@peated/web/lib/urls";
-import {
-  colors,
-  effects,
-  fonts,
-  space,
-} from "../../../../styles/tokens.stylex";
+import { space } from "../../../../styles/tokens.stylex";
 
-import { getEntityPresentation, type Entity } from "./entityPageData";
+import { EntityBottleOverview } from "./entityBottleOverview";
+import { EntityDetails, hasEntityDetails } from "./entityDetails.stylex";
+import { EntityMap } from "./entityMap.stylex";
+import { entityHasBottleCatalog, type Entity } from "./entityPageData";
+import { EntityReleaseOverview } from "./entityReleaseOverview";
+import { EntitySiblingOverview } from "./entitySiblingOverview";
 
 type BottleList = Outputs["bottles"]["list"];
+type EntityList = Outputs["entities"]["list"];
 
 const NARROW = "@media (max-width: 759px)";
-
-function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
-  const location = entity.country ? (
-    <>
-      {entity.region ? (
-        <>
-          <AppLink
-            href={`/locations/${entity.country.slug}/regions/${entity.region.slug}`}
-            {...stylex.props(styles.factLink)}
-          >
-            {entity.region.name}
-          </AppLink>
-          <span>, </span>
-        </>
-      ) : null}
-      <AppLink
-        href={`/locations/${entity.country.slug}`}
-        {...stylex.props(styles.factLink)}
-      >
-        {entity.country.name}
-      </AppLink>
-    </>
-  ) : null;
-
-  return [
-    {
-      label: "Website",
-      value: entity.website ? (
-        <a
-          href={entity.website}
-          rel="noreferrer"
-          target="_blank"
-          {...stylex.props(styles.factLink)}
-        >
-          {parseDomain(entity.website)}
-        </a>
-      ) : null,
-    },
-    { label: "Location", value: location },
-    { label: "Address", value: entity.address },
-    { label: "Also known as", value: entity.shortName },
-  ];
-}
-
-function formatBottleMetadata(bottle: BottleList["results"][number]) {
-  const origins = [
-    ...new Set(
-      bottle.distillers
-        .map((distiller) => distiller.region?.name ?? distiller.country?.name)
-        .filter((value): value is string => Boolean(value)),
-    ),
-  ];
-  const origin =
-    origins.length === 1
-      ? origins[0]
-      : bottle.category
-        ? formatCategoryName(bottle.category)
-        : null;
-
-  return [
-    origin,
-    bottle.statedAge !== null
-      ? `${bottle.statedAge} years`
-      : bottle.noAgeStatement
-        ? "NAS"
-        : null,
-    bottle.abv !== null ? `${formatAbv(bottle.abv)}% ABV` : null,
-  ]
-    .filter((value): value is string => Boolean(value))
-    .join(" · ");
-}
-
-function formatAbv(abv: number) {
-  return abv.toFixed(1).replace(/\.0$/, "");
-}
-
-function toBottleTableRow(
-  bottle: BottleList["results"][number],
-): BottleComparisonRow {
-  return {
-    href: `/bottles/${bottle.id}`,
-    id: bottle.peatedId,
-    metadata: formatBottleMetadata(bottle),
-    name: formatBottleDisplayName(bottle),
-    values: [
-      <RatingMeasure
-        counts={bottle.tastingBandCounts}
-        high={bottle.maxScore}
-        key={`${bottle.id}-rating`}
-        low={bottle.minScore}
-        median={bottle.medianScore}
-        scoreCount={bottle.scoreCount}
-      />,
-    ],
-  };
-}
-
-function EntityBottleOverview({
-  bottleList,
-  createBottleHref,
-  entity,
-  error,
-  pending,
-  retry,
-  totalBottles,
-}: {
-  bottleList?: BottleList;
-  createBottleHref?: string;
-  entity: Entity;
-  error: boolean;
-  pending: boolean;
-  retry: () => void;
-  totalBottles: number;
-}) {
-  const presentation = getEntityPresentation(entity);
-  const entityHref = getEntityUrl(entity);
-  const ownsBottleModule =
-    entity.kind === "brand" ||
-    entity.kind === "bottler" ||
-    entity.kind === "distillery";
-
-  if (!ownsBottleModule) return null;
-
-  if (pending) {
-    return (
-      <PageSection heading={presentation.bottleSectionLabel}>
-        <LoadingList label="Loading associated bottles" rows={4} />
-      </PageSection>
-    );
-  }
-
-  if (error) {
-    return (
-      <PageSection heading={presentation.bottleSectionLabel}>
-        <SectionError
-          heading="Associated bottles are unavailable"
-          onRetry={retry}
-        >
-          The entity record is still available. Try loading its bottles again.
-        </SectionError>
-      </PageSection>
-    );
-  }
-
-  if (!bottleList?.results.length) {
-    const isBottling = presentation.bottleSectionLabel === "Bottlings";
-    const addBottleHref =
-      createBottleHref ??
-      `/bottles/new?${new URLSearchParams({
-        returnTo: entityHref,
-      }).toString()}`;
-
-    return (
-      <PageSection heading={presentation.bottleSectionLabel}>
-        <EmptyState
-          action={
-            <ButtonLink href={addBottleHref} size="sm" variant="accent">
-              Add a bottle
-            </ButtonLink>
-          }
-          heading={isBottling ? "No bottlings yet" : "No bottles yet"}
-        >
-          No {presentation.bottleSectionLabel.toLowerCase()} have been added for
-          {entity.name} yet.
-        </EmptyState>
-      </PageSection>
-    );
-  }
-
-  const [firstBottle, ...remainingBottles] = bottleList.results;
-
-  return (
-    <PageSection
-      count={bottleList.results.length}
-      heading={presentation.bottleSectionLabel}
-      intro={
-        <TextLink href={`${entityHref}/bottles?sort=-tastings`}>
-          View all {totalBottles.toLocaleString("en-US")} bottles
-        </TextLink>
-      }
-    >
-      <BottleComparisonTable
-        ariaLabel={`${entity.name} ${presentation.bottleSectionLabel.toLowerCase()}`}
-        columns={["Rating"]}
-        rows={[
-          toBottleTableRow(firstBottle),
-          ...remainingBottles.map(toBottleTableRow),
-        ]}
-      />
-    </PageSection>
-  );
-}
 
 export function EntityOverviewClient({
   initialBottleList,
   initialEntity,
+  initialReleaseList,
+  initialSiblingList,
 }: {
   initialBottleList?: BottleList;
   initialEntity: Entity;
+  initialReleaseList?: BottleList;
+  initialSiblingList?: EntityList;
 }) {
   const orpc = useORPC();
+  const ownsBottleSections = entityHasBottleCatalog(initialEntity);
   const entityQuery = useQuery({
     ...orpc.entities.details.queryOptions({
       input: { entity: initialEntity.id },
@@ -252,7 +48,30 @@ export function EntityOverviewClient({
         sort: "-tastings",
       },
     }),
+    enabled: ownsBottleSections,
     initialData: initialBottleList,
+  });
+  const releaseListQuery = useQuery({
+    ...orpc.bottles.list.queryOptions({
+      input: {
+        entity: initialEntity.id,
+        limit: 4,
+        sort: "-release",
+      },
+    }),
+    enabled: ownsBottleSections,
+    initialData: initialReleaseList,
+  });
+  const siblingListQuery = useQuery({
+    ...orpc.entities.list.queryOptions({
+      input: {
+        limit: 5,
+        owner: initialEntity.ownerId ?? undefined,
+        sort: "-bottles",
+      },
+    }),
+    enabled: Boolean(initialEntity.ownerId),
+    initialData: initialSiblingList,
   });
 
   if (entityQuery.error) {
@@ -267,36 +86,48 @@ export function EntityOverviewClient({
   }
 
   const entity = entityQuery.data;
-  const createBottleHref = getEntityBottleCreateHref(entity);
-  const entityFacts = getEntityFacts(entity);
-  const hasDetails = hasVisibleFacts(entityFacts);
+  const hasRail =
+    hasEntityDetails(entity) ||
+    Boolean(entity.location) ||
+    Boolean(entity.ownerId);
 
   return (
     <div
       {...stylex.props(
         styles.overviewGrid,
-        !hasDetails && styles.overviewGridWithoutDetails,
+        !hasRail && styles.overviewGridWithoutDetails,
       )}
     >
-      {hasDetails ? (
+      {hasRail ? (
         <aside {...stylex.props(styles.details)}>
-          <PageSection heading="Details">
-            <Card appearance="surface" padding="sm">
-              <FactList facts={entityFacts} />
-            </Card>
-          </PageSection>
+          <EntityDetails entity={entity} />
+          <EntityMap entity={entity} />
+          <EntitySiblingOverview
+            entity={entity}
+            error={Boolean(siblingListQuery.error)}
+            pending={siblingListQuery.isPending}
+            retry={() => void siblingListQuery.refetch()}
+            siblingList={siblingListQuery.data}
+          />
         </aside>
       ) : null}
 
       <div {...stylex.props(styles.catalog)}>
         <EntityBottleOverview
           bottleList={bottleListQuery.data}
-          createBottleHref={createBottleHref}
+          createBottleHref={getEntityBottleCreateHref(entity)}
           entity={entity}
           error={Boolean(bottleListQuery.error)}
           pending={bottleListQuery.isPending}
           retry={() => void bottleListQuery.refetch()}
           totalBottles={entity.totalBottles}
+        />
+        <EntityReleaseOverview
+          entity={entity}
+          error={Boolean(releaseListQuery.error)}
+          pending={releaseListQuery.isPending}
+          releaseList={releaseListQuery.data}
+          retry={() => void releaseListQuery.refetch()}
         />
       </div>
     </div>
@@ -327,14 +158,5 @@ const styles = stylex.create({
   details: {
     gridArea: "details",
     minWidth: 0,
-  },
-  factLink: {
-    color: colors.accentDeep,
-    outline: "none",
-    textDecoration: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
   },
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -14,6 +14,7 @@ import { EntityDetails, hasEntityDetails } from "./entityDetails.stylex";
 import { EntityMap } from "./entityMap.stylex";
 import { entityHasBottleCatalog, type Entity } from "./entityPageData";
 import { EntityReleaseOverview } from "./entityReleaseOverview";
+import { shouldShowEntitySiblingOverview } from "./entitySiblingData";
 import { EntitySiblingOverview } from "./entitySiblingOverview";
 
 type BottleList = Outputs["bottles"]["list"];
@@ -86,10 +87,15 @@ export function EntityOverviewClient({
   }
 
   const entity = entityQuery.data;
+  const hasSiblingOverview = shouldShowEntitySiblingOverview({
+    entityId: entity.id,
+    error: Boolean(siblingListQuery.error),
+    ownerId: entity.ownerId,
+    pending: siblingListQuery.isPending,
+    siblingList: siblingListQuery.data,
+  });
   const hasRail =
-    hasEntityDetails(entity) ||
-    Boolean(entity.location) ||
-    Boolean(entity.ownerId);
+    hasEntityDetails(entity) || Boolean(entity.location) || hasSiblingOverview;
 
   return (
     <div

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
@@ -1,6 +1,19 @@
 import { describe, expect, it } from "vitest";
 
-import { getEntityCurrentHref, getEntityTabs } from "./entityPageData";
+import {
+  entityHasBottleCatalog,
+  getEntityCurrentHref,
+  getEntityTabs,
+} from "./entityPageData";
+
+describe("entityHasBottleCatalog", () => {
+  it("limits bottle modules to entity kinds that own bottles", () => {
+    expect(entityHasBottleCatalog({ kind: "brand" })).toBe(true);
+    expect(entityHasBottleCatalog({ kind: "bottler" })).toBe(true);
+    expect(entityHasBottleCatalog({ kind: "distillery" })).toBe(true);
+    expect(entityHasBottleCatalog({ kind: "company" })).toBe(false);
+  });
+});
 
 describe("getEntityTabs", () => {
   it("uses the canonical public Entity route", () => {

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -37,10 +37,18 @@ const fallbackPresentation = {
   label: "Entity",
 } as const;
 
-export function getEntityPresentation(entity: Entity) {
+export function getEntityPresentation(entity: Pick<Entity, "kind">) {
   return entity.kind
     ? entityKindPresentation[entity.kind]
     : fallbackPresentation;
+}
+
+export function entityHasBottleCatalog(entity: Pick<Entity, "kind">) {
+  return (
+    entity.kind === "brand" ||
+    entity.kind === "bottler" ||
+    entity.kind === "distillery"
+  );
 }
 
 export function getEntityLocationLabel(entity: Entity) {

--- a/apps/web/src/app/(app)/entities/[entityId]/entityReleaseOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityReleaseOverview.tsx
@@ -1,0 +1,73 @@
+import type { Outputs } from "@peated/server/orpc/router";
+
+import {
+  BottleComparisonTable,
+  LoadingList,
+  SectionError,
+  TextLink,
+} from "@peated/web/components/designSystem/components";
+import { PageSection } from "@peated/web/components/designSystem/patterns/pageLayout.stylex";
+import { getEntityUrl } from "@peated/web/lib/urls";
+
+import { toReleaseTableRow } from "./entityBottleTableRows";
+import { entityHasBottleCatalog, type Entity } from "./entityPageData";
+
+type BottleList = Outputs["bottles"]["list"];
+
+export function EntityReleaseOverview({
+  entity,
+  error,
+  pending,
+  releaseList,
+  retry,
+}: {
+  entity: Entity;
+  error: boolean;
+  pending: boolean;
+  releaseList?: BottleList;
+  retry: () => void;
+}) {
+  if (!entityHasBottleCatalog(entity)) return null;
+
+  if (pending) {
+    return (
+      <PageSection heading="Latest releases">
+        <LoadingList label="Loading latest releases" rows={4} />
+      </PageSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageSection heading="Latest releases">
+        <SectionError heading="Latest releases are unavailable" onRetry={retry}>
+          Try loading the latest releases again.
+        </SectionError>
+      </PageSection>
+    );
+  }
+
+  if (!releaseList?.results.length) return null;
+
+  const [firstRelease, ...remainingReleases] = releaseList.results;
+
+  return (
+    <PageSection
+      heading="Latest releases"
+      intro={
+        <TextLink href={`${getEntityUrl(entity)}/bottles?sort=-release`}>
+          View all releases
+        </TextLink>
+      }
+    >
+      <BottleComparisonTable
+        ariaLabel={`${entity.name} latest releases`}
+        columns={["Rating"]}
+        rows={[
+          toReleaseTableRow(firstRelease),
+          ...remainingReleases.map((bottle) => toReleaseTableRow(bottle)),
+        ]}
+      />
+    </PageSection>
+  );
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { shouldShowEntitySiblingOverview } from "./entitySiblingData";
+
+describe("shouldShowEntitySiblingOverview", () => {
+  it("hides a successful result that only contains the current entity", () => {
+    expect(
+      shouldShowEntitySiblingOverview({
+        entityId: 1,
+        error: false,
+        ownerId: 10,
+        pending: false,
+        siblingList: { results: [{ id: 1 }] },
+      }),
+    ).toBe(false);
+  });
+
+  it("shows related entities and request feedback", () => {
+    expect(
+      shouldShowEntitySiblingOverview({
+        entityId: 1,
+        error: false,
+        ownerId: 10,
+        pending: false,
+        siblingList: { results: [{ id: 1 }, { id: 2 }] },
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowEntitySiblingOverview({
+        entityId: 1,
+        error: false,
+        ownerId: 10,
+        pending: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldShowEntitySiblingOverview({
+        entityId: 1,
+        error: true,
+        ownerId: 10,
+        pending: false,
+      }),
+    ).toBe(true);
+  });
+
+  it("hides the module when the entity has no owner", () => {
+    expect(
+      shouldShowEntitySiblingOverview({
+        entityId: 1,
+        error: false,
+        ownerId: null,
+        pending: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.ts
@@ -1,0 +1,36 @@
+type EntitySiblingCandidate = { id: number };
+type EntitySiblingList<T extends EntitySiblingCandidate> = {
+  results: readonly T[];
+};
+
+export function getEntitySiblings<T extends EntitySiblingCandidate>(
+  entityId: number,
+  siblingList?: EntitySiblingList<T>,
+) {
+  return (
+    siblingList?.results
+      .filter((sibling) => sibling.id !== entityId)
+      .slice(0, 4) ?? []
+  );
+}
+
+export function shouldShowEntitySiblingOverview<
+  T extends EntitySiblingCandidate,
+>({
+  entityId,
+  error,
+  ownerId,
+  pending,
+  siblingList,
+}: {
+  entityId: number;
+  error: boolean;
+  ownerId?: number | null;
+  pending: boolean;
+  siblingList?: EntitySiblingList<T>;
+}) {
+  return Boolean(
+    ownerId &&
+    (pending || error || getEntitySiblings(entityId, siblingList).length),
+  );
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
@@ -1,0 +1,75 @@
+import type { Outputs } from "@peated/server/orpc/router";
+
+import {
+  LoadingList,
+  RailList,
+  RailListItem,
+  SectionError,
+} from "@peated/web/components/designSystem/components";
+import { PageSection } from "@peated/web/components/designSystem/patterns/pageLayout.stylex";
+import { getEntityUrl } from "@peated/web/lib/urls";
+
+import { getEntityPresentation, type Entity } from "./entityPageData";
+
+type EntityList = Outputs["entities"]["list"];
+
+export function EntitySiblingOverview({
+  entity,
+  error,
+  pending,
+  retry,
+  siblingList,
+}: {
+  entity: Entity;
+  error: boolean;
+  pending: boolean;
+  retry: () => void;
+  siblingList?: EntityList;
+}) {
+  if (!entity.ownerId) return null;
+
+  const heading = entity.owner?.name
+    ? `Also owned by ${entity.owner.name}`
+    : "Also owned";
+
+  if (pending) {
+    return (
+      <PageSection heading={heading}>
+        <LoadingList label="Loading related entities" rows={3} />
+      </PageSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageSection heading={heading}>
+        <SectionError
+          heading="Related entities are unavailable"
+          onRetry={retry}
+        >
+          Try loading the related entities again.
+        </SectionError>
+      </PageSection>
+    );
+  }
+
+  const siblings = siblingList?.results
+    .filter((sibling) => sibling.id !== entity.id)
+    .slice(0, 4);
+  if (!siblings?.length) return null;
+
+  return (
+    <PageSection heading={heading}>
+      <RailList ariaLabel={heading}>
+        {siblings.map((sibling) => (
+          <RailListItem
+            href={getEntityUrl(sibling)}
+            key={sibling.id}
+            metadata={`${getEntityPresentation(sibling).label} · ${sibling.totalBottles.toLocaleString("en-US")} bottles`}
+            title={sibling.name}
+          />
+        ))}
+      </RailList>
+    </PageSection>
+  );
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
@@ -10,6 +10,7 @@ import { PageSection } from "@peated/web/components/designSystem/patterns/pageLa
 import { getEntityUrl } from "@peated/web/lib/urls";
 
 import { getEntityPresentation, type Entity } from "./entityPageData";
+import { getEntitySiblings } from "./entitySiblingData";
 
 type EntityList = Outputs["entities"]["list"];
 
@@ -53,10 +54,8 @@ export function EntitySiblingOverview({
     );
   }
 
-  const siblings = siblingList?.results
-    .filter((sibling) => sibling.id !== entity.id)
-    .slice(0, 4);
-  if (!siblings?.length) return null;
+  const siblings = getEntitySiblings(entity.id, siblingList);
+  if (!siblings.length) return null;
 
   return (
     <PageSection heading={heading}>

--- a/apps/web/src/app/(app)/entities/[entityId]/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/page.tsx
@@ -2,6 +2,7 @@ import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 
 import { EntityOverviewClient } from "./entityOverviewClient.stylex";
+import { entityHasBottleCatalog } from "./entityPageData";
 
 export default async function EntityPage(props: {
   params: Promise<{ entityId: string }>;
@@ -9,14 +10,35 @@ export default async function EntityPage(props: {
   const { entityId } = await props.params;
   const { client } = await getAnonymousServerClient();
   const entity = await getEntityPage(Number(entityId));
-  const bottleList = await client.bottles
-    .list({ entity: entity.id, limit: 4, sort: "-tastings" })
-    .catch(() => undefined);
+  const ownsBottleSections = entityHasBottleCatalog(entity);
+  const [bottleList, releaseList, siblingList] = await Promise.all([
+    ownsBottleSections
+      ? client.bottles
+          .list({ entity: entity.id, limit: 4, sort: "-tastings" })
+          .catch(() => undefined)
+      : undefined,
+    ownsBottleSections
+      ? client.bottles
+          .list({ entity: entity.id, limit: 4, sort: "-release" })
+          .catch(() => undefined)
+      : undefined,
+    entity.ownerId
+      ? client.entities
+          .list({
+            limit: 5,
+            owner: entity.ownerId,
+            sort: "-bottles",
+          })
+          .catch(() => undefined)
+      : undefined,
+  ]);
 
   return (
     <EntityOverviewClient
       initialBottleList={bottleList}
       initialEntity={entity}
+      initialReleaseList={releaseList}
+      initialSiblingList={siblingList}
     />
   );
 }


### PR DESCRIPTION
Entity overview pages now show location maps, other entities with the same owner, and latest releases where the entity kind supports bottles. Company pages avoid bottle-specific queries, and optional modules stay hidden when their source data is absent. An owner with no other related entities no longer reserves an empty desktop sidebar.

Details, maps, bottlings, releases, and ownership are separate React components so each surface can be composed and reviewed independently. The mock API includes Diageo-owned distilleries and ordered Laphroaig releases so these states can be exercised through `dev:mock` at desktop and mobile widths.
