### PR TITLE
fix(web): prevent bottle facet text clipping

### DIFF
--- a/apps/web/src/components/facetRow.stylex.tsx
+++ b/apps/web/src/components/facetRow.stylex.tsx
@@ -132,9 +132,9 @@ const styles = stylex.create({
     cursor: "default",
   },
   label: {
-    width: "92px",
+    width: "128px",
     minWidth: 0,
-    flex: "0 1 92px",
+    flex: "0 1 128px",
     overflow: "hidden",
     fontSize: "13px",
     fontWeight: 600,
@@ -182,8 +182,8 @@ const styles = stylex.create({
     backgroundColor: colors.accent,
   },
   count: {
-    width: "26px",
-    flex: "0 0 26px",
+    width: "48px",
+    flex: "0 0 48px",
     overflow: "hidden",
     fontFamily: fonts.data,
     fontSize: "11px",


### PR DESCRIPTION
Bottle catalog facet rows now reserve enough width for full labels and formatted counts, including five-digit totals, while shortening the distribution bars by roughly 20–30%. This keeps category and age filters readable at desktop and mobile widths without changing filtering behavior.
