### PR TITLE
feat(web): add action menus to catalog rows

### DIFF
--- a/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
@@ -195,7 +195,7 @@ export function EntityCatalogPageClient({
         }
         onSortChange={(value) => updateParams({ sort: value })}
         page={page}
-        pendingId={followControls.pendingId}
+        pendingIds={followControls.pendingIds}
         previousHref={getCursorHref(
           pathname,
           searchParams,

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -7,7 +7,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { ButtonLink } from "@peated/web/components";
-import { BottleRowActions } from "@peated/web/components/bottleRowActions.stylex";
+import { addBottleRowActions } from "@peated/web/components/bottleRowActions.stylex";
 import {
   BottleCatalogFilters,
   BottleCatalogList,
@@ -139,26 +139,16 @@ export function BottleCatalogPageClient({
     router.push(buildSearchHref(pathname, nextParams));
   }
 
-  const items = bottleList.results.map((bottle) => {
-    const item = toBottleListItem(bottle, {
-      includeRatings: true,
-      includeRelatedReleases: true,
-    });
-
-    return {
-      ...item,
-      end: (
-        <BottleRowActions
-          bottle={bottle}
-          controls={bottleActions}
-          label={item.name}
-          ratings={item.ratings}
-        />
-      ),
-      isLibrary: bottleActions.isLibrary(bottle),
-      ratings: undefined,
-    };
-  });
+  const items = bottleList.results.map((bottle) =>
+    addBottleRowActions({
+      bottle,
+      controls: bottleActions,
+      item: toBottleListItem(bottle, {
+        includeRatings: true,
+        includeRelatedReleases: true,
+      }),
+    }),
+  );
   const title =
     queryParams.series && bottleList.results[0]?.series
       ? bottleList.results[0].series.name

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -7,6 +7,7 @@ import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { ButtonLink } from "@peated/web/components";
+import { BottleRowActions } from "@peated/web/components/bottleRowActions.stylex";
 import {
   BottleCatalogFilters,
   BottleCatalogList,
@@ -15,6 +16,7 @@ import {
 import { CatalogPage } from "@peated/web/components/pages/catalogPage.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import useAuth from "@peated/web/hooks/useAuth";
+import useBottleRowActions from "@peated/web/hooks/useBottleRowActions";
 import {
   BOTTLE_CATALOG_ALLOWED_VALUES,
   BOTTLE_CATALOG_QUERY_FIELDS,
@@ -83,6 +85,7 @@ export function BottleCatalogPageClient({
 }) {
   const orpc = useORPC();
   const { user } = useAuth();
+  const bottleActions = useBottleRowActions();
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -136,12 +139,26 @@ export function BottleCatalogPageClient({
     router.push(buildSearchHref(pathname, nextParams));
   }
 
-  const items = bottleList.results.map((bottle) =>
-    toBottleListItem(bottle, {
+  const items = bottleList.results.map((bottle) => {
+    const item = toBottleListItem(bottle, {
       includeRatings: true,
       includeRelatedReleases: true,
-    }),
-  );
+    });
+
+    return {
+      ...item,
+      end: (
+        <BottleRowActions
+          bottle={bottle}
+          controls={bottleActions}
+          label={item.name}
+          ratings={item.ratings}
+        />
+      ),
+      isLibrary: bottleActions.isLibrary(bottle),
+      ratings: undefined,
+    };
+  });
   const title =
     queryParams.series && bottleList.results[0]?.series
       ? bottleList.results[0].series.name

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -50,7 +50,7 @@ function EntityFollowAction({ entity }: { entity: Entity }) {
   }
 
   const isFollowing = followControls.isFollowing(entity);
-  const pending = followControls.pendingId === entity.id;
+  const pending = followControls.pendingIds.has(entity.id);
 
   return (
     <Button

--- a/apps/web/src/app/(app)/following/followingPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/following/followingPageClient.stylex.tsx
@@ -152,7 +152,7 @@ export function FollowingPageClient({
           })
         }
         page={state.cursor}
-        pendingId={followControls.pendingId}
+        pendingIds={followControls.pendingIds}
         previousHref={getCursorHref(
           pathname,
           searchParams,

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -1,25 +1,40 @@
 "use client";
 
 import type { BOTTLE_LIST_SORT_OPTIONS } from "@peated/server/constants";
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 
-import { FactList, SectionError, TextLink } from "@peated/web/components";
+import {
+  BottleRatings,
+  FactList,
+  RowMenu,
+  SectionError,
+  TextLink,
+  type RowMenuItem,
+} from "@peated/web/components";
+import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
 import Markdown from "@peated/web/components/markdown";
 import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
 import {
   PageColumns,
   PageHeader,
 } from "@peated/web/components/pages/pageLayout.stylex";
+import useAuth from "@peated/web/hooks/useAuth";
+import { getAddBottleHref } from "@peated/web/lib/addBottle";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getEntityUrl } from "@peated/web/lib/urls";
 import { space } from "../../../../styles/tokens.stylex";
 
+const COMPACT = "@media (max-width: 639px)";
+
 type BottleList = Outputs["bottles"]["list"];
+type Bottle = BottleList["results"][number];
 type Series = Outputs["bottleSeries"]["details"];
 type BottleSort = (typeof BOTTLE_LIST_SORT_OPTIONS)[number];
 
@@ -31,6 +46,55 @@ const sortOptions = [
   { label: "Oldest age", value: "-age" },
   { label: "Recently added", value: "-created" },
 ] as const;
+
+export function getSeriesBottleActionGroups({
+  bottle,
+  isLibrary,
+  isLoggedIn,
+  libraryMutationPending,
+  onLibraryToggle,
+  thisBottlePending,
+}: {
+  bottle: Pick<Bottle, "id">;
+  isLibrary: boolean;
+  isLoggedIn: boolean;
+  libraryMutationPending: boolean;
+  onLibraryToggle: () => void;
+  thisBottlePending: boolean;
+}): RowMenuItem[][] {
+  const libraryAction: RowMenuItem = isLoggedIn
+    ? {
+        disabled: libraryMutationPending,
+        label: thisBottlePending
+          ? isLibrary
+            ? "Removing from Library…"
+            : "Adding to Library…"
+          : isLibrary
+            ? "Remove from Library"
+            : "Add to Library",
+        onSelect: onLibraryToggle,
+      }
+    : {
+        href: getAddBottleHref({
+          bottleId: bottle.id,
+          intent: "library",
+        }),
+        label: "Add to Library",
+      };
+
+  return [
+    [
+      {
+        href: getAddBottleHref({
+          bottleId: bottle.id,
+          intent: "tasting",
+        }),
+        label: "Log a tasting",
+      },
+    ],
+    [libraryAction],
+  ];
+}
 
 export function SeriesPageClient({
   initialBottleList,
@@ -44,9 +108,26 @@ export function SeriesPageClient({
   initialSort: BottleSort;
 }) {
   const orpc = useORPC();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const { flash } = useFlashMessages();
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [libraryOverrides, setLibraryOverrides] = useState<
+    Record<number, boolean>
+  >({});
+  const [pendingLibraryBottleId, setPendingLibraryBottleId] = useState<
+    number | null
+  >(null);
+  const addLibraryMutation = useMutation(
+    orpc.collections.bottles.create.mutationOptions(),
+  );
+  const removeLibraryMutation = useMutation(
+    orpc.collections.bottles.delete.mutationOptions(),
+  );
+  const libraryMutationPending =
+    addLibraryMutation.isPending || removeLibraryMutation.isPending;
   const bottleListQuery = useQuery({
     ...orpc.bottles.list.queryOptions({
       input: {
@@ -58,6 +139,53 @@ export function SeriesPageClient({
     }),
     initialData: initialBottleList,
   });
+
+  async function toggleLibrary(bottle: Bottle, isLibrary: boolean) {
+    if (!user || pendingLibraryBottleId !== null) return;
+
+    setPendingLibraryBottleId(bottle.id);
+    try {
+      if (isLibrary) {
+        await removeLibraryMutation.mutateAsync({
+          bottle: bottle.id,
+          collection: "library",
+          user: "me",
+        });
+      } else {
+        await addLibraryMutation.mutateAsync({
+          bottle: bottle.id,
+          collection: "library",
+          user: "me",
+        });
+      }
+
+      setLibraryOverrides((current) => ({
+        ...current,
+        [bottle.id]: !isLibrary,
+      }));
+      flash(
+        isLibrary ? "Removed from your Library." : "Added to your Library.",
+      );
+      void queryClient.invalidateQueries({
+        queryKey: orpc.bottles.list.key({ type: "query" }),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: orpc.collections.bottles.list.key({ type: "query" }),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: orpc.users.libraryStats.key({ type: "query" }),
+      });
+    } catch {
+      flash(
+        isLibrary
+          ? "We couldn't remove this bottle from your Library. Try again."
+          : "We couldn't add this bottle to your Library. Try again.",
+        "error",
+      );
+    } finally {
+      setPendingLibraryBottleId(null);
+    }
+  }
 
   function updateSort(value: string) {
     const nextParams = new URLSearchParams(searchParams);
@@ -104,15 +232,49 @@ export function SeriesPageClient({
             <BottleCatalogList
               emptyDescription={`No bottles have been added to ${initialSeries.fullName} yet.`}
               emptyHeading="No bottles in this series yet"
-              items={bottleList.results.map((bottle) =>
-                toBottleListItem(bottle, {
+              items={bottleList.results.map((bottle) => {
+                const item = toBottleListItem(bottle, {
                   includeBrandInName: false,
                   includeBrandRow: false,
                   includeRatings: true,
                   includeRelatedReleases: true,
                   includeSeriesInName: false,
-                }),
-              )}
+                });
+                const isLibrary =
+                  libraryOverrides[bottle.id] ?? bottle.isLibrary;
+
+                return {
+                  ...item,
+                  end: (
+                    <div {...stylex.props(styles.rowEnd)}>
+                      {item.ratings ? (
+                        <BottleRatings {...item.ratings} />
+                      ) : null}
+                      <span {...stylex.props(styles.desktopActions)}>
+                        <RowMenu
+                          groups={getSeriesBottleActionGroups({
+                            bottle,
+                            isLibrary,
+                            isLoggedIn: Boolean(user),
+                            libraryMutationPending,
+                            onLibraryToggle: () =>
+                              void toggleLibrary(bottle, isLibrary),
+                            thisBottlePending:
+                              pendingLibraryBottleId === bottle.id,
+                          })}
+                          label={formatBottleDisplayName(bottle, {
+                            includeBrand: false,
+                            includeSeries: false,
+                          })}
+                          triggerVariant="text"
+                        />
+                      </span>
+                    </div>
+                  ),
+                  isLibrary,
+                  ratings: undefined,
+                };
+              })}
               nextHref={getCursorHref(
                 pathname,
                 searchParams,
@@ -143,5 +305,16 @@ const styles = stylex.create({
   bottles: {
     minWidth: 0,
     paddingTop: space.x4,
+  },
+  rowEnd: {
+    display: "flex",
+    alignItems: "center",
+    gap: space.x2,
+  },
+  desktopActions: {
+    display: "inline-flex",
+    [COMPACT]: {
+      display: "none",
+    },
   },
 });

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -7,7 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
 import { FactList, SectionError, TextLink } from "@peated/web/components";
-import { BottleRowActions } from "@peated/web/components/bottleRowActions.stylex";
+import { addBottleRowActions } from "@peated/web/components/bottleRowActions.stylex";
 import Markdown from "@peated/web/components/markdown";
 import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
 import {
@@ -107,30 +107,19 @@ export function SeriesPageClient({
             <BottleCatalogList
               emptyDescription={`No bottles have been added to ${initialSeries.fullName} yet.`}
               emptyHeading="No bottles in this series yet"
-              items={bottleList.results.map((bottle) => {
-                const item = toBottleListItem(bottle, {
-                  includeBrandInName: false,
-                  includeBrandRow: false,
-                  includeRatings: true,
-                  includeRelatedReleases: true,
-                  includeSeriesInName: false,
-                });
-                const isLibrary = bottleActions.isLibrary(bottle);
-
-                return {
-                  ...item,
-                  end: (
-                    <BottleRowActions
-                      bottle={bottle}
-                      controls={bottleActions}
-                      label={item.name}
-                      ratings={item.ratings}
-                    />
-                  ),
-                  isLibrary,
-                  ratings: undefined,
-                };
-              })}
+              items={bottleList.results.map((bottle) =>
+                addBottleRowActions({
+                  bottle,
+                  controls: bottleActions,
+                  item: toBottleListItem(bottle, {
+                    includeBrandInName: false,
+                    includeBrandRow: false,
+                    includeRatings: true,
+                    includeRelatedReleases: true,
+                    includeSeriesInName: false,
+                  }),
+                }),
+              )}
               nextHref={getCursorHref(
                 pathname,
                 searchParams,

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -1,40 +1,27 @@
 "use client";
 
 import type { BOTTLE_LIST_SORT_OPTIONS } from "@peated/server/constants";
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
 
-import {
-  BottleRatings,
-  FactList,
-  RowMenu,
-  SectionError,
-  TextLink,
-  type RowMenuItem,
-} from "@peated/web/components";
-import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import { FactList, SectionError, TextLink } from "@peated/web/components";
+import { BottleRowActions } from "@peated/web/components/bottleRowActions.stylex";
 import Markdown from "@peated/web/components/markdown";
 import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
 import {
   PageColumns,
   PageHeader,
 } from "@peated/web/components/pages/pageLayout.stylex";
-import useAuth from "@peated/web/hooks/useAuth";
-import { getAddBottleHref } from "@peated/web/lib/addBottle";
+import useBottleRowActions from "@peated/web/hooks/useBottleRowActions";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getEntityUrl } from "@peated/web/lib/urls";
 import { space } from "../../../../styles/tokens.stylex";
 
-const COMPACT = "@media (max-width: 639px)";
-
 type BottleList = Outputs["bottles"]["list"];
-type Bottle = BottleList["results"][number];
 type Series = Outputs["bottleSeries"]["details"];
 type BottleSort = (typeof BOTTLE_LIST_SORT_OPTIONS)[number];
 
@@ -46,55 +33,6 @@ const sortOptions = [
   { label: "Oldest age", value: "-age" },
   { label: "Recently added", value: "-created" },
 ] as const;
-
-export function getSeriesBottleActionGroups({
-  bottle,
-  isLibrary,
-  isLoggedIn,
-  libraryMutationPending,
-  onLibraryToggle,
-  thisBottlePending,
-}: {
-  bottle: Pick<Bottle, "id">;
-  isLibrary: boolean;
-  isLoggedIn: boolean;
-  libraryMutationPending: boolean;
-  onLibraryToggle: () => void;
-  thisBottlePending: boolean;
-}): RowMenuItem[][] {
-  const libraryAction: RowMenuItem = isLoggedIn
-    ? {
-        disabled: libraryMutationPending,
-        label: thisBottlePending
-          ? isLibrary
-            ? "Removing from Library…"
-            : "Adding to Library…"
-          : isLibrary
-            ? "Remove from Library"
-            : "Add to Library",
-        onSelect: onLibraryToggle,
-      }
-    : {
-        href: getAddBottleHref({
-          bottleId: bottle.id,
-          intent: "library",
-        }),
-        label: "Add to Library",
-      };
-
-  return [
-    [
-      {
-        href: getAddBottleHref({
-          bottleId: bottle.id,
-          intent: "tasting",
-        }),
-        label: "Log a tasting",
-      },
-    ],
-    [libraryAction],
-  ];
-}
 
 export function SeriesPageClient({
   initialBottleList,
@@ -108,26 +46,10 @@ export function SeriesPageClient({
   initialSort: BottleSort;
 }) {
   const orpc = useORPC();
-  const queryClient = useQueryClient();
-  const { user } = useAuth();
-  const { flash } = useFlashMessages();
+  const bottleActions = useBottleRowActions();
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [libraryOverrides, setLibraryOverrides] = useState<
-    Record<number, boolean>
-  >({});
-  const [pendingLibraryBottleId, setPendingLibraryBottleId] = useState<
-    number | null
-  >(null);
-  const addLibraryMutation = useMutation(
-    orpc.collections.bottles.create.mutationOptions(),
-  );
-  const removeLibraryMutation = useMutation(
-    orpc.collections.bottles.delete.mutationOptions(),
-  );
-  const libraryMutationPending =
-    addLibraryMutation.isPending || removeLibraryMutation.isPending;
   const bottleListQuery = useQuery({
     ...orpc.bottles.list.queryOptions({
       input: {
@@ -139,53 +61,6 @@ export function SeriesPageClient({
     }),
     initialData: initialBottleList,
   });
-
-  async function toggleLibrary(bottle: Bottle, isLibrary: boolean) {
-    if (!user || pendingLibraryBottleId !== null) return;
-
-    setPendingLibraryBottleId(bottle.id);
-    try {
-      if (isLibrary) {
-        await removeLibraryMutation.mutateAsync({
-          bottle: bottle.id,
-          collection: "library",
-          user: "me",
-        });
-      } else {
-        await addLibraryMutation.mutateAsync({
-          bottle: bottle.id,
-          collection: "library",
-          user: "me",
-        });
-      }
-
-      setLibraryOverrides((current) => ({
-        ...current,
-        [bottle.id]: !isLibrary,
-      }));
-      flash(
-        isLibrary ? "Removed from your Library." : "Added to your Library.",
-      );
-      void queryClient.invalidateQueries({
-        queryKey: orpc.bottles.list.key({ type: "query" }),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: orpc.collections.bottles.list.key({ type: "query" }),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: orpc.users.libraryStats.key({ type: "query" }),
-      });
-    } catch {
-      flash(
-        isLibrary
-          ? "We couldn't remove this bottle from your Library. Try again."
-          : "We couldn't add this bottle to your Library. Try again.",
-        "error",
-      );
-    } finally {
-      setPendingLibraryBottleId(null);
-    }
-  }
 
   function updateSort(value: string) {
     const nextParams = new URLSearchParams(searchParams);
@@ -240,36 +115,17 @@ export function SeriesPageClient({
                   includeRelatedReleases: true,
                   includeSeriesInName: false,
                 });
-                const isLibrary =
-                  libraryOverrides[bottle.id] ?? bottle.isLibrary;
+                const isLibrary = bottleActions.isLibrary(bottle);
 
                 return {
                   ...item,
                   end: (
-                    <div {...stylex.props(styles.rowEnd)}>
-                      {item.ratings ? (
-                        <BottleRatings {...item.ratings} />
-                      ) : null}
-                      <span {...stylex.props(styles.desktopActions)}>
-                        <RowMenu
-                          groups={getSeriesBottleActionGroups({
-                            bottle,
-                            isLibrary,
-                            isLoggedIn: Boolean(user),
-                            libraryMutationPending,
-                            onLibraryToggle: () =>
-                              void toggleLibrary(bottle, isLibrary),
-                            thisBottlePending:
-                              pendingLibraryBottleId === bottle.id,
-                          })}
-                          label={formatBottleDisplayName(bottle, {
-                            includeBrand: false,
-                            includeSeries: false,
-                          })}
-                          triggerVariant="text"
-                        />
-                      </span>
-                    </div>
+                    <BottleRowActions
+                      bottle={bottle}
+                      controls={bottleActions}
+                      label={item.name}
+                      ratings={item.ratings}
+                    />
                   ),
                   isLibrary,
                   ratings: undefined,
@@ -305,16 +161,5 @@ const styles = stylex.create({
   bottles: {
     minWidth: 0,
     paddingTop: space.x4,
-  },
-  rowEnd: {
-    display: "flex",
-    alignItems: "center",
-    gap: space.x2,
-  },
-  desktopActions: {
-    display: "inline-flex",
-    [COMPACT]: {
-      display: "none",
-    },
   },
 });

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.test.ts
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { getSeriesBottleActionGroups } from "./seriesPageClient.stylex";
+
+function getGroups(
+  overrides: Partial<Parameters<typeof getSeriesBottleActionGroups>[0]> = {},
+) {
+  return getSeriesBottleActionGroups({
+    bottle: { id: 42 },
+    isLibrary: false,
+    isLoggedIn: true,
+    libraryMutationPending: false,
+    onLibraryToggle: vi.fn(),
+    thisBottlePending: false,
+    ...overrides,
+  });
+}
+
+describe("getSeriesBottleActionGroups", () => {
+  it("links to the tasting form", () => {
+    expect(getGroups()[0]).toEqual([
+      {
+        href: "/addBottle?bottle=42&intent=tasting",
+        label: "Log a tasting",
+      },
+    ]);
+  });
+
+  it("sends anonymous members through the protected library flow", () => {
+    expect(getGroups({ isLoggedIn: false })[1]).toEqual([
+      {
+        href: "/addBottle?bottle=42&intent=library",
+        label: "Add to Library",
+      },
+    ]);
+  });
+
+  it("toggles the signed-in member's library state", () => {
+    const onLibraryToggle = vi.fn();
+    const action = getGroups({ isLibrary: true, onLibraryToggle })[1]?.[0];
+
+    expect(action).toMatchObject({
+      disabled: false,
+      label: "Remove from Library",
+      onSelect: onLibraryToggle,
+    });
+  });
+
+  it("shows which library change is pending", () => {
+    expect(
+      getGroups({
+        libraryMutationPending: true,
+        thisBottlePending: true,
+      })[1]?.[0],
+    ).toMatchObject({
+      disabled: true,
+      label: "Adding to Library…",
+    });
+  });
+});

--- a/apps/web/src/components/applicationHeader.stylex.tsx
+++ b/apps/web/src/components/applicationHeader.stylex.tsx
@@ -20,6 +20,7 @@ import {
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { IconButton } from "./button.stylex";
+import { menuSurfaceStyles } from "./menuSurface.stylex";
 import {
   isCurrentNavigationHref,
   NavigationTabs,
@@ -185,28 +186,47 @@ export function ApplicationHeader({
             </div>
           ) : null}
           {account ? (
-            <HeadlessMenu
-              as="div"
-              {...stylex.props(
-                styles.account,
-                searchOpen && styles.hiddenDuringSearch,
+            <HeadlessMenu as={Fragment}>
+              {({ open }) => (
+                <div
+                  {...stylex.props(
+                    styles.account,
+                    open && styles.accountOpen,
+                    searchOpen && styles.hiddenDuringSearch,
+                  )}
+                >
+                  <MenuButton
+                    aria-label={accountLabel}
+                    {...stylex.props(
+                      styles.accountButton,
+                      open && styles.accountButtonOpen,
+                    )}
+                  >
+                    {account}
+                  </MenuButton>
+                  <MenuItems
+                    portal={false}
+                    {...stylex.props(
+                      styles.accountMenu,
+                      menuSurfaceStyles.surface,
+                    )}
+                  >
+                    <div {...stylex.props(styles.accountMenuHeader)}>
+                      Account
+                    </div>
+                    <div {...stylex.props(styles.accountMenuSeparator)} />
+                    <div {...stylex.props(styles.accountMenuItems)}>
+                      {(accountItems ?? personalItems).map((item) => (
+                        <AccountMenuItem
+                          currentHref={currentHref}
+                          item={item}
+                          key={"onSelect" in item ? item.label : item.href}
+                        />
+                      ))}
+                    </div>
+                  </MenuItems>
+                </div>
               )}
-            >
-              <MenuButton
-                aria-label={accountLabel}
-                {...stylex.props(styles.accountButton)}
-              >
-                {account}
-              </MenuButton>
-              <MenuItems portal={false} {...stylex.props(styles.accountMenu)}>
-                {(accountItems ?? personalItems).map((item) => (
-                  <AccountMenuItem
-                    currentHref={currentHref}
-                    item={item}
-                    key={"onSelect" in item ? item.label : item.href}
-                  />
-                ))}
-              </MenuItems>
             </HeadlessMenu>
           ) : null}
           {hasSearch ? (
@@ -461,8 +481,14 @@ const styles = stylex.create({
   account: {
     position: "relative",
     display: "inline-flex",
+    isolation: "isolate",
+  },
+  accountOpen: {
+    zIndex: zIndices.menuControl,
   },
   accountButton: {
+    position: "relative",
+    zIndex: zIndices.localControl,
     display: "inline-flex",
     width: controlMetrics.controlHeightSmall,
     height: controlMetrics.controlHeightSmall,
@@ -480,18 +506,43 @@ const styles = stylex.create({
       ":focus-visible": effects.focusRing,
     },
   },
+  accountButtonOpen: {
+    backgroundColor: {
+      default: "transparent",
+      ":hover": "transparent",
+      ":active": "transparent",
+    },
+  },
   accountMenu: {
     position: "absolute",
-    top: "calc(100% + 4px)",
+    top: 0,
     right: 0,
-    zIndex: zIndices.menu,
+    zIndex: zIndices.localContent,
     width: "220px",
+    outline: "none",
+  },
+  accountMenuHeader: {
+    boxSizing: "border-box",
+    height: controlMetrics.controlHeightSmall,
+    paddingTop: "11px",
+    paddingRight: "48px",
+    paddingLeft: space.x3,
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "10px",
+    letterSpacing: "0.08em",
+    lineHeight: 1.3,
+    textTransform: "uppercase",
+  },
+  accountMenuSeparator: {
+    height: "1px",
+    marginRight: space.x3,
+    marginLeft: space.x3,
+    backgroundColor: colors.hairline,
+  },
+  accountMenuItems: {
     paddingTop: space.x1,
     paddingBottom: space.x1,
-    borderRadius: "3px",
-    outline: "none",
-    backgroundColor: colors.ground,
-    boxShadow: effects.overlayShadow,
   },
   accountMenuItem: {
     display: "flex",

--- a/apps/web/src/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stories.tsx
@@ -28,7 +28,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Use Bottle Identity Row in bottle lists. The bottle name is the primary destination; brand, related-release, and row-action controls remain independently interactive.",
+          "Use Bottle Identity Row in bottle lists. The bottle name is the main destination. Brand links, related releases, and action menus remain separate controls.",
       },
     },
   },
@@ -81,12 +81,19 @@ export const Overview: Story = {
               groups={[
                 [
                   {
-                    label: "Remove from library",
+                    label: "Log a tasting",
+                    onSelect: () => undefined,
+                  },
+                ],
+                [
+                  {
+                    label: "Remove from Library",
                     onSelect: () => undefined,
                   },
                 ],
               ]}
               label={args.name}
+              triggerVariant="text"
             />
           }
           isLibrary

--- a/apps/web/src/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stories.tsx
@@ -1,10 +1,20 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
+import type { BottleRowActionControls } from "@peated/web/hooks/useBottleRowActions";
+
 import BottleImage from "../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
 import { BottleIdentityRow } from "./bottleIdentityRow.stylex";
+import { BottleRowActions } from "./bottleRowActions.stylex";
 import { ItemList, ItemListItem } from "./itemList.stylex";
-import { RowMenu } from "./rowMenu.stylex";
 import { StoryCanvas, StoryStack } from "./storyFixtures.stylex";
+
+const bottleActions = {
+  groupsFor: () => [
+    [{ label: "Log a tasting", onSelect: () => undefined }],
+    [{ label: "Remove from Library", onSelect: () => undefined }],
+  ],
+  isLibrary: () => true,
+} satisfies BottleRowActionControls;
 
 const meta = {
   title: "Components/Bottles/Bottle Identity Row",
@@ -77,23 +87,10 @@ export const Overview: Story = {
         <BottleIdentityRow
           {...args}
           end={
-            <RowMenu
-              groups={[
-                [
-                  {
-                    label: "Log a tasting",
-                    onSelect: () => undefined,
-                  },
-                ],
-                [
-                  {
-                    label: "Remove from Library",
-                    onSelect: () => undefined,
-                  },
-                ],
-              ]}
+            <BottleRowActions
+              bottle={{ id: 42, isLibrary: true }}
+              controls={bottleActions}
               label={args.name}
-              triggerVariant="text"
             />
           }
           isLibrary

--- a/apps/web/src/components/bottleRowActions.stylex.tsx
+++ b/apps/web/src/components/bottleRowActions.stylex.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { Outputs } from "@peated/server/orpc/router";
+import * as stylex from "@stylexjs/stylex";
+
+import type { BottleRowActionControls } from "@peated/web/hooks/useBottleRowActions";
+
+import { space } from "../styles/tokens.stylex";
+import { RowMenu } from "./rowMenu.stylex";
+import { BottleRatings, type BottleRatingsProps } from "./scoring.stylex";
+
+const COMPACT = "@media (max-width: 639px)";
+
+type Bottle = Outputs["bottles"]["list"]["results"][number];
+
+export function BottleRowActions({
+  controls,
+  bottle,
+  label,
+  ratings,
+}: {
+  controls: BottleRowActionControls;
+  bottle: Pick<Bottle, "id" | "isLibrary">;
+  label: string;
+  ratings?: BottleRatingsProps;
+}) {
+  return (
+    <div {...stylex.props(styles.rowEnd)}>
+      {ratings ? <BottleRatings {...ratings} /> : null}
+      <span {...stylex.props(styles.desktopMenu)}>
+        <RowMenu
+          groups={controls.groupsFor(bottle)}
+          label={label}
+          triggerVariant="text"
+        />
+      </span>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  rowEnd: {
+    display: "flex",
+    alignItems: "center",
+    gap: space.x2,
+  },
+  desktopMenu: {
+    display: "inline-flex",
+    [COMPACT]: {
+      display: "none",
+    },
+  },
+});

--- a/apps/web/src/components/bottleRowActions.stylex.tsx
+++ b/apps/web/src/components/bottleRowActions.stylex.tsx
@@ -6,12 +6,37 @@ import * as stylex from "@stylexjs/stylex";
 import type { BottleRowActionControls } from "@peated/web/hooks/useBottleRowActions";
 
 import { space } from "../styles/tokens.stylex";
+import type { BottleListItem } from "./bottleList.stylex";
 import { RowMenu } from "./rowMenu.stylex";
 import { BottleRatings, type BottleRatingsProps } from "./scoring.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
 
 type Bottle = Outputs["bottles"]["list"]["results"][number];
+
+export function addBottleRowActions({
+  bottle,
+  controls,
+  item,
+}: {
+  bottle: Pick<Bottle, "id" | "isLibrary">;
+  controls: BottleRowActionControls;
+  item: BottleListItem;
+}): BottleListItem {
+  return {
+    ...item,
+    end: (
+      <BottleRowActions
+        bottle={bottle}
+        controls={controls}
+        label={item.name}
+        ratings={item.ratings}
+      />
+    ),
+    isLibrary: controls.isLibrary(bottle),
+    ratings: undefined,
+  };
+}
 
 export function BottleRowActions({
   controls,

--- a/apps/web/src/components/button.stylex.tsx
+++ b/apps/web/src/components/button.stylex.tsx
@@ -109,15 +109,21 @@ export type IconButtonProps = Omit<
 > & {
   icon: ReactNode;
   label: string;
+  /** Removes the frame and fill so the parent surface shows through. */
+  mergeWithSurface?: boolean;
 };
 
 export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
-  function IconButton({ icon, label, variant = "tonal", ...props }, ref) {
+  function IconButton(
+    { icon, label, mergeWithSurface = false, variant = "tonal", ...props },
+    ref,
+  ) {
     return (
       <ButtonBase
         {...props}
         aria-label={label}
         layout="icon"
+        mergeWithSurface={mergeWithSurface}
         ref={ref}
         variant={variant}
       >
@@ -132,6 +138,7 @@ type ButtonBaseProps = SharedButtonProps & {
   children: ReactNode;
   fullWidth?: boolean;
   layout: "icon" | "label";
+  mergeWithSurface?: boolean;
 };
 
 const ButtonBase = forwardRef<HTMLButtonElement, ButtonBaseProps>(
@@ -143,6 +150,7 @@ const ButtonBase = forwardRef<HTMLButtonElement, ButtonBaseProps>(
       fullWidth = false,
       layout,
       loading = false,
+      mergeWithSurface = false,
       size = "md",
       type = "button",
       variant = "default",
@@ -169,6 +177,7 @@ const ButtonBase = forwardRef<HTMLButtonElement, ButtonBaseProps>(
           layout === "label" && buttonSizeStyles[size],
           layout === "icon" && iconButtonSizeStyles[size],
           variantStyles[variant],
+          mergeWithSurface && styles.mergedWithSurface,
           loading && styles.loading,
           loading && variant === "accent" && styles.loadingAccent,
         )}
@@ -310,6 +319,22 @@ const styles = stylex.create({
       ":active": colors.accentTint,
     },
     color: colors.accentDeep,
+  },
+  mergedWithSurface: {
+    backgroundColor: {
+      default: "transparent",
+      ":hover": "transparent",
+      ":active": "transparent",
+    },
+    opacity: {
+      default: 1,
+      ":hover": 1,
+      ":active": 1,
+    },
+    boxShadow: {
+      default: "none",
+      ":focus-visible": "none",
+    },
   },
   loading: {
     position: "relative",

--- a/apps/web/src/components/menuSurface.stylex.ts
+++ b/apps/web/src/components/menuSurface.stylex.ts
@@ -1,0 +1,25 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { colors, controlMetrics, effects } from "../styles/tokens.stylex";
+
+/** Draws one complete surface around an open menu and its trigger area. */
+export const menuSurfaceStyles = stylex.create({
+  surface: {
+    overflow: "hidden",
+    borderRadius: controlMetrics.radius,
+    backgroundColor: colors.ground,
+    color: colors.ink,
+    boxShadow: effects.overlayShadow,
+    "::after": {
+      boxSizing: "border-box",
+      position: "absolute",
+      inset: 0,
+      borderWidth: "1px",
+      borderStyle: "solid",
+      borderColor: colors.sectionRule,
+      borderRadius: controlMetrics.radius,
+      content: '""',
+      pointerEvents: "none",
+    },
+  },
+});

--- a/apps/web/src/components/pages/applicationHeader.stories.tsx
+++ b/apps/web/src/components/pages/applicationHeader.stories.tsx
@@ -126,6 +126,15 @@ type Story = StoryObj<typeof meta>;
 
 export const SignedIn: Story = { render: () => <HeaderExample /> };
 
+export const AccountMenuOpen: Story = {
+  render: () => <HeaderExample />,
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Open account menu" }),
+    );
+  },
+};
+
 export const SignedOut: Story = {
   render: () => <HeaderExample signedIn={false} />,
 };

--- a/apps/web/src/components/pages/catalogTable.stylex.tsx
+++ b/apps/web/src/components/pages/catalogTable.stylex.tsx
@@ -14,7 +14,7 @@ export type CatalogTableColumn<Item> = {
   key: string;
   padding?: "default" | "flush";
   priority?: "primary" | "secondary";
-  width?: "action" | "count" | "rating";
+  width?: "action" | "count" | "menu" | "rating";
 };
 
 export type CatalogTableProps<Item> = {
@@ -182,6 +182,9 @@ const styles = stylex.create({
       width: "92px",
     },
   },
+  menuWidth: {
+    width: "40px",
+  },
   ratingWidth: {
     width: "184px",
     [COMPACT]: {
@@ -202,5 +205,6 @@ const alignStyles = {
 const widthStyles = {
   action: styles.actionWidth,
   count: styles.countWidth,
+  menu: styles.menuWidth,
   rating: styles.ratingWidth,
 } as const;

--- a/apps/web/src/components/pages/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/entityCatalog.stylex.tsx
@@ -36,11 +36,11 @@ export type EntityCatalogItem = {
 export function getEntityRowActionGroups({
   item,
   onToggleFollowing,
-  pendingId,
+  pendingIds,
 }: {
   item: EntityCatalogItem;
   onToggleFollowing?: (item: EntityCatalogItem) => void;
-  pendingId?: number;
+  pendingIds?: ReadonlySet<number>;
 }): RowMenuItem[][] {
   const groups: RowMenuItem[][] = [];
 
@@ -49,7 +49,7 @@ export function getEntityRowActionGroups({
   }
 
   if (onToggleFollowing) {
-    const pending = pendingId === item.id;
+    const pending = pendingIds?.has(item.id) ?? false;
 
     groups.push([
       {
@@ -81,7 +81,7 @@ export type EntityCatalogListProps = {
   onToggleFollowing?: (item: EntityCatalogItem) => void;
   onSortChange: (value: string) => void;
   page: number;
-  pendingId?: number;
+  pendingIds?: ReadonlySet<number>;
   previousHref?: string;
   showFollowingMarks?: boolean;
   sort: string;
@@ -102,7 +102,7 @@ export function EntityCatalogList({
   onToggleFollowing,
   onSortChange,
   page,
-  pendingId,
+  pendingIds,
   previousHref,
   showFollowingMarks = true,
   sort,
@@ -125,7 +125,7 @@ export function EntityCatalogList({
             items={items}
             noun={noun}
             onToggleFollowing={onToggleFollowing}
-            pendingId={pendingId}
+            pendingIds={pendingIds}
             showFollowingMarks={showFollowingMarks}
           />
         </>
@@ -162,13 +162,13 @@ function EntityCatalogTable({
   items,
   noun,
   onToggleFollowing,
-  pendingId,
+  pendingIds,
   showFollowingMarks,
 }: {
   items: readonly EntityCatalogItem[];
   noun: string;
   onToggleFollowing?: (item: EntityCatalogItem) => void;
-  pendingId?: number;
+  pendingIds?: ReadonlySet<number>;
   showFollowingMarks: boolean;
 }) {
   const columns: CatalogTableColumn<EntityCatalogItem>[] = [
@@ -216,7 +216,7 @@ function EntityCatalogTable({
         const groups = getEntityRowActionGroups({
           item,
           onToggleFollowing,
-          pendingId,
+          pendingIds,
         });
 
         return groups.length ? (

--- a/apps/web/src/components/pages/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/entityCatalog.stylex.tsx
@@ -12,7 +12,9 @@ import {
   FilterPanel,
   ListToolbar,
   MemberStatus,
+  RowMenu,
   type ListSortOption,
+  type RowMenuItem,
 } from "..";
 import { colors, fonts, space } from "../../styles/tokens.stylex";
 import { AppLink } from "../appLink";
@@ -21,6 +23,7 @@ import { CatalogPageLoading } from "./catalogPage.stylex";
 import { CatalogTable, type CatalogTableColumn } from "./catalogTable.stylex";
 
 export type EntityCatalogItem = {
+  createBottleHref?: string;
   href: string;
   id: number;
   isFollowing: boolean;
@@ -29,6 +32,41 @@ export type EntityCatalogItem = {
   totalBottles: number;
   totalTastings: number;
 };
+
+export function getEntityRowActionGroups({
+  item,
+  onToggleFollowing,
+  pendingId,
+}: {
+  item: EntityCatalogItem;
+  onToggleFollowing?: (item: EntityCatalogItem) => void;
+  pendingId?: number;
+}): RowMenuItem[][] {
+  const groups: RowMenuItem[][] = [];
+
+  if (item.createBottleHref) {
+    groups.push([{ href: item.createBottleHref, label: "Add a bottle" }]);
+  }
+
+  if (onToggleFollowing) {
+    groups.push([
+      {
+        disabled: pendingId !== undefined,
+        label:
+          pendingId === item.id
+            ? item.isFollowing
+              ? "Unfollowing…"
+              : "Following…"
+            : item.isFollowing
+              ? "Unfollow"
+              : "Follow",
+        onSelect: () => onToggleFollowing(item),
+      },
+    ]);
+  }
+
+  return groups;
+}
 
 export type EntityCatalogListProps = {
   addHref?: string;
@@ -170,28 +208,25 @@ function EntityCatalogTable({
     },
   ];
 
-  if (onToggleFollowing) {
+  if (onToggleFollowing || items.some((item) => item.createBottleHref)) {
     columns.push({
       align: "right",
-      cell: (item) => (
-        <Button
-          aria-label={
-            item.isFollowing ? `Unfollow ${item.name}` : `Follow ${item.name}`
-          }
-          aria-pressed={item.isFollowing}
-          loading={pendingId === item.id}
-          loadingLabel={item.isFollowing ? "Unfollowing…" : "Following…"}
-          onClick={() => onToggleFollowing(item)}
-          size="sm"
-          variant={item.isFollowing ? "text" : "tonal"}
-        >
-          {item.isFollowing ? "Following" : "Follow"}
-        </Button>
-      ),
-      header: "Follow",
+      cell: (item) => {
+        const groups = getEntityRowActionGroups({
+          item,
+          onToggleFollowing,
+          pendingId,
+        });
+
+        return groups.length ? (
+          <RowMenu groups={groups} label={item.name} triggerVariant="text" />
+        ) : null;
+      },
+      header: <span {...stylex.props(styles.visuallyHidden)}>Actions</span>,
       interactive: true,
-      key: "follow",
-      width: "action",
+      key: "actions",
+      priority: "secondary",
+      width: "menu",
     });
   }
 
@@ -269,6 +304,16 @@ export function EntityCatalogLoading({ title }: { title: string }) {
 }
 
 const styles = stylex.create({
+  visuallyHidden: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    padding: 0,
+    overflow: "hidden",
+    clip: "rect(0, 0, 0, 0)",
+    whiteSpace: "nowrap",
+    borderWidth: 0,
+  },
   catalog: {
     minWidth: 0,
   },

--- a/apps/web/src/components/pages/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/entityCatalog.stylex.tsx
@@ -49,17 +49,18 @@ export function getEntityRowActionGroups({
   }
 
   if (onToggleFollowing) {
+    const pending = pendingId === item.id;
+
     groups.push([
       {
-        disabled: pendingId !== undefined,
-        label:
-          pendingId === item.id
-            ? item.isFollowing
-              ? "Unfollowing…"
-              : "Following…"
-            : item.isFollowing
-              ? "Unfollow"
-              : "Follow",
+        disabled: pending,
+        label: pending
+          ? item.isFollowing
+            ? "Unfollowing…"
+            : "Following…"
+          : item.isFollowing
+            ? "Unfollow"
+            : "Follow",
         onSelect: () => onToggleFollowing(item),
       },
     ]);

--- a/apps/web/src/components/pages/entityCatalog.test.ts
+++ b/apps/web/src/components/pages/entityCatalog.test.ts
@@ -53,4 +53,17 @@ describe("getEntityRowActionGroups", () => {
       label: "Following…",
     });
   });
+
+  it("keeps other follow actions enabled", () => {
+    expect(
+      getEntityRowActionGroups({
+        item,
+        onToggleFollowing: vi.fn(),
+        pendingId: 7,
+      })[1]?.[0],
+    ).toMatchObject({
+      disabled: false,
+      label: "Follow",
+    });
+  });
 });

--- a/apps/web/src/components/pages/entityCatalog.test.ts
+++ b/apps/web/src/components/pages/entityCatalog.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  getEntityRowActionGroups,
+  type EntityCatalogItem,
+} from "./entityCatalog.stylex";
+
+const item: EntityCatalogItem = {
+  createBottleHref: "/bottles/new?brand=42",
+  href: "/brands/42",
+  id: 42,
+  isFollowing: false,
+  metadata: ["Brand"],
+  name: "Example Brand",
+  totalBottles: 3,
+  totalTastings: 8,
+};
+
+describe("getEntityRowActionGroups", () => {
+  it("offers bottle creation when the entity supports it", () => {
+    expect(getEntityRowActionGroups({ item })[0]).toEqual([
+      { href: "/bottles/new?brand=42", label: "Add a bottle" },
+    ]);
+  });
+
+  it("offers the current follow action", () => {
+    const onToggleFollowing = vi.fn();
+    const action = getEntityRowActionGroups({
+      item: { ...item, isFollowing: true },
+      onToggleFollowing,
+    })[1]?.[0];
+
+    expect(action).toMatchObject({
+      disabled: false,
+      label: "Unfollow",
+    });
+    if (action?.onSelect) action.onSelect();
+    expect(onToggleFollowing).toHaveBeenCalledWith({
+      ...item,
+      isFollowing: true,
+    });
+  });
+
+  it("disables follow actions while one change is pending", () => {
+    expect(
+      getEntityRowActionGroups({
+        item,
+        onToggleFollowing: vi.fn(),
+        pendingId: item.id,
+      })[1]?.[0],
+    ).toMatchObject({
+      disabled: true,
+      label: "Following…",
+    });
+  });
+});

--- a/apps/web/src/components/pages/entityCatalog.test.ts
+++ b/apps/web/src/components/pages/entityCatalog.test.ts
@@ -46,7 +46,7 @@ describe("getEntityRowActionGroups", () => {
       getEntityRowActionGroups({
         item,
         onToggleFollowing: vi.fn(),
-        pendingId: item.id,
+        pendingIds: new Set([item.id]),
       })[1]?.[0],
     ).toMatchObject({
       disabled: true,
@@ -59,7 +59,7 @@ describe("getEntityRowActionGroups", () => {
       getEntityRowActionGroups({
         item,
         onToggleFollowing: vi.fn(),
-        pendingId: 7,
+        pendingIds: new Set([7]),
       })[1]?.[0],
     ).toMatchObject({
       disabled: false,

--- a/apps/web/src/components/rowMenu.stories.tsx
+++ b/apps/web/src/components/rowMenu.stories.tsx
@@ -8,7 +8,7 @@ const groups = [
     { label: "Log a tasting", onSelect: () => undefined },
     { label: "Add what you paid", onSelect: () => undefined },
   ],
-  [{ label: "Remove from library", onSelect: () => undefined }],
+  [{ label: "Remove from Library", onSelect: () => undefined }],
 ] as const;
 
 const meta = {
@@ -32,7 +32,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Use Row Menu for secondary actions on one item. Keep the primary destination on the row and put only secondary actions in the menu.",
+          "Use this menu for actions that do not need a permanent button.",
       },
     },
   },
@@ -41,25 +41,35 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Overview: Story = {
+export const Closed: Story = {
   render: (args) => (
     <StoryRow>
       <RowMenu {...args} />
-      <RowMenu {...args} variant="page" />
-      <RowMenu
-        {...args}
-        groups={[
-          [
-            { label: "Log a tasting", onSelect: () => undefined },
-            {
-              disabled: true,
-              label: "Add what you paid",
-              onSelect: () => undefined,
-            },
-          ],
-          [{ label: "Remove from library", onSelect: () => undefined }],
-        ]}
-      />
+      <RowMenu {...args} label="Frameless menu" triggerVariant="text" />
     </StoryRow>
   ),
+};
+
+export const FramedOpen: Story = {
+  args: {
+    label: "Bottle actions",
+    variant: "page",
+  },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Actions for Bottle actions" }),
+    );
+  },
+};
+
+export const FramelessOpen: Story = {
+  args: {
+    label: "Bowmore 15",
+    triggerVariant: "text",
+  },
+  play: async ({ canvas, userEvent }) => {
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Actions for Bowmore 15" }),
+    );
+  },
 };

--- a/apps/web/src/components/rowMenu.stylex.tsx
+++ b/apps/web/src/components/rowMenu.stylex.tsx
@@ -12,7 +12,7 @@ import {
   zIndices,
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
-import { IconButton } from "./button.stylex";
+import { IconButton, type ButtonVariant } from "./button.stylex";
 
 const MENU_ANCHORS = {
   page: {
@@ -44,14 +44,16 @@ export type RowMenuProps = {
   groups: readonly (RowMenuGroup | readonly RowMenuItem[])[];
   label: string;
   triggerLabel?: string;
+  triggerVariant?: ButtonVariant;
   variant?: "page" | "row";
 };
 
-/** Collects an item's secondary actions behind one vertical-dots control. */
+/** Shows an item's actions in a menu. */
 export function RowMenu({
   groups,
   label,
   triggerLabel = `Actions for ${label}`,
+  triggerVariant = "tonal",
   variant = "row",
 }: RowMenuProps) {
   const normalizedGroups = groups.map(normalizeGroup);
@@ -63,16 +65,11 @@ export function RowMenu({
           <span {...stylex.props(styles.triggerLayer)}>
             <MenuButton
               as={IconButton}
-              icon={
-                <span aria-hidden="true" {...stylex.props(styles.dots)}>
-                  <span {...stylex.props(styles.dot)} />
-                  <span {...stylex.props(styles.dot)} />
-                  <span {...stylex.props(styles.dot)} />
-                </span>
-              }
+              icon={<MenuDots />}
               label={triggerLabel}
+              mergeWithSurface={open}
               size={variant === "page" ? "lg" : "sm"}
-              variant="tonal"
+              variant={triggerVariant}
             />
           </span>
           <MenuItems
@@ -88,6 +85,17 @@ export function RowMenu({
               )}
             >
               {label}
+              <span aria-hidden="true" {...stylex.props(styles.menuTrigger)}>
+                <IconButton
+                  aria-hidden="true"
+                  icon={<MenuDots />}
+                  label=""
+                  mergeWithSurface
+                  size={variant === "page" ? "lg" : "sm"}
+                  tabIndex={-1}
+                  variant={triggerVariant}
+                />
+              </span>
             </div>
             <div {...stylex.props(styles.separator)} />
             {normalizedGroups.map((group, groupIndex) => (
@@ -141,6 +149,16 @@ export function RowMenu({
   );
 }
 
+function MenuDots() {
+  return (
+    <span aria-hidden="true" {...stylex.props(styles.dots)}>
+      <span {...stylex.props(styles.dot)} />
+      <span {...stylex.props(styles.dot)} />
+      <span {...stylex.props(styles.dot)} />
+    </span>
+  );
+}
+
 function normalizeGroup(
   group: RowMenuGroup | readonly RowMenuItem[],
 ): RowMenuGroup {
@@ -152,11 +170,9 @@ const styles = stylex.create({
     position: "relative",
     display: "inline-flex",
     flexShrink: 0,
-    // Keep the trigger inside this component's stacking context.
     isolation: "isolate",
   },
   openRoot: {
-    // The anchored menu uses a portal, so its open trigger must sit above it.
     zIndex: zIndices.menuControl,
   },
   triggerLayer: {
@@ -185,6 +201,24 @@ const styles = stylex.create({
     backgroundColor: colors.ground,
     color: colors.ink,
     boxShadow: effects.overlayShadow,
+    "::after": {
+      boxSizing: "border-box",
+      position: "absolute",
+      inset: 0,
+      borderWidth: "1px",
+      borderStyle: "solid",
+      borderColor: colors.sectionRule,
+      borderRadius: controlMetrics.radius,
+      content: '""',
+      pointerEvents: "none",
+    },
+  },
+  menuTrigger: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    display: "inline-flex",
+    pointerEvents: "none",
   },
   header: {
     boxSizing: "border-box",

--- a/apps/web/src/components/rowMenu.stylex.tsx
+++ b/apps/web/src/components/rowMenu.stylex.tsx
@@ -13,6 +13,7 @@ import {
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { IconButton, type ButtonVariant } from "./button.stylex";
+import { menuSurfaceStyles } from "./menuSurface.stylex";
 
 const MENU_ANCHORS = {
   page: {
@@ -75,7 +76,7 @@ export function RowMenu({
           <MenuItems
             anchor={MENU_ANCHORS[variant]}
             aria-label={`${label} actions`}
-            {...stylex.props(styles.menu)}
+            {...stylex.props(styles.menu, menuSurfaceStyles.surface)}
           >
             <div
               title={label}
@@ -195,23 +196,7 @@ const styles = stylex.create({
   menu: {
     zIndex: zIndices.menu,
     width: "216px",
-    overflow: "hidden",
-    borderRadius: controlMetrics.radius,
     outline: "none",
-    backgroundColor: colors.ground,
-    color: colors.ink,
-    boxShadow: effects.overlayShadow,
-    "::after": {
-      boxSizing: "border-box",
-      position: "absolute",
-      inset: 0,
-      borderWidth: "1px",
-      borderStyle: "solid",
-      borderColor: colors.sectionRule,
-      borderRadius: controlMetrics.radius,
-      content: '""',
-      pointerEvents: "none",
-    },
   },
   menuTrigger: {
     position: "absolute",

--- a/apps/web/src/hooks/useBottleRowActions.test.ts
+++ b/apps/web/src/hooks/useBottleRowActions.test.ts
@@ -1,22 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { getSeriesBottleActionGroups } from "./seriesPageClient.stylex";
+import { getBottleRowActionGroups } from "./useBottleRowActions";
 
 function getGroups(
-  overrides: Partial<Parameters<typeof getSeriesBottleActionGroups>[0]> = {},
+  overrides: Partial<Parameters<typeof getBottleRowActionGroups>[0]> = {},
 ) {
-  return getSeriesBottleActionGroups({
+  return getBottleRowActionGroups({
     bottle: { id: 42 },
+    changePending: false,
     isLibrary: false,
     isLoggedIn: true,
-    libraryMutationPending: false,
     onLibraryToggle: vi.fn(),
     thisBottlePending: false,
     ...overrides,
   });
 }
 
-describe("getSeriesBottleActionGroups", () => {
+describe("getBottleRowActionGroups", () => {
   it("links to the tasting form", () => {
     expect(getGroups()[0]).toEqual([
       {
@@ -26,7 +26,7 @@ describe("getSeriesBottleActionGroups", () => {
     ]);
   });
 
-  it("sends anonymous members through the protected library flow", () => {
+  it("sends anonymous members through the protected Library flow", () => {
     expect(getGroups({ isLoggedIn: false })[1]).toEqual([
       {
         href: "/addBottle?bottle=42&intent=library",
@@ -35,7 +35,7 @@ describe("getSeriesBottleActionGroups", () => {
     ]);
   });
 
-  it("toggles the signed-in member's library state", () => {
+  it("toggles the signed-in member's Library state", () => {
     const onLibraryToggle = vi.fn();
     const action = getGroups({ isLibrary: true, onLibraryToggle })[1]?.[0];
 
@@ -46,10 +46,10 @@ describe("getSeriesBottleActionGroups", () => {
     });
   });
 
-  it("shows which library change is pending", () => {
+  it("shows which Library change is pending", () => {
     expect(
       getGroups({
-        libraryMutationPending: true,
+        changePending: true,
         thisBottlePending: true,
       })[1]?.[0],
     ).toMatchObject({

--- a/apps/web/src/hooks/useBottleRowActions.test.ts
+++ b/apps/web/src/hooks/useBottleRowActions.test.ts
@@ -7,9 +7,9 @@ function getGroups(
 ) {
   return getBottleRowActionGroups({
     bottle: { id: 42 },
-    changePending: false,
     isLibrary: false,
     isLoggedIn: true,
+    libraryChangePending: false,
     onLibraryToggle: vi.fn(),
     thisBottlePending: false,
     ...overrides,
@@ -49,12 +49,23 @@ describe("getBottleRowActionGroups", () => {
   it("shows which Library change is pending", () => {
     expect(
       getGroups({
-        changePending: true,
+        libraryChangePending: true,
         thisBottlePending: true,
       })[1]?.[0],
     ).toMatchObject({
       disabled: true,
       label: "Adding to Library…",
+    });
+  });
+
+  it("waits for the current Library change before starting another", () => {
+    expect(
+      getGroups({
+        libraryChangePending: true,
+      })[1]?.[0],
+    ).toMatchObject({
+      disabled: true,
+      label: "Add to Library",
     });
   });
 });

--- a/apps/web/src/hooks/useBottleRowActions.tsx
+++ b/apps/web/src/hooks/useBottleRowActions.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import type { Outputs } from "@peated/server/orpc/router";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+
+import type { RowMenuItem } from "@peated/web/components";
+import { useFlashMessages } from "@peated/web/components/flashMessages.stylex";
+import { getAddBottleHref } from "@peated/web/lib/addBottle";
+import { useORPC } from "@peated/web/lib/orpc/context";
+
+import useAuth from "./useAuth";
+
+type Bottle = Outputs["bottles"]["list"]["results"][number];
+type BottleActionTarget = Pick<Bottle, "id" | "isLibrary">;
+
+export type BottleRowActionControls = {
+  groupsFor: (bottle: BottleActionTarget) => RowMenuItem[][];
+  isLibrary: (bottle: BottleActionTarget) => boolean;
+};
+
+export function getBottleRowActionGroups({
+  bottle,
+  changePending,
+  isLibrary,
+  isLoggedIn,
+  onLibraryToggle,
+  thisBottlePending,
+}: {
+  bottle: Pick<Bottle, "id">;
+  changePending: boolean;
+  isLibrary: boolean;
+  isLoggedIn: boolean;
+  onLibraryToggle: () => void;
+  thisBottlePending: boolean;
+}): RowMenuItem[][] {
+  const libraryAction: RowMenuItem = isLoggedIn
+    ? {
+        disabled: changePending,
+        label: thisBottlePending
+          ? isLibrary
+            ? "Removing from Library…"
+            : "Adding to Library…"
+          : isLibrary
+            ? "Remove from Library"
+            : "Add to Library",
+        onSelect: onLibraryToggle,
+      }
+    : {
+        href: getAddBottleHref({
+          bottleId: bottle.id,
+          intent: "library",
+        }),
+        label: "Add to Library",
+      };
+
+  return [
+    [
+      {
+        href: getAddBottleHref({
+          bottleId: bottle.id,
+          intent: "tasting",
+        }),
+        label: "Log a tasting",
+      },
+    ],
+    [libraryAction],
+  ];
+}
+
+export default function useBottleRowActions(): BottleRowActionControls {
+  const orpc = useORPC();
+  const queryClient = useQueryClient();
+  const { user } = useAuth();
+  const { flash } = useFlashMessages();
+  const [libraryOverrides, setLibraryOverrides] = useState<
+    Record<number, boolean>
+  >({});
+  const [pendingBottleId, setPendingBottleId] = useState<number>();
+  const addMutation = useMutation(
+    orpc.collections.bottles.create.mutationOptions(),
+  );
+  const removeMutation = useMutation(
+    orpc.collections.bottles.delete.mutationOptions(),
+  );
+  const changePending = addMutation.isPending || removeMutation.isPending;
+
+  function isLibrary(bottle: BottleActionTarget) {
+    return libraryOverrides[bottle.id] ?? bottle.isLibrary;
+  }
+
+  async function toggleLibrary(bottle: BottleActionTarget) {
+    if (!user || pendingBottleId !== undefined) return;
+
+    const current = isLibrary(bottle);
+    setPendingBottleId(bottle.id);
+    try {
+      if (current) {
+        await removeMutation.mutateAsync({
+          bottle: bottle.id,
+          collection: "library",
+          user: "me",
+        });
+      } else {
+        await addMutation.mutateAsync({
+          bottle: bottle.id,
+          collection: "library",
+          user: "me",
+        });
+      }
+
+      setLibraryOverrides((values) => ({
+        ...values,
+        [bottle.id]: !current,
+      }));
+      flash(current ? "Removed from your Library." : "Added to your Library.");
+      void queryClient.invalidateQueries({
+        queryKey: orpc.bottles.list.key({ type: "query" }),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: orpc.collections.bottles.list.key({ type: "query" }),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: orpc.users.libraryStats.key({ type: "query" }),
+      });
+    } catch {
+      flash(
+        current
+          ? "We couldn't remove this bottle from your Library. Try again."
+          : "We couldn't add this bottle to your Library. Try again.",
+        "error",
+      );
+    } finally {
+      setPendingBottleId(undefined);
+    }
+  }
+
+  return {
+    groupsFor: (bottle) =>
+      getBottleRowActionGroups({
+        bottle,
+        changePending,
+        isLibrary: isLibrary(bottle),
+        isLoggedIn: Boolean(user),
+        onLibraryToggle: () => void toggleLibrary(bottle),
+        thisBottlePending: pendingBottleId === bottle.id,
+      }),
+    isLibrary,
+  };
+}

--- a/apps/web/src/hooks/useBottleRowActions.tsx
+++ b/apps/web/src/hooks/useBottleRowActions.tsx
@@ -21,22 +21,22 @@ export type BottleRowActionControls = {
 
 export function getBottleRowActionGroups({
   bottle,
-  changePending,
   isLibrary,
   isLoggedIn,
+  libraryChangePending,
   onLibraryToggle,
   thisBottlePending,
 }: {
   bottle: Pick<Bottle, "id">;
-  changePending: boolean;
   isLibrary: boolean;
   isLoggedIn: boolean;
+  libraryChangePending: boolean;
   onLibraryToggle: () => void;
   thisBottlePending: boolean;
 }): RowMenuItem[][] {
   const libraryAction: RowMenuItem = isLoggedIn
     ? {
-        disabled: changePending,
+        disabled: libraryChangePending,
         label: thisBottlePending
           ? isLibrary
             ? "Removing from Library…"
@@ -83,7 +83,6 @@ export default function useBottleRowActions(): BottleRowActionControls {
   const removeMutation = useMutation(
     orpc.collections.bottles.delete.mutationOptions(),
   );
-  const changePending = addMutation.isPending || removeMutation.isPending;
 
   function isLibrary(bottle: BottleActionTarget) {
     return libraryOverrides[bottle.id] ?? bottle.isLibrary;
@@ -139,9 +138,9 @@ export default function useBottleRowActions(): BottleRowActionControls {
     groupsFor: (bottle) =>
       getBottleRowActionGroups({
         bottle,
-        changePending,
         isLibrary: isLibrary(bottle),
         isLoggedIn: Boolean(user),
+        libraryChangePending: pendingBottleId !== undefined,
         onLibraryToggle: () => void toggleLibrary(bottle),
         thisBottlePending: pendingBottleId === bottle.id,
       }),

--- a/apps/web/src/hooks/useEntityFollowing.tsx
+++ b/apps/web/src/hooks/useEntityFollowing.tsx
@@ -12,7 +12,9 @@ export default function useEntityFollowing() {
   const queryClient = useQueryClient();
   const { flash } = useFlashMessages();
   const [overrides, setOverrides] = useState<Record<number, boolean>>({});
-  const [pendingId, setPendingId] = useState<number>();
+  const [pendingIds, setPendingIds] = useState<ReadonlySet<number>>(
+    () => new Set(),
+  );
   const followMutation = useMutation(orpc.entities.follow.mutationOptions());
   const unfollowMutation = useMutation(
     orpc.entities.unfollow.mutationOptions(),
@@ -23,7 +25,7 @@ export default function useEntityFollowing() {
 
   async function toggle(entity: Pick<Entity, "id" | "isFollowing">) {
     const current = isFollowing(entity);
-    setPendingId(entity.id);
+    setPendingIds((ids) => new Set(ids).add(entity.id));
 
     try {
       if (current) {
@@ -48,9 +50,13 @@ export default function useEntityFollowing() {
         "error",
       );
     } finally {
-      setPendingId(undefined);
+      setPendingIds((ids) => {
+        const nextIds = new Set(ids);
+        nextIds.delete(entity.id);
+        return nextIds;
+      });
     }
   }
 
-  return { isFollowing, pendingId, toggle };
+  return { isFollowing, pendingIds, toggle };
 }

--- a/apps/web/src/lib/entityCatalogItem.ts
+++ b/apps/web/src/lib/entityCatalogItem.ts
@@ -2,6 +2,7 @@ import { toTitleCase } from "@peated/server/lib/strings";
 import type { Entity } from "@peated/server/types";
 
 import type { EntityCatalogItem } from "@peated/web/components/pages/entityCatalog.stylex";
+import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
 export function toEntityCatalogItem(
@@ -18,6 +19,7 @@ export function toEntityCatalogItem(
   ].filter((value): value is string => value !== null);
 
   return {
+    createBottleHref: getEntityBottleCreateHref(entity),
     href: getEntityUrl(entity),
     id: entity.id,
     isFollowing,


### PR DESCRIPTION
Desktop bottle rows in the main catalog and Series pages now share an action menu for logging a tasting or adding and removing a bottle from the Library. Entity catalogs use the same compact menu for adding bottles and following or unfollowing records when those actions apply. Mobile list layouts stay unchanged.

Open menus now appear as one surface. A muted border wraps the full menu, the trigger frame and fill disappear, and the menu background shows through the trigger area. The account avatar menu uses the same behavior.

Storybook shows the closed and open row-menu styles, an action menu inside a bottle row, and the open account menu. Bottle and entity action tests cover their links, labels, and pending states.
