### PR TITLE
fix(bottles): move release facts out of names

### DIFF
--- a/apps/server/src/lib/bottleDisplayName.test.ts
+++ b/apps/server/src/lib/bottleDisplayName.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { formatBottleDisplayName } from "./bottleDisplayName";
+import {
+  formatBottleDisplayName,
+  getBottleReleaseMetadata,
+} from "./bottleDisplayName";
 
 const bottle = {
   name: "Glenburgie 38-year-old",
@@ -38,13 +41,38 @@ describe("formatBottleDisplayName", () => {
     );
   });
 
-  it("uses at most one year when no marketed release marker exists", () => {
+  it("keeps inferred years out of the bottle name", () => {
     expect(
       formatBottleDisplayName({
         ...bottle,
         edition: null,
       }),
-    ).toBe("Decadent Drinks Whiskyland Glenburgie 38-year-old - 1988 Vintage");
+    ).toBe("Decadent Drinks Whiskyland Glenburgie 38-year-old");
+  });
+
+  it("keeps a numbered batch beside the bottle name", () => {
+    const batchedBottle = {
+      ...bottle,
+      edition: "Batch C923",
+      vintageYear: null,
+    };
+
+    expect(formatBottleDisplayName(batchedBottle)).toBe(
+      "Decadent Drinks Whiskyland Glenburgie 38-year-old",
+    );
+    expect(getBottleReleaseMetadata(batchedBottle)).toBe("Batch C923");
+  });
+
+  it("preserves stable batch wording in the expression", () => {
+    expect(
+      formatBottleDisplayName({
+        ...bottle,
+        name: "Small Batch",
+        group: { name: "Small Batch" },
+        edition: null,
+        series: null,
+      }),
+    ).toBe("Decadent Drinks Small Batch");
   });
 
   it("does not add a release year already used as the edition", () => {
@@ -67,5 +95,22 @@ describe("formatBottleDisplayName", () => {
         series: { name: "Exploration Series" },
       }),
     ).toBe("Pōkeno Exploration Series No. 1 - Chapter Thirty Two");
+  });
+
+  it("returns at most one supporting release fact", () => {
+    expect(
+      getBottleReleaseMetadata({
+        edition: null,
+        releaseYear: 2026,
+        vintageYear: 1988,
+      }),
+    ).toBe("1988 vintage");
+    expect(
+      getBottleReleaseMetadata({
+        edition: "Chapter Thirty Two",
+        releaseYear: 2026,
+        vintageYear: 1988,
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/server/src/lib/bottleDisplayName.ts
+++ b/apps/server/src/lib/bottleDisplayName.ts
@@ -27,6 +27,30 @@ function includesIdentityText(value: string, candidate: string) {
   return value.toLocaleLowerCase().includes(candidate.toLocaleLowerCase());
 }
 
+export function isBatchEdition(edition: string | null | undefined) {
+  return edition
+    ? /^batch(?:\s+(?:no\.?|number))?\s+\S/iu.test(edition)
+    : false;
+}
+
+/** Returns an exact release fact that belongs beside, rather than inside, the title. */
+export function getBottleReleaseMetadata(
+  bottle: Pick<
+    BottleDisplayNameSource,
+    "edition" | "releaseYear" | "vintageYear"
+  >,
+) {
+  if (bottle.edition && isBatchEdition(bottle.edition)) return bottle.edition;
+  if (bottle.edition) return null;
+  if (bottle.vintageYear !== null && bottle.vintageYear !== undefined) {
+    return `${bottle.vintageYear} vintage`;
+  }
+  if (bottle.releaseYear !== null && bottle.releaseYear !== undefined) {
+    return `${bottle.releaseYear} release`;
+  }
+  return null;
+}
+
 function getExpressionName(bottle: BottleDisplayNameSource) {
   if (bottle.group) return bottle.group.name;
 
@@ -67,23 +91,10 @@ function getExpressionName(bottle: BottleDisplayNameSource) {
 function getReleaseName(bottle: BottleDisplayNameSource) {
   const expressionName = getExpressionName(bottle);
 
-  if (bottle.edition) {
+  if (bottle.edition && !isBatchEdition(bottle.edition)) {
     return includesIdentityText(expressionName, bottle.edition)
       ? expressionName
       : `${expressionName} - ${bottle.edition}`;
-  }
-  if (!bottle.group) return expressionName;
-  if (bottle.vintageYear !== null && bottle.vintageYear !== undefined) {
-    const vintage = `${bottle.vintageYear} Vintage`;
-    return includesIdentityText(expressionName, vintage)
-      ? expressionName
-      : `${expressionName} - ${vintage}`;
-  }
-  if (bottle.releaseYear !== null && bottle.releaseYear !== undefined) {
-    const release = `${bottle.releaseYear} Release`;
-    return includesIdentityText(expressionName, release)
-      ? expressionName
-      : `${expressionName} - ${release}`;
   }
 
   return expressionName;

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import {
+  formatBottleDisplayName,
+  isBatchEdition,
+} from "@peated/server/lib/bottleDisplayName";
+import { formatReleaseDate } from "@peated/server/lib/bottleRelease";
+import {
   formatCategoryName,
   formatServingStyle,
 } from "@peated/server/lib/format";
@@ -10,8 +15,6 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter } from "next/navigation";
 import { createContext, useContext, useState, type ReactNode } from "react";
 
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
-import { formatReleaseDate } from "@peated/server/lib/bottleRelease";
 import {
   Button,
   ButtonLink,
@@ -102,13 +105,27 @@ function getBottleSpecs(bottle: Bottle) {
     { label: "Cask", value: bottle.maturation },
     {
       label: "Release",
-      value: formatReleaseDate(bottle),
+      value:
+        (isBatchEdition(bottle.edition) ? bottle.edition : null) ??
+        formatReleaseDate(bottle),
     },
   ] as const;
 }
 
 function getDeclaredFacts(bottle: Bottle): [FactListItem, ...FactListItem[]] {
   return [
+    {
+      label: "Vintage",
+      value: bottle.vintageYear === null ? null : String(bottle.vintageYear),
+    },
+    {
+      label: "Bottled",
+      value: bottle.bottlingYear === null ? null : String(bottle.bottlingYear),
+    },
+    {
+      label: "Released",
+      value: formatReleaseDate(bottle),
+    },
     {
       label: "Phenols",
       value:

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleTableRows.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleTableRows.tsx
@@ -1,4 +1,7 @@
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
+import {
+  formatBottleDisplayName,
+  getBottleReleaseMetadata,
+} from "@peated/server/lib/bottleDisplayName";
 import { formatReleaseDate } from "@peated/server/lib/bottleRelease";
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
@@ -30,6 +33,7 @@ function formatBottleMetadata(bottle: Bottle) {
         : null;
 
   return [
+    getBottleReleaseMetadata(bottle),
     origin,
     bottle.statedAge !== null
       ? `${bottle.statedAge} years`

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
-import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
 import type {
   SearchResultGroup,
@@ -13,6 +12,7 @@ import {
 } from "@peated/web/components/designSystem/components";
 import { getCreateBottleHref } from "@peated/web/components/search/createBottleHref";
 import useAuth from "@peated/web/hooks/useAuth";
+import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getEntityUrl } from "@peated/web/lib/urls";
 import * as stylex from "@stylexjs/stylex";
@@ -145,12 +145,6 @@ function bottleItem(
     showMeasures: boolean;
   },
 ) {
-  const metadata = [
-    bottle.category ? formatCategoryName(bottle.category) : null,
-    bottle.statedAge === null ? null : `${bottle.statedAge} years`,
-    bottle.abv === null ? null : `${bottle.abv.toFixed(1)}% ABV`,
-  ].filter((value): value is string => Boolean(value));
-
   return {
     href: getBottleHref(bottle.id),
     id: `bottle-${bottle.id}`,
@@ -163,7 +157,7 @@ function bottleItem(
           bands: bottle.tastingBandCounts,
         }
       : undefined,
-    metadata: metadata.join(" · "),
+    metadata: getBottleMetadata(bottle),
     title: formatBottleDisplayName(bottle),
     visual: {
       fallback: "B",

--- a/apps/web/src/lib/bottleMetadata.test.ts
+++ b/apps/web/src/lib/bottleMetadata.test.ts
@@ -8,27 +8,56 @@ describe("bottle metadata", () => {
       getBottleMetadata({
         abv: 43,
         category: "single_malt",
+        edition: null,
         noAgeStatement: true,
+        releaseYear: null,
         statedAge: null,
+        vintageYear: null,
       }),
     ).toBe("Single Malt · No age statement · 43% ABV");
   });
 
-  it("keeps reviewed release facts out of the bottle name", () => {
+  it("uses one supporting release fact", () => {
     expect(
       getBottleReviewMetadata({
         abv: 52.4,
+        edition: null,
         releaseYear: 2026,
         statedAge: 36,
         vintageYear: 1989,
       }),
-    ).toEqual(["36 years", "52.4% ABV", "1989 vintage", "2026 release"]);
+    ).toEqual(["36 years", "52.4% ABV", "1989 vintage"]);
+  });
+
+  it("shows a numbered batch as release metadata", () => {
+    expect(
+      getBottleReviewMetadata({
+        abv: 68.3,
+        edition: "Batch C923",
+        releaseYear: 2023,
+        statedAge: 12,
+        vintageYear: null,
+      }),
+    ).toEqual(["12 years", "68.3% ABV", "Batch C923"]);
+
+    expect(
+      getBottleMetadata({
+        abv: 68.3,
+        category: "bourbon",
+        edition: "Batch C923",
+        noAgeStatement: false,
+        releaseYear: 2023,
+        statedAge: 12,
+        vintageYear: null,
+      }),
+    ).toBe("Batch C923 · Bourbon · 12 years · 68.3% ABV");
   });
 
   it("omits missing facts and unnecessary ABV decimals", () => {
     expect(
       getBottleReviewMetadata({
         abv: 43,
+        edition: null,
         releaseYear: null,
         statedAge: null,
         vintageYear: null,

--- a/apps/web/src/lib/bottleMetadata.ts
+++ b/apps/web/src/lib/bottleMetadata.ts
@@ -1,18 +1,21 @@
+import { getBottleReleaseMetadata } from "@peated/server/lib/bottleDisplayName";
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Bottle } from "@peated/server/types";
 
 export type BottleMetadata = Pick<
   Bottle,
   "abv" | "category" | "noAgeStatement" | "statedAge"
->;
+> &
+  Partial<Pick<Bottle, "edition" | "releaseYear" | "vintageYear">>;
 
 export type BottleReviewMetadata = Pick<
   Bottle,
-  "abv" | "releaseYear" | "statedAge" | "vintageYear"
+  "abv" | "edition" | "releaseYear" | "statedAge" | "vintageYear"
 >;
 
 export function getBottleMetadata(bottle: BottleMetadata) {
   return [
+    getBottleReleaseMetadata(bottle),
     bottle.category ? formatCategoryName(bottle.category) : null,
     bottle.statedAge !== null
       ? `${bottle.statedAge} years`
@@ -34,7 +37,6 @@ export function getBottleReviewMetadata(bottle: BottleReviewMetadata) {
     bottle.abv === null
       ? null
       : `${bottle.abv.toFixed(1).replace(/\.0$/, "")}% ABV`,
-    bottle.vintageYear === null ? null : `${bottle.vintageYear} vintage`,
-    bottle.releaseYear === null ? null : `${bottle.releaseYear} release`,
+    getBottleReleaseMetadata(bottle),
   ].filter((value): value is string => Boolean(value));
 }

--- a/docs/architecture/bottle-identity-presentation.md
+++ b/docs/architecture/bottle-identity-presentation.md
@@ -74,11 +74,15 @@ that present bottle identity should display it when present unless:
 
 Series must remain searchable even on surfaces that do not render it.
 
-### Prefer a release name or code over years
+### Separate release names from supporting release facts
 
-A meaningful `edition` is normally more recognizable than a year. When a
-chapter, batch, volume, scene, edition, or exact marketed code is present,
-compact views should not also append years by default.
+A meaningful named edition is normally more recognizable than a year. Keep a
+chapter, volume, scene, or other marketed release name in the title. Put a
+numbered or coded batch beside the title as supporting metadata. Do not also
+append years by default.
+
+Stable wording such as `Small Batch` or `Batch Proof` remains part of the title.
+Only an exact batch marker such as `Batch 24` or `Batch C923` moves to metadata.
 
 An exact cask or barrel code is useful when it identifies the marketed release.
 The generic fact that the bottle is single-cask is not a substitute for that
@@ -167,6 +171,7 @@ subject.
 - Show producer context and nonduplicative series.
 - Make the expression the primary title.
 - Show a meaningful release marker prominently.
+- Show an exact batch marker in the supporting release facts.
 - Show stated age once and show ABV when known.
 - Show a year only when it is part of, or necessary to understand, the release
   identity.
@@ -183,7 +188,8 @@ similar repeated items that support a title plus secondary metadata.
 
 - Show enough producer, series, and expression context to recognize the Bottle
   outside its detail page.
-- Include the release marker before an optional year.
+- Include a named release marker in the title.
+- Put an exact batch marker or optional year in secondary metadata.
 - Include age or ABV when the component's density makes them useful.
 - Do not let a year crowd out a more meaningful release marker or ABV.
 - Do not add single-cask or cask-strength labels.
@@ -197,7 +203,8 @@ Use inside prose, notifications, narrow activity items, controls, or other
 places that cannot support a metadata row.
 
 - Produce a recognizable marketed label, not a field inventory.
-- Prefer expression plus release marker.
+- Prefer the expression plus a named release marker.
+- Omit exact batch markers when the surface has no supporting metadata.
 - Include series when it is essential to recognizing the product and is not
   already represented; secondary context may otherwise be omitted.
 - Omit ABV, general production details, and years that are not needed.
@@ -207,9 +214,10 @@ places that cannot support a metadata row.
 Use when a BottleGroup heading or surrounding view already establishes the
 producer and shared expression.
 
-- Show the smallest exact release marker that identifies the member within the
+- Show the smallest exact release fact that identifies the member within the
   family.
-- Prefer an explicit edition, batch, chapter, volume, scene, or marketed code.
+- Prefer an explicit chapter, volume, scene, or other named edition in the
+  title. Put an exact batch marker in supporting metadata.
 - If no explicit release marker exists, use a marketed distillation, bottling,
   or release year that distinguishes the member.
 - Use an exact age override when it differs from the group and is the useful
@@ -242,6 +250,8 @@ Open Graph metadata, share text, accessible labels, and some exports.
   field.
 - Include producer, nonduplicative series, expression, and a meaningful release
   marker.
+- Omit an exact batch marker unless the text must distinguish releases that
+  otherwise have the same name.
 - Include a year only when it is a necessary part of that marketed identity.
 - Omit generic single-cask and cask-strength flags and normally omit ABV.
 - Do not assume the stored `fullName` is the ideal text for every consumer.
@@ -276,7 +286,8 @@ particular result component omits some of them visually.
 | Bottler                   | When distinct and useful | Optional          | Rarely             | Context supplies | When needed       | Yes          |
 | Series                    | If nonduplicative        | If nonduplicative | When essential     | Context supplies | If nonduplicative | Yes          |
 | Expression                | Primary                  | Primary           | Primary            | Context supplies | Primary           | Yes          |
-| Edition/release marker    | Prominent                | Yes               | Yes                | Primary          | Yes               | Yes          |
+| Named edition             | Prominent                | In title          | In title           | Primary          | Yes               | Yes          |
+| Exact batch marker        | Supporting fact          | Metadata          | Rarely             | Metadata         | Conditional       | Yes          |
 | Stated age                | Once                     | Optional          | Only when integral | Exact override   | If integral       | Yes          |
 | ABV                       | Yes when known           | Optional          | No                 | Optional support | Normally no       | Yes          |
 | Distillation year         | Conditional              | Conditional       | Rarely             | When useful      | Conditional       | Yes          |
@@ -300,7 +311,7 @@ the implementation.
 | ----------------------------------------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
 | Whiskyland Glenburgie 38-year-old, Chapter Thirty Two | `Whiskyland` is the Brand; `Chapter Thirty Two` is the release marker           | Show both; omit 1988 vintage and 2026 release from the ordinary header |
 | High West A Midwinter Night's Dram, Act 12 Scene 9    | Act and scene identify the release                                              | Prefer the edition; do not also require its release year               |
-| Elijah Craig Barrel Proof, Batch C923                 | `Barrel Proof` is marketed expression wording; the batch identifies the release | Preserve the expression and batch; do not add a cask-strength flag     |
+| Elijah Craig Barrel Proof, Batch C923                 | `Barrel Proof` is marketed expression wording; the batch identifies the release | Keep the expression as the title and show the batch beside it          |
 | Four Roses Limited Edition Small Batch 2017           | The year is the annual release identity when no stronger marker exists          | Show the release year                                                  |
 | Macallan Sherry Oak 18-year-old, 1994 Vintage         | Vintage is how the producer distinguishes the release                           | Show the vintage and do not add another year label                     |
 | Willett Family Estate, Barrel 4769                    | The exact barrel code identifies the marketed release                           | Show the code; do not add `Single cask` merely from the boolean        |
@@ -313,7 +324,8 @@ the implementation.
 The contract is applied at the presentation site that owns each branch:
 
 - Bottle headers, result rows, previews, and tasting identities compose their
-  own structured layouts from the shared Bottle fields.
+  own structured layouts from the shared Bottle fields. Numbered batches and
+  inferred years use supporting metadata when the layout provides it.
 - Relative release-family labels show the most useful difference without adding
   general cask labels.
 - SEO, sharing, notifications, and other unstructured consumers use concise


### PR DESCRIPTION
Bottle titles now keep the marketed brand, series, expression, and named edition while moving inferred vintage or release years and exact batch markers into supporting metadata. Search results, bottle tables, review cards, and bottle details keep those release facts visible without making them part of the title; stable product wording such as `Small Batch` remains unchanged.

The shared formatter owns the title boundary, and a separate release-metadata helper selects at most one supporting discriminator. Review should start in `apps/server/src/lib/bottleDisplayName.ts`, then follow its use in the web metadata helpers and bottle page.
