### PR TITLE
style(web): unify open search dropdown border

### DIFF
--- a/apps/web/src/components/scopedSearch.stylex.tsx
+++ b/apps/web/src/components/scopedSearch.stylex.tsx
@@ -260,7 +260,7 @@ const styles = stylex.create({
     borderTopRightRadius: controlMetrics.radius,
     borderBottomRightRadius: 0,
     borderBottomLeftRadius: 0,
-    outlineWidth: "2px",
+    outlineWidth: 0,
     backgroundColor: colors.ground,
   },
   scopeMenuRoot: {

--- a/apps/web/src/components/searchBox.stylex.tsx
+++ b/apps/web/src/components/searchBox.stylex.tsx
@@ -377,6 +377,7 @@ export function SearchBox({
         {...stylex.props(
           styles.surface,
           expanded && styles.expandedSurface,
+          expanded && placement === "overlay" && styles.overlaySurface,
           placement === "page" && styles.pageSurface,
         )}
       >
@@ -386,7 +387,7 @@ export function SearchBox({
             <div aria-hidden="true" {...stylex.props(styles.dividerTrack)}>
               <span
                 {...stylex.props(
-                  styles.divider,
+                  styles.dropdownDivider,
                   status === "searching" && styles.searchingDivider,
                 )}
               />
@@ -507,13 +508,28 @@ const styles = stylex.create({
     width: "100%",
   },
   expandedSurface: {
+    position: "relative",
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.ground,
+    "::after": {
+      boxSizing: "border-box",
+      position: "absolute",
+      zIndex: 30,
+      inset: 0,
+      borderWidth: "2px",
+      borderStyle: "solid",
+      borderColor: colors.accent,
+      borderRadius: controlMetrics.radius,
+      content: '""',
+      pointerEvents: "none",
+    },
+  },
+  overlaySurface: {
     position: "absolute",
     zIndex: 10,
     top: 0,
     right: 0,
     left: 0,
-    borderRadius: controlMetrics.radius,
-    backgroundColor: colors.ground,
     boxShadow: effects.overlayShadow,
   },
   pageSurface: {
@@ -532,6 +548,12 @@ const styles = stylex.create({
     width: "100%",
     height: "1px",
     backgroundColor: colors.hairline,
+  },
+  dropdownDivider: {
+    display: "block",
+    width: "100%",
+    height: "1px",
+    backgroundColor: "transparent",
   },
   dividerTrack: {
     height: "2px",


### PR DESCRIPTION
Open search results now share one continuous accent border with the input instead of outlining the input separately. This applies through the shared search component across home, header, and page search surfaces, and removes the idle divider below the input while preserving the animated search-progress treatment.

The border uses a non-layout overlay so opening the dropdown does not change the control dimensions or alignment. The combined surface was checked at desktop and mobile widths, including the mobile scope controls.
