### PR TITLE
feat(events): filter upcoming events by region

### DIFF
--- a/apps/web/src/app/(app)/events/eventRegionData.test.ts
+++ b/apps/web/src/app/(app)/events/eventRegionData.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "vitest";
+
+import { getEventRegionPageState } from "./eventRegionData";
+
+const events = [
+  { country: { slug: "scotland" }, name: "Edinburgh" },
+  { country: { slug: "united-states" }, name: "Kentucky" },
+  { country: { slug: "japan" }, name: "Tokyo" },
+  { country: { slug: "scotland" }, name: "Glasgow" },
+  { country: null, name: "Online" },
+  { country: { slug: "unmapped-country" }, name: "Unknown" },
+];
+
+describe("event region page state", () => {
+  test("groups upcoming events into represented world regions", () => {
+    const state = getEventRegionPageState(events, undefined);
+
+    expect(state.options).toEqual([
+      { count: 1, label: "Americas", slug: "americas" },
+      { count: 2, label: "Europe", slug: "europe" },
+      { count: 1, label: "Asia", slug: "asia" },
+    ]);
+    expect(state.results).toEqual(events);
+    expect(state.selectedRegion).toBeNull();
+  });
+
+  test("filters events for a selected region", () => {
+    const state = getEventRegionPageState(events, "europe");
+
+    expect(state.results.map((event) => event.name)).toEqual([
+      "Edinburgh",
+      "Glasgow",
+    ]);
+    expect(state.selectedRegion).toEqual({
+      label: "Europe",
+      slug: "europe",
+    });
+  });
+
+  test("keeps a selected empty region available to clear", () => {
+    const state = getEventRegionPageState(events, "africa");
+
+    expect(state.options.at(-1)).toEqual({
+      count: 0,
+      label: "Africa",
+      slug: "africa",
+    });
+    expect(state.results).toEqual([]);
+  });
+
+  test("ignores unknown or repeated region parameters", () => {
+    expect(getEventRegionPageState(events, "unknown").results).toEqual(events);
+    expect(getEventRegionPageState(events, ["europe", "asia"]).results).toEqual(
+      events,
+    );
+  });
+});

