### PR TITLE
feat(web): add unified following catalog

### DIFF
--- a/apps/server/src/orpc/contracts/entities/list.ts
+++ b/apps/server/src/orpc/contracts/entities/list.ts
@@ -1,6 +1,25 @@
 import { EntitySchema, listResponse } from "@peated/server/schemas";
+import { EntityKindEnum } from "@peated/server/schemas/common";
+import { z } from "zod";
 import { contract } from "../base";
 import { EntityKindListInputSchema } from "../entityKinds/list";
+
+export const EntityListInputSchema = EntityKindListInputSchema.unwrap()
+  .extend({
+    kinds: z
+      .array(EntityKindEnum)
+      .min(1)
+      .max(4)
+      .optional()
+      .describe("Only return Entities with one of these kinds"),
+  })
+  .default({
+    query: "",
+    filter: "all",
+    sort: "rank",
+    cursor: 1,
+    limit: 100,
+  });
 
 export default contract
   .route({
@@ -10,5 +29,5 @@ export default contract
     description: "Find Entities of any kind for selection fields",
     operationId: "listEntities",
   })
-  .input(EntityKindListInputSchema)
+  .input(EntityListInputSchema)
   .output(listResponse(EntitySchema));

--- a/apps/server/src/orpc/mock/fixtures/entities.ts
+++ b/apps/server/src/orpc/mock/fixtures/entities.ts
@@ -22,6 +22,7 @@ export const mockEntity = {
   location: [-6.126, 55.635],
   totalTastings: 1200,
   totalBottles: 84,
+  isFollowing: false,
   createdAt: timestamp,
   updatedAt: timestamp,
 } satisfies Entity;
@@ -255,6 +256,19 @@ export const mockEntities: Entity[] = [
     totalBottles: 188,
   },
 ];
+
+const followedEntityIds = new Set([9201, 9207, 9208]);
+
+export function isMockEntityFollowing(entityId: number) {
+  return followedEntityIds.has(entityId);
+}
+
+export function mockEntityFor(signedIn: boolean, entity: Entity): Entity {
+  return {
+    ...entity,
+    isFollowing: signedIn && isMockEntityFollowing(entity.id),
+  };
+}
 
 export const mockMacallanEntity = mockEntities[1]!;
 export const mockSpringbankEntity = mockEntities[2]!;

--- a/apps/server/src/orpc/mock/routes/bottlers/list.ts
+++ b/apps/server/src/orpc/mock/routes/bottlers/list.ts
@@ -6,6 +6,6 @@ export default mockOS.bottlers.list.handler(
     if (input.filter === "following" && !context.user) {
       throw errors.UNAUTHORIZED();
     }
-    return listEntityKind("bottler", input);
+    return listEntityKind("bottler", input, Boolean(context.user));
   },
 );

--- a/apps/server/src/orpc/mock/routes/brands/list.ts
+++ b/apps/server/src/orpc/mock/routes/brands/list.ts
@@ -6,6 +6,6 @@ export default mockOS.brands.list.handler(
     if (input.filter === "following" && !context.user) {
       throw errors.UNAUTHORIZED();
     }
-    return listEntityKind("brand", input);
+    return listEntityKind("brand", input, Boolean(context.user));
   },
 );

--- a/apps/server/src/orpc/mock/routes/companies/list.ts
+++ b/apps/server/src/orpc/mock/routes/companies/list.ts
@@ -6,6 +6,6 @@ export default mockOS.companies.list.handler(
     if (input.filter === "following" && !context.user) {
       throw errors.UNAUTHORIZED();
     }
-    return listEntityKind("company", input);
+    return listEntityKind("company", input, Boolean(context.user));
   },
 );

--- a/apps/server/src/orpc/mock/routes/distilleries/list.ts
+++ b/apps/server/src/orpc/mock/routes/distilleries/list.ts
@@ -6,6 +6,6 @@ export default mockOS.distilleries.list.handler(
     if (input.filter === "following" && !context.user) {
       throw errors.UNAUTHORIZED();
     }
-    return listEntityKind("distillery", input);
+    return listEntityKind("distillery", input, Boolean(context.user));
   },
 );

--- a/apps/server/src/orpc/mock/routes/entities/list.ts
+++ b/apps/server/src/orpc/mock/routes/entities/list.ts
@@ -6,6 +6,6 @@ export default mockOS.entities.list.handler(
     if (input.filter === "following" && !context.user) {
       throw errors.UNAUTHORIZED();
     }
-    return listEntities(input);
+    return listEntities(input, undefined, Boolean(context.user));
   },
 );

--- a/apps/server/src/orpc/mock/routes/entityKinds/list.ts
+++ b/apps/server/src/orpc/mock/routes/entityKinds/list.ts
@@ -1,6 +1,8 @@
 import {
   includesQuery,
+  isMockEntityFollowing,
   mockEntities,
+  mockEntityFor,
   mockPage,
 } from "@peated/server/orpc/mock/fixtures";
 import type { EntityKind } from "@peated/server/types";
@@ -15,22 +17,30 @@ type EntityListInput = {
   sort: string;
   cursor: number;
   limit: number;
+  kinds?: EntityKind[];
 };
 
-const followedEntityIds = new Set([9201, 9207, 9208]);
-
-export function listEntityKind(kind: EntityKind, input: EntityListInput) {
-  return listEntities(input, kind);
+export function listEntityKind(
+  kind: EntityKind,
+  input: EntityListInput,
+  signedIn = false,
+) {
+  return listEntities(input, kind, signedIn);
 }
 
-export function listEntities(input: EntityListInput, kind?: EntityKind) {
+export function listEntities(
+  input: EntityListInput,
+  kind?: EntityKind,
+  signedIn = false,
+) {
   const direction = input.sort.startsWith("-") ? -1 : 1;
   const sort = input.sort.replace(/^-/, "");
   const entities = mockEntities
     .filter(
       (entity) =>
         (kind === undefined || entity.kind === kind) &&
-        (input.filter !== "following" || followedEntityIds.has(entity.id)) &&
+        (input.kinds === undefined || input.kinds.includes(entity.kind)) &&
+        (input.filter !== "following" || isMockEntityFollowing(entity.id)) &&
         (input.owner == null || entity.ownerId === input.owner) &&
         includesQuery(input.query, entity.name, entity.shortName) &&
         (input.name == null || entity.name === input.name) &&
@@ -54,7 +64,8 @@ export function listEntities(input: EntityListInput, kind?: EntityKind) {
         default:
           return 0;
       }
-    });
+    })
+    .map((entity) => mockEntityFor(signedIn, entity));
 
   return mockPage(entities, input.cursor, input.limit);
 }

