### PR TITLE
feat(web): refresh about reference pages

### DIFF
--- a/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
+++ b/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
@@ -1,0 +1,191 @@
+import * as stylex from "@stylexjs/stylex";
+import type { ReactNode } from "react";
+
+import { TextLink, type TextLinkProps } from "@peated/web/components";
+import {
+  PageColumns,
+  PageHeader,
+  TabbedPage,
+} from "@peated/web/components/pages/pageLayout.stylex";
+import { colors, fonts, space } from "../../../styles/tokens.stylex";
+
+const MOBILE = "@media (max-width: 559px)";
+
+const aboutTabs = [
+  { href: "/about", label: "About" },
+  { href: "/about/categories", label: "Whisky categories" },
+  { href: "/about/ratings", label: "Rating guide" },
+  { href: "/updates", label: "Recent changes" },
+] as const;
+
+export function AboutPage({
+  children,
+  currentHref,
+  description,
+  eyebrow,
+  rail,
+  title,
+}: {
+  children: ReactNode;
+  currentHref: string;
+  description: ReactNode;
+  eyebrow: ReactNode;
+  rail?: ReactNode;
+  title: ReactNode;
+}) {
+  return (
+    <TabbedPage
+      currentHref={currentHref}
+      header={
+        <PageHeader description={description} eyebrow={eyebrow} title={title} />
+      }
+      tabs={aboutTabs}
+      tabsLabel="About Peated"
+    >
+      <PageColumns rail={rail} railBehavior="stack">
+        {children}
+      </PageColumns>
+    </TabbedPage>
+  );
+}
+
+export function AboutText({ children }: { children: ReactNode }) {
+  return <p {...stylex.props(styles.text)}>{children}</p>;
+}
+
+export function AboutLink({ children, ...props }: TextLinkProps) {
+  return (
+    <TextLink {...props} size="inherit">
+      {children}
+    </TextLink>
+  );
+}
+
+export function AboutTextStack({ children }: { children: ReactNode }) {
+  return <div {...stylex.props(styles.textStack)}>{children}</div>;
+}
+
+export function ReviewSteps({
+  steps,
+}: {
+  steps: readonly { body: ReactNode; title: string }[];
+}) {
+  return (
+    <ol {...stylex.props(styles.steps)}>
+      {steps.map((step, index) => (
+        <li key={step.title} {...stylex.props(styles.step)}>
+          <span {...stylex.props(styles.stepNumber)}>
+            {String(index + 1).padStart(2, "0")}
+          </span>
+          <h3 {...stylex.props(styles.stepTitle)}>{step.title}</h3>
+          <div {...stylex.props(styles.stepBody)}>{step.body}</div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+export function ReviewDirections({
+  down,
+  up,
+}: {
+  down: ReactNode;
+  up: ReactNode;
+}) {
+  return (
+    <dl {...stylex.props(styles.directions)}>
+      <div>
+        <dt {...stylex.props(styles.directionLabel)}>Move up for</dt>
+        <dd {...stylex.props(styles.directionBody)}>{up}</dd>
+      </div>
+      <div>
+        <dt {...stylex.props(styles.directionLabel)}>Move down for</dt>
+        <dd {...stylex.props(styles.directionBody)}>{down}</dd>
+      </div>
+    </dl>
+  );
+}
+
+const styles = stylex.create({
+  textStack: {
+    display: "flex",
+    flexDirection: "column",
+    rowGap: space.x3,
+  },
+  text: {
+    maxWidth: "74ch",
+    margin: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "15px",
+    lineHeight: 1.7,
+  },
+  steps: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "repeat(3, minmax(0, 1fr))",
+      [MOBILE]: "minmax(0, 1fr)",
+    },
+    gap: space.x6,
+    margin: 0,
+    padding: 0,
+    listStyle: "none",
+  },
+  step: {
+    minWidth: 0,
+    paddingTop: space.x3,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.hairline,
+  },
+  stepNumber: {
+    color: colors.accentDeep,
+    fontFamily: fonts.data,
+    fontSize: "10px",
+    fontVariantNumeric: "tabular-nums",
+    lineHeight: 1.3,
+  },
+  stepTitle: {
+    margin: 0,
+    marginTop: space.x2,
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontSize: "17px",
+    fontWeight: 700,
+    letterSpacing: "-0.015em",
+    lineHeight: 1.25,
+  },
+  stepBody: {
+    marginTop: space.x2,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.55,
+  },
+  directions: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "repeat(2, minmax(0, 1fr))",
+      [MOBILE]: "minmax(0, 1fr)",
+    },
+    gap: space.x6,
+    margin: 0,
+    paddingTop: space.x3,
+  },
+  directionLabel: {
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "10px",
+    letterSpacing: "0.04em",
+    lineHeight: 1.3,
+    textTransform: "uppercase",
+  },
+  directionBody: {
+    margin: 0,
+    marginTop: space.x2,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.55,
+  },
+});

--- a/apps/web/src/app/(app)/about/categories/page.tsx
+++ b/apps/web/src/app/(app)/about/categories/page.tsx
@@ -1,11 +1,15 @@
-import { DataTable, type DataTableColumn } from "@peated/web/components";
 import {
-  ContentLink,
-  ContentPage,
-  ContentSection,
-  ContentText,
-} from "@peated/web/components/pages/contentPage.stylex";
+  DataTable,
+  RailList,
+  RailListItem,
+  type DataTableColumn,
+} from "@peated/web/components";
+import {
+  PageSection,
+  RailSection,
+} from "@peated/web/components/pages/pageLayout.stylex";
 import type { Metadata } from "next";
