### PR TITLE
style(web): simplify detail page metadata

### DIFF
--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -79,12 +79,10 @@ function getBottleNotes(bottle: Bottle) {
   return [
     bottle.caskStrength ? "Cask strength" : null,
     bottle.singleCask ? "Single cask" : null,
-    bottle.nonChillFiltered ? "Non-chill filtered" : null,
-    bottle.naturalColor ? "Natural color" : null,
   ].filter((value): value is string => value !== null);
 }
 
-function getBottleSpecs(bottle: Bottle) {
+function getDeclaredFacts(bottle: Bottle): [FactListItem, ...FactListItem[]] {
   return [
     {
       label: "ABV",
@@ -104,11 +102,6 @@ function getBottleSpecs(bottle: Bottle) {
       label: "Release",
       value: getBottleReleasePlacement(bottle).header,
     },
-  ] as const;
-}
-
-function getDeclaredFacts(bottle: Bottle): [FactListItem, ...FactListItem[]] {
-  return [
     {
       label: "Vintage",
       value: bottle.vintageYear === null ? null : String(bottle.vintageYear),
@@ -145,12 +138,6 @@ function getDeclaredFacts(bottle: Bottle): [FactListItem, ...FactListItem[]] {
           : bottle.nonChillFiltered
             ? "Non-chill filtered"
             : "Chill filtered",
-    },
-    {
-      label: "Bottler",
-      value: bottle.bottler ? (
-        <EntityLinks entities={[bottle.bottler]} />
-      ) : null,
     },
   ];
 }
@@ -441,7 +428,6 @@ export function BottlePageFrameClient({
                   median: bottle.medianScore,
                 }
           }
-          specs={getBottleSpecs(bottle)}
         />
         {bottle.aliases.length ? (
           <p {...stylex.props(styles.aliases)}>

--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
@@ -32,6 +32,7 @@ function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
 
   return [
     { label: "Region", value: location },
+    { label: "Established", value: entity.yearEstablished },
     {
       label: "Owned by",
       value: entity.owner ? (

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
@@ -4,7 +4,6 @@ import {
   entityHasBottleCatalog,
   getEntityClassification,
   getEntityCurrentHref,
-  getEntityOwnerLabel,
   getEntityTabs,
 } from "./entityPageData";
 
@@ -18,35 +17,8 @@ describe("entityHasBottleCatalog", () => {
 });
 
 describe("getEntityClassification", () => {
-  it("uses the entity kind, establishment term, and most specific location", () => {
-    expect(
-      getEntityClassification({
-        country: { name: "Scotland" },
-        kind: "distillery",
-        region: { name: "Islay" },
-        yearEstablished: 1816,
-      }),
-    ).toBe("Distillery · founded 1816 · Islay");
-  });
-});
-
-describe("getEntityOwnerLabel", () => {
-  it("describes a brand through its owner", () => {
-    expect(
-      getEntityOwnerLabel(
-        { kind: "brand" },
-        { name: "Diageo plc", shortName: "Diageo" },
-      ),
-    ).toBe("A Diageo brand");
-  });
-
-  it("describes other entity kinds as part of their owner", () => {
-    expect(
-      getEntityOwnerLabel(
-        { kind: "distillery" },
-        { name: "Diageo", shortName: null },
-      ),
-    ).toBe("Part of Diageo");
+  it("uses the entity kind", () => {
+    expect(getEntityClassification({ kind: "distillery" })).toBe("Distillery");
   });
 });
 

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -7,38 +7,27 @@ type EntityTabSource = Pick<
   Entity,
   "id" | "kind" | "shortName" | "totalBottles" | "totalTastings"
 >;
-type EntityLocation = Pick<NonNullable<Entity["country"]>, "name">;
-type EntityClassificationSource = Pick<Entity, "kind" | "yearEstablished"> & {
-  country?: EntityLocation | null;
-  region?: EntityLocation | null;
-};
-
 const entityKindPresentation = {
   bottler: {
     bottleSectionLabel: "Bottles",
-    establishmentLabel: "Founded",
     label: "Bottler",
   },
   brand: {
     bottleSectionLabel: "Bottles",
-    establishmentLabel: "Established",
     label: "Brand",
   },
   company: {
     bottleSectionLabel: "Bottles",
-    establishmentLabel: "Founded",
     label: "Company",
   },
   distillery: {
     bottleSectionLabel: "Bottles",
-    establishmentLabel: "Founded",
     label: "Distillery",
   },
 } as const;
 
 const fallbackPresentation = {
   bottleSectionLabel: "Bottles",
-  establishmentLabel: "Established",
   label: "Brand or producer",
 } as const;
 
@@ -48,30 +37,8 @@ export function getEntityPresentation(entity: Pick<Entity, "kind">) {
     : fallbackPresentation;
 }
 
-export function getEntityClassification(entity: EntityClassificationSource) {
-  const presentation = getEntityPresentation(entity);
-  const location = entity.region?.name ?? entity.country?.name;
-
-  return [
-    presentation.label,
-    entity.yearEstablished
-      ? `${presentation.establishmentLabel.toLowerCase()} ${entity.yearEstablished}`
-      : null,
-    location,
-  ]
-    .filter((value): value is string => Boolean(value))
-    .join(" · ");
-}
-
-export function getEntityOwnerLabel(
-  entity: Pick<Entity, "kind">,
-  owner: Pick<Entity, "name" | "shortName">,
-) {
-  const ownerName = owner.shortName || owner.name;
-
-  return entity.kind === "brand"
-    ? `A ${ownerName} brand`
-    : `Part of ${ownerName}`;
+export function getEntityClassification(entity: Pick<Entity, "kind">) {
+  return getEntityPresentation(entity).label;
 }
 
 export function entityHasBottleCatalog(entity: Pick<Entity, "kind">) {

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -8,11 +8,9 @@ import { type ReactNode } from "react";
 import {
   Button,
   ButtonLink,
-  KeyFacts,
   PageTabs,
   RowMenu,
   SectionError,
-  TextLink,
   type RowMenuItem,
 } from "@peated/web/components";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
@@ -29,7 +27,6 @@ import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 import {
   getEntityClassification,
   getEntityCurrentHref,
-  getEntityOwnerLabel,
   getEntityPresentation,
   getEntityTabs,
   type Entity,
@@ -146,11 +143,9 @@ function EntityActions({ entity }: { entity: Entity }) {
 export function EntityPageFrameClient({
   children,
   initialEntity,
-  owner,
 }: {
   children: ReactNode;
   initialEntity: Entity;
-  owner?: Entity | null;
 }) {
   const orpc = useORPC();
   const pathname = usePathname();
@@ -178,7 +173,6 @@ export function EntityPageFrameClient({
     entity.kind === "brand" ||
     entity.kind === "bottler" ||
     entity.kind === "distillery";
-  const presentation = getEntityPresentation(entity);
   const currentHref = getEntityCurrentHref(entity, pathname);
   const bottleActionLabel = "Add a bottle";
 
@@ -195,11 +189,6 @@ export function EntityPageFrameClient({
         </div>
 
         <div {...stylex.props(styles.summary)}>
-          {owner ? (
-            <TextLink href={getEntityUrl(owner)} size="inherit">
-              {getEntityOwnerLabel(entity, owner)}
-            </TextLink>
-          ) : null}
           {entity.description ? (
             <div {...stylex.props(styles.description)}>
               <Markdown content={entity.description} />
@@ -220,25 +209,6 @@ export function EntityPageFrameClient({
             ) : null}
             <EntityActions entity={entity} />
           </div>
-        </div>
-
-        <div {...stylex.props(styles.specs)}>
-          <KeyFacts
-            facts={[
-              {
-                label: presentation.establishmentLabel,
-                value: entity.yearEstablished,
-              },
-              {
-                label: "Bottles recorded",
-                value: entity.totalBottles.toLocaleString("en-US"),
-              },
-              {
-                label: "Member tastings",
-                value: entity.totalTastings.toLocaleString("en-US"),
-              },
-            ]}
-          />
         </div>
       </header>
 
@@ -301,8 +271,5 @@ const styles = stylex.create({
     alignItems: "center",
     gap: space.x2,
     flexWrap: "wrap",
-  },
-  specs: {
-    marginBottom: space.x4,
   },
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/layout.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/layout.tsx
@@ -1,7 +1,6 @@
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { summarize } from "@peated/web/lib/markdown";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
-import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
 import type { ReactNode } from "react";
 import type { Organization, WithContext } from "schema-dts";
 
@@ -33,11 +32,6 @@ export default async function EntityLayout(props: {
   const { client } = await getServerClient();
   const entity = await client.entities.details({ entity: canonicalEntity.id });
 
-  const owner = entity.ownerId
-    ? await resolveOrNotFound(
-        client.entities.details({ entity: entity.ownerId }),
-      )
-    : null;
   const jsonLd: WithContext<Organization> = {
     "@context": "https://schema.org",
     "@type": "Organization",
@@ -61,7 +55,7 @@ export default async function EntityLayout(props: {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <EntityPageFrameClient initialEntity={entity} owner={owner}>
+      <EntityPageFrameClient initialEntity={entity}>
         {props.children}
       </EntityPageFrameClient>
     </>

--- a/apps/web/src/components/pages/bottlePageHeader.stories.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stories.tsx
@@ -50,12 +50,6 @@ const meta = {
       showCounts: true,
     },
     score: { count: 48, high: 96, low: 78, median: 88 },
-    specs: [
-      { label: "ABV", value: "59.6%" },
-      { label: "Age", value: null },
-      { label: "Cask", value: "Ex-bourbon" },
-      { label: "Release", value: "2024" },
-    ],
   },
   argTypes: {
     actions: { control: false },
@@ -95,12 +89,6 @@ export const LongName: Story = {
     id: "B49748",
     name: "SMWS Highland peaty potion",
     notes: [],
-    specs: [
-      { label: "ABV", value: "50.0%" },
-      { label: "Age", value: "10 years" },
-      { label: "Cask", value: "1st fill barrels and oloroso sherry hogsheads" },
-      { label: "Release", value: "Batch 42" },
-    ],
   },
 };
 
@@ -118,11 +106,5 @@ export const ThinData: Story = {
     notes: [],
     bands: null,
     score: null,
-    specs: [
-      { label: "ABV", value: "46.0%" },
-      { label: "Age", value: null },
-      { label: "Cask", value: null },
-      { label: "Release", value: null },
-    ],
   },
 };

--- a/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
@@ -1,20 +1,14 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import type {
-  KeyFactList,
-  ReviewScoreProps,
-  TastingRatingDistributionProps,
-} from "..";
+import type { ReviewScoreProps, TastingRatingDistributionProps } from "..";
 import {
   AppLink,
   BottleVisual,
   Chip,
-  KeyFacts,
   PeatedId,
   ReviewScore,
   TastingRatingDistribution,
-  hasVisibleKeyFacts,
 } from "..";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
@@ -41,10 +35,9 @@ export type BottlePageHeaderProps = {
   name: string;
   notes?: readonly string[];
   score?: ReviewScoreProps | null;
-  specs: KeyFactList;
 };
 
-/** Presents a bottle's catalog identity, member actions, community ratings, and core facts. */
+/** Presents a bottle's catalog identity, member actions, and community ratings. */
 export function BottlePageHeader({
   actions,
   bands,
@@ -58,7 +51,6 @@ export function BottlePageHeader({
   name,
   notes = [],
   score,
-  specs,
 }: BottlePageHeaderProps) {
   const hasActions = Boolean(actions || menu);
   const hasRatings = Boolean(score || bands);
@@ -133,11 +125,6 @@ export function BottlePageHeader({
           </div>
         </div>
       </div>
-      {hasVisibleKeyFacts(specs) ? (
-        <div {...stylex.props(styles.specs)}>
-          <KeyFacts facts={specs} />
-        </div>
-      ) : null}
       {hasRatings ? (
         <div aria-label="Community ratings" {...stylex.props(styles.ratings)}>
           {score ? (
@@ -329,11 +316,5 @@ const styles = stylex.create({
   },
   ratingContent: {
     minWidth: 0,
-  },
-  specs: {
-    minWidth: 0,
-    gridColumn: "1 / -1",
-    gridRow: "3",
-    marginTop: space.x3,
   },
 });


### PR DESCRIPTION
Entity pages now keep the masthead to the entity kind and move the establishment year into the overview facts. Ownership and location remain in the overview, while bottle and tasting counts remain in their tabs. Bottle pages follow the same structure by moving ABV, age, cask, and release details into “Declared on the label” and removing repeated bottler, coloring, and filtration metadata from the header.

This keeps each fact in one place without removing catalog data. The entity layout also stops fetching full owner details solely for the removed summary line.
