### PR TITLE
feat(web): redesign entity overview pages

### DIFF
--- a/apps/server/src/orpc/contracts/entities/events/list.ts
+++ b/apps/server/src/orpc/contracts/entities/events/list.ts
@@ -1,0 +1,15 @@
+import { EntityEventSchema } from "@peated/server/schemas";
+import { z } from "zod";
+
+import { contract } from "../../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/entities/{entity}/events",
+    summary: "List entity history",
+    description: "List the dated items in an entity's history.",
+    operationId: "listEntityEvents",
+  })
+  .input(z.object({ entity: z.coerce.number() }))
+  .output(z.object({ results: z.array(EntityEventSchema) }));

--- a/apps/server/src/orpc/mock/contract.ts
+++ b/apps/server/src/orpc/mock/contract.ts
@@ -26,6 +26,7 @@ import distilleryList from "@peated/server/orpc/contracts/distilleries/list";
 import entityCatalog from "@peated/server/orpc/contracts/entities/catalog";
 import entityCreate from "@peated/server/orpc/contracts/entities/create";
 import entityDetails from "@peated/server/orpc/contracts/entities/details";
+import entityEventList from "@peated/server/orpc/contracts/entities/events/list";
 import entityList from "@peated/server/orpc/contracts/entities/list";
 import eventList from "@peated/server/orpc/contracts/events/list";
 import externalReviewList from "@peated/server/orpc/contracts/externalReviews/list";
