### PR TITLE
style(web): improve bottle row hierarchy

### DIFF
--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -6,6 +6,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
+import { formatCategoryName } from "@peated/server/lib/format";
 import { ButtonLink, LoadingList, SectionError } from "@peated/web/components";
 import { EntityLinks } from "@peated/web/components/entityLinks";
 import Join from "@peated/web/components/join";
@@ -146,18 +147,31 @@ function LatestReleases() {
     );
   }
 
-  const items = releases.results.flatMap((bottle) =>
-    bottle.releaseYear === null
-      ? []
-      : [
-          {
-            href: `/bottles/${bottle.id}`,
-            imageUrl: bottle.imageUrl,
-            metadata: getReleaseMetadata(bottle),
-            name: formatBottleDisplayName(bottle),
-          },
-        ],
-  );
+  const items = releases.results.flatMap((bottle) => {
+    if (bottle.releaseYear === null) return [];
+
+    const distillers = bottle.distillers.filter(
+      (distiller) => distiller.id !== bottle.brand.id,
+    );
+    const subtitle = [
+      distillers.length ? (
+        <EntityLinks entities={distillers} key="distillers" />
+      ) : null,
+      bottle.category ? formatCategoryName(bottle.category) : null,
+    ].filter((value) => value !== null);
+
+    return [
+      {
+        href: `/bottles/${bottle.id}`,
+        imageUrl: bottle.imageUrl,
+        metadata: getReleaseMetadata(bottle),
+        name: formatBottleDisplayName(bottle),
+        subtitle: subtitle.length ? (
+          <Join divider=" · ">{subtitle}</Join>
+        ) : undefined,
+      },
+    ];
+  });
 
   return items.length ? (
     <HomeLatestReleases
@@ -402,25 +416,11 @@ function getBottleMetadata(bottle: Bottle) {
 }
 
 function getReleaseMetadata(bottle: Bottle) {
-  const facts = [
+  return [
     bottle.releaseYear === null ? null : `${bottle.releaseYear} release`,
     bottle.statedAge === null ? null : `${bottle.statedAge} years`,
     bottle.abv === null ? null : `${bottle.abv.toFixed(1)}% ABV`,
   ].filter((value): value is string => Boolean(value));
-
-  return (
-    <Join divider=" · ">
-      {[
-        <EntityLinks
-          entities={
-            bottle.distillers.length ? bottle.distillers : [bottle.brand]
-          }
-          key="producers"
-        />,
-        ...facts,
-      ]}
-    </Join>
-  );
 }
 
 const STACKED = "@media (max-width: 759px)";

--- a/apps/web/src/components/itemList.stories.tsx
+++ b/apps/web/src/components/itemList.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import * as stylex from "@stylexjs/stylex";
 
 import { colors, fonts } from "../styles/tokens.stylex";
+import { BottleVisual } from "./bottleIdentityRow.stylex";
 import { ItemList, ItemRow } from "./itemList.stylex";
 import { BottleRatings } from "./scoring.stylex";
 import { StoryCanvas, StoryStack } from "./storyFixtures.stylex";
@@ -103,8 +104,11 @@ export const Overview: Story = {
               scoreCount={28}
             />
           }
+          align="start"
           href="#yamazaki"
+          leading={<BottleVisual />}
           metadata="Japan · 12 years · 43.0% ABV"
+          subtitle="Japanese single malt"
           title="Yamazaki 12-year-old"
         />
         <ItemRow

--- a/apps/web/src/components/itemList.stylex.tsx
+++ b/apps/web/src/components/itemList.stylex.tsx
@@ -58,6 +58,7 @@ export function ItemListItem({ children, id }: ItemListItemProps) {
 
 export type ItemRowProps = {
   action?: ReactNode;
+  align?: "center" | "start";
   description?: ReactNode;
   end?: ReactNode;
   href?: string;
@@ -66,12 +67,14 @@ export type ItemRowProps = {
   metadata?: ReactNode;
   metadataWrap?: boolean;
   size?: ItemRowSize;
+  subtitle?: ReactNode;
   title: ReactNode;
 };
 
 /** Renders one aligned item with a primary link across the complete row. */
 export function ItemRow({
   action,
+  align = "center",
   description,
   end,
   href,
@@ -80,6 +83,7 @@ export function ItemRow({
   metadata,
   metadataWrap = false,
   size = "md",
+  subtitle,
   title,
 }: ItemRowProps) {
   const hasLinkedContent = Boolean(href);
@@ -90,6 +94,7 @@ export function ItemRow({
         {...stylex.props(
           styles.content,
           size === "sm" && styles.smallContent,
+          align === "start" && styles.startAlignedContent,
           hasLinkedContent && styles.interactiveContent,
           hasLinkedContent && linkedRowStyles.container,
           hasLinkedContent && linkedRowStyles.onGround,
@@ -122,6 +127,14 @@ export function ItemRow({
               {title}
             </span>
           )}
+          {subtitle ? (
+            <div
+              title={getTextTitle(subtitle)}
+              {...stylex.props(styles.subtitle)}
+            >
+              {subtitle}
+            </div>
+          ) : null}
           {metadata ? (
             <div
               title={getTextTitle(metadata)}
@@ -185,6 +198,9 @@ const styles = stylex.create({
     paddingTop: "11px",
     paddingBottom: "11px",
   },
+  startAlignedContent: {
+    alignItems: "flex-start",
+  },
   interactiveContent: {
     width: "calc(100% + 24px)",
     marginRight: "-12px",
@@ -194,7 +210,8 @@ const styles = stylex.create({
   },
   leading: {
     display: "flex",
-    width: "32px",
+    width: "auto",
+    minWidth: "32px",
     minHeight: "48px",
     flexShrink: 0,
     alignItems: "center",
@@ -203,6 +220,17 @@ const styles = stylex.create({
   copy: {
     minWidth: 0,
     flex: 1,
+  },
+  subtitle: {
+    marginTop: "3px",
+    maxWidth: "100%",
+    overflow: "hidden",
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.3,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
   title: {
     display: "block",

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -110,8 +110,9 @@ export function HomeHighestRated({
 export type HomeRelease = {
   href: string;
   imageUrl?: string | null;
-  metadata: ReactNode;
+  metadata: readonly string[];
   name: string;
+  subtitle?: ReactNode;
 };
 
 /** Shows bottles with known release years in API release order. */
@@ -138,11 +139,12 @@ export function HomeLatestReleases({
         <ItemList ariaLabel={title}>
           {bottles.map((bottle) => (
             <ItemRow
+              align="start"
               href={bottle.href}
               key={bottle.href}
               leading={<BottleVisual imageUrl={bottle.imageUrl} />}
-              metadata={bottle.metadata}
-              metadataWrap
+              metadata={bottle.metadata.join(" · ")}
+              subtitle={bottle.subtitle}
               title={bottle.name}
             />
           ))}


### PR DESCRIPTION
Homepage release rows now keep bottle images inside the list edge and top-align them with the copy. Each row leads with the brand-inclusive bottle name, then uses a smaller subtitle for nonredundant distillers and category, followed by release facts.

The shared item row now supports start alignment and subtitles while preserving the existing hover overhang. Distillers that match the brand are omitted from the subtitle, so rows gain useful context without repeating names such as `Caol Ila` on consecutive lines.
