### PR TITLE
ref(web): reuse shared bottle identity rows

### DIFF
--- a/apps/web/src/app/(app)/_components/home/homeActivity.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/homeActivity.stylex.tsx
@@ -8,9 +8,11 @@ import { useEventListener } from "usehooks-ts";
 
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import {
+  BottleIdentityRow,
   ButtonLink,
   EmptyState,
   ItemList,
+  ItemListItem,
   ItemRow,
   LoadingList,
   MemberAvatar,
@@ -24,6 +26,7 @@ import TimeSince from "@peated/web/components/timeSince";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { memberHomeQueries } from "@peated/web/lib/orpc/homeQueries";
+import { getEntityUrl } from "@peated/web/lib/urls";
 import { colors } from "../../../../styles/tokens.stylex";
 
 type ActivityList = Outputs["activity"]["list"];
@@ -103,12 +106,21 @@ function CollectionActivityItem({
       {visibleItems.length ? (
         <ItemList ariaLabel={`${activity.collection.name} additions`}>
           {visibleItems.map((item) => (
-            <ItemRow
-              href={`/bottles/${item.bottle.id}`}
-              key={item.id}
-              metadata={getBottleMetadata(item.bottle)}
-              title={formatBottleDisplayName(item.bottle)}
-            />
+            <ItemListItem key={item.id}>
+              <BottleIdentityRow
+                brand={item.bottle.brand.shortName || item.bottle.brand.name}
+                brandHref={getEntityUrl({
+                  id: item.bottle.brand.id,
+                  kind: "brand",
+                })}
+                href={`/bottles/${item.bottle.id}`}
+                imageUrl={item.bottle.imageUrl}
+                metadata={getBottleMetadata(item.bottle).split(" · ")}
+                name={formatBottleDisplayName(item.bottle, {
+                  includeBrand: false,
+                })}
+              />
+            </ItemListItem>
           ))}
           {remaining > 0 ? (
             <ItemRow

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleTableRows.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleTableRows.tsx
@@ -1,70 +1,27 @@
-import {
-  formatBottleDisplayName,
-  getBottleReleaseMetadata,
-} from "@peated/server/lib/bottleDisplayName";
-import { formatReleaseDate } from "@peated/server/lib/bottleRelease";
-import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
 
 import {
   BottleRatings,
   type BottleComparisonRow,
 } from "@peated/web/components";
+import { toBottleCatalogItem } from "@peated/web/lib/bottleCatalogItem";
 
 type Bottle = Outputs["bottles"]["list"]["results"][number];
 
-function formatAbv(abv: number) {
-  return abv.toFixed(1).replace(/\.0$/, "");
-}
+export function toBottleTableRow(bottle: Bottle): BottleComparisonRow {
+  const item = toBottleCatalogItem(bottle);
 
-function formatBottleMetadata(bottle: Bottle) {
-  const origins = [
-    ...new Set(
-      bottle.distillers
-        .map((distiller) => distiller.region?.name ?? distiller.country?.name)
-        .filter((value): value is string => Boolean(value)),
-    ),
-  ];
-  const origin =
-    origins.length === 1
-      ? origins[0]
-      : bottle.category
-        ? formatCategoryName(bottle.category)
-        : null;
-
-  return [
-    getBottleReleaseMetadata(bottle),
-    origin,
-    bottle.statedAge !== null
-      ? `${bottle.statedAge} years`
-      : bottle.noAgeStatement
-        ? "No age statement"
-        : null,
-    bottle.abv !== null ? `${formatAbv(bottle.abv)}% ABV` : null,
-  ]
-    .filter((value): value is string => Boolean(value))
-    .join(" · ");
-}
-
-function formatReleaseMetadata(bottle: Bottle) {
-  const formattedRelease = formatReleaseDate(bottle);
-  const release = formattedRelease ? `Released ${formattedRelease}` : null;
-
-  return [release, formatBottleMetadata(bottle)]
-    .filter((value): value is string => Boolean(value))
-    .join(" · ");
-}
-
-export function toBottleTableRow(
-  bottle: Bottle,
-  metadata = formatBottleMetadata(bottle),
-): BottleComparisonRow {
   return {
-    href: `/bottles/${bottle.id}`,
-    id: bottle.peatedId,
-    imageUrl: bottle.imageUrl,
-    metadata,
-    name: formatBottleDisplayName(bottle),
+    brand: item.brand,
+    brandHref: item.brandHref,
+    hasTasted: item.hasTasted,
+    href: item.href,
+    id: item.id,
+    imageUrl: item.imageUrl,
+    isLibrary: item.isLibrary,
+    metadata: item.metadata,
+    name: item.name,
+    relatedReleases: item.relatedReleases,
     values: [
       <BottleRatings
         counts={bottle.tastingBandCounts}
@@ -76,8 +33,4 @@ export function toBottleTableRow(
       />,
     ],
   };
-}
-
-export function toReleaseTableRow(bottle: Bottle): BottleComparisonRow {
-  return toBottleTableRow(bottle, formatReleaseMetadata(bottle));
 }

--- a/apps/web/src/app/(app)/entities/[entityId]/entityReleaseOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityReleaseOverview.tsx
@@ -9,7 +9,7 @@ import {
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
-import { toReleaseTableRow } from "./entityBottleTableRows";
+import { toBottleTableRow } from "./entityBottleTableRows";
 import { entityHasBottleCatalog, type Entity } from "./entityPageData";
 
 type BottleList = Outputs["bottles"]["list"];
@@ -64,8 +64,8 @@ export function EntityReleaseOverview({
         ariaLabel={`${entity.name} latest releases`}
         columns={["Rating"]}
         rows={[
-          toReleaseTableRow(firstRelease),
-          ...remainingReleases.map((bottle) => toReleaseTableRow(bottle)),
+          toBottleTableRow(firstRelease),
+          ...remainingReleases.map((bottle) => toBottleTableRow(bottle)),
         ]}
       />
     </PageSection>

--- a/apps/web/src/components/bottleComparisonTable.stories.tsx
+++ b/apps/web/src/components/bottleComparisonTable.stories.tsx
@@ -10,11 +10,12 @@ import { StoryCanvas } from "./storyFixtures.stylex";
 
 const rows: BottleComparisonTableProps["rows"] = [
   {
+    brand: "Port Charlotte",
     href: "/bottles/1",
     id: "1",
     imageUrl: BottleImage.src,
-    metadata: "Islay · 10 years · 46% ABV",
-    name: "Port Charlotte 10 Year Old",
+    metadata: ["Single Malt", "10 years", "46% ABV"],
+    name: "10 Year Old",
     values: [
       <BottleRatings
         counts={{
@@ -33,10 +34,11 @@ const rows: BottleComparisonTableProps["rows"] = [
     ],
   },
   {
+    brand: "Ardbeg",
     href: "/bottles/2",
     id: "2",
-    metadata: "Islay · No age statement · 54.2% ABV",
-    name: "Ardbeg Uigeadail",
+    metadata: ["Single Malt", "No age statement", "54.2% ABV"],
+    name: "Uigeadail",
     values: [
       <BottleRatings
         counts={{
@@ -55,16 +57,18 @@ const rows: BottleComparisonTableProps["rows"] = [
     ],
   },
   {
+    brand: "Caol Ila",
     href: "/bottles/3",
     id: "3",
-    metadata: "Islay · 12 years · 43% ABV",
-    name: "Caol Ila 12 Year Old",
+    metadata: ["Single Malt", "12 years", "43% ABV"],
+    name: "12 Year Old",
     values: [<BottleRatings counts={{}} key="rating" />],
   },
   {
+    brand: "Independent Bottler",
     href: "/bottles/4",
     id: "4",
-    metadata: "Campbeltown · 15 years · 51.4% ABV",
+    metadata: ["Single Malt", "15 years", "51.4% ABV"],
     name: "A deliberately long independent bottle name that tests the aligned row",
     values: [
       <BottleRatings

--- a/apps/web/src/components/bottleComparisonTable.stylex.tsx
+++ b/apps/web/src/components/bottleComparisonTable.stylex.tsx
@@ -1,20 +1,31 @@
 import * as stylex from "@stylexjs/stylex";
 import { type ReactNode, useId } from "react";
 
-import { colors, effects, fonts, space } from "../styles/tokens.stylex";
-import { AppLink } from "./appLink";
-import { BottleVisual } from "./bottleIdentityRow.stylex";
+import { colors, fonts, space } from "../styles/tokens.stylex";
+import {
+  BottleIdentityRow,
+  type BottleIdentityRowProps,
+} from "./bottleIdentityRow.stylex";
 import { linkedRowStyles } from "./linkedRow.stylex";
 import { getTextTitle } from "./textTitle";
 
 const COMPACT = "@media (max-width: 639px)";
 
-export type BottleComparisonRow = {
-  href?: string;
+export type BottleComparisonRow = Pick<
+  BottleIdentityRowProps,
+  | "align"
+  | "brand"
+  | "brandHref"
+  | "hasTasted"
+  | "href"
+  | "imageUrl"
+  | "isLibrary"
+  | "metadata"
+  | "name"
+  | "relatedReleases"
+  | "subtitle"
+> & {
   id: string;
-  imageUrl?: string | null;
-  metadata?: string;
-  name: string;
   values: readonly [ReactNode, ...ReactNode[]];
 };
 
@@ -80,36 +91,20 @@ export function BottleComparisonTable({
               )}
             >
               <th scope="row" {...stylex.props(styles.nameCell)}>
-                <div {...stylex.props(styles.identity)}>
-                  <BottleVisual imageUrl={row.imageUrl} />
-                  <div {...stylex.props(styles.copy)}>
-                    {row.href ? (
-                      <AppLink
-                        href={row.href}
-                        title={row.name}
-                        {...stylex.props(
-                          styles.name,
-                          styles.nameLink,
-                          linkedRowStyles.primaryLink,
-                        )}
-                      >
-                        {row.name}
-                      </AppLink>
-                    ) : (
-                      <span title={row.name} {...stylex.props(styles.name)}>
-                        {row.name}
-                      </span>
-                    )}
-                    {row.metadata ? (
-                      <span
-                        title={row.metadata}
-                        {...stylex.props(styles.metadata)}
-                      >
-                        {row.metadata}
-                      </span>
-                    ) : null}
-                  </div>
-                </div>
+                <BottleIdentityRow
+                  align={row.align}
+                  brand={row.brand}
+                  brandHref={row.brandHref}
+                  hasTasted={row.hasTasted}
+                  href={row.href}
+                  imageUrl={row.imageUrl}
+                  isLibrary={row.isLibrary}
+                  layout="cell"
+                  metadata={row.metadata}
+                  name={row.name}
+                  relatedReleases={row.relatedReleases}
+                  subtitle={row.subtitle}
+                />
               </th>
               {row.values.map((value, index) => (
                 <td key={index} {...stylex.props(styles.valueCell)}>
@@ -230,59 +225,6 @@ const styles = stylex.create({
       paddingRight: 0,
       paddingBottom: space.x3,
     },
-  },
-  identity: {
-    display: "flex",
-    minWidth: 0,
-    alignItems: "center",
-    gap: space.x3,
-  },
-  copy: {
-    minWidth: 0,
-    flex: 1,
-  },
-  name: {
-    display: "block",
-    overflow: "hidden",
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "15px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
-    textDecoration: "none",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-    outline: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
-  },
-  nameLink: {
-    color: {
-      default: colors.ink,
-      ":hover": colors.accentDeep,
-      ":active": colors.accent,
-    },
-    textDecorationLine: {
-      default: "none",
-      ":hover": "underline",
-    },
-    textDecorationThickness: "1px",
-    textUnderlineOffset: "2px",
-  },
-  metadata: {
-    display: "block",
-    marginTop: space.x1,
-    overflow: "hidden",
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    fontWeight: 400,
-    lineHeight: 1.35,
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
   },
   valueCell: {
     paddingTop: "14px",

--- a/apps/web/src/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stories.tsx
@@ -45,12 +45,22 @@ export const Overview: Story = {
       </ItemListItem>
       <ItemListItem>
         <BottleIdentityRow
+          align="start"
+          href="/bottles/19936"
+          imageUrl={BottleImage.src}
+          metadata={["2026 release", "10 years", "50% ABV"]}
+          name="SMWS Highland peaty potion"
+          subtitle="Highland · Single Malt"
+        />
+      </ItemListItem>
+      <ItemListItem>
+        <BottleIdentityRow
           brand="Lagavulin"
           brandHref="/entities/245"
           href="/bottles/42"
           imageUrl={null}
           metadata={["16 years", "43.0% ABV", "Distillers Edition"]}
-          name="Lagavulin 16-year-old"
+          name="16-year-old"
           relatedReleases={{ count: 3, href: "/bottles/42/releases" }}
         />
       </ItemListItem>

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -12,6 +12,7 @@ import { AppLink } from "./appLink";
 import { ImageViewer } from "./imageViewer.stylex";
 import { linkedRowStyles } from "./linkedRow.stylex";
 import { MemberStatus } from "./memberStatus.stylex";
+import { getTextTitle } from "./textTitle";
 
 const COMPACT = "@media (max-width: 639px)";
 const bottleIconUrl = "/assets/bottle.svg";
@@ -67,6 +68,7 @@ export function BottleVisual({
 }
 
 export type BottleIdentityRowProps = {
+  align?: "center" | "start";
   brand?: string;
   brandHref?: string;
   end?: ReactNode;
@@ -81,10 +83,12 @@ export type BottleIdentityRowProps = {
     count: number;
     href: string;
   };
+  subtitle?: ReactNode;
 };
 
 /** Presents one catalog bottle using Peated's existing identity and member-status meanings. */
 export function BottleIdentityRow({
+  align = "center",
   brand,
   brandHref,
   end,
@@ -96,11 +100,13 @@ export function BottleIdentityRow({
   metadata = [],
   name,
   relatedReleases,
+  subtitle,
 }: BottleIdentityRowProps) {
   return (
     <div
       {...stylex.props(
         styles.row,
+        align === "start" && styles.startAlignedRow,
         layout === "cell" && styles.cellLayout,
         Boolean(href) && layout === "row" && linkedRowStyles.container,
         Boolean(href) && layout === "row" && linkedRowStyles.onGround,
@@ -145,6 +151,14 @@ export function BottleIdentityRow({
           {isLibrary ? <MemberStatus kind="library" /> : null}
           {hasTasted ? <MemberStatus kind="tasted" /> : null}
         </div>
+        {subtitle ? (
+          <div
+            title={getTextTitle(subtitle)}
+            {...stylex.props(styles.subtitle)}
+          >
+            {subtitle}
+          </div>
+        ) : null}
         {metadata.length ? (
           <div title={metadata.join(" · ")} {...stylex.props(styles.metadata)}>
             {metadata.map((item, index) => (
@@ -235,6 +249,9 @@ const styles = stylex.create({
     paddingBottom: space.x3,
     paddingLeft: "12px",
   },
+  startAlignedRow: {
+    alignItems: "flex-start",
+  },
   cellLayout: {
     width: "100%",
     marginRight: 0,
@@ -324,6 +341,17 @@ const styles = stylex.create({
     fontFamily: fonts.data,
     fontSize: "11px",
     lineHeight: 1.4,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  subtitle: {
+    maxWidth: "100%",
+    overflow: "hidden",
+    marginTop: "3px",
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.3,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 
 import {
   AppLink,
+  BottleIdentityRow,
   BottleRatings,
   BottleVisual,
   Card,
@@ -11,6 +12,7 @@ import {
   CardLink,
   CardPrimaryLink,
   ItemList,
+  ItemListItem,
   ItemRow,
   TextLink,
   type TastingRatingCounts,
@@ -84,22 +86,23 @@ export function HomeHighestRated({
       <div {...stylex.props(styles.rows)}>
         <ItemList ariaLabel="Highest rated bottles">
           {bottles.map((bottle) => (
-            <ItemRow
-              end={
-                <BottleRatings
-                  counts={bottle.bandCounts}
-                  high={bottle.scoreHigh}
-                  low={bottle.scoreLow}
-                  median={bottle.score}
-                  scoreCount={bottle.scoreCount}
-                />
-              }
-              href={bottle.href}
-              key={bottle.href}
-              leading={<BottleVisual imageUrl={bottle.imageUrl} />}
-              metadata={bottle.metadata.join(" · ")}
-              title={bottle.name}
-            />
+            <ItemListItem key={bottle.href}>
+              <BottleIdentityRow
+                end={
+                  <BottleRatings
+                    counts={bottle.bandCounts}
+                    high={bottle.scoreHigh}
+                    low={bottle.scoreLow}
+                    median={bottle.score}
+                    scoreCount={bottle.scoreCount}
+                  />
+                }
+                href={bottle.href}
+                imageUrl={bottle.imageUrl}
+                metadata={bottle.metadata}
+                name={bottle.name}
+              />
+            </ItemListItem>
           ))}
         </ItemList>
       </div>
@@ -138,15 +141,16 @@ export function HomeLatestReleases({
       <div {...stylex.props(styles.rows)}>
         <ItemList ariaLabel={title}>
           {bottles.map((bottle) => (
-            <ItemRow
-              align="start"
-              href={bottle.href}
-              key={bottle.href}
-              leading={<BottleVisual imageUrl={bottle.imageUrl} />}
-              metadata={bottle.metadata.join(" · ")}
-              subtitle={bottle.subtitle}
-              title={bottle.name}
-            />
+            <ItemListItem key={bottle.href}>
+              <BottleIdentityRow
+                align="start"
+                href={bottle.href}
+                imageUrl={bottle.imageUrl}
+                metadata={bottle.metadata}
+                name={bottle.name}
+                subtitle={bottle.subtitle}
+              />
+            </ItemListItem>
           ))}
         </ItemList>
       </div>


### PR DESCRIPTION
Standard bottle lists now use `BottleIdentityRow` across the homepage, entity overviews, rating tables, catalogs, flights, release families, and member activity. Entity overview rows now show the same brand, bottle name, and metadata hierarchy as other catalog surfaces, while homepage release rows keep their distiller/category subtitle through shared subtitle and alignment support.

Compact recent-bottle rows, attributed critic reviews, search results, workflow summaries, cards, and page headers keep their purpose-specific presentations. The comparison table also delegates bottle identity markup and catalog mapping to the shared component, which removes its separate formatting rules.
