### PR TITLE
style(web): simplify section and tab counts

### DIFF
--- a/apps/web/src/app/(app)/badges/[badgeId]/badgePage.stylex.tsx
+++ b/apps/web/src/app/(app)/badges/[badgeId]/badgePage.stylex.tsx
@@ -34,7 +34,7 @@ export function BadgePage({
         identity={<BadgeImage badge={badge} size={72} />}
         title={badge.name}
       />
-      <PageSection count={awardList.results.length} heading="Leaderboard">
+      <PageSection heading="Leaderboard">
         <ItemList ariaLabel={`${badge.name} leaderboard`}>
           {awardList.results.map((award, index) => (
             <ItemRow

--- a/apps/web/src/app/(app)/bottles/[bottleId]/aliases/aliasList.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/aliases/aliasList.stylex.tsx
@@ -27,7 +27,7 @@ export function AliasList({
   const deleteAlias = useMutation(orpc.bottleAliases.delete.mutationOptions());
 
   return (
-    <BottleSection count={aliases.length} heading="Also known as">
+    <BottleSection heading="Also known as">
       <AliasManager
         aliases={aliases.map((alias) => ({
           created: <TimeSince date={alias.createdAt} />,

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottleSection.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottleSection.stylex.tsx
@@ -6,16 +6,14 @@ import { space } from "../../../../styles/tokens.stylex";
 
 export function BottleSection({
   children,
-  count,
   heading,
 }: {
   children: ReactNode;
-  count?: number;
   heading: ReactNode;
 }) {
   return (
     <section {...stylex.props(styles.section)}>
-      <SectionHeading count={count}>{heading}</SectionHeading>
+      <SectionHeading>{heading}</SectionHeading>
       {children}
     </section>
   );

--- a/apps/web/src/app/(app)/bottles/[bottleId]/prices/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/prices/page.tsx
@@ -54,7 +54,7 @@ export default async function BottlePricesPage(props: {
   const priceList = await client.bottles.prices.list({ bottle: bottle.id });
 
   return (
-    <BottleSection count={priceList.results.length} heading="Sellers">
+    <BottleSection heading="Sellers">
       {priceList.results.length ? (
         <DataTable
           caption="Bottle sellers"

--- a/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
@@ -54,7 +54,7 @@ export default async function BottleReleasesPage(props: {
   const pathname = `/bottles/${anchorId}/releases`;
 
   return (
-    <BottleSection count={bottleList.results.length} heading="Releases">
+    <BottleSection heading="Releases">
       {bottleList.results.length ? (
         <ItemList ariaLabel="Bottle releases">
           {bottleList.results.map((bottle) => (

--- a/apps/web/src/app/(app)/bottles/[bottleId]/tastings/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/tastings/page.tsx
@@ -32,7 +32,7 @@ export default async function BottleTastingsPage(props: {
   const pathname = `/bottles/${id}/tastings`;
 
   return (
-    <BottleSection count={tastingList.results.length} heading="Tastings">
+    <BottleSection heading="Tastings">
       {tastingList.results.length ? (
         <ItemList ariaLabel="Bottle tasting records">
           {tastingList.results.map((tasting) => (

--- a/apps/web/src/app/(app)/entities/[entityId]/aliases/entityAliasList.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/aliases/entityAliasList.stylex.tsx
@@ -30,7 +30,7 @@ export function EntityAliasList({
   );
 
   return (
-    <PageSection count={aliases.length} heading="Aliases">
+    <PageSection heading="Aliases">
       <AliasManager
         aliases={aliases.map((alias) => ({
           created: <TimeSince date={alias.createdAt} />,

--- a/apps/web/src/app/(app)/entities/[entityId]/codes/entityCodes.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/codes/entityCodes.stylex.tsx
@@ -48,7 +48,6 @@ export function EntityCodes({
 
       {groups.map((group) => (
         <PageSection
-          count={group.rows.length}
           heading={
             group.code ? `${group.heading} (${group.code})` : group.heading
           }

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
@@ -91,7 +91,6 @@ export function EntityBottleOverview({
 
   return (
     <PageSection
-      count={bottleList.results.length}
       heading={presentation.bottleSectionLabel}
       intro={
         <TextLink href={`${entityHref}/bottles?sort=-tastings`}>

--- a/apps/web/src/app/(app)/flights/[flightId]/page.tsx
+++ b/apps/web/src/app/(app)/flights/[flightId]/page.tsx
@@ -60,7 +60,7 @@ export default async function FlightPage(props: {
         menu={<FlightActions flight={flight} />}
         title={flight.name}
       />
-      <PageSection count={flight.bottles.length} heading="Bottles">
+      <PageSection heading="Bottles">
         {flight.bottles.length ? (
           <ItemList ariaLabel="Flight bottles">
             {flight.bottles.map(({ bottle, hasTasted, isLibrary }) => (

--- a/apps/web/src/app/(app)/flights/page.tsx
+++ b/apps/web/src/app/(app)/flights/page.tsx
@@ -45,7 +45,7 @@ export default async function FlightsPage(props: {
         eyebrow="Your record"
         title="Flights"
       />
-      <PageSection count={flightList.results.length} heading="Your flights">
+      <PageSection heading="Your flights">
         {flightList.results.length ? (
           <ItemList ariaLabel="Tasting flights">
             {flightList.results.map((flight) => (

--- a/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
@@ -64,7 +64,7 @@ export default async function TastingPage(props: {
       <PageSection heading="Tasting">
         <TastingRecordEntry showFullNotes tasting={tasting} />
       </PageSection>
-      <PageSection count={commentList.results.length} heading="Comments">
+      <PageSection heading="Comments">
         <TastingComments
           initialCommentList={commentList}
           tastingId={tasting.id}

--- a/apps/web/src/app/(app)/updates/page.tsx
+++ b/apps/web/src/app/(app)/updates/page.tsx
@@ -25,7 +25,7 @@ export default async function UpdatesPage(props: {
   return (
     <div>
       <PageHeader eyebrow="Whisky database" title="Updates" />
-      <PageSection count={changeList.results.length} heading="Recent changes">
+      <PageSection heading="Recent changes">
         {changeList.results.length ? (
           <UpdateList
             changes={changeList.results}

--- a/apps/web/src/components/card.stories.tsx
+++ b/apps/web/src/components/card.stories.tsx
@@ -24,7 +24,7 @@ export const Overview: Story = {
   render: () => (
     <StoryStack>
       <Card>
-        <SectionHeading count={312}>Distilleries</SectionHeading>
+        <SectionHeading>Distilleries</SectionHeading>
       </Card>
       <CardLink href="#lagavulin">
         <SectionHeading>Lagavulin</SectionHeading>

--- a/apps/web/src/components/historyTimeline.stories.tsx
+++ b/apps/web/src/components/historyTimeline.stories.tsx
@@ -47,12 +47,10 @@ const meta = {
   title: "Components/History/History Timeline",
   component: HistoryTimeline,
   decorators: [
-    (Story, context) => (
+    (Story) => (
       <StoryCanvas width="wide">
         <StoryStack>
-          <SectionHeading count={context.args.events.length}>
-            History
-          </SectionHeading>
+          <SectionHeading>History</SectionHeading>
           <Story />
         </StoryStack>
       </StoryCanvas>

--- a/apps/web/src/components/pageTabs.stylex.tsx
+++ b/apps/web/src/components/pageTabs.stylex.tsx
@@ -1,7 +1,13 @@
 import * as stylex from "@stylexjs/stylex";
 import Link from "next/link";
 
-import { colors, effects, fonts, space } from "../styles/tokens.stylex";
+import {
+  colors,
+  controlMetrics,
+  effects,
+  fonts,
+  space,
+} from "../styles/tokens.stylex";
 
 export type PageTabItem = {
   count?: number;
@@ -91,10 +97,19 @@ const styles = stylex.create({
     },
   },
   count: {
+    minWidth: "20px",
+    borderRadius: controlMetrics.radiusSmall,
+    paddingTop: "2px",
+    paddingRight: "6px",
+    paddingBottom: "2px",
+    paddingLeft: "6px",
+    backgroundColor: colors.surface,
     color: colors.inkMuted,
     fontFamily: fonts.data,
-    fontSize: "13px",
+    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
-    fontWeight: 400,
+    fontWeight: 600,
+    lineHeight: 1.2,
+    textAlign: "center",
   },
 });

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -30,7 +30,6 @@ export type BottleRecommendation = {
 };
 
 export type BottleOverviewProps = {
-  criticReviewCount?: number;
   criticReviewDetail?: string;
   criticReviews?: readonly CriticReviewProps[];
   declaredFacts: readonly [FactListItem, ...FactListItem[]];
@@ -45,7 +44,6 @@ export type BottleOverviewProps = {
 
 /** Composes the bounded content section beneath a bottle's page header. */
 export function BottleOverview({
-  criticReviewCount,
   criticReviewDetail,
   criticReviews = [],
   declaredFacts,
@@ -66,9 +64,7 @@ export function BottleOverview({
         {criticReviews.length ? (
           <section {...stylex.props(styles.section)}>
             <div {...stylex.props(styles.sectionHeader)}>
-              <SectionHeading count={criticReviewCount}>
-                Critic reviews
-              </SectionHeading>
+              <SectionHeading>Critic reviews</SectionHeading>
               {criticReviewDetail ? (
                 <span {...stylex.props(styles.sectionDetail)}>
                   {criticReviewDetail}
@@ -89,9 +85,7 @@ export function BottleOverview({
 
         {tastings.length ? (
           <section {...stylex.props(styles.section)}>
-            <SectionHeading count={tastingCount ?? tastings.length}>
-              Tastings
-            </SectionHeading>
+            <SectionHeading>Tastings</SectionHeading>
             <ItemList ariaLabel="Bottle tastings">
               {tastings.map((tasting, index) => (
                 <ItemListItem key={`${tasting.author}-${index}`}>

--- a/apps/web/src/components/pages/pageLayout.stylex.tsx
+++ b/apps/web/src/components/pages/pageLayout.stylex.tsx
@@ -127,19 +127,17 @@ export function TabbedPage({
 
 export function PageSection({
   children,
-  count,
   heading,
   intro,
 }: {
   children: ReactNode;
-  count?: number;
   heading: ReactNode;
   intro?: ReactNode;
 }) {
   return (
     <section {...stylex.props(styles.section)}>
       <div {...stylex.props(styles.sectionHeader)}>
-        <SectionHeading count={count}>{heading}</SectionHeading>
+        <SectionHeading>{heading}</SectionHeading>
         {intro ? (
           <div {...stylex.props(styles.sectionIntro)}>{intro}</div>
         ) : null}

--- a/apps/web/src/components/sectionHeading.stories.tsx
+++ b/apps/web/src/components/sectionHeading.stories.tsx
@@ -6,7 +6,7 @@ import { StoryStack } from "./storyFixtures.stylex";
 const meta = {
   title: "Components/Layout/Section Heading",
   component: SectionHeading,
-  args: { children: "Similar bottles", count: 12 },
+  args: { children: "Similar bottles" },
 } satisfies Meta<typeof SectionHeading>;
 
 export default meta;
@@ -16,10 +16,8 @@ export const Overview: Story = {
   render: (args) => (
     <StoryStack>
       <SectionHeading {...args} />
-      <SectionHeading count={12}>Similar bottles</SectionHeading>
-      <SectionHeading count={2841}>Tastings</SectionHeading>
-      <SectionHeading count={0}>Critic reviews</SectionHeading>
       <SectionHeading>History</SectionHeading>
+      <SectionHeading level={3}>Details</SectionHeading>
     </StoryStack>
   ),
 };

--- a/apps/web/src/components/sectionHeading.stylex.tsx
+++ b/apps/web/src/components/sectionHeading.stylex.tsx
@@ -2,36 +2,19 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import { foundationStyles } from "../styles/foundations.stylex";
-import { space } from "../styles/tokens.stylex";
-import { CountChip } from "./chip.stylex";
 
 export function SectionHeading({
   children,
-  count,
   level = 2,
 }: {
   children: ReactNode;
-  count?: number;
   level?: 2 | 3;
 }) {
   const Heading = level === 2 ? "h2" : "h3";
 
   return (
-    <div {...stylex.props(styles.root)}>
-      <Heading {...stylex.props(foundationStyles.sectionHeading)}>
-        {children}
-      </Heading>
-      {count === undefined ? null : <CountChip count={count} />}
-    </div>
+    <Heading {...stylex.props(foundationStyles.sectionHeading)}>
+      {children}
+    </Heading>
   );
 }
-
-const styles = stylex.create({
-  root: {
-    display: "flex",
-    alignItems: "center",
-    columnGap: "10px",
-    rowGap: space.x2,
-    flexWrap: "wrap",
-  },
-});


### PR DESCRIPTION
Section headings no longer show item counts, which removes misleading page-size numbers such as “Bottles 4” from overview and paginated sections. Links that expose full totals remain unchanged.

Page-tab totals remain visible and now use compact neutral badges so they read as supporting metadata instead of part of the tab label.
