### PR TITLE
feat: keep retired names during merges

### DIFF
--- a/apps/server/src/lib/entityAliases.ts
+++ b/apps/server/src/lib/entityAliases.ts
@@ -118,9 +118,11 @@ export async function removePrimaryEntityAliases(
 
 export async function moveEntityAliases(
   tx: AnyTransaction,
-  sourceEntityIds: readonly number[],
+  sourceEntities: readonly { id: number; name: string }[],
   destination: { id: number; name: string; shortName: string | null },
+  options: { createdByActorId: number; keepRetiredName: boolean },
 ) {
+  const sourceEntityIds = sourceEntities.map(({ id }) => id);
   const aliases = await tx
     .select()
     .from(entityAliases)
@@ -137,6 +139,21 @@ export async function moveEntityAliases(
   destinationKeys.add(nameKey(destination.name));
   if (destination.shortName) {
     destinationKeys.add(nameKey(destination.shortName));
+  }
+
+  if (options.keepRetiredName) {
+    for (const source of sourceEntities) {
+      const name = normalizeName(source.name);
+      const normalizedName = nameKey(name);
+      if (destinationKeys.has(normalizedName)) continue;
+      await tx.insert(entityAliases).values({
+        entityId: destination.id,
+        name,
+        normalizedName,
+        createdByActorId: options.createdByActorId,
+      });
+      destinationKeys.add(normalizedName);
+    }
   }
 
   for (const alias of aliases.filter(({ entityId }) =>

--- a/apps/server/src/orpc/routes/entities/merge.ts
+++ b/apps/server/src/orpc/routes/entities/merge.ts
@@ -24,6 +24,7 @@ export default procedure
       entity: z.coerce.number(),
       other: z.number(),
       direction: z.enum(["mergeInto", "mergeFrom"]).default("mergeInto"),
+      keepRetiredName: z.boolean().default(false),
     }),
   )
   .output(EntitySchema)
@@ -64,6 +65,7 @@ export default procedure
     await pushJob("MergeEntity", {
       toEntityId: toEntity.id,
       fromEntityIds: [fromEntity.id],
+      keepRetiredName: input.keepRetiredName,
     });
 
     return await serialize(EntitySerializer, toEntity, context.user);

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -192,4 +192,5 @@ export const EntityMergeSchema = z.object({
   direction: z
     .enum(["mergeInto", "mergeFrom"])
     .describe("Direction of the merge operation"),
+  keepRetiredName: z.boolean().default(false),
 });

--- a/apps/server/src/worker/entityMerge.ts
+++ b/apps/server/src/worker/entityMerge.ts
@@ -8,6 +8,7 @@ export const LegacyEntityMergeJobInputSchema = z
   .object({
     toEntityId: PositiveIdSchema,
     fromEntityIds: z.array(PositiveIdSchema).nonempty(),
+    keepRetiredName: z.boolean().default(false),
   })
   .strict();
 

--- a/apps/server/src/worker/jobs/mergeEntity.test.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.test.ts
@@ -545,6 +545,24 @@ test("moves and deduplicates display aliases", async ({ fixtures }) => {
   ).toEqual([{ entityId: destination.id, name: "Moved Name" }]);
 });
 
+test("keeps retired names when requested", async ({ fixtures }) => {
+  const source = await fixtures.Entity({ name: "Hillside" });
+  const destination = await fixtures.Entity({ name: "Glenesk" });
+
+  await mergeEntity({
+    fromEntityIds: [source.id],
+    keepRetiredName: true,
+    toEntityId: destination.id,
+  });
+
+  expect(
+    await db
+      .select({ entityId: entityAliases.entityId, name: entityAliases.name })
+      .from(entityAliases)
+      .where(eq(entityAliases.entityId, destination.id)),
+  ).toEqual([{ entityId: destination.id, name: "Hillside" }]);
+});
+
 test("preserves generated Bottle content during an equivalent Entity merge", async ({
   fixtures,
 }) => {

--- a/apps/server/src/worker/jobs/mergeEntity.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.ts
@@ -129,10 +129,12 @@ async function assertOperationResultState(
 async function performEntityMerge({
   toEntityId,
   fromEntityIds,
+  keepRetiredName,
   operation,
 }: {
   toEntityId: number;
   fromEntityIds: number[];
+  keepRetiredName: boolean;
   operation: LoadedEntityMergeOperation | null;
 }) {
   logInfo("Merging entities into {toEntityId}", {
@@ -578,11 +580,16 @@ async function performEntityMerge({
       );
     }
 
-    await moveEntityAliases(tx, fromEntityIds, {
-      id: toEntity.id,
-      name: toEntity.name,
-      shortName: toEntity.shortName,
-    });
+    await moveEntityAliases(
+      tx,
+      mergeEntityRows.filter(({ id }) => fromEntityIds.includes(id)),
+      {
+        id: toEntity.id,
+        name: toEntity.name,
+        shortName: toEntity.shortName,
+      },
+      { createdByActorId: actor.id, keepRetiredName },
+    );
 
     await tx
       .update(entityReferences)
@@ -825,6 +832,7 @@ export default async function mergeEntity(rawInput: JobPayload) {
     return await performEntityMerge({
       toEntityId: input.toEntityId,
       fromEntityIds: input.fromEntityIds,
+      keepRetiredName: input.keepRetiredName,
       operation: null,
     });
   }
@@ -848,6 +856,7 @@ export default async function mergeEntity(rawInput: JobPayload) {
     return await performEntityMerge({
       toEntityId: operation.destinationEntityId,
       fromEntityIds: [operation.sourceEntityId],
+      keepRetiredName: false,
       operation,
     });
   } catch (error) {

--- a/apps/web/src/app/(layout-free)/entities/[entityId]/merge/page.tsx
+++ b/apps/web/src/app/(layout-free)/entities/[entityId]/merge/page.tsx
@@ -3,6 +3,7 @@
 import { toTitleCase } from "@peated/server/lib/strings";
 import { EntityMergeSchema } from "@peated/server/schemas";
 import {
+  Checkbox,
   ChoiceList,
   FieldGroup,
   FormNotice,
@@ -51,6 +52,8 @@ function EntityMergeForm({ entityId }: { entityId: string }) {
   );
   const [query, setQuery] = useState("");
   const [other, setOther] = useState<SearchPickerOption | null>(null);
+  const [direction, setDirection] =
+    useState<FormSchemaType["direction"]>("mergeInto");
   const [submitError, setSubmitError] = useState<string>();
   const noun = toTitleCase(entity.kind ?? "producer");
   const results = useQuery(
@@ -77,7 +80,7 @@ function EntityMergeForm({ entityId }: { entityId: string }) {
     formState: { errors, isSubmitting },
     handleSubmit,
   } = useForm<FormSchemaType>({
-    defaultValues: { direction: "mergeInto" },
+    defaultValues: { direction: "mergeInto", keepRetiredName: false },
     resolver: zodResolver(EntityMergeSchema),
   });
 
@@ -87,6 +90,7 @@ function EntityMergeForm({ entityId }: { entityId: string }) {
       const nextEntity = await merge.mutateAsync({
         direction: data.direction,
         entity: entity.id,
+        keepRetiredName: data.keepRetiredName,
         other: data.entityId,
       });
       flash(
@@ -160,7 +164,13 @@ function EntityMergeForm({ entityId }: { entityId: string }) {
                   id="entity-merge-direction"
                   label="Record to keep"
                   name={field.name}
-                  onChange={field.onChange}
+                  onChange={(value) => {
+                    const { direction: nextDirection } = EntityMergeSchema.pick(
+                      { direction: true },
+                    ).parse({ direction: value });
+                    field.onChange(nextDirection);
+                    setDirection(nextDirection);
+                  }}
                   options={[
                     {
                       description: other
@@ -180,6 +190,38 @@ function EntityMergeForm({ entityId }: { entityId: string }) {
                   value={field.value}
                 />
               )}
+            />
+          </FormSection>
+          <FormSection title="Retired name">
+            <Controller
+              control={control}
+              name="keepRetiredName"
+              render={({ field }) => {
+                const retiredName =
+                  direction === "mergeInto" ? entity.name : other?.label;
+                const keptName =
+                  direction === "mergeInto" ? other?.label : entity.name;
+                return (
+                  <Checkbox
+                    checked={field.value}
+                    description={
+                      retiredName
+                        ? `${retiredName} will still work in search if you leave this off.`
+                        : "The retired name will still work in search if you leave this off."
+                    }
+                    label={
+                      retiredName && keptName
+                        ? `Keep ${retiredName} as another name for ${keptName}`
+                        : "Keep the retired name as another name"
+                    }
+                    name={field.name}
+                    onBlur={field.onBlur}
+                    onChange={(event) =>
+                      field.onChange(event.currentTarget.checked)
+                    }
+                  />
+                );
+              }}
             />
           </FormSection>
         </FormStack>


### PR DESCRIPTION
Moderator merges can now keep the retired primary name as another visible name on the surviving brand or producer. The merge form presents this as an optional, plain-language choice and updates both names when the merge direction changes. The option is off by default, so typo and duplicate cleanup keeps the existing behavior.

The API carries the choice through the validated merge job. The worker saves the retired name in the same transaction as the merge and avoids duplicates against the kept name, short name, and other saved names. Jobs created before this change continue with the option off.
