### PR TITLE
fix(web): link complete bottle producer names

### DIFF
--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -22,6 +22,8 @@ import {
 import { HomePage } from "@peated/web/components/designSystem/patterns/homePage.stylex";
 import { HomeSectionLoading } from "@peated/web/components/designSystem/patterns/homeSummary.stylex";
 import { PageColumns } from "@peated/web/components/designSystem/patterns/pageLayout.stylex";
+import { EntityLinks } from "@peated/web/components/entityLinks";
+import Join from "@peated/web/components/join";
 import { Search } from "@peated/web/components/search/search.stylex";
 import TimeSince from "@peated/web/components/timeSince";
 import useAuth from "@peated/web/hooks/useAuth";
@@ -406,14 +408,25 @@ function getBottleMetadata(bottle: Bottle) {
 }
 
 function getReleaseMetadata(bottle: Bottle) {
-  const distiller = bottle.distillers[0]?.name ?? bottle.brand.name;
-
-  return [
-    distiller,
+  const facts = [
     bottle.releaseYear === null ? null : `${bottle.releaseYear} release`,
-    bottle.statedAge === null ? null : `${bottle.statedAge} yr`,
-    bottle.abv === null ? null : `${bottle.abv.toFixed(1)}%`,
+    bottle.statedAge === null ? null : `${bottle.statedAge} years`,
+    bottle.abv === null ? null : `${bottle.abv.toFixed(1)}% ABV`,
   ].filter((value): value is string => Boolean(value));
+
+  return (
+    <Join divider=" · ">
+      {[
+        <EntityLinks
+          entities={
+            bottle.distillers.length ? bottle.distillers : [bottle.brand]
+          }
+          key="producers"
+        />,
+        ...facts,
+      ]}
+    </Join>
+  );
 }
 
 const STACKED = "@media (max-width: 759px)";

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -41,7 +41,7 @@ const categoryOptions = [
 ] satisfies readonly BottleCatalogFilterOption[];
 
 const ageBandLabels = {
-  nas: "NAS",
+  nas: "No age statement",
   under_12: "Under 12",
   "12_17": "12–17 years",
   "18_24": "18–24 years",

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -28,7 +28,9 @@ import {
 } from "@peated/web/components/designSystem/components";
 import { BottleOverview } from "@peated/web/components/designSystem/patterns/bottleOverview.stylex";
 import { BottlePageHeader } from "@peated/web/components/designSystem/patterns/bottlePageHeader.stylex";
+import { EntityLinks } from "@peated/web/components/entityLinks";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import Join from "@peated/web/components/join";
 import TimeSince from "@peated/web/components/timeSince";
 import useAuth from "@peated/web/hooks/useAuth";
 import {
@@ -57,13 +59,19 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
 });
 
 function getBottleDetail(bottle: Bottle) {
-  return [
-    formatCategoryName(bottle.category),
-    bottle.distillers[0]?.name,
-    bottle.bottler?.name,
-  ]
-    .filter((value): value is string => Boolean(value))
-    .join(" · ");
+  return (
+    <Join divider=" · ">
+      {[
+        formatCategoryName(bottle.category),
+        bottle.distillers.length ? (
+          <EntityLinks entities={bottle.distillers} key="distillers" />
+        ) : null,
+        bottle.bottler ? (
+          <EntityLinks entities={[bottle.bottler]} key="bottler" />
+        ) : null,
+      ].filter((value) => value !== null)}
+    </Join>
+  );
 }
 
 function getBottleNotes(bottle: Bottle) {
@@ -86,7 +94,7 @@ function getBottleSpecs(bottle: Bottle) {
       value:
         bottle.statedAge === null
           ? bottle.noAgeStatement
-            ? "NAS"
+            ? "No age statement"
             : null
           : `${bottle.statedAge} years`,
     },
@@ -127,7 +135,12 @@ function getDeclaredFacts(bottle: Bottle): [FactListItem, ...FactListItem[]] {
             ? "Non-chill filtered"
             : "Chill filtered",
     },
-    { label: "Bottler", value: bottle.bottler?.name },
+    {
+      label: "Bottler",
+      value: bottle.bottler ? (
+        <EntityLinks entities={[bottle.bottler]} />
+      ) : null,
+    },
   ];
 }
 

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -62,7 +62,7 @@ function getBottleDetail(bottle: Bottle) {
   return (
     <Join divider=" · ">
       {[
-        formatCategoryName(bottle.category),
+        bottle.category ? formatCategoryName(bottle.category) : null,
         bottle.distillers.length ? (
           <EntityLinks entities={bottle.distillers} key="distillers" />
         ) : null,

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleTableRows.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleTableRows.tsx
@@ -40,7 +40,7 @@ function formatBottleMetadata(bottle: Bottle) {
     bottle.statedAge !== null
       ? `${bottle.statedAge} years`
       : bottle.noAgeStatement
-        ? "NAS"
+        ? "No age statement"
         : null,
     bottle.abv !== null ? `${formatAbv(bottle.abv)}% ABV` : null,
   ]

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
@@ -368,7 +368,7 @@ function getLibraryMetadata(bottle: LibraryEntry["bottle"]) {
     bottle.statedAge !== null
       ? `${bottle.statedAge} years`
       : bottle.noAgeStatement
-        ? "NAS"
+        ? "No age statement"
         : null,
     bottle.abv !== null
       ? `${bottle.abv.toFixed(1).replace(/\.0$/, "")}% ABV`

--- a/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
+++ b/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
@@ -11,7 +11,7 @@ import {
 } from "@peated/web/components/designSystem/components";
 import QRCodeClient from "@peated/web/components/qrcode.client.stylex";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
-import { getBottleUrl } from "@peated/web/lib/urls";
+import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 import * as stylex from "@stylexjs/stylex";
 import { foundationStyles } from "../../../../../styles/foundations.stylex";
 import { colors, space } from "../../../../../styles/tokens.stylex";
@@ -51,6 +51,10 @@ export function FlightOverlay({
                 <ItemListItem key={bottle.id}>
                   <BottleIdentityRow
                     brand={bottle.brand.name}
+                    brandHref={getEntityUrl({
+                      id: bottle.brand.id,
+                      kind: "brand",
+                    })}
                     href={getBottleUrl(bottle)}
                     imageUrl={bottle.imageUrl}
                     metadata={getBottleMetadata(bottle).split(" · ")}

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -392,8 +392,12 @@ export default function BottleForm({
     () =>
       [
         category ? formatCategoryName(category) : null,
-        noAgeStatement ? "NAS" : statedAge != null ? `${statedAge} yr` : null,
-        abv != null ? `${abv}%` : null,
+        noAgeStatement
+          ? "No age statement"
+          : statedAge != null
+            ? `${statedAge} years`
+            : null,
+        abv != null ? `${abv}% ABV` : null,
       ].filter((item): item is string => Boolean(item)),
     [abv, category, noAgeStatement, statedAge],
   );

--- a/apps/web/src/components/designSystem/components/bottleComparisonTable.stories.tsx
+++ b/apps/web/src/components/designSystem/components/bottleComparisonTable.stories.tsx
@@ -33,7 +33,7 @@ const rows: BottleComparisonTableProps["rows"] = [
   {
     href: "/bottles/2",
     id: "2",
-    metadata: "Islay · NAS · 54.2% ABV",
+    metadata: "Islay · No age statement · 54.2% ABV",
     name: "Ardbeg Uigeadail",
     values: [
       <RatingMeasure

--- a/apps/web/src/components/designSystem/components/dataDevices.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/dataDevices.stylex.tsx
@@ -1,4 +1,5 @@
 import * as stylex from "@stylexjs/stylex";
+import type { ReactNode } from "react";
 
 import {
   colors,
@@ -7,10 +8,11 @@ import {
   space,
 } from "../../../styles/tokens.stylex";
 
+const COMPACT = "@media (max-width: 639px)";
 const PHONE = "@media (max-width: 480px)";
 
 export type RecordIdProps = {
-  detail?: string;
+  detail?: ReactNode;
   id: string;
 };
 
@@ -75,6 +77,7 @@ const styles = stylex.create({
     display: "flex",
     minWidth: 0,
     alignItems: "center",
+    flexWrap: { default: "nowrap", [COMPACT]: "wrap" },
     columnGap: space.x3,
     color: colors.inkMuted,
     fontFamily: fonts.data,
@@ -99,9 +102,10 @@ const styles = stylex.create({
   },
   idDetail: {
     minWidth: 0,
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
+    width: { default: "auto", [COMPACT]: "100%" },
+    overflow: { default: "hidden", [COMPACT]: "visible" },
+    textOverflow: { default: "ellipsis", [COMPACT]: "clip" },
+    whiteSpace: { default: "nowrap", [COMPACT]: "normal" },
   },
   specStrip: {
     display: "grid",

--- a/apps/web/src/components/designSystem/components/floatingPanel.stories.tsx
+++ b/apps/web/src/components/designSystem/components/floatingPanel.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
           Port Charlotte 10
         </strong>
         <span {...stylex.props(foundationStyles.metadata)}>
-          Islay · 10 yr · 50.0%
+          Islay · 10 years · 50.0% ABV
         </span>
       </StorySurfaceContent>
     ),

--- a/apps/web/src/components/designSystem/components/itemList.stories.tsx
+++ b/apps/web/src/components/designSystem/components/itemList.stories.tsx
@@ -127,6 +127,12 @@ export const Overview: Story = {
           metadata="Japan · 12 years · 43.0% ABV"
           title="Yamazaki 12-year-old"
         />
+        <ItemRow
+          href="#blended-malt"
+          metadata="Glen Moray, Caol Ila, Glen Spey · 36 years · 52.4% ABV"
+          metadataWrap
+          title="Long release metadata"
+        />
       </ItemList>
     </StoryStack>
   ),

--- a/apps/web/src/components/designSystem/components/itemList.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/itemList.stylex.tsx
@@ -67,6 +67,7 @@ export type ItemRowProps = {
   id?: string;
   leading?: ReactNode;
   metadata?: ReactNode;
+  metadataWrap?: boolean;
   size?: ItemRowSize;
   title: ReactNode;
   variant?: ItemListVariant;
@@ -81,6 +82,7 @@ export function ItemRow({
   id,
   leading,
   metadata,
+  metadataWrap = false,
   size = "md",
   title,
   variant = "plain",
@@ -134,6 +136,7 @@ export function ItemRow({
               {...stylex.props(
                 styles.metadata,
                 size === "sm" && styles.smallMetadata,
+                metadataWrap && styles.wrappedMetadata,
               )}
             >
               {metadata}
@@ -251,6 +254,11 @@ const styles = stylex.create({
   },
   smallMetadata: {
     marginTop: "2px",
+  },
+  wrappedMetadata: {
+    overflow: "visible",
+    textOverflow: "clip",
+    whiteSpace: "normal",
   },
   description: {
     marginTop: space.x2,

--- a/apps/web/src/components/designSystem/components/selectedBottleSummary.stories.tsx
+++ b/apps/web/src/components/designSystem/components/selectedBottleSummary.stories.tsx
@@ -10,7 +10,7 @@ const meta = {
   args: {
     bottleId: "B00872",
     imageUrl: BottleImage.src,
-    metadata: "Islay · 16 yr · 43.0% · ex-bourbon",
+    metadata: "Islay · 16 years · 43.0% ABV · ex-bourbon",
     name: "Lagavulin 16",
     onChange: () => undefined,
   },
@@ -37,7 +37,7 @@ export const Overview: Story = {
       <SelectedBottleSummary
         bottleId="B104281"
         imageUrl={null}
-        metadata="Islay · NAS · 61.5% · oloroso and bourbon casks"
+        metadata="Islay · No age statement · 61.5% ABV · oloroso and bourbon casks"
         name="Octomore Edition 15.3 Islay Barley Super Heavily Peated"
       />
     </StoryStack>

--- a/apps/web/src/components/designSystem/components/specStrip.stories.tsx
+++ b/apps/web/src/components/designSystem/components/specStrip.stories.tsx
@@ -9,7 +9,7 @@ const meta = {
   args: {
     cells: [
       { label: "ABV", value: "43.0%" },
-      { label: "Age", value: "16 yr" },
+      { label: "Age", value: "16 years" },
       { label: "Cask", value: "ex-bourbon" },
       { label: "Size", value: "700 ml" },
     ],

--- a/apps/web/src/components/designSystem/components/tastingEntry.stories.tsx
+++ b/apps/web/src/components/designSystem/components/tastingEntry.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
       },
       {
         href: "/bottles/ardbeg-uigeadail",
-        metadata: "Islay · NAS · 54.2% ABV",
+        metadata: "Islay · No age statement · 54.2% ABV",
         name: "Ardbeg Uigeadail",
         notes: ["Tar", "Raisin", "Espresso"],
         ratingBand: "good",

--- a/apps/web/src/components/designSystem/components/unitInput.stories.tsx
+++ b/apps/web/src/components/designSystem/components/unitInput.stories.tsx
@@ -31,7 +31,7 @@ export const Overview: Story = {
         <UnitInput {...args} />
       </Field>
       <Field htmlFor="age-input" label="Age">
-        <UnitInput defaultValue={16} id="age-input" unit="yr" />
+        <UnitInput defaultValue={16} id="age-input" unit="years" />
       </Field>
       <Field htmlFor="invalid-unit-input" label="ABV">
         <UnitInput

--- a/apps/web/src/components/designSystem/patterns/bottlePageHeader.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/bottlePageHeader.stylex.tsx
@@ -35,7 +35,7 @@ export type BottlePageHeaderProps = {
   bands?: BandStackProps | null;
   brand: string;
   brandHref?: string;
-  detail?: string;
+  detail?: ReactNode;
   id: string;
   imageUrl?: string | null;
   memberStatus?: BottleMemberStatus;

--- a/apps/web/src/components/designSystem/patterns/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/homeBrowse.stylex.tsx
@@ -105,7 +105,7 @@ export function HomeHighestRated({
 
 export type HomeRelease = {
   href: string;
-  metadata: readonly string[];
+  metadata: ReactNode;
   name: string;
 };
 
@@ -135,7 +135,7 @@ export function HomeLatestReleases({
             <ItemRow
               href={bottle.href}
               key={bottle.href}
-              metadata={bottle.metadata.join(" · ")}
+              metadata={bottle.metadata}
               title={bottle.name}
             />
           ))}

--- a/apps/web/src/components/designSystem/patterns/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/homeBrowse.stylex.tsx
@@ -136,6 +136,7 @@ export function HomeLatestReleases({
               href={bottle.href}
               key={bottle.href}
               metadata={bottle.metadata}
+              metadataWrap
               title={bottle.name}
             />
           ))}

--- a/apps/web/src/components/entityLinks.test.tsx
+++ b/apps/web/src/components/entityLinks.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { EntityLinks } from "./entityLinks";
+
+describe("EntityLinks", () => {
+  it("links every entity in display order", () => {
+    const html = renderToStaticMarkup(
+      <EntityLinks
+        entities={[
+          { id: 129, kind: "distillery", name: "Glen Moray" },
+          { id: 366, kind: "distillery", name: "Caol Ila" },
+          { id: 142, kind: "distillery", name: "Glen Spey" },
+        ]}
+      />,
+    );
+
+    expect(html).toContain('href="/distillers/129"');
+    expect(html).toContain('href="/distillers/366"');
+    expect(html).toContain('href="/distillers/142"');
+    expect(html).toContain("Glen Moray");
+    expect(html).toContain("Caol Ila");
+    expect(html).toContain("Glen Spey");
+    expect(html.indexOf("Glen Moray")).toBeLessThan(html.indexOf("Caol Ila"));
+    expect(html.indexOf("Caol Ila")).toBeLessThan(html.indexOf("Glen Spey"));
+  });
+
+  it("uses the entity fallback route when the kind is unknown", () => {
+    const html = renderToStaticMarkup(
+      <EntityLinks entities={[{ id: 5, kind: null, name: "Unknown" }]} />,
+    );
+
+    expect(html).toContain('href="/entities/5"');
+  });
+});

--- a/apps/web/src/components/entityLinks.tsx
+++ b/apps/web/src/components/entityLinks.tsx
@@ -1,0 +1,30 @@
+import type { EntityKind } from "@peated/server/types";
+
+import { TextLink } from "@peated/web/components/designSystem/components";
+import { getEntityUrl } from "@peated/web/lib/urls";
+
+import Join from "./join";
+
+type LinkedEntity = {
+  id: number;
+  kind: EntityKind | null;
+  name: string;
+};
+
+export function EntityLinks({
+  entities,
+}: {
+  entities: readonly LinkedEntity[];
+}) {
+  if (!entities.length) return null;
+
+  return (
+    <Join divider=", ">
+      {entities.map((entity) => (
+        <TextLink href={getEntityUrl(entity)} key={entity.id} size="inherit">
+          {entity.name}
+        </TextLink>
+      ))}
+    </Join>
+  );
+}

--- a/apps/web/src/lib/bottleCatalogItem.ts
+++ b/apps/web/src/lib/bottleCatalogItem.ts
@@ -14,7 +14,7 @@ export function toBottleCatalogItem(bottle: Bottle): BottleCatalogItem {
     bottle.statedAge !== null
       ? `${bottle.statedAge} years`
       : bottle.noAgeStatement
-        ? "NAS"
+        ? "No age statement"
         : null,
     bottle.abv !== null ? `${formatAbv(bottle.abv)}% ABV` : null,
     `${bottle.totalTastings.toLocaleString("en-US")} ${bottle.totalTastings === 1 ? "tasting" : "tastings"}`,

--- a/apps/web/src/lib/bottleMetadata.test.ts
+++ b/apps/web/src/lib/bottleMetadata.test.ts
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
 
-import { getBottleReviewMetadata } from "./bottleMetadata";
+import { getBottleMetadata, getBottleReviewMetadata } from "./bottleMetadata";
 
 describe("bottle metadata", () => {
+  it("spells out a missing age statement", () => {
+    expect(
+      getBottleMetadata({
+        abv: 43,
+        category: "single_malt",
+        noAgeStatement: true,
+        statedAge: null,
+      }),
+    ).toBe("Single Malt · No age statement · 43% ABV");
+  });
+
   it("keeps reviewed release facts out of the bottle name", () => {
     expect(
       getBottleReviewMetadata({

--- a/apps/web/src/lib/bottleMetadata.ts
+++ b/apps/web/src/lib/bottleMetadata.ts
@@ -17,7 +17,7 @@ export function getBottleMetadata(bottle: BottleMetadata) {
     bottle.statedAge !== null
       ? `${bottle.statedAge} years`
       : bottle.noAgeStatement
-        ? "NAS"
+        ? "No age statement"
         : null,
     bottle.abv !== null
       ? `${bottle.abv.toFixed(1).replace(/\.0$/, "")}% ABV`


### PR DESCRIPTION
Bottle headers and homepage release rows now show every distillery in API display order. Each distillery links to its entity page. Bottle facts also link the bottler, and the flight overlay now links bottle brands. Missing categories are omitted cleanly, so the first available detail does not receive a leading separator.

Long producer lists wrap at compact widths through an opt-in `ItemRow` mode, while existing rows retain their single-line truncation. The copy cleanup expands `NAS`, `yr`, and bare alcohol percentages in customer-facing bottle metadata and its matching component stories.
