### PR TITLE
style(home): show bottle identity in critic reviews

### DIFF
--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -215,6 +215,7 @@ function RecentReviews() {
       ? [
           {
             bottleHref: `/bottles/${review.bottle.id}`,
+            bottleImageUrl: review.bottle.imageUrl,
             bottleName: formatBottleDisplayName(review.bottle),
             date: (
               <TimeSince

--- a/apps/web/src/components/pages/homeBrowse.stories.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
+import BottleImage from "../../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import { HomeRecentReviews } from "./homeBrowse.stylex";
 
@@ -23,6 +24,7 @@ export const RecentReviews: Story = {
     reviews: [
       {
         bottleHref: "/bottles/47529",
+        bottleImageUrl: BottleImage.src,
         bottleName: "Milroy's of Soho Tun 89 Teaspooned Malt",
         date: "2 days ago",
         id: "47529",

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -160,6 +160,7 @@ export function HomeLatestReleases({
 
 export type HomeReview = {
   bottleHref: string;
+  bottleImageUrl?: string | null;
   bottleName: string;
   date: ReactNode;
   id: string;
@@ -181,21 +182,24 @@ export function HomeRecentReviews({
       <div {...stylex.props(styles.rows)}>
         <ItemList ariaLabel="From the critics">
           {reviews.map((review) => (
-            <ItemRow
-              end={
-                <span {...stylex.props(styles.reviewFacts)}>
-                  {review.rating !== null && review.rating !== undefined ? (
-                    <strong {...stylex.props(styles.reviewRating)}>
-                      {review.rating}
-                    </strong>
-                  ) : null}
-                  <span {...stylex.props(styles.rowDate)}>{review.date}</span>
-                </span>
-              }
-              href={review.bottleHref}
-              key={review.id}
-              metadata={
-                <>
+            <ItemListItem key={review.id}>
+              <BottleIdentityRow
+                align="start"
+                end={
+                  <span {...stylex.props(styles.reviewFacts)}>
+                    {review.rating !== null && review.rating !== undefined ? (
+                      <strong {...stylex.props(styles.reviewRating)}>
+                        {review.rating}
+                      </strong>
+                    ) : null}
+                    <span {...stylex.props(styles.rowDate)}>{review.date}</span>
+                  </span>
+                }
+                href={review.bottleHref}
+                imageUrl={review.bottleImageUrl}
+                metadata={review.metadata}
+                name={review.bottleName}
+                subtitle={
                   <TextLink
                     href={review.sourceHref}
                     rel="noreferrer"
@@ -204,16 +208,9 @@ export function HomeRecentReviews({
                   >
                     {review.source}
                   </TextLink>
-                  {review.metadata.map((item) => (
-                    <span key={item}>
-                      <span aria-hidden="true"> · </span>
-                      {item}
-                    </span>
-                  ))}
-                </>
-              }
-              title={review.bottleName}
-            />
+                }
+              />
+            </ItemListItem>
           ))}
         </ItemList>
       </div>


### PR DESCRIPTION
The homepage’s “From the critics” rows now use the shared bottle identity presentation: bottle image or fallback icon, bottle name, critic source, and release facts. Scores and dates remain at the end of each row, and the critic source remains an independent external link.

This makes critic reviews consistent with the other bottle lists on the homepage. The component story now includes a real bottle image so reviewers can inspect the complete row at desktop and mobile widths.
