### PR TITLE
fix(web): rebuild tasting cards and detail

### DIFF
--- a/apps/web/src/app/(app)/_components/home/homeActivity.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/homeActivity.stylex.tsx
@@ -44,6 +44,7 @@ function TastingActivity({ session }: { session: TastingSession }) {
     <TastingEntry
       author={session.createdBy.username}
       authorHref={`/users/${session.createdBy.username}`}
+      authorId={session.createdBy.id}
       context={
         members.length > 1
           ? `${members.length.toLocaleString()} tastings`

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -3,6 +3,7 @@
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import {
   formatCategoryName,
+  formatColor,
   formatServingStyle,
 } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
@@ -164,19 +165,27 @@ function getCriticReview(
 
 function getTasting(tasting: Tasting, bottle: Bottle): TastingEntryProps {
   const member = {
+    color: tasting.color === null ? undefined : formatColor(tasting.color),
+    comments: tasting.comments,
     description: tasting.notes ?? undefined,
     descriptionHref: `/tastings/${tasting.id}`,
+    hasToasted: tasting.hasToasted,
+    imageKind: tasting.imageUrl ? ("photo" as const) : ("bottle" as const),
+    imageUrl: tasting.imageUrl ?? bottle.imageUrl,
     name: formatBottleDisplayName(bottle, { includeBrand: false }),
     notes: tasting.tags,
     ratingBand: tasting.ratingBand ?? undefined,
+    servingStyle: tasting.servingStyle
+      ? formatServingStyle(tasting.servingStyle)
+      : undefined,
+    tastingId: tasting.id,
+    toasts: tasting.toasts,
   };
 
   return {
     author: tasting.createdBy.username,
     authorHref: `/users/${tasting.createdBy.username}`,
-    context: tasting.servingStyle
-      ? formatServingStyle(tasting.servingStyle)
-      : undefined,
+    authorId: tasting.createdBy.id,
     date: <TimeSince date={tasting.createdAt} />,
     members: [member],
   };

--- a/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
@@ -1,15 +1,11 @@
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
-import { TextLink } from "@peated/web/components";
-import {
-  PageHeader,
-  PageSection,
-} from "@peated/web/components/pages/pageLayout.stylex";
-import { TastingRecordEntry } from "@peated/web/components/tastingRecordEntry";
+import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
 import { cache } from "react";
 
 import { TastingComments } from "./tastingComments.stylex";
+import { TastingDetail } from "./tastingDetail.stylex";
 
 const getTasting = cache(async (tastingId: number) => {
   const { client } = await getPublicPageServerClient();
@@ -49,27 +45,15 @@ export default async function TastingPage(props: {
   const commentList = await client.comments.list({ tasting: tasting.id });
   return (
     <div>
-      <PageHeader
-        eyebrow="Tasting record"
-        parent={
-          <TextLink
-            href={`/users/${tasting.createdBy.username}`}
-            size="inherit"
-          >
-            {tasting.createdBy.username}
-          </TextLink>
-        }
-        title={formatBottleDisplayName(tasting.bottle)}
-      />
-      <PageSection heading="Tasting">
-        <TastingRecordEntry showFullNotes tasting={tasting} />
-      </PageSection>
-      <PageSection heading="Comments">
-        <TastingComments
-          initialCommentList={commentList}
-          tastingId={tasting.id}
-        />
-      </PageSection>
+      <TastingDetail tasting={tasting} />
+      <div id="comments">
+        <PageSection heading="Conversation">
+          <TastingComments
+            initialCommentList={commentList}
+            tastingId={tasting.id}
+          />
+        </PageSection>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
@@ -1,0 +1,314 @@
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
+import { formatColor, formatServingStyle } from "@peated/server/lib/format";
+import type { Outputs } from "@peated/server/orpc/router";
+import * as stylex from "@stylexjs/stylex";
+
+import {
+  AppLink,
+  Chip,
+  MemberAvatar,
+  RATING_BANDS,
+  TastingMedia,
+  TastingRating,
+  TastingToastSummary,
+  TextLink,
+} from "@peated/web/components";
+import TimeSince from "@peated/web/components/timeSince";
+import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
+import { colors, fonts, space } from "../../../../styles/tokens.stylex";
+
+type Tasting = Outputs["tastings"]["details"];
+const COMPACT = "@media (max-width: 639px)";
+
+const fullDateFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "long",
+  timeZone: "UTC",
+  year: "numeric",
+});
+
+/** Renders the complete record for one member's pour. */
+export function TastingDetail({ tasting }: { tasting: Tasting }) {
+  const bottleName = formatBottleDisplayName(tasting.bottle);
+  const rating = tasting.ratingBand
+    ? RATING_BANDS.find((item) => item.key === tasting.ratingBand)
+    : undefined;
+  const specs = [
+    tasting.servingStyle
+      ? {
+          label: "Serving",
+          value: formatServingStyle(tasting.servingStyle),
+        }
+      : null,
+    tasting.color === null
+      ? null
+      : { label: "Colour", value: formatColor(tasting.color) },
+  ].filter((item): item is { label: string; value: string } => item !== null);
+
+  return (
+    <article {...stylex.props(styles.detail)}>
+      <header {...stylex.props(styles.authorLine)}>
+        <MemberAvatar
+          pictureUrl={tasting.createdBy.pictureUrl}
+          size="sm"
+          username={tasting.createdBy.username}
+        />
+        <TextLink href={`/users/${tasting.createdBy.username}`}>
+          {tasting.createdBy.username}
+        </TextLink>
+        <span {...stylex.props(styles.date)}>
+          <TimeSince date={tasting.createdAt} />
+          <span aria-hidden="true"> · </span>
+          <time dateTime={tasting.createdAt}>
+            {fullDateFormatter.format(new Date(tasting.createdAt))}
+          </time>
+        </span>
+      </header>
+
+      <AppLink
+        href={`/bottles/${tasting.bottle.id}`}
+        {...stylex.props(styles.bottleName)}
+      >
+        {bottleName}
+      </AppLink>
+      <p {...stylex.props(styles.metadata)}>
+        {getBottleMetadata(tasting.bottle)}
+      </p>
+
+      <div {...stylex.props(styles.hero)}>
+        <TastingMedia
+          imageKind={tasting.imageUrl ? "photo" : "bottle"}
+          imageUrl={tasting.imageUrl ?? tasting.bottle.imageUrl}
+          size="detail"
+        />
+        <div {...stylex.props(styles.verdict)}>
+          <strong {...stylex.props(styles.ratingLabel)}>
+            {rating?.label ?? "Not rated"}
+          </strong>
+          {tasting.ratingBand ? (
+            <div {...stylex.props(styles.ratingMark)}>
+              <TastingRating band={tasting.ratingBand} />
+            </div>
+          ) : null}
+          {rating ? (
+            <span {...stylex.props(styles.ratingRange)}>{rating.range}</span>
+          ) : null}
+        </div>
+      </div>
+
+      <p {...stylex.props(styles.notes, !tasting.notes && styles.emptyNotes)}>
+        {tasting.notes || "No notes."}
+      </p>
+
+      {tasting.tags.length ? (
+        <div {...stylex.props(styles.tags)}>
+          {tasting.tags.map((tag, index) => (
+            <Chip
+              key={`${tag}-${index}`}
+              variant={index < 2 ? "tinted" : "neutral"}
+            >
+              {tag}
+            </Chip>
+          ))}
+        </div>
+      ) : null}
+
+      {specs.length ? (
+        <dl {...stylex.props(styles.specs)}>
+          {specs.map((spec) => (
+            <div key={spec.label} {...stylex.props(styles.spec)}>
+              <dt {...stylex.props(styles.specLabel)}>{spec.label}</dt>
+              <dd {...stylex.props(styles.specValue)}>{spec.value}</dd>
+            </div>
+          ))}
+        </dl>
+      ) : null}
+
+      {tasting.friends.length ? (
+        <p {...stylex.props(styles.friends)}>
+          Poured with{" "}
+          {tasting.friends.map((friend, index) => (
+            <span key={friend.id}>
+              {index > 0
+                ? index === tasting.friends.length - 1
+                  ? " and "
+                  : ", "
+                : null}
+              <TextLink href={`/users/${friend.username}`} size="inherit">
+                {friend.username}
+              </TextLink>
+            </span>
+          ))}
+        </p>
+      ) : null}
+
+      <footer {...stylex.props(styles.footer)}>
+        <TastingToastSummary
+          authorId={tasting.createdBy.id}
+          hasToasted={tasting.hasToasted}
+          initialCount={tasting.toasts}
+          tastingId={tasting.id}
+        />
+      </footer>
+    </article>
+  );
+}
+
+const styles = stylex.create({
+  detail: {
+    maxWidth: "760px",
+    paddingTop: "20px",
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.sectionRule,
+  },
+  authorLine: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "center",
+    gap: "10px",
+    [COMPACT]: {
+      alignItems: "flex-start",
+      flexWrap: "wrap",
+    },
+  },
+  date: {
+    minWidth: 0,
+    overflow: "hidden",
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "11px",
+    lineHeight: 1.35,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  bottleName: {
+    display: "block",
+    width: "fit-content",
+    maxWidth: "100%",
+    marginTop: space.x3,
+    overflowWrap: "anywhere",
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontSize: "40px",
+    fontWeight: 700,
+    letterSpacing: "-0.045em",
+    lineHeight: 0.98,
+    textDecoration: "none",
+    [COMPACT]: {
+      fontSize: "34px",
+    },
+  },
+  metadata: {
+    margin: 0,
+    marginTop: "10px",
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "11px",
+    lineHeight: 1.4,
+  },
+  hero: {
+    display: "flex",
+    alignItems: "flex-start",
+    gap: space.x6,
+    paddingTop: space.x6,
+    [COMPACT]: {
+      flexDirection: "column",
+      gap: space.x4,
+    },
+  },
+  verdict: {
+    display: "flex",
+    minWidth: 0,
+    flex: 1,
+    flexDirection: "column",
+    paddingTop: "2px",
+  },
+  ratingLabel: {
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontSize: "20px",
+    fontWeight: 700,
+    letterSpacing: "-0.025em",
+    lineHeight: 1.2,
+  },
+  ratingMark: {
+    paddingTop: space.x2,
+  },
+  ratingRange: {
+    marginTop: space.x4,
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "11px",
+  },
+  notes: {
+    maxWidth: "58ch",
+    margin: 0,
+    marginTop: space.x6,
+    color: colors.ink,
+    fontFamily: fonts.reading,
+    fontSize: "15px",
+    lineHeight: 1.6,
+    whiteSpace: "pre-wrap",
+  },
+  emptyNotes: {
+    color: colors.inkMuted,
+  },
+  tags: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "6px",
+    marginTop: space.x4,
+  },
+  specs: {
+    display: "grid",
+    gridTemplateColumns: "repeat(auto-fit, minmax(132px, 1fr))",
+    margin: 0,
+    marginTop: space.x6,
+    padding: 0,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.hairline,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+  },
+  spec: {
+    minWidth: 0,
+    paddingTop: space.x3,
+    paddingRight: space.x4,
+    paddingBottom: space.x3,
+  },
+  specLabel: {
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "12px",
+    lineHeight: 1.3,
+  },
+  specValue: {
+    margin: 0,
+    marginTop: space.x1,
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontSize: "20px",
+    fontWeight: 700,
+    letterSpacing: "-0.025em",
+    lineHeight: 1.2,
+  },
+  friends: {
+    margin: 0,
+    marginTop: space.x3,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.5,
+  },
+  footer: {
+    display: "flex",
+    marginTop: space.x6,
+    paddingTop: space.x4,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.hairline,
+  },
+});

--- a/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
@@ -183,6 +183,7 @@ function toActivityItem(activity: Activity): MemberActivityItem {
     tasting: {
       author: activity.createdBy.username,
       authorHref: `/users/${activity.createdBy.username}`,
+      authorId: activity.createdBy.id,
       date: <TimeSince date={activity.lastActivityAt} />,
       leading: (
         <MemberAvatar

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -232,10 +232,11 @@ export type {
   SummaryStripCell,
   SummaryStripCells,
 } from "./summaryStrip.stylex";
-export { TastingEntry } from "./tastingEntry.stylex";
+export { TastingEntry, TastingMedia } from "./tastingEntry.stylex";
 export type {
   TastingEntryMember,
   TastingEntryProps,
+  TastingMediaKind,
 } from "./tastingEntry.stylex";
 export {
   ColorInput,
@@ -247,6 +248,7 @@ export type {
   PictureInputProps,
   RatingBandInputProps,
 } from "./tastingInputs.stylex";
+export { TastingToastSummary } from "./tastingToastButton.stylex";
 export { TextLink } from "./textLink.stylex";
 export type { TextLinkProps } from "./textLink.stylex";
 export { UnitInput } from "./unitInput.stylex";

--- a/apps/web/src/components/tastingEntry.stylex.tsx
+++ b/apps/web/src/components/tastingEntry.stylex.tsx
@@ -1,23 +1,45 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { colors, effects, fonts, space } from "../styles/tokens.stylex";
+import {
+  colors,
+  controlMetrics,
+  effects,
+  fonts,
+  space,
+} from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
+import { Chip } from "./chip.stylex";
 import { TastingRating, type RatingBand } from "./scoring.stylex";
+import { TastingToastSummary } from "./tastingToastButton.stylex";
+
+const COMPACT = "@media (max-width: 639px)";
+const bottleIconUrl = "/assets/bottle.svg";
+
+export type TastingMediaKind = "bottle" | "photo";
 
 export type TastingEntryMember = {
+  color?: string;
+  comments?: number;
   description?: string;
   descriptionHref?: string;
+  hasToasted?: boolean;
   href?: string;
+  imageKind?: TastingMediaKind;
+  imageUrl?: string | null;
   metadata?: string;
   name: string;
   notes?: readonly string[];
   ratingBand?: RatingBand;
+  servingStyle?: string;
+  tastingId?: number;
+  toasts?: number;
 };
 
 export type TastingEntryProps = {
   author: string;
   authorHref?: string;
+  authorId?: number;
   comment?: string;
   context?: string;
   date: ReactNode;
@@ -30,6 +52,7 @@ export type TastingEntryProps = {
 export function TastingEntry({
   author,
   authorHref,
+  authorId,
   comment,
   context,
   date,
@@ -39,76 +62,130 @@ export function TastingEntry({
 }: TastingEntryProps) {
   return (
     <article {...stylex.props(styles.entry)}>
-      <header {...stylex.props(styles.header)}>
-        {leading}
-        <div {...stylex.props(styles.headerCopy)}>
-          {authorHref ? (
-            <AppLink
-              href={authorHref}
-              {...stylex.props(styles.author, styles.authorLink)}
-            >
-              {author}
-            </AppLink>
-          ) : (
-            <strong {...stylex.props(styles.author)}>{author}</strong>
-          )}
-          <span {...stylex.props(styles.date)}>
-            {date}
-            {context ? (
-              <>
-                <span aria-hidden="true"> · </span>
-                {context}
-              </>
-            ) : null}
-          </span>
-        </div>
-        {menu ? <div {...stylex.props(styles.menu)}>{menu}</div> : null}
-      </header>
       <ul {...stylex.props(styles.members)}>
         {members.map((member) => (
           <li
-            key={`${member.href ?? member.name}-${member.name}`}
+            key={`${member.tastingId ?? member.href ?? member.name}-${member.name}`}
             {...stylex.props(styles.member)}
           >
-            <div {...stylex.props(styles.memberCopy)}>
-              {member.href ? (
-                <AppLink
-                  href={member.href}
-                  title={member.name}
-                  {...stylex.props(styles.name, styles.nameLink)}
-                >
-                  {member.name}
-                </AppLink>
-              ) : (
-                <span title={member.name} {...stylex.props(styles.name)}>
-                  {member.name}
-                </span>
-              )}
-              {member.metadata ? (
-                <span
-                  title={member.metadata}
-                  {...stylex.props(styles.metadata)}
-                >
-                  {member.metadata}
-                </span>
-              ) : null}
-              {member.notes?.length ? (
-                <span {...stylex.props(styles.notes)}>
-                  {member.notes.join(" · ")}
-                </span>
-              ) : null}
-              {member.description ? (
-                <span {...stylex.props(styles.description)}>
+            <TastingMedia
+              imageKind={member.imageKind}
+              imageUrl={member.imageUrl}
+              size="card"
+            />
+            <div {...stylex.props(styles.memberBody)}>
+              <div {...stylex.props(styles.headingRow)}>
+                <div {...stylex.props(styles.memberCopy)}>
+                  <header {...stylex.props(styles.header)}>
+                    {leading}
+                    <div {...stylex.props(styles.headerCopy)}>
+                      {authorHref ? (
+                        <AppLink
+                          href={authorHref}
+                          {...stylex.props(styles.author, styles.authorLink)}
+                        >
+                          {author}
+                        </AppLink>
+                      ) : (
+                        <strong {...stylex.props(styles.author)}>
+                          {author}
+                        </strong>
+                      )}
+                      <span {...stylex.props(styles.date)}>
+                        {date}
+                        {context ? (
+                          <>
+                            <span aria-hidden="true"> · </span>
+                            {context}
+                          </>
+                        ) : null}
+                      </span>
+                    </div>
+                  </header>
+                  {member.href ? (
+                    <AppLink
+                      href={member.href}
+                      title={member.name}
+                      {...stylex.props(styles.name, styles.nameLink)}
+                    >
+                      {member.name}
+                    </AppLink>
+                  ) : (
+                    <span title={member.name} {...stylex.props(styles.name)}>
+                      {member.name}
+                    </span>
+                  )}
+                  {member.metadata ? (
+                    <span
+                      title={member.metadata}
+                      {...stylex.props(styles.metadata)}
+                    >
+                      {member.metadata}
+                    </span>
+                  ) : null}
+                </div>
+                <div {...stylex.props(styles.rating)}>
+                  {member.ratingBand ? (
+                    <TastingRating band={member.ratingBand} />
+                  ) : (
+                    <span {...stylex.props(styles.unknown)}>–</span>
+                  )}
+                </div>
+                {menu ? <div {...stylex.props(styles.menu)}>{menu}</div> : null}
+              </div>
+              <p
+                {...stylex.props(
+                  styles.description,
+                  !member.description && styles.emptyDescription,
+                )}
+              >
+                {member.description ? (
                   <TastingDescription member={member} />
-                </span>
+                ) : (
+                  "No notes."
+                )}
+              </p>
+              {member.notes?.length ? (
+                <div {...stylex.props(styles.notes)}>
+                  {member.notes.map((note, index) => (
+                    <Chip
+                      key={`${note}-${index}`}
+                      variant={index < 2 ? "tinted" : "neutral"}
+                    >
+                      {note}
+                    </Chip>
+                  ))}
+                </div>
               ) : null}
-            </div>
-            <div {...stylex.props(styles.rating)}>
-              {member.ratingBand ? (
-                <TastingRating band={member.ratingBand} />
-              ) : (
-                <span {...stylex.props(styles.unknown)}>–</span>
-              )}
+              {member.servingStyle || member.color ? (
+                <div {...stylex.props(styles.specs)}>
+                  {member.servingStyle ? (
+                    <span>{member.servingStyle}</span>
+                  ) : null}
+                  {member.color ? <span>{member.color}</span> : null}
+                </div>
+              ) : null}
+              {member.tastingId !== undefined &&
+              (member.toasts !== undefined || member.comments !== undefined) ? (
+                <footer {...stylex.props(styles.footer)}>
+                  {member.toasts !== undefined ? (
+                    <TastingToastSummary
+                      authorId={authorId}
+                      hasToasted={member.hasToasted}
+                      initialCount={member.toasts}
+                      tastingId={member.tastingId}
+                    />
+                  ) : null}
+                  {member.comments !== undefined ? (
+                    <AppLink
+                      href={`/tastings/${member.tastingId}#comments`}
+                      {...stylex.props(styles.commentsLink)}
+                    >
+                      {formatCommentCount(member.comments)}
+                    </AppLink>
+                  ) : null}
+                </footer>
+              ) : null}
             </div>
           </li>
         ))}
@@ -118,7 +195,47 @@ export function TastingEntry({
   );
 }
 
-const DESCRIPTION_PREVIEW_LENGTH = 60;
+export function TastingMedia({
+  imageKind = "bottle",
+  imageUrl,
+  size,
+}: {
+  imageKind?: TastingMediaKind;
+  imageUrl?: string | null;
+  size: "card" | "detail";
+}) {
+  return (
+    <span
+      aria-hidden="true"
+      {...stylex.props(
+        styles.media,
+        size === "card" ? styles.cardMedia : styles.detailMedia,
+        Boolean(imageUrl) && styles.mediaWithImage,
+      )}
+    >
+      {imageUrl ? (
+        <img
+          alt=""
+          src={imageUrl}
+          {...stylex.props(
+            styles.mediaImage,
+            imageKind === "photo" ? styles.photoImage : styles.bottleImage,
+          )}
+        />
+      ) : (
+        <span
+          style={{
+            maskImage: `url("${bottleIconUrl}")`,
+            WebkitMaskImage: `url("${bottleIconUrl}")`,
+          }}
+          {...stylex.props(styles.fallbackAsset)}
+        />
+      )}
+    </span>
+  );
+}
+
+const DESCRIPTION_PREVIEW_LENGTH = 180;
 
 function TastingDescription({ member }: { member: TastingEntryMember }) {
   const description = member.description?.trim().replace(/\s+/g, " ");
@@ -139,7 +256,7 @@ function TastingDescription({ member }: { member: TastingEntryMember }) {
 
   return (
     <>
-      <span {...stylex.props(styles.descriptionPreview)}>{preview}</span>
+      {preview}{" "}
       <AppLink
         aria-label={`Read the full tasting notes for ${member.name}`}
         href={member.descriptionHref}
@@ -151,33 +268,79 @@ function TastingDescription({ member }: { member: TastingEntryMember }) {
   );
 }
 
+function formatCommentCount(count: number) {
+  return `${count.toLocaleString("en-US")} ${count === 1 ? "comment" : "comments"}`;
+}
+
 const styles = stylex.create({
   entry: {
-    paddingTop: space.x4,
-    paddingBottom: space.x4,
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
-    borderTopColor: colors.hairline,
+    width: "100%",
+    maxWidth: "760px",
+    minWidth: 0,
   },
-  header: {
+  members: {
+    margin: 0,
+    padding: 0,
+    listStyle: "none",
+  },
+  member: {
     display: "flex",
     minWidth: 0,
-    alignItems: "center",
+    alignItems: "flex-start",
+    gap: space.x4,
+    paddingTop: "20px",
+    paddingBottom: "20px",
+    [COMPACT]: {
+      gap: space.x3,
+      paddingTop: space.x4,
+      paddingBottom: space.x4,
+    },
+  },
+  memberBody: {
+    minWidth: 0,
+    flex: 1,
+  },
+  headingRow: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "flex-start",
     gap: space.x3,
   },
-  headerCopy: {
+  memberCopy: {
     display: "flex",
     minWidth: 0,
     flex: 1,
     flexDirection: "column",
   },
+  header: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "center",
+    gap: space.x2,
+  },
+  headerCopy: {
+    display: "flex",
+    minWidth: 0,
+    flex: 1,
+    alignItems: "baseline",
+    gap: space.x2,
+    [COMPACT]: {
+      alignItems: "flex-start",
+      flexDirection: "column",
+      gap: "2px",
+    },
+  },
   author: {
+    overflow: "hidden",
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    fontWeight: 600,
-    lineHeight: 1.3,
+    fontFamily: fonts.display,
+    fontSize: "15px",
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    lineHeight: 1.25,
     textDecoration: "none",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
     outline: "none",
     boxShadow: {
       default: "none",
@@ -186,62 +349,37 @@ const styles = stylex.create({
   },
   authorLink: {
     color: {
-      default: null,
+      default: colors.ink,
       ":hover": colors.accentDeep,
       ":active": colors.accent,
     },
   },
   date: {
-    marginTop: "2px",
+    overflow: "hidden",
     color: colors.inkMuted,
     fontFamily: fonts.data,
-    fontSize: "10px",
+    fontSize: "11px",
     lineHeight: 1.35,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
   menu: {
     display: "flex",
     flexShrink: 0,
   },
-  members: {
-    margin: 0,
-    marginTop: space.x3,
-    padding: 0,
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
-    borderTopColor: colors.hairline,
-    backgroundColor: "transparent",
-    listStyle: "none",
-  },
-  member: {
-    display: "flex",
-    minWidth: 0,
-    alignItems: "center",
-    gap: space.x4,
-    paddingTop: "12px",
-    paddingBottom: "12px",
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
-    ":last-child": {
-      borderBottomWidth: 0,
-    },
-  },
-  memberCopy: {
-    display: "flex",
-    minWidth: 0,
-    flex: 1,
-    flexDirection: "column",
-  },
   name: {
+    display: "block",
+    marginTop: space.x2,
     overflow: "hidden",
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    fontWeight: 600,
-    lineHeight: 1.3,
+    fontFamily: fonts.display,
+    fontSize: "19px",
+    fontWeight: 700,
+    letterSpacing: "-0.03em",
+    lineHeight: 1.15,
     textDecoration: "none",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
+    textOverflow: { default: "ellipsis", [COMPACT]: "clip" },
+    whiteSpace: { default: "nowrap", [COMPACT]: "normal" },
     outline: "none",
     boxShadow: {
       default: "none",
@@ -250,39 +388,34 @@ const styles = stylex.create({
   },
   nameLink: {
     color: {
-      default: null,
+      default: colors.ink,
       ":hover": colors.accentDeep,
       ":active": colors.accent,
     },
   },
   metadata: {
-    marginTop: "2px",
+    marginTop: space.x1,
     overflow: "hidden",
     color: colors.inkMuted,
     fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.35,
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-  },
-  notes: {
-    marginTop: space.x1,
-    color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "12px",
-    lineHeight: 1.35,
+    fontSize: "11px",
+    lineHeight: 1.4,
+    textOverflow: { default: "ellipsis", [COMPACT]: "clip" },
+    whiteSpace: { default: "nowrap", [COMPACT]: "normal" },
   },
   description: {
-    marginTop: space.x2,
-    color: colors.inkMuted,
+    margin: 0,
+    marginTop: "14px",
+    color: colors.ink,
     fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
+    fontSize: "15px",
+    lineHeight: 1.6,
     whiteSpace: "pre-wrap",
   },
+  emptyDescription: {
+    color: colors.inkMuted,
+  },
   descriptionLink: {
-    display: "inline-block",
-    marginTop: space.x2,
     color: colors.accentDeep,
     fontWeight: 600,
     textDecoration: {
@@ -296,26 +429,133 @@ const styles = stylex.create({
     },
     whiteSpace: "nowrap",
   },
-  descriptionPreview: {
-    display: "block",
+  notes: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "6px",
+    marginTop: space.x3,
+  },
+  specs: {
+    display: "flex",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: "14px",
+    marginTop: space.x3,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.4,
   },
   rating: {
     display: "flex",
-    minWidth: "76px",
     flexShrink: 0,
     justifyContent: "flex-end",
+    paddingTop: space.x1,
   },
   unknown: {
     color: colors.inkMuted,
     fontFamily: fonts.data,
     fontSize: "12px",
   },
+  footer: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "center",
+    gap: space.x3,
+    marginTop: space.x4,
+    paddingTop: "14px",
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.hairline,
+    [COMPACT]: {
+      alignItems: "flex-start",
+      flexWrap: "wrap",
+    },
+  },
+  commentsLink: {
+    flexShrink: 0,
+    color: colors.accentDeep,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    fontWeight: 600,
+    lineHeight: 1.4,
+    textDecoration: {
+      default: "none",
+      ":hover": "underline",
+    },
+    outline: "none",
+    boxShadow: {
+      default: "none",
+      ":focus-visible": effects.focusRing,
+    },
+  },
   comment: {
     margin: 0,
-    marginTop: space.x3,
+    marginBottom: space.x4,
     color: colors.inkMuted,
     fontFamily: fonts.reading,
     fontSize: "13px",
     lineHeight: 1.5,
+  },
+  media: {
+    boxSizing: "border-box",
+    display: "inline-flex",
+    flexShrink: 0,
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+    borderRadius: controlMetrics.radiusSmall,
+    backgroundColor: colors.inset,
+    color: colors.inkMuted,
+  },
+  cardMedia: {
+    width: "88px",
+    height: "88px",
+    padding: space.x3,
+    [COMPACT]: {
+      width: "72px",
+      height: "72px",
+      padding: space.x2,
+    },
+  },
+  detailMedia: {
+    width: "300px",
+    height: "300px",
+    padding: space.x6,
+    [COMPACT]: {
+      width: "100%",
+      height: "auto",
+      aspectRatio: "1 / 1",
+    },
+  },
+  mediaWithImage: {
+    backgroundColor: colors.imageBackground,
+    boxShadow: `inset 0 0 0 1px ${colors.hairline}`,
+    padding: 0,
+  },
+  mediaImage: {
+    display: "block",
+    width: "100%",
+    height: "100%",
+  },
+  photoImage: {
+    objectFit: "cover",
+  },
+  bottleImage: {
+    objectFit: "contain",
+    padding: space.x2,
+  },
+  fallbackAsset: {
+    display: "block",
+    width: "42%",
+    height: "72%",
+    backgroundColor: "currentColor",
+    opacity: 0.5,
+    maskPosition: "center",
+    maskRepeat: "no-repeat",
+    maskSize: "contain",
+    WebkitMaskPosition: "center",
+    WebkitMaskRepeat: "no-repeat",
+    WebkitMaskSize: "contain",
   },
 });

--- a/apps/web/src/components/tastingEntry.test.tsx
+++ b/apps/web/src/components/tastingEntry.test.tsx
@@ -51,4 +51,34 @@ describe("TastingEntry descriptions", () => {
     expect(html).toContain("The final sentence.");
     expect(html).not.toContain("Read more");
   });
+
+  it("shows the recorded tasting details and discussion link", () => {
+    const html = renderToStaticMarkup(
+      <TastingEntry
+        author="peatfan"
+        date="Today"
+        members={[
+          {
+            color: "Deep gold",
+            comments: 4,
+            imageKind: "photo",
+            imageUrl: "/tasting.jpg",
+            name: "Springbank 15",
+            notes: ["wax", "coal smoke"],
+            ratingBand: "outstanding",
+            servingStyle: "Neat",
+            tastingId: 42,
+          },
+        ]}
+      />,
+    );
+
+    expect(html).toContain('src="/tasting.jpg"');
+    expect(html).toContain("No notes.");
+    expect(html).toContain("wax");
+    expect(html).toContain("Neat");
+    expect(html).toContain("Deep gold");
+    expect(html).toContain('href="/tastings/42#comments"');
+    expect(html).toContain("4 comments");
+  });
 });

--- a/apps/web/src/components/tastingRecordEntry.tsx
+++ b/apps/web/src/components/tastingRecordEntry.tsx
@@ -4,6 +4,7 @@ import {
   formatBottleDisplayName,
   type BottleDisplayNameSource,
 } from "@peated/server/lib/bottleDisplayName";
+import { formatColor, formatServingStyle } from "@peated/server/lib/format";
 import {
   MemberAvatar,
   TastingEntry,
@@ -18,34 +19,52 @@ import {
 type Tasting = Outputs["tastings"]["list"]["results"][number];
 
 type TastingEntryRecord = {
-  bottle: BottleDisplayNameSource & BottleMetadata & { id: number };
+  bottle: BottleDisplayNameSource &
+    BottleMetadata & { id: number; imageUrl?: string | null };
+  color?: number | null;
+  comments?: number;
+  hasToasted?: boolean;
   id: number;
+  imageUrl?: string | null;
   notes?: string | null;
   ratingBand?: TastingEntryMember["ratingBand"] | null;
+  servingStyle?: Parameters<typeof formatServingStyle>[0] | null;
   tags?: readonly string[] | null;
+  toasts?: number;
 };
 
 export function getTastingEntryMember(
   tasting: TastingEntryRecord,
 ): TastingEntryMember {
   return {
+    color:
+      tasting.color === null || tasting.color === undefined
+        ? undefined
+        : formatColor(tasting.color),
+    comments: tasting.comments,
     description: tasting.notes ?? undefined,
     descriptionHref: `/tastings/${tasting.id}`,
+    hasToasted: tasting.hasToasted,
     href: `/bottles/${tasting.bottle.id}`,
+    imageKind: tasting.imageUrl ? "photo" : "bottle",
+    imageUrl: tasting.imageUrl ?? tasting.bottle.imageUrl,
     metadata: getBottleMetadata(tasting.bottle),
     name: formatBottleDisplayName(tasting.bottle),
     notes: tasting.tags ?? undefined,
     ratingBand: tasting.ratingBand ?? undefined,
+    servingStyle: tasting.servingStyle
+      ? formatServingStyle(tasting.servingStyle)
+      : undefined,
+    tastingId: tasting.id,
+    toasts: tasting.toasts,
   };
 }
 
 export function TastingRecordEntry({
   showAvatar = true,
-  showFullNotes = false,
   tasting,
 }: {
   showAvatar?: boolean;
-  showFullNotes?: boolean;
   tasting: Tasting;
 }) {
   const member = getTastingEntryMember(tasting);
@@ -54,6 +73,7 @@ export function TastingRecordEntry({
     <TastingEntry
       author={tasting.createdBy.username}
       authorHref={`/users/${tasting.createdBy.username}`}
+      authorId={tasting.createdBy.id}
       date={<TimeSince date={tasting.createdAt} />}
       leading={
         showAvatar ? (
@@ -63,9 +83,7 @@ export function TastingRecordEntry({
           />
         ) : undefined
       }
-      members={[
-        showFullNotes ? { ...member, descriptionHref: undefined } : member,
-      ]}
+      members={[member]}
     />
   );
 }

--- a/apps/web/src/components/tastingToastButton.stylex.tsx
+++ b/apps/web/src/components/tastingToastButton.stylex.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useMutation } from "@tanstack/react-query";
+import { useState } from "react";
+
+import useAuth from "@peated/web/hooks/useAuth";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { colors, fonts, space } from "../styles/tokens.stylex";
+import { Button, ButtonLink } from "./button.stylex";
+
+/** Owns the member-specific toast action and count for one tasting. */
+export function TastingToastSummary({
+  authorId,
+  hasToasted = false,
+  initialCount,
+  tastingId,
+}: {
+  authorId?: number;
+  hasToasted?: boolean;
+  initialCount: number;
+  tastingId: number;
+}) {
+  const { user } = useAuth();
+  const orpc = useORPC();
+  const createToast = useMutation(orpc.toasts.create.mutationOptions());
+  const [toasted, setToasted] = useState(hasToasted);
+  const [count, setCount] = useState(initialCount);
+  const canToast = Boolean(
+    user && authorId !== undefined && user.id !== authorId,
+  );
+
+  function toast() {
+    if (!canToast || toasted || createToast.isPending) return;
+
+    createToast.mutate(
+      { tasting: tastingId },
+      {
+        onSuccess: () => {
+          setToasted(true);
+          setCount((value) => value + 1);
+        },
+      },
+    );
+  }
+
+  return (
+    <div {...stylex.props(styles.summary)}>
+      {!user ? (
+        <ButtonLink href="/login" size="sm" variant="tonal">
+          Toast
+        </ButtonLink>
+      ) : canToast ? (
+        <Button
+          disabled={toasted}
+          loading={createToast.isPending}
+          onClick={toast}
+          size="sm"
+          variant="tonal"
+        >
+          {toasted ? "Toasted" : "Toast"}
+        </Button>
+      ) : null}
+      <span {...stylex.props(styles.count)}>
+        {formatToastCount(count, toasted)}
+      </span>
+      {createToast.error ? (
+        <span aria-live="polite" {...stylex.props(styles.error)}>
+          We couldn't save your toast. Try again.
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+function formatToastCount(count: number, hasToasted: boolean) {
+  if (hasToasted && count > 1)
+    return `You and ${count - 1} others toasted this`;
+  if (hasToasted) return "You toasted this";
+  return `${count.toLocaleString("en-US")} ${count === 1 ? "person" : "people"} toasted this`;
+}
+
+const styles = stylex.create({
+  summary: {
+    display: "flex",
+    minWidth: 0,
+    flex: 1,
+    alignItems: "center",
+    gap: space.x3,
+  },
+  count: {
+    minWidth: 0,
+    overflow: "hidden",
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.4,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  error: {
+    flexShrink: 0,
+    color: colors.critical,
+    fontFamily: fonts.reading,
+    fontSize: "12px",
+  },
+});


### PR DESCRIPTION
Tasting cards now present each pour as a complete record across activity, bottle, entity, and profile surfaces. Cards include tasting or bottle imagery, author and bottle context, rating, notes, tags, serving and colour details, toast state, and a direct link to the conversation while preserving grouped tasting sessions.

The tasting detail route now uses a dedicated responsive layout instead of repeating the compact list row. It gives the photo or bottle fallback, rating range, full notes, tasting facts, friends, toast action, and conversation a clear hierarchy on desktop and mobile.
