### PR TITLE
fix(web): use simple screenshot names

### DIFF
--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -82,7 +82,7 @@ test.describe("log tasting", () => {
     await expect(
       page.getByRole("heading", { exact: true, name: "Log a tasting" }).first(),
     ).toBeVisible();
-    await snapshot("start");
+    await snapshot("Start a tasting");
 
     await uploadLabel(page);
 

--- a/apps/web/e2e/routes.spec.ts
+++ b/apps/web/e2e/routes.spec.ts
@@ -17,43 +17,43 @@ import { signIn } from "./session";
 const publicRoutes = [
   {
     heading: "A record of whisky, bottle by bottle.",
-    name: "home",
+    name: "Home",
     path: "/",
   },
   {
     heading: "Search the database",
-    name: "search",
+    name: "Search",
     path: "/search",
   },
   {
     heading: existingBottleDetails.group.fullName,
-    name: "bottle detail",
+    name: "Bottle",
     path: `/bottles/${existingBottle.id}`,
   },
   {
     heading: testRegion.name,
-    name: "region detail",
+    name: "Region",
     path: `/locations/${testRegion.country.slug}/regions/${testRegion.slug}`,
   },
   {
     heading: testUser.username,
-    name: "member profile",
+    name: "Profile",
     path: `/users/${testUser.username}`,
   },
-  { heading: "Sign in", name: "login", path: "/login" },
+  { heading: "Sign in", name: "Sign in", path: "/login" },
   {
     heading: testBrand.name,
-    name: "brand detail",
+    name: "Brand",
     path: `/brands/${testBrand.id}`,
   },
   {
     heading: testOwnedEntity.name,
-    name: "distillery detail",
+    name: "Distillery",
     path: `/distillers/${testOwnedEntity.id}`,
   },
   {
     heading: testBottler.name,
-    name: "bottler detail",
+    name: "Bottler",
     path: `/bottlers/${testBottler.id}`,
   },
 ] as const;
@@ -115,7 +115,7 @@ test(
     });
 
     await expect(navigation).toBeVisible();
-    await snapshot("navigation open", { fullPage: false });
+    await snapshot("Menu", { fullPage: false });
     await navigation.getByRole("link", { name: "Bottles" }).click();
     await expect(page).toHaveURL(/\/bottles$/);
   },

