### PR TITLE
fix(web): define z-index layers

### DIFF
--- a/apps/web/src/components/admin/adminForm.stylex.tsx
+++ b/apps/web/src/components/admin/adminForm.stylex.tsx
@@ -17,7 +17,7 @@ import {
   Textarea,
   TextInput,
 } from "..";
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { colors, fonts, space, zIndices } from "../../styles/tokens.stylex";
 import { WorkflowScreen } from "../workflowScreen.stylex";
 
 type FieldError = { message?: string } | undefined;
@@ -324,7 +324,7 @@ const styles = stylex.create({
   fieldset: { minWidth: 0, margin: 0, padding: 0, borderWidth: 0 },
   saving: {
     position: "fixed",
-    zIndex: 80,
+    zIndex: zIndices.dialog,
     inset: 0,
     display: "flex",
     alignItems: "center",

--- a/apps/web/src/components/admin/adminLayout.stylex.tsx
+++ b/apps/web/src/components/admin/adminLayout.stylex.tsx
@@ -14,6 +14,7 @@ import {
   effects,
   fonts,
   space,
+  zIndices,
 } from "../../styles/tokens.stylex";
 
 const COMPACT = "@media (max-width: 759px)";
@@ -140,7 +141,7 @@ const styles = stylex.create({
   },
   mobileHeader: {
     position: "sticky",
-    zIndex: 40,
+    zIndex: zIndices.navigation,
     top: 0,
     display: "flex",
     minHeight: "56px",
@@ -203,7 +204,7 @@ const styles = stylex.create({
   },
   sidebar: {
     position: "fixed",
-    zIndex: 30,
+    zIndex: zIndices.navigation,
     top: 0,
     bottom: 0,
     left: 0,

--- a/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
@@ -24,6 +24,7 @@ import {
   effects,
   fonts,
   space,
+  zIndices,
 } from "../../../styles/tokens.stylex";
 
 export default function ModerationBottlePicker({
@@ -225,7 +226,7 @@ export default function ModerationBottlePicker({
 }
 
 const styles = stylex.create({
-  dialog: { position: "relative", zIndex: 60 },
+  dialog: { position: "relative", zIndex: zIndices.dialog },
   backdrop: {
     position: "fixed",
     inset: 0,
@@ -253,7 +254,7 @@ const styles = stylex.create({
   },
   header: {
     position: "sticky",
-    zIndex: 2,
+    zIndex: zIndices.localControl,
     top: 0,
     display: "flex",
     alignItems: "center",

--- a/apps/web/src/components/applicationHeader.stylex.tsx
+++ b/apps/web/src/components/applicationHeader.stylex.tsx
@@ -16,6 +16,7 @@ import {
   effects,
   fonts,
   space,
+  zIndices,
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { IconButton } from "./button.stylex";
@@ -483,7 +484,7 @@ const styles = stylex.create({
     position: "absolute",
     top: "calc(100% + 4px)",
     right: 0,
-    zIndex: 40,
+    zIndex: zIndices.menu,
     width: "220px",
     paddingTop: space.x1,
     paddingBottom: space.x1,

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -7,6 +7,7 @@ import {
   effects,
   fonts,
   space,
+  zIndices,
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { ImageViewer } from "./imageViewer.stylex";
@@ -407,7 +408,7 @@ const styles = stylex.create({
   },
   end: {
     position: "relative",
-    zIndex: 2,
+    zIndex: zIndices.localControl,
     display: "flex",
     flexShrink: 0,
     alignItems: "center",

--- a/apps/web/src/components/card.stylex.tsx
+++ b/apps/web/src/components/card.stylex.tsx
@@ -6,6 +6,7 @@ import {
   controlMetrics,
   effects,
   space,
+  zIndices,
 } from "../styles/tokens.stylex";
 import { AppLink, type AppLinkProps } from "./appLink";
 
@@ -214,14 +215,14 @@ const styles = stylex.create({
     "::after": {
       content: "''",
       position: "absolute",
-      zIndex: 1,
+      zIndex: zIndices.localContent,
       inset: 0,
       borderRadius: controlMetrics.radius,
     },
   },
   nestedAction: {
     position: "relative",
-    zIndex: 2,
+    zIndex: zIndices.localControl,
     borderRadius: controlMetrics.radiusSmall,
     outline: "none",
     color: {

--- a/apps/web/src/components/confirmationDialog.stylex.tsx
+++ b/apps/web/src/components/confirmationDialog.stylex.tsx
@@ -10,7 +10,13 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import { Button } from ".";
-import { colors, effects, fonts, space } from "../styles/tokens.stylex";
+import {
+  colors,
+  effects,
+  fonts,
+  space,
+  zIndices,
+} from "../styles/tokens.stylex";
 
 export default function ConfirmationDialog({
   continueLabel = "Continue",
@@ -49,7 +55,7 @@ export default function ConfirmationDialog({
 }
 
 const styles = stylex.create({
-  dialog: { position: "relative", zIndex: 70 },
+  dialog: { position: "relative", zIndex: zIndices.dialog },
   backdrop: {
     position: "fixed",
     inset: 0,

--- a/apps/web/src/components/flashMessages.stylex.tsx
+++ b/apps/web/src/components/flashMessages.stylex.tsx
@@ -15,7 +15,7 @@ import {
   FlashMessage,
   type FlashMessageTone,
 } from "@peated/web/components/feedback.stylex";
-import { space } from "../styles/tokens.stylex";
+import { space, zIndices } from "../styles/tokens.stylex";
 
 const MESSAGE_LIFETIME = 8000;
 
@@ -88,7 +88,7 @@ export function FlashMessages({ children }: { children: ReactNode }) {
 const styles = stylex.create({
   messages: {
     position: "fixed",
-    zIndex: 80,
+    zIndex: zIndices.notification,
     top: `max(${space.x4}, env(safe-area-inset-top))`,
     right: `max(${space.x4}, env(safe-area-inset-right))`,
     left: {

--- a/apps/web/src/components/imageField.stylex.tsx
+++ b/apps/web/src/components/imageField.stylex.tsx
@@ -21,7 +21,13 @@ import { z } from "zod";
 
 import { Button, Field } from ".";
 import setRef from "../lib/setRef";
-import { colors, effects, fonts, space } from "../styles/tokens.stylex";
+import {
+  colors,
+  effects,
+  fonts,
+  space,
+  zIndices,
+} from "../styles/tokens.stylex";
 import { ImageViewer } from "./imageViewer.stylex";
 
 type Props = {
@@ -314,7 +320,7 @@ const styles = stylex.create({
     overflow: "hidden",
     clip: "rect(0, 0, 0, 0)",
   },
-  dialog: { position: "relative", zIndex: 80 },
+  dialog: { position: "relative", zIndex: zIndices.dialog },
   backdrop: {
     position: "fixed",
     inset: 0,

--- a/apps/web/src/components/imageViewer.stylex.tsx
+++ b/apps/web/src/components/imageViewer.stylex.tsx
@@ -10,7 +10,13 @@ import * as stylex from "@stylexjs/stylex";
 import { ExternalLink, Maximize2, X } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
-import { controlMetrics, effects, fonts, space } from "../styles/tokens.stylex";
+import {
+  controlMetrics,
+  effects,
+  fonts,
+  space,
+  zIndices,
+} from "../styles/tokens.stylex";
 
 export type ImageViewerProps = {
   alt: string;
@@ -122,7 +128,7 @@ const styles = stylex.create({
   },
   dialog: {
     position: "relative",
-    zIndex: 100,
+    zIndex: zIndices.fullscreen,
   },
   backdrop: {
     position: "fixed",

--- a/apps/web/src/components/itemList.stories.tsx
+++ b/apps/web/src/components/itemList.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, fonts } from "../styles/tokens.stylex";
+import { colors, fonts, zIndices } from "../styles/tokens.stylex";
 import { BottleVisual } from "./bottleIdentityRow.stylex";
 import { ItemList, ItemRow } from "./itemList.stylex";
 import { BottleRatings } from "./scoring.stylex";
@@ -140,7 +140,7 @@ export const InteractionStates: Story = {
 const styles = stylex.create({
   secondaryLink: {
     position: "relative",
-    zIndex: 2,
+    zIndex: zIndices.localControl,
     color: {
       default: colors.inkMuted,
       ":hover": colors.accentDeep,

--- a/apps/web/src/components/itemList.stylex.tsx
+++ b/apps/web/src/components/itemList.stylex.tsx
@@ -7,6 +7,7 @@ import {
   effects,
   fonts,
   space,
+  zIndices,
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { linkedRowStyles } from "./linkedRow.stylex";
@@ -270,7 +271,7 @@ const styles = stylex.create({
   },
   action: {
     position: "relative",
-    zIndex: 2,
+    zIndex: zIndices.localControl,
     display: "flex",
     flexShrink: 0,
   },

--- a/apps/web/src/components/linkedRow.stylex.ts
+++ b/apps/web/src/components/linkedRow.stylex.ts
@@ -1,6 +1,11 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, controlMetrics, effects } from "../styles/tokens.stylex";
+import {
+  colors,
+  controlMetrics,
+  effects,
+  zIndices,
+} from "../styles/tokens.stylex";
 
 /** Shared interaction geometry for rows with one primary destination. */
 export const linkedRowStyles = stylex.create({
@@ -41,13 +46,13 @@ export const linkedRowStyles = stylex.create({
     "::after": {
       content: "''",
       position: "absolute",
-      zIndex: 1,
+      zIndex: zIndices.localContent,
       inset: 0,
       borderRadius: controlMetrics.radiusSmall,
     },
   },
   nestedAction: {
     position: "relative",
-    zIndex: 2,
+    zIndex: zIndices.localControl,
   },
 });

--- a/apps/web/src/components/notePicker.stylex.tsx
+++ b/apps/web/src/components/notePicker.stylex.tsx
@@ -11,6 +11,7 @@ import {
   effects,
   fonts,
   space,
+  zIndices,
 } from "../styles/tokens.stylex";
 import { Button } from "./button.stylex";
 import { Chip } from "./chip.stylex";
@@ -436,7 +437,7 @@ const styles = stylex.create({
   },
   suggestionOverlay: {
     position: "absolute",
-    zIndex: 21,
+    zIndex: zIndices.menuControl,
     top: "calc(100% + 4px)",
     right: 0,
     left: 0,
@@ -499,7 +500,7 @@ const styles = stylex.create({
   },
   fieldOverlay: {
     position: "absolute",
-    zIndex: 20,
+    zIndex: zIndices.menu,
     top: "calc(100% + 4px)",
     left: 0,
     width: "min(640px, calc(100vw - 48px))",

--- a/apps/web/src/components/pages/authentication.stylex.tsx
+++ b/apps/web/src/components/pages/authentication.stylex.tsx
@@ -10,6 +10,7 @@ import {
   effects,
   fonts,
   space,
+  zIndices,
 } from "../../styles/tokens.stylex";
 
 const NARROW = "@media (max-width: 759px)";
@@ -222,7 +223,7 @@ const styles = stylex.create({
   },
   brand: {
     position: "relative",
-    zIndex: 1,
+    zIndex: zIndices.localContent,
     alignSelf: "flex-start",
     color: colors.ink,
     fontFamily: fonts.display,
@@ -242,7 +243,7 @@ const styles = stylex.create({
   },
   introBody: {
     position: "relative",
-    zIndex: 1,
+    zIndex: zIndices.localContent,
     display: "flex",
     maxWidth: "440px",
     flex: 1,
@@ -331,7 +332,7 @@ const styles = stylex.create({
   },
   introFooter: {
     position: "relative",
-    zIndex: 1,
+    zIndex: zIndices.localContent,
     color: colors.inkMuted,
     fontFamily: fonts.data,
     fontSize: "11px",

--- a/apps/web/src/components/rowMenu.stylex.tsx
+++ b/apps/web/src/components/rowMenu.stylex.tsx
@@ -9,6 +9,7 @@ import {
   controlMetrics,
   effects,
   fonts,
+  zIndices,
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { IconButton } from "./button.stylex";
@@ -156,11 +157,11 @@ const styles = stylex.create({
   },
   openRoot: {
     // The anchored menu uses a portal, so its open trigger must sit above it.
-    zIndex: 2,
+    zIndex: zIndices.menuControl,
   },
   triggerLayer: {
     position: "relative",
-    zIndex: 2,
+    zIndex: zIndices.localControl,
     display: "inline-flex",
   },
   dots: {
@@ -176,7 +177,7 @@ const styles = stylex.create({
     backgroundColor: "currentColor",
   },
   menu: {
-    zIndex: 1,
+    zIndex: zIndices.menu,
     width: "216px",
     overflow: "hidden",
     borderRadius: controlMetrics.radius,

--- a/apps/web/src/components/scopedSearch.stylex.tsx
+++ b/apps/web/src/components/scopedSearch.stylex.tsx
@@ -11,6 +11,7 @@ import {
   effects,
   fonts,
   space,
+  zIndices,
 } from "../styles/tokens.stylex";
 import { Chip } from "./chip.stylex";
 
@@ -324,10 +325,10 @@ const styles = stylex.create({
   },
   openScope: {
     position: "relative",
-    zIndex: 21,
+    zIndex: zIndices.menuControl,
   },
   openScopeIcon: {
-    zIndex: 21,
+    zIndex: zIndices.menuControl,
   },
   appliedScope: {
     backgroundColor: colors.accent,
@@ -338,7 +339,7 @@ const styles = stylex.create({
   },
   scopeMenu: {
     position: "absolute",
-    zIndex: 20,
+    zIndex: zIndices.menu,
     top: "-8px",
     left: "-8px",
     width: "232px",

--- a/apps/web/src/components/searchBox.stylex.tsx
+++ b/apps/web/src/components/searchBox.stylex.tsx
@@ -17,6 +17,7 @@ import {
   effects,
   fonts,
   space,
+  zIndices,
 } from "../styles/tokens.stylex";
 import { Button } from "./button.stylex";
 import { FacetGroup, FilterPanel } from "./filterPanel.stylex";
@@ -508,7 +509,7 @@ const styles = stylex.create({
   },
   expandedSurface: {
     position: "absolute",
-    zIndex: 10,
+    zIndex: zIndices.menu,
     top: 0,
     right: 0,
     left: 0,
@@ -518,7 +519,7 @@ const styles = stylex.create({
   },
   pageSurface: {
     position: "relative",
-    zIndex: 0,
+    zIndex: zIndices.base,
     top: "auto",
     right: "auto",
     left: "auto",

--- a/apps/web/src/components/searchPicker.stylex.tsx
+++ b/apps/web/src/components/searchPicker.stylex.tsx
@@ -11,6 +11,7 @@ import {
   effects,
   fonts,
   space,
+  zIndices,
 } from "../styles/tokens.stylex";
 import { Chip } from "./chip.stylex";
 import { FloatingPanel } from "./feedback.stylex";
@@ -457,7 +458,7 @@ const styles = stylex.create({
   invalid: { boxShadow: effects.errorRing },
   overlay: {
     position: "absolute",
-    zIndex: 10,
+    zIndex: zIndices.menu,
     top: "calc(100% + 4px)",
     right: 0,
     left: 0,

--- a/apps/web/src/components/skipLink.stylex.tsx
+++ b/apps/web/src/components/skipLink.stylex.tsx
@@ -1,7 +1,13 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { colors, controlMetrics, fonts, space } from "../styles/tokens.stylex";
+import {
+  colors,
+  controlMetrics,
+  fonts,
+  space,
+  zIndices,
+} from "../styles/tokens.stylex";
 
 export function SkipLink({
   children,
@@ -20,7 +26,7 @@ export function SkipLink({
 const styles = stylex.create({
   link: {
     position: "fixed",
-    zIndex: 100,
+    zIndex: zIndices.accessibility,
     top: space.x2,
     left: space.x2,
     paddingTop: space.x2,

--- a/apps/web/src/components/textLinkStyles.stylex.ts
+++ b/apps/web/src/components/textLinkStyles.stylex.ts
@@ -1,12 +1,12 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, effects, fonts } from "../styles/tokens.stylex";
+import { colors, effects, fonts, zIndices } from "../styles/tokens.stylex";
 
 /** Shared text-link interaction styles for TextLink and bare AppLink fallback. */
 export const textLinkStyles = stylex.create({
   link: {
     position: "relative",
-    zIndex: 2,
+    zIndex: zIndices.localControl,
     display: "inline-flex",
     width: "fit-content",
     color: {

--- a/apps/web/src/components/workflowScreen.stylex.tsx
+++ b/apps/web/src/components/workflowScreen.stylex.tsx
@@ -14,6 +14,7 @@ import {
   effects,
   fonts,
   space,
+  zIndices,
 } from "../styles/tokens.stylex";
 
 export type WorkflowScreenProps = {
@@ -179,7 +180,7 @@ const styles = stylex.create({
   },
   header: {
     position: "sticky",
-    zIndex: 20,
+    zIndex: zIndices.sticky,
     top: 0,
     paddingTop: "env(safe-area-inset-top)",
     borderBottomWidth: "1px",
@@ -269,7 +270,7 @@ const styles = stylex.create({
     display: "none",
     "@media (max-width: 559px)": {
       position: "fixed",
-      zIndex: 20,
+      zIndex: zIndices.sticky,
       right: 0,
       bottom: 0,
       left: 0,

--- a/apps/web/src/styles/tokens.stylex.ts
+++ b/apps/web/src/styles/tokens.stylex.ts
@@ -176,6 +176,23 @@ export const space = stylex.defineVars({
   x12: "48px",
 });
 
+// These tokens own cross-component stacking. Local stacking contexts can use
+// localContent and localControl. Page-level surfaces must use the semantic
+// layer that matches their runtime role.
+export const zIndices = stylex.defineVars({
+  base: "0",
+  localContent: "1",
+  localControl: "2",
+  sticky: "100",
+  navigation: "200",
+  menu: "300",
+  menuControl: "301",
+  dialog: "400",
+  notification: "500",
+  fullscreen: "600",
+  accessibility: "700",
+});
+
 export const controlMetrics = stylex.defineVars({
   radius: "3px",
   radiusSmall: "2px",

--- a/tools/ast-grep/rules/web-z-index-requires-token.yml
+++ b/tools/ast-grep/rules/web-z-index-requires-token.yml
@@ -1,0 +1,17 @@
+id: web-z-index-requires-token
+language: TypeScript
+severity: error
+message: Use a named zIndices token for StyleX stacking.
+note: Select the layer by runtime role from apps/web/src/styles/tokens.stylex.ts.
+files:
+  - apps/web/src/**/*.ts
+  - apps/web/src/**/*.tsx
+rule:
+  all:
+    - pattern:
+        context: "{ zIndex: $VALUE }"
+        selector: pair
+    - not:
+        pattern:
+          context: "{ zIndex: zIndices.$LAYER }"
+          selector: pair

--- a/tools/ast-grep/tests/web-z-index-requires-token-test.yml
+++ b/tools/ast-grep/tests/web-z-index-requires-token-test.yml
@@ -1,0 +1,7 @@
+id: web-z-index-requires-token
+valid:
+  - "const styles = stylex.create({ menu: { zIndex: zIndices.menu } });"
+  - "const styles = stylex.create({ control: { zIndex: zIndices.localControl } });"
+invalid:
+  - "const styles = stylex.create({ menu: { zIndex: 300 } });"
+  - 'const styles = stylex.create({ menu: { zIndex: "auto" } });'


### PR DESCRIPTION
Web stacking now uses one semantic layer scale instead of unrelated numeric values. Menus render above ordinary page controls, which prevents the bottle actions menu and other portaled overlays from allowing page content to paint through them. Sticky UI, navigation, dialogs, notifications, full-screen viewers, and accessibility controls retain an explicit order.

All existing web `zIndex` declarations now use these tokens. An ast-grep rule rejects raw values so new components must select a named layer. The main review points are the layer ordering in `tokens.stylex.ts` and the `RowMenu` menu/trigger relationship; compiled Storybook renders verified that relationship at desktop and mobile widths.
