### PR TITLE
fix(scraper): recover Single Cask Nation matches

### DIFF
--- a/apps/server/src/lib/createStorePrices.ts
+++ b/apps/server/src/lib/createStorePrices.ts
@@ -262,7 +262,13 @@ async function persistStorePriceInTransaction({
       })
       .onConflictDoNothing()
       .returning();
-    if (created) return { price: created, sourceIdentityReused: false };
+    if (created) {
+      return {
+        price: created,
+        identityChanged: false,
+        sourceIdentityReused: false,
+      };
+    }
 
     existing = await findStorePriceForUpdate(tx, identity);
     if (!existing) {
@@ -336,7 +342,7 @@ async function persistStorePriceInTransaction({
       `Store price changed while it was being saved (${existing.id}).`,
     );
   }
-  return { price: updated, sourceIdentityReused };
+  return { price: updated, identityChanged, sourceIdentityReused };
 }
 
 /** Persists one scraper batch with attribution chosen by the owning boundary. */
@@ -443,6 +449,7 @@ export async function createStorePrices(
               price: {
                 id: priceId,
                 imageUrl: persisted.price.imageUrl,
+                identityChanged: persisted.identityChanged,
                 hasDirectMatch,
                 directMatchSource: persisted.sourceIdentityReused
                   ? "source"
@@ -468,7 +475,13 @@ export async function createStorePrices(
           });
         }
 
