### PR TITLE
feat(search): show recent searches

### DIFF
--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -11,6 +11,11 @@ import { getCreateBottleHref } from "@peated/web/components/search/createBottleH
 import useAuth from "@peated/web/hooks/useAuth";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import {
+  addRecentSearch,
+  readRecentSearches,
+  writeRecentSearches,
+} from "@peated/web/lib/recentSearches";
 import { getEntityUrl } from "@peated/web/lib/urls";
 import * as stylex from "@stylexjs/stylex";
 import { useRouter } from "next/navigation";
@@ -105,6 +110,21 @@ function getDefaultBottleHref(bottleId: number) {
 
 function getDefaultContributionHref(query: string) {
   return getCreateBottleHref({ query });
+}
+
+function recentSearchGroups(searches: readonly string[]): SearchResultGroup[] {
+  if (!searches.length) return [];
+  return [
+    {
+      id: "recent-searches",
+      items: searches.map((query) => ({
+        href: `/search?q=${encodeURIComponent(query)}`,
+        id: `recent-search-${query.toLocaleLowerCase()}`,
+        title: query,
+      })),
+      label: "Recent searches",
+    },
+  ];
 }
 
 function waitForSearchIndicator() {
@@ -393,6 +413,7 @@ export function Search({
   const orpc = useORPC();
   const router = useRouter();
   const [query, setQuery] = useState(initialQuery);
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
   const [scope, setScope] = useState<SearchScope>(initialScope);
   const [snapshot, setSnapshot] = useState<SearchSnapshot>();
   const [status, setStatus] = useState<"error" | "ready" | "searching">(
@@ -495,6 +516,13 @@ export function Search({
   useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch]);
 
   useEffect(() => {
+    if (placement === "page") return;
+    // Browser storage is unavailable during server rendering.
+    // oxlint-disable-next-line react/set-state-in-effect
+    setRecentSearches(readRecentSearches());
+  }, [placement]);
+
+  useEffect(() => {
     if (initialSearchStarted.current || !initialQuery.trim()) return;
     initialSearchStarted.current = true;
     void runSearch(initialQuery, effectiveScope);
@@ -532,12 +560,24 @@ export function Search({
 
   function submitSearch(value: string) {
     const trimmedValue = value.trim();
+    rememberSearch(trimmedValue);
     if (onSubmit) {
       onSubmit(trimmedValue);
       return;
     }
     router.push(`/search?q=${encodeURIComponent(trimmedValue)}`);
   }
+
+  function rememberSearch(value: string) {
+    if (placement === "page") return;
+    const next = addRecentSearch(readRecentSearches(), value);
+    writeRecentSearches(next);
+    setRecentSearches(next);
+  }
+
+  const groups = query.trim()
+    ? (currentSnapshot?.groups ?? [])
+    : recentSearchGroups(recentSearches);
 
   const searchBox = (
     <SearchBox
@@ -558,10 +598,13 @@ export function Search({
       defaultOpen={defaultOpen || placement === "page"}
       emptyText={currentSnapshot?.emptyText}
       fluid={Boolean(submitLabel)}
-      groups={snapshot?.groups ?? []}
+      groups={groups}
       onQueryChange={updateQuery}
       onRetry={() => void runSearch(query, effectiveScope)}
-      onResultSelect={(item) => router.push(item.href)}
+      onResultSelect={(item) => {
+        rememberSearch(query.trim() || item.title);
+        router.push(item.href);
+      }}
       onScopeChange={(nextScope) => {
         if (!isSearchScope(nextScope)) return;
         debouncedSearch.cancel();

--- a/apps/web/src/components/searchBox.stylex.tsx
+++ b/apps/web/src/components/searchBox.stylex.tsx
@@ -87,9 +87,14 @@ export function SearchBox({
   const panelId = useId();
   const rootRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const [activeId, setActiveId] = useState<string>();
+  const [selectedId, setSelectedId] = useState<string>();
   const [open, setOpen] = useState(defaultOpen);
   const items = useMemo(() => groups.flatMap((group) => group.items), [groups]);
+  const activeId =
+    items.find((item) => item.id === selectedId)?.id ??
+    (query.trim() && resultQuery.trim() === query.trim()
+      ? items[0]?.id
+      : undefined);
   const hasPanelContent =
     groups.length > 0 ||
     Boolean(emptyText) ||
@@ -152,7 +157,7 @@ export function SearchBox({
           ? 0
           : items.length - 1
         : (currentIndex + offset + items.length) % items.length;
-    setActiveId(items[nextIndex]?.id);
+    setSelectedId(items[nextIndex]?.id);
     setOpen(true);
   }
 
@@ -178,7 +183,7 @@ export function SearchBox({
       event.preventDefault();
       if (query) {
         onQueryChange("");
-        setActiveId(undefined);
+        setSelectedId(undefined);
       } else {
         setOpen(false);
         onClose?.();
@@ -208,19 +213,19 @@ export function SearchBox({
       inputRef={inputRef}
       onChange={(event) => {
         onQueryChange(event.currentTarget.value);
-        setActiveId(query.trim() ? items[0]?.id : undefined);
+        setSelectedId(undefined);
         setOpen(true);
       }}
       onClear={() => {
         onQueryChange("");
-        setActiveId(undefined);
+        setSelectedId(undefined);
         inputRef.current?.focus();
       }}
       onFocus={() => setOpen(true)}
       onKeyDown={handleKeyDown}
       onScopeChange={(nextScope) => {
         onScopeChange(nextScope);
-        setActiveId(undefined);
+        setSelectedId(undefined);
         inputRef.current?.focus();
         setOpen(true);
       }}

--- a/apps/web/src/components/searchBox.stylex.tsx
+++ b/apps/web/src/components/searchBox.stylex.tsx
@@ -208,7 +208,7 @@ export function SearchBox({
       inputRef={inputRef}
       onChange={(event) => {
         onQueryChange(event.currentTarget.value);
-        setActiveId(items[0]?.id);
+        setActiveId(query.trim() ? items[0]?.id : undefined);
         setOpen(true);
       }}
       onClear={() => {
@@ -274,6 +274,21 @@ export function SearchBox({
             {browseHeader}
             <div {...stylex.props(styles.databaseBrowseSearch)}>
               {searchRow}
+              {expanded ? (
+                <SearchResults
+                  activeId={activeId}
+                  embedded
+                  groups={groups}
+                  label="Recent searches"
+                  onItemSelect={selectResult}
+                  optionIdPrefix={panelId}
+                  panelId={panelId}
+                  query=""
+                  scroll={false}
+                  status={status}
+                  variant="database"
+                />
+              ) : null}
             </div>
           </>
         ) : (
@@ -364,6 +379,7 @@ export function SearchBox({
               embedded
               emptyText={emptyText}
               groups={groups}
+              label={query.trim() ? "Search results" : "Recent searches"}
               onItemSelect={selectResult}
               onRetry={onRetry}
               optionIdPrefix={panelId}

--- a/apps/web/src/components/searchBox.test.tsx
+++ b/apps/web/src/components/searchBox.test.tsx
@@ -70,5 +70,42 @@ describe("SearchBox database empty state", () => {
 
     expect(html).toContain("Recent searches");
     expect(html).toContain("Ardbeg 10");
+    expect(html).not.toContain("aria-activedescendant");
+  });
+});
+
+describe("SearchBox active result", () => {
+  const groups = [
+    {
+      id: "bottles",
+      items: [{ href: "/bottles/1", id: "bottle-1", title: "Ardbeg 10" }],
+      label: "Bottles",
+    },
+  ];
+
+  function renderSearch(resultQuery: string) {
+    return renderToStaticMarkup(
+      <SearchBox
+        groups={groups}
+        onQueryChange={() => undefined}
+        onScopeChange={() => undefined}
+        query="ardbeg"
+        resultQuery={resultQuery}
+        scope="all"
+        scopes={[{ label: "Everything", value: "all" }]}
+      />,
+    );
+  }
+
+  it("activates the first result for the current query", () => {
+    const html = renderSearch("ardbeg");
+
+    expect(html).toMatch(/aria-activedescendant="[^"]*bottle-1"/);
+  });
+
+  it("does not activate a result from an older query", () => {
+    const html = renderSearch("ard");
+
+    expect(html).not.toContain("aria-activedescendant");
   });
 });

--- a/apps/web/src/components/searchBox.test.tsx
+++ b/apps/web/src/components/searchBox.test.tsx
@@ -41,3 +41,34 @@ describe("SearchBox database result count", () => {
     expect(html).toContain("0 results");
   });
 });
+
+describe("SearchBox database empty state", () => {
+  it("shows recent searches when the query is empty", () => {
+    const html = renderToStaticMarkup(
+      <SearchBox
+        groups={[
+          {
+            id: "recent-searches",
+            items: [
+              {
+                href: "/search?q=Ardbeg%2010",
+                id: "recent-search-ardbeg-10",
+                title: "Ardbeg 10",
+              },
+            ],
+            label: "Recent searches",
+          },
+        ]}
+        onQueryChange={() => undefined}
+        onScopeChange={() => undefined}
+        placement="database"
+        query=""
+        scope="all"
+        scopes={[{ label: "Everything", value: "all" }]}
+      />,
+    );
+
+    expect(html).toContain("Recent searches");
+    expect(html).toContain("Ardbeg 10");
+  });
+});

--- a/apps/web/src/lib/recentSearches.test.ts
+++ b/apps/web/src/lib/recentSearches.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { addRecentSearch, parseRecentSearches } from "./recentSearches";
+
+describe("addRecentSearch", () => {
+  it("puts the newest search first and keeps 3 searches", () => {
+    expect(
+      addRecentSearch(["Ardbeg", "Lagavulin", "Cadenhead's"], "Laphroaig"),
+    ).toEqual(["Laphroaig", "Ardbeg", "Lagavulin"]);
+  });
+
+  it("normalizes whitespace and moves a repeated search to the front", () => {
+    expect(
+      addRecentSearch(["Ardbeg 10", "Lagavulin"], "  ardbeg   10 "),
+    ).toEqual(["ardbeg 10", "Lagavulin"]);
+  });
+
+  it("does not record an empty search", () => {
+    expect(addRecentSearch(["Ardbeg"], "   ")).toEqual(["Ardbeg"]);
+  });
+});
+
+describe("parseRecentSearches", () => {
+  it("rejects malformed browser storage", () => {
+    expect(parseRecentSearches("not json")).toEqual([]);
+    expect(parseRecentSearches('{"query":"Ardbeg"}')).toEqual([]);
+  });
+
+  it("keeps the newest 3 valid stored searches", () => {
+    expect(
+      parseRecentSearches(
+        JSON.stringify([" Ardbeg ", "ardbeg", "Lagavulin", "", "Macallan"]),
+      ),
+    ).toEqual(["Ardbeg", "Lagavulin", "Macallan"]);
+  });
+});

--- a/apps/web/src/lib/recentSearches.ts
+++ b/apps/web/src/lib/recentSearches.ts
@@ -1,0 +1,71 @@
+import { z } from "zod";
+
+const RECENT_SEARCHES_KEY = "peated:recent-searches";
+const RECENT_SEARCHES_LIMIT = 3;
+const RecentSearchesSchema = z.array(z.string());
+
+function normalizeSearchQuery(query: string) {
+  return query.trim().replace(/\s+/g, " ");
+}
+
+export function addRecentSearch(
+  searches: readonly string[],
+  query: string,
+): string[] {
+  const normalizedQuery = normalizeSearchQuery(query);
+  if (!normalizedQuery) return [...searches];
+
+  const key = normalizedQuery.toLocaleLowerCase();
+  return [
+    normalizedQuery,
+    ...searches.filter(
+      (search) => normalizeSearchQuery(search).toLocaleLowerCase() !== key,
+    ),
+  ].slice(0, RECENT_SEARCHES_LIMIT);
+}
+
+export function parseRecentSearches(value: string) {
+  try {
+    const result = RecentSearchesSchema.safeParse(JSON.parse(value));
+    if (!result.success) return [];
+
+    const searches: string[] = [];
+    for (const search of result.data) {
+      const normalizedSearch = normalizeSearchQuery(search);
+      if (
+        normalizedSearch &&
+        !searches.some(
+          (recent) =>
+            recent.toLocaleLowerCase() === normalizedSearch.toLocaleLowerCase(),
+        )
+      ) {
+        searches.push(normalizedSearch);
+      }
+      if (searches.length === RECENT_SEARCHES_LIMIT) break;
+    }
+    return searches;
+  } catch {
+    return [];
+  }
+}
+
+export function readRecentSearches() {
+  try {
+    return parseRecentSearches(
+      window.localStorage.getItem(RECENT_SEARCHES_KEY) ?? "[]",
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function writeRecentSearches(searches: readonly string[]) {
+  try {
+    window.localStorage.setItem(
+      RECENT_SEARCHES_KEY,
+      JSON.stringify(searches.slice(0, RECENT_SEARCHES_LIMIT)),
+    );
+  } catch {
+    // Search still works when browser storage is unavailable.
+  }
+}


### PR DESCRIPTION
Global search now keeps the 3 most recent completed searches in browser storage and shows them when the header search or database search page is empty. A query is saved only when the user submits it or chooses a result, so typeahead requests are never retained.

This stays client-side: there is no account history, API write, or schema change. Search-specific selection pages do not show global history, so add-bottle and member-picking flows keep their current context.
