### PR TITLE
fix(scraper): keep SMWS release labels out of cask numbers

### DIFF
--- a/apps/server/src/scraper/adapters/legacy/scrapeSMWS.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSMWS.test.ts
@@ -141,6 +141,70 @@ test("marks an explicitly multi-cask Society release as a small batch", () => {
   });
 });
 
+test("keeps reused Society labels out of bottle names and cask numbers", () => {
+  const result = parseArchivePage(`
+    <p class="productCount">3 Products</p>
+    <ul class="productGrid">
+      <li class="product"><article class="itemSmall"
+        data-item-name="Bazaar Berries"
+        data-item-sku="SM0123GB0700609">
+        <div class="itemInfoWrap"><ul>
+          <li><span class="name">CASK NO.</span><span class="value">Small Batch</span></li>
+          <li><span class="name">ABV</span><span class="value">50.0%</span></li>
+          <li><span class="name">SPIRIT</span><span class="value">Malt Whisky</span></li>
+        </ul></div>
+      </article></li>
+      <li class="product"><article class="itemSmall"
+        data-item-name="Viking toothpaste"
+        data-item-sku="SM0124GB0700610">
+        <div class="itemInfoWrap"><ul>
+          <li><span class="name">CASK NO.</span><span class="value">Distillery 93 Rare Release</span></li>
+          <li><span class="name">REGION</span><span class="value">Campbeltown</span></li>
+          <li><span class="name">ABV</span><span class="value">60.0%</span></li>
+          <li><span class="name">SPIRIT</span><span class="value">Malt Whisky</span></li>
+        </ul></div>
+      </article></li>
+      <li class="product"><article class="itemSmall"
+        data-item-name="Lime and thyme"
+        data-item-sku="SM0125GB0700611">
+        <div class="itemInfoWrap"><ul>
+          <li><span class="name">CASK NO.</span><span class="value">5 Lowland Batch 2022</span></li>
+          <li><span class="name">REGION</span><span class="value">Lowland</span></li>
+          <li><span class="name">ABV</span><span class="value">55.8%</span></li>
+          <li><span class="name">SPIRIT</span><span class="value">Malt Whisky</span></li>
+        </ul></div>
+      </article></li>
+    </ul>
+  `);
+
+  expect(result.bottles.map(({ bottle }) => bottle)).toEqual([
+    expect.objectContaining({
+      name: "Bazaar Berries",
+      category: null,
+      caskNumber: null,
+      singleCask: false,
+      distillers: [],
+    }),
+    expect.objectContaining({
+      name: "Viking toothpaste",
+      category: "single_malt",
+      caskNumber: null,
+      singleCask: false,
+      distillers: [{ name: "Glen Scotia" }],
+    }),
+    expect.objectContaining({
+      name: "Lime and thyme",
+      category: "single_malt",
+      caskNumber: null,
+      singleCask: false,
+      distillers: [{ name: "Auchentoshan" }],
+    }),
+  ]);
+  for (const { bottle } of result.bottles) {
+    expect(bottle).not.toHaveProperty("edition");
+  }
+});
+
 test("reads the public storefront token from plain or escaped page context", () => {
   expect(
     parseStorefrontToken('{"storefront_api":{"token":"plain-token"}}'),
@@ -514,7 +578,7 @@ test("prefers a known cask code encoded in the official SKU", async ({
   });
 });
 
-test("categorizes current small batches without distillery codes", async ({
+test("keeps current batch and rare-release titles clean", async ({
   axiosMock,
 }) => {
   const url = "https://smws.com/all-whisky?filter-page=1&per-page=128";
@@ -528,13 +592,14 @@ test("categorizes current small batches without distillery codes", async ({
             cask_no: z.string().nullable(),
             region: z.string().nullish(),
             spirit_type: z.string().nullish(),
+            list_description: z.string().nullish(),
           })
           .passthrough(),
       ),
     })
     .passthrough()
     .parse(JSON.parse(await loadFixture("smws", "bottle-list.json")));
-  payload.items = payload.items.slice(0, 2);
+  payload.items = payload.items.slice(0, 4);
   payload.items[0].sku = "SM0123GB0700609";
   payload.items[0].name = "Incognito";
   payload.items[0].cask_no = "Batch 41";
@@ -545,6 +610,18 @@ test("categorizes current small batches without distillery codes", async ({
   payload.items[1].cask_no = "Batch 42";
   payload.items[1].region = "Highland";
   payload.items[1].spirit_type = "Malt Whisky";
+  payload.items[2].sku = "SM0125GB0700611";
+  payload.items[2].name = "Bazaar Berries";
+  payload.items[2].cask_no = "Small Batch";
+  payload.items[2].region = null;
+  payload.items[2].spirit_type = "Malt Whisky";
+  payload.items[2].list_description =
+    "A delightful small batch sherried single malt.";
+  payload.items[3].sku = "SM0126GB0700612";
+  payload.items[3].name = "Dark 'n' stormy crème brûlée";
+  payload.items[3].cask_no = "Distillery G16 Rare Release";
+  payload.items[3].region = "Lowland";
+  payload.items[3].spirit_type = "Grain Whisky";
   axiosMock.onGet(url).reply(200, payload);
 
   const items: any[] = [];
@@ -552,7 +629,7 @@ test("categorizes current small batches without distillery codes", async ({
     items.push(item);
   });
 
-  expect(items).toHaveLength(2);
+  expect(items).toHaveLength(4);
   expect(items.map(([bottle]) => bottle)).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -571,6 +648,22 @@ test("categorizes current small batches without distillery codes", async ({
         singleCask: false,
         distillers: [],
       }),
+      expect.objectContaining({
+        name: "Bazaar Berries",
+        category: "single_malt",
+        caskNumber: null,
+        singleCask: false,
+        distillers: [],
+      }),
+      expect.objectContaining({
+        name: "Dark 'n' stormy crème brûlée",
+        category: "single_grain",
+        caskNumber: null,
+        singleCask: false,
+        distillers: [{ name: "Glasgow Distillery" }],
+      }),
     ]),
   );
+  expect(items[2][0]).not.toHaveProperty("edition");
+  expect(items[3][0]).not.toHaveProperty("edition");
 });

--- a/apps/server/src/scraper/adapters/legacy/scrapeSMWS.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSMWS.test.ts
@@ -143,7 +143,7 @@ test("marks an explicitly multi-cask Society release as a small batch", () => {
 
 test("keeps reused Society labels out of bottle names and cask numbers", () => {
   const result = parseArchivePage(`
-    <p class="productCount">3 Products</p>
+    <p class="productCount">4 Products</p>
     <ul class="productGrid">
       <li class="product"><article class="itemSmall"
         data-item-name="Bazaar Berries"
@@ -174,6 +174,15 @@ test("keeps reused Society labels out of bottle names and cask numbers", () => {
           <li><span class="name">SPIRIT</span><span class="value">Malt Whisky</span></li>
         </ul></div>
       </article></li>
+      <li class="product"><article class="itemSmall"
+        data-item-name="Shades of green"
+        data-item-sku="SM0126GB0700612">
+        <div class="itemInfoWrap"><ul>
+          <li><span class="name">CASK NO.</span><span class="value">G17.1</span></li>
+          <li><span class="name">ABV</span><span class="value">60.9%</span></li>
+          <li><span class="name">SPIRIT</span><span class="value">Single Grain Whisky</span></li>
+        </ul></div>
+      </article></li>
     </ul>
   `);
 
@@ -198,6 +207,13 @@ test("keeps reused Society labels out of bottle names and cask numbers", () => {
       caskNumber: null,
       singleCask: false,
       distillers: [{ name: "Auchentoshan" }],
+    }),
+    expect.objectContaining({
+      name: "G17.1 Shades of green",
+      category: "single_grain",
+      caskNumber: "G17.1",
+      singleCask: true,
+      distillers: [],
     }),
   ]);
   for (const { bottle } of result.bottles) {

--- a/apps/server/src/scraper/adapters/legacy/scrapeSMWS.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSMWS.ts
@@ -231,10 +231,18 @@ function categoryFromSmwsDescription(
 }
 
 function isSingleCask(
-  hasKnownDistiller: boolean,
+  caskNumber: string | null,
+  category: z.input<typeof BottleInputSchema>["category"],
   maturation: string | null,
 ): boolean {
-  if (!hasKnownDistiller) return false;
+  if (
+    !caskNumber ||
+    category === "blend" ||
+    category === "blended_malt" ||
+    category === "blended_grain"
+  ) {
+    return false;
+  }
   return !/^(?:two|three|four|five|six|seven|eight|nine|ten)\b/iu.test(
     maturation?.trim() ?? "",
   );
@@ -314,6 +322,12 @@ export function parseArchivePage(body: string): ArchivePage {
       vintageYear,
       isFullName: false,
     });
+    const category = categoryFromSmwsFacts({
+      caskNumber,
+      distilleryCode,
+      region,
+      spirit,
+    });
 
     const bottle: z.input<typeof BottleInputSchema> = {
       name: normalized.name,
@@ -321,12 +335,7 @@ export function parseArchivePage(body: string): ArchivePage {
       vintageYear: normalized.vintageYear,
       releaseYear: normalized.releaseYear,
       abv,
-      category: categoryFromSmwsFacts({
-        caskNumber,
-        distilleryCode,
-        region,
-        spirit,
-      }),
+      category,
       brand: { name: "The Scotch Malt Whisky Society" },
       bottler: { name: "The Scotch Malt Whisky Society" },
       distillers: distiller ? [{ name: distiller }] : [],
@@ -335,7 +344,7 @@ export function parseArchivePage(body: string): ArchivePage {
       outturn: parsePositiveInteger(
         facts.get("OUTTURN") ?? facts.get("BOTTLES PRODUCED"),
       ),
-      singleCask: isSingleCask(Boolean(caskNumber && distiller), maturation),
+      singleCask: isSingleCask(caskNumber, category, maturation),
     };
     if (edition) bottle.edition = edition;
 
@@ -713,7 +722,8 @@ export async function scrapeBottles(
           maturation: item.cask_type?.trim() || null,
           caskNumber,
           singleCask: isSingleCask(
-            Boolean(caskNumber && distiller),
+            caskNumber,
+            category,
             item.cask_type?.trim() || null,
           ),
           description: item.list_description?.trim() || null,

--- a/apps/server/src/scraper/adapters/legacy/scrapeSMWS.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSMWS.ts
@@ -1,5 +1,6 @@
 import { normalizeBottle } from "@peated/bottle-classifier/normalize";
 import {
+  getCategoryFromCask,
   parseDetailsFromName,
   SMWS_DISTILLERY_CODES,
 } from "@peated/bottle-classifier/smws";
@@ -129,25 +130,53 @@ export function parseCaskNumberFromSku(sku: string): string | null {
 }
 
 function getSmwsCodeIdentity(societyCode: string) {
-  // SMWS puts numbered Heresy releases in its cask-number API field, but the
-  // product presents them as batch editions rather than single-cask codes.
+  const caskMatch = /^(?<distillery>[A-Z0-9]+)\.(?<cask>\d+)$/iu.exec(
+    societyCode,
+  );
+  if (caskMatch?.groups) {
+    return {
+      caskNumber: societyCode,
+      edition: null,
+      distilleryCode: caskMatch.groups.distillery.toUpperCase(),
+    };
+  }
+
+  // SMWS puts numbered batch releases in its cask-number API field, but the
+  // product presents them as editions rather than single-cask codes.
   const batchMatch = /^Batch (?<number>\d+)$/iu.exec(societyCode);
   if (batchMatch?.groups) {
     return {
       caskNumber: null,
       edition: `Batch ${batchMatch.groups.number}`,
+      distilleryCode: null,
     };
   }
 
-  return { caskNumber: societyCode, edition: null };
+  // SMWS also puts batch and rare-release labels in its cask-number field.
+  // These labels can be reused, so they are not bottle cask numbers.
+  const namedDistilleryMatch =
+    /^Distillery (?<code>[A-Z0-9]+)(?: Rare Release| \(\d{4}\))$/iu.exec(
+      societyCode,
+    ) ??
+    /^(?<code>[A-Z0-9]+) (?:Campbeltown|Highland|Islay|Lowland|Speyside) Batch \d{4}$/iu.exec(
+      societyCode,
+    );
+
+  return {
+    caskNumber: null,
+    edition: null,
+    distilleryCode: namedDistilleryMatch?.groups?.code.toUpperCase() ?? null,
+  };
 }
 
 function categoryFromSmwsFacts({
   caskNumber,
+  distilleryCode,
   region,
   spirit,
 }: {
   caskNumber: string | null;
+  distilleryCode: string | null;
   region: string | null;
   spirit: string | null;
 }): z.input<typeof BottleInputSchema>["category"] {
@@ -155,6 +184,9 @@ function categoryFromSmwsFacts({
     ? parseDetailsFromName(`${caskNumber} Society bottle`)
     : null;
   if (details?.distiller) return details.category;
+  if (distilleryCode && SMWS_DISTILLERY_CODES[distilleryCode]) {
+    return getCategoryFromCask(distilleryCode);
+  }
 
   const normalizedSpirit = spirit?.toLowerCase() ?? "";
   const normalizedRegion = region?.toLowerCase() ?? "";
@@ -181,6 +213,20 @@ function categoryFromSmwsFacts({
   if (normalizedSpirit.includes("rye")) return "rye";
   if (normalizedSpirit.includes("wheat whisky")) return "wheat";
   if (normalizedSpirit.includes("single malt whisky")) return "single_malt";
+  return null;
+}
+
+function categoryFromSmwsDescription(
+  description: string | null | undefined,
+): z.input<typeof BottleInputSchema>["category"] {
+  if (
+    /\bsmall[- ]batch(?: sherried)? single malt\b/iu.test(description ?? "")
+  ) {
+    return "single_malt";
+  }
+  if (/\bsmall[- ]batch blended malt\b/iu.test(description ?? "")) {
+    return "blended_malt";
+  }
   return null;
 }
 
@@ -244,11 +290,16 @@ export function parseArchivePage(body: string): ArchivePage {
     const displayedSocietyCode = facts.get("CASK NO.") ?? null;
     const societyCode = parseCaskNumberFromSku(sku) ?? displayedSocietyCode;
     if (!societyCode) continue;
-    const standardCaskNumber = /^[A-Z0-9]+\.\d+$/iu.test(societyCode);
+    const { caskNumber, edition, distilleryCode } =
+      getSmwsCodeIdentity(societyCode);
     const bundleTitle = /\b(?:case|collection|duo|pack|trio)\b/iu.test(title);
-    if (!standardCaskNumber && bundleTitle) continue;
-    const { caskNumber, edition } = getSmwsCodeIdentity(societyCode);
-    const details = parseDetailsFromName(`${societyCode} ${title}`);
+    if (!caskNumber && bundleTitle) continue;
+    const details = caskNumber
+      ? parseDetailsFromName(`${caskNumber} ${title}`)
+      : null;
+    const distiller =
+      details?.distiller ??
+      (distilleryCode ? SMWS_DISTILLERY_CODES[distilleryCode] : null);
     const age = Number.parseInt(facts.get("AGE") ?? "", 10);
     const statedAge = Number.isSafeInteger(age) && age > 0 ? age : null;
     const vintageYear = parseVintageYear(card.attr("data-item-distilleddate"));
@@ -256,8 +307,7 @@ export function parseArchivePage(body: string): ArchivePage {
       card.attr("data-item-type")?.trim() || facts.get("CASK") || null;
     const region = facts.get("REGION") ?? null;
     const spirit = facts.get("SPIRIT") ?? null;
-    const rawName =
-      details?.name ?? (edition ? title : `${societyCode} ${title}`);
+    const rawName = details?.name ?? title;
     const normalized = normalizeBottle({
       name: rawName,
       statedAge,
@@ -271,16 +321,21 @@ export function parseArchivePage(body: string): ArchivePage {
       vintageYear: normalized.vintageYear,
       releaseYear: normalized.releaseYear,
       abv,
-      category: categoryFromSmwsFacts({ caskNumber, region, spirit }),
+      category: categoryFromSmwsFacts({
+        caskNumber,
+        distilleryCode,
+        region,
+        spirit,
+      }),
       brand: { name: "The Scotch Malt Whisky Society" },
       bottler: { name: "The Scotch Malt Whisky Society" },
-      distillers: details?.distiller ? [{ name: details.distiller }] : [],
+      distillers: distiller ? [{ name: distiller }] : [],
       maturation,
       caskNumber,
       outturn: parsePositiveInteger(
         facts.get("OUTTURN") ?? facts.get("BOTTLES PRODUCED"),
       ),
-      singleCask: isSingleCask(Boolean(details?.distiller), maturation),
+      singleCask: isSingleCask(Boolean(caskNumber && distiller), maturation),
     };
     if (edition) bottle.edition = edition;
 
@@ -393,6 +448,7 @@ function mergeArchiveDetails(
     ]),
   );
   const release = parseReleaseDate(customFields.get("release date"));
+  const description = textFromHtml(product.description);
   const caskNumber = archived.bottle.caskNumber;
   const productTitle = caskNumber
     ? repairMojibake(product.name)
@@ -436,7 +492,9 @@ function mergeArchiveDetails(
           customFields.get("bottles produced") ??
           customFields.get("number of bottles"),
       ),
-      description: textFromHtml(product.description),
+      category:
+        archived.bottle.category ?? categoryFromSmwsDescription(description),
+      description,
       flavorProfile: parseFlavorProfile(customFields.get("flavour profile")),
     },
   };
@@ -604,20 +662,26 @@ export async function scrapeBottles(
           return;
         }
 
-        const { caskNumber, edition } = getSmwsCodeIdentity(societyCode);
-        const details = parseDetailsFromName(`${societyCode} ${caskName}`);
-        const category = categoryFromSmwsFacts({
-          caskNumber,
-          region: item.region ?? null,
-          spirit: item.spirit_type ?? null,
-        });
+        const { caskNumber, edition, distilleryCode } =
+          getSmwsCodeIdentity(societyCode);
+        const details = caskNumber
+          ? parseDetailsFromName(`${caskNumber} ${caskName}`)
+          : null;
+        const distiller =
+          details?.distiller ??
+          (distilleryCode ? SMWS_DISTILLERY_CODES[distilleryCode] : null);
+        const category =
+          categoryFromSmwsFacts({
+            caskNumber,
+            distilleryCode,
+            region: item.region ?? null,
+            spirit: item.spirit_type ?? null,
+          }) ?? categoryFromSmwsDescription(item.list_description);
 
         const release = parseReleaseDate(item.release_date);
 
         const { name, statedAge, vintageYear, releaseYear } = normalizeBottle({
-          name:
-            details?.name ??
-            (edition ? caskName : `${societyCode} ${caskName}`),
+          name: details?.name ?? caskName,
           statedAge: item.age,
           vintageYear: parseVintageYear(item.distilleddate),
           releaseYear: release?.releaseYear ?? null,
@@ -645,17 +709,11 @@ export async function scrapeBottles(
           bottler: {
             name: "The Scotch Malt Whisky Society",
           },
-          distillers: details?.distiller
-            ? [
-                {
-                  name: details.distiller,
-                },
-              ]
-            : [],
+          distillers: distiller ? [{ name: distiller }] : [],
           maturation: item.cask_type?.trim() || null,
           caskNumber,
           singleCask: isSingleCask(
-            Boolean(details?.distiller),
+            Boolean(caskNumber && distiller),
             item.cask_type?.trim() || null,
           ),
           description: item.list_description?.trim() || null,


### PR DESCRIPTION
The SMWS scraper now stores only real Society codes such as `93.216` in
`caskNumber`. Numbered values such as `Batch 42` stay in `edition`. Reused
labels such as `Small Batch`, `Renewal Batch`, and `Distillery 93 Rare Release`
are left out of both the bottle name and cask number, so the bottle keeps the
title shown by SMWS.

When one of these labels gives a known distillery number, the scraper still
uses it to set the distiller and whisky category. It also sets the category
when the official description calls the release a small-batch single malt or
blended malt. Both the current shop feed and the full archive use the same
rules.

A real cask code remains a single-cask release even when its distillery code is
new to Peated. Blended-malt product codes such as `BAT.13` remain small-batch
releases.
