### PR TITLE
fix(search): prioritize exact matches

### DIFF
--- a/apps/server/src/orpc/routes/search.test.ts
+++ b/apps/server/src/orpc/routes/search.test.ts
@@ -259,6 +259,27 @@ describe("GET /search", () => {
     ]);
   });
 
+  test("puts a case-insensitive exact Entity group before Bottle matches", async ({
+    fixtures,
+  }) => {
+    await fixtures.Bottle({ name: "Exactgroupneedle Bottle" });
+    const brand = await fixtures.Entity({
+      name: "Exactgroupneedle",
+      kind: "brand",
+    });
+
+    const data = await routerClient.search({
+      query: "EXACTGROUPNEEDLE",
+      scopes: ["bottles", "brands"],
+      limit: 10,
+    });
+
+    expect(data.groups).toMatchObject([
+      { type: "brands", results: [{ id: brand.id }] },
+      { type: "bottles" },
+    ]);
+  });
+
   test("uses community rating count only to break equal text matches", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/search.ts
+++ b/apps/server/src/orpc/routes/search.ts
@@ -63,10 +63,30 @@ type EntityRow = EntityResult & {
 type RegionRow = RegionResult & { totalBottles: number };
 type ScopeTotals = SearchOutput["scopeTotals"];
 type GroupRows =
-  | { type: "bottles"; total: number; results: BottleRow[] }
-  | { type: EntitySearchScope; total: number; results: EntityRow[] }
-  | { type: "regions"; total: number; results: RegionRow[] }
-  | { type: "members"; total: number; results: MemberResult[] };
+  | {
+      type: "bottles";
+      total: number;
+      results: BottleRow[];
+      exactMatch: boolean;
+    }
+  | {
+      type: EntitySearchScope;
+      total: number;
+      results: EntityRow[];
+      exactMatch: boolean;
+    }
+  | {
+      type: "regions";
+      total: number;
+      results: RegionRow[];
+      exactMatch: boolean;
+    }
+  | {
+      type: "members";
+      total: number;
+      results: MemberResult[];
+      exactMatch: boolean;
+    };
 
 type ExactRow =
   | { type: "bottle"; ref: BottleRow }
@@ -286,8 +306,8 @@ async function searchBottles(
   database: AnyDatabase,
   query: string,
   limit: number,
-): Promise<{ total: number; results: BottleRow[] }> {
-  if (!query) return { total: 0, results: [] };
+): Promise<{ total: number; results: BottleRow[]; exactMatch: boolean }> {
+  if (!query) return { total: 0, results: [], exactMatch: false };
   const textQuery = plainTextSearchQuery(query);
   const prefixQuery = prefixTextSearchQuery(query);
   const referenceMatch = exactBottleReferenceMatch(query);
@@ -307,6 +327,7 @@ async function searchBottles(
   const rows = await database
     .select({
       ...bottleColumns(),
+      searchRank: rank,
       searchTotal: sql<number>`COUNT(*) OVER()`,
     })
     .from(bottles)
@@ -318,7 +339,10 @@ async function searchBottles(
     .orderBy(rank, sql`${bottleRatingCount()} DESC`, asc(bottles.id));
   return {
     total: Number(rows[0]?.searchTotal ?? 0),
-    results: rows.map(({ searchTotal: _, ...result }) => result),
+    results: rows.map(
+      ({ searchRank: _, searchTotal: __, ...result }) => result,
+    ),
+    exactMatch: Number(rows[0]?.searchRank) === 0,
   };
 }
 
@@ -328,8 +352,8 @@ async function searchEntities(
   scope: EntitySearchScope,
   query: string,
   limit: number,
-): Promise<{ total: number; results: EntityRow[] }> {
-  if (!query) return { total: 0, results: [] };
+): Promise<{ total: number; results: EntityRow[]; exactMatch: boolean }> {
+  if (!query) return { total: 0, results: [], exactMatch: false };
   const textQuery = plainTextSearchQuery(query);
   const prefixQuery = prefixTextSearchQuery(query);
   const referenceMatch = exactEntityReferenceMatch(query);
@@ -349,6 +373,7 @@ async function searchEntities(
   const rows = await database
     .select({
       ...entityColumns(context),
+      searchRank: rank,
       searchTotal: sql<number>`COUNT(*) OVER()`,
     })
     .from(entities)
@@ -358,7 +383,10 @@ async function searchEntities(
     .orderBy(rank, sql`${entities.totalTastings} DESC`, asc(entities.id));
   return {
     total: Number(rows[0]?.searchTotal ?? 0),
-    results: rows.map(({ searchTotal: _, ...result }) => result),
+    results: rows.map(
+      ({ searchRank: _, searchTotal: __, ...result }) => result,
+    ),
+    exactMatch: Number(rows[0]?.searchRank) === 0,
   };
 }
 
@@ -366,8 +394,8 @@ async function searchRegions(
   database: AnyDatabase,
   query: string,
   limit: number,
-): Promise<{ total: number; results: RegionRow[] }> {
-  if (!query) return { total: 0, results: [] };
+): Promise<{ total: number; results: RegionRow[]; exactMatch: boolean }> {
+  if (!query) return { total: 0, results: [], exactMatch: false };
   const normalizedQuery = normalizeText(query);
   const name = sql`LOWER(unaccent(${regions.name}))`;
   const where = like(name, `%${escapeLike(normalizedQuery)}%`);
@@ -375,6 +403,7 @@ async function searchRegions(
   const rows = await database
     .select({
       ...regionColumns(),
+      searchRank: rank,
       searchTotal: sql<number>`COUNT(*) OVER()`,
     })
     .from(regions)
@@ -384,7 +413,10 @@ async function searchRegions(
     .orderBy(rank, sql`${regions.totalBottles} DESC`, asc(regions.id));
   return {
     total: Number(rows[0]?.searchTotal ?? 0),
-    results: rows.map(({ searchTotal: _, ...result }) => result),
+    results: rows.map(
+      ({ searchRank: _, searchTotal: __, ...result }) => result,
+    ),
+    exactMatch: Number(rows[0]?.searchRank) === 0,
   };
 }
 
@@ -393,9 +425,9 @@ async function searchMembers(
   context: Context,
   query: string,
   limit: number,
-): Promise<{ total: number; results: MemberResult[] }> {
+): Promise<{ total: number; results: MemberResult[]; exactMatch: boolean }> {
   if (!context.user || !query) {
-    return { total: 0, results: [] };
+    return { total: 0, results: [], exactMatch: false };
   }
   const normalizedQuery = normalizeText(query.replace(/^@/, ""));
   const username = sql`LOWER(unaccent(${users.username}))`;
@@ -415,6 +447,7 @@ async function searchMembers(
         pictureUrl: users.pictureUrl,
       },
       totalTastings: publicTastingCount,
+      searchRank: rank,
       searchTotal: sql<number>`COUNT(*) OVER()`,
     })
     .from(users)
@@ -429,6 +462,7 @@ async function searchMembers(
       member: row.member,
       totalTastings: Number(row.totalTastings),
     })),
+    exactMatch: Number(rows[0]?.searchRank) === 0,
   };
 }
 
@@ -744,6 +778,10 @@ async function readSearchRows(
           ),
         );
       }
+      // Exact name matches own the first group position across search scopes.
+      groups.sort(
+        (left, right) => Number(right.exactMatch) - Number(left.exactMatch),
+      );
       const matchTotal = groups.reduce(
         (total, group) => total + group.total,
         0,
@@ -795,7 +833,8 @@ function serializeGroup(group: GroupRows) {
   switch (group.type) {
     case "bottles":
       return {
-        ...group,
+        type: group.type,
+        total: group.total,
         results: group.results.map((row) => bottleResult(row, true)),
       };
     case "distilleries":
@@ -803,10 +842,15 @@ function serializeGroup(group: GroupRows) {
     case "bottlers":
     case "companies":
     case "regions":
-      return group;
+      return {
+        type: group.type,
+        total: group.total,
+        results: group.results,
+      };
     case "members":
       return {
-        ...group,
+        type: group.type,
+        total: group.total,
         results: group.results.map(memberResult),
       };
   }

--- a/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
@@ -202,6 +202,7 @@ export function SearchPageClient({
           scopeValues={scopeValues}
           showBottleRatings={false}
           submitLabel={databaseSearch ? "Search" : undefined}
+          typeaheadNavigation={false}
         />
       </section>
     </div>

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -100,6 +100,7 @@ export type SearchProps = {
   scopeValues?: readonly SearchScope[];
   showBottleRatings?: boolean;
   submitLabel?: string;
+  typeaheadNavigation?: boolean;
 };
 
 const SEARCH_DEBOUNCE_MS = 140;
@@ -437,6 +438,7 @@ export function Search({
   scopeValues,
   showBottleRatings = true,
   submitLabel,
+  typeaheadNavigation = true,
 }: SearchProps = {}) {
   const { user } = useAuth();
   const orpc = useORPC();
@@ -659,6 +661,7 @@ export function Search({
           : undefined
       }
       submitLabel={submitLabel}
+      typeaheadNavigation={typeaheadNavigation}
     />
   );
 

--- a/apps/web/src/components/searchBox.stylex.tsx
+++ b/apps/web/src/components/searchBox.stylex.tsx
@@ -54,6 +54,7 @@ export type SearchBoxProps = Pick<
   scopeFacets?: readonly ScopedSearchOption[];
   scopes: readonly ScopedSearchOption[];
   submitLabel?: string;
+  typeaheadNavigation?: boolean;
 };
 
 /** Owns the keyboard and disclosure behavior for Peated's scoped search UI. */
@@ -83,6 +84,7 @@ export function SearchBox({
   status = "ready",
   statusText,
   submitLabel = "Search",
+  typeaheadNavigation = true,
 }: SearchBoxProps) {
   const panelId = useId();
   const rootRef = useRef<HTMLDivElement>(null);
@@ -90,11 +92,12 @@ export function SearchBox({
   const [selectedId, setSelectedId] = useState<string>();
   const [open, setOpen] = useState(defaultOpen);
   const items = useMemo(() => groups.flatMap((group) => group.items), [groups]);
-  const activeId =
-    items.find((item) => item.id === selectedId)?.id ??
-    (query.trim() && resultQuery.trim() === query.trim()
-      ? items[0]?.id
-      : undefined);
+  const activeId = typeaheadNavigation
+    ? (items.find((item) => item.id === selectedId)?.id ??
+      (query.trim() && resultQuery.trim() === query.trim()
+        ? items[0]?.id
+        : undefined))
+    : undefined;
   const hasPanelContent =
     groups.length > 0 ||
     Boolean(emptyText) ||
@@ -162,6 +165,14 @@ export function SearchBox({
   }
 
   function handleKeyDown(event: ReactKeyboardEvent<HTMLInputElement>) {
+    if (!typeaheadNavigation) {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        onSubmit?.(query);
+      }
+      return;
+    }
+
     if (event.key === "ArrowDown" || event.key === "ArrowUp") {
       event.preventDefault();
       moveActive(event.key === "ArrowDown" ? 1 : -1);
@@ -203,9 +214,11 @@ export function SearchBox({
   const searchControl = (
     <ScopedSearch
       aria-activedescendant={
-        activeId ? `${panelId}-${encodeURIComponent(activeId)}` : undefined
+        typeaheadNavigation && activeId
+          ? `${panelId}-${encodeURIComponent(activeId)}`
+          : undefined
       }
-      aria-autocomplete="list"
+      aria-autocomplete={typeaheadNavigation ? "list" : undefined}
       aria-controls={expanded ? panelId : undefined}
       autoFocus={autoFocus}
       disabled={disabled}
@@ -281,12 +294,12 @@ export function SearchBox({
               {searchRow}
               {expanded ? (
                 <SearchResults
-                  activeId={activeId}
+                  activeId={typeaheadNavigation ? activeId : undefined}
                   embedded
                   groups={groups}
                   label="Recent searches"
-                  onItemSelect={selectResult}
-                  optionIdPrefix={panelId}
+                  onItemSelect={typeaheadNavigation ? selectResult : undefined}
+                  optionIdPrefix={typeaheadNavigation ? panelId : undefined}
                   panelId={panelId}
                   query=""
                   scroll={false}
@@ -325,14 +338,14 @@ export function SearchBox({
               ) : null}
               {expanded ? (
                 <SearchResults
-                  activeId={activeId}
+                  activeId={typeaheadNavigation ? activeId : undefined}
                   contribution={contribution}
                   embedded
                   emptyText={emptyText}
                   groups={groups}
-                  onItemSelect={selectResult}
+                  onItemSelect={typeaheadNavigation ? selectResult : undefined}
                   onRetry={onRetry}
-                  optionIdPrefix={panelId}
+                  optionIdPrefix={typeaheadNavigation ? panelId : undefined}
                   panelId={panelId}
                   query={resultQuery}
                   scroll={false}
@@ -379,15 +392,15 @@ export function SearchBox({
               />
             </div>
             <SearchResults
-              activeId={activeId}
+              activeId={typeaheadNavigation ? activeId : undefined}
               contribution={contribution}
               embedded
               emptyText={emptyText}
               groups={groups}
               label={query.trim() ? "Search results" : "Recent searches"}
-              onItemSelect={selectResult}
+              onItemSelect={typeaheadNavigation ? selectResult : undefined}
               onRetry={onRetry}
-              optionIdPrefix={panelId}
+              optionIdPrefix={typeaheadNavigation ? panelId : undefined}
               panelId={panelId}
               query={resultQuery}
               scroll={placement === "overlay"}

--- a/apps/web/src/components/searchBox.test.tsx
+++ b/apps/web/src/components/searchBox.test.tsx
@@ -108,4 +108,22 @@ describe("SearchBox active result", () => {
 
     expect(html).not.toContain("aria-activedescendant");
   });
+
+  it("does not activate results when typeahead navigation is disabled", () => {
+    const html = renderToStaticMarkup(
+      <SearchBox
+        groups={groups}
+        onQueryChange={() => undefined}
+        onScopeChange={() => undefined}
+        query="ardbeg"
+        resultQuery="ardbeg"
+        scope="all"
+        scopes={[{ label: "Everything", value: "all" }]}
+        typeaheadNavigation={false}
+      />,
+    );
+
+    expect(html).not.toContain("aria-activedescendant");
+    expect(html).not.toContain('aria-autocomplete="list"');
+  });
 });


### PR DESCRIPTION
Search now puts case-insensitive exact name matches first across result types, so an exact distiller, brand, bottler, region, or member no longer sits below partial Bottle matches. The server preserves the existing ranking inside each group and only changes the group order when an exact match exists.

Dedicated search-page results now behave as normal links without controlled pointer selection, arrow-key selection, or an automatic first-result outline. Header and home-page typeaheads keep their existing navigation behavior.
