### PR TITLE
fix(web): restore region map layout

### DIFF
--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -54,6 +54,7 @@ import {
   testBrand,
   testOwnedEntity,
   testOwner,
+  testRegion,
   testUser,
   unifiedBottleEditContext,
 } from "./rpc-fixtures.mjs";
@@ -261,6 +262,16 @@ async function handleRpcRequest({ request, response, url }) {
         results:
           input?.owner && input.owner !== testOwner.id ? [] : [testOwnedEntity],
       });
+      return true;
+    case "regions/details":
+      if (
+        input?.country !== testRegion.country.slug ||
+        input?.region !== testRegion.slug
+      ) {
+        sendRpcError(response, "Unexpected region details payload");
+        return true;
+      }
+      sendRpcResponse(response, testRegion);
       return true;
     case "bottlers/list":
     case "companies/list":

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -89,6 +89,28 @@ export const libraryInsightsStats = {
 
 export const testAccessToken = "peated-playwright-access-token";
 
+export const testCountry = {
+  id: 9151,
+  name: "Scotland",
+  slug: "scotland",
+  description: "A major whisky-producing country.",
+  summary: "Home to distinct whisky regions and styles.",
+  location: [-4.2, 56.5],
+  totalBottles: 8_200,
+  totalDistillers: 150,
+};
+
+export const testRegion = {
+  id: 9152,
+  name: "Islay",
+  slug: "islay",
+  country: testCountry,
+  description: "An island region known for smoky single malt whisky.",
+  location: [-6.2, 55.8],
+  totalBottles: 680,
+  totalDistillers: 10,
+};
+
 export const testBrand = {
   id: 9201,
   peatedId: "E9201",

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/layout.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/layout.tsx
@@ -58,11 +58,13 @@ export default async function CountryLayout(props: {
       }
       name={country.name}
       tabs={[
-        { href: rootHref, label: "Distillers" },
+        {
+          count: country.totalDistillers,
+          href: rootHref,
+          label: "Distillers",
+        },
         { href: `${rootHref}/regions`, label: "Regions" },
       ]}
-      totalBottles={country.totalBottles}
-      totalDistillers={country.totalDistillers}
       visual={{ kind: "country", slug: country.slug }}
     >
       {props.children}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
@@ -74,9 +74,13 @@ export default async function RegionPage(props: {
         ) : undefined
       }
       name={region.name}
-      tabs={[{ href: pathname, label: "Distillers" }]}
-      totalBottles={region.totalBottles}
-      totalDistillers={region.totalDistillers}
+      tabs={[
+        {
+          count: region.totalDistillers,
+          href: pathname,
+          label: "Distillers",
+        },
+      ]}
       visual={
         countrySlug === "united-states"
           ? { kind: "state", slug: region.slug }

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
@@ -80,7 +80,7 @@ export default async function RegionPage(props: {
       visual={
         countrySlug === "united-states"
           ? { kind: "state", slug: region.slug }
-          : undefined
+          : { kind: "country", slug: region.country.slug }
       }
     >
       <LocationDistillerList

--- a/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
@@ -4,7 +4,7 @@ import * as stylex from "@stylexjs/stylex";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 
-import { KeyFacts, PageTabs, TextLink } from "@peated/web/components";
+import { PageTabs, TextLink, type PageTabItem } from "@peated/web/components";
 import CountryMapIcon from "@peated/web/components/countryMapIcon";
 import { PageHeader } from "@peated/web/components/pages/pageLayout.stylex";
 import UsStateMapIcon from "@peated/web/components/usStateMapIcon";
@@ -16,7 +16,7 @@ export function LocationsIndexFrame({ children }: { children: ReactNode }) {
   return (
     <div>
       <PageHeader eyebrow="Whisky database" title="Locations" />
-      <div {...stylex.props(styles.tabs)}>
+      <div {...stylex.props(styles.indexTabs)}>
         <PageTabs
           ariaLabel="Location sections"
           currentHref={pathname}
@@ -38,8 +38,6 @@ export function LocationPageFrame({
   description,
   name,
   tabs,
-  totalBottles,
-  totalDistillers,
   visual,
 }: {
   actions?: ReactNode;
@@ -47,12 +45,7 @@ export function LocationPageFrame({
   country?: { href: string; name: string };
   description?: ReactNode;
   name: string;
-  tabs: readonly [
-    { href: string; label: string },
-    ...{ href: string; label: string }[],
-  ];
-  totalBottles: number;
-  totalDistillers: number;
+  tabs: readonly [PageTabItem, ...PageTabItem[]];
   visual?: { kind: "country" | "state"; slug: string };
 }) {
   const pathname = usePathname();
@@ -72,14 +65,6 @@ export function LocationPageFrame({
         }
         title={name}
       />
-      <div {...stylex.props(styles.specs)}>
-        <KeyFacts
-          facts={[
-            { label: "Distillers", value: totalDistillers.toLocaleString() },
-            { label: "Bottles", value: totalBottles.toLocaleString() },
-          ]}
-        />
-      </div>
       <div {...stylex.props(styles.tabs)}>
         <PageTabs
           ariaLabel={`${name} sections`}
@@ -123,8 +108,8 @@ function LocationVisual({
 const NARROW = "@media (max-width: 759px)";
 
 const styles = stylex.create({
-  specs: { marginTop: space.x4 },
-  tabs: { marginTop: space.x6 },
+  indexTabs: { marginTop: space.x6 },
+  tabs: { marginTop: 0 },
   overviewGrid: {
     display: "grid",
     gridTemplateAreas: {

--- a/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
@@ -26,7 +26,7 @@ export function LocationsIndexFrame({ children }: { children: ReactNode }) {
           ]}
         />
       </div>
-      <div {...stylex.props(styles.content)}>{children}</div>
+      <div {...stylex.props(styles.indexContent)}>{children}</div>
     </div>
   );
 }
@@ -63,7 +63,6 @@ export function LocationPageFrame({
         actions={actions}
         description={description}
         eyebrow={country ? "Whisky region" : "Whisky country"}
-        identity={visual ? <LocationVisual visual={visual} /> : undefined}
         parent={
           country ? (
             <TextLink href={country.href} size="inherit">
@@ -88,7 +87,14 @@ export function LocationPageFrame({
           items={tabs}
         />
       </div>
-      <div {...stylex.props(styles.content)}>{children}</div>
+      <div {...stylex.props(styles.overviewGrid)}>
+        <div {...stylex.props(styles.content)}>{children}</div>
+        {visual ? (
+          <aside {...stylex.props(styles.details)}>
+            <LocationVisual visual={visual} />
+          </aside>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -100,24 +106,66 @@ function LocationVisual({
 }) {
   const props = {
     "aria-hidden": true,
-    ...stylex.props(styles.visual),
+    ...stylex.props(styles.visualIcon),
   } as const;
 
-  return visual.kind === "state" ? (
-    <UsStateMapIcon slug={visual.slug} {...props} />
-  ) : (
-    <CountryMapIcon slug={visual.slug} {...props} />
+  return (
+    <div {...stylex.props(styles.visual)}>
+      {visual.kind === "state" ? (
+        <UsStateMapIcon slug={visual.slug} {...props} />
+      ) : (
+        <CountryMapIcon slug={visual.slug} {...props} />
+      )}
+    </div>
   );
 }
+
+const NARROW = "@media (max-width: 759px)";
 
 const styles = stylex.create({
   specs: { marginTop: space.x4 },
   tabs: { marginTop: space.x6 },
-  content: { minWidth: 0, marginTop: space.x6 },
+  overviewGrid: {
+    display: "grid",
+    gridTemplateAreas: {
+      default: '"content details"',
+      [NARROW]: '"details" "content"',
+    },
+    gridTemplateColumns: {
+      default: "minmax(0, 1fr) 336px",
+      [NARROW]: "minmax(0, 1fr)",
+    },
+    columnGap: space.x12,
+  },
+  content: {
+    gridArea: "content",
+    minWidth: 0,
+    paddingTop: space.x4,
+  },
+  indexContent: {
+    minWidth: 0,
+    marginTop: space.x6,
+  },
+  details: {
+    gridArea: "details",
+    minWidth: 0,
+  },
   visual: {
+    display: "flex",
+    height: "220px",
+    alignItems: "center",
+    justifyContent: "center",
+    boxSizing: "border-box",
+    marginTop: space.x4,
+    padding: space.x6,
+    borderRadius: "3px",
+    backgroundColor: colors.inset,
+  },
+  visualIcon: {
     display: "block",
-    width: "96px",
-    maxHeight: "72px",
-    color: colors.inkMuted,
+    width: "100%",
+    maxWidth: "240px",
+    height: "100%",
+    color: colors.ink,
   },
 });

--- a/apps/web/visual/scenarios/index.mjs
+++ b/apps/web/visual/scenarios/index.mjs
@@ -6,12 +6,14 @@ import { distilleryDetailScenario } from "./distillery-detail.mjs";
 import { homeScenario } from "./home.mjs";
 import { loginScenario } from "./login.mjs";
 import { memberProfileScenario } from "./member-profile.mjs";
+import { regionDetailScenario } from "./region-detail.mjs";
 import { searchScenario } from "./search.mjs";
 
 export const SCENARIOS = [
   homeScenario,
   searchScenario,
   bottleDetailScenario,
+  regionDetailScenario,
   memberProfileScenario,
   addTastingScenario,
   loginScenario,

--- a/apps/web/visual/scenarios/region-detail.mjs
+++ b/apps/web/visual/scenarios/region-detail.mjs
@@ -1,0 +1,16 @@
+import { testRegion } from "../../e2e/rpc-fixtures.mjs";
+import { isTestDataChange } from "./shared-changes.mjs";
+import { DESKTOP, MOBILE } from "./viewports.mjs";
+
+export const regionDetailScenario = {
+  heading: testRegion.name,
+  id: "region-detail",
+  label: "Region detail",
+  path: `/locations/${testRegion.country.slug}/regions/${testRegion.slug}`,
+  shouldRunFor: (filePath) =>
+    filePath.startsWith("apps/web/src/app/(app)/locations/") ||
+    filePath.startsWith("apps/web/src/components/countryMapIcon/") ||
+    filePath.startsWith("apps/web/src/components/usStateMapIcon/") ||
+    isTestDataChange(filePath),
+  viewports: [DESKTOP, MOBILE],
+};

--- a/apps/web/visual/select-scenarios.test.mjs
+++ b/apps/web/visual/select-scenarios.test.mjs
@@ -46,6 +46,22 @@ describe("selectScenarioIds", () => {
     ).toEqual(["search"]);
   });
 
+  it("selects region detail for location page changes", () => {
+    expect(
+      selectScenarioIds([
+        "apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx",
+      ]),
+    ).toEqual(["region-detail"]);
+  });
+
+  it("does not select region detail for unrelated page changes", () => {
+    expect(
+      selectScenarioIds([
+        "apps/web/src/app/(app)/notifications/notificationList.stylex.tsx",
+      ]),
+    ).toEqual([]);
+  });
+
   it("selects search for shared search result changes", () => {
     expect(
       selectScenarioIds(["apps/web/src/components/searchResults.stylex.tsx"]),
@@ -91,6 +107,7 @@ describe("selectScenarioIds", () => {
       "home",
       "search",
       "bottle-detail",
+      "region-detail",
       "member-profile",
       "add-tasting",
       "brand-detail",


### PR DESCRIPTION
## Summary

- Move country and region outlines into a detail rail that matches bottle and entity pages.
- Show the country outline for non-US regions such as Islay and keep state-specific outlines for US regions.
- Simplify location metadata after the detail-page refresh by moving the distiller count to its tab.
- Add a deterministic Islay visual scenario for desktop and mobile layouts.

## Testing

- `pnpm --filter @peated/web typecheck`
- `pnpm --filter @peated/web test -- visual/select-scenarios.test.mjs` (60 files, 210 tests)
- `pnpm exec oxlint` on changed web and visual-scenario files
- `VISUAL_WEB_PORT=3213 VISUAL_API_PORT=5001 pnpm visual:web -- --scenarios region-detail` (2 screenshots)
