### PR TITLE
fix(web): unify inline link styles

### DIFF
--- a/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
+++ b/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
@@ -8,13 +8,13 @@ import { useState } from "react";
 
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import {
-  AppLink,
   Button,
   CursorPager,
   EmptyState,
   IconButton,
   ItemList,
   ItemListItem,
+  TextLink,
 } from "@peated/web/components";
 import { Avatar } from "@peated/web/components/avatar.stylex";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
@@ -25,7 +25,6 @@ import { useORPC } from "@peated/web/lib/orpc/context";
 import {
   colors,
   controlMetrics,
-  effects,
   fonts,
   space,
 } from "../../../styles/tokens.stylex";
@@ -147,21 +146,18 @@ export function NotificationList({
                 <div {...stylex.props(styles.copy)}>
                   <div {...stylex.props(styles.message)}>
                     {from ? (
-                      <AppLink
-                        href={`/users/${from.username}`}
-                        {...stylex.props(styles.author)}
-                      >
+                      <TextLink href={`/users/${from.username}`} size="inherit">
                         {from.username}
-                      </AppLink>
+                      </TextLink>
                     ) : null}{" "}
                     {href ? (
-                      <AppLink
+                      <TextLink
                         href={href}
                         onClick={() => markRead(notification.id)}
-                        {...stylex.props(styles.target)}
+                        size="inherit"
                       >
                         {getNotificationMessage(notification)}
-                      </AppLink>
+                      </TextLink>
                     ) : (
                       getNotificationMessage(notification)
                     )}
@@ -267,22 +263,6 @@ const styles = stylex.create({
     fontFamily: fonts.reading,
     fontSize: "13px",
     lineHeight: 1.45,
-  },
-  author: {
-    color: { default: colors.ink, ":hover": colors.accentDeep },
-    fontWeight: 700,
-    textDecorationLine: { default: "none", ":hover": "underline" },
-    textDecorationThickness: "1px",
-    textUnderlineOffset: "2px",
-    outline: "none",
-    boxShadow: { default: "none", ":focus-visible": effects.focusRing },
-  },
-  target: {
-    color: "inherit",
-    textDecoration: "none",
-    outline: "none",
-    boxShadow: { default: "none", ":focus-visible": effects.focusRing },
-    ":hover": { color: colors.ink, textDecoration: "underline" },
   },
   date: {
     display: "block",

--- a/apps/web/src/components/bottleChecks/checkSummary.stylex.tsx
+++ b/apps/web/src/components/bottleChecks/checkSummary.stylex.tsx
@@ -1,8 +1,8 @@
 import type { Finding } from "@peated/bottle-classifier";
 import type { Outputs } from "@peated/server/orpc/router";
-import { AppLink as Link } from "@peated/web/components";
+import { TextLink } from "@peated/web/components";
 import * as stylex from "@stylexjs/stylex";
-import { colors, effects } from "../../styles/tokens.stylex";
+import { colors } from "../../styles/tokens.stylex";
 
 export type BottleCheck = Outputs["audits"]["list"]["results"][number];
 
@@ -68,12 +68,9 @@ export function BottleCheckSubject({
 }) {
   if (check.bottleId) {
     return (
-      <Link
-        href={`/bottles/${check.bottleId}`}
-        {...stylex.props(styles.subjectLink)}
-      >
+      <TextLink href={`/bottles/${check.bottleId}`} size="inherit">
         Bottle #{check.bottleId}
-      </Link>
+      </TextLink>
     );
   }
   if (check.intent === "resolve_reference") {
@@ -91,16 +88,6 @@ export function BottleCheckSubject({
 
 const styles = stylex.create({
   subject: { color: colors.inkMuted },
-  subjectLink: {
-    color: { default: colors.ink, ":hover": colors.accentDeep },
-    fontWeight: 600,
-    textDecoration: "underline",
-    outline: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
-  },
 });
 
 export function BottleCheckOrigin({

--- a/apps/web/src/components/bottleChecks/operationCard.stylex.tsx
+++ b/apps/web/src/components/bottleChecks/operationCard.stylex.tsx
@@ -1175,8 +1175,18 @@ const styles = stylex.create({
     flexWrap: "wrap",
   },
   link: {
-    color: { default: colors.inkMuted, ":hover": colors.accentDeep },
-    textDecoration: "underline",
+    color: {
+      default: colors.accentDeep,
+      ":hover": colors.accent,
+      ":active": colors.ink,
+    },
+    fontWeight: 600,
+    textDecorationLine: {
+      default: "none",
+      ":hover": "underline",
+    },
+    textDecorationThickness: "1px",
+    textUnderlineOffset: "2px",
     outline: "none",
     boxShadow: {
       default: "none",
@@ -1184,8 +1194,18 @@ const styles = stylex.create({
     },
   },
   externalLink: {
-    color: { default: colors.inkMuted, ":hover": colors.accentDeep },
-    textDecoration: "underline",
+    color: {
+      default: colors.accentDeep,
+      ":hover": colors.accent,
+      ":active": colors.ink,
+    },
+    fontWeight: 600,
+    textDecorationLine: {
+      default: "none",
+      ":hover": "underline",
+    },
+    textDecorationThickness: "1px",
+    textUnderlineOffset: "2px",
     overflowWrap: "anywhere",
     outline: "none",
     boxShadow: {

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -328,7 +328,11 @@ const styles = stylex.create({
     fontSize: "12px",
     fontWeight: 600,
     lineHeight: 1.3,
-    textDecorationLine: "underline",
+    textDecorationLine: {
+      default: "none",
+      ":hover": "underline",
+    },
+    textDecorationThickness: "1px",
     textUnderlineOffset: "2px",
     boxShadow: {
       default: "none",

--- a/apps/web/src/components/criticReview.stylex.tsx
+++ b/apps/web/src/components/criticReview.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, effects, fonts, space } from "../styles/tokens.stylex";
+import { colors, fonts, space } from "../styles/tokens.stylex";
+import { TextLink } from "./textLink.stylex";
 
 export type CriticReviewProps = {
   href?: string;
@@ -46,9 +47,11 @@ export function CriticReview({
       {summary ? <p {...stylex.props(styles.summary)}>{summary}</p> : null}
 
       {href ? (
-        <a href={href} {...stylex.props(styles.reviewLink)}>
-          Read the full review on {publication} →
-        </a>
+        <div {...stylex.props(styles.reviewLink)}>
+          <TextLink href={href} size="inherit">
+            Read the full review on {publication} →
+          </TextLink>
+        </div>
       ) : null}
     </article>
   );
@@ -115,23 +118,9 @@ const styles = stylex.create({
     textWrap: "pretty",
   },
   reviewLink: {
-    display: "inline-block",
     marginTop: space.x3,
-    borderRadius: "2px",
-    outline: "none",
-    color: {
-      default: colors.accentDeep,
-      ":hover": colors.accent,
-      ":active": colors.ink,
-    },
     fontFamily: fonts.reading,
     fontSize: "13px",
-    fontWeight: 700,
     lineHeight: 1.35,
-    textDecoration: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
   },
 });

--- a/apps/web/src/components/historyTimeline.stylex.tsx
+++ b/apps/web/src/components/historyTimeline.stylex.tsx
@@ -1,13 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
-import {
-  colors,
-  controlMetrics,
-  effects,
-  fonts,
-  space,
-} from "../styles/tokens.stylex";
+import { colors, fonts, space } from "../styles/tokens.stylex";
+import { TextLink } from "./textLink.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
 
@@ -66,14 +61,16 @@ export function HistoryTimeline({ events, summary }: HistoryTimelineProps) {
                 </span>
               ) : null}
               {event.source ? (
-                <a
-                  href={event.source.href}
-                  rel="noreferrer"
-                  target="_blank"
-                  {...stylex.props(styles.source)}
-                >
-                  {event.source.label ?? "Source"}
-                </a>
+                <span {...stylex.props(styles.source)}>
+                  <TextLink
+                    href={event.source.href}
+                    rel="noreferrer"
+                    size="inherit"
+                    target="_blank"
+                  >
+                    {event.source.label ?? "Source"}
+                  </TextLink>
+                </span>
               ) : null}
             </div>
           </li>
@@ -140,18 +137,9 @@ const styles = stylex.create({
     color: colors.inkMuted,
   },
   source: {
-    color: { default: colors.accentDeep, ":hover": colors.accent },
     fontFamily: fonts.data,
     fontSize: "11px",
     lineHeight: 1.45,
-    textDecorationLine: "underline",
-    textUnderlineOffset: "2px",
-    outline: "none",
-    borderRadius: controlMetrics.radiusSmall,
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
   },
   summary: {
     marginTop: space.x3,

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -12,6 +12,7 @@ import {
   CardPrimaryLink,
   ItemList,
   ItemRow,
+  TextLink,
   type TastingRatingCounts,
 } from "..";
 import {
@@ -189,14 +190,14 @@ export function HomeRecentReviews({
               key={review.id}
               metadata={
                 <>
-                  <a
+                  <TextLink
                     href={review.sourceHref}
                     rel="noreferrer"
+                    size="inherit"
                     target="_blank"
-                    {...stylex.props(styles.sourceLink)}
                   >
                     {review.source}
-                  </a>
+                  </TextLink>
                   {review.metadata.map((item) => (
                     <span key={item}>
                       <span aria-hidden="true"> · </span>
@@ -532,29 +533,6 @@ const styles = stylex.create({
   },
   rows: {
     marginTop: space.x2,
-  },
-  sourceLink: {
-    position: "relative",
-    zIndex: 2,
-    width: "fit-content",
-    maxWidth: "100%",
-    borderRadius: controlMetrics.radiusSmall,
-    outline: "none",
-    color: {
-      default: colors.inkMuted,
-      ":hover": colors.accentDeep,
-      ":active": colors.accent,
-    },
-    textDecorationLine: {
-      default: "none",
-      ":hover": "underline",
-    },
-    textDecorationThickness: "1px",
-    textUnderlineOffset: "2px",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": "none",
-    },
   },
   reviewFacts: {
     display: "flex",


### PR DESCRIPTION
Ordinary text links now use Peated's shared orange link treatment across critic attribution, history sources, notifications, bottle-check evidence, related-release links, and full-review actions. They have no underline at rest, add one on hover, and use the existing keyboard focus ring; buttons, cards, tabs, navigation, and linked rows keep their own styles.

This removes the remaining local rules that made sources such as Whiskyfun look like unlinked metadata or left links underlined by default. The critic review and history stories were checked in light and dark themes at desktop and mobile widths.
