### PR TITLE
fix(bottles): default catalog to release sorting

### DIFF
--- a/apps/server/src/orpc/routes/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/list.test.ts
@@ -781,7 +781,7 @@ describe("GET /bottles", () => {
     expect(results[1].id).toBe(bottle1.id);
   });
 
-  test("requires a release year and orders year-only releases by creation time", async ({
+  test("sorts known releases first and undated bottles last", async ({
     fixtures,
   }) => {
     const earlierAddition = await fixtures.Bottle({
@@ -794,7 +794,7 @@ describe("GET /bottles", () => {
       releaseYear: 2026,
       createdAt: new Date("2026-06-01T00:00:00.000Z"),
     });
-    await fixtures.Bottle({
+    const undated = await fixtures.Bottle({
       name: "Recently Added",
       createdAt: new Date("2027-01-01T00:00:00.000Z"),
     });
@@ -806,8 +806,9 @@ describe("GET /bottles", () => {
     expect(results.map(({ id }) => id)).toEqual([
       laterAddition.id,
       earlierAddition.id,
+      undated.id,
     ]);
-    expect(total).toBe(2);
+    expect(total).toBe(3);
   });
 
   test("requires authentication for followed entity releases", async () => {
@@ -878,7 +879,7 @@ describe("GET /bottles", () => {
       releaseYear: 2026,
       createdAt: new Date("2026-07-01T00:00:00.000Z"),
     });
-    await fixtures.Bottle({
+    const addedThisYear = await fixtures.Bottle({
       name: "Added This Year",
       distillerIds: [distiller.id],
       createdAt: new Date("2026-09-01T00:00:00.000Z"),
@@ -889,7 +890,7 @@ describe("GET /bottles", () => {
       releaseYear: 2025,
       createdAt: new Date("2026-08-15T00:00:00.000Z"),
     });
-    await fixtures.Bottle({
+    const addedLastYear = await fixtures.Bottle({
       name: "Added Last Year",
       distillerIds: [distiller.id],
       createdAt: new Date("2025-12-01T00:00:00.000Z"),
@@ -921,6 +922,8 @@ describe("GET /bottles", () => {
       exactEarlierThisYear.id,
       yearOnlyThisYear.id,
       knownLastYear.id,
+      addedThisYear.id,
+      addedLastYear.id,
     ]);
     expect(followedEntityCount).toBe(3);
   });

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -185,11 +185,6 @@ export default implement(bottleListContract).handler(async function ({
       ),
     );
   }
-  // Release sorting owns release eligibility. Creation time only orders known releases.
-  if (rest.sort === "-release") {
-    where.push(isNotNull(bottles.releaseYear));
-  }
-
   if (rest.flight) {
     const [flight] = await db
       .select({ id: flights.id })

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -27,7 +27,7 @@ import { useORPC } from "@peated/web/lib/orpc/context";
 
 import { BottleCatalogNavigation } from "./bottleCatalogNavigation.stylex";
 
-const DEFAULT_SORT = "-tastings";
+const DEFAULT_SORT = "-release";
 
 type BottleList = Outputs["bottles"]["list"];
 
@@ -85,6 +85,7 @@ export function BottleCatalogPageClient({
   const searchParams = useSearchParams();
   const queryParams = normalizeBottleCatalogQueryParams(
     useApiQueryParams({
+      defaults: { sort: DEFAULT_SORT },
       allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
       fields: BOTTLE_CATALOG_QUERY_FIELDS,
       numericFields: [

--- a/apps/web/src/app/(app)/bottles/(index)/page.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/page.tsx
@@ -19,6 +19,7 @@ export default async function BottleListPage(props: {
 }) {
   const queryParams = normalizeBottleCatalogQueryParams(
     getApiQueryParams(await props.searchParams, {
+      defaults: { sort: "-release" },
       allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
       fields: BOTTLE_CATALOG_QUERY_FIELDS,
       numericFields: [


### PR DESCRIPTION
The bottle index now defaults to latest-release sorting instead of most tasted. Release sorting keeps the complete catalog visible: known release dates appear first, followed by undated bottles ordered by when they were added.

The general bottle-list API default remains unchanged for other callers. Focused integration coverage now verifies the dated and undated ordering in both the full catalog and the following scope.
