### PR TITLE
feat(entities)!: support following bottlers

### DIFF
--- a/apps/server/src/orpc/contracts/bottles/list.ts
+++ b/apps/server/src/orpc/contracts/bottles/list.ts
@@ -41,7 +41,7 @@ const OutputSchema = listResponse(BottleSchema).extend({
       }),
     ),
   }),
-  followedDistillerCount: z.number().int().nonnegative().nullable(),
+  followedEntityCount: z.number().int().nonnegative().nullable(),
 });
 
 export default contract
@@ -50,7 +50,7 @@ export default contract
     path: "/bottles",
     summary: "List bottles",
     description:
-      "Find bottles, including releases from distillers the signed-in user follows",
+      "Find bottles, including releases from distillers and bottlers the signed-in user follows",
     spec: (spec) => ({
       ...spec,
       operationId: "listBottles",

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -574,7 +574,7 @@ describe("mock oRPC router", () => {
     await expect(
       authenticatedClient.bottles.list({ filter: "following" }),
     ).resolves.toMatchObject({
-      followedDistillerCount: 2,
+      followedEntityCount: 2,
     });
   });
 

--- a/apps/server/src/orpc/mock/routes/bottles/list.ts
+++ b/apps/server/src/orpc/mock/routes/bottles/list.ts
@@ -131,7 +131,7 @@ export default mockOS.bottles.list.handler(
       ),
       total,
       facets,
-      followedDistillerCount: input.filter === "following" ? 2 : null,
+      followedEntityCount: input.filter === "following" ? 2 : null,
     };
   },
 );