-        if (price.directMatchSource === "barcode") {
+        // The old match was cleared. Do not reuse its completed job.
+        if (price.identityChanged) {
+          await pushJob("ResolveStorePriceBottle", {
+            priceId: price.id,
+            force: true,
+          });
+        } else if (price.directMatchSource === "barcode") {
           await pushUniqueJob("ResolveStorePriceBottle", {
             priceId: price.id,
             force: true,

--- a/apps/server/src/orpc/routes/prices/create-batch.test.ts
+++ b/apps/server/src/orpc/routes/prices/create-batch.test.ts
@@ -429,9 +429,13 @@ describe("POST /external-sites/:site/prices", () => {
       externalProductId: listing.externalProductId,
     });
     expect(updated!.sourceFingerprint).not.toBe(initial!.sourceFingerprint);
-    expect(workerClient.pushUniqueJob).toHaveBeenCalledWith(
+    expect(workerClient.pushJob).toHaveBeenCalledWith(
       "ResolveStorePriceBottle",
-      { priceId: initial!.id },
+      { priceId: initial!.id, force: true },
+    );
+    expect(workerClient.pushUniqueJob).not.toHaveBeenCalledWith(
+      "ResolveStorePriceBottle",
+      expect.anything(),
     );
   });
 

--- a/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.test.ts
@@ -35,9 +35,10 @@ test("scrapes every supported whisky type and excludes ineligible records", asyn
   const items: unknown[] = [];
   const identities: unknown[] = [];
   await scrapeProducts(firstPageUrl, async (item) => {
-    const { sourceBottleIdentity, ...price } =
+    const { sourceBottleIdentity, sourceFingerprint, ...price } =
       StorePriceInputSchema.parse(item);
     identities.push(sourceBottleIdentity);
+    expect(sourceFingerprint).toBe("release-month-v1");
     items.push(price);
   });
 
@@ -49,7 +50,6 @@ test("scrapes every supported whisky type and excludes ineligible records", asyn
     { category: "single_malt", release_year: 2024, release_month: 10 },
     { category: "rye", release_year: 2024, release_month: 10 },
   ]);
-
   expect(items).toEqual([
     {
       barcode: "036602301979",
@@ -137,6 +137,31 @@ test("uses a saved release without fetching its product page", async ({
         url === "https://singlecasknation.com/products/rock-town-10-year-old",
     ),
   ).toBe(false);
+});
+
+test("returns each listing before fetching the next missing page", async ({
+  axiosMock,
+}) => {
+  const result = await loadFixture("singlecasknation", "bottle-list.json");
+  axiosMock.onGet(firstPageUrl).reply(200, result);
+  const events: string[] = [];
+  axiosMock
+    .onGet(/^https:\/\/singlecasknation\.com\/products\//u)
+    .reply(({ url }: { url?: string }) => {
+      events.push(`fetch ${url}`);
+      return [200, "<p>October 2024 Online Exclusive Release</p>"];
+    });
+
+  await scrapeProducts(firstPageUrl, async (item) => {
+    events.push(`listing ${item.url}`);
+  });
+
+  expect(events.slice(0, 4)).toEqual([
+    "fetch https://singlecasknation.com/products/rock-town-10-year-old",
+    "listing https://singlecasknation.com/products/rock-town-10-year-old",
+    "fetch https://singlecasknation.com/products/balcones-6-year-old",
+    "listing https://singlecasknation.com/products/balcones-6-year-old",
+  ]);
 });
 
 test("rejects malformed Shopify payloads", async ({ axiosMock }) => {

--- a/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSingleCaskNation.ts
@@ -83,87 +83,81 @@ export function parseReleaseMonth(input: string) {
   };
 }
 
-async function parseSingleCaskNationProducts(
+async function scrapeSingleCaskNationProducts(
   input: JsonValue,
   sourceUrl: string,
+  onListing: ScrapePricesCallback,
   loadReleases: LoadReleases,
-): Promise<StorePrice[]> {
+) {
   const payload = SingleCaskNationProductsSchema.parse(input);
   const savedReleases = await loadReleases(
     payload.products.flatMap((product) =>
       product.id === undefined ? [] : [String(product.id)],
     ),
   );
-  const products = await Promise.all(
-    payload.products.map(async (product): Promise<StorePrice | null> => {
-      const category = CATEGORY_BY_PRODUCT_TYPE.get(product.product_type);
-      if (!category) return null;
+  for (const product of payload.products) {
+    const category = CATEGORY_BY_PRODUCT_TYPE.get(product.product_type);
+    if (!category) continue;
 
-      const pricedVariant = product.variants
-        .map((variant) => ({
-          ...variant,
-          parsedPrice: parseShopifyPrice(variant.price),
-        }))
-        .find((variant) => variant.available && variant.parsedPrice !== null);
-      if (!pricedVariant || pricedVariant.parsedPrice === null) return null;
+    const pricedVariant = product.variants
+      .map((variant) => ({
+        ...variant,
+        parsedPrice: parseShopifyPrice(variant.price),
+      }))
+      .find((variant) => variant.available && variant.parsedPrice !== null);
+    if (!pricedVariant || pricedVariant.parsedPrice === null) continue;
 
-      const { name } = normalizeBottle({
-        name: `Single Cask Nation ${product.title}`,
-      });
-      const productUrl = absoluteUrl(
-        sourceUrl,
-        `/products/${encodeURIComponent(product.handle)}`,
-      );
-      const shopifyIdentity = getShopifyStorePriceIdentity(
-        product,
-        pricedVariant,
-      );
-      let release: Release | null | undefined =
-        shopifyIdentity.externalProductId
-          ? savedReleases.get(shopifyIdentity.externalProductId)
-          : undefined;
-      // A saved release date does not change. Fetch the page until we have one.
-      if (!release) release = parseReleaseMonth(await getUrl(productUrl));
-      const listing: StorePrice = {
-        ...shopifyIdentity,
-        name,
-        price: pricedVariant.parsedPrice,
-        currency: "usd",
-        volume: DEFAULT_VOLUME,
-        url: productUrl,
-        imageUrl: product.images[0]?.src ?? null,
-        sourceBottleIdentity: BottleExtractedDetailsSchema.parse({
-          brand: "Single Cask Nation",
-          bottler: "Single Cask Nation",
-          expression: product.title,
-          category,
-          single_cask: true,
-          release_year: release?.releaseYear ?? null,
-          release_month: release?.releaseMonth ?? null,
-        }),
-      };
+    const { name } = normalizeBottle({
+      name: `Single Cask Nation ${product.title}`,
+    });
+    const productUrl = absoluteUrl(
+      sourceUrl,
+      `/products/${encodeURIComponent(product.handle)}`,
+    );
+    const shopifyIdentity = getShopifyStorePriceIdentity(
+      product,
+      pricedVariant,
+    );
+    let release: Release | null | undefined = shopifyIdentity.externalProductId
+      ? savedReleases.get(shopifyIdentity.externalProductId)
+      : undefined;
+    // A saved release date does not change. Fetch the page until we have one.
+    if (!release) {
+      release = parseReleaseMonth(await getUrl(productUrl));
+    }
+    const listing: StorePrice = {
+      ...shopifyIdentity,
+      sourceFingerprint: "release-month-v1",
+      name,
+      price: pricedVariant.parsedPrice,
+      currency: "usd",
+      volume: DEFAULT_VOLUME,
+      url: productUrl,
+      imageUrl: product.images[0]?.src ?? null,
+      sourceBottleIdentity: BottleExtractedDetailsSchema.parse({
+        brand: "Single Cask Nation",
+        bottler: "Single Cask Nation",
+        expression: product.title,
+        category,
+        single_cask: true,
+        release_year: release?.releaseYear ?? null,
+        release_month: release?.releaseMonth ?? null,
+      }),
+    };
 
-      logScrapedProduct(SITE, listing);
-      return listing;
-    }),
-  );
-
-  return products.filter((product): product is StorePrice => product !== null);
+    logScrapedProduct(SITE, listing);
+    await onListing(listing);
+  }
 }
 
 export async function scrapeProducts(
   url: string,
-  cb: ScrapePricesCallback,
+  onListing: ScrapePricesCallback,
   loadReleases: LoadReleases = noSavedReleases,
 ) {
   const data = await getUrl(url);
   const catalog = ShopifyCatalogSchema.parse(JSON.parse(data));
-  const products = await parseSingleCaskNationProducts(
-    catalog,
-    url,
-    loadReleases,
-  );
-  await Promise.all(products.map(cb));
+  await scrapeSingleCaskNationProducts(catalog, url, onListing, loadReleases);
   return { hasSourceProducts: catalog.products.length > 0 };
 }
 
@@ -175,7 +169,7 @@ export default async function scrapeSingleCaskNation(
     SITE,
     (page) =>
       `${STORE_ORIGIN}/collections/frontpage/products.json?limit=250&page=${page}&country=US`,
-    (url, cb) => scrapeProducts(url, cb, loadReleases),
+    (url, onListing) => scrapeProducts(url, onListing, loadReleases),
     { dryRun },
   );
 }


### PR DESCRIPTION
Single Cask Nation now uses saved release months and visits only products that still need one. It visits those pages one at a time and submits each listing before moving to the next. If interrupted, the next attempt can use dates already saved instead of starting over.

When product details change and an old bottle match is removed, saving the listing now starts a new match check. An old completed check could previously prevent matching from running again. The scraper marks its release-month data as version 1 so the 25 listings backfilled in production are checked again after deployment.

After deployment, run the Single Cask Nation scraper once and confirm that it reads 25 listings with two catalog requests. Then watch the number of listings without a bottle match until the checks finish.
