### PR TITLE
fix(smws): render current distillery codes

### DIFF
--- a/apps/server/src/orpc/contracts/smws/distiller-list.ts
+++ b/apps/server/src/orpc/contracts/smws/distiller-list.ts
@@ -1,6 +1,14 @@
 import { EntitySchema, listResponse } from "@peated/server/schemas";
+import { z } from "zod";
 
 import { contract } from "../base";
+
+const SmwsDistillerSchema = EntitySchema.extend({
+  smwsCodes: z
+    .array(z.string())
+    .readonly()
+    .describe("SMWS codes that resolve to this distillery"),
+});
 
 export default contract
   .route({
@@ -11,4 +19,4 @@ export default contract
       "Retrieve distillers that are part of the Scotch Malt Whisky Society (SMWS) system",
     spec: (spec) => ({ ...spec, operationId: "listSmwsDistillers" }),
   })
-  .output(listResponse(EntitySchema));
+  .output(listResponse(SmwsDistillerSchema));

--- a/apps/server/src/orpc/mock/routes/smws/distiller-list.ts
+++ b/apps/server/src/orpc/mock/routes/smws/distiller-list.ts
@@ -1,7 +1,20 @@
+import { SMWS_DISTILLERY_CODES } from "@peated/bottle-classifier/smws";
 import { mockEntities } from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.smws.distillerList.handler(async () => ({
-  results: mockEntities.filter((entity) => entity.kind === "distillery"),
+  results: mockEntities
+    .filter((entity) => entity.kind === "distillery")
+    .map((entity) => ({
+      ...entity,
+      smwsCodes: Object.entries(SMWS_DISTILLERY_CODES)
+        .filter(([, name]) =>
+          [entity.name, entity.shortName].some(
+            (entityName) => entityName?.toLowerCase() === name.toLowerCase(),
+          ),
+        )
+        .map(([code]) => code),
+    }))
+    .filter((entity) => entity.smwsCodes.length),
   rel: { nextCursor: null, prevCursor: null },
 }));

--- a/apps/server/src/orpc/routes/smws/distiller-list.test.ts
+++ b/apps/server/src/orpc/routes/smws/distiller-list.test.ts
@@ -24,6 +24,11 @@ describe("GET /smws/distillers", () => {
       name: "Glenlivet",
     });
 
+    const inchDairnie = await fixtures.Entity({
+      name: "InchDairnie Distillery",
+      kind: "distillery",
+    });
+
     await fixtures.Entity({ name: "Bowmore", kind: "company" });
     await fixtures.Entity({
       name: "Not an SMWS distillery",
@@ -37,7 +42,16 @@ describe("GET /smws/distillers", () => {
     );
 
     expect(new Set(results.map((result) => result.id))).toEqual(
-      new Set([cascadeHollow.id, theGlenlivet.id]),
+      new Set([cascadeHollow.id, theGlenlivet.id, inchDairnie.id]),
     );
+    expect(
+      results.find((result) => result.id === cascadeHollow.id)?.smwsCodes,
+    ).toContain("B5");
+    expect(
+      results.find((result) => result.id === theGlenlivet.id)?.smwsCodes,
+    ).toContain("2");
+    expect(
+      results.find((result) => result.id === inchDairnie.id)?.smwsCodes,
+    ).toEqual(["168", "169"]);
   });
 });

--- a/apps/server/src/orpc/routes/smws/distiller-list.ts
+++ b/apps/server/src/orpc/routes/smws/distiller-list.ts
@@ -5,14 +5,20 @@ import { implement } from "@peated/server/orpc";
 import smwsDistillerListContract from "@peated/server/orpc/contracts/smws/distiller-list";
 import { serialize } from "@peated/server/serializers";
 import { EntitySerializer } from "@peated/server/serializers/entity";
