### PR TITLE
perf(web): prioritize primary page content

### DIFF
--- a/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
@@ -15,7 +15,7 @@ function formatCount(value: number, noun: string) {
   return `${value.toLocaleString("en-US")} ${noun}`;
 }
 
-/** Renders the server-supplied platform snapshot without owning data access. */
+/** Renders platform coverage when the secondary stats query is available. */
 export function ApplicationFooter({ stats }: { stats?: Outputs["stats"] }) {
   const coverage = stats
     ? [

--- a/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import type { Outputs } from "@peated/server/orpc/router";
+import { useQuery } from "@tanstack/react-query";
 import { CircleUserRound } from "lucide-react";
 import { usePathname } from "next/navigation";
-import type { ReactNode } from "react";
+import { useTransition, type ReactNode } from "react";
 
 import {
   ApplicationHeader,
@@ -14,7 +14,8 @@ import { PageFrame } from "@peated/web/components/pages/pageLayout.stylex";
 import { Search } from "@peated/web/components/search/search.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
 import { logout } from "@peated/web/lib/auth.actions";
-import { useTransition } from "react";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { publicHomeQueries } from "@peated/web/lib/orpc/homeQueries";
 import { ApplicationFooter } from "./applicationFooter.stylex";
 
 const databaseItems = [
@@ -41,15 +42,11 @@ function AccountVisual({
   return <CircleUserRound aria-hidden="true" size={19} />;
 }
 
-export function ApplicationLayout({
-  children,
-  initialStats,
-}: {
-  children: ReactNode;
-  initialStats?: Outputs["stats"];
-}) {
+export function ApplicationLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const { user } = useAuth();
+  const orpc = useORPC();
+  const stats = useQuery(publicHomeQueries.stats(orpc));
   const [logoutPending, startLogout] = useTransition();
   const isHome = pathname === "/";
   const usesInlineNavigation = isHome || pathname === "/search";
@@ -78,7 +75,7 @@ export function ApplicationLayout({
 
   return (
     <PageFrame
-      footer={<ApplicationFooter stats={initialStats} />}
+      footer={<ApplicationFooter stats={stats.data} />}
       header={
         <ApplicationHeader
           account={

--- a/apps/web/src/app/(app)/bottles/[bottleId]/loading.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingList } from "@peated/web/components";
+
+export default function BottleLoading() {
+  return <LoadingList label="Loading bottle details" rows={4} />;
+}

--- a/apps/web/src/app/(app)/bottles/[bottleId]/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/page.tsx
@@ -1,5 +1,4 @@
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
-import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 import { parseReleaseFamilyRouteId } from "@peated/web/lib/releaseFamily";
 import { getBottleSeoMetadata } from "@peated/web/lib/seoMetadata";
 import type { Metadata } from "next";
@@ -14,41 +13,6 @@ export async function generateMetadata(props: {
   return getBottleSeoMetadata(bottle, { canonical: true });
 }
 
-export default async function BottlePage(props: {
-  params: Promise<{ bottleId: string }>;
-}) {
-  const { bottleId } = await props.params;
-  const canonicalBottle = await getBottlePage(
-    parseReleaseFamilyRouteId(bottleId),
-  );
-  const { client } = await getAnonymousServerClient();
-  const secondaryData = await Promise.allSettled([
-    client.externalReviews.list({
-      bottle: canonicalBottle.id,
-      limit: 3,
-      sort: "recent",
-    }),
-    client.tastings.list({ bottle: canonicalBottle.id, limit: 3 }),
-    client.bottles.recommendations({
-      bottle: canonicalBottle.id,
-      limit: 3,
-    }),
-  ]);
-  const [reviews, tastings, recommendations] = secondaryData;
-
-  return (
-    <BottleOverviewClient
-      initialRecommendations={
-        recommendations.status === "fulfilled"
-          ? recommendations.value
-          : undefined
-      }
-      initialReviews={
-        reviews.status === "fulfilled" ? reviews.value : undefined
-      }
-      initialTastings={
-        tastings.status === "fulfilled" ? tastings.value : undefined
-      }
-    />
-  );
+export default function BottlePage() {
+  return <BottleOverviewClient />;
 }

--- a/apps/web/src/app/(app)/entities/[entityId]/loading.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/loading.tsx
@@ -1,0 +1,5 @@
+import { EntityTabLoading } from "./entityTabLoading.stylex";
+
+export default function EntityOverviewLoading() {
+  return <EntityTabLoading label="Loading entity overview" />;
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/page.tsx
@@ -20,43 +20,16 @@ export default async function EntityPage(props: {
   const { entityId } = await props.params;
   const { client } = await getAnonymousServerClient();
   const entity = await getEntityPage(Number(entityId));
-  const ownsBottleSections = entityHasBottleCatalog(entity);
-  const [bottleList, releaseList, siblingList, catalog, eventList] =
-    await Promise.all([
-      ownsBottleSections
-        ? client.bottles
-            .list({ entity: entity.id, limit: 4, sort: "-tastings" })
-            .catch(() => undefined)
-        : undefined,
-      ownsBottleSections
-        ? client.bottles
-            .list({ entity: entity.id, limit: 4, sort: "-release" })
-            .catch(() => undefined)
-        : undefined,
-      entity.ownerId
-        ? client.entities
-            .list({
-              kinds: ["distillery", "bottler"],
-              limit: 5,
-              owner: entity.ownerId,
-              sort: "-bottles",
-            })
-            .catch(() => undefined)
-        : undefined,
-      ownsBottleSections
-        ? client.entities.catalog({ entity: entity.id }).catch(() => undefined)
-        : undefined,
-      client.entities.events.list({ entity: entity.id }).catch(() => undefined),
-    ]);
+  const bottleList = entityHasBottleCatalog(entity)
+    ? await client.bottles
+        .list({ entity: entity.id, limit: 4, sort: "-tastings" })
+        .catch(() => undefined)
+    : undefined;
 
   return (
     <EntityOverviewClient
       initialBottleList={bottleList}
-      initialCatalog={catalog}
       initialEntity={entity}
-      initialEventList={eventList}
-      initialReleaseList={releaseList}
-      initialSiblingList={siblingList}
     />
   );
 }

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -1,13 +1,10 @@
-import { getPublicStats } from "@peated/web/lib/publicStats.server";
 import type { ReactNode } from "react";
 import { ApplicationLayout } from "./_components/applicationLayout.stylex";
 
-export default async function ApplicationRouteLayout({
+export default function ApplicationRouteLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  const stats = await getPublicStats().catch(() => undefined);
-
-  return <ApplicationLayout initialStats={stats}>{children}</ApplicationLayout>;
+  return <ApplicationLayout>{children}</ApplicationLayout>;
 }

--- a/apps/web/src/app/(app)/loading.tsx
+++ b/apps/web/src/app/(app)/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingList } from "@peated/web/components";
+
+export default function ApplicationLoading() {
+  return <LoadingList label="Loading page" rows={4} />;
+}

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -31,10 +31,6 @@ export default async function Page() {
       queryFn: getPublicStats,
     }),
     queryClient.prefetchQuery(publicHomeQueries.recentReviews(orpc)),
-    queryClient.prefetchQuery(publicHomeQueries.regions(orpc)),
-    queryClient.prefetchQuery(publicHomeQueries.countries(orpc)),
-    queryClient.prefetchQuery(publicHomeQueries.distilleries(orpc)),
-    queryClient.prefetchQuery(publicHomeQueries.recentBottles(orpc)),
     queryClient.prefetchQuery(publicHomeQueries.releases(orpc)),
     ...(session.user
       ? [queryClient.prefetchQuery(memberHomeQueries.followedReleases(orpc))]

--- a/apps/web/src/app/(app)/search/page.tsx
+++ b/apps/web/src/app/(app)/search/page.tsx
@@ -1,4 +1,5 @@
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getSession } from "@peated/web/lib/session.server";
 import type { Metadata } from "next";
 
 import { SearchPageClient } from "./searchPageClient.stylex";
@@ -8,9 +9,82 @@ export const metadata: Metadata = {
   description: "Search the Peated whisky database.",
 };
 
-export default async function SearchPage() {
-  const { client } = await getPublicPageServerClient();
-  const stats = await client.stats();
+const apiScopes = [
+  "bottles",
+  "distilleries",
+  "brands",
+  "bottlers",
+  "companies",
+  "regions",
+  "members",
+] as const;
 
-  return <SearchPageClient bottleTotal={stats.bottles} />;
+const databasePageScopes = [
+  "all",
+  "bottles",
+  "distilleries",
+  "brands",
+  "bottlers",
+  "members",
+] as const;
+
+const bottleSelectionIntents = [
+  "addBottle",
+  "catalog",
+  "choose",
+  "library",
+  "tasting",
+  "view",
+] as const;
+
+function getValue(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+export default async function SearchPage(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [searchParams, session, { client }] = await Promise.all([
+    props.searchParams,
+    getSession(),
+    getPublicPageServerClient(),
+  ]);
+  const query = getValue(searchParams.q)?.trim() ?? "";
+  const type = getValue(searchParams.type);
+  const intent = getValue(searchParams.intent);
+  const memberSearch = type === "users";
+  const bottleSelection =
+    bottleSelectionIntents.some((value) => value === intent) ||
+    searchParams.tasting !== undefined;
+  const databaseSearch = !memberSearch && !bottleSelection;
+  const requestedScope = memberSearch
+    ? "members"
+    : bottleSelection
+      ? "bottles"
+      : (databasePageScopes.find((scope) => scope === type) ?? "all");
+  const selectedScope =
+    databaseSearch && requestedScope === "members" && !session.user
+      ? "all"
+      : requestedScope;
+  const searchScopes = databaseSearch
+    ? apiScopes.filter((scope) => Boolean(session.user) || scope !== "members")
+    : memberSearch
+      ? (["members"] as const)
+      : (["bottles"] as const);
+  const searchLimit = databaseSearch && selectedScope === "all" ? 5 : 50;
+  const [stats, initialResponse] = await Promise.all([
+    client.stats(),
+    query
+      ? client
+          .search({ limit: searchLimit, query, scopes: [...searchScopes] })
+          .catch(() => undefined)
+      : undefined,
+  ]);
+
+  return (
+    <SearchPageClient
+      bottleTotal={stats.bottles}
+      initialResponse={initialResponse}
+    />
+  );
 }

--- a/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback } from "react";
@@ -92,7 +93,13 @@ function getTitle({
   return "Search";
 }
 
-export function SearchPageClient({ bottleTotal }: { bottleTotal: number }) {
+export function SearchPageClient({
+  bottleTotal,
+  initialResponse,
+}: {
+  bottleTotal: number;
+  initialResponse?: Outputs["search"];
+}) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const query = searchParams.get("q") ?? "";
@@ -182,7 +189,9 @@ export function SearchPageClient({ bottleTotal }: { bottleTotal: number }) {
           getBottleHref={getBottleHref}
           getContributionHref={getContributionHref}
           initialQuery={query}
+          initialResponse={initialResponse}
           initialScope={initialScope}
+          key={`${query}:${initialScope}`}
           limit={databaseSearch ? 5 : 50}
           onScopeChange={databaseSearch ? updateScope : undefined}
           onSubmit={submitSearch}

--- a/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/page.tsx
@@ -40,18 +40,13 @@ export default async function TastingPage(props: {
   params: Promise<{ tastingId: string }>;
 }) {
   const { tastingId } = await props.params;
-  const { client } = await getPublicPageServerClient();
   const tasting = await getTasting(Number(tastingId));
-  const commentList = await client.comments.list({ tasting: tasting.id });
   return (
     <div>
       <TastingDetail tasting={tasting} />
       <div id="comments">
         <PageSection heading="Conversation">
-          <TastingComments
-            initialCommentList={commentList}
-            tastingId={tasting.id}
-          />
+          <TastingComments tastingId={tasting.id} />
         </PageSection>
       </div>
     </div>

--- a/apps/web/src/app/(app)/tastings/[tastingId]/tastingComments.stylex.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/tastingComments.stylex.tsx
@@ -12,6 +12,7 @@ import {
   Field,
   ItemList,
   ItemRow,
+  LoadingList,
   MemberAvatar,
   RowMenu,
   SectionError,
@@ -29,7 +30,7 @@ export function TastingComments({
   initialCommentList,
   tastingId,
 }: {
-  initialCommentList: CommentList;
+  initialCommentList?: CommentList;
   tastingId: number;
 }) {
   const orpc = useORPC();
@@ -117,7 +118,9 @@ export function TastingComments({
         </ButtonLink>
       )}
 
-      {comments.length ? (
+      {commentList.isPending ? (
+        <LoadingList label="Loading tasting comments" rows={3} />
+      ) : comments.length ? (
         <ItemList ariaLabel="Tasting comments">
           {comments.map((item) => {
             const canDelete = Boolean(

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -90,6 +90,7 @@ export type SearchProps = {
   getBottleHref?: (bottleId: number) => string;
   getContributionHref?: (query: string) => string;
   initialQuery?: string;
+  initialResponse?: SearchResponse;
   initialScope?: SearchScope;
   limit?: number;
   onScopeChange?: (scope: SearchScope, query: string) => void;
@@ -357,6 +358,33 @@ function getResultScopeTotals(response: SearchResponse) {
   } satisfies Record<SearchScope, number>;
 }
 
+function getSearchSnapshot(
+  response: SearchResponse,
+  query: string,
+  scope: SearchScope,
+  bottleOptions: BottleItemOptions,
+  showMoreLinks: boolean,
+): SearchSnapshot {
+  const count = getResultCount(response, scope);
+  return {
+    count,
+    emptyText:
+      count > 0
+        ? undefined
+        : response.nearest.length
+          ? `No exact matches for “${query}”.`
+          : `Nothing matches “${query}”.`,
+    groups: resultGroups(response, query, bottleOptions, showMoreLinks, scope),
+    hasExact: Boolean(
+      response.exact && exactMatchesScope(response.exact, scope),
+    ),
+    query,
+    scope,
+    scopeCounts: getResultScopeTotals(response),
+    scopeTotals: response.scopeTotals,
+  };
+}
+
 function exactItem(exact: SearchExact, bottleOptions: BottleItemOptions) {
   return exact.type === "bottle"
     ? bottleItem(exact.ref, bottleOptions)
@@ -399,6 +427,7 @@ export function Search({
   getBottleHref = getDefaultBottleHref,
   getContributionHref = getDefaultContributionHref,
   initialQuery = "",
+  initialResponse,
   initialScope = "all",
   limit = 3,
   onScopeChange,
@@ -412,22 +441,39 @@ export function Search({
   const { user } = useAuth();
   const orpc = useORPC();
   const router = useRouter();
-  const [query, setQuery] = useState(initialQuery);
-  const [recentSearches, setRecentSearches] = useState<string[]>([]);
-  const [scope, setScope] = useState<SearchScope>(initialScope);
-  const [snapshot, setSnapshot] = useState<SearchSnapshot>();
-  const [status, setStatus] = useState<"error" | "ready" | "searching">(
-    initialQuery.trim() ? "searching" : "ready",
-  );
-  const latestRequest = useRef(0);
-  const initialSearchStarted = useRef(false);
-  const previousInitialQuery = useRef(initialQuery);
-  const previousInitialScope = useRef(initialScope);
   const availableScopeDefinitions = scopeValues
     ? searchScopes.filter((option) => scopeValues.includes(option.value))
     : user
       ? searchScopes
       : searchScopes.filter((option) => option.value !== "members");
+  const resolvedInitialScope = availableScopeDefinitions.some(
+    (option) => option.value === initialScope,
+  )
+    ? initialScope
+    : (availableScopeDefinitions[0]?.value ?? "all");
+  const initialSnapshot =
+    initialResponse && initialResponse.query === initialQuery.trim()
+      ? getSearchSnapshot(
+          initialResponse,
+          initialQuery.trim(),
+          resolvedInitialScope,
+          { getBottleHref, showRatings: showBottleRatings },
+          placement === "database" || placement === "overlay",
+        )
+      : undefined;
+  const [query, setQuery] = useState(initialQuery);
+  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const [scope, setScope] = useState<SearchScope>(initialScope);
+  const [snapshot, setSnapshot] = useState<SearchSnapshot | undefined>(
+    initialSnapshot,
+  );
+  const [status, setStatus] = useState<"error" | "ready" | "searching">(
+    initialQuery.trim() && !initialSnapshot ? "searching" : "ready",
+  );
+  const latestRequest = useRef(0);
+  const initialSearchStarted = useRef(Boolean(initialSnapshot));
+  const previousInitialQuery = useRef(initialQuery);
+  const previousInitialScope = useRef(initialScope);
   const effectiveScope = availableScopeDefinitions.some(
     (option) => option.value === scope,
   )
@@ -477,31 +523,15 @@ export function Search({
           indicatorFloor,
         ]);
         if (latestRequest.current !== requestId) return;
-        const nextGroups = resultGroups(
-          response,
-          trimmedQuery,
-          { getBottleHref, showRatings: showBottleRatings },
-          placement === "database" || placement === "overlay",
-          nextScope,
-        );
-        const nextResultCount = getResultCount(response, nextScope);
-        const hasMatches = nextResultCount > 0;
-        setSnapshot({
-          count: nextResultCount,
-          emptyText: hasMatches
-            ? undefined
-            : response.nearest.length
-              ? `No exact matches for “${trimmedQuery}”.`
-              : `Nothing matches “${trimmedQuery}”.`,
-          groups: nextGroups,
-          hasExact: Boolean(
-            response.exact && exactMatchesScope(response.exact, nextScope),
+        setSnapshot(
+          getSearchSnapshot(
+            response,
+            trimmedQuery,
+            nextScope,
+            { getBottleHref, showRatings: showBottleRatings },
+            placement === "database" || placement === "overlay",
           ),
-          query: trimmedQuery,
-          scope: nextScope,
-          scopeCounts: getResultScopeTotals(response),
-          scopeTotals: response.scopeTotals,
-        });
+        );
         setStatus("ready");
       } catch {
         await indicatorFloor;


### PR DESCRIPTION
Primary page content no longer waits for unrelated secondary requests. Bottle and entity overviews render their core records first, tasting details no longer wait for comments, and scoped app, entity, and bottle loaders keep the surrounding interface visible during navigation.

Search URLs with a query now fetch their initial results on the server and initialize the client search state from that response. Footer statistics and secondary home sections also stop blocking the shared application layout and initial home response.

This change adds no shared Next.js data cache. Viewer state and user-driven reviews, tastings, and comments retain their existing query freshness. The tradeoff is that secondary overview lists are no longer part of the initial server payload; cached server rendering for safe public catalog data remains separate follow-up work.
