### PR TITLE
fix(web): wait for loading states before snapshots

### DIFF
--- a/apps/web/e2e/test.ts
+++ b/apps/web/e2e/test.ts
@@ -25,6 +25,8 @@ export const test = base.extend<{ snapshot: Snapshot }>({
       }
       titles.add(snapshotName);
 
+      await page.waitForLoadState("domcontentloaded");
+      await expect(page.locator('[aria-busy="true"]:visible')).toHaveCount(0);
       await page.evaluate(async () => document.fonts.ready);
       await page.addStyleTag({
         content: "nextjs-portal { display: none !important; }",

--- a/apps/web/visual/README.md
+++ b/apps/web/visual/README.md
@@ -25,8 +25,10 @@ test("opens the account menu", async ({ page, snapshot }) => {
 });
 ```
 
-The fixture waits for fonts, disables animation and caret differences, and
-hides the Next.js development portal. It uses a full-page screenshot by
+The fixture waits for visible elements with `aria-busy="true"` to finish and
+for fonts to load. It also disables animation and caret differences and hides
+the Next.js development portal. Use `aria-busy="true"` on loading states that
+must finish before a snapshot. The fixture uses a full-page screenshot by
 default. Pass `{ fullPage: false }` when the viewport itself is part of the
 workflow state, such as an open mobile menu.
 

--- a/docs/development/frontend-testing.md
+++ b/docs/development/frontend-testing.md
@@ -54,7 +54,8 @@ pnpm test:e2e:install
   browser screenshots.
 - E2E tests can call the shared `snapshot` fixture after they prove a useful
   workflow state. Frameshift reviews the image change, but the image is not a
-  test assertion. Do not add screenshot-only E2E tests.
+  test assertion. The fixture waits for visible `aria-busy="true"` loading
+  states to finish before capture. Do not add screenshot-only E2E tests.
 - Prefer the fewest assertions that prove the material outcome. Avoid repeating
   lower-level component or API contracts inside an end-to-end workflow.
 - Test a loading fallback only when it changes what a user can do. Check how it


### PR DESCRIPTION
Visual snapshots now wait for the document to load and for visible `aria-busy="true"` states to clear before capture. This prevents Frameshift images from recording loading skeletons while secondary client data is still loading.

The shared fixture uses the existing accessibility state as its readiness contract. The visual and frontend testing guides now document that loading states which must block capture need `aria-busy="true"`.
