### PR TITLE
ci(web): add screenshots to pull requests

### DIFF
--- a/.github/workflows/web-visual-comment.yml
+++ b/.github/workflows/web-visual-comment.yml
@@ -1,0 +1,100 @@
+name: Web screenshot comment
+
+on: # zizmor: ignore[dangerous-triggers] This workflow uses code from the default branch and never runs pull request code.
+  workflow_run:
+    workflows: ["Web screenshots"]
+    types: [completed]
+
+concurrency:
+  group: web-screenshot-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    name: screenshots / comment
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: apps/web/visual/post-pr-comment.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Check comment script
+        id: comment_script
+        run: |
+          set -euo pipefail
+          if [[ -f apps/web/visual/post-pr-comment.mjs ]]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "The screenshot comment script is not on the default branch yet."
+          fi
+
+      - name: Resolve pull request
+        id: pr
+        if: steps.comment_script.outputs.present == 'true'
+        env:
+          EVENT_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          pr_number="${EVENT_PR_NUMBER:-}"
+          if [[ -z "$pr_number" ]]; then
+            pr_number="$(
+              gh api "repos/${REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+                --jq 'map(select(.state == "open" or .merged_at != null)) | .[0].number // empty'
+            )"
+          fi
+          if [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          head_sha="$(gh api "repos/${REPOSITORY}/pulls/${pr_number}" --jq .head.sha)"
+          if [[ "$head_sha" != "$HEAD_SHA" ]]; then
+            echo "found=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "found=true" >> "$GITHUB_OUTPUT"
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Download screenshots
+        id: download
+        if: steps.comment_script.outputs.present == 'true' && steps.pr.outputs.found == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: web-screenshots
+          path: apps/web/.playwright/visual
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment screenshots on pull request
+        if: >-
+          steps.comment_script.outputs.present == 'true' &&
+          steps.pr.outputs.found == 'true' &&
+          steps.download.outcome == 'success'
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.event.workflow_run.head_sha }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: |
+          set -euo pipefail
+          out_dir=apps/web/.playwright/visual
+          if [[ ! -f "$out_dir/manifest.json" ]]; then
+            echo "No screenshot manifest was downloaded."
+            exit 0
+          fi
+          node apps/web/visual/post-pr-comment.mjs "$out_dir"

--- a/.github/workflows/web-visual.yml
+++ b/.github/workflows/web-visual.yml
@@ -1,0 +1,82 @@
+name: Web screenshots
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    paths:
+      - "apps/web/**"
+      - "packages/design/**"
+      - "packages/orpc/**"
+      - ".github/workflows/web-visual.yml"
+      - ".github/workflows/web-visual-comment.yml"
+      - "package.json"
+      - "pnpm-lock.yaml"
+
+concurrency:
+  group: web-screenshots-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  capture:
+    name: screenshots / capture
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Choose pages
+        id: mode
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+          PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          set -euo pipefail
+          if [[ ",$PR_LABELS," == *",run-all-screenshots,"* ]]; then
+            echo "all=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "all=false" >> "$GITHUB_OUTPUT"
+          fi
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > /tmp/peated-screenshot-changes.txt
+          cat /tmp/peated-screenshot-changes.txt
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        with:
+          run_install: false
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.18.0
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Install Playwright
+        run: pnpm --dir apps/web exec playwright install --with-deps chromium
+      - name: Capture screenshots
+        env:
+          ALL: ${{ steps.mode.outputs.all }}
+        run: |
+          set -euo pipefail
+          args=(
+            --changed-file /tmp/peated-screenshot-changes.txt
+            --out-dir .playwright/visual
+          )
+          if [[ "$ALL" == "true" ]]; then
+            args+=(--all)
+          fi
+          pnpm visual:web -- "${args[@]}"
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: web-screenshots
+          path: apps/web/.playwright/visual
+          if-no-files-found: warn
+          retention-days: 14

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -50,6 +50,7 @@ import {
   storePriceList,
   suggestedTags,
   tastingNotes,
+  testBottler,
   testBrand,
   testOwnedEntity,
   testOwner,
@@ -199,16 +200,23 @@ async function handleRpcRequest({ request, response, url }) {
         });
         return true;
       }
