### PR TITLE
fix(web): align catalog list columns

### DIFF
--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -63,6 +63,7 @@ export type BottleIdentityRowProps = {
   href?: string;
   imageUrl?: string | null;
   isLibrary?: boolean;
+  layout?: "cell" | "row";
   metadata?: readonly string[];
   name: string;
   relatedReleases?: {
@@ -80,6 +81,7 @@ export function BottleIdentityRow({
   href,
   imageUrl,
   isLibrary = false,
+  layout = "row",
   metadata = [],
   name,
   relatedReleases,
@@ -88,8 +90,9 @@ export function BottleIdentityRow({
     <div
       {...stylex.props(
         styles.row,
-        Boolean(href) && linkedRowStyles.container,
-        Boolean(href) && linkedRowStyles.onGround,
+        layout === "cell" && styles.cellLayout,
+        Boolean(href) && layout === "row" && linkedRowStyles.container,
+        Boolean(href) && layout === "row" && linkedRowStyles.onGround,
       )}
     >
       <BottleVisual imageUrl={imageUrl} />
@@ -220,6 +223,13 @@ const styles = stylex.create({
     paddingRight: "12px",
     paddingBottom: space.x3,
     paddingLeft: "12px",
+  },
+  cellLayout: {
+    width: "100%",
+    marginRight: 0,
+    marginLeft: 0,
+    paddingRight: space.x3,
+    paddingLeft: 0,
   },
   copy: {
     display: "flex",

--- a/apps/web/src/components/pages/bottleCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/bottleCatalog.stylex.tsx
@@ -14,8 +14,6 @@ import {
   FacetGroup,
   FilterPanel,
   FilterQuery,
-  ItemList,
-  ItemListItem,
   ListToolbar,
   Select,
   TextInput,
@@ -24,8 +22,8 @@ import {
 } from "..";
 import { colors, fonts, space } from "../../styles/tokens.stylex";
 import { CatalogPageLoading } from "./catalogPage.stylex";
+import { CatalogTable, type CatalogTableColumn } from "./catalogTable.stylex";
 
-const COMPACT = "@media (max-width: 639px)";
 const NARROW = "@media (max-width: 759px)";
 
 export type BottleCatalogItem = {
@@ -47,6 +45,7 @@ export type BottleCatalogItem = {
   scoreHigh: number | null;
   scoreLow: number | null;
   scoreCount: number;
+  totalTastings: number;
 };
 
 export type BottleCatalogListProps = {
@@ -90,24 +89,7 @@ export function BottleCatalogList({
         total={total}
       />
       {items.length ? (
-        <ItemList ariaLabel="Bottles" showTopDivider={false}>
-          {items.map((item) => (
-            <ItemListItem key={item.id}>
-              <BottleIdentityRow
-                brand={item.brand}
-                brandHref={item.brandHref}
-                end={<BottleCatalogRatings item={item} />}
-                hasTasted={item.hasTasted}
-                href={item.href}
-                imageUrl={item.imageUrl}
-                isLibrary={item.isLibrary}
-                metadata={item.metadata}
-                name={item.name}
-                relatedReleases={item.relatedReleases}
-              />
-            </ItemListItem>
-          ))}
-        </ItemList>
+        <BottleCatalogTable items={items} />
       ) : (
         <EmptyState
           action={
@@ -141,17 +123,64 @@ export function BottleCatalogList({
   );
 }
 
-function BottleCatalogRatings({ item }: { item: BottleCatalogItem }) {
+function BottleCatalogTable({
+  items,
+}: {
+  items: readonly BottleCatalogItem[];
+}) {
+  const columns: CatalogTableColumn<BottleCatalogItem>[] = [
+    {
+      cell: (item) => (
+        <BottleIdentityRow
+          brand={item.brand}
+          brandHref={item.brandHref}
+          hasTasted={item.hasTasted}
+          href={item.href}
+          imageUrl={item.imageUrl}
+          isLibrary={item.isLibrary}
+          layout="cell"
+          metadata={item.metadata}
+          name={item.name}
+          relatedReleases={item.relatedReleases}
+        />
+      ),
+      header: "Bottle",
+      key: "bottle",
+      padding: "flush",
+    },
+    {
+      align: "right",
+      cell: (item) => item.totalTastings.toLocaleString("en-US"),
+      header: "Tastings",
+      key: "tastings",
+      width: "count",
+    },
+    {
+      align: "right",
+      cell: (item) => (
+        <BottleRatings
+          counts={item.bandCounts}
+          high={item.scoreHigh}
+          low={item.scoreLow}
+          median={item.medianScore}
+          scoreCount={item.scoreCount}
+        />
+      ),
+      header: "Rating",
+      key: "rating",
+      padding: "flush",
+      width: "rating",
+    },
+  ];
+
   return (
-    <div {...stylex.props(styles.ratings)}>
-      <BottleRatings
-        counts={item.bandCounts}
-        high={item.scoreHigh}
-        low={item.scoreLow}
-        median={item.medianScore}
-        scoreCount={item.scoreCount}
-      />
-    </div>
+    <CatalogTable
+      caption="Bottle records"
+      columns={columns}
+      getKey={(item) => item.id}
+      items={items}
+      linked
+    />
   );
 }
 
@@ -305,14 +334,6 @@ export function BottleCatalogLoading() {
 const styles = stylex.create({
   catalog: {
     minWidth: 0,
-  },
-  ratings: {
-    display: "flex",
-    width: "152px",
-    justifyContent: "flex-end",
-    [COMPACT]: {
-      width: "104px",
-    },
   },
   field: {
     display: "flex",

--- a/apps/web/src/components/pages/catalogTable.stylex.tsx
+++ b/apps/web/src/components/pages/catalogTable.stylex.tsx
@@ -1,0 +1,206 @@
+import * as stylex from "@stylexjs/stylex";
+import type { ReactNode } from "react";
+
+import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { linkedRowStyles } from "../linkedRow.stylex";
+
+const COMPACT = "@media (max-width: 639px)";
+
+export type CatalogTableColumn<Item> = {
+  align?: "left" | "center" | "right";
+  cell: (item: Item) => ReactNode;
+  header: ReactNode;
+  interactive?: boolean;
+  key: string;
+  padding?: "default" | "flush";
+  priority?: "primary" | "secondary";
+  width?: "action" | "count" | "rating";
+};
+
+export type CatalogTableProps<Item> = {
+  caption: string;
+  columns: readonly CatalogTableColumn<Item>[];
+  getKey: (item: Item) => string | number;
+  items: readonly Item[];
+  linked?: boolean;
+};
+
+/** Aligns rich catalog identities, metrics, and row actions under shared headers. */
+export function CatalogTable<Item>({
+  caption,
+  columns,
+  getKey,
+  items,
+  linked = false,
+}: CatalogTableProps<Item>) {
+  return (
+    <div {...stylex.props(styles.frame)}>
+      <table {...stylex.props(styles.table)}>
+        <caption {...stylex.props(styles.caption)}>{caption}</caption>
+        <thead>
+          <tr {...stylex.props(styles.headerRow)}>
+            {columns.map((column, index) => (
+              <th
+                key={column.key}
+                scope="col"
+                {...stylex.props(
+                  styles.header,
+                  index === 0 && styles.firstColumn,
+                  alignStyles[column.align ?? "left"],
+                  column.priority === "secondary" && styles.secondary,
+                  column.width && widthStyles[column.width],
+                )}
+              >
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr
+              data-record-key={getKey(item)}
+              key={getKey(item)}
+              {...stylex.props(
+                styles.row,
+                linked && linkedRowStyles.container,
+                linked && linkedRowStyles.onGround,
+              )}
+            >
+              {columns.map((column, index) => (
+                <td
+                  key={column.key}
+                  {...stylex.props(
+                    styles.cell,
+                    index === 0 && styles.firstColumn,
+                    alignStyles[column.align ?? "left"],
+                    column.padding === "flush" && styles.flushCell,
+                    column.priority === "secondary" && styles.secondary,
+                    column.width && widthStyles[column.width],
+                    column.width === "count" && styles.countCell,
+                    column.interactive && linkedRowStyles.nestedAction,
+                  )}
+                >
+                  {column.cell(item)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  frame: {
+    width: "100%",
+    minWidth: 0,
+    overflowX: "hidden",
+  },
+  table: {
+    width: "100%",
+    borderCollapse: "collapse",
+    tableLayout: "fixed",
+  },
+  caption: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    overflow: "hidden",
+    clip: "rect(0, 0, 0, 0)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
+  },
+  headerRow: {
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+  },
+  header: {
+    boxSizing: "border-box",
+    paddingTop: space.x2,
+    paddingRight: 0,
+    paddingBottom: space.x2,
+    paddingLeft: space.x3,
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "10px",
+    fontWeight: 500,
+    letterSpacing: "0.08em",
+    lineHeight: 1.3,
+    textTransform: "uppercase",
+    whiteSpace: "nowrap",
+  },
+  row: {
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+    ":last-child": {
+      borderBottomWidth: 0,
+    },
+  },
+  cell: {
+    boxSizing: "border-box",
+    minWidth: 0,
+    paddingTop: "14px",
+    paddingRight: 0,
+    paddingBottom: "14px",
+    paddingLeft: space.x3,
+    verticalAlign: "middle",
+  },
+  firstColumn: {
+    paddingLeft: 0,
+  },
+  flushCell: {
+    paddingTop: 0,
+    paddingRight: 0,
+    paddingBottom: 0,
+    paddingLeft: 0,
+  },
+  secondary: {
+    [COMPACT]: {
+      display: "none",
+    },
+  },
+  countWidth: {
+    width: "76px",
+  },
+  countCell: {
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontSize: "15px",
+    fontVariantNumeric: "tabular-nums",
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    lineHeight: 1,
+  },
+  actionWidth: {
+    width: "104px",
+    [COMPACT]: {
+      width: "92px",
+    },
+  },
+  ratingWidth: {
+    width: "152px",
+    [COMPACT]: {
+      width: "104px",
+    },
+  },
+  left: { textAlign: "left" },
+  center: { textAlign: "center" },
+  right: { textAlign: "right" },
+});
+
+const alignStyles = {
+  left: styles.left,
+  center: styles.center,
+  right: styles.right,
+} as const;
+
+const widthStyles = {
+  action: styles.actionWidth,
+  count: styles.countWidth,
+  rating: styles.ratingWidth,
+} as const;

--- a/apps/web/src/components/pages/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/entityCatalog.stylex.tsx
@@ -11,16 +11,15 @@ import {
   FacetGroup,
   FilterPanel,
   FilterQuery,
-  ItemList,
-  ItemRow,
   ListToolbar,
   MemberStatus,
   type ListSortOption,
 } from "..";
 import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { AppLink } from "../appLink";
+import { linkedRowStyles } from "../linkedRow.stylex";
 import { CatalogPageLoading } from "./catalogPage.stylex";
-
-const COMPACT = "@media (max-width: 639px)";
+import { CatalogTable, type CatalogTableColumn } from "./catalogTable.stylex";
 
 export type EntityCatalogItem = {
   href: string;
@@ -80,45 +79,13 @@ export function EntityCatalogList({
         sortOptions={sortOptions}
       />
       {items.length ? (
-        <ItemList ariaLabel={`${noun} records`} showTopDivider={false}>
-          {items.map((item) => (
-            <ItemRow
-              action={
-                onToggleFollowing ? (
-                  <Button
-                    aria-label={
-                      item.isFollowing
-                        ? `Unfollow ${item.name}`
-                        : `Follow ${item.name}`
-                    }
-                    aria-pressed={item.isFollowing}
-                    loading={pendingId === item.id}
-                    loadingLabel={
-                      item.isFollowing ? "Unfollowing…" : "Following…"
-                    }
-                    onClick={() => onToggleFollowing(item)}
-                    size="sm"
-                    variant={item.isFollowing ? "text" : "tonal"}
-                  >
-                    {item.isFollowing ? "Following" : "Follow"}
-                  </Button>
-                ) : undefined
-              }
-              end={<EntityCounts item={item} />}
-              href={item.href}
-              key={item.id}
-              metadata={item.metadata.join(" · ")}
-              title={
-                <>
-                  {item.name}
-                  {item.isFollowing && showFollowingMarks ? (
-                    <MemberStatus kind="following" />
-                  ) : null}
-                </>
-              }
-            />
-          ))}
-        </ItemList>
+        <EntityCatalogTable
+          items={items}
+          noun={noun}
+          onToggleFollowing={onToggleFollowing}
+          pendingId={pendingId}
+          showFollowingMarks={showFollowingMarks}
+        />
       ) : (
         <EmptyState
           action={
@@ -148,35 +115,90 @@ export function EntityCatalogList({
   );
 }
 
-function EntityCounts({ item }: { item: EntityCatalogItem }) {
-  const bottleNoun = item.totalBottles === 1 ? "bottle" : "bottles";
-  const tastingNoun = item.totalTastings === 1 ? "tasting" : "tastings";
+function EntityCatalogTable({
+  items,
+  noun,
+  onToggleFollowing,
+  pendingId,
+  showFollowingMarks,
+}: {
+  items: readonly EntityCatalogItem[];
+  noun: string;
+  onToggleFollowing?: (item: EntityCatalogItem) => void;
+  pendingId?: number;
+  showFollowingMarks: boolean;
+}) {
+  const columns: CatalogTableColumn<EntityCatalogItem>[] = [
+    {
+      cell: (item) => (
+        <>
+          <AppLink
+            href={item.href}
+            {...stylex.props(styles.title, linkedRowStyles.primaryLink)}
+          >
+            {item.name}
+            {item.isFollowing && showFollowingMarks ? (
+              <MemberStatus kind="following" />
+            ) : null}
+          </AppLink>
+          <div {...stylex.props(styles.metadata)}>
+            {item.metadata.join(" · ")}
+          </div>
+        </>
+      ),
+      header: "Name",
+      key: "name",
+    },
+    {
+      align: "right",
+      cell: (item) => item.totalBottles.toLocaleString("en-US"),
+      header: "Bottles",
+      key: "bottles",
+      width: "count",
+    },
+    {
+      align: "right",
+      cell: (item) => item.totalTastings.toLocaleString("en-US"),
+      header: "Tastings",
+      key: "tastings",
+      priority: "secondary",
+      width: "count",
+    },
+  ];
+
+  if (onToggleFollowing) {
+    columns.push({
+      align: "right",
+      cell: (item) => (
+        <Button
+          aria-label={
+            item.isFollowing ? `Unfollow ${item.name}` : `Follow ${item.name}`
+          }
+          aria-pressed={item.isFollowing}
+          loading={pendingId === item.id}
+          loadingLabel={item.isFollowing ? "Unfollowing…" : "Following…"}
+          onClick={() => onToggleFollowing(item)}
+          size="sm"
+          variant={item.isFollowing ? "text" : "tonal"}
+        >
+          {item.isFollowing ? "Following" : "Follow"}
+        </Button>
+      ),
+      header: "Follow",
+      interactive: true,
+      key: "follow",
+      width: "action",
+    });
+  }
 
   return (
-    <span
-      aria-label={`${item.totalBottles.toLocaleString("en-US")} ${bottleNoun} and ${item.totalTastings.toLocaleString("en-US")} ${tastingNoun}`}
-      role="group"
-      {...stylex.props(styles.counts)}
-    >
-      <span {...stylex.props(styles.count)}>
-        <strong
-          title={item.totalBottles.toLocaleString("en-US")}
-          {...stylex.props(styles.countValue)}
-        >
-          {item.totalBottles.toLocaleString("en-US")}
-        </strong>
-        <span {...stylex.props(styles.countLabel)}>{bottleNoun}</span>
-      </span>
-      <span {...stylex.props(styles.count, styles.tastingCount)}>
-        <strong
-          title={item.totalTastings.toLocaleString("en-US")}
-          {...stylex.props(styles.countValue)}
-        >
-          {item.totalTastings.toLocaleString("en-US")}
-        </strong>
-        <span {...stylex.props(styles.countLabel)}>{tastingNoun}</span>
-      </span>
-    </span>
+    <CatalogTable
+      caption={`${noun} records`}
+      columns={columns}
+      getKey={(item) => item.id}
+      items={items}
+      linked
+    />
   );
 }
 
@@ -246,49 +268,27 @@ const styles = stylex.create({
   catalog: {
     minWidth: 0,
   },
-  counts: {
-    display: "grid",
-    width: "156px",
-    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
-    gap: space.x4,
-    [COMPACT]: {
-      width: "52px",
-      gridTemplateColumns: "52px",
-    },
-  },
-  count: {
-    display: "flex",
-    minWidth: 0,
-    flexDirection: "column",
-    alignItems: "flex-end",
-    gap: space.x1,
-  },
-  countValue: {
+  title: {
+    display: "block",
     overflow: "hidden",
-    maxWidth: "100%",
     color: colors.ink,
     fontFamily: fonts.display,
-    fontSize: "15px",
-    fontVariantNumeric: "tabular-nums",
+    fontSize: "18px",
     fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1,
+    letterSpacing: "-0.025em",
+    lineHeight: 1.25,
+    textDecoration: "none",
     textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
-  countLabel: {
+  metadata: {
+    marginTop: "3px",
+    overflow: "hidden",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "9px",
-    letterSpacing: "0.07em",
-    lineHeight: 1.2,
-    textTransform: "uppercase",
-    [COMPACT]: {
-      fontSize: "8px",
-    },
-  },
-  tastingCount: {
-    [COMPACT]: {
-      display: "none",
-    },
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.4,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
 });

--- a/apps/web/src/lib/bottleCatalogItem.ts
+++ b/apps/web/src/lib/bottleCatalogItem.ts
@@ -17,7 +17,6 @@ export function toBottleCatalogItem(bottle: Bottle): BottleCatalogItem {
         ? "No age statement"
         : null,
     bottle.abv !== null ? `${formatAbv(bottle.abv)}% ABV` : null,
-    `${bottle.totalTastings.toLocaleString("en-US")} ${bottle.totalTastings === 1 ? "tasting" : "tastings"}`,
   ].filter((value): value is string => value !== null);
   const relatedReleaseCount = bottle.group?.totalBottles ?? 1;
 
@@ -43,6 +42,7 @@ export function toBottleCatalogItem(bottle: Bottle): BottleCatalogItem {
     scoreHigh: bottle.maxScore,
     scoreLow: bottle.minScore,
     scoreCount: bottle.scoreCount,
+    totalTastings: bottle.totalTastings,
   };
 }
 


### PR DESCRIPTION
Entity and bottle catalogs now use one semantic table component. Count, rating, and Follow columns share fixed widths and responsive behavior across Distillers, Brands, Bottlers, Companies, Following, the main Bottles page, and entity Bottle tabs.

Bottle tasting totals move from repeated row metadata into a dedicated Tastings column. The bottle identity row keeps its existing brand, status, release, and full-row link behavior through a table-cell layout. On compact screens, secondary entity metrics stay hidden while primary counts and actions remain aligned.

Simple data tables and bottle comparison views keep their existing specialized components.
