### PR TITLE
feat(web): align bottle details with entity layout

### DIFF
--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -30,7 +30,6 @@ import {
 } from "@peated/web/components";
 import { EntityLinks } from "@peated/web/components/entityLinks";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
-import Join from "@peated/web/components/join";
 import { BottleOverview } from "@peated/web/components/pages/bottleOverview.stylex";
 import { BottlePageHeader } from "@peated/web/components/pages/bottlePageHeader.stylex";
 import TimeSince from "@peated/web/components/timeSince";
@@ -61,31 +60,32 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
 });
 
-function getBottleDetail(bottle: Bottle) {
-  return (
-    <Join divider=" · ">
-      {[
-        bottle.category ? formatCategoryName(bottle.category) : null,
-        bottle.distillers.length ? (
-          <EntityLinks entities={bottle.distillers} key="distillers" />
-        ) : null,
-        bottle.bottler ? (
-          <EntityLinks entities={[bottle.bottler]} key="bottler" />
-        ) : null,
-      ].filter((value) => value !== null)}
-    </Join>
-  );
-}
-
-function getBottleNotes(bottle: Bottle) {
-  return [
-    bottle.caskStrength ? "Cask strength" : null,
-    bottle.singleCask ? "Single cask" : null,
-  ].filter((value): value is string => value !== null);
+function getBottleEyebrow(bottle: Bottle) {
+  return bottle.distillers.length ? (
+    <EntityLinks entities={bottle.distillers} />
+  ) : null;
 }
 
 function getDeclaredFacts(bottle: Bottle): [FactListItem, ...FactListItem[]] {
   return [
+    {
+      label: "Category",
+      value: bottle.category ? formatCategoryName(bottle.category) : null,
+    },
+    {
+      label: "Bottled by",
+      value: bottle.bottler ? (
+        <EntityLinks entities={[bottle.bottler]} />
+      ) : null,
+    },
+    {
+      label: "Strength",
+      value: bottle.caskStrength ? "Cask strength" : null,
+    },
+    {
+      label: "Cask selection",
+      value: bottle.singleCask ? "Single cask" : null,
+    },
     {
       label: "ABV",
       value: bottle.abv === null ? null : `${bottle.abv.toFixed(1)}%`,
@@ -363,7 +363,6 @@ export function BottlePageFrameClient({
   children: ReactNode;
   initialBottle: Bottle;
 }) {
-  const { user } = useAuth();
   const orpc = useORPC();
   const pathname = usePathname();
   const bottleQuery = useQuery({
@@ -414,22 +413,9 @@ export function BottlePageFrameClient({
           }
           brand={bottle.brand.shortName || bottle.brand.name}
           brandHref={getEntityUrl({ id: bottle.brand.id, kind: "brand" })}
-          detail={getBottleDetail(bottle)}
-          id={bottle.peatedId}
-          imageUrl={bottle.imageUrl}
-          imageSourceUrl={bottle.imageSourceUrl}
-          imageLicense={bottle.imageLicense}
-          memberStatus={
-            user
-              ? {
-                  hasTasted: bottle.hasTasted,
-                  isLibrary: bottle.isLibrary,
-                }
-              : undefined
-          }
+          eyebrow={getBottleEyebrow(bottle)}
           menu={<BottleActions bottle={bottle} />}
           name={formatBottleDisplayName(bottle, { includeBrand: false })}
-          notes={getBottleNotes(bottle)}
           score={
             bottle.scoreCount === 0
               ? null
@@ -574,6 +560,12 @@ export function BottleOverviewClient({
         }
         criticReviews={criticReviews}
         declaredFacts={getDeclaredFacts(bottle)}
+        image={{
+          label: formatBottleDisplayName(bottle),
+          license: bottle.imageLicense,
+          sourceUrl: bottle.imageSourceUrl,
+          url: bottle.imageUrl,
+        }}
         mainState={mainState}
         moreTastingsHref={`/bottles/${bottle.id}/tastings`}
         recommendationIntro={recommendationsQuery.data?.reason}
@@ -628,7 +620,7 @@ const styles = stylex.create({
     lineHeight: 1.55,
   },
   overview: {
-    marginTop: space.x8,
+    minWidth: 0,
   },
   partialError: {
     margin: 0,

--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.stylex.tsx
@@ -1,12 +1,10 @@
-import * as stylex from "@stylexjs/stylex";
-
 import {
+  FactList,
   TextLink,
   hasVisibleFacts,
   type FactListItem,
 } from "@peated/web/components";
 import { getEntityUrl, parseDomain } from "@peated/web/lib/urls";
-import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 import type { Entity } from "./entityPageData";
 
@@ -66,58 +64,5 @@ export function EntityDetails({ entity }: { entity: Entity }) {
   const facts = getEntityFacts(entity);
   if (!hasVisibleFacts(facts)) return null;
 
-  const visibleFacts = facts.filter(
-    (fact) =>
-      fact.value !== null &&
-      fact.value !== undefined &&
-      fact.value !== "" &&
-      fact.value !== false &&
-      fact.value !== true,
-  );
-
-  return (
-    <dl {...stylex.props(styles.factGrid)}>
-      {visibleFacts.map((fact) => (
-        <div key={fact.label} {...stylex.props(styles.fact)}>
-          <dt {...stylex.props(styles.factLabel)}>{fact.label}</dt>
-          <dd {...stylex.props(styles.factValue)}>{fact.value}</dd>
-        </div>
-      ))}
-    </dl>
-  );
+  return <FactList facts={facts} layout="grid" />;
 }
-
-const styles = stylex.create({
-  factGrid: {
-    display: "grid",
-    gridTemplateColumns: {
-      default: "repeat(auto-fit, minmax(160px, 1fr))",
-      "@media (max-width: 559px)": "minmax(0, 1fr)",
-    },
-    gap: space.x4,
-    margin: 0,
-    paddingTop: space.x4,
-    paddingBottom: space.x4,
-  },
-  fact: {
-    minWidth: 0,
-  },
-  factLabel: {
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.04em",
-    lineHeight: 1.3,
-  },
-  factValue: {
-    minWidth: 0,
-    margin: 0,
-    marginTop: space.x1,
-    color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    fontWeight: 700,
-    lineHeight: 1.35,
-    overflowWrap: "anywhere",
-  },
-});

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -17,7 +17,7 @@ import { getTextTitle } from "./textTitle";
 const COMPACT = "@media (max-width: 639px)";
 const bottleIconUrl = "/assets/bottle.svg";
 
-export type BottleVisualSize = "sm" | "md" | "lg";
+export type BottleVisualSize = "sm" | "md" | "lg" | "xl";
 export type BottleIdentityRowSize = Extract<BottleVisualSize, "sm" | "md">;
 
 export type BottleVisualProps = {
@@ -228,6 +228,11 @@ const styles = stylex.create({
     height: { default: "176px", [COMPACT]: "120px" },
     padding: { default: space.x2, [COMPACT]: space.x1 },
   },
+  visualExtraLarge: {
+    width: "100%",
+    aspectRatio: "4 / 5",
+    padding: space.x4,
+  },
   image: {
     display: "block",
     width: "100%",
@@ -414,4 +419,5 @@ const visualSizeStyles = {
   sm: styles.visualSmall,
   md: styles.visualMedium,
   lg: styles.visualLarge,
+  xl: styles.visualExtraLarge,
 } satisfies Record<BottleVisualSize, stylex.StyleXStyles>;

--- a/apps/web/src/components/factList.stories.tsx
+++ b/apps/web/src/components/factList.stories.tsx
@@ -40,6 +40,15 @@ export const Overview: Story = {
           },
         ]}
       />
+      <FactList
+        facts={[
+          { label: "Category", value: "Single malt" },
+          { label: "ABV", value: "58.8%" },
+          { label: "Age", value: "11 years" },
+          { label: "Cask", value: "First-fill ex-bourbon barrel" },
+        ]}
+        layout="grid"
+      />
     </StoryStack>
   ),
 };

--- a/apps/web/src/components/factList.stylex.tsx
+++ b/apps/web/src/components/factList.stylex.tsx
@@ -10,6 +10,7 @@ export type FactListItem = {
 
 export type FactListProps = {
   facts: readonly [FactListItem, ...FactListItem[]];
+  layout?: "grid" | "list";
 };
 
 function hasFactValue(value: ReactNode) {
@@ -27,17 +28,34 @@ export function hasVisibleFacts(facts: readonly FactListItem[]) {
 }
 
 /** Presents supplied facts and omits facts that have no value. */
-export function FactList({ facts }: FactListProps) {
+export function FactList({ facts, layout = "list" }: FactListProps) {
   const visibleFacts = facts.filter((fact) => hasFactValue(fact.value));
 
   if (!visibleFacts.length) return null;
 
   return (
-    <dl {...stylex.props(styles.list)}>
+    <dl {...stylex.props(styles.list, layout === "grid" && styles.grid)}>
       {visibleFacts.map((fact) => (
-        <div key={fact.label} {...stylex.props(styles.row)}>
-          <dt {...stylex.props(styles.label)}>{fact.label}</dt>
-          <dd {...stylex.props(styles.value)}>{fact.value}</dd>
+        <div
+          key={fact.label}
+          {...stylex.props(styles.row, layout === "grid" && styles.gridItem)}
+        >
+          <dt
+            {...stylex.props(
+              styles.label,
+              layout === "grid" && styles.gridLabel,
+            )}
+          >
+            {fact.label}
+          </dt>
+          <dd
+            {...stylex.props(
+              styles.value,
+              layout === "grid" && styles.gridValue,
+            )}
+          >
+            {fact.value}
+          </dd>
         </div>
       ))}
     </dl>
@@ -48,6 +66,16 @@ const styles = stylex.create({
   list: {
     margin: 0,
     padding: 0,
+  },
+  grid: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "repeat(auto-fit, minmax(160px, 1fr))",
+      "@media (max-width: 559px)": "minmax(0, 1fr)",
+    },
+    gap: space.x4,
+    paddingTop: space.x4,
+    paddingBottom: space.x4,
   },
   row: {
     display: "flex",
@@ -63,6 +91,12 @@ const styles = stylex.create({
       borderBottomWidth: 0,
     },
   },
+  gridItem: {
+    display: "block",
+    paddingTop: 0,
+    paddingBottom: 0,
+    borderBottomWidth: 0,
+  },
   label: {
     width: "100px",
     flexShrink: 0,
@@ -71,6 +105,14 @@ const styles = stylex.create({
     fontSize: "13px",
     letterSpacing: 0,
     lineHeight: 1.4,
+  },
+  gridLabel: {
+    width: "auto",
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "10px",
+    letterSpacing: "0.04em",
+    lineHeight: 1.3,
   },
   value: {
     minWidth: 0,
@@ -83,5 +125,14 @@ const styles = stylex.create({
     letterSpacing: "-0.02em",
     lineHeight: 1.35,
     overflowWrap: "anywhere",
+  },
+  gridValue: {
+    marginTop: space.x1,
+    color: colors.ink,
+    fontFamily: fonts.reading,
+    fontSize: "14px",
+    fontWeight: 700,
+    letterSpacing: 0,
+    lineHeight: 1.35,
   },
 });

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -8,6 +8,7 @@ import {
   CriticReview,
   FactList,
   hasVisibleFacts,
+  ImageAttribution,
   ItemList,
   ItemListItem,
   RailList,
@@ -17,9 +18,7 @@ import {
 } from "..";
 import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
 
-const RAIL_SHRINKS = "@media (max-width: 1040px)";
-const RAIL_FOLDS = "@media (max-width: 900px)";
-const RAIL_STACKS = "@media (max-width: 680px)";
+const NARROW = "@media (max-width: 759px)";
 
 export type BottleRecommendation = {
   end?: ReactNode;
@@ -29,10 +28,18 @@ export type BottleRecommendation = {
   name: string;
 };
 
+export type BottleOverviewImage = {
+  label: string;
+  license?: string | null;
+  sourceUrl?: string | null;
+  url?: string | null;
+};
+
 export type BottleOverviewProps = {
   criticReviewDetail?: string;
   criticReviews?: readonly CriticReviewProps[];
   declaredFacts: readonly [FactListItem, ...FactListItem[]];
+  image: BottleOverviewImage;
   mainState?: ReactNode;
   moreTastingsHref?: string;
   recommendationHeading?: string;
@@ -42,11 +49,12 @@ export type BottleOverviewProps = {
   tastings?: readonly TastingEntryProps[];
 };
 
-/** Composes the bounded content section beneath a bottle's page header. */
+/** Composes the bottle facts, image, reviews, tastings, and recommendations. */
 export function BottleOverview({
   criticReviewDetail,
   criticReviews = [],
   declaredFacts,
+  image,
   mainState,
   moreTastingsHref,
   recommendationHeading = "If you liked this",
@@ -56,98 +64,115 @@ export function BottleOverview({
   tastings = [],
 }: BottleOverviewProps) {
   const hasDeclaredFacts = hasVisibleFacts(declaredFacts);
-  const hasRail = hasDeclaredFacts || recommendations.length > 0;
 
   return (
-    <div {...stylex.props(styles.layout, !hasRail && styles.layoutWithoutRail)}>
+    <div {...stylex.props(styles.layout)}>
       <div {...stylex.props(styles.main)}>
-        {criticReviews.length ? (
-          <section {...stylex.props(styles.section)}>
-            <div {...stylex.props(styles.sectionHeader)}>
-              <SectionHeading>Critic reviews</SectionHeading>
-              {criticReviewDetail ? (
-                <span {...stylex.props(styles.sectionDetail)}>
-                  {criticReviewDetail}
-                </span>
-              ) : null}
-            </div>
-            <ItemList ariaLabel="Critic reviews">
-              {criticReviews.map((review, index) => (
-                <ItemListItem
-                  key={`${review.publication}-${review.publishedAt ?? index}`}
-                >
-                  <CriticReview {...review} />
-                </ItemListItem>
-              ))}
-            </ItemList>
-          </section>
+        {hasDeclaredFacts ? (
+          <div {...stylex.props(styles.facts)}>
+            <FactList facts={declaredFacts} layout="grid" />
+          </div>
         ) : null}
 
-        {tastings.length ? (
-          <section {...stylex.props(styles.section)}>
-            <SectionHeading>Tastings</SectionHeading>
-            <ItemList ariaLabel="Bottle tastings">
-              {tastings.map((tasting, index) => (
-                <ItemListItem key={`${tasting.author}-${index}`}>
-                  <TastingEntry {...tasting} />
-                </ItemListItem>
-              ))}
-            </ItemList>
-            {moreTastingsHref &&
-            tastingCount !== undefined &&
-            tastingCount > tastings.length ? (
-              <AppLink
-                href={moreTastingsHref}
-                {...stylex.props(styles.moreLink)}
-              >
-                Show all {tastingCount.toLocaleString("en-US")} tastings →
-              </AppLink>
-            ) : null}
-          </section>
-        ) : null}
-
-        {!criticReviews.length && !tastings.length ? mainState : null}
-      </div>
-
-      {hasRail ? (
-        <aside aria-label="Bottle details" {...stylex.props(styles.rail)}>
-          {hasDeclaredFacts ? (
-            <div {...stylex.props(styles.railSection)}>
-              <div {...stylex.props(styles.panel)}>
-                <FactList facts={declaredFacts} />
+        <div {...stylex.props(styles.content)}>
+          {criticReviews.length ? (
+            <section {...stylex.props(styles.section)}>
+              <div {...stylex.props(styles.sectionHeader)}>
+                <SectionHeading>Critic reviews</SectionHeading>
+                {criticReviewDetail ? (
+                  <span {...stylex.props(styles.sectionDetail)}>
+                    {criticReviewDetail}
+                  </span>
+                ) : null}
               </div>
-            </div>
-          ) : null}
-
-          {recommendations.length ? (
-            <section {...stylex.props(styles.railSection)}>
-              <h2 {...stylex.props(styles.railHeading)}>
-                {recommendationHeading}
-              </h2>
-              {recommendationIntro ? (
-                <p {...stylex.props(styles.railIntro)}>{recommendationIntro}</p>
-              ) : null}
-              <RailList ariaLabel={recommendationHeading}>
-                {recommendations.map((recommendation) => (
-                  <RailListItem
-                    end={recommendation.end}
-                    href={recommendation.href}
-                    key={recommendation.href}
-                    leading={
-                      <BottleVisual
-                        imageUrl={recommendation.imageUrl}
-                        size="sm"
-                      />
-                    }
-                    metadata={recommendation.metadata}
-                    title={recommendation.name}
-                  />
+              <ItemList ariaLabel="Critic reviews">
+                {criticReviews.map((review, index) => (
+                  <ItemListItem
+                    key={`${review.publication}-${review.publishedAt ?? index}`}
+                  >
+                    <CriticReview {...review} />
+                  </ItemListItem>
                 ))}
-              </RailList>
+              </ItemList>
             </section>
           ) : null}
-        </aside>
-      ) : null}
+
+          {tastings.length ? (
+            <section {...stylex.props(styles.section)}>
+              <SectionHeading>Tastings</SectionHeading>
+              <ItemList ariaLabel="Bottle tastings">
+                {tastings.map((tasting, index) => (
+                  <ItemListItem key={`${tasting.author}-${index}`}>
+                    <TastingEntry {...tasting} />
+                  </ItemListItem>
+                ))}
+              </ItemList>
+              {moreTastingsHref &&
+              tastingCount !== undefined &&
+              tastingCount > tastings.length ? (
+                <AppLink
+                  href={moreTastingsHref}
+                  {...stylex.props(styles.moreLink)}
+                >
+                  Show all {tastingCount.toLocaleString("en-US")} tastings →
+                </AppLink>
+              ) : null}
+            </section>
+          ) : null}
+
+          {!criticReviews.length && !tastings.length ? mainState : null}
+        </div>
+      </div>
+
+      <aside
+        aria-label="Bottle media and recommendations"
+        {...stylex.props(styles.rail)}
+      >
+        <figure {...stylex.props(styles.media)}>
+          <BottleVisual
+            expandable
+            imageUrl={image.url}
+            label={image.label}
+            size="xl"
+          />
+          {image.url && (image.sourceUrl || image.license) ? (
+            <figcaption {...stylex.props(styles.caption)}>
+              <ImageAttribution
+                license={image.license}
+                sourceUrl={image.sourceUrl}
+              />
+            </figcaption>
+          ) : null}
+        </figure>
+
+        {recommendations.length ? (
+          <section {...stylex.props(styles.recommendations)}>
+            <h2 {...stylex.props(styles.railHeading)}>
+              {recommendationHeading}
+            </h2>
+            {recommendationIntro ? (
+              <p {...stylex.props(styles.railIntro)}>{recommendationIntro}</p>
+            ) : null}
+            <RailList ariaLabel={recommendationHeading}>
+              {recommendations.map((recommendation) => (
+                <RailListItem
+                  end={recommendation.end}
+                  href={recommendation.href}
+                  key={recommendation.href}
+                  leading={
+                    <BottleVisual
+                      imageUrl={recommendation.imageUrl}
+                      size="sm"
+                    />
+                  }
+                  metadata={recommendation.metadata}
+                  title={recommendation.name}
+                />
+              ))}
+            </RailList>
+          </section>
+        ) : null}
+      </aside>
     </div>
   );
 }
@@ -155,24 +180,59 @@ export function BottleOverview({
 const styles = stylex.create({
   layout: {
     display: "grid",
+    gridTemplateAreas: {
+      default: '"main rail"',
+      [NARROW]: '"facts" "media" "content" "recommendations"',
+    },
     gridTemplateColumns: {
       default: "minmax(0, 1fr) 336px",
-      [RAIL_SHRINKS]: "minmax(0, 1fr) 300px",
-      [RAIL_FOLDS]: "minmax(0, 1fr)",
+      [NARROW]: "minmax(0, 1fr)",
     },
     minWidth: 0,
     alignItems: "start",
-    columnGap: space.x8,
-    rowGap: space.x8,
-  },
-  layoutWithoutRail: {
-    gridTemplateColumns: "minmax(0, 1fr)",
+    columnGap: space.x12,
   },
   main: {
+    gridArea: "main",
+    display: { default: "flex", [NARROW]: "contents" },
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x8,
+  },
+  facts: {
+    gridArea: "facts",
+    minWidth: 0,
+  },
+  content: {
+    gridArea: "content",
     display: "flex",
     minWidth: 0,
     flexDirection: "column",
     gap: space.x8,
+  },
+  rail: {
+    gridArea: "rail",
+    display: { default: "flex", [NARROW]: "contents" },
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x8,
+  },
+  media: {
+    gridArea: "media",
+    minWidth: 0,
+    margin: 0,
+    marginTop: space.x4,
+  },
+  caption: {
+    marginTop: space.x2,
+    color: colors.inkMuted,
+  },
+  recommendations: {
+    gridArea: "recommendations",
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x2,
   },
   section: {
     minWidth: 0,
@@ -219,23 +279,6 @@ const styles = stylex.create({
       ":focus-visible": effects.focusRing,
     },
   },
-  rail: {
-    display: { default: "flex", [RAIL_FOLDS]: "grid" },
-    minWidth: 0,
-    flexDirection: "column",
-    gridTemplateColumns: {
-      default: "none",
-      [RAIL_FOLDS]: "repeat(2, minmax(0, 1fr))",
-      [RAIL_STACKS]: "minmax(0, 1fr)",
-    },
-    gap: { default: space.x6, [RAIL_FOLDS]: "6px", [RAIL_STACKS]: space.x6 },
-  },
-  railSection: {
-    display: "flex",
-    minWidth: 0,
-    flexDirection: "column",
-    gap: space.x2,
-  },
   railHeading: {
     margin: 0,
     fontFamily: fonts.display,
@@ -250,12 +293,5 @@ const styles = stylex.create({
     fontFamily: fonts.data,
     fontSize: "10px",
     lineHeight: 1.4,
-  },
-  panel: {
-    paddingTop: space.x1,
-    paddingRight: 0,
-    paddingBottom: space.x1,
-    paddingLeft: 0,
-    backgroundColor: "transparent",
   },
 });

--- a/apps/web/src/components/pages/bottlePageHeader.stories.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import { Button, ButtonLink, RowMenu } from "..";
-import BottleImage from "../../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import { BottlePageHeader } from "./bottlePageHeader.stylex";
 
@@ -21,10 +20,7 @@ const meta = {
     ),
     brand: "Laphroaig",
     brandHref: "/entities/809",
-    detail: "Islay · single malt · official bottling",
-    id: "B19936",
-    imageUrl: BottleImage.src,
-    memberStatus: { hasTasted: true, isLibrary: false },
+    eyebrow: "Laphroaig Distillery",
     menu: (
       <RowMenu
         groups={[
@@ -38,7 +34,6 @@ const meta = {
       />
     ),
     name: "Elements L 2.0",
-    notes: ["Cask strength", "Non-chill filtered"],
     bands: {
       counts: {
         good: 8,
@@ -69,26 +64,12 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const MissingImage: Story = {
-  args: {
-    brand: "Lagavulin",
-    brandHref: "/entities/245",
-    detail: "Islay · single malt · official bottling",
-    id: "B00042",
-    imageUrl: null,
-    name: "16-year-old",
-    notes: ["Sherry cask finish"],
-  },
-};
-
 export const LongName: Story = {
   args: {
     brand: "The Scotch Malt Whisky Society",
     brandHref: "/entities/3417",
-    detail: "Highland · single malt · independent bottling",
-    id: "B49748",
+    eyebrow: "Caol Ila Distillery",
     name: "SMWS Highland peaty potion",
-    notes: [],
   },
 };
 
@@ -97,13 +78,9 @@ export const ThinData: Story = {
     actions: null,
     brand: "Port Ellen",
     brandHref: "/entities/214",
-    detail: "Islay · single malt",
-    id: "B08172",
-    imageUrl: null,
-    memberStatus: undefined,
+    eyebrow: "Port Ellen Distillery",
     menu: null,
     name: "Independent bottling",
-    notes: [],
     bands: null,
     score: null,
   },

--- a/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
@@ -2,41 +2,21 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import type { ReviewScoreProps, TastingRatingDistributionProps } from "..";
-import {
-  AppLink,
-  BottleVisual,
-  Chip,
-  ImageAttribution,
-  PeatedId,
-  ReviewScore,
-  TastingRatingDistribution,
-} from "..";
-import { foundationStyles } from "../../styles/foundations.stylex";
+import { AppLink, ReviewScore, TastingRatingDistribution } from "..";
 import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
+import { PageHeader } from "./pageLayout.stylex";
 
 const NARROW = "@media (max-width: 900px)";
-const COMPACT = "@media (max-width: 639px)";
 const PHONE = "@media (max-width: 480px)";
-
-export type BottleMemberStatus = {
-  hasTasted: boolean;
-  isLibrary: boolean;
-};
 
 export type BottlePageHeaderProps = {
   actions?: ReactNode;
   bands?: TastingRatingDistributionProps | null;
   brand: string;
   brandHref?: string;
-  detail?: ReactNode;
-  id: string;
-  imageUrl?: string | null;
-  imageSourceUrl?: string | null;
-  imageLicense?: string | null;
-  memberStatus?: BottleMemberStatus;
+  eyebrow?: ReactNode;
   menu?: ReactNode;
   name: string;
-  notes?: readonly string[];
   score?: ReviewScoreProps | null;
 };
 
@@ -46,101 +26,37 @@ export function BottlePageHeader({
   bands,
   brand,
   brandHref,
-  detail,
-  id,
-  imageUrl,
-  imageSourceUrl,
-  imageLicense,
-  memberStatus,
+  eyebrow,
   menu,
   name,
-  notes = [],
   score,
 }: BottlePageHeaderProps) {
-  const hasActions = Boolean(actions || menu);
   const hasRatings = Boolean(score || bands);
-  const hasLongName = `${brand} ${name}`.length > 24;
 
   return (
-    <header
-      {...stylex.props(styles.root, hasRatings && styles.rootWithRatings)}
-    >
-      <div {...stylex.props(styles.stampPanel)}>
-        <PeatedId detail={detail} id={id} />
-      </div>
-      <div
-        {...stylex.props(
-          styles.identityPanel,
-          hasRatings && styles.identityPanelWithRatings,
-        )}
-      >
-        <div {...stylex.props(styles.identityContent)}>
-          <div {...stylex.props(styles.image)}>
-            <BottleVisual
-              expandable
-              imageUrl={imageUrl}
-              label={`${brand} ${name}`}
-              size="lg"
-            />
-          </div>
-          <div {...stylex.props(styles.identity)}>
-            <h1
-              {...stylex.props(
-                foundationStyles.pageTitle,
-                styles.name,
-                hasLongName && styles.longName,
-              )}
-            >
-              {brandHref ? (
-                <AppLink
-                  href={brandHref}
-                  title={brand}
-                  {...stylex.props(styles.brand)}
-                >
-                  {brand}
-                </AppLink>
-              ) : (
-                <span title={brand}>{brand}</span>
-              )}{" "}
-              {name}
-            </h1>
-            {notes.length ? (
-              <div
-                aria-label="Bottle details"
-                role="group"
-                {...stylex.props(styles.notes)}
+    <div {...stylex.props(styles.root, hasRatings && styles.rootWithRatings)}>
+      <PageHeader
+        actions={actions}
+        actionsPosition="start"
+        eyebrow={eyebrow}
+        menu={menu}
+        title={
+          <>
+            {brandHref ? (
+              <AppLink
+                href={brandHref}
+                title={brand}
+                {...stylex.props(styles.brand)}
               >
-                {notes.map((note, index) => (
-                  <Chip key={`${note}-${index}`} variant="tinted">
-                    {note}
-                  </Chip>
-                ))}
-              </div>
-            ) : null}
-            {hasActions ? (
-              <div {...stylex.props(styles.actions)}>
-                {actions}
-                {menu}
-              </div>
-            ) : null}
-            {memberStatus ? (
-              <p {...stylex.props(styles.memberStatus)}>
-                {memberStatus.isLibrary ? "In Library" : "Not in Library"}
-                <span aria-hidden="true"> · </span>
-                {memberStatus.hasTasted ? "Tasted" : "Not tasted"}
-              </p>
-            ) : null}
-          </div>
-          {imageUrl ? (
-            <div {...stylex.props(styles.attribution)}>
-              <ImageAttribution
-                license={imageLicense}
-                sourceUrl={imageSourceUrl}
-              />
-            </div>
-          ) : null}
-        </div>
-      </div>
+                {brand}
+              </AppLink>
+            ) : (
+              <span title={brand}>{brand}</span>
+            )}{" "}
+            {name}
+          </>
+        }
+      />
       {hasRatings ? (
         <div aria-label="Community ratings" {...stylex.props(styles.ratings)}>
           {score ? (
@@ -160,7 +76,7 @@ export function BottlePageHeader({
           ) : null}
         </div>
       ) : null}
-    </header>
+    </div>
   );
 }
 
@@ -177,46 +93,7 @@ const styles = stylex.create({
       default: "minmax(0, 1fr) 260px",
       [NARROW]: "minmax(0, 1fr)",
     },
-  },
-  stampPanel: {
-    boxSizing: "border-box",
-    minWidth: 0,
-    gridColumn: "1 / -1",
-    paddingTop: { default: space.x6, [PHONE]: 0 },
-    backgroundColor: "transparent",
-  },
-  identityPanel: {
-    boxSizing: "border-box",
-    minWidth: 0,
-    gridColumn: "1",
-    gridRow: "2",
-    paddingTop: space.x4,
-    paddingBottom: { default: space.x6, [PHONE]: 0 },
-    backgroundColor: "transparent",
-  },
-  identityPanelWithRatings: {
-    borderBottomRightRadius: 0,
-  },
-  identityContent: {
-    display: "grid",
-    gridTemplateColumns: {
-      default: "132px minmax(0, 1fr)",
-      [COMPACT]: "80px minmax(0, 1fr)",
-    },
-    minWidth: 0,
-    alignItems: "start",
-    columnGap: { default: space.x4, [COMPACT]: space.x2 },
-  },
-  identity: {
-    minWidth: 0,
-  },
-  image: {
-    minWidth: 0,
-  },
-  attribution: {
-    gridColumn: { default: "1", [COMPACT]: "1 / -1" },
-    marginTop: space.x1,
-    minWidth: 0,
+    columnGap: space.x6,
   },
   brand: {
     outline: "none",
@@ -235,90 +112,20 @@ const styles = stylex.create({
       ":focus-visible": effects.focusRing,
     },
   },
-  name: {
-    overflowWrap: "anywhere",
-    fontSize: {
-      default: "clamp(30px, 4vw, 40px)",
-      [COMPACT]: "28px",
-      [PHONE]: "26px",
-    },
-    textWrap: "balance",
-  },
-  longName: {
-    fontSize: {
-      default: "clamp(28px, 3.5vw, 36px)",
-      [COMPACT]: "26px",
-      [PHONE]: "24px",
-    },
-  },
-  notes: {
-    display: "flex",
-    gap: space.x2,
-    marginTop: space.x3,
-    flexWrap: "wrap",
-  },
-  actions: {
-    position: { default: "static", [PHONE]: "fixed" },
-    right: { default: "auto", [PHONE]: 0 },
-    bottom: { default: "auto", [PHONE]: 0 },
-    left: { default: "auto", [PHONE]: 0 },
-    zIndex: { default: "auto", [PHONE]: 40 },
-    boxSizing: "border-box",
-    display: { default: "flex", [PHONE]: "grid" },
-    width: { default: "auto", [PHONE]: "100%" },
-    gridTemplateColumns: {
-      default: "none",
-      [PHONE]: "minmax(0, 1fr) auto auto",
-    },
-    gap: space.x2,
-    marginTop: space.x4,
-    alignItems: "center",
-    flexWrap: "wrap",
-    paddingTop: { default: 0, [PHONE]: "10px" },
-    paddingRight: {
-      default: 0,
-      [PHONE]: `max(${space.x4}, env(safe-area-inset-right))`,
-    },
-    paddingBottom: {
-      default: 0,
-      [PHONE]: "calc(10px + env(safe-area-inset-bottom))",
-    },
-    paddingLeft: {
-      default: 0,
-      [PHONE]: `max(${space.x4}, env(safe-area-inset-left))`,
-    },
-    borderTopWidth: { default: 0, [PHONE]: "1px" },
-    borderTopStyle: "solid",
-    borderTopColor: colors.hairline,
-    backgroundColor: { default: "transparent", [PHONE]: colors.surface },
-  },
-  memberStatus: {
-    margin: 0,
-    marginTop: space.x3,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.45,
-  },
   ratings: {
     boxSizing: "border-box",
     display: "grid",
     minWidth: 0,
     gridColumn: { default: "2", [NARROW]: "1" },
-    gridRow: { default: "2", [NARROW]: "auto" },
+    gridRow: { default: "1", [NARROW]: "auto" },
     gridTemplateColumns: {
       default: "minmax(0, 1fr)",
       [NARROW]: "repeat(2, minmax(0, 1fr))",
       [PHONE]: "minmax(0, 1fr)",
     },
     gap: space.x4,
-    marginTop: { default: 0, [NARROW]: "6px", [PHONE]: space.x4 },
-    paddingTop: space.x4,
-    paddingRight: 0,
-    paddingBottom: { default: space.x6, [NARROW]: space.x4 },
-    paddingLeft: { default: space.x6, [NARROW]: 0 },
-    backgroundColor: "transparent",
+    paddingTop: { default: space.x4, [NARROW]: 0 },
+    paddingBottom: { default: space.x4, [NARROW]: 0 },
   },
   rating: {
     display: { default: "block", [PHONE]: "grid" },


### PR DESCRIPTION
Bottle detail pages now follow the entity detail hierarchy: the distillery stays above the title, the bottle image moves to the overview rail, and catalog facts appear in a responsive grid below the Overview tab. Peated ID and redundant negative library/tasting status text no longer occupy the header.

The mobile layout preserves the same information order by placing facts first, then the bottle image, then reviews and tastings. Bottle and entity pages share the grid variant of the fact-list component so their detail presentation stays consistent.
