### PR TITLE
style(home): shorten followed releases heading

### DIFF
--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -170,11 +170,7 @@ function LatestReleases() {
           ? "/bottles?filter=following&sort=-release"
           : "/bottles?sort=-release"
       }
-      title={
-        useFollowedReleases
-          ? "New from distillers, brands, and bottlers you follow"
-          : "Recent releases"
-      }
+      title={useFollowedReleases ? "New for you" : "Recent releases"}
     />
   ) : null;
 }


### PR DESCRIPTION
The personalized home release section now uses the shorter “New for you” heading instead of listing each followed source type. The global “Recent releases” heading is unchanged.
