### PR TITLE
fix(web): show cask facts on bottle details

### DIFF
--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -100,6 +100,14 @@ function getDeclaredFacts(bottle: Bottle): [FactListItem, ...FactListItem[]] {
           : `${bottle.statedAge} years`,
     },
     { label: "Cask", value: bottle.maturation },
+    { label: "Cask number", value: bottle.caskNumber },
+    {
+      label: "Outturn",
+      value:
+        bottle.outturn === null
+          ? null
+          : `${bottle.outturn.toLocaleString("en-US")} bottles`,
+    },
     {
       label: "Release",
       value: getBottleReleasePlacement(bottle).header,


### PR DESCRIPTION
Bottle overviews now show the stored cask number and producer-stated outturn alongside maturation in the fact cloud. Missing values remain hidden, and outturn counts use grouped numerals with a `bottles` suffix.
