### PR TITLE
style(web): remove redundant detail dividers

### DIFF
--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
@@ -98,9 +98,6 @@ const styles = stylex.create({
     margin: 0,
     paddingTop: space.x4,
     paddingBottom: space.x4,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
   },
   fact: {
     minWidth: 0,

--- a/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
@@ -55,6 +55,7 @@ export function LocationPageFrame({
       <PageHeader
         actions={actions}
         description={description}
+        divider={false}
         eyebrow={country ? "Whisky region" : "Whisky country"}
         parent={
           country ? (

--- a/apps/web/src/components/pages/pageLayout.stylex.tsx
+++ b/apps/web/src/components/pages/pageLayout.stylex.tsx
@@ -58,6 +58,7 @@ export function PageColumns({
 export function PageHeader({
   actions,
   description,
+  divider = true,
   eyebrow,
   identity,
   menu,
@@ -66,6 +67,7 @@ export function PageHeader({
 }: {
   actions?: ReactNode;
   description?: ReactNode;
+  divider?: boolean;
   eyebrow?: ReactNode;
   identity?: ReactNode;
   menu?: ReactNode;
@@ -73,7 +75,12 @@ export function PageHeader({
   title: ReactNode;
 }) {
   return (
-    <header {...stylex.props(styles.pageHeader)}>
+    <header
+      {...stylex.props(
+        styles.pageHeader,
+        !divider && styles.pageHeaderNoDivider,
+      )}
+    >
       {identity}
       <div {...stylex.props(styles.pageHeaderBody)}>
         <div {...stylex.props(styles.pageHeaderCopy)}>
@@ -239,6 +246,9 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.sectionRule,
     backgroundColor: "transparent",
+  },
+  pageHeaderNoDivider: {
+    borderBottomWidth: 0,
   },
   pageHeaderBody: {
     display: "flex",


### PR DESCRIPTION
Entity overview facts no longer render a redundant separator before bottle content, and country and region detail headers omit their divider when followed by page tabs. Existing tab and table rules remain, so each transition keeps one visual boundary.
