### PR TITLE
style(home): simplify section headers

### DIFF
--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -128,7 +128,7 @@ function LatestReleases() {
   ) {
     return (
       <HomeSectionLoading>
-        <LoadingList label="Loading latest releases" rows={4} />
+        <LoadingList label="Loading recent releases" rows={4} />
       </HomeSectionLoading>
     );
   }
@@ -136,13 +136,13 @@ function LatestReleases() {
   if (!releases) {
     return (
       <SectionError
-        heading="Latest releases are unavailable"
+        heading="Recent releases are unavailable"
         onRetry={() => {
           void globalReleases.refetch();
           if (user) void followedReleases.refetch();
         }}
       >
-        We couldn't load the latest releases. The rest of the database is still
+        We couldn't load the recent releases. The rest of the database is still
         available.
       </SectionError>
     );
@@ -171,7 +171,7 @@ function LatestReleases() {
       title={
         useFollowedReleases
           ? "New from distilleries you follow"
-          : "Latest releases"
+          : "Recent releases"
       }
     />
   ) : null;

--- a/apps/web/src/components/designSystem/patterns/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/homeBrowse.stylex.tsx
@@ -164,9 +164,9 @@ export function HomeRecentReviews({
 }) {
   return (
     <section {...stylex.props(styles.section)}>
-      <HomeModuleHeading title="Newest critic reviews" />
+      <HomeModuleHeading title="From the critics" />
       <div {...stylex.props(styles.rows)}>
-        <ItemList ariaLabel="Newest critic reviews">
+        <ItemList ariaLabel="From the critics">
           {reviews.map((review) => (
             <ItemRow
               end={
@@ -480,10 +480,6 @@ export function HomeContributionPrompt({
 const styles = stylex.create({
   section: {
     minWidth: 0,
-    paddingTop: space.x6,
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
-    borderTopColor: colors.sectionRule,
   },
   heading: {
     display: "flex",


### PR DESCRIPTION
Homepage browse modules no longer draw a divider above each heading or reserve spacing for that divider. The release and critic sections now use the clearer labels “Recent releases” and “From the critics,” with matching loading, error, and accessibility text.
