### PR TITLE
fix(web): standardize link interaction states

### DIFF
--- a/apps/web/src/app/(admin)/admin/(default)/bottle-references/referenceAuditPage.stylex.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/bottle-references/referenceAuditPage.stylex.tsx
@@ -2,7 +2,6 @@
 
 import type { Inputs, Outputs } from "@peated/server/orpc/router";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import Link from "next/link";
 import { useState } from "react";
 
 import { AdminButton } from "@peated/web/components/admin/adminButton.stylex";
@@ -12,6 +11,7 @@ import {
   AdminPage,
   AdminPageHeader,
   AdminStatus,
+  AdminTextLink,
 } from "@peated/web/components/admin/adminContent.stylex";
 import { AdminTable } from "@peated/web/components/admin/adminTable.stylex";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
@@ -109,9 +109,9 @@ export default function BottleReferenceAuditPage() {
       name: "Bottle",
       value: (item: AuditItem) => (
         <div>
-          <Link href={`/bottles/${item.bottle.id}`}>
+          <AdminTextLink href={`/bottles/${item.bottle.id}`}>
             {item.bottle.fullName}
-          </Link>
+          </AdminTextLink>
           <div>
             {item.group.siblings.length} other Bottle
             {item.group.siblings.length === 1 ? "" : "s"} in this group

--- a/apps/web/src/app/(app)/_components/home/homeActivity.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/homeActivity.stylex.tsx
@@ -8,7 +8,6 @@ import { useEventListener } from "usehooks-ts";
 
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import {
-  AppLink,
   ButtonLink,
   EmptyState,
   ItemList,
@@ -17,6 +16,7 @@ import {
   MemberAvatar,
   SectionError,
   TastingEntry,
+  TextLink,
   type TastingEntryMember,
 } from "@peated/web/components";
 import { getTastingEntryMember } from "@peated/web/components/tastingRecordEntry";
@@ -83,18 +83,15 @@ function CollectionActivityItem({
           username={activity.createdBy.username}
         />
         <div {...stylex.props(styles.collectionCopy)}>
-          <AppLink
-            href={`/users/${activity.createdBy.username}`}
-            {...stylex.props(styles.collectionAuthor)}
-          >
+          <TextLink href={`/users/${activity.createdBy.username}`}>
             {activity.createdBy.username}
-          </AppLink>
+          </TextLink>
           <span {...stylex.props(styles.collectionContext)}>
             added {formatBottleCount(activity.totalItems)} to{" "}
             {activity.collection.href ? (
-              <AppLink href={activity.collection.href}>
+              <TextLink href={activity.collection.href} size="inherit">
                 {activity.collection.name}
-              </AppLink>
+              </TextLink>
             ) : (
               activity.collection.name
             )}
@@ -265,12 +262,6 @@ const styles = stylex.create({
     display: "flex",
     minWidth: 0,
     flexDirection: "column",
-  },
-  collectionAuthor: {
-    color: colors.ink,
-    fontSize: "13px",
-    fontWeight: 600,
-    textDecoration: "none",
   },
   collectionContext: {
     marginTop: "2px",

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogNavigation.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogNavigation.stylex.tsx
@@ -2,7 +2,7 @@
 
 import * as stylex from "@stylexjs/stylex";
 
-import { AppLink, PageTabs } from "@peated/web/components";
+import { PageTabs, TextLink } from "@peated/web/components";
 import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 export function BottleCatalogNavigation({
@@ -27,9 +27,18 @@ export function BottleCatalogNavigation({
       {scope === "following" ? (
         <p {...stylex.props(styles.scopeHelp)}>
           Bottles from distillers, brands, and bottlers you follow. See followed{" "}
-          <AppLink href="/distillers?filter=following">distillers</AppLink>,{" "}
-          <AppLink href="/brands?filter=following">brands</AppLink>, or{" "}
-          <AppLink href="/bottlers?filter=following">bottlers</AppLink>.
+          <TextLink href="/distillers?filter=following" size="inherit">
+            distillers
+          </TextLink>
+          ,{" "}
+          <TextLink href="/brands?filter=following" size="inherit">
+            brands
+          </TextLink>
+          , or{" "}
+          <TextLink href="/bottlers?filter=following" size="inherit">
+            bottlers
+          </TextLink>
+          .
         </p>
       ) : null}
     </div>

--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
@@ -1,17 +1,12 @@
 import * as stylex from "@stylexjs/stylex";
 
 import {
-  AppLink,
+  TextLink,
   hasVisibleFacts,
   type FactListItem,
 } from "@peated/web/components";
 import { parseDomain } from "@peated/web/lib/urls";
-import {
-  colors,
-  effects,
-  fonts,
-  space,
-} from "../../../../styles/tokens.stylex";
+import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 import type { Entity } from "./entityPageData";
 
@@ -20,21 +15,18 @@ function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
     <>
       {entity.region ? (
         <>
-          <AppLink
+          <TextLink
             href={`/locations/${entity.country.slug}/regions/${entity.region.slug}`}
-            {...stylex.props(styles.factLink)}
+            size="inherit"
           >
             {entity.region.name}
-          </AppLink>
+          </TextLink>
           <span>, </span>
         </>
       ) : null}
-      <AppLink
-        href={`/locations/${entity.country.slug}`}
-        {...stylex.props(styles.factLink)}
-      >
+      <TextLink href={`/locations/${entity.country.slug}`} size="inherit">
         {entity.country.name}
-      </AppLink>
+      </TextLink>
     </>
   ) : null;
 
@@ -43,25 +35,22 @@ function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
     {
       label: "Owned by",
       value: entity.owner ? (
-        <AppLink
-          href={`/entities/${entity.owner.id}`}
-          {...stylex.props(styles.factLink)}
-        >
+        <TextLink href={`/entities/${entity.owner.id}`} size="inherit">
           {entity.owner.name}
-        </AppLink>
+        </TextLink>
       ) : null,
     },
     {
       label: "Website",
       value: entity.website ? (
-        <a
+        <TextLink
           href={entity.website}
           rel="noreferrer"
+          size="inherit"
           target="_blank"
-          {...stylex.props(styles.factLink)}
         >
           {parseDomain(entity.website)}
-        </a>
+        </TextLink>
       ) : null,
     },
     { label: "Also known as", value: entity.shortName },
@@ -132,14 +121,5 @@ const styles = stylex.create({
     fontWeight: 700,
     lineHeight: 1.35,
     overflowWrap: "anywhere",
-  },
-  factLink: {
-    color: colors.accentDeep,
-    outline: "none",
-    textDecoration: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
   },
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
@@ -1,13 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { Card } from "@peated/web/components";
+import { Card, TextLink } from "@peated/web/components";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
-import {
-  colors,
-  effects,
-  fonts,
-  space,
-} from "../../../../styles/tokens.stylex";
+import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 import type { Entity } from "./entityPageData";
 
@@ -47,14 +42,9 @@ export function EntityMap({ entity }: { entity: Entity }) {
         />
         <div {...stylex.props(styles.mapFooter)}>
           <span {...stylex.props(styles.coordinates)}>{coordinateLabel}</span>
-          <a
-            href={mapHref}
-            rel="noreferrer"
-            target="_blank"
-            {...stylex.props(styles.mapLink)}
-          >
+          <TextLink href={mapHref} rel="noreferrer" target="_blank">
             Open in map →
-          </a>
+          </TextLink>
         </div>
       </Card>
     </PageSection>
@@ -91,18 +81,5 @@ const styles = stylex.create({
     fontFamily: fonts.data,
     fontSize: "10px",
     lineHeight: 1.4,
-  },
-  mapLink: {
-    color: colors.accentDeep,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    fontWeight: 700,
-    lineHeight: 1.3,
-    outline: "none",
-    textDecoration: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
   },
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -6,13 +6,13 @@ import { usePathname, useRouter } from "next/navigation";
 import { type ReactNode } from "react";
 
 import {
-  AppLink,
   Button,
   ButtonLink,
   KeyFacts,
   PageTabs,
   RowMenu,
   SectionError,
+  TextLink,
   type RowMenuItem,
 } from "@peated/web/components";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
@@ -24,12 +24,7 @@ import { logTelemetryError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getEntityUrl } from "@peated/web/lib/urls";
 import { foundationStyles } from "@peated/web/styles/foundations.stylex";
-import {
-  colors,
-  effects,
-  fonts,
-  space,
-} from "../../../../styles/tokens.stylex";
+import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 import {
   getEntityClassification,
@@ -201,12 +196,9 @@ export function EntityPageFrameClient({
 
         <div {...stylex.props(styles.summary)}>
           {owner ? (
-            <AppLink
-              href={getEntityUrl(owner)}
-              {...stylex.props(styles.ownerLink)}
-            >
+            <TextLink href={getEntityUrl(owner)} size="inherit">
               {getEntityOwnerLabel(entity, owner)}
-            </AppLink>
+            </TextLink>
           ) : null}
           {entity.description ? (
             <div {...stylex.props(styles.description)}>
@@ -312,14 +304,5 @@ const styles = stylex.create({
   },
   specs: {
     marginBottom: space.x4,
-  },
-  ownerLink: {
-    color: "inherit",
-    outline: "none",
-    textDecoration: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
   },
 });

--- a/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
@@ -4,7 +4,7 @@ import * as stylex from "@stylexjs/stylex";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 
-import { AppLink, KeyFacts, PageTabs } from "@peated/web/components";
+import { KeyFacts, PageTabs, TextLink } from "@peated/web/components";
 import CountryMapIcon from "@peated/web/components/countryMapIcon";
 import { PageHeader } from "@peated/web/components/pages/pageLayout.stylex";
 import UsStateMapIcon from "@peated/web/components/usStateMapIcon";
@@ -66,7 +66,9 @@ export function LocationPageFrame({
         identity={visual ? <LocationVisual visual={visual} /> : undefined}
         parent={
           country ? (
-            <AppLink href={country.href}>{country.name}</AppLink>
+            <TextLink href={country.href} size="inherit">
+              {country.name}
+            </TextLink>
           ) : undefined
         }
         title={name}

--- a/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
+++ b/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
@@ -269,9 +269,11 @@ const styles = stylex.create({
     lineHeight: 1.45,
   },
   author: {
-    color: colors.ink,
+    color: { default: colors.ink, ":hover": colors.accentDeep },
     fontWeight: 700,
-    textDecoration: "none",
+    textDecorationLine: { default: "none", ":hover": "underline" },
+    textDecorationThickness: "1px",
+    textUnderlineOffset: "2px",
     outline: "none",
     boxShadow: { default: "none", ":focus-visible": effects.focusRing },
   },

--- a/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
@@ -1,5 +1,5 @@
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
-import { AppLink } from "@peated/web/components";
+import { TextLink } from "@peated/web/components";
 import {
   PageHeader,
   PageSection,
@@ -52,9 +52,12 @@ export default async function TastingPage(props: {
       <PageHeader
         eyebrow="Tasting record"
         parent={
-          <AppLink href={`/users/${tasting.createdBy.username}`}>
+          <TextLink
+            href={`/users/${tasting.createdBy.username}`}
+            size="inherit"
+          >
             {tasting.createdBy.username}
-          </AppLink>
+          </TextLink>
         }
         title={formatBottleDisplayName(tasting.bottle)}
       />

--- a/apps/web/src/app/(layout-free)/addBottle/badgeAwardMessage.stylex.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/badgeAwardMessage.stylex.tsx
@@ -39,6 +39,7 @@ const styles = stylex.create({
     gap: space.x3,
     borderRadius: "2px",
     outline: "none",
+    backgroundColor: { default: "transparent", ":hover": colors.surface },
     color: colors.ink,
     textDecoration: "none",
     boxShadow: {

--- a/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
@@ -16,7 +16,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useDebounceCallback } from "usehooks-ts";
 
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
-import { IconButton } from "../..";
+import { IconButton, TextLink } from "../..";
 import { useORPC } from "../../../lib/orpc/context";
 import {
   colors,
@@ -159,9 +159,14 @@ export default function ModerationBottlePicker({
               <>
                 {" "}
                 Source:{" "}
-                <a href={source} target="_blank" rel="noreferrer">
+                <TextLink
+                  href={source}
+                  rel="noreferrer"
+                  size="inherit"
+                  target="_blank"
+                >
                   {source}
-                </a>
+                </TextLink>
                 .
               </>
             ) : null}

--- a/apps/web/src/components/admin/scraperPreviewResult.stylex.tsx
+++ b/apps/web/src/components/admin/scraperPreviewResult.stylex.tsx
@@ -149,8 +149,10 @@ const styles = stylex.create({
     borderTopColor: colors.hairline,
   },
   link: {
-    color: colors.accentDeep,
+    color: { default: colors.accentDeep, ":hover": colors.accent },
     overflowWrap: "anywhere",
+    textDecorationLine: { default: "none", ":hover": "underline" },
+    textUnderlineOffset: "2px",
     outline: "none",
     boxShadow: {
       default: "none",

--- a/apps/web/src/components/appLink.tsx
+++ b/apps/web/src/components/appLink.tsx
@@ -1,9 +1,12 @@
+import * as stylex from "@stylexjs/stylex";
 import NextLink from "next/link";
 import {
   forwardRef,
   type AnchorHTMLAttributes,
   type ForwardedRef,
 } from "react";
+
+import { textLinkStyles } from "./textLinkStyles.stylex";
 
 export type AppLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   prefetch?: boolean;
@@ -13,21 +16,43 @@ export function isInternalAppHref(href: string) {
   return href.startsWith("/") && !href.startsWith("//");
 }
 
-/** Uses client navigation for app routes and native anchors for other targets. */
+/**
+ * Uses client navigation for app routes and native anchors for other targets.
+ * A bare link gets the shared text-link interaction treatment. Composite
+ * components replace it by supplying their own class. Use TextLink for inline
+ * text because its API also owns typography and truncation.
+ */
 export const AppLink = forwardRef(function AppLink(
-  { children, download, href, prefetch = false, ...props }: AppLinkProps,
+  {
+    children,
+    className,
+    download,
+    href,
+    prefetch = false,
+    style,
+    ...props
+  }: AppLinkProps,
   ref: ForwardedRef<HTMLAnchorElement>,
 ) {
+  const fallbackProps = className
+    ? undefined
+    : stylex.props(textLinkStyles.link, textLinkStyles.small);
+  const linkProps = {
+    ...props,
+    className: className ?? fallbackProps?.className,
+    style: fallbackProps?.style ? { ...fallbackProps.style, ...style } : style,
+  };
+
   if (!href || !isInternalAppHref(href) || download !== undefined) {
     return (
-      <a {...props} download={download} href={href} ref={ref}>
+      <a {...linkProps} download={download} href={href} ref={ref}>
         {children}
       </a>
     );
   }
 
   return (
-    <NextLink {...props} href={href} prefetch={prefetch} ref={ref}>
+    <NextLink {...linkProps} href={href} prefetch={prefetch} ref={ref}>
       {children}
     </NextLink>
   );

--- a/apps/web/src/components/bottleChecks/checkSummary.stylex.tsx
+++ b/apps/web/src/components/bottleChecks/checkSummary.stylex.tsx
@@ -92,7 +92,7 @@ export function BottleCheckSubject({
 const styles = stylex.create({
   subject: { color: colors.inkMuted },
   subjectLink: {
-    color: colors.ink,
+    color: { default: colors.ink, ":hover": colors.accentDeep },
     fontWeight: 600,
     textDecoration: "underline",
     outline: "none",

--- a/apps/web/src/components/historyTimeline.stylex.tsx
+++ b/apps/web/src/components/historyTimeline.stylex.tsx
@@ -140,7 +140,7 @@ const styles = stylex.create({
     color: colors.inkMuted,
   },
   source: {
-    color: colors.accentDeep,
+    color: { default: colors.accentDeep, ":hover": colors.accent },
     fontFamily: fonts.data,
     fontSize: "11px",
     lineHeight: 1.45,

--- a/apps/web/src/components/pages/memberProfileContent.stylex.tsx
+++ b/apps/web/src/components/pages/memberProfileContent.stylex.tsx
@@ -4,7 +4,6 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import {
-  AppLink,
   BottleIdentityRow,
   Button,
   Chip,
@@ -16,6 +15,7 @@ import {
   ItemListItem,
   RowMenu,
   TastingEntry,
+  TextLink,
   type BottleIdentityRowProps,
   type RowMenuGroup,
   type TastingEntryProps,
@@ -225,12 +225,14 @@ function CollectionActivity({
       <header {...stylex.props(styles.activityHeader)}>
         <div {...stylex.props(styles.activityCopy)}>
           <div {...stylex.props(styles.activitySentence)}>
-            <AppLink href={activity.authorHref}>{activity.author}</AppLink>
+            <TextLink href={activity.authorHref} size="inherit">
+              {activity.author}
+            </TextLink>
             <span> added {formatBottleCount(activity.totalItems)} to </span>
             {activity.collectionHref ? (
-              <AppLink href={activity.collectionHref}>
+              <TextLink href={activity.collectionHref} size="inherit">
                 {activity.collectionName}
-              </AppLink>
+              </TextLink>
             ) : (
               <strong>{activity.collectionName}</strong>
             )}

--- a/apps/web/src/components/skipLink.stylex.tsx
+++ b/apps/web/src/components/skipLink.stylex.tsx
@@ -28,7 +28,7 @@ const styles = stylex.create({
     paddingBottom: space.x2,
     paddingLeft: space.x3,
     borderRadius: controlMetrics.radius,
-    backgroundColor: colors.ink,
+    backgroundColor: { default: colors.ink, ":hover": colors.accentDeep },
     color: colors.ground,
     fontFamily: fonts.reading,
     fontSize: "13px",

--- a/apps/web/src/components/textLink.stylex.tsx
+++ b/apps/web/src/components/textLink.stylex.tsx
@@ -1,7 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, effects, fonts } from "../styles/tokens.stylex";
 import { AppLink, type AppLinkProps } from "./appLink";
+import { textLinkStyles } from "./textLinkStyles.stylex";
 import { getTextTitle } from "./textTitle";
 
 export type TextLinkProps = Omit<
@@ -26,15 +26,15 @@ export function TextLink({
       href={href}
       {...props}
       {...stylex.props(
-        styles.link,
-        size === "sm" && styles.small,
-        truncate && styles.truncate,
+        textLinkStyles.link,
+        size === "sm" && textLinkStyles.small,
+        truncate && textLinkStyles.truncate,
       )}
     >
       {truncate ? (
         <span
           title={getTextTitle(children)}
-          {...stylex.props(styles.truncateContent)}
+          {...stylex.props(textLinkStyles.truncateContent)}
         >
           {children}
         </span>
@@ -44,45 +44,3 @@ export function TextLink({
     </AppLink>
   );
 }
-
-const styles = stylex.create({
-  link: {
-    position: "relative",
-    zIndex: 2,
-    display: "inline-flex",
-    width: "fit-content",
-    color: {
-      default: colors.accentDeep,
-      ":hover": colors.accent,
-      ":active": colors.ink,
-    },
-    fontWeight: 600,
-    textDecorationLine: {
-      default: "none",
-      ":hover": "underline",
-    },
-    textDecorationThickness: "1px",
-    textUnderlineOffset: "2px",
-    outline: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
-  },
-  small: {
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.3,
-  },
-  truncate: {
-    minWidth: 0,
-    maxWidth: "100%",
-  },
-  truncateContent: {
-    minWidth: 0,
-    maxWidth: "100%",
-    overflow: "hidden",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-  },
-});

--- a/apps/web/src/components/textLinkStyles.stylex.ts
+++ b/apps/web/src/components/textLinkStyles.stylex.ts
@@ -1,0 +1,46 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { colors, effects, fonts } from "../styles/tokens.stylex";
+
+/** Shared text-link interaction styles for TextLink and bare AppLink fallback. */
+export const textLinkStyles = stylex.create({
+  link: {
+    position: "relative",
+    zIndex: 2,
+    display: "inline-flex",
+    width: "fit-content",
+    color: {
+      default: colors.accentDeep,
+      ":hover": colors.accent,
+      ":active": colors.ink,
+    },
+    fontWeight: 600,
+    textDecorationLine: {
+      default: "none",
+      ":hover": "underline",
+    },
+    textDecorationThickness: "1px",
+    textUnderlineOffset: "2px",
+    outline: "none",
+    boxShadow: {
+      default: "none",
+      ":focus-visible": effects.focusRing,
+    },
+  },
+  small: {
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.3,
+  },
+  truncate: {
+    minWidth: 0,
+    maxWidth: "100%",
+  },
+  truncateContent: {
+    minWidth: 0,
+    maxWidth: "100%",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+});

--- a/apps/web/src/components/workflowScreen.stylex.tsx
+++ b/apps/web/src/components/workflowScreen.stylex.tsx
@@ -206,7 +206,7 @@ const styles = stylex.create({
     },
   },
   brand: {
-    color: colors.ink,
+    color: { default: colors.ink, ":hover": colors.accentDeep },
     fontFamily: fonts.display,
     fontSize: "15px",
     fontWeight: 700,


### PR DESCRIPTION
Plain text links now use one shared hover, active, and keyboard-focus treatment across entity details, ownership headers, activity copy, catalog help, moderation, and admin surfaces. Bare `AppLink` usage receives the same interaction fallback, while cards, buttons, tabs, menus, and linked rows continue to own their composite states.

Review starts in `AppLink`, `TextLink`, and the extracted shared styles. The remaining changes replace one-off or unstyled text links and add missing hover feedback to custom link treatments.
