### PR TITLE
test(web): stabilize home search snapshots

### DIFF
--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
           command: `pnpm exec next dev -p ${webPort}`,
           env: {
             API_SERVER: apiServer,
+            PLAYWRIGHT_TEST: "1",
             SESSION_SECRET:
               process.env.SESSION_SECRET ??
               "peated-playwright-session-secret-for-local-browser-tests",

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -20,7 +20,10 @@ export const metadata = homeMetadata;
 
 export default async function Page() {
   const session = await getSession();
-  const searchPlaceholder = getHomeSearchPlaceholder();
+  // Playwright screenshots require stable copy. Production keeps rotating hints.
+  const searchPlaceholder = getHomeSearchPlaceholder(
+    process.env.PLAYWRIGHT_TEST ? () => 0 : undefined,
+  );
   const queryClient = getQueryClient();
   const { client } = session.user
     ? await getServerClient()


### PR DESCRIPTION
Home page visual snapshots now use a fixed search hint, which prevents random placeholder copy from creating unrelated Frameshift diffs. Production continues to rotate through all search hints; only the Playwright server injects the deterministic selector.
