### PR TITLE
feat(reviews): refine tasting and review flow

### DIFF
--- a/apps/server/migrations/0263_slow_mordo.sql
+++ b/apps/server/migrations/0263_slow_mordo.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "member_review" ADD COLUMN "tags" varchar(64)[] DEFAULT array[]::varchar[] NOT NULL;
+ALTER TABLE "member_review" ADD COLUMN "color" integer;
+ALTER TABLE "member_review" ADD COLUMN "serving_style" "servingStyle";
+ALTER TABLE "member_review" ADD COLUMN "friends" bigint[] DEFAULT array[]::bigint[] NOT NULL;

--- a/apps/server/migrations/meta/0263_snapshot.json
+++ b/apps/server/migrations/meta/0263_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "015bd389-addb-4674-993e-aad84977f7b1",
-  "prevId": "be080010-c6b6-49a7-89c4-4383eed78f29",
+  "id": "4211a0eb-89ee-4176-a50f-4ddee67756dc",
+  "prevId": "015bd389-addb-4674-993e-aad84977f7b1",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -6656,11 +6656,38 @@
           "primaryKey": false,
           "notNull": true
         },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "color": {
+          "name": "color",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
         "notes": {
           "name": "notes",
           "type": "text",
           "primaryKey": false,
           "notNull": false
+        },
+        "serving_style": {
+          "name": "serving_style",
+          "type": "servingStyle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "friends": {
+          "name": "friends",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::bigint[]"
         },
         "image_url": {
           "name": "image_url",

--- a/apps/server/migrations/meta/_journal.json
+++ b/apps/server/migrations/meta/_journal.json
@@ -1842,6 +1842,13 @@
       "when": 1788291863112,
       "tag": "0262_huge_la_nuit",
       "breakpoints": false
+    },
+    {
+      "idx": 263,
+      "version": "7",
+      "when": 1788298555632,
+      "tag": "0263_slow_mordo",
+      "breakpoints": false
     }
   ]
 }

--- a/apps/server/src/db/schema/memberReviews.ts
+++ b/apps/server/src/db/schema/memberReviews.ts
@@ -4,13 +4,16 @@ import {
   bigserial,
   check,
   index,
+  integer,
   pgTable,
   smallint,
   text,
   timestamp,
   uniqueIndex,
+  varchar,
 } from "drizzle-orm/pg-core";
 import { bottles } from "./bottles";
