### PR TITLE
ci(web): skip empty screenshot comments

### DIFF
--- a/apps/web/visual/post-pr-comment.mjs
+++ b/apps/web/visual/post-pr-comment.mjs
@@ -42,16 +42,6 @@ function git(args, options = {}) {
 }
 
 export function buildBody(manifest, imageBaseUrl) {
-  if (manifest.skipped || manifest.screenshots.length === 0) {
-    return [
-      MARKER,
-      "## Web screenshots",
-      "",
-      "_No screenshot scenarios match these changed files._",
-      "",
-    ].join("\n");
-  }
-
   const changedFiles = manifest.changedFiles.length
     ? manifest.changedFiles
         .slice(0, 8)
@@ -90,6 +80,10 @@ export function buildBody(manifest, imageBaseUrl) {
     "_Captured from local Peated with fixed test data. These images help review a change. They do not compare pixels or block a pull request because the page changed._",
     "",
   ].join("\n");
+}
+
+export function shouldPostComment(manifest) {
+  return !manifest.skipped && manifest.screenshots.length > 0;
 }
 
 function publishImages(outDir, branch, commitSha) {
@@ -165,20 +159,22 @@ function upsertComment(repo, prNumber, body) {
 
 function main() {
   const outDir = path.resolve(process.argv[2] ?? "apps/web/.playwright/visual");
-  const prNumber = requiredEnv("PR_NUMBER");
-  const repo = requiredEnv("GITHUB_REPOSITORY");
-  const commitSha = process.env.GITHUB_SHA ?? "unknown";
-  const branch = `web-screenshots/pr-${prNumber}`;
   const manifestPath = path.join(outDir, "manifest.json");
   if (!fs.existsSync(manifestPath)) {
     throw new Error(`Missing manifest at ${manifestPath}`);
   }
 
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
-  const hasScreenshots = !manifest.skipped && manifest.screenshots.length > 0;
-  const imageRef = hasScreenshots
-    ? publishImages(outDir, branch, commitSha)
-    : branch;
+  if (!shouldPostComment(manifest)) {
+    console.log("no screenshot scenarios matched; skipping PR comment");
+    return;
+  }
+
+  const prNumber = requiredEnv("PR_NUMBER");
+  const repo = requiredEnv("GITHUB_REPOSITORY");
+  const commitSha = process.env.GITHUB_SHA ?? "unknown";
+  const branch = `web-screenshots/pr-${prNumber}`;
+  const imageRef = publishImages(outDir, branch, commitSha);
   const body = buildBody(
     manifest,
     `https://raw.githubusercontent.com/${repo}/${imageRef}`,

--- a/apps/web/visual/post-pr-comment.test.mjs
+++ b/apps/web/visual/post-pr-comment.test.mjs
@@ -1,20 +1,19 @@
 import { describe, expect, it } from "vitest";
 
-import { buildBody } from "./post-pr-comment.mjs";
+import { buildBody, shouldPostComment } from "./post-pr-comment.mjs";
 
-describe("buildBody", () => {
+describe("post PR comment", () => {
   it("describes selected pages and changed files", () => {
-    const body = buildBody(
-      {
-        changedFiles: ["apps/web/src/components/loginForm.tsx"],
-        scenarioIds: ["login"],
-        screenshots: [{ file: "login__desktop.png", label: "Login · desktop" }],
-        selection: "changed-files",
-        skipped: false,
-      },
-      "https://example.com/screenshots",
-    );
+    const manifest = {
+      changedFiles: ["apps/web/src/components/loginForm.tsx"],
+      scenarioIds: ["login"],
+      screenshots: [{ file: "login__desktop.png", label: "Login · desktop" }],
+      selection: "changed-files",
+      skipped: false,
+    };
+    const body = buildBody(manifest, "https://example.com/screenshots");
 
+    expect(shouldPostComment(manifest)).toBe(true);
     expect(body).toContain("## Web screenshots");
     expect(body).toContain("Run: pages matched to changed files");
     expect(body).toContain("Pages: `login`");
@@ -24,20 +23,15 @@ describe("buildBody", () => {
     );
   });
 
-  it("explains when no page matches", () => {
-    const body = buildBody(
-      {
+  it("skips the comment when no page matches", () => {
+    expect(
+      shouldPostComment({
         changedFiles: ["apps/web/e2e/activity-feed.spec.ts"],
         scenarioIds: [],
         screenshots: [],
         selection: "changed-files",
         skipped: true,
-      },
-      "https://example.com/screenshots",
-    );
-
-    expect(body).toContain(
-      "No screenshot scenarios match these changed files.",
-    );
+      }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
Web screenshot CI now exits without creating or updating a pull request comment when no scenarios match the changed files. Screenshot runs that produce images keep the existing publish-and-comment flow.

The focused test now covers both the comment and no-comment decisions.
