### PR TITLE
fix(entities): improve company ownership pages

### DIFF
--- a/apps/server/src/orpc/mock/fixtures/entities.ts
+++ b/apps/server/src/orpc/mock/fixtures/entities.ts
@@ -227,7 +227,12 @@ export const mockEntities: Entity[] = [
     name: "Caol Ila",
     shortName: null,
     ownerId: 9210,
-    owner: { id: 9210, peatedId: "E9210", name: "Diageo" },
+    owner: {
+      id: 9210,
+      kind: "company",
+      peatedId: "E9210",
+      name: "Diageo",
+    },
     description:
       "An Islay distillery known for a lighter, maritime style of peated single malt.",
     yearEstablished: 1846,
@@ -244,7 +249,12 @@ export const mockEntities: Entity[] = [
     name: "Talisker",
     shortName: null,
     ownerId: 9210,
-    owner: { id: 9210, peatedId: "E9210", name: "Diageo" },
+    owner: {
+      id: 9210,
+      kind: "company",
+      peatedId: "E9210",
+      name: "Diageo",
+    },
     description:
       "An island distillery known for peppery, maritime single malt.",
     yearEstablished: 1830,

--- a/apps/server/src/orpc/routes/entities/details.test.ts
+++ b/apps/server/src/orpc/routes/entities/details.test.ts
@@ -76,6 +76,7 @@ describe("GET /entities/:entity", () => {
 
     expect(data.owner).toEqual({
       id: owner.id,
+      kind: "company",
       peatedId: formatPeatedId("entity", owner.id),
       name: owner.name,
     });

--- a/apps/server/src/schemas/entities.ts
+++ b/apps/server/src/schemas/entities.ts
@@ -31,6 +31,7 @@ const EntityOwnerSchema = z
     id: z.number().readonly(),
     peatedId: z.string().readonly(),
     name: EntityNameSchema,
+    kind: EntityKindSchema,
   })
   .nullable()
   .optional()

--- a/apps/server/src/serializers/entity.ts
+++ b/apps/server/src/serializers/entity.ts
@@ -58,7 +58,11 @@ export const EntitySerializer = serializer({
           : [],
         ownerIds.length
           ? db
-              .select({ id: entities.id, name: entities.name })
+              .select({
+                id: entities.id,
+                kind: entities.kind,
+                name: entities.name,
+              })
               .from(entities)
               .where(inArray(entities.id, ownerIds))
           : [],
@@ -89,6 +93,7 @@ export const EntitySerializer = serializer({
         owner.id,
         {
           id: owner.id,
+          kind: owner.kind,
           peatedId: formatPeatedId("entity", owner.id),
           name: owner.name,
         },

--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
@@ -5,7 +5,7 @@ import {
   hasVisibleFacts,
   type FactListItem,
 } from "@peated/web/components";
-import { parseDomain } from "@peated/web/lib/urls";
+import { getEntityUrl, parseDomain } from "@peated/web/lib/urls";
 import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 import type { Entity } from "./entityPageData";
@@ -36,7 +36,7 @@ function getEntityFacts(entity: Entity): [FactListItem, ...FactListItem[]] {
     {
       label: "Part of",
       value: entity.owner ? (
-        <TextLink href={`/entities/${entity.owner.id}`} size="inherit">
+        <TextLink href={getEntityUrl(entity.owner)} size="inherit">
           {entity.owner.name}
         </TextLink>
       ) : null,

--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.test.tsx
@@ -1,0 +1,27 @@
+import { mockEntity } from "@peated/server/orpc/mock/fixtures";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { EntityDetails } from "./entityDetails.stylex";
+import type { Entity } from "./entityPageData";
+
+describe("EntityDetails", () => {
+  test("links an owner to its canonical public route", () => {
+    const entity = {
+      ...mockEntity,
+      images: [],
+      ownerId: 2,
+      owner: {
+        id: 2,
+        kind: "company",
+        name: "Example Company",
+        peatedId: "E0002",
+      },
+    } satisfies Entity;
+
+    const html = renderToStaticMarkup(<EntityDetails entity={entity} />);
+
+    expect(html).toContain('href="/companies/2"');
+    expect(html).not.toContain('href="/entities/2"');
+  });
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOperatedOverview.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOperatedOverview.test.tsx
@@ -1,0 +1,72 @@
+import { mockEntity } from "@peated/server/orpc/mock/fixtures";
+import type { Outputs } from "@peated/server/orpc/router";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "vitest";
+
+import { EntityOperatedOverview } from "./entityOperatedOverview";
+import type { Entity } from "./entityPageData";
+
+type EntityList = Outputs["entities"]["list"];
+
+const company = {
+  ...mockEntity,
+  id: 1,
+  images: [],
+  kind: "company",
+  name: "Example Company",
+} satisfies Entity;
+
+function render(operatedList?: EntityList) {
+  return renderToStaticMarkup(
+    <EntityOperatedOverview
+      entity={company}
+      error={false}
+      operatedList={operatedList}
+      pending={false}
+      retry={() => undefined}
+    />,
+  );
+}
+
+describe("EntityOperatedOverview", () => {
+  test("shows the brands and producers operated by a company", () => {
+    const html = render({
+      results: [
+        {
+          ...mockEntity,
+          id: 2,
+          kind: "bottler",
+          name: "The Scotch Malt Whisky Society",
+          shortName: "SMWS",
+          totalBottles: 3_499,
+        },
+        {
+          ...mockEntity,
+          id: 3,
+          kind: "brand",
+          name: "Single Cask Nation",
+          totalBottles: 24,
+        },
+      ],
+      rel: { nextCursor: null, prevCursor: null },
+      total: 2,
+    });
+
+    expect(html).toContain("Operates");
+    expect(html).toContain("The Scotch Malt Whisky Society");
+    expect(html).toContain('href="/bottlers/2"');
+    expect(html).toContain("Bottler · 3,499 bottles");
+    expect(html).toContain("Single Cask Nation");
+    expect(html).toContain('href="/brands/3"');
+  });
+
+  test("does not render an empty section", () => {
+    expect(
+      render({
+        results: [],
+        rel: { nextCursor: null, prevCursor: null },
+        total: 0,
+      }),
+    ).toBe("");
+  });
+});

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOperatedOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOperatedOverview.tsx
@@ -1,0 +1,71 @@
+import type { Outputs } from "@peated/server/orpc/router";
+
+import {
+  LoadingList,
+  RailList,
+  RailListItem,
+  SectionError,
+} from "@peated/web/components";
+import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
+import { getEntityUrl } from "@peated/web/lib/urls";
+
+import { getEntityPresentation, type Entity } from "./entityPageData";
+
+type EntityList = Outputs["entities"]["list"];
+
+export function EntityOperatedOverview({
+  entity,
+  error,
+  operatedList,
+  pending,
+  retry,
+}: {
+  entity: Entity;
+  error: boolean;
+  operatedList?: EntityList;
+  pending: boolean;
+  retry: () => void;
+}) {
+  if (entity.kind !== "company") return null;
+
+  const heading = "Operates";
+
+  if (pending) {
+    return (
+      <PageSection heading={heading}>
+        <LoadingList label="Loading brands and producers" rows={2} />
+      </PageSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageSection heading={heading}>
+        <SectionError
+          heading="Could not load brands and producers"
+          onRetry={retry}
+        >
+          Try again.
+        </SectionError>
+      </PageSection>
+    );
+  }
+
+  const operated = operatedList?.results.slice(0, 4) ?? [];
+  if (!operated.length) return null;
+
+  return (
+    <PageSection heading={heading}>
+      <RailList ariaLabel={`${entity.name} brands and producers`}>
+        {operated.map((item) => (
+          <RailListItem
+            href={getEntityUrl(item)}
+            key={item.id}
+            metadata={`${getEntityPresentation(item).label} · ${item.totalBottles.toLocaleString("en-US")} bottles`}
+            title={item.name}
+          />
+        ))}
+      </RailList>
+    </PageSection>
+  );
+}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -16,6 +16,7 @@ import { EntityHistoryOverview } from "./entityHistoryOverview.stylex";
 import { EntityImageGallery } from "./entityImageGallery.stylex";
 import { EntityImagePlaceholder } from "./entityImagePlaceholder.stylex";
 import { EntityMap } from "./entityMap.stylex";
+import { EntityOperatedOverview } from "./entityOperatedOverview";
 import { entityHasBottleCatalog, type Entity } from "./entityPageData";
 import { EntityReleaseOverview } from "./entityReleaseOverview";
 import { EntitySiblingOverview } from "./entitySiblingOverview";
@@ -44,6 +45,8 @@ export function EntityOverviewClient({
 }) {
   const orpc = useORPC();
   const ownsBottleSections = entityHasBottleCatalog(initialEntity);
+  const relationshipOwnerId =
+    initialEntity.kind === "company" ? initialEntity.id : initialEntity.ownerId;
   const entityQuery = useQuery({
     ...orpc.entities.details.queryOptions({
       input: { entity: initialEntity.id },
@@ -88,13 +91,16 @@ export function EntityOverviewClient({
   const siblingListQuery = useQuery({
     ...orpc.entities.list.queryOptions({
       input: {
-        kinds: ["distillery", "bottler"],
+        kinds:
+          initialEntity.kind === "company"
+            ? undefined
+            : ["distillery", "bottler"],
         limit: 5,
-        owner: initialEntity.ownerId ?? undefined,
+        owner: relationshipOwnerId ?? undefined,
         sort: "-bottles",
       },
     }),
-    enabled: Boolean(initialEntity.ownerId),
+    enabled: Boolean(relationshipOwnerId),
     initialData: initialSiblingList,
   });
 
@@ -117,6 +123,13 @@ export function EntityOverviewClient({
           {hasEntityDetails(entity) ? <EntityDetails entity={entity} /> : null}
         </div>
         <div {...stylex.props(styles.catalogSections)}>
+          <EntityOperatedOverview
+            entity={entity}
+            error={Boolean(siblingListQuery.error)}
+            operatedList={siblingListQuery.data}
+            pending={siblingListQuery.isPending}
+            retry={() => void siblingListQuery.refetch()}
+          />
           <EntityReleaseOverview
             entity={entity}
             error={Boolean(releaseListQuery.error)}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -17,7 +17,11 @@ import { EntityImageGallery } from "./entityImageGallery.stylex";
 import { EntityImagePlaceholder } from "./entityImagePlaceholder.stylex";
 import { EntityMap } from "./entityMap.stylex";
 import { EntityOperatedOverview } from "./entityOperatedOverview";
-import { entityHasBottleCatalog, type Entity } from "./entityPageData";
+import {
+  entityHasBottleCatalog,
+  getEntityRelationshipOwnerIds,
+  type Entity,
+} from "./entityPageData";
 import { EntityReleaseOverview } from "./entityReleaseOverview";
 import { EntitySiblingOverview } from "./entitySiblingOverview";
 
@@ -45,8 +49,8 @@ export function EntityOverviewClient({
 }) {
   const orpc = useORPC();
   const ownsBottleSections = entityHasBottleCatalog(initialEntity);
-  const relationshipOwnerId =
-    initialEntity.kind === "company" ? initialEntity.id : initialEntity.ownerId;
+  const { operatedOwnerId, siblingOwnerId } =
+    getEntityRelationshipOwnerIds(initialEntity);
   const entityQuery = useQuery({
     ...orpc.entities.details.queryOptions({
       input: { entity: initialEntity.id },
@@ -88,6 +92,16 @@ export function EntityOverviewClient({
     enabled: ownsBottleSections,
     initialData: initialReleaseList,
   });
+  const operatedListQuery = useQuery({
+    ...orpc.entities.list.queryOptions({
+      input: {
+        limit: 5,
+        owner: operatedOwnerId ?? undefined,
+        sort: "-bottles",
+      },
+    }),
+    enabled: Boolean(operatedOwnerId),
+  });
   const siblingListQuery = useQuery({
     ...orpc.entities.list.queryOptions({
       input: {
@@ -96,11 +110,11 @@ export function EntityOverviewClient({
             ? undefined
             : ["distillery", "bottler"],
         limit: 5,
-        owner: relationshipOwnerId ?? undefined,
+        owner: siblingOwnerId ?? undefined,
         sort: "-bottles",
       },
     }),
-    enabled: Boolean(relationshipOwnerId),
+    enabled: Boolean(siblingOwnerId),
     initialData: initialSiblingList,
   });
 
@@ -125,10 +139,10 @@ export function EntityOverviewClient({
         <div {...stylex.props(styles.catalogSections)}>
           <EntityOperatedOverview
             entity={entity}
-            error={Boolean(siblingListQuery.error)}
-            operatedList={siblingListQuery.data}
-            pending={siblingListQuery.isPending}
-            retry={() => void siblingListQuery.refetch()}
+            error={Boolean(operatedListQuery.error)}
+            operatedList={operatedListQuery.data}
+            pending={operatedListQuery.isPending}
+            retry={() => void operatedListQuery.refetch()}
           />
           <EntityReleaseOverview
             entity={entity}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
@@ -4,6 +4,7 @@ import {
   entityHasBottleCatalog,
   getEntityClassification,
   getEntityCurrentHref,
+  getEntityRelationshipOwnerIds,
   getEntityTabs,
 } from "./entityPageData";
 
@@ -19,6 +20,21 @@ describe("entityHasBottleCatalog", () => {
 describe("getEntityClassification", () => {
   it("uses the entity kind", () => {
     expect(getEntityClassification({ kind: "distillery" })).toBe("Distillery");
+  });
+});
+
+describe("getEntityRelationshipOwnerIds", () => {
+  it("keeps a company's operated entities separate from its siblings", () => {
+    expect(
+      getEntityRelationshipOwnerIds({
+        id: 10,
+        kind: "company",
+        ownerId: 42,
+      }),
+    ).toEqual({
+      operatedOwnerId: 10,
+      siblingOwnerId: 42,
+    });
   });
 });
 

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -49,6 +49,15 @@ export function entityHasBottleCatalog(entity: Pick<Entity, "kind">) {
   );
 }
 
+export function getEntityRelationshipOwnerIds(
+  entity: Pick<Entity, "id" | "kind" | "ownerId">,
+) {
+  return {
+    operatedOwnerId: entity.kind === "company" ? entity.id : null,
+    siblingOwnerId: entity.ownerId,
+  };
+}
+
 export function getEntityLocationLabel(entity: Entity) {
   return [entity.region?.name, entity.country?.name]
     .filter((value): value is string => Boolean(value))

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.test.tsx
@@ -13,6 +13,7 @@ describe("EntitySiblingOverview", () => {
       ownerId: 42,
       owner: {
         id: 42,
+        kind: "company",
         name: "Suntory Global Spirits",
         peatedId: "E0042",
       },
@@ -34,7 +35,7 @@ describe("EntitySiblingOverview", () => {
     );
 
     expect(html).toContain("Also part of Suntory Global Spirits");
-    expect(html).toContain('href="/entities/42"');
+    expect(html).toContain('href="/companies/42"');
     expect(html).toContain("View company");
   });
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
@@ -34,9 +34,7 @@ export function EntitySiblingOverview({
     ? `Also part of ${entity.owner.name}`
     : "Other distilleries and bottlers";
   const companyLink = entity.owner ? (
-    <TextLink href={getEntityUrl({ id: entity.owner.id, kind: null })}>
-      View company
-    </TextLink>
+    <TextLink href={getEntityUrl(entity.owner)}>View company</TextLink>
   ) : null;
 
   if (pending) {


### PR DESCRIPTION
Company overview pages now show the brands and producers they operate, with canonical links and bottle totals. Companies without relationships keep the existing layout without an empty section.

Entity owner payloads now include the entity kind, so owned-entity pages link directly to canonical company routes. This removes the generic entity redirect that could trigger repeated RSC fetches during client navigation, with focused coverage for relationship rendering and owner URLs.