--- a/apps/web/src/app/(app)/events/eventRegionData.ts
+++ b/apps/web/src/app/(app)/events/eventRegionData.ts
@@ -1,0 +1,151 @@
+import { z } from "zod";
+
+type LocatedEvent = {
+  country: { slug: string } | null;
+};
+
+export const EVENT_REGIONS = [
+  {
+    countrySlugs: [
+      "argentina",
+      "brazil",
+      "canada",
+      "chile",
+      "colombia",
+      "mexico",
+      "peru",
+      "united-states",
+      "united-states-of-america",
+      "uruguay",
+    ],
+    label: "Americas",
+    slug: "americas",
+  },
+  {
+    countrySlugs: [
+      "austria",
+      "belgium",
+      "czech-republic",
+      "czechia",
+      "denmark",
+      "england",
+      "estonia",
+      "finland",
+      "france",
+      "germany",
+      "iceland",
+      "ireland",
+      "italy",
+      "netherlands",
+      "northern-ireland",
+      "norway",
+      "poland",
+      "portugal",
+      "scotland",
+      "spain",
+      "sweden",
+      "switzerland",
+      "united-kingdom",
+      "wales",
+    ],
+    label: "Europe",
+    slug: "europe",
+  },
+  {
+    countrySlugs: [
+      "china",
+      "hong-kong",
+      "india",
+      "indonesia",
+      "israel",
+      "japan",
+      "malaysia",
+      "philippines",
+      "singapore",
+      "south-korea",
+      "taiwan",
+      "thailand",
+      "turkey",
+      "united-arab-emirates",
+    ],
+    label: "Asia",
+    slug: "asia",
+  },
+  {
+    countrySlugs: ["australia", "new-zealand"],
+    label: "Oceania",
+    slug: "oceania",
+  },
+  {
+    countrySlugs: ["south-africa"],
+    label: "Africa",
+    slug: "africa",
+  },
+] as const;
+
+export type EventRegion = Pick<
+  (typeof EVENT_REGIONS)[number],
+  "label" | "slug"
+>;
+
+export type EventRegionOption = EventRegion & { count: number };
+
+const EventRegionSlugSchema = z.enum([
+  "americas",
+  "europe",
+  "asia",
+  "oceania",
+  "africa",
+]);
+
+const eventRegionByCountrySlug: ReadonlyMap<
+  string,
+  (typeof EVENT_REGIONS)[number]
+> = new Map(
+  EVENT_REGIONS.flatMap((region) =>
+    region.countrySlugs.map((countrySlug) => [countrySlug, region] as const),
+  ),
+);
+
+/** Owns the events page's display-only world grouping and URL selection. */
+export function getEventRegionPageState<T extends LocatedEvent>(
+  events: readonly T[],
+  requestedRegion: string | string[] | undefined,
+) {
+  const parsedRegion = EventRegionSlugSchema.safeParse(requestedRegion);
+  const selectedRegion = parsedRegion.success
+    ? (EVENT_REGIONS.find((region) => region.slug === parsedRegion.data) ??
+      null)
+    : null;
+  const counts = new Map<EventRegion["slug"], number>();
+
+  events.forEach((event) => {
+    const region = event.country
+      ? eventRegionByCountrySlug.get(event.country.slug)
+      : undefined;
+    if (region) counts.set(region.slug, (counts.get(region.slug) ?? 0) + 1);
+  });
+
+  const options: EventRegionOption[] = EVENT_REGIONS.flatMap((region) => {
+    const count = counts.get(region.slug) ?? 0;
+    return count || selectedRegion?.slug === region.slug
+      ? [{ count, label: region.label, slug: region.slug }]
+      : [];
+  });
+  const results = selectedRegion
+    ? events.filter(
+        (event) =>
+          event.country &&
+          eventRegionByCountrySlug.get(event.country.slug)?.slug ===
+            selectedRegion.slug,
+      )
+    : [...events];
+
+  return {
+    options,
+    results,
+    selectedRegion: selectedRegion
+      ? { label: selectedRegion.label, slug: selectedRegion.slug }
+      : null,
+  };
+}

--- a/apps/web/src/app/(app)/events/eventRegionFilter.stylex.tsx
+++ b/apps/web/src/app/(app)/events/eventRegionFilter.stylex.tsx
@@ -1,0 +1,98 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { ButtonLink } from "@peated/web/components";
+import { colors, fonts, space } from "../../../styles/tokens.stylex";
+import type { EventRegion, EventRegionOption } from "./eventRegionData";
+
+export function EventRegionFilter({
+  options,
+  selectedRegion,
+  total,
+  visible,
+}: {
+  options: readonly EventRegionOption[];
+  selectedRegion: EventRegion | null;
+  total: number;
+  visible: number;
+}) {
+  return (
+    <section aria-label="Event region" {...stylex.props(styles.root)}>
+      <div {...stylex.props(styles.row)}>
+        <span {...stylex.props(styles.label)}>Show events in</span>
+        <nav aria-label="World regions" {...stylex.props(styles.options)}>
+          <ButtonLink
+            aria-current={!selectedRegion ? "page" : undefined}
+            href="/events"
+            size="sm"
+            variant={!selectedRegion ? "accent" : "tonal"}
+          >
+            <span>All regions</span>
+            <span {...stylex.props(styles.count)}>{total}</span>
+          </ButtonLink>
+          {options.map((option) => {
+            const current = selectedRegion?.slug === option.slug;
+            return (
+              <ButtonLink
+                aria-current={current ? "page" : undefined}
+                href={`/events?region=${option.slug}`}
+                key={option.slug}
+                size="sm"
+                variant={current ? "accent" : "tonal"}
+              >
+                <span>{option.label}</span>
+                <span {...stylex.props(styles.count)}>{option.count}</span>
+              </ButtonLink>
+            );
+          })}
+        </nav>
+      </div>
+      <div {...stylex.props(styles.summary)}>
+        {selectedRegion
+          ? `Showing ${visible} upcoming ${visible === 1 ? "event" : "events"} in ${selectedRegion.label}`
+          : `Showing ${total} upcoming ${total === 1 ? "event" : "events"} worldwide`}
+      </div>
+    </section>
+  );
+}
+
+const styles = stylex.create({
+  root: {
+    paddingTop: space.x4,
+    paddingBottom: space.x4,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.sectionRule,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+  },
+  row: {
+    display: "flex",
+    alignItems: "center",
+    gap: `${space.x3} ${space.x4}`,
+    flexWrap: "wrap",
+  },
+  label: {
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "14px",
+    fontWeight: 600,
+  },
+  options: {
+    display: "flex",
+    gap: space.x2,
+    flexWrap: "wrap",
+  },
+  count: {
+    fontFamily: fonts.data,
+    fontSize: "11px",
+    fontVariantNumeric: "tabular-nums",
+  },
+  summary: {
+    marginTop: space.x3,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.4,
+  },
+});

