### PR TITLE
style(web): remove interaction focus outlines

### DIFF
--- a/apps/web/src/components/admin/adminContent.stylex.tsx
+++ b/apps/web/src/components/admin/adminContent.stylex.tsx
@@ -293,7 +293,7 @@ const styles = stylex.create({
     color: {
       default: colors.inkMuted,
       ":hover": colors.accentDeep,
-      ":active": colors.accent,
+      ":active": colors.accentDeep,
     },
     fontFamily: fonts.data,
     fontSize: "11px",

--- a/apps/web/src/components/admin/adminLayout.stylex.tsx
+++ b/apps/web/src/components/admin/adminLayout.stylex.tsx
@@ -267,7 +267,7 @@ const styles = stylex.create({
     backgroundColor: {
       default: colors.ground,
       ":hover": colors.inset,
-      ":active": colors.accentTint,
+      ":active": colors.inset,
     },
     color: colors.ink,
     fontFamily: fonts.reading,
@@ -320,7 +320,7 @@ const styles = stylex.create({
     backgroundColor: {
       default: "transparent",
       ":hover": colors.inset,
-      ":active": colors.accentTint,
+      ":active": colors.inset,
     },
     color: colors.inkMuted,
     fontFamily: fonts.reading,

--- a/apps/web/src/components/bottleChecks/operationCard.stylex.tsx
+++ b/apps/web/src/components/bottleChecks/operationCard.stylex.tsx
@@ -1178,7 +1178,7 @@ const styles = stylex.create({
     color: {
       default: colors.accentDeep,
       ":hover": colors.accent,
-      ":active": colors.ink,
+      ":active": colors.accent,
     },
     fontWeight: 600,
     textDecorationLine: {
@@ -1197,7 +1197,7 @@ const styles = stylex.create({
     color: {
       default: colors.accentDeep,
       ":hover": colors.accent,
-      ":active": colors.ink,
+      ":active": colors.accent,
     },
     fontWeight: 600,
     textDecorationLine: {

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -305,7 +305,7 @@ const styles = stylex.create({
     color: {
       default: colors.inkMuted,
       ":hover": colors.accentDeep,
-      ":active": colors.accent,
+      ":active": colors.accentDeep,
     },
     textDecorationLine: {
       default: "none",
@@ -340,7 +340,7 @@ const styles = stylex.create({
     color: {
       default: colors.ink,
       ":hover": colors.accentDeep,
-      ":active": colors.accent,
+      ":active": colors.accentDeep,
     },
     textDecorationLine: {
       default: "none",
@@ -383,7 +383,7 @@ const styles = stylex.create({
     color: {
       default: colors.accentDeep,
       ":hover": colors.accent,
-      ":active": colors.ink,
+      ":active": colors.accent,
     },
     fontFamily: fonts.reading,
     fontSize: "12px",

--- a/apps/web/src/components/button.stylex.tsx
+++ b/apps/web/src/components/button.stylex.tsx
@@ -211,18 +211,14 @@ const styles = stylex.create({
     opacity: {
       default: 1,
       ":hover": 0.86,
+      ":active": 0.86,
       ":disabled": 0.45,
     },
     boxShadow: {
       default: "none",
       ":focus-visible": effects.focusRing,
     },
-    transform: {
-      default: "none",
-      ":active": "translateY(1px)",
-      ":disabled": "none",
-    },
-    transitionProperty: "background-color, color, opacity, transform",
+    transitionProperty: "background-color, color, opacity",
     transitionDuration: "120ms",
   },
   button: {
@@ -283,10 +279,11 @@ const styles = stylex.create({
     backgroundColor: {
       default: "transparent",
       ":hover": colors.surface,
+      ":active": colors.surface,
     },
     boxShadow: {
       default: `inset 0 0 0 1px ${colors.sectionRule}`,
-      ":focus-visible": effects.focusRing,
+      ":focus-visible": `inset 0 0 0 1px ${colors.sectionRule}`,
     },
     color: colors.ink,
   },
@@ -298,10 +295,11 @@ const styles = stylex.create({
     backgroundColor: {
       default: "transparent",
       ":hover": colors.criticalQuiet,
+      ":active": colors.criticalQuiet,
     },
     boxShadow: {
       default: `inset 0 0 0 1px ${colors.critical}`,
-      ":focus-visible": effects.focusRing,
+      ":focus-visible": `inset 0 0 0 1px ${colors.critical}`,
     },
     color: colors.critical,
   },
@@ -309,6 +307,7 @@ const styles = stylex.create({
     backgroundColor: {
       default: "transparent",
       ":hover": colors.accentTint,
+      ":active": colors.accentTint,
     },
     color: colors.accentDeep,
   },

--- a/apps/web/src/components/card.stylex.tsx
+++ b/apps/web/src/components/card.stylex.tsx
@@ -171,7 +171,7 @@ const styles = stylex.create({
     backgroundColor: {
       default: "transparent",
       ":hover": colors.surface,
-      ":active": colors.inset,
+      ":active": colors.surface,
     },
     boxShadow: {
       default: "none",
@@ -193,7 +193,7 @@ const styles = stylex.create({
     backgroundColor: {
       default: "transparent",
       ":hover": colors.surface,
-      ":active": colors.inset,
+      ":active": colors.surface,
     },
     boxShadow: {
       default: "none",
@@ -227,7 +227,7 @@ const styles = stylex.create({
     color: {
       default: colors.inkMuted,
       ":hover": colors.accentDeep,
-      ":active": colors.accent,
+      ":active": colors.accentDeep,
     },
     textDecorationLine: {
       default: "none",

--- a/apps/web/src/components/chip.stylex.tsx
+++ b/apps/web/src/components/chip.stylex.tsx
@@ -107,7 +107,7 @@ const styles = stylex.create({
     backgroundColor: "transparent",
     boxShadow: {
       default: `inset 0 0 0 1px ${colors.sectionRule}`,
-      ":focus-visible": effects.focusRing,
+      ":focus-visible": `inset 0 0 0 1px ${colors.sectionRule}`,
     },
     color: colors.inkMuted,
   },
@@ -115,7 +115,7 @@ const styles = stylex.create({
     backgroundColor: "transparent",
     boxShadow: {
       default: `inset 0 0 0 1px ${colors.accent}`,
-      ":focus-visible": effects.focusRing,
+      ":focus-visible": `inset 0 0 0 1px ${colors.accent}`,
     },
     color: colors.accentDeep,
   },

--- a/apps/web/src/components/collectionBottleStatus.stylex.tsx
+++ b/apps/web/src/components/collectionBottleStatus.stylex.tsx
@@ -86,7 +86,7 @@ const styles = stylex.create({
     backgroundColor: {
       default: "transparent",
       ":hover": colors.surface,
-      ":active": colors.inset,
+      ":active": colors.surface,
     },
     color: colors.ink,
     fontFamily: fonts.reading,

--- a/apps/web/src/components/dataTable.stylex.tsx
+++ b/apps/web/src/components/dataTable.stylex.tsx
@@ -158,7 +158,7 @@ const styles = stylex.create({
     color: {
       default: colors.accentDeep,
       ":hover": colors.accent,
-      ":active": colors.ink,
+      ":active": colors.accent,
     },
     fontWeight: 600,
     textDecorationLine: {

--- a/apps/web/src/components/filterPanel.stylex.tsx
+++ b/apps/web/src/components/filterPanel.stylex.tsx
@@ -171,7 +171,7 @@ const styles = stylex.create({
     backgroundColor: {
       default: "transparent",
       ":hover": colors.surface,
-      ":active": colors.inset,
+      ":active": colors.surface,
     },
     color: colors.ink,
     fontFamily: fonts.display,

--- a/apps/web/src/components/imageViewer.stylex.tsx
+++ b/apps/web/src/components/imageViewer.stylex.tsx
@@ -226,7 +226,7 @@ const styles = stylex.create({
     },
     boxShadow: {
       default: "none",
-      ":focus-visible": "inset 0 0 0 2px white",
+      ":focus-visible": "none",
     },
   },
   close: {
@@ -249,7 +249,7 @@ const styles = stylex.create({
     cursor: "pointer",
     boxShadow: {
       default: "0 0 0 1px rgb(255 255 255 / 0.24)",
-      ":focus-visible": "inset 0 0 0 2px white",
+      ":focus-visible": "0 0 0 1px rgb(255 255 255 / 0.24)",
     },
   },
 });

--- a/apps/web/src/components/itemList.stories.tsx
+++ b/apps/web/src/components/itemList.stories.tsx
@@ -144,7 +144,7 @@ const styles = stylex.create({
     color: {
       default: colors.inkMuted,
       ":hover": colors.accentDeep,
-      ":active": colors.accent,
+      ":active": colors.accentDeep,
     },
     fontFamily: fonts.data,
     fontSize: "11px",

--- a/apps/web/src/components/linkedRow.stylex.ts
+++ b/apps/web/src/components/linkedRow.stylex.ts
@@ -13,7 +13,7 @@ export const linkedRowStyles = stylex.create({
     backgroundColor: {
       default: "transparent",
       ":hover": colors.surface,
-      ":active": colors.inset,
+      ":active": colors.surface,
     },
     boxShadow: {
       default: "none",
@@ -25,7 +25,7 @@ export const linkedRowStyles = stylex.create({
     backgroundColor: {
       default: "transparent",
       ":hover": colors.inset,
-      ":active": colors.sunken,
+      ":active": colors.inset,
     },
     boxShadow: {
       default: "none",

--- a/apps/web/src/components/lists.stylex.tsx
+++ b/apps/web/src/components/lists.stylex.tsx
@@ -350,7 +350,7 @@ const styles = stylex.create({
     color: {
       default: colors.ink,
       ":hover": colors.accentDeep,
-      ":active": colors.accent,
+      ":active": colors.accentDeep,
     },
   },
   railMetadata: {

--- a/apps/web/src/components/notePicker.stylex.tsx
+++ b/apps/web/src/components/notePicker.stylex.tsx
@@ -610,7 +610,7 @@ const styles = stylex.create({
     cursor: "pointer",
     boxShadow: {
       default: `inset 0 0 0 1px ${colors.sectionRule}`,
-      ":focus-visible": effects.focusRing,
+      ":focus-visible": `inset 0 0 0 1px ${colors.sectionRule}`,
     },
   },
   activeCategory: {
@@ -659,7 +659,7 @@ const styles = stylex.create({
     },
     boxShadow: {
       default: `inset 0 0 0 1px ${colors.sectionRule}`,
-      ":focus-visible": effects.focusRing,
+      ":focus-visible": `inset 0 0 0 1px ${colors.sectionRule}`,
     },
   },
   selectedNote: {
@@ -675,7 +675,7 @@ const styles = stylex.create({
     color: colors.accentDeep,
     boxShadow: {
       default: `inset 0 0 0 1px ${colors.accent}`,
-      ":focus-visible": effects.focusRing,
+      ":focus-visible": `inset 0 0 0 1px ${colors.accent}`,
     },
   },
   availableNote: {

--- a/apps/web/src/components/pageTabs.stylex.tsx
+++ b/apps/web/src/components/pageTabs.stylex.tsx
@@ -94,7 +94,7 @@ const styles = stylex.create({
     fontWeight: 700,
     boxShadow: {
       default: `inset 0 -2px 0 ${colors.ink}`,
-      ":focus-visible": effects.focusRing,
+      ":focus-visible": `inset 0 -2px 0 ${colors.ink}`,
     },
   },
   count: {

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -206,7 +206,7 @@ const styles = stylex.create({
     backgroundColor: {
       default: "transparent",
       ":hover": colors.surface,
-      ":active": colors.inset,
+      ":active": colors.surface,
     },
     color: colors.accentDeep,
     fontFamily: fonts.display,

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -651,7 +651,7 @@ const styles = stylex.create({
     color: {
       default: colors.accent,
       ":hover": colors.accentDeep,
-      ":active": colors.accent,
+      ":active": colors.accentDeep,
     },
     fontFamily: fonts.display,
     fontSize: "13px",

--- a/apps/web/src/components/recordTypeInput.stylex.tsx
+++ b/apps/web/src/components/recordTypeInput.stylex.tsx
@@ -83,7 +83,7 @@ const styles = stylex.create({
     fontWeight: 700,
     boxShadow: {
       default: `inset 0 -2px 0 ${colors.ink}`,
-      ":focus-within": effects.focusRing,
+      ":focus-within": `inset 0 -2px 0 ${colors.ink}`,
     },
   },
   disabledTab: { cursor: "not-allowed", opacity: 0.45 },

--- a/apps/web/src/components/tastingEntry.stylex.tsx
+++ b/apps/web/src/components/tastingEntry.stylex.tsx
@@ -351,7 +351,7 @@ const styles = stylex.create({
     color: {
       default: colors.ink,
       ":hover": colors.accentDeep,
-      ":active": colors.accent,
+      ":active": colors.accentDeep,
     },
   },
   date: {
@@ -390,7 +390,7 @@ const styles = stylex.create({
     color: {
       default: colors.ink,
       ":hover": colors.accentDeep,
-      ":active": colors.accent,
+      ":active": colors.accentDeep,
     },
   },
   metadata: {

--- a/apps/web/src/components/textLinkStyles.stylex.ts
+++ b/apps/web/src/components/textLinkStyles.stylex.ts
@@ -12,7 +12,7 @@ export const textLinkStyles = stylex.create({
     color: {
       default: colors.accentDeep,
       ":hover": colors.accent,
-      ":active": colors.ink,
+      ":active": colors.accent,
     },
     fontWeight: 600,
     textDecorationLine: {

--- a/apps/web/src/styles/tokens.stylex.ts
+++ b/apps/web/src/styles/tokens.stylex.ts
@@ -193,10 +193,9 @@ export const controlMetrics = stylex.defineVars({
 });
 
 export const effects = stylex.defineVars({
-  focusRing: {
-    default: "inset 0 0 0 2px #9a5b12",
-    [DARK]: "inset 0 0 0 2px #d9922f",
-  },
+  // Interactive controls use their local hover and pressed treatments.
+  // Do not add a separate focus outline around the control.
+  focusRing: "none",
   errorRing: {
     default: "inset 0 0 0 2px #a3231a",
     [DARK]: "inset 0 0 0 2px #f0776b",
@@ -208,13 +207,13 @@ export const effects = stylex.defineVars({
 });
 
 export const lightEffectTheme = stylex.createTheme(effects, {
-  focusRing: "inset 0 0 0 2px #9a5b12",
+  focusRing: "none",
   errorRing: "inset 0 0 0 2px #a3231a",
   overlayShadow: "0 18px 40px rgb(22 25 20 / 0.16)",
 });
 
 export const darkEffectTheme = stylex.createTheme(effects, {
-  focusRing: "inset 0 0 0 2px #d9922f",
+  focusRing: "none",
   errorRing: "inset 0 0 0 2px #f0776b",
   overlayShadow: "0 18px 40px rgb(0 0 0 / 0.55)",
 });


### PR DESCRIPTION
Interactive controls no longer render a separate focus outline. Pressed states now reuse hover styling across shared buttons, links, cards, tabs, lists, image controls, and admin controls, while normal borders, selected-tab underlines, and validation error indicators remain visible.
