### PR TITLE
perf(server)!: reduce serializer query load

### DIFF
--- a/apps/server/src/orpc/routes/bottleSeries/create.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/create.test.ts
@@ -24,10 +24,6 @@ describe("POST /bottle-series", () => {
     expect(result).toMatchObject({
       name: data.name,
       description: data.description,
-      brand: {
-        id: brand.id,
-        name: brand.name,
-      },
       numReleases: 0,
     });
 

--- a/apps/server/src/orpc/routes/bottleSeries/details.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/details.test.ts
@@ -21,11 +21,8 @@ describe("GET /bottle-series/:series", () => {
       fullName: series.fullName,
       description: series.description,
       numReleases: series.numReleases,
-      brand: expect.objectContaining({
-        id: brand.id,
-        name: brand.name,
-      }),
     });
+    expect(result).not.toHaveProperty("brand");
   });
 
   it("returns 404 for non-existent series", async function () {

--- a/apps/server/src/orpc/routes/bottleSeries/list.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/list.test.ts
@@ -36,19 +36,11 @@ describe("GET /bottle-series", () => {
           id: series1.id,
           name: series1.name,
           description: series1.description,
-          brand: expect.objectContaining({
-            id: brand.id,
-            name: brand.name,
-          }),
         }),
         expect.objectContaining({
           id: series2.id,
           name: series2.name,
           description: series2.description,
-          brand: expect.objectContaining({
-            id: brand.id,
-            name: brand.name,
-          }),
         }),
       ]),
     );
@@ -77,10 +69,6 @@ describe("GET /bottle-series", () => {
       id: series1.id,
       name: series1.name,
       description: series1.description,
-      brand: expect.objectContaining({
-        id: brand.id,
-        name: brand.name,
-      }),
     });
   });
 

--- a/apps/server/src/orpc/routes/bottleSeries/update.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/update.test.ts
@@ -51,10 +51,6 @@ describe("PATCH /bottle-series/:series", () => {
       id: series.id,
       name: data.name,
       description: data.description,
-      brand: expect.objectContaining({
-        id: brand.id,
-        name: brand.name,
-      }),
     });
 
     // Verify changes were recorded
@@ -131,10 +127,6 @@ describe("PATCH /bottle-series/:series", () => {
       id: series.id,
       name: "Updated Series",
       description: "The original description", // Description should remain unchanged
-      brand: expect.objectContaining({
-        id: brand.id,
-        name: brand.name,
-      }),
     });
 
     // Verify changes were recorded

--- a/apps/server/src/schemas/bottleSeries.ts
+++ b/apps/server/src/schemas/bottleSeries.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { EntitySchema } from "./entities";
 
 const BottleSeriesNameSchema = z
   .string()
@@ -14,7 +13,6 @@ const BottleSeriesDescriptionSchema = z
 export const BottleSeriesSchema = z.object({
   id: z.number().readonly().describe("Unique identifier for the bottle series"),
   name: BottleSeriesNameSchema,
-  brand: EntitySchema.describe("The brand that produces this series"),
   fullName: z
     .string()
     .describe("Full name of the series (brand name + series name)")

--- a/apps/server/src/serializers/bottle.test.ts
+++ b/apps/server/src/serializers/bottle.test.ts
@@ -240,10 +240,6 @@ describe("BottleSerializer", () => {
         id: series.id,
         name: series.name,
         description: series.description,
-        brand: expect.objectContaining({
-          id: brand.id,
-          name: brand.name,
-        }),
       }),
     });
 

--- a/apps/server/src/serializers/bottleSeries.ts
+++ b/apps/server/src/serializers/bottleSeries.ts
@@ -1,61 +1,15 @@
-import { inArray } from "drizzle-orm";
 import { type z } from "zod";
-import { serialize, serializer } from ".";
-import { db } from "../db";
-import type { BottleSeries, User } from "../db/schema";
-import { entities } from "../db/schema";
-import { notEmpty } from "../lib/filter";
+import { serializer } from ".";
+import type { BottleSeries } from "../db/schema";
 import { type BottleSeriesSchema } from "../schemas/bottleSeries";