--- a/apps/web/src/app/(app)/events/page.tsx
+++ b/apps/web/src/app/(app)/events/page.tsx
@@ -1,4 +1,4 @@
-import { EmptyState } from "@peated/web/components";
+import { ButtonLink, EmptyState } from "@peated/web/components";
 import {
   PageHeader,
   PageSection,
@@ -8,6 +8,8 @@ import dayjs from "dayjs";
 import type { Metadata } from "next";
 
 import { EventList } from "./eventList.stylex";
+import { getEventRegionPageState } from "./eventRegionData";
+import { EventRegionFilter } from "./eventRegionFilter.stylex";
 
 export const metadata: Metadata = {
   title: "Whisky events",
@@ -15,14 +17,22 @@ export const metadata: Metadata = {
     "Major whisky festivals and shows, with dates and official websites.",
 };
 
-export default async function EventsPage() {
-  const { client } = await getAnonymousServerClient();
+export default async function EventsPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ region?: string | string[] }>;
+}) {
+  const [{ client }, params] = await Promise.all([
+    getAnonymousServerClient(),
+    searchParams,
+  ]);
   const eventList = await client.events.list({
     limit: 100,
     onlyUpcoming: true,
     sort: "date",
   });
-  const monthGroups = Map.groupBy(eventList.results, (event) =>
+  const regionState = getEventRegionPageState(eventList.results, params.region);
+  const monthGroups = Map.groupBy(regionState.results, (event) =>
     dayjs(event.dateStart).format("YYYY-MM"),
   );
 
@@ -34,6 +44,14 @@ export default async function EventsPage() {
         title="Whisky events"
       />
       {eventList.results.length ? (
+        <EventRegionFilter
+          options={regionState.options}
+          selectedRegion={regionState.selectedRegion}
+          total={eventList.results.length}
+          visible={regionState.results.length}
+        />
+      ) : null}
+      {regionState.results.length ? (
         [...monthGroups].map(([month, events]) => (
           <PageSection
             heading={dayjs(`${month}-01`).format("MMMM YYYY")}
@@ -44,8 +62,23 @@ export default async function EventsPage() {
         ))
       ) : (
         <PageSection heading="Upcoming events">
-          <EmptyState heading="No upcoming events">
-            There are no confirmed dates to show.
+          <EmptyState
+            action={
+              regionState.selectedRegion ? (
+                <ButtonLink href="/events" size="sm" variant="tonal">
+                  View all events
+                </ButtonLink>
+              ) : undefined
+            }
+            heading={
+              regionState.selectedRegion
+                ? `No upcoming events in ${regionState.selectedRegion.label}`
+                : "No upcoming events"
+            }
+          >
+            {regionState.selectedRegion
+              ? "There are no confirmed dates in this region."
+              : "There are no confirmed dates to show."}
           </EmptyState>
         </PageSection>
       )}


### PR DESCRIPTION
The public whisky events page now offers URL-backed world-region filters with upcoming-event counts. Only represented regions appear during normal browsing, and direct links to an empty region keep the selection visible with a clear path back to all events. Each event keeps its existing calendar action.

The grouping is display-only and owned by the events page. It derives regions from each event country without changing the event API or database; events without a mapped country remain available under “All regions.”
