### PR TITLE
fix(web): show images in bottle lists

### DIFF
--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -152,6 +152,7 @@ function LatestReleases() {
       : [
           {
             href: `/bottles/${bottle.id}`,
+            imageUrl: bottle.imageUrl,
             metadata: getReleaseMetadata(bottle),
             name: formatBottleDisplayName(bottle),
           },
@@ -383,6 +384,7 @@ function RecentBottles({ totalBottles }: { totalBottles?: number }) {
     <HomeRecentBottles
       bottles={bottles.data.results.map((bottle) => ({
         href: `/bottles/${bottle.id}`,
+        imageUrl: bottle.imageUrl,
         metadata: getBottleMetadata(bottle),
         name: formatBottleDisplayName(bottle),
       }))}

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -511,6 +511,7 @@ export function BottleOverviewClient({
         />
       ),
       href: `/bottles/${recommendation.id}`,
+      imageUrl: recommendation.imageUrl,
       metadata: [
         formatCategoryName(recommendation.category),
         recommendation.abv === null

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleTableRows.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleTableRows.tsx
@@ -62,6 +62,7 @@ export function toBottleTableRow(
   return {
     href: `/bottles/${bottle.id}`,
     id: bottle.peatedId,
+    imageUrl: bottle.imageUrl,
     metadata,
     name: formatBottleDisplayName(bottle),
     values: [

--- a/apps/web/src/components/bottleComparisonTable.stories.tsx
+++ b/apps/web/src/components/bottleComparisonTable.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
+import BottleImage from "../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
 import {
   BottleComparisonTable,
   type BottleComparisonTableProps,
@@ -11,6 +12,7 @@ const rows: BottleComparisonTableProps["rows"] = [
   {
     href: "/bottles/1",
     id: "1",
+    imageUrl: BottleImage.src,
     metadata: "Islay · 10 years · 46% ABV",
     name: "Port Charlotte 10 Year Old",
     values: [

--- a/apps/web/src/components/bottleComparisonTable.stylex.tsx
+++ b/apps/web/src/components/bottleComparisonTable.stylex.tsx
@@ -3,6 +3,7 @@ import { type ReactNode, useId } from "react";
 
 import { colors, effects, fonts, space } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
+import { BottleVisual } from "./bottleIdentityRow.stylex";
 import { linkedRowStyles } from "./linkedRow.stylex";
 import { getTextTitle } from "./textTitle";
 
@@ -11,6 +12,7 @@ const COMPACT = "@media (max-width: 639px)";
 export type BottleComparisonRow = {
   href?: string;
   id: string;
+  imageUrl?: string | null;
   metadata?: string;
   name: string;
   values: readonly [ReactNode, ...ReactNode[]];
@@ -78,28 +80,36 @@ export function BottleComparisonTable({
               )}
             >
               <th scope="row" {...stylex.props(styles.nameCell)}>
-                {row.href ? (
-                  <AppLink
-                    href={row.href}
-                    title={row.name}
-                    {...stylex.props(
-                      styles.name,
-                      styles.nameLink,
-                      linkedRowStyles.primaryLink,
+                <div {...stylex.props(styles.identity)}>
+                  <BottleVisual imageUrl={row.imageUrl} />
+                  <div {...stylex.props(styles.copy)}>
+                    {row.href ? (
+                      <AppLink
+                        href={row.href}
+                        title={row.name}
+                        {...stylex.props(
+                          styles.name,
+                          styles.nameLink,
+                          linkedRowStyles.primaryLink,
+                        )}
+                      >
+                        {row.name}
+                      </AppLink>
+                    ) : (
+                      <span title={row.name} {...stylex.props(styles.name)}>
+                        {row.name}
+                      </span>
                     )}
-                  >
-                    {row.name}
-                  </AppLink>
-                ) : (
-                  <span title={row.name} {...stylex.props(styles.name)}>
-                    {row.name}
-                  </span>
-                )}
-                {row.metadata ? (
-                  <span title={row.metadata} {...stylex.props(styles.metadata)}>
-                    {row.metadata}
-                  </span>
-                ) : null}
+                    {row.metadata ? (
+                      <span
+                        title={row.metadata}
+                        {...stylex.props(styles.metadata)}
+                      >
+                        {row.metadata}
+                      </span>
+                    ) : null}
+                  </div>
+                </div>
               </th>
               {row.values.map((value, index) => (
                 <td key={index} {...stylex.props(styles.valueCell)}>
@@ -220,6 +230,16 @@ const styles = stylex.create({
       paddingRight: 0,
       paddingBottom: space.x3,
     },
+  },
+  identity: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "center",
+    gap: space.x3,
+  },
+  copy: {
+    minWidth: 0,
+    flex: 1,
   },
   name: {
     display: "block",

--- a/apps/web/src/components/lists.stylex.tsx
+++ b/apps/web/src/components/lists.stylex.tsx
@@ -161,6 +161,7 @@ export function RailList({
 export type RailListItemProps = {
   end?: ReactNode;
   href?: string;
+  leading?: ReactNode;
   metadata?: string;
   title: string;
 };
@@ -168,12 +169,14 @@ export type RailListItemProps = {
 export function RailListItem({
   end,
   href,
+  leading,
   metadata,
   title,
 }: RailListItemProps) {
   return (
     <ItemListItem>
       <div {...stylex.props(styles.railRow)}>
+        {leading}
         <div {...stylex.props(styles.railCopy)}>
           {href ? (
             <AppLink

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 import type { CriticReviewProps, FactListItem, TastingEntryProps } from "..";
 import {
   AppLink,
+  BottleVisual,
   CriticReview,
   FactList,
   hasVisibleFacts,
@@ -23,6 +24,7 @@ const RAIL_STACKS = "@media (max-width: 680px)";
 export type BottleRecommendation = {
   end?: ReactNode;
   href: string;
+  imageUrl?: string | null;
   metadata?: string;
   name: string;
 };
@@ -140,6 +142,12 @@ export function BottleOverview({
                     end={recommendation.end}
                     href={recommendation.href}
                     key={recommendation.href}
+                    leading={
+                      <BottleVisual
+                        imageUrl={recommendation.imageUrl}
+                        size="sm"
+                      />
+                    }
                     metadata={recommendation.metadata}
                     title={recommendation.name}
                   />

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 import {
   AppLink,
   BottleRatings,
+  BottleVisual,
   Card,
   CardActionLink,
   CardLink,
@@ -48,6 +49,7 @@ function HomeModuleHeading({
 export type HomeRatedBottle = {
   bandCounts: TastingRatingCounts;
   href: string;
+  imageUrl?: string | null;
   metadata: readonly string[];
   name: string;
   scoreCount: number;
@@ -93,6 +95,7 @@ export function HomeHighestRated({
               }
               href={bottle.href}
               key={bottle.href}
+              leading={<BottleVisual imageUrl={bottle.imageUrl} />}
               metadata={bottle.metadata.join(" · ")}
               title={bottle.name}
             />
@@ -105,6 +108,7 @@ export function HomeHighestRated({
 
 export type HomeRelease = {
   href: string;
+  imageUrl?: string | null;
   metadata: ReactNode;
   name: string;
 };
@@ -135,6 +139,7 @@ export function HomeLatestReleases({
             <ItemRow
               href={bottle.href}
               key={bottle.href}
+              leading={<BottleVisual imageUrl={bottle.imageUrl} />}
               metadata={bottle.metadata}
               metadataWrap
               title={bottle.name}
@@ -427,6 +432,7 @@ export function HomeDistilleries({
 
 export type HomeRecentBottle = {
   href: string;
+  imageUrl?: string | null;
   metadata: readonly string[];
   name: string;
 };
@@ -454,6 +460,7 @@ export function HomeRecentBottles({
             <ItemRow
               href={bottle.href}
               key={bottle.href}
+              leading={<BottleVisual imageUrl={bottle.imageUrl} size="sm" />}
               metadata={bottle.metadata.join(" · ")}
               size="sm"
               title={bottle.name}


### PR DESCRIPTION
Home-page bottle modules, entity comparison tables, and bottle recommendation rails now use the same bottle visual as search and the catalog. Stored bottle images appear when available, while records without images keep the existing bottle glyph fallback.

The entity comparison layout now treats the visual and bottle copy as one identity cell, preserving the existing rating columns and linked-row behavior at desktop and mobile widths.