+import { AboutPage, AboutText, AboutTextStack } from "../aboutPage.stylex";
 
 export const dynamic = "force-static";
 
@@ -76,59 +80,84 @@ const categoryColumns: DataTableColumn<CategoryDefinition>[] = [
   },
   {
     cell: (category) => category.definition,
-    header: "Peated baseline",
+    header: "Definition",
     key: "definition",
   },
 ];
 
 export default function CategoriesPage() {
   return (
-    <ContentPage
-      eyebrow="Category guide"
-      intro="Peated records the most specific whisky style supported by the bottle's label or another reliable source. Country and region stay separate."
+    <AboutPage
+      currentHref="/about/categories"
+      description="Peated records the most specific whisky style the bottle's label or another reliable source supports. Country and region stay separate from style."
+      eyebrow={`Reference · ${categories.length} categories`}
+      rail={
+        <>
+          <RailSection heading="Sources">
+            <RailList ariaLabel="Whisky category sources">
+              <RailListItem
+                href="https://www.worldwhiskiesawards.com/shares/WWA_Categories_2026-Category-Definitions.pdf"
+                metadata="Category definitions, 2026"
+                title="World Whiskies Awards"
+              />
+              <RailListItem
+                href="https://www.ecfr.gov/current/title-27/chapter-I/subchapter-A/part-5/subpart-I/section-5.143"
+                metadata="27 CFR 5.143"
+                title="US whisky standards"
+              />
+              <RailListItem
+                href="https://assets.publishing.service.gov.uk/media/5fd36667e90e07662ed92c85/Scotch_Whisky_Technical_File_-_June_2019.pdf"
+                metadata="June 2019"
+                title="Scotch Whisky technical file"
+              />
+            </RailList>
+          </RailSection>
+          <RailSection heading="Browse by category">
+            <RailList ariaLabel="Browse bottles by category">
+              <RailListItem
+                href="/bottles?category=single_malt"
+                title="Single malt"
+              />
+              <RailListItem href="/bottles?category=bourbon" title="Bourbon" />
+              <RailListItem
+                href="/bottles?category=blended_malt"
+                title="Blended malt"
+              />
+              <RailListItem href="/bottles?category=rye" title="Rye whisky" />
+            </RailList>
+          </RailSection>
+        </>
+      }
       title="Whisky categories"
     >
-      <ContentSection title="How Peated chooses a category">
-        <ContentText>
-          Local rules come first. When a country does not define a style, Peated
-          uses the baselines below. A category stays blank until a label or
-          another reliable source supports it. You can submit a correction when
-          a category is missing or wrong.
-        </ContentText>
-        <ContentText>
-          Use the most specific category. Bourbon is not corn whisky. Rye, corn
-          whisky, and wheat whisky are more specific than blended whisky or
-          single grain. Blended malt and blended grain are more specific than
-          blended whisky.
-        </ContentText>
-      </ContentSection>
+      <PageSection heading="How a category gets chosen">
+        <AboutTextStack>
+          <AboutText>
+            Local rules come first. When a country does not define a style,
+            Peated uses the definitions below. A category stays blank until a
+            label or another reliable source supports it. Submit a correction
+            when one is missing or wrong.
+          </AboutText>
+          <AboutText>
+            Always use the most specific category. Bourbon is not corn whisky.
+            Rye, corn whisky, and wheat whisky are more specific than blended
+            whisky or single grain. Blended malt and blended grain are more
+            specific than blended whisky.
+          </AboutText>
+        </AboutTextStack>
+      </PageSection>
 
-      <ContentSection title="Category definitions">
+      <PageSection heading="Definitions">
         <DataTable
           caption="Peated whisky category definitions"
           columns={categoryColumns}
           getKey={(category) => category.category}
           items={categories}
         />
-      </ContentSection>
-
-      <ContentSection title="References">
-        <ContentText>
-          These baselines use the{" "}
-          <ContentLink href="https://www.worldwhiskiesawards.com/shares/WWA_Categories_2026-Category-Definitions.pdf">
-            World Whiskies Awards definitions
-          </ContentLink>
-          , the{" "}
-          <ContentLink href="https://www.ecfr.gov/current/title-27/chapter-I/subchapter-A/part-5/subpart-I/section-5.143">
-            United States whisky standards
-          </ContentLink>
-          , and the{" "}
-          <ContentLink href="https://assets.publishing.service.gov.uk/media/5fd36667e90e07662ed92c85/Scotch_Whisky_Technical_File_-_June_2019.pdf">
-            Scotch Whisky technical file
-          </ContentLink>
-          . Local rules can be stricter than these baselines.
-        </ContentText>
-      </ContentSection>
-    </ContentPage>
+        <AboutText>
+          Local rules can be stricter than these definitions.
+        </AboutText>
+      </PageSection>
+    </AboutPage>
   );
 }

