### PR TITLE
fix(web): contain image viewer thumbnails

### DIFF
--- a/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
@@ -20,10 +20,15 @@ export function EntityImageGallery({ entity }: { entity: Entity }) {
         <ImageViewer
           alt={primary.caption || `${entity.name} primary image`}
           caption={primary.caption}
-          imageProps={stylex.props(styles.primaryImage)}
           label={primary.caption || `${entity.name} primary image`}
           src={primary.imageUrl}
-        />
+        >
+          <img
+            alt={primary.caption || `${entity.name} primary image`}
+            src={primary.imageUrl}
+            {...stylex.props(styles.primaryImage)}
+          />
+        </ImageViewer>
         {primary.caption || primary.sourceUrl || primary.license ? (
           <figcaption {...stylex.props(styles.caption)}>
             {primary.caption ? <span>{primary.caption}</span> : null}
@@ -41,10 +46,15 @@ export function EntityImageGallery({ entity }: { entity: Entity }) {
               <ImageViewer
                 alt={image.caption || `${entity.name} image`}
                 caption={image.caption}
-                imageProps={stylex.props(styles.secondaryImage)}
                 label={image.caption || `${entity.name} image`}
                 src={image.imageUrl}
-              />
+              >
+                <img
+                  alt={image.caption || `${entity.name} image`}
+                  src={image.imageUrl}
+                  {...stylex.props(styles.secondaryImage)}
+                />
+              </ImageViewer>
               {image.caption || image.sourceUrl || image.license ? (
                 <figcaption {...stylex.props(styles.caption)}>
                   {image.caption ? <span>{image.caption}</span> : null}

--- a/apps/web/src/components/admin/moderation/moderationDetail.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationDetail.stylex.tsx
@@ -99,13 +99,9 @@ export function ModerationMedia({
     <div {...stylex.props(styles.media)}>
       {imageUrl ? (
         <div {...stylex.props(styles.imageFrame)}>
-          <ImageViewer
-            alt=""
-            fill
-            imageProps={stylex.props(styles.image)}
-            label="submitted image"
-            src={imageUrl}
-          />
+          <ImageViewer alt="" fill label="submitted image" src={imageUrl}>
+            <img alt="" src={imageUrl} {...stylex.props(styles.image)} />
+          </ImageViewer>
         </div>
       ) : null}
       <div {...stylex.props(styles.mediaCopy)}>{children}</div>

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -45,13 +45,9 @@ export function BottleVisual({
       )}
     >
       {imageUrl && expandable && label ? (
-        <ImageViewer
-          alt=""
-          fill
-          imageProps={stylex.props(styles.image)}
-          label={label}
-          src={imageUrl}
-        />
+        <ImageViewer alt="" fill label={label} src={imageUrl}>
+          <img alt="" src={imageUrl} {...stylex.props(styles.image)} />
+        </ImageViewer>
       ) : imageUrl ? (
         <img alt="" src={imageUrl} {...stylex.props(styles.image)} />
       ) : (

--- a/apps/web/src/components/bottleResolver/photoPreview.stylex.tsx
+++ b/apps/web/src/components/bottleResolver/photoPreview.stylex.tsx
@@ -38,13 +38,15 @@ export function PhotoPreview({
         <ImageViewer
           alt="Uploaded bottle label"
           fill
-          imageProps={stylex.props(
-            styles.image,
-            loading && styles.loadingImage,
-          )}
           label="uploaded bottle label"
           src={src}
-        />
+        >
+          <img
+            alt="Uploaded bottle label"
+            src={src}
+            {...stylex.props(styles.image, loading && styles.loadingImage)}
+          />
+        </ImageViewer>
         {loading ? (
           <span aria-hidden="true" {...stylex.props(styles.progress)}>
             <span {...stylex.props(styles.progressSweep)} />

--- a/apps/web/src/components/entityImageEditor.stylex.tsx
+++ b/apps/web/src/components/entityImageEditor.stylex.tsx
@@ -70,10 +70,15 @@ export function EntityImageEditor({
           <div key={image.key} {...stylex.props(styles.row)}>
             <ImageViewer
               alt={image.caption || "Image preview"}
-              imageProps={stylex.props(styles.preview)}
               label={image.caption || "image preview"}
               src={image.imageUrl}
-            />
+            >
+              <img
+                alt={image.caption || "Image preview"}
+                src={image.imageUrl}
+                {...stylex.props(styles.preview)}
+              />
+            </ImageViewer>
             <div {...stylex.props(styles.fields)}>
               <Field
                 htmlFor={`entity-image-caption-${image.key}`}

--- a/apps/web/src/components/imageField.stylex.tsx
+++ b/apps/web/src/components/imageField.stylex.tsx
@@ -135,12 +135,13 @@ const ImageField = forwardRef<HTMLInputElement, Props>(function ImageField(
         {...stylex.props(styles.frame, Boolean(preview) && styles.previewFrame)}
       >
         {preview ? (
-          <ImageViewer
-            alt="Image preview"
-            imageProps={stylex.props(styles.preview)}
-            label="image preview"
-            src={preview}
-          />
+          <ImageViewer alt="Image preview" label="image preview" src={preview}>
+            <img
+              alt="Image preview"
+              src={preview}
+              {...stylex.props(styles.preview)}
+            />
+          </ImageViewer>
         ) : (
           <ImagePlus
             aria-hidden="true"

--- a/apps/web/src/components/imageViewer.stories.tsx
+++ b/apps/web/src/components/imageViewer.stories.tsx
@@ -25,7 +25,13 @@ const meta = {
     alt: "A whisky bottle on a white background",
     label: "Whisky bottle",
     src: "/assets/auth-discovery-illustration.webp",
-    imageProps: stylex.props(styles.image),
+    children: (
+      <img
+        alt="A whisky bottle on a white background"
+        src="/assets/auth-discovery-illustration.webp"
+        {...stylex.props(styles.image)}
+      />
+    ),
   },
   decorators: [
     (Story) => (

--- a/apps/web/src/components/imageViewer.stylex.tsx
+++ b/apps/web/src/components/imageViewer.stylex.tsx
@@ -8,15 +8,15 @@ import {
 } from "@headlessui/react";
 import * as stylex from "@stylexjs/stylex";
 import { ExternalLink, Maximize2, X } from "lucide-react";
-import { useState, type ImgHTMLAttributes, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import { controlMetrics, effects, fonts, space } from "../styles/tokens.stylex";
 
 export type ImageViewerProps = {
   alt: string;
   caption?: ReactNode;
+  children: ReactNode;
   fill?: boolean;
-  imageProps?: Omit<ImgHTMLAttributes<HTMLImageElement>, "alt" | "src">;
   label: string;
   src: string;
 };
@@ -25,8 +25,8 @@ export type ImageViewerProps = {
 export function ImageViewer({
   alt,
   caption,
+  children,
   fill = false,
-  imageProps,
   label,
   src,
 }: ImageViewerProps) {
@@ -40,7 +40,7 @@ export function ImageViewer({
         type="button"
         {...stylex.props(styles.trigger, fill && styles.fillTrigger)}
       >
-        <img {...imageProps} alt={alt} src={src} />
+        {children}
         <span aria-hidden="true" {...stylex.props(styles.expandCue)}>
           <Maximize2 size={15} strokeWidth={1.75} />
         </span>
@@ -104,6 +104,8 @@ const styles = stylex.create({
   },
   fillTrigger: {
     height: "100%",
+    gridTemplateColumns: "minmax(0, 1fr)",
+    gridTemplateRows: "minmax(0, 1fr)",
   },
   expandCue: {
     position: "absolute",

--- a/apps/web/src/components/imageViewer.test.tsx
+++ b/apps/web/src/components/imageViewer.test.tsx
@@ -24,11 +24,9 @@ describe("ImageViewer", () => {
   it("opens the full image and closes it again", () => {
     act(() =>
       root.render(
-        <ImageViewer
-          alt="Bottle label"
-          label="bottle label"
-          src="/label.jpg"
-        />,
+        <ImageViewer alt="Bottle label" label="bottle label" src="/label.jpg">
+          <img alt="Bottle label" className="thumbnail" src="/label.jpg" />
+        </ImageViewer>,
       ),
     );
 
@@ -36,6 +34,7 @@ describe("ImageViewer", () => {
     expect(trigger?.getAttribute("aria-label")).toBe(
       "View bottle label at full size",
     );
+    expect(trigger?.querySelector("img")?.className).toBe("thumbnail");
 
     act(() => trigger?.click());
 


### PR DESCRIPTION
Image viewer thumbnails now retain their caller-owned StyleX rules instead of passing generated style props through the client component boundary, which left the rendered image unstyled. This fixes clipped or natural-size images in bottle headers, bottle-photo resolution, image fields, entity galleries and editors, and moderation previews.

Fill-mode viewers also constrain their grid tracks so a loaded image's intrinsic aspect ratio cannot expand beyond the thumbnail frame. The full-size dialog behavior is unchanged.
