### PR TITLE
feat(series): add public series pages

### DIFF
--- a/apps/server/migrations/0264_right_demogoblin.sql
+++ b/apps/server/migrations/0264_right_demogoblin.sql
@@ -1,0 +1,4 @@
+CREATE TABLE "bottle_series_tombstone" (
+	"series_id" bigint PRIMARY KEY NOT NULL,
+	"new_series_id" bigint
+);

--- a/apps/server/migrations/meta/0264_snapshot.json
+++ b/apps/server/migrations/meta/0264_snapshot.json
@@ -1,0 +1,10963 @@
+{
+  "id": "412debe6-5dd9-4a3b-bd7f-079606a6ea86",
+  "prevId": "4211a0eb-89ee-4176-a50f-4ddee67756dc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.bottle_release_promotion": {
+      "name": "bottle_release_promotion",
+      "schema": "",
+      "columns": {
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "promoted_bottle_id": {
+          "name": "promoted_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_release_promotion_bottle_idx": {
+          "name": "bottle_release_promotion_bottle_idx",
+          "columns": [
+            {
+              "expression": "promoted_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_release": {
+      "name": "bottle_release",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vintage_year": {
+          "name": "vintage_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abv": {
+          "name": "abv",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "single_cask": {
+          "name": "single_cask",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_strength": {
+          "name": "cask_strength",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stated_age": {
+          "name": "stated_age",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_size": {
+          "name": "cask_size",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_type": {
+          "name": "cask_type",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_fill": {
+          "name": "cask_fill",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tasting_notes": {
+          "name": "tasting_notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_tags": {
+          "name": "suggested_tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_release_bottle_idx": {
+          "name": "bottle_release_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_release_created_by_actor_idx": {
+          "name": "bottle_release_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_release_full_name_idx": {
+          "name": "bottle_release_full_name_idx",
+          "columns": [
+            {
+              "expression": "full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_release_bottle_id_bottle_id_fk": {
+          "name": "bottle_release_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_release",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_release_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_release_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_release",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bottle_release_stated_age_check": {
+          "name": "bottle_release_stated_age_check",
+          "value": "\"bottle_release\".\"stated_age\" IS NULL OR (\"bottle_release\".\"stated_age\" >= 0 AND \"bottle_release\".\"stated_age\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.legacy_release_repair_review": {
+      "name": "legacy_release_repair_review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "legacy_bottle_id": {
+          "name": "legacy_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_parent_full_name": {
+          "name": "proposed_parent_full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "legacy_bottle_fingerprint": {
+          "name": "legacy_bottle_fingerprint",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_candidates_fingerprint": {
+          "name": "parent_candidates_fingerprint",
+          "type": "varchar(40)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_edition": {
+          "name": "release_edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution": {
+          "name": "resolution",
+          "type": "legacy_release_repair_review_resolution",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_parent_bottle_id": {
+          "name": "reviewed_parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_reason": {
+          "name": "blocked_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_version": {
+          "name": "review_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "legacy_release_repair_review_bottle_idx": {
+          "name": "legacy_release_repair_review_bottle_idx",
+          "columns": [
+            {
+              "expression": "legacy_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_release_repair_review_parent_idx": {
+          "name": "legacy_release_repair_review_parent_idx",
+          "columns": [
+            {
+              "expression": "reviewed_parent_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "legacy_release_repair_review_resolution_idx": {
+          "name": "legacy_release_repair_review_resolution_idx",
+          "columns": [
+            {
+              "expression": "resolution",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor": {
+      "name": "actor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "actor_type_key_unq": {
+          "name": "actor_type_key_unq",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "actor_user_idx": {
+          "name": "actor_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "actor_user_id_user_id_fk": {
+          "name": "actor_user_id_user_id_fk",
+          "tableFrom": "actor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badge_award_tracked_object": {
+      "name": "badge_award_tracked_object",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "award_id": {
+          "name": "award_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "badge_award_object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "badge_award_tracked_object_unq": {
+          "name": "badge_award_tracked_object_unq",
+          "columns": [
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "badge_award_tracked_object_award_id_badge_award_id_fk": {
+          "name": "badge_award_tracked_object_award_id_badge_award_id_fk",
+          "tableFrom": "badge_award_tracked_object",
+          "tableTo": "badge_award",
+          "columnsFrom": [
+            "award_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badge_award": {
+      "name": "badge_award",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "badge_id": {
+          "name": "badge_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xp": {
+          "name": "xp",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "level": {
+          "name": "level",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "badge_award_unq": {
+          "name": "badge_award_unq",
+          "columns": [
+            {
+              "expression": "badge_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "badge_award_badge_id_badges_id_fk": {
+          "name": "badge_award_badge_id_badges_id_fk",
+          "tableFrom": "badge_award",
+          "tableTo": "badges",
+          "columnsFrom": [
+            "badge_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "badge_award_user_id_user_id_fk": {
+          "name": "badge_award_user_id_user_id_fk",
+          "tableFrom": "badge_award",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.badges": {
+      "name": "badges",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_level": {
+          "name": "max_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 50
+        },
+        "tracker": {
+          "name": "tracker",
+          "type": "badge_award_object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'bottle'"
+        },
+        "formula": {
+          "name": "formula",
+          "type": "badge_formula",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "checks": {
+          "name": "checks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        }
+      },
+      "indexes": {
+        "badge_name_unq": {
+          "name": "badge_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_check": {
+      "name": "bottle_check",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "intent": {
+          "name": "intent",
+          "type": "bottle_check_intent",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "bottle_check_origin",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subject_key": {
+          "name": "subject_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_event_key": {
+          "name": "background_event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "input_snapshot": {
+          "name": "input_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artifacts": {
+          "name": "artifacts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_metadata": {
+          "name": "model_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_price_match_proposal_id": {
+          "name": "store_price_match_proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "store_price_match_attempt_id": {
+          "name": "store_price_match_attempt_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_by_id": {
+          "name": "closed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_reason": {
+          "name": "close_reason",
+          "type": "bottle_check_close_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "close_note": {
+          "name": "close_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bottle_check_subject_created_idx": {
+          "name": "bottle_check_subject_created_idx",
+          "columns": [
+            {
+              "expression": "subject_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_bottle_idx": {
+          "name": "bottle_check_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_source_idx": {
+          "name": "bottle_check_source_idx",
+          "columns": [
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_background_event_unq": {
+          "name": "bottle_check_background_event_unq",
+          "columns": [
+            {
+              "expression": "background_event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_store_price_proposal_idx": {
+          "name": "bottle_check_store_price_proposal_idx",
+          "columns": [
+            {
+              "expression": "store_price_match_proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_store_price_attempt_idx": {
+          "name": "bottle_check_store_price_attempt_idx",
+          "columns": [
+            {
+              "expression": "store_price_match_attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_check_closed_idx": {
+          "name": "bottle_check_closed_idx",
+          "columns": [
+            {
+              "expression": "closed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_check_bottle_id_bottle_id_fk": {
+          "name": "bottle_check_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bottle_check_store_price_match_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "bottle_check_store_price_match_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "store_price_match_proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bottle_check_store_price_match_attempt_id_store_price_match_attempt_id_fk": {
+          "name": "bottle_check_store_price_match_attempt_id_store_price_match_attempt_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "store_price_match_attempt",
+          "columnsFrom": [
+            "store_price_match_attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "bottle_check_closed_by_id_user_id_fk": {
+          "name": "bottle_check_closed_by_id_user_id_fk",
+          "tableFrom": "bottle_check",
+          "tableTo": "user",
+          "columnsFrom": [
+            "closed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_operation": {
+      "name": "bottle_operation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "check_id": {
+          "name": "check_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal": {
+          "name": "proposal",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excluded_fields": {
+          "name": "excluded_fields",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "state_token": {
+          "name": "state_token",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preparation_error": {
+          "name": "preparation_error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "bottle_operation_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "bottle_operation_rejection_reason",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_note": {
+          "name": "reviewer_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_started_at": {
+          "name": "execution_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_completed_at": {
+          "name": "execution_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bottle_operation_check_idx": {
+          "name": "bottle_operation_check_idx",
+          "columns": [
+            {
+              "expression": "check_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_operation_status_idx": {
+          "name": "bottle_operation_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_operation_reviewer_idx": {
+          "name": "bottle_operation_reviewer_idx",
+          "columns": [
+            {
+              "expression": "reviewed_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_operation_check_id_bottle_check_id_fk": {
+          "name": "bottle_operation_check_id_bottle_check_id_fk",
+          "tableFrom": "bottle_operation",
+          "tableTo": "bottle_check",
+          "columnsFrom": [
+            "check_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_operation_reviewed_by_id_user_id_fk": {
+          "name": "bottle_operation_reviewed_by_id_user_id_fk",
+          "tableFrom": "bottle_operation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_alias": {
+      "name": "bottle_alias",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bottle_alias_bottle_normalized_name_idx": {
+          "name": "bottle_alias_bottle_normalized_name_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_alias_bottle_idx": {
+          "name": "bottle_alias_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_alias_created_by_actor_idx": {
+          "name": "bottle_alias_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_alias_bottle_id_bottle_id_fk": {
+          "name": "bottle_alias_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_alias",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_alias_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_alias_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_alias",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_barcode": {
+      "name": "bottle_barcode",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gtin14": {
+          "name": "gtin14",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_barcode_gtin14_unq": {
+          "name": "bottle_barcode_gtin14_unq",
+          "columns": [
+            {
+              "expression": "gtin14",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_barcode_bottle_idx": {
+          "name": "bottle_barcode_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_barcode_created_by_actor_idx": {
+          "name": "bottle_barcode_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_barcode_bottle_id_bottle_id_fk": {
+          "name": "bottle_barcode_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_barcode",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_barcode_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_barcode_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_barcode",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bottle_barcode_value_check": {
+          "name": "bottle_barcode_value_check",
+          "value": "\"bottle_barcode\".\"value\" ~ '^[0-9]+$' AND char_length(\"bottle_barcode\".\"value\") IN (8, 12, 13, 14)"
+        },
+        "bottle_barcode_gtin14_check": {
+          "name": "bottle_barcode_gtin14_check",
+          "value": "\"bottle_barcode\".\"gtin14\" ~ '^[0-9]{14}$'"
+        },
+        "bottle_barcode_volume_check": {
+          "name": "bottle_barcode_volume_check",
+          "value": "\"bottle_barcode\".\"volume\" IS NULL OR \"bottle_barcode\".\"volume\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bottle_flavor_profile": {
+      "name": "bottle_flavor_profile",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_flavor_profile_bottle_id_bottle_id_fk": {
+          "name": "bottle_flavor_profile_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_flavor_profile",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_flavor_profile_bottle_id_flavor_profile_pk": {
+          "name": "bottle_flavor_profile_bottle_id_flavor_profile_pk",
+          "columns": [
+            "bottle_id",
+            "flavor_profile"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_group_distiller": {
+      "name": "bottle_group_distiller",
+      "schema": "",
+      "columns": {
+        "group_id": {
+          "name": "group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distiller_id": {
+          "name": "distiller_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_group_distiller_group_id_bottle_group_id_fk": {
+          "name": "bottle_group_distiller_group_id_bottle_group_id_fk",
+          "tableFrom": "bottle_group_distiller",
+          "tableTo": "bottle_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_distiller_distiller_id_entity_id_fk": {
+          "name": "bottle_group_distiller_distiller_id_entity_id_fk",
+          "tableFrom": "bottle_group_distiller",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "distiller_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_group_distiller_group_id_distiller_id_pk": {
+          "name": "bottle_group_distiller_group_id_distiller_id_pk",
+          "columns": [
+            "group_id",
+            "distiller_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_group": {
+      "name": "bottle_group",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stated_age": {
+          "name": "stated_age",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottler_id": {
+          "name": "bottler_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "representative_bottle_id": {
+          "name": "representative_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "median_score": {
+          "name": "median_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_score": {
+          "name": "min_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_score_count": {
+          "name": "member_score_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_score_count": {
+          "name": "external_score_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tasting_band_counts": {
+          "name": "tasting_band_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"mediocre\":0,\"good\":0,\"very_good\":0,\"outstanding\":0,\"unicorn\":0}'::jsonb"
+        },
+        "rating_stats": {
+          "name": "rating_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pass\":0,\"sip\":0,\"savor\":0,\"total\":0,\"avg\":null,\"percentage\":{\"pass\":0,\"sip\":0,\"savor\":0}}'::jsonb"
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_group_brand_idx": {
+          "name": "bottle_group_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_bottler_idx": {
+          "name": "bottle_group_bottler_idx",
+          "columns": [
+            {
+              "expression": "bottler_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_series_idx": {
+          "name": "bottle_group_series_idx",
+          "columns": [
+            {
+              "expression": "series_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_category_idx": {
+          "name": "bottle_group_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_representative_bottle_idx": {
+          "name": "bottle_group_representative_bottle_idx",
+          "columns": [
+            {
+              "expression": "representative_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_group_created_by_actor_idx": {
+          "name": "bottle_group_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_group_series_id_bottle_series_id_fk": {
+          "name": "bottle_group_series_id_bottle_series_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "bottle_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_brand_id_entity_id_fk": {
+          "name": "bottle_group_brand_id_entity_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_bottler_id_entity_id_fk": {
+          "name": "bottle_group_bottler_id_entity_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "bottler_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_group_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_group_representative_membership_fk": {
+          "name": "bottle_group_representative_membership_fk",
+          "tableFrom": "bottle_group",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "representative_bottle_id",
+            "id"
+          ],
+          "columnsTo": [
+            "id",
+            "group_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "bottle_group_stated_age_check": {
+          "name": "bottle_group_stated_age_check",
+          "value": "\"bottle_group\".\"stated_age\" IS NULL OR (\"bottle_group\".\"stated_age\" >= 0 AND \"bottle_group\".\"stated_age\" <= 100)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bottle_image": {
+      "name": "bottle_image",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bottle_image_bottle_idx": {
+          "name": "bottle_image_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_image_created_by_actor_idx": {
+          "name": "bottle_image_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_image_primary_unq": {
+          "name": "bottle_image_primary_unq",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"bottle_image\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_image_bottle_id_bottle_id_fk": {
+          "name": "bottle_image_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_image",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_image_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_image_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_image",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_observation": {
+      "name": "bottle_observation",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_text": {
+          "name": "raw_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parsed_identity": {
+          "name": "parsed_identity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "facts": {
+          "name": "facts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "bottle_observation_source_idx": {
+          "name": "bottle_observation_source_idx",
+          "columns": [
+            {
+              "expression": "source_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_bottle_idx": {
+          "name": "bottle_observation_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_release_idx": {
+          "name": "bottle_observation_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_observation_external_site_idx": {
+          "name": "bottle_observation_external_site_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_observation_bottle_id_bottle_id_fk": {
+          "name": "bottle_observation_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bottle_observation_external_site_id_external_site_id_fk": {
+          "name": "bottle_observation_external_site_id_external_site_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_observation_created_by_id_user_id_fk": {
+          "name": "bottle_observation_created_by_id_user_id_fk",
+          "tableFrom": "bottle_observation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_reference": {
+      "name": "bottle_reference",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(3072)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ignored": {
+          "name": "ignored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "assignment_source": {
+          "name": "assignment_source",
+          "type": "bottle_reference_assignment_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'legacy'"
+        },
+        "assigned_by_actor_id": {
+          "name": "assigned_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_by_actor_id": {
+          "name": "reviewed_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "bottle_reference_name_idx": {
+          "name": "bottle_reference_name_idx",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_reference_bottle_idx": {
+          "name": "bottle_reference_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_reference_release_idx": {
+          "name": "bottle_reference_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_reference_assigned_by_actor_idx": {
+          "name": "bottle_reference_assigned_by_actor_idx",
+          "columns": [
+            {
+              "expression": "assigned_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_reference_reviewed_by_actor_idx": {
+          "name": "bottle_reference_reviewed_by_actor_idx",
+          "columns": [
+            {
+              "expression": "reviewed_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_reference_bottle_id_bottle_id_fk": {
+          "name": "bottle_reference_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_reference",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_reference_assigned_by_actor_id_actor_id_fk": {
+          "name": "bottle_reference_assigned_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_reference",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "assigned_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_reference_reviewed_by_actor_id_actor_id_fk": {
+          "name": "bottle_reference_reviewed_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_reference",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "reviewed_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_series": {
+      "name": "bottle_series",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "num_releases": {
+          "name": "num_releases",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_series_full_name_key": {
+          "name": "bottle_series_full_name_key",
+          "columns": [
+            {
+              "expression": "LOWER(\"full_name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_series_search_idx": {
+          "name": "bottle_series_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bottle_series_brand_idx": {
+          "name": "bottle_series_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_series_created_by_actor_idx": {
+          "name": "bottle_series_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_series_brand_id_entity_id_fk": {
+          "name": "bottle_series_brand_id_entity_id_fk",
+          "tableFrom": "bottle_series",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_series_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_series_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle_series",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_series_tombstone": {
+      "name": "bottle_series_tombstone",
+      "schema": "",
+      "columns": {
+        "series_id": {
+          "name": "series_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_series_id": {
+          "name": "new_series_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_tag": {
+      "name": "bottle_tag",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag": {
+          "name": "tag",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "count": {
+          "name": "count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bottle_tag_bottle_id_bottle_id_fk": {
+          "name": "bottle_tag_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_tag",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_tag_bottle_id_tag_pk": {
+          "name": "bottle_tag_bottle_id_tag_pk",
+          "columns": [
+            "bottle_id",
+            "tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle_tombstone": {
+      "name": "bottle_tombstone",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_bottle_id": {
+          "name": "new_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.bottle": {
+      "name": "bottle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stated_age": {
+          "name": "stated_age",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "no_age_statement": {
+          "name": "no_age_statement",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "series_id": {
+          "name": "series_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "brand_id": {
+          "name": "brand_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottler_id": {
+          "name": "bottler_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "edition": {
+          "name": "edition",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "abv": {
+          "name": "abv",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "single_cask": {
+          "name": "single_cask",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_strength": {
+          "name": "cask_strength",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "natural_color": {
+          "name": "natural_color",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "non_chill_filtered": {
+          "name": "non_chill_filtered",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "malt_phenol_ppm": {
+          "name": "malt_phenol_ppm",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vintage_year": {
+          "name": "vintage_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bottling_year": {
+          "name": "bottling_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_year": {
+          "name": "release_year",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_month": {
+          "name": "release_month",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_day": {
+          "name": "release_day",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_date": {
+          "name": "release_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "maturation": {
+          "name": "maturation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cask_number": {
+          "name": "cask_number",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outturn": {
+          "name": "outturn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_image_urls": {
+          "name": "rejected_image_urls",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::text[]"
+        },
+        "tasting_notes": {
+          "name": "tasting_notes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_tags": {
+          "name": "suggested_tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "avg_rating": {
+          "name": "avg_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "median_score": {
+          "name": "median_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_score": {
+          "name": "min_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_score": {
+          "name": "max_score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "member_score_count": {
+          "name": "member_score_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "external_score_count": {
+          "name": "external_score_count",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tasting_band_counts": {
+          "name": "tasting_band_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"mediocre\":0,\"good\":0,\"very_good\":0,\"outstanding\":0,\"unicorn\":0}'::jsonb"
+        },
+        "rating_stats": {
+          "name": "rating_stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"pass\":0,\"sip\":0,\"savor\":0,\"total\":0,\"avg\":null,\"percentage\":{\"pass\":0,\"sip\":0,\"savor\":0}}'::jsonb"
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "num_releases": {
+          "name": "num_releases",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_group_idx": {
+          "name": "bottle_group_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_search_idx": {
+          "name": "bottle_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "bottle_brand_idx": {
+          "name": "bottle_brand_idx",
+          "columns": [
+            {
+              "expression": "brand_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_bottler_idx": {
+          "name": "bottle_bottler_idx",
+          "columns": [
+            {
+              "expression": "bottler_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_created_by_actor_idx": {
+          "name": "bottle_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_category_idx": {
+          "name": "bottle_category_idx",
+          "columns": [
+            {
+              "expression": "category",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_flavor_profile_idx": {
+          "name": "bottle_flavor_profile_idx",
+          "columns": [
+            {
+              "expression": "flavor_profile",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "bottle_release_sort_idx": {
+          "name": "bottle_release_sort_idx",
+          "columns": [
+            {
+              "expression": "release_year",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "release_month",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "release_day",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_group_id_bottle_group_id_fk": {
+          "name": "bottle_group_id_bottle_group_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "bottle_group",
+          "columnsFrom": [
+            "group_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_series_id_bottle_series_id_fk": {
+          "name": "bottle_series_id_bottle_series_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "bottle_series",
+          "columnsFrom": [
+            "series_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_brand_id_entity_id_fk": {
+          "name": "bottle_brand_id_entity_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "brand_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_bottler_id_entity_id_fk": {
+          "name": "bottle_bottler_id_entity_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "bottler_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_created_by_actor_id_actor_id_fk": {
+          "name": "bottle_created_by_actor_id_actor_id_fk",
+          "tableFrom": "bottle",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bottle_id_group_id_unq": {
+          "name": "bottle_id_group_id_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "group_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "bottle_stated_age_check": {
+          "name": "bottle_stated_age_check",
+          "value": "\"bottle\".\"stated_age\" IS NULL OR (\"bottle\".\"stated_age\" >= 0 AND \"bottle\".\"stated_age\" <= 100)"
+        },
+        "bottle_age_statement_check": {
+          "name": "bottle_age_statement_check",
+          "value": "\"bottle\".\"stated_age\" IS NULL OR \"bottle\".\"no_age_statement\" IS NOT TRUE"
+        },
+        "bottle_abv_check": {
+          "name": "bottle_abv_check",
+          "value": "\"bottle\".\"abv\" IS NULL OR (\"bottle\".\"abv\" >= 0 AND \"bottle\".\"abv\" <= 100)"
+        },
+        "bottle_malt_phenol_ppm_check": {
+          "name": "bottle_malt_phenol_ppm_check",
+          "value": "\"bottle\".\"malt_phenol_ppm\" IS NULL OR \"bottle\".\"malt_phenol_ppm\" >= 0"
+        },
+        "bottle_vintage_year_check": {
+          "name": "bottle_vintage_year_check",
+          "value": "\"bottle\".\"vintage_year\" IS NULL OR \"bottle\".\"vintage_year\" >= 1800"
+        },
+        "bottle_bottling_year_check": {
+          "name": "bottle_bottling_year_check",
+          "value": "\"bottle\".\"bottling_year\" IS NULL OR \"bottle\".\"bottling_year\" >= 1800"
+        },
+        "bottle_release_year_check": {
+          "name": "bottle_release_year_check",
+          "value": "\"bottle\".\"release_year\" IS NULL OR \"bottle\".\"release_year\" >= 1800"
+        },
+        "bottle_release_month_check": {
+          "name": "bottle_release_month_check",
+          "value": "\"bottle\".\"release_month\" IS NULL OR (\"bottle\".\"release_year\" IS NOT NULL AND \"bottle\".\"release_month\" BETWEEN 1 AND 12)"
+        },
+        "bottle_release_day_check": {
+          "name": "bottle_release_day_check",
+          "value": "CASE\n        WHEN \"bottle\".\"release_day\" IS NULL THEN TRUE\n        WHEN \"bottle\".\"release_year\" IS NULL OR \"bottle\".\"release_month\" IS NULL OR \"bottle\".\"release_month\" NOT BETWEEN 1 AND 12 THEN FALSE\n        ELSE \"bottle\".\"release_day\" BETWEEN 1 AND EXTRACT(DAY FROM (MAKE_DATE(\"bottle\".\"release_year\", \"bottle\".\"release_month\", 1) + INTERVAL '1 month - 1 day'))\n      END"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.bottle_distiller": {
+      "name": "bottle_distiller",
+      "schema": "",
+      "columns": {
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distiller_id": {
+          "name": "distiller_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "bottle_distiller_distiller_bottle_idx": {
+          "name": "bottle_distiller_distiller_bottle_idx",
+          "columns": [
+            {
+              "expression": "distiller_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "bottle_distiller_bottle_id_bottle_id_fk": {
+          "name": "bottle_distiller_bottle_id_bottle_id_fk",
+          "tableFrom": "bottle_distiller",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "bottle_distiller_distiller_id_entity_id_fk": {
+          "name": "bottle_distiller_distiller_id_entity_id_fk",
+          "tableFrom": "bottle_distiller",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "distiller_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "bottle_distiller_bottle_id_distiller_id_pk": {
+          "name": "bottle_distiller_bottle_id_distiller_id_pk",
+          "columns": [
+            "bottle_id",
+            "distiller_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.change": {
+      "name": "change",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "object_type": {
+          "name": "object_type",
+          "type": "object_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'add'"
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "change_actor_idx": {
+          "name": "change_actor_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "change_actor_id_actor_id_fk": {
+          "name": "change_actor_id_actor_id_fk",
+          "tableFrom": "change",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection_bottle": {
+      "name": "collection_bottle",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "collection_bottle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "collection_bottle_bottle_idx": {
+          "name": "collection_bottle_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_bottle_release_idx": {
+          "name": "collection_bottle_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_bottle_collection_id_collection_id_fk": {
+          "name": "collection_bottle_collection_id_collection_id_fk",
+          "tableFrom": "collection_bottle",
+          "tableTo": "collection",
+          "columnsFrom": [
+            "collection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collection_bottle_bottle_id_bottle_id_fk": {
+          "name": "collection_bottle_bottle_id_bottle_id_fk",
+          "tableFrom": "collection_bottle",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "collection_bottle_collection_id_bottle_id_unique": {
+          "name": "collection_bottle_collection_id_bottle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "collection_id",
+            "bottle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collection": {
+      "name": "collection",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "collection_name_unq": {
+          "name": "collection_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\"), \"created_by_id\"",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collection_created_by_idx": {
+          "name": "collection_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collection_created_by_id_user_id_fk": {
+          "name": "collection_created_by_id_user_id_fk",
+          "tableFrom": "collection",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "comment_unq": {
+          "name": "comment_unq",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "comments_tasting_id_tasting_id_fk": {
+          "name": "comments_tasting_id_tasting_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_created_by_id_user_id_fk": {
+          "name": "comments_created_by_id_user_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.country": {
+      "name": "country",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alpha2": {
+          "name": "alpha2",
+          "type": "char(2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_distillers": {
+          "name": "total_distillers",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "country_name_unq": {
+          "name": "country_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "country_slug_unq": {
+          "name": "country_slug_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity": {
+      "name": "entity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_vector": {
+          "name": "search_vector",
+          "type": "tsvector",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region_id": {
+          "name": "region_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "entity_type[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "ARRAY[]::entity_type[]"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "entity_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year_established": {
+          "name": "year_established",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_tastings": {
+          "name": "total_tastings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "entity_name_unq": {
+          "name": "entity_name_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_kind_idx": {
+          "name": "entity_kind_idx",
+          "columns": [
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_owner_idx": {
+          "name": "entity_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_search_idx": {
+          "name": "entity_search_idx",
+          "columns": [
+            {
+              "expression": "search_vector",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        },
+        "entity_country_by_idx": {
+          "name": "entity_country_by_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_region_idx": {
+          "name": "entity_region_idx",
+          "columns": [
+            {
+              "expression": "region_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_created_by_actor_idx": {
+          "name": "entity_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_country_id_country_id_fk": {
+          "name": "entity_country_id_country_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_region_id_region_id_fk": {
+          "name": "entity_region_id_region_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "region",
+          "columnsFrom": [
+            "region_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_created_by_actor_id_actor_id_fk": {
+          "name": "entity_created_by_actor_id_actor_id_fk",
+          "tableFrom": "entity",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_owner_fk": {
+          "name": "entity_owner_fk",
+          "tableFrom": "entity",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_alias": {
+      "name": "entity_alias",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "normalized_name": {
+          "name": "normalized_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entity_alias_entity_normalized_name_idx": {
+          "name": "entity_alias_entity_normalized_name_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "normalized_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_alias_entity_idx": {
+          "name": "entity_alias_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_alias_created_by_actor_idx": {
+          "name": "entity_alias_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_alias_entity_id_entity_id_fk": {
+          "name": "entity_alias_entity_id_entity_id_fk",
+          "tableFrom": "entity_alias",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_alias_created_by_actor_id_actor_id_fk": {
+          "name": "entity_alias_created_by_actor_id_actor_id_fk",
+          "tableFrom": "entity_alias",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_image": {
+      "name": "entity_image",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caption": {
+          "name": "caption",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_primary": {
+          "name": "is_primary",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entity_image_entity_idx": {
+          "name": "entity_image_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_image_created_by_actor_idx": {
+          "name": "entity_image_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_image_primary_unq": {
+          "name": "entity_image_primary_unq",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"entity_image\".\"is_primary\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_image_idempotency_unq": {
+          "name": "entity_image_idempotency_unq",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_image_entity_id_entity_id_fk": {
+          "name": "entity_image_entity_id_entity_id_fk",
+          "tableFrom": "entity_image",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_image_created_by_actor_id_actor_id_fk": {
+          "name": "entity_image_created_by_actor_id_actor_id_fk",
+          "tableFrom": "entity_image",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_reference": {
+      "name": "entity_reference",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entity_reference_entity_idx": {
+          "name": "entity_reference_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_reference_name_idx": {
+          "name": "entity_reference_name_idx",
+          "columns": [
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_reference_entity_id_entity_id_fk": {
+          "name": "entity_reference_entity_id_entity_id_fk",
+          "tableFrom": "entity_reference",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_tombstone": {
+      "name": "entity_tombstone",
+      "schema": "",
+      "columns": {
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "new_entity_id": {
+          "name": "new_entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.entity_event": {
+      "name": "entity_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "entity_event_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "new_owner_id": {
+          "name": "new_owner_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entity_event_entity_date_idx": {
+          "name": "entity_event_entity_date_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_event_new_owner_idx": {
+          "name": "entity_event_new_owner_idx",
+          "columns": [
+            {
+              "expression": "new_owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "entity_event_created_by_actor_idx": {
+          "name": "entity_event_created_by_actor_idx",
+          "columns": [
+            {
+              "expression": "created_by_actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_event_entity_id_entity_id_fk": {
+          "name": "entity_event_entity_id_entity_id_fk",
+          "tableFrom": "entity_event",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_event_new_owner_id_entity_id_fk": {
+          "name": "entity_event_new_owner_id_entity_id_fk",
+          "tableFrom": "entity_event",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "new_owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "entity_event_created_by_actor_id_actor_id_fk": {
+          "name": "entity_event_created_by_actor_id_actor_id_fk",
+          "tableFrom": "entity_event",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "created_by_actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "entity_event_date_check": {
+          "name": "entity_event_date_check",
+          "value": "\"entity_event\".\"date\" ~ '^[0-9]{4}(-[0-9]{2}(-[0-9]{2})?)?$'"
+        },
+        "entity_event_generic_description_check": {
+          "name": "entity_event_generic_description_check",
+          "value": "\"entity_event\".\"kind\" <> 'generic' OR NULLIF(BTRIM(\"entity_event\".\"description\"), '') IS NOT NULL"
+        },
+        "entity_event_owner_check": {
+          "name": "entity_event_owner_check",
+          "value": "(\"entity_event\".\"kind\" = 'acquired' AND \"entity_event\".\"new_owner_id\" IS NOT NULL) OR (\"entity_event\".\"kind\" <> 'acquired' AND \"entity_event\".\"new_owner_id\" IS NULL)"
+        },
+        "entity_event_owner_not_self_check": {
+          "name": "entity_event_owner_not_self_check",
+          "value": "\"entity_event\".\"new_owner_id\" IS NULL OR \"entity_event\".\"entity_id\" <> \"entity_event\".\"new_owner_id\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.entity_follow": {
+      "name": "entity_follow",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "entity_follow_entity_idx": {
+          "name": "entity_follow_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "entity_follow_user_id_user_id_fk": {
+          "name": "entity_follow_user_id_user_id_fk",
+          "tableFrom": "entity_follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "entity_follow_entity_id_entity_id_fk": {
+          "name": "entity_follow_entity_id_entity_id_fk",
+          "tableFrom": "entity_follow",
+          "tableTo": "entity",
+          "columnsFrom": [
+            "entity_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "entity_follow_user_id_entity_id_pk": {
+          "name": "entity_follow_user_id_entity_id_pk",
+          "columns": [
+            "user_id",
+            "entity_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event": {
+      "name": "event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_start": {
+          "name": "date_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date_end": {
+          "name": "date_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repeats": {
+          "name": "repeats",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_name_unq": {
+          "name": "event_name_unq",
+          "columns": [
+            {
+              "expression": "date_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "event_country_id": {
+          "name": "event_country_id",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_country_id_country_id_fk": {
+          "name": "event_country_id_country_id_fk",
+          "tableFrom": "event",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "event_date_range_check": {
+          "name": "event_date_range_check",
+          "value": "\"event\".\"date_end\" IS NULL OR \"event\".\"date_end\" >= \"event\".\"date_start\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_review_publication": {
+      "name": "external_review_publication",
+      "schema": "",
+      "columns": {
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "external_review_publication_external_site_id_external_site_id_fk": {
+          "name": "external_review_publication_external_site_id_external_site_id_fk",
+          "tableFrom": "external_review_publication",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review_article": {
+      "name": "review_article",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "issue": {
+          "name": "issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_article_site_url_unq": {
+          "name": "review_article_site_url_unq",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "canonical_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_article_external_site_id_external_site_id_fk": {
+          "name": "review_article_external_site_id_external_site_id_fk",
+          "tableFrom": "review_article",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.review": {
+      "name": "review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_key": {
+          "name": "source_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewer_name": {
+          "name": "reviewer_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "native_score_value": {
+          "name": "native_score_value",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "native_score_scale": {
+          "name": "native_score_scale",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "native_score_display": {
+          "name": "native_score_display",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "review_article_source_key_unq": {
+          "name": "review_article_source_key_unq",
+          "columns": [
+            {
+              "expression": "article_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_bottle_idx": {
+          "name": "review_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_article_idx": {
+          "name": "review_article_idx",
+          "columns": [
+            {
+              "expression": "article_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "review_release_idx": {
+          "name": "review_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "review_bottle_id_bottle_id_fk": {
+          "name": "review_bottle_id_bottle_id_fk",
+          "tableFrom": "review",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "review_article_id_review_article_id_fk": {
+          "name": "review_article_id_review_article_id_fk",
+          "tableFrom": "review",
+          "tableTo": "review_article",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "review_rating_check": {
+          "name": "review_rating_check",
+          "value": "\"review\".\"rating\" IS NULL OR \"review\".\"rating\" BETWEEN 0 AND 100"
+        },
+        "review_native_score_check": {
+          "name": "review_native_score_check",
+          "value": "(\n        \"review\".\"native_score_value\" IS NULL\n        AND \"review\".\"native_score_scale\" IS NULL\n        AND \"review\".\"native_score_display\" IS NULL\n      ) OR (\n        \"review\".\"native_score_value\" IS NOT NULL\n        AND \"review\".\"native_score_scale\" IS NOT NULL\n        AND \"review\".\"native_score_display\" IS NOT NULL\n        AND \"review\".\"native_score_value\" >= 0\n        AND \"review\".\"native_score_scale\" > 0\n        AND \"review\".\"native_score_value\" <= \"review\".\"native_score_scale\"\n      )"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_site_config": {
+      "name": "external_site_config",
+      "schema": "",
+      "columns": {
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "external_site_config_external_site_id_external_site_id_fk": {
+          "name": "external_site_config_external_site_id_external_site_id_fk",
+          "tableFrom": "external_site_config",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "external_site_config_external_site_id_key_pk": {
+          "name": "external_site_config_external_site_id_key_pk",
+          "columns": [
+            "external_site_id",
+            "key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_site_run": {
+      "name": "external_site_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "external_site_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "external_site_run_trigger",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_id": {
+          "name": "requested_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempt_count": {
+          "name": "attempt_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_limit": {
+          "name": "request_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "slice_request_count": {
+          "name": "slice_request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "request_count": {
+          "name": "request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rate_limit_count": {
+          "name": "rate_limit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "emitted_item_count": {
+          "name": "emitted_item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_attempt_at": {
+          "name": "next_attempt_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_token": {
+          "name": "execution_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_expires_at": {
+          "name": "execution_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_count": {
+          "name": "item_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_site_run_active_unq": {
+          "name": "external_site_run_active_unq",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"external_site_run\".\"status\" IN ('queued', 'running')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_site_run_site_created_idx": {
+          "name": "external_site_run_site_created_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_site_run_site_status_completed_idx": {
+          "name": "external_site_run_site_status_completed_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "completed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "external_site_run_dispatch_idx": {
+          "name": "external_site_run_dispatch_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_attempt_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "execution_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_site_run_external_site_id_external_site_id_fk": {
+          "name": "external_site_run_external_site_id_external_site_id_fk",
+          "tableFrom": "external_site_run",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_site_run_requested_by_id_user_id_fk": {
+          "name": "external_site_run_requested_by_id_user_id_fk",
+          "tableFrom": "external_site_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "requested_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "external_site_run_request_budget_check": {
+          "name": "external_site_run_request_budget_check",
+          "value": "\"external_site_run\".\"request_limit\" > 0\n        AND \"external_site_run\".\"slice_request_count\" >= 0\n        AND \"external_site_run\".\"slice_request_count\" <= \"external_site_run\".\"request_limit\"\n        AND \"external_site_run\".\"request_count\" >= 0\n        AND \"external_site_run\".\"retry_count\" >= 0\n        AND \"external_site_run\".\"rate_limit_count\" >= 0\n        AND \"external_site_run\".\"emitted_item_count\" >= 0"
+        },
+        "external_site_run_execution_pair_check": {
+          "name": "external_site_run_execution_pair_check",
+          "value": "(\"external_site_run\".\"execution_token\" IS NULL) = (\"external_site_run\".\"execution_expires_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.external_site": {
+      "name": "external_site",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_run_id": {
+          "name": "last_run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_every": {
+          "name": "run_every",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 60
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_site_type": {
+          "name": "external_site_type",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_site_last_run_id_external_site_run_id_fk": {
+          "name": "external_site_last_run_id_external_site_run_id_fk",
+          "tableFrom": "external_site",
+          "tableTo": "external_site_run",
+          "columnsFrom": [
+            "last_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight_bottle": {
+      "name": "flight_bottle",
+      "schema": "",
+      "columns": {
+        "flight_id": {
+          "name": "flight_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "flight_bottle_bottle_idx": {
+          "name": "flight_bottle_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "flight_bottle_release_idx": {
+          "name": "flight_bottle_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flight_bottle_flight_id_flight_id_fk": {
+          "name": "flight_bottle_flight_id_flight_id_fk",
+          "tableFrom": "flight_bottle",
+          "tableTo": "flight",
+          "columnsFrom": [
+            "flight_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "flight_bottle_bottle_id_bottle_id_fk": {
+          "name": "flight_bottle_bottle_id_bottle_id_fk",
+          "tableFrom": "flight_bottle",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "flight_bottle_flight_id_bottle_id_unique": {
+          "name": "flight_bottle_flight_id_bottle_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "flight_id",
+            "bottle_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.flight": {
+      "name": "flight",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "public_id": {
+          "name": "public_id",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "flight_public_id": {
+          "name": "flight_public_id",
+          "columns": [
+            {
+              "expression": "public_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "flight_created_by_id_user_id_fk": {
+          "name": "flight_created_by_id_user_id_fk",
+          "tableFrom": "flight",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.follow": {
+      "name": "follow",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "follow_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "follow_unq": {
+          "name": "follow_unq",
+          "columns": [
+            {
+              "expression": "from_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "follow_to_user_idx": {
+          "name": "follow_to_user_idx",
+          "columns": [
+            {
+              "expression": "to_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "follow_from_user_id_user_id_fk": {
+          "name": "follow_from_user_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "follow_to_user_id_user_id_fk": {
+          "name": "follow_to_user_id_user_id_fk",
+          "tableFrom": "follow",
+          "tableTo": "user",
+          "columnsFrom": [
+            "to_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity": {
+      "name": "identity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "identity_provider",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "identity_unq": {
+          "name": "identity_unq",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "identity_user_idx": {
+          "name": "identity_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "identity_user_id_user_id_fk": {
+          "name": "identity_user_id_user_id_fk",
+          "tableFrom": "identity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.incoming_bottle_decision_log": {
+      "name": "incoming_bottle_decision_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "incoming_bottle_decision_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decision": {
+          "name": "decision",
+          "type": "incoming_bottle_decision_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_bottle": {
+          "name": "created_bottle",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_release": {
+          "name": "created_release",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "incoming_bottle_decision_source_unq": {
+          "name": "incoming_bottle_decision_source_unq",
+          "columns": [
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_created_idx": {
+          "name": "incoming_bottle_decision_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_external_site_idx": {
+          "name": "incoming_bottle_decision_external_site_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_bottle_idx": {
+          "name": "incoming_bottle_decision_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_release_idx": {
+          "name": "incoming_bottle_decision_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "incoming_bottle_decision_actor_ref_idx": {
+          "name": "incoming_bottle_decision_actor_ref_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "incoming_bottle_decision_log_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "incoming_bottle_decision_log_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_external_site_id_external_site_id_fk": {
+          "name": "incoming_bottle_decision_log_external_site_id_external_site_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_actor_id_actor_id_fk": {
+          "name": "incoming_bottle_decision_log_actor_id_actor_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "actor",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "incoming_bottle_decision_log_bottle_id_bottle_id_fk": {
+          "name": "incoming_bottle_decision_log_bottle_id_bottle_id_fk",
+          "tableFrom": "incoming_bottle_decision_log",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_review": {
+      "name": "member_review",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "color": {
+          "name": "color",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_style": {
+          "name": "serving_style",
+          "type": "servingStyle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "friends": {
+          "name": "friends",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::bigint[]"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "member_review_bottle_member_unq": {
+          "name": "member_review_bottle_member_unq",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_review_bottle_idx": {
+          "name": "member_review_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "member_review_created_by_idx": {
+          "name": "member_review_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_review_bottle_id_bottle_id_fk": {
+          "name": "member_review_bottle_id_bottle_id_fk",
+          "tableFrom": "member_review",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_review_created_by_id_user_id_fk": {
+          "name": "member_review_created_by_id_user_id_fk",
+          "tableFrom": "member_review",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "member_review_score_check": {
+          "name": "member_review_score_check",
+          "value": "\"member_review\".\"score\" BETWEEN 0 AND 100"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_id": {
+          "name": "object_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "notification_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "read": {
+          "name": "read",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "notifications_unq": {
+          "name": "notifications_unq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "object_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notifications_from_user_id_user_id_fk": {
+          "name": "notifications_from_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "from_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_authorization_code": {
+      "name": "oauth_authorization_code",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code_digest": {
+          "name": "code_digest",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "oauth_client_id": {
+          "name": "oauth_client_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uri": {
+          "name": "redirect_uri",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code_challenge": {
+          "name": "code_challenge",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "oauth_authorization_code_digest_unq": {
+          "name": "oauth_authorization_code_digest_unq",
+          "columns": [
+            {
+              "expression": "code_digest",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_code_client_idx": {
+          "name": "oauth_authorization_code_client_idx",
+          "columns": [
+            {
+              "expression": "oauth_client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_code_user_idx": {
+          "name": "oauth_authorization_code_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "oauth_authorization_code_expires_idx": {
+          "name": "oauth_authorization_code_expires_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "oauth_authorization_code_oauth_client_id_oauth_client_id_fk": {
+          "name": "oauth_authorization_code_oauth_client_id_oauth_client_id_fk",
+          "tableFrom": "oauth_authorization_code",
+          "tableTo": "oauth_client",
+          "columnsFrom": [
+            "oauth_client_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "oauth_authorization_code_user_id_user_id_fk": {
+          "name": "oauth_authorization_code_user_id_user_id_fk",
+          "tableFrom": "oauth_authorization_code",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_client": {
+      "name": "oauth_client",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "client_id": {
+          "name": "client_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_uris": {
+          "name": "redirect_uris",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "oauth_client_client_id_unq": {
+          "name": "oauth_client_client_id_unq",
+          "columns": [
+            {
+              "expression": "client_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.passkey": {
+      "name": "passkey",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "credential_id": {
+          "name": "credential_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public_key": {
+          "name": "public_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "counter": {
+          "name": "counter",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "transports": {
+          "name": "transports",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "passkey_credential_id_unq": {
+          "name": "passkey_credential_id_unq",
+          "columns": [
+            {
+              "expression": "credential_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "passkey_user_idx": {
+          "name": "passkey_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "passkey_user_id_user_id_fk": {
+          "name": "passkey_user_id_user_id_fk",
+          "tableFrom": "passkey",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_upload": {
+      "name": "pending_upload",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "pendingUploadKind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "pendingUploadPurpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "pendingUploadStatus",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_to_type": {
+          "name": "attached_to_type",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attached_to_id": {
+          "name": "attached_to_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "object_deleted_at": {
+          "name": "object_deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_upload_created_by_idx": {
+          "name": "pending_upload_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_upload_status_expires_at_idx": {
+          "name": "pending_upload_status_expires_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_upload_created_by_id_user_id_fk": {
+          "name": "pending_upload_created_by_id_user_id_fk",
+          "tableFrom": "pending_upload",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pending_upload_idempotency_key": {
+          "name": "pending_upload_idempotency_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "created_by_id",
+            "purpose",
+            "idempotency_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.region": {
+      "name": "region",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_id": {
+          "name": "country_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "geometry(Point, 4326)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description_src": {
+          "name": "description_src",
+          "type": "content_source",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_bottles": {
+          "name": "total_bottles",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_distillers": {
+          "name": "total_distillers",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "region_name_unq": {
+          "name": "region_name_unq",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "region_slug_unq": {
+          "name": "region_slug_unq",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"slug\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "region_country_idx": {
+          "name": "region_country_idx",
+          "columns": [
+            {
+              "expression": "country_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "region_country_id_country_id_fk": {
+          "name": "region_country_id_country_id_fk",
+          "tableFrom": "region",
+          "tableTo": "country",
+          "columnsFrom": [
+            "country_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.external_site_scrape_target": {
+      "name": "external_site_scrape_target",
+      "schema": "",
+      "columns": {
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "managed_by": {
+          "name": "managed_by",
+          "type": "scrape_definition_manager",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'code'"
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "external_site_scrape_target_target_idx": {
+          "name": "external_site_scrape_target_target_idx",
+          "columns": [
+            {
+              "expression": "target_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "external_site_scrape_target_external_site_id_external_site_id_fk": {
+          "name": "external_site_scrape_target_external_site_id_external_site_id_fk",
+          "tableFrom": "external_site_scrape_target",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "external_site_scrape_target_target_key_scrape_target_key_fk": {
+          "name": "external_site_scrape_target_target_key_scrape_target_key_fk",
+          "tableFrom": "external_site_scrape_target",
+          "tableTo": "scrape_target",
+          "columnsFrom": [
+            "target_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "external_site_scrape_target_external_site_id_target_key_pk": {
+          "name": "external_site_scrape_target_external_site_id_target_key_pk",
+          "columns": [
+            "external_site_id",
+            "target_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scrape_origin": {
+      "name": "scrape_origin",
+      "schema": "",
+      "columns": {
+        "origin": {
+          "name": "origin",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "managed_by": {
+          "name": "managed_by",
+          "type": "scrape_definition_manager",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'code'"
+        },
+        "target_key": {
+          "name": "target_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "robots_mode": {
+          "name": "robots_mode",
+          "type": "scrape_origin_robots_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "robots_rationale": {
+          "name": "robots_rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "robots_state": {
+          "name": "robots_state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "robots_fetched_at": {
+          "name": "robots_fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "robots_expires_at": {
+          "name": "robots_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scrape_origin_target_idx": {
+          "name": "scrape_origin_target_idx",
+          "columns": [
+            {
+              "expression": "target_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scrape_origin_target_key_scrape_target_key_fk": {
+          "name": "scrape_origin_target_key_scrape_target_key_fk",
+          "tableFrom": "scrape_origin",
+          "tableTo": "scrape_target",
+          "columnsFrom": [
+            "target_key"
+          ],
+          "columnsTo": [
+            "key"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scrape_origin_value_check": {
+          "name": "scrape_origin_value_check",
+          "value": "\"scrape_origin\".\"origin\" ~ '^https?://[^/]+$'"
+        },
+        "scrape_origin_robots_rationale_check": {
+          "name": "scrape_origin_robots_rationale_check",
+          "value": "(\"scrape_origin\".\"robots_mode\" = 'enforce' AND \"scrape_origin\".\"robots_rationale\" IS NULL)\n        OR (\"scrape_origin\".\"robots_mode\" = 'not_applicable' AND \"scrape_origin\".\"robots_rationale\" IS NOT NULL)"
+        },
+        "scrape_origin_robots_cache_check": {
+          "name": "scrape_origin_robots_cache_check",
+          "value": "(\"scrape_origin\".\"robots_state\" IS NULL\n          AND \"scrape_origin\".\"robots_fetched_at\" IS NULL\n          AND \"scrape_origin\".\"robots_expires_at\" IS NULL)\n        OR (\"scrape_origin\".\"robots_state\" IS NOT NULL\n          AND \"scrape_origin\".\"robots_fetched_at\" IS NOT NULL\n          AND \"scrape_origin\".\"robots_expires_at\" IS NOT NULL\n          AND \"scrape_origin\".\"robots_expires_at\" > \"scrape_origin\".\"robots_fetched_at\")"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scrape_target": {
+      "name": "scrape_target",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "managed_by": {
+          "name": "managed_by",
+          "type": "scrape_definition_manager",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'code'"
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "minimum_spacing_ms": {
+          "name": "minimum_spacing_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requests_per_window": {
+          "name": "requests_per_window",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "window_ms": {
+          "name": "window_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "timeout_ms": {
+          "name": "timeout_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_response_bytes": {
+          "name": "max_response_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "max_retries": {
+          "name": "max_retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "next_request_at": {
+          "name": "next_request_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blocked_until": {
+          "name": "blocked_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "window_request_count": {
+          "name": "window_request_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rate_limit_streak": {
+          "name": "rate_limit_streak",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scrape_target_eligibility_idx": {
+          "name": "scrape_target_eligibility_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "blocked_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "next_request_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scrape_target_policy_check": {
+          "name": "scrape_target_policy_check",
+          "value": "\"scrape_target\".\"minimum_spacing_ms\" >= 0\n        AND \"scrape_target\".\"requests_per_window\" > 0\n        AND \"scrape_target\".\"window_ms\" > 0\n        AND \"scrape_target\".\"timeout_ms\" > 0\n        AND \"scrape_target\".\"max_response_bytes\" > 0\n        AND \"scrape_target\".\"max_retries\" >= 0"
+        },
+        "scrape_target_counters_check": {
+          "name": "scrape_target_counters_check",
+          "value": "\"scrape_target\".\"window_request_count\" >= 0 AND \"scrape_target\".\"rate_limit_streak\" >= 0"
+        },
+        "scrape_target_lease_pair_check": {
+          "name": "scrape_target_lease_pair_check",
+          "value": "(\"scrape_target\".\"lease_token\" IS NULL) = (\"scrape_target\".\"lease_expires_at\" IS NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scrape_source_revision": {
+      "name": "scrape_source_revision",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scrape_source_id": {
+          "name": "scrape_source_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rules_version": {
+          "name": "rules_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "list_url": {
+          "name": "list_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rules": {
+          "name": "rules",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author": {
+          "name": "author",
+          "type": "scrape_source_revision_author",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_model": {
+          "name": "ai_model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ai_instructions_version": {
+          "name": "ai_instructions_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "preview_status": {
+          "name": "preview_status",
+          "type": "scrape_source_preview_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "preview_result": {
+          "name": "preview_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previewed_at": {
+          "name": "previewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scrape_source_revision_number_unq": {
+          "name": "scrape_source_revision_number_unq",
+          "columns": [
+            {
+              "expression": "scrape_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scrape_source_revision_active_unq": {
+          "name": "scrape_source_revision_active_unq",
+          "columns": [
+            {
+              "expression": "scrape_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"scrape_source_revision\".\"active\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scrape_source_revision_scrape_source_id_scrape_source_id_fk": {
+          "name": "scrape_source_revision_scrape_source_id_scrape_source_id_fk",
+          "tableFrom": "scrape_source_revision",
+          "tableTo": "scrape_source",
+          "columnsFrom": [
+            "scrape_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scrape_source_revision_created_by_id_user_id_fk": {
+          "name": "scrape_source_revision_created_by_id_user_id_fk",
+          "tableFrom": "scrape_source_revision",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "scrape_source_revision_id_source_unq": {
+          "name": "scrape_source_revision_id_source_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "id",
+            "scrape_source_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "scrape_source_revision_numbers_check": {
+          "name": "scrape_source_revision_numbers_check",
+          "value": "\"scrape_source_revision\".\"revision\" > 0 AND \"scrape_source_revision\".\"rules_version\" > 0"
+        },
+        "scrape_source_revision_ai_details_check": {
+          "name": "scrape_source_revision_ai_details_check",
+          "value": "(\"scrape_source_revision\".\"author\" = 'person' AND \"scrape_source_revision\".\"ai_model\" IS NULL AND \"scrape_source_revision\".\"ai_instructions_version\" IS NULL)\n        OR (\"scrape_source_revision\".\"author\" = 'ai' AND \"scrape_source_revision\".\"ai_model\" IS NOT NULL AND \"scrape_source_revision\".\"ai_instructions_version\" IS NOT NULL)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scrape_source_run": {
+      "name": "scrape_source_run",
+      "schema": "",
+      "columns": {
+        "external_site_run_id": {
+          "name": "external_site_run_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "scrape_source_id": {
+          "name": "scrape_source_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision_id": {
+          "name": "revision_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "scrape_source_run_purpose",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scrape_source_run_source_revision_idx": {
+          "name": "scrape_source_run_source_revision_idx",
+          "columns": [
+            {
+              "expression": "scrape_source_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scrape_source_run_external_site_run_id_external_site_run_id_fk": {
+          "name": "scrape_source_run_external_site_run_id_external_site_run_id_fk",
+          "tableFrom": "scrape_source_run",
+          "tableTo": "external_site_run",
+          "columnsFrom": [
+            "external_site_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scrape_source_run_scrape_source_id_scrape_source_id_fk": {
+          "name": "scrape_source_run_scrape_source_id_scrape_source_id_fk",
+          "tableFrom": "scrape_source_run",
+          "tableTo": "scrape_source",
+          "columnsFrom": [
+            "scrape_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scrape_source_run_revision_fk": {
+          "name": "scrape_source_run_revision_fk",
+          "tableFrom": "scrape_source_run",
+          "tableTo": "scrape_source_revision",
+          "columnsFrom": [
+            "revision_id",
+            "scrape_source_id"
+          ],
+          "columnsTo": [
+            "id",
+            "scrape_source_id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "scrape_source_run_revision_check": {
+          "name": "scrape_source_run_revision_check",
+          "value": "\"scrape_source_run\".\"purpose\" = 'suggest' OR \"scrape_source_run\".\"revision_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.scrape_source": {
+      "name": "scrape_source",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "scrape_source_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "list_url": {
+          "name": "list_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sample_urls": {
+          "name": "sample_urls",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "scrape_source_site_unq": {
+          "name": "scrape_source_site_unq",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scrape_source_external_site_id_external_site_id_fk": {
+          "name": "scrape_source_external_site_id_external_site_id_fk",
+          "tableFrom": "scrape_source",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scrape_source_created_by_id_user_id_fk": {
+          "name": "scrape_source_created_by_id_user_id_fk",
+          "tableFrom": "scrape_source",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_history": {
+      "name": "store_price_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'usd'"
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_history_unq": {
+          "name": "store_price_history_unq",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "volume",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_history_price_id_store_price_id_fk": {
+          "name": "store_price_history_price_id_store_price_id_fk",
+          "tableFrom": "store_price_history",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "store_price_history_price_check": {
+          "name": "store_price_history_price_check",
+          "value": "\"store_price_history\".\"price\" > 0"
+        },
+        "store_price_history_volume_check": {
+          "name": "store_price_history_volume_check",
+          "value": "\"store_price_history\".\"volume\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_attempt": {
+      "name": "store_price_match_attempt",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "store_price_match_proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "initial_status": {
+          "name": "initial_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "final_status": {
+          "name": "final_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bottle_id": {
+          "name": "current_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_release_id": {
+          "name": "current_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_bottle_id": {
+          "name": "suggested_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_release_id": {
+          "name": "suggested_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_bottle_id": {
+          "name": "parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_target": {
+          "name": "creation_target",
+          "type": "store_price_match_creation_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "automation_eligible": {
+          "name": "automation_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "automation_score": {
+          "name": "automation_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_attempt_price_idx": {
+          "name": "store_price_match_attempt_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_proposal_idx": {
+          "name": "store_price_match_attempt_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_created_idx": {
+          "name": "store_price_match_attempt_created_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_attempt_final_status_idx": {
+          "name": "store_price_match_attempt_final_status_idx",
+          "columns": [
+            {
+              "expression": "final_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_attempt_price_id_store_price_id_fk": {
+          "name": "store_price_match_attempt_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "store_price_match_attempt_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_current_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_current_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "current_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_suggested_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_suggested_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "suggested_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_parent_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_attempt_parent_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "parent_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "store_price_match_attempt_reviewed_by_id_user_id_fk": {
+          "name": "store_price_match_attempt_reviewed_by_id_user_id_fk",
+          "tableFrom": "store_price_match_attempt",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_proposal": {
+      "name": "store_price_match_proposal",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending_review'"
+        },
+        "proposal_type": {
+          "name": "proposal_type",
+          "type": "store_price_match_proposal_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_bottle_id": {
+          "name": "current_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_release_id": {
+          "name": "current_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_bottle_id": {
+          "name": "suggested_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_release_id": {
+          "name": "suggested_release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_bottle_id": {
+          "name": "parent_bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creation_target": {
+          "name": "creation_target",
+          "type": "store_price_match_creation_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_scope": {
+          "name": "reference_scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "candidate_bottles": {
+          "name": "candidate_bottles",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "extracted_label": {
+          "name": "extracted_label",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_bottle": {
+          "name": "proposed_bottle",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "proposed_release": {
+          "name": "proposed_release",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "search_evidence": {
+          "name": "search_evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "automation_assessment": {
+          "name": "automation_assessment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rationale": {
+          "name": "rationale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evaluated_at": {
+          "name": "last_evaluated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entered_queue_at": {
+          "name": "entered_queue_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_token": {
+          "name": "processing_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_queued_at": {
+          "name": "processing_queued_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processing_expires_at": {
+          "name": "processing_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_proposal_price_idx": {
+          "name": "store_price_match_proposal_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_status_idx": {
+          "name": "store_price_match_proposal_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_type_idx": {
+          "name": "store_price_match_proposal_type_idx",
+          "columns": [
+            {
+              "expression": "proposal_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_current_bottle_idx": {
+          "name": "store_price_match_proposal_current_bottle_idx",
+          "columns": [
+            {
+              "expression": "current_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_current_release_idx": {
+          "name": "store_price_match_proposal_current_release_idx",
+          "columns": [
+            {
+              "expression": "current_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_processing_expires_idx": {
+          "name": "store_price_match_proposal_processing_expires_idx",
+          "columns": [
+            {
+              "expression": "processing_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_entered_queue_idx": {
+          "name": "store_price_match_proposal_entered_queue_idx",
+          "columns": [
+            {
+              "expression": "entered_queue_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_suggested_bottle_idx": {
+          "name": "store_price_match_proposal_suggested_bottle_idx",
+          "columns": [
+            {
+              "expression": "suggested_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_suggested_release_idx": {
+          "name": "store_price_match_proposal_suggested_release_idx",
+          "columns": [
+            {
+              "expression": "suggested_release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_parent_bottle_idx": {
+          "name": "store_price_match_proposal_parent_bottle_idx",
+          "columns": [
+            {
+              "expression": "parent_bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_proposal_reviewed_by_idx": {
+          "name": "store_price_match_proposal_reviewed_by_idx",
+          "columns": [
+            {
+              "expression": "reviewed_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_proposal_price_id_store_price_id_fk": {
+          "name": "store_price_match_proposal_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_current_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_current_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "current_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_suggested_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_suggested_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "suggested_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_parent_bottle_id_bottle_id_fk": {
+          "name": "store_price_match_proposal_parent_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "parent_bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_match_proposal_reviewed_by_id_user_id_fk": {
+          "name": "store_price_match_proposal_reviewed_by_id_user_id_fk",
+          "tableFrom": "store_price_match_proposal",
+          "tableTo": "user",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_retry_run_item": {
+      "name": "store_price_match_retry_run_item",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposal_id": {
+          "name": "proposal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_retry_run_item_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "result_status": {
+          "name": "result_status",
+          "type": "store_price_match_proposal_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_retry_run_item_unq": {
+          "name": "store_price_match_retry_run_item_unq",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_run_status_idx": {
+          "name": "store_price_match_retry_run_item_run_status_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_proposal_idx": {
+          "name": "store_price_match_retry_run_item_proposal_idx",
+          "columns": [
+            {
+              "expression": "proposal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_item_price_idx": {
+          "name": "store_price_match_retry_run_item_price_idx",
+          "columns": [
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_retry_run_item_run_id_store_price_match_retry_run_id_fk": {
+          "name": "store_price_match_retry_run_item_run_id_store_price_match_retry_run_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price_match_retry_run",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_retry_run_item_proposal_id_store_price_match_proposal_id_fk": {
+          "name": "store_price_match_retry_run_item_proposal_id_store_price_match_proposal_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price_match_proposal",
+          "columnsFrom": [
+            "proposal_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "store_price_match_retry_run_item_price_id_store_price_id_fk": {
+          "name": "store_price_match_retry_run_item_price_id_store_price_id_fk",
+          "tableFrom": "store_price_match_retry_run_item",
+          "tableTo": "store_price",
+          "columnsFrom": [
+            "price_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price_match_retry_run": {
+      "name": "store_price_match_retry_run",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "site": {
+          "name": "site",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "store_price_match_retry_run_kind",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "store_price_match_retry_run_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'no_web'"
+        },
+        "status": {
+          "name": "status",
+          "type": "store_price_match_retry_run_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "matched_count": {
+          "name": "matched_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_count": {
+          "name": "processed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "resolved_count": {
+          "name": "resolved_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "reviewable_count": {
+          "name": "reviewable_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errored_count": {
+          "name": "errored_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failed_count": {
+          "name": "failed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancel_requested_at": {
+          "name": "cancel_requested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_match_retry_run_status_idx": {
+          "name": "store_price_match_retry_run_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_created_by_idx": {
+          "name": "store_price_match_retry_run_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_match_retry_run_created_at_idx": {
+          "name": "store_price_match_retry_run_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_match_retry_run_created_by_id_user_id_fk": {
+          "name": "store_price_match_retry_run_created_by_id_user_id_fk",
+          "tableFrom": "store_price_match_retry_run",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.store_price": {
+      "name": "store_price",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "external_site_id": {
+          "name": "external_site_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_product_id": {
+          "name": "external_product_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_fingerprint": {
+          "name": "source_fingerprint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "barcode": {
+          "name": "barcode",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_bottle_identity": {
+          "name": "source_bottle_identity",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "currency",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "volume": {
+          "name": "volume",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "store_price_site_external_product_unq": {
+          "name": "store_price_site_external_product_unq",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"store_price\".\"external_product_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_site_name_volume_idx": {
+          "name": "store_price_site_name_volume_idx",
+          "columns": [
+            {
+              "expression": "external_site_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "LOWER(\"name\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "volume",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_bottle_idx": {
+          "name": "store_price_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "store_price_release_idx": {
+          "name": "store_price_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "store_price_external_site_id_external_site_id_fk": {
+          "name": "store_price_external_site_id_external_site_id_fk",
+          "tableFrom": "store_price",
+          "tableTo": "external_site",
+          "columnsFrom": [
+            "external_site_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "store_price_bottle_id_bottle_id_fk": {
+          "name": "store_price_bottle_id_bottle_id_fk",
+          "tableFrom": "store_price",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "store_price_url_unique": {
+          "name": "store_price_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "store_price_barcode_check": {
+          "name": "store_price_barcode_check",
+          "value": "\"store_price\".\"barcode\" IS NULL OR (\"store_price\".\"barcode\" ~ '^[0-9]+$' AND char_length(\"store_price\".\"barcode\") IN (8, 12, 13, 14))"
+        },
+        "store_price_price_check": {
+          "name": "store_price_price_check",
+          "value": "\"store_price\".\"price\" > 0"
+        },
+        "store_price_volume_check": {
+          "name": "store_price_volume_check",
+          "value": "\"store_price\".\"volume\" > 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.tag": {
+      "name": "tag",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "synonyms": {
+          "name": "synonyms",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "tag_category": {
+          "name": "tag_category",
+          "type": "tag_category",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "flavor_profile": {
+          "name": "flavor_profile",
+          "type": "flavor_profile[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasting_badge_award": {
+      "name": "tasting_badge_award",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "award_id": {
+          "name": "award_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "level": {
+          "name": "level",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "tasting_badge_award_key": {
+          "name": "tasting_badge_award_key",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_badge_award_award_id": {
+          "name": "tasting_badge_award_award_id",
+          "columns": [
+            {
+              "expression": "award_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasting_badge_award_tasting_id_tasting_id_fk": {
+          "name": "tasting_badge_award_tasting_id_tasting_id_fk",
+          "tableFrom": "tasting_badge_award",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "tasting_badge_award_award_id_badge_award_id_fk": {
+          "name": "tasting_badge_award_award_id_badge_award_id_fk",
+          "tableFrom": "tasting_badge_award",
+          "tableTo": "badge_award",
+          "columnsFrom": [
+            "award_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tasting": {
+      "name": "tasting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bottle_id": {
+          "name": "bottle_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "release_id": {
+          "name": "release_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "varchar(64)[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::varchar[]"
+        },
+        "color": {
+          "name": "color",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating_band": {
+          "name": "rating_band",
+          "type": "tasting_band",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_star_rating": {
+          "name": "legacy_star_rating",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legacy_simple_rating": {
+          "name": "legacy_simple_rating",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "serving_style": {
+          "name": "serving_style",
+          "type": "servingStyle",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "friends": {
+          "name": "friends",
+          "type": "bigint[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "array[]::bigint[]"
+        },
+        "flight_id": {
+          "name": "flight_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "comments": {
+          "name": "comments",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "toasts": {
+          "name": "toasts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tasting_bottle_idx": {
+          "name": "tasting_bottle_idx",
+          "columns": [
+            {
+              "expression": "bottle_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_release_idx": {
+          "name": "tasting_release_idx",
+          "columns": [
+            {
+              "expression": "release_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_flight_idx": {
+          "name": "tasting_flight_idx",
+          "columns": [
+            {
+              "expression": "flight_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "tasting_created_by_idx": {
+          "name": "tasting_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "tasting_bottle_id_bottle_id_fk": {
+          "name": "tasting_bottle_id_bottle_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "bottle",
+          "columnsFrom": [
+            "bottle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasting_flight_id_flight_id_fk": {
+          "name": "tasting_flight_id_flight_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "flight",
+          "columnsFrom": [
+            "flight_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasting_created_by_id_user_id_fk": {
+          "name": "tasting_created_by_id_user_id_fk",
+          "tableFrom": "tasting",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "tasting_unq": {
+          "name": "tasting_unq",
+          "nullsNotDistinct": false,
+          "columns": [
+            "bottle_id",
+            "created_by_id",
+            "created_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.toasts": {
+      "name": "toasts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tasting_id": {
+          "name": "tasting_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "toast_unq": {
+          "name": "toast_unq",
+          "columns": [
+            {
+              "expression": "tasting_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_by_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "toasts_tasting_id_tasting_id_fk": {
+          "name": "toasts_tasting_id_tasting_id_fk",
+          "tableFrom": "toasts",
+          "tableTo": "tasting",
+          "columnsFrom": [
+            "tasting_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "toasts_created_by_id_user_id_fk": {
+          "name": "toasts_created_by_id_user_id_fk",
+          "tableFrom": "toasts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "picture_url": {
+          "name": "picture_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "private": {
+          "name": "private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "admin": {
+          "name": "admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "mod": {
+          "name": "mod",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_comments": {
+          "name": "notify_comments",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "terms_accepted_at": {
+          "name": "terms_accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "user_email_unq": {
+          "name": "user_email_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"email\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_username_unq": {
+          "name": "user_username_unq",
+          "columns": [
+            {
+              "expression": "LOWER(\"username\")",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.legacy_release_repair_review_resolution": {
+      "name": "legacy_release_repair_review_resolution",
+      "schema": "public",
+      "values": [
+        "allow_create_parent",
+        "blocked",
+        "reuse_existing_parent"
+      ]
+    },
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": [
+        "system",
+        "user"
+      ]
+    },
+    "public.badge_award_object_type": {
+      "name": "badge_award_object_type",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "entity",
+        "country",
+        "region"
+      ]
+    },
+    "public.badge_formula": {
+      "name": "badge_formula",
+      "schema": "public",
+      "values": [
+        "default",
+        "linear",
+        "fibonacci"
+      ]
+    },
+    "public.bottle_check_close_reason": {
+      "name": "bottle_check_close_reason",
+      "schema": "public",
+      "values": [
+        "dismissed",
+        "resolved_manually"
+      ]
+    },
+    "public.bottle_check_intent": {
+      "name": "bottle_check_intent",
+      "schema": "public",
+      "values": [
+        "resolve_reference",
+        "audit_bottle"
+      ]
+    },
+    "public.bottle_check_origin": {
+      "name": "bottle_check_origin",
+      "schema": "public",
+      "values": [
+        "moderator",
+        "post_user_creation"
+      ]
+    },
+    "public.bottle_operation_rejection_reason": {
+      "name": "bottle_operation_rejection_reason",
+      "schema": "public",
+      "values": [
+        "wrong_target",
+        "wrong_change",
+        "insufficient_evidence",
+        "resolved_manually",
+        "other"
+      ]
+    },
+    "public.bottle_operation_status": {
+      "name": "bottle_operation_status",
+      "schema": "public",
+      "values": [
+        "blocked",
+        "pending_review",
+        "rejected",
+        "applying",
+        "applied",
+        "stale",
+        "failed"
+      ]
+    },
+    "public.bottle_reference_assignment_source": {
+      "name": "bottle_reference_assignment_source",
+      "schema": "public",
+      "values": [
+        "legacy",
+        "canonical",
+        "source_approved",
+        "classifier_approved",
+        "human_approved"
+      ]
+    },
+    "public.type": {
+      "name": "type",
+      "schema": "public",
+      "values": [
+        "add",
+        "update",
+        "delete"
+      ]
+    },
+    "public.collection_bottle_status": {
+      "name": "collection_bottle_status",
+      "schema": "public",
+      "values": [
+        "sealed",
+        "open",
+        "empty"
+      ]
+    },
+    "public.entity_kind": {
+      "name": "entity_kind",
+      "schema": "public",
+      "values": [
+        "brand",
+        "distillery",
+        "bottler",
+        "company"
+      ]
+    },
+    "public.entity_type": {
+      "name": "entity_type",
+      "schema": "public",
+      "values": [
+        "brand",
+        "distiller",
+        "bottler"
+      ]
+    },
+    "public.entity_event_kind": {
+      "name": "entity_event_kind",
+      "schema": "public",
+      "values": [
+        "generic",
+        "opened",
+        "closed",
+        "mothballed",
+        "reopened",
+        "acquired"
+      ]
+    },
+    "public.category": {
+      "name": "category",
+      "schema": "public",
+      "values": [
+        "blend",
+        "blended_grain",
+        "blended_malt",
+        "bourbon",
+        "corn",
+        "rye",
+        "single_grain",
+        "single_malt",
+        "single_pot_still",
+        "wheat"
+      ]
+    },
+    "public.content_source": {
+      "name": "content_source",
+      "schema": "public",
+      "values": [
+        "generated",
+        "user"
+      ]
+    },
+    "public.flavor_profile": {
+      "name": "flavor_profile",
+      "schema": "public",
+      "values": [
+        "young_spritely",
+        "sweet_fruit_mellow",
+        "spicy_sweet",
+        "spicy_dry",
+        "deep_rich_dried_fruit",
+        "old_dignified",
+        "light_delicate",
+        "juicy_oak_vanilla",
+        "oily_coastal",
+        "lightly_peated",
+        "peated",
+        "heavily_peated"
+      ]
+    },
+    "public.object_type": {
+      "name": "object_type",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "bottle_group",
+        "bottle_release",
+        "bottle_series",
+        "comment",
+        "entity",
+        "tasting",
+        "toast",
+        "follow"
+      ]
+    },
+    "public.tag_category": {
+      "name": "tag_category",
+      "schema": "public",
+      "values": [
+        "cereal",
+        "fruity",
+        "floral",
+        "peaty",
+        "feinty",
+        "sulphury",
+        "woody",
+        "winey"
+      ]
+    },
+    "public.external_site_run_status": {
+      "name": "external_site_run_status",
+      "schema": "public",
+      "values": [
+        "queued",
+        "running",
+        "succeeded",
+        "failed"
+      ]
+    },
+    "public.external_site_run_trigger": {
+      "name": "external_site_run_trigger",
+      "schema": "public",
+      "values": [
+        "scheduled",
+        "manual"
+      ]
+    },
+    "public.follow_status": {
+      "name": "follow_status",
+      "schema": "public",
+      "values": [
+        "none",
+        "pending",
+        "following"
+      ]
+    },
+    "public.identity_provider": {
+      "name": "identity_provider",
+      "schema": "public",
+      "values": [
+        "google",
+        "passkey"
+      ]
+    },
+    "public.incoming_bottle_decision_source_kind": {
+      "name": "incoming_bottle_decision_source_kind",
+      "schema": "public",
+      "values": [
+        "review",
+        "store_price"
+      ]
+    },
+    "public.incoming_bottle_decision_type": {
+      "name": "incoming_bottle_decision_type",
+      "schema": "public",
+      "values": [
+        "match_existing",
+        "create_bottle",
+        "create_release",
+        "create_bottle_and_release"
+      ]
+    },
+    "public.notification_type": {
+      "name": "notification_type",
+      "schema": "public",
+      "values": [
+        "comment",
+        "toast",
+        "friend_request"
+      ]
+    },
+    "public.pendingUploadKind": {
+      "name": "pendingUploadKind",
+      "schema": "public",
+      "values": [
+        "image"
+      ]
+    },
+    "public.pendingUploadPurpose": {
+      "name": "pendingUploadPurpose",
+      "schema": "public",
+      "values": [
+        "photo_tasting_entry",
+        "tasting_image",
+        "bottle_image",
+        "bottle_release_image",
+        "badge_image",
+        "avatar"
+      ]
+    },
+    "public.pendingUploadStatus": {
+      "name": "pendingUploadStatus",
+      "schema": "public",
+      "values": [
+        "pending",
+        "attached",
+        "expired"
+      ]
+    },
+    "public.scrape_definition_manager": {
+      "name": "scrape_definition_manager",
+      "schema": "public",
+      "values": [
+        "code",
+        "admin"
+      ]
+    },
+    "public.scrape_origin_robots_mode": {
+      "name": "scrape_origin_robots_mode",
+      "schema": "public",
+      "values": [
+        "enforce",
+        "not_applicable"
+      ]
+    },
+    "public.scrape_source_kind": {
+      "name": "scrape_source_kind",
+      "schema": "public",
+      "values": [
+        "review",
+        "price"
+      ]
+    },
+    "public.scrape_source_preview_status": {
+      "name": "scrape_source_preview_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "passed",
+        "failed"
+      ]
+    },
+    "public.scrape_source_revision_author": {
+      "name": "scrape_source_revision_author",
+      "schema": "public",
+      "values": [
+        "person",
+        "ai"
+      ]
+    },
+    "public.scrape_source_run_purpose": {
+      "name": "scrape_source_run_purpose",
+      "schema": "public",
+      "values": [
+        "collect",
+        "preview",
+        "suggest"
+      ]
+    },
+    "public.currency": {
+      "name": "currency",
+      "schema": "public",
+      "values": [
+        "usd",
+        "gbp",
+        "eur"
+      ]
+    },
+    "public.store_price_match_creation_target": {
+      "name": "store_price_match_creation_target",
+      "schema": "public",
+      "values": [
+        "bottle",
+        "release",
+        "bottle_and_release"
+      ]
+    },
+    "public.store_price_match_proposal_status": {
+      "name": "store_price_match_proposal_status",
+      "schema": "public",
+      "values": [
+        "verified",
+        "pending_review",
+        "approved",
+        "ignored",
+        "errored"
+      ]
+    },
+    "public.store_price_match_proposal_type": {
+      "name": "store_price_match_proposal_type",
+      "schema": "public",
+      "values": [
+        "match_existing",
+        "create_new",
+        "correction",
+        "no_match"
+      ]
+    },
+    "public.store_price_match_retry_run_item_status": {
+      "name": "store_price_match_retry_run_item_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "processing",
+        "completed",
+        "skipped",
+        "failed"
+      ]
+    },
+    "public.store_price_match_retry_run_kind": {
+      "name": "store_price_match_retry_run_kind",
+      "schema": "public",
+      "values": [
+        "create_new",
+        "match_existing",
+        "correction",
+        "errored"
+      ]
+    },
+    "public.store_price_match_retry_run_mode": {
+      "name": "store_price_match_retry_run_mode",
+      "schema": "public",
+      "values": [
+        "no_web",
+        "full"
+      ]
+    },
+    "public.store_price_match_retry_run_status": {
+      "name": "store_price_match_retry_run_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "running",
+        "completed",
+        "failed",
+        "canceled"
+      ]
+    },
+    "public.tasting_band": {
+      "name": "tasting_band",
+      "schema": "public",
+      "values": [
+        "mediocre",
+        "good",
+        "very_good",
+        "outstanding",
+        "unicorn"
+      ]
+    },
+    "public.servingStyle": {
+      "name": "servingStyle",
+      "schema": "public",
+      "values": [
+        "neat",
+        "rocks",
+        "splash"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/migrations/meta/_journal.json
+++ b/apps/server/migrations/meta/_journal.json
@@ -1849,6 +1849,13 @@
       "when": 1788298555632,
       "tag": "0263_slow_mordo",
       "breakpoints": false
+    },
+    {
+      "idx": 264,
+      "version": "7",
+      "when": 1788304399017,
+      "tag": "0264_right_demogoblin",
+      "breakpoints": false
     }
   ]
 }

--- a/apps/server/src/db/schema/bottles.ts
+++ b/apps/server/src/db/schema/bottles.ts
@@ -142,6 +142,26 @@ export const bottleSeries = pgTable(
 export type BottleSeries = typeof bottleSeries.$inferSelect;
 export type NewBottleSeries = typeof bottleSeries.$inferInsert;
 
+/** Preserves public Series references after a merge or deletion. */
+export const bottleSeriesTombstones = pgTable("bottle_series_tombstone", {
+  seriesId: bigint("series_id", { mode: "number" }).primaryKey(),
+  newSeriesId: bigint("new_series_id", { mode: "number" }),
+});
+
+export const bottleSeriesTombstonesRelations = relations(
+  bottleSeriesTombstones,
+  ({ one }) => ({
+    newSeries: one(bottleSeries, {
+      fields: [bottleSeriesTombstones.newSeriesId],
+      references: [bottleSeries.id],
+    }),
+  }),
+);
+
+export type BottleSeriesTombstone = typeof bottleSeriesTombstones.$inferSelect;
+export type NewBottleSeriesTombstone =
+  typeof bottleSeriesTombstones.$inferInsert;
+
 /**
  * Represents one independently complete marketed release.
  *

--- a/apps/server/src/lib/bottleDisplayName.test.ts
+++ b/apps/server/src/lib/bottleDisplayName.test.ts
@@ -41,6 +41,15 @@ describe("formatBottleDisplayName", () => {
     );
   });
 
+  it("omits Brand and Series context inside a Series-owned list", () => {
+    expect(
+      formatBottleDisplayName(bottle, {
+        includeBrand: false,
+        includeSeries: false,
+      }),
+    ).toBe("Glenburgie 38-year-old - Chapter Thirty Two");
+  });
+
   it("keeps inferred years out of the bottle name", () => {
     expect(
       formatBottleDisplayName({

--- a/apps/server/src/lib/bottleDisplayName.ts
+++ b/apps/server/src/lib/bottleDisplayName.ts
@@ -21,6 +21,7 @@ export type BottleDisplayNameSource = {
 
 export type BottleDisplayNameOptions = {
   includeBrand?: boolean;
+  includeSeries?: boolean;
 };
 
 function includesIdentityText(value: string, candidate: string) {
@@ -112,7 +113,7 @@ function getReleaseName(bottle: BottleDisplayNameSource) {
 /** Formats the concise marketed identity used for human-facing bottle names. */
 export function formatBottleDisplayName(
   bottle: BottleDisplayNameSource,
-  { includeBrand = true }: BottleDisplayNameOptions = {},
+  { includeBrand = true, includeSeries = true }: BottleDisplayNameOptions = {},
 ) {
   const expressionName = getReleaseName(bottle);
   const brandName = bottle.brand.shortName || bottle.brand.name;
@@ -121,7 +122,11 @@ export function formatBottleDisplayName(
       ? bottle.series.name
       : null;
 
-  return [includeBrand ? brandName : null, seriesName, expressionName]
+  return [
+    includeBrand ? brandName : null,
+    includeSeries ? seriesName : null,
+    expressionName,
+  ]
     .filter(Boolean)
     .join(" ");
 }

--- a/apps/server/src/lib/peatedId.test.ts
+++ b/apps/server/src/lib/peatedId.test.ts
@@ -1,9 +1,10 @@
 import { formatPeatedId, isCanonicalPeatedId, parsePeatedId } from "./peatedId";
 
 describe("Peated IDs", () => {
-  test("formats bottle and entity IDs", () => {
+  test("formats public catalog IDs", () => {
     expect(formatPeatedId("bottle", 123)).toBe("B0123");
     expect(formatPeatedId("entity", 123)).toBe("E0123");
+    expect(formatPeatedId("series", 123)).toBe("S0123");
     expect(formatPeatedId("bottle", 1234567)).toBe("B1234567");
   });
 
@@ -18,6 +19,11 @@ describe("Peated IDs", () => {
       id: 456,
       peatedId: "E0456",
     });
+    expect(parsePeatedId("s789")).toEqual({
+      type: "series",
+      id: 789,
+      peatedId: "S0789",
+    });
   });
 
   test("recognizes only canonical output", () => {
@@ -25,6 +31,7 @@ describe("Peated IDs", () => {
     expect(isCanonicalPeatedId("B123", "bottle")).toBe(false);
     expect(isCanonicalPeatedId("B000123", "bottle")).toBe(false);
     expect(isCanonicalPeatedId("b0123", "bottle")).toBe(false);
+    expect(isCanonicalPeatedId("S0123", "series")).toBe(true);
   });
 
   test.each(["", "B0", "B0000", "B-1", "B1.5", "X123", "BB123", "123"])(

--- a/apps/server/src/lib/peatedId.ts
+++ b/apps/server/src/lib/peatedId.ts
@@ -1,6 +1,7 @@
 export const PEATED_ID_PREFIXES = {
   bottle: "B",
   entity: "E",
+  series: "S",
 } as const;
 
 export type PeatedIdType = keyof typeof PEATED_ID_PREFIXES;
@@ -11,7 +12,7 @@ export type ParsedPeatedId = {
   peatedId: string;
 };
 
-const PEATED_ID_PATTERN = /^([BE])(\d+)$/i;
+const PEATED_ID_PATTERN = /^([BES])(\d+)$/i;
 const MINIMUM_DIGITS = 4;
 
 export function formatPeatedId(type: PeatedIdType, id: number): string {
@@ -26,7 +27,11 @@ export function parsePeatedId(value: string): ParsedPeatedId | null {
   const match = PEATED_ID_PATTERN.exec(value.trim());
   if (!match) return null;
 
-  const type = match[1].toUpperCase() === "B" ? "bottle" : "entity";
+  const prefix = match[1].toUpperCase();
+  let type: PeatedIdType;
+  if (prefix === "B") type = "bottle";
+  else if (prefix === "E") type = "entity";
+  else type = "series";
   const id = Number(match[2]);
   if (!Number.isSafeInteger(id) || id < 1) return null;
 

--- a/apps/server/src/orpc/contracts/search.ts
+++ b/apps/server/src/orpc/contracts/search.ts
@@ -1,5 +1,6 @@
 import {
   BottleSchema,
+  BottleSeriesSchema,
   EntitySchema,
   RegionSchema,
   UserSchema,
@@ -28,6 +29,7 @@ export const ENTITY_KIND_BY_SEARCH_SCOPE = {
 
 export const SEARCH_SCOPE_LIST = [
   "bottles",
+  "series",
   ...ENTITY_SEARCH_SCOPE_LIST,
   "regions",
   "members",
@@ -66,6 +68,22 @@ const EntityResultSchema = EntitySchema.pick({
   region: z.object({ name: z.string() }).nullable(),
 });
 
+const SeriesResultSchema = BottleSeriesSchema.pick({
+  id: true,
+  peatedId: true,
+  name: true,
+  fullName: true,
+  numReleases: true,
+}).extend({
+  brand: EntitySchema.pick({
+    id: true,
+    peatedId: true,
+    name: true,
+    shortName: true,
+    kind: true,
+  }),
+});
+
 const RegionResultSchema = RegionSchema.pick({
   id: true,
   name: true,
@@ -94,6 +112,11 @@ const GroupSchema = z.discriminatedUnion("type", [
     type: z.literal("bottles"),
     total: z.number().int().nonnegative(),
     results: z.array(BottleResultSchema),
+  }),
+  z.object({
+    type: z.literal("series"),
+    total: z.number().int().nonnegative(),
+    results: z.array(SeriesResultSchema),
   }),
   z.object({
     type: z.literal("distilleries"),
@@ -131,11 +154,13 @@ export const ExactSchema = z
   .discriminatedUnion("type", [
     z.object({ type: z.literal("bottle"), ref: BottleResultSchema }),
     z.object({ type: z.literal("entity"), ref: EntityResultSchema }),
+    z.object({ type: z.literal("series"), ref: SeriesResultSchema }),
   ])
   .nullable();
 
 const NearestSchema = z.discriminatedUnion("type", [
   z.object({ type: z.literal("bottles"), result: BottleResultSchema }),
+  z.object({ type: z.literal("series"), result: SeriesResultSchema }),
   z.object({ type: z.literal("distilleries"), result: EntityResultSchema }),
   z.object({ type: z.literal("brands"), result: EntityResultSchema }),
   z.object({ type: z.literal("bottlers"), result: EntityResultSchema }),
@@ -146,6 +171,7 @@ const NearestSchema = z.discriminatedUnion("type", [
 
 export const ScopeTotalsSchema = z.object({
   bottles: z.number().int().nonnegative(),
+  series: z.number().int().nonnegative(),
   distilleries: z.number().int().nonnegative(),
   brands: z.number().int().nonnegative(),
   bottlers: z.number().int().nonnegative(),
@@ -168,7 +194,7 @@ export default contract
     path: "/search",
     summary: "Global search",
     description:
-      "Search bottles, brands, distilleries, bottlers, companies, regions, and members",
+      "Search bottles, series, brands, distilleries, bottlers, companies, regions, and members",
     spec: (spec) => ({ ...spec, operationId: "search" }),
   })
   .input(

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -528,6 +528,7 @@ describe("mock oRPC router", () => {
       ],
       scopeTotals: {
         bottles: mockBottles.length,
+        series: 0,
         distilleries: mockEntities.filter(
           (entity) => entity.kind === "distillery",
         ).length,

--- a/apps/server/src/orpc/mock/routes/search.ts
+++ b/apps/server/src/orpc/mock/routes/search.ts
@@ -54,6 +54,9 @@ export default mockOS.search.handler(async ({ input, context }) => {
       results: bottles.slice(0, input.limit),
     });
   }
+  if (input.scopes.includes("series")) {
+    groups.push({ type: "series", total: 0, results: [] });
+  }
   for (const scope of [
     "distilleries",
     "brands",
@@ -117,6 +120,7 @@ export default mockOS.search.handler(async ({ input, context }) => {
         case "companies":
           return entity.kind === "company";
         case "bottles":
+        case "series":
         case "members":
         case "regions":
           return false;
@@ -133,6 +137,7 @@ export default mockOS.search.handler(async ({ input, context }) => {
   const scopeTotals: MockOutputs["search"]["scopeTotals"] = input.includeFacets
     ? {
         bottles: mockBottles.length,
+        series: 0,
         distilleries: mockEntities.filter(
           (entity) => entity.kind === "distillery",
         ).length,

--- a/apps/server/src/orpc/routes/bottleSeries/delete.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/delete.test.ts
@@ -1,87 +1,18 @@
 import { db } from "@peated/server/db";
-import { getPostgresConnectionConfig } from "@peated/server/db/connection";
-import type { User } from "@peated/server/db/schema";
 import {
-  bottleGroups,
-  bottles,
   bottleSeries,
+  bottleSeriesTombstones,
   changes,
 } from "@peated/server/db/schema";
-import { createBottle } from "@peated/server/lib/createBottle";
-import * as testFixtures from "@peated/server/lib/test/fixtures";
 import waitError from "@peated/server/lib/test/waitError";
-import * as workerClient from "@peated/server/lib/test/workerDispatch";
 import { routerClient } from "@peated/server/orpc/router";
-import { and, asc, eq, inArray } from "drizzle-orm";
-import pg from "pg";
-import { beforeEach, describe, expect, test, vi } from "vitest";
-import { z } from "zod";
-
-const { Client } = pg;
-type NodePgClient = InstanceType<typeof Client>;
-
-beforeEach(() => {
-  vi.mocked(workerClient.pushUniqueJob).mockReset();
-});
-
-async function waitForSessionBlockedBy(client: NodePgClient): Promise<void> {
-  const session = await client.query<{ pid: number }>(
-    "SELECT pg_backend_pid() AS pid",
-  );
-  const blockerPid = session.rows[0]?.pid;
-  if (!blockerPid) throw new Error("Unable to identify the lock holder.");
-
-  const deadline = Date.now() + 2000;
-  while (Date.now() < deadline) {
-    const result = await client.query<{ blocked: boolean }>(
-      `SELECT EXISTS (
-        SELECT 1
-        FROM pg_stat_activity
-        WHERE $1 = ANY(pg_blocking_pids(pid))
-      ) AS blocked`,
-      [blockerPid],
-    );
-    if (result.rows[0]?.blocked) return;
-    await new Promise((resolve) => setTimeout(resolve, 5));
-  }
-  throw new Error("Timed out waiting for BottleSeries deletion group lock.");
-}
-
-async function createGroup({
-  user,
-  brandId,
-  seriesId,
-  name,
-}: {
-  user: User;
-  brandId: number;
-  seriesId: number;
-  name: string;
-}) {
-  const first = await createBottle({
-    context: { user },
-    input: {
-      name,
-      brand: brandId,
-      series: seriesId,
-      edition: "Batch One",
-    },
-  });
-  const second = {
-    bottle: await testFixtures.BottleGroupMember({
-      groupId: first.group.id,
-      edition: "Batch Two",
-    }),
-  };
-  return { first, members: [first, second] };
-}
+import { and, eq } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
 
 describe("DELETE /bottle-series/:series", () => {
   test("requires authentication", async () => {
     const err = await waitError(() =>
-      routerClient.bottleSeries.delete({
-        series: 1,
-      }),
+      routerClient.bottleSeries.delete({ series: 1 }),
     );
     expect(err).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
   });
@@ -89,62 +20,60 @@ describe("DELETE /bottle-series/:series", () => {
   test("requires moderator access", async ({ defaults }) => {
     const err = await waitError(() =>
       routerClient.bottleSeries.delete(
-        {
-          series: 1,
-        },
+        { series: 1 },
         { context: { user: defaults.user } },
       ),
     );
     expect(err).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
   });
 
-  test("deletes a series through canonical group fan-out and legacy clearing", async ({
-    fixtures,
-  }) => {
-    const user = await fixtures.User({ admin: true });
+  test("rejects deletion when the series has bottles", async ({ fixtures }) => {
+    const user = await fixtures.User({ mod: true });
     const brand = await fixtures.Entity({ name: "Series Delete Brand" });
     const series = await fixtures.BottleSeries({
-      name: "Test Series",
+      name: "Populated Series",
       brandId: brand.id,
     });
-    const firstGroup = await createGroup({
-      user,
-      brandId: brand.id,
-      seriesId: series.id,
-      name: "First Expression",
-    });
-    const secondGroup = await createGroup({
-      user,
-      brandId: brand.id,
-      seriesId: series.id,
-      name: "Second Expression",
-    });
-    const groupedMembers = [...firstGroup.members, ...secondGroup.members];
-    const groupedBottleIds = groupedMembers.map(({ bottle }) => bottle.id);
-    const groupIds = [firstGroup.first.group.id, secondGroup.first.group.id];
-    const legacyBottle = await fixtures.LegacyBottle({
-      name: "Legacy Bottle",
+    const bottle = await fixtures.LegacyBottle({
+      name: "Member Bottle",
       brandId: brand.id,
       seriesId: series.id,
     });
 
-    let finalizedAfterCommit = false;
-    vi.mocked(workerClient.pushUniqueJob).mockReset();
-    vi.mocked(workerClient.pushUniqueJob).mockImplementation(
-      async (jobName) => {
-        if (jobName === "OnBottleChange") {
-          finalizedAfterCommit =
-            (await db.query.bottleSeries.findFirst({
-              where: eq(bottleSeries.id, series.id),
-            })) === undefined;
-        }
-      },
+    const err = await waitError(() =>
+      routerClient.bottleSeries.delete(
+        { series: series.id },
+        { context: { user } },
+      ),
     );
 
+    expect(err).toMatchInlineSnapshot(
+      `[Error: This series still contains bottles. Merge it instead.]`,
+    );
+    expect(
+      await db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, series.id),
+      }),
+    ).toBeDefined();
+    expect(
+      await db.query.bottles.findFirst({
+        where: (bottles, { eq }) => eq(bottles.id, bottle.id),
+      }),
+    ).toMatchObject({ seriesId: series.id });
+  });
+
+  test("deletes an empty series and preserves its public ID", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ mod: true });
+    const brand = await fixtures.Entity({ name: "Empty Series Brand" });
+    const series = await fixtures.BottleSeries({
+      name: "Empty Series",
+      brandId: brand.id,
+    });
+
     await routerClient.bottleSeries.delete(
-      {
-        series: series.id,
-      },
+      { series: series.id },
       { context: { user } },
     );
 
@@ -153,307 +82,32 @@ describe("DELETE /bottle-series/:series", () => {
         where: eq(bottleSeries.id, series.id),
       }),
     ).toBeUndefined();
-    expect(finalizedAfterCommit).toBe(true);
-
-    const updatedGroups = await db
-      .select()
-      .from(bottleGroups)
-      .where(inArray(bottleGroups.id, groupIds))
-      .orderBy(asc(bottleGroups.id));
-    expect(updatedGroups).toHaveLength(2);
-    expect(updatedGroups.every(({ seriesId }) => seriesId === null)).toBe(true);
-
-    const updatedBottles = await db
-      .select()
-      .from(bottles)
-      .where(inArray(bottles.id, [...groupedBottleIds, legacyBottle.id]))
-      .orderBy(asc(bottles.id));
-    expect(updatedBottles).toHaveLength(5);
-    expect(updatedBottles.every(({ seriesId }) => seriesId === null)).toBe(
-      true,
-    );
-
-    const bottleAudits = await db
-      .select()
-      .from(changes)
-      .where(
-        and(
-          eq(changes.objectType, "bottle"),
-          eq(changes.type, "update"),
-          inArray(changes.objectId, [...groupedBottleIds, legacyBottle.id]),
-        ),
-      )
-      .orderBy(asc(changes.objectId));
-    const expectedAuditContext = new Map([
-      ...firstGroup.members.map(
-        ({ bottle }) =>
-          [
-            bottle.id,
-            {
-              groupId: firstGroup.first.group.id,
-              requestedBottleId: firstGroup.first.bottle.id,
-            },
-          ] as const,
-      ),
-      ...secondGroup.members.map(
-        ({ bottle }) =>
-          [
-            bottle.id,
-            {
-              groupId: secondGroup.first.group.id,
-              requestedBottleId: secondGroup.first.bottle.id,
-            },
-          ] as const,
-      ),
-    ]);
-    expect(bottleAudits).toHaveLength(4);
-    for (const audit of bottleAudits) {
-      expect(audit.data).toMatchObject({
-        seriesId: null,
-        updateScope: "shared",
-        ...expectedAuditContext.get(audit.objectId),
-      });
-    }
-    expect(bottleAudits.map(({ objectId }) => objectId)).toEqual(
-      groupedBottleIds.sort((left, right) => left - right),
-    );
-
-    const [change] = await db
-      .select()
-      .from(changes)
-      .where(
-        and(
-          eq(changes.objectId, series.id),
+    expect(
+      await db.query.bottleSeriesTombstones.findFirst({
+        where: eq(bottleSeriesTombstones.seriesId, series.id),
+      }),
+    ).toEqual({ seriesId: series.id, newSeriesId: null });
+    expect(
+      await db.query.changes.findFirst({
+        where: and(
           eq(changes.objectType, "bottle_series"),
+          eq(changes.objectId, series.id),
+          eq(changes.type, "delete"),
         ),
-      );
-    expect(change).toBeDefined();
-    expect(change?.type).toBe("delete");
-    expect(change?.data).toMatchObject({
-      id: series.id,
-      name: series.name,
-      description: series.description,
-      brandId: series.brandId,
-    });
-
-    const changedBottleIds = vi
-      .mocked(workerClient.pushUniqueJob)
-      .mock.calls.filter(([jobName]) => jobName === "OnBottleChange")
-      .map(
-        ([, payload]) =>
-          z.object({ bottleId: z.number() }).parse(payload).bottleId,
-      )
-      .sort((left, right) => left - right);
-    expect(changedBottleIds).toEqual(
-      groupedBottleIds.sort((left, right) => left - right),
-    );
-    expect(workerClient.pushUniqueJob).not.toHaveBeenCalledWith(
-      "IndexBottleSeriesSearchVectors",
-      { seriesId: series.id },
-    );
+      }),
+    ).toMatchObject({ displayName: series.name });
   });
 
-  test("rolls back earlier group fan-out when a later group is invalid", async ({
-    fixtures,
-  }) => {
-    const user = await fixtures.User({ admin: true });
-    const brand = await fixtures.Entity({ name: "Atomic Delete Brand" });
-    const series = await fixtures.BottleSeries({
-      name: "Atomic Delete Series",
-      brandId: brand.id,
-    });
-    const validGroup = await createGroup({
-      user,
-      brandId: brand.id,
-      seriesId: series.id,
-      name: "Valid Expression",
-    });
-    const invalidGroup = await createGroup({
-      user,
-      brandId: brand.id,
-      seriesId: series.id,
-      name: "Invalid Expression",
-    });
-    await db
-      .update(bottleGroups)
-      .set({ representativeBottleId: null })
-      .where(eq(bottleGroups.id, invalidGroup.first.group.id));
-    const groupedBottleIds = [...validGroup.members, ...invalidGroup.members]
-      .map(({ bottle }) => bottle.id)
-      .sort((left, right) => left - right);
-    const seriesBefore = await db.query.bottleSeries.findFirst({
-      where: eq(bottleSeries.id, series.id),
-    });
-    vi.mocked(workerClient.pushUniqueJob).mockReset();
-
-    const error = await waitError(() =>
-      routerClient.bottleSeries.delete(
-        { series: series.id },
-        { context: { user } },
-      ),
-    );
-    expect(error.message).toBe(
-      `BottleGroup ${invalidGroup.first.group.id} has no representative Bottle.`,
-    );
-
-    expect(
-      await db.query.bottleSeries.findFirst({
-        where: eq(bottleSeries.id, series.id),
-      }),
-    ).toEqual(seriesBefore);
-    const groups = await db
-      .select()
-      .from(bottleGroups)
-      .where(
-        inArray(bottleGroups.id, [
-          validGroup.first.group.id,
-          invalidGroup.first.group.id,
-        ]),
-      );
-    expect(groups.every(({ seriesId }) => seriesId === series.id)).toBe(true);
-    const members = await db
-      .select()
-      .from(bottles)
-      .where(inArray(bottles.id, groupedBottleIds));
-    expect(members.every(({ seriesId }) => seriesId === series.id)).toBe(true);
-    expect(
-      await db
-        .select()
-        .from(changes)
-        .where(
-          and(
-            eq(changes.objectType, "bottle"),
-            eq(changes.type, "update"),
-            inArray(changes.objectId, groupedBottleIds),
-          ),
-        ),
-    ).toEqual([]);
-    expect(
-      await db
-        .select()
-        .from(changes)
-        .where(
-          and(
-            eq(changes.objectType, "bottle_series"),
-            eq(changes.objectId, series.id),
-            eq(changes.type, "delete"),
-          ),
-        ),
-    ).toEqual([]);
-    expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
-  });
-
-  test("does not overwrite a concurrent group series move", async ({
-    fixtures,
-  }) => {
-    const user = await fixtures.User({ admin: true });
-    const brand = await fixtures.Entity({ name: "Concurrent Series Brand" });
-    const deletedSeries = await fixtures.BottleSeries({
-      name: "Deleted Series",
-      brandId: brand.id,
-    });
-    const destinationSeries = await fixtures.BottleSeries({
-      name: "Destination Series",
-      brandId: brand.id,
-    });
-    const group = await createGroup({
-      user,
-      brandId: brand.id,
-      seriesId: deletedSeries.id,
-      name: "Concurrent Expression",
-    });
-    const memberIds = group.members.map(({ bottle }) => bottle.id);
-    vi.mocked(workerClient.pushUniqueJob).mockReset();
-
-    const mover = new Client(getPostgresConnectionConfig());
-    let moverCommitted = false;
-    let deletion:
-      | ReturnType<typeof routerClient.bottleSeries.delete>
-      | undefined;
-    await mover.connect();
-    try {
-      await mover.query("BEGIN");
-      await mover.query(
-        `SELECT id
-         FROM bottle_group
-         WHERE id = $1
-         FOR UPDATE`,
-        [group.first.group.id],
-      );
-
-      deletion = routerClient.bottleSeries.delete(
-        { series: deletedSeries.id },
-        { context: { user } },
-      );
-      void deletion.catch(() => undefined);
-      await waitForSessionBlockedBy(mover);
-
-      await mover.query(
-        `UPDATE bottle_group
-         SET series_id = $2
-         WHERE id = $1`,
-        [group.first.group.id, destinationSeries.id],
-      );
-      await mover.query(
-        `UPDATE bottle
-         SET series_id = $2
-         WHERE group_id = $1`,
-        [group.first.group.id, destinationSeries.id],
-      );
-      await mover.query("COMMIT");
-      moverCommitted = true;
-
-      await deletion;
-    } finally {
-      if (!moverCommitted) await mover.query("ROLLBACK").catch(() => undefined);
-      await deletion?.catch(() => undefined);
-      await mover.end();
-    }
-
-    expect(
-      await db.query.bottleSeries.findFirst({
-        where: eq(bottleSeries.id, deletedSeries.id),
-      }),
-    ).toBeUndefined();
-    expect(
-      await db.query.bottleGroups.findFirst({
-        where: eq(bottleGroups.id, group.first.group.id),
-      }),
-    ).toMatchObject({ seriesId: destinationSeries.id });
-    const members = await db
-      .select()
-      .from(bottles)
-      .where(inArray(bottles.id, memberIds));
-    expect(members).toHaveLength(2);
-    expect(
-      members.every(({ seriesId }) => seriesId === destinationSeries.id),
-    ).toBe(true);
-    expect(
-      await db
-        .select()
-        .from(changes)
-        .where(
-          and(
-            eq(changes.objectType, "bottle"),
-            eq(changes.type, "update"),
-            inArray(changes.objectId, memberIds),
-          ),
-        ),
-    ).toEqual([]);
-    expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
-  });
-
-  test("returns 404 for non-existent series", async function ({ fixtures }) {
-    const user = await fixtures.User({ admin: true });
+  test("returns 404 for a missing series", async ({ fixtures }) => {
+    const user = await fixtures.User({ mod: true });
 
     const err = await waitError(() =>
       routerClient.bottleSeries.delete(
-        {
-          series: 12345,
-        },
+        { series: 12345 },
         { context: { user } },
       ),
     );
+
     expect(err).toMatchInlineSnapshot(`[Error: Series not found.]`);
   });
 });

--- a/apps/server/src/orpc/routes/bottleSeries/delete.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/delete.ts
@@ -3,17 +3,13 @@ import {
   bottleGroups,
   bottles,
   bottleSeries,
+  bottleSeriesTombstones,
   changes,
 } from "@peated/server/db/schema";
 import { getUserActorForDatabase } from "@peated/server/lib/actors";
-import {
-  finalizeBottleUpdate,
-  updateBottleInTransaction,
-  type BottleUpdateFinalizationManifest,
-} from "@peated/server/lib/updateBottle";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
-import { and, asc, eq, isNull } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 
 export default procedure
@@ -23,17 +19,18 @@ export default procedure
     path: "/bottle-series/{series}",
     summary: "Delete bottle series",
     description:
-      "Delete a bottle series and remove its reference from associated bottles. Requires moderator privileges",
-    operationId: "deleteBottleSeries",
+      "Delete an empty bottle series and preserve its public ID. Requires moderator privileges.",
+    spec: (spec) => ({ ...spec, operationId: "deleteBottleSeries" }),
   })
   .input(z.object({ series: z.coerce.number() }))
   .output(z.object({}))
   .handler(async function ({ input, context, errors }) {
-    const manifests = await db.transaction(async (tx) => {
+    await db.transaction(async (tx) => {
       const [series] = await tx
         .select()
         .from(bottleSeries)
         .where(eq(bottleSeries.id, input.series))
+        .for("update")
         .limit(1);
       if (!series) {
         throw errors.NOT_FOUND({
@@ -41,38 +38,36 @@ export default procedure
         });
       }
 
-      const actorId = (await getUserActorForDatabase(tx, context.user)).id;
-      const groups = await tx
-        .select({
-          id: bottleGroups.id,
-          representativeBottleId: bottleGroups.representativeBottleId,
-        })
+      const [member] = await tx
+        .select({ id: bottles.id })
+        .from(bottles)
+        .where(eq(bottles.seriesId, series.id))
+        .limit(1);
+      const [group] = await tx
+        .select({ id: bottleGroups.id })
         .from(bottleGroups)
         .where(eq(bottleGroups.seriesId, series.id))
-        .orderBy(asc(bottleGroups.id))
-        .for("update");
-      const manifests: BottleUpdateFinalizationManifest[] = [];
-
-      for (const group of groups) {
-        if (group.representativeBottleId === null) {
-          throw errors.CONFLICT({
-            message: `BottleGroup ${group.id} has no representative Bottle.`,
-          });
-        }
-        manifests.push(
-          await updateBottleInTransaction(tx, {
-            bottleId: group.representativeBottleId,
-            input: { series: null },
-            actorId,
-            creationSource: "manual_entry",
-          }),
-        );
+        .limit(1);
+      if (member || group) {
+        throw errors.CONFLICT({
+          message: "This series still contains bottles. Merge it instead.",
+        });
       }
 
+      const actorId = (await getUserActorForDatabase(tx, context.user)).id;
+
       await tx
-        .update(bottles)
-        .set({ seriesId: null })
-        .where(and(eq(bottles.seriesId, series.id), isNull(bottles.groupId)));
+        .update(bottleSeriesTombstones)
+        .set({ newSeriesId: null })
+        .where(eq(bottleSeriesTombstones.newSeriesId, series.id));
+
+      await tx
+        .insert(bottleSeriesTombstones)
+        .values({ seriesId: series.id })
+        .onConflictDoUpdate({
+          target: bottleSeriesTombstones.seriesId,
+          set: { newSeriesId: null },
+        });
 
       await tx.insert(changes).values({
         objectType: "bottle_series",
@@ -84,19 +79,7 @@ export default procedure
       });
 
       await tx.delete(bottleSeries).where(eq(bottleSeries.id, series.id));
-
-      return manifests;
     });
-
-    for (const manifest of manifests) {
-      // The deleted series has no search vector to rebuild.
-      await finalizeBottleUpdate({
-        ...manifest,
-        affectedSeriesIds: manifest.affectedSeriesIds.filter(
-          (seriesId) => seriesId !== input.series,
-        ),
-      });
-    }
 
     return {};
   });

--- a/apps/server/src/orpc/routes/bottleSeries/details.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/details.test.ts
@@ -17,12 +17,16 @@ describe("GET /bottle-series/:series", () => {
 
     expect(result).toMatchObject({
       id: series.id,
+      peatedId: `S${String(series.id).padStart(4, "0")}`,
       name: series.name,
       fullName: series.fullName,
       description: series.description,
       numReleases: series.numReleases,
+      brand: {
+        id: brand.id,
+        name: brand.name,
+      },
     });
-    expect(result).not.toHaveProperty("brand");
   });
 
   it("returns 404 for non-existent series", async function () {

--- a/apps/server/src/orpc/routes/bottleSeries/details.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/details.ts
@@ -1,10 +1,18 @@
 import { db } from "@peated/server/db";
-import { bottleSeries } from "@peated/server/db/schema";
+import {
+  bottleSeries,
+  bottleSeriesTombstones,
+  entities,
+} from "@peated/server/db/schema";
+import { formatPeatedId } from "@peated/server/lib/peatedId";
 import { procedure } from "@peated/server/orpc";
-import { BottleSeriesSchema, detailsResponse } from "@peated/server/schemas";
+import {
+  BottleSeriesDetailsSchema,
+  detailsResponse,
+} from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
 import { BottleSeriesSerializer } from "@peated/server/serializers/bottleSeries";
-import { eq } from "drizzle-orm";
+import { eq, getTableColumns } from "drizzle-orm";
 import { z } from "zod";
 
 export default procedure
@@ -12,24 +20,58 @@ export default procedure
     method: "GET",
     path: "/bottle-series/{series}",
     summary: "Get bottle series details",
-    description:
-      "Retrieve detailed information about a specific bottle series by its ID",
-    operationId: "getBottleSeries",
+    description: "Get detailed information about a bottle series by its ID.",
+    spec: (spec) => ({ ...spec, operationId: "getBottleSeries" }),
   })
   .input(z.object({ series: z.coerce.number() }))
   // TODO(response-envelope): wrap in { data } by updating detailsResponse() at cutover
-  .output(detailsResponse(BottleSeriesSchema))
+  .output(detailsResponse(BottleSeriesDetailsSchema))
   .handler(async function ({ input, context, errors }) {
-    const [series] = await db
-      .select()
+    let [result] = await db
+      .select({
+        series: getTableColumns(bottleSeries),
+        brand: {
+          id: entities.id,
+          name: entities.name,
+          shortName: entities.shortName,
+          kind: entities.kind,
+        },
+      })
       .from(bottleSeries)
+      .innerJoin(entities, eq(bottleSeries.brandId, entities.id))
       .where(eq(bottleSeries.id, input.series));
 
-    if (!series) {
-      throw errors.NOT_FOUND({
-        message: "Series not found.",
-      });
+    if (!result) {
+      [result] = await db
+        .select({
+          series: getTableColumns(bottleSeries),
+          brand: {
+            id: entities.id,
+            name: entities.name,
+            shortName: entities.shortName,
+            kind: entities.kind,
+          },
+        })
+        .from(bottleSeriesTombstones)
+        .innerJoin(
+          bottleSeries,
+          eq(bottleSeriesTombstones.newSeriesId, bottleSeries.id),
+        )
+        .innerJoin(entities, eq(bottleSeries.brandId, entities.id))
+        .where(eq(bottleSeriesTombstones.seriesId, input.series));
+
+      if (!result) {
+        throw errors.NOT_FOUND({
+          message: "Series not found.",
+        });
+      }
     }
 
-    return await serialize(BottleSeriesSerializer, series, context.user);
+    return {
+      ...(await serialize(BottleSeriesSerializer, result.series, context.user)),
+      brand: {
+        ...result.brand,
+        peatedId: formatPeatedId("entity", result.brand.id),
+      },
+    };
   });

--- a/apps/server/src/orpc/routes/bottleSeries/index.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/index.ts
@@ -3,6 +3,7 @@ import create from "./create";
 import delete_ from "./delete";
 import details from "./details";
 import list from "./list";
+import merge from "./merge";
 import update from "./update";
 
 export default base.tag("bottleSeries").router({
@@ -10,5 +11,6 @@ export default base.tag("bottleSeries").router({
   list,
   create,
   update,
+  merge,
   delete: delete_,
 });

--- a/apps/server/src/orpc/routes/bottleSeries/list.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/list.test.ts
@@ -82,4 +82,25 @@ describe("GET /bottle-series", () => {
 
     expect(results).toHaveLength(0);
   });
+
+  it("lists all series with working cursor pagination", async function ({
+    fixtures,
+  }) {
+    const firstBrand = await fixtures.Entity({ name: "A Series Brand" });
+    const secondBrand = await fixtures.Entity({ name: "B Series Brand" });
+    await fixtures.BottleSeries({ name: "Alpha", brandId: firstBrand.id });
+    await fixtures.BottleSeries({ name: "Beta", brandId: secondBrand.id });
+
+    const firstPage = await routerClient.bottleSeries.list({ limit: 1 });
+    const secondPage = await routerClient.bottleSeries.list({
+      cursor: firstPage.rel.nextCursor!,
+      limit: 1,
+    });
+
+    expect(firstPage.total).toBeGreaterThanOrEqual(2);
+    expect(firstPage.results).toHaveLength(1);
+    expect(firstPage.rel.nextCursor).toBe(2);
+    expect(secondPage.results).toHaveLength(1);
+    expect(secondPage.results[0]?.id).not.toBe(firstPage.results[0]?.id);
+  });
 });

--- a/apps/server/src/orpc/routes/bottleSeries/list.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/list.ts
@@ -15,8 +15,8 @@ export default procedure
     path: "/bottle-series",
     summary: "List bottle series",
     description:
-      "Retrieve bottle series for a specific brand with search and pagination support",
-    operationId: "listBottleSeries",
+      "List bottle series, with optional brand filtering, search, and pagination.",
+    spec: (spec) => ({ ...spec, operationId: "listBottleSeries" }),
   })
   .input(
     z.object({
@@ -24,7 +24,7 @@ export default procedure
         .string()
         .default("")
         .describe("Search text only. Search operators are not supported."),
-      brand: z.coerce.number(),
+      brand: z.coerce.number().optional().describe("Filter by brand ID."),
       cursor: z.coerce.number().gte(1).default(1),
       limit: z.coerce.number().gte(1).lte(100).default(25),
     }),
@@ -40,9 +40,9 @@ export default procedure
     const { query, brand, cursor, limit } = input;
     const offset = (cursor - 1) * limit;
 
-    const where: (SQL<unknown> | undefined)[] = [
-      eq(bottleSeries.brandId, brand),
-    ];
+    const where: (SQL<unknown> | undefined)[] = [];
+
+    if (brand) where.push(eq(bottleSeries.brandId, brand));
 
     if (query) {
       where.push(
@@ -56,7 +56,7 @@ export default procedure
         .from(bottleSeries)
         .where(where ? and(...where) : undefined)
         .orderBy(asc(bottleSeries.name))
-        .limit(limit)
+        .limit(limit + 1)
         .offset(offset),
       db
         .select({ count: sql<string>`count(*)` })
@@ -65,7 +65,11 @@ export default procedure
     ]);
 
     return {
-      results: await serialize(BottleSeriesSerializer, results, context.user),
+      results: await serialize(
+        BottleSeriesSerializer,
+        results.slice(0, limit),
+        context.user,
+      ),
       total: Number(total[0].count),
       rel: {
         nextCursor: results.length > limit ? cursor + 1 : null,

--- a/apps/server/src/orpc/routes/bottleSeries/merge.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/merge.test.ts
@@ -167,7 +167,7 @@ describe("POST /bottle-series/:series/merge", () => {
     );
   });
 
-  test("rolls back when a bottle group cannot be moved", async ({
+  test("rolls back when a BottleGroup cannot be moved", async ({
     fixtures,
   }) => {
     const user = await fixtures.User({ admin: true });
@@ -213,7 +213,7 @@ describe("POST /bottle-series/:series/merge", () => {
     );
 
     expect(err.message).toBe(
-      `Bottle group ${incompleteGroup.group.id} is incomplete and cannot be moved.`,
+      `BottleGroup ${incompleteGroup.group.id} is incomplete and cannot be moved.`,
     );
     expect(
       await db.query.bottleSeries.findFirst({

--- a/apps/server/src/orpc/routes/bottleSeries/merge.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/merge.test.ts
@@ -1,0 +1,251 @@
+import { db } from "@peated/server/db";
+import {
+  bottleGroups,
+  bottles,
+  bottleSeries,
+  bottleSeriesTombstones,
+  changes,
+} from "@peated/server/db/schema";
+import { createBottle } from "@peated/server/lib/createBottle";
+import waitError from "@peated/server/lib/test/waitError";
+import { routerClient } from "@peated/server/orpc/router";
+import { and, eq, inArray } from "drizzle-orm";
+import { describe, expect, test } from "vitest";
+
+describe("POST /bottle-series/:series/merge", () => {
+  test("requires moderator access", async ({ defaults }) => {
+    const err = await waitError(() =>
+      routerClient.bottleSeries.merge(
+        { series: 1, other: 2, direction: "mergeInto" },
+        { context: { user: defaults.user } },
+      ),
+    );
+    expect(err).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
+  });
+
+  test("moves bottles and preserves redirects and audit history", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ admin: true });
+    const brand = await fixtures.Entity({ name: "Series Merge Brand" });
+    const source = await fixtures.BottleSeries({
+      name: "Release One",
+      brandId: brand.id,
+    });
+    const destination = await fixtures.BottleSeries({
+      name: "Signature Collection",
+      brandId: brand.id,
+    });
+    const olderSource = await fixtures.BottleSeries({
+      name: "Old Name",
+      brandId: brand.id,
+    });
+    await db.insert(bottleSeriesTombstones).values({
+      seriesId: olderSource.id,
+      newSeriesId: source.id,
+    });
+    await db.delete(bottleSeries).where(eq(bottleSeries.id, olderSource.id));
+
+    const grouped = await createBottle({
+      context: { user },
+      input: {
+        name: "Port Charlotte",
+        brand: brand.id,
+        series: source.id,
+        edition: "Batch One",
+      },
+    });
+    const secondMember = await fixtures.BottleGroupMember({
+      groupId: grouped.group.id,
+      edition: "Batch Two",
+    });
+    const legacyBottle = await fixtures.LegacyBottle({
+      name: "Legacy Release",
+      brandId: brand.id,
+      seriesId: source.id,
+    });
+
+    const result = await routerClient.bottleSeries.merge(
+      {
+        series: source.id,
+        other: destination.id,
+        direction: "mergeInto",
+      },
+      { context: { user } },
+    );
+
+    expect(result).toMatchObject({
+      id: destination.id,
+      peatedId: `S${String(destination.id).padStart(4, "0")}`,
+      numReleases: 3,
+    });
+    expect(
+      await db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, source.id),
+      }),
+    ).toBeUndefined();
+    expect(
+      await db.query.bottleGroups.findFirst({
+        where: eq(bottleGroups.id, grouped.group.id),
+      }),
+    ).toMatchObject({ seriesId: destination.id });
+
+    const updatedBottles = await db
+      .select({ id: bottles.id, seriesId: bottles.seriesId })
+      .from(bottles)
+      .where(
+        inArray(bottles.id, [
+          grouped.bottle.id,
+          secondMember.id,
+          legacyBottle.id,
+        ]),
+      );
+    expect(updatedBottles).toHaveLength(3);
+    expect(
+      updatedBottles.every(({ seriesId }) => seriesId === destination.id),
+    ).toBe(true);
+
+    expect(
+      await db.query.bottleSeriesTombstones.findMany({
+        where: inArray(bottleSeriesTombstones.seriesId, [
+          olderSource.id,
+          source.id,
+        ]),
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        { seriesId: olderSource.id, newSeriesId: destination.id },
+        { seriesId: source.id, newSeriesId: destination.id },
+      ]),
+    );
+    expect(
+      await db.query.changes.findFirst({
+        where: and(
+          eq(changes.objectType, "bottle_series"),
+          eq(changes.objectId, source.id),
+          eq(changes.type, "delete"),
+        ),
+      }),
+    ).toMatchObject({
+      data: expect.objectContaining({ destinationSeriesId: destination.id }),
+    });
+
+    await expect(
+      routerClient.bottleSeries.details({ series: source.id }),
+    ).resolves.toMatchObject({ id: destination.id });
+    await expect(
+      routerClient.bottleSeries.details({ series: olderSource.id }),
+    ).resolves.toMatchObject({ id: destination.id });
+  });
+
+  test("rejects a merge across brands", async ({ fixtures }) => {
+    const user = await fixtures.User({ mod: true });
+    const firstBrand = await fixtures.Entity({ name: "First Brand" });
+    const secondBrand = await fixtures.Entity({ name: "Second Brand" });
+    const source = await fixtures.BottleSeries({
+      name: "Source",
+      brandId: firstBrand.id,
+    });
+    const destination = await fixtures.BottleSeries({
+      name: "Destination",
+      brandId: secondBrand.id,
+    });
+
+    const err = await waitError(() =>
+      routerClient.bottleSeries.merge(
+        {
+          series: source.id,
+          other: destination.id,
+          direction: "mergeInto",
+        },
+        { context: { user } },
+      ),
+    );
+
+    expect(err).toMatchInlineSnapshot(
+      `[Error: Only series from the same brand can be merged.]`,
+    );
+  });
+
+  test("rolls back when a bottle group cannot be moved", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ admin: true });
+    const brand = await fixtures.Entity({ name: "Atomic Series Brand" });
+    const source = await fixtures.BottleSeries({
+      name: "Source",
+      brandId: brand.id,
+    });
+    const destination = await fixtures.BottleSeries({
+      name: "Destination",
+      brandId: brand.id,
+    });
+    const firstGroup = await createBottle({
+      context: { user },
+      input: {
+        name: "First Bottle",
+        brand: brand.id,
+        series: source.id,
+      },
+    });
+    const incompleteGroup = await createBottle({
+      context: { user },
+      input: {
+        name: "Incomplete Bottle",
+        brand: brand.id,
+        series: source.id,
+      },
+    });
+    await db
+      .update(bottleGroups)
+      .set({ representativeBottleId: null })
+      .where(eq(bottleGroups.id, incompleteGroup.group.id));
+
+    const err = await waitError(() =>
+      routerClient.bottleSeries.merge(
+        {
+          series: source.id,
+          other: destination.id,
+          direction: "mergeInto",
+        },
+        { context: { user } },
+      ),
+    );
+
+    expect(err.message).toBe(
+      `Bottle group ${incompleteGroup.group.id} is incomplete and cannot be moved.`,
+    );
+    expect(
+      await db.query.bottleSeries.findFirst({
+        where: eq(bottleSeries.id, source.id),
+      }),
+    ).toBeDefined();
+
+    const groups = await db.query.bottleGroups.findMany({
+      where: inArray(bottleGroups.id, [
+        firstGroup.group.id,
+        incompleteGroup.group.id,
+      ]),
+    });
+    expect(groups).toHaveLength(2);
+    expect(groups.every(({ seriesId }) => seriesId === source.id)).toBe(true);
+
+    const members = await db.query.bottles.findMany({
+      where: inArray(bottles.id, [
+        firstGroup.bottle.id,
+        incompleteGroup.bottle.id,
+      ]),
+    });
+    expect(members).toHaveLength(2);
+    expect(members.every(({ seriesId }) => seriesId === source.id)).toBe(true);
+    expect(
+      await db.query.changes.findFirst({
+        where: and(
+          eq(changes.objectType, "bottle_series"),
+          eq(changes.objectId, source.id),
+          eq(changes.type, "delete"),
+        ),
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/apps/server/src/orpc/routes/bottleSeries/merge.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/merge.ts
@@ -86,7 +86,7 @@ export default procedure
       for (const group of groups) {
         if (group.representativeBottleId === null) {
           throw errors.CONFLICT({
-            message: `Bottle group ${group.id} is incomplete and cannot be moved.`,
+            message: `BottleGroup ${group.id} is incomplete and cannot be moved.`,
           });
         }
         manifests.push(

--- a/apps/server/src/orpc/routes/bottleSeries/merge.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/merge.ts
@@ -1,0 +1,155 @@
+import { db } from "@peated/server/db";
+import {
+  bottleGroups,
+  bottles,
+  bottleSeries,
+  bottleSeriesTombstones,
+  changes,
+} from "@peated/server/db/schema";
+import { getUserActorForDatabase } from "@peated/server/lib/actors";
+import {
+  finalizeBottleUpdate,
+  updateBottleInTransaction,
+  type BottleUpdateFinalizationManifest,
+} from "@peated/server/lib/updateBottle";
+import { procedure } from "@peated/server/orpc";
+import { requireMod } from "@peated/server/orpc/middleware";
+import { BottleSeriesSchema } from "@peated/server/schemas";
+import { serialize } from "@peated/server/serializers";
+import { BottleSeriesSerializer } from "@peated/server/serializers/bottleSeries";
+import { and, asc, eq, inArray, isNull, sql } from "drizzle-orm";
+import { z } from "zod";
+
+export default procedure
+  .use(requireMod)
+  .route({
+    method: "POST",
+    path: "/bottle-series/{series}/merge",
+    summary: "Merge bottle series",
+    description:
+      "Move every bottle into another series from the same brand and preserve the retired public ID. Requires moderator privileges.",
+    spec: (spec) => ({ ...spec, operationId: "mergeBottleSeries" }),
+  })
+  .input(
+    z.object({
+      series: z.coerce.number(),
+      other: z.number(),
+      direction: z.enum(["mergeInto", "mergeFrom"]).default("mergeInto"),
+    }),
+  )
+  .output(BottleSeriesSchema)
+  .handler(async function ({ input, context, errors }) {
+    const sourceSeriesId =
+      input.direction === "mergeInto" ? input.series : input.other;
+    const destinationSeriesId =
+      input.direction === "mergeInto" ? input.other : input.series;
+
+    if (sourceSeriesId === destinationSeriesId) {
+      throw errors.BAD_REQUEST({
+        message: "A series cannot be merged into itself.",
+      });
+    }
+
+    // This transaction retires the source ID only after every bottle has moved.
+    const { destination, manifests } = await db.transaction(async (tx) => {
+      const lockedSeries = await tx
+        .select()
+        .from(bottleSeries)
+        .where(inArray(bottleSeries.id, [sourceSeriesId, destinationSeriesId]))
+        .orderBy(asc(bottleSeries.id))
+        .for("update");
+      const source = lockedSeries.find(({ id }) => id === sourceSeriesId);
+      const destination = lockedSeries.find(
+        ({ id }) => id === destinationSeriesId,
+      );
+
+      if (!source || !destination) {
+        throw errors.NOT_FOUND({ message: "Series not found." });
+      }
+      if (source.brandId !== destination.brandId) {
+        throw errors.CONFLICT({
+          message: "Only series from the same brand can be merged.",
+        });
+      }
+
+      const actorId = (await getUserActorForDatabase(tx, context.user)).id;
+      const groups = await tx
+        .select({
+          id: bottleGroups.id,
+          representativeBottleId: bottleGroups.representativeBottleId,
+        })
+        .from(bottleGroups)
+        .where(eq(bottleGroups.seriesId, source.id))
+        .orderBy(asc(bottleGroups.id));
+      const manifests: BottleUpdateFinalizationManifest[] = [];
+
+      for (const group of groups) {
+        if (group.representativeBottleId === null) {
+          throw errors.CONFLICT({
+            message: `Bottle group ${group.id} is incomplete and cannot be moved.`,
+          });
+        }
+        manifests.push(
+          await updateBottleInTransaction(tx, {
+            bottleId: group.representativeBottleId,
+            input: { series: destination.id },
+            actorId,
+            creationSource: "manual_entry",
+          }),
+        );
+      }
+
+      await tx
+        .update(bottles)
+        .set({ seriesId: destination.id, updatedAt: new Date() })
+        .where(and(eq(bottles.seriesId, source.id), isNull(bottles.groupId)));
+
+      await tx
+        .update(bottleSeries)
+        .set({
+          numReleases: sql`(SELECT COUNT(*) FROM ${bottles} WHERE ${bottles.seriesId} = ${destination.id})`,
+          updatedAt: new Date(),
+        })
+        .where(eq(bottleSeries.id, destination.id));
+
+      await tx
+        .update(bottleSeriesTombstones)
+        .set({ newSeriesId: destination.id })
+        .where(eq(bottleSeriesTombstones.newSeriesId, source.id));
+      await tx
+        .insert(bottleSeriesTombstones)
+        .values({ seriesId: source.id, newSeriesId: destination.id })
+        .onConflictDoUpdate({
+          target: bottleSeriesTombstones.seriesId,
+          set: { newSeriesId: destination.id },
+        });
+
+      await tx.insert(changes).values({
+        objectType: "bottle_series",
+        objectId: source.id,
+        actorId,
+        displayName: source.fullName,
+        type: "delete",
+        data: { ...source, destinationSeriesId: destination.id },
+      });
+      await tx.delete(bottleSeries).where(eq(bottleSeries.id, source.id));
+
+      const [updatedDestination] = await tx
+        .select()
+        .from(bottleSeries)
+        .where(eq(bottleSeries.id, destination.id));
+
+      return { destination: updatedDestination, manifests };
+    });
+
+    for (const manifest of manifests) {
+      await finalizeBottleUpdate({
+        ...manifest,
+        affectedSeriesIds: manifest.affectedSeriesIds.filter(
+          (seriesId) => seriesId !== sourceSeriesId,
+        ),
+      });
+    }
+
+    return await serialize(BottleSeriesSerializer, destination, context.user);
+  });

--- a/apps/server/src/orpc/routes/search.test.ts
+++ b/apps/server/src/orpc/routes/search.test.ts
@@ -1,6 +1,8 @@
 import { db } from "@peated/server/db";
 import {
   bottleReferences,
+  bottleSeries,
+  bottleSeriesTombstones,
   bottleTombstones,
   entityReferences,
   entityTombstones,
@@ -9,6 +11,7 @@ import { formatPeatedId } from "@peated/server/lib/peatedId";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import indexBottleSearchVectors from "@peated/server/worker/jobs/indexBottleSearchVectors";
+import indexBottleSeriesSearchVectors from "@peated/server/worker/jobs/indexBottleSeriesSearchVectors";
 import indexEntitySearchVectors from "@peated/server/worker/jobs/indexEntitySearchVectors";
 import { describe, expect, test } from "vitest";
 
@@ -97,6 +100,46 @@ describe("GET /search", () => {
       { type: "bottlers", total: 1, results: [{ id: bottler.id }] },
       { type: "companies", total: 1, results: [{ id: company.id }] },
       { type: "regions", total: 1, results: [{ id: region.id }] },
+    ]);
+  });
+
+  test("finds Series with Brand context and exact totals", async ({
+    fixtures,
+  }) => {
+    const brand = await fixtures.Entity({ name: "Dramfool" });
+    const first = await fixtures.BottleSeries({
+      name: "Jim McEwan Signature Collection",
+      brandId: brand.id,
+      numReleases: 12,
+    });
+    const second = await fixtures.BottleSeries({
+      name: "Jim McEwan Signature Archive",
+      brandId: brand.id,
+      numReleases: 4,
+    });
+    await Promise.all([
+      indexBottleSeriesSearchVectors({ seriesId: first.id }),
+      indexBottleSeriesSearchVectors({ seriesId: second.id }),
+    ]);
+
+    const data = await routerClient.search({
+      query: "Jim McEwan Signature",
+      scopes: ["series"],
+      limit: 1,
+    });
+
+    expect(data.groups).toMatchObject([
+      {
+        type: "series",
+        total: 2,
+        results: [
+          {
+            id: first.id,
+            peatedId: formatPeatedId("series", first.id),
+            brand: { id: brand.id, name: brand.name },
+          },
+        ],
+      },
     ]);
   });
 
@@ -366,11 +409,16 @@ describe("GET /search", () => {
     ]);
   });
 
-  test("resolves Bottle and Entity Peated ID tombstones directly", async ({
+  test("resolves Bottle, Entity, and Series Peated ID tombstones directly", async ({
     fixtures,
   }) => {
     const bottle = await fixtures.Bottle();
     const entity = await fixtures.Entity({ type: [], kind: "company" });
+    const brand = await fixtures.Entity({ name: "Redirect Brand" });
+    const series = await fixtures.BottleSeries({
+      name: "Redirect Destination",
+      brandId: brand.id,
+    });
     await db.insert(bottleTombstones).values({
       bottleId: 9001,
       newBottleId: bottle.id,
@@ -379,8 +427,12 @@ describe("GET /search", () => {
       entityId: 9002,
       newEntityId: entity.id,
     });
+    await db.insert(bottleSeriesTombstones).values({
+      seriesId: 9003,
+      newSeriesId: series.id,
+    });
 
-    const [bottleData, entityData] = await Promise.all([
+    const [bottleData, entityData, seriesData] = await Promise.all([
       routerClient.search({
         query: formatPeatedId("bottle", 9001),
         scopes: ["bottles"],
@@ -388,6 +440,10 @@ describe("GET /search", () => {
       routerClient.search({
         query: formatPeatedId("entity", 9002),
         scopes: ["companies"],
+      }),
+      routerClient.search({
+        query: formatPeatedId("series", 9003),
+        scopes: ["series"],
       }),
     ]);
 
@@ -399,6 +455,10 @@ describe("GET /search", () => {
     expect(entityData.exact).toMatchObject({
       type: "entity",
       ref: { id: entity.id },
+    });
+    expect(seriesData.exact).toMatchObject({
+      type: "series",
+      ref: { id: series.id, brand: { id: brand.id } },
     });
   });
 

--- a/apps/server/src/orpc/routes/search.ts
+++ b/apps/server/src/orpc/routes/search.ts
@@ -5,6 +5,7 @@ import {
   bottleReferences,
   bottles,
   bottleSeries,
+  bottleSeriesTombstones,
   bottleTombstones,
   countries,
   entities,
@@ -16,7 +17,7 @@ import {
   tastings,
   users,
 } from "@peated/server/db/schema";
-import { parsePeatedId } from "@peated/server/lib/peatedId";
+import { formatPeatedId, parsePeatedId } from "@peated/server/lib/peatedId";
 import {
   plainTextSearchQuery,
   prefixTextSearchQuery,
@@ -43,6 +44,7 @@ type BottleResult = Extract<
   { type: "bottles" }
 >["results"][number];
 type EntityResult = Extract<OutputGroup, { type: "brands" }>["results"][number];
+type SeriesResult = Extract<OutputGroup, { type: "series" }>["results"][number];
 type RegionResult = Extract<
   OutputGroup,
   { type: "regions" }
@@ -60,6 +62,9 @@ type EntityRow = EntityResult & {
   shortName: string | null;
   totalTastings: number;
 };
+type SeriesRow = Omit<SeriesResult, "peatedId" | "brand"> & {
+  brand: Omit<SeriesResult["brand"], "peatedId">;
+};
 type RegionRow = RegionResult & { totalBottles: number };
 type ScopeTotals = NonNullable<SearchOutput["scopeTotals"]>;
 type GroupRows =
@@ -67,6 +72,12 @@ type GroupRows =
       type: "bottles";
       total: number;
       results: BottleRow[];
+      exactMatch: boolean;
+    }
+  | {
+      type: "series";
+      total: number;
+      results: SeriesRow[];
       exactMatch: boolean;
     }
   | {
@@ -91,10 +102,12 @@ type GroupRows =
 type ExactRow =
   | { type: "bottle"; ref: BottleRow }
   | { type: "entity"; ref: EntityRow }
+  | { type: "series"; ref: SeriesRow }
   | null;
 
 type NearestRow =
   | { type: "bottles"; result: BottleRow; distance: number; tie: number }
+  | { type: "series"; result: SeriesRow; distance: number; tie: number }
   | {
       type: EntitySearchScope;
       result: EntityRow;
@@ -270,6 +283,21 @@ function entityColumns(context: Context) {
   };
 }
 
+function seriesColumns() {
+  return {
+    id: bottleSeries.id,
+    name: bottleSeries.name,
+    fullName: bottleSeries.fullName,
+    numReleases: bottleSeries.numReleases,
+    brand: {
+      id: entities.id,
+      name: entities.name,
+      shortName: entities.shortName,
+      kind: entities.kind,
+    },
+  };
+}
+
 function regionColumns() {
   return {
     id: regions.id,
@@ -290,13 +318,20 @@ function entityScopeWhere(scope: EntitySearchScope) {
 
 async function countRows(
   database: AnyDatabase,
-  table: typeof bottles | typeof entities | typeof regions | typeof users,
+  table:
+    | typeof bottles
+    | typeof bottleSeries
+    | typeof entities
+    | typeof regions
+    | typeof users,
   where: SQL<unknown> | undefined,
 ) {
   const query = database.select({ total: sql<string>`COUNT(*)` });
   let row: { total: string } | undefined;
   if (table === bottles) {
     [row] = await query.from(bottles).where(where);
+  } else if (table === bottleSeries) {
+    [row] = await query.from(bottleSeries).where(where);
   } else if (table === entities) {
     [row] = await query.from(entities).where(where);
   } else if (table === regions) {
@@ -305,6 +340,42 @@ async function countRows(
     [row] = await query.from(users).where(where);
   }
   return Number(row?.total ?? 0);
+}
+
+async function searchSeries(
+  database: AnyDatabase,
+  query: string,
+  limit: number,
+): Promise<{ total: number; results: SeriesRow[]; exactMatch: boolean }> {
+  if (!query) return { total: 0, results: [], exactMatch: false };
+  const textQuery = plainTextSearchQuery(query);
+  const prefixQuery = prefixTextSearchQuery(query);
+  const where = or(
+    sql`${bottleSeries.searchVector} @@ ${textQuery}`,
+    sql`${bottleSeries.searchVector} @@ ${prefixQuery}`,
+  );
+  const rank = nameRank(
+    [sql`${bottleSeries.fullName}`, sql`${bottleSeries.name}`],
+    query,
+  );
+  const rows = await database
+    .select({
+      ...seriesColumns(),
+      searchRank: rank,
+      searchTotal: sql<number>`COUNT(*) OVER()`,
+    })
+    .from(bottleSeries)
+    .innerJoin(entities, eq(bottleSeries.brandId, entities.id))
+    .where(where)
+    .limit(limit)
+    .orderBy(rank, sql`${bottleSeries.numReleases} DESC`, asc(bottleSeries.id));
+  return {
+    total: Number(rows[0]?.searchTotal ?? 0),
+    results: rows.map(
+      ({ searchRank: _, searchTotal: __, ...result }) => result,
+    ),
+    exactMatch: Number(rows[0]?.searchRank) === 0,
+  };
 }
 
 async function searchBottles(
@@ -477,6 +548,7 @@ async function getScopeTotals(
 ): Promise<ScopeTotals> {
   const totals: ScopeTotals = {
     bottles: await countRows(database, bottles, activeBottleWhere()),
+    series: await countRows(database, bottleSeries, undefined),
     distilleries: await countRows(
       database,
       entities,
@@ -541,6 +613,26 @@ async function findExact(
     return bottle ? { type: "bottle", ref: bottle } : null;
   }
 
+  if (peatedId.type === "series" && scopes.includes("series")) {
+    let [series] = await database
+      .select(seriesColumns())
+      .from(bottleSeries)
+      .innerJoin(entities, eq(bottleSeries.brandId, entities.id))
+      .where(eq(bottleSeries.id, peatedId.id));
+    if (!series) {
+      [series] = await database
+        .select(seriesColumns())
+        .from(bottleSeriesTombstones)
+        .innerJoin(
+          bottleSeries,
+          eq(bottleSeriesTombstones.newSeriesId, bottleSeries.id),
+        )
+        .innerJoin(entities, eq(bottleSeries.brandId, entities.id))
+        .where(eq(bottleSeriesTombstones.seriesId, peatedId.id));
+    }
+    return series ? { type: "series", ref: series } : null;
+  }
+
   if (peatedId.type === "entity") {
     let [entity] = await database
       .select(entityColumns(context))
@@ -573,6 +665,8 @@ async function searchGroup(
   switch (scope) {
     case "bottles":
       return { type: scope, ...(await searchBottles(database, query, limit)) };
+    case "series":
+      return { type: scope, ...(await searchSeries(database, query, limit)) };
     case "distilleries":
     case "brands":
     case "bottlers":
@@ -675,6 +769,22 @@ async function findNearest(
                 (total, count) => total + count,
                 0,
               ),
+          });
+        }
+        break;
+      case "series":
+        for (const result of group.results) {
+          const key = `series:${result.id}`;
+          if (seen.has(key)) continue;
+          seen.add(key);
+          nearest.push({
+            type: "series",
+            result,
+            distance: nearestDistance(normalizedQuery, [
+              result.fullName,
+              result.name,
+            ]),
+            tie: result.numReleases,
           });
         }
         break;
@@ -838,6 +948,17 @@ function memberResult(row: MemberResult): MemberResult {
   };
 }
 
+function seriesResult(row: SeriesRow): SeriesResult {
+  return {
+    ...row,
+    peatedId: formatPeatedId("series", row.id),
+    brand: {
+      ...row.brand,
+      peatedId: formatPeatedId("entity", row.brand.id),
+    },
+  };
+}
+
 function serializeGroup(group: GroupRows) {
   switch (group.type) {
     case "bottles":
@@ -845,6 +966,12 @@ function serializeGroup(group: GroupRows) {
         type: group.type,
         total: group.total,
         results: group.results.map((row) => bottleResult(row, true)),
+      };
+    case "series":
+      return {
+        type: group.type,
+        total: group.total,
+        results: group.results.map(seriesResult),
       };
     case "distilleries":
     case "brands":
@@ -872,6 +999,11 @@ function serializeNearest(row: NearestRow) {
         type: row.type,
         result: bottleResult(row.result),
       };
+    case "series":
+      return {
+        type: row.type,
+        result: seriesResult(row.result),
+      };
     case "distilleries":
     case "brands":
     case "bottlers":
@@ -894,7 +1026,9 @@ function serializeSearch(rows: SearchRows) {
   const exact =
     rows.exact?.type === "bottle"
       ? { type: "bottle", ref: bottleResult(rows.exact.ref) }
-      : rows.exact;
+      : rows.exact?.type === "series"
+        ? { type: "series", ref: seriesResult(rows.exact.ref) }
+        : rows.exact;
   const nearest = rows.nearest.map(serializeNearest);
   return SearchOutputSchema.parse({
     query: rows.query,

--- a/apps/server/src/schemas/bottleSeries.ts
+++ b/apps/server/src/schemas/bottleSeries.ts
@@ -1,4 +1,6 @@
+import { isCanonicalPeatedId } from "@peated/server/lib/peatedId";
 import { z } from "zod";
+import { EntitySchema } from "./entities";
 
 const BottleSeriesNameSchema = z
   .string()
@@ -12,6 +14,12 @@ const BottleSeriesDescriptionSchema = z
 
 export const BottleSeriesSchema = z.object({
   id: z.number().readonly().describe("Unique identifier for the bottle series"),
+  peatedId: z
+    .string()
+    .regex(/^S\d{4,}$/)
+    .refine((value) => isCanonicalPeatedId(value, "series"))
+    .readonly()
+    .describe("Permanent Peated ID for the bottle series"),
   name: BottleSeriesNameSchema,
   fullName: z
     .string()
@@ -33,6 +41,16 @@ export const BottleSeriesSchema = z.object({
     .datetime()
     .readonly()
     .describe("Timestamp when the series was last updated"),
+});
+
+export const BottleSeriesDetailsSchema = BottleSeriesSchema.extend({
+  brand: EntitySchema.pick({
+    id: true,
+    peatedId: true,
+    name: true,
+    shortName: true,
+    kind: true,
+  }).describe("Brand that owns this bottle series"),
 });
 
 export const BottleSeriesInputFields = {

--- a/apps/server/src/serializers/bottleSeries.ts
+++ b/apps/server/src/serializers/bottleSeries.ts
@@ -1,6 +1,7 @@
 import { type z } from "zod";
 import { serializer } from ".";
 import type { BottleSeries } from "../db/schema";
+import { formatPeatedId } from "../lib/peatedId";
 import { type BottleSeriesSchema } from "../schemas/bottleSeries";
 
 export const BottleSeriesSerializer = serializer({
@@ -8,6 +9,7 @@ export const BottleSeriesSerializer = serializer({
   item(item: BottleSeries): z.infer<typeof BottleSeriesSchema> {
     return {
       id: item.id,
+      peatedId: formatPeatedId("series", item.id),
       name: item.name,
       fullName: item.fullName,
       description: item.description,

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -142,6 +142,10 @@ export function BottleCatalogPageClient({
       includeRelatedReleases: true,
     }),
   );
+  const title =
+    queryParams.series && bottleList.results[0]?.series
+      ? bottleList.results[0].series.name
+      : "Bottles";
   return (
     <CatalogPage
       action={
@@ -172,7 +176,7 @@ export function BottleCatalogPageClient({
           />
         ) : undefined
       }
-      title="Bottles"
+      title={title}
     >
       <BottleCatalogList
         emptyAction={

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -13,6 +13,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { createContext, useContext, useState, type ReactNode } from "react";
 
 import {
+  AppLink,
   BottleRatings,
   Button,
   ButtonLink,
@@ -32,6 +33,7 @@ import { EntityLinks } from "@peated/web/components/entityLinks";
 import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
 import { BottleOverview } from "@peated/web/components/pages/bottleOverview.stylex";
 import { BottlePageHeader } from "@peated/web/components/pages/bottlePageHeader.stylex";
+import { BottleRailSection } from "@peated/web/components/pages/bottleRailSection.stylex";
 import TimeSince from "@peated/web/components/timeSince";
 import useAuth from "@peated/web/hooks/useAuth";
 import {
@@ -41,11 +43,17 @@ import {
 import { getBottleReleasePlacement } from "@peated/web/lib/bottleMetadata";
 import { logTelemetryError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
+import { selectOtherSeriesBottles } from "@peated/web/lib/seriesBottleRail";
+import {
+  getBottleSeriesUrl,
+  getBottleUrl,
+  getEntityUrl,
+} from "@peated/web/lib/urls";
 import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 type Bottle = Outputs["bottles"]["details"];
 type RecommendationList = Outputs["bottles"]["recommendations"];
+type BottleList = Outputs["bottles"]["list"];
 type ExternalReviewList = Outputs["externalReviews"]["list"];
 type TastingList = Outputs["tastings"]["list"];
 type ExternalReview = Outputs["externalReviews"]["list"]["results"][number];
@@ -68,6 +76,14 @@ function getBottleEyebrow(bottle: Bottle) {
 
 function getDeclaredFacts(bottle: Bottle): [FactListItem, ...FactListItem[]] {
   return [
+    {
+      label: "Series",
+      value: bottle.series ? (
+        <AppLink href={getBottleSeriesUrl(bottle.series)}>
+          {bottle.series.name}
+        </AppLink>
+      ) : null,
+    },
     {
       label: "Category",
       value: bottle.category ? formatCategoryName(bottle.category) : null,
@@ -466,10 +482,12 @@ export function BottlePageFrameClient({
 export function BottleOverviewClient({
   initialRecommendations,
   initialReviews,
+  initialSeriesBottles,
   initialTastings,
 }: {
   initialRecommendations?: RecommendationList;
   initialReviews?: ExternalReviewList;
+  initialSeriesBottles?: BottleList;
   initialTastings?: TastingList;
 }) {
   const orpc = useORPC();
@@ -491,6 +509,17 @@ export function BottleOverviewClient({
       input: { bottle: bottle.id, limit: 3 },
     }),
     initialData: initialRecommendations,
+  });
+  const seriesBottlesQuery = useQuery({
+    ...orpc.bottles.list.queryOptions({
+      input: {
+        limit: 4,
+        series: bottle.series?.id,
+        sort: "-release",
+      },
+    }),
+    enabled: Boolean(bottle.series),
+    initialData: initialSeriesBottles,
   });
 
   const criticReviews =
@@ -523,6 +552,43 @@ export function BottleOverviewClient({
         .join(" · "),
       name: formatBottleDisplayName(recommendation),
     })) ?? [];
+  const otherSeriesBottles = seriesBottlesQuery.data
+    ? selectOtherSeriesBottles(seriesBottlesQuery.data.results, bottle.id).map(
+        (seriesBottle) => ({
+          href: getBottleUrl(seriesBottle),
+          imageUrl: seriesBottle.imageUrl,
+          metadata: [
+            formatCategoryName(seriesBottle.category),
+            getBottleReleasePlacement(seriesBottle).header,
+          ]
+            .filter((value): value is string => Boolean(value))
+            .join(" · "),
+          name: formatBottleDisplayName(seriesBottle, {
+            includeBrand: false,
+            includeSeries: false,
+          }),
+        }),
+      )
+    : [];
+  const seriesRail = !bottle.series ? null : seriesBottlesQuery.isPending ? (
+    <BottleRailSection heading="Other bottles in this series">
+      <LoadingList label="Loading other bottles in this series" rows={3} />
+    </BottleRailSection>
+  ) : seriesBottlesQuery.error ? (
+    <SectionError
+      heading="Other bottles in this series are unavailable"
+      onRetry={() => void seriesBottlesQuery.refetch()}
+    >
+      Try loading this list again.
+    </SectionError>
+  ) : otherSeriesBottles.length ? (
+    <BottleRailSection
+      heading="Other bottles in this series"
+      items={otherSeriesBottles}
+      moreHref={getBottleSeriesUrl(bottle.series)}
+      moreLabel={`See all ${(seriesBottlesQuery.data?.total ?? otherSeriesBottles.length + 1).toLocaleString("en-US")} bottles`}
+    />
+  ) : null;
   const mainPending =
     !criticReviews.length &&
     !tastings.length &&
@@ -582,6 +648,7 @@ export function BottleOverviewClient({
         moreTastingsHref={`${getBottleUrl(bottle)}/tastings`}
         recommendationIntro={recommendationsQuery.data?.reason}
         recommendations={recommendations}
+        railSections={seriesRail}
         tastingCount={bottle.totalTastings}
         tastings={tastings}
       />

--- a/apps/web/src/app/(app)/bottles/[bottleId]/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/page.tsx
@@ -1,5 +1,6 @@
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
+import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 import { getBottleSeoMetadata } from "@peated/web/lib/seoMetadata";
 import type { Metadata } from "next";
 
@@ -13,6 +14,21 @@ export async function generateMetadata(props: {
   return getBottleSeoMetadata(bottle, { canonical: true });
 }
 
-export default function BottlePage() {
-  return <BottleOverviewClient />;
+export default async function BottlePage(props: {
+  params: Promise<{ bottleId: string }>;
+}) {
+  const { bottleId } = await props.params;
+  const bottle = await getBottlePage(parseCatalogRouteId(bottleId));
+  const { client } = await getAnonymousServerClient();
+  const seriesBottleList = bottle.series
+    ? await client.bottles
+        .list({
+          limit: 4,
+          series: bottle.series.id,
+          sort: "-release",
+        })
+        .catch(() => undefined)
+    : undefined;
+
+  return <BottleOverviewClient initialSeriesBottles={seriesBottleList} />;
 }

--- a/apps/web/src/app/(app)/search/page.tsx
+++ b/apps/web/src/app/(app)/search/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
 
 const apiScopes = [
   "bottles",
+  "series",
   "distilleries",
   "brands",
   "bottlers",
@@ -22,6 +23,7 @@ const apiScopes = [
 const databasePageScopes = [
   "all",
   "bottles",
+  "series",
   "distilleries",
   "brands",
   "bottlers",

--- a/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
@@ -32,6 +32,7 @@ const addBottleIntents = [
 const databaseScopes = [
   "all",
   "bottles",
+  "series",
   "distilleries",
   "brands",
   "bottlers",
@@ -50,7 +51,7 @@ function BrowseHeader({ bottleTotal }: { bottleTotal: number }) {
       </h1>
       <p {...stylex.props(styles.browseDescription)}>
         {bottleTotal.toLocaleString("en-US")} bottles, and someone has probably
-        logged yours. Search bottles, distillers, brands, and bottlers.
+        logged yours. Search bottles, series, distillers, brands, and bottlers.
       </p>
     </header>
   );
@@ -201,7 +202,7 @@ export function SearchPageClient({
           onSubmit={submitSearch}
           placement={databaseSearch ? "database" : "page"}
           placeholder={
-            databaseSearch ? "Ardbeg 10, Lagavulin, Cadenhead's…" : undefined
+            databaseSearch ? "Ardbeg 10, Supernova, Lagavulin…" : undefined
           }
           scopeValues={scopeValues}
           showBottleRatings={false}

--- a/apps/web/src/app/(app)/series/[seriesId]/loading.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/loading.tsx
@@ -1,0 +1,5 @@
+import { CatalogPageLoading } from "@peated/web/components/pages/catalogPage.stylex";
+
+export default function SeriesLoading() {
+  return <CatalogPageLoading title="Series" />;
+}

--- a/apps/web/src/app/(app)/series/[seriesId]/page.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/page.tsx
@@ -1,0 +1,60 @@
+import { BOTTLE_LIST_SORT_OPTIONS } from "@peated/server/constants";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
+import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getSeriesSeoMetadata } from "@peated/web/lib/seoMetadata";
+import { getSeriesPage } from "@peated/web/lib/seriesPage.server";
+import type { Metadata } from "next";
+
+import { SeriesPageClient } from "./seriesPageClient.stylex";
+
+type SearchParams = Record<string, string | string[] | undefined>;
+
+function firstValue(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function getCursor(value: string | undefined) {
+  const cursor = Number(value);
+  return Number.isSafeInteger(cursor) && cursor > 0 ? cursor : 1;
+}
+
+function getSort(value: string | undefined) {
+  return BOTTLE_LIST_SORT_OPTIONS.find((sort) => sort === value) ?? "-release";
+}
+
+export async function generateMetadata(props: {
+  params: Promise<{ seriesId: string }>;
+}): Promise<Metadata> {
+  const { seriesId } = await props.params;
+  const series = await getSeriesPage(parseCatalogRouteId(seriesId));
+  return getSeriesSeoMetadata(series, { canonical: true });
+}
+
+export default async function SeriesPage(props: {
+  params: Promise<{ seriesId: string }>;
+  searchParams: Promise<SearchParams>;
+}) {
+  const [{ seriesId }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const series = await getSeriesPage(parseCatalogRouteId(seriesId));
+  const cursor = getCursor(firstValue(searchParams.cursor));
+  const sort = getSort(firstValue(searchParams.sort));
+  const { client } = await getPublicPageServerClient();
+  const bottleList = await client.bottles.list({
+    cursor,
+    limit: 25,
+    series: series.id,
+    sort,
+  });
+
+  return (
+    <SeriesPageClient
+      initialBottleList={bottleList}
+      initialCursor={cursor}
+      initialSeries={series}
+      initialSort={sort}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import type { BOTTLE_LIST_SORT_OPTIONS } from "@peated/server/constants";
+import type { Outputs } from "@peated/server/orpc/router";
+import * as stylex from "@stylexjs/stylex";
+import { useQuery } from "@tanstack/react-query";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { FactList, SectionError, TextLink } from "@peated/web/components";
+import Markdown from "@peated/web/components/markdown";
+import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
+import {
+  PageColumns,
+  PageHeader,
+} from "@peated/web/components/pages/pageLayout.stylex";
+import { toBottleListItem } from "@peated/web/lib/bottleListItem";
+import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { getEntityUrl } from "@peated/web/lib/urls";
+import { space } from "../../../../styles/tokens.stylex";
+
+type BottleList = Outputs["bottles"]["list"];
+type Series = Outputs["bottleSeries"]["details"];
+type BottleSort = (typeof BOTTLE_LIST_SORT_OPTIONS)[number];
+
+const sortOptions = [
+  { label: "Latest release", value: "-release" },
+  { label: "Most tasted", value: "-tastings" },
+  { label: "Highest score", value: "-score" },
+  { label: "Bottle name", value: "name" },
+  { label: "Oldest age", value: "-age" },
+  { label: "Recently added", value: "-created" },
+] as const;
+
+export function SeriesPageClient({
+  initialBottleList,
+  initialCursor,
+  initialSeries,
+  initialSort,
+}: {
+  initialBottleList: BottleList;
+  initialCursor: number;
+  initialSeries: Series;
+  initialSort: BottleSort;
+}) {
+  const orpc = useORPC();
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const bottleListQuery = useQuery({
+    ...orpc.bottles.list.queryOptions({
+      input: {
+        cursor: initialCursor,
+        limit: 25,
+        series: initialSeries.id,
+        sort: initialSort,
+      },
+    }),
+    initialData: initialBottleList,
+  });
+
+  function updateSort(value: string) {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set("sort", value);
+    nextParams.delete("cursor");
+    router.push(buildSearchHref(pathname, nextParams));
+  }
+
+  const facts = [
+    { label: "Series ID", value: initialSeries.peatedId },
+    {
+      label: "Bottles",
+      value: initialBottleList.total.toLocaleString("en-US"),
+    },
+  ] as const;
+  const bottleList = bottleListQuery.data;
+
+  return (
+    <div {...stylex.props(styles.page)}>
+      <PageHeader
+        description={
+          initialSeries.description ? (
+            <Markdown content={initialSeries.description} />
+          ) : undefined
+        }
+        eyebrow="Whisky series"
+        parent={
+          <TextLink href={getEntityUrl(initialSeries.brand)}>
+            {initialSeries.brand.name}
+          </TextLink>
+        }
+        title={initialSeries.name}
+      />
+      <PageColumns rail={<FactList facts={facts} />} railBehavior="stack">
+        <div {...stylex.props(styles.bottles)}>
+          {bottleListQuery.error ? (
+            <SectionError
+              heading="Bottles in this series are unavailable"
+              onRetry={() => void bottleListQuery.refetch()}
+            >
+              The series page still works. Try loading the bottles again.
+            </SectionError>
+          ) : bottleList ? (
+            <BottleCatalogList
+              emptyDescription={`No bottles have been added to ${initialSeries.fullName} yet.`}
+              emptyHeading="No bottles in this series yet"
+              items={bottleList.results.map((bottle) =>
+                toBottleListItem(bottle, {
+                  includeBrandInName: false,
+                  includeBrandRow: false,
+                  includeRatings: true,
+                  includeRelatedReleases: true,
+                  includeSeriesInName: false,
+                }),
+              )}
+              nextHref={getCursorHref(
+                pathname,
+                searchParams,
+                bottleList.rel.nextCursor,
+              )}
+              onSortChange={updateSort}
+              page={initialCursor}
+              previousHref={getCursorHref(
+                pathname,
+                searchParams,
+                bottleList.rel.prevCursor,
+              )}
+              sort={initialSort}
+              sortOptions={sortOptions}
+              total={bottleList.total}
+            />
+          ) : null}
+        </div>
+      </PageColumns>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  page: {
+    minWidth: 0,
+  },
+  bottles: {
+    minWidth: 0,
+    paddingTop: space.x4,
+  },
+});

--- a/apps/web/src/app/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemap.xml/route.ts
@@ -16,6 +16,7 @@ export async function GET() {
       ({ collection }) => `/sitemaps/${collection}/sitemap.xml`,
     ),
     "/sitemaps/bottles/sitemap.xml",
+    "/sitemaps/series/sitemap.xml",
     "/sitemaps/static.xml",
   ]);
 

--- a/apps/web/src/app/sitemaps/series/[id]/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemaps/series/[id]/sitemap.xml/route.ts
@@ -1,0 +1,44 @@
+import { createAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
+import { buildPagesSitemap, type Sitemap } from "@peated/web/lib/sitemaps";
+import { getBottleSeriesUrl } from "@peated/web/lib/urls";
+
+const SITEMAP_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800";
+const API_PAGE_LIMIT = 100;
+const API_PAGES_PER_SITEMAP = 10;
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: Request,
+  props: { params: Promise<{ id: string }> },
+) {
+  const { id } = await props.params;
+  const sitemapPage = Number(id);
+  const { client } = await createAnonymousServerClient();
+  const pages: Sitemap = [];
+  let cursor = (sitemapPage - 1) * API_PAGES_PER_SITEMAP + 1;
+
+  for (let index = 0; index < API_PAGES_PER_SITEMAP; index += 1) {
+    const result = await client.bottleSeries.list({
+      cursor,
+      limit: API_PAGE_LIMIT,
+    });
+    pages.push(
+      ...result.results.map((series) => ({
+        url: getBottleSeriesUrl(series),
+        lastModified: series.updatedAt,
+      })),
+    );
+    if (!result.rel.nextCursor) break;
+    cursor = result.rel.nextCursor;
+  }
+
+  const pagesSitemapXML = await buildPagesSitemap(pages);
+  return new Response(pagesSitemapXML, {
+    headers: {
+      "Cache-Control": SITEMAP_CACHE_CONTROL,
+      "Content-Type": "application/xml",
+    },
+  });
+}

--- a/apps/web/src/app/sitemaps/series/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemaps/series/sitemap.xml/route.ts
@@ -1,0 +1,27 @@
+import { createAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
+import { buildSitemapIndex } from "@peated/web/lib/sitemaps";
+
+const SITEMAP_CACHE_CONTROL =
+  "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800";
+const PAGE_LIMIT = 1000;
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const { client } = await createAnonymousServerClient();
+  const { total } = await client.bottleSeries.list({ limit: 1 });
+  const pageCount = Math.ceil(total / PAGE_LIMIT);
+  const sitemapIndexXML = await buildSitemapIndex(
+    Array.from(
+      { length: pageCount },
+      (_, index) => `/sitemaps/series/${index + 1}/sitemap.xml`,
+    ),
+  );
+
+  return new Response(sitemapIndexXML, {
+    headers: {
+      "Cache-Control": SITEMAP_CACHE_CONTROL,
+      "Content-Type": "application/xml",
+    },
+  });
+}

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -11,22 +11,18 @@ import {
   ImageAttribution,
   ItemList,
   ItemListItem,
-  RailList,
-  RailListItem,
   SectionHeading,
   TastingEntry,
 } from "..";
 import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
+import {
+  BottleRailSection,
+  type BottleRailItem,
+} from "./bottleRailSection.stylex";
 
 const NARROW = "@media (max-width: 759px)";
 
-export type BottleRecommendation = {
-  end?: ReactNode;
-  href: string;
-  imageUrl?: string | null;
-  metadata?: string;
-  name: string;
-};
+export type BottleRecommendation = BottleRailItem;
 
 export type BottleOverviewImage = {
   label: string;
@@ -45,6 +41,7 @@ export type BottleOverviewProps = {
   recommendationHeading?: string;
   recommendationIntro?: string;
   recommendations?: readonly BottleRecommendation[];
+  railSections?: ReactNode;
   tastingCount?: number;
   tastings?: readonly TastingEntryProps[];
 };
@@ -60,6 +57,7 @@ export function BottleOverview({
   recommendationHeading = "If you liked this",
   recommendationIntro,
   recommendations = [],
+  railSections,
   tastingCount,
   tastings = [],
 }: BottleOverviewProps) {
@@ -145,32 +143,17 @@ export function BottleOverview({
           ) : null}
         </figure>
 
-        {recommendations.length ? (
-          <section {...stylex.props(styles.recommendations)}>
-            <h2 {...stylex.props(styles.railHeading)}>
-              {recommendationHeading}
-            </h2>
-            {recommendationIntro ? (
-              <p {...stylex.props(styles.railIntro)}>{recommendationIntro}</p>
+        {recommendations.length || railSections ? (
+          <div {...stylex.props(styles.railSections)}>
+            {recommendations.length ? (
+              <BottleRailSection
+                heading={recommendationHeading}
+                intro={recommendationIntro}
+                items={recommendations}
+              />
             ) : null}
-            <RailList ariaLabel={recommendationHeading}>
-              {recommendations.map((recommendation) => (
-                <RailListItem
-                  end={recommendation.end}
-                  href={recommendation.href}
-                  key={recommendation.href}
-                  leading={
-                    <BottleVisual
-                      imageUrl={recommendation.imageUrl}
-                      size="sm"
-                    />
-                  }
-                  metadata={recommendation.metadata}
-                  title={recommendation.name}
-                />
-              ))}
-            </RailList>
-          </section>
+            {railSections}
+          </div>
         ) : null}
       </aside>
     </div>
@@ -182,7 +165,7 @@ const styles = stylex.create({
     display: "grid",
     gridTemplateAreas: {
       default: '"main rail"',
-      [NARROW]: '"facts" "media" "content" "recommendations"',
+      [NARROW]: '"facts" "media" "content" "railSections"',
     },
     gridTemplateColumns: {
       default: "minmax(0, 1fr) 336px",
@@ -227,12 +210,12 @@ const styles = stylex.create({
     marginTop: space.x2,
     color: colors.inkMuted,
   },
-  recommendations: {
-    gridArea: "recommendations",
+  railSections: {
+    gridArea: "railSections",
     display: "flex",
     minWidth: 0,
     flexDirection: "column",
-    gap: space.x2,
+    gap: space.x8,
   },
   section: {
     minWidth: 0,
@@ -278,20 +261,5 @@ const styles = stylex.create({
       default: "none",
       ":focus-visible": effects.focusRing,
     },
-  },
-  railHeading: {
-    margin: 0,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
-  },
-  railIntro: {
-    margin: 0,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.4,
   },
 });

--- a/apps/web/src/components/pages/bottleRailSection.stylex.tsx
+++ b/apps/web/src/components/pages/bottleRailSection.stylex.tsx
@@ -1,0 +1,113 @@
+import * as stylex from "@stylexjs/stylex";
+import type { ReactNode } from "react";
+
+import {
+  AppLink,
+  BottleVisual,
+  RailList,
+  RailListItem,
+} from "@peated/web/components";
+import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
+
+export type BottleRailItem = {
+  end?: ReactNode;
+  href: string;
+  imageUrl?: string | null;
+  metadata?: string;
+  name: string;
+};
+
+/** Presents a compact bottle list in a page rail or its mobile stack. */
+export function BottleRailSection({
+  children,
+  heading,
+  intro,
+  items = [],
+  moreHref,
+  moreLabel,
+}: {
+  children?: ReactNode;
+  heading: string;
+  intro?: string;
+  items?: readonly BottleRailItem[];
+  moreHref?: string;
+  moreLabel?: string;
+}) {
+  return (
+    <section {...stylex.props(styles.section)}>
+      <h2 {...stylex.props(styles.heading)}>{heading}</h2>
+      {intro ? <p {...stylex.props(styles.intro)}>{intro}</p> : null}
+      {items.length ? (
+        <RailList ariaLabel={heading}>
+          {items.map((item) => (
+            <RailListItem
+              end={item.end}
+              href={item.href}
+              key={item.href}
+              leading={<BottleVisual imageUrl={item.imageUrl} size="sm" />}
+              metadata={item.metadata}
+              title={item.name}
+            />
+          ))}
+        </RailList>
+      ) : null}
+      {children}
+      {moreHref && moreLabel ? (
+        <AppLink href={moreHref} {...stylex.props(styles.moreLink)}>
+          {moreLabel} →
+        </AppLink>
+      ) : null}
+    </section>
+  );
+}
+
+const styles = stylex.create({
+  section: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x2,
+  },
+  heading: {
+    margin: 0,
+    fontFamily: fonts.display,
+    fontSize: "18px",
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    lineHeight: 1.2,
+  },
+  intro: {
+    margin: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "10px",
+    lineHeight: 1.4,
+  },
+  moreLink: {
+    display: "block",
+    boxSizing: "border-box",
+    width: "100%",
+    marginTop: "6px",
+    paddingTop: space.x3,
+    paddingRight: 0,
+    paddingBottom: space.x3,
+    paddingLeft: 0,
+    borderRadius: 0,
+    outline: "none",
+    backgroundColor: {
+      default: "transparent",
+      ":hover": colors.surface,
+      ":active": colors.surface,
+    },
+    color: colors.accentDeep,
+    fontFamily: fonts.display,
+    fontSize: "13px",
+    fontWeight: 700,
+    lineHeight: 1.3,
+    textDecoration: "none",
+    boxShadow: {
+      default: "none",
+      ":focus-visible": effects.focusRing,
+    },
+  },
+});

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -16,7 +16,11 @@ import {
   readRecentSearches,
   writeRecentSearches,
 } from "@peated/web/lib/recentSearches";
-import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
+import {
+  getBottleSeriesUrl,
+  getBottleUrl,
+  getEntityUrl,
+} from "@peated/web/lib/urls";
 import * as stylex from "@stylexjs/stylex";
 import { useRouter } from "next/navigation";
 import {
@@ -33,6 +37,7 @@ import { space } from "../../styles/tokens.stylex";
 const searchScopes = [
   { label: "Everything", value: "all" },
   { label: "Bottles", value: "bottles" },
+  { label: "Series", value: "series" },
   { label: "Distillers", value: "distilleries" },
   { label: "Brands", value: "brands" },
   { label: "Bottlers", value: "bottlers" },
@@ -41,6 +46,7 @@ const searchScopes = [
 
 const allApiScopes = [
   "bottles",
+  "series",
   "distilleries",
   "brands",
   "bottlers",
@@ -60,6 +66,10 @@ type BottleSearchResult = Extract<
 type EntitySearchResult = Extract<
   SearchGroup,
   { type: "distilleries" }
+>["results"][number];
+type SeriesSearchResult = Extract<
+  SearchGroup,
+  { type: "series" }
 >["results"][number];
 type RegionSearchResult = Extract<
   SearchGroup,
@@ -143,8 +153,8 @@ function getApiScopes(scope: SearchScope, signedIn: boolean) {
 function getSearchingText(scope: SearchScope, signedIn: boolean) {
   if (scope === "all") {
     return signedIn
-      ? "Searching bottles, distillers, brands, bottlers, and members…"
-      : "Searching bottles, distillers, brands, and bottlers…";
+      ? "Searching bottles, series, distillers, brands, bottlers, and members…"
+      : "Searching bottles, series, distillers, brands, and bottlers…";
   }
   const label = searchScopes.find((option) => option.value === scope)?.label;
   return label ? `Searching ${label.toLocaleLowerCase()}…` : "Searching…";
@@ -196,6 +206,19 @@ function entityItem(entity: EntitySearchResult) {
   } satisfies SearchResultItem;
 }
 
+function seriesItem(series: SeriesSearchResult) {
+  return {
+    href: getBottleSeriesUrl(series),
+    id: `series-${series.id}`,
+    metadata: `${series.brand.name} · ${series.numReleases.toLocaleString("en-US")} ${series.numReleases === 1 ? "bottle" : "bottles"}`,
+    title: series.name,
+    visual: {
+      fallback: "S",
+      label: series.fullName,
+    },
+  } satisfies SearchResultItem;
+}
+
 function memberItem({ member, totalTastings }: MemberSearchResult) {
   return {
     href: `/users/${member.username}`,
@@ -227,6 +250,8 @@ function getGroupLabel(type: SearchGroup["type"]) {
   switch (type) {
     case "bottles":
       return "Bottles";
+    case "series":
+      return "Series";
     case "distilleries":
       return "Distillers";
     case "brands":
@@ -261,6 +286,8 @@ function groupItems(
   switch (group.type) {
     case "bottles":
       return group.results.map((bottle) => bottleItem(bottle, bottleOptions));
+    case "series":
+      return group.results.map(seriesItem);
     case "distilleries":
     case "brands":
     case "bottlers":
@@ -328,6 +355,7 @@ function groupMatchesScope(type: SearchGroup["type"], scope: SearchScope) {
 function exactMatchesScope(exact: SearchExact, scope: SearchScope) {
   if (scope === "all") return true;
   if (exact.type === "bottle") return scope === "bottles";
+  if (exact.type === "series") return scope === "series";
   return (
     (exact.ref.kind === "distillery" && scope === "distilleries") ||
     (exact.ref.kind === "brand" && scope === "brands") ||
@@ -348,6 +376,7 @@ function getResultScopeTotals(response: SearchResponse) {
   return {
     all: getResultCount(response, "all"),
     bottles: getResultCount(response, "bottles"),
+    series: getResultCount(response, "series"),
     distilleries: getResultCount(response, "distilleries"),
     brands: getResultCount(response, "brands"),
     bottlers: getResultCount(response, "bottlers"),
@@ -383,15 +412,17 @@ function getSearchSnapshot(
 }
 
 function exactItem(exact: SearchExact, bottleOptions: BottleItemOptions) {
-  return exact.type === "bottle"
-    ? bottleItem(exact.ref, bottleOptions)
-    : entityItem(exact.ref);
+  if (exact.type === "bottle") return bottleItem(exact.ref, bottleOptions);
+  if (exact.type === "series") return seriesItem(exact.ref);
+  return entityItem(exact.ref);
 }
 
 function nearestItem(nearest: SearchNearest, bottleOptions: BottleItemOptions) {
   switch (nearest.type) {
     case "bottles":
       return bottleItem(nearest.result, bottleOptions);
+    case "series":
+      return seriesItem(nearest.result);
     case "distilleries":
     case "brands":
     case "bottlers":
@@ -430,7 +461,7 @@ export function Search({
   onScopeChange,
   onSubmit,
   placement = "overlay",
-  placeholder = "bottles, distillers, brands…",
+  placeholder = "bottles, series, distillers, brands…",
   scopeValues,
   showBottleRatings = true,
   submitLabel,

--- a/apps/web/src/lib/bottleListItem.test.ts
+++ b/apps/web/src/lib/bottleListItem.test.ts
@@ -22,6 +22,19 @@ describe("toBottleListItem", () => {
     });
   });
 
+  test("can omit the brand from a list owned by that brand", () => {
+    expect(
+      toBottleListItem(mockBottle, {
+        includeBrandInName: false,
+        includeBrandRow: false,
+      }),
+    ).toMatchObject({
+      brand: undefined,
+      brandHref: undefined,
+      name: "16-year-old",
+    });
+  });
+
   test("identifies a distinct bottler when the surrounding view needs it", () => {
     const bottler = {
       ...mockBottle.brand,

--- a/apps/web/src/lib/bottleListItem.ts
+++ b/apps/web/src/lib/bottleListItem.ts
@@ -11,9 +11,11 @@ type Bottle = Outputs["bottles"]["list"]["results"][number];
 
 export type BottleListItemOptions = {
   includeBottler?: boolean;
+  includeBrandInName?: boolean;
   includeBrandRow?: boolean;
   includeRatings?: boolean;
   includeRelatedReleases?: boolean;
+  includeSeriesInName?: boolean;
 };
 
 /** Maps one API Bottle to the shared standard list presentation. */
@@ -21,9 +23,11 @@ export function toBottleListItem(
   bottle: Bottle,
   {
     includeBottler = false,
+    includeBrandInName,
     includeBrandRow = true,
     includeRatings = false,
     includeRelatedReleases = false,
+    includeSeriesInName = true,
   }: BottleListItemOptions = {},
 ): BottleListItem {
   const releaseDate = formatReleaseDate(bottle);
@@ -56,7 +60,8 @@ export function toBottleListItem(
       bottle.abv !== null ? `${formatAbv(bottle.abv)}% ABV` : null,
     ].filter((value): value is string => value !== null),
     name: formatBottleDisplayName(bottle, {
-      includeBrand: !includeBrandRow,
+      includeBrand: includeBrandInName ?? !includeBrandRow,
+      includeSeries: includeSeriesInName,
     }),
     ratings: includeRatings
       ? {

--- a/apps/web/src/lib/peatedIdRoutes.test.ts
+++ b/apps/web/src/lib/peatedIdRoutes.test.ts
@@ -1,19 +1,30 @@
 import { describe, expect, it } from "vitest";
 import {
   matchEntityRoute,
-  resolveBottlePeatedIdRoute,
+  resolveCatalogPeatedIdRoute,
   resolveEntityRoute,
 } from "./peatedIdRoutes";
 
 describe("Peated ID routes", () => {
   it("redirects Bottle IDs to the Bottle collection route", () => {
-    expect(resolveBottlePeatedIdRoute("/B0123")).toEqual({
+    expect(resolveCatalogPeatedIdRoute("/B0123")).toEqual({
       action: "redirect",
       pathname: "/bottles/123",
     });
-    expect(resolveBottlePeatedIdRoute("/b123")).toEqual({
+    expect(resolveCatalogPeatedIdRoute("/b123")).toEqual({
       action: "redirect",
       pathname: "/bottles/123",
+    });
+  });
+
+  it("redirects Series IDs to the Series collection route", () => {
+    expect(resolveCatalogPeatedIdRoute("/S0421")).toEqual({
+      action: "redirect",
+      pathname: "/series/421",
+    });
+    expect(resolveCatalogPeatedIdRoute("/s421")).toEqual({
+      action: "redirect",
+      pathname: "/series/421",
     });
   });
 
@@ -94,7 +105,7 @@ describe("Peated ID routes", () => {
   );
 
   it("does not claim unrelated or malformed routes", () => {
-    expect(resolveBottlePeatedIdRoute("/bottles/123")).toBeNull();
+    expect(resolveCatalogPeatedIdRoute("/bottles/123")).toBeNull();
     expect(matchEntityRoute("/bottles/123")).toBeNull();
     expect(matchEntityRoute("/distillers")).toBeNull();
     expect(matchEntityRoute("/entities/0")).toBeNull();

--- a/apps/web/src/lib/peatedIdRoutes.ts
+++ b/apps/web/src/lib/peatedIdRoutes.ts
@@ -7,7 +7,7 @@ export type PeatedIdRouteResolution = {
   pathname: string;
 };
 
-const ROOT_PEATED_ID_PATTERN = /^\/([BE]\d+)\/?$/i;
+const ROOT_PEATED_ID_PATTERN = /^\/([BES]\d+)\/?$/i;
 const PUBLIC_ENTITY_PATTERN =
   /^\/(brands|distillers|bottlers|companies)\/([1-9]\d*)(?:-[^/]+)?(\/.*)?$/;
 const LEGACY_ENTITY_PATTERN = /^\/entities\/([1-9]\d*)(?:-[^/]+)?(\/.*)?$/;
@@ -44,7 +44,7 @@ function getEntityKind(collection: string): EntityKind | null {
   }
 }
 
-export function resolveBottlePeatedIdRoute(
+export function resolveCatalogPeatedIdRoute(
   pathname: string,
 ): PeatedIdRouteResolution | null {
   const rootMatch = ROOT_PEATED_ID_PATTERN.exec(pathname);
@@ -52,9 +52,13 @@ export function resolveBottlePeatedIdRoute(
     const parsed = parsePeatedId(rootMatch[1]);
     if (!parsed) return null;
 
-    return parsed.type === "bottle"
-      ? { action: "redirect", pathname: `/bottles/${parsed.id}` }
-      : null;
+    if (parsed.type === "bottle") {
+      return { action: "redirect", pathname: `/bottles/${parsed.id}` };
+    }
+    if (parsed.type === "series") {
+      return { action: "redirect", pathname: `/series/${parsed.id}` };
+    }
+    return null;
   }
 
   return null;

--- a/apps/web/src/lib/seoMetadata.test.ts
+++ b/apps/web/src/lib/seoMetadata.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   getBottleSeoMetadata,
   getEntitySeoMetadata,
+  getSeriesSeoMetadata,
   homeMetadata,
 } from "./seoMetadata";
 
@@ -120,6 +121,33 @@ describe("SEO metadata", () => {
 
     expect(metadata).toMatchObject({
       title: "Lagavulin — Whisky distillery",
+      twitter: { card: "summary" },
+    });
+  });
+
+  it("builds canonical Series metadata with its bottle count", () => {
+    const metadata = getSeriesSeoMetadata(
+      {
+        id: 421,
+        fullName: "Dramfool Jim McEwan Signature Collection",
+        description: null,
+        numReleases: 12,
+      },
+      { canonical: true },
+    );
+
+    expect(metadata).toMatchObject({
+      title: "Dramfool Jim McEwan Signature Collection — Whisky series",
+      description:
+        "See 12 bottles in the Dramfool Jim McEwan Signature Collection series.",
+      alternates: {
+        canonical: "/series/421-dramfool-jim-mc-ewan-signature-collection",
+      },
+      openGraph: {
+        locale: "en_US",
+        siteName: "Peated",
+        url: "/series/421-dramfool-jim-mc-ewan-signature-collection",
+      },
       twitter: { card: "summary" },
     });
   });

--- a/apps/web/src/lib/seoMetadata.ts
+++ b/apps/web/src/lib/seoMetadata.ts
@@ -5,7 +5,7 @@ import config from "@peated/web/config";
 import type { Metadata } from "next";
 
 import { summarize } from "./markdown";
-import { getBottleUrl, getEntityUrl } from "./urls";
+import { getBottleSeriesUrl, getBottleUrl, getEntityUrl } from "./urls";
 
 const HOME_TITLE = "Peated: Whisky bottles, reviews, and tasting notes";
 
@@ -40,6 +40,13 @@ type EntitySeoMetadataSource = {
   name: string;
   description: string | null;
   images?: readonly { imageUrl: string }[];
+};
+
+type SeriesSeoMetadataSource = {
+  id: number;
+  fullName: string;
+  description: string | null;
+  numReleases: number;
 };
 
 type MetadataOptions = {
@@ -121,6 +128,37 @@ export function getEntitySeoMetadata(
       title,
       description,
       images,
+    },
+  };
+}
+
+export function getSeriesSeoMetadata(
+  series: SeriesSeoMetadataSource,
+  { canonical = false }: MetadataOptions = {},
+): Metadata {
+  const title = `${series.fullName} — Whisky series`;
+  const bottleCount = series.numReleases.toLocaleString("en-US");
+  const description =
+    summarize(series.description || "", 160) ||
+    `See ${bottleCount} ${series.numReleases === 1 ? "bottle" : "bottles"} in the ${series.fullName} series.`;
+  const url = getBottleSeriesUrl(series);
+
+  return {
+    title,
+    description,
+    alternates: canonical ? { canonical: url } : undefined,
+    openGraph: {
+      type: "website",
+      locale: "en_US",
+      siteName: "Peated",
+      title,
+      description,
+      url: canonical ? url : undefined,
+    },
+    twitter: {
+      card: "summary",
+      title,
+      description,
     },
   };
 }

--- a/apps/web/src/lib/seriesBottleRail.test.ts
+++ b/apps/web/src/lib/seriesBottleRail.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { selectOtherSeriesBottles } from "./seriesBottleRail";
+
+describe("Series bottle rail", () => {
+  it("excludes the current Bottle and keeps at most three siblings", () => {
+    const bottles = [1, 2, 3, 4, 5].map((id) => ({ id }));
+
+    expect(selectOtherSeriesBottles(bottles, 2)).toEqual([
+      { id: 1 },
+      { id: 3 },
+      { id: 4 },
+    ]);
+  });
+
+  it("returns no siblings for a one-Bottle Series", () => {
+    expect(selectOtherSeriesBottles([{ id: 2 }], 2)).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/seriesBottleRail.ts
+++ b/apps/web/src/lib/seriesBottleRail.ts
@@ -1,0 +1,10 @@
+/** Keeps the current Bottle out of a compact Series rail. */
+export function selectOtherSeriesBottles<T extends { id: number }>(
+  bottles: readonly T[],
+  currentBottleId: number,
+  limit = 3,
+) {
+  return bottles
+    .filter((bottle) => bottle.id !== currentBottleId)
+    .slice(0, limit);
+}

--- a/apps/web/src/lib/seriesPage.server.test.ts
+++ b/apps/web/src/lib/seriesPage.server.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createSeriesPageLoader,
+  type SeriesPageServices,
+} from "./seriesPage.server";
+
+type TestSeries = { id: number; fullName: string };
+
+const series = { id: 421, fullName: "Dramfool Signature Collection" };
+const loadSeries = vi.fn<SeriesPageServices<TestSeries>["loadSeries"]>();
+const getRedirectPath =
+  vi.fn<SeriesPageServices<TestSeries>["getRedirectPath"]>();
+const redirect = vi.fn<SeriesPageServices<TestSeries>["redirect"]>();
+const getSeriesPage = createSeriesPageLoader({
+  loadSeries,
+  getRedirectPath,
+  redirect,
+});
+const redirectSignal = new Error("permanent redirect");
+
+describe("getSeriesPage", () => {
+  beforeEach(() => {
+    loadSeries.mockReset();
+    getRedirectPath.mockReset();
+    redirect.mockReset();
+    redirect.mockImplementation(() => {
+      throw redirectSignal;
+    });
+  });
+
+  it("returns an active Series at its canonical route", async () => {
+    loadSeries.mockResolvedValue(series);
+    getRedirectPath.mockResolvedValue(null);
+
+    await expect(getSeriesPage(421)).resolves.toBe(series);
+    expect(redirect).not.toHaveBeenCalled();
+  });
+
+  it("redirects a merged or stale Series route", async () => {
+    const replacement = { ...series, id: 422 };
+    loadSeries.mockResolvedValue(replacement);
+    getRedirectPath.mockResolvedValue(
+      "/series/422-dramfool-signature-collection?sort=name",
+    );
+
+    await expect(getSeriesPage(421)).rejects.toBe(redirectSignal);
+    expect(getRedirectPath).toHaveBeenCalledWith({
+      canonicalSeries: replacement,
+      currentId: 421,
+    });
+    expect(redirect).toHaveBeenCalledWith(
+      "/series/422-dramfool-signature-collection?sort=name",
+    );
+  });
+});

--- a/apps/web/src/lib/seriesPage.server.ts
+++ b/apps/web/src/lib/seriesPage.server.ts
@@ -1,0 +1,57 @@
+"server only";
+
+import { permanentRedirect } from "next/navigation";
+import { cache } from "react";
+import { getAnonymousServerClient } from "./orpc/client.server";
+import { resolveOrNotFound } from "./orpc/notFound.server";
+import { getCanonicalPublicRouteRedirectPath } from "./tombstoneRedirect";
+import { getBottleSeriesUrl } from "./urls";
+
+export type SeriesPageServices<
+  Series extends { id: number; fullName: string },
+> = {
+  loadSeries: (seriesId: number) => Promise<Series>;
+  getRedirectPath: (options: {
+    canonicalSeries: Series;
+    currentId: number;
+  }) => Promise<string | null>;
+  redirect: (path: string) => never;
+};
+
+/** Loads a Series and follows its canonical tombstone and public slug. */
+export function createSeriesPageLoader<
+  Series extends { id: number; fullName: string },
+>(services: SeriesPageServices<Series>) {
+  return async function loadSeriesPage(seriesId: number) {
+    const series = await services.loadSeries(seriesId);
+    const redirectPath = await services.getRedirectPath({
+      canonicalSeries: series,
+      currentId: seriesId,
+    });
+
+    if (redirectPath) services.redirect(redirectPath);
+    return series;
+  };
+}
+
+const loadSeriesPage = createSeriesPageLoader({
+  async loadSeries(seriesId: number) {
+    const { client } = await getAnonymousServerClient();
+    return await resolveOrNotFound(
+      client.bottleSeries.details({ series: seriesId }),
+    );
+  },
+  getRedirectPath: ({ canonicalSeries, currentId }) =>
+    getCanonicalPublicRouteRedirectPath({
+      canonicalId: canonicalSeries.id,
+      canonicalPath: getBottleSeriesUrl(canonicalSeries),
+      currentId,
+      currentPathPrefixes: [
+        `/series/${currentId}`,
+        `/${canonicalSeries.peatedId}`,
+      ],
+    }),
+  redirect: permanentRedirect,
+});
+
+export const getSeriesPage = cache(loadSeriesPage);

--- a/apps/web/src/lib/urls.test.ts
+++ b/apps/web/src/lib/urls.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getBottleUrl, getEntityUrl } from "./urls";
+import { getBottleSeriesUrl, getBottleUrl, getEntityUrl } from "./urls";
 
 const bottle = {
   id: 123,
@@ -10,6 +10,15 @@ const bottle = {
 describe("public catalog URLs", () => {
   it("uses the Bottle collection, ID, and display name", () => {
     expect(getBottleUrl(bottle)).toBe("/bottles/123-lagavulin-16-year-old");
+  });
+
+  it("uses the Series collection, ID, and full name", () => {
+    expect(
+      getBottleSeriesUrl({
+        id: 421,
+        fullName: "Dramfool Jim McEwan Signature Collection",
+      }),
+    ).toBe("/series/421-dramfool-jim-mc-ewan-signature-collection");
   });
 
   it.each([

--- a/apps/web/src/lib/urls.ts
+++ b/apps/web/src/lib/urls.ts
@@ -17,6 +17,13 @@ export function getBottleUrl(
   return `/bottles/${bottle.id}-${slug}`;
 }
 
+export function getBottleSeriesUrl(series: {
+  id: number;
+  fullName: string;
+}): `/series/${number}-${string}` {
+  return `/series/${series.id}-${createUrlSlug(series.fullName, "series")}`;
+}
+
 export function getEntityUrl(entity: {
   id: number;
   kind: EntityKind | null;
@@ -28,7 +35,10 @@ export function getEntityUrl(entity: {
   return `${collection}/${entity.id}-${createUrlSlug(entity.name, "entity")}`;
 }
 
-function createUrlSlug(value: string, fallback: "bottle" | "entity"): string {
+function createUrlSlug(
+  value: string,
+  fallback: "bottle" | "entity" | "series",
+): string {
   const asciiSlug = slugify(value);
   if (asciiSlug) return asciiSlug;
 

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -2,7 +2,7 @@ import { isORPCNotFoundError } from "@peated/orpc/client/errors";
 import { createAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 import {
   matchEntityRoute,
-  resolveBottlePeatedIdRoute,
+  resolveCatalogPeatedIdRoute,
   resolveEntityRoute,
 } from "@peated/web/lib/peatedIdRoutes";
 import { type NextRequest, NextResponse } from "next/server";
@@ -18,7 +18,7 @@ export async function proxy(request: NextRequest) {
     `${request.nextUrl.pathname}${request.nextUrl.search}`,
   );
   const entityMatch = matchEntityRoute(request.nextUrl.pathname);
-  let resolution = resolveBottlePeatedIdRoute(request.nextUrl.pathname);
+  let resolution = resolveCatalogPeatedIdRoute(request.nextUrl.pathname);
 
   if (entityMatch) {
     try {

--- a/docs/architecture/peated-ids.md
+++ b/docs/architecture/peated-ids.md
@@ -8,8 +8,9 @@ Peated IDs are short, permanent references for public catalog objects. They are 
 | ------ | --------------------- | ------- | ------------------------------------------------------ |
 | Bottle | `B` plus four+ digits | `B0123` | `https://peated.com/bottles/123-lagavulin-16-year-old` |
 | Entity | `E` plus four+ digits | `E0123` | `https://peated.com/distillers/123-lagavulin`          |
+| Series | `S` plus four+ digits | `S0123` | `https://peated.com/series/123-ardbeg-supernova`       |
 
-The number is the object's existing positive database ID. Numbers shorter than four digits use leading zeroes. The prefix identifies the type, so `B0123` and `E0123` are different Peated IDs.
+The number is the object's existing positive database ID. Numbers shorter than four digits use leading zeroes. The prefix identifies the type, so `B0123`, `E0123`, and `S0123` are different Peated IDs.
 
 Peated IDs are serialized in uppercase with at least four digits. Input and search are case-insensitive and accept omitted leading zeroes, so `b123` is normalized to `B0123`.
 
@@ -19,18 +20,23 @@ Peated IDs are serialized in uppercase with at least four digits. Input and sear
 - Entity URLs use the collection for their primary kind: `/brands`,
   `/distillers`, `/bottlers`, or `/companies`, followed by the numeric ID and
   current name slug.
+- Series URLs use `/series/{numeric ID}-{current full-name slug}`. The full name
+  includes the Brand.
 - The numeric ID identifies the object. The web app creates the slug when it
   builds a URL. It does not store slugs. Numeric-only and old slug URLs redirect
   permanently to the current URL.
-- Root ID URLs such as `/B0123`, `/B123`, and `/E0123` redirect permanently to
-  the canonical collection URL.
+- Root ID URLs such as `/B0123`, `/B123`, `/E0123`, and `/S0123` redirect
+  permanently to the canonical collection URL.
 - Legacy `/entities/{numeric ID}` URLs redirect permanently to the Entity's
   primary-kind collection. Nested routes keep their suffix and query string.
-- Bottle and entity API responses include `peatedId` alongside the existing numeric `id`.
+- Bottle, Entity, and Series API responses include `peatedId` alongside the
+  existing numeric `id`.
 - Global search recognizes an exact Peated ID and returns that object when its type is included in the search.
-- Bottle and entity pages display the compact label `ID` and provide a way to
+- Bottle, Entity, and Series pages display the compact label `ID` and provide a way to
   copy the canonical URL.
-- IDs for merged bottles and entities redirect to the remaining object.
+- IDs for merged Bottles, Entities, and Series redirect to the remaining object.
+- A populated Series must be merged instead of deleted. Deleting an empty
+  Series preserves its ID as a tombstone without a destination.
 
 ## Scope
 

--- a/openspec/changes/add-public-bottle-series-pages/.openspec.yaml
+++ b/openspec/changes/add-public-bottle-series-pages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-01

--- a/openspec/changes/add-public-bottle-series-pages/design.md
+++ b/openspec/changes/add-public-bottle-series-pages/design.md
@@ -1,0 +1,77 @@
+## Context
+
+Bottle Series already have stable database IDs, Brand ownership, names, descriptions, search vectors, and release counts. Bottle responses embed the assigned Series, and the Bottle list route accepts a Series filter. The web app currently has no public Series route, the Series details response does not expose its owning Brand, global search cannot return a Series, and Series deletion hard-deletes the record after removing its Bottle assignments.
+
+The new surface crosses catalog identity, search, moderation lifecycle, API serialization, canonical web routing, and responsive page composition. It must preserve the distinction between a Series and a BottleGroup: a Series is a named Brand range containing independently complete Bottles, while a BottleGroup only relates variants of one marketed Bottle.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Give every active Bottle Series a permanent public identity and canonical page.
+- Present verified Series-owned context and the complete paginated Bottle membership.
+- Make Series discoverable from Bottle pages, canonical IDs, and global search.
+- Preserve old public references when duplicate Series merge.
+- Reuse the existing page layout, Bottle list, Bottle rail, ratings, pager, error, and empty-state components.
+
+**Non-Goals:**
+
+- A standalone Series directory or browse index.
+- Series-owned images, ratings, tasting aggregates, or manually curated Bottle positions.
+- New Bottle or BottleGroup identity rules.
+- A complete moderator UI for editing and merging Series.
+
+## Decisions
+
+### Series are public catalog objects
+
+Add `series: "S"` to Peated ID formatting and parsing. Series `421` becomes `S0421`. The canonical web route is `/series/{numeric ID}-{slug}`, where the slug comes from `fullName` so Brand context remains present and name collisions do not matter. Numeric-only, stale-slug, merged-ID, and root Peated ID routes redirect permanently to the active canonical route.
+
+This follows the existing Bottle route model. Keeping `/bottles?series=421` as the public destination was rejected because it exposes an internal filter, cannot own Series metadata, and gives Series no stable external identity.
+
+### Summary and details contracts stay separate
+
+The lightweight Series object embedded in Bottle responses gains only `peatedId`. A new details schema adds the owning Brand reference. This avoids making every Bottle serialization load Brand data that the Bottle already contains.
+
+The dedicated page loads Series details and uses the existing `bottles.list` Series filter for membership. No parallel Series-Bottles endpoint is added.
+
+### Series merge owns public-reference preservation
+
+Add a Bottle Series tombstone table with source and destination IDs. A moderator merge operation moves Bottle and BottleGroup assignments through the existing Bottle update boundary, redirects older tombstones that target the source, records the change, and deletes the source. Series details follow a tombstone to the active destination.
+
+The existing delete operation becomes valid only for an empty Series. A populated Series returns a conflict and must be merged instead. Empty deletion leaves a tombstone without a destination, matching current Bottle deletion behavior while preventing an active object from silently losing public membership.
+
+### Search treats Series as a distinct result type
+
+Add a `series` search scope, result group, nearest result, exact Peated ID result, and facet count. “Everything” includes Series. The web search renders Series with its Brand and Bottle count and links to the canonical Series page. This prevents a named range from appearing only as many near-identical Bottle results.
+
+### The Series page is a focused server-rendered catalog page
+
+The page uses the shared page header, Bottle list, sort control, cursor pager, error, and empty-state components. It shows a Brand link, Series name, optional description, Peated ID, and total Bottle count. Membership defaults to newest release and supports the existing relevant Bottle sort choices. Category and age filters are omitted because this page is already a scoped collection.
+
+### Bottle pages use a shared Bottle rail section
+
+Extract the current recommendation rail markup into a small reusable Bottle rail section inside the Bottle overview component. The Series widget uses the same Bottle visual, metadata, and rating presentation. It requests up to four Series Bottles, removes the current Bottle, shows at most three other Bottles, and links “See all N bottles” to the canonical Series page. It renders only when the Series contains another Bottle and does not show an empty shell.
+
+The existing Series fact remains and links to the same canonical page.
+
+## Risks / Trade-offs
+
+- **Series search adds another global-search scope and query.** → Run it only when requested, retain the existing per-scope limit, and use the current indexed Series search vector.
+- **Merging a large Series can update many Bottle groups.** → Reuse the transactional Bottle update boundary and finalize affected search/stat work after commit, as current Series deletion does.
+- **Some Series have incomplete descriptions or release dates.** → Omit missing description text and use existing Bottle list fallbacks; do not infer Series prose or sequence.
+- **Adding `S` changes Peated ID parsing exhaustiveness.** → Update exact-ID search and route tests at the same cutover.
+- **A Series can become empty after all Bottles are reassigned.** → The page remains valid while the Series exists; moderators may delete it explicitly, producing a destination-less tombstone and a not-found response.
+
+## Migration Plan
+
+1. Add the Series tombstone schema and generate the migration with `pnpm db:generate`.
+2. Deploy API identity, details, search, merge, and guarded-delete behavior.
+3. Deploy canonical Series routing, search rendering, Series page, and Bottle widget links.
+4. No data backfill is required because `S` IDs derive from existing numeric IDs and all current Series remain active.
+
+Rollback can remove the web links and search scope while leaving the tombstone table in place. Merged Series must not be recreated under their old IDs.
+
+## Open Questions
+
+None. Explicit Series ordering, images, and aggregate scoring remain future decisions supported by evidence from real Series pages.

--- a/openspec/changes/add-public-bottle-series-pages/proposal.md
+++ b/openspec/changes/add-public-bottle-series-pages/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Bottle Series are durable catalog records, but people can only encounter them as hidden Bottle metadata or an opaque Bottle catalog filter. Peated needs a public Series destination that explains the collection, lists its Bottles, and makes movement between one Bottle and the rest of its Series direct and predictable.
+
+## What Changes
+
+- Treat Bottle Series as permanent public catalog objects with canonical URLs and Peated IDs.
+- Add a dedicated Series page with Brand context, description, Bottle count, and a paginated Bottle list.
+- Link Series references and global search results to the dedicated page.
+- Add an "Other bottles in this series" section to Bottle pages, built from existing Bottle rail and list components, with a link to the complete Series page.
+- Preserve public Series identity when duplicate Series are merged. **BREAKING**: populated Series can no longer be deleted without a destination.
+
+## Capabilities
+
+### New Capabilities
+
+- `bottle-series-catalog`: Public identity, routing, lifecycle, discovery, Series pages, and Bottle-page navigation for Bottle Series.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Bottle Series schemas, serializers, API routes, search, Peated ID parsing, and catalog lifecycle behavior.
+- Web catalog URLs, canonical routing, metadata, sitemaps, search results, Series pages, and Bottle overview composition.
+- Database schema and generated migration metadata for Series tombstones.
+- Focused server and web tests plus desktop and mobile UI verification.

--- a/openspec/changes/add-public-bottle-series-pages/specs/bottle-series-catalog/spec.md
+++ b/openspec/changes/add-public-bottle-series-pages/specs/bottle-series-catalog/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Public Series identity
+
+The system SHALL expose each active Bottle Series as a public catalog object with a computed Peated ID and canonical Series URL.
+
+#### Scenario: Canonical Series URL
+
+- **WHEN** a person opens an active Series by numeric ID, stale slug, or `S` Peated ID
+- **THEN** the system redirects permanently to `/series/{id}-{current full-name slug}`
+
+#### Scenario: Merged Series URL
+
+- **WHEN** a person opens the ID or URL of a Series that was merged
+- **THEN** the system redirects permanently to the surviving Series canonical URL
+
+### Requirement: Series details contract
+
+The system SHALL return Series-owned details separately from the lightweight Series summary embedded in Bottle responses.
+
+#### Scenario: Load Series details
+
+- **WHEN** a client requests an active or merged Series ID
+- **THEN** the response identifies the active Series, its Peated ID, owning Brand, name, description, and Bottle count
+
+### Requirement: Dedicated Series page
+
+The system SHALL provide a responsive Series page that explains the Series and lists all active member Bottles.
+
+#### Scenario: Series with Bottles
+
+- **WHEN** a person opens a Series that contains Bottles
+- **THEN** the page shows Brand context, Series identity, optional description, total Bottle count, sorting, pagination, and standard Bottle list rows
+
+#### Scenario: Empty Series
+
+- **WHEN** a person opens an active Series with no Bottles
+- **THEN** the page shows the Series identity and a clear empty state without an inactive Bottle list shell
+
+### Requirement: Bottle-to-Series navigation
+
+The system SHALL make the assigned Series and other member Bottles discoverable from a Bottle page.
+
+#### Scenario: Bottle has other Series members
+
+- **WHEN** a Bottle belongs to a Series with at least one other Bottle
+- **THEN** the overview shows the linked Series fact and up to three other member Bottles in a shared Bottle rail section with a link to the complete Series page
+
+#### Scenario: Bottle is the only Series member
+
+- **WHEN** a Bottle is the only active member of its Series
+- **THEN** the overview shows the linked Series fact but omits the other-Bottles section
+
+### Requirement: Series search discovery
+
+The system SHALL return Bottle Series as a distinct global-search result type.
+
+#### Scenario: Search by Series name
+
+- **WHEN** a query matches an active Series name
+- **THEN** search can return a Series result with its Brand, Bottle count, and canonical page link
+
+#### Scenario: Search by Series Peated ID
+
+- **WHEN** a query is an exact active or merged Series Peated ID
+- **THEN** search returns the active Series as the exact match
+
+### Requirement: Safe Series lifecycle
+
+The system SHALL preserve public Series references across merges and prevent populated Series from being removed without a destination.
+
+#### Scenario: Merge duplicate Series
+
+- **WHEN** a moderator merges a source Series into an active destination Series owned by the same Brand
+- **THEN** all member Bottles and BottleGroups reference the destination, the source becomes a redirect tombstone, and Series counts remain correct
+
+#### Scenario: Delete populated Series
+
+- **WHEN** a moderator tries to delete a Series that still contains Bottles
+- **THEN** the system rejects the operation with a conflict and does not change any Bottle assignment
+
+#### Scenario: Delete empty Series
+
+- **WHEN** a moderator deletes a Series with no Bottle members
+- **THEN** the system removes the active Series and records a destination-less tombstone

--- a/openspec/changes/add-public-bottle-series-pages/tasks.md
+++ b/openspec/changes/add-public-bottle-series-pages/tasks.md
@@ -1,0 +1,26 @@
+## 1. Public Series identity and lifecycle
+
+- [x] 1.1 Extend Peated IDs, Series schemas, serializers, and details reads with public Series identity and Brand context.
+- [x] 1.2 Add Bottle Series tombstones and generate the database migration.
+- [x] 1.3 Guard Series deletion, implement same-Brand Series merging, and test assignment, count, change-log, and tombstone behavior.
+
+## 2. Series discovery
+
+- [x] 2.1 Add Series groups, facets, nearest matches, and exact Peated ID resolution to the global search contract and server query.
+- [x] 2.2 Render Series results and scope controls in web search with canonical links and focused tests.
+
+## 3. Public Series routes
+
+- [x] 3.1 Add canonical Series URL helpers, stale/merged/root-ID redirects, metadata, and sitemap support.
+- [x] 3.2 Build the responsive Series detail page from shared page, Bottle list, sorting, pager, error, and empty-state components.
+
+## 4. Bottle overview integration
+
+- [x] 4.1 Extract a reusable Bottle rail section from the existing recommendation presentation.
+- [x] 4.2 Add the linked Series fact and other-Series-Bottles rail with a canonical see-all destination and partial-failure handling.
+
+## 5. Verification and documentation
+
+- [x] 5.1 Update the Peated ID architecture documentation for Series identity and lifecycle.
+- [x] 5.2 Run focused server and web tests, typechecks, lint, formatting, and OpenSpec validation.
+- [x] 5.3 Verify the Series page and Bottle widget at desktop and mobile widths with production-shaped Series data.


### PR DESCRIPTION
Public Series pages give named bottle ranges their own catalog records. Bottle pages now link their Series, show up to 3 other bottles from it, and lead to a dedicated page with shared catalog sorting, paging, empty, and error states. Series also appear in global search, canonical `S` ID routes, metadata, and sitemaps.

The API now exposes Series identity and Brand context. Same-Brand merges move all bottle memberships and preserve retired public IDs through tombstones. Populated Series must be merged instead of deleted; empty deletion keeps the public ID retired.

Review focus: the merge and deletion lifecycle, canonical redirect behavior, and the server-to-client handoff for the bottle-page Series rail. The database change is additive and was regenerated as migration 264 after rebasing onto current `main`.
