### PR TITLE
fix(web): tolerate stale catalog requests

### DIFF
--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -28,6 +28,31 @@ export const BOTTLE_AGE_BAND_LIST = [
   "25_plus",
 ] as const;
 
+export const BOTTLE_LIST_SORT_OPTIONS = [
+  "rank",
+  "brand",
+  "created",
+  "name",
+  "age",
+  "score",
+  "tastings",
+  "-created",
+  "-name",
+  "-age",
+  "-release",
+  "-score",
+  "-tastings",
+] as const;
+
+export const REGION_LIST_SORT_OPTIONS = [
+  "name",
+  "bottles",
+  "distillers",
+  "-name",
+  "-bottles",
+  "-distillers",
+] as const;
+
 export const SERVING_STYLE_LIST = ["neat", "rocks", "splash"] as const;
 
 export const RESERVED_COLLECTION_SLUGS = ["default", "library"] as const;

--- a/apps/server/src/orpc/contracts/bottles/list.ts
+++ b/apps/server/src/orpc/contracts/bottles/list.ts
@@ -1,5 +1,6 @@
 import {
   BOTTLE_AGE_BAND_LIST,
+  BOTTLE_LIST_SORT_OPTIONS,
   CATEGORY_LIST,
   FLAVOR_PROFILES,
 } from "@peated/server/constants";
@@ -8,22 +9,6 @@ import { z } from "zod";
 import { contract } from "../base";
 
 const DEFAULT_SORT = "-tastings";
-
-const SORT_OPTIONS = [
-  "rank",
-  "brand",
-  "created",
-  "name",
-  "age",
-  "score",
-  "tastings",
-  "-created",
-  "-name",
-  "-age",
-  "-release",
-  "-score",
-  "-tastings",
-] as const;
 
 const OutputSchema = listResponse(BottleSchema).extend({
   total: z.number().int().nonnegative(),
@@ -77,7 +62,7 @@ export default contract
       cursor: z.coerce.number().gte(1).default(1),
       limit: z.coerce.number().gte(1).lte(100).default(25),
       filter: z.enum(["all", "following"]).default("all"),
-      sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
+      sort: z.enum(BOTTLE_LIST_SORT_OPTIONS).default(DEFAULT_SORT),
     }),
   )
   // TODO(response-envelope): Return { data, meta } when all list routes use the

--- a/apps/server/src/orpc/contracts/regions/list.ts
+++ b/apps/server/src/orpc/contracts/regions/list.ts
@@ -1,10 +1,9 @@
+import { REGION_LIST_SORT_OPTIONS } from "@peated/server/constants";
 import { RegionSchema, listResponse } from "@peated/server/schemas";
 import { z } from "zod";
 import { contract } from "../base";
 
 const DEFAULT_SORT = "name";
-const SORT_OPTIONS = ["name", "bottles", "-name", "-bottles"] as const;
-
 export default contract
   .route({
     method: "GET",
@@ -19,7 +18,7 @@ export default contract
       query: z.string().default(""),
       cursor: z.coerce.number().gte(1).default(1),
       limit: z.coerce.number().gte(1).lte(100).default(100),
-      sort: z.enum(SORT_OPTIONS).default(DEFAULT_SORT),
+      sort: z.enum(REGION_LIST_SORT_OPTIONS).default(DEFAULT_SORT),
       hasBottles: z.coerce.boolean().default(false),
     }),
   )

--- a/apps/server/src/orpc/routes/regions/list.test.ts
+++ b/apps/server/src/orpc/routes/regions/list.test.ts
@@ -95,6 +95,38 @@ describe("GET /countries/:country/regions", () => {
     expect(results[1].id).toBe(region1.id);
   });
 
