### PR TITLE
fix: address recent production regressions

### DIFF
--- a/apps/server/src/orpc/routes/bottles/prices/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/prices/list.test.ts
@@ -1,3 +1,5 @@
+import { db } from "@peated/server/db";
+import { bottleTombstones } from "@peated/server/db/schema";
 import { routerClient } from "@peated/server/orpc/router";
 
 describe("GET /bottles/:bottle/prices", () => {
@@ -95,6 +97,20 @@ describe("GET /bottles/:bottle/prices", () => {
       ),
     ).toBe(true);
     expect(result.results.every((price) => !("target" in price))).toBe(true);
+  });
+
+  test("uses the replacement Bottle for a tombstone", async ({ fixtures }) => {
+    const replacement = await fixtures.Bottle();
+    const price = await fixtures.StorePrice({ bottleId: replacement.id });
+    await db.insert(bottleTombstones).values({
+      bottleId: 999,
+      newBottleId: replacement.id,
+    });
+
+    const result = await routerClient.bottles.prices.list({ bottle: 999 });
+
+    expect(result.results.map(({ id }) => id)).toEqual([price.id]);
+    expect(result.results[0]?.bottle?.id).toBe(replacement.id);
   });
 
   test("filters direct Bottle prices by validity", async ({ fixtures }) => {

--- a/apps/server/src/orpc/routes/bottles/prices/list.ts
+++ b/apps/server/src/orpc/routes/bottles/prices/list.ts
@@ -1,5 +1,10 @@
 import { db } from "@peated/server/db";
-import { bottles, externalSites, storePrices } from "@peated/server/db/schema";
+import {
+  bottles,
+  bottleTombstones,
+  externalSites,
+  storePrices,
+} from "@peated/server/db/schema";
 import { currentStorePriceCondition } from "@peated/server/lib/storePriceValidity";
 import { implement } from "@peated/server/orpc";
 import bottlePriceListContract from "@peated/server/orpc/contracts/bottles/prices/list";
@@ -20,10 +25,18 @@ export default implement(bottlePriceListContract).handler(async function ({
   context,
   errors,
 }) {
-  const [bottle] = await db
+  let [bottle] = await db
     .select()
     .from(bottles)
     .where(eq(bottles.id, input.bottle));
+
+  if (!bottle) {
+    [bottle] = await db
+      .select({ ...getTableColumns(bottles) })
+      .from(bottleTombstones)
+      .innerJoin(bottles, eq(bottleTombstones.newBottleId, bottles.id))
+      .where(eq(bottleTombstones.bottleId, input.bottle));
+  }
 
   if (!bottle) {
     throw errors.NOT_FOUND({

--- a/apps/server/src/scraper/adapters/whiskeyReviewer.test.ts
+++ b/apps/server/src/scraper/adapters/whiskeyReviewer.test.ts
@@ -60,6 +60,18 @@ test("extracts the grade and only tasting-note paragraphs", async () => {
   );
 });
 
+test("accepts the publisher's misspelled review suffix", async () => {
+  const html = await loadFixture("whiskeyreviewer", "review.html");
+  const parsed = parseWhiskeyReviewerArticle(
+    html.replace("Bourbon Review", "Bourbon Rview"),
+    new URL(BOURBON_URL),
+  );
+
+  expect(parsed.article.externalReviews[0]?.name).toBe(
+    "Example 8 Year Old Bourbon",
+  );
+});
+
 test("rejects an article without an encoded date", async () => {
   const html = await loadFixture("whiskeyreviewer", "review.html");
   const undatedUrl =

--- a/apps/server/src/scraper/adapters/whiskeyReviewer.ts
+++ b/apps/server/src/scraper/adapters/whiskeyReviewer.ts
@@ -128,7 +128,7 @@ function reviewGrade(value: string) {
 }
 
 function bottleName(title: string): string | null {
-  const name = normalizeText(title.replace(/\s+Review$/iu, ""));
+  const name = normalizeText(title.replace(/\s+R(?:e)?view$/iu, ""));
   return name === title ? null : name;
 }
 

--- a/apps/server/src/scraper/adapters/whiskyNotes.test.ts
+++ b/apps/server/src/scraper/adapters/whiskyNotes.test.ts
@@ -64,6 +64,21 @@ test("extracts multi-bottle reviews with stable source keys", async () => {
   ).toEqual(reparsed.article.externalReviews.map(({ sourceKey }) => sourceKey));
 });
 
+test("accepts proof-strength review headings", async () => {
+  const html = await loadFixture("whiskynotes", "single-review.html");
+  const parsed = parseWhiskyNotesArticle(
+    html.replace("43%", "100 Proof"),
+    new URL(SINGLE_URL),
+  );
+
+  expect(parsed.article.externalReviews).toEqual([
+    expect.objectContaining({
+      name: "Kanekou Okinawa Whisky (100 Proof, OB +/- 2025)",
+      nativeScore: { value: 52, scale: 100, display: "52/100" },
+    }),
+  ]);
+});
+
 async function runAdapter(
   cursor: WhiskyNotesCursor | null,
   {

--- a/apps/server/src/scraper/adapters/whiskyNotes.ts
+++ b/apps/server/src/scraper/adapters/whiskyNotes.ts
@@ -96,7 +96,9 @@ function score(value: string) {
 
 function bottleName(heading: string): string | null {
   const name = normalizeText(heading);
-  return /^.+\s+\((?=[^)]*\d{1,3}(?:[.,]\d+)?\s*%)[^)]*\)\s*$/u.test(name)
+  return /^.+\s+\((?=[^)]*\d{1,3}(?:[.,]\d+)?\s*(?:%|proof\b))[^)]*\)\s*$/iu.test(
+    name,
+  )
     ? name
     : null;
 }

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/page.stylex.ts
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/page.stylex.ts
@@ -1,0 +1,19 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { colors, space } from "../../../../../../../styles/tokens.stylex";
+
+export const styles = stylex.create({
+  settings: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+  },
+  dividedSetting: {
+    minWidth: 0,
+    marginTop: space.x6,
+    paddingTop: space.x6,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.hairline,
+  },
+});

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/page.tsx
@@ -13,10 +13,11 @@ import ScraperPublicationSettings from "@peated/web/components/admin/scraperPubl
 import ScraperReadiness from "@peated/web/components/admin/scraperReadiness";
 import ScraperScheduleSettings from "@peated/web/components/admin/scraperScheduleSettings.stylex";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { colors, space } from "@peated/web/styles/tokens.stylex";
 import * as stylex from "@stylexjs/stylex";
 import { useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { use } from "react";
+
+import { styles } from "./page.stylex";
 
 export default function Page(props: { params: Promise<{ siteId: string }> }) {
   const { siteId } = use(props.params);
@@ -83,19 +84,3 @@ export default function Page(props: { params: Promise<{ siteId: string }> }) {
     </AdminPage>
   );
 }
-
-const styles = stylex.create({
-  settings: {
-    display: "flex",
-    minWidth: 0,
-    flexDirection: "column",
-  },
-  dividedSetting: {
-    minWidth: 0,
-    marginTop: space.x6,
-    paddingTop: space.x6,
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
-    borderTopColor: colors.hairline,
-  },
-});

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -16,6 +16,7 @@ import {
 import { CatalogPage } from "@peated/web/components/designSystem/patterns/catalogPage.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import { toBottleCatalogItem } from "@peated/web/lib/bottleCatalogItem";
+import { normalizeBottleCatalogQueryParams } from "@peated/web/lib/bottleCatalogQueryParams";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 
@@ -75,20 +76,22 @@ export function BottleCatalogPageClient({
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const queryParams = useApiQueryParams({
-    numericFields: [
-      "age",
-      "brand",
-      "bottler",
-      "cursor",
-      "distiller",
-      "entity",
-      "limit",
-      "minScore",
-      "series",
-    ],
-    overrides: { limit: 50 },
-  });
+  const queryParams = normalizeBottleCatalogQueryParams(
+    useApiQueryParams({
+      numericFields: [
+        "age",
+        "brand",
+        "bottler",
+        "cursor",
+        "distiller",
+        "entity",
+        "limit",
+        "minScore",
+        "series",
+      ],
+      overrides: { limit: 50 },
+    }),
+  );
   const { data: bottleList } = useSuspenseQuery({
     ...orpc.bottles.list.queryOptions({ input: queryParams }),
     initialData: initialBottleList,

--- a/apps/web/src/app/(app)/bottles/(index)/page.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/page.tsx
@@ -1,4 +1,5 @@
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
+import { normalizeBottleCatalogQueryParams } from "@peated/web/lib/bottleCatalogQueryParams";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import type { Metadata } from "next";
 
@@ -12,20 +13,22 @@ export const metadata: Metadata = {
 export default async function BottleListPage(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  const queryParams = getApiQueryParams(await props.searchParams, {
-    numericFields: [
-      "age",
-      "brand",
-      "bottler",
-      "cursor",
-      "distiller",
-      "entity",
-      "limit",
-      "minScore",
-      "series",
-    ],
-    overrides: { limit: 50 },
-  });
+  const queryParams = normalizeBottleCatalogQueryParams(
+    getApiQueryParams(await props.searchParams, {
+      numericFields: [
+        "age",
+        "brand",
+        "bottler",
+        "cursor",
+        "distiller",
+        "entity",
+        "limit",
+        "minScore",
+        "series",
+      ],
+      overrides: { limit: 50 },
+    }),
+  );
   const { client } = await getPublicPageServerClient();
   const bottleList = await client.bottles.list(queryParams);
 

--- a/apps/web/src/app/(app)/bottles/[bottleId]/prices/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/prices/page.tsx
@@ -6,6 +6,7 @@ import {
 } from "@peated/web/components/designSystem/components";
 import Price from "@peated/web/components/price";
 import TimeSince from "@peated/web/components/timeSince";
+import { getBottlePage } from "@peated/web/lib/bottlePage.server";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 import { parseReleaseFamilyRouteId } from "@peated/web/lib/releaseFamily";
 
@@ -48,9 +49,9 @@ export default async function BottlePricesPage(props: {
   params: Promise<{ bottleId: string }>;
 }) {
   const { bottleId } = await props.params;
-  const id = parseReleaseFamilyRouteId(bottleId);
+  const bottle = await getBottlePage(parseReleaseFamilyRouteId(bottleId));
   const { client } = await getAnonymousServerClient();
-  const priceList = await client.bottles.prices.list({ bottle: id });
+  const priceList = await client.bottles.prices.list({ bottle: bottle.id });
 
   return (
     <BottleSection count={priceList.results.length} heading="Sellers">

--- a/apps/web/src/lib/bottleCatalogQueryParams.test.ts
+++ b/apps/web/src/lib/bottleCatalogQueryParams.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "vitest";
+
+import { normalizeBottleCatalogQueryParams } from "./bottleCatalogQueryParams";
+
+test.each([
+  ["rating", "score"],
+  ["-rating", "-score"],
+  ["-tastings", "-tastings"],
+])("normalizes the bottle sort %s to %s", (sort, expected) => {
+  expect(
+    normalizeBottleCatalogQueryParams({
+      category: "single_malt",
+      sort,
+    }),
+  ).toEqual({
+    category: "single_malt",
+    sort: expected,
+  });
+});

--- a/apps/web/src/lib/bottleCatalogQueryParams.ts
+++ b/apps/web/src/lib/bottleCatalogQueryParams.ts
@@ -1,0 +1,13 @@
+import type { ApiQueryParams } from "./apiQueryParams";
+
+export function normalizeBottleCatalogQueryParams(
+  queryParams: ApiQueryParams,
+): ApiQueryParams {
+  if (queryParams.sort === "rating") {
+    return { ...queryParams, sort: "score" };
+  }
+  if (queryParams.sort === "-rating") {
+    return { ...queryParams, sort: "-score" };
+  }
+  return queryParams;
+}


### PR DESCRIPTION
Fixes the actionable errors found in recent production Sentry reports. WhiskyNotes accepts proof-based strength headings, Whiskey Reviewer tolerates the publisher's `Rview` typo, bottle price reads follow merge tombstones, and the bottle catalog maps legacy rating sorts to the current score field.

The admin scraper settings styles now live in a compiled `.stylex.ts` module, which prevents `stylex.create` from reaching the production runtime. Focused regression tests cover the scraper formats, tombstone price lookup, and legacy sort mapping. The production web build passes on the current `main` base.