-import { EntitySerializer } from "./entity";
-
-type Attrs = {
-  brand: ReturnType<(typeof EntitySerializer)["item"]>;
-};
 
 export const BottleSeriesSerializer = serializer({
   name: "bottleSeries",
-  attrs: async (
-    itemList: BottleSeries[],
-    currentUser?: User,
-  ): Promise<Record<number, Attrs>> => {
-    const brandIds = Array.from(new Set(itemList.map((i) => i.brandId))).filter(
-      notEmpty,
-    );
-
-    const brandList = await db
-      .select()
-      .from(entities)
-      .where(inArray(entities.id, brandIds));
-
-    const entitiesById = Object.fromEntries(
-      (await serialize(EntitySerializer, brandList, currentUser)).map(
-        (data, index) => [brandList[index].id, data],
-      ),
-    );
-
-    const results: Record<number, Attrs> = {};
-    itemList.forEach((item) => {
-      const brand = entitiesById[item.brandId];
-      if (!brand) return;
-
-      results[item.id] = {
-        brand,
-      };
-    });
-
-    return results;
-  },
-
-  item(
-    item: BottleSeries,
-    attrs: Attrs,
-    currentUser?: User,
-  ): z.infer<typeof BottleSeriesSchema> {
+  item(item: BottleSeries): z.infer<typeof BottleSeriesSchema> {
     return {
       id: item.id,
       name: item.name,
       fullName: item.fullName,
-      brand: attrs.brand,
       description: item.description,
       numReleases: item.numReleases,
       createdAt: item.createdAt.toISOString(),

--- a/apps/server/src/serializers/entity.ts
+++ b/apps/server/src/serializers/entity.ts
@@ -26,11 +26,21 @@ interface EntityAttrs {
 export const EntitySerializer = serializer({
   name: "entity",
   attrs: async (itemList: Entity[], currentUser?: User) => {
-    const itemIds = itemList.map((item) => item.id);
-    const followedEntityIds = new Set(
-      currentUser && itemIds.length
-        ? (
-            await db
+    const itemIds = [...new Set(itemList.map((item) => item.id))];
+    const countryIds = [
+      ...new Set(itemList.map((item) => item.countryId).filter(notEmpty)),
+    ];
+    const regionIds = [
+      ...new Set(itemList.map((item) => item.regionId).filter(notEmpty)),
+    ];
+    const ownerIds = [
+      ...new Set(itemList.map((item) => item.ownerId).filter(notEmpty)),
+    ];
+
+    const [followedEntityList, countryList, regionList, ownerList] =
+      await Promise.all([
+        currentUser && itemIds.length
+          ? db
               .select({ entityId: entityFollows.entityId })
               .from(entityFollows)
               .where(
@@ -39,16 +49,24 @@ export const EntitySerializer = serializer({
                   inArray(entityFollows.entityId, itemIds),
                 ),
               )
-          ).map(({ entityId }) => entityId)
-        : [],
+          : [],
+        countryIds.length
+          ? db.select().from(countries).where(inArray(countries.id, countryIds))
+          : [],
+        regionIds.length
+          ? db.select().from(regions).where(inArray(regions.id, regionIds))
+          : [],
+        ownerIds.length
+          ? db
+              .select({ id: entities.id, name: entities.name })
+              .from(entities)
+              .where(inArray(entities.id, ownerIds))
+          : [],
+      ]);
+
+    const followedEntityIds = new Set(
+      followedEntityList.map(({ entityId }) => entityId),
     );
-    const countryIds = itemList.map((i) => i.countryId).filter(notEmpty);
-    const countryList = countryIds.length
-      ? await db
-          .select()
-          .from(countries)
-          .where(inArray(countries.id, countryIds))
-      : [];
 
     const countriesById = countryList.length
       ? Object.fromEntries(
@@ -58,11 +76,6 @@ export const EntitySerializer = serializer({
         )
       : {};
 
-    const regionIds = itemList.map((i) => i.regionId).filter(notEmpty);
-    const regionList = regionIds.length
-      ? await db.select().from(regions).where(inArray(regions.id, regionIds))
-      : [];
-
     const regionsById = regionList.length
       ? Object.fromEntries(
           (await serialize(RegionSerializer, regionList, currentUser)).map(
@@ -71,13 +84,6 @@ export const EntitySerializer = serializer({
         )
       : {};
 
-    const ownerIds = itemList.map((item) => item.ownerId).filter(notEmpty);
-    const ownerList = ownerIds.length
-      ? await db
-          .select({ id: entities.id, name: entities.name })
-          .from(entities)
-          .where(inArray(entities.id, ownerIds))
-      : [];
     const ownersById = Object.fromEntries(
       ownerList.map((owner) => [
         owner.id,


### PR DESCRIPTION
Entity serialization now starts its existing bulk lookups for follows, countries, regions, and owners concurrently instead of waiting for each query in sequence. It also deduplicates relation IDs before querying. Entity response behavior remains unchanged.

Bottle Series responses no longer include a full `brand` Entity. Peated's UI does not consume that field, and Bottle responses already expose the same Entity as `bottle.brand`. Removing it makes Bottle Series serialization query-free, including when it is nested under a Bottle.

This changes the output contract for Bottle Series routes and `bottle.series`. Clients that read `series.brand` must use the containing Bottle's `brand` when available. Bottle Series inputs and brand filtering are unchanged.