--- a/apps/web/src/app/(app)/about/page.tsx
+++ b/apps/web/src/app/(app)/about/page.tsx
@@ -1,28 +1,76 @@
-import { SummaryStrip } from "@peated/web/components";
 import {
-  ContentLink,
-  ContentPage,
-  ContentSection,
-  ContentText,
-} from "@peated/web/components/pages/contentPage.stylex";
+  FactList,
+  RailList,
+  RailListItem,
+  SummaryStrip,
+} from "@peated/web/components";
+import {
+  PageSection,
+  RailSection,
+} from "@peated/web/components/pages/pageLayout.stylex";
 import config from "@peated/web/config";
 import { getPublicStats } from "@peated/web/lib/publicStats.server";
 import type { Metadata } from "next";
+import {
+  AboutLink,
+  AboutPage,
+  AboutText,
+  AboutTextStack,
+} from "./aboutPage.stylex";
 
 export const dynamic = "force-static";
 
 export const metadata: Metadata = {
   title: "About",
+  description:
+    "How Peated records whisky bottles, the people who make them, and what drinkers thought.",
 };
 
-export default async function AboutPage() {
+export default async function AboutRoute() {
   const stats = await getPublicStats().catch(() => undefined);
 
   return (
-    <ContentPage
-      eyebrow="About Peated"
-      intro="A community-maintained record of whisky bottles and the people who make them."
-      title="The mission"
+    <AboutPage
+      currentHref="/about"
+      description="A community-maintained record of whisky bottles, the people who make them, and what the people who drank them thought."
+      eyebrow="Reference · edited by members"
+      rail={
+        <>
+          <RailSection heading="Contribute">
+            <RailList ariaLabel="Contribute to Peated">
+              <RailListItem
+                href="/addBottle?intent=catalog"
+                metadata="Anything the catalog is missing"
+                title="Record a bottle"
+              />
+              <RailListItem
+                href="/bottles"
+                metadata="Open any bottle record"
+                title="Suggest a correction"
+              />
+              <RailListItem
+                href={config.DISCORD_LINK}
+                title="Peated on Discord"
+              />
+              <RailListItem
+                href={config.GITHUB_REPO}
+                title="Source on GitHub"
+              />
+            </RailList>
+          </RailSection>
+          <RailSection heading="Reference">
+            <RailList ariaLabel="Peated reference pages">
+              <RailListItem
+                href="/bottlers/4263/codes"
+                title="SMWS distillery codes"
+              />
+              <RailListItem href="/updates" title="Recent changes" />
+              <RailListItem href="/terms" title="Terms" />
+            </RailList>
+          </RailSection>
+        </>
+      }
+      title="About Peated"
     >
       {stats ? (
         <SummaryStrip
@@ -40,39 +88,46 @@ export default async function AboutPage() {
           ]}
         />
       ) : null}
-      <ContentSection title="Why Peated exists">
-        <ContentText>
-          Peated is a social record for tasting and collecting whisky. It gives
-          the community one place to identify bottles, record what they drank,
-          and share useful notes.
-        </ContentText>
-        <ContentText>
-          The catalog is central to that work. It combines public sources and
-          community corrections, and the same modern API powers the product.
-        </ContentText>
-      </ContentSection>
-      <ContentSection title="Built in the open">
-        <ContentText>
-          Peated was started by David Cramer and is{" "}
-          <ContentLink href={config.GITHUB_REPO}>
-            open source on GitHub
-          </ContentLink>
-          . Join the{" "}
-          <ContentLink href={config.DISCORD_LINK}>Peated Discord</ContentLink>{" "}
-          to help improve it.
-        </ContentText>
+      <PageSection heading="Why Peated exists">
+        <AboutTextStack>
+          <AboutText>
+            Peated is a social record for tasting and collecting whisky. It
+            gives you one place to identify a bottle, record what you drank, and
+            leave useful notes.
+          </AboutText>
+          <AboutText>
+            The catalog is central to that work. It combines public sources with
+            corrections from members. The same API that serves the site is open
+            to anyone building on top of it.
+          </AboutText>
+        </AboutTextStack>
+      </PageSection>
+      <PageSection heading="Built in the open">
+        <AboutText>
+          Peated was started by David Cramer. The source is on GitHub, and the
+          Discord is where members discuss corrections and contributions.
+        </AboutText>
         {config.VERSION ? (
-          <ContentText>
+          <AboutText>
             This site runs version{" "}
-            <ContentLink
-              href={`${config.GITHUB_REPO}/commit/${config.VERSION}`}
-            >
+            <AboutLink href={`${config.GITHUB_REPO}/commit/${config.VERSION}`}>
               {config.VERSION}
-            </ContentLink>
+            </AboutLink>
             .
-          </ContentText>
+          </AboutText>
         ) : null}
-      </ContentSection>
-    </ContentPage>
+      </PageSection>
+      <PageSection heading="What Peated holds">
+        <FactList
+          facts={[
+            { label: "Started", value: "2023" },
+            { label: "Maintained by", value: "Members" },
+            { label: "License", value: "Apache 2.0" },
+            { label: "API", value: "Public" },
+          ]}
+          layout="grid"
+        />
+      </PageSection>
+    </AboutPage>
   );
 }

