### PR TITLE
fix(web): target Frameshift status at PR commit

### DIFF
--- a/.github/workflows/web-visual-comment.yml
+++ b/.github/workflows/web-visual-comment.yml
@@ -88,8 +88,8 @@ jobs:
           steps.download.outcome == 'success'
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}
-          GITHUB_SHA: ${{ github.event.workflow_run.head_sha }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
           PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
           set -euo pipefail

--- a/apps/web/visual/post-pr-comment.mjs
+++ b/apps/web/visual/post-pr-comment.mjs
@@ -339,7 +339,8 @@ function main() {
 
   const prNumber = requiredEnv("PR_NUMBER");
   const repo = requiredEnv("GITHUB_REPOSITORY");
-  const commitSha = process.env.GITHUB_SHA ?? "unknown";
+  // GitHub does not let workflows override reserved GITHUB_* variables.
+  const commitSha = requiredEnv("PR_HEAD_SHA");
   const branch = `web-screenshots/pr-${prNumber}`;
   const imageRef = publishImages(reportDir, result.report, branch, commitSha);
   const viewerUrl = frameshiftViewerUrl(repo, imageRef);


### PR DESCRIPTION
Frameshift statuses and archive tags now target the pull request head commit. GitHub reserves `GITHUB_SHA` for the default-branch `workflow_run` commit, so the publisher now receives the validated pull request SHA through an explicit `PR_HEAD_SHA` boundary.

The hosted report and screenshot comment already used the correct artifact. This fixes the native status placement and makes the archive tag name identify the pull request revision.
