### PR TITLE
feat(web): add image viewer

### DIFF
--- a/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
@@ -1,6 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { ImageAttribution } from "@peated/web/components";
+import { ImageAttribution, ImageViewer } from "@peated/web/components";
 import { colors, space } from "../../../../styles/tokens.stylex";
 
 import type { Entity } from "./entityPageData";
@@ -17,10 +17,12 @@ export function EntityImageGallery({ entity }: { entity: Entity }) {
       {...stylex.props(styles.gallery)}
     >
       <figure {...stylex.props(styles.primaryFigure)}>
-        <img
+        <ImageViewer
           alt={primary.caption || `${entity.name} primary image`}
+          caption={primary.caption}
+          imageProps={stylex.props(styles.primaryImage)}
+          label={primary.caption || `${entity.name} primary image`}
           src={primary.imageUrl}
-          {...stylex.props(styles.primaryImage)}
         />
         {primary.caption || primary.sourceUrl || primary.license ? (
           <figcaption {...stylex.props(styles.caption)}>
@@ -36,10 +38,12 @@ export function EntityImageGallery({ entity }: { entity: Entity }) {
         <div {...stylex.props(styles.secondaryGrid)}>
           {otherImages.map((image) => (
             <figure key={image.id} {...stylex.props(styles.secondaryFigure)}>
-              <img
+              <ImageViewer
                 alt={image.caption || `${entity.name} image`}
+                caption={image.caption}
+                imageProps={stylex.props(styles.secondaryImage)}
+                label={image.caption || `${entity.name} image`}
                 src={image.imageUrl}
-                {...stylex.props(styles.secondaryImage)}
               />
               {image.caption || image.sourceUrl || image.license ? (
                 <figcaption {...stylex.props(styles.caption)}>

--- a/apps/web/src/components/admin/moderation/moderationDetail.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationDetail.stylex.tsx
@@ -9,6 +9,7 @@ import {
   fonts,
   space,
 } from "../../../styles/tokens.stylex";
+import { ImageViewer } from "../../imageViewer.stylex";
 
 export function ModerationDetailFrame({ children }: { children: ReactNode }) {
   return <div {...stylex.props(styles.frame)}>{children}</div>;
@@ -97,7 +98,15 @@ export function ModerationMedia({
   return (
     <div {...stylex.props(styles.media)}>
       {imageUrl ? (
-        <img alt="" src={imageUrl} {...stylex.props(styles.image)} />
+        <div {...stylex.props(styles.imageFrame)}>
+          <ImageViewer
+            alt=""
+            fill
+            imageProps={stylex.props(styles.image)}
+            label="submitted image"
+            src={imageUrl}
+          />
+        </div>
       ) : null}
       <div {...stylex.props(styles.mediaCopy)}>{children}</div>
     </div>
@@ -197,15 +206,19 @@ const styles = stylex.create({
   },
   image: {
     boxSizing: "border-box",
-    width: "80px",
-    height: "96px",
-    flexShrink: 0,
+    width: "100%",
+    height: "100%",
     borderWidth: "1px",
     borderStyle: "solid",
     borderColor: colors.hairline,
     borderRadius: controlMetrics.radiusSmall,
     objectFit: "contain",
     backgroundColor: colors.imageBackground,
+  },
+  imageFrame: {
+    width: "80px",
+    height: "96px",
+    flexShrink: 0,
   },
   mediaCopy: {
     minWidth: 0,

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -9,6 +9,7 @@ import {
   space,
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
+import { ImageViewer } from "./imageViewer.stylex";
 import { linkedRowStyles } from "./linkedRow.stylex";
 import { MemberStatus } from "./memberStatus.stylex";
 
@@ -18,6 +19,7 @@ const bottleIconUrl = "/assets/bottle.svg";
 export type BottleVisualSize = "sm" | "md" | "lg";
 
 export type BottleVisualProps = {
+  expandable?: boolean;
   imageUrl?: string | null;
   label?: string;
   size?: BottleVisualSize;
@@ -25,6 +27,7 @@ export type BottleVisualProps = {
 
 /** Shows a supplied bottle image and uses Peated's bottle glyph when no image exists. */
 export function BottleVisual({
+  expandable = false,
   imageUrl,
   label,
   size = "md",
@@ -40,7 +43,15 @@ export function BottleVisual({
         visualSizeStyles[size],
       )}
     >
-      {imageUrl ? (
+      {imageUrl && expandable && label ? (
+        <ImageViewer
+          alt=""
+          fill
+          imageProps={stylex.props(styles.image)}
+          label={label}
+          src={imageUrl}
+        />
+      ) : imageUrl ? (
         <img alt="" src={imageUrl} {...stylex.props(styles.image)} />
       ) : (
         <span

--- a/apps/web/src/components/bottleResolver/photoPreview.stylex.tsx
+++ b/apps/web/src/components/bottleResolver/photoPreview.stylex.tsx
@@ -6,6 +6,7 @@ import {
   fonts,
   space,
 } from "../../styles/tokens.stylex";
+import { ImageViewer } from "../imageViewer.stylex";
 
 export type PhotoPreviewProps = {
   loading?: boolean;
@@ -34,10 +35,15 @@ export function PhotoPreview({
           loading && styles.loadingImageFrame,
         )}
       >
-        <img
+        <ImageViewer
           alt="Uploaded bottle label"
+          fill
+          imageProps={stylex.props(
+            styles.image,
+            loading && styles.loadingImage,
+          )}
+          label="uploaded bottle label"
           src={src}
-          {...stylex.props(styles.image, loading && styles.loadingImage)}
         />
         {loading ? (
           <span aria-hidden="true" {...stylex.props(styles.progress)}>

--- a/apps/web/src/components/entityImageEditor.stylex.tsx
+++ b/apps/web/src/components/entityImageEditor.stylex.tsx
@@ -7,6 +7,7 @@ import { useRef } from "react";
 
 import { Button, Field, FieldGroup, TextInput } from ".";
 import { colors, space } from "../styles/tokens.stylex";
+import { ImageViewer } from "./imageViewer.stylex";
 
 type EntityImage = Outputs["entities"]["details"]["images"][number];
 
@@ -67,10 +68,11 @@ export function EntityImageEditor({
       <div {...stylex.props(styles.root)}>
         {images.map((image) => (
           <div key={image.key} {...stylex.props(styles.row)}>
-            <img
+            <ImageViewer
               alt={image.caption || "Image preview"}
+              imageProps={stylex.props(styles.preview)}
+              label={image.caption || "image preview"}
               src={image.imageUrl}
-              {...stylex.props(styles.preview)}
             />
             <div {...stylex.props(styles.fields)}>
               <Field

--- a/apps/web/src/components/imageField.stylex.tsx
+++ b/apps/web/src/components/imageField.stylex.tsx
@@ -22,6 +22,7 @@ import { z } from "zod";
 import { Button, Field } from ".";
 import setRef from "../lib/setRef";
 import { colors, effects, fonts, space } from "../styles/tokens.stylex";
+import { ImageViewer } from "./imageViewer.stylex";
 
 type Props = {
   error?: { message?: string };
@@ -134,10 +135,11 @@ const ImageField = forwardRef<HTMLInputElement, Props>(function ImageField(
         {...stylex.props(styles.frame, Boolean(preview) && styles.previewFrame)}
       >
         {preview ? (
-          <img
+          <ImageViewer
             alt="Image preview"
+            imageProps={stylex.props(styles.preview)}
+            label="image preview"
             src={preview}
-            {...stylex.props(styles.preview)}
           />
         ) : (
           <ImagePlus

--- a/apps/web/src/components/imageViewer.stories.tsx
+++ b/apps/web/src/components/imageViewer.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import * as stylex from "@stylexjs/stylex";
+
+import { colors } from "../styles/tokens.stylex";
+import { ImageViewer } from "./imageViewer.stylex";
+import { StoryCanvas } from "./storyFixtures.stylex";
+
+const styles = stylex.create({
+  frame: {
+    width: "240px",
+    height: "240px",
+    backgroundColor: colors.imageBackground,
+  },
+  image: {
+    display: "block",
+    width: "100%",
+    height: "auto",
+  },
+});
+
+const meta = {
+  title: "Components/Content/Image Viewer",
+  component: ImageViewer,
+  args: {
+    alt: "A whisky bottle on a white background",
+    label: "Whisky bottle",
+    src: "/assets/auth-discovery-illustration.webp",
+    imageProps: stylex.props(styles.image),
+  },
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="compact">
+        <div {...stylex.props(styles.frame)}>
+          <Story />
+        </div>
+      </StoryCanvas>
+    ),
+  ],
+} satisfies Meta<typeof ImageViewer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {};

--- a/apps/web/src/components/imageViewer.stylex.tsx
+++ b/apps/web/src/components/imageViewer.stylex.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import {
+  Dialog,
+  DialogBackdrop,
+  DialogPanel,
+  DialogTitle,
+} from "@headlessui/react";
+import * as stylex from "@stylexjs/stylex";
+import { ExternalLink, Maximize2, X } from "lucide-react";
+import { useState, type ImgHTMLAttributes, type ReactNode } from "react";
+
+import { controlMetrics, effects, fonts, space } from "../styles/tokens.stylex";
+
+export type ImageViewerProps = {
+  alt: string;
+  caption?: ReactNode;
+  fill?: boolean;
+  imageProps?: Omit<ImgHTMLAttributes<HTMLImageElement>, "alt" | "src">;
+  label: string;
+  src: string;
+};
+
+/** Opens a content image in an accessible, viewport-sized dialog. */
+export function ImageViewer({
+  alt,
+  caption,
+  fill = false,
+  imageProps,
+  label,
+  src,
+}: ImageViewerProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        aria-label={`View ${label} at full size`}
+        onClick={() => setOpen(true)}
+        type="button"
+        {...stylex.props(styles.trigger, fill && styles.fillTrigger)}
+      >
+        <img {...imageProps} alt={alt} src={src} />
+        <span aria-hidden="true" {...stylex.props(styles.expandCue)}>
+          <Maximize2 size={15} strokeWidth={1.75} />
+        </span>
+      </button>
+      <Dialog onClose={setOpen} open={open} {...stylex.props(styles.dialog)}>
+        <DialogBackdrop {...stylex.props(styles.backdrop)} />
+        <div {...stylex.props(styles.position)}>
+          <DialogPanel {...stylex.props(styles.panel)}>
+            <div {...stylex.props(styles.imageStage)}>
+              <img alt={alt} src={src} {...stylex.props(styles.fullImage)} />
+            </div>
+            <div {...stylex.props(styles.footer)}>
+              <DialogTitle {...stylex.props(styles.title)}>
+                {caption ?? label}
+              </DialogTitle>
+              <a
+                href={src}
+                rel="noreferrer"
+                target="_blank"
+                {...stylex.props(styles.originalLink)}
+              >
+                Open original
+                <ExternalLink aria-hidden="true" size={14} strokeWidth={1.75} />
+              </a>
+            </div>
+            <button
+              aria-label="Close image viewer"
+              onClick={() => setOpen(false)}
+              type="button"
+              {...stylex.props(styles.close)}
+            >
+              <X aria-hidden="true" size={20} strokeWidth={1.75} />
+            </button>
+          </DialogPanel>
+        </div>
+      </Dialog>
+    </>
+  );
+}
+
+const styles = stylex.create({
+  trigger: {
+    boxSizing: "border-box",
+    position: "relative",
+    display: "grid",
+    width: "100%",
+    overflow: "hidden",
+    padding: 0,
+    borderWidth: 0,
+    borderRadius: "inherit",
+    outline: "none",
+    backgroundColor: "transparent",
+    color: "inherit",
+    font: "inherit",
+    cursor: "zoom-in",
+    placeItems: "center",
+    boxShadow: {
+      default: "none",
+      ":focus-visible": effects.focusRing,
+    },
+  },
+  fillTrigger: {
+    height: "100%",
+  },
+  expandCue: {
+    position: "absolute",
+    right: space.x1,
+    bottom: space.x1,
+    display: "grid",
+    width: "28px",
+    height: "28px",
+    placeItems: "center",
+    borderRadius: controlMetrics.radiusSmall,
+    backgroundColor: "rgb(16 18 16 / 0.78)",
+    color: "white",
+    pointerEvents: "none",
+  },
+  dialog: {
+    position: "relative",
+    zIndex: 100,
+  },
+  backdrop: {
+    position: "fixed",
+    inset: 0,
+    backgroundColor: "rgb(0 0 0 / 0.88)",
+  },
+  position: {
+    boxSizing: "border-box",
+    position: "fixed",
+    inset: 0,
+    display: "grid",
+    overflow: "auto",
+    padding: { default: space.x6, "@media (max-width: 639px)": space.x3 },
+    placeItems: "center",
+    pointerEvents: "none",
+  },
+  panel: {
+    position: "relative",
+    display: "flex",
+    width: "fit-content",
+    maxWidth: "calc(100vw - 48px)",
+    maxHeight: "calc(100dvh - 48px)",
+    flexDirection: "column",
+    outline: "none",
+    backgroundColor: "rgb(16 18 16 / 0.96)",
+    boxShadow: "0 18px 40px rgb(0 0 0 / 0.55)",
+    pointerEvents: "auto",
+    "@media (max-width: 639px)": {
+      maxWidth: "calc(100vw - 24px)",
+      maxHeight: "calc(100dvh - 24px)",
+    },
+  },
+  imageStage: {
+    display: "grid",
+    minWidth: 0,
+    minHeight: 0,
+    overflow: "auto",
+    placeItems: "center",
+    backgroundColor: "white",
+  },
+  fullImage: {
+    display: "block",
+    width: "auto",
+    maxWidth: "100%",
+    height: "auto",
+    maxHeight: "calc(100dvh - 120px)",
+    objectFit: "contain",
+    "@media (max-width: 639px)": {
+      maxHeight: "calc(100dvh - 96px)",
+    },
+  },
+  footer: {
+    boxSizing: "border-box",
+    display: "flex",
+    minHeight: "56px",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: space.x4,
+    paddingTop: space.x3,
+    paddingRight: space.x4,
+    paddingBottom: space.x3,
+    paddingLeft: space.x4,
+  },
+  title: {
+    minWidth: 0,
+    flex: 1,
+    overflow: "hidden",
+    margin: 0,
+    color: "white",
+    fontFamily: fonts.reading,
+    fontSize: "14px",
+    fontWeight: 600,
+    lineHeight: 1.35,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  originalLink: {
+    display: "inline-flex",
+    flexShrink: 0,
+    alignItems: "center",
+    gap: space.x1,
+    borderRadius: controlMetrics.radiusSmall,
+    outline: "none",
+    color: "white",
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    fontWeight: 600,
+    lineHeight: 1.2,
+    textDecorationLine: {
+      default: "none",
+      ":hover": "underline",
+    },
+    boxShadow: {
+      default: "none",
+      ":focus-visible": "inset 0 0 0 2px white",
+    },
+  },
+  close: {
+    position: "absolute",
+    top: space.x2,
+    right: space.x2,
+    display: "grid",
+    width: "40px",
+    height: "40px",
+    padding: 0,
+    placeItems: "center",
+    borderWidth: 0,
+    borderRadius: controlMetrics.radius,
+    outline: "none",
+    backgroundColor: {
+      default: "rgb(16 18 16 / 0.82)",
+      ":hover": "rgb(16 18 16 / 0.96)",
+    },
+    color: "white",
+    cursor: "pointer",
+    boxShadow: {
+      default: "0 0 0 1px rgb(255 255 255 / 0.24)",
+      ":focus-visible": "inset 0 0 0 2px white",
+    },
+  },
+});

--- a/apps/web/src/components/imageViewer.test.tsx
+++ b/apps/web/src/components/imageViewer.test.tsx
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ImageViewer } from "./imageViewer.stylex";
+
+describe("ImageViewer", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("opens the full image and closes it again", () => {
+    act(() =>
+      root.render(
+        <ImageViewer
+          alt="Bottle label"
+          label="bottle label"
+          src="/label.jpg"
+        />,
+      ),
+    );
+
+    const trigger = container.querySelector("button");
+    expect(trigger?.getAttribute("aria-label")).toBe(
+      "View bottle label at full size",
+    );
+
+    act(() => trigger?.click());
+
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+    expect(
+      document.querySelector<HTMLAnchorElement>('a[href="/label.jpg"]')
+        ?.textContent,
+    ).toContain("Open original");
+
+    const close = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Close image viewer"]',
+    );
+    act(() => close?.click());
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -139,6 +139,8 @@ export type {
 } from "./historyTimeline.stylex";
 export { ImageAttribution } from "./imageAttribution.stylex";
 export type { ImageAttributionProps } from "./imageAttribution.stylex";
+export { ImageViewer } from "./imageViewer.stylex";
+export type { ImageViewerProps } from "./imageViewer.stylex";
 export { ItemList, ItemListItem, ItemRow } from "./itemList.stylex";
 export type {
   ItemListItemProps,

--- a/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
@@ -77,6 +77,7 @@ export function BottlePageHeader({
         <div {...stylex.props(styles.identityContent)}>
           <div {...stylex.props(styles.image)}>
             <BottleVisual
+              expandable
               imageUrl={imageUrl}
               label={`${brand} ${name}`}
               size="lg"


### PR DESCRIPTION
Content images can now open in a viewport-sized viewer with a clear zoom cue, close and backdrop actions, Escape handling, focus restoration, and a link to the original asset. The shared Storybook component is used for bottle detail images, entity galleries, bottle-label previews, entity and generic image editors, and moderation media.

Small navigation thumbnails, avatars, icons, and decorative images keep their existing behavior. Saved tasting photos are also unchanged because tasting records do not currently render those images; that gap needs a separate product and layout change.
