### PR TITLE
style(entities): clarify ownership labels

### DIFF
--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
@@ -4,6 +4,7 @@ import {
   entityHasBottleCatalog,
   getEntityClassification,
   getEntityCurrentHref,
+  getEntityOwnerLabel,
   getEntityTabs,
 } from "./entityPageData";
 
@@ -26,6 +27,26 @@ describe("getEntityClassification", () => {
         yearEstablished: 1816,
       }),
     ).toBe("Distillery · founded 1816 · Islay");
+  });
+});
+
+describe("getEntityOwnerLabel", () => {
+  it("describes a brand through its owner", () => {
+    expect(
+      getEntityOwnerLabel(
+        { kind: "brand" },
+        { name: "Diageo plc", shortName: "Diageo" },
+      ),
+    ).toBe("A Diageo brand");
+  });
+
+  it("describes other entity kinds as part of their owner", () => {
+    expect(
+      getEntityOwnerLabel(
+        { kind: "distillery" },
+        { name: "Diageo", shortName: null },
+      ),
+    ).toBe("Part of Diageo");
   });
 });
 

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -63,6 +63,17 @@ export function getEntityClassification(entity: EntityClassificationSource) {
     .join(" · ");
 }
 
+export function getEntityOwnerLabel(
+  entity: Pick<Entity, "kind">,
+  owner: Pick<Entity, "name" | "shortName">,
+) {
+  const ownerName = owner.shortName || owner.name;
+
+  return entity.kind === "brand"
+    ? `A ${ownerName} brand`
+    : `Part of ${ownerName}`;
+}
+
 export function entityHasBottleCatalog(entity: Pick<Entity, "kind">) {
   return (
     entity.kind === "brand" ||

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -32,6 +32,7 @@ import {
 import {
   getEntityClassification,
   getEntityCurrentHref,
+  getEntityOwnerLabel,
   getEntityPresentation,
   getEntityTabs,
   type Entity,
@@ -232,7 +233,7 @@ export function EntityPageFrameClient({
               href={getEntityUrl(owner)}
               {...stylex.props(styles.ownerLink)}
             >
-              Owned by {owner.shortName || owner.name}
+              {getEntityOwnerLabel(entity, owner)}
             </AppLink>
           ) : null}
           {entity.description ? (

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
@@ -30,8 +30,8 @@ export function EntitySiblingOverview({
   if (!entity.ownerId) return null;
 
   const heading = entity.owner?.name
-    ? `Also owned by ${entity.owner.name}`
-    : "Also owned";
+    ? `Also part of ${entity.owner.name}`
+    : "Related entities";
 
   if (pending) {
     return (

--- a/apps/web/src/components/designSystem/patterns/entityPageHeader.stories.tsx
+++ b/apps/web/src/components/designSystem/patterns/entityPageHeader.stories.tsx
@@ -37,7 +37,7 @@ const meta = {
         variant="page"
       />
     ),
-    parent: "Owned by Diageo",
+    parent: "Part of Diageo",
     specs: [
       { label: "Founded", value: 1816 },
       { label: "Country", value: "Scotland" },

--- a/openspec/specs/entity-identity/spec.md
+++ b/openspec/specs/entity-identity/spec.md
@@ -127,7 +127,13 @@ current owner and the Entities directly owned by an owner.
 #### Scenario: Distillery owner
 
 - **WHEN** Lagavulin points to Diageo as its owner
-- **THEN** Lagavulin shows “Owned by Diageo” and Diageo lists Lagavulin
+- **THEN** Lagavulin shows “Part of Diageo” and Diageo lists Lagavulin
+
+#### Scenario: Brand owner
+
+- **WHEN** Johnnie Walker points to Diageo as its owner
+- **THEN** Johnnie Walker shows “A Diageo brand” and Diageo lists Johnnie
+  Walker
 
 #### Scenario: Owner chain
 


### PR DESCRIPTION
Entity pages now describe brand ownership as “A [owner] brand” and other ownership relationships as “Part of [owner].” The related-entity section uses the same language, while the moderator form keeps its explicit ownership label and the underlying ownership model remains unchanged.
