### PR TITLE
feat(web): add readable catalog URLs

### DIFF
--- a/apps/server/src/orpc/contracts/entities/resolve.ts
+++ b/apps/server/src/orpc/contracts/entities/resolve.ts
@@ -15,5 +15,6 @@ export default contract
     z.object({
       id: z.number().readonly(),
       kind: EntityKindEnum,
+      name: z.string(),
     }),
   );

--- a/apps/server/src/orpc/mock/routes/entities/resolve.ts
+++ b/apps/server/src/orpc/mock/routes/entities/resolve.ts
@@ -9,5 +9,5 @@ export default mockOS.entities.resolve.handler(async ({ input, errors }) => {
     throw errors.NOT_FOUND({ message: "Mock entity not found." });
   }
 
-  return { id: entity.id, kind: entity.kind };
+  return { id: entity.id, kind: entity.kind, name: entity.name };
 });

--- a/apps/server/src/orpc/routes/entities/resolve.test.ts
+++ b/apps/server/src/orpc/routes/entities/resolve.test.ts
@@ -4,12 +4,16 @@ import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 
 describe("GET /entities/:entity/resolve", () => {
-  test("returns the Entity ID and primary kind", async ({ fixtures }) => {
+  test("returns the Entity route fields", async ({ fixtures }) => {
     const entity = await fixtures.Entity({ kind: "company" });
 
     await expect(
       routerClient.entities.resolve({ entity: entity.id }),
-    ).resolves.toEqual({ id: entity.id, kind: "company" });
+    ).resolves.toEqual({
+      id: entity.id,
+      kind: "company",
+      name: entity.name,
+    });
   });
 
   test("resolves an Entity tombstone", async ({ fixtures }) => {
@@ -21,7 +25,11 @@ describe("GET /entities/:entity/resolve", () => {
 
     await expect(
       routerClient.entities.resolve({ entity: 999 }),
-    ).resolves.toEqual({ id: entity.id, kind: "distillery" });
+    ).resolves.toEqual({
+      id: entity.id,
+      kind: "distillery",
+      name: entity.name,
+    });
   });
 
   test("rejects a missing Entity", async () => {

--- a/apps/server/src/orpc/routes/entities/resolve.ts
+++ b/apps/server/src/orpc/routes/entities/resolve.ts
@@ -8,5 +8,5 @@ export default implement(contract).handler(async ({ input, errors }) => {
     throw errors.NOT_FOUND({ message: "Entity not found." });
   }
 
-  return { id: entity.id, kind: entity.kind };
+  return { id: entity.id, kind: entity.kind, name: entity.name };
 });

--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -16,7 +16,7 @@ declare global {
   }
 }
 
-import { bottlePath } from "./assertions";
+import { bottleHrefSelector, bottlePathPattern } from "./assertions";
 import {
   addAnotherReleaseSourceBottle,
   createdBottleId,
@@ -179,7 +179,7 @@ test.describe("create bottle", () => {
       expect(createInput).not.toHaveProperty(authorityField);
     }
 
-    await expect(page).toHaveURL(bottlePath(createdBottleId));
+    await expect(page).toHaveURL(bottlePathPattern(createdBottleId));
   });
 
   test("continues to tasting from explicit tasting intent", async ({
@@ -211,7 +211,7 @@ test.describe("create bottle", () => {
     );
     await submitCreateBottle(page);
 
-    await expect(page).toHaveURL(bottlePath(createdBottleId));
+    await expect(page).toHaveURL(bottlePathPattern(createdBottleId));
   });
 
   test("returns to the catalog outcome from catalog intent", async ({
@@ -235,7 +235,7 @@ test.describe("create bottle", () => {
     ).toBeVisible();
     await expect(
       page.getByRole("link", { name: "View bottle" }),
-    ).toHaveAttribute("href", bottlePath(createdBottleId));
+    ).toHaveAttribute("href", bottlePathPattern(createdBottleId));
   });
 
   test("returns to the created bottle from choose intent", async ({
@@ -487,7 +487,7 @@ test.describe("create bottle", () => {
     expect(createInput).not.toHaveProperty("sourceBottleId");
     expect(createInput).not.toHaveProperty("release");
     expect(createInput).not.toHaveProperty("releaseId");
-    await expect(page).toHaveURL(bottlePath(createdBottleId));
+    await expect(page).toHaveURL(bottlePathPattern(createdBottleId));
   });
 
   test("shows validation when saving without a brand", async ({
@@ -572,7 +572,7 @@ test.describe("add bottle flow", () => {
     expect(addBottleUrl.searchParams.get("release")).toBeNull();
     await expect(
       page.getByRole("link", { name: "View bottle" }),
-    ).toHaveAttribute("href", `/bottles/${exactSearchBottle.id}`);
+    ).toHaveAttribute("href", bottlePathPattern(exactSearchBottle.id));
     await expect(
       page.getByRole("button", { name: "Add to Library" }),
     ).toBeVisible();
@@ -726,7 +726,7 @@ test.describe("add bottle flow", () => {
     ).toBeVisible();
     await expect(
       page.getByRole("link", { name: "View Bottle" }),
-    ).toHaveAttribute("href", `/bottles/${existingBottle.id}`);
+    ).toHaveAttribute("href", bottlePathPattern(existingBottle.id));
     await expectFooterBelowAction(
       page.getByRole("link", { name: "View Bottle" }),
       traceFooter,
@@ -755,7 +755,7 @@ test.describe("add bottle flow", () => {
     await page.getByRole("link", { name: "View Library" }).click();
     await expect(page).toHaveURL(`/users/${testUser.username}/library`);
     await expect(
-      page.locator(`a[href="/bottles/${existingBottle.id}"]`).first(),
+      page.locator(bottleHrefSelector(existingBottle.id)).first(),
     ).toBeVisible();
 
     await page.goto("/addBottle");
@@ -878,7 +878,7 @@ test.describe("add bottle flow", () => {
       "playwright-create-token:create_bottle:suitable",
     );
     expect(input).not.toHaveProperty("catalogImageApproval");
-    await expect(page).toHaveURL(bottlePath(createdBottleId));
+    await expect(page).toHaveURL(bottlePathPattern(createdBottleId));
   });
 
   test("creates a complete bottle from a scan when Add a bottle is clicked", async ({
@@ -902,7 +902,7 @@ test.describe("add bottle flow", () => {
       "playwright-create-token:create_bottle:suitable",
     );
     expect(input).not.toHaveProperty("catalogImageApproval");
-    await expect(page).toHaveURL(bottlePath(createdBottleId));
+    await expect(page).toHaveURL(bottlePathPattern(createdBottleId));
   });
 
   test("prefills exact bottle fields from a scan before creating it", async ({
@@ -932,7 +932,7 @@ test.describe("add bottle flow", () => {
     expect(input.createToken).toBe(
       "playwright-create-token:create_bottle:suitable",
     );
-    await expect(page).toHaveURL(bottlePath(createdBottleId));
+    await expect(page).toHaveURL(bottlePathPattern(createdBottleId));
   });
 
   test("creates from an unsuitable scan without requesting image approval", async ({
@@ -956,7 +956,7 @@ test.describe("add bottle flow", () => {
       "playwright-create-token:create_bottle:unsuitable",
     );
     expect(input).not.toHaveProperty("catalogImageApproval");
-    await expect(page).toHaveURL(bottlePath(createdBottleId));
+    await expect(page).toHaveURL(bottlePathPattern(createdBottleId));
   });
 
   test("shows catalog image warning without blocking created Bottle resolution", async ({
@@ -979,7 +979,7 @@ test.describe("add bottle flow", () => {
         "The bottle was added, but the public image was not saved.",
       ),
     ).toBeVisible();
-    await expect(page).toHaveURL(bottlePath(createdBottleId));
+    await expect(page).toHaveURL(bottlePathPattern(createdBottleId));
   });
 
   test("creates a scan proposal as part of Add to Library", async ({
@@ -1112,7 +1112,7 @@ test.describe("add bottle flow", () => {
     expect(input.createToken).toBe(
       "playwright-create-token:create_bottle:suitable",
     );
-    await expect(page).toHaveURL(bottlePath(existingBottle.id));
+    await expect(page).toHaveURL(bottlePathPattern(existingBottle.id));
   });
 
   test("adds an existing reused create proposal to Library", async ({

--- a/apps/web/e2e/assertions.ts
+++ b/apps/web/e2e/assertions.ts
@@ -1,3 +1,7 @@
-export function bottlePath(id: number) {
-  return `/bottles/${id}`;
+export function bottlePathPattern(id: number) {
+  return new RegExp(`/bottles/${id}-[^/?#]+$`);
+}
+
+export function bottleHrefSelector(id: number) {
+  return `a[href^="/bottles/${id}-"]`;
 }

--- a/apps/web/e2e/bottle-checks.spec.ts
+++ b/apps/web/e2e/bottle-checks.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type TestInfo } from "@playwright/test";
 
-import { bottlePath } from "./assertions";
+import { bottlePathPattern } from "./assertions";
 import {
   existingBottleId,
   moderatorUser,
@@ -106,7 +106,7 @@ test("runs a clean moderator Bottle audit inline and returns to the Bottle", asy
   ).toBeVisible();
 
   await page.getByRole("button", { name: "Return to bottle" }).click();
-  await expect(page).toHaveURL(bottlePath(existingBottleId));
+  await expect(page).toHaveURL(bottlePathPattern(existingBottleId));
 });
 
 test("opens an actionable admin audit in its focused Moderation task", async ({

--- a/apps/web/e2e/bottle-page-redirects.spec.ts
+++ b/apps/web/e2e/bottle-page-redirects.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "@playwright/test";
 
-import { bottlePath } from "./assertions";
 import {
   exactMatchedBottleId,
   missingBottleId,
@@ -14,7 +13,9 @@ test.describe("Bottle page redirects", () => {
     page,
   }) => {
     const sourcePath = `/bottles/${replacementSourceBottleId}/tastings?source=legacy&tag=one&tag=two`;
-    const replacementPath = `/bottles/${exactMatchedBottleId}/tastings?source=legacy&tag=one&tag=two`;
+    const replacementPath = new RegExp(
+      `/bottles/${exactMatchedBottleId}-[^/?#]+/tastings\\?source=legacy&tag=one&tag=two$`,
+    );
 
     await page.goto(sourcePath, { waitUntil: "commit" });
     await expect(page).toHaveURL(replacementPath);
@@ -39,7 +40,7 @@ test.describe("Bottle page redirects", () => {
     page,
   }) => {
     await page.goto(`/bottles/${missingBottleId}`);
-    await expect(page).toHaveURL(bottlePath(missingBottleId));
+    await expect(page).toHaveURL(`/bottles/${missingBottleId}`);
     await expect(
       page.getByRole("heading", { name: "Nothing lives here" }),
     ).toBeVisible();

--- a/apps/web/e2e/entity-page-redirects.spec.ts
+++ b/apps/web/e2e/entity-page-redirects.spec.ts
@@ -13,12 +13,15 @@ test.describe("Entity page routes", () => {
     request,
   }) => {
     for (const [source, destination] of [
-      [`/entities/${testOwner.id}`, `/companies/${testOwner.id}`],
-      [`/E${testOwner.id}`, `/companies/${testOwner.id}`],
-      [`/brands/${testOwnedEntity.id}`, `/distillers/${testOwnedEntity.id}`],
+      [`/entities/${testOwner.id}`, `/companies/${testOwner.id}-diageo`],
+      [`/E${testOwner.id}`, `/companies/${testOwner.id}-diageo`],
+      [
+        `/brands/${testOwnedEntity.id}`,
+        `/distillers/${testOwnedEntity.id}-lagavulin-distillery`,
+      ],
       [
         `/entities/${replacementSourceEntityId}/edit?source=legacy`,
-        `/distillers/${testOwnedEntity.id}/edit?source=legacy`,
+        `/distillers/${testOwnedEntity.id}-lagavulin-distillery/edit?source=legacy`,
       ],
     ]) {
       const response = await request.get(source, { maxRedirects: 0 });
@@ -36,12 +39,12 @@ test.describe("Entity page routes", () => {
     const companyLink = page.getByRole("link", { name: "View company" });
     await expect(companyLink).toHaveAttribute(
       "href",
-      `/companies/${testOwner.id}`,
+      `/companies/${testOwner.id}-diageo`,
     );
 
     await companyLink.click();
 
-    await expect(page).toHaveURL(`/companies/${testOwner.id}`);
+    await expect(page).toHaveURL(`/companies/${testOwner.id}-diageo`);
     await expect(
       page.getByRole("heading", { name: testOwner.name, exact: true }),
     ).toBeVisible();

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -231,6 +231,7 @@ async function handleRpcRequest({ request, response, url }) {
         sendRpcResponse(response, {
           id: testOwnedEntity.id,
           kind: testOwnedEntity.kind,
+          name: testOwnedEntity.name,
         });
         return true;
       }
@@ -241,7 +242,11 @@ async function handleRpcRequest({ request, response, url }) {
         sendRpcError(response, "Unexpected entity resolve payload");
         return true;
       }
-      sendRpcResponse(response, { id: entity.id, kind: entity.kind });
+      sendRpcResponse(response, {
+        id: entity.id,
+        kind: entity.kind,
+        name: entity.name,
+      });
       return true;
     }
     case "entities/catalog":

--- a/apps/web/e2e/profile-library.spec.ts
+++ b/apps/web/e2e/profile-library.spec.ts
@@ -1,5 +1,6 @@
 import { expect, type Page, test } from "@playwright/test";
 
+import { bottleHrefSelector } from "./assertions";
 import { existingBottle, testAccessToken, testUser } from "./rpc-fixtures.mjs";
 import { signIn } from "./session";
 
@@ -171,14 +172,14 @@ test.describe("profile library", () => {
 });
 
 function libraryBottleLink(page: Page, bottleId: number) {
-  return page.locator(`a[href="/bottles/${bottleId}"]`).first();
+  return page.locator(bottleHrefSelector(bottleId)).first();
 }
 
 function libraryBottleRow(page: Page, bottleId: number) {
   return page
     .locator("li")
     .filter({
-      has: page.locator(`a[href="/bottles/${bottleId}"]`),
+      has: page.locator(bottleHrefSelector(bottleId)),
     })
     .filter({ visible: true });
 }

--- a/apps/web/e2e/unified-bottle-workflows.spec.ts
+++ b/apps/web/e2e/unified-bottle-workflows.spec.ts
@@ -2,7 +2,7 @@ import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { expect, type Request, test, type TestInfo } from "@playwright/test";
 import { z } from "zod";
 
-import { bottlePath } from "./assertions";
+import { bottlePathPattern } from "./assertions";
 import {
   anotherReleaseSourceBottle,
   createdBottleName,
@@ -212,7 +212,7 @@ test.describe("unified Bottle workflows", () => {
       expect(input).not.toHaveProperty(legacyField);
       expect(independentBottle).not.toHaveProperty(legacyField);
     }
-    await expect(page).toHaveURL(bottlePath(existingBottleId));
+    await expect(page).toHaveURL(bottlePathPattern(existingBottleId));
   });
 
   test("keeps exact age ownership behind the unified Bottle form", async ({
@@ -320,7 +320,7 @@ test.describe("unified Bottle workflows", () => {
       other: exactMergeOtherBottleId,
       direction: "mergeInto",
     });
-    await expect(page).toHaveURL(bottlePath(exactMergeOtherBottleId));
+    await expect(page).toHaveURL(bottlePathPattern(exactMergeOtherBottleId));
   });
 });
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,6 +40,7 @@
     "@sentry/core": "catalog:",
     "@sentry/nextjs": "catalog:",
     "@simplewebauthn/browser": "^13.2.2",
+    "@sindresorhus/slugify": "^2.2.1",
     "@stylexjs/stylex": "0.19.0",
     "@tanstack/react-query": "catalog:",
     "@tanstack/react-query-next-experimental": "catalog:",

--- a/apps/web/src/app/(app)/_components/home/homeActivity.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/homeActivity.stylex.tsx
@@ -26,7 +26,7 @@ import TimeSince from "@peated/web/components/timeSince";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { memberHomeQueries } from "@peated/web/lib/orpc/homeQueries";
-import { getEntityUrl } from "@peated/web/lib/urls";
+import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 import { colors } from "../../../../styles/tokens.stylex";
 
 type ActivityList = Outputs["activity"]["list"];
@@ -113,8 +113,9 @@ function CollectionActivityItem({
                 brandHref={getEntityUrl({
                   id: item.bottle.brand.id,
                   kind: "brand",
+                  name: item.bottle.brand.name,
                 })}
-                href={`/bottles/${item.bottle.id}`}
+                href={getBottleUrl(item.bottle)}
                 imageUrl={item.bottle.imageUrl}
                 metadata={getBottleMetadata(item.bottle).split(" · ")}
                 name={formatBottleDisplayName(item.bottle, {

--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -31,7 +31,7 @@ import {
   memberHomeQueries,
   publicHomeQueries,
 } from "@peated/web/lib/orpc/homeQueries";
-import { getEntityUrl } from "@peated/web/lib/urls";
+import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 import { space } from "../../../../styles/tokens.stylex";
 
 type Bottle = Outputs["bottles"]["list"]["results"][number];
@@ -214,7 +214,7 @@ function RecentReviews() {
     review.bottle
       ? [
           {
-            bottleHref: `/bottles/${review.bottle.id}`,
+            bottleHref: getBottleUrl(review.bottle),
             bottleImageUrl: review.bottle.imageUrl,
             bottleName: formatBottleDisplayName(review.bottle),
             date: (

--- a/apps/web/src/app/(app)/bottles/[bottleId]/aliases/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/aliases/page.tsx
@@ -1,7 +1,7 @@
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
-import { parseReleaseFamilyRouteId } from "@peated/web/lib/releaseFamily";
 
 import { AliasList } from "./aliasList.stylex";
 
@@ -9,7 +9,7 @@ export async function generateMetadata(props: {
   params: Promise<{ bottleId: string }>;
 }) {
   const { bottleId } = await props.params;
-  const bottle = await getBottlePage(parseReleaseFamilyRouteId(bottleId));
+  const bottle = await getBottlePage(parseCatalogRouteId(bottleId));
   return { title: `Other names for ${formatBottleDisplayName(bottle)}` };
 }
 
@@ -17,7 +17,7 @@ export default async function BottleAliasesPage(props: {
   params: Promise<{ bottleId: string }>;
 }) {
   const { bottleId } = await props.params;
-  const id = parseReleaseFamilyRouteId(bottleId);
+  const id = parseCatalogRouteId(bottleId);
   const { client } = await getServerClient();
   const aliasList = await client.bottleAliases.list({ bottle: id });
 

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -41,7 +41,7 @@ import {
 import { getBottleReleasePlacement } from "@peated/web/lib/bottleMetadata";
 import { logTelemetryError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { getEntityUrl } from "@peated/web/lib/urls";
+import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 type Bottle = Outputs["bottles"]["details"];
@@ -192,7 +192,7 @@ function getTasting(tasting: Tasting, bottle: Bottle): TastingEntryProps {
 }
 
 function getTabs(bottle: Bottle): [PageTabItem, ...PageTabItem[]] {
-  const baseUrl = `/bottles/${bottle.id}`;
+  const baseUrl = getBottleUrl(bottle);
   const tabs: [PageTabItem, ...PageTabItem[]] = [
     { href: baseUrl, label: "Overview" },
     {
@@ -385,7 +385,7 @@ export function BottlePageFrameClient({
 
   const bottle = bottleQuery.data;
   const currentHref =
-    pathname === `/${bottle.peatedId}` ? `/bottles/${bottle.id}` : pathname;
+    pathname === `/${bottle.peatedId}` ? getBottleUrl(bottle) : pathname;
 
   return (
     <BottlePageContext.Provider value={bottle}>
@@ -412,7 +412,11 @@ export function BottlePageFrameClient({
               : null
           }
           brand={bottle.brand.shortName || bottle.brand.name}
-          brandHref={getEntityUrl({ id: bottle.brand.id, kind: "brand" })}
+          brandHref={getEntityUrl({
+            id: bottle.brand.id,
+            kind: "brand",
+            name: bottle.brand.name,
+          })}
           eyebrow={getBottleEyebrow(bottle)}
           menu={<BottleActions bottle={bottle} />}
           name={formatBottleDisplayName(bottle, { includeBrand: false })}
@@ -499,7 +503,7 @@ export function BottleOverviewClient({
           scoreCount={recommendation.scoreCount}
         />
       ),
-      href: `/bottles/${recommendation.id}`,
+      href: getBottleUrl(recommendation),
       imageUrl: recommendation.imageUrl,
       metadata: [
         formatCategoryName(recommendation.category),
@@ -567,7 +571,7 @@ export function BottleOverviewClient({
           url: bottle.imageUrl,
         }}
         mainState={mainState}
-        moreTastingsHref={`/bottles/${bottle.id}/tastings`}
+        moreTastingsHref={`${getBottleUrl(bottle)}/tastings`}
         recommendationIntro={recommendationsQuery.data?.reason}
         recommendations={recommendations}
         tastingCount={bottle.totalTastings}

--- a/apps/web/src/app/(app)/bottles/[bottleId]/layout.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/layout.tsx
@@ -3,9 +3,9 @@ import type { Product, WithContext } from "schema-dts";
 
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { summarize } from "@peated/web/lib/markdown";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
-import { parseReleaseFamilyRouteId } from "@peated/web/lib/releaseFamily";
 import { getBottleSeoMetadata } from "@peated/web/lib/seoMetadata";
 import type { Metadata } from "next";
 
@@ -15,7 +15,7 @@ export async function generateMetadata(props: {
   params: Promise<{ bottleId: string }>;
 }): Promise<Metadata> {
   const { bottleId } = await props.params;
-  const bottle = await getBottlePage(parseReleaseFamilyRouteId(bottleId));
+  const bottle = await getBottlePage(parseCatalogRouteId(bottleId));
   return getBottleSeoMetadata(bottle);
 }
 
@@ -24,9 +24,7 @@ export default async function BottleLayout(props: {
   params: Promise<{ bottleId: string }>;
 }) {
   const { bottleId } = await props.params;
-  const canonicalBottle = await getBottlePage(
-    parseReleaseFamilyRouteId(bottleId),
-  );
+  const canonicalBottle = await getBottlePage(parseCatalogRouteId(bottleId));
   const { client } = await getServerClient();
   const bottle = await client.bottles.details({ bottle: canonicalBottle.id });
   const title = formatBottleDisplayName(bottle);

--- a/apps/web/src/app/(app)/bottles/[bottleId]/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/page.tsx
@@ -1,5 +1,5 @@
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
-import { parseReleaseFamilyRouteId } from "@peated/web/lib/releaseFamily";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getBottleSeoMetadata } from "@peated/web/lib/seoMetadata";
 import type { Metadata } from "next";
 
@@ -9,7 +9,7 @@ export async function generateMetadata(props: {
   params: Promise<{ bottleId: string }>;
 }): Promise<Metadata> {
   const { bottleId } = await props.params;
-  const bottle = await getBottlePage(parseReleaseFamilyRouteId(bottleId));
+  const bottle = await getBottlePage(parseCatalogRouteId(bottleId));
   return getBottleSeoMetadata(bottle, { canonical: true });
 }
 

--- a/apps/web/src/app/(app)/bottles/[bottleId]/prices/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/prices/page.tsx
@@ -7,8 +7,8 @@ import {
 import Price from "@peated/web/components/price";
 import TimeSince from "@peated/web/components/timeSince";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
-import { parseReleaseFamilyRouteId } from "@peated/web/lib/releaseFamily";
 
 import { BottleSection } from "../bottleSection.stylex";
 
@@ -49,7 +49,7 @@ export default async function BottlePricesPage(props: {
   params: Promise<{ bottleId: string }>;
 }) {
   const { bottleId } = await props.params;
-  const bottle = await getBottlePage(parseReleaseFamilyRouteId(bottleId));
+  const bottle = await getBottlePage(parseCatalogRouteId(bottleId));
   const { client } = await getAnonymousServerClient();
   const priceList = await client.bottles.prices.list({ bottle: bottle.id });
 

--- a/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
@@ -8,15 +8,15 @@ import {
 } from "@peated/web/components";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
 import {
-  parseReleaseFamilyRouteId,
   requireReleaseFamilyAnchor,
   requireReleaseFamilyGroup,
 } from "@peated/web/lib/releaseFamily";
-import { getEntityUrl } from "@peated/web/lib/urls";
+import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 
 import { BottleSection } from "../bottleSection.stylex";
 
@@ -24,7 +24,7 @@ export async function generateMetadata(props: {
   params: Promise<{ bottleId: string }>;
 }) {
   const { bottleId } = await props.params;
-  const { group } = await getReleaseGroup(parseReleaseFamilyRouteId(bottleId));
+  const { group } = await getReleaseGroup(parseCatalogRouteId(bottleId));
   return {
     title: `${group.fullName} releases`,
     description: `Explore releases of ${group.fullName}.`,
@@ -39,9 +39,9 @@ export default async function BottleReleasesPage(props: {
     props.params,
     props.searchParams,
   ]);
-  const anchorId = parseReleaseFamilyRouteId(bottleId);
+  const anchorId = parseCatalogRouteId(bottleId);
   const cursor = Number(searchParams.cursor ?? 1) || 1;
-  const { client, group } = await getReleaseGroup(anchorId);
+  const { anchorBottle, client, group } = await getReleaseGroup(anchorId);
   const bottleList = await resolveOrNotFound(
     client.bottleGroups.bottles({
       cursor,
@@ -51,7 +51,7 @@ export default async function BottleReleasesPage(props: {
       sort: "-tastings",
     }),
   );
-  const pathname = `/bottles/${anchorId}/releases`;
+  const pathname = `${getBottleUrl(anchorBottle)}/releases`;
 
   return (
     <BottleSection heading="Releases">
@@ -64,13 +64,14 @@ export default async function BottleReleasesPage(props: {
                 brandHref={getEntityUrl({
                   id: bottle.brand.id,
                   kind: "brand",
+                  name: bottle.brand.name,
                 })}
                 end={
                   bottle.medianScore !== null && bottle.scoreCount >= 20
                     ? `${bottle.medianScore} / 100`
                     : undefined
                 }
-                href={`/bottles/${bottle.id}`}
+                href={getBottleUrl(bottle)}
                 imageUrl={bottle.imageUrl}
                 metadata={getBottleMetadata(bottle).split(" · ")}
                 name={formatBottleDisplayName(bottle, {
@@ -113,5 +114,5 @@ async function getReleaseGroup(anchorId: number) {
     client.bottleGroups.details({ group: summary.id }),
   );
   requireReleaseFamilyAnchor(group);
-  return { client, group };
+  return { anchorBottle, client, group };
 }

--- a/apps/web/src/app/(app)/bottles/[bottleId]/similar/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/similar/page.tsx
@@ -1,12 +1,12 @@
-import {
-  getReleaseFamilyHref,
-  parseReleaseFamilyRouteId,
-} from "@peated/web/lib/releaseFamily";
+import { getBottlePage } from "@peated/web/lib/bottlePage.server";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
+import { getReleaseFamilyHref } from "@peated/web/lib/releaseFamily";
 import { permanentRedirect } from "next/navigation";
 
 export default async function SimilarBottlePage(props: {
   params: Promise<{ bottleId: string }>;
 }) {
   const { bottleId } = await props.params;
-  permanentRedirect(getReleaseFamilyHref(parseReleaseFamilyRouteId(bottleId)));
+  const bottle = await getBottlePage(parseCatalogRouteId(bottleId));
+  permanentRedirect(getReleaseFamilyHref(bottle));
 }

--- a/apps/web/src/app/(app)/bottles/[bottleId]/tastings/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/tastings/page.tsx
@@ -7,9 +7,11 @@ import {
 } from "@peated/web/components";
 import { TastingRecordEntry } from "@peated/web/components/tastingRecordEntry";
 import { getAddBottleHref } from "@peated/web/lib/addBottle";
+import { getBottlePage } from "@peated/web/lib/bottlePage.server";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
-import { parseReleaseFamilyRouteId } from "@peated/web/lib/releaseFamily";
+import { getBottleUrl } from "@peated/web/lib/urls";
 
 import { BottleSection } from "../bottleSection.stylex";
 
@@ -21,15 +23,18 @@ export default async function BottleTastingsPage(props: {
     props.params,
     props.searchParams,
   ]);
-  const id = parseReleaseFamilyRouteId(bottleId);
+  const id = parseCatalogRouteId(bottleId);
   const cursor = Number(searchParams.cursor ?? 1) || 1;
-  const { client } = await getAnonymousServerClient();
+  const [bottle, { client }] = await Promise.all([
+    getBottlePage(id),
+    getAnonymousServerClient(),
+  ]);
   const tastingList = await client.tastings.list({
     bottle: id,
     cursor,
     limit: 25,
   });
-  const pathname = `/bottles/${id}/tastings`;
+  const pathname = `${getBottleUrl(bottle)}/tastings`;
 
   return (
     <BottleSection heading="Tastings">

--- a/apps/web/src/app/(app)/entities/[entityId]/aliases/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/aliases/page.tsx
@@ -1,3 +1,4 @@
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
 
@@ -7,7 +8,7 @@ export async function generateMetadata(props: {
   params: Promise<{ entityId: string }>;
 }) {
   const { entityId } = await props.params;
-  const entity = await getEntityPage(Number(entityId));
+  const entity = await getEntityPage(parseCatalogRouteId(entityId));
   return { title: `Other names for ${entity.name}` };
 }
 
@@ -15,7 +16,7 @@ export default async function EntityAliasesPage(props: {
   params: Promise<{ entityId: string }>;
 }) {
   const { entityId } = await props.params;
-  const id = Number(entityId);
+  const id = parseCatalogRouteId(entityId);
   const { client } = await getServerClient();
   const aliasList = await client.entities.aliases.list({ entity: id });
 

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
@@ -5,6 +5,7 @@ import {
   BOTTLE_CATALOG_QUERY_FIELDS,
   normalizeBottleCatalogQueryParams,
 } from "@peated/web/lib/bottleCatalogQueryParams";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
@@ -18,7 +19,7 @@ export default async function EntityBottlesPage(props: {
 }) {
   const { entityId } = await props.params;
   const { client } = await getPublicPageServerClient();
-  const entity = await getEntityPage(Number(entityId));
+  const entity = await getEntityPage(parseCatalogRouteId(entityId));
   const createBottleHref = getEntityBottleCreateHref(entity);
   const queryParams = normalizeBottleCatalogQueryParams(
     getApiQueryParams(await props.searchParams, {

--- a/apps/web/src/app/(app)/entities/[entityId]/codes/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/codes/page.tsx
@@ -2,6 +2,7 @@ import {
   SMWS_CATEGORY_LIST,
   SMWS_DISTILLERY_CODES,
 } from "@peated/bottle-classifier/smws";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { logError } from "@peated/web/lib/log";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
@@ -15,7 +16,7 @@ export default async function EntityCodesPage(props: {
 }) {
   const { entityId } = await props.params;
   const { client } = await getAnonymousServerClient();
-  const entity = await getEntityPage(Number(entityId));
+  const entity = await getEntityPage(parseCatalogRouteId(entityId));
 
   if (entity.shortName !== "SMWS") notFound();
 
@@ -53,7 +54,11 @@ export default async function EntityCodesPage(props: {
         code,
         country: distiller?.country?.name ?? null,
         href: distiller
-          ? getEntityUrl({ id: distiller.id, kind: "distillery" })
+          ? getEntityUrl({
+              id: distiller.id,
+              kind: "distillery",
+              name: distiller.name,
+            })
           : undefined,
         name: distiller?.name ?? distillerName ?? "Unknown",
       });
@@ -68,7 +73,11 @@ export default async function EntityCodesPage(props: {
     <EntityCodes
       entityName={entity.name}
       example={{
-        href: getEntityUrl({ id: exampleDistiller.id, kind: "distillery" }),
+        href: getEntityUrl({
+          id: exampleDistiller.id,
+          kind: "distillery",
+          name: exampleDistiller.name,
+        }),
         name: exampleDistiller.name,
       }}
       groups={groups}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityDetails.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityDetails.test.tsx
@@ -6,7 +6,7 @@ import { EntityDetails } from "./entityDetails.stylex";
 import type { Entity } from "./entityPageData";
 
 describe("EntityDetails", () => {
-  test("links an owner to its canonical public route", () => {
+  test("links an owner to its current public route", () => {
     const entity = {
       ...mockEntity,
       images: [],
@@ -21,7 +21,7 @@ describe("EntityDetails", () => {
 
     const html = renderToStaticMarkup(<EntityDetails entity={entity} />);
 
-    expect(html).toContain('href="/companies/2"');
+    expect(html).toContain('href="/companies/2-example-company"');
     expect(html).not.toContain('href="/entities/2"');
   });
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOperatedOverview.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOperatedOverview.test.tsx
@@ -54,10 +54,10 @@ describe("EntityOperatedOverview", () => {
 
     expect(html).toContain("Operates");
     expect(html).toContain("The Scotch Malt Whisky Society");
-    expect(html).toContain('href="/bottlers/2"');
+    expect(html).toContain('href="/bottlers/2-the-scotch-malt-whisky-society"');
     expect(html).toContain("Bottler · 3,499 bottles");
     expect(html).toContain("Single Cask Nation");
-    expect(html).toContain('href="/brands/3"');
+    expect(html).toContain('href="/brands/3-single-cask-nation"');
   });
 
   test("does not render an empty section", () => {

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
@@ -44,15 +44,30 @@ describe("getEntityTabs", () => {
       getEntityTabs({
         id: 4263,
         kind: "bottler",
+        name: "Scotch Malt Whisky Society",
         shortName: "SMWS",
         totalBottles: 1_301,
         totalTastings: 29,
       }),
     ).toEqual([
-      { href: "/bottlers/4263", label: "Overview" },
-      { count: 1_301, href: "/bottlers/4263/bottles", label: "Bottles" },
-      { count: 29, href: "/bottlers/4263/tastings", label: "Tastings" },
-      { href: "/bottlers/4263/codes", label: "Distillery codes" },
+      {
+        href: "/bottlers/4263-scotch-malt-whisky-society",
+        label: "Overview",
+      },
+      {
+        count: 1_301,
+        href: "/bottlers/4263-scotch-malt-whisky-society/bottles",
+        label: "Bottles",
+      },
+      {
+        count: 29,
+        href: "/bottlers/4263-scotch-malt-whisky-society/tastings",
+        label: "Tastings",
+      },
+      {
+        href: "/bottlers/4263-scotch-malt-whisky-society/codes",
+        label: "Distillery codes",
+      },
     ]);
   });
 });
@@ -61,9 +76,14 @@ describe("getEntityCurrentHref", () => {
   it("maps a Peated ID route to the canonical public route", () => {
     expect(
       getEntityCurrentHref(
-        { id: 4263, kind: "bottler", peatedId: "E4263" },
+        {
+          id: 4263,
+          kind: "bottler",
+          name: "Scotch Malt Whisky Society",
+          peatedId: "E4263",
+        },
         "/E4263",
       ),
-    ).toBe("/bottlers/4263");
+    ).toBe("/bottlers/4263-scotch-malt-whisky-society");
   });
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -5,7 +5,7 @@ import { getEntityUrl } from "@peated/web/lib/urls";
 export type Entity = Outputs["entities"]["details"];
 type EntityTabSource = Pick<
   Entity,
-  "id" | "kind" | "shortName" | "totalBottles" | "totalTastings"
+  "id" | "kind" | "name" | "shortName" | "totalBottles" | "totalTastings"
 >;
 const entityKindPresentation = {
   bottler: {
@@ -90,7 +90,7 @@ export function getEntityTabs(
 }
 
 export function getEntityCurrentHref(
-  entity: Pick<Entity, "id" | "kind" | "peatedId">,
+  entity: Pick<Entity, "id" | "kind" | "name" | "peatedId">,
   pathname: string,
 ) {
   return pathname === `/${entity.peatedId}` ? getEntityUrl(entity) : pathname;

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.test.tsx
@@ -35,7 +35,7 @@ describe("EntitySiblingOverview", () => {
     );
 
     expect(html).toContain("Also part of Suntory Global Spirits");
-    expect(html).toContain('href="/companies/42"');
+    expect(html).toContain('href="/companies/42-suntory-global-spirits"');
     expect(html).toContain("View company");
   });
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/layout.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/layout.tsx
@@ -1,3 +1,4 @@
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
 import { getEntitySeoMetadata } from "@peated/web/lib/seoMetadata";
@@ -11,7 +12,7 @@ export async function generateMetadata(props: {
   params: Promise<{ entityId: string }>;
 }): Promise<Metadata> {
   const { entityId } = await props.params;
-  const entity = await getEntityPage(Number(entityId));
+  const entity = await getEntityPage(parseCatalogRouteId(entityId));
   return getEntitySeoMetadata(entity);
 }
 
@@ -20,7 +21,7 @@ export default async function EntityLayout(props: {
   params: Promise<{ entityId: string }>;
 }) {
   const { entityId } = await props.params;
-  const canonicalEntity = await getEntityPage(Number(entityId));
+  const canonicalEntity = await getEntityPage(parseCatalogRouteId(entityId));
   const { client } = await getServerClient();
   const entity = await client.entities.details({ entity: canonicalEntity.id });
 

--- a/apps/web/src/app/(app)/entities/[entityId]/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/page.tsx
@@ -1,3 +1,4 @@
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 import { getEntitySeoMetadata } from "@peated/web/lib/seoMetadata";
@@ -10,7 +11,7 @@ export async function generateMetadata(props: {
   params: Promise<{ entityId: string }>;
 }): Promise<Metadata> {
   const { entityId } = await props.params;
-  const entity = await getEntityPage(Number(entityId));
+  const entity = await getEntityPage(parseCatalogRouteId(entityId));
   return getEntitySeoMetadata(entity, { canonical: true });
 }
 
@@ -19,7 +20,7 @@ export default async function EntityPage(props: {
 }) {
   const { entityId } = await props.params;
   const { client } = await getAnonymousServerClient();
-  const entity = await getEntityPage(Number(entityId));
+  const entity = await getEntityPage(parseCatalogRouteId(entityId));
   const bottleList = entityHasBottleCatalog(entity)
     ? await client.bottles
         .list({ entity: entity.id, limit: 4, sort: "-tastings" })

--- a/apps/web/src/app/(app)/entities/[entityId]/tastings/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/tastings/page.tsx
@@ -1,4 +1,5 @@
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 
@@ -10,7 +11,7 @@ export default async function EntityTastingsPage(props: {
 }) {
   const { entityId } = await props.params;
   const { client } = await getAnonymousServerClient();
-  const entity = await getEntityPage(Number(entityId));
+  const entity = await getEntityPage(parseCatalogRouteId(entityId));
   const queryParams = getApiQueryParams(await props.searchParams, {
     numericFields: ["cursor"],
     overrides: { entity: entity.id, limit: 25 },

--- a/apps/web/src/app/(app)/flights/[flightId]/page.tsx
+++ b/apps/web/src/app/(app)/flights/[flightId]/page.tsx
@@ -15,7 +15,7 @@ import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { summarize } from "@peated/web/lib/markdown";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
 import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
-import { getEntityUrl } from "@peated/web/lib/urls";
+import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 import { cache } from "react";
 
 import { FlightActions } from "./flightActions";
@@ -70,6 +70,7 @@ export default async function FlightPage(props: {
                   brandHref={getEntityUrl({
                     id: bottle.brand.id,
                     kind: "brand",
+                    name: bottle.brand.name,
                   })}
                   end={
                     <ButtonLink
@@ -85,7 +86,7 @@ export default async function FlightPage(props: {
                     </ButtonLink>
                   }
                   hasTasted={hasTasted}
-                  href={`/bottles/${bottle.id}`}
+                  href={getBottleUrl(bottle)}
                   imageUrl={bottle.imageUrl}
                   isLibrary={isLibrary}
                   metadata={getBottleMetadata(bottle).split(" · ")}

--- a/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
@@ -15,8 +15,11 @@ import {
   getPendingImageFromParams,
   type AddBottleRouteIntent,
 } from "@peated/web/lib/addBottle";
+import { getBottleUrl } from "@peated/web/lib/urls";
 import { foundationStyles } from "../../../styles/foundations.stylex";
 import { colors, fonts, space } from "../../../styles/tokens.stylex";
+
+type BottleUrlSource = Parameters<typeof getBottleUrl>[0];
 
 const addBottleIntents = [
   "catalog",
@@ -122,7 +125,8 @@ export function SearchPageClient({
   const createReturnAction = getCreateReturnAction(intent, directToTasting);
 
   const getBottleHref = useCallback(
-    (bottleId: number) => {
+    (bottle: BottleUrlSource) => {
+      const bottleId = bottle.id;
       if (intent) {
         return getAddBottleHref({
           bottleId,
@@ -134,7 +138,7 @@ export function SearchPageClient({
       if (directToTasting) {
         return getAddBottleHref({ bottleId, intent: "tasting" });
       }
-      return `/bottles/${bottleId}`;
+      return getBottleUrl(bottle);
     },
     [directToTasting, intent, pendingImage?.id, pendingImage?.imageUrl],
   );

--- a/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
@@ -15,6 +15,7 @@ import {
 } from "@peated/web/components";
 import TimeSince from "@peated/web/components/timeSince";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
+import { getBottleUrl } from "@peated/web/lib/urls";
 import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 type Tasting = Outputs["tastings"]["details"];
@@ -66,7 +67,7 @@ export function TastingDetail({ tasting }: { tasting: Tasting }) {
       </header>
 
       <AppLink
-        href={`/bottles/${tasting.bottle.id}`}
+        href={getBottleUrl(tasting.bottle)}
         {...stylex.props(styles.bottleName)}
       >
         {bottleName}

--- a/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
@@ -27,7 +27,7 @@ import TimeSince from "@peated/web/components/timeSince";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { getEntityUrl } from "@peated/web/lib/urls";
+import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 import { useProfile } from "../profileContext";
 
 type Activity = Outputs["users"]["activity"]["list"]["results"][number];
@@ -154,8 +154,9 @@ function toActivityItem(activity: Activity): MemberActivityItem {
           brandHref: getEntityUrl({
             id: entry.bottle.brand.id,
             kind: "brand",
+            name: entry.bottle.brand.name,
           }),
-          href: `/bottles/${entry.bottle.id}`,
+          href: getBottleUrl(entry.bottle),
           id: String(entry.id),
           imageUrl: entry.imageUrl ?? entry.bottle.imageUrl,
           metadata: getBottleMetadata(entry.bottle).split(" · "),

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
@@ -18,7 +18,7 @@ import {
 import { PageColumns } from "@peated/web/components/pages/pageLayout.stylex";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { getEntityUrl } from "@peated/web/lib/urls";
+import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 import { colors, fonts, space } from "../../../../../styles/tokens.stylex";
 import { useProfile } from "../profileContext";
 
@@ -348,8 +348,12 @@ function toLibraryItem(
         ]
       : undefined,
     brand: bottle.brand.shortName || bottle.brand.name,
-    brandHref: getEntityUrl({ id: bottle.brand.id, kind: "brand" }),
-    href: `/bottles/${bottle.id}`,
+    brandHref: getEntityUrl({
+      id: bottle.brand.id,
+      kind: "brand",
+      name: bottle.brand.name,
+    }),
+    href: getBottleUrl(bottle),
     id: String(entry.id),
     imageUrl: entry.imageUrl ?? bottle.imageUrl,
     metadata: getLibraryMetadata(bottle),

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -45,6 +45,7 @@ import { uploadImageAfterSave } from "@peated/web/lib/imageUpload";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import type { TastingTagSuggestion } from "@peated/web/lib/tastingForm";
+import { getBottleUrl } from "@peated/web/lib/urls";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { BookOpen, Eye, Plus, RotateCcw, Search, Wine } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
@@ -113,7 +114,7 @@ function getSearchHref(
 }
 
 function getViewBottleHref(bottle: Bottle) {
-  return `/bottles/${bottle.id}`;
+  return getBottleUrl(bottle);
 }
 
 function canSaveBottleToLibrary(selection: FlowBottle) {
@@ -622,9 +623,9 @@ function AddBottleFlowContent() {
   const [loadingTastingDraft, setLoadingTastingDraft] = useState(false);
   const userLibraryHref = user ? `/users/${user.username}/library` : "/library";
   const inlineBottleHref = useCallback(
-    (bottleId: number) =>
+    (bottle: { id: number }) =>
       getAddBottleHref({
-        bottleId,
+        bottleId: bottle.id,
         intent: getCreateReturnAction(intent),
       }),
     [intent],
@@ -1035,7 +1036,7 @@ function AddBottleFlowContent() {
     });
 
     flash("Review saved.", "info");
-    router.push(`/bottles/${review.bottleId}`);
+    router.push(getBottleUrl(tastingDraft.bottle));
   }
 
   if (loadingBottle) {

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/addRelease/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/addRelease/page.tsx
@@ -10,6 +10,7 @@ import { VerifiedRequired } from "@peated/web/hooks/useAuthRequired";
 import { buildBottleProposalDraft } from "@peated/web/lib/bottleProposalDraft";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getBottleUrl } from "@peated/web/lib/urls";
 import { useMutation, useQuery, useSuspenseQuery } from "@tanstack/react-query";
 import { redirect, useRouter, useSearchParams } from "next/navigation";
 
@@ -114,7 +115,7 @@ function AddSimilarBottleForm({ bottleId }: { bottleId: string }) {
         }
 
         if (returnTo) router.push(returnTo);
-        else router.replace(`/bottles/${createdBottle.id}`);
+        else router.replace(getBottleUrl(createdBottle));
       }}
     />
   );

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/audit/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/audit/page.tsx
@@ -15,6 +15,7 @@ import { ModRequired } from "@peated/web/hooks/useAuthRequired";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getBottleUrl } from "@peated/web/lib/urls";
 import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 import { use, useState, type FormEvent } from "react";
@@ -46,7 +47,7 @@ function AuditBottleForm({ bottleId }: { bottleId: string }) {
   ) {
     event.preventDefault();
     if (summary) {
-      router.push(`/bottles/${bottle.id}`);
+      router.push(getBottleUrl(bottle));
       return;
     }
 

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
@@ -7,6 +7,7 @@ import { ModRequired } from "@peated/web/hooks/useAuthRequired";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { formQueryOptions } from "@peated/web/lib/orpc/query";
+import { getBottleUrl } from "@peated/web/lib/urls";
 import {
   useMutation,
   useQueryClient,
@@ -50,7 +51,7 @@ function BottleEditForm({ bottleId }: { bottleId: string }) {
     <BottleForm
       onSubmit={async (value, meta) => {
         const { image } = value;
-        await bottleUpdateMutation.mutateAsync({
+        const updatedBottle = await bottleUpdateMutation.mutateAsync({
           bottle: context.bottleId,
           ...buildBottlePatch(value, meta),
         });
@@ -84,7 +85,7 @@ function BottleEditForm({ bottleId }: { bottleId: string }) {
           }),
           refetchType: "all",
         });
-        router.push(`/bottles/${bottleId}`);
+        router.push(getBottleUrl(updatedBottle));
       }}
       initialData={{
         ...context.shared,

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
@@ -19,6 +19,7 @@ import { ModRequired } from "@peated/web/hooks/useAuthRequired";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getBottleUrl } from "@peated/web/lib/urls";
 import { zodResolver } from "@peated/web/lib/zodResolver";
 import {
   useMutation,
@@ -115,7 +116,7 @@ function MergeBottleForm({ bottleId }: { bottleId: string }) {
         other: data.bottleId,
       });
       flash(<div>Bottles merged successfully.</div>);
-      router.push(`/bottles/${nextBottle.id}`);
+      router.push(getBottleUrl(nextBottle));
     } catch (error) {
       setSubmitError(
         getFormErrorMessage(error, { allowAnyErrorMessage: true }),

--- a/apps/web/src/app/(layout-free)/bottles/new/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/new/page.tsx
@@ -12,6 +12,7 @@ import { VerifiedRequired } from "@peated/web/hooks/useAuthRequired";
 import { getAddBottleHref } from "@peated/web/lib/addBottle";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getBottleUrl } from "@peated/web/lib/urls";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { redirect, useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -298,7 +299,7 @@ function CreateBottleForm() {
             }),
           );
         } else if (returnAction === "view") {
-          router.replace(`/bottles/${createdBottle.id}`);
+          router.replace(getBottleUrl(createdBottle));
         } else if (returnAction === "catalog" || returnAction === "choose") {
           router.replace(
             getAddBottleHref({
@@ -322,7 +323,7 @@ function CreateBottleForm() {
         } else if (returnTo) {
           router.push(returnTo);
         } else {
-          router.replace(`/bottles/${createdBottle.id}`);
+          router.replace(getBottleUrl(createdBottle));
         }
       }}
       initialData={initialData}

--- a/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
+++ b/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
@@ -54,6 +54,7 @@ export function FlightOverlay({
                     brandHref={getEntityUrl({
                       id: bottle.brand.id,
                       kind: "brand",
+                      name: bottle.brand.name,
                     })}
                     href={getBottleUrl(bottle)}
                     imageUrl={bottle.imageUrl}

--- a/apps/web/src/components/admin/moderation/taskDetail.tsx
+++ b/apps/web/src/components/admin/moderation/taskDetail.tsx
@@ -24,6 +24,7 @@ import type { ExcludedOperationField } from "@peated/web/components/bottleChecks
 import OperationCard from "@peated/web/components/bottleChecks/operationCard.stylex";
 import { copyTextToClipboard } from "@peated/web/lib/clipboard";
 import { useORPC } from "@peated/web/lib/orpc/context";
+import { getBottleUrl } from "@peated/web/lib/urls";
 import {
   useMutation,
   useQuery,
@@ -282,7 +283,7 @@ function ListingTask({
         <AdminSection title="Recommended bottle" tone="accent">
           <strong>{formatBottleDisplayName(item.suggestedBottle)}</strong>
           {" · "}
-          <AdminTextLink href={`/bottles/${item.suggestedBottle.id}`}>
+          <AdminTextLink href={getBottleUrl(item.suggestedBottle)}>
             View bottle #{item.suggestedBottle.id}
           </AdminTextLink>
         </AdminSection>

--- a/apps/web/src/components/admin/reviewTable.stylex.tsx
+++ b/apps/web/src/components/admin/reviewTable.stylex.tsx
@@ -1,5 +1,6 @@
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { ExternalReview, PagingRel } from "@peated/server/types";
+import { getBottleUrl } from "@peated/web/lib/urls";
 import * as stylex from "@stylexjs/stylex";
 
 import { colors, fonts, space } from "../../styles/tokens.stylex";
@@ -51,7 +52,7 @@ export function ReviewRows({
                   </span>
                   {review.bottle ? (
                     <AdminTextLink
-                      href={`/bottles/${review.bottle.id}`}
+                      href={getBottleUrl(review.bottle)}
                       title={bottleName}
                       truncate
                     >

--- a/apps/web/src/components/admin/reviewTable.test.tsx
+++ b/apps/web/src/components/admin/reviewTable.test.tsx
@@ -102,7 +102,9 @@ describe("ReviewTable", () => {
       <ReviewRows reviews={[makeReview(1, bottle)]} />,
     );
 
-    expect(html).toContain('href="/bottles/19"');
+    expect(html).toContain(
+      'href="/bottles/19-springbank-12-cask-strength-batch-24"',
+    );
     expect(html).toContain('title="Springbank review"');
     expect(html).toContain('title="Springbank 12 Cask Strength Batch 24"');
     expect(html).toContain("Springbank 12 Cask Strength Batch 24");

--- a/apps/web/src/components/admin/storePriceTable.test.tsx
+++ b/apps/web/src/components/admin/storePriceTable.test.tsx
@@ -116,7 +116,9 @@ describe("StorePriceTable", () => {
       <StorePriceTable priceList={[makePrice({ bottle })]} />,
     );
 
-    expect(html).toContain('href="/bottles/19"');
+    expect(html).toContain(
+      'href="/bottles/19-springbank-12-cask-strength-batch-24"',
+    );
     expect(html).toContain("Springbank 12 Cask Strength Batch 24");
   });
 

--- a/apps/web/src/components/admin/storePriceTable.tsx
+++ b/apps/web/src/components/admin/storePriceTable.tsx
@@ -2,6 +2,7 @@ import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { PagingRel, StorePrice } from "@peated/server/types";
 import Price from "@peated/web/components/price";
 import TimeSince from "@peated/web/components/timeSince";
+import { getBottleUrl } from "@peated/web/lib/urls";
 
 import { AdminTextLink } from "./adminContent.stylex";
 import { AdminTable } from "./adminTable.stylex";
@@ -24,7 +25,7 @@ export default function StorePriceTable({
               {price.bottle ? (
                 <>
                   {" · "}
-                  <AdminTextLink href={`/bottles/${price.bottle.id}`}>
+                  <AdminTextLink href={getBottleUrl(price.bottle)}>
                     {formatBottleDisplayName(price.bottle)}
                   </AdminTextLink>
                 </>

--- a/apps/web/src/components/entityLinks.test.tsx
+++ b/apps/web/src/components/entityLinks.test.tsx
@@ -15,9 +15,9 @@ describe("EntityLinks", () => {
       />,
     );
 
-    expect(html).toContain('href="/distillers/129"');
-    expect(html).toContain('href="/distillers/366"');
-    expect(html).toContain('href="/distillers/142"');
+    expect(html).toContain('href="/distillers/129-glen-moray"');
+    expect(html).toContain('href="/distillers/366-caol-ila"');
+    expect(html).toContain('href="/distillers/142-glen-spey"');
     expect(html).toContain("Glen Moray");
     expect(html).toContain("Caol Ila");
     expect(html).toContain("Glen Spey");
@@ -30,6 +30,6 @@ describe("EntityLinks", () => {
       <EntityLinks entities={[{ id: 5, kind: null, name: "Unknown" }]} />,
     );
 
-    expect(html).toContain('href="/entities/5"');
+    expect(html).toContain('href="/entities/5-unknown"');
   });
 });

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -16,7 +16,7 @@ import {
   readRecentSearches,
   writeRecentSearches,
 } from "@peated/web/lib/recentSearches";
-import { getEntityUrl } from "@peated/web/lib/urls";
+import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 import * as stylex from "@stylexjs/stylex";
 import { useRouter } from "next/navigation";
 import {
@@ -87,7 +87,7 @@ export type SearchProps = {
   browseHeader?: ReactNode;
   contributionLabel?: string;
   defaultOpen?: boolean;
-  getBottleHref?: (bottleId: number) => string;
+  getBottleHref?: (bottle: BottleSearchResult) => string;
   getContributionHref?: (query: string) => string;
   initialQuery?: string;
   initialResponse?: SearchResponse;
@@ -105,10 +105,6 @@ export type SearchProps = {
 
 const SEARCH_DEBOUNCE_MS = 140;
 const SEARCH_INDICATOR_FLOOR_MS = 250;
-
-function getDefaultBottleHref(bottleId: number) {
-  return `/bottles/${bottleId}`;
-}
 
 function getDefaultContributionHref(query: string) {
   return getCreateBottleHref({ query });
@@ -160,12 +156,12 @@ function bottleItem(
     getBottleHref,
     showRatings,
   }: {
-    getBottleHref: (bottleId: number) => string;
+    getBottleHref: (bottle: BottleSearchResult) => string;
     showRatings: boolean;
   },
 ) {
   return {
-    href: getBottleHref(bottle.id),
+    href: getBottleHref(bottle),
     id: `bottle-${bottle.id}`,
     ratings: showRatings
       ? {
@@ -425,7 +421,7 @@ export function Search({
   browseHeader,
   contributionLabel = "Add a new bottle",
   defaultOpen = false,
-  getBottleHref = getDefaultBottleHref,
+  getBottleHref = getBottleUrl,
   getContributionHref = getDefaultContributionHref,
   initialQuery = "",
   initialResponse,

--- a/apps/web/src/components/tastingRecordEntry.tsx
+++ b/apps/web/src/components/tastingRecordEntry.tsx
@@ -15,6 +15,7 @@ import {
   getBottleMetadata,
   type BottleMetadata,
 } from "@peated/web/lib/bottleMetadata";
+import { getBottleUrl } from "@peated/web/lib/urls";
 
 type Tasting = Outputs["tastings"]["list"]["results"][number];
 
@@ -45,7 +46,7 @@ export function getTastingEntryMember(
     description: tasting.notes ?? undefined,
     descriptionHref: `/tastings/${tasting.id}`,
     hasToasted: tasting.hasToasted,
-    href: `/bottles/${tasting.bottle.id}`,
+    href: getBottleUrl(tasting.bottle),
     imageKind: tasting.imageUrl ? "photo" : "bottle",
     imageUrl: tasting.imageUrl ?? tasting.bottle.imageUrl,
     metadata: getBottleMetadata(tasting.bottle),

--- a/apps/web/src/lib/bottleListItem.ts
+++ b/apps/web/src/lib/bottleListItem.ts
@@ -5,6 +5,7 @@ import type { Outputs } from "@peated/server/orpc/router";
 import type { BottleListItem } from "@peated/web/components";
 
 import { getReleaseFamilyHref } from "./releaseFamily";
+import { getBottleUrl } from "./urls";
 
 type Bottle = Outputs["bottles"]["list"]["results"][number];
 
@@ -26,7 +27,7 @@ export function toBottleListItem(
 
   return {
     hasTasted: bottle.hasTasted,
-    href: `/bottles/${bottle.id}`,
+    href: getBottleUrl(bottle),
     id: bottle.peatedId,
     imageUrl: bottle.imageUrl,
     isLibrary: bottle.isLibrary,
@@ -54,7 +55,7 @@ export function toBottleListItem(
       includeRelatedReleases && relatedReleaseCount > 1
         ? {
             count: relatedReleaseCount,
-            href: getReleaseFamilyHref(bottle.id),
+            href: getReleaseFamilyHref(bottle),
           }
         : undefined,
   };

--- a/apps/web/src/lib/bottlePage.server.test.ts
+++ b/apps/web/src/lib/bottlePage.server.test.ts
@@ -4,7 +4,17 @@ import {
   type BottlePageServices,
 } from "./bottlePage.server";
 
-type TestBottle = { id: number; fullName?: string };
+type TestBottle = {
+  id: number;
+  name: string;
+  brand: { name: string };
+};
+
+const bottle = {
+  id: 11,
+  name: "16-year-old",
+  brand: { name: "Lagavulin" },
+};
 
 const loadBottle = vi.fn<BottlePageServices<TestBottle>["loadBottle"]>();
 const getRedirectPath =
@@ -28,16 +38,17 @@ describe("getBottlePage", () => {
   });
 
   it("returns an active independently complete Bottle", async () => {
-    const bottle = { id: 11, fullName: "Lagavulin 16-year-old" };
     loadBottle.mockResolvedValue(bottle);
+    getRedirectPath.mockResolvedValue(null);
 
     await expect(getBottlePage(11)).resolves.toBe(bottle);
 
     expect(redirect).not.toHaveBeenCalled();
   });
 
-  it("permanently redirects an exact replacement with its suffix and query", async () => {
-    loadBottle.mockResolvedValue({ id: 22 });
+  it("redirects a merged Bottle with its suffix and query", async () => {
+    const replacement = { ...bottle, id: 22 };
+    loadBottle.mockResolvedValue(replacement);
     getRedirectPath.mockResolvedValue(
       "/bottles/22/tastings?source=legacy&tag=one&tag=two",
     );
@@ -45,7 +56,7 @@ describe("getBottlePage", () => {
     await expect(getBottlePage(11)).rejects.toBe(redirectSignal);
 
     expect(getRedirectPath).toHaveBeenCalledWith({
-      canonicalId: 22,
+      canonicalBottle: replacement,
       currentId: 11,
     });
     expect(redirect).toHaveBeenCalledOnce();

--- a/apps/web/src/lib/bottlePage.server.ts
+++ b/apps/web/src/lib/bottlePage.server.ts
@@ -1,34 +1,37 @@
 "server only";
 
+import type { BottleDisplayNameSource } from "@peated/server/lib/bottleDisplayName";
 import { permanentRedirect } from "next/navigation";
 import { cache } from "react";
 import { getAnonymousServerClient } from "./orpc/client.server";
 import { resolveOrNotFound } from "./orpc/notFound.server";
-import { getCanonicalRouteRedirectPath } from "./tombstoneRedirect";
+import { getCanonicalPublicRouteRedirectPath } from "./tombstoneRedirect";
+import { getBottleUrl } from "./urls";
 
-export type BottlePageServices<Bottle extends { id: number }> = {
+export type BottlePageServices<
+  Bottle extends BottleDisplayNameSource & { id: number },
+> = {
   loadBottle: (bottleId: number) => Promise<Bottle>;
-  getRedirectPath: (ids: {
-    canonicalId: number;
+  getRedirectPath: (options: {
+    canonicalBottle: Bottle;
     currentId: number;
-  }) => Promise<string>;
+  }) => Promise<string | null>;
   redirect: (path: string) => never;
 };
 
 /** Loads an independently complete Bottle and follows its canonical tombstone. */
-export function createBottlePageLoader<Bottle extends { id: number }>(
-  services: BottlePageServices<Bottle>,
-) {
+export function createBottlePageLoader<
+  Bottle extends BottleDisplayNameSource & { id: number },
+>(services: BottlePageServices<Bottle>) {
   return async function loadBottlePage(bottleId: number) {
     const bottle = await services.loadBottle(bottleId);
+    const redirectPath = await services.getRedirectPath({
+      canonicalBottle: bottle,
+      currentId: bottleId,
+    });
 
-    if (bottle.id !== bottleId) {
-      services.redirect(
-        await services.getRedirectPath({
-          currentId: bottleId,
-          canonicalId: bottle.id,
-        }),
-      );
+    if (redirectPath) {
+      services.redirect(redirectPath);
     }
 
     return bottle;
@@ -42,11 +45,12 @@ const loadBottlePage = createBottlePageLoader({
       client.bottles.details({ bottle: bottleId }),
     );
   },
-  getRedirectPath: ({ canonicalId, currentId }) =>
-    getCanonicalRouteRedirectPath({
+  getRedirectPath: ({ canonicalBottle, currentId }) =>
+    getCanonicalPublicRouteRedirectPath({
+      canonicalId: canonicalBottle.id,
+      canonicalPath: getBottleUrl(canonicalBottle),
       currentId,
-      canonicalId,
-      collectionPath: "/bottles",
+      currentPathPrefixes: [`/bottles/${currentId}`],
     }),
   redirect: permanentRedirect,
 });

--- a/apps/web/src/lib/catalogRoute.test.ts
+++ b/apps/web/src/lib/catalogRoute.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { parseCatalogRouteId } from "./catalogRoute";
+
+describe("public catalog route identifiers", () => {
+  it.each([
+    ["123", 123],
+    ["123-lagavulin-16-year-old", 123],
+    ["123-東京", 123],
+  ])("parses %s by its numeric ID", (value, expected) => {
+    expect(parseCatalogRouteId(value)).toBe(expected);
+  });
+
+  it.each(["0", "0123-name", "123-", "name", "9007199254740992-name"])(
+    "rejects malformed identifier %s",
+    (value) => {
+      expect(() => parseCatalogRouteId(value)).toThrow();
+    },
+  );
+});

--- a/apps/web/src/lib/catalogRoute.ts
+++ b/apps/web/src/lib/catalogRoute.ts
@@ -1,0 +1,10 @@
+import { notFound } from "next/navigation";
+
+export function parseCatalogRouteId(value: string): number {
+  const match = /^([1-9]\d*)(?:-(.+))?$/u.exec(value);
+  if (!match) notFound();
+
+  const id = Number(match[1]);
+  if (!Number.isSafeInteger(id)) notFound();
+  return id;
+}

--- a/apps/web/src/lib/entityBottleCreateHref.test.ts
+++ b/apps/web/src/lib/entityBottleCreateHref.test.ts
@@ -4,17 +4,23 @@ import { getEntityBottleCreateHref } from "./entityBottleCreateHref";
 
 describe("getEntityBottleCreateHref", () => {
   it("returns to the canonical public Entity route", () => {
-    const href = getEntityBottleCreateHref({ id: 4263, kind: "bottler" });
+    const href = getEntityBottleCreateHref({
+      id: 4263,
+      kind: "bottler",
+      name: "Scotch Malt Whisky Society",
+    });
     const url = new URL(href!, "https://peated.com");
 
     expect(url.pathname).toBe("/bottles/new");
     expect(url.searchParams.get("bottler")).toBe("4263");
-    expect(url.searchParams.get("returnTo")).toBe("/bottlers/4263");
+    expect(url.searchParams.get("returnTo")).toBe(
+      "/bottlers/4263-scotch-malt-whisky-society",
+    );
   });
 
   it("does not offer bottle creation for a company", () => {
-    expect(getEntityBottleCreateHref({ id: 1, kind: "company" })).toBe(
-      undefined,
-    );
+    expect(
+      getEntityBottleCreateHref({ id: 1, kind: "company", name: "Diageo" }),
+    ).toBe(undefined);
   });
 });

--- a/apps/web/src/lib/entityBottleCreateHref.ts
+++ b/apps/web/src/lib/entityBottleCreateHref.ts
@@ -5,11 +5,15 @@ import { getEntityUrl } from "./urls";
 export function getEntityBottleCreateHref({
   id,
   kind,
+  name,
 }: {
   id: number;
   kind: EntityKind | null;
+  name: string;
 }) {
-  const params = new URLSearchParams({ returnTo: getEntityUrl({ id, kind }) });
+  const params = new URLSearchParams({
+    returnTo: getEntityUrl({ id, kind, name }),
+  });
 
   switch (kind) {
     case "brand":

--- a/apps/web/src/lib/entitySitemaps.test.ts
+++ b/apps/web/src/lib/entitySitemaps.test.ts
@@ -53,6 +53,7 @@ describe("Entity sitemaps", () => {
           {
             id: 1001,
             kind: "brand",
+            name: "Lagavulin",
             updatedAt: "2026-08-27T12:00:00.000Z",
           },
         ],
@@ -63,6 +64,7 @@ describe("Entity sitemaps", () => {
           {
             id: 1002,
             kind: "brand",
+            name: "Ardbeg",
             updatedAt: "2026-08-28T12:00:00.000Z",
           },
         ],
@@ -72,11 +74,11 @@ describe("Entity sitemaps", () => {
     await expect(loadEntitySitemapPage(2, listEntities)).resolves.toEqual({
       pages: [
         {
-          url: "/brands/1001",
+          url: "/brands/1001-lagavulin",
           lastModified: "2026-08-27T12:00:00.000Z",
         },
         {
-          url: "/brands/1002",
+          url: "/brands/1002-ardbeg",
           lastModified: "2026-08-28T12:00:00.000Z",
         },
       ],

--- a/apps/web/src/lib/entitySitemaps.ts
+++ b/apps/web/src/lib/entitySitemaps.ts
@@ -46,7 +46,7 @@ export const ENTITY_SITEMAP_COLLECTIONS = [
 export type EntitySitemapCollection =
   (typeof ENTITY_SITEMAP_COLLECTIONS)[number];
 
-type SitemapEntity = Pick<Entity, "id" | "kind" | "updatedAt">;
+type SitemapEntity = Pick<Entity, "id" | "kind" | "name" | "updatedAt">;
 
 export type ListSitemapEntities = (input: {
   cursor: number;

--- a/apps/web/src/lib/peatedIdRoutes.test.ts
+++ b/apps/web/src/lib/peatedIdRoutes.test.ts
@@ -6,7 +6,7 @@ import {
 } from "./peatedIdRoutes";
 
 describe("Peated ID routes", () => {
-  it("redirects Bottle IDs to the canonical Bottle collection route", () => {
+  it("redirects Bottle IDs to the Bottle collection route", () => {
     expect(resolveBottlePeatedIdRoute("/B0123")).toEqual({
       action: "redirect",
       pathname: "/bottles/123",
@@ -21,49 +21,72 @@ describe("Peated ID routes", () => {
     expect(matchEntityRoute("/E0456")).toEqual({
       entityId: 456,
       kind: null,
+      pathname: "/E0456",
       source: "peated-id",
       suffix: "",
     });
-    expect(matchEntityRoute("/distillers/456")).toEqual({
+    expect(matchEntityRoute("/distillers/456-lagavulin")).toEqual({
       entityId: 456,
       kind: "distillery",
+      pathname: "/distillers/456-lagavulin",
       source: "collection",
       suffix: "",
     });
-    expect(matchEntityRoute("/companies/456/edit")).toEqual({
+    expect(matchEntityRoute("/companies/456-diageo/edit")).toEqual({
       entityId: 456,
       kind: "company",
+      pathname: "/companies/456-diageo",
       source: "collection",
       suffix: "/edit",
     });
-    expect(matchEntityRoute("/entities/456/aliases")).toEqual({
+    expect(matchEntityRoute("/entities/456-old-name/aliases")).toEqual({
       entityId: 456,
       kind: null,
+      pathname: "/entities/456-old-name",
       source: "legacy",
       suffix: "/aliases",
     });
   });
 
   it("rewrites a canonical Entity route to the page tree", () => {
-    const match = matchEntityRoute("/companies/456/edit");
+    const match = matchEntityRoute("/companies/456-diageo/edit");
     expect(match).not.toBeNull();
-    expect(resolveEntityRoute(match!, { id: 456, kind: "company" })).toEqual({
+    expect(
+      resolveEntityRoute(match!, {
+        id: 456,
+        kind: "company",
+        name: "Diageo",
+      }),
+    ).toEqual({
       action: "rewrite",
       pathname: "/entities/456/edit",
     });
   });
 
   it.each([
-    ["/E0456", 456, "company", "/companies/456"],
-    ["/entities/456", 456, "company", "/companies/456"],
-    ["/brands/456/bottles", 456, "company", "/companies/456/bottles"],
-    ["/entities/12/edit", 34, "distillery", "/distillers/34/edit"],
+    ["/E0456", 456, "company", "Diageo", "/companies/456-diageo"],
+    ["/entities/456", 456, "company", "Diageo", "/companies/456-diageo"],
+    ["/companies/456", 456, "company", "Diageo", "/companies/456-diageo"],
+    [
+      "/brands/456-old-name/bottles",
+      456,
+      "company",
+      "Diageo",
+      "/companies/456-diageo/bottles",
+    ],
+    [
+      "/entities/12-old-name/edit",
+      34,
+      "distillery",
+      "東京",
+      "/distillers/34-東京/edit",
+    ],
   ] as const)(
     "redirects %s to its canonical Entity route",
-    (pathname, id, kind, expected) => {
+    (pathname, id, kind, name, expected) => {
       const match = matchEntityRoute(pathname);
       expect(match).not.toBeNull();
-      expect(resolveEntityRoute(match!, { id, kind })).toEqual({
+      expect(resolveEntityRoute(match!, { id, kind, name })).toEqual({
         action: "redirect",
         pathname: expected,
       });

--- a/apps/web/src/lib/peatedIdRoutes.ts
+++ b/apps/web/src/lib/peatedIdRoutes.ts
@@ -9,12 +9,13 @@ export type PeatedIdRouteResolution = {
 
 const ROOT_PEATED_ID_PATTERN = /^\/([BE]\d+)\/?$/i;
 const PUBLIC_ENTITY_PATTERN =
-  /^\/(brands|distillers|bottlers|companies)\/([1-9]\d*)(\/.*)?$/;
-const LEGACY_ENTITY_PATTERN = /^\/entities\/([1-9]\d*)(\/.*)?$/;
+  /^\/(brands|distillers|bottlers|companies)\/([1-9]\d*)(?:-[^/]+)?(\/.*)?$/;
+const LEGACY_ENTITY_PATTERN = /^\/entities\/([1-9]\d*)(?:-[^/]+)?(\/.*)?$/;
 
 export type EntityRouteMatch = {
   entityId: number;
   kind: EntityKind | null;
+  pathname: string;
   source: "collection" | "legacy" | "peated-id";
   suffix: string;
 };
@@ -68,6 +69,7 @@ export function matchEntityRoute(pathname: string): EntityRouteMatch | null {
     return {
       entityId: parsed.id,
       kind: null,
+      pathname,
       source: "peated-id",
       suffix: "",
     };
@@ -78,12 +80,14 @@ export function matchEntityRoute(pathname: string): EntityRouteMatch | null {
     const entityId = parseEntityId(entityMatch[2]);
     const kind = getEntityKind(entityMatch[1]);
     if (!entityId || !kind) return null;
+    const suffix = normalizeSuffix(entityMatch[3]);
 
     return {
       entityId,
       kind,
+      pathname: suffix ? pathname.slice(0, -suffix.length) : pathname,
       source: "collection",
-      suffix: normalizeSuffix(entityMatch[3]),
+      suffix,
     };
   }
 
@@ -91,12 +95,14 @@ export function matchEntityRoute(pathname: string): EntityRouteMatch | null {
   if (legacyMatch) {
     const entityId = parseEntityId(legacyMatch[1]);
     if (!entityId) return null;
+    const suffix = normalizeSuffix(legacyMatch[2]);
 
     return {
       entityId,
       kind: null,
+      pathname: suffix ? pathname.slice(0, -suffix.length) : pathname,
       source: "legacy",
-      suffix: normalizeSuffix(legacyMatch[2]),
+      suffix,
     };
   }
 
@@ -105,19 +111,20 @@ export function matchEntityRoute(pathname: string): EntityRouteMatch | null {
 
 export function resolveEntityRoute(
   match: EntityRouteMatch,
-  entity: { id: number; kind: EntityKind },
+  entity: { id: number; kind: EntityKind; name: string },
 ): PeatedIdRouteResolution {
   const suffix = match.suffix;
-  const canonicalPath = `${getEntityUrl(entity)}${suffix}`;
+  const canonicalPath = getEntityUrl(entity);
   const canonicalRequest =
     match.source === "collection" &&
     match.entityId === entity.id &&
-    match.kind === entity.kind;
+    match.kind === entity.kind &&
+    match.pathname === canonicalPath;
 
   return canonicalRequest
     ? {
         action: "rewrite",
         pathname: `/entities/${entity.id}${suffix}`,
       }
-    : { action: "redirect", pathname: canonicalPath };
+    : { action: "redirect", pathname: `${canonicalPath}${suffix}` };
 }

--- a/apps/web/src/lib/releaseFamily.ts
+++ b/apps/web/src/lib/releaseFamily.ts
@@ -1,21 +1,10 @@
-import { notFound } from "next/navigation";
+import type { BottleDisplayNameSource } from "@peated/server/lib/bottleDisplayName";
+import { getBottleUrl } from "./urls";
 
 type ReleaseFamilyGroup = {
   id: number;
   representativeBottleId: number | null;
 };
-
-export function parseReleaseFamilyRouteId(value: string): number {
-  if (!/^[1-9]\d*$/.test(value)) {
-    notFound();
-  }
-
-  const bottleId = Number(value);
-  if (!Number.isSafeInteger(bottleId)) {
-    notFound();
-  }
-  return bottleId;
-}
 
 export function requireReleaseFamilyGroup<
   Group extends ReleaseFamilyGroup,
@@ -44,11 +33,11 @@ export function requireReleaseFamilyAnchor(group: ReleaseFamilyGroup): number {
 }
 
 export function getReleaseFamilyHref(
-  anchorBottleId: number,
+  anchorBottle: BottleDisplayNameSource & { id: number },
   search = "",
 ): string {
-  if (!Number.isSafeInteger(anchorBottleId) || anchorBottleId < 1) {
+  if (!Number.isSafeInteger(anchorBottle.id) || anchorBottle.id < 1) {
     throw new Error("A valid Bottle anchor is required for a release family.");
   }
-  return `/bottles/${anchorBottleId}/releases${search}`;
+  return `${getBottleUrl(anchorBottle)}/releases${search}`;
 }

--- a/apps/web/src/lib/seoMetadata.test.ts
+++ b/apps/web/src/lib/seoMetadata.test.ts
@@ -42,12 +42,12 @@ describe("SEO metadata", () => {
     expect(metadata).toMatchObject({
       title: "Lagavulin 16-year-old",
       description: "A smoky Islay single malt.",
-      alternates: { canonical: "/bottles/42" },
+      alternates: { canonical: "/bottles/42-lagavulin-16-year-old" },
       openGraph: {
         locale: "en_US",
         siteName: "Peated",
         title: "Lagavulin 16-year-old",
-        url: "/bottles/42",
+        url: "/bottles/42-lagavulin-16-year-old",
         images: [
           {
             url: "https://images.peated.com/lagavulin.jpg",
@@ -94,11 +94,11 @@ describe("SEO metadata", () => {
       title: "Lagavulin — Whisky distillery",
       description:
         "See details for Lagavulin, a whisky distillery, in the Peated whisky database.",
-      alternates: { canonical: "/distillers/12" },
+      alternates: { canonical: "/distillers/12-lagavulin" },
       openGraph: {
         locale: "en_US",
         siteName: "Peated",
-        url: "/distillers/12",
+        url: "/distillers/12-lagavulin",
         images: [
           {
             url: "https://images.peated.com/lagavulin-distillery.jpg",

--- a/apps/web/src/lib/tombstoneRedirect.test.ts
+++ b/apps/web/src/lib/tombstoneRedirect.test.ts
@@ -1,8 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
-  getCanonicalRouteRedirectPath,
-  getReleaseFamilyRouteRedirectPath,
+  getCanonicalPublicRouteRedirectPath,
   type LoadRequestHeaders,
 } from "./tombstoneRedirect";
 
@@ -14,7 +13,7 @@ describe("tombstone redirects", () => {
     loadHeaders.mockResolvedValue(new Headers());
   });
 
-  it("preserves a compatible Bottle suffix and query parameters", async () => {
+  it("preserves a Bottle suffix and query parameters", async () => {
     loadHeaders.mockResolvedValue(
       new Headers({
         "x-peated-request-path":
@@ -23,15 +22,38 @@ describe("tombstone redirects", () => {
     );
 
     await expect(
-      getCanonicalRouteRedirectPath(
+      getCanonicalPublicRouteRedirectPath(
         {
           canonicalId: 34,
-          collectionPath: "/bottles",
+          canonicalPath: "/bottles/34-lagavulin-16-year-old",
           currentId: 12,
+          currentPathPrefixes: ["/bottles/12"],
         },
         loadHeaders,
       ),
-    ).resolves.toBe("/bottles/34/tastings?source=legacy&tag=one&tag=two");
+    ).resolves.toBe(
+      "/bottles/34-lagavulin-16-year-old/tastings?source=legacy&tag=one&tag=two",
+    );
+  });
+
+  it("replaces a stale Bottle slug while preserving its nested route", async () => {
+    loadHeaders.mockResolvedValue(
+      new Headers({
+        "x-peated-request-path": "/bottles/12-old-name/prices?currency=USD",
+      }),
+    );
+
+    await expect(
+      getCanonicalPublicRouteRedirectPath(
+        {
+          canonicalId: 12,
+          canonicalPath: "/bottles/12-current-name",
+          currentId: 12,
+          currentPathPrefixes: ["/bottles/12"],
+        },
+        loadHeaders,
+      ),
+    ).resolves.toBe("/bottles/12-current-name/prices?currency=USD");
   });
 
   it("rejects a malformed proxy-owned request path", async () => {
@@ -42,43 +64,29 @@ describe("tombstone redirects", () => {
     );
 
     await expect(
-      getCanonicalRouteRedirectPath(
+      getCanonicalPublicRouteRedirectPath(
         {
           canonicalId: 34,
-          collectionPath: "/bottles",
+          canonicalPath: "/bottles/34-lagavulin-16-year-old",
           currentId: 12,
+          currentPathPrefixes: ["/bottles/12"],
         },
         loadHeaders,
       ),
     ).rejects.toThrow("Invalid proxy-owned request path");
   });
 
-  it("drops Bottle suffixes while preserving query for a release family", async () => {
-    loadHeaders.mockResolvedValue(
-      new Headers({
-        "x-peated-request-path":
-          "/bottles/12/tastings?source=legacy&tag=one&tag=two",
-      }),
-    );
-
-    await expect(
-      getReleaseFamilyRouteRedirectPath(56, loadHeaders),
-    ).resolves.toBe("/bottles/56/releases?source=legacy&tag=one&tag=two");
-  });
-
   it("returns a stable root path without request headers", async () => {
     await expect(
-      getCanonicalRouteRedirectPath(
+      getCanonicalPublicRouteRedirectPath(
         {
           canonicalId: 34,
-          collectionPath: "/bottles",
+          canonicalPath: "/bottles/34-lagavulin-16-year-old",
           currentId: 12,
+          currentPathPrefixes: ["/bottles/12"],
         },
         loadHeaders,
       ),
-    ).resolves.toBe("/bottles/34");
-    await expect(
-      getReleaseFamilyRouteRedirectPath(56, loadHeaders),
-    ).resolves.toBe("/bottles/56/releases");
+    ).resolves.toBe("/bottles/34-lagavulin-16-year-old");
   });
 });

--- a/apps/web/src/lib/tombstoneRedirect.ts
+++ b/apps/web/src/lib/tombstoneRedirect.ts
@@ -1,15 +1,15 @@
 import { headers } from "next/headers";
-import { getReleaseFamilyHref } from "./releaseFamily";
-
-type CanonicalRouteRedirectOptions = {
-  canonicalId: number | string;
-  collectionPath: `/${string}`;
-  currentId: number | string;
-};
 
 type RequestedRoute = {
   pathname: string;
   search: string;
+};
+
+type CanonicalPublicRouteOptions = {
+  canonicalId: number;
+  canonicalPath: `/${string}`;
+  currentId: number;
+  currentPathPrefixes: `/${string}`[];
 };
 
 export type LoadRequestHeaders = () => Promise<Pick<Headers, "get">>;
@@ -23,7 +23,7 @@ function parseRequestedRoute(value: string): RequestedRoute {
     }
 
     const url = new URL(value, "http://n");
-    return { pathname: url.pathname, search: url.search };
+    return { pathname: decodeURI(url.pathname), search: url.search };
   } catch (error) {
     throw new Error("Invalid proxy-owned request path", { cause: error });
   }
@@ -40,37 +40,38 @@ async function getRequestedRoute(loadHeaders: LoadRequestHeaders) {
   return parseRequestedRoute(requestPath);
 }
 
-export async function getCanonicalRouteRedirectPath(
-  { canonicalId, collectionPath, currentId }: CanonicalRouteRedirectOptions,
+function getNestedRouteSuffix(pathname: string, prefix: string) {
+  if (pathname === prefix) return "";
+  if (pathname.startsWith(`${prefix}/`)) return pathname.slice(prefix.length);
+  if (!pathname.startsWith(`${prefix}-`)) return null;
+
+  const nestedRouteIndex = pathname.indexOf("/", prefix.length + 1);
+  return nestedRouteIndex === -1 ? "" : pathname.slice(nestedRouteIndex);
+}
+
+export async function getCanonicalPublicRouteRedirectPath(
+  {
+    canonicalId,
+    canonicalPath,
+    currentId,
+    currentPathPrefixes,
+  }: CanonicalPublicRouteOptions,
   loadHeaders: LoadRequestHeaders = loadRequestHeaders,
 ) {
-  const currentPrefix = `${collectionPath}/${currentId}`;
-  const canonicalPrefix = `${collectionPath}/${canonicalId}`;
   const requestedRoute = await getRequestedRoute(loadHeaders);
 
   if (!requestedRoute) {
-    return canonicalPrefix;
+    return canonicalId === currentId ? null : canonicalPath;
   }
 
-  const { pathname: requestedPathname, search } = requestedRoute;
-  const suffix = requestedPathname.slice(currentPrefix.length);
-  if (
-    !requestedPathname.startsWith(currentPrefix) ||
-    (suffix && !suffix.startsWith("/"))
-  ) {
-    return `${canonicalPrefix}${search}`;
+  const { pathname, search } = requestedRoute;
+  if (pathname === canonicalPath || pathname.startsWith(`${canonicalPath}/`)) {
+    return null;
   }
 
-  return `${canonicalPrefix}${suffix}${search}`;
-}
-
-export async function getReleaseFamilyRouteRedirectPath(
-  representativeBottleId: number,
-  loadHeaders: LoadRequestHeaders = loadRequestHeaders,
-) {
-  const requestedRoute = await getRequestedRoute(loadHeaders);
-  return getReleaseFamilyHref(
-    representativeBottleId,
-    requestedRoute?.search ?? "",
-  );
+  const suffix =
+    currentPathPrefixes
+      .map((prefix) => getNestedRouteSuffix(pathname, prefix))
+      .find((candidate) => candidate !== null) ?? "";
+  return `${canonicalPath}${suffix}${search}`;
 }

--- a/apps/web/src/lib/urls.test.ts
+++ b/apps/web/src/lib/urls.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { getBottleUrl, getEntityUrl } from "./urls";
 
+const bottle = {
+  id: 123,
+  name: "16-year-old",
+  brand: { name: "Lagavulin" },
+};
+
 describe("public catalog URLs", () => {
-  it("uses the Bottle collection and numeric ID", () => {
-    expect(getBottleUrl({ id: 123 })).toBe("/bottles/123");
+  it("uses the Bottle collection, ID, and display name", () => {
+    expect(getBottleUrl(bottle)).toBe("/bottles/123-lagavulin-16-year-old");
   });
 
   it.each([
@@ -12,10 +18,31 @@ describe("public catalog URLs", () => {
     ["bottler", "/bottlers/123"],
     ["company", "/companies/123"],
   ] as const)("uses the %s Entity collection", (kind, expected) => {
-    expect(getEntityUrl({ id: 123, kind })).toBe(expected);
+    expect(getEntityUrl({ id: 123, kind, name: "Lagavulin" })).toBe(
+      `${expected}-lagavulin`,
+    );
   });
 
   it("uses the generic Entity route when kind is unavailable", () => {
-    expect(getEntityUrl({ id: 123, kind: null })).toBe("/entities/123");
+    expect(getEntityUrl({ id: 123, kind: null, name: "Lagavulin" })).toBe(
+      "/entities/123-lagavulin",
+    );
+  });
+
+  it.each([
+    ["Pōkeno", "pokeno"],
+    ["Nikka 宮城峡", "nikka"],
+    ["東京", "東京"],
+    ["🥃", "entity"],
+  ])("creates an Entity URL for %s", (name, slug) => {
+    expect(getEntityUrl({ id: 123, kind: "distillery", name })).toBe(
+      `/distillers/123-${slug}`,
+    );
+  });
+
+  it("uses a non-empty Bottle slug when the display name has no letters", () => {
+    expect(getBottleUrl({ id: 123, name: "🥃", brand: { name: "🥃" } })).toBe(
+      "/bottles/123-bottle",
+    );
   });
 });

--- a/apps/web/src/lib/urls.ts
+++ b/apps/web/src/lib/urls.ts
@@ -1,4 +1,7 @@
+import type { BottleDisplayNameSource } from "@peated/server/lib/bottleDisplayName";
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { EntityKind } from "@peated/server/types";
+import slugify from "@sindresorhus/slugify";
 
 const ENTITY_COLLECTION_BY_KIND = {
   brand: "/brands",
@@ -8,17 +11,34 @@ const ENTITY_COLLECTION_BY_KIND = {
 } as const satisfies Record<EntityKind, `/${string}`>;
 
 export function getBottleUrl(
-  bottle: Pick<{ id: number }, "id">,
-): `/bottles/${number}` {
-  return `/bottles/${bottle.id}`;
+  bottle: BottleDisplayNameSource & { id: number },
+): `/bottles/${number}-${string}` {
+  const slug = createUrlSlug(formatBottleDisplayName(bottle), "bottle");
+  return `/bottles/${bottle.id}-${slug}`;
 }
 
 export function getEntityUrl(entity: {
   id: number;
   kind: EntityKind | null;
+  name: string;
 }): `/${string}` {
-  if (!entity.kind) return `/entities/${entity.id}`;
-  return `${ENTITY_COLLECTION_BY_KIND[entity.kind]}/${entity.id}`;
+  const collection = entity.kind
+    ? ENTITY_COLLECTION_BY_KIND[entity.kind]
+    : "/entities";
+  return `${collection}/${entity.id}-${createUrlSlug(entity.name, "entity")}`;
+}
+
+function createUrlSlug(value: string, fallback: "bottle" | "entity"): string {
+  const asciiSlug = slugify(value);
+  if (asciiSlug) return asciiSlug;
+
+  const unicodeSlug = value
+    .normalize("NFKC")
+    .toLowerCase()
+    .match(/[\p{Letter}\p{Mark}\p{Number}]+/gu)
+    ?.join("-")
+    .normalize("NFC");
+  return unicodeSlug || fallback;
 }
 
 export function getEntityKindSearchUrl(kind: EntityKind) {

--- a/docs/architecture/peated-ids.md
+++ b/docs/architecture/peated-ids.md
@@ -4,10 +4,10 @@ Peated IDs are short, permanent references for public catalog objects. They are 
 
 ## Supported Objects
 
-| Object | Format                | Example | Canonical URL                       |
-| ------ | --------------------- | ------- | ----------------------------------- |
-| Bottle | `B` plus four+ digits | `B0123` | `https://peated.com/bottles/123`    |
-| Entity | `E` plus four+ digits | `E0123` | `https://peated.com/distillers/123` |
+| Object | Format                | Example | Canonical URL                                          |
+| ------ | --------------------- | ------- | ------------------------------------------------------ |
+| Bottle | `B` plus four+ digits | `B0123` | `https://peated.com/bottles/123-lagavulin-16-year-old` |
+| Entity | `E` plus four+ digits | `E0123` | `https://peated.com/distillers/123-lagavulin`          |
 
 The number is the object's existing positive database ID. Numbers shorter than four digits use leading zeroes. The prefix identifies the type, so `B0123` and `E0123` are different Peated IDs.
 
@@ -15,9 +15,13 @@ Peated IDs are serialized in uppercase with at least four digits. Input and sear
 
 ## Public Behavior
 
-- Bottle URLs use `/bottles/{numeric ID}`.
+- Bottle URLs use `/bottles/{numeric ID}-{current display-name slug}`.
 - Entity URLs use the collection for their primary kind: `/brands`,
-  `/distillers`, `/bottlers`, or `/companies`.
+  `/distillers`, `/bottlers`, or `/companies`, followed by the numeric ID and
+  current name slug.
+- The numeric ID identifies the object. The web app creates the slug when it
+  builds a URL. It does not store slugs. Numeric-only and old slug URLs redirect
+  permanently to the current URL.
 - Root ID URLs such as `/B0123`, `/B123`, and `/E0123` redirect permanently to
   the canonical collection URL.
 - Legacy `/entities/{numeric ID}` URLs redirect permanently to the Entity's
@@ -26,7 +30,7 @@ Peated IDs are serialized in uppercase with at least four digits. Input and sear
 - Global search recognizes an exact Peated ID and returns that object when its type is included in the search.
 - Bottle and entity pages display the compact label `ID` and provide a way to
   copy the canonical URL.
-- IDs for merged bottles and entities continue to resolve through the existing tombstones to the surviving object.
+- IDs for merged bottles and entities redirect to the remaining object.
 
 ## Scope
 

--- a/openspec/changes/add-virtual-catalog-slugs/.openspec.yaml
+++ b/openspec/changes/add-virtual-catalog-slugs/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/add-virtual-catalog-slugs/design.md
+++ b/openspec/changes/add-virtual-catalog-slugs/design.md
@@ -1,0 +1,78 @@
+## Context
+
+Public Bottle pages use `/bottles/{id}`. Public Entity pages use the primary
+kind collection and ID, such as `/distillers/{id}`. Shared URL helpers already
+own most public links. Page loaders already redirect merged IDs and wrong
+Entity collections. Bottle display names are already centralized in
+`formatBottleDisplayName`.
+
+The slug is part of the displayed URL. It can change when a Bottle or Entity
+name changes. The numeric database ID remains stable and handles all lookups.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Generate readable Bottle and Entity URL segments without stored slug data.
+- Accept numeric-only and old slug URLs, then redirect them to the current URL.
+- Preserve merged-object redirects, Entity kind routes, nested page paths,
+  query parameters, Peated ID routes, metadata, and sitemaps.
+- Handle Unicode input without ever returning an empty slug.
+
+**Non-Goals:**
+
+- Find Bottles or Entities by slug alone.
+- Add editable or historically stable slugs.
+- Change API routes, database schemas, or mutation inputs.
+- Add slugs to administrative and standalone mutation workflows.
+
+## Decisions
+
+### Generate slugs at the web URL boundary
+
+`getBottleUrl` formats the current Bottle display name and then creates a slug.
+`getEntityUrl` creates a slug from the Entity name. Both functions build public
+URLs. No migration or backfill is needed.
+
+The app does not store slugs because it does not use them for lookups. A stored
+slug would also need an update after each name change.
+
+### Prefer ASCII transliteration with a non-empty Unicode fallback
+
+The URL helper uses `@sindresorhus/slugify` first. If the result is empty, it
+keeps normalized Unicode letters and numbers. If the result is still empty, it
+uses `bottle` or `entity`.
+
+Always preserving Unicode was rejected because the desired common case is an
+ASCII URL. Always requiring ASCII was rejected because names written only in
+scripts that the library cannot transliterate would produce no slug.
+
+### Use the ID for route lookups
+
+The route parser accepts a positive safe integer followed by an optional slug.
+It loads the object by the integer only. The page redirects when the requested
+collection, ID, or slug is not current.
+
+The redirect keeps nested paths such as `/tastings` and their query parameters.
+
+### Keep workflow URLs numeric
+
+Public links, page metadata, copied URLs, and sitemaps use slugs. API routes and
+standalone edit, merge, audit, and creation workflows continue to use numeric
+IDs.
+
+## Risks / Trade-offs
+
+- **A rename changes the current URL:** The ID keeps old links valid and the
+  page redirects them to the new URL.
+- **Some names do not have an ASCII form:** Keep normalized Unicode when the
+  slug library returns an empty result.
+- **Some callers have only an ID and kind:** Keep their workflow paths numeric.
+- **Old numeric links add a redirect:** Update public links and sitemaps in the
+  same change so normal navigation is direct.
+
+## Migration Plan
+
+Deploy the route parser, redirects, and new links together. Existing numeric
+URLs remain valid, so no data migration is required. A rollback restores
+numeric URLs without changing stored data.

--- a/openspec/changes/add-virtual-catalog-slugs/design.md
+++ b/openspec/changes/add-virtual-catalog-slugs/design.md
@@ -2,9 +2,9 @@
 
 Public Bottle pages use `/bottles/{id}`. Public Entity pages use the primary
 kind collection and ID, such as `/distillers/{id}`. Shared URL helpers already
-own most public links. Page loaders already redirect merged IDs and wrong
-Entity collections. Bottle display names are already centralized in
-`formatBottleDisplayName`.
+own most public links. The web route boundary redirects Entity routes before
+rendering, and Bottle pages redirect merged IDs. Bottle display names are
+already centralized in `formatBottleDisplayName`.
 
 The slug is part of the displayed URL. It can change when a Bottle or Entity
 name changes. The numeric database ID remains stable and handles all lookups.

--- a/openspec/changes/add-virtual-catalog-slugs/proposal.md
+++ b/openspec/changes/add-virtual-catalog-slugs/proposal.md
@@ -1,0 +1,32 @@
+## Why
+
+Public Bottle and Entity URLs contain only numeric IDs. This makes shared links
+hard to recognize. Peated can add readable names because the numeric ID still
+identifies each object.
+
+## What Changes
+
+- Generate virtual Bottle and Entity slugs from their current display names.
+- Use `{numeric ID}-{slug}` in public URLs.
+- Use the numeric ID for lookups. Accept numeric-only, old slug, and merged URLs.
+- Redirect old URLs to the current collection, ID, and slug
+  while preserving nested paths and query parameters.
+- Publish slugged URLs in internal links, metadata, copied URLs, and sitemaps.
+- Keep API paths, mutation inputs, and database schemas unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `catalog-public-urls`: Defines readable name slugs and redirects for public
+  Bottle and Entity pages.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+The change affects public web URLs, redirects, Peated ID routes, page metadata,
+and sitemaps. It uses the same slug library as other apps in the repository. It
+does not change the database or API.

--- a/openspec/changes/add-virtual-catalog-slugs/specs/catalog-public-urls/spec.md
+++ b/openspec/changes/add-virtual-catalog-slugs/specs/catalog-public-urls/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+### Requirement: Virtual catalog slugs
+
+The web application SHALL derive each public Bottle and Entity slug from the
+object's current display name. It MUST NOT store the slug or use it to find the
+object.
+
+#### Scenario: Bottle URL generation
+
+- **WHEN** a caller generates a public URL for Bottle 123 whose display name is
+  `Lagavulin 16-year-old`
+- **THEN** the URL is `/bottles/123-lagavulin-16-year-old`
+
+#### Scenario: Entity URL generation
+
+- **WHEN** a caller generates a public URL for Distillery Entity 123 named
+  `Lagavulin`
+- **THEN** the URL is `/distillers/123-lagavulin`
+
+#### Scenario: Name change
+
+- **WHEN** a Bottle or Entity display name changes
+- **THEN** newly generated URLs use the slug derived from the new name without
+  updating stored slug data
+
+### Requirement: Non-empty Unicode-safe slugs
+
+The web application SHALL prefer ASCII slugification and MUST produce a
+non-empty slug for every Bottle and Entity.
+
+#### Scenario: Latin diacritic
+
+- **WHEN** the source name is `Pōkeno`
+- **THEN** the generated slug is `pokeno`
+
+#### Scenario: Mixed Latin and non-Latin text
+
+- **WHEN** the source name is `Nikka 宮城峡`
+- **THEN** the generated slug is `nikka`
+
+#### Scenario: Non-Latin-only text
+
+- **WHEN** ASCII slugification removes the complete source name `東京`
+- **THEN** the generated slug preserves its normalized Unicode letters as
+  `東京`
+
+#### Scenario: Name without letters or numbers
+
+- **WHEN** slugification finds no usable characters in a Bottle or Entity name
+- **THEN** the generated slug is the object-kind fallback `bottle` or `entity`
+
+### Requirement: Public route lookup by ID
+
+The web application SHALL resolve a public catalog route by its positive
+numeric ID. It SHALL ignore the slug during the lookup.
+
+#### Scenario: Current slug
+
+- **WHEN** a user requests the current collection, ID, and slug
+- **THEN** the page renders without a redirect
+
+#### Scenario: Numeric-only URL
+
+- **WHEN** a user requests a public Bottle or Entity URL with only its numeric
+  ID
+- **THEN** the application permanently redirects to the current slugged URL
+
+#### Scenario: Stale or incorrect slug
+
+- **WHEN** a user requests a valid ID with a slug that is missing, stale, or
+  incorrect
+- **THEN** the application permanently redirects to the slug generated from
+  current object data
+
+#### Scenario: Invalid route identifier
+
+- **WHEN** a public route segment does not start with a positive safe integer
+- **THEN** the application returns not found without performing a catalog
+  lookup
+
+### Requirement: Redirect old public URLs
+
+The web application SHALL keep existing Entity kind and merged-object redirects
+when it adds the current slug.
+
+#### Scenario: Nested stale URL
+
+- **WHEN** a stale public URL includes a nested page suffix and query string
+- **THEN** the permanent redirect updates the collection, ID, and slug while
+  preserving the suffix and query string
+
+#### Scenario: Merged object
+
+- **WHEN** a public URL names an ID that merged into another Bottle or Entity
+- **THEN** the permanent redirect uses the survivor's current ID, collection,
+  and slug
+
+#### Scenario: Peated ID
+
+- **WHEN** a root Peated ID resolves to a Bottle or Entity
+- **THEN** its permanent redirect uses the object's current public URL
+
+### Requirement: Published public URLs
+
+The web application SHALL publish slugged URLs for public Bottle and Entity
+navigation and discovery.
+
+#### Scenario: Public navigation
+
+- **WHEN** the web application renders a public Bottle or Entity link
+- **THEN** the link uses the current virtual slug when the source data includes
+  the display name
+
+#### Scenario: Search metadata and sitemap
+
+- **WHEN** the application emits canonical metadata, copied public URLs, or a
+  sitemap entry
+- **THEN** it uses the current slugged URL
+
+#### Scenario: API and workflow route
+
+- **WHEN** the application calls an API or opens a standalone edit workflow
+- **THEN** that route continues to identify the object with its numeric ID

--- a/openspec/changes/add-virtual-catalog-slugs/tasks.md
+++ b/openspec/changes/add-virtual-catalog-slugs/tasks.md
@@ -1,0 +1,25 @@
+## 1. URL Generation
+
+- [x] 1.1 Add the web slugification dependency and implement non-empty
+      Unicode-safe catalog slug generation with focused tests
+- [x] 1.2 Generate canonical Bottle and Entity URLs from their current display
+      names and update URL helper tests
+
+## 2. Route Resolution
+
+- [x] 2.1 Parse numeric and slugged public route segments by authoritative ID
+      and reject malformed identifiers
+- [x] 2.2 Canonicalize numeric, stale-slug, wrong-kind, Peated ID, and merged
+      routes while preserving nested suffixes and query parameters
+
+## 3. Public URL Consumers
+
+- [x] 3.1 Update public Bottle and Entity links, page tabs, metadata, copied
+      URLs, release-family links, and sitemaps to emit canonical slugged URLs
+- [x] 3.2 Keep API and standalone mutation workflow routes numeric
+
+## 4. Verification
+
+- [x] 4.1 Run focused web tests for URL generation, routing, redirects,
+      metadata, and sitemaps
+- [x] 4.2 Run the web typecheck, lint changed files, and verify formatting

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,6 +487,9 @@ importers:
       '@simplewebauthn/browser':
         specifier: ^13.2.2
         version: 13.2.2
+      '@sindresorhus/slugify':
+        specifier: ^2.2.1
+        version: 2.2.1
       '@stylexjs/stylex':
         specifier: 0.19.0
         version: 0.19.0


### PR DESCRIPTION
Public Bottle and Entity URLs now include a slug made from the current display
name, such as `/bottles/123-lagavulin-16-year-old` and
`/distillers/123-lagavulin`. Shared links, search results, page tabs, metadata,
and sitemaps now publish this form.

The numeric ID remains the lookup key. Numeric-only URLs, old slugs, merged
IDs, Peated IDs, and wrong Entity collections redirect permanently to the
current URL while preserving nested paths and query parameters. Slugs are made
at runtime with a non-empty Unicode fallback, so this does not change the
database, API, or numeric edit routes.
