### PR TITLE
style(web): describe entity affiliations as part of

### DIFF
--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
@@ -34,7 +34,7 @@ function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
     { label: "Region", value: location },
     { label: "Established", value: entity.yearEstablished },
     {
-      label: "Owned by",
+      label: "Part of",
       value: entity.owner ? (
         <TextLink href={`/entities/${entity.owner.id}`} size="inherit">
           {entity.owner.name}

--- a/apps/web/src/components/entityForm.tsx
+++ b/apps/web/src/components/entityForm.tsx
@@ -62,7 +62,7 @@ export default function EntityForm({
   const [owner, setOwner] = useState<ProducerPickerOption | null>(() =>
     initialData.owner
       ? {
-          detail: "Current direct owner",
+          detail: "Currently part of",
           id: String(initialData.owner.id),
           meta: initialData.owner.peatedId,
           name: initialData.owner.name,
@@ -281,9 +281,9 @@ export default function EntityForm({
             title="Details"
           >
             <ProducerPicker
-              help="The current direct owner, when one is known."
+              help="The company or organization this is part of, when known."
               kind="producer"
-              label="Owned by"
+              label="Part of"
               loading={ownerResults.isFetching}
               onChange={(value) => {
                 setOwner(value);

--- a/apps/web/src/components/storyData.ts
+++ b/apps/web/src/components/storyData.ts
@@ -5,19 +5,19 @@ import type { SearchResultGroup } from "./searchResults.stylex";
 
 export const distillerOptions = [
   {
-    detail: "Islay · 412 bottles · owned by Rémy Cointreau",
+    detail: "Islay · 412 bottles · part of Rémy Cointreau",
     id: "D00192",
     meta: "412 bottles",
     name: "Bruichladdich",
   },
   {
-    detail: "Islay · 86 bottles · owned by Rémy Cointreau",
+    detail: "Islay · 86 bottles · part of Rémy Cointreau",
     id: "D00193",
     meta: "86 bottles",
     name: "Bruichladdich (Port Charlotte)",
   },
   {
-    detail: "Islay · 64 bottles · owned by Rémy Cointreau",
+    detail: "Islay · 64 bottles · part of Rémy Cointreau",
     id: "D00481",
     meta: "64 bottles",
     name: "Bruichladdich (Octomore)",


### PR DESCRIPTION
Entity detail facts and the entity editor now describe the parent relationship as “Part of,” which avoids making a stronger legal-ownership claim in the interface. Picker guidance and example data use the same wording, while the underlying owner field and acquisition behavior remain unchanged.
