### PR TITLE
fix(catalog): render compact edition codes inline

### DIFF
--- a/apps/server/src/lib/bottleDisplayName.test.ts
+++ b/apps/server/src/lib/bottleDisplayName.test.ts
@@ -63,6 +63,27 @@ describe("formatBottleDisplayName", () => {
     expect(getBottleReleaseMetadata(batchedBottle)).toBe("Batch C923");
   });
 
+  it.each(["9.3", "S2B13"])(
+    "renders compact edition code %s inline with the expression",
+    (edition) => {
+      expect(
+        formatBottleDisplayName({
+          ...bottle,
+          edition,
+        }),
+      ).toBe(`Decadent Drinks Whiskyland Glenburgie 38-year-old ${edition}`);
+    },
+  );
+
+  it("keeps a separator before a worded edition", () => {
+    expect(
+      formatBottleDisplayName({
+        ...bottle,
+        edition: "2026 Release",
+      }),
+    ).toBe("Decadent Drinks Whiskyland Glenburgie 38-year-old - 2026 Release");
+  });
+
   it("preserves stable batch wording in the expression", () => {
     expect(
       formatBottleDisplayName({

--- a/apps/server/src/lib/bottleDisplayName.ts
+++ b/apps/server/src/lib/bottleDisplayName.ts
@@ -27,6 +27,12 @@ function includesIdentityText(value: string, candidate: string) {
   return value.toLocaleLowerCase().includes(candidate.toLocaleLowerCase());
 }
 
+function isCompactEditionCode(edition: string) {
+  return (
+    /\d/u.test(edition) && /^[A-Za-z0-9]+(?:[./-][A-Za-z0-9]+)*$/u.test(edition)
+  );
+}
+
 export function isBatchEdition(edition: string | null | undefined) {
   return edition
     ? /^batch(?:\s+(?:no\.?|number))?\s+\S/iu.test(edition)
@@ -92,9 +98,12 @@ function getReleaseName(bottle: BottleDisplayNameSource) {
   const expressionName = getExpressionName(bottle);
 
   if (bottle.edition && !isBatchEdition(bottle.edition)) {
-    return includesIdentityText(expressionName, bottle.edition)
-      ? expressionName
-      : `${expressionName} - ${bottle.edition}`;
+    if (includesIdentityText(expressionName, bottle.edition)) {
+      return expressionName;
+    }
+
+    const separator = isCompactEditionCode(bottle.edition) ? " " : " - ";
+    return `${expressionName}${separator}${bottle.edition}`;
   }
 
   return expressionName;


### PR DESCRIPTION
Human-facing bottle names now render compact edition codes inline, such as `Expression 9.3`, instead of applying the generic `Expression - 9.3` separator. The shared formatter carries this presentation through bottle pages, lists, search, notifications, email, and SEO.

The rule is limited to compact letter-and-number codes that contain a digit. Worded editions keep their separator, explicit batches remain release metadata, and stored canonical names do not change.
