### PR TITLE
feat(web): collapse long catalog descriptions

### DIFF
--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -16,6 +16,7 @@ import {
   Button,
   ButtonLink,
   EmptyState,
+  ExpandableDescription,
   LoadingList,
   PageTabs,
   RowMenu,
@@ -435,6 +436,11 @@ export function BottlePageFrameClient({
             {bottle.aliases.join(" · ")}
           </p>
         ) : null}
+        {bottle.description ? (
+          <div {...stylex.props(styles.description)}>
+            <ExpandableDescription content={bottle.description} />
+          </div>
+        ) : null}
         <div {...stylex.props(styles.tabs)}>
           <PageTabs
             ariaLabel="Bottle sections"
@@ -601,6 +607,14 @@ const styles = stylex.create({
   aliasLabel: {
     color: colors.ink,
     fontWeight: 600,
+  },
+  description: {
+    maxWidth: "680px",
+    marginTop: space.x4,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "14px",
+    lineHeight: 1.55,
   },
   overview: {
     marginTop: space.x8,

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -8,13 +8,13 @@ import { type ReactNode } from "react";
 import {
   Button,
   ButtonLink,
+  ExpandableDescription,
   PageTabs,
   RowMenu,
   SectionError,
   type RowMenuItem,
 } from "@peated/web/components";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
-import Markdown from "@peated/web/components/markdown";
 import { PageHeader } from "@peated/web/components/pages/pageLayout.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
 import useEntityFollowing from "@peated/web/hooks/useEntityFollowing";
@@ -196,7 +196,9 @@ export function EntityPageFrameClient({
           </>
         }
         description={
-          entity.description ? <Markdown content={entity.description} /> : null
+          entity.description ? (
+            <ExpandableDescription content={entity.description} />
+          ) : null
         }
         eyebrow={getEntityClassification(entity)}
         menu={<EntityActions entity={entity} />}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/layout.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/layout.tsx
@@ -1,5 +1,4 @@
-import { ButtonLink } from "@peated/web/components";
-import Markdown from "@peated/web/components/markdown";
+import { ButtonLink, ExpandableDescription } from "@peated/web/components";
 import { getCurrentUser } from "@peated/web/lib/auth.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
@@ -53,7 +52,7 @@ export default async function CountryLayout(props: {
       country={undefined}
       description={
         country.description ? (
-          <Markdown content={country.description} noLinks />
+          <ExpandableDescription content={country.description} noLinks />
         ) : undefined
       }
       name={country.name}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
@@ -1,5 +1,4 @@
-import { ButtonLink } from "@peated/web/components";
-import Markdown from "@peated/web/components/markdown";
+import { ButtonLink, ExpandableDescription } from "@peated/web/components";
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import { getCurrentUser } from "@peated/web/lib/auth.server";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
@@ -70,7 +69,7 @@ export default async function RegionPage(props: {
       }}
       description={
         region.description ? (
-          <Markdown content={region.description} noLinks />
+          <ExpandableDescription content={region.description} noLinks />
         ) : undefined
       }
       name={region.name}

--- a/apps/web/src/components/expandableDescription.stylex.tsx
+++ b/apps/web/src/components/expandableDescription.stylex.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useId, useState } from "react";
+
+import { summarize } from "../lib/markdown";
+import { space } from "../styles/tokens.stylex";
+import { Button } from "./button.stylex";
+import Markdown from "./markdown";
+
+const PREVIEW_SENTENCES = 2;
+
+export function getDescriptionPreview(content: string) {
+  const text = summarize(content, Number.MAX_SAFE_INTEGER)
+    .replace(/\s+/g, " ")
+    .trim();
+  const sentences = [
+    ...new Intl.Segmenter("en", { granularity: "sentence" }).segment(text),
+  ];
+  const preview = sentences
+    .slice(0, PREVIEW_SENTENCES)
+    .map(({ segment }) => segment.trim())
+    .join(" ");
+
+  return {
+    text: preview,
+    truncated: sentences.length > PREVIEW_SENTENCES,
+  };
+}
+
+export function ExpandableDescription({
+  content,
+  noLinks = false,
+}: {
+  content: string;
+  noLinks?: boolean;
+}) {
+  const contentId = useId();
+  const [expanded, setExpanded] = useState(false);
+  const preview = getDescriptionPreview(content);
+
+  if (!preview.truncated) {
+    return <Markdown content={content} noLinks={noLinks} />;
+  }
+
+  return (
+    <div>
+      <div id={contentId}>
+        <Markdown
+          content={expanded ? content : preview.text}
+          noLinks={noLinks}
+        />
+      </div>
+      <div {...stylex.props(styles.action)}>
+        <Button
+          aria-controls={contentId}
+          aria-expanded={expanded}
+          onClick={() => setExpanded((value) => !value)}
+          size="sm"
+          variant="text"
+        >
+          {expanded ? "Show less" : "Read more"}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  action: {
+    marginTop: space.x1,
+    marginLeft: "-12px",
+  },
+});

--- a/apps/web/src/components/expandableDescription.test.tsx
+++ b/apps/web/src/components/expandableDescription.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  ExpandableDescription,
+  getDescriptionPreview,
+} from "./expandableDescription.stylex";
+
+describe("ExpandableDescription", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("shows short descriptions without a disclosure", () => {
+    act(() => root.render(<ExpandableDescription content="One sentence." />));
+
+    expect(container.textContent?.trim()).toBe("One sentence.");
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("uses the first two complete sentences for the preview", () => {
+    expect(
+      getDescriptionPreview(
+        "First sentence. Second sentence with **detail**. Third sentence.",
+      ),
+    ).toEqual({
+      text: "First sentence. Second sentence with detail.",
+      truncated: true,
+    });
+  });
+
+  it("expands and collapses the full description", () => {
+    act(() =>
+      root.render(
+        <ExpandableDescription content="First sentence. Second sentence. Third sentence." />,
+      ),
+    );
+
+    const button = container.querySelector("button");
+    expect(container.textContent).toContain("First sentence. Second sentence.");
+    expect(container.textContent).not.toContain("Third sentence.");
+    expect(button?.textContent).toBe("Read more");
+    expect(button?.getAttribute("aria-expanded")).toBe("false");
+
+    act(() => button?.click());
+
+    expect(container.textContent).toContain("Third sentence.");
+    expect(button?.textContent).toBe("Show less");
+    expect(button?.getAttribute("aria-expanded")).toBe("true");
+
+    act(() => button?.click());
+
+    expect(container.textContent).not.toContain("Third sentence.");
+    expect(button?.textContent).toBe("Read more");
+  });
+});

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -65,6 +65,7 @@ export { CriticReview } from "./criticReview.stylex";
 export type { CriticReviewProps } from "./criticReview.stylex";
 export { DataTable } from "./dataTable.stylex";
 export type { DataTableColumn, DataTableProps } from "./dataTable.stylex";
+export { ExpandableDescription } from "./expandableDescription.stylex";
 export { FacetRow } from "./facetRow.stylex";
 export type { FacetRowProps } from "./facetRow.stylex";
 export { FactList, hasVisibleFacts } from "./factList.stylex";


### PR DESCRIPTION
Long descriptions on bottle, entity, country, and region pages now start with a two-sentence preview and an accessible **Read more** / **Show less** control. Short descriptions remain unchanged, and bottle pages now show their existing description data instead of omitting it.

The shared component preserves full Markdown after expansion while using plain text for the sentence preview. Interaction coverage verifies short descriptions, sentence selection, expansion, and collapse. The Islay region was also checked at desktop and mobile widths to confirm that its distiller list stays near the top of the page.