-import { and, eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 
 export default implement(smwsDistillerListContract).handler(async function ({
   context,
 }) {
-  const distilleryNames = Object.values(SMWS_DISTILLERY_CODES).map((name) =>
-    name.toLowerCase(),
-  );
+  const codesByName = new Map<string, string[]>();
+  for (const [code, name] of Object.entries(SMWS_DISTILLERY_CODES)) {
+    const normalizedName = name.toLowerCase();
+    codesByName.set(normalizedName, [
+      ...(codesByName.get(normalizedName) ?? []),
+      code,
+    ]);
+  }
+  const distilleryNames = [...codesByName.keys()];
   const results = await db
     .select()
     .from(entities)
@@ -27,8 +33,50 @@ export default implement(smwsDistillerListContract).handler(async function ({
       ),
     );
 
+  const matchingReferences = results.length
+    ? await db
+        .select({
+          entityId: entityReferences.entityId,
+          name: entityReferences.name,
+        })
+        .from(entityReferences)
+        .where(
+          and(
+            inArray(
+              entityReferences.entityId,
+              results.map((result) => result.id),
+            ),
+            sql`LOWER(${entityReferences.name}) IN ${distilleryNames}`,
+          ),
+        )
+    : [];
+
+  const codesByEntityId = new Map<number, Set<string>>();
+  const addCodes = (entityId: number, name: string) => {
+    const codes = codesByName.get(name.toLowerCase());
+    if (!codes) return;
+
+    const entityCodes = codesByEntityId.get(entityId) ?? new Set<string>();
+    for (const code of codes) entityCodes.add(code);
+    codesByEntityId.set(entityId, entityCodes);
+  };
+
+  for (const result of results) addCodes(result.id, result.name);
+  for (const reference of matchingReferences) {
+    if (reference.entityId) addCodes(reference.entityId, reference.name);
+  }
+
+  const serializedResults = await serialize(
+    EntitySerializer,
+    results,
+    context.user,
+  );
+
   return {
-    results: await serialize(EntitySerializer, results, context.user),
+    results: serializedResults.map((result) => ({
+      ...result,
+      smwsCodes: [...(codesByEntityId.get(result.id) ?? [])],
+    })),
     rel: {
       nextCursor: null,
       prevCursor: null,

--- a/apps/server/src/scraper/adapters/legacy/scrapeSMWS.test.ts
+++ b/apps/server/src/scraper/adapters/legacy/scrapeSMWS.test.ts
@@ -213,7 +213,7 @@ test("keeps reused Society labels out of bottle names and cask numbers", () => {
       category: "single_grain",
       caskNumber: "G17.1",
       singleCask: true,
-      distillers: [],
+      distillers: [{ name: "Starlaw" }],
     }),
   ]);
   for (const { bottle } of result.bottles) {

--- a/apps/web/src/app/(app)/entities/[entityId]/codes/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/codes/page.tsx
@@ -20,10 +20,12 @@ export default async function EntityCodesPage(props: {
   if (entity.shortName !== "SMWS") notFound();
 
   const { results: distillerList } = await client.smws.distillerList();
-  const exampleDistiller = distillerList.find(
-    (distiller) =>
-      distiller.name.toLowerCase() === SMWS_DISTILLERY_CODES[4].toLowerCase(),
+  const distillersByCode = Object.fromEntries(
+    distillerList.flatMap((distiller) =>
+      distiller.smwsCodes.map((code) => [code, distiller]),
+    ),
   );
+  const exampleDistiller = distillersByCode["4"];
 
   if (!exampleDistiller) {
     const error = new Error("Unable to find example distiller for SMWS codes.");
@@ -38,15 +40,6 @@ export default async function EntityCodesPage(props: {
     throw error;
   }
 
-  const distillersByName = Object.fromEntries([
-    ...distillerList.map((distiller) => [
-      distiller.name.toLowerCase(),
-      distiller,
-    ]),
-    ...distillerList
-      .filter((distiller) => Boolean(distiller.shortName))
-      .map((distiller) => [distiller.shortName!.toLowerCase(), distiller]),
-  ]);
   const groups = SMWS_CATEGORY_LIST.flatMap(([categoryCode, categoryTitle]) => {
     const rows = [];
 
@@ -54,9 +47,7 @@ export default async function EntityCodesPage(props: {
       const code = `${categoryCode}${index}`;
       const distillerName = SMWS_DISTILLERY_CODES[code];
       if (distillerName === undefined) break;
-      const distiller = distillerName
-        ? distillersByName[distillerName.toLowerCase()]
-        : null;
+      const distiller = distillersByCode[code] ?? null;
 
       rows.push({
         code,

--- a/packages/bottle-classifier/src/smws.test.ts
+++ b/packages/bottle-classifier/src/smws.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import {
+  SMWS_CATEGORY_LIST,
   SMWS_DISTILLERY_CODES,
   composeExactCaskCodeFromComponents,
   getCategoryFromCask,
@@ -43,11 +44,35 @@ describe("smws", () => {
       B1: "Heaven Hill Distillery",
       B2: "Heaven Hill Bernheim Distillery",
       B3: "Rock Town Distillery",
+      B9: "Wilderness Trail Distillery",
+      G17: "Starlaw",
+      169: "InchDairnie Distillery",
       RW4: "Kentucky Peerless Distilling Co.",
+      RW8: "Catoctin Creek",
+      RW9: "Wilderness Trail Distillery",
       CW1: "Heaven Hill Distillery",
       CW2: "Balcones Distilling",
+      A9: "Domaine de Saurine",
       GN7: "Cotswolds Distillery",
     });
+  });
+
+  test("lists every code in a renderable category sequence", () => {
+    const listedCodes = SMWS_CATEGORY_LIST.flatMap(([prefix]) => {
+      const codes = [];
+
+      for (let index = 1; index < 1000; index += 1) {
+        const code = `${prefix}${index}`;
+        if (SMWS_DISTILLERY_CODES[code] === undefined) break;
+        codes.push(code);
+      }
+
+      return codes;
+    });
+
+    expect(listedCodes.sort()).toEqual(
+      Object.keys(SMWS_DISTILLERY_CODES).sort(),
+    );
   });
 
   test("parses SMWS reference titles into code identity and selector", () => {

--- a/packages/bottle-classifier/src/smws.ts
+++ b/packages/bottle-classifier/src/smws.ts
@@ -11,6 +11,8 @@ interface SmwsDistilleryCodes {
 // backed by a cited source and tests until this moves into an editable database.
 // SMWS code format: https://unfiltered.smws.com/uk/welcome-magazine/smws-101.html
 // Source: https://www.whiskysaga.com/smws-codes
+// Current inventory: Cask Code, 2026-08-28, CC BY 4.0
+// https://caskcode.co.uk/data/smws-codes.json
 export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   // Single Malt
   1: "Glenfarclas",
@@ -180,7 +182,12 @@ export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   165: "Wolfburn", // peated
   166: "Torabhaig",
   167: "The Clydeside Distillery",
-  168: "InchDairnie Distillery", // KinGlassie
+  168: "InchDairnie Distillery",
+  // Peated InchDairnie spirit. Corroborated by two current code indexes:
+  // https://www.whiskygoodness.com/smws/169
+  // https://whisky-taru-blog.com/%e3%80%90smws%e3%80%91%e3%82%b9%e3%82%b3%e3%83%83%e3%83%81%e3%83%a2%e3%83%ab%e3%83%88%e3%82%a6%e3%82%b9%e3%82%ad%e3%83%bc%e3%82%bd%e3%82%b5%e3%82%a8%e3%83%86%e3%82%a3%ef%bd%9c%e8%92%b8/
+  // InchDairnie's peated malt: https://www.inchdairniedistillery.com/product/kinglassie/
+  169: "InchDairnie Distillery",
 
   // Single Grain
   G1: "North British",
@@ -199,6 +206,7 @@ export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   G14: "Dumbarton",
   G15: "Loch Lomond", // Rhosdhu
   G16: "Glasgow Distillery",
+  G17: "Starlaw",
 
   // Bourbon
   B1: "Heaven Hill Distillery",
@@ -209,6 +217,7 @@ export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   B6: "Finger Lakes Distilling",
   B7: "Ross & Squibb",
   B8: "Woodinville Whiskey Co.",
+  B9: "Wilderness Trail Distillery",
 
   // Rye
   RW1: "FEW Spirits",
@@ -218,6 +227,8 @@ export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   RW5: "Lux Row Distillers",
   RW6: "Kyrö",
   RW7: "Journeyman",
+  RW8: "Catoctin Creek",
+  RW9: "Wilderness Trail Distillery",
 
   // Corn
   CW1: "Heaven Hill Distillery",
@@ -248,6 +259,7 @@ export const SMWS_DISTILLERY_CODES: SmwsDistilleryCodes = {
   A6: "Domaine Lasalle",
   A7: "Domaine Lasalle",
   A8: "Domaine de Cavaillon",
+  A9: "Domaine de Saurine",
 
   // Cognac
   C1: "Camus",
@@ -275,7 +287,7 @@ export const SMWS_CATEGORY_LIST = [
   ["G", "Single Grain Whisky"],
   ["B", "Bourbon"],
   ["RW", "Rye"],
-  ["CW1", "Corn Whisky"],
+  ["CW", "Corn Whisky"],
   ["R", "Rum"],
   ["GN", "Gin"],
   ["C", "Cognac"],


### PR DESCRIPTION
The SMWS codes page now links distilleries by codes resolved on the server, including entities matched through references. It also refreshes the inventory to 245 codes and fixes the Corn Whisky category prefix so CW1 and CW2 render.

The distiller-list API now exposes every SMWS code for each entity, including multiple codes for one distillery such as InchDairnie. Regression coverage verifies canonical, reference-only, and multi-code matches, and ensures every known code belongs to a sequence the page can render. Codes without a catalog entity still render as plain text; this PR does not change catalog records.