+import { servingStyleEnum } from "./tastings";
 import { users } from "./users";
 
 export const memberReviews = pgTable(
@@ -24,7 +27,17 @@ export const memberReviews = pgTable(
       .references(() => users.id, { onDelete: "cascade" })
       .notNull(),
     score: smallint("score").notNull(),
+    tags: varchar("tags", { length: 64 })
+      .array()
+      .default(sql`array[]::varchar[]`)
+      .notNull(),
+    color: integer("color"),
     notes: text("notes"),
+    servingStyle: servingStyleEnum("serving_style"),
+    friends: bigint("friends", { mode: "number" })
+      .array()
+      .default(sql`array[]::bigint[]`)
+      .notNull(),
     imageUrl: text("image_url"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),

--- a/apps/server/src/orpc/routes/memberReviews/memberReviews.test.ts
+++ b/apps/server/src/orpc/routes/memberReviews/memberReviews.test.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { memberReviews } from "@peated/server/db/schema";
+import { follows, memberReviews } from "@peated/server/db/schema";
 import { createPendingImageUpload } from "@peated/server/lib/pendingUploads";
 import { recomputeBottleStats } from "@peated/server/lib/recomputeBottleStats";
 import waitError from "@peated/server/lib/test/waitError";
@@ -18,23 +18,64 @@ describe("member reviews", () => {
     fixtures,
   }) => {
     const bottle = await fixtures.Bottle();
+    const friend = await fixtures.User();
+    await Promise.all(
+      ["apple", "wax", "smoke"].map((name) => fixtures.Tag({ name })),
+    );
+    await db.insert(follows).values({
+      fromUserId: defaults.user.id,
+      toUserId: friend.id,
+      status: "following",
+    });
 
     const created = await routerClient.memberReviews.save(
-      { bottle: bottle.id, score: 88, notes: "Bright fruit." },
+      {
+        bottle: bottle.id,
+        score: 88,
+        tags: ["apple", "wax"],
+        color: 7,
+        notes: "Bright fruit.",
+        servingStyle: "neat",
+        friends: [friend.id],
+      },
       { context: { user: defaults.user } },
     );
     const updated = await routerClient.memberReviews.save(
-      { bottle: bottle.id, score: 90, notes: null },
+      {
+        bottle: bottle.id,
+        score: 90,
+        tags: ["smoke"],
+        color: 9,
+        notes: null,
+        servingStyle: "splash",
+        friends: [friend.id],
+      },
       { context: { user: defaults.user } },
     );
 
-    expect(updated).toMatchObject({ id: created.id, score: 90, notes: null });
+    expect(updated).toMatchObject({
+      id: created.id,
+      score: 90,
+      tags: ["smoke"],
+      color: 9,
+      notes: null,
+      servingStyle: "splash",
+      friends: [{ id: friend.id }],
+    });
     await expect(
       routerClient.memberReviews.getMy(
         { bottle: bottle.id },
         { context: { user: defaults.user } },
       ),
-    ).resolves.toMatchObject({ id: created.id, score: 90, notes: null });
+    ).resolves.toMatchObject({
+      id: created.id,
+      score: 90,
+      tags: ["smoke"],
+      color: 9,
+      notes: null,
+      servingStyle: "splash",
+      friends: [{ id: friend.id }],
+    });
     await expect(
       db.query.memberReviews.findMany({
         where: and(
@@ -48,6 +89,21 @@ describe("member reviews", () => {
       { bottleId: bottle.id },
       { delay: 5000, removeOnComplete: true, removeOnFail: false },
     );
+  });
+
+  test("rejects friends who are not active relationships", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const other = await fixtures.User();
+
+    await expect(
+      routerClient.memberReviews.save(
+        { bottle: bottle.id, score: 88, friends: [other.id] },
+        { context: { user: defaults.user } },
+      ),
+    ).rejects.toThrow("Friends must all be active relationships.");
   });
 
   test("rejects invalid scores", async ({ defaults, fixtures }) => {

--- a/apps/server/src/orpc/routes/memberReviews/save.ts
+++ b/apps/server/src/orpc/routes/memberReviews/save.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { memberReviews } from "@peated/server/db/schema";
+import { follows, memberReviews } from "@peated/server/db/schema";
 import { dispatchBottleStatsRecompute } from "@peated/server/lib/dispatchBottleStatsRecompute";
 import { logError } from "@peated/server/lib/log";
 import {
@@ -16,13 +16,14 @@ import {
   requireAuth,
   requireTosAccepted,
 } from "@peated/server/orpc/middleware";
+import { validateTags } from "@peated/server/orpc/validators/tags";
 import {
   MemberReviewInputSchema,
   MemberReviewSchema,
 } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
 import { MemberReviewSerializer } from "@peated/server/serializers/memberReview";
-import { eq, sql } from "drizzle-orm";
+import { and, eq, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 
 export default procedure
@@ -61,6 +62,26 @@ export default procedure
       }
     }
 
+    const tags = await validateTags(input.tags);
+    const friendUserIds = Array.from(new Set(input.friends));
+    if (friendUserIds.length) {
+      const matches = await db
+        .select()
+        .from(follows)
+        .where(
+          and(
+            eq(follows.fromUserId, context.user.id),
+            eq(follows.status, "following"),
+            inArray(follows.toUserId, friendUserIds),
+          ),
+        );
+      if (matches.length !== friendUserIds.length) {
+        throw errors.BAD_REQUEST({
+          message: "Friends must all be active relationships.",
+        });
+      }
+    }
+
     let review = await db.transaction(async (tx) => {
       try {
         await resolveActiveBottleIds(tx, [input.bottle], { lock: "update" });
@@ -78,13 +99,21 @@ export default procedure
           bottleId: input.bottle,
           createdById: context.user.id,
           score: input.score,
+          tags,
+          color: input.color,
           notes: input.notes,
+          servingStyle: input.servingStyle,
+          friends: friendUserIds,
         })
         .onConflictDoUpdate({
           target: [memberReviews.bottleId, memberReviews.createdById],
           set: {
             score: input.score,
+            tags,
+            color: input.color,
             notes: input.notes,
+            servingStyle: input.servingStyle,
+            friends: friendUserIds,
             updatedAt: sql`NOW()`,
           },
         })

--- a/apps/server/src/schemas/memberReviews.ts
+++ b/apps/server/src/schemas/memberReviews.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { ServingStyleEnum } from "./common";
 import { UserSchema } from "./users";
 
 export const MemberReviewScoreSchema = z
@@ -15,11 +16,33 @@ export const MemberReviewNotesSchema = z
   .default(null)
   .describe("Optional review notes");
 
+const MemberReviewTagsSchema = z
+  .array(z.string())
+  .default([])
+  .describe("Tasting notes associated with this review");
+const MemberReviewColorSchema = z
+  .number()
+  .gte(0)
+  .lte(20)
+  .nullable()
+  .default(null)
+  .describe("Observed color on a scale from 0 through 20");
+const MemberReviewServingStyleSchema = ServingStyleEnum.nullable()
+  .default(null)
+  .describe("How the reviewed pour was served");
+
 export const MemberReviewSchema = z.object({
   id: z.number().int().positive(),
   bottleId: z.number().int().positive(),
   score: MemberReviewScoreSchema,
+  tags: MemberReviewTagsSchema,
+  color: MemberReviewColorSchema,
   notes: MemberReviewNotesSchema,
+  servingStyle: MemberReviewServingStyleSchema,
+  friends: z
+    .array(UserSchema)
+    .default([])
+    .describe("Friends who were present for the reviewed pour"),
   imageUrl: z.string().nullable(),
   createdBy: UserSchema.readonly(),
   createdAt: z.string().datetime().readonly(),
@@ -29,6 +52,13 @@ export const MemberReviewSchema = z.object({
 export const MemberReviewInputSchema = z
   .object({
     score: MemberReviewScoreSchema,
+    tags: MemberReviewTagsSchema,
+    color: MemberReviewColorSchema,
     notes: MemberReviewNotesSchema,
+    servingStyle: MemberReviewServingStyleSchema,
+    friends: z
+      .array(z.number().int().positive())
+      .default([])
+      .describe("Friend user IDs present for the reviewed pour"),
   })
   .strict();

--- a/apps/server/src/serializers/memberReview.ts
+++ b/apps/server/src/serializers/memberReview.ts
@@ -1,5 +1,6 @@
 import type { MemberReview, User } from "@peated/server/db/schema";
 import { users } from "@peated/server/db/schema";
+import { notEmpty } from "@peated/server/lib/filter";
 import type { MemberReviewSchema } from "@peated/server/schemas";
 import { inArray } from "drizzle-orm";
 import type { z } from "zod";
@@ -11,6 +12,7 @@ import { UserSerializer } from "./user";
 
 type Attrs = {
   createdBy: ReturnType<(typeof UserSerializer)["item"]>;
+  friends: ReturnType<(typeof UserSerializer)["item"]>[];
 };
 
 export const MemberReviewSerializer = serializer({
@@ -20,7 +22,12 @@ export const MemberReviewSerializer = serializer({
     currentUser?: User,
   ): Promise<Record<number, Attrs>> => {
     const userIds = [
-      ...new Set(itemList.map(({ createdById }) => createdById)),
+      ...new Set(
+        itemList.flatMap(({ createdById, friends }) => [
+          createdById,
+          ...friends,
+        ]),
+      ),
     ];
     const userList = await db
       .select()
@@ -38,7 +45,15 @@ export const MemberReviewSerializer = serializer({
             `Member review ${review.id} references missing member ${review.createdById}.`,
           );
         }
-        return [review.id, { createdBy }];
+        return [
+          review.id,
+          {
+            createdBy,
+            friends: review.friends
+              .map((friendId) => usersById.get(friendId))
+              .filter(notEmpty),
+          },
+        ];
       }),
     );
   },
@@ -49,7 +64,11 @@ export const MemberReviewSerializer = serializer({
     id: item.id,
     bottleId: item.bottleId,
     score: item.score,
+    tags: item.tags,
+    color: item.color,
     notes: item.notes,
+    servingStyle: item.servingStyle,
+    friends: attrs.friends,
     imageUrl: item.imageUrl
       ? absoluteUrl(config.API_SERVER, item.imageUrl)
       : null,

--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -1078,6 +1078,7 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByText(`${testBrand.name} ${createdBottleName}`),
     ).toBeVisible();
+    await page.getByRole("button", { name: /^Log a tasting/ }).click();
     await page
       .getByRole("radio", { name: /^Very good/ })
       .check({ force: true });

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -1252,6 +1252,19 @@ async function handleRpcRequest({ request, response, url }) {
     case "comments/list":
       sendRpcResponse(response, emptyList);
       return true;
+    case "friends/list":
+      sendRpcResponse(response, {
+        results: [
+          {
+            id: moderatorUser.id,
+            status: "friends",
+            createdAt: "2026-06-07T12:00:00.000Z",
+            user: moderatorUser,
+          },
+        ],
+        rel: { nextCursor: null, prevCursor: null },
+      });
+      return true;
     case "memberReviews/list":
       if (!isNumber(input?.bottle)) {
         sendRpcError(response, "Unexpected member review list payload");
@@ -1267,6 +1280,35 @@ async function handleRpcRequest({ request, response, url }) {
       }
 
       sendRpcResponse(response, null);
+      return true;
+    case "memberReviews/save":
+      if (
+        !isNumber(input?.bottle) ||
+        input?.score !== 80 ||
+        input?.color !== 8 ||
+        input?.notes !== "Coastal and waxy." ||
+        input?.servingStyle !== "neat" ||
+        JSON.stringify(input?.tags) !== JSON.stringify(["smoke"]) ||
+        JSON.stringify(input?.friends) !== JSON.stringify([moderatorUser.id])
+      ) {
+        sendRpcError(response, "Unexpected member review save payload");
+        return true;
+      }
+
+      sendRpcResponse(response, {
+        id: 9402,
+        bottleId: input.bottle,
+        score: input.score,
+        tags: input.tags,
+        color: input.color,
+        notes: input.notes,
+        servingStyle: input.servingStyle,
+        friends: [moderatorUser],
+        imageUrl: null,
+        createdBy: testUser,
+        createdAt: "2026-06-07T12:00:00.000Z",
+        updatedAt: "2026-06-07T12:00:00.000Z",
+      });
       return true;
     case "externalReviews/list":
       if (input?.bottle !== undefined && !isNumber(input.bottle)) {

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -6,6 +6,7 @@ import {
   createdTastingId,
   existingBottle,
   failingTastingNotes,
+  moderatorUser,
   photoTastingNotes,
   tastingNotes,
   testAccessToken,
@@ -45,13 +46,25 @@ test.describe("log tasting", () => {
 
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(
-      page.getByRole("heading", { name: "Your notes" }),
+      page.getByRole("heading", { name: "What you noticed" }),
     ).toBeVisible();
-    await page.getByLabel("Notes").fill("Coastal and waxy.");
+    await page.getByLabel("Find a tasting note").fill("smoke");
+    await page.getByRole("option", { name: /smoke/ }).click();
+    await page.getByLabel("Color of the pour").fill("8");
+    await page.getByLabel("Comments").fill("Coastal and waxy.");
     await snapshot("Tasting form / Review / 2 Notes");
+    await page.getByRole("button", { name: "Browse" }).click();
+    await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+    await snapshot("Tasting form / Review / 2 Notes browser");
+    await page.getByRole("button", { name: "Close note picker" }).click();
 
     await page.getByRole("button", { name: "Continue" }).click();
-    await expect(page.getByRole("heading", { name: "Picture" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Picture and company" }),
+    ).toBeVisible();
+    await page.getByLabel("Served").selectOption("neat");
+    await page.getByLabel("Drinking with").fill("moderator");
+    await page.getByRole("option", { name: /moderator-review/ }).click();
     await snapshot("Tasting form / Review / 3 Details");
     await expect(
       page.getByRole("button", { name: "Save review" }),
@@ -59,6 +72,23 @@ test.describe("log tasting", () => {
     await expect(
       page.getByRole("button", { name: /^Write a review/ }),
     ).toHaveCount(0);
+
+    const saveRequestPromise = page.waitForRequest((request) =>
+      request.url().includes("/rpc/memberReviews/save"),
+    );
+    await page.getByRole("button", { name: "Save review" }).click();
+    expect(getRpcInput(await saveRequestPromise)).toMatchObject({
+      bottle: existingBottle.id,
+      score: 80,
+      tags: ["smoke"],
+      color: 8,
+      notes: "Coastal and waxy.",
+      servingStyle: "neat",
+      friends: [moderatorUser.id],
+    });
+    await expect(page).toHaveURL(
+      new RegExp(`/bottles/${existingBottle.id}(?:-|$)`),
+    );
   });
 
   test("logs a tasting for a fixture bottle", async ({

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -18,6 +18,47 @@ const testImage = Buffer.from(
 );
 
 test.describe("log tasting", () => {
+  test("chooses the record type once and steps through a review", async ({
+    context,
+    page,
+    snapshot,
+  }) => {
+    await signIn(context);
+
+    await page.goto(`/bottles/${existingBottle.id}/addTasting`);
+
+    await expect(
+      page.getByRole("heading", { name: "What do you want to log?" }),
+    ).toBeVisible();
+    await snapshot("Choose tasting or review");
+    await page.getByRole("button", { name: /^Write a review/ }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Write a review" }),
+    ).toBeVisible();
+    await expect(page.getByLabel("Score out of 100")).toHaveValue("80");
+    await snapshot("Review score step");
+    const progress = page.getByRole("navigation", { name: "Form progress" });
+    await expect(progress).toContainText("Score");
+    await expect(progress).toContainText("Notes");
+    await expect(progress).toContainText("Details");
+
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(
+      page.getByRole("heading", { name: "Your notes" }),
+    ).toBeVisible();
+    await page.getByLabel("Notes").fill("Coastal and waxy.");
+
+    await page.getByRole("button", { name: "Continue" }).click();
+    await expect(page.getByRole("heading", { name: "Picture" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Save review" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /^Write a review/ }),
+    ).toHaveCount(0);
+  });
+
   test("logs a tasting for a fixture bottle", async ({ context, page }) => {
     await signIn(context);
 
@@ -176,6 +217,7 @@ async function fillComments(page: Page, value: string) {
 }
 
 async function chooseVeryGood(page: Page) {
+  await page.getByRole("button", { name: /^Log a tasting/ }).click();
   await page.getByRole("radio", { name: /^Very good/ }).check({ force: true });
 }
 

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -48,9 +48,11 @@ test.describe("log tasting", () => {
       page.getByRole("heading", { name: "Your notes" }),
     ).toBeVisible();
     await page.getByLabel("Notes").fill("Coastal and waxy.");
+    await snapshot("Review notes step");
 
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(page.getByRole("heading", { name: "Picture" })).toBeVisible();
+    await snapshot("Review details step");
     await expect(
       page.getByRole("button", { name: "Save review" }),
     ).toBeVisible();
@@ -59,7 +61,11 @@ test.describe("log tasting", () => {
     ).toHaveCount(0);
   });
 
-  test("logs a tasting for a fixture bottle", async ({ context, page }) => {
+  test("logs a tasting for a fixture bottle", async ({
+    context,
+    page,
+    snapshot,
+  }) => {
     await signIn(context);
 
     await page.goto(`/bottles/${existingBottle.id}/addTasting`);
@@ -68,8 +74,15 @@ test.describe("log tasting", () => {
       new RegExp(`/addBottle\\?bottle=${existingBottle.id}&intent=tasting$`),
     );
     await chooseVeryGood(page);
+    await snapshot("Tasting rating step");
     await fillComments(page, tastingNotes);
+    await snapshot("Tasting notes step");
+    await page.getByRole("button", { name: "Browse" }).click();
+    await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
+    await snapshot("Tasting note browser");
+    await page.getByRole("button", { name: "Close note picker" }).click();
     await uploadTastingImage(page);
+    await snapshot("Tasting details step");
     const createRequestPromise = waitForTastingCreate(page);
     const imageRequestPromise = page.waitForRequest((request) =>
       request.url().includes("/rpc/tastings/imageUpdate"),

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -30,14 +30,14 @@ test.describe("log tasting", () => {
     await expect(
       page.getByRole("heading", { name: "What do you want to log?" }),
     ).toBeVisible();
-    await snapshot("Choose tasting or review");
+    await snapshot("Tasting form / Choose entry type");
     await page.getByRole("button", { name: /^Write a review/ }).click();
 
     await expect(
       page.getByRole("heading", { name: "Write a review" }),
     ).toBeVisible();
     await expect(page.getByLabel("Score out of 100")).toHaveValue("80");
-    await snapshot("Review score step");
+    await snapshot("Tasting form / Review / 1 Score");
     const progress = page.getByRole("navigation", { name: "Form progress" });
     await expect(progress).toContainText("Score");
     await expect(progress).toContainText("Notes");
@@ -48,11 +48,11 @@ test.describe("log tasting", () => {
       page.getByRole("heading", { name: "Your notes" }),
     ).toBeVisible();
     await page.getByLabel("Notes").fill("Coastal and waxy.");
-    await snapshot("Review notes step");
+    await snapshot("Tasting form / Review / 2 Notes");
 
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(page.getByRole("heading", { name: "Picture" })).toBeVisible();
-    await snapshot("Review details step");
+    await snapshot("Tasting form / Review / 3 Details");
     await expect(
       page.getByRole("button", { name: "Save review" }),
     ).toBeVisible();
@@ -74,15 +74,15 @@ test.describe("log tasting", () => {
       new RegExp(`/addBottle\\?bottle=${existingBottle.id}&intent=tasting$`),
     );
     await chooseVeryGood(page);
-    await snapshot("Tasting rating step");
+    await snapshot("Tasting form / Tasting / 1 Rating");
     await fillComments(page, tastingNotes);
-    await snapshot("Tasting notes step");
+    await snapshot("Tasting form / Tasting / 2 Notes");
     await page.getByRole("button", { name: "Browse" }).click();
     await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
-    await snapshot("Tasting note browser");
+    await snapshot("Tasting form / Tasting / 2 Notes browser");
     await page.getByRole("button", { name: "Close note picker" }).click();
     await uploadTastingImage(page);
-    await snapshot("Tasting details step");
+    await snapshot("Tasting form / Tasting / 3 Details");
     const createRequestPromise = waitForTastingCreate(page);
     const imageRequestPromise = page.waitForRequest((request) =>
       request.url().includes("/rpc/tastings/imageUpdate"),

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -31,14 +31,18 @@ test.describe("log tasting", () => {
     await expect(
       page.getByRole("heading", { name: "What do you want to log?" }),
     ).toBeVisible();
-    await snapshot("Tasting form / Choose entry type");
+    await snapshot("Tasting form / Choose entry type", {
+      ready: page.getByRole("heading", { name: "What do you want to log?" }),
+    });
     await page.getByRole("button", { name: /^Write a review/ }).click();
 
     await expect(
       page.getByRole("heading", { name: "Write a review" }),
     ).toBeVisible();
     await expect(page.getByLabel("Score out of 100")).toHaveValue("80");
-    await snapshot("Tasting form / Review / 1 Score");
+    await snapshot("Tasting form / Review / 1 Score", {
+      ready: page.getByLabel("Score out of 100"),
+    });
     const progress = page.getByRole("navigation", { name: "Form progress" });
     await expect(progress).toContainText("Score");
     await expect(progress).toContainText("Notes");
@@ -46,26 +50,32 @@ test.describe("log tasting", () => {
 
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(
-      page.getByRole("heading", { name: "What you noticed" }),
+      page.getByRole("heading", { name: "What you tasted" }),
     ).toBeVisible();
     await page.getByLabel("Find a tasting note").fill("smoke");
     await page.getByRole("option", { name: /smoke/ }).click();
     await page.getByLabel("Color of the pour").fill("8");
     await page.getByLabel("Comments").fill("Coastal and waxy.");
-    await snapshot("Tasting form / Review / 2 Notes");
+    await snapshot("Tasting form / Review / 2 Notes", {
+      ready: page.getByRole("heading", { name: "What you tasted" }),
+    });
     await page.getByRole("button", { name: "Browse" }).click();
     await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
-    await snapshot("Tasting form / Review / 2 Notes browser");
+    await snapshot("Tasting form / Review / 2 Notes browser", {
+      ready: page.getByRole("heading", { name: "Notes" }),
+    });
     await page.getByRole("button", { name: "Close note picker" }).click();
 
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(
-      page.getByRole("heading", { name: "Picture and company" }),
+      page.getByRole("heading", { name: "The sitting" }),
     ).toBeVisible();
-    await page.getByLabel("Served").selectOption("neat");
-    await page.getByLabel("Drinking with").fill("moderator");
+    await page.getByRole("radio", { name: "Neat" }).check({ force: true });
+    await page.getByLabel("Friends").fill("moderator");
     await page.getByRole("option", { name: /moderator-review/ }).click();
-    await snapshot("Tasting form / Review / 3 Details");
+    await snapshot("Tasting form / Review / 3 Details", {
+      ready: page.getByRole("heading", { name: "The sitting" }),
+    });
     await expect(
       page.getByRole("button", { name: "Save review" }),
     ).toBeVisible();
@@ -104,15 +114,24 @@ test.describe("log tasting", () => {
       new RegExp(`/addBottle\\?bottle=${existingBottle.id}&intent=tasting$`),
     );
     await chooseVeryGood(page);
-    await snapshot("Tasting form / Tasting / 1 Rating");
+    await snapshot("Tasting form / Tasting / 1 Rating", {
+      ready: page.getByRole("heading", { name: "Your rating" }),
+    });
     await fillComments(page, tastingNotes);
-    await snapshot("Tasting form / Tasting / 2 Notes");
+    await snapshot("Tasting form / Tasting / 2 Notes", {
+      ready: page.getByRole("heading", { name: "What you tasted" }),
+    });
     await page.getByRole("button", { name: "Browse" }).click();
     await expect(page.getByRole("heading", { name: "Notes" })).toBeVisible();
-    await snapshot("Tasting form / Tasting / 2 Notes browser");
+    await snapshot("Tasting form / Tasting / 2 Notes browser", {
+      ready: page.getByRole("heading", { name: "Notes" }),
+    });
     await page.getByRole("button", { name: "Close note picker" }).click();
     await uploadTastingImage(page);
-    await snapshot("Tasting form / Tasting / 3 Details");
+    await page.getByRole("radio", { name: "Neat" }).check({ force: true });
+    await snapshot("Tasting form / Tasting / 3 Details", {
+      ready: page.getByRole("heading", { name: "The sitting" }),
+    });
     const createRequestPromise = waitForTastingCreate(page);
     const imageRequestPromise = page.waitForRequest((request) =>
       request.url().includes("/rpc/tastings/imageUpdate"),
@@ -122,6 +141,7 @@ test.describe("log tasting", () => {
     await imageRequestPromise;
 
     expect(createInput.bottle).toBe(existingBottle.id);
+    expect(createInput.servingStyle).toBe("neat");
     expect(createInput).not.toHaveProperty("target");
     expect(createInput).not.toHaveProperty("release");
 

--- a/apps/web/e2e/test.ts
+++ b/apps/web/e2e/test.ts
@@ -22,9 +22,8 @@ export const test = base.extend<{ snapshot: Snapshot }>({
     const titles = new Set<string>();
 
     await use(async (title, { fullPage = true, ready }) => {
-      const snapshotName = slug(title);
-      if (!snapshotName)
-        throw new Error("Snapshot titles must contain a letter or number.");
+      const file = snapshotFile(title);
+      const snapshotName = file.slice(0, -".png".length);
       if (titles.has(snapshotName)) {
         throw new Error(`Duplicate snapshot title in one test: ${title}`);
       }
@@ -38,7 +37,6 @@ export const test = base.extend<{ snapshot: Snapshot }>({
       });
 
       const outputRoot = visualOutputRoot();
-      const file = snapshotFile(snapshotName);
       const imagePath = path.join(outputRoot, file);
       const metadataFile = snapshotMetadataFile(testInfo, snapshotName);
       const metadataPath = path.join(outputRoot, ".metadata", metadataFile);
@@ -90,8 +88,14 @@ function visualOutputRoot() {
     : path.resolve(process.cwd(), ".playwright/visual");
 }
 
-export function snapshotFile(snapshotName: string) {
-  return `${snapshotName}.png`;
+export function snapshotFile(title: string) {
+  const segments = title.split("/").map(slug);
+  if (segments.some((segment) => !segment)) {
+    throw new Error(
+      "Snapshot titles and category segments must contain a letter or number.",
+    );
+  }
+  return `${segments.join("/")}.png`;
 }
 
 export function snapshotMetadataFile(testInfo: TestInfo, snapshotName: string) {

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -241,12 +241,15 @@ export {
   PictureInput,
   RatingBandInput,
   ReviewScoreInput,
+  ServingStyleInput,
 } from "./tastingInputs.stylex";
 export type {
   ColorInputProps,
   PictureInputProps,
   RatingBandInputProps,
   ReviewScoreInputProps,
+  ServingStyle,
+  ServingStyleInputProps,
 } from "./tastingInputs.stylex";
 export { TastingToastSummary } from "./tastingToastButton.stylex";
 export { TextLink } from "./textLink.stylex";

--- a/apps/web/src/components/memberPicker.stylex.tsx
+++ b/apps/web/src/components/memberPicker.stylex.tsx
@@ -44,7 +44,7 @@ export function MemberPicker({
   return (
     <SearchPicker
       emptyText="No matching friends."
-      help="The people enjoying this tasting with you."
+      help="The people sharing this pour with you."
       label={label}
       loading={loading}
       onChange={(nextValue) =>

--- a/apps/web/src/components/notePicker.stylex.tsx
+++ b/apps/web/src/components/notePicker.stylex.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
 import * as stylex from "@stylexjs/stylex";
 import type { FocusEvent } from "react";
 import { useId, useMemo, useState } from "react";
@@ -193,15 +194,25 @@ export function NotePickerField({
       ) : null}
 
       {isBrowserOpen ? (
-        <div {...stylex.props(styles.fieldOverlay)}>
-          <NotePicker
-            notes={notes}
-            onChange={onChange}
-            onClose={() => setIsBrowserOpen(false)}
-            onConfirm={() => setIsBrowserOpen(false)}
-            value={value}
-          />
-        </div>
+        <Dialog
+          aria-label="Browse tasting notes"
+          onClose={() => setIsBrowserOpen(false)}
+          open
+          {...stylex.props(styles.browserDialog)}
+        >
+          <DialogBackdrop {...stylex.props(styles.browserBackdrop)} />
+          <div {...stylex.props(styles.browserPosition)}>
+            <DialogPanel {...stylex.props(styles.browserPanel)}>
+              <NotePicker
+                notes={notes}
+                onChange={onChange}
+                onClose={() => setIsBrowserOpen(false)}
+                onConfirm={() => setIsBrowserOpen(false)}
+                value={value}
+              />
+            </DialogPanel>
+          </div>
+        </Dialog>
       ) : null}
 
       {value.length ? (
@@ -259,12 +270,7 @@ export function NotePicker({
     : "none";
 
   return (
-    <FloatingPanel
-      aria-labelledby={titleId}
-      data-state="open"
-      role="dialog"
-      {...stylex.props(styles.picker)}
-    >
+    <div data-state="open" {...stylex.props(styles.picker)}>
       <div {...stylex.props(styles.header)}>
         <h3
           id={titleId}
@@ -379,7 +385,7 @@ export function NotePicker({
           </Button>
         ) : null}
       </footer>
-    </FloatingPanel>
+    </div>
   );
 }
 
@@ -498,12 +504,52 @@ const styles = stylex.create({
     fontSize: "13px",
     lineHeight: 1.4,
   },
-  fieldOverlay: {
-    position: "absolute",
-    zIndex: zIndices.menu,
-    top: "calc(100% + 4px)",
-    left: 0,
-    width: "min(640px, calc(100vw - 48px))",
+  browserDialog: {
+    position: "relative",
+    zIndex: zIndices.dialog,
+  },
+  browserBackdrop: {
+    position: "fixed",
+    inset: 0,
+    backgroundColor: "rgb(16 18 16 / 0.48)",
+  },
+  browserPosition: {
+    boxSizing: "border-box",
+    position: "fixed",
+    inset: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingTop: {
+      default: `max(${space.x6}, env(safe-area-inset-top))`,
+      [COMPACT]: 0,
+    },
+    paddingRight: {
+      default: `max(${space.x6}, env(safe-area-inset-right))`,
+      [COMPACT]: 0,
+    },
+    paddingBottom: {
+      default: `max(${space.x6}, env(safe-area-inset-bottom))`,
+      [COMPACT]: 0,
+    },
+    paddingLeft: {
+      default: `max(${space.x6}, env(safe-area-inset-left))`,
+      [COMPACT]: 0,
+    },
+    pointerEvents: "none",
+  },
+  browserPanel: {
+    width: "100%",
+    maxWidth: "640px",
+    maxHeight: "min(720px, calc(100dvh - 48px))",
+    overflow: "hidden",
+    outline: "none",
+    pointerEvents: "auto",
+    [COMPACT]: {
+      maxWidth: "none",
+      height: "100dvh",
+      maxHeight: "none",
+    },
   },
   fieldSummary: {
     margin: 0,
@@ -514,9 +560,23 @@ const styles = stylex.create({
     lineHeight: 1.3,
   },
   picker: {
+    boxSizing: "border-box",
+    display: "flex",
     width: "100%",
     maxWidth: "640px",
+    maxHeight: "inherit",
+    flexDirection: "column",
     overflow: "hidden",
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.ground,
+    color: colors.ink,
+    boxShadow: effects.overlayShadow,
+    [COMPACT]: {
+      height: "100%",
+      maxWidth: "none",
+      borderRadius: 0,
+      boxShadow: "none",
+    },
   },
   header: {
     display: "grid",
@@ -627,6 +687,9 @@ const styles = stylex.create({
     color: colors.ground,
   },
   noteArea: {
+    minHeight: 0,
+    flex: 1,
+    overflowY: "auto",
     paddingRight: { default: space.x4, [COMPACT]: space.x3 },
     paddingBottom: space.x6,
     paddingLeft: { default: space.x4, [COMPACT]: space.x3 },

--- a/apps/web/src/components/notePicker.test.tsx
+++ b/apps/web/src/components/notePicker.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { NotePickerField, type NotePickerOption } from "./notePicker.stylex";
+
+const notes: NotePickerOption[] = [
+  { category: "Smoke", name: "Bonfire", usageCount: 12 },
+  { category: "Fruit", name: "Apple", usageCount: 8 },
+];
+
+function NotePickerHarness() {
+  const [value, setValue] = useState<readonly string[]>([]);
+  return <NotePickerField notes={notes} onChange={setValue} value={value} />;
+}
+
+describe("NotePickerField", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("opens the note browser as a modal panel and closes it", () => {
+    act(() => root.render(<NotePickerHarness />));
+
+    act(() => {
+      container.querySelector<HTMLButtonElement>("button")?.click();
+    });
+
+    expect(
+      document.querySelector(
+        '[role="dialog"][aria-label="Browse tasting notes"]',
+      ),
+    ).not.toBeNull();
+    expect(document.body.textContent).toContain("Bonfire");
+
+    act(() => {
+      document
+        .querySelector<HTMLButtonElement>(
+          'button[aria-label="Close note picker"]',
+        )
+        ?.click();
+    });
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/recordTypeInput.stylex.tsx
+++ b/apps/web/src/components/recordTypeInput.stylex.tsx
@@ -1,8 +1,15 @@
 "use client";
 
 import * as stylex from "@stylexjs/stylex";
+import { ArrowRight } from "lucide-react";
 
-import { colors, effects, fonts, space } from "../styles/tokens.stylex";
+import {
+  colors,
+  controlMetrics,
+  effects,
+  fonts,
+  space,
+} from "../styles/tokens.stylex";
 
 export type RecordType = "tasting" | "review";
 
@@ -13,36 +20,54 @@ export function RecordTypeInput({
 }: {
   disabled: boolean;
   onChange: (value: RecordType) => void;
-  value: RecordType;
+  value: RecordType | null;
 }) {
+  const choices = [
+    {
+      description:
+        "Record this pour with a rating, tasting notes, color, and details.",
+      label: "Log a tasting",
+      value: "tasting",
+    },
+    {
+      description:
+        "Give this bottle one overall score and a considered review.",
+      label: "Write a review",
+      value: "review",
+    },
+  ] as const;
+
   return (
     <div
       aria-label="Record type"
-      role="radiogroup"
-      {...stylex.props(styles.tabs)}
+      role="group"
+      {...stylex.props(styles.choices)}
     >
-      {(["tasting", "review"] as const).map((recordType) => {
-        const checked = recordType === value;
+      {choices.map((choice) => {
+        const checked = choice.value === value;
         return (
-          <label
-            key={recordType}
+          <button
+            aria-pressed={checked || undefined}
+            disabled={disabled}
+            key={choice.value}
+            onClick={() => onChange(choice.value)}
+            type="button"
             {...stylex.props(
-              styles.tab,
-              checked && styles.selectedTab,
-              disabled && styles.disabledTab,
+              styles.choice,
+              checked && styles.selectedChoice,
+              disabled && styles.disabledChoice,
             )}
           >
-            <input
-              checked={checked}
-              disabled={disabled}
-              name="record-type"
-              onChange={() => onChange(recordType)}
-              type="radio"
-              value={recordType}
-              {...stylex.props(styles.visuallyHiddenInput)}
-            />
-            {recordType === "tasting" ? "Tasting" : "Review"}
-          </label>
+            <span {...stylex.props(styles.choiceCopy)}>
+              <strong {...stylex.props(styles.choiceLabel)}>
+                {choice.label}
+              </strong>
+              <span {...stylex.props(styles.choiceDescription)}>
+                {choice.description}
+              </span>
+            </span>
+            <ArrowRight aria-hidden="true" size={19} strokeWidth={1.8} />
+          </button>
         );
       })}
     </div>
@@ -50,49 +75,69 @@ export function RecordTypeInput({
 }
 
 const styles = stylex.create({
-  tabs: {
-    display: "flex",
+  choices: {
+    display: "grid",
     width: "100%",
     minWidth: 0,
-    columnGap: space.x6,
-    paddingRight: space.x1,
-    paddingLeft: space.x1,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
+    gridTemplateColumns: {
+      default: "repeat(2, minmax(0, 1fr))",
+      "@media (max-width: 559px)": "minmax(0, 1fr)",
+    },
+    gap: space.x3,
   },
-  tab: {
-    display: "inline-flex",
-    minHeight: "40px",
-    flexShrink: 0,
+  choice: {
+    boxSizing: "border-box",
+    display: "flex",
+    minWidth: 0,
+    minHeight: "112px",
     alignItems: "center",
-    color: { default: colors.inkMuted, ":hover": colors.ink },
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    fontWeight: 600,
-    lineHeight: 1.2,
+    gap: space.x4,
+    padding: space.x4,
+    borderWidth: "1px",
+    borderStyle: "solid",
+    borderColor: {
+      default: colors.fieldRule,
+      ":hover": colors.inkMuted,
+    },
+    borderRadius: controlMetrics.radius,
+    backgroundColor: {
+      default: colors.fieldBackground,
+      ":hover": colors.surface,
+    },
+    color: colors.ink,
+    textAlign: "left",
     cursor: "pointer",
     boxShadow: {
       default: "none",
-      ":focus-within": effects.focusRing,
+      ":focus-visible": effects.focusRing,
     },
   },
-  selectedTab: {
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontWeight: 700,
+  selectedChoice: {
+    borderColor: colors.accent,
     boxShadow: {
-      default: `inset 0 -2px 0 ${colors.ink}`,
-      ":focus-within": `inset 0 -2px 0 ${colors.ink}`,
+      default: `inset 0 0 0 1px ${colors.accent}`,
+      ":focus-visible": effects.focusRing,
     },
   },
-  disabledTab: { cursor: "not-allowed", opacity: 0.45 },
-  visuallyHiddenInput: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    overflow: "hidden",
-    opacity: 0,
-    pointerEvents: "none",
+  choiceCopy: {
+    display: "flex",
+    minWidth: 0,
+    flex: 1,
+    flexDirection: "column",
+    gap: space.x1,
   },
+  choiceLabel: {
+    fontFamily: fonts.display,
+    fontSize: "16px",
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    lineHeight: 1.2,
+  },
+  choiceDescription: {
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.45,
+  },
+  disabledChoice: { cursor: "not-allowed", opacity: 0.45 },
 });

--- a/apps/web/src/components/reviewScoreInput.test.tsx
+++ b/apps/web/src/components/reviewScoreInput.test.tsx
@@ -53,8 +53,12 @@ describe("ReviewScoreInput", () => {
     expect(container.textContent).toContain("90–94");
   });
 
-  it("starts an empty score at 85 and stays within the 0–100 range", () => {
+  it("suggests 80 for an empty score and stays within the 0–100 range", () => {
     act(() => root.render(<ReviewScoreHarness initialValue={null} />));
+
+    expect(
+      container.querySelector<HTMLInputElement>("#score")?.placeholder,
+    ).toBe("80");
 
     const increase = container.querySelector<HTMLButtonElement>(
       'button[aria-label="One point higher"]',
@@ -62,7 +66,7 @@ describe("ReviewScoreInput", () => {
     act(() => increase?.click());
 
     expect(container.querySelector<HTMLInputElement>("#score")?.value).toBe(
-      "85",
+      "80",
     );
 
     act(() =>

--- a/apps/web/src/components/servingStyleInput.test.tsx
+++ b/apps/web/src/components/servingStyleInput.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+
+import { act, useState } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { ServingStyleInput, type ServingStyle } from "./tastingInputs.stylex";
+
+function ServingStyleHarness() {
+  const [value, setValue] = useState<ServingStyle | null>(null);
+
+  return (
+    <ServingStyleInput
+      id="serving"
+      name="servingStyle"
+      onChange={setValue}
+      value={value}
+    />
+  );
+}
+
+describe("ServingStyleInput", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("selects one serving style", () => {
+    act(() => root.render(<ServingStyleHarness />));
+
+    const neat = container.querySelector<HTMLInputElement>("#serving-neat")!;
+    const rocks = container.querySelector<HTMLInputElement>("#serving-rocks")!;
+
+    expect(neat.checked).toBe(false);
+    expect(rocks.checked).toBe(false);
+
+    act(() => rocks.click());
+
+    expect(neat.checked).toBe(false);
+    expect(rocks.checked).toBe(true);
+  });
+});

--- a/apps/web/src/components/tastingForm.tsx
+++ b/apps/web/src/components/tastingForm.tsx
@@ -89,8 +89,10 @@ export default function TastingForm(
   const { errorMessage, initialData, suggestedTags, title } = props;
   const orpc = useORPC();
   const canRecordReview = props.mode !== "edit";
-  const [recordType, setRecordType] = useState<RecordType>("tasting");
-  const isReview = canRecordReview && recordType === "review";
+  const [recordType, setRecordType] = useState<RecordType | null>(
+    canRecordReview ? null : "tasting",
+  );
+  const isReview = recordType === "review";
   const [submitError, setSubmitError] = useState<string>();
   const [image, setImage] = useState<ImageUploadValue>();
   const [imagePreview, setImagePreview] = useState(
@@ -136,8 +138,9 @@ export default function TastingForm(
     register: registerReview,
     reset: resetReview,
     control: reviewControl,
+    trigger: triggerReview,
   } = useForm<MemberReviewFormFields>({
-    defaultValues: { score: null, notes: null },
+    defaultValues: { score: 80, notes: null },
     resolver: zodResolver(MemberReviewFormFieldsSchema),
   });
   const ratingBand = useWatch({ control, name: "ratingBand" });
@@ -150,7 +153,9 @@ export default function TastingForm(
     staleTime: Infinity,
   });
   const [currentStep, setCurrentStep] = useState(0);
-  const steps = ["Rating", "Notes", "Details"] as const;
+  const steps = isReview
+    ? (["Score", "Notes", "Details"] as const)
+    : (["Rating", "Notes", "Details"] as const);
   const isLastStep = currentStep === steps.length - 1;
   const needsRating = props.mode !== "edit" && !ratingBand;
   const noteOptions: NotePickerOption[] = buildTastingTagOptions(
@@ -180,7 +185,7 @@ export default function TastingForm(
   useEffect(() => {
     if (reviewQuery.data === undefined) return;
     resetReview({
-      score: reviewQuery.data?.score ?? null,
+      score: reviewQuery.data?.score ?? 80,
       notes: reviewQuery.data?.notes ?? null,
     });
   }, [resetReview, reviewQuery.data]);
@@ -241,15 +246,20 @@ export default function TastingForm(
   };
 
   async function continueForm() {
-    const stepIsValid = await trigger(
-      currentStep === 0
-        ? ["ratingBand"]
-        : currentStep === 1
-          ? ["tags", "color", "notes"]
-          : ["servingStyle", "friends"],
-    );
+    const stepIsValid = isReview
+      ? await triggerReview(
+          currentStep === 0 ? ["score"] : currentStep === 1 ? ["notes"] : [],
+        )
+      : await trigger(
+          currentStep === 0
+            ? ["ratingBand"]
+            : currentStep === 1
+              ? ["tags", "color", "notes"]
+              : ["servingStyle", "friends"],
+        );
     if (!stepIsValid) return;
     setCurrentStep((step) => Math.min(step + 1, steps.length - 1));
+    scrollToFormTop();
   }
 
   const tastingFormAction = isLastStep
@@ -258,9 +268,13 @@ export default function TastingForm(
         event.preventDefault();
         void continueForm();
       };
-  const formAction = isReview
+  const reviewFormAction = isLastStep
     ? handleReviewSubmit(submitReview)
-    : tastingFormAction;
+    : (event: React.FormEvent) => {
+        event.preventDefault();
+        void continueForm();
+      };
+  const formAction = isReview ? reviewFormAction : tastingFormAction;
   const saving = isReview ? isReviewSubmitting : isSubmitting;
   const reviewIsLoading = isReview && reviewQuery.isPending;
   const reviewLoadFailed = isReview && Boolean(reviewQuery.error);
@@ -274,29 +288,52 @@ export default function TastingForm(
         ? "Your review could not be loaded."
         : reviewScore === null
           ? "Enter a score to save."
-          : reviewQuery.data
-            ? "Saving updates your existing review."
-            : "Score this bottle from 0 to 100."
+          : `Step ${currentStep + 1} of ${steps.length}`
     : needsRating
       ? "Pick a rating to continue."
       : `Step ${currentStep + 1} of ${steps.length}`;
   const saveLabel = isReview
-    ? reviewQuery.data
-      ? "Update review"
-      : "Save review"
+    ? isLastStep
+      ? reviewQuery.data
+        ? "Update review"
+        : "Save review"
+      : "Continue"
     : isLastStep
       ? "Save tasting"
       : "Continue";
+
+  function selectRecordType(nextType: RecordType) {
+    setSubmitError(undefined);
+    setCurrentStep(0);
+    setRecordType(nextType);
+    scrollToFormTop();
+  }
+
+  function previousStep() {
+    if (currentStep > 0) {
+      setCurrentStep((step) => Math.max(0, step - 1));
+      scrollToFormTop();
+      return;
+    }
+    if (canRecordReview) {
+      setRecordType(null);
+      scrollToFormTop();
+    }
+  }
+
+  function scrollToFormTop() {
+    requestAnimationFrame(() => window.scrollTo({ top: 0 }));
+  }
 
   return (
     <WorkflowScreen
       mobileSaveBar
       onPrevious={
-        !isReview && currentStep > 0
-          ? () => setCurrentStep((step) => Math.max(0, step - 1))
+        recordType && (currentStep > 0 || canRecordReview)
+          ? previousStep
           : undefined
       }
-      onSave={formAction}
+      onSave={recordType ? formAction : undefined}
       saveDisabled={saveDisabled}
       saveHint={saveHint}
       saveLabel={saveLabel}
@@ -323,17 +360,19 @@ export default function TastingForm(
           {submitError || errorMessage ? (
             <FormNotice>{submitError ?? errorMessage}</FormNotice>
           ) : null}
-          {canRecordReview ? (
-            <RecordTypeInput
-              disabled={saving}
-              onChange={(nextType) => {
-                setSubmitError(undefined);
-                setRecordType(nextType);
-              }}
-              value={recordType}
-            />
+          {recordType === null ? (
+            <FormSection
+              description="A tasting records one pour. A review is your overall opinion of the bottle."
+              title="What do you want to log?"
+            >
+              <RecordTypeInput
+                disabled={saving}
+                onChange={selectRecordType}
+                value={recordType}
+              />
+            </FormSection>
           ) : null}
-          {!isReview ? (
+          {recordType !== null ? (
             <FormSteps currentStep={currentStep} steps={steps} />
           ) : null}
           {isReview && reviewIsLoading ? (
@@ -342,7 +381,7 @@ export default function TastingForm(
           {isReview && reviewLoadFailed ? (
             <>
               <FormNotice role="alert">
-                We couldn't load your review. Try again or switch back to your
+                We couldn't load your review. Try again or go back and choose a
                 tasting.
               </FormNotice>
               <Button
@@ -356,7 +395,7 @@ export default function TastingForm(
             </>
           ) : null}
           {isReview && !reviewIsLoading && !reviewLoadFailed ? (
-            <>
+            currentStep === 0 ? (
               <FormSection title="Your score">
                 <Controller
                   control={reviewControl}
@@ -379,14 +418,15 @@ export default function TastingForm(
                   </ValidationMessage>
                 ) : null}
               </FormSection>
+            ) : currentStep === 1 ? (
               <FormSection
                 description="Review the bottle as a whole, not only this pour."
-                title="Your review"
+                title="Your notes"
               >
                 <Field
                   error={reviewErrors.notes?.message}
                   htmlFor="review-notes"
-                  label="Review"
+                  label="Notes"
                   optional
                 >
                   <Textarea
@@ -395,10 +435,13 @@ export default function TastingForm(
                     })}
                     id="review-notes"
                     invalid={Boolean(reviewErrors.notes)}
-                    placeholder="Make your case."
+                    placeholder="What stands out across the bottle?"
                     rows={10}
                   />
                 </Field>
+              </FormSection>
+            ) : (
+              <FormSection title="Picture">
                 <Field htmlFor="review-picture" label="Picture" optional>
                   <PictureInput
                     disabled={isReviewSubmitting}
@@ -429,9 +472,9 @@ export default function TastingForm(
                   />
                 </Field>
               </FormSection>
-            </>
+            )
           ) : null}
-          {!isReview && currentStep === 0 ? (
+          {recordType === "tasting" && currentStep === 0 ? (
             <FormSection title="Your rating">
               <Controller
                 control={control}
@@ -455,7 +498,7 @@ export default function TastingForm(
               ) : null}
             </FormSection>
           ) : null}
-          {!isReview && currentStep === 1 ? (
+          {recordType === "tasting" && currentStep === 1 ? (
             <FormSection title="What you noticed">
               <Field htmlFor="tasting-notes" label="Notes" optional>
                 <Controller
@@ -511,7 +554,7 @@ export default function TastingForm(
               </Field>
             </FormSection>
           ) : null}
-          {!isReview && currentStep === 2 ? (
+          {recordType === "tasting" && currentStep === 2 ? (
             <FormSection title="Picture and company">
               {props.mode === "edit" ? (
                 <Field

--- a/apps/web/src/components/tastingForm.tsx
+++ b/apps/web/src/components/tastingForm.tsx
@@ -140,11 +140,22 @@ export default function TastingForm(
     control: reviewControl,
     trigger: triggerReview,
   } = useForm<MemberReviewFormFields>({
-    defaultValues: { score: 80, notes: null },
+    defaultValues: {
+      score: 80,
+      tags: [],
+      color: null,
+      notes: null,
+      servingStyle: null,
+      friends: [],
+    },
     resolver: zodResolver(MemberReviewFormFieldsSchema),
   });
   const ratingBand = useWatch({ control, name: "ratingBand" });
   const reviewScore = useWatch({ control: reviewControl, name: "score" });
+  const reviewFriendIds = useWatch({
+    control: reviewControl,
+    name: "friends",
+  });
   const reviewQuery = useQuery({
     ...orpc.memberReviews.getMy.queryOptions({
       input: { bottle: initialData.bottle.id },
@@ -152,6 +163,17 @@ export default function TastingForm(
     enabled: isReview,
     staleTime: Infinity,
   });
+  const reviewFriendOptions = new Map(
+    [
+      ...(reviewQuery.data?.friends ?? []).map(userToMember),
+      ...(friendResults.data?.results ?? []).map(({ user }) =>
+        userToMember(user),
+      ),
+    ].map((friend) => [friend.id, friend]),
+  );
+  const selectedReviewFriends = (reviewFriendIds ?? [])
+    .map((friendId) => reviewFriendOptions.get(friendId))
+    .filter((friend): friend is MemberPickerOption => Boolean(friend));
   const [currentStep, setCurrentStep] = useState(0);
   const steps = isReview
     ? (["Score", "Notes", "Details"] as const)
@@ -160,7 +182,7 @@ export default function TastingForm(
   const needsRating = props.mode !== "edit" && !ratingBand;
   const noteOptions: NotePickerOption[] = buildTastingTagOptions(
     suggestedTags.results,
-    initialData.tags ?? [],
+    isReview ? (reviewQuery.data?.tags ?? []) : (initialData.tags ?? []),
   ).map((option) => ({
     category: option.tag ? toTitleCase(option.tag.tagCategory) : "Other notes",
     common: option.count > 0,
@@ -186,7 +208,11 @@ export default function TastingForm(
     if (reviewQuery.data === undefined) return;
     resetReview({
       score: reviewQuery.data?.score ?? 80,
+      tags: reviewQuery.data?.tags ?? [],
+      color: reviewQuery.data?.color ?? null,
       notes: reviewQuery.data?.notes ?? null,
+      servingStyle: reviewQuery.data?.servingStyle ?? null,
+      friends: reviewQuery.data?.friends.map((friend) => friend.id) ?? [],
     });
   }, [resetReview, reviewQuery.data]);
 
@@ -248,7 +274,11 @@ export default function TastingForm(
   async function continueForm() {
     const stepIsValid = isReview
       ? await triggerReview(
-          currentStep === 0 ? ["score"] : currentStep === 1 ? ["notes"] : [],
+          currentStep === 0
+            ? ["score"]
+            : currentStep === 1
+              ? ["tags", "color", "notes"]
+              : ["servingStyle", "friends"],
         )
       : await trigger(
           currentStep === 0
@@ -419,29 +449,87 @@ export default function TastingForm(
                 ) : null}
               </FormSection>
             ) : currentStep === 1 ? (
-              <FormSection
-                description="Review the bottle as a whole, not only this pour."
-                title="Your notes"
-              >
+              <FormSection title="What you noticed">
+                <Field htmlFor="review-notes" label="Notes" optional>
+                  <Controller
+                    control={reviewControl}
+                    name="tags"
+                    render={({ field }) => (
+                      <NotePickerField
+                        id="review-notes"
+                        notes={noteOptions}
+                        onChange={field.onChange}
+                        value={field.value ?? []}
+                      />
+                    )}
+                  />
+                  {reviewErrors.tags?.message ? (
+                    <ValidationMessage>
+                      {reviewErrors.tags.message}
+                    </ValidationMessage>
+                  ) : null}
+                </Field>
+                <Field htmlFor="review-color" label="Color" optional>
+                  <Controller
+                    control={reviewControl}
+                    name="color"
+                    render={({ field }) => (
+                      <ColorInput
+                        disabled={isReviewSubmitting}
+                        id="review-color"
+                        name={field.name}
+                        onChange={field.onChange}
+                        value={field.value ?? null}
+                      />
+                    )}
+                  />
+                  {reviewErrors.color?.message ? (
+                    <ValidationMessage>
+                      {reviewErrors.color.message}
+                    </ValidationMessage>
+                  ) : null}
+                </Field>
                 <Field
                   error={reviewErrors.notes?.message}
-                  htmlFor="review-notes"
-                  label="Notes"
+                  htmlFor="review-comments"
+                  label="Comment"
                   optional
                 >
                   <Textarea
                     {...registerReview("notes", {
                       setValueAs: (value) => value || null,
                     })}
-                    id="review-notes"
+                    aria-label="Comments"
+                    id="review-comments"
                     invalid={Boolean(reviewErrors.notes)}
-                    placeholder="What stands out across the bottle?"
-                    rows={10}
+                    placeholder="What stood out?"
+                    rows={6}
                   />
                 </Field>
               </FormSection>
             ) : (
-              <FormSection title="Picture">
+              <FormSection title="Picture and company">
+                <Field
+                  error={reviewErrors.servingStyle?.message}
+                  htmlFor="review-serving-style"
+                  label="Served"
+                  optional
+                >
+                  <Select
+                    {...registerReview("servingStyle", {
+                      setValueAs: (value) => value || null,
+                    })}
+                    id="review-serving-style"
+                    invalid={Boolean(reviewErrors.servingStyle)}
+                  >
+                    <option value="">Not set</option>
+                    {SERVING_STYLE_LIST.map((style) => (
+                      <option key={style} value={style}>
+                        {toTitleCase(style)}
+                      </option>
+                    ))}
+                  </Select>
+                </Field>
                 <Field htmlFor="review-picture" label="Picture" optional>
                   <PictureInput
                     disabled={isReviewSubmitting}
@@ -471,6 +559,24 @@ export default function TastingForm(
                     }
                   />
                 </Field>
+                <Controller
+                  control={reviewControl}
+                  name="friends"
+                  render={({ field }) => (
+                    <MemberPicker
+                      label="Drinking with"
+                      loading={friendResults.isFetching}
+                      onChange={(nextFriends) => {
+                        field.onChange(nextFriends.map((friend) => friend.id));
+                      }}
+                      onQueryChange={setFriendQuery}
+                      options={(friendResults.data?.results ?? []).map(
+                        ({ user }) => userToMember(user),
+                      )}
+                      value={selectedReviewFriends}
+                    />
+                  )}
+                />
               </FormSection>
             )
           ) : null}
@@ -556,29 +662,27 @@ export default function TastingForm(
           ) : null}
           {recordType === "tasting" && currentStep === 2 ? (
             <FormSection title="Picture and company">
-              {props.mode === "edit" ? (
-                <Field
-                  error={errors.servingStyle?.message}
-                  htmlFor="tasting-serving-style"
-                  label="Served"
-                  optional
+              <Field
+                error={errors.servingStyle?.message}
+                htmlFor="tasting-serving-style"
+                label="Served"
+                optional
+              >
+                <Select
+                  {...register("servingStyle", {
+                    setValueAs: (value) => value || null,
+                  })}
+                  id="tasting-serving-style"
+                  invalid={Boolean(errors.servingStyle)}
                 >
-                  <Select
-                    {...register("servingStyle", {
-                      setValueAs: (value) => value || null,
-                    })}
-                    id="tasting-serving-style"
-                    invalid={Boolean(errors.servingStyle)}
-                  >
-                    <option value="">Not set</option>
-                    {SERVING_STYLE_LIST.map((style) => (
-                      <option key={style} value={style}>
-                        {toTitleCase(style)}
-                      </option>
-                    ))}
-                  </Select>
-                </Field>
-              ) : null}
+                  <option value="">Not set</option>
+                  {SERVING_STYLE_LIST.map((style) => (
+                    <option key={style} value={style}>
+                      {toTitleCase(style)}
+                    </option>
+                  ))}
+                </Select>
+              </Field>
               <Field htmlFor="tasting-picture" label="Picture" optional>
                 <PictureInput
                   disabled={isSubmitting}

--- a/apps/web/src/components/tastingForm.tsx
+++ b/apps/web/src/components/tastingForm.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { SERVING_STYLE_LIST } from "@peated/server/constants";
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { toTitleCase } from "@peated/server/lib/strings";
 import type { TastingSchema } from "@peated/server/schemas";
@@ -9,6 +8,7 @@ import {
   Button,
   ColorInput,
   Field,
+  FieldGroup,
   FormNotice,
   FormSection,
   FormStack,
@@ -19,8 +19,8 @@ import {
   PictureInput,
   RatingBandInput,
   ReviewScoreInput,
-  Select,
   SelectedBottleSummary,
+  ServingStyleInput,
   Textarea,
   ValidationMessage,
   type MemberPickerOption,
@@ -449,8 +449,13 @@ export default function TastingForm(
                 ) : null}
               </FormSection>
             ) : currentStep === 1 ? (
-              <FormSection title="What you noticed">
-                <Field htmlFor="review-notes" label="Notes" optional>
+              <FormSection title="What you tasted">
+                <Field
+                  hint="Suggested from this bottle's own tastings."
+                  htmlFor="review-notes"
+                  label="Notes"
+                  optional
+                >
                   <Controller
                     control={reviewControl}
                     name="tags"
@@ -502,34 +507,33 @@ export default function TastingForm(
                     aria-label="Comments"
                     id="review-comments"
                     invalid={Boolean(reviewErrors.notes)}
-                    placeholder="What stood out?"
+                    placeholder="What do you want to remember about this pour?"
                     rows={6}
                   />
                 </Field>
               </FormSection>
             ) : (
-              <FormSection title="Picture and company">
-                <Field
+              <FormSection title="The sitting">
+                <FieldGroup
                   error={reviewErrors.servingStyle?.message}
-                  htmlFor="review-serving-style"
-                  label="Served"
+                  hint="How you took it, not how the bottle ships."
+                  label="Serving"
                   optional
                 >
-                  <Select
-                    {...registerReview("servingStyle", {
-                      setValueAs: (value) => value || null,
-                    })}
-                    id="review-serving-style"
-                    invalid={Boolean(reviewErrors.servingStyle)}
-                  >
-                    <option value="">Not set</option>
-                    {SERVING_STYLE_LIST.map((style) => (
-                      <option key={style} value={style}>
-                        {toTitleCase(style)}
-                      </option>
-                    ))}
-                  </Select>
-                </Field>
+                  <Controller
+                    control={reviewControl}
+                    name="servingStyle"
+                    render={({ field }) => (
+                      <ServingStyleInput
+                        disabled={isReviewSubmitting}
+                        id="review-serving-style"
+                        name={field.name}
+                        onChange={field.onChange}
+                        value={field.value ?? null}
+                      />
+                    )}
+                  />
+                </FieldGroup>
                 <Field htmlFor="review-picture" label="Picture" optional>
                   <PictureInput
                     disabled={isReviewSubmitting}
@@ -564,7 +568,7 @@ export default function TastingForm(
                   name="friends"
                   render={({ field }) => (
                     <MemberPicker
-                      label="Drinking with"
+                      label="Friends"
                       loading={friendResults.isFetching}
                       onChange={(nextFriends) => {
                         field.onChange(nextFriends.map((friend) => friend.id));
@@ -605,8 +609,13 @@ export default function TastingForm(
             </FormSection>
           ) : null}
           {recordType === "tasting" && currentStep === 1 ? (
-            <FormSection title="What you noticed">
-              <Field htmlFor="tasting-notes" label="Notes" optional>
+            <FormSection title="What you tasted">
+              <Field
+                hint="Suggested from this bottle's own tastings."
+                htmlFor="tasting-notes"
+                label="Notes"
+                optional
+              >
                 <Controller
                   control={control}
                   name="tags"
@@ -654,35 +663,34 @@ export default function TastingForm(
                   aria-label="Comments"
                   id="tasting-comments"
                   invalid={Boolean(errors.notes)}
-                  placeholder="What stood out?"
+                  placeholder="What do you want to remember about this pour?"
                   rows={6}
                 />
               </Field>
             </FormSection>
           ) : null}
           {recordType === "tasting" && currentStep === 2 ? (
-            <FormSection title="Picture and company">
-              <Field
+            <FormSection title="The sitting">
+              <FieldGroup
                 error={errors.servingStyle?.message}
-                htmlFor="tasting-serving-style"
-                label="Served"
+                hint="How you took it, not how the bottle ships."
+                label="Serving"
                 optional
               >
-                <Select
-                  {...register("servingStyle", {
-                    setValueAs: (value) => value || null,
-                  })}
-                  id="tasting-serving-style"
-                  invalid={Boolean(errors.servingStyle)}
-                >
-                  <option value="">Not set</option>
-                  {SERVING_STYLE_LIST.map((style) => (
-                    <option key={style} value={style}>
-                      {toTitleCase(style)}
-                    </option>
-                  ))}
-                </Select>
-              </Field>
+                <Controller
+                  control={control}
+                  name="servingStyle"
+                  render={({ field }) => (
+                    <ServingStyleInput
+                      disabled={isSubmitting}
+                      id="tasting-serving-style"
+                      name={field.name}
+                      onChange={field.onChange}
+                      value={field.value ?? null}
+                    />
+                  )}
+                />
+              </FieldGroup>
               <Field htmlFor="tasting-picture" label="Picture" optional>
                 <PictureInput
                   disabled={isSubmitting}
@@ -714,7 +722,7 @@ export default function TastingForm(
                 name="friends"
                 render={({ field }) => (
                   <MemberPicker
-                    label="Drinking with"
+                    label="Friends"
                     loading={friendResults.isFetching}
                     onChange={(nextFriends) => {
                       setFriends(nextFriends);

--- a/apps/web/src/components/tastingInputs.stylex.tsx
+++ b/apps/web/src/components/tastingInputs.stylex.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { COLOR_SCALE } from "@peated/server/constants";
+import { COLOR_SCALE, type SERVING_STYLE_LIST } from "@peated/server/constants";
 import * as stylex from "@stylexjs/stylex";
-import { Minus, Plus, Upload } from "lucide-react";
+import { Box, Droplets, GlassWater, Minus, Plus, Upload } from "lucide-react";
 import { useRef } from "react";
 
 import {
@@ -16,6 +16,8 @@ import { Button, IconButton } from "./button.stylex";
 import { RATING_BANDS, type RatingBand } from "./scoring.stylex";
 
 const REVIEW_SCORE_TRACK_MIN = 60;
+
+export type ServingStyle = (typeof SERVING_STYLE_LIST)[number];
 
 export type ReviewScoreInputProps = {
   disabled?: boolean;
@@ -241,6 +243,58 @@ export function RatingBandInput({
   );
 }
 
+export type ServingStyleInputProps = {
+  disabled?: boolean;
+  id: string;
+  name: string;
+  onChange: (value: ServingStyle) => void;
+  value: ServingStyle | null;
+};
+
+/** Records how the whisky was served with the three canonical choices. */
+export function ServingStyleInput({
+  disabled = false,
+  id,
+  name,
+  onChange,
+  value,
+}: ServingStyleInputProps) {
+  return (
+    <div
+      aria-label="Serving"
+      role="radiogroup"
+      {...stylex.props(styles.servingStyleTrack, disabled && styles.disabled)}
+    >
+      {SERVING_STYLE_OPTIONS.map(({ icon: Icon, label, value: option }) => {
+        const checked = value === option;
+
+        return (
+          <label
+            key={option}
+            {...stylex.props(
+              styles.servingStyleCell,
+              checked && styles.servingStyleCellSelected,
+            )}
+          >
+            <input
+              checked={checked}
+              disabled={disabled}
+              id={`${id}-${option}`}
+              name={name}
+              onChange={() => onChange(option)}
+              type="radio"
+              value={option}
+              {...stylex.props(styles.visuallyHiddenInput)}
+            />
+            <Icon aria-hidden="true" size={16} strokeWidth={1.75} />
+            <span>{label}</span>
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
 export type ColorInputProps = {
   disabled?: boolean;
   id: string;
@@ -316,6 +370,11 @@ export function ColorInput({
         <span>amber</span>
         <span>dark</span>
       </div>
+      <p aria-live="polite" {...stylex.props(styles.colorHint)}>
+        {selected
+          ? `${selected[1]} · ${selected[0]} of 20`
+          : "Bar light can lie. Unsure is a real answer."}
+      </p>
     </div>
   );
 }
@@ -671,6 +730,43 @@ const styles = stylex.create({
     color: colors.ground,
     opacity: 0.62,
   },
+  servingStyleTrack: {
+    display: "grid",
+    width: "100%",
+    gridTemplateColumns: "repeat(3, minmax(0, 1fr))",
+    gap: space.x2,
+  },
+  servingStyleCell: {
+    position: "relative",
+    display: "flex",
+    minWidth: 0,
+    height: "44px",
+    alignItems: "center",
+    justifyContent: "center",
+    columnGap: space.x2,
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.fieldBackground,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "15px",
+    fontWeight: 600,
+    lineHeight: 1,
+    cursor: "pointer",
+    boxShadow: {
+      default: `inset 0 0 0 1px ${colors.fieldRule}`,
+      ":hover": `inset 0 0 0 1px ${colors.inkMuted}`,
+      ":focus-within": effects.focusRing,
+    },
+  },
+  servingStyleCellSelected: {
+    backgroundColor: colors.ground,
+    color: colors.ink,
+    boxShadow: {
+      default: `inset 0 0 0 2px ${colors.ink}`,
+      ":hover": `inset 0 0 0 2px ${colors.ink}`,
+      ":focus-within": effects.focusRing,
+    },
+  },
   visuallyHiddenText: {
     position: "absolute",
     width: "1px",
@@ -748,6 +844,16 @@ const styles = stylex.create({
     fontSize: "10px",
     lineHeight: 1.3,
   },
+  colorHint: {
+    marginTop: space.x2,
+    marginRight: 0,
+    marginBottom: 0,
+    marginLeft: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.45,
+  },
   pictureRoot: {
     width: "100%",
   },
@@ -817,3 +923,13 @@ const bandInputBracketSelectedStyles = {
   outstanding: styles.bandInputBracketSelectedDark,
   unicorn: styles.bandInputBracketSelectedDarkest,
 } satisfies Record<RatingBand, stylex.StyleXStyles>;
+
+const SERVING_STYLE_OPTIONS = [
+  { icon: GlassWater, label: "Neat", value: "neat" },
+  { icon: Box, label: "Rocks", value: "rocks" },
+  { icon: Droplets, label: "Splash", value: "splash" },
+] as const satisfies ReadonlyArray<{
+  icon: typeof GlassWater;
+  label: string;
+  value: ServingStyle;
+}>;

--- a/apps/web/src/components/tastingInputs.stylex.tsx
+++ b/apps/web/src/components/tastingInputs.stylex.tsx
@@ -24,6 +24,7 @@ export type ReviewScoreInputProps = {
   label?: string;
   name: string;
   onChange: (value: number | null) => void;
+  placeholder?: string;
   required?: boolean;
   value: number | null;
 };
@@ -36,6 +37,7 @@ export function ReviewScoreInput({
   label = "Score out of 100",
   name,
   onChange,
+  placeholder = "80",
   required = false,
   value,
 }: ReviewScoreInputProps) {
@@ -44,7 +46,7 @@ export function ReviewScoreInput({
   );
 
   function stepScore(direction: -1 | 1) {
-    const nextValue = value === null ? 85 : value + direction;
+    const nextValue = value === null ? 80 : value + direction;
     onChange(Math.max(0, Math.min(100, nextValue)));
   }
 
@@ -88,6 +90,7 @@ export function ReviewScoreInput({
                 .slice(0, 3);
               onChange(digits === "" ? null : Math.min(100, Number(digits)));
             }}
+            placeholder={placeholder}
             type="text"
             value={value ?? ""}
             {...stylex.props(

--- a/apps/web/src/components/workflowScreen.stylex.tsx
+++ b/apps/web/src/components/workflowScreen.stylex.tsx
@@ -67,10 +67,12 @@ export function WorkflowScreen({
     <main {...stylex.props(foundationStyles.document, styles.screen)}>
       <header {...stylex.props(styles.header)}>
         <div {...stylex.props(styles.headerInner)}>
-          {onClose ? <BackButton onClick={onClose} /> : <RouterBackButton />}
-          <Link href="/" {...stylex.props(styles.brand)}>
-            Peated
-          </Link>
+          <div {...stylex.props(styles.headerLeading)}>
+            {onClose ? <BackButton onClick={onClose} /> : <RouterBackButton />}
+            <Link href="/" {...stylex.props(styles.brand)}>
+              Peated
+            </Link>
+          </div>
           <h1 title={title} {...stylex.props(styles.title)}>
             {title}
           </h1>
@@ -194,7 +196,7 @@ const styles = stylex.create({
     width: "100%",
     maxWidth: "960px",
     minHeight: "56px",
-    gridTemplateColumns: "34px auto minmax(0, 1fr) auto",
+    gridTemplateColumns: "minmax(0, 1fr) auto minmax(0, 1fr)",
     alignItems: "center",
     columnGap: space.x3,
     marginRight: "auto",
@@ -202,10 +204,16 @@ const styles = stylex.create({
     paddingRight: `max(${space.x6}, env(safe-area-inset-right))`,
     paddingLeft: `max(${space.x6}, env(safe-area-inset-left))`,
     "@media (max-width: 559px)": {
-      gridTemplateColumns: `${controlMetrics.controlHeightSmall} minmax(0, 1fr) auto`,
       paddingRight: `max(${space.x3}, env(safe-area-inset-right))`,
       paddingLeft: `max(${space.x3}, env(safe-area-inset-left))`,
     },
+  },
+  headerLeading: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "center",
+    justifySelf: "start",
+    gap: space.x3,
   },
   brand: {
     color: { default: colors.ink, ":hover": colors.accentDeep },
@@ -235,10 +243,12 @@ const styles = stylex.create({
     lineHeight: 1.2,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
+    textAlign: "center",
   },
   headerActions: {
     display: "flex",
     alignItems: "center",
+    justifySelf: "end",
     gap: space.x2,
   },
   content: {

--- a/apps/web/src/lib/memberReviewForm.test.ts
+++ b/apps/web/src/lib/memberReviewForm.test.ts
@@ -35,13 +35,24 @@ describe("member review form submissions", () => {
     expect(
       buildMemberReviewFormSubmission({
         bottleId: 12,
-        fields: { score: 91, notes: "Coastal and waxy." },
+        fields: {
+          score: 91,
+          tags: ["coastal", "wax"],
+          color: 8,
+          notes: "Coastal and waxy.",
+          servingStyle: "neat",
+          friends: [34],
+        },
         image: null,
       }),
     ).toEqual({
       bottle: 12,
       score: 91,
+      tags: ["coastal", "wax"],
+      color: 8,
       notes: "Coastal and waxy.",
+      servingStyle: "neat",
+      friends: [34],
       image: null,
     });
   });

--- a/apps/web/src/lib/memberReviewForm.ts
+++ b/apps/web/src/lib/memberReviewForm.ts
@@ -1,16 +1,17 @@
-import { MemberReviewNotesSchema } from "@peated/server/schemas";
+import { MemberReviewInputSchema } from "@peated/server/schemas";
 import { z } from "zod";
 import type { ImageUploadValue } from "./imageUpload";
 
-export const MemberReviewFormFieldsSchema = z
-  .object({
+export const MemberReviewFormFieldsSchema = MemberReviewInputSchema.omit({
+  score: true,
+})
+  .extend({
     score: z
       .number()
       .int("Use a whole number.")
       .min(0, "Score must be 0 or higher.")
       .max(100, "Score must be 100 or lower.")
       .nullable(),
-    notes: MemberReviewNotesSchema,
   })
   .strict()
   .refine(({ score }) => score !== null, {
@@ -24,10 +25,8 @@ export type MemberReviewFormFields = z.infer<
 
 export type MemberReviewFormSubmitData = {
   bottle: number;
-  score: number;
-  notes: string | null;
   image: ImageUploadValue;
-};
+} & Omit<MemberReviewFormFields, "score"> & { score: number };
 
 export function buildMemberReviewFormSubmission({
   bottleId,
@@ -43,9 +42,9 @@ export function buildMemberReviewFormSubmission({
   }
 
   return {
-    bottle: bottleId,
+    ...fields,
     score: fields.score,
-    notes: fields.notes,
+    bottle: bottleId,
     image,
   };
 }

--- a/apps/web/visual/README.md
+++ b/apps/web/visual/README.md
@@ -39,6 +39,11 @@ Use a short title that says what the image shows, such as "Home," "Bottle," or
 "Menu." This title appears in Frameshift and sets the file name. Each title must
 be unique.
 
+Use `/` to group related states in Frameshift. For example,
+`snapshot("Tasting form / Review / 1 Score")` writes
+`tasting-form/review/1-score.png`. Keep the final segment specific to the visible
+state. Use a number when workflow order matters.
+
 ## Run locally
 
 Run the normal E2E suite:

--- a/apps/web/visual/snapshot-path.test.mjs
+++ b/apps/web/visual/snapshot-path.test.mjs
@@ -13,27 +13,39 @@ describe("snapshotFile", () => {
     expect(snapshotFile("bottle")).toBe("bottle.png");
   });
 
+  test("uses slash-separated titles as Frameshift categories", () => {
+    expect(snapshotFile("Tasting form / Review / 1 Score")).toBe(
+      "tasting-form/review/1-score.png",
+    );
+  });
+
+  test("rejects empty category segments", () => {
+    expect(() => snapshotFile("Tasting form / / Score")).toThrow(
+      "Snapshot titles and category segments must contain a letter or number.",
+    );
+  });
+
   test("keeps test titles in hidden metadata paths", () => {
     const first = snapshotMetadataFile(
       {
         ...commonTest,
         titlePath: ["example.spec.ts", "first flow", "renders the state"],
       },
-      "ready",
+      "account/ready",
     );
     const second = snapshotMetadataFile(
       {
         ...commonTest,
         titlePath: ["example.spec.ts", "second flow", "renders the state"],
       },
-      "ready",
+      "account/ready",
     );
 
     expect(first).toBe(
-      "example/first-flow/renders-the-state/ready__chromium-desktop.json",
+      "example/first-flow/renders-the-state/account/ready__chromium-desktop.json",
     );
     expect(second).toBe(
-      "example/second-flow/renders-the-state/ready__chromium-desktop.json",
+      "example/second-flow/renders-the-state/account/ready__chromium-desktop.json",
     );
   });
 });

--- a/docs/architecture/rating-systems.md
+++ b/docs/architecture/rating-systems.md
@@ -11,8 +11,9 @@ These records have different intent. Do not add review fields to a tasting.
 
 Member reviews and external reviews share the same basic meaning. Their source
 and fields differ. A member review has a member, a whole-number score from 0
-through 100, and optional notes. An external review can have a publication,
-reviewer, article link, and the score format used by its source.
+through 100, and optional tasting notes, color, comments, serving style,
+friends, and picture. An external review can have a publication, reviewer,
+article link, and the score format used by its source.
 
 ## Tasting bands
 


### PR DESCRIPTION
Logging a bottle now starts with a one-time tasting-or-review choice. Both paths use a centered, three-step workflow with stable back navigation, scroll reset between steps, and a default review score of 80.

Member reviews now persist the same pour details as tastings: tasting-note tags, color, comments, serving style, friends, and picture. Existing reviews load those values for editing. The additive `member_review` migration gives existing rows empty tag and friend lists while leaving optional detail fields unset.

The pour-detail controls retain the established tasting-form treatment inside the multi-step flow. Serving uses explicit Neat, Rocks, and Splash choices; color shows its name and position on the 20-point scale; and notes, comments, and sitting details use the more specific field guidance shared by both paths.

The tasting-note browser is a desktop panel and full-screen mobile dialog. Behavioral E2E coverage submits the expanded review and tasting payloads and captures the choice, each path's three steps, and both note browsers. Slash-separated snapshot titles keep those images grouped by flow in Frameshift.
