### PR TITLE
feat(catalog): split distillery bottle views

### DIFF
--- a/apps/server/src/constants.ts
+++ b/apps/server/src/constants.ts
@@ -47,6 +47,8 @@ export const BOTTLE_LIST_SORT_OPTIONS = [
   "-tastings",
 ] as const;
 
+export const DISTILLERY_BOTTLE_VIEW_LIST = ["releases", "other"] as const;
+
 export const REGION_LIST_SORT_OPTIONS = [
   "name",
   "bottles",

--- a/apps/server/src/lib/distilleryBottleView.ts
+++ b/apps/server/src/lib/distilleryBottleView.ts
@@ -1,0 +1,47 @@
+import {
+  bottles,
+  bottlesToDistillers,
+  entities,
+} from "@peated/server/db/schema";
+import type { SQL } from "drizzle-orm";
+import { and, eq, isNull, not, or, sql } from "drizzle-orm";
+
+/**
+ * A distillery release uses the distillery or one of its directly owned
+ * labels as the brand, with no outside bottler. Other bottlings use an
+ * outside brand or bottler.
+ */
+export function bottlesForDistilleryView(
+  distilleryId: number,
+  view: "releases" | "other",
+): SQL<unknown> {
+  const ownBrand = or(
+    eq(bottles.brandId, distilleryId),
+    sql`EXISTS(
+      SELECT FROM ${entities}
+      WHERE ${entities.id} = ${bottles.brandId}
+        AND ${entities.ownerId} = ${distilleryId}
+        AND ${entities.kind} IN ('brand', 'bottler')
+    )`,
+  )!;
+  const ownBottler = or(
+    isNull(bottles.bottlerId),
+    eq(bottles.bottlerId, distilleryId),
+    sql`EXISTS(
+      SELECT FROM ${entities}
+      WHERE ${entities.id} = ${bottles.bottlerId}
+        AND ${entities.ownerId} = ${distilleryId}
+        AND ${entities.kind} IN ('brand', 'bottler')
+    )`,
+  )!;
+  const madeByDistillery = sql`EXISTS(
+    SELECT FROM ${bottlesToDistillers}
+    WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
+      AND ${bottlesToDistillers.distillerId} = ${distilleryId}
+  )`;
+  const ownRelease = and(ownBrand, ownBottler)!;
+
+  return view === "releases"
+    ? ownRelease
+    : and(or(ownBrand, madeByDistillery), not(ownRelease))!;
+}

--- a/apps/server/src/orpc/contracts/bottles/list.ts
+++ b/apps/server/src/orpc/contracts/bottles/list.ts
@@ -2,6 +2,7 @@ import {
   BOTTLE_AGE_BAND_LIST,
   BOTTLE_LIST_SORT_OPTIONS,
   CATEGORY_LIST,
+  DISTILLERY_BOTTLE_VIEW_LIST,
   FLAVOR_PROFILES,
 } from "@peated/server/constants";
 import { BottleSchema, listResponse } from "@peated/server/schemas";
@@ -37,6 +38,12 @@ export default contract
       distiller: z.coerce.number().nullish(),
       bottler: z.coerce.number().nullish(),
       entity: z.coerce.number().nullish(),
+      distilleryView: z
+        .enum(DISTILLERY_BOTTLE_VIEW_LIST)
+        .nullish()
+        .describe(
+          "Filter a distillery to its own releases or releases from other brands and bottlers.",
+        ),
       series: z.coerce.number().nullish(),
       tag: z.string().nullish(),
       flavorProfile: z.enum(FLAVOR_PROFILES).nullish(),

--- a/apps/server/src/orpc/mock/routes/bottles/list.ts
+++ b/apps/server/src/orpc/mock/routes/bottles/list.ts
@@ -11,6 +11,27 @@ import { mockOS } from "@peated/server/orpc/mock/implementer";
 type MockBottle = (typeof mockBottles)[number];
 type BottleAgeBand = (typeof BOTTLE_AGE_BAND_LIST)[number];
 
+function matchesDistilleryView(
+  bottle: MockBottle,
+  entityId: number,
+  view: "releases" | "other",
+) {
+  const ownBrand =
+    bottle.brand.id === entityId || bottle.brand.ownerId === entityId;
+  const ownBottler =
+    bottle.bottler === null ||
+    bottle.bottler.id === entityId ||
+    bottle.bottler.ownerId === entityId;
+  const madeByDistillery = bottle.distillers.some(
+    (distiller) => distiller.id === entityId,
+  );
+  const ownRelease = ownBrand && ownBottler;
+
+  return view === "releases"
+    ? ownRelease
+    : (ownBrand || madeByDistillery) && !ownRelease;
+}
+
 function matchesAgeBand(bottle: MockBottle, ageBand: BottleAgeBand) {
   switch (ageBand) {
     case "nas":
@@ -55,9 +76,11 @@ export default mockOS.bottles.list.handler(
         bottle.distillers.some((entity) => entity.id === input.distiller)) &&
       (input.bottler == null || bottle.bottler?.id === input.bottler) &&
       (input.entity == null ||
-        bottle.brand.id === input.entity ||
-        bottle.bottler?.id === input.entity ||
-        bottle.distillers.some((entity) => entity.id === input.entity)) &&
+        (input.distilleryView
+          ? matchesDistilleryView(bottle, input.entity, input.distilleryView)
+          : bottle.brand.id === input.entity ||
+            bottle.bottler?.id === input.entity ||
+            bottle.distillers.some((entity) => entity.id === input.entity))) &&
       (input.series == null || bottle.series?.id === input.series) &&
       (input.tag == null || bottle.suggestedTags?.includes(input.tag)) &&
       (input.flavorProfile == null ||

--- a/apps/server/src/orpc/routes/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/list.test.ts
@@ -289,6 +289,106 @@ describe("GET /bottles", () => {
     expect(results[0].id).toBe(bottle1.id);
   });
 
+  test("separates distillery releases from other bottlings", async ({
+    fixtures,
+  }) => {
+    const distillery = await fixtures.Entity({
+      name: "Bottle View Distillery",
+      kind: "distillery",
+    });
+    const ownedBrand = await fixtures.Entity({
+      name: "Owned Distillery Brand",
+      kind: "brand",
+      ownerId: distillery.id,
+    });
+    const ownedBottler = await fixtures.Entity({
+      name: "Owned Release Imprint",
+      kind: "bottler",
+      ownerId: distillery.id,
+    });
+    const outsideBrand = await fixtures.Entity({
+      name: "Outside Distillery Brand",
+      kind: "brand",
+    });
+    const outsideBottler = await fixtures.Entity({
+      name: "Outside Distillery Bottler",
+      kind: "bottler",
+    });
+    const otherDistillery = await fixtures.Entity({
+      name: "Second Bottle View Distillery",
+      kind: "distillery",
+    });
+
+    const directRelease = await fixtures.Bottle({
+      name: "Direct Release",
+      brandId: distillery.id,
+      bottlerId: null,
+      distillerIds: [],
+    });
+    const ownedBrandRelease = await fixtures.Bottle({
+      name: "Owned Brand Release",
+      brandId: ownedBrand.id,
+      bottlerId: ownedBottler.id,
+      distillerIds: [distillery.id],
+    });
+    const outsideBottling = await fixtures.Bottle({
+      name: "Outside Bottling",
+      brandId: outsideBrand.id,
+      bottlerId: outsideBottler.id,
+      distillerIds: [distillery.id],
+    });
+    const outsideBottlerOnOfficialBrand = await fixtures.Bottle({
+      name: "Outside Bottler Official Brand",
+      brandId: distillery.id,
+      bottlerId: outsideBottler.id,
+      distillerIds: [],
+    });
+    await fixtures.Bottle({
+      name: "Bottler Role Only",
+      brandId: outsideBrand.id,
+      bottlerId: distillery.id,
+      distillerIds: [otherDistillery.id],
+    });
+
+    const [releases, other] = await Promise.all([
+      routerClient.bottles.list({
+        entity: distillery.id,
+        distilleryView: "releases",
+        sort: "name",
+      }),
+      routerClient.bottles.list({
+        entity: distillery.id,
+        distilleryView: "other",
+        sort: "name",
+      }),
+    ]);
+
+    expect(new Set(releases.results.map(({ id }) => id))).toEqual(
+      new Set([directRelease.id, ownedBrandRelease.id]),
+    );
+    expect(releases.total).toBe(2);
+    expect(new Set(other.results.map(({ id }) => id))).toEqual(
+      new Set([outsideBottling.id, outsideBottlerOnOfficialBrand.id]),
+    );
+    expect(other.total).toBe(2);
+  });
+
+  test("rejects a distillery view without a distillery", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ kind: "brand" });
+
+    await expect(
+      routerClient.bottles.list({ distilleryView: "releases" }),
+    ).rejects.toThrow("Choose a distillery for this view.");
+    await expect(
+      routerClient.bottles.list({
+        entity: brand.id,
+        distilleryView: "releases",
+      }),
+    ).rejects.toThrow("Choose a distillery for this view.");
+  });
+
   test("lists bottles with flavor profile filter", async ({ fixtures }) => {
     const bottle1 = await fixtures.Bottle({
       name: "Peated Whisky",

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -11,6 +11,7 @@ import {
   flights,
   tastings,
 } from "@peated/server/db/schema";
+import { bottlesForDistilleryView } from "@peated/server/lib/distilleryBottleView";
 import {
   plainTextSearchQuery,
   prefixTextSearchQuery,
@@ -154,7 +155,23 @@ export default implement(bottleListContract).handler(async function ({
   if (rest.bottler) {
     where.push(eq(bottles.bottlerId, rest.bottler));
   }
-  if (rest.entity) {
+  if (rest.distilleryView) {
+    if (!rest.entity) {
+      throw errors.BAD_REQUEST({
+        message: "Choose a distillery for this view.",
+      });
+    }
+    const [entity] = await db
+      .select({ kind: entities.kind })
+      .from(entities)
+      .where(eq(entities.id, rest.entity));
+    if (entity?.kind !== "distillery") {
+      throw errors.BAD_REQUEST({
+        message: "Choose a distillery for this view.",
+      });
+    }
+    where.push(bottlesForDistilleryView(rest.entity, rest.distilleryView));
+  } else if (rest.entity) {
     where.push(
       or(
         eq(bottles.brandId, rest.entity),

--- a/apps/web/e2e/distillery-bottle-views.spec.ts
+++ b/apps/web/e2e/distillery-bottle-views.spec.ts
@@ -13,14 +13,14 @@ test("switches between distillery releases and other bottlings", async ({
   await page.goto(`/distillers/${testOwnedEntity.id}/bottles`);
 
   await expect(
-    page.getByRole("link", { name: bottleGroupRepresentative.fullName }),
+    page.getByRole("link", { name: bottleGroupRepresentative.name }),
   ).toBeVisible();
 
   await page.getByRole("link", { name: "Other bottlings" }).click();
 
   await expect(page).toHaveURL(/\/bottles\?view=other$/);
   await expect(
-    page.getByRole("link", { name: homeBottle.group.fullName }),
+    page.getByRole("link", { name: homeBottle.group.name }),
   ).toBeVisible();
   await expect(page.getByText(`Bottled by ${testBottler.name}`)).toBeVisible();
 });

--- a/apps/web/e2e/distillery-bottle-views.spec.ts
+++ b/apps/web/e2e/distillery-bottle-views.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  bottleGroupRepresentative,
+  homeBottle,
+  testBottler,
+  testOwnedEntity,
+} from "./rpc-fixtures.mjs";
+
+test("switches between distillery releases and other bottlings", async ({
+  page,
+}) => {
+  await page.goto(`/distillers/${testOwnedEntity.id}/bottles`);
+
+  await expect(
+    page.getByRole("link", { name: bottleGroupRepresentative.fullName }),
+  ).toBeVisible();
+
+  await page.getByRole("link", { name: "Other bottlings" }).click();
+
+  await expect(page).toHaveURL(/\/bottles\?view=other$/);
+  await expect(
+    page.getByRole("link", { name: homeBottle.group.fullName }),
+  ).toBeVisible();
+  await expect(page.getByText(`Bottled by ${testBottler.name}`)).toBeVisible();
+});

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -741,6 +741,26 @@ async function handleRpcRequest({ request, response, url }) {
         return true;
       }
       if (
+        input?.entity === testOwnedEntity.id &&
+        input?.distilleryView === "releases"
+      ) {
+        sendRpcResponse(
+          response,
+          buildBottleListResponse([bottleGroupRepresentative]),
+        );
+        return true;
+      }
+      if (
+        input?.entity === testOwnedEntity.id &&
+        input?.distilleryView === "other"
+      ) {
+        sendRpcResponse(
+          response,
+          buildBottleListResponse([{ ...homeBottle, bottler: testBottler }]),
+        );
+        return true;
+      }
+      if (
         !getAccessToken(request).includes("flight-bottles") &&
         [testBrand.id, testBottler.id, testOwnedEntity.id].includes(
           input?.entity,
@@ -1259,6 +1279,16 @@ async function handleRpcRequest({ request, response, url }) {
     default:
       return false;
   }
+}
+
+function buildBottleListResponse(results) {
+  return {
+    results,
+    rel: { nextCursor: null, prevCursor: null },
+    total: results.length,
+    facets: { ageBand: [], category: [] },
+    followedEntityCount: null,
+  };
 }
 
 /**

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/entityBottleListClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/entityBottleListClient.stylex.tsx
@@ -6,6 +6,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
 
+import { PageTabs } from "@peated/web/components";
 import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import {
@@ -17,6 +18,8 @@ import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { space } from "../../../../../styles/tokens.stylex";
+
+import { getDistilleryBottleView } from "../entityPageData";
 
 const DEFAULT_SORT = "-release";
 
@@ -34,18 +37,27 @@ const sortOptions = [
 export function EntityBottleListClient({
   emptyAction,
   entityId,
+  entityKind,
   entityName,
+  initialDistilleryView,
   initialBottleList,
 }: {
   emptyAction: ReactNode;
   entityId: number;
+  entityKind: "brand" | "bottler" | "company" | "distillery";
   entityName: string;
+  initialDistilleryView?: "other" | "releases";
   initialBottleList: BottleList;
 }) {
   const orpc = useORPC();
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const distilleryView = getDistilleryBottleView(
+    { kind: entityKind },
+    searchParams.get("view") ?? undefined,
+    initialDistilleryView,
+  );
   const queryParams = normalizeBottleCatalogQueryParams(
     useApiQueryParams({
       defaults: { sort: DEFAULT_SORT },
@@ -62,6 +74,7 @@ export function EntityBottleListClient({
         "series",
       ],
       overrides: {
+        distilleryView,
         entity: entityId,
         limit: 25,
       },
@@ -74,6 +87,13 @@ export function EntityBottleListClient({
   const page = Number(searchParams.get("cursor") ?? "1") || 1;
   const sort = String(queryParams.sort ?? DEFAULT_SORT);
 
+  function getViewHref(view: "other" | "releases") {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set("view", view);
+    nextParams.delete("cursor");
+    return buildSearchHref(pathname, nextParams);
+  }
+
   function updateSort(value: string) {
     const nextParams = new URLSearchParams(searchParams);
     nextParams.set("sort", value);
@@ -83,12 +103,40 @@ export function EntityBottleListClient({
 
   return (
     <div {...stylex.props(styles.content)}>
+      {distilleryView ? (
+        <div {...stylex.props(styles.views)}>
+          <PageTabs
+            ariaLabel={`Bottles for ${entityName}`}
+            currentHref={getViewHref(distilleryView)}
+            items={[
+              {
+                href: getViewHref("releases"),
+                label: "Distillery releases",
+              },
+              { href: getViewHref("other"), label: "Other bottlings" },
+            ]}
+          />
+        </div>
+      ) : null}
       <BottleCatalogList
         emptyAction={emptyAction}
-        emptyDescription={`No bottles have been added for ${entityName} yet.`}
-        emptyHeading="No bottles yet"
+        emptyDescription={
+          distilleryView === "releases"
+            ? `No distillery releases have been added for ${entityName} yet.`
+            : distilleryView === "other"
+              ? `No other bottlings have been added for ${entityName} yet.`
+              : `No bottles have been added for ${entityName} yet.`
+        }
+        emptyHeading={
+          distilleryView === "releases"
+            ? "No distillery releases yet"
+            : distilleryView === "other"
+              ? "No other bottlings yet"
+              : "No bottles yet"
+        }
         items={bottleList.results.map((bottle) =>
           toBottleListItem(bottle, {
+            includeBottler: distilleryView === "other",
             includeRatings: true,
             includeRelatedReleases: true,
           }),
@@ -117,5 +165,8 @@ const styles = stylex.create({
   content: {
     minWidth: 0,
     paddingTop: space.x6,
+  },
+  views: {
+    marginBottom: space.x6,
   },
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
@@ -11,6 +11,7 @@ import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
+import { getDistilleryBottleView } from "../entityPageData";
 import { EntityBottleListClient } from "./entityBottleListClient.stylex";
 
 export default async function EntityBottlesPage(props: {
@@ -18,11 +19,13 @@ export default async function EntityBottlesPage(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { entityId } = await props.params;
+  const searchParams = await props.searchParams;
   const { client } = await getPublicPageServerClient();
   const entity = await getEntityPage(parseCatalogRouteId(entityId));
   const createBottleHref = getEntityBottleCreateHref(entity);
-  const queryParams = normalizeBottleCatalogQueryParams(
-    getApiQueryParams(await props.searchParams, {
+  let distilleryView = getDistilleryBottleView(entity, searchParams.view);
+  let queryParams = normalizeBottleCatalogQueryParams(
+    getApiQueryParams(searchParams, {
       defaults: { sort: "-release" },
       allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
       fields: BOTTLE_CATALOG_QUERY_FIELDS,
@@ -37,12 +40,24 @@ export default async function EntityBottlesPage(props: {
         "series",
       ],
       overrides: {
+        distilleryView,
         entity: entity.id,
         limit: 25,
       },
     }),
   );
-  const bottleList = await client.bottles.list(queryParams);
+  let bottleList = await client.bottles.list(queryParams);
+
+  if (
+    entity.kind === "distillery" &&
+    searchParams.view === undefined &&
+    distilleryView === "releases" &&
+    bottleList.total === 0
+  ) {
+    distilleryView = "other";
+    queryParams = { ...queryParams, distilleryView };
+    bottleList = await client.bottles.list(queryParams);
+  }
 
   return (
     <EntityBottleListClient
@@ -61,7 +76,9 @@ export default async function EntityBottlesPage(props: {
         </ButtonLink>
       }
       entityId={entity.id}
+      entityKind={entity.kind}
       entityName={entity.name}
+      initialDistilleryView={distilleryView}
       initialBottleList={bottleList}
     />
   );

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
@@ -27,7 +27,6 @@ export function EntityBottleOverview({
   error,
   pending,
   retry,
-  totalBottles,
 }: {
   bottleList?: BottleList;
   createBottleHref?: string;
@@ -35,33 +34,37 @@ export function EntityBottleOverview({
   error: boolean;
   pending: boolean;
   retry: () => void;
-  totalBottles: number;
 }) {
   const presentation = getEntityPresentation(entity);
   const entityHref = getEntityUrl(entity);
+  const isDistillery = entity.kind === "distillery";
+  const heading = isDistillery ? "Popular other bottlings" : "Popular bottles";
+  const viewAllParams = new URLSearchParams({ sort: "-tastings" });
+  if (isDistillery) viewAllParams.set("view", "other");
 
   if (!entityHasBottleCatalog(entity)) return null;
 
   if (pending) {
     return (
-      <PageSection heading="Popular bottles">
-        <LoadingList label="Loading popular bottles" rows={4} />
+      <PageSection heading={heading}>
+        <LoadingList label={`Loading ${heading.toLowerCase()}`} rows={4} />
       </PageSection>
     );
   }
 
   if (error) {
     return (
-      <PageSection heading="Popular bottles">
-        <SectionError heading="Popular bottles are unavailable" onRetry={retry}>
-          The rest of this page still works. Try loading its popular bottles
-          again.
+      <PageSection heading={heading}>
+        <SectionError heading={`${heading} are unavailable`} onRetry={retry}>
+          The rest of this page still works. Try loading this list again.
         </SectionError>
       </PageSection>
     );
   }
 
   if (!bottleList?.results.length) {
+    if (isDistillery) return null;
+
     const addBottleHref =
       createBottleHref ??
       `/bottles/new?${new URLSearchParams({
@@ -69,7 +72,7 @@ export function EntityBottleOverview({
       }).toString()}`;
 
     return (
-      <PageSection heading="Popular bottles">
+      <PageSection heading={heading}>
         <EmptyState
           action={
             <ButtonLink href={addBottleHref} size="sm" variant="accent">
@@ -85,19 +88,29 @@ export function EntityBottleOverview({
     );
   }
 
+  const viewAllLabel =
+    bottleList.total === 1
+      ? "View 1 bottle"
+      : `View all ${bottleList.total.toLocaleString("en-US")} bottles`;
+
   return (
     <PageSection
-      heading="Popular bottles"
+      heading={heading}
       intro={
-        <TextLink href={`${entityHref}/bottles?sort=-tastings`}>
-          View all {totalBottles.toLocaleString("en-US")} bottles
+        <TextLink href={`${entityHref}/bottles?${viewAllParams.toString()}`}>
+          {viewAllLabel}
         </TextLink>
       }
     >
       <BottleList
-        ariaLabel={`${entity.name} popular bottles`}
+        ariaLabel={
+          isDistillery
+            ? `${entity.name} popular other bottlings`
+            : `${entity.name} popular bottles`
+        }
         items={bottleList.results.map((bottle) =>
           toBottleListItem(bottle, {
+            includeBottler: isDistillery,
             includeRatings: true,
             includeRelatedReleases: true,
           }),

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
@@ -27,6 +27,7 @@ export function EntityBottleOverview({
   error,
   pending,
   retry,
+  totalBottles,
 }: {
   bottleList?: BottleList;
   createBottleHref?: string;
@@ -34,6 +35,7 @@ export function EntityBottleOverview({
   error: boolean;
   pending: boolean;
   retry: () => void;
+  totalBottles: number;
 }) {
   const presentation = getEntityPresentation(entity);
   const entityHref = getEntityUrl(entity);
@@ -88,10 +90,11 @@ export function EntityBottleOverview({
     );
   }
 
+  const total = isDistillery ? bottleList.total : totalBottles;
   const viewAllLabel =
-    bottleList.total === 1
+    total === 1
       ? "View 1 bottle"
-      : `View all ${bottleList.total.toLocaleString("en-US")} bottles`;
+      : `View all ${total.toLocaleString("en-US")} bottles`;
 
   return (
     <PageSection

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -162,6 +162,7 @@ export function EntityOverviewClient({
             error={Boolean(bottleListQuery.error)}
             pending={bottleListQuery.isPending}
             retry={() => void bottleListQuery.refetch()}
+            totalBottles={entity.totalBottles}
           />
           <EntityHistoryOverview
             entityName={entity.name}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -73,6 +73,8 @@ export function EntityOverviewClient({
   const bottleListQuery = useQuery({
     ...orpc.bottles.list.queryOptions({
       input: {
+        distilleryView:
+          initialEntity.kind === "distillery" ? "other" : undefined,
         entity: initialEntity.id,
         limit: 4,
         sort: "-tastings",
@@ -84,6 +86,8 @@ export function EntityOverviewClient({
   const releaseListQuery = useQuery({
     ...orpc.bottles.list.queryOptions({
       input: {
+        distilleryView:
+          initialEntity.kind === "distillery" ? "releases" : undefined,
         entity: initialEntity.id,
         limit: 4,
         sort: "-release",
@@ -158,7 +162,6 @@ export function EntityOverviewClient({
             error={Boolean(bottleListQuery.error)}
             pending={bottleListQuery.isPending}
             retry={() => void bottleListQuery.refetch()}
-            totalBottles={entity.totalBottles}
           />
           <EntityHistoryOverview
             entityName={entity.name}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   entityHasBottleCatalog,
+  getDistilleryBottleView,
   getEntityClassification,
   getEntityCurrentHref,
   getEntityRelationshipOwnerIds,
@@ -14,6 +15,27 @@ describe("entityHasBottleCatalog", () => {
     expect(entityHasBottleCatalog({ kind: "bottler" })).toBe(true);
     expect(entityHasBottleCatalog({ kind: "distillery" })).toBe(true);
     expect(entityHasBottleCatalog({ kind: "company" })).toBe(false);
+  });
+});
+
+describe("getDistilleryBottleView", () => {
+  it("defaults distillery pages to their releases", () => {
+    expect(getDistilleryBottleView({ kind: "distillery" }, undefined)).toBe(
+      "releases",
+    );
+    expect(getDistilleryBottleView({ kind: "distillery" }, "other")).toBe(
+      "other",
+    );
+    expect(getDistilleryBottleView({ kind: "distillery" }, "unknown")).toBe(
+      "releases",
+    );
+    expect(
+      getDistilleryBottleView({ kind: "distillery" }, undefined, "other"),
+    ).toBe("other");
+  });
+
+  it("does not add a view for other kinds", () => {
+    expect(getDistilleryBottleView({ kind: "brand" }, "other")).toBe(undefined);
   });
 });
 

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -49,6 +49,15 @@ export function entityHasBottleCatalog(entity: Pick<Entity, "kind">) {
   );
 }
 
+export function getDistilleryBottleView(
+  entity: Pick<Entity, "kind">,
+  view: string | string[] | undefined,
+  fallback: "other" | "releases" = "releases",
+) {
+  if (entity.kind !== "distillery") return undefined;
+  return view === "other" || view === "releases" ? view : fallback;
+}
+
 export function getEntityRelationshipOwnerIds(
   entity: Pick<Entity, "id" | "kind" | "ownerId">,
 ) {

--- a/apps/web/src/app/(app)/entities/[entityId]/entityReleaseOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityReleaseOverview.tsx
@@ -28,20 +28,26 @@ export function EntityReleaseOverview({
   retry: () => void;
 }) {
   if (!entityHasBottleCatalog(entity)) return null;
+  const isDistillery = entity.kind === "distillery";
+  const heading = isDistillery
+    ? "Latest distillery releases"
+    : "Latest releases";
+  const viewAllParams = new URLSearchParams({ sort: "-release" });
+  if (isDistillery) viewAllParams.set("view", "releases");
 
   if (pending) {
     return (
-      <PageSection heading="Latest releases">
-        <LoadingList label="Loading latest releases" rows={4} />
+      <PageSection heading={heading}>
+        <LoadingList label={`Loading ${heading.toLowerCase()}`} rows={4} />
       </PageSection>
     );
   }
 
   if (error) {
     return (
-      <PageSection heading="Latest releases">
-        <SectionError heading="Latest releases are unavailable" onRetry={retry}>
-          Try loading the latest releases again.
+      <PageSection heading={heading}>
+        <SectionError heading={`${heading} are unavailable`} onRetry={retry}>
+          Try loading this list again.
         </SectionError>
       </PageSection>
     );
@@ -51,15 +57,21 @@ export function EntityReleaseOverview({
 
   return (
     <PageSection
-      heading="Latest releases"
+      heading={heading}
       intro={
-        <TextLink href={`${getEntityUrl(entity)}/bottles?sort=-release`}>
+        <TextLink
+          href={`${getEntityUrl(entity)}/bottles?${viewAllParams.toString()}`}
+        >
           View all releases
         </TextLink>
       }
     >
       <BottleList
-        ariaLabel={`${entity.name} latest releases`}
+        ariaLabel={
+          isDistillery
+            ? `${entity.name} latest distillery releases`
+            : `${entity.name} latest releases`
+        }
         items={releaseList.results.map((bottle) =>
           toBottleListItem(bottle, {
             includeRatings: true,

--- a/apps/web/src/app/(app)/entities/[entityId]/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/page.tsx
@@ -23,7 +23,12 @@ export default async function EntityPage(props: {
   const entity = await getEntityPage(parseCatalogRouteId(entityId));
   const bottleList = entityHasBottleCatalog(entity)
     ? await client.bottles
-        .list({ entity: entity.id, limit: 4, sort: "-tastings" })
+        .list({
+          distilleryView: entity.kind === "distillery" ? "other" : undefined,
+          entity: entity.id,
+          limit: 4,
+          sort: "-tastings",
+        })
         .catch(() => undefined)
     : undefined;
 

--- a/apps/web/src/lib/bottleListItem.test.ts
+++ b/apps/web/src/lib/bottleListItem.test.ts
@@ -21,4 +21,29 @@ describe("toBottleListItem", () => {
       name: "Lagavulin 16-year-old",
     });
   });
+
+  test("identifies a distinct bottler when the surrounding view needs it", () => {
+    const bottler = {
+      ...mockBottle.brand,
+      id: 4263,
+      peatedId: "E4263",
+      name: "The Scotch Malt Whisky Society",
+      shortName: "SMWS",
+      kind: "bottler" as const,
+    };
+
+    expect(
+      toBottleListItem({ ...mockBottle, bottler }, { includeBottler: true })
+        .subtitle,
+    ).toBe("Bottled by SMWS");
+  });
+
+  test("does not repeat the brand when it also fills the bottler role", () => {
+    expect(
+      toBottleListItem(
+        { ...mockBottle, bottler: mockBottle.brand },
+        { includeBottler: true },
+      ).subtitle,
+    ).toBeUndefined();
+  });
 });

--- a/apps/web/src/lib/bottleListItem.ts
+++ b/apps/web/src/lib/bottleListItem.ts
@@ -10,6 +10,7 @@ import { getBottleUrl, getEntityUrl } from "./urls";
 type Bottle = Outputs["bottles"]["list"]["results"][number];
 
 export type BottleListItemOptions = {
+  includeBottler?: boolean;
   includeBrandRow?: boolean;
   includeRatings?: boolean;
   includeRelatedReleases?: boolean;
@@ -19,6 +20,7 @@ export type BottleListItemOptions = {
 export function toBottleListItem(
   bottle: Bottle,
   {
+    includeBottler = false,
     includeBrandRow = true,
     includeRatings = false,
     includeRelatedReleases = false,
@@ -71,6 +73,10 @@ export function toBottleListItem(
             count: relatedReleaseCount,
             href: getReleaseFamilyHref(bottle),
           }
+        : undefined,
+    subtitle:
+      includeBottler && bottle.bottler && bottle.bottler.id !== bottle.brand.id
+        ? `Bottled by ${bottle.bottler.shortName || bottle.bottler.name}`
         : undefined,
   };
 }


### PR DESCRIPTION
Distillery pages now separate the distillery's own releases from bottles released by other brands or bottlers. The overview leads with the latest distillery releases and keeps other bottlings in a separate popular section. The full Bottle page uses shareable views and automatically shows other bottlings when no distillery releases are recorded. Other bottlings name the distinct bottler when one is known.

The API adds `distilleryView=releases|other`. A distillery release uses the distillery or one of its directly owned labels as the brand, with no outside bottler. This keeps the existing Bottle role model: the change does not rewrite bottler data or require a migration.
