### PR TITLE
fix(entities): match relationship sections to entity kind

### DIFF
--- a/apps/server/src/orpc/contracts/entities/catalog.ts
+++ b/apps/server/src/orpc/contracts/entities/catalog.ts
@@ -1,4 +1,5 @@
-import { CategoryEnum, EntityKindEnum } from "@peated/server/schemas";
+import type { EntityKindEnum } from "@peated/server/schemas";
+import { CategoryEnum } from "@peated/server/schemas";
 import { z } from "zod";
 import { contract } from "../base";
 
@@ -6,9 +7,12 @@ const RelatedEntitySchema = z.object({
   id: z.number(),
   name: z.string(),
   shortName: z.string().nullable(),
-  kind: EntityKindEnum,
   count: z.number(),
 });
+
+const relatedEntitySchema = <Kind extends z.infer<typeof EntityKindEnum>>(
+  kind: Kind,
+) => RelatedEntitySchema.extend({ kind: z.literal(kind) });
 
 export default contract
   .route({
@@ -38,9 +42,9 @@ export default contract
         }),
       ),
       related: z.object({
-        brands: z.array(RelatedEntitySchema),
-        bottlers: z.array(RelatedEntitySchema),
-        distillers: z.array(RelatedEntitySchema),
+        brands: z.array(relatedEntitySchema("brand")),
+        bottlers: z.array(relatedEntitySchema("bottler")),
+        distillers: z.array(relatedEntitySchema("distillery")),
       }),
       notableBottles: z.array(
         z.object({

--- a/apps/server/src/orpc/mock/fixtures/catalog.ts
+++ b/apps/server/src/orpc/mock/fixtures/catalog.ts
@@ -63,12 +63,15 @@ export function mockEntityCatalogFor(
       (categoryCounts.get(bottle.category) ?? 0) + 1,
     );
   }
-  const relatedEntities = (
+  const relatedEntities = <Kind extends "brand" | "bottler" | "distillery">(
     values: Entity[],
-  ): MockOutputs["entities"]["catalog"]["related"]["brands"] =>
+    kind: Kind,
+    matches: (bottle: Bottle, entityId: number) => boolean,
+  ) =>
     values
       .filter(
         (value, index) =>
+          value.kind === kind &&
           value.id !== entity.id &&
           values.findIndex((candidate) => candidate.id === value.id) === index,
       )
@@ -76,13 +79,9 @@ export function mockEntityCatalogFor(
         id: value.id,
         name: value.name,
         shortName: value.shortName,
-        kind: value.kind,
-        count: relatedBottles.filter(
-          (bottle) =>
-            bottle.brand.id === value.id ||
-            bottle.bottler?.id === value.id ||
-            bottle.distillers.some((distiller) => distiller.id === value.id),
-        ).length,
+        kind,
+        count: relatedBottles.filter((bottle) => matches(bottle, value.id))
+          .length,
       }));
 
   return {
@@ -112,14 +111,23 @@ export function mockEntityCatalogFor(
       ),
     })),
     related: {
-      brands: relatedEntities(relatedBottles.map((bottle) => bottle.brand)),
+      brands: relatedEntities(
+        relatedBottles.map((bottle) => bottle.brand),
+        "brand",
+        (bottle, entityId) => bottle.brand.id === entityId,
+      ),
       bottlers: relatedEntities(
         relatedBottles.flatMap((bottle) =>
           bottle.bottler ? [bottle.bottler] : [],
         ),
+        "bottler",
+        (bottle, entityId) => bottle.bottler?.id === entityId,
       ),
       distillers: relatedEntities(
         relatedBottles.flatMap((bottle) => bottle.distillers),
+        "distillery",
+        (bottle, entityId) =>
+          bottle.distillers.some((distiller) => distiller.id === entityId),
       ),
     },
     notableBottles: relatedBottles.map((bottle) => ({

--- a/apps/server/src/orpc/routes/entities/catalog.test.ts
+++ b/apps/server/src/orpc/routes/entities/catalog.test.ts
@@ -10,11 +10,26 @@ describe("GET /entities/:entity/catalog", () => {
       name: "Summary Entity",
       kind: "distillery",
     });
-    const alphaBrand = await fixtures.Entity({ name: "Alpha Brand" });
-    const betaBrand = await fixtures.Entity({ name: "Beta Brand" });
-    const outsideBottler = await fixtures.Entity({ name: "Outside Bottler" });
-    const sourceA = await fixtures.Entity({ name: "Source A" });
-    const sourceB = await fixtures.Entity({ name: "Source B" });
+    const alphaBrand = await fixtures.Entity({
+      name: "Alpha Brand",
+      kind: "brand",
+    });
+    const betaBrand = await fixtures.Entity({
+      name: "Beta Brand",
+      kind: "brand",
+    });
+    const outsideBottler = await fixtures.Entity({
+      name: "Outside Bottler",
+      kind: "bottler",
+    });
+    const sourceA = await fixtures.Entity({
+      name: "Source A",
+      kind: "distillery",
+    });
+    const sourceB = await fixtures.Entity({
+      name: "Source B",
+      kind: "distillery",
+    });
 
     await fixtures.Bottle({
       name: "Overlapping Roles",
@@ -82,7 +97,7 @@ describe("GET /entities/:entity/catalog", () => {
             id: outsideBottler.id,
             name: "Outside Bottler",
             shortName: null,
-            kind: "brand",
+            kind: "bottler",
             count: 1,
           },
         ],
@@ -91,14 +106,14 @@ describe("GET /entities/:entity/catalog", () => {
             id: sourceA.id,
             name: "Source A",
             shortName: null,
-            kind: "brand",
+            kind: "distillery",
             count: 1,
           },
           {
             id: sourceB.id,
             name: "Source B",
             shortName: null,
-            kind: "brand",
+            kind: "distillery",
             count: 1,
           },
         ],
@@ -123,6 +138,38 @@ describe("GET /entities/:entity/catalog", () => {
           medianScore: null,
         },
       ],
+    });
+  });
+
+  test("excludes related Entities whose kind does not match their Bottle relationship", async ({
+    fixtures,
+  }) => {
+    const entity = await fixtures.Entity({ kind: "distillery" });
+    const brandUsedAsBottler = await fixtures.Entity({
+      name: "Brand Used as Bottler",
+      kind: "brand",
+    });
+    const bottlerUsedAsBrand = await fixtures.Entity({
+      name: "Bottler Used as Brand",
+      kind: "bottler",
+    });
+    const brandUsedAsDistiller = await fixtures.Entity({
+      name: "Brand Used as Distiller",
+      kind: "brand",
+    });
+
+    await fixtures.Bottle({
+      brandId: bottlerUsedAsBrand.id,
+      bottlerId: brandUsedAsBottler.id,
+      distillerIds: [entity.id, brandUsedAsDistiller.id],
+    });
+
+    const data = await routerClient.entities.catalog({ entity: entity.id });
+
+    expect(data.related).toEqual({
+      brands: [],
+      bottlers: [],
+      distillers: [],
     });
   });
 

--- a/apps/server/src/orpc/routes/entities/catalog.ts
+++ b/apps/server/src/orpc/routes/entities/catalog.ts
@@ -81,7 +81,13 @@ export default implement(entityCatalogContract).handler(async function ({
       })
       .from(bottles)
       .innerJoin(entities, eq(entities.id, bottles.brandId))
-      .where(and(associatedBottle, ne(entities.id, entity.id)))
+      .where(
+        and(
+          associatedBottle,
+          ne(entities.id, entity.id),
+          eq(entities.kind, "brand"),
+        ),
+      )
       .groupBy(entities.id)
       .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
       .limit(7),
@@ -95,7 +101,13 @@ export default implement(entityCatalogContract).handler(async function ({
       })
       .from(bottles)
       .innerJoin(entities, eq(entities.id, bottles.bottlerId))
-      .where(and(associatedBottle, ne(entities.id, entity.id)))
+      .where(
+        and(
+          associatedBottle,
+          ne(entities.id, entity.id),
+          eq(entities.kind, "bottler"),
+        ),
+      )
       .groupBy(entities.id)
       .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
       .limit(7),
@@ -113,7 +125,13 @@ export default implement(entityCatalogContract).handler(async function ({
         eq(bottlesToDistillers.bottleId, bottles.id),
       )
       .innerJoin(entities, eq(entities.id, bottlesToDistillers.distillerId))
-      .where(and(associatedBottle, ne(entities.id, entity.id)))
+      .where(
+        and(
+          associatedBottle,
+          ne(entities.id, entity.id),
+          eq(entities.kind, "distillery"),
+        ),
+      )
       .groupBy(entities.id)
       .orderBy(desc(sql`COUNT(DISTINCT ${bottles.id})`), asc(entities.name))
       .limit(7),
@@ -135,12 +153,17 @@ export default implement(entityCatalogContract).handler(async function ({
     throw new Error(`Missing catalog summary for Entity ${entity.id}.`);
   }
 
-  const related = (rows: typeof brandRows) =>
+  const related = <Kind extends "brand" | "bottler" | "distillery">(
+    rows: typeof brandRows,
+    kind: Kind,
+  ) =>
     rows.map((row) => {
-      if (!row.kind) {
-        throw new Error(`Related Entity ${row.id} has no kind.`);
+      if (row.kind !== kind) {
+        throw new Error(
+          `Related Entity ${row.id} must have kind ${kind}, got ${row.kind}.`,
+        );
       }
-      return { ...row, kind: row.kind, count: Number(row.count) };
+      return { ...row, kind, count: Number(row.count) };
     });
   const totalBottles = Number(summary.totalBottles);
 
@@ -160,9 +183,9 @@ export default implement(entityCatalogContract).handler(async function ({
       count: Number(row.count),
     })),
     related: {
-      brands: related(brandRows),
-      bottlers: related(bottlerRows),
-      distillers: related(distillerRows),
+      brands: related(brandRows, "brand"),
+      bottlers: related(bottlerRows, "bottler"),
+      distillers: related(distillerRows, "distillery"),
     },
     notableBottles: notableBottleRows,
   };

--- a/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.test.tsx
@@ -1,0 +1,113 @@
+import { mockEntity } from "@peated/server/orpc/mock/fixtures";
+import type { Outputs } from "@peated/server/orpc/router";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { EntityCatalogRelationships } from "./entityCatalogRelationships";
+import type { Entity } from "./entityPageData";
+
+type EntityCatalog = Outputs["entities"]["catalog"];
+
+const baseCatalog: EntityCatalog = {
+  totalBottles: 1,
+  relationships: { brand: 0, bottler: 0, distiller: 1 },
+  distilleryCoverage: { documented: 1, total: 1 },
+  categories: [],
+  related: { brands: [], bottlers: [], distillers: [] },
+  notableBottles: [],
+};
+
+function renderRelationships(
+  kind: Entity["kind"],
+  related: EntityCatalog["related"],
+) {
+  const entity = {
+    ...mockEntity,
+    id: 1,
+    images: [],
+    kind,
+    name: "Example",
+  } satisfies Entity;
+
+  return renderToStaticMarkup(
+    <EntityCatalogRelationships
+      catalog={{ ...baseCatalog, related }}
+      entity={entity}
+      error={false}
+      pending={false}
+      retry={() => undefined}
+    />,
+  );
+}
+
+describe("EntityCatalogRelationships", () => {
+  test("shows bottlers on a distillery page and does not show brands", () => {
+    const html = renderRelationships("distillery", {
+      brands: [
+        {
+          id: 2,
+          name: "Unused Brand",
+          shortName: null,
+          kind: "brand",
+          count: 2,
+        },
+      ],
+      bottlers: [
+        {
+          id: 3,
+          name: "The Scotch Malt Whisky Society",
+          shortName: "SMWS",
+          kind: "bottler",
+          count: 20,
+        },
+      ],
+      distillers: [],
+    });
+
+    expect(html).toContain("Bottled by");
+    expect(html).toContain("SMWS");
+    expect(html).not.toContain("Unused Brand");
+    expect(html).not.toContain(">Brands<");
+  });
+
+  test.each(["brand", "bottler"] as const)(
+    "shows distilleries on a %s page",
+    (kind) => {
+      const html = renderRelationships(kind, {
+        brands: [],
+        bottlers: [],
+        distillers: [
+          {
+            id: 4,
+            name: "Caol Ila",
+            shortName: null,
+            kind: "distillery",
+            count: 5,
+          },
+        ],
+      });
+
+      expect(html).toContain("Distilled at");
+      expect(html).toContain("Caol Ila");
+    },
+  );
+
+  test("shows bottlers on a brand page when no distillery is known", () => {
+    const html = renderRelationships("brand", {
+      brands: [],
+      bottlers: [
+        {
+          id: 5,
+          name: "Independent Bottler",
+          shortName: null,
+          kind: "bottler",
+          count: 3,
+        },
+      ],
+      distillers: [],
+    });
+
+    expect(html).toContain("Bottled by");
+    expect(html).toContain("Independent Bottler");
+  });
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.test.tsx
@@ -20,6 +20,11 @@ const baseCatalog: EntityCatalog = {
 function renderRelationships(
   kind: Entity["kind"],
   related: EntityCatalog["related"],
+  state: {
+    error?: boolean;
+    pending?: boolean;
+    withCatalog?: boolean;
+  } = {},
 ) {
   const entity = {
     ...mockEntity,
@@ -31,10 +36,12 @@ function renderRelationships(
 
   return renderToStaticMarkup(
     <EntityCatalogRelationships
-      catalog={{ ...baseCatalog, related }}
+      catalog={
+        state.withCatalog === false ? undefined : { ...baseCatalog, related }
+      }
       entity={entity}
-      error={false}
-      pending={false}
+      error={state.error ?? false}
+      pending={state.pending ?? false}
       retry={() => undefined}
     />,
   );
@@ -109,5 +116,46 @@ describe("EntityCatalogRelationships", () => {
 
     expect(html).toContain("Bottled by");
     expect(html).toContain("Independent Bottler");
+  });
+
+  test.each([
+    ["loading", { pending: true }, "Loading distilleries and bottlers"],
+    ["error", { error: true }, "Could not load distilleries and bottlers"],
+  ] as const)(
+    "uses a neutral heading for a brand %s state without catalog data",
+    (_state, options, message) => {
+      const html = renderRelationships(
+        "brand",
+        { brands: [], bottlers: [], distillers: [] },
+        { ...options, withCatalog: false },
+      );
+
+      expect(html).toContain("Distilleries and bottlers");
+      expect(html).toContain(message);
+    },
+  );
+
+  test("uses the known brand fallback in an error state", () => {
+    const html = renderRelationships(
+      "brand",
+      {
+        brands: [],
+        bottlers: [
+          {
+            id: 5,
+            name: "Independent Bottler",
+            shortName: null,
+            kind: "bottler",
+            count: 3,
+          },
+        ],
+        distillers: [],
+      },
+      { error: true },
+    );
+
+    expect(html).toContain("Bottled by");
+    expect(html).toContain("Could not load bottlers");
+    expect(html).not.toContain("Distilled at");
   });
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
@@ -12,23 +12,27 @@ import { getEntityUrl } from "@peated/web/lib/urls";
 import type { Entity } from "./entityPageData";
 
 type EntityCatalog = Outputs["entities"]["catalog"];
-type RelatedEntity = EntityCatalog["related"]["brands"][number];
+type RelatedEntity =
+  | EntityCatalog["related"]["bottlers"][number]
+  | EntityCatalog["related"]["distillers"][number];
 
 function getRelationshipGroup(entity: Entity, catalog?: EntityCatalog) {
   if (!catalog) return null;
 
-  const candidates: Array<{
+  const groups: {
     heading: string;
     items: RelatedEntity[];
-  }> =
-    entity.kind === "brand"
-      ? [
-          { heading: "Distillers", items: catalog.related.distillers },
-          { heading: "Bottlers", items: catalog.related.bottlers },
-        ]
-      : [{ heading: "Brands", items: catalog.related.brands }];
+  }[] =
+    entity.kind === "distillery"
+      ? [{ heading: "Bottled by", items: catalog.related.bottlers }]
+      : entity.kind === "brand"
+        ? [
+            { heading: "Distilled at", items: catalog.related.distillers },
+            { heading: "Bottled by", items: catalog.related.bottlers },
+          ]
+        : [{ heading: "Distilled at", items: catalog.related.distillers }];
 
-  return candidates.find((candidate) => candidate.items.length > 0) ?? null;
+  return groups.find((group) => group.items.length) ?? null;
 }
 
 export function EntityCatalogRelationships({
@@ -46,22 +50,23 @@ export function EntityCatalogRelationships({
 }) {
   if (entity.kind === "company") return null;
 
+  const heading = entity.kind === "distillery" ? "Bottled by" : "Distilled at";
+  const relatedKind =
+    entity.kind === "distillery" ? "bottlers" : "distilleries";
+
   if (pending) {
     return (
-      <PageSection heading="Related brands and producers">
-        <LoadingList label="Loading related brands and producers" rows={3} />
+      <PageSection heading={heading}>
+        <LoadingList label={`Loading ${relatedKind}`} rows={3} />
       </PageSection>
     );
   }
 
   if (error) {
     return (
-      <PageSection heading="Related brands and producers">
-        <SectionError
-          heading="Related brands and producers are unavailable"
-          onRetry={retry}
-        >
-          Try loading the related brands and producers again.
+      <PageSection heading={heading}>
+        <SectionError heading={`Could not load ${relatedKind}`} onRetry={retry}>
+          Try again.
         </SectionError>
       </PageSection>
     );
@@ -78,7 +83,6 @@ export function EntityCatalogRelationships({
             end={related.count.toLocaleString("en-US")}
             href={getEntityUrl(related)}
             key={related.id}
-            metadata={related.kind === "brand" ? "Bottle brand" : undefined}
             title={related.shortName || related.name}
           />
         ))}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
@@ -21,16 +21,37 @@ function getRelationshipGroup(entity: Entity, catalog?: EntityCatalog) {
 
   const groups: {
     heading: string;
+    itemLabel: string;
     items: RelatedEntity[];
   }[] =
     entity.kind === "distillery"
-      ? [{ heading: "Bottled by", items: catalog.related.bottlers }]
+      ? [
+          {
+            heading: "Bottled by",
+            itemLabel: "bottlers",
+            items: catalog.related.bottlers,
+          },
+        ]
       : entity.kind === "brand"
         ? [
-            { heading: "Distilled at", items: catalog.related.distillers },
-            { heading: "Bottled by", items: catalog.related.bottlers },
+            {
+              heading: "Distilled at",
+              itemLabel: "distilleries",
+              items: catalog.related.distillers,
+            },
+            {
+              heading: "Bottled by",
+              itemLabel: "bottlers",
+              items: catalog.related.bottlers,
+            },
           ]
-        : [{ heading: "Distilled at", items: catalog.related.distillers }];
+        : [
+            {
+              heading: "Distilled at",
+              itemLabel: "distilleries",
+              items: catalog.related.distillers,
+            },
+          ];
 
   return groups.find((group) => group.items.length) ?? null;
 }
@@ -50,29 +71,39 @@ export function EntityCatalogRelationships({
 }) {
   if (entity.kind === "company") return null;
 
-  const heading = entity.kind === "distillery" ? "Bottled by" : "Distilled at";
-  const relatedKind =
-    entity.kind === "distillery" ? "bottlers" : "distilleries";
+  const group = getRelationshipGroup(entity, catalog);
+  const state =
+    group ??
+    (entity.kind === "brand"
+      ? {
+          heading: "Distilleries and bottlers",
+          itemLabel: "distilleries and bottlers",
+        }
+      : entity.kind === "distillery"
+        ? { heading: "Bottled by", itemLabel: "bottlers" }
+        : { heading: "Distilled at", itemLabel: "distilleries" });
 
   if (pending) {
     return (
-      <PageSection heading={heading}>
-        <LoadingList label={`Loading ${relatedKind}`} rows={3} />
+      <PageSection heading={state.heading}>
+        <LoadingList label={`Loading ${state.itemLabel}`} rows={3} />
       </PageSection>
     );
   }
 
   if (error) {
     return (
-      <PageSection heading={heading}>
-        <SectionError heading={`Could not load ${relatedKind}`} onRetry={retry}>
+      <PageSection heading={state.heading}>
+        <SectionError
+          heading={`Could not load ${state.itemLabel}`}
+          onRetry={retry}
+        >
           Try again.
         </SectionError>
       </PageSection>
     );
   }
 
-  const group = getRelationshipGroup(entity, catalog);
   if (!group) return null;
 
   return (

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -88,6 +88,7 @@ export function EntityOverviewClient({
   const siblingListQuery = useQuery({
     ...orpc.entities.list.queryOptions({
       input: {
+        kinds: ["distillery", "bottler"],
         limit: 5,
         owner: initialEntity.ownerId ?? undefined,
         sort: "-bottles",

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.test.ts
@@ -4,8 +4,29 @@ import { getEntitySiblings } from "./entitySiblingData";
 
 describe("getEntitySiblings", () => {
   it("removes the current entity", () => {
-    expect(getEntitySiblings(1, { results: [{ id: 1 }, { id: 2 }] })).toEqual([
-      { id: 2 },
+    expect(
+      getEntitySiblings(1, {
+        results: [
+          { id: 1, kind: "distillery" },
+          { id: 2, kind: "bottler" },
+        ],
+      }),
+    ).toEqual([{ id: 2, kind: "bottler" }]);
+  });
+
+  it("includes only distilleries and bottlers", () => {
+    expect(
+      getEntitySiblings(1, {
+        results: [
+          { id: 2, kind: "brand" },
+          { id: 3, kind: "distillery" },
+          { id: 4, kind: "company" },
+          { id: 5, kind: "bottler" },
+        ],
+      }),
+    ).toEqual([
+      { id: 3, kind: "distillery" },
+      { id: 5, kind: "bottler" },
     ]);
   });
 
@@ -13,15 +34,20 @@ describe("getEntitySiblings", () => {
     expect(
       getEntitySiblings(1, {
         results: [
-          { id: 1 },
-          { id: 2 },
-          { id: 3 },
-          { id: 4 },
-          { id: 5 },
-          { id: 6 },
+          { id: 1, kind: "distillery" },
+          { id: 2, kind: "distillery" },
+          { id: 3, kind: "distillery" },
+          { id: 4, kind: "distillery" },
+          { id: 5, kind: "distillery" },
+          { id: 6, kind: "distillery" },
         ],
       }),
-    ).toEqual([{ id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]);
+    ).toEqual([
+      { id: 2, kind: "distillery" },
+      { id: 3, kind: "distillery" },
+      { id: 4, kind: "distillery" },
+      { id: 5, kind: "distillery" },
+    ]);
   });
 
   it("returns no siblings before data is available", () => {

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingData.ts
@@ -1,4 +1,4 @@
-type EntitySiblingCandidate = { id: number };
+type EntitySiblingCandidate = { id: number; kind: string };
 type EntitySiblingList<T extends EntitySiblingCandidate> = {
   results: readonly T[];
 };
@@ -9,7 +9,11 @@ export function getEntitySiblings<T extends EntitySiblingCandidate>(
 ) {
   return (
     siblingList?.results
-      .filter((sibling) => sibling.id !== entityId)
+      .filter(
+        (sibling) =>
+          sibling.id !== entityId &&
+          (sibling.kind === "distillery" || sibling.kind === "bottler"),
+      )
       .slice(0, 4) ?? []
   );
 }

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
@@ -31,12 +31,12 @@ export function EntitySiblingOverview({
 
   const heading = entity.owner?.name
     ? `Also part of ${entity.owner.name}`
-    : "Related brands and producers";
+    : "Other distilleries and bottlers";
 
   if (pending) {
     return (
       <PageSection heading={heading}>
-        <LoadingList label="Loading related brands and producers" rows={3} />
+        <LoadingList label="Loading distilleries and bottlers" rows={3} />
       </PageSection>
     );
   }
@@ -45,10 +45,10 @@ export function EntitySiblingOverview({
     return (
       <PageSection heading={heading}>
         <SectionError
-          heading="Related brands and producers are unavailable"
+          heading="Could not load distilleries and bottlers"
           onRetry={retry}
         >
-          Try loading the related brands and producers again.
+          Try again.
         </SectionError>
       </PageSection>
     );

--- a/apps/web/src/app/(app)/entities/[entityId]/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/page.tsx
@@ -26,6 +26,7 @@ export default async function EntityPage(props: {
       entity.ownerId
         ? client.entities
             .list({
+              kinds: ["distillery", "bottler"],
               limit: 5,
               owner: entity.ownerId,
               sort: "-bottles",


### PR DESCRIPTION
Entity pages now show each relationship with the matching entity kind. Distilleries list bottlers under "Bottled by." Brand and bottler pages list distilleries under "Distilled at," and "Also part of" lists only distilleries and bottlers. Brand pages keep their existing bottler fallback. Until a brand's result is known, loading and error states use the neutral heading "Distilleries and bottlers."

The catalog response requires both the Bottle relationship and entity kind to match. The ownership rail uses the existing `kinds` filter in its server and client requests, then applies the same limit to preloaded results.
