### PR TITLE
fix(web): wait for complete visual snapshots

### DIFF
--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -79,10 +79,11 @@ test.describe("log tasting", () => {
     await page.goto("/addTasting");
 
     await expect(page).toHaveURL(/\/addBottle\?intent=tasting$/);
-    await expect(
-      page.getByRole("heading", { exact: true, name: "Log a tasting" }).first(),
-    ).toBeVisible();
-    await snapshot("Start a tasting");
+    const heading = page
+      .getByRole("heading", { exact: true, name: "Log a tasting" })
+      .first();
+    await expect(heading).toBeVisible();
+    await snapshot("Start a tasting", { ready: heading });
 
     await uploadLabel(page);
 

--- a/apps/web/e2e/routes.spec.ts
+++ b/apps/web/e2e/routes.spec.ts
@@ -71,12 +71,11 @@ test("public routes load", async ({ page, snapshot }) => {
 
       expect(response?.status()).toBeLessThan(400);
       if ("heading" in route) {
-        await expect(
-          page
-            .getByRole("heading", { exact: true, name: route.heading })
-            .first(),
-        ).toBeVisible();
-        await snapshot(route.name);
+        const heading = page
+          .getByRole("heading", { exact: true, name: route.heading })
+          .first();
+        await expect(heading).toBeVisible();
+        await snapshot(route.name, { ready: heading });
       }
     });
   }
@@ -115,7 +114,7 @@ test(
     });
 
     await expect(navigation).toBeVisible();
-    await snapshot("Menu", { fullPage: false });
+    await snapshot("Menu", { fullPage: false, ready: navigation });
     await navigation.getByRole("link", { name: "Bottles" }).click();
     await expect(page).toHaveURL(/\/bottles$/);
   },

--- a/apps/web/e2e/test.ts
+++ b/apps/web/e2e/test.ts
@@ -1,4 +1,9 @@
-import { test as base, expect, type TestInfo } from "@playwright/test";
+import {
+  test as base,
+  expect,
+  type Locator,
+  type TestInfo,
+} from "@playwright/test";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -8,7 +13,7 @@ export type { TestInfo };
 
 type Snapshot = (
   title: string,
-  options?: { fullPage?: boolean },
+  options: { fullPage?: boolean; ready: Locator },
 ) => Promise<void>;
 
 /** Snapshot paths are durable Frameshift identities. Keep retries and workers out of them. */
