### PR TITLE
style(web): compact sidebar search input

### DIFF
--- a/apps/web/src/components/field.stylex.tsx
+++ b/apps/web/src/components/field.stylex.tsx
@@ -107,26 +107,33 @@ export function FieldGroup({
 }
 
 type InputFormat = "text" | "data";
+type InputSize = "sm" | "md" | "lg";
 
 export type TextInputProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
   "className" | "style"
 > & {
+  controlSize?: InputSize;
   format?: InputFormat;
   invalid?: boolean;
 };
 
 export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
-  function TextInput({ format = "text", invalid = false, ...props }, ref) {
+  function TextInput(
+    { controlSize = "lg", format = "text", invalid = false, ...props },
+    ref,
+  ) {
     return (
       <input
         {...props}
         aria-invalid={invalid || undefined}
         data-format={format}
+        data-size={controlSize}
         ref={ref}
         {...stylex.props(
           styles.control,
           styles.input,
+          inputSizeStyles[controlSize],
           format === "data" && styles.data,
           invalid && styles.invalid,
         )}
@@ -228,7 +235,7 @@ const styles = stylex.create({
     borderWidth: "1px",
     borderStyle: "solid",
     borderColor: {
-      default: colors.fieldRule,
+      default: colors.sectionRule,
       ":hover": colors.inkMuted,
       ":focus": colors.accent,
     },
@@ -253,9 +260,17 @@ const styles = stylex.create({
     },
   },
   input: {
-    height: controlMetrics.controlHeightLarge,
     paddingRight: "13px",
     paddingLeft: "13px",
+  },
+  inputSmall: {
+    height: controlMetrics.controlHeightSmall,
+  },
+  inputMedium: {
+    height: controlMetrics.controlHeight,
+  },
+  inputLarge: {
+    height: controlMetrics.controlHeightLarge,
   },
   textarea: {
     minHeight: "96px",
@@ -288,3 +303,9 @@ const styles = stylex.create({
     fontWeight: 600,
   },
 });
+
+const inputSizeStyles = {
+  sm: styles.inputSmall,
+  md: styles.inputMedium,
+  lg: styles.inputLarge,
+} satisfies Record<InputSize, stylex.StyleXStyles>;

--- a/apps/web/src/components/filterPanel.stylex.tsx
+++ b/apps/web/src/components/filterPanel.stylex.tsx
@@ -76,6 +76,7 @@ export function FilterQuery({
         <span {...stylex.props(styles.heading)}>{label}</span>
         <TextInput
           aria-label={label}
+          controlSize="sm"
           id={id}
           onChange={(event) =>
             setDraft({ source: query, value: event.currentTarget.value })


### PR DESCRIPTION
Catalog filter searches now use a compact 34px input that matches the adjacent Search button. Shared text inputs also use the same quiet border color as tonal buttons.

`TextInput` now accepts explicit small, medium, and large control sizes while keeping the existing large size as its default, so regular forms retain their current height.