--- a/apps/server/src/orpc/mock/routes/search.ts
+++ b/apps/server/src/orpc/mock/routes/search.ts
@@ -4,6 +4,7 @@ import {
   mockBottleFor,
   mockBottles,
   mockEntities,
+  mockEntityFor,
   mockFriendDetails,
   mockFriends,
   mockRegions,
@@ -14,6 +15,9 @@ import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.search.handler(async ({ input, context }) => {
   const groups: MockOutputs["search"]["groups"] = [];
+  const entities = mockEntities.map((entity) =>
+    mockEntityFor(Boolean(context.user), entity),
+  );
   const bottles = mockBottles
     .filter((bottle) =>
       includesQuery(
@@ -27,7 +31,7 @@ export default mockOS.search.handler(async ({ input, context }) => {
   const matchingEntities = (
     predicate: (entity: (typeof mockEntities)[number]) => boolean,
   ) =>
-    mockEntities.filter(
+    entities.filter(
       (entity) =>
         predicate(entity) &&
         includesQuery(input.query, entity.name, entity.shortName),
@@ -117,7 +121,7 @@ export default mockOS.search.handler(async ({ input, context }) => {
           return false;
       }
     });
-  const exactEntity = mockEntities.find(
+  const exactEntity = entities.find(
     (entity) =>
       entityMatchesSelectedScope(entity) &&
       [entity.peatedId, entity.name, entity.shortName].some(

--- a/apps/server/src/orpc/routes/bottles/validation.ts
+++ b/apps/server/src/orpc/routes/bottles/validation.ts
@@ -57,6 +57,7 @@ async function getEntityById(entityId: number, entityDb: AnyDatabase) {
     location: entity.location,
     totalTastings: entity.totalTastings,
     totalBottles: entity.totalBottles,
+    isFollowing: false,
     createdAt: entity.createdAt.toISOString(),
     updatedAt: entity.updatedAt.toISOString(),
   });
@@ -106,6 +107,7 @@ async function getEntity(
     location: existingEntity.location,
     totalTastings: existingEntity.totalTastings,
     totalBottles: existingEntity.totalBottles,
+    isFollowing: false,
     createdAt: existingEntity.createdAt.toISOString(),
     updatedAt: existingEntity.updatedAt.toISOString(),
   });

--- a/apps/server/src/orpc/routes/entities/follow.test.ts
+++ b/apps/server/src/orpc/routes/entities/follow.test.ts
@@ -27,6 +27,24 @@ describe("PUT /entities/:entity/follow", () => {
     expect(err).toMatchInlineSnapshot(`[Error: Entity not found.]`);
   });
 
+  test("rejects an Entity kind that cannot be followed", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const company = await fixtures.Entity({ kind: "company" });
+
+    const err = await waitError(() =>
+      routerClient.entities.follow(
+        { entity: company.id },
+        { context: { user: defaults.user } },
+      ),
+    );
+
+    expect(err).toMatchInlineSnapshot(
+      `[Error: You can follow distillers, brands, and bottlers.]`,
+    );
+  });
+
   test("does not create duplicate follows", async ({ defaults, fixtures }) => {
     const entity = await fixtures.Entity();
 

--- a/apps/server/src/orpc/routes/entities/follow.ts
+++ b/apps/server/src/orpc/routes/entities/follow.ts
@@ -23,12 +23,22 @@ export default procedure
   .output(z.object({ following: z.literal(true) }))
   .handler(async function ({ input, context, errors }) {
     const [entity] = await db
-      .select({ id: entities.id })
+      .select({ id: entities.id, kind: entities.kind })
       .from(entities)
       .where(eq(entities.id, input.entity))
       .limit(1);
     if (!entity) {
       throw errors.NOT_FOUND({ message: "Entity not found." });
+    }
+    // This boundary owns which catalog records can participate in following.
+    if (
+      entity.kind !== "brand" &&
+      entity.kind !== "bottler" &&
+      entity.kind !== "distillery"
+    ) {
+      throw errors.BAD_REQUEST({
+        message: "You can follow distillers, brands, and bottlers.",
+      });
     }
 
     await db

--- a/apps/server/src/orpc/routes/entities/list.test.ts
+++ b/apps/server/src/orpc/routes/entities/list.test.ts
@@ -1,3 +1,5 @@
+import { db } from "@peated/server/db";
+import { entityFollows } from "@peated/server/db/schema";
 import { routerClient } from "@peated/server/orpc/router";
 
 describe("GET /entities", () => {
@@ -65,5 +67,43 @@ describe("GET /entities", () => {
     });
 
     expect(results.map(({ id }) => id)).toEqual([brand.id, distillery.id]);
+  });
+
+  test("filters Entities by several kinds", async ({ fixtures }) => {
+    const brand = await fixtures.Entity({ name: "A Brand", kind: "brand" });
+    const bottler = await fixtures.Entity({
+      name: "B Bottler",
+      kind: "bottler",
+    });
+    await fixtures.Entity({ name: "C Company", kind: "company" });
+
+    const { results } = await routerClient.entities.list({
+      kinds: ["brand", "bottler"],
+      sort: "name",
+    });
+
+    expect(results.map(({ id }) => id)).toEqual([brand.id, bottler.id]);
+  });
+
+  test("includes the current user's follow state", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const followed = await fixtures.Entity({ kind: "distillery" });
+    await db.insert(entityFollows).values({
+      userId: defaults.user.id,
+      entityId: followed.id,
+    });
+
+    const anonymous = await routerClient.entities.list({
+      kinds: ["distillery"],
+    });
+    const authenticated = await routerClient.entities.list(
+      { kinds: ["distillery"] },
+      { context: { user: defaults.user } },
+    );
+
+    expect(anonymous.results[0]?.isFollowing).toBe(false);
+    expect(authenticated.results[0]?.isFollowing).toBe(true);
   });
 });

--- a/apps/server/src/orpc/routes/entityKinds/list.ts
+++ b/apps/server/src/orpc/routes/entityKinds/list.ts
@@ -16,15 +16,17 @@ import type { EntityKindListInputSchema } from "@peated/server/orpc/contracts/en
 import { serialize } from "@peated/server/serializers";
 import { EntitySerializer } from "@peated/server/serializers/entity";
 import type { SQL } from "drizzle-orm";
-import { and, asc, desc, eq, ilike, or, sql } from "drizzle-orm";
+import { and, asc, desc, eq, ilike, inArray, or, sql } from "drizzle-orm";
 import type { z } from "zod";
 
 type Input = z.infer<typeof EntityKindListInputSchema>;
 
+type ListEntitiesInput = Input & { kinds?: EntityKind[] };
+
 type ListEntitiesOptions = {
   badRequest: (message: string) => never;
   currentUser?: User | null;
-  input: Input;
+  input: ListEntitiesInput;
   unauthorized: () => never;
 };
 
@@ -39,8 +41,9 @@ export async function listEntities({
   const offset = (cursor - 1) * limit;
   const textQuery = plainTextSearchQuery(query);
   const prefixQuery = prefixTextSearchQuery(query);
+  const requestedKinds = kind ? [kind] : input.kinds;
   const where: (SQL<unknown> | undefined)[] = [
-    kind ? eq(entities.kind, kind) : undefined,
+    requestedKinds?.length ? inArray(entities.kind, requestedKinds) : undefined,
   ];
 
   if (input.filter === "following") {

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -100,6 +100,11 @@ export const EntitySchema = z.object({
     .readonly()
     .describe("Total number of bottles associated with this entity"),
 
+  isFollowing: z
+    .boolean()
+    .readonly()
+    .describe("Whether the current user follows this entity"),
+
   createdAt: z
     .string()
     .datetime()

--- a/apps/server/src/serializers/entity.ts
+++ b/apps/server/src/serializers/entity.ts
@@ -1,10 +1,11 @@
-import { inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { type z } from "zod";
 import { serialize, serializer } from ".";
 import { db } from "../db";
 import {
   countries,
   entities,
+  entityFollows,
   regions,
   type Entity,
   type User,
@@ -17,6 +18,7 @@ import { RegionSerializer } from "./region";
 
 interface EntityAttrs {
   country: z.infer<typeof EntitySchema>["country"];
+  isFollowing: boolean;
   owner: z.infer<typeof EntitySchema>["owner"];
   region: z.infer<typeof EntitySchema>["region"];
 }
@@ -24,6 +26,22 @@ interface EntityAttrs {
 export const EntitySerializer = serializer({
   name: "entity",
   attrs: async (itemList: Entity[], currentUser?: User) => {
+    const itemIds = itemList.map((item) => item.id);
+    const followedEntityIds = new Set(
+      currentUser && itemIds.length
+        ? (
+            await db
+              .select({ entityId: entityFollows.entityId })
+              .from(entityFollows)
+              .where(
+                and(
+                  eq(entityFollows.userId, currentUser.id),
+                  inArray(entityFollows.entityId, itemIds),
+                ),
+              )
+          ).map(({ entityId }) => entityId)
+        : [],
+    );
     const countryIds = itemList.map((i) => i.countryId).filter(notEmpty);
     const countryList = countryIds.length
       ? await db
@@ -77,6 +95,7 @@ export const EntitySerializer = serializer({
           item.id,
           {
             country: item.countryId ? countriesById[item.countryId] : null,
+            isFollowing: followedEntityIds.has(item.id),
             owner: item.ownerId ? ownersById[item.ownerId] : null,
             region: item.regionId ? regionsById[item.regionId] : null,
           },
@@ -109,6 +128,7 @@ export const EntitySerializer = serializer({
 
       totalTastings: item.totalTastings,
       totalBottles: item.totalBottles,
+      isFollowing: attrs.isFollowing,
     };
   },
 });

--- a/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
@@ -2,7 +2,7 @@
 
 import { toTitleCase } from "@peated/server/lib/strings";
 import type { Outputs } from "@peated/server/orpc/router";
-import type { Entity, EntityKind } from "@peated/server/types";
+import type { EntityKind } from "@peated/server/types";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
@@ -14,13 +14,13 @@ import { CatalogPage } from "@peated/web/components/designSystem/patterns/catalo
 import {
   EntityCatalogFilters,
   EntityCatalogList,
-  type EntityCatalogItem,
 } from "@peated/web/components/designSystem/patterns/entityCatalog.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import useAuth from "@peated/web/hooks/useAuth";
+import useEntityFollowing from "@peated/web/hooks/useEntityFollowing";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
+import { toEntityCatalogItem } from "@peated/web/lib/entityCatalogItem";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { getEntityUrl } from "@peated/web/lib/urls";
 
 const DEFAULT_SORT = "-tastings";
 
@@ -57,6 +57,7 @@ export function EntityCatalogPageClient({
   const config = catalogConfig[kind];
   const orpc = useORPC();
   const { user } = useAuth();
+  const followControls = useEntityFollowing();
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -114,7 +115,13 @@ export function EntityCatalogPageClient({
   }
 
   const addHref = `/addEntity?kind=${kind}`;
-  const items = entityList.results.map(toCatalogItem);
+  const visibleEntities =
+    filter === "following"
+      ? entityList.results.filter(followControls.isFollowing)
+      : entityList.results;
+  const items = visibleEntities.map((entity) =>
+    toEntityCatalogItem(entity, followControls.isFollowing(entity)),
+  );
 
   return (
     <CatalogPage
@@ -185,13 +192,24 @@ export function EntityCatalogPageClient({
         )}
         noun={config.noun}
         onClear={hasFilters ? clearFilters : undefined}
+        onToggleFollowing={
+          showFollowing
+            ? (item) =>
+                followControls.toggle({
+                  id: item.id,
+                  isFollowing: item.isFollowing,
+                })
+            : undefined
+        }
         onSortChange={(value) => updateParams({ sort: value })}
         page={page}
+        pendingId={followControls.pendingId}
         previousHref={getCursorHref(
           pathname,
           searchParams,
           entityList.rel.prevCursor,
         )}
+        showFollowingMarks={filter !== "following"}
         sort={sort}
         sortOptions={sortOptions}
       />
@@ -209,26 +227,6 @@ function getScopeHref(
   else nextParams.delete("filter");
   nextParams.delete("cursor");
   return buildSearchHref(pathname, nextParams);
-}
-
-function toCatalogItem(entity: Entity): EntityCatalogItem {
-  const location = [entity.region?.name, entity.country?.name]
-    .filter((value): value is string => Boolean(value))
-    .join(", ");
-  const metadata = [
-    entity.peatedId,
-    toTitleCase(entity.kind),
-    location || null,
-  ].filter((value): value is string => value !== null);
-
-  return {
-    href: getEntityUrl(entity),
-    id: entity.peatedId,
-    metadata,
-    name: entity.name,
-    totalBottles: entity.totalBottles,
-    totalTastings: entity.totalTastings,
-  };
 }
 
 function formatRegion(region: string) {

--- a/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
@@ -21,6 +21,7 @@ const groups = [
     links: [
       { href: "/library", label: "Library" },
       { href: "/tastings", label: "Tastings" },
+      { href: "/following", label: "Following" },
       { href: "/friends", label: "Friends" },
       { href: "/settings", label: "Settings" },
     ],

--- a/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
@@ -59,6 +59,7 @@ export function ApplicationLayout({
           label: "Library",
         },
         { href: "/tastings", label: "Tastings" },
+        { href: "/following", label: "Following" },
         { href: "/friends", label: "Friends" },
       ]
     : [];

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
-import { useState, type ReactNode } from "react";
+import { type ReactNode } from "react";
 
 import {
   AppLink,
@@ -17,6 +17,7 @@ import {
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
 import Markdown from "@peated/web/components/markdown";
 import useAuth from "@peated/web/hooks/useAuth";
+import useEntityFollowing from "@peated/web/hooks/useEntityFollowing";
 import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";
 import { logTelemetryError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
@@ -40,16 +41,7 @@ import {
 
 function EntityFollowAction({ entity }: { entity: Entity }) {
   const { user } = useAuth();
-  const orpc = useORPC();
-  const queryClient = useQueryClient();
-  const { flash } = useFlashMessages();
-  const [followingOverride, setFollowingOverride] = useState<boolean | null>(
-    null,
-  );
-  const followMutation = useMutation(orpc.entities.follow.mutationOptions());
-  const unfollowMutation = useMutation(
-    orpc.entities.unfollow.mutationOptions(),
-  );
+  const followControls = useEntityFollowing();
 
   if (!user) {
     return (
@@ -64,8 +56,8 @@ function EntityFollowAction({ entity }: { entity: Entity }) {
     );
   }
 
-  const isFollowing = followingOverride ?? entity.isFollowing;
-  const pending = followMutation.isPending || unfollowMutation.isPending;
+  const isFollowing = followControls.isFollowing(entity);
+  const pending = followControls.pendingId === entity.id;
 
   return (
     <Button
@@ -75,28 +67,7 @@ function EntityFollowAction({ entity }: { entity: Entity }) {
       aria-pressed={isFollowing}
       loading={pending}
       loadingLabel={isFollowing ? "Unfollowing…" : "Following…"}
-      onClick={async () => {
-        try {
-          if (isFollowing) {
-            await unfollowMutation.mutateAsync({ entity: entity.id });
-          } else {
-            await followMutation.mutateAsync({ entity: entity.id });
-          }
-          setFollowingOverride(!isFollowing);
-          await queryClient.invalidateQueries({
-            queryKey: orpc.entities.details.key({
-              input: { entity: entity.id },
-            }),
-          });
-        } catch (error) {
-          flash(
-            error instanceof Error
-              ? error.message
-              : "We couldn't update this follow. Try again.",
-            "error",
-          );
-        }
-      }}
+      onClick={() => followControls.toggle(entity)}
       size="md"
       variant="accent"
     >

--- a/apps/web/src/app/(app)/following/followingPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/following/followingPageClient.stylex.tsx
@@ -1,0 +1,181 @@
+"use client";
+
+import type { Outputs } from "@peated/server/orpc/router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import {
+  Button,
+  ButtonLink,
+  FacetGroup,
+  FilterPanel,
+  FilterQuery,
+  PageTabs,
+} from "@peated/web/components/designSystem/components";
+import { CatalogPage } from "@peated/web/components/designSystem/patterns/catalogPage.stylex";
+import { EntityCatalogList } from "@peated/web/components/designSystem/patterns/entityCatalog.stylex";
+import useEntityFollowing from "@peated/web/hooks/useEntityFollowing";
+import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
+import { toEntityCatalogItem } from "@peated/web/lib/entityCatalogItem";
+import { useORPC } from "@peated/web/lib/orpc/context";
+
+import { getFollowingPageState } from "./followingPageData";
+
+type EntityList = Outputs["entities"]["list"];
+
+const sortOptions = [
+  { label: "Name", value: "name" },
+  { label: "Most tasted", value: "-tastings" },
+  { label: "Recently added", value: "-created" },
+] as const;
+
+const typeOptions = [
+  { label: "Distillers", value: "distillery" },
+  { label: "Brands", value: "brand" },
+  { label: "Bottlers", value: "bottler" },
+] as const;
+
+export function FollowingPageClient({
+  initialEntityList,
+}: {
+  initialEntityList: EntityList;
+}) {
+  const orpc = useORPC();
+  const followControls = useEntityFollowing();
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const state = getFollowingPageState(Object.fromEntries(searchParams));
+  const listQueryOptions = orpc.entities.list.queryOptions({
+    input: state.input,
+  });
+  const { data: entityList } = useSuspenseQuery({
+    ...listQueryOptions,
+    initialData: initialEntityList,
+  });
+  const followingHref = getViewHref(pathname, searchParams, "following");
+  const findHref = getViewHref(pathname, searchParams, "find");
+  const visibleEntities =
+    state.view === "following"
+      ? entityList.results.filter(followControls.isFollowing)
+      : entityList.results;
+  const items = visibleEntities.map((entity) =>
+    toEntityCatalogItem(entity, followControls.isFollowing(entity)),
+  );
+
+  function updateParams(updates: Record<string, string>) {
+    const nextParams = new URLSearchParams(searchParams);
+    Object.entries(updates).forEach(([name, value]) => {
+      if (value) nextParams.set(name, value);
+      else nextParams.delete(name);
+    });
+    nextParams.delete("cursor");
+    router.push(buildSearchHref(pathname, nextParams));
+  }
+
+  function clearFilters() {
+    const nextParams = new URLSearchParams(searchParams);
+    ["cursor", "query", "type"].forEach((name) => nextParams.delete(name));
+    router.push(buildSearchHref(pathname, nextParams));
+  }
+
+  const noMatches = state.hasFilters;
+
+  return (
+    <CatalogPage
+      eyebrow="Your record"
+      filters={
+        <FilterPanel ariaLabel="Following filters">
+          <FilterQuery
+            key={state.query}
+            label="Name"
+            onSubmit={(value) => updateParams({ query: value })}
+            placeholder="Distiller, brand, or bottler"
+            query={state.query}
+          />
+          <FacetGroup
+            label="Type"
+            onChange={(value) => updateParams({ type: value })}
+            options={typeOptions}
+            selected={state.type === "all" ? "" : state.type}
+          />
+          <Button align="start" onClick={clearFilters} size="sm" variant="text">
+            Clear filters
+          </Button>
+        </FilterPanel>
+      }
+      navigation={
+        <PageTabs
+          ariaLabel="Following views"
+          currentHref={state.view === "following" ? followingHref : findHref}
+          items={[
+            { href: followingHref, label: "Following" },
+            { href: findHref, label: "Find more" },
+          ]}
+        />
+      }
+      title="Following"
+    >
+      <EntityCatalogList
+        emptyAction={
+          state.view === "following" && !noMatches ? (
+            <ButtonLink href={findHref} size="sm" variant="tonal">
+              Find one
+            </ButtonLink>
+          ) : undefined
+        }
+        emptyDescription={
+          noMatches
+            ? "Try a broader search or choose another type."
+            : state.view === "following"
+              ? "Find a distiller, brand, or bottler to start."
+              : "Add the missing record if it isn't in Peated yet."
+        }
+        emptyHeading={
+          noMatches
+            ? "Nothing matches"
+            : state.view === "following"
+              ? "Nothing followed yet"
+              : "Nothing here yet"
+        }
+        items={items}
+        nextHref={getCursorHref(
+          pathname,
+          searchParams,
+          entityList.rel.nextCursor,
+        )}
+        noun="result"
+        onClear={noMatches ? clearFilters : undefined}
+        onSortChange={(value) => updateParams({ sort: value })}
+        onToggleFollowing={(item) =>
+          followControls.toggle({
+            id: item.id,
+            isFollowing: item.isFollowing,
+          })
+        }
+        page={state.cursor}
+        pendingId={followControls.pendingId}
+        previousHref={getCursorHref(
+          pathname,
+          searchParams,
+          entityList.rel.prevCursor,
+        )}
+        showFollowingMarks={state.view === "find"}
+        sort={state.sort}
+        sortOptions={sortOptions}
+      />
+    </CatalogPage>
+  );
+}
+
+function getViewHref(
+  pathname: string,
+  searchParams: { toString(): string },
+  view: "find" | "following",
+) {
+  const nextParams = new URLSearchParams(searchParams.toString());
+  if (view === "find") nextParams.set("view", "find");
+  else nextParams.delete("view");
+  nextParams.delete("cursor");
+  return buildSearchHref(pathname, nextParams);
+}

--- a/apps/web/src/app/(app)/following/followingPageData.test.ts
+++ b/apps/web/src/app/(app)/following/followingPageData.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+
+import { getFollowingPageState } from "./followingPageData";
+
+describe("getFollowingPageState", () => {
+  test("defaults to all followed records", () => {
+    expect(getFollowingPageState({})).toMatchObject({
+      cursor: 1,
+      hasFilters: false,
+      input: {
+        filter: "following",
+        kinds: ["brand", "bottler", "distillery"],
+        sort: "name",
+      },
+      type: "all",
+      view: "following",
+    });
+  });
+
+  test("builds a filtered find query", () => {
+    expect(
+      getFollowingPageState({
+        cursor: "2",
+        query: "  Ardbeg  ",
+        sort: "-tastings",
+        type: "distillery",
+        view: "find",
+      }),
+    ).toMatchObject({
+      cursor: 2,
+      hasFilters: true,
+      input: {
+        filter: "all",
+        kinds: ["distillery"],
+        query: "Ardbeg",
+        sort: "-tastings",
+      },
+      type: "distillery",
+      view: "find",
+    });
+  });
+});

--- a/apps/web/src/app/(app)/following/followingPageData.ts
+++ b/apps/web/src/app/(app)/following/followingPageData.ts
@@ -1,0 +1,63 @@
+import type { EntityKind } from "@peated/server/types";
+
+export type FollowingPageSearchParams = Record<
+  string,
+  string | string[] | undefined
+>;
+export type FollowingType = "all" | "brand" | "bottler" | "distillery";
+export type FollowingView = "find" | "following";
+
+const followableKinds = [
+  "brand",
+  "bottler",
+  "distillery",
+] as const satisfies readonly EntityKind[];
+const sortValues = ["name", "-created", "-tastings"] as const;
+
+export function getFollowingPageState(params: FollowingPageSearchParams) {
+  const view: FollowingView =
+    readParam(params, "view") === "find" ? "find" : "following";
+  const type = parseType(readParam(params, "type"));
+  const query = readParam(params, "query").trim();
+  const cursor = parseCursor(readParam(params, "cursor"));
+  const requestedSort = readParam(params, "sort");
+  const sort = isSortValue(requestedSort) ? requestedSort : "name";
+  const kinds: EntityKind[] = type === "all" ? [...followableKinds] : [type];
+
+  return {
+    cursor,
+    hasFilters: Boolean(query || type !== "all"),
+    input: {
+      cursor,
+      filter: view === "following" ? "following" : "all",
+      kinds,
+      limit: 50,
+      query,
+      sort,
+    } as const,
+    query,
+    sort,
+    type,
+    view,
+  };
+}
+
+function readParam(params: FollowingPageSearchParams, name: string) {
+  const value = params[name];
+  return Array.isArray(value) ? (value[0] ?? "") : (value ?? "");
+}
+
+function parseType(value: string): FollowingType {
+  return value === "brand" || value === "bottler" || value === "distillery"
+    ? value
+    : "all";
+}
+
+function parseCursor(value: string) {
+  const cursor = Number.parseInt(value, 10);
+  return Number.isInteger(cursor) && cursor > 0 ? cursor : 1;
+}
+
+function isSortValue(value: string): value is (typeof sortValues)[number] {
+  return sortValues.some((sort) => sort === value);
+}

--- a/apps/web/src/app/(app)/following/loading.tsx
+++ b/apps/web/src/app/(app)/following/loading.tsx
@@ -1,0 +1,5 @@
+import { CatalogPageLoading } from "@peated/web/components/designSystem/patterns/catalogPage.stylex";
+
+export default function FollowingLoading() {
+  return <CatalogPageLoading title="Following" />;
+}

--- a/apps/web/src/app/(app)/following/page.tsx
+++ b/apps/web/src/app/(app)/following/page.tsx
@@ -1,0 +1,26 @@
+import { redirectToAuth } from "@peated/web/lib/auth";
+import { isLoggedIn } from "@peated/web/lib/auth.server";
+import { getServerClient } from "@peated/web/lib/orpc/client.server";
+import type { Metadata } from "next";
+
+import { FollowingPageClient } from "./followingPageClient.stylex";
+import {
+  getFollowingPageState,
+  type FollowingPageSearchParams,
+} from "./followingPageData";
+
+export const metadata: Metadata = { title: "Following" };
+
+export default async function FollowingPage(props: {
+  searchParams: Promise<FollowingPageSearchParams>;
+}) {
+  if (!(await isLoggedIn())) {
+    redirectToAuth({ pathname: "/following" });
+  }
+
+  const state = getFollowingPageState(await props.searchParams);
+  const { client } = await getServerClient();
+  const entityList = await client.entities.list(state.input);
+
+  return <FollowingPageClient initialEntityList={entityList} />;
+}

--- a/apps/web/src/components/admin/moderation/llmExport.test.ts
+++ b/apps/web/src/components/admin/moderation/llmExport.test.ts
@@ -24,6 +24,7 @@ const brand = {
   location: null,
   totalTastings: 0,
   totalBottles: 1,
+  isFollowing: false,
   createdAt: timestamp,
   updatedAt: timestamp,
 } satisfies QueueBottle["brand"];

--- a/apps/web/src/components/admin/reviewTable.test.tsx
+++ b/apps/web/src/components/admin/reviewTable.test.tsx
@@ -23,6 +23,7 @@ const brand = {
   location: null,
   totalTastings: 0,
   totalBottles: 1,
+  isFollowing: false,
   createdAt: timestamp,
   updatedAt: timestamp,
 } satisfies Entity;

--- a/apps/web/src/components/admin/storePriceTable.test.tsx
+++ b/apps/web/src/components/admin/storePriceTable.test.tsx
@@ -23,6 +23,7 @@ const brand = {
   location: null,
   totalTastings: 0,
   totalBottles: 1,
+  isFollowing: false,
   createdAt: timestamp,
   updatedAt: timestamp,
 } satisfies Entity;

--- a/apps/web/src/components/bottleResolver/states.test.tsx
+++ b/apps/web/src/components/bottleResolver/states.test.tsx
@@ -30,6 +30,7 @@ function makeBottle(overrides: Partial<Bottle> = {}): Bottle {
       location: null,
       totalTastings: 0,
       totalBottles: 1,
+      isFollowing: false,
       createdAt: timestamp,
       updatedAt: timestamp,
     },

--- a/apps/web/src/components/designSystem/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/bottleIdentityRow.stylex.tsx
@@ -11,6 +11,7 @@ import {
 import { AppLink } from "./appLink";
 import type { ItemListVariant } from "./itemList.stylex";
 import { linkedRowStyles } from "./linkedRow.stylex";
+import { MemberStatusMark } from "./memberStatusMark.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
 const bottleIconUrl = "/assets/bottle.svg";
@@ -67,49 +68,6 @@ export type BottleIdentityRowProps = {
   };
   variant?: ItemListVariant;
 };
-
-function LibraryStatusMark() {
-  return (
-    <svg
-      aria-hidden="true"
-      fill="none"
-      focusable="false"
-      height="12"
-      viewBox="0 0 16 16"
-      width="12"
-    >
-      <path
-        d="M8 4.2C6.9 3.4 5.4 3 3.5 3H2v9h1.5c1.9 0 3.4.4 4.5 1.2 1.1-.8 2.6-1.2 4.5-1.2H14V3h-1.5C10.6 3 9.1 3.4 8 4.2Z"
-        stroke="currentColor"
-        strokeLinejoin="round"
-        strokeWidth="1.4"
-      />
-      <path d="M8 4.4v8.8" stroke="currentColor" strokeWidth="1.4" />
-    </svg>
-  );
-}
-
-function TastedStatusMark() {
-  return (
-    <svg
-      aria-hidden="true"
-      fill="none"
-      focusable="false"
-      height="12"
-      viewBox="0 0 16 16"
-      width="12"
-    >
-      <circle cx="8" cy="8" r="5.6" stroke="currentColor" strokeWidth="1.4" />
-      <path
-        d="M5.6 8.2 7.3 9.9l3.1-3.5"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="1.6"
-      />
-    </svg>
-  );
-}
 
 /** Presents one catalog bottle using Peated's existing identity and member-status meanings. */
 export function BottleIdentityRow({
@@ -170,26 +128,8 @@ export function BottleIdentityRow({
           ) : (
             <span {...stylex.props(styles.name)}>{name}</span>
           )}
-          {isLibrary ? (
-            <span
-              aria-label="In Library"
-              role="img"
-              title="In Library"
-              {...stylex.props(styles.status)}
-            >
-              <LibraryStatusMark />
-            </span>
-          ) : null}
-          {hasTasted ? (
-            <span
-              aria-label="Tasted"
-              role="img"
-              title="Tasted"
-              {...stylex.props(styles.status)}
-            >
-              <TastedStatusMark />
-            </span>
-          ) : null}
+          {isLibrary ? <MemberStatusMark kind="library" /> : null}
+          {hasTasted ? <MemberStatusMark kind="tasted" /> : null}
         </div>
         {metadata.length ? (
           <div {...stylex.props(styles.metadata)}>
@@ -357,12 +297,6 @@ const styles = stylex.create({
     },
     textDecorationThickness: "1px",
     textUnderlineOffset: "2px",
-  },
-  status: {
-    display: "inline-flex",
-    marginLeft: "6px",
-    color: colors.inkMuted,
-    verticalAlign: "-1px",
   },
   metadata: {
     maxWidth: "100%",

--- a/apps/web/src/components/designSystem/components/index.ts
+++ b/apps/web/src/components/designSystem/components/index.ts
@@ -168,6 +168,8 @@ export type {
   MemberPickerOption,
   MemberPickerProps,
 } from "./memberPicker.stylex";
+export { MemberStatusMark } from "./memberStatusMark.stylex";
+export type { MemberStatusMarkKind } from "./memberStatusMark.stylex";
 export { NotePickerField } from "./notePicker.stylex";
 export type {
   NotePickerFieldProps,

--- a/apps/web/src/components/designSystem/components/memberStatusMark.stories.tsx
+++ b/apps/web/src/components/designSystem/components/memberStatusMark.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { StoryCanvas, StoryStack } from "../storyFixtures.stylex";
+import { MemberStatusMark } from "./memberStatusMark.stylex";
+
+const meta = {
+  title: "Components/Data Display/Member Status Mark",
+  component: MemberStatusMark,
+  decorators: [
+    (Story) => (
+      <StoryCanvas>
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+  args: { kind: "following" },
+} satisfies Meta<typeof MemberStatusMark>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {
+  render: () => (
+    <StoryStack>
+      <span>
+        Ardbeg
+        <MemberStatusMark kind="following" />
+      </span>
+      <span>
+        Uigeadail
+        <MemberStatusMark kind="library" />
+      </span>
+      <span>
+        Corryvreckan
+        <MemberStatusMark kind="tasted" />
+      </span>
+    </StoryStack>
+  ),
+};

--- a/apps/web/src/components/designSystem/components/memberStatusMark.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/memberStatusMark.stylex.tsx
@@ -1,0 +1,106 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { colors } from "../../../styles/tokens.stylex";
+
+export type MemberStatusMarkKind = "following" | "library" | "tasted";
+
+const labels = {
+  following: "Following",
+  library: "In Library",
+  tasted: "Tasted",
+} satisfies Record<MemberStatusMarkKind, string>;
+
+/** Marks personal state beside a record name without acting as a control. */
+export function MemberStatusMark({ kind }: { kind: MemberStatusMarkKind }) {
+  const label = labels[kind];
+
+  return (
+    <span
+      aria-label={label}
+      role="img"
+      title={label}
+      {...stylex.props(styles.status)}
+    >
+      {kind === "library" ? (
+        <LibraryMark />
+      ) : kind === "tasted" ? (
+        <TastedMark />
+      ) : (
+        <FollowingMark />
+      )}
+    </span>
+  );
+}
+
+function LibraryMark() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      focusable="false"
+      height="12"
+      viewBox="0 0 16 16"
+      width="12"
+    >
+      <path
+        d="M8 4.2C6.9 3.4 5.4 3 3.5 3H2v9h1.5c1.9 0 3.4.4 4.5 1.2 1.1-.8 2.6-1.2 4.5-1.2H14V3h-1.5C10.6 3 9.1 3.4 8 4.2Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.4"
+      />
+      <path d="M8 4.4v8.8" stroke="currentColor" strokeWidth="1.4" />
+    </svg>
+  );
+}
+
+function TastedMark() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      focusable="false"
+      height="12"
+      viewBox="0 0 16 16"
+      width="12"
+    >
+      <circle cx="8" cy="8" r="5.6" stroke="currentColor" strokeWidth="1.4" />
+      <path
+        d="M5.6 8.2 7.3 9.9l3.1-3.5"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth="1.6"
+      />
+    </svg>
+  );
+}
+
+function FollowingMark() {
+  return (
+    <svg
+      aria-hidden="true"
+      fill="none"
+      focusable="false"
+      height="12"
+      viewBox="0 0 16 16"
+      width="12"
+    >
+      <path
+        d="M1.6 8s2.2-3.5 6.4-3.5S14.4 8 14.4 8 12.2 11.5 8 11.5 1.6 8 1.6 8Z"
+        stroke="currentColor"
+        strokeLinejoin="round"
+        strokeWidth="1.4"
+      />
+      <circle cx="8" cy="8" r="1.5" stroke="currentColor" strokeWidth="1.4" />
+    </svg>
+  );
+}
+
+const styles = stylex.create({
+  status: {
+    display: "inline-flex",
+    marginLeft: "6px",
+    color: colors.inkMuted,
+    verticalAlign: "-1px",
+  },
+});

--- a/apps/web/src/components/designSystem/components/searchResults.stylex.tsx
+++ b/apps/web/src/components/designSystem/components/searchResults.stylex.tsx
@@ -11,6 +11,7 @@ import {
 import { AppLink } from "./appLink";
 import { Button } from "./button.stylex";
 import { FloatingPanel } from "./feedback.stylex";
+import { MemberStatusMark } from "./memberStatusMark.stylex";
 import { RatingMeasure, type BandCounts } from "./scoring.stylex";
 
 const COMPACT = "@media (max-width: 559px)";
@@ -26,6 +27,7 @@ export type SearchResultMeasure = {
 export type SearchResultItem = {
   href: string;
   id: string;
+  isFollowing?: boolean;
   measures?: SearchResultMeasure;
   metadata?: string;
   title: string;
@@ -229,6 +231,9 @@ function SearchResultsGroup({
               <span {...stylex.props(styles.copy)}>
                 <strong {...stylex.props(styles.title)}>
                   <MatchedText query={query} text={item.title} />
+                  {item.isFollowing ? (
+                    <MemberStatusMark kind="following" />
+                  ) : null}
                 </strong>
                 {item.metadata ? (
                   <span {...stylex.props(styles.metadata)}>

--- a/apps/web/src/components/designSystem/patterns/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/designSystem/patterns/entityCatalog.stylex.tsx
@@ -15,6 +15,7 @@ import {
   ItemList,
   ItemRow,
   ListToolbar,
+  MemberStatusMark,
   type ListSortOption,
 } from "../components";
 import { CatalogPageLoading } from "./catalogPage.stylex";
@@ -23,7 +24,8 @@ const COMPACT = "@media (max-width: 639px)";
 
 export type EntityCatalogItem = {
   href: string;
-  id: string;
+  id: number;
+  isFollowing: boolean;
   metadata: readonly string[];
   name: string;
   totalBottles: number;
@@ -31,7 +33,7 @@ export type EntityCatalogItem = {
 };
 
 export type EntityCatalogListProps = {
-  addHref: string;
+  addHref?: string;
   emptyAction?: ReactNode;
   emptyDescription?: ReactNode;
   emptyHeading?: string;
@@ -39,9 +41,12 @@ export type EntityCatalogListProps = {
   nextHref?: string;
   noun: string;
   onClear?: () => void;
+  onToggleFollowing?: (item: EntityCatalogItem) => void;
   onSortChange: (value: string) => void;
   page: number;
+  pendingId?: number;
   previousHref?: string;
+  showFollowingMarks?: boolean;
   sort: string;
   sortOptions: readonly [ListSortOption, ...ListSortOption[]];
 };
@@ -56,9 +61,12 @@ export function EntityCatalogList({
   nextHref,
   noun,
   onClear,
+  onToggleFollowing,
   onSortChange,
   page,
+  pendingId,
   previousHref,
+  showFollowingMarks = true,
   sort,
   sortOptions,
 }: EntityCatalogListProps) {
@@ -75,11 +83,39 @@ export function EntityCatalogList({
         <ItemList ariaLabel={`${noun} records`} showTopDivider={false}>
           {items.map((item) => (
             <ItemRow
+              action={
+                onToggleFollowing ? (
+                  <Button
+                    aria-label={
+                      item.isFollowing
+                        ? `Unfollow ${item.name}`
+                        : `Follow ${item.name}`
+                    }
+                    aria-pressed={item.isFollowing}
+                    loading={pendingId === item.id}
+                    loadingLabel={
+                      item.isFollowing ? "Unfollowing…" : "Following…"
+                    }
+                    onClick={() => onToggleFollowing(item)}
+                    size="sm"
+                    variant={item.isFollowing ? "text" : "tonal"}
+                  >
+                    {item.isFollowing ? "Following" : "Follow"}
+                  </Button>
+                ) : undefined
+              }
               end={<EntityMeasures item={item} />}
               href={item.href}
               key={item.id}
               metadata={item.metadata.join(" · ")}
-              title={item.name}
+              title={
+                <>
+                  {item.name}
+                  {item.isFollowing && showFollowingMarks ? (
+                    <MemberStatusMark kind="following" />
+                  ) : null}
+                </>
+              }
             />
           ))}
         </ItemList>
@@ -91,11 +127,11 @@ export function EntityCatalogList({
               <Button onClick={onClear} size="sm" variant="tonal">
                 Clear filters
               </Button>
-            ) : (
+            ) : addHref ? (
               <ButtonLink href={addHref} size="sm" variant="tonal">
                 Add {noun}
               </ButtonLink>
-            ))
+            ) : undefined)
           }
           heading={emptyHeading ?? `No ${noun}s found`}
         >
@@ -116,6 +152,7 @@ function EntityMeasures({ item }: { item: EntityCatalogItem }) {
   return (
     <span
       aria-label={`${item.totalBottles.toLocaleString("en-US")} bottles and ${item.totalTastings.toLocaleString("en-US")} tastings`}
+      role="group"
       {...stylex.props(styles.measures)}
     >
       <span {...stylex.props(styles.measure)}>

--- a/apps/web/src/components/designSystem/patterns/following.stories.tsx
+++ b/apps/web/src/components/designSystem/patterns/following.stories.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
+
+import {
+  Button,
+  FacetGroup,
+  FilterPanel,
+  FilterQuery,
+  PageTabs,
+} from "../components";
+import { StoryCanvas } from "../storyFixtures.stylex";
+import { CatalogPage } from "./catalogPage.stylex";
+import {
+  EntityCatalogList,
+  type EntityCatalogItem,
+} from "./entityCatalog.stylex";
+
+const initialItems = [
+  {
+    href: "/distillers/E0034",
+    id: 34,
+    isFollowing: true,
+    metadata: ["E0034", "Distillery", "Islay, Scotland"],
+    name: "Ardbeg",
+    totalBottles: 284,
+    totalTastings: 3187,
+  },
+  {
+    href: "/brands/E0201",
+    id: 201,
+    isFollowing: false,
+    metadata: ["E0201", "Brand", "Japan"],
+    name: "Nikka",
+    totalBottles: 146,
+    totalTastings: 982,
+  },
+  {
+    href: "/bottlers/E0312",
+    id: 312,
+    isFollowing: false,
+    metadata: ["E0312", "Bottler", "London, England"],
+    name: "Berry Bros. & Rudd",
+    totalBottles: 417,
+    totalTastings: 624,
+  },
+  {
+    href: "/distillers/E0022",
+    id: 22,
+    isFollowing: true,
+    metadata: ["E0022", "Distillery", "Islay, Scotland"],
+    name: "Laphroaig",
+    totalBottles: 231,
+    totalTastings: 2741,
+  },
+] satisfies readonly EntityCatalogItem[];
+
+const meta = {
+  title: "Patterns/Following",
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="page">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const FindMore: Story = {
+  render: () => <FollowingScenario />,
+};
+
+function FollowingScenario() {
+  const [items, setItems] = useState(initialItems);
+  const [query, setQuery] = useState("");
+  const [type, setType] = useState("");
+  const visibleItems = items.filter((item) => {
+    const matchesQuery = item.name.toLowerCase().includes(query.toLowerCase());
+    const matchesType = !type || item.metadata[1]?.toLowerCase() === type;
+    return matchesQuery && matchesType;
+  });
+
+  function clearFilters() {
+    setQuery("");
+    setType("");
+  }
+
+  function toggleFollowing(item: EntityCatalogItem) {
+    setItems((current) =>
+      current.map((candidate) =>
+        candidate.id === item.id
+          ? { ...candidate, isFollowing: !candidate.isFollowing }
+          : candidate,
+      ),
+    );
+  }
+
+  return (
+    <CatalogPage
+      eyebrow="Your record"
+      filters={
+        <FilterPanel ariaLabel="Following filters">
+          <FilterQuery
+            label="Name"
+            onSubmit={setQuery}
+            placeholder="Distiller, brand, or bottler"
+            query={query}
+          />
+          <FacetGroup
+            label="Type"
+            onChange={setType}
+            options={[
+              { label: "Distillers", value: "distillery" },
+              { label: "Brands", value: "brand" },
+              { label: "Bottlers", value: "bottler" },
+            ]}
+            selected={type}
+          />
+          <Button align="start" onClick={clearFilters} size="sm" variant="text">
+            Clear filters
+          </Button>
+        </FilterPanel>
+      }
+      navigation={
+        <PageTabs
+          ariaLabel="Following views"
+          currentHref="/following?view=find"
+          items={[
+            { href: "/following", label: "Following" },
+            { href: "/following?view=find", label: "Find more" },
+          ]}
+        />
+      }
+      title="Following"
+    >
+      <EntityCatalogList
+        emptyDescription="Try a broader search or choose another type."
+        emptyHeading="Nothing matches"
+        items={visibleItems}
+        noun="result"
+        onClear={clearFilters}
+        onSortChange={() => undefined}
+        onToggleFollowing={toggleFollowing}
+        page={1}
+        showFollowingMarks
+        sort="name"
+        sortOptions={[
+          { label: "Name", value: "name" },
+          { label: "Most tasted", value: "-tastings" },
+          { label: "Recently added", value: "-created" },
+        ]}
+      />
+    </CatalogPage>
+  );
+}

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -109,8 +109,8 @@ function getApiScopes(scope: SearchScope, signedIn: boolean) {
 function getSearchingText(scope: SearchScope, signedIn: boolean) {
   if (scope === "all") {
     return signedIn
-      ? "Searching bottles, entities, and members…"
-      : "Searching bottles and entities…";
+      ? "Searching bottles, distillers, brands, bottlers, and members…"
+      : "Searching bottles, distillers, brands, and bottlers…";
   }
   const label = searchScopes.find((option) => option.value === scope)?.label;
   return label ? `Searching ${label.toLocaleLowerCase()}…` : "Searching…";
@@ -158,6 +158,7 @@ function entityItem(entity: EntitySearchResult) {
   return {
     href: getEntityUrl(entity),
     id: `entity-${entity.id}`,
+    isFollowing: entity.isFollowing,
     metadata: entity.region?.name,
     title: entity.name,
     visual: {

--- a/apps/web/src/hooks/useEntityFollowing.tsx
+++ b/apps/web/src/hooks/useEntityFollowing.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import type { Entity } from "@peated/server/types";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import { useORPC } from "@peated/web/lib/orpc/context";
+
+export default function useEntityFollowing() {
+  const orpc = useORPC();
+  const queryClient = useQueryClient();
+  const { flash } = useFlashMessages();
+  const [overrides, setOverrides] = useState<Record<number, boolean>>({});
+  const [pendingId, setPendingId] = useState<number>();
+  const followMutation = useMutation(orpc.entities.follow.mutationOptions());
+  const unfollowMutation = useMutation(
+    orpc.entities.unfollow.mutationOptions(),
+  );
+  function isFollowing(entity: Pick<Entity, "id" | "isFollowing">) {
+    return overrides[entity.id] ?? entity.isFollowing;
+  }
+
+  async function toggle(entity: Pick<Entity, "id" | "isFollowing">) {
+    const current = isFollowing(entity);
+    setPendingId(entity.id);
+
+    try {
+      if (current) {
+        await unfollowMutation.mutateAsync({ entity: entity.id });
+      } else {
+        await followMutation.mutateAsync({ entity: entity.id });
+      }
+      setOverrides((values) => ({ ...values, [entity.id]: !current }));
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: orpc.entities.key() }),
+        queryClient.invalidateQueries({ queryKey: orpc.brands.key() }),
+        queryClient.invalidateQueries({ queryKey: orpc.bottlers.key() }),
+        queryClient.invalidateQueries({ queryKey: orpc.distilleries.key() }),
+        queryClient.invalidateQueries({ queryKey: orpc.bottles.key() }),
+        queryClient.invalidateQueries({ queryKey: orpc.search.key() }),
+      ]);
+    } catch (error) {
+      flash(
+        error instanceof Error
+          ? error.message
+          : "We couldn't update this follow. Try again.",
+        "error",
+      );
+    } finally {
+      setPendingId(undefined);
+    }
+  }
+
+  return { isFollowing, pendingId, toggle };
+}

--- a/apps/web/src/lib/entityCatalogItem.ts
+++ b/apps/web/src/lib/entityCatalogItem.ts
@@ -1,0 +1,29 @@
+import { toTitleCase } from "@peated/server/lib/strings";
+import type { Entity } from "@peated/server/types";
+
+import type { EntityCatalogItem } from "@peated/web/components/designSystem/patterns/entityCatalog.stylex";
+import { getEntityUrl } from "@peated/web/lib/urls";
+
+export function toEntityCatalogItem(
+  entity: Entity,
+  isFollowing = entity.isFollowing,
+): EntityCatalogItem {
+  const location = [entity.region?.name, entity.country?.name]
+    .filter((value): value is string => Boolean(value))
+    .join(", ");
+  const metadata = [
+    entity.peatedId,
+    toTitleCase(entity.kind),
+    location || null,
+  ].filter((value): value is string => value !== null);
+
+  return {
+    href: getEntityUrl(entity),
+    id: entity.id,
+    isFollowing,
+    metadata,
+    name: entity.name,
+    totalBottles: entity.totalBottles,
+    totalTastings: entity.totalTastings,
+  };
+}


### PR DESCRIPTION
Adds a signed-in Following page that brings followed distillers, brands, and bottlers into one searchable catalog. The Find more view supports inline follow and unfollow actions, the same controls now appear in the existing catalog lists, and a small eye marker carries followed state into discovery lists and search results.

Entity list responses now include the current member's follow state and support multi-kind filters. The follow boundary also rejects companies so the API matches the records exposed by the interface. Review the complete interactive treatment in Storybook under `Patterns / Following / Find More`; backend and web coverage exercise the new list state and supported record kinds.