@@ -16,7 +21,7 @@ export const test = base.extend<{ snapshot: Snapshot }>({
   snapshot: async ({ page }, use, testInfo) => {
     const titles = new Set<string>();
 
-    await use(async (title, { fullPage = true } = {}) => {
+    await use(async (title, { fullPage = true, ready }) => {
       const snapshotName = slug(title);
       if (!snapshotName)
         throw new Error("Snapshot titles must contain a letter or number.");
@@ -26,7 +31,7 @@ export const test = base.extend<{ snapshot: Snapshot }>({
       titles.add(snapshotName);
 
       await page.waitForLoadState("domcontentloaded");
-      await expect(page.locator('[aria-busy="true"]:visible')).toHaveCount(0);
+      const loadingStates = page.locator('[aria-busy="true"]:visible');
       await page.evaluate(async () => document.fonts.ready);
       await page.addStyleTag({
         content: "nextjs-portal { display: none !important; }",
@@ -39,13 +44,27 @@ export const test = base.extend<{ snapshot: Snapshot }>({
       const metadataPath = path.join(outputRoot, ".metadata", metadataFile);
       await fs.mkdir(path.dirname(imagePath), { recursive: true });
       await reserveSnapshot(outputRoot, file, testInfo, snapshotName);
-      await page.screenshot({
-        animations: "disabled",
-        caret: "hide",
-        fullPage,
-        path: imagePath,
-        type: "png",
-      });
+      let captured = false;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        await expect(ready).toBeVisible();
+        await expect(loadingStates).toHaveCount(0);
+        await page.screenshot({
+          animations: "disabled",
+          caret: "hide",
+          fullPage,
+          path: imagePath,
+          type: "png",
+        });
+        if ((await ready.isVisible()) && (await loadingStates.count()) === 0) {
+          captured = true;
+          break;
+        }
+      }
+      if (!captured) {
+        throw new Error(
+          "The expected page state changed during visual snapshot capture.",
+        );
+      }
 
       await fs.mkdir(path.dirname(metadataPath), { recursive: true });
       await fs.writeFile(

--- a/apps/web/src/components/auth/authenticationPage.stylex.tsx
+++ b/apps/web/src/components/auth/authenticationPage.stylex.tsx
@@ -50,6 +50,7 @@ function DatabaseIntro() {
           value: reviewCount?.toLocaleString("en-US") ?? "–",
         },
       ]}
+      loading={stats.isPending}
       footer={
         <AuthenticationLink href="/bottles">
           Browse without an account →

--- a/apps/web/src/components/pages/authentication.stylex.tsx
+++ b/apps/web/src/components/pages/authentication.stylex.tsx
@@ -29,6 +29,7 @@ export type AuthenticationIntroProps = {
   description?: ReactNode;
   facts?: readonly AuthenticationFact[];
   footer?: ReactNode;
+  loading?: boolean;
   points?: readonly ReactNode[];
   title: ReactNode;
 };
@@ -38,11 +39,12 @@ export function AuthenticationIntro({
   description,
   facts,
   footer,
+  loading = false,
   points,
   title,
 }: AuthenticationIntroProps) {
   return (
-    <aside {...stylex.props(styles.intro)}>
+    <aside aria-busy={loading || undefined} {...stylex.props(styles.intro)}>
       {artwork ? (
         <img
           alt={artwork.alt}

--- a/apps/web/src/components/pages/authentication.test.tsx
+++ b/apps/web/src/components/pages/authentication.test.tsx
@@ -1,0 +1,12 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { expect, test } from "vitest";
+
+import { AuthenticationIntro } from "./authentication.stylex";
+
+test("marks the sign-in facts as busy while they load", () => {
+  const html = renderToStaticMarkup(
+    <AuthenticationIntro loading title="Welcome" />,
+  );
+
+  expect(html).toContain('aria-busy="true"');
+});

--- a/apps/web/visual/README.md
+++ b/apps/web/visual/README.md
@@ -19,18 +19,21 @@ import { expect, test } from "./test";
 test("opens the account menu", async ({ page, snapshot }) => {
   await page.goto("/settings");
   await page.getByRole("button", { name: "Account" }).click();
-  await expect(page.getByRole("menu")).toBeVisible();
+  const menu = page.getByRole("menu");
+  await expect(menu).toBeVisible();
 
-  await snapshot("Account menu open");
+  await snapshot("Account menu open", { ready: menu });
 });
 ```
 
-The fixture waits for visible elements with `aria-busy="true"` to finish and
-for fonts to load. It also disables animation and caret differences and hides
-the Next.js development portal. Use `aria-busy="true"` on loading states that
-must finish before a snapshot. The fixture uses a full-page screenshot by
-default. Pass `{ fullPage: false }` when the viewport itself is part of the
-workflow state, such as an open mobile menu.
+Pass the page element that proves the page is ready as `ready`. The fixture
+checks that this element stays visible while it takes the screenshot. It also
+waits for visible elements with `aria-busy="true"` to finish and for fonts to
+load. Use `aria-busy="true"` on loading states that must block a screenshot. The
+fixture disables animation and caret differences and hides the Next.js
+development portal. It uses a full-page screenshot by default. Pass
+`fullPage: false` when the screen size is part of the test, such as an open
+mobile menu.
 
 Use a short title that says what the image shows, such as "Home," "Bottle," or
 "Menu." This title appears in Frameshift and sets the file name. Each title must

--- a/docs/development/frontend-testing.md
+++ b/docs/development/frontend-testing.md
@@ -53,9 +53,11 @@ pnpm test:e2e:install
 - Check spacing, color, artwork, copy, and responsive layouts manually or with
   browser screenshots.
 - E2E tests can call the shared `snapshot` fixture after they prove a useful
-  workflow state. Frameshift reviews the image change, but the image is not a
-  test assertion. The fixture waits for visible `aria-busy="true"` loading
-  states to finish before capture. Do not add screenshot-only E2E tests.
+  workflow state. Pass the page element that proves the page is ready as the
+  snapshot's `ready` option. Frameshift reviews the image change, but the image
+  is not a test assertion. The fixture also waits for visible
+  `aria-busy="true"` loading states to finish before it takes the screenshot.
+  Do not add screenshot-only E2E tests.
 - Prefer the fewest assertions that prove the material outcome. Avoid repeating
   lower-level component or API contracts inside an end-to-end workflow.
 - Test a loading fallback only when it changes what a user can do. Check how it


### PR DESCRIPTION
Visual snapshots now wait for the page element that proves the expected screen is ready. If that element disappears while the screenshot is taken, the test waits and tries once more. Sign-in facts also report when they are still loading, so Frameshift no longer captures the loading page, a blank page, or empty fact values.

Sign-in still works if the facts cannot load. Only the screenshot waits while those facts are loading.
