### PR TITLE
fix(web): improve bottle titles and truncated text

### DIFF
--- a/apps/web/src/components/admin/adminContent.stylex.tsx
+++ b/apps/web/src/components/admin/adminContent.stylex.tsx
@@ -51,6 +51,7 @@ export function AdminBreadcrumbs({
             <Link
               aria-current={item.current ? "page" : undefined}
               href={item.href}
+              title={item.label}
               {...stylex.props(
                 styles.breadcrumbLink,
                 item.current && styles.currentBreadcrumb,

--- a/apps/web/src/components/admin/moderation/moderationInbox.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationInbox.stylex.tsx
@@ -203,14 +203,23 @@ export function ModerationInboxContent({
                     <span>{task.category}</span>
                     <TimeSince date={task.attentionAt} />
                   </span>
-                  <strong {...stylex.props(styles.taskTitle)}>
+                  <strong
+                    title={task.title}
+                    {...stylex.props(styles.taskTitle)}
+                  >
                     {task.title}
                   </strong>
-                  <span {...stylex.props(styles.question)}>
+                  <span
+                    title={task.question}
+                    {...stylex.props(styles.question)}
+                  >
                     {task.question}
                   </span>
                   <span {...stylex.props(styles.taskMeta)}>
-                    <span {...stylex.props(styles.truncate)}>
+                    <span
+                      title={task.sourceLabel}
+                      {...stylex.props(styles.truncate)}
+                    >
                       {task.sourceLabel}
                     </span>
                     <span

--- a/apps/web/src/components/admin/reviewTable.stylex.tsx
+++ b/apps/web/src/components/admin/reviewTable.stylex.tsx
@@ -58,7 +58,9 @@ export function ReviewRows({
                       {bottleName}
                     </AdminTextLink>
                   ) : (
-                    <span {...stylex.props(styles.match)}>{bottleName}</span>
+                    <span title={bottleName} {...stylex.props(styles.match)}>
+                      {bottleName}
+                    </span>
                   )}
                   <span {...stylex.props(styles.metadata)}>
                     {" · "}

--- a/apps/web/src/components/bottleComparisonTable.stylex.tsx
+++ b/apps/web/src/components/bottleComparisonTable.stylex.tsx
@@ -4,6 +4,7 @@ import { type ReactNode, useId } from "react";
 import { colors, effects, fonts, space } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { linkedRowStyles } from "./linkedRow.stylex";
+import { getTextTitle } from "./textTitle";
 
 const COMPACT = "@media (max-width: 639px)";
 
@@ -80,6 +81,7 @@ export function BottleComparisonTable({
                 {row.href ? (
                   <AppLink
                     href={row.href}
+                    title={row.name}
                     {...stylex.props(
                       styles.name,
                       styles.nameLink,
@@ -89,18 +91,30 @@ export function BottleComparisonTable({
                     {row.name}
                   </AppLink>
                 ) : (
-                  <span {...stylex.props(styles.name)}>{row.name}</span>
+                  <span title={row.name} {...stylex.props(styles.name)}>
+                    {row.name}
+                  </span>
                 )}
                 {row.metadata ? (
-                  <span {...stylex.props(styles.metadata)}>{row.metadata}</span>
+                  <span title={row.metadata} {...stylex.props(styles.metadata)}>
+                    {row.metadata}
+                  </span>
                 ) : null}
               </th>
               {row.values.map((value, index) => (
                 <td key={index} {...stylex.props(styles.valueCell)}>
-                  <span {...stylex.props(styles.mobileLabel)}>
+                  <span
+                    title={columns[index]}
+                    {...stylex.props(styles.mobileLabel)}
+                  >
                     {columns[index]}
                   </span>
-                  <span {...stylex.props(styles.value)}>{value ?? "–"}</span>
+                  <span
+                    title={getTextTitle(value ?? "–")}
+                    {...stylex.props(styles.value)}
+                  >
+                    {value ?? "–"}
+                  </span>
                 </td>
               ))}
             </tr>

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -98,6 +98,7 @@ export function BottleIdentityRow({
           brandHref ? (
             <AppLink
               href={brandHref}
+              title={brand}
               {...stylex.props(
                 styles.brand,
                 styles.brandLink,
@@ -107,7 +108,9 @@ export function BottleIdentityRow({
               {brand}
             </AppLink>
           ) : (
-            <span {...stylex.props(styles.brand)}>{brand}</span>
+            <span title={brand} {...stylex.props(styles.brand)}>
+              {brand}
+            </span>
           )
         ) : null}
         <div {...stylex.props(styles.nameLine)}>
@@ -129,7 +132,7 @@ export function BottleIdentityRow({
           {hasTasted ? <MemberStatus kind="tasted" /> : null}
         </div>
         {metadata.length ? (
-          <div {...stylex.props(styles.metadata)}>
+          <div title={metadata.join(" · ")} {...stylex.props(styles.metadata)}>
             {metadata.map((item, index) => (
               <span key={`${item}-${index}`}>
                 {index ? <span aria-hidden="true"> · </span> : null}

--- a/apps/web/src/components/catalogDetails.stylex.tsx
+++ b/apps/web/src/components/catalogDetails.stylex.tsx
@@ -2,6 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import { colors, fonts, space } from "../styles/tokens.stylex";
+import { getTextTitle } from "./textTitle";
 
 const COMPACT = "@media (max-width: 639px)";
 const PHONE = "@media (max-width: 480px)";
@@ -16,7 +17,11 @@ export function PeatedId({ detail, id }: PeatedIdProps) {
     <div {...stylex.props(styles.idStamp)}>
       <span {...stylex.props(styles.idLabel)}>Peated ID</span>
       <span {...stylex.props(styles.idValue)}>{id}</span>
-      {detail ? <span {...stylex.props(styles.idDetail)}>{detail}</span> : null}
+      {detail ? (
+        <span title={getTextTitle(detail)} {...stylex.props(styles.idDetail)}>
+          {detail}
+        </span>
+      ) : null}
     </div>
   );
 }
@@ -66,8 +71,12 @@ export function KeyFacts({ facts }: { facts: KeyFactList }) {
               styles.keyFactPhoneEven,
           )}
         >
-          <dt {...stylex.props(styles.keyFactLabel)}>{fact.label}</dt>
-          <dd {...stylex.props(styles.keyFactValue)}>{fact.value}</dd>
+          <dt title={fact.label} {...stylex.props(styles.keyFactLabel)}>
+            {fact.label}
+          </dt>
+          <dd title={String(fact.value)} {...stylex.props(styles.keyFactValue)}>
+            {fact.value}
+          </dd>
         </div>
       ))}
     </dl>

--- a/apps/web/src/components/detailValues.test.tsx
+++ b/apps/web/src/components/detailValues.test.tsx
@@ -45,5 +45,7 @@ describe("detail values", () => {
     expect(html).not.toContain("Country");
     expect(html).toContain("Bottles");
     expect(html).toContain(">0<");
+    expect(html).toContain('title="Bottles"');
+    expect(html).toContain('title="0"');
   });
 });

--- a/apps/web/src/components/facetRow.stylex.tsx
+++ b/apps/web/src/components/facetRow.stylex.tsx
@@ -58,6 +58,7 @@ export function FacetRow({
       )}
     >
       <span
+        title={label}
         {...stylex.props(
           styles.label,
           !counted && styles.labelWide,

--- a/apps/web/src/components/formLayout.stylex.tsx
+++ b/apps/web/src/components/formLayout.stylex.tsx
@@ -83,7 +83,9 @@ export function FormSteps({ currentStep, steps }: FormStepsProps) {
             )}
           >
             <span aria-hidden="true">{index + 1}</span>
-            <span {...stylex.props(styles.stepLabel)}>{step}</span>
+            <span title={step} {...stylex.props(styles.stepLabel)}>
+              {step}
+            </span>
           </li>
         ))}
       </ol>

--- a/apps/web/src/components/itemList.stylex.tsx
+++ b/apps/web/src/components/itemList.stylex.tsx
@@ -10,6 +10,7 @@ import {
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { linkedRowStyles } from "./linkedRow.stylex";
+import { getTextTitle } from "./textTitle";
 
 const MOBILE = "@media (max-width: 559px)";
 
@@ -101,6 +102,7 @@ export function ItemRow({
           {href ? (
             <AppLink
               href={href}
+              title={getTextTitle(title)}
               {...stylex.props(
                 styles.title,
                 size === "sm" && styles.smallTitle,
@@ -111,6 +113,7 @@ export function ItemRow({
             </AppLink>
           ) : (
             <span
+              title={getTextTitle(title)}
               {...stylex.props(
                 styles.title,
                 size === "sm" && styles.smallTitle,
@@ -121,6 +124,7 @@ export function ItemRow({
           )}
           {metadata ? (
             <div
+              title={getTextTitle(metadata)}
               {...stylex.props(
                 styles.metadata,
                 size === "sm" && styles.smallMetadata,

--- a/apps/web/src/components/lists.stylex.tsx
+++ b/apps/web/src/components/lists.stylex.tsx
@@ -178,15 +178,20 @@ export function RailListItem({
           {href ? (
             <AppLink
               href={href}
+              title={title}
               {...stylex.props(styles.railTitle, styles.railTitleLink)}
             >
               {title}
             </AppLink>
           ) : (
-            <span {...stylex.props(styles.railTitle)}>{title}</span>
+            <span title={title} {...stylex.props(styles.railTitle)}>
+              {title}
+            </span>
           )}
           {metadata ? (
-            <span {...stylex.props(styles.railMetadata)}>{metadata}</span>
+            <span title={metadata} {...stylex.props(styles.railMetadata)}>
+              {metadata}
+            </span>
           ) : null}
         </div>
         {end ? <span {...stylex.props(styles.railEnd)}>{end}</span> : null}

--- a/apps/web/src/components/notePicker.stylex.tsx
+++ b/apps/web/src/components/notePicker.stylex.tsx
@@ -171,7 +171,10 @@ export function NotePickerField({
                     index === activeIndex && styles.activeSuggestion,
                   )}
                 >
-                  <span {...stylex.props(styles.suggestionName)}>
+                  <span
+                    title={note.name}
+                    {...stylex.props(styles.suggestionName)}
+                  >
                     {note.name}
                   </span>
                   <span {...stylex.props(styles.suggestionCount)}>

--- a/apps/web/src/components/pages/bottlePageHeader.stories.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stories.tsx
@@ -87,6 +87,23 @@ export const MissingImage: Story = {
   },
 };
 
+export const LongName: Story = {
+  args: {
+    brand: "The Scotch Malt Whisky Society",
+    brandHref: "/entities/3417",
+    detail: "Highland · single malt · independent bottling",
+    id: "B49748",
+    name: "SMWS Highland peaty potion",
+    notes: [],
+    specs: [
+      { label: "ABV", value: "50.0%" },
+      { label: "Age", value: "10 years" },
+      { label: "Cask", value: "1st fill barrels and oloroso sherry hogsheads" },
+      { label: "Release", value: "Batch 42" },
+    ],
+  },
+};
+
 export const ThinData: Story = {
   args: {
     actions: null,

--- a/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
@@ -62,6 +62,7 @@ export function BottlePageHeader({
 }: BottlePageHeaderProps) {
   const hasActions = Boolean(actions || menu);
   const hasRatings = Boolean(score || bands);
+  const hasLongName = `${brand} ${name}`.length > 24;
 
   return (
     <header
@@ -83,13 +84,23 @@ export function BottlePageHeader({
             size="lg"
           />
           <div {...stylex.props(styles.identity)}>
-            <h1 {...stylex.props(foundationStyles.pageTitle, styles.name)}>
+            <h1
+              {...stylex.props(
+                foundationStyles.pageTitle,
+                styles.name,
+                hasLongName && styles.longName,
+              )}
+            >
               {brandHref ? (
-                <AppLink href={brandHref} {...stylex.props(styles.brand)}>
+                <AppLink
+                  href={brandHref}
+                  title={brand}
+                  {...stylex.props(styles.brand)}
+                >
                   {brand}
                 </AppLink>
               ) : (
-                <span>{brand}</span>
+                <span title={brand}>{brand}</span>
               )}{" "}
               {name}
             </h1>
@@ -215,6 +226,19 @@ const styles = stylex.create({
   },
   name: {
     overflowWrap: "anywhere",
+    fontSize: {
+      default: "clamp(30px, 4vw, 40px)",
+      [COMPACT]: "28px",
+      [PHONE]: "26px",
+    },
+    textWrap: "balance",
+  },
+  longName: {
+    fontSize: {
+      default: "clamp(28px, 3.5vw, 36px)",
+      [COMPACT]: "26px",
+      [PHONE]: "24px",
+    },
   },
   notes: {
     display: "flex",

--- a/apps/web/src/components/pages/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/entityCatalog.stylex.tsx
@@ -159,13 +159,19 @@ function EntityCounts({ item }: { item: EntityCatalogItem }) {
       {...stylex.props(styles.counts)}
     >
       <span {...stylex.props(styles.count)}>
-        <strong {...stylex.props(styles.countValue)}>
+        <strong
+          title={item.totalBottles.toLocaleString("en-US")}
+          {...stylex.props(styles.countValue)}
+        >
           {item.totalBottles.toLocaleString("en-US")}
         </strong>
         <span {...stylex.props(styles.countLabel)}>{bottleNoun}</span>
       </span>
       <span {...stylex.props(styles.count, styles.tastingCount)}>
-        <strong {...stylex.props(styles.countValue)}>
+        <strong
+          title={item.totalTastings.toLocaleString("en-US")}
+          {...stylex.props(styles.countValue)}
+        >
           {item.totalTastings.toLocaleString("en-US")}
         </strong>
         <span {...stylex.props(styles.countLabel)}>{tastingNoun}</span>

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -320,7 +320,10 @@ export function HomeOrigins({
               />
             </span>
             <span {...stylex.props(styles.countryHeading)}>
-              <strong {...stylex.props(styles.countryName)}>
+              <strong
+                title={country.name}
+                {...stylex.props(styles.countryName)}
+              >
                 {country.name}
               </strong>
             </span>
@@ -343,7 +346,10 @@ export function HomeOrigins({
               +{remainingCountries.count}
             </span>
             <span {...stylex.props(styles.countryHeading)}>
-              <strong {...stylex.props(styles.countryName)}>
+              <strong
+                title="Everywhere else"
+                {...stylex.props(styles.countryName)}
+              >
                 Everywhere else
               </strong>
             </span>

--- a/apps/web/src/components/pages/homeSummary.stylex.tsx
+++ b/apps/web/src/components/pages/homeSummary.stylex.tsx
@@ -54,7 +54,9 @@ export function HomeMemberSummary({
               <dd {...stylex.props(styles.recordFactValue)}>
                 {fact.value.toLocaleString("en-US")}
               </dd>
-              <dt {...stylex.props(styles.recordFactLabel)}>{fact.label}</dt>
+              <dt title={fact.label} {...stylex.props(styles.recordFactLabel)}>
+                {fact.label}
+              </dt>
             </div>
           ))}
         </dl>

--- a/apps/web/src/components/passport.stylex.tsx
+++ b/apps/web/src/components/passport.stylex.tsx
@@ -98,7 +98,9 @@ function PassportCount({ count, detail }: { count: number; detail: string }) {
       <strong {...stylex.props(styles.count)}>
         {count.toLocaleString("en-US")}
       </strong>
-      <span {...stylex.props(styles.countDetail)}>{detail}</span>
+      <span title={detail} {...stylex.props(styles.countDetail)}>
+        {detail}
+      </span>
     </div>
   );
 }

--- a/apps/web/src/components/rowMenu.stylex.tsx
+++ b/apps/web/src/components/rowMenu.stylex.tsx
@@ -72,6 +72,7 @@ export function RowMenu({
             )}
           >
             <div
+              title={label}
               {...stylex.props(
                 styles.header,
                 variant === "page" && styles.pageHeader,

--- a/apps/web/src/components/scopedSearch.stylex.tsx
+++ b/apps/web/src/components/scopedSearch.stylex.tsx
@@ -104,6 +104,7 @@ export function ScopedSearch({
               aria-expanded={scopeMenuOpen}
               aria-haspopup="listbox"
               aria-label={scopeLabel}
+              title={selectedScope?.label ?? "Search"}
               disabled={disabled}
               onClick={() => setScopeMenuOpen((open) => !open)}
               onKeyDown={(event) => {

--- a/apps/web/src/components/scoring.stylex.tsx
+++ b/apps/web/src/components/scoring.stylex.tsx
@@ -164,6 +164,7 @@ export function TastingRatingDistribution({
           {bins.map((bin, index) => (
             <span
               key={bin.key}
+              title={formatCount(bin.count)}
               {...stylex.props(styles.tastingRatingLabel(shares[index] ?? 0))}
             >
               {formatCount(bin.count)}

--- a/apps/web/src/components/searchPicker.stylex.tsx
+++ b/apps/web/src/components/searchPicker.stylex.tsx
@@ -195,9 +195,14 @@ function PickerControl({
           )}
         >
           <span {...stylex.props(styles.selectedCopy)}>
-            <span {...stylex.props(styles.selectedName)}>{value[0].label}</span>
+            <span title={value[0].label} {...stylex.props(styles.selectedName)}>
+              {value[0].label}
+            </span>
             {(value[0].selectedDetail ?? value[0].detail) ? (
-              <span {...stylex.props(styles.selectedDetail)}>
+              <span
+                title={value[0].selectedDetail ?? value[0].detail}
+                {...stylex.props(styles.selectedDetail)}
+              >
                 {value[0].selectedDetail ?? value[0].detail}
               </span>
             ) : null}

--- a/apps/web/src/components/searchResults.stylex.tsx
+++ b/apps/web/src/components/searchResults.stylex.tsx
@@ -273,12 +273,15 @@ function SearchResultsGroup({
             >
               {item.visual ? <ResultVisual visual={item.visual} /> : null}
               <span {...stylex.props(styles.copy)}>
-                <strong {...stylex.props(styles.title)}>
+                <strong title={item.title} {...stylex.props(styles.title)}>
                   <MatchedText query={query} text={item.title} />
                   {item.isFollowing ? <MemberStatus kind="following" /> : null}
                 </strong>
                 {item.metadata ? (
-                  <span {...stylex.props(styles.metadata)}>
+                  <span
+                    title={item.metadata}
+                    {...stylex.props(styles.metadata)}
+                  >
                     {item.metadata}
                   </span>
                 ) : null}

--- a/apps/web/src/components/selectedBottleSummary.stylex.tsx
+++ b/apps/web/src/components/selectedBottleSummary.stylex.tsx
@@ -25,8 +25,13 @@ export function SelectedBottleSummary({
     <section aria-label="Selected bottle" {...stylex.props(styles.summary)}>
       <BottleVisual imageUrl={imageUrl} label={`${name} bottle`} size="sm" />
       <div {...stylex.props(styles.copy)}>
-        <strong {...stylex.props(styles.name)}>{name}</strong>
-        <span {...stylex.props(styles.metadata)}>
+        <strong title={name} {...stylex.props(styles.name)}>
+          {name}
+        </strong>
+        <span
+          title={`${bottleId} · ${metadata}`}
+          {...stylex.props(styles.metadata)}
+        >
           {bottleId} · {metadata}
         </span>
       </div>

--- a/apps/web/src/components/summaryStrip.stylex.tsx
+++ b/apps/web/src/components/summaryStrip.stylex.tsx
@@ -34,11 +34,15 @@ export function SummaryStrip({ cells }: { cells: SummaryStripCells }) {
           key={`${cell.label}-${index}`}
           {...stylex.props(styles.cell)}
         >
-          <dt {...stylex.props(styles.label)}>{cell.label}</dt>
+          <dt title={cell.label} {...stylex.props(styles.label)}>
+            {cell.label}
+          </dt>
           <dd {...stylex.props(styles.valueRow)}>
             <strong {...stylex.props(styles.value)}>{cell.value}</strong>
             {cell.detail ? (
-              <span {...stylex.props(styles.detail)}>{cell.detail}</span>
+              <span title={cell.detail} {...stylex.props(styles.detail)}>
+                {cell.detail}
+              </span>
             ) : null}
           </dd>
         </div>

--- a/apps/web/src/components/tastingEntry.stylex.tsx
+++ b/apps/web/src/components/tastingEntry.stylex.tsx
@@ -74,15 +74,21 @@ export function TastingEntry({
               {member.href ? (
                 <AppLink
                   href={member.href}
+                  title={member.name}
                   {...stylex.props(styles.name, styles.nameLink)}
                 >
                   {member.name}
                 </AppLink>
               ) : (
-                <span {...stylex.props(styles.name)}>{member.name}</span>
+                <span title={member.name} {...stylex.props(styles.name)}>
+                  {member.name}
+                </span>
               )}
               {member.metadata ? (
-                <span {...stylex.props(styles.metadata)}>
+                <span
+                  title={member.metadata}
+                  {...stylex.props(styles.metadata)}
+                >
                   {member.metadata}
                 </span>
               ) : null}

--- a/apps/web/src/components/tastingInputs.stylex.tsx
+++ b/apps/web/src/components/tastingInputs.stylex.tsx
@@ -126,7 +126,10 @@ export function ColorInput({
   return (
     <div {...stylex.props(styles.colorRoot, disabled && styles.disabled)}>
       <div {...stylex.props(styles.colorHeading)}>
-        <strong {...stylex.props(styles.colorName)}>
+        <strong
+          title={selected?.[1] ?? "Unsure"}
+          {...stylex.props(styles.colorName)}
+        >
           {selected?.[1] ?? "Unsure"}
         </strong>
         {value !== null ? (

--- a/apps/web/src/components/textLink.stylex.tsx
+++ b/apps/web/src/components/textLink.stylex.tsx
@@ -2,6 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 
 import { colors, effects, fonts } from "../styles/tokens.stylex";
 import { AppLink, type AppLinkProps } from "./appLink";
+import { getTextTitle } from "./textTitle";
 
 export type TextLinkProps = Omit<
   AppLinkProps,
@@ -31,7 +32,12 @@ export function TextLink({
       )}
     >
       {truncate ? (
-        <span {...stylex.props(styles.truncateContent)}>{children}</span>
+        <span
+          title={getTextTitle(children)}
+          {...stylex.props(styles.truncateContent)}
+        >
+          {children}
+        </span>
       ) : (
         children
       )}

--- a/apps/web/src/components/textTitle.test.tsx
+++ b/apps/web/src/components/textTitle.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { getTextTitle } from "./textTitle";
+
+describe("getTextTitle", () => {
+  it("extracts text from fragments and ignores non-text components", () => {
+    expect(
+      getTextTitle(
+        <>
+          Highland <span>peaty potion</span>
+          <span aria-hidden="true" />
+        </>,
+      ),
+    ).toBe("Highland peaty potion");
+  });
+
+  it("returns undefined without visible text", () => {
+    expect(getTextTitle(<span aria-hidden="true" />)).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/textTitle.ts
+++ b/apps/web/src/components/textTitle.ts
@@ -1,0 +1,21 @@
+import { Children, isValidElement, type ReactNode } from "react";
+
+/** Returns the visible text from simple React content for a native title. */
+export function getTextTitle(content: ReactNode): string | undefined {
+  const parts: string[] = [];
+
+  function collect(value: ReactNode) {
+    Children.forEach(value, (child) => {
+      if (isValidElement<{ children?: ReactNode }>(child)) {
+        collect(child.props.children);
+      } else if (child !== null && child !== undefined) {
+        // SAFETY: React.Children normalizes empty nodes and rejects object children before this callback.
+        parts.push(String(child as string | number | bigint));
+      }
+    });
+  }
+
+  collect(content);
+  const title = parts.join("").trim();
+  return title || undefined;
+}

--- a/apps/web/src/components/workflowScreen.stylex.tsx
+++ b/apps/web/src/components/workflowScreen.stylex.tsx
@@ -70,7 +70,9 @@ export function WorkflowScreen({
           <Link href="/" {...stylex.props(styles.brand)}>
             Peated
           </Link>
-          <h1 {...stylex.props(styles.title)}>{title}</h1>
+          <h1 title={title} {...stylex.props(styles.title)}>
+            {title}
+          </h1>
           {onSave ? (
             <span
               {...stylex.props(


### PR DESCRIPTION
Bottle page headings now use a smaller responsive scale, with an extra compact step for long bottle names. Explicitly truncated text now exposes its full value through the native title tooltip, including key facts such as cask details and shared list, picker, table, admin, and workflow components.

The truncation handling is cross-cutting because the ellipsis styles live in shared primitives. `getTextTitle` preserves useful tooltip text when those primitives receive nested React content, and the SMWS bottle story covers both the long heading and a truncated cask value.
