### PR TITLE
fix(web): prevent visited rail link colors

### DIFF
--- a/apps/web/src/components/lists.stylex.tsx
+++ b/apps/web/src/components/lists.stylex.tsx
@@ -356,7 +356,7 @@ const styles = stylex.create({
   },
   railTitleLink: {
     color: {
-      default: null,
+      default: colors.ink,
       ":hover": colors.accentDeep,
       ":active": colors.accent,
     },


### PR DESCRIPTION
Rail list links now set their intended ink color explicitly. This prevents browser-native blue and visited purple colors from appearing in sidebar relationship lists such as “Distilled at,” while preserving the existing hover, pressed, and keyboard-focus states.
