### PR TITLE
feat(catalog): add following views

### DIFF
--- a/apps/server/src/orpc/contracts/bottles/list.ts
+++ b/apps/server/src/orpc/contracts/bottles/list.ts
@@ -50,7 +50,7 @@ export default contract
     path: "/bottles",
     summary: "List bottles",
     description:
-      "Find bottles, including releases from distillers and bottlers the signed-in user follows",
+      "Find bottles, including releases from distillers, brands, and bottlers the signed-in user follows",
     spec: (spec) => ({
       ...spec,
       operationId: "listBottles",

--- a/apps/server/src/orpc/contracts/entityKinds/list.ts
+++ b/apps/server/src/orpc/contracts/entityKinds/list.ts
@@ -42,6 +42,7 @@ export const EntityKindListInputSchema = z
       .describe(
         "Filter by region slug or numeric ID. A slug requires `country`.",
       ),
+    filter: z.enum(["all", "following"]).default("all"),
     sort: z
       .enum(SORT_OPTIONS)
       .default(DEFAULT_SORT)
@@ -61,6 +62,7 @@ export const EntityKindListInputSchema = z
   })
   .default({
     query: "",
+    filter: "all",
     sort: DEFAULT_SORT,
     cursor: 1,
     limit: 100,

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -592,7 +592,19 @@ describe("mock oRPC router", () => {
     await expect(
       authenticatedClient.bottles.list({ filter: "following" }),
     ).resolves.toMatchObject({
-      followedEntityCount: 2,
+      followedEntityCount: 3,
+    });
+  });
+
+  it("requires sign-in for followed catalog records", async () => {
+    await expect(
+      anonymousClient.brands.list({ filter: "following" }),
+    ).rejects.toMatchObject({ code: "UNAUTHORIZED" });
+
+    await expect(
+      authenticatedClient.brands.list({ filter: "following" }),
+    ).resolves.toMatchObject({
+      results: [expect.objectContaining({ id: 9207, name: "Redbreast" })],
     });
   });
 

--- a/apps/server/src/orpc/mock/routes/bottlers/list.ts
+++ b/apps/server/src/orpc/mock/routes/bottlers/list.ts
@@ -1,6 +1,11 @@
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 import { listEntityKind } from "@peated/server/orpc/mock/routes/entityKinds/list";
 
-export default mockOS.bottlers.list.handler(async ({ input }) =>
-  listEntityKind("bottler", input),
+export default mockOS.bottlers.list.handler(
+  async ({ input, context, errors }) => {
+    if (input.filter === "following" && !context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+    return listEntityKind("bottler", input);
+  },
 );

--- a/apps/server/src/orpc/mock/routes/bottles/list.ts
+++ b/apps/server/src/orpc/mock/routes/bottles/list.ts
@@ -131,7 +131,7 @@ export default mockOS.bottles.list.handler(
       ),
       total,
       facets,
-      followedEntityCount: input.filter === "following" ? 2 : null,
+      followedEntityCount: input.filter === "following" ? 3 : null,
     };
   },
 );

--- a/apps/server/src/orpc/mock/routes/brands/list.ts
+++ b/apps/server/src/orpc/mock/routes/brands/list.ts
@@ -1,6 +1,11 @@
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 import { listEntityKind } from "@peated/server/orpc/mock/routes/entityKinds/list";
 
-export default mockOS.brands.list.handler(async ({ input }) =>
-  listEntityKind("brand", input),
+export default mockOS.brands.list.handler(
+  async ({ input, context, errors }) => {
+    if (input.filter === "following" && !context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+    return listEntityKind("brand", input);
+  },
 );

--- a/apps/server/src/orpc/mock/routes/companies/list.ts
+++ b/apps/server/src/orpc/mock/routes/companies/list.ts
@@ -1,6 +1,11 @@
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 import { listEntityKind } from "@peated/server/orpc/mock/routes/entityKinds/list";
 
-export default mockOS.companies.list.handler(async ({ input }) =>
-  listEntityKind("company", input),
+export default mockOS.companies.list.handler(
+  async ({ input, context, errors }) => {
+    if (input.filter === "following" && !context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+    return listEntityKind("company", input);
+  },
 );

--- a/apps/server/src/orpc/mock/routes/distilleries/list.ts
+++ b/apps/server/src/orpc/mock/routes/distilleries/list.ts
@@ -1,6 +1,11 @@
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 import { listEntityKind } from "@peated/server/orpc/mock/routes/entityKinds/list";
 
-export default mockOS.distilleries.list.handler(async ({ input }) =>
-  listEntityKind("distillery", input),
+export default mockOS.distilleries.list.handler(
+  async ({ input, context, errors }) => {
+    if (input.filter === "following" && !context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+    return listEntityKind("distillery", input);
+  },
 );

--- a/apps/server/src/orpc/mock/routes/entities/list.ts
+++ b/apps/server/src/orpc/mock/routes/entities/list.ts
@@ -1,6 +1,11 @@
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 import { listEntities } from "@peated/server/orpc/mock/routes/entityKinds/list";
 
-export default mockOS.entities.list.handler(async ({ input }) =>
-  listEntities(input),
+export default mockOS.entities.list.handler(
+  async ({ input, context, errors }) => {
+    if (input.filter === "following" && !context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+    return listEntities(input);
+  },
 );

--- a/apps/server/src/orpc/mock/routes/entityKinds/list.ts
+++ b/apps/server/src/orpc/mock/routes/entityKinds/list.ts
@@ -11,10 +11,13 @@ type EntityListInput = {
   owner?: number | null;
   country?: string | null;
   region?: string | null;
+  filter: "all" | "following";
   sort: string;
   cursor: number;
   limit: number;
 };
+
+const followedEntityIds = new Set([9201, 9207, 9208]);
 
 export function listEntityKind(kind: EntityKind, input: EntityListInput) {
   return listEntities(input, kind);
@@ -27,6 +30,7 @@ export function listEntities(input: EntityListInput, kind?: EntityKind) {
     .filter(
       (entity) =>
         (kind === undefined || entity.kind === kind) &&
+        (input.filter !== "following" || followedEntityIds.has(entity.id)) &&
         (input.owner == null || entity.ownerId === input.owner) &&
         includesQuery(input.query, entity.name, entity.shortName) &&
         (input.name == null || entity.name === input.name) &&

--- a/apps/server/src/orpc/routes/bottlers/list.ts
+++ b/apps/server/src/orpc/routes/bottlers/list.ts
@@ -10,5 +10,8 @@ export default implement(contract).handler(({ input, context, errors }) =>
     badRequest: (message) => {
       throw errors.BAD_REQUEST({ message });
     },
+    unauthorized: () => {
+      throw errors.UNAUTHORIZED();
+    },
   }),
 );

--- a/apps/server/src/orpc/routes/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/list.test.ts
@@ -829,7 +829,7 @@ describe("GET /bottles", () => {
     expect(response.followedEntityCount).toBe(0);
   });
 
-  test("lists known releases from followed distillers and bottlers", async ({
+  test("lists bottles from followed distillers, brands, and bottlers", async ({
     defaults,
     fixtures,
   }) => {
@@ -892,10 +892,11 @@ describe("GET /bottles", () => {
       distillerIds: [distiller.id],
       createdAt: new Date("2025-12-01T00:00:00.000Z"),
     });
-    await fixtures.Bottle({
+    const followedBrandRelease = await fixtures.Bottle({
       name: "Followed Brand Release",
       brandId: followedBrand.id,
       releaseYear: 2026,
+      releaseDate: "2026-06-01",
     });
     await fixtures.Bottle({ name: "Unrelated Release", releaseYear: 2026 });
 
@@ -913,11 +914,12 @@ describe("GET /bottles", () => {
     expect(results.map(({ id }) => id)).toEqual([
       followedBottlerRelease.id,
       exactLaterThisYear.id,
+      followedBrandRelease.id,
       exactEarlierThisYear.id,
       yearOnlyThisYear.id,
       knownLastYear.id,
     ]);
-    expect(followedEntityCount).toBe(2);
+    expect(followedEntityCount).toBe(3);
   });
 
   test("sorts bottles by tastings ascending", async ({ fixtures }) => {

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -95,10 +95,13 @@ export default implement(bottleListContract).handler(async function ({
       .where(
         and(
           eq(entityFollows.userId, context.user.id),
-          inArray(entities.kind, ["bottler", "distillery"]),
+          inArray(entities.kind, ["brand", "bottler", "distillery"]),
         ),
       );
     followedEntityIds = followedEntities.map(({ entityId }) => entityId);
+    const followedBrandIds = followedEntities.flatMap((entity) =>
+      entity.kind === "brand" ? [entity.entityId] : [],
+    );
     const followedDistillerIds = followedEntities.flatMap((entity) =>
       entity.kind === "distillery" ? [entity.entityId] : [],
     );
@@ -108,6 +111,9 @@ export default implement(bottleListContract).handler(async function ({
     where.push(
       followedEntityIds.length
         ? or(
+            followedBrandIds.length
+              ? inArray(bottles.brandId, followedBrandIds)
+              : undefined,
             followedDistillerIds.length
               ? sql`EXISTS(
                   SELECT FROM ${bottlesToDistillers}

--- a/apps/server/src/orpc/routes/brands/list.ts
+++ b/apps/server/src/orpc/routes/brands/list.ts
@@ -10,5 +10,8 @@ export default implement(contract).handler(({ input, context, errors }) =>
     badRequest: (message) => {
       throw errors.BAD_REQUEST({ message });
     },
+    unauthorized: () => {
+      throw errors.UNAUTHORIZED();
+    },
   }),
 );

--- a/apps/server/src/orpc/routes/companies/list.ts
+++ b/apps/server/src/orpc/routes/companies/list.ts
@@ -10,5 +10,8 @@ export default implement(contract).handler(({ input, context, errors }) =>
     badRequest: (message) => {
       throw errors.BAD_REQUEST({ message });
     },
+    unauthorized: () => {
+      throw errors.UNAUTHORIZED();
+    },
   }),
 );

--- a/apps/server/src/orpc/routes/distilleries/list.ts
+++ b/apps/server/src/orpc/routes/distilleries/list.ts
@@ -10,5 +10,8 @@ export default implement(contract).handler(({ input, context, errors }) =>
     badRequest: (message) => {
       throw errors.BAD_REQUEST({ message });
     },
+    unauthorized: () => {
+      throw errors.UNAUTHORIZED();
+    },
   }),
 );

--- a/apps/server/src/orpc/routes/entities/list.ts
+++ b/apps/server/src/orpc/routes/entities/list.ts
@@ -9,5 +9,8 @@ export default implement(contract).handler(({ input, context, errors }) =>
     badRequest: (message) => {
       throw errors.BAD_REQUEST({ message });
     },
+    unauthorized: () => {
+      throw errors.UNAUTHORIZED();
+    },
   }),
 );

--- a/apps/server/src/orpc/routes/entityKinds/list.test.ts
+++ b/apps/server/src/orpc/routes/entityKinds/list.test.ts
@@ -1,3 +1,6 @@
+import { db } from "@peated/server/db";
+import { entityFollows } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 
 describe("Entity kind collections", () => {
@@ -83,5 +86,35 @@ describe("Entity kind collections", () => {
     });
 
     expect(results.map(({ id }) => id)).toEqual([expected.id]);
+  });
+
+  test("requires authentication for followed entities", async () => {
+    const error = await waitError(() =>
+      routerClient.distilleries.list({ filter: "following" }),
+    );
+
+    expect(error).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("lists followed entities of the requested kind", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const followed = await fixtures.Entity({
+      name: "Followed Brand",
+      kind: "brand",
+    });
+    await fixtures.Entity({ name: "Other Brand", kind: "brand" });
+    await db.insert(entityFollows).values({
+      userId: defaults.user.id,
+      entityId: followed.id,
+    });
+
+    const { results } = await routerClient.brands.list(
+      { filter: "following" },
+      { context: { user: defaults.user } },
+    );
+
+    expect(results.map(({ id }) => id)).toEqual([followed.id]);
   });
 });

--- a/apps/server/src/orpc/routes/entityKinds/list.ts
+++ b/apps/server/src/orpc/routes/entityKinds/list.ts
@@ -3,6 +3,7 @@ import {
   countries,
   entities,
   entityAliases,
+  entityFollows,
   regions,
   type EntityKind,
   type User,
@@ -24,6 +25,7 @@ type ListEntitiesOptions = {
   badRequest: (message: string) => never;
   currentUser?: User | null;
   input: Input;
+  unauthorized: () => never;
 };
 
 export async function listEntities({
@@ -31,6 +33,7 @@ export async function listEntities({
   currentUser,
   input,
   kind,
+  unauthorized,
 }: ListEntitiesOptions & { kind?: EntityKind }) {
   const { query, cursor, limit } = input;
   const offset = (cursor - 1) * limit;
@@ -39,6 +42,17 @@ export async function listEntities({
   const where: (SQL<unknown> | undefined)[] = [
     kind ? eq(entities.kind, kind) : undefined,
   ];
+
+  if (input.filter === "following") {
+    if (!currentUser) return unauthorized();
+    where.push(
+      sql`EXISTS(
+        SELECT FROM ${entityFollows}
+        WHERE ${entityFollows.entityId} = ${entities.id}
+          AND ${entityFollows.userId} = ${currentUser.id}
+      )`,
+    );
+  }
 
   if (input.owner) {
     where.push(eq(entities.ownerId, input.owner));

--- a/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPage.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPage.tsx
@@ -1,5 +1,5 @@
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
-import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
+import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 
 import {
   EntityCatalogPageClient,
@@ -16,7 +16,7 @@ export async function EntityCatalogPage({
   const queryParams = getApiQueryParams(await searchParams, {
     numericFields: ["cursor", "limit"],
   });
-  const { client } = await getAnonymousServerClient();
+  const { client } = await getPublicPageServerClient();
   const entityListPromise =
     kind === "distillery"
       ? client.distilleries.list(queryParams)

--- a/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
@@ -6,7 +6,10 @@ import type { Entity, EntityKind } from "@peated/server/types";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { ButtonLink } from "@peated/web/components/designSystem/components";
+import {
+  ButtonLink,
+  PageTabs,
+} from "@peated/web/components/designSystem/components";
 import { CatalogPage } from "@peated/web/components/designSystem/patterns/catalogPage.stylex";
 import {
   EntityCatalogFilters,
@@ -14,6 +17,7 @@ import {
   type EntityCatalogItem,
 } from "@peated/web/components/designSystem/patterns/entityCatalog.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
+import useAuth from "@peated/web/hooks/useAuth";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getEntityUrl } from "@peated/web/lib/urls";
@@ -52,6 +56,7 @@ export function EntityCatalogPageClient({
 }) {
   const config = catalogConfig[kind];
   const orpc = useORPC();
+  const { user } = useAuth();
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -82,6 +87,11 @@ export function EntityCatalogPageClient({
   const query = searchParams.get("query") ?? "";
   const region = searchParams.get("region") ?? "";
   const hasFilters = Boolean(country || query || region);
+  const filter =
+    searchParams.get("filter") === "following" ? "following" : "all";
+  const allHref = getScopeHref(pathname, searchParams, "all");
+  const followingHref = getScopeHref(pathname, searchParams, "following");
+  const showFollowing = Boolean(user && kind !== "company");
 
   function updateParams(updates: Record<string, string>) {
     const nextParams = new URLSearchParams(searchParams);
@@ -115,6 +125,7 @@ export function EntityCatalogPageClient({
       }
       filters={
         <EntityCatalogFilters
+          ariaLabel={`${config.title} filters`}
           countries={countryList.results.map((item) => ({
             label: item.name,
             value: String(item.id),
@@ -131,10 +142,41 @@ export function EntityCatalogPageClient({
           region={region ? formatRegion(region) : undefined}
         />
       }
+      navigation={
+        showFollowing ? (
+          <PageTabs
+            ariaLabel={`${config.title} views`}
+            currentHref={filter === "following" ? followingHref : allHref}
+            items={[
+              { href: allHref, label: `All ${config.title.toLowerCase()}` },
+              { href: followingHref, label: "Following" },
+            ]}
+          />
+        ) : undefined
+      }
       title={config.title}
     >
       <EntityCatalogList
         addHref={addHref}
+        emptyAction={
+          filter === "following" && !hasFilters ? (
+            <ButtonLink href={allHref} size="sm" variant="tonal">
+              Browse all {config.title.toLowerCase()}
+            </ButtonLink>
+          ) : undefined
+        }
+        emptyDescription={
+          filter === "following"
+            ? hasFilters
+              ? `No ${config.title.toLowerCase()} you follow match these filters.`
+              : `Follow a ${config.noun} to add it to this list.`
+            : undefined
+        }
+        emptyHeading={
+          filter === "following"
+            ? `You don't follow any ${config.title.toLowerCase()} yet`
+            : undefined
+        }
         items={items}
         nextHref={getCursorHref(
           pathname,
@@ -155,6 +197,18 @@ export function EntityCatalogPageClient({
       />
     </CatalogPage>
   );
+}
+
+function getScopeHref(
+  pathname: string,
+  searchParams: { toString(): string },
+  filter: "all" | "following",
+) {
+  const nextParams = new URLSearchParams(searchParams.toString());
+  if (filter === "following") nextParams.set("filter", "following");
+  else nextParams.delete("filter");
+  nextParams.delete("cursor");
+  return buildSearchHref(pathname, nextParams);
 }
 
 function toCatalogItem(entity: Entity): EntityCatalogItem {

--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -170,7 +170,7 @@ function LatestReleases() {
       }
       title={
         useFollowedReleases
-          ? "New from distilleries and bottlers you follow"
+          ? "New from distillers, brands, and bottlers you follow"
           : "Recent releases"
       }
     />

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogNavigation.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogNavigation.stylex.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+
+import {
+  AppLink,
+  PageTabs,
+} from "@peated/web/components/designSystem/components";
+import { colors, fonts, space } from "../../../../styles/tokens.stylex";
+
+export function BottleCatalogNavigation({
+  allHref,
+  followingHref,
+  scope,
+}: {
+  allHref: string;
+  followingHref: string;
+  scope: "all" | "following";
+}) {
+  return (
+    <div {...stylex.props(styles.navigation)}>
+      <PageTabs
+        ariaLabel="Bottle views"
+        currentHref={scope === "following" ? followingHref : allHref}
+        items={[
+          { href: allHref, label: "All bottles" },
+          { href: followingHref, label: "Following" },
+        ]}
+      />
+      {scope === "following" ? (
+        <p {...stylex.props(styles.scopeHelp)}>
+          Bottles from distillers, brands, and bottlers you follow. See followed{" "}
+          <AppLink href="/distillers?filter=following">distillers</AppLink>,{" "}
+          <AppLink href="/brands?filter=following">brands</AppLink>, or{" "}
+          <AppLink href="/bottlers?filter=following">bottlers</AppLink>.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  navigation: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x3,
+  },
+  scopeHelp: {
+    margin: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "14px",
+    lineHeight: 1.5,
+  },
+});

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -15,9 +15,12 @@ import {
 } from "@peated/web/components/designSystem/patterns/bottleCatalog.stylex";
 import { CatalogPage } from "@peated/web/components/designSystem/patterns/catalogPage.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
+import useAuth from "@peated/web/hooks/useAuth";
 import { toBottleCatalogItem } from "@peated/web/lib/bottleCatalogItem";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
+
+import { BottleCatalogNavigation } from "./bottleCatalogNavigation.stylex";
 
 const DEFAULT_SORT = "-tastings";
 
@@ -57,7 +60,6 @@ const clearedFilterKeys = [
   "cursor",
   "distiller",
   "entity",
-  "filter",
   "flavorProfile",
   "flight",
   "minScore",
@@ -72,6 +74,7 @@ export function BottleCatalogPageClient({
   initialBottleList: BottleList;
 }) {
   const orpc = useORPC();
+  const { user } = useAuth();
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -95,6 +98,10 @@ export function BottleCatalogPageClient({
   });
   const page = Number(searchParams.get("cursor") ?? "1") || 1;
   const sort = searchParams.get("sort") ?? DEFAULT_SORT;
+  const filter =
+    searchParams.get("filter") === "following" ? "following" : "all";
+  const allHref = getScopeHref(pathname, searchParams, "all");
+  const followingHref = getScopeHref(pathname, searchParams, "following");
 
   function updateParams(updates: Record<string, string>) {
     const nextParams = new URLSearchParams(searchParams);
@@ -166,9 +173,35 @@ export function BottleCatalogPageClient({
           query={searchParams.get("query") ?? ""}
         />
       }
+      navigation={
+        user ? (
+          <BottleCatalogNavigation
+            allHref={allHref}
+            followingHref={followingHref}
+            scope={filter}
+          />
+        ) : undefined
+      }
       title="Bottles"
     >
       <BottleCatalogList
+        emptyAction={
+          filter === "following" && bottleList.followedEntityCount === 0 ? (
+            <ButtonLink href="/distillers" size="sm" variant="tonal">
+              Browse distillers
+            </ButtonLink>
+          ) : undefined
+        }
+        emptyDescription={
+          filter === "following" && bottleList.followedEntityCount === 0
+            ? "Follow a distiller, brand, or bottler to see its bottles here."
+            : undefined
+        }
+        emptyHeading={
+          filter === "following" && bottleList.followedEntityCount === 0
+            ? "No bottles here yet"
+            : undefined
+        }
         items={items}
         nextHref={getCursorHref(
           pathname,
@@ -189,4 +222,16 @@ export function BottleCatalogPageClient({
       />
     </CatalogPage>
   );
+}
+
+function getScopeHref(
+  pathname: string,
+  searchParams: { toString(): string },
+  filter: "all" | "following",
+) {
+  const nextParams = new URLSearchParams(searchParams.toString());
+  if (filter === "following") nextParams.set("filter", "following");
+  else nextParams.delete("filter");
+  nextParams.delete("cursor");
+  return buildSearchHref(pathname, nextParams);
 }

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -198,7 +198,10 @@ export function EntityPageFrameClient({
 
   const entity = entityQuery.data;
   const createBottleHref = getEntityBottleCreateHref(entity);
-  const canFollow = entity.kind === "bottler" || entity.kind === "distillery";
+  const canFollow =
+    entity.kind === "brand" ||
+    entity.kind === "bottler" ||
+    entity.kind === "distillery";
   const presentation = getEntityPresentation(entity);
   const currentHref = getEntityCurrentHref(entity, pathname);
 

--- a/apps/web/src/components/designSystem/components/pageTabs.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/pageTabs.stylex.tsx
@@ -15,7 +15,7 @@ export type PageTabsProps = {
   items: readonly [PageTabItem, ...PageTabItem[]];
 };
 
-/** Shows peer destinations within one record or member page. */
+/** Shows peer destinations within one page or section. */
 export function PageTabs({ ariaLabel, currentHref, items }: PageTabsProps) {
   return (
     <nav aria-label={ariaLabel} {...stylex.props(styles.tabs)}>

--- a/apps/web/src/components/designSystem/patterns/catalogPage.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/catalogPage.stylex.tsx
@@ -12,23 +12,33 @@ export function CatalogPage({
   children,
   eyebrow = "Whisky database",
   filters,
+  navigation,
   title,
 }: {
   action?: ReactNode;
   children: ReactNode;
   eyebrow?: ReactNode;
   filters: ReactNode;
+  navigation?: ReactNode;
   title: ReactNode;
 }) {
   return (
     <div {...stylex.props(styles.page)}>
-      <header {...stylex.props(styles.titleRow)}>
+      <header
+        {...stylex.props(
+          styles.titleRow,
+          navigation ? styles.titleRowWithNavigation : null,
+        )}
+      >
         <div>
           <div {...stylex.props(styles.eyebrow)}>{eyebrow}</div>
           <h1 {...stylex.props(foundationStyles.pageTitle)}>{title}</h1>
         </div>
         {action}
       </header>
+      {navigation ? (
+        <div {...stylex.props(styles.navigation)}>{navigation}</div>
+      ) : null}
       <div {...stylex.props(styles.layout)}>
         <div {...stylex.props(styles.results)}>{children}</div>
         <aside {...stylex.props(styles.filters)}>{filters}</aside>
@@ -64,6 +74,12 @@ const styles = stylex.create({
     [NARROW]: {
       alignItems: "flex-start",
     },
+  },
+  titleRowWithNavigation: {
+    marginBottom: space.x2,
+  },
+  navigation: {
+    marginBottom: space.x6,
   },
   eyebrow: {
     marginBottom: space.x1,

--- a/apps/web/src/components/designSystem/patterns/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/entityCatalog.stylex.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import type { ReactNode } from "react";
 
 import { colors, fonts, space } from "../../../styles/tokens.stylex";
 import {
@@ -31,6 +32,9 @@ export type EntityCatalogItem = {
 
 export type EntityCatalogListProps = {
   addHref: string;
+  emptyAction?: ReactNode;
+  emptyDescription?: ReactNode;
+  emptyHeading?: string;
   items: readonly EntityCatalogItem[];
   nextHref?: string;
   noun: string;
@@ -45,6 +49,9 @@ export type EntityCatalogListProps = {
 /** Presents one API-owned cursor page without inventing a total. */
 export function EntityCatalogList({
   addHref,
+  emptyAction,
+  emptyDescription = "Try a broader search or remove the current location filter.",
+  emptyHeading,
   items,
   nextHref,
   noun,
@@ -79,7 +86,8 @@ export function EntityCatalogList({
       ) : (
         <EmptyState
           action={
-            onClear ? (
+            emptyAction ??
+            (onClear ? (
               <Button onClick={onClear} size="sm" variant="tonal">
                 Clear filters
               </Button>
@@ -87,11 +95,11 @@ export function EntityCatalogList({
               <ButtonLink href={addHref} size="sm" variant="tonal">
                 Add {noun}
               </ButtonLink>
-            )
+            ))
           }
-          heading={`No ${noun}s found`}
+          heading={emptyHeading ?? `No ${noun}s found`}
         >
-          Try a broader search or remove the current location filter.
+          {emptyDescription}
         </EmptyState>
       )}
       <CursorPager
@@ -132,6 +140,7 @@ export type EntityCatalogCountry = {
 };
 
 export type EntityCatalogFiltersProps = {
+  ariaLabel: string;
   countries: readonly EntityCatalogCountry[];
   country: string;
   onClear: () => void;
@@ -144,6 +153,7 @@ export type EntityCatalogFiltersProps = {
 
 /** Keeps query and location filters reachable while the route owns URL state. */
 export function EntityCatalogFilters({
+  ariaLabel,
   countries,
   country,
   onClear,
@@ -154,7 +164,7 @@ export function EntityCatalogFilters({
   region,
 }: EntityCatalogFiltersProps) {
   return (
-    <FilterPanel ariaLabel="Entity filters">
+    <FilterPanel ariaLabel={ariaLabel}>
       <FilterQuery
         label="Find a record"
         onSubmit={onQuerySubmit}


### PR DESCRIPTION
Signed-in catalog pages now expose “All” and “Following” tabs. The bottle view includes releases from followed distillers, brands, and bottlers, with links to each matching followed catalog. Those catalogs use the same tabs and direct empty-state copy, and brand pages expose the existing follow action so members can add brands to the list.

This extends the existing following filter and shared catalog components. It does not add a separate followed-items page or a new domain abstraction. Anonymous catalog browsing is unchanged, while direct following requests still require sign-in.
