### PR TITLE
fix(web): show full totals in list headers

### DIFF
--- a/apps/server/src/orpc/contracts/entities/list.ts
+++ b/apps/server/src/orpc/contracts/entities/list.ts
@@ -1,8 +1,10 @@
-import { EntitySchema, listResponse } from "@peated/server/schemas";
 import { EntityKindEnum } from "@peated/server/schemas/common";
 import { z } from "zod";
 import { contract } from "../base";
-import { EntityKindListInputSchema } from "../entityKinds/list";
+import {
+  EntityKindListInputSchema,
+  EntityKindListOutputSchema,
+} from "../entityKinds/list";
 
 export const EntityListInputSchema = EntityKindListInputSchema.unwrap()
   .extend({
@@ -30,4 +32,4 @@ export default contract
     operationId: "listEntities",
   })
   .input(EntityListInputSchema)
-  .output(listResponse(EntitySchema));
+  .output(EntityKindListOutputSchema);

--- a/apps/server/src/orpc/contracts/entityKinds/list.ts
+++ b/apps/server/src/orpc/contracts/entityKinds/list.ts
@@ -16,6 +16,10 @@ const SORT_OPTIONS = [
   "-bottles",
 ] as const;
 
+export const EntityKindListOutputSchema = listResponse(EntitySchema).extend({
+  total: z.number().int().nonnegative(),
+});
+
 export const EntityKindListInputSchema = z
   .object({
     query: z
@@ -88,5 +92,5 @@ export function createEntityKindListContract({
       operationId,
     })
     .input(EntityKindListInputSchema)
-    .output(listResponse(EntitySchema));
+    .output(EntityKindListOutputSchema);
 }

--- a/apps/server/src/orpc/mock/routes/entityKinds/list.ts
+++ b/apps/server/src/orpc/mock/routes/entityKinds/list.ts
@@ -67,5 +67,8 @@ export function listEntities(
     })
     .map((entity) => mockEntityFor(signedIn, entity));
 
-  return mockPage(entities, input.cursor, input.limit);
+  return {
+    ...mockPage(entities, input.cursor, input.limit),
+    total: entities.length,
+  };
 }

--- a/apps/server/src/orpc/routes/entityKinds/list.test.ts
+++ b/apps/server/src/orpc/routes/entityKinds/list.test.ts
@@ -42,9 +42,26 @@ describe("Entity kind collections", () => {
       kind: "distillery",
     });
 
-    const { results } = await routerClient.brands.list({ query: "Highland" });
+    const { results, total } = await routerClient.brands.list({
+      query: "Highland",
+    });
 
     expect(results.map(({ id }) => id)).toEqual([expected.id]);
