### PR TITLE
feat(entities): paginate image galleries

### DIFF
--- a/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
@@ -1,73 +1,132 @@
+"use client";
+
 import * as stylex from "@stylexjs/stylex";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
 
 import { ImageAttribution, ImageViewer } from "@peated/web/components";
-import { colors, space } from "../../../../styles/tokens.stylex";
+import {
+  colors,
+  controlMetrics,
+  fonts,
+  space,
+} from "../../../../styles/tokens.stylex";
 
 import type { Entity } from "./entityPageData";
 
+function ImageNavigationButton({
+  direction,
+  disabled,
+  label,
+  onClick,
+}: {
+  direction: "next" | "previous";
+  disabled: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  const Icon = direction === "previous" ? ChevronLeft : ChevronRight;
+
+  return (
+    <button
+      aria-label={label}
+      disabled={disabled}
+      onClick={onClick}
+      type="button"
+      {...stylex.props(styles.navigationButton)}
+    >
+      <span
+        aria-hidden="true"
+        {...stylex.props(
+          styles.navigationButtonSurface,
+          disabled && styles.navigationButtonSurfaceDisabled,
+        )}
+      >
+        <Icon size={17} strokeWidth={1.75} />
+      </span>
+    </button>
+  );
+}
+
 export function EntityImageGallery({ entity }: { entity: Entity }) {
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const images = entity.images ?? [];
   if (!images.length) return null;
 
-  const [primary, ...otherImages] = images;
+  const currentIndex = Math.min(selectedIndex, images.length - 1);
+  const image = images[currentIndex]!;
+  const multipleImages = images.length > 1;
+  const imageLabel =
+    image.caption ||
+    (multipleImages
+      ? `${entity.name} image ${currentIndex + 1} of ${images.length}`
+      : `${entity.name} primary image`);
+  const hasDetails = image.caption || image.sourceUrl || image.license;
 
   return (
     <section
       aria-label={`Images of ${entity.name}`}
       {...stylex.props(styles.gallery)}
     >
-      <figure {...stylex.props(styles.primaryFigure)}>
+      <figure {...stylex.props(styles.figure)}>
         <ImageViewer
-          alt={primary.caption || `${entity.name} primary image`}
-          caption={primary.caption}
-          label={primary.caption || `${entity.name} primary image`}
-          src={primary.imageUrl}
+          alt={imageLabel}
+          caption={image.caption}
+          key={image.id}
+          label={imageLabel}
+          src={image.imageUrl}
         >
           <img
-            alt={primary.caption || `${entity.name} primary image`}
-            src={primary.imageUrl}
-            {...stylex.props(styles.primaryImage)}
+            alt={imageLabel}
+            src={image.imageUrl}
+            {...stylex.props(styles.image)}
           />
         </ImageViewer>
-        {primary.caption || primary.sourceUrl || primary.license ? (
-          <figcaption {...stylex.props(styles.caption)}>
-            {primary.caption ? <span>{primary.caption}</span> : null}
-            <ImageAttribution
-              license={primary.license}
-              sourceUrl={primary.sourceUrl}
-            />
+        {hasDetails || multipleImages ? (
+          <figcaption {...stylex.props(styles.footer)}>
+            {hasDetails ? (
+              <div {...stylex.props(styles.caption)}>
+                {image.caption ? (
+                  <span title={image.caption} {...stylex.props(styles.title)}>
+                    {image.caption}
+                  </span>
+                ) : null}
+                <ImageAttribution
+                  license={image.license}
+                  sourceUrl={image.sourceUrl}
+                />
+              </div>
+            ) : null}
+            {multipleImages ? (
+              <div
+                aria-label="Image navigation"
+                role="group"
+                {...stylex.props(styles.pagination)}
+              >
+                <ImageNavigationButton
+                  direction="previous"
+                  disabled={currentIndex === 0}
+                  label="Show previous image"
+                  onClick={() => setSelectedIndex(currentIndex - 1)}
+                />
+                <span
+                  aria-atomic="true"
+                  aria-live="polite"
+                  {...stylex.props(styles.position)}
+                >
+                  {currentIndex + 1} / {images.length}
+                </span>
+                <ImageNavigationButton
+                  direction="next"
+                  disabled={currentIndex === images.length - 1}
+                  label="Show next image"
+                  onClick={() => setSelectedIndex(currentIndex + 1)}
+                />
+              </div>
+            ) : null}
           </figcaption>
         ) : null}
       </figure>
-      {otherImages.length ? (
-        <div {...stylex.props(styles.secondaryGrid)}>
-          {otherImages.map((image) => (
-            <figure key={image.id} {...stylex.props(styles.secondaryFigure)}>
-              <ImageViewer
-                alt={image.caption || `${entity.name} image`}
-                caption={image.caption}
-                label={image.caption || `${entity.name} image`}
-                src={image.imageUrl}
-              >
-                <img
-                  alt={image.caption || `${entity.name} image`}
-                  src={image.imageUrl}
-                  {...stylex.props(styles.secondaryImage)}
-                />
-              </ImageViewer>
-              {image.caption || image.sourceUrl || image.license ? (
-                <figcaption {...stylex.props(styles.caption)}>
-                  {image.caption ? <span>{image.caption}</span> : null}
-                  <ImageAttribution
-                    license={image.license}
-                    sourceUrl={image.sourceUrl}
-                  />
-                </figcaption>
-              ) : null}
-            </figure>
-          ))}
-        </div>
-      ) : null}
     </section>
   );
 }
@@ -79,10 +138,10 @@ const styles = stylex.create({
     gap: space.x3,
     marginTop: space.x4,
   },
-  primaryFigure: {
+  figure: {
     margin: 0,
   },
-  primaryImage: {
+  image: {
     aspectRatio: "16 / 10",
     boxSizing: "border-box",
     backgroundColor: colors.imageBackground,
@@ -92,31 +151,82 @@ const styles = stylex.create({
     borderRadius: "3px",
     display: "block",
     objectFit: "contain",
+    padding: "2px",
     width: "100%",
   },
-  secondaryGrid: {
-    display: "grid",
-    gap: space.x3,
-    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
-  },
-  secondaryFigure: {
-    margin: 0,
+  footer: {
+    display: "flex",
     minWidth: 0,
-  },
-  secondaryImage: {
-    aspectRatio: "4 / 3",
-    boxSizing: "border-box",
-    backgroundColor: colors.imageBackground,
-    borderWidth: "1px",
-    borderStyle: "solid",
-    borderColor: colors.hairline,
-    borderRadius: "3px",
-    display: "block",
-    objectFit: "contain",
-    width: "100%",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: space.x4,
+    marginTop: space.x2,
+    flexWrap: "wrap",
   },
   caption: {
+    display: "flex",
+    minWidth: 0,
+    flex: 1,
+    flexDirection: "column",
+    gap: space.x1,
     color: colors.inkMuted,
-    marginTop: space.x2,
+  },
+  title: {
+    display: "block",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  pagination: {
+    display: "flex",
+    alignItems: "center",
+    gap: space.x1,
+    marginLeft: "auto",
+  },
+  navigationButton: {
+    display: "grid",
+    width: controlMetrics.controlHeightSmall,
+    height: controlMetrics.controlHeightSmall,
+    flexShrink: 0,
+    placeItems: "center",
+    padding: 0,
+    borderWidth: 0,
+    outline: "none",
+    backgroundColor: "transparent",
+    color: colors.ink,
+    cursor: {
+      default: "pointer",
+      ":disabled": "default",
+    },
+    opacity: {
+      default: 1,
+      ":hover": 0.78,
+      ":active": 0.78,
+      ":disabled": 1,
+    },
+    transitionDuration: "120ms",
+    transitionProperty: "opacity",
+  },
+  navigationButtonSurface: {
+    display: "grid",
+    width: "34px",
+    height: "34px",
+    placeItems: "center",
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.fieldBackground,
+    boxShadow: `inset 0 0 0 1px ${colors.sectionRule}`,
+    pointerEvents: "none",
+  },
+  navigationButtonSurfaceDisabled: {
+    opacity: 0.35,
+  },
+  position: {
+    minWidth: "40px",
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "12px",
+    fontVariantNumeric: "tabular-nums",
+    lineHeight: 1,
+    textAlign: "center",
   },
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+
+import { mockEntity } from "@peated/server/orpc/mock/fixtures";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { EntityImageGallery } from "./entityImageGallery.stylex";
+import type { Entity } from "./entityPageData";
+
+const timestamp = "2026-01-01T00:00:00.000Z";
+
+const entity = {
+  ...mockEntity,
+  images: [
+    {
+      id: 1,
+      entityId: mockEntity.id,
+      imageUrl: "https://example.com/primary.jpg",
+      caption: "Distillery entrance",
+      sourceUrl: "https://example.com/primary-source",
+      license: "CC BY 4.0",
+      isPrimary: true,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+    {
+      id: 2,
+      entityId: mockEntity.id,
+      imageUrl: "https://example.com/secondary.jpg",
+      caption: "Still house",
+      sourceUrl: "https://example.com/secondary-source",
+      license: null,
+      isPrimary: false,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+  ],
+} satisfies Entity;
+
+describe("EntityImageGallery", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  test("shows one image and pages through the remaining images", () => {
+    act(() => root.render(<EntityImageGallery entity={entity} />));
+
+    const previous = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Show previous image"]',
+    );
+    const next = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Show next image"]',
+    );
+
+    expect(container.querySelectorAll("figure img")).toHaveLength(1);
+    expect(container.querySelector("figure img")?.getAttribute("src")).toBe(
+      "https://example.com/primary.jpg",
+    );
+    expect(container.textContent).toContain("1 / 2");
+    expect(container.textContent).toContain("Distillery entrance");
+    expect(previous?.disabled).toBe(true);
+    expect(next?.disabled).toBe(false);
+
+    act(() => next?.click());
+
+    expect(container.querySelectorAll("figure img")).toHaveLength(1);
+    expect(container.querySelector("figure img")?.getAttribute("src")).toBe(
+      "https://example.com/secondary.jpg",
+    );
+    expect(container.textContent).toContain("2 / 2");
+    expect(container.textContent).toContain("Still house");
+    expect(previous?.disabled).toBe(false);
+    expect(next?.disabled).toBe(true);
+  });
+
+  test("does not show pagination for one image", () => {
+    act(() =>
+      root.render(
+        <EntityImageGallery
+          entity={{ ...entity, images: [entity.images[0]!] }}
+        />,
+      ),
+    );
+
+    expect(container.querySelector('[role="group"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -44,11 +44,16 @@ export function BottleVisual({
         styles.visual,
         Boolean(imageUrl) && styles.imageVisual,
         visualSizeStyles[size],
+        Boolean(imageUrl && expandable && label) && styles.expandableVisual,
       )}
     >
       {imageUrl && expandable && label ? (
         <ImageViewer alt="" fill label={label} src={imageUrl}>
-          <img alt="" src={imageUrl} {...stylex.props(styles.image)} />
+          <img
+            alt=""
+            src={imageUrl}
+            {...stylex.props(styles.image, expandableImagePaddingStyles[size])}
+          />
         </ImageViewer>
       ) : imageUrl ? (
         <img alt="" src={imageUrl} {...stylex.props(styles.image)} />
@@ -214,6 +219,9 @@ const styles = stylex.create({
     backgroundColor: colors.imageBackground,
     boxShadow: `inset 0 0 0 1px ${colors.hairline}`,
   },
+  expandableVisual: {
+    padding: 0,
+  },
   visualSmall: {
     width: "32px",
     height: "46px",
@@ -235,10 +243,23 @@ const styles = stylex.create({
     padding: space.x4,
   },
   image: {
+    boxSizing: "border-box",
     display: "block",
     width: "100%",
     height: "100%",
     objectFit: "contain",
+  },
+  expandableImageSmall: {
+    padding: space.x1,
+  },
+  expandableImageMedium: {
+    padding: space.x2,
+  },
+  expandableImageLarge: {
+    padding: { default: space.x2, [COMPACT]: space.x1 },
+  },
+  expandableImageExtraLarge: {
+    padding: space.x4,
   },
   fallbackAsset: {
     display: "block",
@@ -421,4 +442,11 @@ const visualSizeStyles = {
   md: styles.visualMedium,
   lg: styles.visualLarge,
   xl: styles.visualExtraLarge,
+} satisfies Record<BottleVisualSize, stylex.StyleXStyles>;
+
+const expandableImagePaddingStyles = {
+  sm: styles.expandableImageSmall,
+  md: styles.expandableImageMedium,
+  lg: styles.expandableImageLarge,
+  xl: styles.expandableImageExtraLarge,
 } satisfies Record<BottleVisualSize, stylex.StyleXStyles>;


### PR DESCRIPTION
Entity overview pages now show one image at a time with previous and next controls, a position counter, and metadata for the selected image. Long captions truncate cleanly, while compact mobile controls retain full-size touch targets and stay centered with the caption and attribution.

Bottle detail images now use the entire white image frame as the full-size viewer trigger while preserving the existing visual inset. Single-image entity pages keep their current control-free presentation.
