### PR TITLE
style(home): replace bottle count with search hints

### DIFF
--- a/apps/web/src/app/(app)/_components/home/homeSearchPlaceholder.test.ts
+++ b/apps/web/src/app/(app)/_components/home/homeSearchPlaceholder.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { getHomeSearchPlaceholder } from "./homeSearchPlaceholder";
+
+describe("getHomeSearchPlaceholder", () => {
+  it("uses the supplied random value to select a hint", () => {
+    expect(getHomeSearchPlaceholder(() => 0)).toBe("Try “Lagavulin 16”…");
+    expect(getHomeSearchPlaceholder(() => 0.999)).toBe(
+      "Try a bottle, distiller, brand, or bottler…",
+    );
+  });
+});

--- a/apps/web/src/app/(app)/_components/home/homeSearchPlaceholder.ts
+++ b/apps/web/src/app/(app)/_components/home/homeSearchPlaceholder.ts
@@ -1,0 +1,11 @@
+const SEARCH_PLACEHOLDERS = [
+  "Try “Lagavulin 16”…",
+  "Try “Ardbeg Uigeadail”…",
+  "Try “Springbank 10”…",
+  "Try a bottle, distiller, brand, or bottler…",
+] as const;
+
+export function getHomeSearchPlaceholder(random = Math.random) {
+  const index = Math.floor(random() * SEARCH_PLACEHOLDERS.length);
+  return SEARCH_PLACEHOLDERS[index] ?? SEARCH_PLACEHOLDERS[0];
+}

--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -36,7 +36,11 @@ import { space } from "../../../../styles/tokens.stylex";
 
 type Bottle = Outputs["bottles"]["list"]["results"][number];
 
-export function PublicHome() {
+export function PublicHome({
+  searchPlaceholder,
+}: {
+  searchPlaceholder: string;
+}) {
   const orpc = useORPC();
   const router = useRouter();
   const { user } = useAuth();
@@ -92,11 +96,7 @@ export function PublicHome() {
               query ? `/search?q=${encodeURIComponent(query)}` : "/search",
             )
           }
-          placeholder={
-            totalBottles === undefined
-              ? "Search bottles…"
-              : `Search ${totalBottles.toLocaleString("en-US")} bottles…`
-          }
+          placeholder={searchPlaceholder}
           scopeValues={["all"]}
           showBottleRatings={false}
           submitLabel="Search"

--- a/apps/web/src/app/(app)/homePageClient.tsx
+++ b/apps/web/src/app/(app)/homePageClient.tsx
@@ -2,6 +2,10 @@
 
 import { PublicHome } from "@peated/web/app/(app)/_components/home/publicHome.stylex";
 
-export function HomePageClient() {
-  return <PublicHome />;
+export function HomePageClient({
+  searchPlaceholder,
+}: {
+  searchPlaceholder: string;
+}) {
+  return <PublicHome searchPlaceholder={searchPlaceholder} />;
 }

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -1,4 +1,5 @@
 import { createTanstackQueryUtils } from "@orpc/tanstack-query";
+import { getHomeSearchPlaceholder } from "@peated/web/app/(app)/_components/home/homeSearchPlaceholder";
 import {
   getAnonymousServerClient,
   getServerClient,
@@ -19,6 +20,7 @@ export const metadata = homeMetadata;
 
 export default async function Page() {
   const session = await getSession();
+  const searchPlaceholder = getHomeSearchPlaceholder();
   const queryClient = getQueryClient();
   const { client } = session.user
     ? await getServerClient()
@@ -39,7 +41,7 @@ export default async function Page() {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <HomePageClient />
+      <HomePageClient searchPlaceholder={searchPlaceholder} />
     </HydrationBoundary>
   );
 }


### PR DESCRIPTION
The homepage search now replaces the live bottle count with a rotating set of useful search hints, including bottle examples and the supported producer types.

The server selects each hint and passes the resolved text to the client. This keeps hydration stable, while the selector accepts an injected random source so tests stay deterministic.
