### PR TITLE
fix(admin): constrain scraper review names

### DIFF
--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/reviews/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/(tabs)/reviews/page.tsx
@@ -2,7 +2,6 @@
 import { use } from "react";
 
 import { type ExternalSiteKey } from "@peated/server/types";
-import { AdminSection } from "@peated/web/components/admin/adminContent.stylex";
 import { AdminEmptyActivity as EmptyActivity } from "@peated/web/components/admin/adminUtility.stylex";
 import ReviewTable from "@peated/web/components/admin/reviewTable.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
@@ -28,16 +27,9 @@ export default function Page(props: {
       input: queryParams,
     }),
   );
-  return (
-    <AdminSection
-      title="Reviews"
-      description="Check each review's bottle match and score."
-    >
-      {reviews.results.length > 0 ? (
-        <ReviewTable reviews={reviews.results} rel={reviews.rel} />
-      ) : (
-        <EmptyActivity>This site has no reviews yet.</EmptyActivity>
-      )}
-    </AdminSection>
+  return reviews.results.length > 0 ? (
+    <ReviewTable reviews={reviews.results} rel={reviews.rel} />
+  ) : (
+    <EmptyActivity>This site has no reviews yet.</EmptyActivity>
   );
 }

--- a/apps/web/src/components/admin/adminContent.stylex.tsx
+++ b/apps/web/src/components/admin/adminContent.stylex.tsx
@@ -191,11 +191,19 @@ export function AdminStatus({
 export function AdminTextLink({
   children,
   href,
+  title,
+  truncate = false,
 }: {
   children: ReactNode;
   href: string;
+  title?: string;
+  truncate?: boolean;
 }) {
-  return <TextLink href={href}>{children}</TextLink>;
+  return (
+    <TextLink href={href} title={title} truncate={truncate}>
+      {children}
+    </TextLink>
+  );
 }
 
 export function AdminCode({ children }: { children: ReactNode }) {

--- a/apps/web/src/components/admin/adminTable.stylex.tsx
+++ b/apps/web/src/components/admin/adminTable.stylex.tsx
@@ -21,6 +21,7 @@ import { AdminPager } from "./adminUtility.stylex";
 
 export type AdminTableColumn<Item extends object> = {
   align?: "center" | "default" | "left" | "right";
+  fill?: boolean;
   hidden?: boolean;
   name: string;
   sort?: string;
@@ -186,6 +187,7 @@ export function AdminTableContent<
                         {...stylex.props(
                           styles.cell,
                           alignStyles[align],
+                          column.fill && styles.fill,
                           index > 0 && styles.secondary,
                         )}
                       >
@@ -343,6 +345,7 @@ const styles = stylex.create({
     lineHeight: 1.4,
     verticalAlign: "middle",
   },
+  fill: { width: "100%", maxWidth: 0 },
   cellContent: {},
   secondary: { "@media (max-width: 639px)": { display: "none" } },
   groupRow: {

--- a/apps/web/src/components/admin/reviewTable.stylex.tsx
+++ b/apps/web/src/components/admin/reviewTable.stylex.tsx
@@ -34,39 +34,58 @@ export function ReviewRows({
     <AdminTable
       columns={[
         {
+          fill: true,
           name: "review",
-          value: (review) => (
-            <span {...stylex.props(styles.review)}>
-              <span>
-                <AdminTextLink href={review.url}>{review.name}</AdminTextLink>
-              </span>
-              <span {...stylex.props(styles.metadata)}>
-                {review.bottle ? (
-                  <AdminTextLink href={`/bottles/${review.bottle.id}`}>
-                    {formatBottleDisplayName(review.bottle)}
-                  </AdminTextLink>
-                ) : (
-                  "No bottle"
-                )}
-                {" · "}
-                {review.article.publishedAt ? (
-                  <time dateTime={review.article.publishedAt}>
-                    Published{" "}
-                    {publishedDateFormatter.format(
-                      new Date(review.article.publishedAt),
+          value: (review) => {
+            const bottleName = review.bottle
+              ? formatBottleDisplayName(review.bottle)
+              : "No bottle";
+            return (
+              <span {...stylex.props(styles.review)}>
+                <AdminTextLink href={review.url} title={review.name} truncate>
+                  {review.name}
+                </AdminTextLink>
+                <span {...stylex.props(styles.matchLine)}>
+                  <span aria-hidden="true" {...stylex.props(styles.arrow)}>
+                    →
+                  </span>
+                  {review.bottle ? (
+                    <AdminTextLink
+                      href={`/bottles/${review.bottle.id}`}
+                      title={bottleName}
+                      truncate
+                    >
+                      {bottleName}
+                    </AdminTextLink>
+                  ) : (
+                    <span {...stylex.props(styles.match)}>{bottleName}</span>
+                  )}
+                  <span {...stylex.props(styles.metadata)}>
+                    {" · "}
+                    {review.article.publishedAt ? (
+                      <time dateTime={review.article.publishedAt}>
+                        Published{" "}
+                        {publishedDateFormatter.format(
+                          new Date(review.article.publishedAt),
+                        )}
+                      </time>
+                    ) : (
+                      "Publish date unknown"
                     )}
-                  </time>
-                ) : (
-                  "Publish date unknown"
-                )}
+                  </span>
+                </span>
               </span>
-            </span>
-          ),
+            );
+          },
         },
         {
           align: "right",
           name: "score",
-          value: (review) => review.nativeScore?.display ?? "—",
+          value: (review) => (
+            <span {...stylex.props(styles.score)}>
+              {review.nativeScore?.display ?? "—"}
+            </span>
+          ),
         },
       ]}
       items={reviews}
@@ -78,13 +97,33 @@ export function ReviewRows({
 const styles = stylex.create({
   review: {
     display: "flex",
+    minWidth: 0,
     flexDirection: "column",
     gap: space.x1,
+  },
+  matchLine: {
+    display: "flex",
     minWidth: 0,
+    alignItems: "baseline",
+    gap: space.x1,
+  },
+  arrow: {
+    flexShrink: 0,
+    color: colors.inkMuted,
+  },
+  match: {
+    minWidth: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
   metadata: {
+    flexShrink: 0,
     color: colors.inkMuted,
     fontFamily: fonts.data,
     fontSize: "11px",
+  },
+  score: {
+    whiteSpace: "nowrap",
   },
 });

--- a/apps/web/src/components/admin/reviewTable.test.tsx
+++ b/apps/web/src/components/admin/reviewTable.test.tsx
@@ -101,6 +101,8 @@ describe("ReviewTable", () => {
     );
 
     expect(html).toContain('href="/bottles/19"');
+    expect(html).toContain('title="Springbank review"');
+    expect(html).toContain('title="Springbank 12 Cask Strength Batch 24"');
     expect(html).toContain("Springbank 12 Cask Strength Batch 24");
     expect(html).toContain("Published Jul 21, 2026");
     expect(html).toContain('dateTime="2026-07-21T00:00:00.000Z"');

--- a/apps/web/src/components/designSystem/components/textLink.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/textLink.stylex.tsx
@@ -9,6 +9,7 @@ export type TextLinkProps = Omit<
 > & {
   href: string;
   size?: "inherit" | "sm";
+  truncate?: boolean;
 };
 
 /** Uses the shared inline-link interaction treatment. */
@@ -16,15 +17,24 @@ export function TextLink({
   children,
   href,
   size = "sm",
+  truncate = false,
   ...props
 }: TextLinkProps) {
   return (
     <AppLink
       href={href}
       {...props}
-      {...stylex.props(styles.link, size === "sm" && styles.small)}
+      {...stylex.props(
+        styles.link,
+        size === "sm" && styles.small,
+        truncate && styles.truncate,
+      )}
     >
-      {children}
+      {truncate ? (
+        <span {...stylex.props(styles.truncateContent)}>{children}</span>
+      ) : (
+        children
+      )}
     </AppLink>
   );
 }
@@ -57,5 +67,16 @@ const styles = stylex.create({
     fontFamily: fonts.reading,
     fontSize: "13px",
     lineHeight: 1.3,
+  },
+  truncate: {
+    minWidth: 0,
+    maxWidth: "100%",
+  },
+  truncateContent: {
+    minWidth: 0,
+    maxWidth: "100%",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
 });


### PR DESCRIPTION
Scraper review rows now show the original review name and identified bottle on separate lines. Long names truncate with visible ellipses while their full values remain available on hover, publication metadata stays visible, and scores no longer wrap. The reviews tab also removes its redundant nested section frame so it aligns with the other scraper tabs.

The shared table and text-link additions are opt-in, so existing admin tables and links keep their current layout.