--- a/apps/web/e2e/test.ts
+++ b/apps/web/e2e/test.ts
@@ -7,23 +7,23 @@ export { expect };
 export type { TestInfo };
 
 type Snapshot = (
-  name: string,
+  title: string,
   options?: { fullPage?: boolean },
 ) => Promise<void>;
 
 /** Snapshot paths are durable Frameshift identities. Keep retries and workers out of them. */
 export const test = base.extend<{ snapshot: Snapshot }>({
   snapshot: async ({ page }, use, testInfo) => {
-    const names = new Set<string>();
+    const titles = new Set<string>();
 
-    await use(async (name, { fullPage = true } = {}) => {
-      const snapshotName = slug(name);
+    await use(async (title, { fullPage = true } = {}) => {
+      const snapshotName = slug(title);
       if (!snapshotName)
-        throw new Error("Snapshot names must contain a letter or number.");
-      if (names.has(snapshotName)) {
-        throw new Error(`Duplicate snapshot name in one test: ${name}`);
+        throw new Error("Snapshot titles must contain a letter or number.");
+      if (titles.has(snapshotName)) {
+        throw new Error(`Duplicate snapshot title in one test: ${title}`);
       }
-      names.add(snapshotName);
+      titles.add(snapshotName);
 
       await page.evaluate(async () => document.fonts.ready);
       await page.addStyleTag({
@@ -31,9 +31,12 @@ export const test = base.extend<{ snapshot: Snapshot }>({
       });
 
       const outputRoot = visualOutputRoot();
-      const file = snapshotFile(testInfo, snapshotName);
+      const file = snapshotFile(snapshotName);
       const imagePath = path.join(outputRoot, file);
+      const metadataFile = snapshotMetadataFile(testInfo, snapshotName);
+      const metadataPath = path.join(outputRoot, ".metadata", metadataFile);
       await fs.mkdir(path.dirname(imagePath), { recursive: true });
+      await reserveSnapshot(outputRoot, file, testInfo, snapshotName);
       await page.screenshot({
         animations: "disabled",
         caret: "hide",
@@ -42,7 +45,6 @@ export const test = base.extend<{ snapshot: Snapshot }>({
         type: "png",
       });
 
-      const metadataPath = path.join(outputRoot, ".metadata", `${file}.json`);
       await fs.mkdir(path.dirname(metadataPath), { recursive: true });
       await fs.writeFile(
         metadataPath,
@@ -50,14 +52,7 @@ export const test = base.extend<{ snapshot: Snapshot }>({
           {
             browserVersion: page.context().browser()?.version() ?? null,
             file,
-            label: [
-              ...snapshotTitles(testInfo),
-              name,
-              projectLabel(testInfo.project.name),
-            ].join(" · "),
-            project: testInfo.project.name,
-            snapshot: name,
-            test: snapshotTitles(testInfo).join(" › "),
+            label: title,
           },
           null,
           2,
@@ -74,7 +69,11 @@ function visualOutputRoot() {
     : path.resolve(process.cwd(), ".playwright/visual");
 }
 
-export function snapshotFile(testInfo: TestInfo, snapshotName: string) {
+export function snapshotFile(snapshotName: string) {
+  return `${snapshotName}.png`;
+}
+
+export function snapshotMetadataFile(testInfo: TestInfo, snapshotName: string) {
   const specPath = path
     .relative(testInfo.project.testDir, testInfo.file)
     .replaceAll(path.sep, "/")
@@ -86,21 +85,43 @@ export function snapshotFile(testInfo: TestInfo, snapshotName: string) {
   return path.posix.join(
     ...(specPath.length > 0 ? specPath : ["test"]),
     ...testPath,
-    `${snapshotName}__${slug(testInfo.project.name) || "project"}.png`,
+    `${snapshotName}__${slug(testInfo.project.name) || "project"}.json`,
   );
+}
+
+async function reserveSnapshot(
+  outputRoot: string,
+  file: string,
+  testInfo: TestInfo,
+  snapshotName: string,
+) {
+  const lockPath = path.join(outputRoot, ".metadata", ".locks", `${file}.lock`);
+  const owner = JSON.stringify({
+    file: path.relative(testInfo.project.testDir, testInfo.file),
+    project: testInfo.project.name,
+    snapshot: snapshotName,
+    titlePath: testInfo.titlePath,
+  });
+  await fs.mkdir(path.dirname(lockPath), { recursive: true });
+  try {
+    await fs.writeFile(lockPath, owner, { flag: "wx" });
+  } catch (error) {
+    if (
+      !(error instanceof Error && "code" in error && error.code === "EEXIST")
+    ) {
+      throw error;
+    }
+    if ((await fs.readFile(lockPath, "utf8")) !== owner) {
+      throw new Error(`Duplicate visual snapshot file: ${file}`, {
+        cause: error,
+      });
+    }
+  }
 }
 
 function snapshotTitles(testInfo: Pick<TestInfo, "title" | "titlePath">) {
   const titles = testInfo.titlePath.slice(1);
   return titles.length > 0 ? titles : [testInfo.title];
-}
-
-function projectLabel(project: string) {
-  return project
-    .split(/[-_]/)
-    .filter(Boolean)
-    .map((part) => part[0]?.toUpperCase() + part.slice(1))
-    .join(" ");
 }
 
 function slug(value: string) {

--- a/apps/web/visual/README.md
+++ b/apps/web/visual/README.md
@@ -21,7 +21,7 @@ test("opens the account menu", async ({ page, snapshot }) => {
   await page.getByRole("button", { name: "Account" }).click();
   await expect(page.getByRole("menu")).toBeVisible();
 
-  await snapshot("account menu open");
+  await snapshot("Account menu open");
 });
 ```
 
@@ -30,9 +30,9 @@ hides the Next.js development portal. It uses a full-page screenshot by
 default. Pass `{ fullPage: false }` when the viewport itself is part of the
 workflow state, such as an open mobile menu.
 
-Use a short checkpoint name that describes the visible state. The stable path
-also includes the spec, test titles, and Playwright project. A test cannot use
-the same checkpoint name twice.
+Use a short title that says what the image shows, such as "Home," "Bottle," or
+"Menu." This title appears in Frameshift and sets the file name. Each title must
+be unique.
 
 ## Run locally
 
@@ -68,5 +68,5 @@ report for pull requests. A dependent job does not check out pull request code;
 it publishes the validated report and adds the pull request link. Published
 reports and baseline artifacts expire after 30 days.
 
-Snapshot paths identify the same state across revisions. Renaming a spec, test,
-or checkpoint intentionally removes the old path and adds a new one.
+Snapshot paths identify the same state across revisions. Renaming a snapshot
+title intentionally removes the old path and adds a new one.

--- a/apps/web/visual/snapshot-path.test.mjs
+++ b/apps/web/visual/snapshot-path.test.mjs
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { snapshotFile } from "../e2e/test";
+import { snapshotFile, snapshotMetadataFile } from "../e2e/test";
 
 const commonTest = {
   file: "/project/e2e/example.spec.ts",
@@ -9,15 +9,19 @@ const commonTest = {
 };
 
 describe("snapshotFile", () => {
-  test("keeps describe titles in the durable snapshot path", () => {
-    const first = snapshotFile(
+  test("uses only the title in the review path", () => {
+    expect(snapshotFile("bottle")).toBe("bottle.png");
+  });
+
+  test("keeps test titles in hidden metadata paths", () => {
+    const first = snapshotMetadataFile(
       {
         ...commonTest,
         titlePath: ["example.spec.ts", "first flow", "renders the state"],
       },
       "ready",
     );
-    const second = snapshotFile(
+    const second = snapshotMetadataFile(
       {
         ...commonTest,
         titlePath: ["example.spec.ts", "second flow", "renders the state"],
@@ -26,10 +30,10 @@ describe("snapshotFile", () => {
     );
 
     expect(first).toBe(
-      "example/first-flow/renders-the-state/ready__chromium-desktop.png",
+      "example/first-flow/renders-the-state/ready__chromium-desktop.json",
     );
     expect(second).toBe(
-      "example/second-flow/renders-the-state/ready__chromium-desktop.png",
+      "example/second-flow/renders-the-state/ready__chromium-desktop.json",
     );
   });
 });


### PR DESCRIPTION
Frameshift now identifies screenshots with simple names such as `Home`,
`Bottle`, and `Menu`. Report data no longer exposes Playwright test names,
browser names, or test folders; matching files use flat names such as
`home.png`. Capture fails if two tests try to claim the same name, which
prevents silent overwrites.
