### PR TITLE
feat(web): improve entity overview hierarchy

### DIFF
--- a/apps/server/src/db/schema/bottles.ts
+++ b/apps/server/src/db/schema/bottles.ts
@@ -166,7 +166,7 @@ export const bottles = pgTable(
     // True only when the label was confirmed to have no age statement.
     noAgeStatement: boolean("no_age_statement"),
 
-    // a NULL series represents a "core bottling"
+    // A NULL series means that no named product range has been assigned.
     seriesId: bigint("series_id", { mode: "number" }).references(
       () => bottleSeries.id,
     ),
@@ -183,6 +183,8 @@ export const bottles = pgTable(
     flavorProfile: flavorProfileEnum("flavor_profile"),
 
     // Exact marketed-release identity.
+    // TODO(catalog): Add a Bottle-owned core-range flag after Peated has a
+    // reliable sourcing and moderation workflow for the designation.
     edition: varchar("edition", { length: 255 }),
     abv: doublePrecision("abv"),
     singleCask: boolean("single_cask"),

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
@@ -44,20 +44,18 @@ export function EntityBottleOverview({
 
   if (pending) {
     return (
-      <PageSection heading={presentation.bottleSectionLabel}>
-        <LoadingList label="Loading associated bottles" rows={4} />
+      <PageSection heading="Popular bottles">
+        <LoadingList label="Loading popular bottles" rows={4} />
       </PageSection>
     );
   }
 
   if (error) {
     return (
-      <PageSection heading={presentation.bottleSectionLabel}>
-        <SectionError
-          heading="Associated bottles are unavailable"
-          onRetry={retry}
-        >
-          The rest of this page still works. Try loading its bottles again.
+      <PageSection heading="Popular bottles">
+        <SectionError heading="Popular bottles are unavailable" onRetry={retry}>
+          The rest of this page still works. Try loading its popular bottles
+          again.
         </SectionError>
       </PageSection>
     );
@@ -71,7 +69,7 @@ export function EntityBottleOverview({
       }).toString()}`;
 
     return (
-      <PageSection heading={presentation.bottleSectionLabel}>
+      <PageSection heading="Popular bottles">
         <EmptyState
           action={
             <ButtonLink href={addBottleHref} size="sm" variant="accent">
@@ -91,7 +89,7 @@ export function EntityBottleOverview({
 
   return (
     <PageSection
-      heading={presentation.bottleSectionLabel}
+      heading="Popular bottles"
       intro={
         <TextLink href={`${entityHref}/bottles?sort=-tastings`}>
           View all {totalBottles.toLocaleString("en-US")} bottles
@@ -99,7 +97,7 @@ export function EntityBottleOverview({
       }
     >
       <BottleComparisonTable
-        ariaLabel={`${entity.name} ${presentation.bottleSectionLabel.toLowerCase()}`}
+        ariaLabel={`${entity.name} popular bottles`}
         columns={["Rating"]}
         rows={[
           toBottleTableRow(firstBottle),

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -113,53 +113,64 @@ export function EntityOverviewClient({
   return (
     <div {...stylex.props(styles.overviewGrid)}>
       <div {...stylex.props(styles.catalog)}>
-        {hasEntityDetails(entity) ? <EntityDetails entity={entity} /> : null}
-        <EntityBottleOverview
-          bottleList={bottleListQuery.data}
-          createBottleHref={getEntityBottleCreateHref(entity)}
-          entity={entity}
-          error={Boolean(bottleListQuery.error)}
-          pending={bottleListQuery.isPending}
-          retry={() => void bottleListQuery.refetch()}
-          totalBottles={entity.totalBottles}
-        />
-        <EntityReleaseOverview
-          entity={entity}
-          error={Boolean(releaseListQuery.error)}
-          pending={releaseListQuery.isPending}
-          releaseList={releaseListQuery.data}
-          retry={() => void releaseListQuery.refetch()}
-        />
-        <EntityHistoryOverview
-          entityName={entity.name}
-          error={Boolean(eventListQuery.error)}
-          eventList={eventListQuery.data}
-          pending={eventListQuery.isPending}
-          retry={() => void eventListQuery.refetch()}
-        />
+        <div {...stylex.props(styles.facts)}>
+          {hasEntityDetails(entity) ? <EntityDetails entity={entity} /> : null}
+        </div>
+        <div {...stylex.props(styles.catalogSections)}>
+          <EntityBottleOverview
+            bottleList={bottleListQuery.data}
+            createBottleHref={getEntityBottleCreateHref(entity)}
+            entity={entity}
+            error={Boolean(bottleListQuery.error)}
+            pending={bottleListQuery.isPending}
+            retry={() => void bottleListQuery.refetch()}
+            totalBottles={entity.totalBottles}
+          />
+          <EntityReleaseOverview
+            entity={entity}
+            error={Boolean(releaseListQuery.error)}
+            pending={releaseListQuery.isPending}
+            releaseList={releaseListQuery.data}
+            retry={() => void releaseListQuery.refetch()}
+          />
+          <EntityHistoryOverview
+            entityName={entity.name}
+            error={Boolean(eventListQuery.error)}
+            eventList={eventListQuery.data}
+            pending={eventListQuery.isPending}
+            retry={() => void eventListQuery.refetch()}
+          />
+        </div>
       </div>
 
       <aside {...stylex.props(styles.details)}>
-        {entity.images?.length ? (
-          <EntityImageGallery entity={entity} />
-        ) : (
-          <EntityImagePlaceholder entityName={entity.name} kind={entity.kind} />
-        )}
-        <EntityMap entity={entity} />
-        <EntityCatalogRelationships
-          catalog={catalogQuery.data}
-          entity={entity}
-          error={Boolean(catalogQuery.error)}
-          pending={catalogQuery.isPending}
-          retry={() => void catalogQuery.refetch()}
-        />
-        <EntitySiblingOverview
-          entity={entity}
-          error={Boolean(siblingListQuery.error)}
-          pending={siblingListQuery.isPending}
-          retry={() => void siblingListQuery.refetch()}
-          siblingList={siblingListQuery.data}
-        />
+        <div {...stylex.props(styles.media)}>
+          {entity.images?.length ? (
+            <EntityImageGallery entity={entity} />
+          ) : (
+            <EntityImagePlaceholder
+              entityName={entity.name}
+              kind={entity.kind}
+            />
+          )}
+        </div>
+        <div {...stylex.props(styles.relationships)}>
+          <EntityMap entity={entity} />
+          <EntityCatalogRelationships
+            catalog={catalogQuery.data}
+            entity={entity}
+            error={Boolean(catalogQuery.error)}
+            pending={catalogQuery.isPending}
+            retry={() => void catalogQuery.refetch()}
+          />
+          <EntitySiblingOverview
+            entity={entity}
+            error={Boolean(siblingListQuery.error)}
+            pending={siblingListQuery.isPending}
+            retry={() => void siblingListQuery.refetch()}
+            siblingList={siblingListQuery.data}
+          />
+        </div>
       </aside>
     </div>
   );
@@ -170,7 +181,7 @@ const styles = stylex.create({
     display: "grid",
     gridTemplateAreas: {
       default: '"catalog details"',
-      [NARROW]: '"catalog" "details"',
+      [NARROW]: '"facts" "media" "catalogSections" "relationships"',
     },
     gridTemplateColumns: {
       default: "minmax(0, 1fr) 336px",
@@ -182,9 +193,31 @@ const styles = stylex.create({
     gridArea: "catalog",
     minWidth: 0,
     paddingTop: space.x4,
+    display: {
+      [NARROW]: "contents",
+    },
   },
   details: {
     gridArea: "details",
+    minWidth: 0,
+    display: {
+      [NARROW]: "contents",
+    },
+  },
+  facts: {
+    gridArea: "facts",
+    minWidth: 0,
+  },
+  catalogSections: {
+    gridArea: "catalogSections",
+    minWidth: 0,
+  },
+  media: {
+    gridArea: "media",
+    minWidth: 0,
+  },
+  relationships: {
+    gridArea: "relationships",
     minWidth: 0,
   },
 });


### PR DESCRIPTION
The entity overview now uses a deliberate mobile reading order: facts, image, catalog sections, then related records. Desktop keeps the existing sidebar structure. The catalog starts with “Popular bottles” ranked by total tastings, followed by latest releases, so recognizable bottles appear first without presenting them as an editorial core range.

The Bottle schema comment now treats a missing series as unassigned and leaves an owner-tagged TODO for a future Bottle-owned core-range flag once Peated has reliable sourcing and moderation for that designation.
