### PR TITLE
fix(web): balance location card spacing

### DIFF
--- a/apps/web/src/components/locationCard.stylex.tsx
+++ b/apps/web/src/components/locationCard.stylex.tsx
@@ -25,7 +25,7 @@ export function LocationCard({
   const distillerNoun = totalDistillers === 1 ? "distiller" : "distillers";
 
   return (
-    <CardLink href={href}>
+    <CardLink href={href} padding="none" {...stylex.props(styles.card)}>
       <div {...stylex.props(styles.map)}>
         <CountryMapIcon
           aria-hidden="true"
@@ -44,6 +44,9 @@ export function LocationCard({
 }
 
 const styles = stylex.create({
+  card: {
+    padding: space.x4,
+  },
   map: {
     display: "flex",
     height: "132px",


### PR DESCRIPTION
Location cards now use a consistent 16px inset on every side, so maps, headings, descriptions, and counts no longer sit flush against the side borders or inherit uneven vertical-only spacing.

The shared card remains unchanged. The correction is scoped to the locations surface and was checked at desktop and mobile widths.