+    expect(total).toBe(1);
+  });
+
+  test("returns the full filtered total for a page", async ({ fixtures }) => {
+    await fixtures.Entity({ name: "First Distillery", kind: "distillery" });
+    await fixtures.Entity({ name: "Second Distillery", kind: "distillery" });
+    await fixtures.Entity({ name: "Other Brand", kind: "brand" });
+
+    const { results, total } = await routerClient.distilleries.list({
+      limit: 1,
+      sort: "name",
+    });
+
+    expect(results).toHaveLength(1);
+    expect(total).toBe(2);
   });
 
   test("filters a kind collection by location", async ({ fixtures }) => {

--- a/apps/server/src/orpc/routes/entityKinds/list.ts
+++ b/apps/server/src/orpc/routes/entityKinds/list.ts
@@ -161,13 +161,19 @@ export async function listEntities({
       orderBy = desc(entities.totalTastings);
   }
 
-  const results = await db
-    .select()
-    .from(entities)
-    .where(and(...where))
-    .limit(limit + 1)
-    .offset(offset)
-    .orderBy(orderBy, asc(entities.id));
+  const [results, [totalRow]] = await Promise.all([
+    db
+      .select()
+      .from(entities)
+      .where(and(...where))
+      .limit(limit + 1)
+      .offset(offset)
+      .orderBy(orderBy, asc(entities.id)),
+    db
+      .select({ count: sql<string>`COUNT(*)` })
+      .from(entities)
+      .where(and(...where)),
+  ]);
 
   return {
     results: await serialize(
@@ -175,6 +181,7 @@ export async function listEntities({
       results.slice(0, limit),
       currentUser,
     ),
+    total: Number(totalRow?.count ?? 0),
     rel: {
       nextCursor: results.length > limit ? cursor + 1 : null,
       prevCursor: cursor > 1 ? cursor - 1 : null,

--- a/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
@@ -17,6 +17,7 @@ import useAuth from "@peated/web/hooks/useAuth";
 import useEntityFollowing from "@peated/web/hooks/useEntityFollowing";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { toEntityCatalogItem } from "@peated/web/lib/entityCatalogItem";
+import { filterFollowingEntities } from "@peated/web/lib/entityFollowing";
 import { useORPC } from "@peated/web/lib/orpc/context";
 
 const DEFAULT_SORT = "-tastings";
@@ -112,11 +113,11 @@ export function EntityCatalogPageClient({
   }
 
   const addHref = `/addEntity?kind=${kind}`;
-  const visibleEntities =
+  const visibleList =
     filter === "following"
-      ? entityList.results.filter(followControls.isFollowing)
-      : entityList.results;
-  const items = visibleEntities.map((entity) =>
+      ? filterFollowingEntities(entityList, followControls.isFollowing)
+      : entityList;
+  const items = visibleList.results.map((entity) =>
     toEntityCatalogItem(entity, followControls.isFollowing(entity)),
   );
 
@@ -209,6 +210,7 @@ export function EntityCatalogPageClient({
         showFollowingMarks={filter !== "following"}
         sort={sort}
         sortOptions={sortOptions}
+        total={visibleList.total}
       />
     </CatalogPage>
   );

--- a/apps/web/src/app/(app)/following/followingPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/following/followingPageClient.stylex.tsx
@@ -17,6 +17,7 @@ import { EntityCatalogList } from "@peated/web/components/pages/entityCatalog.st
 import useEntityFollowing from "@peated/web/hooks/useEntityFollowing";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { toEntityCatalogItem } from "@peated/web/lib/entityCatalogItem";
+import { filterFollowingEntities } from "@peated/web/lib/entityFollowing";
 import { useORPC } from "@peated/web/lib/orpc/context";
 
 import { getFollowingPageState } from "./followingPageData";
@@ -55,11 +56,11 @@ export function FollowingPageClient({
   });
   const followingHref = getViewHref(pathname, searchParams, "following");
   const findHref = getViewHref(pathname, searchParams, "find");
-  const visibleEntities =
+  const visibleList =
     state.view === "following"
-      ? entityList.results.filter(followControls.isFollowing)
-      : entityList.results;
-  const items = visibleEntities.map((entity) =>
+      ? filterFollowingEntities(entityList, followControls.isFollowing)
+      : entityList;
+  const items = visibleList.results.map((entity) =>
     toEntityCatalogItem(entity, followControls.isFollowing(entity)),
   );
 
@@ -163,6 +164,7 @@ export function FollowingPageClient({
         showFollowingMarks={state.view === "find"}
         sort={state.sort}
         sortOptions={sortOptions}
+        total={visibleList.total}
       />
     </CatalogPage>
   );

--- a/apps/web/src/components/pages/bottleCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/bottleCatalog.stylex.tsx
@@ -80,16 +80,18 @@ export function BottleCatalogList({
 }: BottleCatalogListProps) {
   return (
     <section aria-label="Bottle catalog" {...stylex.props(styles.catalog)}>
-      <ListToolbar
-        count={items.length}
-        noun="bottle"
-        onSortChange={onSortChange}
-        sort={sort}
-        sortOptions={sortOptions}
-        total={total}
-      />
       {items.length ? (
-        <BottleCatalogTable items={items} />
+        <>
+          <ListToolbar
+            count={items.length}
+            noun="bottle"
+            onSortChange={onSortChange}
+            sort={sort}
+            sortOptions={sortOptions}
+            total={total}
+          />
+          <BottleCatalogTable items={items} />
+        </>
       ) : (
         <EmptyState
           action={

--- a/apps/web/src/components/pages/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/entityCatalog.stylex.tsx
@@ -48,9 +48,10 @@ export type EntityCatalogListProps = {
   showFollowingMarks?: boolean;
   sort: string;
   sortOptions: readonly [ListSortOption, ...ListSortOption[]];
+  total: number;
 };
 
-/** Presents one API-owned cursor page without inventing a total. */
+/** Presents one API-owned cursor page and its full-result total. */
 export function EntityCatalogList({
   addHref,
   emptyAction,
@@ -68,24 +69,28 @@ export function EntityCatalogList({
   showFollowingMarks = true,
   sort,
   sortOptions,
+  total,
 }: EntityCatalogListProps) {
   return (
     <section aria-label={`${noun} catalog`} {...stylex.props(styles.catalog)}>
-      <ListToolbar
-        count={items.length}
-        noun={noun}
-        onSortChange={onSortChange}
-        sort={sort}
-        sortOptions={sortOptions}
-      />
       {items.length ? (
-        <EntityCatalogTable
-          items={items}
-          noun={noun}
-          onToggleFollowing={onToggleFollowing}
-          pendingId={pendingId}
-          showFollowingMarks={showFollowingMarks}
-        />
+        <>
+          <ListToolbar
+            count={items.length}
+            noun={noun}
+            onSortChange={onSortChange}
+            sort={sort}
+            sortOptions={sortOptions}
+            total={total}
+          />
+          <EntityCatalogTable
+            items={items}
+            noun={noun}
+            onToggleFollowing={onToggleFollowing}
+            pendingId={pendingId}
+            showFollowingMarks={showFollowingMarks}
+          />
+        </>
       ) : (
         <EmptyState
           action={

--- a/apps/web/src/lib/entityFollowing.test.ts
+++ b/apps/web/src/lib/entityFollowing.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "vitest";
+
+import { filterFollowingEntities } from "./entityFollowing";
+
+describe("filterFollowingEntities", () => {
+  test("removes local unfollows from the rows and total", () => {
+    const list = {
+      results: [
+        { id: 1, isFollowing: true },
+        { id: 2, isFollowing: true },
+      ],
+      total: 8,
+    };
+
+    expect(filterFollowingEntities(list, (entity) => entity.id !== 2)).toEqual({
+      results: [{ id: 1, isFollowing: true }],
+      total: 7,
+    });
+  });
+
+  test("preserves the server total when every result remains visible", () => {
+    const list = {
+      results: [{ id: 1, isFollowing: true }],
+      total: 8,
+    };
+
+    expect(filterFollowingEntities(list, () => true)).toEqual(list);
+  });
+});

--- a/apps/web/src/lib/entityFollowing.ts
+++ b/apps/web/src/lib/entityFollowing.ts
@@ -1,0 +1,14 @@
+import type { Entity } from "@peated/server/types";
+
+type FollowingEntity = Pick<Entity, "id" | "isFollowing">;
+
+/** Applies local follow overrides to both rows and total until the server list refreshes. */
+export function filterFollowingEntities<T extends FollowingEntity>(
+  list: { results: readonly T[]; total: number },
+  isFollowing: (entity: T) => boolean,
+) {
+  const results = list.results.filter(isFollowing);
+  const hiddenCount = list.results.length - results.length;
+
+  return { results, total: list.total - hiddenCount };
+}


### PR DESCRIPTION
Catalog list headers now pair the current page count with the full filtered result total, such as `100 distillers of 162`, while empty catalogs go directly to their existing actionable empty state without a redundant count or sort control. This applies to distillers, brands, bottlers, companies, Following, and bottle lists. During follow updates, the local row projection adjusts its total at the same boundary, so the header cannot mix locally removed rows with a stale server total.

Entity list API responses gain an authoritative `total` field while preserving existing results and cursor behavior. Production and mock handlers use the same contract, and focused coverage proves that the total remains independent of page size.
