### PR TITLE
feat(web): refine entity overview hierarchy

### DIFF
--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -117,6 +117,13 @@ export function EntityOverviewClient({
           {hasEntityDetails(entity) ? <EntityDetails entity={entity} /> : null}
         </div>
         <div {...stylex.props(styles.catalogSections)}>
+          <EntityReleaseOverview
+            entity={entity}
+            error={Boolean(releaseListQuery.error)}
+            pending={releaseListQuery.isPending}
+            releaseList={releaseListQuery.data}
+            retry={() => void releaseListQuery.refetch()}
+          />
           <EntityBottleOverview
             bottleList={bottleListQuery.data}
             createBottleHref={getEntityBottleCreateHref(entity)}
@@ -125,13 +132,6 @@ export function EntityOverviewClient({
             pending={bottleListQuery.isPending}
             retry={() => void bottleListQuery.refetch()}
             totalBottles={entity.totalBottles}
-          />
-          <EntityReleaseOverview
-            entity={entity}
-            error={Boolean(releaseListQuery.error)}
-            pending={releaseListQuery.isPending}
-            releaseList={releaseListQuery.data}
-            retry={() => void releaseListQuery.refetch()}
           />
           <EntityHistoryOverview
             entityName={entity.name}

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.test.tsx
@@ -1,0 +1,40 @@
+import { mockEntity } from "@peated/server/orpc/mock/fixtures";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import type { Entity } from "./entityPageData";
+import { EntitySiblingOverview } from "./entitySiblingOverview";
+
+describe("EntitySiblingOverview", () => {
+  test("links to the owner company when there are no sibling entities", () => {
+    const entity = {
+      ...mockEntity,
+      id: 1,
+      ownerId: 42,
+      owner: {
+        id: 42,
+        name: "Suntory Global Spirits",
+        peatedId: "E0042",
+      },
+      images: [],
+    } satisfies Entity;
+
+    const html = renderToStaticMarkup(
+      <EntitySiblingOverview
+        entity={entity}
+        error={false}
+        pending={false}
+        retry={() => undefined}
+        siblingList={{
+          rel: { nextCursor: null, prevCursor: null },
+          results: [],
+          total: 0,
+        }}
+      />,
+    );
+
+    expect(html).toContain("Also part of Suntory Global Spirits");
+    expect(html).toContain('href="/entities/42"');
+    expect(html).toContain("View company");
+  });
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
@@ -5,6 +5,7 @@ import {
   RailList,
   RailListItem,
   SectionError,
+  TextLink,
 } from "@peated/web/components";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import { getEntityUrl } from "@peated/web/lib/urls";
@@ -32,10 +33,15 @@ export function EntitySiblingOverview({
   const heading = entity.owner?.name
     ? `Also part of ${entity.owner.name}`
     : "Other distilleries and bottlers";
+  const companyLink = entity.owner ? (
+    <TextLink href={getEntityUrl({ id: entity.owner.id, kind: null })}>
+      View company
+    </TextLink>
+  ) : null;
 
   if (pending) {
     return (
-      <PageSection heading={heading}>
+      <PageSection heading={heading} intro={companyLink}>
         <LoadingList label="Loading distilleries and bottlers" rows={3} />
       </PageSection>
     );
@@ -43,7 +49,7 @@ export function EntitySiblingOverview({
 
   if (error) {
     return (
-      <PageSection heading={heading}>
+      <PageSection heading={heading} intro={companyLink}>
         <SectionError
           heading="Could not load distilleries and bottlers"
           onRetry={retry}
@@ -55,10 +61,16 @@ export function EntitySiblingOverview({
   }
 
   const siblings = getEntitySiblings(entity.id, siblingList);
-  if (!siblings.length) return null;
+  if (!siblings.length) {
+    return companyLink ? (
+      <PageSection heading={heading} intro={companyLink}>
+        {null}
+      </PageSection>
+    ) : null;
+  }
 
   return (
-    <PageSection heading={heading}>
+    <PageSection heading={heading} intro={companyLink}>
       <RailList ariaLabel={heading}>
         {siblings.map((sibling) => (
           <RailListItem


### PR DESCRIPTION
Entity overview pages now show latest releases before popular bottles, so recent catalog activity has higher priority. Ownership sections also include a direct “View company” link, which remains available even when no sibling distilleries or bottlers are returned.
