### PR TITLE
fix(admin): repair scraper reviews page

### DIFF
--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/reviews/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/reviews/page.tsx
@@ -4,7 +4,7 @@ import { use } from "react";
 import { type ExternalSiteKey } from "@peated/server/types";
 import { AdminSection } from "@peated/web/components/admin/adminContent.stylex";
 import { AdminEmptyActivity as EmptyActivity } from "@peated/web/components/admin/adminUtility.stylex";
-import ExternalReviewTable from "@peated/web/components/admin/externalReviewTable";
+import ReviewTable from "@peated/web/components/admin/reviewTable.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
@@ -23,23 +23,20 @@ export default function Page(props: {
   });
 
   const orpc = useORPC();
-  const { data: externalReviewList } = useSuspenseQuery(
+  const { data: reviews } = useSuspenseQuery(
     orpc.externalReviews.list.queryOptions({
       input: queryParams,
     }),
   );
   return (
     <AdminSection
-      title="Collected reviews"
-      description="Review bottle matches and scores collected from this site."
+      title="Reviews"
+      description="Check each review's bottle match and score."
     >
-      {externalReviewList.results.length > 0 ? (
-        <ExternalReviewTable
-          externalReviewList={externalReviewList.results}
-          rel={externalReviewList.rel}
-        />
+      {reviews.results.length > 0 ? (
+        <ReviewTable reviews={reviews.results} rel={reviews.rel} />
       ) : (
-        <EmptyActivity>No reviews have been collected yet.</EmptyActivity>
+        <EmptyActivity>This site has no reviews yet.</EmptyActivity>
       )}
     </AdminSection>
   );

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
@@ -128,7 +128,7 @@ export default function Layout({
           { href: root, label: "Settings" },
           { href: `${root}/runs`, label: "Runs" },
           { href: `${root}/prices`, label: "Prices" },
-          { href: `${root}/external-reviews`, label: "Reviews" },
+          { href: `${root}/reviews`, label: "Reviews" },
         ]}
       />
       {children}

--- a/apps/web/src/components/admin/reviewTable.stylex.tsx
+++ b/apps/web/src/components/admin/reviewTable.stylex.tsx
@@ -13,23 +13,21 @@ const publishedDateFormatter = new Intl.DateTimeFormat("en-US", {
   year: "numeric",
 });
 
-export default function ExternalReviewTable({
-  externalReviewList,
+export default function ReviewTable({
+  reviews,
   rel,
 }: {
-  externalReviewList: ExternalReview[];
+  reviews: ExternalReview[];
   rel?: PagingRel;
 }) {
-  return (
-    <ExternalReviewRows externalReviewList={externalReviewList} rel={rel} />
-  );
+  return <ReviewRows reviews={reviews} rel={rel} />;
 }
 
-export function ExternalReviewRows({
-  externalReviewList,
+export function ReviewRows({
+  reviews,
   rel,
 }: {
-  externalReviewList: ExternalReview[];
+  reviews: ExternalReview[];
   rel?: PagingRel;
 }) {
   return (
@@ -67,11 +65,11 @@ export function ExternalReviewRows({
         },
         {
           align: "right",
-          name: "source score",
+          name: "score",
           value: (review) => review.nativeScore?.display ?? "—",
         },
       ]}
-      items={externalReviewList}
+      items={reviews}
       rel={rel}
     />
   );
@@ -80,9 +78,9 @@ export function ExternalReviewRows({
 const styles = stylex.create({
   review: {
     display: "flex",
-    minWidth: 0,
     flexDirection: "column",
     gap: space.x1,
+    minWidth: 0,
   },
   metadata: {
     color: colors.inkMuted,

--- a/apps/web/src/components/admin/reviewTable.test.tsx
+++ b/apps/web/src/components/admin/reviewTable.test.tsx
@@ -2,7 +2,7 @@ import type { Bottle, Entity, ExternalReview } from "@peated/server/types";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { ExternalReviewRows } from "./externalReviewTable";
+import { ReviewRows } from "./reviewTable.stylex";
 
 const timestamp = "2026-07-22T12:00:00.000Z";
 
@@ -80,10 +80,7 @@ const bottle = {
   hasTasted: false,
 } satisfies Bottle;
 
-function makeExternalReview(
-  id: number,
-  reviewBottle: Bottle | null,
-): ExternalReview {
+function makeReview(id: number, reviewBottle: Bottle | null): ExternalReview {
   return {
     id,
     name: "Springbank review",
@@ -97,12 +94,10 @@ function makeExternalReview(
   };
 }
 
-describe("ExternalReviewTable", () => {
+describe("ReviewTable", () => {
   it("renders the direct Bottle identity", () => {
     const html = renderToStaticMarkup(
-      <ExternalReviewRows
-        externalReviewList={[makeExternalReview(1, bottle)]}
-      />,
+      <ReviewRows reviews={[makeReview(1, bottle)]} />,
     );
 
     expect(html).toContain('href="/bottles/19"');
@@ -113,7 +108,7 @@ describe("ExternalReviewTable", () => {
 
   it("renders unresolved review identity without a catalog link", () => {
     const html = renderToStaticMarkup(
-      <ExternalReviewRows externalReviewList={[makeExternalReview(3, null)]} />,
+      <ReviewRows reviews={[makeReview(3, null)]} />,
     );
 
     expect(html).toContain("No bottle");


### PR DESCRIPTION
The scraper site's Reviews tab now loads at `/admin/sites/:siteId/reviews` and uses plain Review names and copy across the page. The old `external-reviews` URL is removed.

The crash occurred because the table's StyleX code lived in a file that the StyleX build rule did not compile. Renaming it to `reviewTable.stylex.tsx` makes the build compile those styles before the page runs. This fixes Sentry issue [PEATED-4ET](https://peated.sentry.io/issues/7701133769/).
