### PR TITLE
feat(search): redesign database search page

### DIFF
--- a/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
@@ -52,6 +52,7 @@ export function ApplicationLayout({
   const { user } = useAuth();
   const [logoutPending, startLogout] = useTransition();
   const isHome = pathname === "/";
+  const usesInlineNavigation = isHome || pathname === "/search";
   const personalItems = user
     ? [
         {
@@ -109,10 +110,10 @@ export function ApplicationLayout({
               </>
             )
           }
-          background={isHome ? "page" : "surface"}
+          background={usesInlineNavigation ? "page" : "surface"}
           currentHref={pathname}
           databaseItems={databaseItems}
-          navigationPlacement={isHome ? "inline" : "separate"}
+          navigationPlacement={usesInlineNavigation ? "inline" : "separate"}
           personalItems={personalItems}
           search={
             pathname === "/search" || isHome ? undefined : (

--- a/apps/web/src/app/(app)/search/page.tsx
+++ b/apps/web/src/app/(app)/search/page.tsx
@@ -1,3 +1,4 @@
+import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import type { Metadata } from "next";
 
 import { SearchPageClient } from "./searchPageClient.stylex";
@@ -7,6 +8,9 @@ export const metadata: Metadata = {
   description: "Search the Peated whisky database.",
 };
 
-export default function SearchPage() {
-  return <SearchPageClient />;
+export default async function SearchPage() {
+  const { client } = await getPublicPageServerClient();
+  const stats = await client.stats();
+
+  return <SearchPageClient bottleTotal={stats.bottles} />;
 }

--- a/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
@@ -15,7 +15,7 @@ import {
   type AddBottleRouteIntent,
 } from "@peated/web/lib/addBottle";
 import { foundationStyles } from "../../../styles/foundations.stylex";
-import { space } from "../../../styles/tokens.stylex";
+import { colors, fonts, space } from "../../../styles/tokens.stylex";
 
 const addBottleIntents = [
   "catalog",
@@ -24,6 +24,33 @@ const addBottleIntents = [
   "tasting",
   "view",
 ] as const satisfies readonly AddBottleRouteIntent[];
+
+const databaseScopes = [
+  "all",
+  "bottles",
+  "distilleries",
+  "brands",
+  "bottlers",
+  "members",
+] as const satisfies readonly SearchScope[];
+
+function getDatabaseScope(value: string | null): SearchScope {
+  return databaseScopes.find((scope) => scope === value) ?? "all";
+}
+
+function BrowseHeader({ bottleTotal }: { bottleTotal: number }) {
+  return (
+    <header {...stylex.props(styles.browseHeader)}>
+      <h1 {...stylex.props(foundationStyles.pageTitle, styles.browseTitle)}>
+        Search the database
+      </h1>
+      <p {...stylex.props(styles.browseDescription)}>
+        {bottleTotal.toLocaleString("en-US")} bottles, and someone has probably
+        logged yours. Search bottles, distillers, brands, and bottlers.
+      </p>
+    </header>
+  );
+}
 
 function getAddBottleIntent(value: string | null) {
   if (value === "addBottle") return "choose";
@@ -65,7 +92,7 @@ function getTitle({
   return "Search";
 }
 
-export function SearchPageClient() {
+export function SearchPageClient({ bottleTotal }: { bottleTotal: number }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const query = searchParams.get("q") ?? "";
@@ -73,12 +100,13 @@ export function SearchPageClient() {
   const directToTasting = searchParams.has("tasting");
   const memberSearch = searchParams.get("type") === "users";
   const bottleSelection = Boolean(intent) || directToTasting;
+  const databaseSearch = !memberSearch && !bottleSelection;
   const pendingImage = getPendingImageFromParams(searchParams);
   const initialScope: SearchScope = memberSearch
     ? "members"
     : bottleSelection
       ? "bottles"
-      : "all";
+      : getDatabaseScope(searchParams.get("type"));
   const scopeValues = memberSearch
     ? (["members"] as const)
     : bottleSelection
@@ -118,27 +146,53 @@ export function SearchPageClient() {
     const nextParams = new URLSearchParams(searchParams);
     if (nextQuery) nextParams.set("q", nextQuery);
     else nextParams.delete("q");
-    router.replace(`/search?${nextParams.toString()}`);
+    replaceSearch(nextParams);
+  }
+
+  function updateScope(nextScope: SearchScope, nextQuery: string) {
+    const nextParams = new URLSearchParams(searchParams);
+    if (nextQuery) nextParams.set("q", nextQuery);
+    else nextParams.delete("q");
+    if (nextScope === "all") nextParams.delete("type");
+    else nextParams.set("type", nextScope);
+    replaceSearch(nextParams);
+  }
+
+  function replaceSearch(nextParams: URLSearchParams) {
+    const nextQuery = nextParams.toString();
+    router.replace(nextQuery ? `/search?${nextQuery}` : "/search");
   }
 
   return (
-    <div {...stylex.props(styles.page)}>
-      <header {...stylex.props(styles.header)}>
-        <h1 {...stylex.props(foundationStyles.pageTitle, styles.title)}>
-          {getTitle({ directToTasting, intent, memberSearch })}
-        </h1>
-      </header>
+    <div {...stylex.props(styles.page, databaseSearch && styles.databasePage)}>
+      {!databaseSearch ? (
+        <header {...stylex.props(styles.header)}>
+          <h1 {...stylex.props(foundationStyles.pageTitle, styles.title)}>
+            {getTitle({ directToTasting, intent, memberSearch })}
+          </h1>
+        </header>
+      ) : null}
       <section aria-label="Search Peated" {...stylex.props(styles.search)}>
         <Search
+          browseHeader={
+            databaseSearch ? (
+              <BrowseHeader bottleTotal={bottleTotal} />
+            ) : undefined
+          }
           getBottleHref={getBottleHref}
           getContributionHref={getContributionHref}
           initialQuery={query}
           initialScope={initialScope}
-          limit={50}
+          limit={databaseSearch ? 5 : 50}
+          onScopeChange={databaseSearch ? updateScope : undefined}
           onSubmit={submitSearch}
-          placement="page"
+          placement={databaseSearch ? "database" : "page"}
+          placeholder={
+            databaseSearch ? "Ardbeg 10, Lagavulin, Cadenhead's…" : undefined
+          }
           scopeValues={scopeValues}
           showBottleMeasures={false}
+          submitLabel={databaseSearch ? "Search" : undefined}
         />
       </section>
     </div>
@@ -152,6 +206,9 @@ const styles = stylex.create({
     marginRight: "auto",
     marginLeft: "auto",
   },
+  databasePage: {
+    maxWidth: "none",
+  },
   header: { marginBottom: space.x4 },
   title: {
     fontSize: "clamp(26px, 4vw, 32px)",
@@ -159,5 +216,28 @@ const styles = stylex.create({
   },
   search: {
     minWidth: 0,
+  },
+  browseHeader: {
+    maxWidth: "760px",
+    marginRight: "auto",
+    marginBottom: space.x6,
+    marginLeft: "auto",
+    paddingTop: space.x6,
+    textAlign: "center",
+  },
+  browseTitle: {
+    fontSize: "clamp(28px, 5vw, 38px)",
+    lineHeight: 1.05,
+  },
+  browseDescription: {
+    maxWidth: "720px",
+    marginTop: space.x4,
+    marginRight: "auto",
+    marginBottom: 0,
+    marginLeft: "auto",
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "15px",
+    lineHeight: 1.5,
   },
 });

--- a/apps/web/src/components/designSystem/components/searchBox.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/searchBox.stylex.tsx
@@ -49,6 +49,7 @@ export type SearchBoxProps = Pick<
   placement?: "database" | "overlay" | "page";
   query: string;
   resultCount?: number;
+  resultQuery?: string;
   scope: string;
   scopeFacets?: readonly ScopedSearchOption[];
   scopes: readonly ScopedSearchOption[];
@@ -75,6 +76,7 @@ export function SearchBox({
   placement = "overlay",
   query,
   resultCount,
+  resultQuery = query,
   scope,
   scopeFacets,
   scopes,
@@ -295,10 +297,12 @@ export function SearchBox({
                   </FilterPanel>
                 </div>
               ) : null}
-              <p aria-live="polite" {...stylex.props(styles.databaseCount)}>
-                {(resultCount ?? 0).toLocaleString("en-US")}{" "}
-                {resultCount === 1 ? "result" : "results"}
-              </p>
+              {status === "ready" && resultCount !== undefined ? (
+                <p aria-live="polite" {...stylex.props(styles.databaseCount)}>
+                  {resultCount.toLocaleString("en-US")}{" "}
+                  {resultCount === 1 ? "result" : "results"}
+                </p>
+              ) : null}
               {expanded ? (
                 <SearchResults
                   activeId={activeId}
@@ -310,7 +314,7 @@ export function SearchBox({
                   onRetry={onRetry}
                   optionIdPrefix={panelId}
                   panelId={panelId}
-                  query={query}
+                  query={resultQuery}
                   scroll={false}
                   status={status}
                   statusText={statusText}
@@ -364,7 +368,7 @@ export function SearchBox({
               onRetry={onRetry}
               optionIdPrefix={panelId}
               panelId={panelId}
-              query={query}
+              query={resultQuery}
               scroll={placement === "overlay"}
               status={status}
               statusText={statusText}

--- a/apps/web/src/components/designSystem/components/searchBox.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/searchBox.stylex.tsx
@@ -2,9 +2,24 @@
 
 import * as stylex from "@stylexjs/stylex";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
-import { useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
-import { colors, controlMetrics, effects } from "../../../styles/tokens.stylex";
+import {
+  colors,
+  controlMetrics,
+  effects,
+  fonts,
+  space,
+} from "../../../styles/tokens.stylex";
+import { Button } from "./button.stylex";
+import { FacetGroup, FilterPanel } from "./filterPanel.stylex";
 import { ScopedSearch, type ScopedSearchOption } from "./scopedSearch.stylex";
 import {
   SearchResults,
@@ -20,6 +35,7 @@ export type SearchBoxProps = Pick<
   "contribution" | "emptyText" | "onRetry" | "status" | "statusText"
 > & {
   autoFocus?: boolean;
+  browseHeader?: ReactNode;
   defaultOpen?: boolean;
   disabled?: boolean;
   fluid?: boolean;
@@ -30,15 +46,19 @@ export type SearchBoxProps = Pick<
   onScopeChange: (scope: string) => void;
   onSubmit?: (query: string) => void;
   placeholder?: string;
-  placement?: "overlay" | "page";
+  placement?: "database" | "overlay" | "page";
   query: string;
+  resultCount?: number;
   scope: string;
+  scopeFacets?: readonly ScopedSearchOption[];
   scopes: readonly ScopedSearchOption[];
+  submitLabel?: string;
 };
 
 /** Owns the keyboard and disclosure behavior for Peated's scoped search UI. */
 export function SearchBox({
   autoFocus = false,
+  browseHeader,
   contribution,
   defaultOpen = false,
   disabled = false,
@@ -54,10 +74,13 @@ export function SearchBox({
   placeholder = "bottles, distillers, brands…",
   placement = "overlay",
   query,
+  resultCount,
   scope,
+  scopeFacets,
   scopes,
   status = "ready",
   statusText,
+  submitLabel = "Search",
 }: SearchBoxProps) {
   const panelId = useId();
   const rootRef = useRef<HTMLDivElement>(null);
@@ -70,7 +93,9 @@ export function SearchBox({
     Boolean(emptyText) ||
     Boolean(contribution) ||
     status !== "ready";
-  const expanded = (placement === "page" || open) && hasPanelContent;
+  const expanded =
+    (placement === "database" || placement === "page" || open) &&
+    hasPanelContent;
 
   useEffect(() => {
     function focusSearch(event: KeyboardEvent) {
@@ -168,6 +193,140 @@ export function SearchBox({
     window.location.assign(item.href);
   }
 
+  const searchControl = (
+    <ScopedSearch
+      aria-activedescendant={
+        activeId ? `${panelId}-${encodeURIComponent(activeId)}` : undefined
+      }
+      aria-autocomplete="list"
+      aria-controls={expanded ? panelId : undefined}
+      autoFocus={autoFocus}
+      disabled={disabled}
+      expanded={placement !== "database" && expanded}
+      inputRef={inputRef}
+      onChange={(event) => {
+        onQueryChange(event.currentTarget.value);
+        setActiveId(items[0]?.id);
+        setOpen(true);
+      }}
+      onClear={() => {
+        onQueryChange("");
+        setActiveId(undefined);
+        inputRef.current?.focus();
+      }}
+      onFocus={() => setOpen(true)}
+      onKeyDown={handleKeyDown}
+      onScopeChange={(nextScope) => {
+        onScopeChange(nextScope);
+        setActiveId(undefined);
+        inputRef.current?.focus();
+        setOpen(true);
+      }}
+      placeholder={placeholder}
+      scope={scope}
+      scopes={
+        placement === "database"
+          ? scopes.filter((option) => option.value === scope)
+          : scopes
+      }
+      value={query}
+    />
+  );
+
+  if (placement === "database") {
+    const facetOptions = scopeFacets?.filter(
+      (option) => option.value !== "all",
+    );
+    const facetTotal = scopeFacets?.find(
+      (option) => option.value === "all",
+    )?.count;
+    const facets = facetOptions?.length ? (
+      <FacetGroup
+        label="Type"
+        onChange={(nextScope) => onScopeChange(nextScope || "all")}
+        options={facetOptions}
+        selected={scope === "all" ? undefined : scope}
+        total={facetTotal}
+      />
+    ) : null;
+    const searchRow = (
+      <div role="search" {...stylex.props(styles.databaseSearchRow)}>
+        <div {...stylex.props(styles.databaseSearchControl)}>
+          {searchControl}
+        </div>
+        <Button
+          disabled={!query.trim()}
+          onClick={() => onSubmit?.(query)}
+          size="md"
+          variant="accent"
+        >
+          {submitLabel}
+        </Button>
+      </div>
+    );
+
+    return (
+      <div ref={rootRef} {...stylex.props(styles.databaseRoot)}>
+        {!query.trim() ? (
+          <>
+            {browseHeader}
+            <div {...stylex.props(styles.databaseBrowseSearch)}>
+              {searchRow}
+            </div>
+          </>
+        ) : (
+          <div {...stylex.props(styles.databaseLayout)}>
+            <div {...stylex.props(styles.databaseMain)}>
+              {searchRow}
+              <div aria-hidden="true" {...stylex.props(styles.dividerTrack)}>
+                <span
+                  {...stylex.props(
+                    styles.divider,
+                    status === "searching" && styles.searchingDivider,
+                  )}
+                />
+              </div>
+              {facets ? (
+                <div {...stylex.props(styles.databaseMobileFacets)}>
+                  <FilterPanel ariaLabel="Search filters">
+                    <div {...stylex.props(styles.databaseMobileFacetContent)}>
+                      {facets}
+                    </div>
+                  </FilterPanel>
+                </div>
+              ) : null}
+              <p aria-live="polite" {...stylex.props(styles.databaseCount)}>
+                {(resultCount ?? 0).toLocaleString("en-US")}{" "}
+                {resultCount === 1 ? "result" : "results"}
+              </p>
+              {expanded ? (
+                <SearchResults
+                  activeId={activeId}
+                  contribution={contribution}
+                  embedded
+                  emptyText={emptyText}
+                  groups={groups}
+                  onItemSelect={selectResult}
+                  onRetry={onRetry}
+                  optionIdPrefix={panelId}
+                  panelId={panelId}
+                  query={query}
+                  scroll={false}
+                  status={status}
+                  statusText={statusText}
+                  variant="database"
+                />
+              ) : null}
+            </div>
+            {facets ? (
+              <aside {...stylex.props(styles.databaseFacets)}>{facets}</aside>
+            ) : null}
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div
       ref={rootRef}
@@ -184,39 +343,7 @@ export function SearchBox({
           placement === "page" && styles.pageSurface,
         )}
       >
-        <ScopedSearch
-          aria-activedescendant={
-            activeId ? `${panelId}-${encodeURIComponent(activeId)}` : undefined
-          }
-          aria-autocomplete="list"
-          aria-controls={expanded ? panelId : undefined}
-          autoFocus={autoFocus}
-          disabled={disabled}
-          expanded={expanded}
-          inputRef={inputRef}
-          onChange={(event) => {
-            onQueryChange(event.currentTarget.value);
-            setActiveId(items[0]?.id);
-            setOpen(true);
-          }}
-          onClear={() => {
-            onQueryChange("");
-            setActiveId(undefined);
-            inputRef.current?.focus();
-          }}
-          onFocus={() => setOpen(true)}
-          onKeyDown={handleKeyDown}
-          onScopeChange={(nextScope) => {
-            onScopeChange(nextScope);
-            setActiveId(undefined);
-            inputRef.current?.focus();
-            setOpen(true);
-          }}
-          placeholder={placeholder}
-          scope={scope}
-          scopes={scopes}
-          value={query}
-        />
+        {searchControl}
         {expanded ? (
           <div {...stylex.props(styles.results)}>
             <div aria-hidden="true" {...stylex.props(styles.dividerTrack)}>
@@ -255,6 +382,72 @@ const searchSweep = stylex.keyframes({
 });
 
 const styles = stylex.create({
+  databaseRoot: {
+    width: "100%",
+  },
+  databaseBrowseSearch: {
+    width: "100%",
+    maxWidth: "660px",
+    marginRight: "auto",
+    marginLeft: "auto",
+  },
+  databaseLayout: {
+    display: "grid",
+    minWidth: 0,
+    gridTemplateColumns: "minmax(0, 1fr) 300px",
+    gap: space.x12,
+    alignItems: "start",
+    "@media (max-width: 759px)": {
+      gridTemplateColumns: "minmax(0, 1fr)",
+    },
+  },
+  databaseMain: {
+    minWidth: 0,
+  },
+  databaseSearchRow: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "flex-start",
+    gap: space.x2,
+  },
+  databaseSearchControl: {
+    minWidth: 0,
+    flex: 1,
+  },
+  databaseCount: {
+    marginTop: space.x4,
+    marginRight: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    paddingBottom: space.x3,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontSize: "17px",
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    lineHeight: 1.2,
+  },
+  databaseFacets: {
+    minWidth: 0,
+    paddingTop: "2px",
+    "@media (max-width: 759px)": {
+      display: "none",
+    },
+  },
+  databaseMobileFacets: {
+    display: "none",
+    marginTop: space.x4,
+    "@media (max-width: 759px)": {
+      display: "block",
+    },
+  },
+  databaseMobileFacetContent: {
+    minWidth: 0,
+    gridColumn: "1 / -1",
+  },
   root: {
     position: "relative",
     width: "100%",

--- a/apps/web/src/components/designSystem/components/searchBox.test.tsx
+++ b/apps/web/src/components/designSystem/components/searchBox.test.tsx
@@ -1,0 +1,45 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { SearchBox } from "./searchBox.stylex";
+
+function renderDatabaseSearch({
+  resultCount,
+  status,
+}: {
+  resultCount?: number;
+  status: "ready" | "searching";
+}) {
+  return renderToStaticMarkup(
+    <SearchBox
+      emptyText={
+        status === "ready" ? "No records match this query." : undefined
+      }
+      groups={[]}
+      onQueryChange={() => undefined}
+      onScopeChange={() => undefined}
+      placement="database"
+      query="lagavulin"
+      resultCount={resultCount}
+      scope="all"
+      scopes={[{ label: "Everything", value: "all" }]}
+      status={status}
+      statusText="Searching bottles and entities…"
+    />,
+  );
+}
+
+describe("SearchBox database result count", () => {
+  it("does not show an unsettled count while searching", () => {
+    const html = renderDatabaseSearch({ resultCount: 0, status: "searching" });
+
+    expect(html).not.toContain("0 results");
+    expect(html).toContain("Searching bottles and entities");
+  });
+
+  it("shows zero after the search settles", () => {
+    const html = renderDatabaseSearch({ resultCount: 0, status: "ready" });
+
+    expect(html).toContain("0 results");
+  });
+});

--- a/apps/web/src/components/designSystem/components/searchResults.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/searchResults.stylex.tsx
@@ -9,7 +9,7 @@ import {
   space,
 } from "../../../styles/tokens.stylex";
 import { AppLink } from "./appLink";
-import { Button } from "./button.stylex";
+import { Button, ButtonLink } from "./button.stylex";
 import { FloatingPanel } from "./feedback.stylex";
 import { RatingMeasure, type BandCounts } from "./scoring.stylex";
 
@@ -66,6 +66,7 @@ export type SearchResultsProps = {
   scroll?: boolean;
   status?: "error" | "ready" | "searching";
   statusText?: string;
+  variant?: "database" | "default";
 };
 
 /** Presents supplied search results without owning search, ranking, or navigation. */
@@ -84,6 +85,7 @@ export function SearchResults({
   scroll = true,
   status = "ready",
   statusText,
+  variant = "default",
 }: SearchResultsProps) {
   const hasResults = groups.some((group) => group.items.length > 0);
   const hasColdLoadingState =
@@ -107,8 +109,28 @@ export function SearchResults({
         <p aria-live="polite" {...stylex.props(styles.searchingText)}>
           {statusText ?? "Searching…"}
         </p>
-      ) : emptyText ? (
+      ) : emptyText && variant === "default" ? (
         <p {...stylex.props(styles.stateText)}>{emptyText}</p>
+      ) : null}
+      {emptyText && variant === "database" ? (
+        <div {...stylex.props(styles.databaseEmptyState)}>
+          <h2 {...stylex.props(styles.databaseEmptyHeading)}>
+            Nothing matches “{query}”
+          </h2>
+          <p {...stylex.props(styles.databaseEmptyDescription)}>
+            Check the spelling, or record the bottle if the database is missing
+            it.
+          </p>
+          {visibleContribution ? (
+            <ButtonLink
+              href={visibleContribution.href}
+              size="sm"
+              variant="accent"
+            >
+              Record this bottle
+            </ButtonLink>
+          ) : null}
+        </div>
       ) : null}
       <div>
         {hasResults
@@ -121,6 +143,7 @@ export function SearchResults({
                   onItemSelect={onItemSelect}
                   optionIdPrefix={optionIdPrefix}
                   query={query}
+                  variant={variant}
                 />
               ) : null,
             )
@@ -139,7 +162,7 @@ export function SearchResults({
           ) : null}
         </div>
       ) : null}
-      {visibleContribution ? (
+      {visibleContribution && variant === "default" ? (
         <>
           <div aria-hidden="true" {...stylex.props(styles.contributionRule)} />
           <AppLink
@@ -175,12 +198,14 @@ function SearchResultsGroup({
   onItemSelect,
   optionIdPrefix,
   query,
+  variant,
 }: {
   activeId?: string;
   group: SearchResultGroup;
   onItemSelect?: (item: SearchResultItem) => void;
   optionIdPrefix?: string;
   query: string;
+  variant: "database" | "default";
 }) {
   const remaining =
     group.total === undefined
@@ -191,17 +216,35 @@ function SearchResultsGroup({
     <section
       aria-labelledby={`${optionIdPrefix ?? "search"}-group-${group.id}`}
     >
-      <div {...stylex.props(styles.groupHeading)}>
+      <div
+        {...stylex.props(
+          styles.groupHeading,
+          variant === "database" && styles.databaseGroupHeading,
+        )}
+      >
         <h2
           id={`${optionIdPrefix ?? "search"}-group-${group.id}`}
-          {...stylex.props(styles.groupName)}
+          {...stylex.props(
+            styles.groupName,
+            variant === "database" && styles.databaseGroupName,
+          )}
         >
           {group.label}
         </h2>
         {group.total !== undefined ? (
-          <span {...stylex.props(styles.groupCount)}>
+          <span
+            {...stylex.props(
+              styles.groupCount,
+              variant === "database" && styles.databaseGroupCount,
+            )}
+          >
             {group.total.toLocaleString("en-US")}
           </span>
+        ) : null}
+        {variant === "database" && group.moreHref ? (
+          <AppLink href={group.moreHref} {...stylex.props(styles.databaseMore)}>
+            See all {group.total?.toLocaleString("en-US")}
+          </AppLink>
         ) : null}
       </div>
       <ul {...stylex.props(styles.list)}>
@@ -222,6 +265,7 @@ function SearchResultsGroup({
               }}
               {...stylex.props(
                 styles.result,
+                variant === "database" && styles.databaseResult,
                 item.id === activeId && styles.activeResult,
               )}
             >
@@ -250,7 +294,7 @@ function SearchResultsGroup({
           </li>
         ))}
       </ul>
-      {group.moreHref ? (
+      {group.moreHref && variant === "default" ? (
         <AppLink href={group.moreHref} {...stylex.props(styles.more)}>
           <span>
             {remaining === undefined || remaining === 0
@@ -350,6 +394,33 @@ const styles = stylex.create({
     fontSize: "14px",
     lineHeight: 1.55,
   },
+  databaseEmptyState: {
+    paddingTop: space.x6,
+    paddingBottom: space.x2,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+  },
+  databaseEmptyHeading: {
+    margin: 0,
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontSize: "17px",
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    lineHeight: 1.2,
+  },
+  databaseEmptyDescription: {
+    maxWidth: "560px",
+    marginTop: space.x2,
+    marginRight: 0,
+    marginBottom: space.x4,
+    marginLeft: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "14px",
+    lineHeight: 1.5,
+  },
   groupHeading: {
     display: "flex",
     alignItems: "baseline",
@@ -358,6 +429,16 @@ const styles = stylex.create({
     paddingRight: "14px",
     paddingBottom: space.x1,
     paddingLeft: "14px",
+  },
+  databaseGroupHeading: {
+    gap: space.x2,
+    paddingTop: space.x6,
+    paddingRight: 0,
+    paddingBottom: space.x2,
+    paddingLeft: 0,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
   },
   groupName: {
     minWidth: 0,
@@ -371,12 +452,39 @@ const styles = stylex.create({
     lineHeight: 1.3,
     textTransform: "uppercase",
   },
+  databaseGroupName: {
+    flex: 0,
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontSize: "14px",
+    fontWeight: 700,
+    letterSpacing: "-0.01em",
+    textTransform: "none",
+    whiteSpace: "nowrap",
+  },
   groupCount: {
     color: colors.inkMuted,
     fontFamily: fonts.data,
     fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
     lineHeight: 1.3,
+  },
+  databaseGroupCount: {
+    flex: 0,
+  },
+  databaseMore: {
+    marginLeft: "auto",
+    outline: "none",
+    color: colors.accentDeep,
+    fontFamily: fonts.reading,
+    fontSize: "12px",
+    fontWeight: 700,
+    lineHeight: 1.3,
+    textDecoration: "none",
+    boxShadow: {
+      default: "none",
+      ":focus-visible": effects.focusRing,
+    },
   },
   list: {
     margin: 0,
@@ -416,6 +524,12 @@ const styles = stylex.create({
       default: "none",
       ":focus-visible": effects.focusRing,
     },
+  },
+  databaseResult: {
+    marginRight: 0,
+    marginLeft: 0,
+    paddingRight: 0,
+    paddingLeft: 0,
   },
   activeResult: {
     backgroundColor: colors.surface,

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -17,7 +17,13 @@ import { useORPC } from "@peated/web/lib/orpc/context";
 import { getEntityUrl } from "@peated/web/lib/urls";
 import * as stylex from "@stylexjs/stylex";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 import { useDebounceCallback } from "usehooks-ts";
 
 import { space } from "../../styles/tokens.stylex";
@@ -65,6 +71,7 @@ export type SearchScope = (typeof searchScopes)[number]["value"];
 
 export type SearchProps = {
   autoFocus?: boolean;
+  browseHeader?: ReactNode;
   contributionLabel?: string;
   defaultOpen?: boolean;
   getBottleHref?: (bottleId: number) => string;
@@ -72,8 +79,9 @@ export type SearchProps = {
   initialQuery?: string;
   initialScope?: SearchScope;
   limit?: number;
+  onScopeChange?: (scope: SearchScope, query: string) => void;
   onSubmit?: (query: string) => void;
-  placement?: "overlay" | "page";
+  placement?: "database" | "overlay" | "page";
   placeholder?: string;
   scopeValues?: readonly SearchScope[];
   showBottleMeasures?: boolean;
@@ -215,8 +223,9 @@ function getGroupLabel(type: SearchGroup["type"]) {
 
 function getMoreHref(query: string, type: SearchGroup["type"]) {
   const encodedQuery = encodeURIComponent(query);
-  return type === "members"
-    ? `/search?q=${encodedQuery}&type=users`
+  const scope = type === "members" ? "members" : type;
+  return searchScopes.some((option) => option.value === scope)
+    ? `/search?q=${encodedQuery}&type=${scope}`
     : `/search?q=${encodedQuery}`;
 }
 
@@ -246,8 +255,9 @@ function resultGroups(
   query: string,
   bottleOptions: BottleItemOptions,
   showMoreLinks: boolean,
+  scope: SearchScope,
 ): SearchResultGroup[] {
-  if (response.exact) {
+  if (response.exact && exactMatchesScope(response.exact, scope)) {
     return [
       {
         id: "exact",
@@ -259,6 +269,7 @@ function resultGroups(
   }
 
   const groups = response.groups.flatMap((group): SearchResultGroup[] => {
+    if (!groupMatchesScope(group.type, scope)) return [];
     const items = groupItems(group, bottleOptions);
     if (!items.length) return [];
     return [
@@ -278,13 +289,47 @@ function resultGroups(
   if (!groups.length && response.nearest.length) {
     groups.push({
       id: "nearest",
-      items: response.nearest.map((nearest) =>
-        nearestItem(nearest, bottleOptions),
-      ),
+      items: response.nearest
+        .filter((nearest) => groupMatchesScope(nearest.type, scope))
+        .map((nearest) => nearestItem(nearest, bottleOptions)),
       label: "Did you mean?",
     });
   }
-  return groups;
+  return groups.filter((group) => group.items.length > 0);
+}
+
+function groupMatchesScope(type: SearchGroup["type"], scope: SearchScope) {
+  return scope === "all" || type === scope;
+}
+
+function exactMatchesScope(exact: SearchExact, scope: SearchScope) {
+  if (scope === "all") return true;
+  if (exact.type === "bottle") return scope === "bottles";
+  return (
+    (exact.ref.kind === "distillery" && scope === "distilleries") ||
+    (exact.ref.kind === "brand" && scope === "brands") ||
+    (exact.ref.kind === "bottler" && scope === "bottlers")
+  );
+}
+
+function getResultCount(response: SearchResponse, scope: SearchScope) {
+  if (response.exact && exactMatchesScope(response.exact, scope)) return 1;
+  return response.groups.reduce(
+    (total, group) =>
+      total + (groupMatchesScope(group.type, scope) ? group.total : 0),
+    0,
+  );
+}
+
+function getResultScopeTotals(response: SearchResponse) {
+  return {
+    all: getResultCount(response, "all"),
+    bottles: getResultCount(response, "bottles"),
+    distilleries: getResultCount(response, "distilleries"),
+    brands: getResultCount(response, "brands"),
+    bottlers: getResultCount(response, "bottlers"),
+    members: getResultCount(response, "members"),
+  } satisfies Record<SearchScope, number>;
 }
 
 function exactItem(exact: SearchExact, bottleOptions: BottleItemOptions) {
@@ -323,6 +368,7 @@ function getScopeCount(
 
 export function Search({
   autoFocus = false,
+  browseHeader,
   contributionLabel = "Add a new bottle",
   defaultOpen = false,
   getBottleHref = getDefaultBottleHref,
@@ -330,6 +376,7 @@ export function Search({
   initialQuery = "",
   initialScope = "all",
   limit = 3,
+  onScopeChange,
   onSubmit,
   placement = "overlay",
   placeholder = "bottles, distillers, brands…",
@@ -347,6 +394,9 @@ export function Search({
   const [hasExactResult, setHasExactResult] = useState(false);
   const [scopeTotals, setScopeTotals] =
     useState<SearchResponse["scopeTotals"]>();
+  const [resultCount, setResultCount] = useState(0);
+  const [resultScopeTotals, setResultScopeTotals] =
+    useState<Record<SearchScope, number>>();
   const [settledQuery, setSettledQuery] = useState<string>();
   const [status, setStatus] = useState<"error" | "ready" | "searching">(
     initialQuery.trim() ? "searching" : "ready",
@@ -369,6 +419,10 @@ export function Search({
     ...option,
     count: getScopeCount(option.value, scopeTotals),
   }));
+  const availableScopeFacets = availableScopeDefinitions.map((option) => ({
+    ...option,
+    count: resultScopeTotals?.[option.value],
+  }));
 
   const runSearch = useCallback(
     async (nextQuery: string, nextScope: SearchScope) => {
@@ -379,6 +433,8 @@ export function Search({
         setGroups([]);
         setEmptyText(undefined);
         setHasExactResult(false);
+        setResultCount(0);
+        setResultScopeTotals(undefined);
         setSettledQuery(undefined);
         setStatus("ready");
         return;
@@ -389,9 +445,14 @@ export function Search({
       try {
         const [response] = await Promise.all([
           orpc.search.call({
-            limit,
+            limit: placement === "database" && nextScope !== "all" ? 50 : limit,
             query: trimmedQuery,
-            scopes: [...getApiScopes(nextScope, Boolean(user))],
+            scopes: [
+              ...getApiScopes(
+                placement === "database" ? "all" : nextScope,
+                Boolean(user),
+              ),
+            ],
           }),
           indicatorFloor,
         ]);
@@ -400,11 +461,11 @@ export function Search({
           response,
           trimmedQuery,
           { getBottleHref, showMeasures: showBottleMeasures },
-          placement === "overlay",
+          placement === "database" || placement === "overlay",
+          nextScope,
         );
-        const hasMatches =
-          Boolean(response.exact) ||
-          response.groups.some((group) => group.results.length > 0);
+        const nextResultCount = getResultCount(response, nextScope);
+        const hasMatches = nextResultCount > 0;
         setGroups(nextGroups);
         setEmptyText(
           hasMatches
@@ -413,7 +474,13 @@ export function Search({
               ? `No exact records match “${trimmedQuery}”.`
               : `No records match “${trimmedQuery}”.`,
         );
-        setHasExactResult(Boolean(response.exact));
+        setHasExactResult(
+          Boolean(
+            response.exact && exactMatchesScope(response.exact, nextScope),
+          ),
+        );
+        setResultCount(nextResultCount);
+        setResultScopeTotals(getResultScopeTotals(response));
         setScopeTotals(response.scopeTotals);
         setSettledQuery(trimmedQuery);
         setStatus("ready");
@@ -459,6 +526,8 @@ export function Search({
       setGroups([]);
       setEmptyText(undefined);
       setHasExactResult(false);
+      setResultCount(0);
+      setResultScopeTotals(undefined);
       setSettledQuery(undefined);
       setStatus("ready");
       return;
@@ -478,6 +547,7 @@ export function Search({
   const searchBox = (
     <SearchBox
       autoFocus={autoFocus}
+      browseHeader={browseHeader}
       contribution={
         query.trim() &&
         settledQuery &&
@@ -500,14 +570,18 @@ export function Search({
       onScopeChange={(nextScope) => {
         if (!isSearchScope(nextScope)) return;
         debouncedSearch.cancel();
+        previousInitialScope.current = nextScope;
         setScope(nextScope);
+        onScopeChange?.(nextScope, query);
         void runSearch(query, nextScope);
       }}
       onSubmit={submitSearch}
       placement={placement}
       placeholder={placeholder}
       query={query}
+      resultCount={resultCount}
       scope={effectiveScope}
+      scopeFacets={availableScopeFacets}
       scopes={availableScopes}
       status={status}
       statusText={
@@ -515,10 +589,11 @@ export function Search({
           ? getSearchingText(effectiveScope, Boolean(user))
           : undefined
       }
+      submitLabel={submitLabel}
     />
   );
 
-  if (!submitLabel) return searchBox;
+  if (!submitLabel || placement === "database") return searchBox;
 
   return (
     <div {...stylex.props(styles.searchWithSubmit)}>

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -69,6 +69,17 @@ type MemberSearchResult = Extract<
 >["results"][number];
 export type SearchScope = (typeof searchScopes)[number]["value"];
 
+type SearchSnapshot = {
+  count: number;
+  emptyText?: string;
+  groups: SearchResultGroup[];
+  hasExact: boolean;
+  query: string;
+  scope: SearchScope;
+  scopeCounts: Record<SearchScope, number>;
+  scopeTotals: SearchResponse["scopeTotals"];
+};
+
 export type SearchProps = {
   autoFocus?: boolean;
   browseHeader?: ReactNode;
@@ -391,15 +402,7 @@ export function Search({
   const router = useRouter();
   const [query, setQuery] = useState(initialQuery);
   const [scope, setScope] = useState<SearchScope>(initialScope);
-  const [groups, setGroups] = useState<SearchResultGroup[]>([]);
-  const [emptyText, setEmptyText] = useState<string>();
-  const [hasExactResult, setHasExactResult] = useState(false);
-  const [scopeTotals, setScopeTotals] =
-    useState<SearchResponse["scopeTotals"]>();
-  const [resultCount, setResultCount] = useState(0);
-  const [resultScopeTotals, setResultScopeTotals] =
-    useState<Record<SearchScope, number>>();
-  const [settledQuery, setSettledQuery] = useState<string>();
+  const [snapshot, setSnapshot] = useState<SearchSnapshot>();
   const [status, setStatus] = useState<"error" | "ready" | "searching">(
     initialQuery.trim() ? "searching" : "ready",
   );
@@ -417,14 +420,21 @@ export function Search({
   )
     ? scope
     : (availableScopeDefinitions[0]?.value ?? "all");
+  // Result metadata belongs only to the query and scope that produced it.
+  const currentSnapshot =
+    snapshot?.query === query.trim() && snapshot.scope === effectiveScope
+      ? snapshot
+      : undefined;
   const availableScopes = availableScopeDefinitions.map((option) => ({
     ...option,
-    count: getScopeCount(option.value, scopeTotals),
+    count: getScopeCount(option.value, currentSnapshot?.scopeTotals),
   }));
-  const availableScopeFacets = availableScopeDefinitions.map((option) => ({
-    ...option,
-    count: resultScopeTotals?.[option.value],
-  }));
+  const availableScopeFacets = currentSnapshot
+    ? availableScopeDefinitions.map((option) => ({
+        ...option,
+        count: currentSnapshot.scopeCounts[option.value],
+      }))
+    : undefined;
 
   const runSearch = useCallback(
     async (nextQuery: string, nextScope: SearchScope) => {
@@ -432,12 +442,7 @@ export function Search({
       latestRequest.current = requestId;
       const trimmedQuery = nextQuery.trim();
       if (!trimmedQuery) {
-        setGroups([]);
-        setEmptyText(undefined);
-        setHasExactResult(false);
-        setResultCount(0);
-        setResultScopeTotals(undefined);
-        setSettledQuery(undefined);
+        setSnapshot(undefined);
         setStatus("ready");
         return;
       }
@@ -468,23 +473,22 @@ export function Search({
         );
         const nextResultCount = getResultCount(response, nextScope);
         const hasMatches = nextResultCount > 0;
-        setGroups(nextGroups);
-        setEmptyText(
-          hasMatches
+        setSnapshot({
+          count: nextResultCount,
+          emptyText: hasMatches
             ? undefined
             : response.nearest.length
               ? `No exact records match “${trimmedQuery}”.`
               : `No records match “${trimmedQuery}”.`,
-        );
-        setHasExactResult(
-          Boolean(
+          groups: nextGroups,
+          hasExact: Boolean(
             response.exact && exactMatchesScope(response.exact, nextScope),
           ),
-        );
-        setResultCount(nextResultCount);
-        setResultScopeTotals(getResultScopeTotals(response));
-        setScopeTotals(response.scopeTotals);
-        setSettledQuery(trimmedQuery);
+          query: trimmedQuery,
+          scope: nextScope,
+          scopeCounts: getResultScopeTotals(response),
+          scopeTotals: response.scopeTotals,
+        });
         setStatus("ready");
       } catch {
         await indicatorFloor;
@@ -522,18 +526,15 @@ export function Search({
 
   function updateQuery(nextQuery: string) {
     setQuery(nextQuery);
+    // Invalidate the current request before the next debounced request starts.
+    latestRequest.current += 1;
     if (!nextQuery.trim()) {
-      latestRequest.current += 1;
       debouncedSearch.cancel();
-      setGroups([]);
-      setEmptyText(undefined);
-      setHasExactResult(false);
-      setResultCount(0);
-      setResultScopeTotals(undefined);
-      setSettledQuery(undefined);
+      setSnapshot(undefined);
       setStatus("ready");
       return;
     }
+    setStatus("searching");
     void debouncedSearch(nextQuery, effectiveScope);
   }
 
@@ -552,20 +553,20 @@ export function Search({
       browseHeader={browseHeader}
       contribution={
         query.trim() &&
-        settledQuery &&
-        !hasExactResult &&
+        currentSnapshot &&
+        !currentSnapshot.hasExact &&
         (effectiveScope === "all" || effectiveScope === "bottles")
           ? {
-              description: `Can't find “${settledQuery}”?`,
-              href: getContributionHref(settledQuery),
+              description: `Can't find “${currentSnapshot.query}”?`,
+              href: getContributionHref(currentSnapshot.query),
               label: contributionLabel,
             }
           : undefined
       }
       defaultOpen={defaultOpen || placement === "page"}
-      emptyText={emptyText}
+      emptyText={currentSnapshot?.emptyText}
       fluid={Boolean(submitLabel)}
-      groups={groups}
+      groups={snapshot?.groups ?? []}
       onQueryChange={updateQuery}
       onRetry={() => void runSearch(query, effectiveScope)}
       onResultSelect={(item) => router.push(item.href)}
@@ -581,7 +582,8 @@ export function Search({
       placement={placement}
       placeholder={placeholder}
       query={query}
-      resultCount={resultCount}
+      resultCount={currentSnapshot?.count}
+      resultQuery={snapshot?.query}
       scope={effectiveScope}
       scopeFacets={availableScopeFacets}
       scopes={availableScopes}

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -223,9 +223,11 @@ function getGroupLabel(type: SearchGroup["type"]) {
 
 function getMoreHref(query: string, type: SearchGroup["type"]) {
   const encodedQuery = encodeURIComponent(query);
-  const scope = type === "members" ? "members" : type;
-  return searchScopes.some((option) => option.value === scope)
-    ? `/search?q=${encodedQuery}&type=${scope}`
+  if (type === "members") {
+    return `/search?q=${encodedQuery}&type=users`;
+  }
+  return searchScopes.some((option) => option.value === type)
+    ? `/search?q=${encodedQuery}&type=${type}`
     : `/search?q=${encodedQuery}`;
 }
 

--- a/apps/web/visual/scenarios/index.mjs
+++ b/apps/web/visual/scenarios/index.mjs
@@ -6,9 +6,11 @@ import { distilleryDetailScenario } from "./distillery-detail.mjs";
 import { homeScenario } from "./home.mjs";
 import { loginScenario } from "./login.mjs";
 import { memberProfileScenario } from "./member-profile.mjs";
+import { searchScenario } from "./search.mjs";
 
 export const SCENARIOS = [
   homeScenario,
+  searchScenario,
   bottleDetailScenario,
   memberProfileScenario,
   addTastingScenario,

--- a/apps/web/visual/scenarios/search.mjs
+++ b/apps/web/visual/scenarios/search.mjs
@@ -1,0 +1,18 @@
+import { isTestDataChange } from "./shared-changes.mjs";
+import { DESKTOP, MOBILE } from "./viewports.mjs";
+
+export const searchScenario = {
+  heading: "Search the database",
+  id: "search",
+  label: "Search",
+  path: "/search",
+  shouldRunFor: (filePath) =>
+    filePath.startsWith("apps/web/src/app/(app)/search/") ||
+    filePath === "apps/web/src/components/search/search.stylex.tsx" ||
+    filePath ===
+      "apps/web/src/components/designSystem/components/searchBox.stylex.tsx" ||
+    filePath ===
+      "apps/web/src/components/designSystem/components/searchResults.stylex.tsx" ||
+    isTestDataChange(filePath),
+  viewports: [DESKTOP, MOBILE],
+};

--- a/apps/web/visual/select-scenarios.test.mjs
+++ b/apps/web/visual/select-scenarios.test.mjs
@@ -38,6 +38,30 @@ describe("selectScenarioIds", () => {
     ).toEqual(["bottle-detail"]);
   });
 
+  it("selects search for search page changes", () => {
+    expect(
+      selectScenarioIds([
+        "apps/web/src/app/(app)/search/searchPageClient.stylex.tsx",
+      ]),
+    ).toEqual(["search"]);
+  });
+
+  it("selects search for shared search result changes", () => {
+    expect(
+      selectScenarioIds([
+        "apps/web/src/components/designSystem/components/searchResults.stylex.tsx",
+      ]),
+    ).toEqual(["home", "search", "bottle-detail", "member-profile"]);
+  });
+
+  it("does not select search for another page's changes", () => {
+    expect(
+      selectScenarioIds([
+        "apps/web/src/app/(app)/users/[username]/profilePageClient.stylex.tsx",
+      ]),
+    ).toEqual(["member-profile"]);
+  });
+
   it("selects the tasting page for tasting workflow changes", () => {
     expect(
       selectScenarioIds([
@@ -67,6 +91,7 @@ describe("selectScenarioIds", () => {
       selectScenarioIds(["apps/web/e2e/rpc-fixtures.mjs"], { max: 20 }),
     ).toEqual([
       "home",
+      "search",
       "bottle-detail",
       "member-profile",
       "add-tasting",


### PR DESCRIPTION
The `/search` route now opens with a focused catalog search prompt and switches to a responsive results layout after a query. Results include exact and grouped matches, a result count, type facets, and URL-backed query and scope state.

The existing member and bottle-selection search flows keep their current page layout, including the established `type=users` member links. The empty database-search state omits the recently added and most tasted lists so the primary action stays clear.

Search responses now publish one query-and-scope snapshot, so counts, facets, empty states, and result actions stay synchronized. Loading queries do not announce a premature zero count, and input changes invalidate older requests before the next debounced request starts.

The pull request screenshot workflow captures the search landing page at desktop and mobile sizes when the route or shared search components change.