--- a/apps/web/src/app/(app)/about/ratings/page.tsx
+++ b/apps/web/src/app/(app)/about/ratings/page.tsx
@@ -1,17 +1,23 @@
 import {
-  Card,
-  CardGrid,
   DataTable,
-  type DataTableColumn,
+  RailList,
+  RailListItem,
   RATING_BANDS,
+  TastingRating,
+  type DataTableColumn,
 } from "@peated/web/components";
 import {
-  ContentPage,
-  ContentSection,
-  ContentSubsection,
-  ContentText,
-} from "@peated/web/components/pages/contentPage.stylex";
+  PageSection,
+  RailSection,
+} from "@peated/web/components/pages/pageLayout.stylex";
 import type { Metadata } from "next";
+import {
+  AboutPage,
+  AboutText,
+  AboutTextStack,
+  ReviewDirections,
+  ReviewSteps,
+} from "../aboutPage.stylex";
 
 export const dynamic = "force-static";
 
@@ -28,90 +34,97 @@ const bandColumns: DataTableColumn<(typeof RATING_BANDS)[number]>[] = [
     key: "label",
   },
   {
-    align: "right",
     cell: (band) => band.range,
     header: "Range",
     key: "range",
+  },
+  {
+    align: "right",
+    cell: (band) => <TastingRating band={band.key} />,
+    header: "Marker",
+    key: "marker",
+    priority: "secondary",
   },
 ];
 
 export default function RatingsPage() {
   return (
-    <ContentPage
-      eyebrow="Rating guide"
-      intro="Choose one of five ratings for a tasting. Use a 100-point score for a written review."
-      title="Tastings and reviews"
+    <AboutPage
+      currentHref="/about/ratings"
+      description="A tasting takes one of five ratings. A written review takes a whole number out of 100. Neither is ever converted into the other."
+      eyebrow="Reference · two measures"
+      rail={
+        <RailSection heading="Where these appear">
+          <RailList ariaLabel="Rating examples">
+            <RailListItem
+              href="/addBottle?intent=tasting"
+              metadata="Where the five ratings are used"
+              title="Log a tasting"
+            />
+            <RailListItem
+              href="/bottles?sort=-score"
+              metadata="Ordered by median review score"
+              title="Scored bottles"
+            />
+            <RailListItem href="/tastings" title="Recent reviews" />
+          </RailList>
+        </RailSection>
+      }
+      title="Rating guide"
     >
-      <CardGrid>
-        <Card>
-          <ContentSubsection title="Choose a tasting rating">
-            <ContentText>
-              Pick the label that best describes the whole whisky. The fixed
-              vocabulary keeps quick tasting records easy to compare.
-            </ContentText>
-          </ContentSubsection>
-        </Card>
-        <Card>
-          <ContentSubsection title="Score a review out of 100">
-            <ContentText>
-              Pick a whole number from 0 to 100. Add notes when the number needs
-              context.
-            </ContentText>
-          </ContentSubsection>
-        </Card>
-      </CardGrid>
-
-      <ContentSection title="How to write a review">
-        <CardGrid>
-          <Card>
-            <ContentSubsection title="Taste first">
-              <ContentText>
-                Notice what stands out before thinking about a number.
-              </ContentText>
-            </ContentSubsection>
-          </Card>
-          <Card>
-            <ContentSubsection title="Start at 80">
-              <ContentText>
-                An 80 is good: enjoyable, well made, and without a major
-                problem.
-              </ContentText>
-            </ContentSubsection>
-          </Card>
-          <Card>
-            <ContentSubsection title="Move the score">
-              <ContentText>
-                Judge the whisky as a whole. There are no points to add up.
-              </ContentText>
-            </ContentSubsection>
-          </Card>
-        </CardGrid>
-        <ContentText>
-          Move up when flavors are clear, the parts work well together, the
-          texture has depth, and the finish lasts. Move down for off flavors,
-          rough alcohol, thin texture, poor balance, or a short finish.
-        </ContentText>
-        <ContentText>
-          Keep price, rarity, packaging, and reputation out of the score.
-        </ContentText>
-      </ContentSection>
-
-      <ContentSection title="The score at a glance">
+      <PageSection heading="The five ratings">
         <DataTable
-          caption="Peated rating ranges"
+          caption="Peated tasting ratings"
           columns={bandColumns}
           getKey={(band) => band.key}
           items={RATING_BANDS}
         />
-      </ContentSection>
+        <AboutText>
+          Pick the label that describes the whole whisky. The vocabulary is
+          fixed on purpose. Five labels stay comparable across many tastings in
+          a way that free-form numbers do not.
+        </AboutText>
+      </PageSection>
 
-      <ContentSection title="How bottle scores work">
-        <ContentText>
-          Peated shows a median after the first eligible member or external
-          review score. External scores count only when the publication permits
-          their use and uses a whole-number 100-point scale.
-        </ContentText>
-      </ContentSection>
-    </ContentPage>
+      <PageSection heading="Writing a review">
+        <ReviewSteps
+          steps={[
+            {
+              body: "Notice what stands out before you think about a number.",
+              title: "Taste first",
+            },
+            {
+              body: "An 80 is good: enjoyable, well made, and without a major problem.",
+              title: "Start at 80",
+            },
+            {
+              body: "Judge the whisky as a whole. There are no points to add up.",
+              title: "Move the score",
+            },
+          ]}
+        />
+        <ReviewDirections
+          down="Off flavors, rough alcohol, thin texture, poor balance, or a finish that stops short."
+          up="Clear flavors, parts that work together, texture with depth, or a finish that lasts."
+        />
+        <AboutText>
+          Keep price, rarity, packaging, and reputation out of it.
+        </AboutText>
+      </PageSection>
+
+      <PageSection heading="How a bottle score is worked out">
+        <AboutTextStack>
+          <AboutText>
+            A bottle shows a median from the first eligible score onward. It
+            never shows an average or a number converted from tasting ratings.
+          </AboutText>
+          <AboutText>
+            An external score counts only when the publication permits its use
+            and scores on a whole-number 100-point scale. A publication on its
+            own scale gets an en dash beside its quote.
+          </AboutText>
+        </AboutTextStack>
+      </PageSection>
+    </AboutPage>
   );
 }


### PR DESCRIPTION
The About, Whisky categories, and Rating guide pages now share a responsive reference-page frame with peer navigation and supporting rails. The main page surfaces live catalog stats and contribution destinations, the category guide puts sources and filtered browse links beside its definitions, and the rating guide shows the five rating markers with clearer review-scoring guidance.

The presentation reuses the existing page header, tab, column, rail-list, table, and scoring primitives. On narrow screens, supporting links stack below the guide content and the optional rating-marker column hides while the complete guidance remains available.
