### PR TITLE
fix(web): link rating guide from footer

### DIFF
--- a/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
@@ -5,6 +5,7 @@ import { SiteFooter, type SiteFooterProps } from "@peated/web/components";
 const links = [
   { href: "/about", label: "About" },
   { href: "/about/categories", label: "Whisky categories" },
+  { href: "/about/ratings", label: "Rating guide" },
   { href: "/updates", label: "Recent changes" },
   { href: "https://github.com/peated/peated", label: "Source" },
   { href: "/terms", label: "Terms" },


### PR DESCRIPTION
The footer now lists both public whisky guides together: “Whisky categories” and “Rating guide.” This removes the asymmetry introduced when the category guide was added while preserving the compact footer and using the rating page’s own label.