+  test("sorts regions by distiller count", async ({ fixtures }) => {
+    const country = await fixtures.Country();
+    const region1 = await fixtures.Region({
+      countryId: country.id,
+      name: "Alpha",
+      totalDistillers: 1,
+    });
+    const region2 = await fixtures.Region({
+      countryId: country.id,
+      name: "Beta",
+      totalDistillers: 4,
+    });
+
+    const ascending = await routerClient.regions.list({
+      country: country.slug,
+      sort: "distillers",
+    });
+    const descending = await routerClient.regions.list({
+      country: country.slug,
+      sort: "-distillers",
+    });
+
+    expect(ascending.results.map((region) => region.id)).toEqual([
+      region1.id,
+      region2.id,
+    ]);
+    expect(descending.results.map((region) => region.id)).toEqual([
+      region2.id,
+      region1.id,
+    ]);
+  });
+
   test("paginates results", async ({ fixtures }) => {
     const country = await fixtures.Country();
     const regions = await Promise.all(

--- a/apps/server/src/orpc/routes/regions/list.ts
+++ b/apps/server/src/orpc/routes/regions/list.ts
@@ -55,6 +55,12 @@ export default implement(regionListContract).handler(async function ({
     case "-bottles":
       orderBy = desc(regions.totalBottles);
       break;
+    case "distillers":
+      orderBy = asc(regions.totalDistillers);
+      break;
+    case "-distillers":
+      orderBy = desc(regions.totalDistillers);
+      break;
   }
 
   const results = await db

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -17,7 +17,11 @@ import { CatalogPage } from "@peated/web/components/pages/catalogPage.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import useAuth from "@peated/web/hooks/useAuth";
 import { toBottleCatalogItem } from "@peated/web/lib/bottleCatalogItem";
-import { normalizeBottleCatalogQueryParams } from "@peated/web/lib/bottleCatalogQueryParams";
+import {
+  BOTTLE_CATALOG_ALLOWED_VALUES,
+  BOTTLE_CATALOG_QUERY_FIELDS,
+  normalizeBottleCatalogQueryParams,
+} from "@peated/web/lib/bottleCatalogQueryParams";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 
@@ -81,6 +85,8 @@ export function BottleCatalogPageClient({
   const searchParams = useSearchParams();
   const queryParams = normalizeBottleCatalogQueryParams(
     useApiQueryParams({
+      allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
+      fields: BOTTLE_CATALOG_QUERY_FIELDS,
       numericFields: [
         "age",
         "brand",
@@ -100,7 +106,7 @@ export function BottleCatalogPageClient({
     initialData: initialBottleList,
   });
   const page = Number(searchParams.get("cursor") ?? "1") || 1;
-  const sort = searchParams.get("sort") ?? DEFAULT_SORT;
+  const sort = String(queryParams.sort ?? DEFAULT_SORT);
   const filter =
     searchParams.get("filter") === "following" ? "following" : "all";
   const allHref = getScopeHref(pathname, searchParams, "all");

--- a/apps/web/src/app/(app)/bottles/(index)/page.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/page.tsx
@@ -1,5 +1,9 @@
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
-import { normalizeBottleCatalogQueryParams } from "@peated/web/lib/bottleCatalogQueryParams";
+import {
+  BOTTLE_CATALOG_ALLOWED_VALUES,
+  BOTTLE_CATALOG_QUERY_FIELDS,
+  normalizeBottleCatalogQueryParams,
+} from "@peated/web/lib/bottleCatalogQueryParams";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import type { Metadata } from "next";
 
@@ -15,6 +19,8 @@ export default async function BottleListPage(props: {
 }) {
   const queryParams = normalizeBottleCatalogQueryParams(
     getApiQueryParams(await props.searchParams, {
+      allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
+      fields: BOTTLE_CATALOG_QUERY_FIELDS,
       numericFields: [
         "age",
         "brand",

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/entityBottleListClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/entityBottleListClient.stylex.tsx
@@ -9,6 +9,11 @@ import type { ReactNode } from "react";
 import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import { toBottleCatalogItem } from "@peated/web/lib/bottleCatalogItem";
+import {
+  BOTTLE_CATALOG_ALLOWED_VALUES,
+  BOTTLE_CATALOG_QUERY_FIELDS,
+  normalizeBottleCatalogQueryParams,
+} from "@peated/web/lib/bottleCatalogQueryParams";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { space } from "../../../../../styles/tokens.stylex";
@@ -41,29 +46,33 @@ export function EntityBottleListClient({
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const queryParams = useApiQueryParams({
-    defaults: { sort: DEFAULT_SORT },
-    numericFields: [
-      "age",
-      "brand",
-      "bottler",
-      "cursor",
-      "distiller",
-      "entity",
-      "limit",
-      "series",
-    ],
-    overrides: {
-      entity: entityId,
-      limit: 25,
-    },
-  });
+  const queryParams = normalizeBottleCatalogQueryParams(
+    useApiQueryParams({
+      defaults: { sort: DEFAULT_SORT },
+      allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
+      fields: BOTTLE_CATALOG_QUERY_FIELDS,
+      numericFields: [
+        "age",
+        "brand",
+        "bottler",
+        "cursor",
+        "distiller",
+        "entity",
+        "limit",
+        "series",
+      ],
+      overrides: {
+        entity: entityId,
+        limit: 25,
+      },
+    }),
+  );
   const { data: bottleList } = useSuspenseQuery({
     ...orpc.bottles.list.queryOptions({ input: queryParams }),
     initialData: initialBottleList,
   });
   const page = Number(searchParams.get("cursor") ?? "1") || 1;
-  const sort = searchParams.get("sort") ?? DEFAULT_SORT;
+  const sort = String(queryParams.sort ?? DEFAULT_SORT);
 
   function updateSort(value: string) {
     const nextParams = new URLSearchParams(searchParams);

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
@@ -1,5 +1,10 @@
 import { ButtonLink } from "@peated/web/components";
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
+import {
+  BOTTLE_CATALOG_ALLOWED_VALUES,
+  BOTTLE_CATALOG_QUERY_FIELDS,
+  normalizeBottleCatalogQueryParams,
+} from "@peated/web/lib/bottleCatalogQueryParams";
 import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
@@ -15,23 +20,27 @@ export default async function EntityBottlesPage(props: {
   const { client } = await getPublicPageServerClient();
   const entity = await getEntityPage(Number(entityId));
   const createBottleHref = getEntityBottleCreateHref(entity);
-  const queryParams = getApiQueryParams(await props.searchParams, {
-    defaults: { sort: "-release" },
-    numericFields: [
-      "age",
-      "brand",
-      "bottler",
-      "cursor",
-      "distiller",
-      "entity",
-      "limit",
-      "series",
-    ],
-    overrides: {
-      entity: entity.id,
-      limit: 25,
-    },
-  });
+  const queryParams = normalizeBottleCatalogQueryParams(
+    getApiQueryParams(await props.searchParams, {
+      defaults: { sort: "-release" },
+      allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
+      fields: BOTTLE_CATALOG_QUERY_FIELDS,
+      numericFields: [
+        "age",
+        "brand",
+        "bottler",
+        "cursor",
+        "distiller",
+        "entity",
+        "limit",
+        "series",
+      ],
+      overrides: {
+        entity: entity.id,
+        limit: 25,
+      },
+    }),
+  );
   const bottleList = await client.bottles.list(queryParams);
 
   return (

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/regions/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/regions/page.tsx
@@ -3,8 +3,16 @@ import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 
+import { REGION_LIST_SORT_OPTIONS } from "@peated/server/constants";
 import { LocationTable } from "../../../locationLists";
 
+const REGION_QUERY_FIELDS = [
+  "cursor",
+  "hasBottles",
+  "limit",
+  "query",
+  "sort",
+] as const;
 export default async function CountryRegionsPage(props: {
   params: Promise<{ countrySlug: string }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
@@ -15,6 +23,8 @@ export default async function CountryRegionsPage(props: {
   ]);
   const queryParams = getApiQueryParams(searchParams, {
     defaults: { sort: "-bottles" },
+    allowedValues: { sort: REGION_LIST_SORT_OPTIONS },
+    fields: REGION_QUERY_FIELDS,
     numericFields: ["cursor", "limit"],
     overrides: { country: countrySlug, limit: 100 },
   });

--- a/apps/web/src/hooks/useApiQueryParams.tsx
+++ b/apps/web/src/hooks/useApiQueryParams.tsx
@@ -6,18 +6,24 @@ import {
 } from "@peated/web/lib/apiQueryParams";
 
 export default function useApiQueryParams({
+  allowedValues = {},
   defaults = {},
+  fields,
   numericFields = ["cursor", "limit"],
   overrides = {},
 }: {
+  allowedValues?: Readonly<Record<string, readonly string[]>>;
   defaults?: ApiQueryParams;
+  fields?: readonly string[];
   numericFields?: readonly string[];
   overrides?: ApiQueryParams;
 }) {
   const searchParams = useSearchParams();
 
   return getApiQueryParams(searchParams, {
+    allowedValues,
     defaults,
+    fields,
     numericFields,
     overrides,
   });

--- a/apps/web/src/lib/apiQueryParams.test.ts
+++ b/apps/web/src/lib/apiQueryParams.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+
+import { getApiQueryParams } from "./apiQueryParams";
+
+test("keeps only named query fields", () => {
+  expect(
+    getApiQueryParams(
+      {
+        cursor: "2",
+        internalRouteValue: "123",
+        sort: "name",
+      },
+      {
+        fields: ["cursor", "sort"],
+        numericFields: ["cursor"],
+      },
+    ),
+  ).toEqual({ cursor: 2, sort: "name" });
+});
+
+test("uses the default for an unknown allowed value", () => {
+  expect(
+    getApiQueryParams(
+      { sort: "removed-sort" },
+      {
+        defaults: { sort: "name" },
+        allowedValues: { sort: ["name", "-name"] },
+      },
+    ),
+  ).toEqual({ sort: "name" });
+});

--- a/apps/web/src/lib/apiQueryParams.ts
+++ b/apps/web/src/lib/apiQueryParams.ts
@@ -9,7 +9,9 @@ export type SearchParamSource =
   | Record<string, string | string[] | undefined>;
 
 type ApiQueryParamOptions = {
+  allowedValues?: Readonly<Record<string, readonly string[]>>;
   defaults?: ApiQueryParams;
+  fields?: readonly string[];
   numericFields?: readonly string[];
   overrides?: ApiQueryParams;
 };
@@ -18,24 +20,36 @@ type ApiQueryParamOptions = {
 export function getApiQueryParams(
   searchParams: SearchParamSource,
   {
+    allowedValues = {},
     defaults = {},
+    fields,
     numericFields = ["cursor", "limit"],
     overrides = {},
   }: ApiQueryParamOptions = {},
 ) {
+  const fieldSet = fields ? new Set(fields) : null;
   const numericFieldSet = new Set(numericFields);
 
   return {
     ...defaults,
     ...Object.fromEntries(
       getSearchParamEntries(searchParams)
+        .filter(([name]) => !fieldSet || fieldSet.has(name))
         .map(([name, value]) => [
           name,
           parseSearchParamValue(name, value, numericFieldSet),
         ])
-        .filter(
-          ([, value]) => value !== null && value !== undefined && value !== "",
-        ),
+        .filter((entry) => {
+          const name = String(entry[0]);
+          const value = entry[1];
+          return (
+            value !== null &&
+            value !== undefined &&
+            value !== "" &&
+            (!allowedValues[name] ||
+              allowedValues[name].includes(String(value)))
+          );
+        }),
     ),
     ...overrides,
   };

--- a/apps/web/src/lib/bottleCatalogQueryParams.test.ts
+++ b/apps/web/src/lib/bottleCatalogQueryParams.test.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "vitest";
 
-import { normalizeBottleCatalogQueryParams } from "./bottleCatalogQueryParams";
+import { getApiQueryParams } from "./apiQueryParams";
+import {
+  BOTTLE_CATALOG_ALLOWED_VALUES,
+  BOTTLE_CATALOG_QUERY_FIELDS,
+  normalizeBottleCatalogQueryParams,
+} from "./bottleCatalogQueryParams";
 
 test.each([
   ["rating", "score"],
@@ -15,5 +20,23 @@ test.each([
   ).toEqual({
     category: "single_malt",
     sort: expected,
+  });
+});
+
+test("keeps old bottle URLs valid and removes internal route fields", () => {
+  const queryParams = getApiQueryParams(
+    {
+      nxtPentityId: "3023",
+      sort: "-rating",
+    },
+    {
+      defaults: { sort: "-release" },
+      allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
+      fields: BOTTLE_CATALOG_QUERY_FIELDS,
+    },
+  );
+
+  expect(normalizeBottleCatalogQueryParams(queryParams)).toEqual({
+    sort: "-score",
   });
 });

--- a/apps/web/src/lib/bottleCatalogQueryParams.ts
+++ b/apps/web/src/lib/bottleCatalogQueryParams.ts
@@ -1,4 +1,40 @@
+import {
+  BOTTLE_AGE_BAND_LIST,
+  BOTTLE_LIST_SORT_OPTIONS,
+  CATEGORY_LIST,
+  FLAVOR_PROFILES,
+} from "@peated/server/constants";
+
 import type { ApiQueryParams } from "./apiQueryParams";
+
+export const BOTTLE_CATALOG_QUERY_FIELDS = [
+  "age",
+  "ageBand",
+  "brand",
+  "bottler",
+  "category",
+  "cursor",
+  "distiller",
+  "entity",
+  "filter",
+  "flavorProfile",
+  "flight",
+  "limit",
+  "minScore",
+  "query",
+  "series",
+  "sort",
+  "tag",
+] as const;
+
+export const BOTTLE_CATALOG_ALLOWED_VALUES = {
+  ageBand: BOTTLE_AGE_BAND_LIST,
+  category: CATEGORY_LIST,
+  filter: ["all", "following"],
+  flavorProfile: FLAVOR_PROFILES,
+  // Keep old catalog URLs usable after rating was renamed to score.
+  sort: [...BOTTLE_LIST_SORT_OPTIONS, "rating", "-rating"],
+} as const;
 
 export function normalizeBottleCatalogQueryParams(
   queryParams: ApiQueryParams,

--- a/apps/web/src/lib/orpc/errors.test.ts
+++ b/apps/web/src/lib/orpc/errors.test.ts
@@ -1,0 +1,14 @@
+import { shouldCaptureORPCClientError } from "@peated/orpc/client/errors";
+import { expect, test } from "vitest";
+
+test("does not capture an aborted request", () => {
+  expect(
+    shouldCaptureORPCClientError(
+      new DOMException("The request was cancelled.", "AbortError"),
+    ),
+  ).toBe(false);
+});
+
+test("captures an unexpected client failure", () => {
+  expect(shouldCaptureORPCClientError(new Error("Request failed."))).toBe(true);
+});

--- a/packages/orpc/src/client/errors.ts
+++ b/packages/orpc/src/client/errors.ts
@@ -17,9 +17,17 @@ export function isORPCNotFoundError(
   );
 }
 
+export function isRequestAbort(error: ClientErrorCandidate): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
 export function shouldCaptureORPCClientError(
   error: ClientErrorCandidate,
 ): boolean {
+  if (isRequestAbort(error)) {
+    return false;
+  }
+
   if (!isORPCClientError(error)) {
     return true;
   }

--- a/packages/orpc/src/client/interceptors.ts
+++ b/packages/orpc/src/client/interceptors.ts
@@ -1,6 +1,6 @@
 import type { InterceptableOptions, Interceptor } from "@orpc/shared";
 import * as Sentry from "@sentry/core";
-import { shouldCaptureORPCClientError } from "./errors";
+import { isRequestAbort, shouldCaptureORPCClientError } from "./errors";
 
 /**
  * Safely stringify an object, handling circular references and other serialization issues
@@ -37,10 +37,12 @@ type Options = {
  * });
  * ```
  */
-const sentryInterceptor = (
-  options: Options = {},
-): Interceptor<InterceptableOptions, Promise<unknown>> =>
-  async function sentryInterceptor({ next, path, input }) {
+const sentryInterceptor =
+  (
+    options: Options = {},
+  ): Interceptor<InterceptableOptions, Promise<unknown>> =>
+  async (interceptorOptions) => {
+    const { input, path } = interceptorOptions;
     let originalError: unknown;
 
     try {
@@ -59,17 +61,19 @@ const sentryInterceptor = (
         },
         async (span) => {
           try {
-            const result = await next();
+            const result = await interceptorOptions.next();
             return result;
           } catch (error) {
             originalError = error;
 
             try {
-              span.setStatus({
-                code: 2,
-              });
-              if (shouldCaptureORPCClientError(error)) {
-                Sentry.captureException(error);
+              if (!isRequestAbort(error)) {
+                span.setStatus({
+                  code: 2,
+                });
+                if (shouldCaptureORPCClientError(error)) {
+                  Sentry.captureException(error);
+                }
               }
             } catch (sentryError) {
               // Log Sentry errors but don't let them interfere with the original error
@@ -90,7 +94,7 @@ const sentryInterceptor = (
       // If Sentry itself fails, log the error and continue with the original call
       // eslint-disable-next-line no-console
       console.error("Sentry interceptor failed:", sentryError);
-      return await next();
+      return await interceptorOptions.next();
     }
   };
 


### PR DESCRIPTION
Catalog pages now keep only supported URL fields and values before calling the API. Old `rating` sort links map to `score`, entity bottle pages use the same compatibility rule, and region lists support sorting by distiller count again. This prevents stale or framework-added URL values from causing server-rendered validation failures.

Expected request cancellation no longer creates a Sentry error or marks the client request as failed. Bottle and region sort choices are shared with their API contracts so browser validation cannot drift from server behavior. Regression coverage exercises URL filtering, old sort links, cancellation, and region sorting.
