### PR TITLE
fix(web): tolerate entity responses without images

### DIFF
--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -238,6 +238,17 @@ async function handleRpcRequest({ request, response, url }) {
       }
       sendRpcResponse(response, emptyEntityCatalog);
       return true;
+    case "entities/events/list":
+      if (
+        ![testBrand.id, testBottler.id, testOwnedEntity.id].includes(
+          Number(input?.entity),
+        )
+      ) {
+        sendRpcError(response, "Unexpected entity events payload");
+        return true;
+      }
+      sendRpcResponse(response, { results: [] });
+      return true;
     case "brands/list":
       sendRpcResponse(response, {
         ...emptyList,

--- a/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
@@ -5,9 +5,10 @@ import { colors, space } from "../../../../styles/tokens.stylex";
 import type { Entity } from "./entityPageData";
 
 export function EntityImageGallery({ entity }: { entity: Entity }) {
-  if (!entity.images.length) return null;
+  const images = entity.images ?? [];
+  if (!images.length) return null;
 
-  const [primary, ...otherImages] = entity.images;
+  const [primary, ...otherImages] = images;
 
   return (
     <section

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -139,7 +139,7 @@ export function EntityOverviewClient({
       </div>
 
       <aside {...stylex.props(styles.details)}>
-        {entity.images.length ? (
+        {entity.images?.length ? (
           <EntityImageGallery entity={entity} />
         ) : (
           <EntityImagePlaceholder entityName={entity.name} kind={entity.kind} />

--- a/apps/web/src/app/(app)/entities/[entityId]/layout.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/layout.tsx
@@ -13,7 +13,8 @@ export async function generateMetadata(props: {
   const { entityId } = await props.params;
   const entity = await getEntityPage(Number(entityId));
   const description = summarize(entity.description || "", 200);
-  const images = entity.images[0] ? [entity.images[0].imageUrl] : [];
+  const primaryImage = entity.images?.[0];
+  const images = primaryImage ? [primaryImage.imageUrl] : [];
 
   return {
     title: entity.name,
@@ -41,7 +42,7 @@ export default async function EntityLayout(props: {
     "@context": "https://schema.org",
     "@type": "Organization",
     name: entity.name,
-    image: entity.images[0]?.imageUrl,
+    image: entity.images?.[0]?.imageUrl,
     description: entity.description ?? undefined,
     address: entity.country
       ? [


### PR DESCRIPTION
Entity pages now tolerate API responses that omit the recently added `images` field. Metadata and structured data omit the primary image, while the page renders the existing image placeholder instead of throwing during server rendering.

This keeps entity routes available during stale-process or deployment-version mismatches without changing the current API contract, where `images` remains required. The visual-test API now also returns empty entity history data so the shared entity-page screenshot scenarios can finish instead of waiting on an unhandled request.
