### PR TITLE
fix(smws): resolve codes to distillery entities

### DIFF
--- a/apps/server/src/orpc/routes/smws/distiller-list.test.ts
+++ b/apps/server/src/orpc/routes/smws/distiller-list.test.ts
@@ -1,7 +1,17 @@
+import { db } from "@peated/server/db";
+import { entityAliases } from "@peated/server/db/schema";
 import { routerClient } from "@peated/server/orpc/router";
+import { eq } from "drizzle-orm";
 
 describe("GET /smws/distillers", () => {
-  test("lists distillers", async ({ fixtures }) => {
+  test("lists distillers by canonical name or alias", async ({ fixtures }) => {
+    const cascadeHollow = await fixtures.Entity({
+      name: "Cascade Hollow",
+    });
+    await db
+      .delete(entityAliases)
+      .where(eq(entityAliases.entityId, cascadeHollow.id));
+
     const nikka = await fixtures.Entity({
       name: "Nikka",
     });
@@ -10,9 +20,7 @@ describe("GET /smws/distillers", () => {
       name: "Nikka Coffey Grain",
     });
 
-    const macallan = await fixtures.Entity({
-      name: "Macallan",
-    });
+    await fixtures.Entity({ name: "Not an SMWS distiller" });
 
     const user = await fixtures.User({ mod: true });
     const { results } = await routerClient.smws.distillerList(
@@ -20,6 +28,8 @@ describe("GET /smws/distillers", () => {
       { context: { user } },
     );
 
-    expect(results.length).toBe(2);
+    expect(new Set(results.map((result) => result.id))).toEqual(
+      new Set([cascadeHollow.id, nikka.id]),
+    );
   });
 });

--- a/apps/server/src/orpc/routes/smws/distiller-list.test.ts
+++ b/apps/server/src/orpc/routes/smws/distiller-list.test.ts
@@ -4,23 +4,31 @@ import { routerClient } from "@peated/server/orpc/router";
 import { eq } from "drizzle-orm";
 
 describe("GET /smws/distillers", () => {
-  test("lists distillers by canonical name or alias", async ({ fixtures }) => {
+  test("lists distilleries by canonical name or alias", async ({
+    fixtures,
+  }) => {
     const cascadeHollow = await fixtures.Entity({
       name: "Cascade Hollow",
+      kind: "distillery",
     });
     await db
       .delete(entityAliases)
       .where(eq(entityAliases.entityId, cascadeHollow.id));
 
-    const nikka = await fixtures.Entity({
-      name: "Nikka",
+    const theGlenlivet = await fixtures.Entity({
+      name: "The Glenlivet",
+      kind: "distillery",
     });
     await fixtures.EntityAlias({
-      entityId: nikka.id,
-      name: "Nikka Coffey Grain",
+      entityId: theGlenlivet.id,
+      name: "Glenlivet",
     });
 
-    await fixtures.Entity({ name: "Not an SMWS distiller" });
+    await fixtures.Entity({ name: "Bowmore", kind: "company" });
+    await fixtures.Entity({
+      name: "Not an SMWS distillery",
+      kind: "distillery",
+    });
 
     const user = await fixtures.User({ mod: true });
     const { results } = await routerClient.smws.distillerList(
@@ -29,7 +37,7 @@ describe("GET /smws/distillers", () => {
     );
 
     expect(new Set(results.map((result) => result.id))).toEqual(
-      new Set([cascadeHollow.id, nikka.id]),
+      new Set([cascadeHollow.id, theGlenlivet.id]),
     );
   });
 });

--- a/apps/server/src/orpc/routes/smws/distiller-list.ts
+++ b/apps/server/src/orpc/routes/smws/distiller-list.ts
@@ -10,13 +10,17 @@ import { sql } from "drizzle-orm";
 export default implement(smwsDistillerListContract).handler(async function ({
   context,
 }) {
+  const distilleryNames = Object.values(SMWS_DISTILLERY_CODES).map((name) =>
+    name.toLowerCase(),
+  );
   const results = await db
     .select()
     .from(entities)
     .where(
-      sql`${entities.id} IN (
+      sql`LOWER(${entities.name}) IN ${distilleryNames}
+        OR ${entities.id} IN (
           SELECT ${entityAliases.entityId} FROM ${entityAliases}
-          WHERE LOWER(${entityAliases.name}) IN ${Object.values(SMWS_DISTILLERY_CODES).map((s) => s.toLowerCase())}
+          WHERE LOWER(${entityAliases.name}) IN ${distilleryNames}
         )`,
     );
 

--- a/apps/server/src/orpc/routes/smws/distiller-list.ts
+++ b/apps/server/src/orpc/routes/smws/distiller-list.ts
@@ -5,7 +5,7 @@ import { implement } from "@peated/server/orpc";
 import smwsDistillerListContract from "@peated/server/orpc/contracts/smws/distiller-list";
 import { serialize } from "@peated/server/serializers";
 import { EntitySerializer } from "@peated/server/serializers/entity";
-import { sql } from "drizzle-orm";
+import { and, eq, sql } from "drizzle-orm";
 
 export default implement(smwsDistillerListContract).handler(async function ({
   context,
@@ -17,11 +17,14 @@ export default implement(smwsDistillerListContract).handler(async function ({
     .select()
     .from(entities)
     .where(
-      sql`LOWER(${entities.name}) IN ${distilleryNames}
-        OR ${entities.id} IN (
-          SELECT ${entityAliases.entityId} FROM ${entityAliases}
-          WHERE LOWER(${entityAliases.name}) IN ${distilleryNames}
-        )`,
+      and(
+        eq(entities.kind, "distillery"),
+        sql`(LOWER(${entities.name}) IN ${distilleryNames}
+          OR ${entities.id} IN (
+            SELECT ${entityAliases.entityId} FROM ${entityAliases}
+            WHERE LOWER(${entityAliases.name}) IN ${distilleryNames}
+          ))`,
+      ),
     );
 
   return {

--- a/packages/bottle-classifier/src/smws.test.ts
+++ b/packages/bottle-classifier/src/smws.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  SMWS_DISTILLERY_CODES,
   composeExactCaskCodeFromComponents,
   getCategoryFromCask,
   parseDetailsFromName,
@@ -25,6 +26,27 @@ describe("smws", () => {
     expect(getCategoryFromCask("R2.19")).toBeNull();
     expect(getCategoryFromCask("A5.6")).toBeNull();
     expect(getCategoryFromCask("GN1.1")).toBeNull();
+  });
+
+  test("maps producer labels to canonical distillery entities", () => {
+    expect(SMWS_DISTILLERY_CODES).toMatchObject({
+      52: "Pulteney Distillery",
+      121: "Lochranza",
+      134: "Paul John Distillery",
+      140: "Balcones Distilling",
+      146: "Cotswolds Distillery",
+      153: "Thy Whisky Distillery",
+      157: "Distillerie Warenghem",
+      G11: "Miyagikyo",
+      G12: "Miyagikyo",
+      B1: "Heaven Hill Distillery",
+      B2: "Heaven Hill Bernheim Distillery",
+      B3: "Rock Town Distillery",
+      RW4: "Kentucky Peerless Distilling Co.",
+      CW1: "Heaven Hill Distillery",
+      CW2: "Balcones Distilling",
+      GN7: "Cotswolds Distillery",
+    });
   });
 
   test("parses SMWS reference titles into code identity and selector", () => {

--- a/packages/bottle-classifier/src/smws.ts
+++ b/packages/bottle-classifier/src/smws.ts
@@ -64,7 +64,7 @@ export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   49: "St. Magdalene",
   50: "Bladnoch",
   51: "Bushmills",
-  52: "Old Pulteney",
+  52: "Pulteney Distillery", // Old Pulteney
   53: "Caol Ila",
   54: "Aberlour",
   55: "Royal Brackla",
@@ -133,7 +133,7 @@ export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   118: "Cooley", // Connemara (Peated)
   119: "Yamazaki",
   120: "Hakushu",
-  121: "Isle of Arran",
+  121: "Lochranza", // Isle of Arran
   122: "Loch Lomond", // Croftengea
   123: "Glengoyne",
   124: "Miyagikyo",
@@ -146,30 +146,30 @@ export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   131: "Hanyu",
   132: "Karuizawa",
   133: "Westland",
-  134: "Paul John",
+  134: "Paul John Distillery",
   135: "Loch Lomond", // Inchmoan
   136: "Eden Mill",
   137: "St. George's",
   138: "Nantou",
   139: "Kavalan",
-  140: "Balcones",
+  140: "Balcones Distilling", // Balcones
   141: "Fary Lochan",
   142: "Breuckelen Distilling",
   143: "Copperworks Distilling Co.",
   144: "High Coast Distillery",
   145: "Smögen Whisky",
-  146: "Cotswolds",
+  146: "Cotswolds Distillery",
   147: "Archie Rose",
   148: "Starward",
   149: "Ardnamurchan",
   150: "West Cork Distillers",
   151: "Mackmyra",
   152: "Shelter Point",
-  153: "Thy Whisky",
+  153: "Thy Whisky Distillery",
   154: "Mosgaard Whisky",
   155: "Milk & Honey Distillery",
   156: "Glasgow Distillery",
-  157: "Armorik",
+  157: "Distillerie Warenghem", // Armorik
   158: "Yuza",
   159: "Mars Shinshu",
   160: "Mars Tsunuki",
@@ -193,17 +193,17 @@ export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   G8: "Cambus",
   G9: "Loch Lomond",
   G10: "Strathclyde",
-  G11: "Nikka Coffey Grain",
-  G12: "Nikka Coffey Malt",
+  G11: "Miyagikyo", // Nikka Coffey Grain
+  G12: "Miyagikyo", // Nikka Coffey Malt
   G13: "Chita",
   G14: "Dumbarton",
   G15: "Loch Lomond", // Rhosdhu
   G16: "Glasgow Distillery",
 
   // Bourbon
-  B1: "Heaven Hill",
-  B2: "Bernheim",
-  B3: "Rock Town",
+  B1: "Heaven Hill Distillery",
+  B2: "Heaven Hill Bernheim Distillery",
+  B3: "Rock Town Distillery",
   B4: "FEW Spirits",
   B5: "Cascade Hollow",
   B6: "Finger Lakes Distilling",
@@ -214,14 +214,14 @@ export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   RW1: "FEW Spirits",
   RW2: "Finger Lakes Distilling",
   RW3: "New York Distilling Co.",
-  RW4: "Peerless",
+  RW4: "Kentucky Peerless Distilling Co.",
   RW5: "Lux Row Distillers",
   RW6: "Kyrö",
   RW7: "Journeyman",
 
   // Corn
-  CW1: "Heaven Hill",
-  CW2: "Baclones",
+  CW1: "Heaven Hill Distillery",
+  CW2: "Balcones Distilling", // Balcones
 
   // Rum
   R1: "Monymusk",
@@ -267,7 +267,7 @@ export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   GN4: "Boatyard Distillery",
   GN5: "Scottish Gin",
   GN6: "Holyrood Distillery",
-  GN7: "Cotswolds",
+  GN7: "Cotswolds Distillery",
 };
 
 export const SMWS_CATEGORY_LIST = [


### PR DESCRIPTION
The SMWS distiller endpoint now resolves curated producer names through either a canonical Entity name or an alias, and it only returns Entities whose kind is `distillery`. This restores canonical-name-only targets such as Cascade Hollow and prevents matching aliases on brand or company records.

The curated code table now points brand-facing labels at their actual production distilleries, including Pulteney, Lochranza, Miyagikyo, Warenghem, Cotswolds, Heaven Hill, Bernheim, Rock Town, Peerless, and Balcones. Focused coverage locks those mappings and proves the endpoint's name, alias, and Entity-kind boundaries.

The required production catalog updates are already applied. A full audit of all 239 codes now resolves 218 distinct target names with no missing, ambiguous, or non-distillery mappings. Missing producer records were created from authoritative sources; fields that could not be verified were left unset.