--- a/apps/server/src/orpc/routes/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/list.test.ts
@@ -576,7 +576,7 @@ describe("GET /bottles", () => {
         category: [],
         ageBand: [],
       },
-      followedDistillerCount: null,
+      followedEntityCount: null,
       rel: {
         nextCursor: null,
         prevCursor: null,
@@ -819,21 +819,22 @@ describe("GET /bottles", () => {
     expect(err).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
   });
 
-  test("returns an empty followed-distillery feed", async ({ defaults }) => {
+  test("returns an empty followed-entity feed", async ({ defaults }) => {
     const response = await routerClient.bottles.list(
       { filter: "following", sort: "-release" },
       { context: { user: defaults.user } },
     );
 
     expect(response.results).toEqual([]);
-    expect(response.followedDistillerCount).toBe(0);
+    expect(response.followedEntityCount).toBe(0);
   });
 
-  test("lists known releases from followed distillers", async ({
+  test("lists known releases from followed distillers and bottlers", async ({
     defaults,
     fixtures,
   }) => {
     const distiller = await fixtures.Entity({ kind: "distillery" });
+    const bottler = await fixtures.Entity({ kind: "bottler" });
     const followedBrand = await fixtures.Entity({ kind: "brand" });
     await db.insert(entityFollows).values([
       {
@@ -842,9 +843,19 @@ describe("GET /bottles", () => {
       },
       {
         userId: defaults.user.id,
+        entityId: bottler.id,
+      },
+      {
+        userId: defaults.user.id,
         entityId: followedBrand.id,
       },
     ]);
+    const followedBottlerRelease = await fixtures.Bottle({
+      name: "Followed Bottler Release",
+      bottlerId: bottler.id,
+      releaseYear: 2026,
+      releaseDate: "2026-09-01",
+    });
     const exactLaterThisYear = await fixtures.Bottle({
       name: "Exact Later This Year",
       distillerIds: [distiller.id],
@@ -888,7 +899,7 @@ describe("GET /bottles", () => {
     });
     await fixtures.Bottle({ name: "Unrelated Release", releaseYear: 2026 });
 
-    const { followedDistillerCount, results } = await routerClient.bottles.list(
+    const { followedEntityCount, results } = await routerClient.bottles.list(
       {
         filter: "following",
         limit: 10,
@@ -900,12 +911,13 @@ describe("GET /bottles", () => {
     );
 
     expect(results.map(({ id }) => id)).toEqual([
+      followedBottlerRelease.id,
       exactLaterThisYear.id,
       exactEarlierThisYear.id,
       yearOnlyThisYear.id,
       knownLastYear.id,
     ]);
-    expect(followedDistillerCount).toBe(1);
+    expect(followedEntityCount).toBe(2);
   });
 
   test("sorts bottles by tastings ascending", async ({ fixtures }) => {

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -77,7 +77,7 @@ export default implement(bottleListContract).handler(async function ({
     : [];
 
   const where: (SQL<unknown> | undefined)[] = [];
-  let followedDistillerIds: number[] | null = null;
+  let followedEntityIds: number[] | null = null;
   let hasUnknownFlight = false;
   where.push(isNotNull(bottles.groupId));
   where.push(
@@ -88,28 +88,40 @@ export default implement(bottleListContract).handler(async function ({
     if (!context.user) {
       throw errors.UNAUTHORIZED();
     }
-    followedDistillerIds = (
-      await db
-        .select({ entityId: entityFollows.entityId })
-        .from(entityFollows)
-        .innerJoin(entities, eq(entities.id, entityFollows.entityId))
-        .where(
-          and(
-            eq(entityFollows.userId, context.user.id),
-            eq(entities.kind, "distillery"),
-          ),
-        )
-    ).map(({ entityId }) => entityId);
+    const followedEntities = await db
+      .select({ entityId: entityFollows.entityId, kind: entities.kind })
+      .from(entityFollows)
+      .innerJoin(entities, eq(entities.id, entityFollows.entityId))
+      .where(
+        and(
+          eq(entityFollows.userId, context.user.id),
+          inArray(entities.kind, ["bottler", "distillery"]),
+        ),
+      );
+    followedEntityIds = followedEntities.map(({ entityId }) => entityId);
+    const followedDistillerIds = followedEntities.flatMap((entity) =>
+      entity.kind === "distillery" ? [entity.entityId] : [],
+    );
+    const followedBottlerIds = followedEntities.flatMap((entity) =>
+      entity.kind === "bottler" ? [entity.entityId] : [],
+    );
     where.push(
-      followedDistillerIds.length
-        ? sql`EXISTS(
-              SELECT FROM ${bottlesToDistillers}
-              WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
-                AND ${inArray(
-                  bottlesToDistillers.distillerId,
-                  followedDistillerIds,
-                )}
-            )`
+      followedEntityIds.length
+        ? or(
+            followedDistillerIds.length
+              ? sql`EXISTS(
+                  SELECT FROM ${bottlesToDistillers}
+                  WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
+                    AND ${inArray(
+                      bottlesToDistillers.distillerId,
+                      followedDistillerIds,
+                    )}
+                )`
+              : undefined,
+            followedBottlerIds.length
+              ? inArray(bottles.bottlerId, followedBottlerIds)
+              : undefined,
+          )
         : sql`FALSE`,
     );
   }
@@ -317,7 +329,7 @@ export default implement(bottleListContract).handler(async function ({
         return count > 0 ? [{ value, count }] : [];
       }),
     },
-    followedDistillerCount: followedDistillerIds?.length ?? null,
+    followedEntityCount: followedEntityIds?.length ?? null,
     rel: {
       nextCursor: results.length > limit ? cursor + 1 : null,
       prevCursor: !hasUnknownFlight && cursor > 1 ? cursor - 1 : null,

--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -170,7 +170,7 @@ function LatestReleases() {
       }
       title={
         useFollowedReleases
-          ? "New from distilleries you follow"
+          ? "New from distilleries and bottlers you follow"
           : "Recent releases"
       }
     />

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -32,7 +32,7 @@ import {
   type Entity,
 } from "./entityPageData";
 
-function DistilleryFollowAction({ entity }: { entity: Entity }) {
+function EntityFollowAction({ entity }: { entity: Entity }) {
   const { user } = useAuth();
   const orpc = useORPC();
   const queryClient = useQueryClient();
@@ -49,7 +49,7 @@ function DistilleryFollowAction({ entity }: { entity: Entity }) {
     return (
       <ButtonLink
         aria-label={`Follow ${entity.name}`}
-        href={`/login?redirectTo=${encodeURIComponent(`/distillers/${entity.id}`)}`}
+        href={`/login?redirectTo=${encodeURIComponent(getEntityUrl(entity))}`}
         size="lg"
         variant="tonal"
       >
@@ -86,7 +86,7 @@ function DistilleryFollowAction({ entity }: { entity: Entity }) {
           flash(
             error instanceof Error
               ? error.message
-              : "We couldn't update the distilleries you follow. Try again.",
+              : "We couldn't update this follow. Try again.",
             "error",
           );
         }
@@ -198,6 +198,7 @@ export function EntityPageFrameClient({
 
   const entity = entityQuery.data;
   const createBottleHref = getEntityBottleCreateHref(entity);
+  const canFollow = entity.kind === "bottler" || entity.kind === "distillery";
   const presentation = getEntityPresentation(entity);
   const currentHref = getEntityCurrentHref(entity, pathname);
 
@@ -205,15 +206,15 @@ export function EntityPageFrameClient({
     <div {...stylex.props(styles.page)}>
       <EntityPageHeader
         actions={
-          createBottleHref || entity.kind === "distillery" ? (
+          createBottleHref || canFollow ? (
             <>
               {createBottleHref ? (
                 <ButtonLink href={createBottleHref} size="lg" variant="accent">
                   Add a bottle
                 </ButtonLink>
               ) : null}
-              {entity.kind === "distillery" ? (
-                <DistilleryFollowAction key={entity.id} entity={entity} />
+              {canFollow ? (
+                <EntityFollowAction key={entity.id} entity={entity} />
               ) : null}
             </>
           ) : undefined


### PR DESCRIPTION
Bottler pages now expose the same follow and unfollow action as distilleries, including the correct return URL after sign-in. The followed-release feed and home section also include releases from followed bottlers.

This changes the `GET /bottles` response field from `followedDistillerCount` to `followedEntityCount`. API clients must use the new field; its count covers followed distilleries and bottlers.
