### PR TITLE
fix(web): restore bottle list hierarchy

### DIFF
--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -163,7 +163,7 @@ function LatestReleases() {
 
     return [
       {
-        ...toBottleListItem(bottle),
+        ...toBottleListItem(bottle, { includeBrandRow: false }),
         align: "start" as const,
         metadata: getReleaseMetadata(bottle),
         subtitle: subtitle.length ? (

--- a/apps/web/src/lib/bottleListItem.test.ts
+++ b/apps/web/src/lib/bottleListItem.test.ts
@@ -1,0 +1,24 @@
+import { mockBottle } from "@peated/server/orpc/mock/fixtures";
+import { describe, expect, test } from "vitest";
+
+import { toBottleListItem } from "./bottleListItem";
+
+describe("toBottleListItem", () => {
+  test("separates the brand from the expression in standard bottle lists", () => {
+    expect(toBottleListItem(mockBottle)).toMatchObject({
+      brand: "Lagavulin",
+      brandHref: "/brands/9201-lagavulin",
+      name: "16-year-old",
+    });
+  });
+
+  test("keeps the brand in the name when the brand row is disabled", () => {
+    expect(
+      toBottleListItem(mockBottle, { includeBrandRow: false }),
+    ).toMatchObject({
+      brand: undefined,
+      brandHref: undefined,
+      name: "Lagavulin 16-year-old",
+    });
+  });
+});

--- a/apps/web/src/lib/bottleListItem.ts
+++ b/apps/web/src/lib/bottleListItem.ts
@@ -5,11 +5,12 @@ import type { Outputs } from "@peated/server/orpc/router";
 import type { BottleListItem } from "@peated/web/components";
 
 import { getReleaseFamilyHref } from "./releaseFamily";
-import { getBottleUrl } from "./urls";
+import { getBottleUrl, getEntityUrl } from "./urls";
 
 type Bottle = Outputs["bottles"]["list"]["results"][number];
 
 export type BottleListItemOptions = {
+  includeBrandRow?: boolean;
   includeRatings?: boolean;
   includeRelatedReleases?: boolean;
 };
@@ -18,6 +19,7 @@ export type BottleListItemOptions = {
 export function toBottleListItem(
   bottle: Bottle,
   {
+    includeBrandRow = true,
     includeRatings = false,
     includeRelatedReleases = false,
   }: BottleListItemOptions = {},
@@ -26,6 +28,16 @@ export function toBottleListItem(
   const relatedReleaseCount = bottle.group?.totalBottles ?? 1;
 
   return {
+    brand: includeBrandRow
+      ? bottle.brand.shortName || bottle.brand.name
+      : undefined,
+    brandHref: includeBrandRow
+      ? getEntityUrl({
+          id: bottle.brand.id,
+          kind: "brand",
+          name: bottle.brand.name,
+        })
+      : undefined,
     hasTasted: bottle.hasTasted,
     href: getBottleUrl(bottle),
     id: bottle.peatedId,
@@ -41,7 +53,9 @@ export function toBottleListItem(
           : null,
       bottle.abv !== null ? `${formatAbv(bottle.abv)}% ABV` : null,
     ].filter((value): value is string => value !== null),
-    name: formatBottleDisplayName(bottle),
+    name: formatBottleDisplayName(bottle, {
+      includeBrand: !includeBrandRow,
+    }),
     ratings: includeRatings
       ? {
           counts: bottle.tastingBandCounts,


### PR DESCRIPTION
Standard bottle lists now render the brand, expression name, and bottle metadata as distinct rows across the bottle catalog and entity detail sections. Brand links, ratings, member status, and related-release actions remain intact. The homepage release list keeps its existing name, distillery/category subtitle, and release metadata presentation.

The shared API-to-list adapter had folded the brand into the bottle title during the earlier renderer unification. The adapter now owns the standard brand split, with regression coverage for both the standard list shape and the homepage exception.
