### PR TITLE
perf(scraper): reuse Single Cask Nation release dates

### DIFF
--- a/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.test.ts
@@ -104,6 +104,41 @@ test("scrapes every supported whisky type and excludes ineligible records", asyn
   ]);
 });
 
+test("uses a saved release without fetching its product page", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("singlecasknation", "bottle-list.json");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+  mockProductPages(axiosMock);
+
+  const releases: Array<
+    [number | null | undefined, number | null | undefined]
+  > = [];
+  const loadedProductIds: string[][] = [];
+  await scrapeProducts(
+    firstPageUrl,
+    async (item) => {
+      const identity = StorePriceInputSchema.parse(item).sourceBottleIdentity;
+      releases.push([identity?.release_year, identity?.release_month]);
+    },
+    async (externalProductIds) => {
+      loadedProductIds.push(externalProductIds);
+      return new Map([
+        ["9031243464902", { releaseYear: 2025, releaseMonth: 11 }],
+      ]);
+    },
+  );
+
+  expect(loadedProductIds).toEqual([["9031243464902"]]);
+  expect(releases[0]).toEqual([2025, 11]);
+  expect(
+    axiosMock.history.get.some(
+      ({ url }: { url?: string }) =>
+        url === "https://singlecasknation.com/products/rock-town-10-year-old",
+    ),
+  ).toBe(false);
+});
+
 test("rejects malformed Shopify payloads", async ({ axiosMock }) => {
   axiosMock.onGet(firstPageUrl).reply(200, {
     products: [{ title: "Broken" }],

--- a/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.ts
@@ -46,6 +46,17 @@ const RELEASE_MONTHS = new Map(
   ].map((name, index) => [name.toLowerCase(), index + 1]),
 );
 
+type Release = {
+  releaseYear: number;
+  releaseMonth: number;
+};
+
+type LoadReleases = (
+  externalProductIds: string[],
+) => Promise<Map<string, Release>>;
+
+const noSavedReleases: LoadReleases = async () => new Map();
+
 const SingleCaskNationProductSchema = ShopifyProductSchema.extend({
   product_type: z.string(),
   images: z.array(ShopifyImageSchema),
@@ -75,8 +86,14 @@ export function parseReleaseMonth(input: string) {
 async function parseSingleCaskNationProducts(
   input: JsonValue,
   sourceUrl: string,
+  loadReleases: LoadReleases,
 ): Promise<StorePrice[]> {
   const payload = SingleCaskNationProductsSchema.parse(input);
+  const savedReleases = await loadReleases(
+    payload.products.flatMap((product) =>
+      product.id === undefined ? [] : [String(product.id)],
+    ),
+  );
   const products = await Promise.all(
     payload.products.map(async (product): Promise<StorePrice | null> => {
       const category = CATEGORY_BY_PRODUCT_TYPE.get(product.product_type);
@@ -97,9 +114,18 @@ async function parseSingleCaskNationProducts(
         sourceUrl,
         `/products/${encodeURIComponent(product.handle)}`,
       );
-      const release = parseReleaseMonth(await getUrl(productUrl));
+      const shopifyIdentity = getShopifyStorePriceIdentity(
+        product,
+        pricedVariant,
+      );
+      let release: Release | null | undefined =
+        shopifyIdentity.externalProductId
+          ? savedReleases.get(shopifyIdentity.externalProductId)
+          : undefined;
+      // A saved release date does not change. Fetch the page until we have one.
+      if (!release) release = parseReleaseMonth(await getUrl(productUrl));
       const listing: StorePrice = {
-        ...getShopifyStorePriceIdentity(product, pricedVariant),
+        ...shopifyIdentity,
         name,
         price: pricedVariant.parsedPrice,
         currency: "usd",
@@ -125,22 +151,31 @@ async function parseSingleCaskNationProducts(
   return products.filter((product): product is StorePrice => product !== null);
 }
 
-export async function scrapeProducts(url: string, cb: ScrapePricesCallback) {
+export async function scrapeProducts(
+  url: string,
+  cb: ScrapePricesCallback,
+  loadReleases: LoadReleases = noSavedReleases,
+) {
   const data = await getUrl(url);
   const catalog = ShopifyCatalogSchema.parse(JSON.parse(data));
-  const products = await parseSingleCaskNationProducts(catalog, url);
+  const products = await parseSingleCaskNationProducts(
+    catalog,
+    url,
+    loadReleases,
+  );
   await Promise.all(products.map(cb));
   return { hasSourceProducts: catalog.products.length > 0 };
 }
 
-export default async function scrapeSingleCaskNation({
-  dryRun = false,
-}: { dryRun?: boolean } = {}) {
+export default async function scrapeSingleCaskNation(
+  { dryRun = false }: { dryRun?: boolean } = {},
+  loadReleases: LoadReleases = noSavedReleases,
+) {
   return await scrapePrices(
     SITE,
     (page) =>
       `${STORE_ORIGIN}/collections/frontpage/products.json?limit=250&page=${page}&country=US`,
-    scrapeProducts,
+    (url, cb) => scrapeProducts(url, cb, loadReleases),
     { dryRun },
   );
 }

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -89,6 +89,7 @@ import {
   defineScraperSource,
   defineScrapeTarget,
 } from "./definitions";
+import { loadSingleCaskNationReleases } from "./singleCaskNationReleases";
 import { bottleObservationSink } from "./sinks/bottles";
 import { externalReviewSink } from "./sinks/externalReviews";
 import { createStorePriceSink } from "./sinks/storePrices";
@@ -195,7 +196,8 @@ const legacyPriceSources = [
   {
     type: "singlecasknation",
     origin: "https://singlecasknation.com",
-    scrape: scrapeSingleCaskNation,
+    scrape: (options?: { dryRun?: boolean }) =>
+      scrapeSingleCaskNation(options, loadSingleCaskNationReleases),
   },
   {
     type: "thompsonbros",

--- a/apps/server/src/scraper/singleCaskNationReleases.test.ts
+++ b/apps/server/src/scraper/singleCaskNationReleases.test.ts
@@ -1,0 +1,52 @@
+import { BottleExtractedDetailsSchema } from "@peated/bottle-classifier/contract";
+import { loadSingleCaskNationReleases } from "./singleCaskNationReleases";
+
+test("loads complete releases only from Single Cask Nation listings", async ({
+  fixtures,
+}) => {
+  const site = await fixtures.ExternalSiteOrExisting({
+    type: "singlecasknation",
+  });
+  const otherSite = await fixtures.ExternalSiteOrExisting({
+    type: "totalwine",
+  });
+  await fixtures.StorePrice({
+    bottleId: null,
+    externalSiteId: site.id,
+    externalProductId: "complete-release",
+    sourceBottleIdentity: BottleExtractedDetailsSchema.parse({
+      expression: "Complete release",
+      release_year: 2025,
+      release_month: 11,
+    }),
+  });
+  await fixtures.StorePrice({
+    bottleId: null,
+    externalSiteId: site.id,
+    externalProductId: "missing-month",
+    sourceBottleIdentity: BottleExtractedDetailsSchema.parse({
+      expression: "Missing month",
+      release_year: 2025,
+    }),
+  });
+  await fixtures.StorePrice({
+    bottleId: null,
+    externalSiteId: otherSite.id,
+    externalProductId: "complete-release",
+    sourceBottleIdentity: BottleExtractedDetailsSchema.parse({
+      expression: "Other source",
+      release_year: 2024,
+      release_month: 10,
+    }),
+  });
+
+  await expect(
+    loadSingleCaskNationReleases([
+      "complete-release",
+      "missing-month",
+      "unknown",
+    ]),
+  ).resolves.toEqual(
+    new Map([["complete-release", { releaseYear: 2025, releaseMonth: 11 }]]),
+  );
+});

--- a/apps/server/src/scraper/singleCaskNationReleases.ts
+++ b/apps/server/src/scraper/singleCaskNationReleases.ts
@@ -1,0 +1,56 @@
+import { BottleExtractedDetailsSchema } from "@peated/bottle-classifier/contract";
+import { db } from "@peated/server/db";
+import { externalSites, storePrices } from "@peated/server/db/schema";
+import { ExternalSiteNotFoundError } from "@peated/server/lib/externalSites";
+import { and, eq, inArray } from "drizzle-orm";
+
+type Release = {
+  releaseYear: number;
+  releaseMonth: number;
+};
+
+/** Returns saved release dates for Single Cask Nation products. */
+export async function loadSingleCaskNationReleases(
+  externalProductIds: string[],
+): Promise<Map<string, Release>> {
+  if (externalProductIds.length === 0) return new Map();
+
+  const siteKey = "singlecasknation";
+  const site = await db.query.externalSites.findFirst({
+    columns: { id: true },
+    where: eq(externalSites.type, siteKey),
+  });
+  if (!site) throw new ExternalSiteNotFoundError(siteKey);
+
+  const rows = await db
+    .select({
+      externalProductId: storePrices.externalProductId,
+      sourceBottleIdentity: storePrices.sourceBottleIdentity,
+    })
+    .from(storePrices)
+    .where(
+      and(
+        eq(storePrices.externalSiteId, site.id),
+        inArray(storePrices.externalProductId, externalProductIds),
+      ),
+    );
+
+  const releases = new Map<string, Release>();
+  for (const row of rows) {
+    if (!row.externalProductId) continue;
+    const identity = BottleExtractedDetailsSchema.safeParse(
+      row.sourceBottleIdentity,
+    );
+    if (!identity.success) continue;
+
+    const releaseYear = identity.data.release_year;
+    const releaseMonth = identity.data.release_month;
+    if (!releaseYear || !releaseMonth) continue;
+
+    releases.set(row.externalProductId, {
+      releaseYear,
+      releaseMonth,
+    });
+  }
+  return releases;
+}


### PR DESCRIPTION
Single Cask Nation scraping now reuses a complete saved release year and month for known Shopify product IDs. It fetches an individual product page only when the listing is new or its saved release is incomplete, which preserves release metadata while reducing repeat requests.

The database lookup remains outside the scraper adapter and is scoped to Single Cask Nation listings. Coverage verifies source scoping, incomplete release handling, and the no-fetch path for saved releases.
