### PR TITLE
test(web): prove Frameshift visual reporting

### DIFF
--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -83,7 +83,7 @@ export function PublicHome() {
           </PageColumns>
         </>
       }
-      description="Browse whisky bottles, including single casks, with critic scores and tasting notes. No account needed."
+      description="Frameshift test transmission: the visual-diff pipeline is awake."
       search={
         <Search
           onSubmit={(query) =>


### PR DESCRIPTION
This disposable PR changes one visible sentence on the public home page. Do not merge it.

It exists only to prove that Peated selects the home-page scenario, Frameshift finds the desktop and mobile changes, and the default-branch publisher adds a native status plus a hosted report link.