@@ -110,6 +111,9 @@ export const mockContract = {
     catalog: entityCatalog,
     create: entityCreate,
     details: entityDetails,
+    events: {
+      list: entityEventList,
+    },
     list: entityList,
   },
   events: {

--- a/apps/server/src/orpc/mock/fixtures/entity-history.ts
+++ b/apps/server/src/orpc/mock/fixtures/entity-history.ts
@@ -1,0 +1,39 @@
+import type { MockOutputs } from "../contract";
+import { timestamp } from "./constants";
+import { mockEntity } from "./entities";
+
+export const mockEntityHistory = [
+  {
+    id: 9801,
+    entityId: mockEntity.id,
+    kind: "opened",
+    date: "1816",
+    description: "Licensed on the south shore of Islay.",
+    newOwnerId: null,
+    sourceUrl: "https://en.wikipedia.org/wiki/Lagavulin_distillery",
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
+  {
+    id: 9802,
+    entityId: mockEntity.id,
+    kind: "acquired",
+    date: "1927",
+    description: "Ownership passed to the Distillers Company.",
+    newOwnerId: 9210,
+    sourceUrl: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
+  {
+    id: 9803,
+    entityId: mockEntity.id,
+    kind: "generic",
+    date: "2016-05",
+    description: "A third pair of stills was installed.",
+    newOwnerId: null,
+    sourceUrl: null,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
+] satisfies MockOutputs["entities"]["events"]["list"]["results"];

--- a/apps/server/src/orpc/mock/fixtures/index.ts
+++ b/apps/server/src/orpc/mock/fixtures/index.ts
@@ -8,6 +8,7 @@ export * from "./collections";
 export * from "./comments";
 export * from "./constants";
 export * from "./entities";
+export * from "./entity-history";
 export * from "./events";
 export * from "./externalReviews";
 export * from "./flights";

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -19,6 +19,7 @@ import {
   mockEntities,
   mockEntity,
   mockEntityCatalog,
+  mockEntityHistory,
   mockEvents,
   mockExternalReview,
   mockFlight,
@@ -88,6 +89,9 @@ describe("mock oRPC router", () => {
     await expect(
       anonymousClient.entities.details({ entity: mockEntity.id }),
     ).resolves.toEqual({ ...mockEntity, isFollowing: false });
+    await expect(
+      anonymousClient.entities.events.list({ entity: mockEntity.id }),
+    ).resolves.toEqual({ results: mockEntityHistory });
     const entities = await anonymousClient.entities.list({ limit: 100 });
     expect(entities.results).toHaveLength(mockEntities.length);
     expect(entities.results.every((entity) => entity.kind)).toBe(true);

--- a/apps/server/src/orpc/mock/router.ts
+++ b/apps/server/src/orpc/mock/router.ts
@@ -26,6 +26,7 @@ import distilleryList from "./routes/distilleries/list";
 import entityCatalog from "./routes/entities/catalog";
 import entityCreate from "./routes/entities/create";
 import entityDetails from "./routes/entities/details";
+import entityEventList from "./routes/entities/events/list";
 import entityList from "./routes/entities/list";
 import eventList from "./routes/events/list";
 import externalReviewList from "./routes/externalReviews/list";
@@ -110,6 +111,9 @@ export const mockRouter = mockOS.router({
     catalog: entityCatalog,
     create: entityCreate,
     details: entityDetails,
+    events: {
+      list: entityEventList,
+    },
     list: entityList,
   },
   events: {

--- a/apps/server/src/orpc/mock/routes/entities/events/list.ts
+++ b/apps/server/src/orpc/mock/routes/entities/events/list.ts
@@ -1,0 +1,21 @@
+import {
+  mockEntities,
+  mockEntity,
+  mockEntityHistory,
+} from "@peated/server/orpc/mock/fixtures";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.entities.events.list.handler(
+  async ({ input, errors }) => {
+    const entity = mockEntities.find(
+      (candidate) => candidate.id === input.entity,
+    );
+    if (!entity) {
+      throw errors.NOT_FOUND({ message: "Mock entity not found." });
+    }
+
+    return {
+      results: entity.id === mockEntity.id ? mockEntityHistory : [],
+    };
+  },
+);

--- a/apps/server/src/orpc/routes/entities/events/list.ts
+++ b/apps/server/src/orpc/routes/entities/events/list.ts
@@ -1,39 +1,32 @@
 import { db } from "@peated/server/db";
 import { entities, entityEvents } from "@peated/server/db/schema";
-import { procedure } from "@peated/server/orpc";
-import { EntityEventSchema } from "@peated/server/schemas";
+import { implement } from "@peated/server/orpc";
+import entityEventListContract from "@peated/server/orpc/contracts/entities/events/list";
 import { serialize } from "@peated/server/serializers";
 import { EntityEventSerializer } from "@peated/server/serializers/entityEvent";
 import { asc, eq } from "drizzle-orm";
-import { z } from "zod";
 
-export default procedure
-  .route({
-    method: "GET",
-    path: "/entities/{entity}/events",
-    summary: "List entity history",
-    description: "List the dated items in an entity's history.",
-    operationId: "listEntityEvents",
-  })
-  .input(z.object({ entity: z.coerce.number() }))
-  .output(z.object({ results: z.array(EntityEventSchema) }))
-  .handler(async function ({ input, context, errors }) {
-    const [entity] = await db
-      .select({ id: entities.id })
-      .from(entities)
-      .where(eq(entities.id, input.entity))
-      .limit(1);
-    if (!entity) {
-      throw errors.NOT_FOUND({ message: "Entity not found." });
-    }
+export default implement(entityEventListContract).handler(async function ({
+  input,
+  context,
+  errors,
+}) {
+  const [entity] = await db
+    .select({ id: entities.id })
+    .from(entities)
+    .where(eq(entities.id, input.entity))
+    .limit(1);
+  if (!entity) {
+    throw errors.NOT_FOUND({ message: "Entity not found." });
+  }
 
-    const events = await db
-      .select()
-      .from(entityEvents)
-      .where(eq(entityEvents.entityId, entity.id))
-      .orderBy(asc(entityEvents.date), asc(entityEvents.id));
+  const events = await db
+    .select()
+    .from(entityEvents)
+    .where(eq(entityEvents.entityId, entity.id))
+    .orderBy(asc(entityEvents.date), asc(entityEvents.id));
 
-    return {
-      results: await serialize(EntityEventSerializer, events, context.user),
-    };
-  });
+  return {
+    results: await serialize(EntityEventSerializer, events, context.user),
+  };
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
@@ -1,0 +1,85 @@
+import type { Outputs } from "@peated/server/orpc/router";
+
+import {
+  LoadingList,
+  RailList,
+  RailListItem,
+  SectionError,
+} from "@peated/web/components/designSystem/components";
+import { PageSection } from "@peated/web/components/designSystem/patterns/pageLayout.stylex";
+import { getEntityUrl } from "@peated/web/lib/urls";
+
+import type { Entity } from "./entityPageData";
+
+type EntityCatalog = Outputs["entities"]["catalog"];
+type RelatedEntity = EntityCatalog["related"]["brands"][number];
+
+function getRelationshipGroup(entity: Entity, catalog?: EntityCatalog) {
+  if (!catalog) return null;
+
+  const candidates: Array<{
+    heading: string;
+    items: RelatedEntity[];
+  }> =
+    entity.kind === "brand"
+      ? [
+          { heading: "Distillers", items: catalog.related.distillers },
+          { heading: "Bottlers", items: catalog.related.bottlers },
+        ]
+      : [{ heading: "Brands", items: catalog.related.brands }];
+
+  return candidates.find((candidate) => candidate.items.length > 0) ?? null;
+}
+
+export function EntityCatalogRelationships({
+  catalog,
+  entity,
+  error,
+  pending,
+  retry,
+}: {
+  catalog?: EntityCatalog;
+  entity: Entity;
+  error: boolean;
+  pending: boolean;
+  retry: () => void;
+}) {
+  if (entity.kind === "company") return null;
+
+  if (pending) {
+    return (
+      <PageSection heading="Related records">
+        <LoadingList label="Loading related records" rows={3} />
+      </PageSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageSection heading="Related records">
+        <SectionError heading="Related records are unavailable" onRetry={retry}>
+          Try loading the related records again.
+        </SectionError>
+      </PageSection>
+    );
+  }
+
+  const group = getRelationshipGroup(entity, catalog);
+  if (!group) return null;
+
+  return (
+    <PageSection heading={group.heading}>
+      <RailList ariaLabel={`${entity.name} ${group.heading.toLowerCase()}`}>
+        {group.items.map((related) => (
+          <RailListItem
+            end={related.count.toLocaleString("en-US")}
+            href={getEntityUrl(related)}
+            key={related.id}
+            metadata={related.kind === "brand" ? "Bottle brand" : undefined}
+            title={related.shortName || related.name}
+          />
+        ))}
+      </RailList>
+    </PageSection>
+  );
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
@@ -2,14 +2,16 @@ import * as stylex from "@stylexjs/stylex";
 
 import {
   AppLink,
-  Card,
-  FactList,
   hasVisibleFacts,
   type FactListItem,
 } from "@peated/web/components/designSystem/components";
-import { PageSection } from "@peated/web/components/designSystem/patterns/pageLayout.stylex";
 import { parseDomain } from "@peated/web/lib/urls";
-import { colors, effects } from "../../../../styles/tokens.stylex";
+import {
+  colors,
+  effects,
+  fonts,
+  space,
+} from "../../../../styles/tokens.stylex";
 
 import type { Entity } from "./entityPageData";
 
@@ -37,6 +39,18 @@ function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
   ) : null;
 
   return [
+    { label: "Region", value: location },
+    {
+      label: "Owned by",
+      value: entity.owner ? (
+        <AppLink
+          href={`/entities/${entity.owner.id}`}
+          {...stylex.props(styles.factLink)}
+        >
+          {entity.owner.name}
+        </AppLink>
+      ) : null,
+    },
     {
       label: "Website",
       value: entity.website ? (
@@ -50,8 +64,6 @@ function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
         </a>
       ) : null,
     },
-    { label: "Location", value: location },
-    { label: "Address", value: entity.address },
     { label: "Also known as", value: entity.shortName },
   ];
 }
@@ -64,16 +76,63 @@ export function EntityDetails({ entity }: { entity: Entity }) {
   const facts = getEntityFacts(entity);
   if (!hasVisibleFacts(facts)) return null;
 
+  const visibleFacts = facts.filter(
+    (fact) =>
+      fact.value !== null &&
+      fact.value !== undefined &&
+      fact.value !== "" &&
+      fact.value !== false &&
+      fact.value !== true,
+  );
+
   return (
-    <PageSection heading="Details">
-      <Card appearance="surface" padding="sm">
-        <FactList facts={facts} />
-      </Card>
-    </PageSection>
+    <dl {...stylex.props(styles.factGrid)}>
+      {visibleFacts.map((fact) => (
+        <div key={fact.label} {...stylex.props(styles.fact)}>
+          <dt {...stylex.props(styles.factLabel)}>{fact.label}</dt>
+          <dd {...stylex.props(styles.factValue)}>{fact.value}</dd>
+        </div>
+      ))}
+    </dl>
   );
 }
 
 const styles = stylex.create({
+  factGrid: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "repeat(auto-fit, minmax(160px, 1fr))",
+      "@media (max-width: 559px)": "minmax(0, 1fr)",
+    },
+    gap: space.x4,
+    margin: 0,
+    paddingTop: space.x4,
+    paddingBottom: space.x4,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+  },
+  fact: {
+    minWidth: 0,
+  },
+  factLabel: {
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "10px",
+    letterSpacing: "0.04em",
+    lineHeight: 1.3,
+  },
+  factValue: {
+    minWidth: 0,
+    margin: 0,
+    marginTop: space.x1,
+    color: colors.ink,
+    fontFamily: fonts.reading,
+    fontSize: "14px",
+    fontWeight: 700,
+    lineHeight: 1.35,
+    overflowWrap: "anywhere",
+  },
   factLink: {
     color: colors.accentDeep,
     outline: "none",

--- a/apps/web/src/app/(app)/entities/[entityId]/entityHistoryData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityHistoryData.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import { getEntityHistoryEvents } from "./entityHistoryData";
+
+describe("getEntityHistoryEvents", () => {
+  it("formats dates and carries operating state across generic events", () => {
+    expect(
+      getEntityHistoryEvents([
+        {
+          id: 1,
+          entityId: 2,
+          kind: "opened",
+          date: "1816",
+          description: "Licensed on Islay.",
+          newOwnerId: null,
+          sourceUrl: "https://example.com/opened",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: 2,
+          entityId: 2,
+          kind: "closed",
+          date: "1983-05",
+          description: null,
+          newOwnerId: null,
+          sourceUrl: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: 3,
+          entityId: 2,
+          kind: "generic",
+          date: "1984-06-15",
+          description: "The stills remained silent.",
+          newOwnerId: null,
+          sourceUrl: null,
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ]),
+    ).toEqual([
+      {
+        date: "1816",
+        description: "Licensed on Islay.",
+        source: { href: "https://example.com/opened", label: "Source" },
+        state: "operating",
+        title: "Opened",
+      },
+      {
+        date: "May 1983",
+        description: undefined,
+        source: undefined,
+        state: "silent",
+        title: "Closed",
+      },
+      {
+        date: "Jun 15, 1984",
+        description: "The stills remained silent.",
+        source: undefined,
+        state: "silent",
+        title: undefined,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entityHistoryData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityHistoryData.ts
@@ -1,0 +1,60 @@
+import type { Outputs } from "@peated/server/orpc/router";
+
+import type {
+  HistoryEvent,
+  HistoryState,
+} from "@peated/web/components/designSystem/components";
+
+type EntityEvent = Outputs["entities"]["events"]["list"]["results"][number];
+
+const eventTitles = {
+  acquired: "Acquired",
+  closed: "Closed",
+  generic: undefined,
+  mothballed: "Mothballed",
+  opened: "Opened",
+  reopened: "Reopened",
+} as const satisfies Record<EntityEvent["kind"], string | undefined>;
+
+const monthFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+});
+const dayFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "short",
+  timeZone: "UTC",
+  year: "numeric",
+});
+
+function formatEventDate(value: string) {
+  if (value.length === 4) return value;
+  const completeDate = value.length === 7 ? `${value}-01` : value;
+  const formatter = value.length === 7 ? monthFormatter : dayFormatter;
+  return formatter.format(new Date(`${completeDate}T00:00:00Z`));
+}
+
+export function getEntityHistoryEvents(
+  events: readonly EntityEvent[],
+): HistoryEvent[] {
+  let state: HistoryState = "operating";
+
+  return events.map((event) => {
+    if (event.kind === "closed" || event.kind === "mothballed") {
+      state = "silent";
+    } else if (event.kind === "opened" || event.kind === "reopened") {
+      state = "operating";
+    }
+
+    return {
+      date: formatEventDate(event.date),
+      description: event.description ?? undefined,
+      source: event.sourceUrl
+        ? { href: event.sourceUrl, label: "Source" }
+        : undefined,
+      state,
+      title: eventTitles[event.kind],
+    };
+  });
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityHistoryOverview.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityHistoryOverview.stylex.tsx
@@ -1,0 +1,66 @@
+import type { Outputs } from "@peated/server/orpc/router";
+import * as stylex from "@stylexjs/stylex";
+
+import {
+  HistoryTimeline,
+  LoadingList,
+  SectionError,
+} from "@peated/web/components/designSystem/components";
+import { PageSection } from "@peated/web/components/designSystem/patterns/pageLayout.stylex";
+
+import { getEntityHistoryEvents } from "./entityHistoryData";
+
+type EntityEventList = Outputs["entities"]["events"]["list"];
+
+export function EntityHistoryOverview({
+  entityName,
+  error,
+  eventList,
+  pending,
+  retry,
+}: {
+  entityName: string;
+  error: boolean;
+  eventList?: EntityEventList;
+  pending: boolean;
+  retry: () => void;
+}) {
+  if (pending) {
+    return (
+      <div id="history" {...stylex.props(styles.anchor)}>
+        <PageSection heading="History">
+          <LoadingList label={`Loading ${entityName} history`} rows={4} />
+        </PageSection>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div id="history" {...stylex.props(styles.anchor)}>
+        <PageSection heading="History">
+          <SectionError heading="History is unavailable" onRetry={retry}>
+            The rest of this record still works. Try loading its history again.
+          </SectionError>
+        </PageSection>
+      </div>
+    );
+  }
+
+  const events = getEntityHistoryEvents(eventList?.results ?? []);
+  if (!events.length) return null;
+
+  return (
+    <div id="history" {...stylex.props(styles.anchor)}>
+      <PageSection heading="History">
+        <HistoryTimeline events={events} />
+      </PageSection>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  anchor: {
+    scrollMarginTop: "24px",
+  },
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entityImagePlaceholder.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityImagePlaceholder.stylex.tsx
@@ -1,0 +1,22 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { colors, space } from "../../../../styles/tokens.stylex";
+
+export function EntityImagePlaceholder({ entityName }: { entityName: string }) {
+  return (
+    <div
+      aria-label={`No image available for ${entityName}`}
+      role="img"
+      {...stylex.props(styles.placeholder)}
+    />
+  );
+}
+
+const styles = stylex.create({
+  placeholder: {
+    width: "100%",
+    aspectRatio: "8 / 5",
+    marginTop: space.x4,
+    backgroundColor: colors.inset,
+  },
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entityImagePlaceholder.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityImagePlaceholder.stylex.tsx
@@ -1,22 +1,66 @@
 import * as stylex from "@stylexjs/stylex";
 
+import BottlerIcon from "@peated/web/assets/bottler.svg";
+import BrandIcon from "@peated/web/assets/brand.svg";
+import DistillerIcon from "@peated/web/assets/distiller.svg";
+import EntityIcon from "@peated/web/assets/entity.svg";
 import { colors, space } from "../../../../styles/tokens.stylex";
 
-export function EntityImagePlaceholder({ entityName }: { entityName: string }) {
+import type { Entity } from "./entityPageData";
+
+function EntityKindIcon({ kind }: { kind: Entity["kind"] }) {
+  const props = {
+    "aria-hidden": true,
+    focusable: false,
+    ...stylex.props(styles.icon),
+  } as const;
+
+  switch (kind) {
+    case "bottler":
+      return <BottlerIcon {...props} />;
+    case "brand":
+      return <BrandIcon {...props} />;
+    case "company":
+      return <EntityIcon {...props} />;
+    case "distillery":
+      return <DistillerIcon {...props} />;
+    default:
+      return <EntityIcon {...props} />;
+  }
+}
+
+export function EntityImagePlaceholder({
+  entityName,
+  kind,
+}: {
+  entityName: string;
+  kind: Entity["kind"];
+}) {
   return (
     <div
       aria-label={`No image available for ${entityName}`}
       role="img"
       {...stylex.props(styles.placeholder)}
-    />
+    >
+      <EntityKindIcon kind={kind} />
+    </div>
   );
 }
 
 const styles = stylex.create({
   placeholder: {
+    display: "flex",
     width: "100%",
     aspectRatio: "8 / 5",
+    alignItems: "center",
+    justifyContent: "center",
     marginTop: space.x4,
     backgroundColor: colors.inset,
+  },
+  icon: {
+    width: "72px",
+    height: "72px",
+    color: colors.inkMuted,
+    opacity: 0.38,
   },
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
@@ -36,6 +36,9 @@ export function EntityMap({ entity }: { entity: Entity }) {
   return (
     <PageSection heading="Where">
       <Card appearance="surface" padding="sm">
+        {entity.address ? (
+          <p {...stylex.props(styles.address)}>{entity.address}</p>
+        ) : null}
         <iframe
           loading="lazy"
           src={`https://www.openstreetmap.org/export/embed.html?${embedParams.toString()}`}
@@ -59,6 +62,14 @@ export function EntityMap({ entity }: { entity: Entity }) {
 }
 
 const styles = stylex.create({
+  address: {
+    margin: 0,
+    marginBottom: space.x3,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.45,
+  },
   mapFrame: {
     display: "block",
     width: "100%",

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -10,26 +10,34 @@ import { useORPC } from "@peated/web/lib/orpc/context";
 import { space } from "../../../../styles/tokens.stylex";
 
 import { EntityBottleOverview } from "./entityBottleOverview";
+import { EntityCatalogRelationships } from "./entityCatalogRelationships";
 import { EntityDetails, hasEntityDetails } from "./entityDetails.stylex";
+import { EntityHistoryOverview } from "./entityHistoryOverview.stylex";
+import { EntityImagePlaceholder } from "./entityImagePlaceholder.stylex";
 import { EntityMap } from "./entityMap.stylex";
 import { entityHasBottleCatalog, type Entity } from "./entityPageData";
 import { EntityReleaseOverview } from "./entityReleaseOverview";
-import { shouldShowEntitySiblingOverview } from "./entitySiblingData";
 import { EntitySiblingOverview } from "./entitySiblingOverview";
 
 type BottleList = Outputs["bottles"]["list"];
+type EntityCatalog = Outputs["entities"]["catalog"];
+type EntityEventList = Outputs["entities"]["events"]["list"];
 type EntityList = Outputs["entities"]["list"];
 
 const NARROW = "@media (max-width: 759px)";
 
 export function EntityOverviewClient({
   initialBottleList,
+  initialCatalog,
   initialEntity,
+  initialEventList,
   initialReleaseList,
   initialSiblingList,
 }: {
   initialBottleList?: BottleList;
+  initialCatalog?: EntityCatalog;
   initialEntity: Entity;
+  initialEventList?: EntityEventList;
   initialReleaseList?: BottleList;
   initialSiblingList?: EntityList;
 }) {
@@ -40,6 +48,19 @@ export function EntityOverviewClient({
       input: { entity: initialEntity.id },
     }),
     initialData: initialEntity,
+  });
+  const catalogQuery = useQuery({
+    ...orpc.entities.catalog.queryOptions({
+      input: { entity: initialEntity.id },
+    }),
+    enabled: ownsBottleSections,
+    initialData: initialCatalog,
+  });
+  const eventListQuery = useQuery({
+    ...orpc.entities.events.list.queryOptions({
+      input: { entity: initialEntity.id },
+    }),
+    initialData: initialEventList,
   });
   const bottleListQuery = useQuery({
     ...orpc.bottles.list.queryOptions({
@@ -87,38 +108,10 @@ export function EntityOverviewClient({
   }
 
   const entity = entityQuery.data;
-  const hasSiblingOverview = shouldShowEntitySiblingOverview({
-    entityId: entity.id,
-    error: Boolean(siblingListQuery.error),
-    ownerId: entity.ownerId,
-    pending: siblingListQuery.isPending,
-    siblingList: siblingListQuery.data,
-  });
-  const hasRail =
-    hasEntityDetails(entity) || Boolean(entity.location) || hasSiblingOverview;
-
   return (
-    <div
-      {...stylex.props(
-        styles.overviewGrid,
-        !hasRail && styles.overviewGridWithoutDetails,
-      )}
-    >
-      {hasRail ? (
-        <aside {...stylex.props(styles.details)}>
-          <EntityDetails entity={entity} />
-          <EntityMap entity={entity} />
-          <EntitySiblingOverview
-            entity={entity}
-            error={Boolean(siblingListQuery.error)}
-            pending={siblingListQuery.isPending}
-            retry={() => void siblingListQuery.refetch()}
-            siblingList={siblingListQuery.data}
-          />
-        </aside>
-      ) : null}
-
+    <div {...stylex.props(styles.overviewGrid)}>
       <div {...stylex.props(styles.catalog)}>
+        {hasEntityDetails(entity) ? <EntityDetails entity={entity} /> : null}
         <EntityBottleOverview
           bottleList={bottleListQuery.data}
           createBottleHref={getEntityBottleCreateHref(entity)}
@@ -135,7 +128,33 @@ export function EntityOverviewClient({
           releaseList={releaseListQuery.data}
           retry={() => void releaseListQuery.refetch()}
         />
+        <EntityHistoryOverview
+          entityName={entity.name}
+          error={Boolean(eventListQuery.error)}
+          eventList={eventListQuery.data}
+          pending={eventListQuery.isPending}
+          retry={() => void eventListQuery.refetch()}
+        />
       </div>
+
+      <aside {...stylex.props(styles.details)}>
+        <EntityImagePlaceholder entityName={entity.name} />
+        <EntityMap entity={entity} />
+        <EntityCatalogRelationships
+          catalog={catalogQuery.data}
+          entity={entity}
+          error={Boolean(catalogQuery.error)}
+          pending={catalogQuery.isPending}
+          retry={() => void catalogQuery.refetch()}
+        />
+        <EntitySiblingOverview
+          entity={entity}
+          error={Boolean(siblingListQuery.error)}
+          pending={siblingListQuery.isPending}
+          retry={() => void siblingListQuery.refetch()}
+          siblingList={siblingListQuery.data}
+        />
+      </aside>
     </div>
   );
 }
@@ -145,7 +164,7 @@ const styles = stylex.create({
     display: "grid",
     gridTemplateAreas: {
       default: '"catalog details"',
-      [NARROW]: '"details" "catalog"',
+      [NARROW]: '"catalog" "details"',
     },
     gridTemplateColumns: {
       default: "minmax(0, 1fr) 336px",
@@ -153,13 +172,10 @@ const styles = stylex.create({
     },
     columnGap: space.x12,
   },
-  overviewGridWithoutDetails: {
-    gridTemplateAreas: '"catalog"',
-    gridTemplateColumns: "minmax(0, 1fr)",
-  },
   catalog: {
     gridArea: "catalog",
     minWidth: 0,
+    paddingTop: space.x4,
   },
   details: {
     gridArea: "details",

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -138,7 +138,7 @@ export function EntityOverviewClient({
       </div>
 
       <aside {...stylex.props(styles.details)}>
-        <EntityImagePlaceholder entityName={entity.name} />
+        <EntityImagePlaceholder entityName={entity.name} kind={entity.kind} />
         <EntityMap entity={entity} />
         <EntityCatalogRelationships
           catalog={catalogQuery.data}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   entityHasBottleCatalog,
+  getEntityClassification,
   getEntityCurrentHref,
   getEntityTabs,
 } from "./entityPageData";
@@ -12,6 +13,19 @@ describe("entityHasBottleCatalog", () => {
     expect(entityHasBottleCatalog({ kind: "bottler" })).toBe(true);
     expect(entityHasBottleCatalog({ kind: "distillery" })).toBe(true);
     expect(entityHasBottleCatalog({ kind: "company" })).toBe(false);
+  });
+});
+
+describe("getEntityClassification", () => {
+  it("uses the entity kind, establishment term, and most specific location", () => {
+    expect(
+      getEntityClassification({
+        country: { name: "Scotland" },
+        kind: "distillery",
+        region: { name: "Islay" },
+        yearEstablished: 1816,
+      }),
+    ).toBe("Distillery · founded 1816 · Islay");
   });
 });
 

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -7,6 +7,11 @@ type EntityTabSource = Pick<
   Entity,
   "id" | "kind" | "shortName" | "totalBottles" | "totalTastings"
 >;
+type EntityLocation = Pick<NonNullable<Entity["country"]>, "name">;
+type EntityClassificationSource = Pick<Entity, "kind" | "yearEstablished"> & {
+  country?: EntityLocation | null;
+  region?: EntityLocation | null;
+};
 
 const entityKindPresentation = {
   bottler: {
@@ -41,6 +46,21 @@ export function getEntityPresentation(entity: Pick<Entity, "kind">) {
   return entity.kind
     ? entityKindPresentation[entity.kind]
     : fallbackPresentation;
+}
+
+export function getEntityClassification(entity: EntityClassificationSource) {
+  const presentation = getEntityPresentation(entity);
+  const location = entity.region?.name ?? entity.country?.name;
+
+  return [
+    presentation.label,
+    entity.yearEstablished
+      ? `${presentation.establishmentLabel.toLowerCase()} ${entity.yearEstablished}`
+      : null,
+    location,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" · ");
 }
 
 export function entityHasBottleCatalog(entity: Pick<Entity, "kind">) {

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -14,7 +14,6 @@ import {
   SectionError,
   type RowMenuItem,
 } from "@peated/web/components/designSystem/components";
-import { EntityPageHeader } from "@peated/web/components/designSystem/patterns/entityPageHeader.stylex";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
 import Markdown from "@peated/web/components/markdown";
 import useAuth from "@peated/web/hooks/useAuth";
@@ -22,11 +21,17 @@ import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHre
 import { logTelemetryError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getEntityUrl } from "@peated/web/lib/urls";
-import { effects, space } from "../../../../styles/tokens.stylex";
+import { foundationStyles } from "@peated/web/styles/foundations.stylex";
+import {
+  colors,
+  effects,
+  fonts,
+  space,
+} from "../../../../styles/tokens.stylex";
 
 import {
+  getEntityClassification,
   getEntityCurrentHref,
-  getEntityLocationLabel,
   getEntityPresentation,
   getEntityTabs,
   type Entity,
@@ -50,8 +55,8 @@ function EntityFollowAction({ entity }: { entity: Entity }) {
       <ButtonLink
         aria-label={`Follow ${entity.name}`}
         href={`/login?redirectTo=${encodeURIComponent(getEntityUrl(entity))}`}
-        size="lg"
-        variant="tonal"
+        size="md"
+        variant="accent"
       >
         Follow
       </ButtonLink>
@@ -91,8 +96,8 @@ function EntityFollowAction({ entity }: { entity: Entity }) {
           );
         }
       }}
-      size="lg"
-      variant="tonal"
+      size="md"
+      variant="accent"
     >
       {isFollowing ? "Unfollow" : "Follow"}
     </Button>
@@ -204,57 +209,79 @@ export function EntityPageFrameClient({
     entity.kind === "distillery";
   const presentation = getEntityPresentation(entity);
   const currentHref = getEntityCurrentHref(entity, pathname);
+  const bottleActionLabel =
+    entity.kind === "distillery" || entity.kind === "bottler"
+      ? "Record a bottling"
+      : "Add a bottle";
 
   return (
     <div {...stylex.props(styles.page)}>
-      <EntityPageHeader
-        actions={
-          createBottleHref || canFollow ? (
-            <>
-              {createBottleHref ? (
-                <ButtonLink href={createBottleHref} size="lg" variant="accent">
-                  Add a bottle
-                </ButtonLink>
-              ) : null}
-              {canFollow ? (
-                <EntityFollowAction key={entity.id} entity={entity} />
-              ) : null}
-            </>
-          ) : undefined
-        }
-        description={
-          entity.description ? (
-            <Markdown content={entity.description} />
-          ) : undefined
-        }
-        detail={presentation.label}
-        eyebrow={getEntityLocationLabel(entity) || undefined}
-        id={entity.peatedId}
-        menu={<EntityActions entity={entity} />}
-        parent={
-          owner ? (
+      <header>
+        <div {...stylex.props(styles.masthead)}>
+          <div {...stylex.props(styles.classification)}>
+            {getEntityClassification(entity)}
+          </div>
+          <h1 {...stylex.props(foundationStyles.pageTitle, styles.title)}>
+            {entity.name}
+          </h1>
+        </div>
+
+        <div {...stylex.props(styles.summary)}>
+          {owner ? (
             <AppLink
               href={getEntityUrl(owner)}
               {...stylex.props(styles.ownerLink)}
             >
               Owned by {owner.shortName || owner.name}
             </AppLink>
-          ) : undefined
-        }
-        specs={[
-          {
-            label: presentation.establishmentLabel,
-            value: entity.yearEstablished,
-          },
-          { label: "Country", value: entity.country?.name },
-          { label: "Bottles", value: entity.totalBottles },
-          {
-            label: "Tastings",
-            value: entity.totalTastings.toLocaleString("en-US"),
-          },
-        ]}
-        title={entity.name}
-      />
+          ) : null}
+          {entity.description ? (
+            <div {...stylex.props(styles.description)}>
+              <Markdown content={entity.description} />
+            </div>
+          ) : null}
+          <div {...stylex.props(styles.headerActions)}>
+            {canFollow ? (
+              <EntityFollowAction key={entity.id} entity={entity} />
+            ) : null}
+            {createBottleHref ? (
+              <ButtonLink
+                href={createBottleHref}
+                size="md"
+                variant={canFollow ? "tonal" : "accent"}
+              >
+                {bottleActionLabel}
+              </ButtonLink>
+            ) : null}
+            <EntityActions entity={entity} />
+          </div>
+        </div>
+
+        <dl {...stylex.props(styles.figures)}>
+          {entity.yearEstablished ? (
+            <div {...stylex.props(styles.figure)}>
+              <dd {...stylex.props(styles.figureValue)}>
+                {entity.yearEstablished}
+              </dd>
+              <dt {...stylex.props(styles.figureLabel)}>
+                {presentation.establishmentLabel.toLowerCase()}
+              </dt>
+            </div>
+          ) : null}
+          <div {...stylex.props(styles.figure)}>
+            <dd {...stylex.props(styles.figureValue)}>
+              {entity.totalBottles.toLocaleString("en-US")}
+            </dd>
+            <dt {...stylex.props(styles.figureLabel)}>bottles recorded</dt>
+          </div>
+          <div {...stylex.props(styles.figure)}>
+            <dd {...stylex.props(styles.figureValue)}>
+              {entity.totalTastings.toLocaleString("en-US")}
+            </dd>
+            <dt {...stylex.props(styles.figureLabel)}>member tastings</dt>
+          </div>
+        </dl>
+      </header>
 
       <div {...stylex.props(styles.tabs)}>
         <PageTabs
@@ -274,7 +301,103 @@ const styles = stylex.create({
     minWidth: 0,
   },
   tabs: {
-    marginTop: space.x6,
+    marginTop: 0,
+  },
+  masthead: {
+    paddingTop: space.x3,
+    paddingBottom: space.x4,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.sectionRule,
+  },
+  classification: {
+    marginBottom: space.x2,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.4,
+  },
+  title: {
+    fontSize: "clamp(44px, 6vw, 72px)",
+    letterSpacing: "-0.05em",
+    lineHeight: 0.95,
+  },
+  summary: {
+    display: "flex",
+    maxWidth: "66ch",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    gap: space.x3,
+    paddingTop: space.x6,
+    paddingBottom: space.x6,
+  },
+  description: {
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "15px",
+    lineHeight: 1.6,
+  },
+  headerActions: {
+    display: "flex",
+    alignItems: "center",
+    gap: space.x2,
+    flexWrap: "wrap",
+  },
+  figures: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "repeat(3, minmax(0, 1fr))",
+      "@media (max-width: 559px)": "minmax(0, 1fr)",
+    },
+    margin: 0,
+    paddingTop: space.x4,
+    paddingBottom: space.x4,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.sectionRule,
+  },
+  figure: {
+    minWidth: 0,
+    paddingRight: space.x6,
+    paddingLeft: {
+      default: space.x6,
+      "@media (max-width: 559px)": 0,
+    },
+    paddingTop: {
+      default: 0,
+      "@media (max-width: 559px)": space.x3,
+    },
+    paddingBottom: {
+      default: 0,
+      "@media (max-width: 559px)": space.x3,
+    },
+    borderLeftWidth: {
+      default: "1px",
+      "@media (max-width: 559px)": 0,
+    },
+    borderLeftStyle: "solid",
+    borderLeftColor: colors.hairline,
+    ":first-child": {
+      paddingLeft: 0,
+      borderLeftWidth: 0,
+    },
+  },
+  figureValue: {
+    margin: 0,
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontSize: "32px",
+    fontVariantNumeric: "tabular-nums",
+    fontWeight: 700,
+    letterSpacing: "-0.04em",
+    lineHeight: 1,
+  },
+  figureLabel: {
+    marginTop: space.x1,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "12px",
+    lineHeight: 1.35,
   },
   ownerLink: {
     color: "inherit",

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.test.ts
@@ -1,56 +1,30 @@
 import { describe, expect, it } from "vitest";
 
-import { shouldShowEntitySiblingOverview } from "./entitySiblingData";
+import { getEntitySiblings } from "./entitySiblingData";
 
-describe("shouldShowEntitySiblingOverview", () => {
-  it("hides a successful result that only contains the current entity", () => {
-    expect(
-      shouldShowEntitySiblingOverview({
-        entityId: 1,
-        error: false,
-        ownerId: 10,
-        pending: false,
-        siblingList: { results: [{ id: 1 }] },
-      }),
-    ).toBe(false);
+describe("getEntitySiblings", () => {
+  it("removes the current entity", () => {
+    expect(getEntitySiblings(1, { results: [{ id: 1 }, { id: 2 }] })).toEqual([
+      { id: 2 },
+    ]);
   });
 
-  it("shows related entities and request feedback", () => {
+  it("limits the rail to four related entities", () => {
     expect(
-      shouldShowEntitySiblingOverview({
-        entityId: 1,
-        error: false,
-        ownerId: 10,
-        pending: false,
-        siblingList: { results: [{ id: 1 }, { id: 2 }] },
+      getEntitySiblings(1, {
+        results: [
+          { id: 1 },
+          { id: 2 },
+          { id: 3 },
+          { id: 4 },
+          { id: 5 },
+          { id: 6 },
+        ],
       }),
-    ).toBe(true);
-    expect(
-      shouldShowEntitySiblingOverview({
-        entityId: 1,
-        error: false,
-        ownerId: 10,
-        pending: true,
-      }),
-    ).toBe(true);
-    expect(
-      shouldShowEntitySiblingOverview({
-        entityId: 1,
-        error: true,
-        ownerId: 10,
-        pending: false,
-      }),
-    ).toBe(true);
+    ).toEqual([{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]);
   });
 
-  it("hides the module when the entity has no owner", () => {
-    expect(
-      shouldShowEntitySiblingOverview({
-        entityId: 1,
-        error: false,
-        ownerId: null,
-        pending: true,
-      }),
-    ).toBe(false);
+  it("returns no siblings before data is available", () => {
+    expect(getEntitySiblings(1)).toEqual([]);
   });
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.ts
@@ -13,24 +13,3 @@ export function getEntitySiblings<T extends EntitySiblingCandidate>(
       .slice(0, 4) ?? []
   );
 }
-
-export function shouldShowEntitySiblingOverview<
-  T extends EntitySiblingCandidate,
->({
-  entityId,
-  error,
-  ownerId,
-  pending,
-  siblingList,
-}: {
-  entityId: number;
-  error: boolean;
-  ownerId?: number | null;
-  pending: boolean;
-  siblingList?: EntitySiblingList<T>;
-}) {
-  return Boolean(
-    ownerId &&
-    (pending || error || getEntitySiblings(entityId, siblingList).length),
-  );
-}

--- a/apps/web/src/app/(app)/entities/[entityId]/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/page.tsx
@@ -11,32 +11,39 @@ export default async function EntityPage(props: {
   const { client } = await getAnonymousServerClient();
   const entity = await getEntityPage(Number(entityId));
   const ownsBottleSections = entityHasBottleCatalog(entity);
-  const [bottleList, releaseList, siblingList] = await Promise.all([
-    ownsBottleSections
-      ? client.bottles
-          .list({ entity: entity.id, limit: 4, sort: "-tastings" })
-          .catch(() => undefined)
-      : undefined,
-    ownsBottleSections
-      ? client.bottles
-          .list({ entity: entity.id, limit: 4, sort: "-release" })
-          .catch(() => undefined)
-      : undefined,
-    entity.ownerId
-      ? client.entities
-          .list({
-            limit: 5,
-            owner: entity.ownerId,
-            sort: "-bottles",
-          })
-          .catch(() => undefined)
-      : undefined,
-  ]);
+  const [bottleList, releaseList, siblingList, catalog, eventList] =
+    await Promise.all([
+      ownsBottleSections
+        ? client.bottles
+            .list({ entity: entity.id, limit: 4, sort: "-tastings" })
+            .catch(() => undefined)
+        : undefined,
+      ownsBottleSections
+        ? client.bottles
+            .list({ entity: entity.id, limit: 4, sort: "-release" })
+            .catch(() => undefined)
+        : undefined,
+      entity.ownerId
+        ? client.entities
+            .list({
+              limit: 5,
+              owner: entity.ownerId,
+              sort: "-bottles",
+            })
+            .catch(() => undefined)
+        : undefined,
+      ownsBottleSections
+        ? client.entities.catalog({ entity: entity.id }).catch(() => undefined)
+        : undefined,
+      client.entities.events.list({ entity: entity.id }).catch(() => undefined),
+    ]);
 
   return (
     <EntityOverviewClient
       initialBottleList={bottleList}
+      initialCatalog={catalog}
       initialEntity={entity}
+      initialEventList={eventList}
       initialReleaseList={releaseList}
       initialSiblingList={siblingList}
     />

--- a/apps/web/src/components/designSystem/components/index.ts
+++ b/apps/web/src/components/designSystem/components/index.ts
@@ -133,6 +133,12 @@ export type {
   FormSectionProps,
   FormStepsProps,
 } from "./formLayout.stylex";
+export { HistoryTimeline } from "./historyTimeline.stylex";
+export type {
+  HistoryEvent,
+  HistoryState,
+  HistoryTimelineProps,
+} from "./historyTimeline.stylex";
 export { ItemList, ItemListItem, ItemRow } from "./itemList.stylex";
 export type {
   ItemListItemProps,


### PR DESCRIPTION
Entity overview pages now use a record-style masthead with classification, follow and record actions, key figures, a responsive fact grid, denser bottle and release sections, and a permanent media rail. The rail includes an accessible image placeholder, address and map details, catalog relationships, and sibling entities. On mobile, the main record stays first and the rail stacks after history.

The overview now renders dated entity history from the existing events route. The route contract is extracted so the mock server provides the same endpoint for server rendering and local UI verification. History, relationship, and map failures remain isolated so the rest of the entity record can still render.