+      if (input?.owner === testOwner.id) {
+        sendRpcResponse(response, {
+          ...emptyList,
+          results: [testOwnedEntity],
+        });
+        return true;
+      }
       return false;
     case "entities/details":
       if (
-        [testBrand, testOwnedEntity, testOwner].some(
+        [testBrand, testBottler, testOwnedEntity, testOwner].some(
           (entity) => entity.id === Number(input?.entity),
         )
       ) {
         sendRpcResponse(
           response,
-          [testBrand, testOwnedEntity, testOwner].find(
+          [testBrand, testBottler, testOwnedEntity, testOwner].find(
             (entity) => entity.id === Number(input?.entity),
           ),
         );
@@ -218,9 +226,12 @@ async function handleRpcRequest({ request, response, url }) {
       return true;
     case "entities/catalog":
       if (
-        ![testBrand.id, testOwnedEntity.id, testOwner.id].includes(
-          Number(input?.entity),
-        )
+        ![
+          testBrand.id,
+          testBottler.id,
+          testOwnedEntity.id,
+          testOwner.id,
+        ].includes(Number(input?.entity))
       ) {
         sendRpcError(response, "Unexpected entity catalog payload");
         return true;
@@ -685,7 +696,49 @@ async function handleRpcRequest({ request, response, url }) {
       }
       if (
         !getAccessToken(request).includes("flight-bottles") &&
-        input?.limit === 10 &&
+        [testBrand.id, testBottler.id, testOwnedEntity.id].includes(
+          input?.entity,
+        ) &&
+        input?.limit === 4 &&
+        input?.sort === "-tastings"
+      ) {
+        sendRpcResponse(response, {
+          results:
+            input.entity === testBottler.id
+              ? [homeBottle, existingBottle]
+              : [homeBottle],
+          rel: { nextCursor: null, prevCursor: null },
+        });
+        return true;
+      }
+      if (
+        !getAccessToken(request).includes("flight-bottles") &&
+        [testBrand.id, testBottler.id, testOwnedEntity.id].includes(
+          input?.entity,
+        ) &&
+        input?.limit === 4 &&
+        input?.sort === "-release"
+      ) {
+        sendRpcResponse(response, {
+          results: [bottleGroupRepresentative],
+          rel: { nextCursor: null, prevCursor: null },
+        });
+        return true;
+      }
+      if (
+        !getAccessToken(request).includes("flight-bottles") &&
+        input?.limit === 5 &&
+        input?.sort === "-release"
+      ) {
+        sendRpcResponse(response, {
+          results: [bottleGroupRepresentative],
+          rel: { nextCursor: null, prevCursor: null },
+        });
+        return true;
+      }
+      if (
+        !getAccessToken(request).includes("flight-bottles") &&
+        [3, 10].includes(input?.limit) &&
         input?.sort === "-created"
       ) {
         sendRpcResponse(response, {
@@ -707,6 +760,16 @@ async function handleRpcRequest({ request, response, url }) {
       }
 
       sendRpcResponse(response, suggestedTags);
+      return true;
+    case "bottles/recommendations":
+      if (!isNumber(input?.bottle)) {
+        sendRpcError(response, "Unexpected bottle recommendations payload");
+        return true;
+      }
+      sendRpcResponse(response, {
+        reason: "People who liked this bottle also liked these bottles.",
+        results: [],
+      });
       return true;
     case "tastings/create": {
       if (
@@ -1020,6 +1083,30 @@ async function handleRpcRequest({ request, response, url }) {
     }
     case "users/libraryStats":
       sendRpcResponse(response, libraryInsightsStats);
+      return true;
+    case "users/tastingStats":
+      sendRpcResponse(response, {
+        total: 0,
+        uniqueBottles: 0,
+        bands: {
+          total: 0,
+          mediocre: 0,
+          good: 0,
+          very_good: 0,
+          outstanding: 0,
+          unicorn: 0,
+        },
+        mostTastedBottle: null,
+        age: {
+          knownCount: 0,
+          median: null,
+          oldest: null,
+          buckets: libraryInsightsStats.age.buckets.map((bucket) => ({
+            ...bucket,
+            count: 0,
+          })),
+        },
+      });
       return true;
     case "users/badgeList":
       sendRpcResponse(response, emptyList);

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -133,6 +133,15 @@ export const testOwnedEntity = {
   },
 };
 
+export const testBottler = {
+  ...testBrand,
+  id: 9204,
+  peatedId: "E9204",
+  name: "Gordon & MacPhail",
+  kind: "bottler",
+  totalBottles: 2,
+};
+
 export const emptyEntityCatalog = {
   totalBottles: 0,
   relationships: { brand: 0, bottler: 0, distiller: 0 },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "test:e2e:policy": "node scripts/check-e2e-policy.mjs",
     "test:e2e:report": "playwright show-report .playwright/report",
     "test:e2e:ui": "playwright test --ui",
+    "visual:capture": "node visual/capture.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/apps/web/visual/README.md
+++ b/apps/web/visual/README.md
@@ -1,0 +1,63 @@
+# Web screenshots in pull requests
+
+This tool takes repeatable screenshots for web changes. It posts the images on
+the pull request. It does not compare pixels. A page change does not fail CI.
+
+Each page has its own file in `visual/scenarios/`. That file contains:
+
+- The URL to open.
+- The heading that proves the page loaded.
+- Whether the page needs a signed-in user.
+- The desktop and mobile browser sizes.
+- `shouldRunFor`, which lists the source changes that affect the page.
+
+The ordered scenario list is in `visual/scenarios/index.mjs`. The four-page
+limit is in `visual/select-scenarios.mjs`.
+
+## How CI chooses pages
+
+CI checks each changed file against each scenario's `shouldRunFor` function.
+It captures the first four matching scenarios. This keeps the pull request
+comment short.
+
+Shared UI and web setup changes match four representative pages: home, bottle
+detail, member profile, and log a tasting. Changes to fixed test data match
+each page that reads that data. The four-page limit still applies. Test-only
+changes do not capture a page.
+
+Add the `run-all-screenshots` label to capture every scenario.
+
+## Run locally
+
+Capture named scenarios:
+
+```sh
+pnpm visual:web -- --scenarios home,bottle-detail
+```
+
+Capture all scenarios:
+
+```sh
+pnpm visual:web -- --all
+```
+
+Choose scenarios from changed files:
+
+```sh
+git diff --name-only origin/main...HEAD > /tmp/peated-screenshot-changes.txt
+pnpm visual:web -- --changed-file /tmp/peated-screenshot-changes.txt
+```
+
+Images and `manifest.json` go to `apps/web/.playwright/visual/`.
+
+## Add a scenario
+
+1. Copy the nearest scenario file in `visual/scenarios/`.
+2. Set its `id`, `label`, `path`, `heading`, and viewports.
+3. Write `shouldRunFor` so the file states when it runs.
+4. Add it to `visual/scenarios/index.mjs` in review order.
+5. Add selection tests for files that should and should not select it.
+6. Use fixed test data. Do not use production data or credentials.
+
+The tests check the filename, ID, required fields, browser sizes, and ordered
+list. A new scenario cannot pass `pnpm test` until these are complete.

--- a/apps/web/visual/capture.mjs
+++ b/apps/web/visual/capture.mjs
@@ -1,0 +1,286 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { chromium } from "@playwright/test";
+import { sealData } from "iron-session";
+
+import { testAccessToken, testUser } from "../e2e/rpc-fixtures.mjs";
+import { getScenarios } from "./scenarios/index.mjs";
+import { selectScenarioIds } from "./select-scenarios.mjs";
+
+const WEB_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const DEFAULT_OUT_DIR = path.join(WEB_ROOT, ".playwright/visual");
+const SESSION_SECRET =
+  "peated-playwright-session-secret-for-local-browser-tests";
+
+function requireFlagValue(flag, value) {
+  if (!value || value.startsWith("-")) {
+    throw new Error(`${flag} requires a non-empty value`);
+  }
+  return value;
+}
+
+function parseArgs(argv) {
+  let all = false;
+  let changedFile;
+  let outDir = DEFAULT_OUT_DIR;
+  let scenarioList;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") continue;
+    if (arg === "--all") {
+      all = true;
+      continue;
+    }
+    if (arg === "--changed-file") {
+      changedFile = requireFlagValue(arg, argv[++index]);
+      continue;
+    }
+    if (arg === "--out-dir") {
+      const value = requireFlagValue(arg, argv[++index]);
+      outDir = path.isAbsolute(value) ? value : path.resolve(WEB_ROOT, value);
+      continue;
+    }
+    if (arg === "--scenarios") {
+      scenarioList = requireFlagValue(arg, argv[++index]);
+      continue;
+    }
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return { all, changedFile, outDir, scenarioList };
+}
+
+async function readChangedPaths(changedFile) {
+  if (!changedFile) return [];
+  return (await fs.readFile(changedFile, "utf8"))
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function startProcess(command, args, env) {
+  const child = spawn(command, args, {
+    cwd: WEB_ROOT,
+    env: { ...process.env, ...env },
+    stdio: "inherit",
+  });
+  child.on("error", (error) => {
+    console.error(`Could not start ${command}:`, error);
+  });
+  return child;
+}
+
+async function waitForUrl(url, children, timeoutMs) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    for (const child of children) {
+      if (child.exitCode !== null || child.signalCode !== null) {
+        throw new Error(`Server stopped before ${url} was ready`);
+      }
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // The local server is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Timed out waiting for ${url}`);
+}
+
+async function stopProcess(child) {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => child.once("exit", resolve)),
+    new Promise((resolve) => setTimeout(resolve, 5_000)),
+  ]);
+  if (child.exitCode === null && child.signalCode === null) {
+    child.kill("SIGKILL");
+  }
+}
+
+async function startServers() {
+  const apiPort = Number(process.env.VISUAL_API_PORT ?? 4999);
+  const webPort = Number(process.env.VISUAL_WEB_PORT ?? 3200);
+  const apiServer = `http://127.0.0.1:${apiPort}`;
+  const baseURL = `http://127.0.0.1:${webPort}`;
+  const api = startProcess(process.execPath, ["e2e/mock-rpc-server.mjs"], {
+    PLAYWRIGHT_API_PORT: String(apiPort),
+  });
+  const web = startProcess(
+    "pnpm",
+    ["exec", "next", "dev", "-p", String(webPort)],
+    {
+      API_SERVER: apiServer,
+      SESSION_SECRET,
+      URL_PREFIX: baseURL,
+    },
+  );
+
+  try {
+    await Promise.all([
+      waitForUrl(`${apiServer}/health`, [api], 30_000),
+      waitForUrl(`${baseURL}/browser-not-supported`, [web], 120_000),
+    ]);
+  } catch (error) {
+    await Promise.all([stopProcess(web), stopProcess(api)]);
+    throw error;
+  }
+
+  return {
+    baseURL,
+    close: () => Promise.all([stopProcess(web), stopProcess(api)]),
+  };
+}
+
+async function createContext(browser, baseURL, scenario, viewport) {
+  const context = await browser.newContext({
+    baseURL,
+    colorScheme: "light",
+    deviceScaleFactor: 1,
+    locale: "en-US",
+    reducedMotion: "reduce",
+    timezoneId: "America/Los_Angeles",
+    viewport: { height: viewport.height, width: viewport.width },
+  });
+
+  if (scenario.signedIn) {
+    const value = await sealData(
+      { accessToken: testAccessToken, ts: Date.now(), user: testUser },
+      { password: SESSION_SECRET, ttl: 60 * 60 * 24 * 7 },
+    );
+    await context.addCookies([
+      {
+        domain: "127.0.0.1",
+        httpOnly: true,
+        name: "_session",
+        path: "/",
+        sameSite: "Lax",
+        value,
+      },
+    ]);
+  }
+
+  return context;
+}
+
+async function captureScenario({ baseURL, browser, outDir, scenario }) {
+  const screenshots = [];
+  for (const viewport of scenario.viewports) {
+    const context = await createContext(browser, baseURL, scenario, viewport);
+    const page = await context.newPage();
+    try {
+      await page.goto(scenario.path, {
+        timeout: 60_000,
+        waitUntil: "networkidle",
+      });
+      await page
+        .getByRole("heading", { exact: true, name: scenario.heading })
+        .first()
+        .waitFor({ state: "visible", timeout: 20_000 });
+      await page.evaluate(async () => document.fonts.ready);
+      await page.addStyleTag({
+        content: "nextjs-portal { display: none !important; }",
+      });
+
+      const file = `${scenario.id}__${viewport.name}.png`;
+      await page.screenshot({
+        animations: "disabled",
+        caret: "hide",
+        fullPage: true,
+        path: path.join(outDir, file),
+        type: "png",
+      });
+      screenshots.push({ file, label: `${scenario.label} · ${viewport.name}` });
+    } finally {
+      await context.close();
+    }
+  }
+  return screenshots;
+}
+
+async function main() {
+  const { all, changedFile, outDir, scenarioList } = parseArgs(
+    process.argv.slice(2),
+  );
+  const changedFiles = await readChangedPaths(changedFile);
+  const selection = all ? "all" : scenarioList ? "named" : "changed-files";
+  const scenarioIds = all
+    ? selectScenarioIds(changedFiles, { all: true })
+    : scenarioList
+      ? scenarioList
+          .split(",")
+          .map((value) => value.trim())
+          .filter(Boolean)
+      : selectScenarioIds(changedFiles);
+
+  await fs.rm(outDir, { force: true, recursive: true });
+  await fs.mkdir(outDir, { recursive: true });
+
+  if (scenarioIds.length === 0) {
+    await writeManifest(outDir, {
+      changedFiles: changedFiles.slice(0, 20),
+      commitSha: process.env.GITHUB_SHA ?? null,
+      scenarioIds,
+      screenshots: [],
+      selection,
+      skipped: true,
+    });
+    console.log("screenshot capture skipped: no matching pages");
+    return;
+  }
+
+  const scenarios = getScenarios(scenarioIds);
+  const servers = await startServers();
+  let browser;
+  const screenshots = [];
+  try {
+    browser = await chromium.launch({ headless: true });
+    for (const scenario of scenarios) {
+      screenshots.push(
+        ...(await captureScenario({
+          baseURL: servers.baseURL,
+          browser,
+          outDir,
+          scenario,
+        })),
+      );
+    }
+  } finally {
+    await browser?.close();
+    await servers.close();
+  }
+
+  await writeManifest(outDir, {
+    changedFiles: changedFiles.slice(0, 20),
+    commitSha: process.env.GITHUB_SHA ?? null,
+    scenarioIds,
+    screenshots,
+    selection,
+    skipped: false,
+  });
+  console.log(
+    `screenshot capture wrote ${screenshots.length} image(s) for ${scenarioIds.join(", ")}`,
+  );
+}
+
+async function writeManifest(outDir, manifest) {
+  await fs.writeFile(
+    path.join(outDir, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : error);
+  process.exitCode = 1;
+});

--- a/apps/web/visual/post-pr-comment.mjs
+++ b/apps/web/visual/post-pr-comment.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const MARKER = "<!-- peated-web-screenshots -->";
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing env ${name}`);
+  return value;
+}
+
+function ghJson(args) {
+  return JSON.parse(
+    execFileSync("gh", args, {
+      encoding: "utf8",
+      env: process.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  );
+}
+
+function ghInput(args, body) {
+  execFileSync("gh", args, {
+    encoding: "utf8",
+    env: process.env,
+    input: body,
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+}
+
+function git(args, options = {}) {
+  return execFileSync("git", args, {
+    cwd: options.cwd,
+    encoding: "utf8",
+    env: process.env,
+    stdio: options.stdio ?? "inherit",
+  });
+}
+
+export function buildBody(manifest, imageBaseUrl) {
+  if (manifest.skipped || manifest.screenshots.length === 0) {
+    return [
+      MARKER,
+      "## Web screenshots",
+      "",
+      "_No screenshot scenarios match these changed files._",
+      "",
+    ].join("\n");
+  }
+
+  const changedFiles = manifest.changedFiles.length
+    ? manifest.changedFiles
+        .slice(0, 8)
+        .map((file) => `- \`${file}\``)
+        .join("\n")
+    : "- None provided";
+  const screenshots = manifest.screenshots
+    .map((screenshot) => {
+      const url = `${imageBaseUrl}/${screenshot.file}`;
+      return [
+        `### ${screenshot.label}`,
+        "",
+        `![${screenshot.label}](${url})`,
+        "",
+      ].join("\n");
+    })
+    .join("\n");
+  const run =
+    manifest.selection === "all"
+      ? "Run: all pages (`run-all-screenshots` or `--all`)"
+      : manifest.selection === "named"
+        ? "Run: pages named by the command"
+        : "Run: pages matched to changed files";
+
+  return [
+    MARKER,
+    "## Web screenshots",
+    "",
+    run,
+    `Pages: \`${manifest.scenarioIds.join("`, `")}\``,
+    "",
+    "Changed files:",
+    changedFiles,
+    "",
+    screenshots,
+    "_Captured from local Peated with fixed test data. These images help review a change. They do not compare pixels or block a pull request because the page changed._",
+    "",
+  ].join("\n");
+}
+
+function publishImages(outDir, branch, commitSha) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "peated-screenshots-"));
+  for (const file of fs.readdirSync(outDir)) {
+    if (file.endsWith(".png") || file === "manifest.json") {
+      fs.copyFileSync(path.join(outDir, file), path.join(tempDir, file));
+    }
+  }
+
+  git(["init", "-q"], { cwd: tempDir });
+  git(["checkout", "--orphan", branch], { cwd: tempDir });
+  git(["add", "."], { cwd: tempDir });
+  git(
+    [
+      "-c",
+      "user.name=peated-screenshots",
+      "-c",
+      "user.email=peated-screenshots@users.noreply.github.com",
+      "commit",
+      "-m",
+      `web screenshots ${commitSha}`,
+    ],
+    { cwd: tempDir },
+  );
+  const publishedSha = git(["rev-parse", "HEAD"], {
+    cwd: tempDir,
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+  const remote = `https://x-access-token:${requiredEnv("GITHUB_TOKEN")}@github.com/${requiredEnv("GITHUB_REPOSITORY")}.git`;
+  git(["remote", "add", "origin", remote], { cwd: tempDir });
+  git(["push", "-f", "origin", `HEAD:${branch}`], { cwd: tempDir });
+  fs.rmSync(tempDir, { force: true, recursive: true });
+  return publishedSha;
+}
+
+function upsertComment(repo, prNumber, body) {
+  const comments = ghJson([
+    "api",
+    `repos/${repo}/issues/${prNumber}/comments`,
+    "--paginate",
+    "--slurp",
+  ]).flat();
+  const existing = comments.find((comment) => comment.body?.includes(MARKER));
+  const payload = JSON.stringify({ body });
+
+  if (existing) {
+    ghInput(
+      [
+        "api",
+        "-X",
+        "PATCH",
+        `repos/${repo}/issues/comments/${existing.id}`,
+        "--input",
+        "-",
+      ],
+      payload,
+    );
+    return;
+  }
+  ghInput(
+    [
+      "api",
+      "-X",
+      "POST",
+      `repos/${repo}/issues/${prNumber}/comments`,
+      "--input",
+      "-",
+    ],
+    payload,
+  );
+}
+
+function main() {
+  const outDir = path.resolve(process.argv[2] ?? "apps/web/.playwright/visual");
+  const prNumber = requiredEnv("PR_NUMBER");
+  const repo = requiredEnv("GITHUB_REPOSITORY");
+  const commitSha = process.env.GITHUB_SHA ?? "unknown";
+  const branch = `web-screenshots/pr-${prNumber}`;
+  const manifestPath = path.join(outDir, "manifest.json");
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`Missing manifest at ${manifestPath}`);
+  }
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  const hasScreenshots = !manifest.skipped && manifest.screenshots.length > 0;
+  const imageRef = hasScreenshots
+    ? publishImages(outDir, branch, commitSha)
+    : branch;
+  const body = buildBody(
+    manifest,
+    `https://raw.githubusercontent.com/${repo}/${imageRef}`,
+  );
+  upsertComment(repo, prNumber, body);
+  console.log(`updated screenshot comment on PR #${prNumber}`);
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
+}

--- a/apps/web/visual/post-pr-comment.test.mjs
+++ b/apps/web/visual/post-pr-comment.test.mjs
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { buildBody } from "./post-pr-comment.mjs";
+
+describe("buildBody", () => {
+  it("describes selected pages and changed files", () => {
+    const body = buildBody(
+      {
+        changedFiles: ["apps/web/src/components/loginForm.tsx"],
+        scenarioIds: ["login"],
+        screenshots: [{ file: "login__desktop.png", label: "Login · desktop" }],
+        selection: "changed-files",
+        skipped: false,
+      },
+      "https://example.com/screenshots",
+    );
+
+    expect(body).toContain("## Web screenshots");
+    expect(body).toContain("Run: pages matched to changed files");
+    expect(body).toContain("Pages: `login`");
+    expect(body).toContain("`apps/web/src/components/loginForm.tsx`");
+    expect(body).toContain(
+      "![Login · desktop](https://example.com/screenshots/login__desktop.png)",
+    );
+  });
+
+  it("explains when no page matches", () => {
+    const body = buildBody(
+      {
+        changedFiles: ["apps/web/e2e/activity-feed.spec.ts"],
+        scenarioIds: [],
+        screenshots: [],
+        selection: "changed-files",
+        skipped: true,
+      },
+      "https://example.com/screenshots",
+    );
+
+    expect(body).toContain(
+      "No screenshot scenarios match these changed files.",
+    );
+  });
+});

--- a/apps/web/visual/scenarios/add-tasting.mjs
+++ b/apps/web/visual/scenarios/add-tasting.mjs
@@ -1,0 +1,18 @@
+import { isSharedPageChange, isTestDataChange } from "./shared-changes.mjs";
+import { DESKTOP, MOBILE } from "./viewports.mjs";
+
+export const addTastingScenario = {
+  heading: "Log a tasting",
+  id: "add-tasting",
+  label: "Log a tasting",
+  path: "/addBottle?intent=tasting",
+  shouldRunFor: (filePath) =>
+    filePath.startsWith("apps/web/src/app/(layout-free)/addBottle/") ||
+    filePath.includes("/bottleResolver/") ||
+    filePath.includes("/tastingForm") ||
+    filePath.includes("/workflowScreen") ||
+    isTestDataChange(filePath) ||
+    isSharedPageChange(filePath),
+  signedIn: true,
+  viewports: [DESKTOP, MOBILE],
+};

--- a/apps/web/visual/scenarios/bottle-detail.mjs
+++ b/apps/web/visual/scenarios/bottle-detail.mjs
@@ -1,0 +1,20 @@
+import {
+  existingBottle,
+  existingBottleDetails,
+} from "../../e2e/rpc-fixtures.mjs";
+import { isSharedPageChange, isTestDataChange } from "./shared-changes.mjs";
+import { DESKTOP, MOBILE } from "./viewports.mjs";
+
+export const bottleDetailScenario = {
+  heading: existingBottleDetails.group.name,
+  id: "bottle-detail",
+  label: "Bottle detail",
+  path: `/bottles/${existingBottle.id}`,
+  shouldRunFor: (filePath) =>
+    filePath.startsWith("apps/web/src/app/(app)/bottles/[bottleId]/") ||
+    filePath.includes("/bottlePage") ||
+    filePath.includes("/bottleOverview") ||
+    isTestDataChange(filePath) ||
+    isSharedPageChange(filePath),
+  viewports: [DESKTOP, MOBILE],
+};

--- a/apps/web/visual/scenarios/bottler-detail.mjs
+++ b/apps/web/visual/scenarios/bottler-detail.mjs
@@ -1,0 +1,13 @@
+import { testBottler } from "../../e2e/rpc-fixtures.mjs";
+import { isEntityPageChange, isTestDataChange } from "./shared-changes.mjs";
+import { DESKTOP, MOBILE } from "./viewports.mjs";
+
+export const bottlerDetailScenario = {
+  heading: testBottler.name,
+  id: "bottler-detail",
+  label: "Bottler detail",
+  path: `/bottlers/${testBottler.id}`,
+  shouldRunFor: (filePath) =>
+    isEntityPageChange(filePath) || isTestDataChange(filePath),
+  viewports: [DESKTOP, MOBILE],
+};

--- a/apps/web/visual/scenarios/brand-detail.mjs
+++ b/apps/web/visual/scenarios/brand-detail.mjs
@@ -1,0 +1,13 @@
+import { testBrand } from "../../e2e/rpc-fixtures.mjs";
+import { isEntityPageChange, isTestDataChange } from "./shared-changes.mjs";
+import { DESKTOP, MOBILE } from "./viewports.mjs";
+
+export const brandDetailScenario = {
+  heading: testBrand.name,
+  id: "brand-detail",
+  label: "Brand detail",
+  path: `/brands/${testBrand.id}`,
+  shouldRunFor: (filePath) =>
+    isEntityPageChange(filePath) || isTestDataChange(filePath),
+  viewports: [DESKTOP, MOBILE],
+};

--- a/apps/web/visual/scenarios/distillery-detail.mjs
+++ b/apps/web/visual/scenarios/distillery-detail.mjs
@@ -1,0 +1,13 @@
+import { testOwnedEntity } from "../../e2e/rpc-fixtures.mjs";
+import { isEntityPageChange, isTestDataChange } from "./shared-changes.mjs";
+import { DESKTOP, MOBILE } from "./viewports.mjs";
+
+export const distilleryDetailScenario = {
+  heading: testOwnedEntity.name,
+  id: "distillery-detail",
+  label: "Distillery detail",
+  path: `/distillers/${testOwnedEntity.id}`,
+  shouldRunFor: (filePath) =>
+    isEntityPageChange(filePath) || isTestDataChange(filePath),
+  viewports: [DESKTOP, MOBILE],
+};

--- a/apps/web/visual/scenarios/home.mjs
+++ b/apps/web/visual/scenarios/home.mjs
@@ -1,0 +1,16 @@
+import { isSharedPageChange, isTestDataChange } from "./shared-changes.mjs";
+import { DESKTOP, MOBILE } from "./viewports.mjs";
+
+export const homeScenario = {
+  heading: "A record of whisky, bottle by bottle.",
+  id: "home",
+  label: "Home",
+  path: "/",
+  shouldRunFor: (filePath) =>
+    filePath.startsWith("apps/web/src/app/(app)/_components/home/") ||
+    filePath === "apps/web/src/app/(app)/homePageClient.tsx" ||
+    filePath === "apps/web/src/app/(app)/page.tsx" ||
+    isTestDataChange(filePath) ||
+    isSharedPageChange(filePath),
+  viewports: [DESKTOP, MOBILE],
+};

--- a/apps/web/visual/scenarios/index.mjs
+++ b/apps/web/visual/scenarios/index.mjs
@@ -1,0 +1,35 @@
+import { addTastingScenario } from "./add-tasting.mjs";
+import { bottleDetailScenario } from "./bottle-detail.mjs";
+import { bottlerDetailScenario } from "./bottler-detail.mjs";
+import { brandDetailScenario } from "./brand-detail.mjs";
+import { distilleryDetailScenario } from "./distillery-detail.mjs";
+import { homeScenario } from "./home.mjs";
+import { loginScenario } from "./login.mjs";
+import { memberProfileScenario } from "./member-profile.mjs";
+
+export const SCENARIOS = [
+  homeScenario,
+  bottleDetailScenario,
+  memberProfileScenario,
+  addTastingScenario,
+  loginScenario,
+  brandDetailScenario,
+  distilleryDetailScenario,
+  bottlerDetailScenario,
+];
+
+const scenarioById = new Map(
+  SCENARIOS.map((scenario) => [scenario.id, scenario]),
+);
+
+export function allScenarioIds() {
+  return SCENARIOS.map((scenario) => scenario.id);
+}
+
+export function getScenarios(ids) {
+  return ids.map((id) => {
+    const scenario = scenarioById.get(id);
+    if (!scenario) throw new Error(`Unknown screenshot scenario: ${id}`);
+    return scenario;
+  });
+}

--- a/apps/web/visual/scenarios/login.mjs
+++ b/apps/web/visual/scenarios/login.mjs
@@ -1,0 +1,16 @@
+import { DESKTOP, MOBILE } from "./viewports.mjs";
+
+export const loginScenario = {
+  heading: "Sign in",
+  id: "login",
+  label: "Login",
+  path: "/login",
+  shouldRunFor: (filePath) =>
+    filePath.startsWith("apps/web/src/app/(layout-free)/login/") ||
+    filePath.startsWith("apps/web/src/components/auth/") ||
+    filePath === "apps/web/src/components/loginForm.tsx" ||
+    filePath === "apps/web/src/components/googleLoginButton.tsx" ||
+    filePath === "apps/web/src/components/passkeyLoginButton.tsx" ||
+    filePath.includes("/designSystem/patterns/authentication.stylex"),
+  viewports: [DESKTOP, MOBILE],
+};

--- a/apps/web/visual/scenarios/member-profile.mjs
+++ b/apps/web/visual/scenarios/member-profile.mjs
@@ -1,0 +1,16 @@
+import { testUser } from "../../e2e/rpc-fixtures.mjs";
+import { isSharedPageChange, isTestDataChange } from "./shared-changes.mjs";
+import { DESKTOP, MOBILE } from "./viewports.mjs";
+
+export const memberProfileScenario = {
+  heading: testUser.username,
+  id: "member-profile",
+  label: "Member profile",
+  path: `/users/${testUser.username}`,
+  shouldRunFor: (filePath) =>
+    filePath.startsWith("apps/web/src/app/(app)/users/[username]/") ||
+    filePath.includes("/memberProfile") ||
+    isTestDataChange(filePath) ||
+    isSharedPageChange(filePath),
+  viewports: [DESKTOP, MOBILE],
+};

--- a/apps/web/visual/scenarios/shared-changes.mjs
+++ b/apps/web/visual/scenarios/shared-changes.mjs
@@ -1,0 +1,41 @@
+/** Changes to fixed test data affect each page that reads that data. */
+export function isTestDataChange(filePath) {
+  return (
+    filePath === "apps/web/e2e/mock-rpc-server.mjs" ||
+    filePath === "apps/web/e2e/rpc-fixtures.mjs"
+  );
+}
+
+/** Shared UI and web setup changes use a small representative page set. */
+export function isSharedPageChange(filePath) {
+  // Login has a focused scenario. Keep authentication styles out of the
+  // representative page set so the four-page limit cannot hide login.
+  const isLoginPattern = filePath.includes(
+    "/designSystem/patterns/authentication.stylex",
+  );
+
+  return (
+    filePath.startsWith("packages/design/") ||
+    (filePath.startsWith("apps/web/src/components/designSystem/") &&
+      !isLoginPattern) ||
+    filePath.startsWith("apps/web/src/styles/") ||
+    filePath === "apps/web/src/app/(app)/layout.tsx" ||
+    filePath.includes("/defaultLayout") ||
+    filePath === "package.json" ||
+    filePath === "pnpm-lock.yaml" ||
+    filePath === "apps/web/package.json" ||
+    filePath === "apps/web/next.config.mjs" ||
+    filePath === "apps/web/postcss.config.cjs" ||
+    filePath === "apps/web/stylex.config.cjs" ||
+    filePath === "apps/web/src/app/layout.tsx" ||
+    filePath.startsWith("apps/web/src/app/(app)/_components/application")
+  );
+}
+
+/** Brand, distillery, and bottler pages share the same page code. */
+export function isEntityPageChange(filePath) {
+  return (
+    filePath.startsWith("apps/web/src/app/(app)/entities/[entityId]/") ||
+    filePath.includes("/entityPageHeader")
+  );
+}

--- a/apps/web/visual/scenarios/viewports.mjs
+++ b/apps/web/visual/scenarios/viewports.mjs
@@ -1,0 +1,11 @@
+export const DESKTOP = {
+  height: 900,
+  name: "desktop",
+  width: 1440,
+};
+
+export const MOBILE = {
+  height: 844,
+  name: "mobile",
+  width: 390,
+};

--- a/apps/web/visual/select-scenarios.mjs
+++ b/apps/web/visual/select-scenarios.mjs
@@ -1,0 +1,24 @@
+import { allScenarioIds, SCENARIOS } from "./scenarios/index.mjs";
+
+/** Keep the automatic screenshot set small enough to review. */
+export const MAX_SCENARIOS = 4;
+
+/** Pick pages from the changed files. An empty result means there is nothing to capture. */
+export function selectScenarioIds(
+  changedFiles,
+  { all = false, max = MAX_SCENARIOS } = {},
+) {
+  if (all) return allScenarioIds();
+
+  const selected = new Set();
+  for (const changedFile of changedFiles) {
+    const normalized = changedFile.replaceAll("\\", "/");
+    for (const scenario of SCENARIOS) {
+      if (scenario.shouldRunFor(normalized)) selected.add(scenario.id);
+    }
+  }
+
+  return allScenarioIds()
+    .filter((id) => selected.has(id))
+    .slice(0, max);
+}

--- a/apps/web/visual/select-scenarios.test.mjs
+++ b/apps/web/visual/select-scenarios.test.mjs
@@ -1,0 +1,161 @@
+import { readdir } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+import { allScenarioIds, getScenarios, SCENARIOS } from "./scenarios/index.mjs";
+import { MAX_SCENARIOS, selectScenarioIds } from "./select-scenarios.mjs";
+
+const scenarioDirectory = new URL("./scenarios/", import.meta.url);
+const supportFiles = new Set([
+  "index.mjs",
+  "shared-changes.mjs",
+  "viewports.mjs",
+]);
+
+async function loadScenarioFiles() {
+  const files = (await readdir(scenarioDirectory))
+    .filter((file) => file.endsWith(".mjs") && !supportFiles.has(file))
+    .sort();
+
+  return Promise.all(
+    files.map(async (file) => {
+      const exports = await import(new URL(file, scenarioDirectory));
+      const scenarios = Object.entries(exports).filter(([name]) =>
+        name.endsWith("Scenario"),
+      );
+      expect(scenarios, `${file} must export one scenario`).toHaveLength(1);
+      return { file, scenario: scenarios[0][1] };
+    }),
+  );
+}
+
+describe("selectScenarioIds", () => {
+  it("selects the page that owns a changed file", () => {
+    expect(
+      selectScenarioIds([
+        "apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx",
+      ]),
+    ).toEqual(["bottle-detail"]);
+  });
+
+  it("selects the tasting page for tasting workflow changes", () => {
+    expect(
+      selectScenarioIds([
+        "apps/web/src/components/tastingForm/tastingForm.stylex.tsx",
+      ]),
+    ).toEqual(["add-tasting"]);
+  });
+
+  it("selects login for authentication changes", () => {
+    expect(
+      selectScenarioIds([
+        "apps/web/src/components/designSystem/patterns/authentication.stylex.tsx",
+      ]),
+    ).toEqual(["login"]);
+  });
+
+  it("selects brand, distillery, and bottler for their shared page", () => {
+    expect(
+      selectScenarioIds([
+        "apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx",
+      ]),
+    ).toEqual(["brand-detail", "distillery-detail", "bottler-detail"]);
+  });
+
+  it("marks every page that reads fixed test data", () => {
+    expect(
+      selectScenarioIds(["apps/web/e2e/rpc-fixtures.mjs"], { max: 20 }),
+    ).toEqual([
+      "home",
+      "bottle-detail",
+      "member-profile",
+      "add-tasting",
+      "brand-detail",
+      "distillery-detail",
+      "bottler-detail",
+    ]);
+  });
+
+  it("selects four representative pages for shared UI changes", () => {
+    const selected = selectScenarioIds([
+      "apps/web/src/components/designSystem/components/button.stylex.tsx",
+    ]);
+
+    expect(selected).toEqual([
+      "home",
+      "bottle-detail",
+      "member-profile",
+      "add-tasting",
+    ]);
+    expect(selected).toHaveLength(MAX_SCENARIOS);
+  });
+
+  it("selects the representative pages for web setup changes", () => {
+    expect(selectScenarioIds(["apps/web/next.config.mjs"])).toEqual([
+      "home",
+      "bottle-detail",
+      "member-profile",
+      "add-tasting",
+    ]);
+  });
+
+  it("does not run for browser test changes", () => {
+    expect(selectScenarioIds(["apps/web/e2e/activity-feed.spec.ts"])).toEqual(
+      [],
+    );
+  });
+
+  it("returns every page when all is requested", () => {
+    expect(selectScenarioIds([], { all: true })).toEqual(allScenarioIds());
+  });
+});
+
+describe("scenario list", () => {
+  it("registers every scenario file with a matching id", async () => {
+    const files = await loadScenarioFiles();
+    const fileIds = files.map(({ file, scenario }) => {
+      expect(scenario.id).toBe(file.replace(/\.mjs$/, ""));
+      return scenario.id;
+    });
+
+    expect(fileIds.sort()).toEqual(allScenarioIds().sort());
+  });
+
+  it("has one unique id per page", () => {
+    const ids = allScenarioIds();
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("requires each page to explain when it runs", () => {
+    expect(SCENARIOS.every((scenario) => scenario.shouldRunFor)).toBe(true);
+  });
+
+  it.each(SCENARIOS)("defines a complete $id capture", (scenario) => {
+    expect(scenario.id).toMatch(/^[a-z0-9]+(?:-[a-z0-9]+)*$/);
+    expect(scenario.label).toEqual(expect.any(String));
+    expect(scenario.heading).toEqual(expect.any(String));
+    expect(scenario.path).toMatch(/^\//);
+    expect(scenario.shouldRunFor).toEqual(expect.any(Function));
+    expect(scenario.viewports.length).toBeGreaterThan(0);
+
+    for (const viewport of scenario.viewports) {
+      expect(viewport).toEqual({
+        height: expect.any(Number),
+        name: expect.any(String),
+        width: expect.any(Number),
+      });
+      expect(viewport.height).toBeGreaterThan(0);
+      expect(viewport.width).toBeGreaterThan(0);
+    }
+
+    if (scenario.signedIn !== undefined) {
+      expect(scenario.signedIn).toEqual(expect.any(Boolean));
+    }
+  });
+
+  it("rejects unknown ids", () => {
+    expect(() => getScenarios(["missing"])).toThrow(
+      "Unknown screenshot scenario: missing",
+    );
+  });
+});

--- a/apps/web/vitest.config.mts
+++ b/apps/web/vitest.config.mts
@@ -26,7 +26,7 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}", "visual/**/*.test.mjs"],
     restoreMocks: true,
   },
 });

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:e2e:install": "pnpm --dir apps/web test:e2e:install",
     "test:e2e:report": "pnpm --dir apps/web test:e2e:report",
     "test:e2e:ui": "pnpm --dir apps/web test:e2e:ui",
+    "visual:web": "pnpm --dir apps/web visual:capture",
     "test:cli": "pnpm --filter @peated/cli test",
     "evals": "pnpm evals:classifier && pnpm evals:scraper",
     "evals:classifier": "pnpm --filter @peated/bottle-classifier evals",


### PR DESCRIPTION
Web pull requests now capture desktop and mobile screenshots for eight pages and post them in one updated comment. Changed files choose up to four relevant scenarios, while the `run-all-screenshots` label captures every page. Fixed test data keeps each run repeatable, and appearance changes do not fail CI.

Each page owns its URL, heading, sign-in state, browser sizes, and run rules in a small scenario file. A read-only pull request workflow creates the images. A separate workflow uses code from the default branch to post the comment, so pull request code never receives write access.

This PR adds the comment script to the default branch. Its own screenshot run can upload images, but the automatic comment will start working for later pull requests after this is merged.
