### PR TITLE
feat(series): add library progress and distillery context

### DIFF
--- a/apps/server/src/orpc/contracts/bottles/list.ts
+++ b/apps/server/src/orpc/contracts/bottles/list.ts
@@ -45,6 +45,10 @@ export default contract
           "Filter a distillery to its own releases or releases from other brands and bottlers.",
         ),
       series: z.coerce.number().nullish(),
+      library: z
+        .enum(["in", "out"])
+        .nullish()
+        .describe("Filter by the signed-in user's Library."),
       tag: z.string().nullish(),
       flavorProfile: z.enum(FLAVOR_PROFILES).nullish(),
       flight: z.string().nullish(),

--- a/apps/server/src/orpc/routes/bottleSeries/details.test.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/details.test.ts
@@ -26,7 +26,58 @@ describe("GET /bottle-series/:series", () => {
         id: brand.id,
         name: brand.name,
       },
+      distillers: [],
     });
+  });
+
+  it("returns Distilleries with their active Series Bottle counts", async function ({
+    fixtures,
+  }) {
+    const brand = await fixtures.Entity({ name: "Dramfool" });
+    const [bruichladdich, bowmore] = await Promise.all([
+      fixtures.Entity({ kind: "distillery", name: "Bruichladdich" }),
+      fixtures.Entity({ kind: "distillery", name: "Bowmore" }),
+    ]);
+    const series = await fixtures.BottleSeries({
+      brandId: brand.id,
+      name: "Signature Collection",
+    });
+    await Promise.all([
+      fixtures.Bottle({
+        brandId: brand.id,
+        distillerIds: [bruichladdich.id],
+        seriesId: series.id,
+      }),
+      fixtures.Bottle({
+        brandId: brand.id,
+        distillerIds: [bruichladdich.id],
+        seriesId: series.id,
+      }),
+      fixtures.Bottle({
+        brandId: brand.id,
+        distillerIds: [bowmore.id],
+        seriesId: series.id,
+      }),
+    ]);
+
+    const result = await routerClient.bottleSeries.details({
+      series: series.id,
+    });
+
+    expect(result.distillers).toEqual([
+      expect.objectContaining({
+        id: bruichladdich.id,
+        name: "Bruichladdich",
+        numBottles: 2,
+        peatedId: `E${String(bruichladdich.id).padStart(4, "0")}`,
+      }),
+      expect.objectContaining({
+        id: bowmore.id,
+        name: "Bowmore",
+        numBottles: 1,
+        peatedId: `E${String(bowmore.id).padStart(4, "0")}`,
+      }),
+    ]);
   });
 
   it("returns 404 for non-existent series", async function () {

--- a/apps/server/src/orpc/routes/bottleSeries/details.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/details.ts
@@ -1,7 +1,10 @@
 import { db } from "@peated/server/db";
 import {
+  bottles,
   bottleSeries,
   bottleSeriesTombstones,
+  bottlesToDistillers,
+  bottleTombstones,
   entities,
 } from "@peated/server/db/schema";
 import { formatPeatedId } from "@peated/server/lib/peatedId";
@@ -12,7 +15,16 @@ import {
 } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
 import { BottleSeriesSerializer } from "@peated/server/serializers/bottleSeries";
-import { eq, getTableColumns } from "drizzle-orm";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  getTableColumns,
+  isNotNull,
+  isNull,
+  sql,
+} from "drizzle-orm";
 import { z } from "zod";
 
 export default procedure
@@ -67,11 +79,45 @@ export default procedure
       }
     }
 
+    const distillerBottleCount = sql<number>`COUNT(DISTINCT ${bottles.id})::int`;
+    const distillers = await db
+      .select({
+        id: entities.id,
+        name: entities.name,
+        shortName: entities.shortName,
+        kind: entities.kind,
+        numBottles: distillerBottleCount,
+      })
+      .from(bottles)
+      .innerJoin(
+        bottlesToDistillers,
+        eq(bottlesToDistillers.bottleId, bottles.id),
+      )
+      .innerJoin(entities, eq(entities.id, bottlesToDistillers.distillerId))
+      .leftJoin(bottleTombstones, eq(bottleTombstones.bottleId, bottles.id))
+      .where(
+        and(
+          eq(bottles.seriesId, result.series.id),
+          isNotNull(bottles.groupId),
+          isNull(bottleTombstones.bottleId),
+        ),
+      )
+      .groupBy(entities.id, entities.name, entities.shortName, entities.kind)
+      .orderBy(
+        desc(distillerBottleCount),
+        asc(entities.name),
+        asc(entities.id),
+      );
+
     return {
       ...(await serialize(BottleSeriesSerializer, result.series, context.user)),
       brand: {
         ...result.brand,
         peatedId: formatPeatedId("entity", result.brand.id),
       },
+      distillers: distillers.map((distiller) => ({
+        ...distiller,
+        peatedId: formatPeatedId("entity", distiller.id),
+      })),
     };
   });

--- a/apps/server/src/orpc/routes/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/list.test.ts
@@ -2,6 +2,7 @@ import { db } from "@peated/server/db";
 import {
   bottleReferences,
   bottleTombstones,
+  collectionBottles,
   entityFollows,
   flightBottles,
 } from "@peated/server/db/schema";
@@ -594,6 +595,54 @@ describe("GET /bottles", () => {
 
     expect(results.length).toBe(1);
     expect(results[0].id).toBe(bottle1.id);
+  });
+
+  test("filters a Series by the signed-in user's Library", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const series = await fixtures.BottleSeries({ name: "Library Series" });
+    const inLibrary = await fixtures.Bottle({
+      name: "In Library",
+      seriesId: series.id,
+    });
+    const outsideLibrary = await fixtures.Bottle({
+      name: "Outside Library",
+      seriesId: series.id,
+    });
+    const libraryCollection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+      totalBottles: 1,
+    });
+    await db.insert(collectionBottles).values({
+      bottleId: inLibrary.id,
+      collectionId: libraryCollection.id,
+    });
+
+    const [included, excluded] = await Promise.all([
+      routerClient.bottles.list(
+        { library: "in", series: series.id },
+        { context: { user: defaults.user } },
+      ),
+      routerClient.bottles.list(
+        { library: "out", series: series.id },
+        { context: { user: defaults.user } },
+      ),
+    ]);
+
+    expect(included.total).toBe(1);
+    expect(included.results.map(({ id }) => id)).toEqual([inLibrary.id]);
+    expect(excluded.total).toBe(1);
+    expect(excluded.results.map(({ id }) => id)).toEqual([outsideLibrary.id]);
+  });
+
+  test("requires authentication for Library filtering", async () => {
+    const err = await waitError(() =>
+      routerClient.bottles.list({ library: "in" }),
+    );
+
+    expect(err).toMatchInlineSnapshot(`[Error: Unauthorized.]`);
   });
 
   // Sorting tests

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -5,12 +5,14 @@ import {
   bottles,
   bottlesToDistillers,
   bottleTombstones,
+  collectionBottles,
   entities,
   entityFollows,
   flightBottles,
   flights,
   tastings,
 } from "@peated/server/db/schema";
+import { getReservedCollection } from "@peated/server/lib/db";
 import { bottlesForDistilleryView } from "@peated/server/lib/distilleryBottleView";
 import {
   plainTextSearchQuery,
@@ -55,7 +57,8 @@ export default implement(bottleListContract).handler(async function ({
   context,
   errors,
 }) {
-  const { query, cursor, limit, filter, category, ageBand, ...rest } = input;
+  const { query, cursor, limit, filter, library, category, ageBand, ...rest } =
+    input;
   const offset = (cursor - 1) * limit;
   const textQuery = plainTextSearchQuery(query);
   const prefixQuery = prefixTextSearchQuery(query);
@@ -131,6 +134,33 @@ export default implement(bottleListContract).handler(async function ({
           )
         : sql`FALSE`,
     );
+  }
+
+  if (library) {
+    if (!context.user) {
+      throw errors.UNAUTHORIZED();
+    }
+
+    const libraryCollection = await getReservedCollection(
+      db,
+      context.user.id,
+      "library",
+    );
+    if (!libraryCollection) {
+      where.push(library === "in" ? sql`FALSE` : sql`TRUE`);
+    } else if (library === "in") {
+      where.push(sql`EXISTS(
+        SELECT FROM ${collectionBottles}
+        WHERE ${collectionBottles.collectionId} = ${libraryCollection.id}
+          AND ${collectionBottles.bottleId} = ${bottles.id}
+      )`);
+    } else {
+      where.push(sql`NOT EXISTS(
+        SELECT FROM ${collectionBottles}
+        WHERE ${collectionBottles.collectionId} = ${libraryCollection.id}
+          AND ${collectionBottles.bottleId} = ${bottles.id}
+      )`);
+    }
   }
 
   if (query) {

--- a/apps/server/src/schemas/bottleSeries.ts
+++ b/apps/server/src/schemas/bottleSeries.ts
@@ -51,6 +51,23 @@ export const BottleSeriesDetailsSchema = BottleSeriesSchema.extend({
     shortName: true,
     kind: true,
   }).describe("Brand that owns this bottle series"),
+  distillers: z
+    .array(
+      EntitySchema.pick({
+        id: true,
+        peatedId: true,
+        name: true,
+        shortName: true,
+        kind: true,
+      }).extend({
+        numBottles: z
+          .number()
+          .readonly()
+          .describe("Number of active Series Bottles from this Distillery"),
+      }),
+    )
+    .readonly()
+    .describe("Distilleries represented by active Bottles in this Series"),
 });
 
 export const BottleSeriesInputFields = {

--- a/apps/web/src/app/(app)/series/[seriesId]/page.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/page.tsx
@@ -1,11 +1,15 @@
 import { BOTTLE_LIST_SORT_OPTIONS } from "@peated/server/constants";
+import { getCurrentUser } from "@peated/web/lib/auth.server";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import { getSeriesSeoMetadata } from "@peated/web/lib/seoMetadata";
 import { getSeriesPage } from "@peated/web/lib/seriesPage.server";
 import type { Metadata } from "next";
 
-import { SeriesPageClient } from "./seriesPageClient.stylex";
+import {
+  SeriesPageClient,
+  type SeriesLibraryFilter,
+} from "./seriesPageClient.stylex";
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
@@ -20,6 +24,10 @@ function getCursor(value: string | undefined) {
 
 function getSort(value: string | undefined) {
   return BOTTLE_LIST_SORT_OPTIONS.find((sort) => sort === value) ?? "-release";
+}
+
+function getLibraryFilter(value: string | undefined): SeriesLibraryFilter {
+  return value === "in" || value === "out" ? value : "all";
 }
 
 export async function generateMetadata(props: {
@@ -41,18 +49,36 @@ export default async function SeriesPage(props: {
   const series = await getSeriesPage(parseCatalogRouteId(seriesId));
   const cursor = getCursor(firstValue(searchParams.cursor));
   const sort = getSort(firstValue(searchParams.sort));
-  const { client } = await getPublicPageServerClient();
-  const bottleList = await client.bottles.list({
-    cursor,
-    limit: 25,
-    series: series.id,
-    sort,
-  });
+  const [currentUser, { client }] = await Promise.all([
+    getCurrentUser(),
+    getPublicPageServerClient(),
+  ]);
+  const library = currentUser
+    ? getLibraryFilter(firstValue(searchParams.library))
+    : "all";
+  const [bottleList, libraryBottleList] = await Promise.all([
+    client.bottles.list({
+      cursor,
+      library: library === "all" ? undefined : library,
+      limit: 25,
+      series: series.id,
+      sort,
+    }),
+    currentUser
+      ? client.bottles.list({
+          library: "in",
+          limit: 1,
+          series: series.id,
+        })
+      : null,
+  ]);
 
   return (
     <SeriesPageClient
       initialBottleList={bottleList}
       initialCursor={cursor}
+      initialLibrary={library}
+      initialLibraryCount={libraryBottleList?.total ?? null}
       initialSeries={series}
       initialSort={sort}
     />

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -12,6 +12,8 @@ import {
   Chip,
   FactList,
   PeatedId,
+  RailList,
+  RailListItem,
   SectionError,
   TextLink,
 } from "@peated/web/components";
@@ -21,14 +23,14 @@ import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.st
 import {
   PageColumns,
   PageHeader,
-  RailSection,
 } from "@peated/web/components/pages/pageLayout.stylex";
+import { RailListSection } from "@peated/web/components/pages/railListSection.stylex";
 import useBottleRowActions from "@peated/web/hooks/useBottleRowActions";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getEntityUrl } from "@peated/web/lib/urls";
-import { colors, fonts, space } from "../../../../styles/tokens.stylex";
+import { space } from "../../../../styles/tokens.stylex";
 
 type BottleList = Outputs["bottles"]["list"];
 type Series = Outputs["bottleSeries"]["details"];
@@ -247,37 +249,36 @@ function SeriesDistilleries({
     : distillers.slice(0, DISTILLERY_PREVIEW_LIMIT);
 
   return (
-    <RailSection
+    <RailListSection
+      action={
+        hasMore
+          ? {
+              ariaControls: "series-distilleries",
+              expanded,
+              label: expanded
+                ? "Show fewer distilleries"
+                : `View all ${distillers.length.toLocaleString("en-US")} distilleries`,
+              onClick: () => setExpanded((value) => !value),
+            }
+          : undefined
+      }
       heading={distillers.length === 1 ? "Distillery" : "Distilleries"}
     >
-      <ul id="series-distilleries" {...stylex.props(styles.distillerList)}>
-        {visibleDistillers.map((distiller) => (
-          <li key={distiller.id} {...stylex.props(styles.distillerRow)}>
-            <TextLink href={getEntityUrl(distiller)} size="inherit">
-              {distiller.name}
-            </TextLink>
-            <span {...stylex.props(styles.distillerCount)}>
-              {distiller.numBottles.toLocaleString("en-US")}{" "}
-              {distiller.numBottles === 1 ? "bottle" : "bottles"}
-            </span>
-          </li>
-        ))}
-      </ul>
-      {hasMore ? (
-        <div {...stylex.props(styles.distillerMore)}>
-          <Button
-            align="start"
-            aria-controls="series-distilleries"
-            aria-expanded={expanded}
-            onClick={() => setExpanded((value) => !value)}
-            size="sm"
-            variant="text"
-          >
-            {expanded ? "Show less" : "View more"}
-          </Button>
-        </div>
-      ) : null}
-    </RailSection>
+      <div id="series-distilleries">
+        <RailList ariaLabel="Series distilleries">
+          {visibleDistillers.map((distiller) => (
+            <RailListItem
+              end={`${distiller.numBottles.toLocaleString("en-US")} ${
+                distiller.numBottles === 1 ? "bottle" : "bottles"
+              }`}
+              href={getEntityUrl(distiller)}
+              key={distiller.id}
+              title={distiller.name}
+            />
+          ))}
+        </RailList>
+      </div>
+    </RailListSection>
   );
 }
 
@@ -302,32 +303,5 @@ const styles = stylex.create({
   bottles: {
     minWidth: 0,
     paddingTop: space.x4,
-  },
-  distillerList: {
-    margin: 0,
-    padding: 0,
-    listStyle: "none",
-  },
-  distillerRow: {
-    display: "flex",
-    minWidth: 0,
-    alignItems: "baseline",
-    justifyContent: "space-between",
-    gap: space.x3,
-    paddingTop: "9px",
-    paddingBottom: "9px",
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.hairline,
-  },
-  distillerCount: {
-    flexShrink: 0,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.4,
-  },
-  distillerMore: {
-    marginTop: space.x1,
   },
 });

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -6,7 +6,14 @@ import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 
-import { FactList, SectionError, TextLink } from "@peated/web/components";
+import {
+  Button,
+  Chip,
+  KeyFacts,
+  PeatedId,
+  SectionError,
+  TextLink,
+} from "@peated/web/components";
 import { addBottleRowActions } from "@peated/web/components/bottleRowActions.stylex";
 import Markdown from "@peated/web/components/markdown";
 import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
@@ -24,6 +31,7 @@ import { space } from "../../../../styles/tokens.stylex";
 type BottleList = Outputs["bottles"]["list"];
 type Series = Outputs["bottleSeries"]["details"];
 type BottleSort = (typeof BOTTLE_LIST_SORT_OPTIONS)[number];
+export type SeriesLibraryFilter = "all" | "in" | "out";
 
 const sortOptions = [
   { label: "Latest release", value: "-release" },
@@ -34,14 +42,24 @@ const sortOptions = [
   { label: "Recently added", value: "-created" },
 ] as const;
 
+const libraryOptions = [
+  { label: "All", value: "all" },
+  { label: "Not in your Library", value: "out" },
+  { label: "In your Library", value: "in" },
+] as const;
+
 export function SeriesPageClient({
   initialBottleList,
   initialCursor,
+  initialLibrary,
+  initialLibraryCount,
   initialSeries,
   initialSort,
 }: {
   initialBottleList: BottleList;
   initialCursor: number;
+  initialLibrary: SeriesLibraryFilter;
+  initialLibraryCount: number | null;
   initialSeries: Series;
   initialSort: BottleSort;
 }) {
@@ -54,6 +72,7 @@ export function SeriesPageClient({
     ...orpc.bottles.list.queryOptions({
       input: {
         cursor: initialCursor,
+        library: initialLibrary === "all" ? undefined : initialLibrary,
         limit: 25,
         series: initialSeries.id,
         sort: initialSort,
@@ -62,21 +81,43 @@ export function SeriesPageClient({
     initialData: initialBottleList,
   });
 
-  function updateSort(value: string) {
+  function updateParams(updates: Record<string, string>) {
     const nextParams = new URLSearchParams(searchParams);
-    nextParams.set("sort", value);
+    for (const [name, value] of Object.entries(updates)) {
+      if (value) nextParams.set(name, value);
+      else nextParams.delete(name);
+    }
     nextParams.delete("cursor");
     router.push(buildSearchHref(pathname, nextParams));
   }
 
-  const facts = [
-    { label: "Series ID", value: initialSeries.peatedId },
-    {
-      label: "Bottles",
-      value: initialBottleList.total.toLocaleString("en-US"),
-    },
-  ] as const;
+  const facts =
+    initialLibraryCount === null
+      ? ([{ label: "Bottles", value: initialSeries.numReleases }] as const)
+      : ([
+          { label: "Bottles", value: initialSeries.numReleases },
+          {
+            label: "In your Library",
+            value: `${initialLibraryCount.toLocaleString("en-US")} of ${initialSeries.numReleases.toLocaleString("en-US")}`,
+          },
+        ] as const);
   const bottleList = bottleListQuery.data;
+  const filtered = initialLibrary !== "all";
+  const emptyState =
+    initialLibrary === "in"
+      ? {
+          description: `None of the bottles from ${initialSeries.fullName} are in your Library.`,
+          heading: "No bottles in your Library",
+        }
+      : initialLibrary === "out"
+        ? {
+            description: `Every bottle from ${initialSeries.fullName} on Peated is in your Library.`,
+            heading: "Nothing missing",
+          }
+        : {
+            description: `No bottles have been added to ${initialSeries.fullName} yet.`,
+            heading: "No bottles in this series yet",
+          };
 
   return (
     <div {...stylex.props(styles.page)}>
@@ -87,14 +128,43 @@ export function SeriesPageClient({
           ) : undefined
         }
         eyebrow="Whisky series"
+        identity={<PeatedId id={initialSeries.peatedId} />}
         parent={
           <TextLink href={getEntityUrl(initialSeries.brand)}>
             {initialSeries.brand.name}
           </TextLink>
         }
-        title={initialSeries.name}
+        title={
+          <span {...stylex.props(styles.title)}>{initialSeries.name}</span>
+        }
       />
-      <PageColumns rail={<FactList facts={facts} />} railBehavior="stack">
+      <PageColumns>
+        <KeyFacts facts={facts} />
+        {initialLibraryCount !== null && initialSeries.numReleases > 0 ? (
+          <div
+            aria-label="Library filter"
+            role="group"
+            {...stylex.props(styles.filters)}
+          >
+            {libraryOptions.map((option) => {
+              const selected = option.value === initialLibrary;
+              return (
+                <Chip
+                  aria-pressed={selected}
+                  key={option.value}
+                  onClick={() =>
+                    updateParams({
+                      library: option.value === "all" ? "" : option.value,
+                    })
+                  }
+                  variant={selected ? "solid" : "neutral"}
+                >
+                  {option.label}
+                </Chip>
+              );
+            })}
+          </div>
+        ) : null}
         <div {...stylex.props(styles.bottles)}>
           {bottleListQuery.error ? (
             <SectionError
@@ -105,8 +175,19 @@ export function SeriesPageClient({
             </SectionError>
           ) : bottleList ? (
             <BottleCatalogList
-              emptyDescription={`No bottles have been added to ${initialSeries.fullName} yet.`}
-              emptyHeading="No bottles in this series yet"
+              emptyAction={
+                filtered ? (
+                  <Button
+                    onClick={() => updateParams({ library: "" })}
+                    size="sm"
+                    variant="tonal"
+                  >
+                    Show all bottles
+                  </Button>
+                ) : undefined
+              }
+              emptyDescription={emptyState.description}
+              emptyHeading={emptyState.heading}
               items={bottleList.results.map((bottle) =>
                 addBottleRowActions({
                   bottle,
@@ -125,7 +206,7 @@ export function SeriesPageClient({
                 searchParams,
                 bottleList.rel.nextCursor,
               )}
-              onSortChange={updateSort}
+              onSortChange={(value) => updateParams({ sort: value })}
               page={initialCursor}
               previousHref={getCursorHref(
                 pathname,
@@ -146,6 +227,20 @@ export function SeriesPageClient({
 const styles = stylex.create({
   page: {
     minWidth: 0,
+  },
+  title: {
+    display: "block",
+    fontSize: {
+      default: null,
+      "@media (max-width: 480px)": "36px",
+    },
+    overflowWrap: "anywhere",
+  },
+  filters: {
+    display: "flex",
+    alignItems: "center",
+    gap: space.x2,
+    flexWrap: "wrap",
   },
   bottles: {
     minWidth: 0,

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -9,7 +9,7 @@ import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   Button,
   Chip,
-  KeyFacts,
+  FactList,
   PeatedId,
   SectionError,
   TextLink,
@@ -139,7 +139,7 @@ export function SeriesPageClient({
         }
       />
       <PageColumns>
-        <KeyFacts facts={facts} />
+        <FactList facts={facts} layout="grid" />
         {initialLibraryCount !== null && initialSeries.numReleases > 0 ? (
           <div
             aria-label="Library filter"

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -5,6 +5,7 @@ import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
 
 import {
   Button,
@@ -20,13 +21,14 @@ import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.st
 import {
   PageColumns,
   PageHeader,
+  RailSection,
 } from "@peated/web/components/pages/pageLayout.stylex";
 import useBottleRowActions from "@peated/web/hooks/useBottleRowActions";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getEntityUrl } from "@peated/web/lib/urls";
-import { space } from "../../../../styles/tokens.stylex";
+import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 type BottleList = Outputs["bottles"]["list"];
 type Series = Outputs["bottleSeries"]["details"];
@@ -47,6 +49,8 @@ const libraryOptions = [
   { label: "Not in your Library", value: "out" },
   { label: "In your Library", value: "in" },
 ] as const;
+
+const DISTILLERY_PREVIEW_LIMIT = 5;
 
 export function SeriesPageClient({
   initialBottleList,
@@ -138,7 +142,14 @@ export function SeriesPageClient({
           <span {...stylex.props(styles.title)}>{initialSeries.name}</span>
         }
       />
-      <PageColumns>
+      <PageColumns
+        rail={
+          initialSeries.distillers.length ? (
+            <SeriesDistilleries distillers={initialSeries.distillers} />
+          ) : undefined
+        }
+        railBehavior="stack"
+      >
         <FactList facts={facts} layout="grid" />
         {initialLibraryCount !== null && initialSeries.numReleases > 0 ? (
           <div
@@ -224,6 +235,52 @@ export function SeriesPageClient({
   );
 }
 
+function SeriesDistilleries({
+  distillers,
+}: {
+  distillers: Series["distillers"];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const hasMore = distillers.length > DISTILLERY_PREVIEW_LIMIT;
+  const visibleDistillers = expanded
+    ? distillers
+    : distillers.slice(0, DISTILLERY_PREVIEW_LIMIT);
+
+  return (
+    <RailSection
+      heading={distillers.length === 1 ? "Distillery" : "Distilleries"}
+    >
+      <ul id="series-distilleries" {...stylex.props(styles.distillerList)}>
+        {visibleDistillers.map((distiller) => (
+          <li key={distiller.id} {...stylex.props(styles.distillerRow)}>
+            <TextLink href={getEntityUrl(distiller)} size="inherit">
+              {distiller.name}
+            </TextLink>
+            <span {...stylex.props(styles.distillerCount)}>
+              {distiller.numBottles.toLocaleString("en-US")}{" "}
+              {distiller.numBottles === 1 ? "bottle" : "bottles"}
+            </span>
+          </li>
+        ))}
+      </ul>
+      {hasMore ? (
+        <div {...stylex.props(styles.distillerMore)}>
+          <Button
+            align="start"
+            aria-controls="series-distilleries"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((value) => !value)}
+            size="sm"
+            variant="text"
+          >
+            {expanded ? "Show less" : "View more"}
+          </Button>
+        </div>
+      ) : null}
+    </RailSection>
+  );
+}
+
 const styles = stylex.create({
   page: {
     minWidth: 0,
@@ -245,5 +302,32 @@ const styles = stylex.create({
   bottles: {
     minWidth: 0,
     paddingTop: space.x4,
+  },
+  distillerList: {
+    margin: 0,
+    padding: 0,
+    listStyle: "none",
+  },
+  distillerRow: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: space.x3,
+    paddingTop: "9px",
+    paddingBottom: "9px",
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+  },
+  distillerCount: {
+    flexShrink: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "11px",
+    lineHeight: 1.4,
+  },
+  distillerMore: {
+    marginTop: space.x1,
   },
 });

--- a/apps/web/src/components/pages/bottleRailSection.stylex.tsx
+++ b/apps/web/src/components/pages/bottleRailSection.stylex.tsx
@@ -1,13 +1,7 @@
-import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import {
-  AppLink,
-  BottleVisual,
-  RailList,
-  RailListItem,
-} from "@peated/web/components";
-import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
+import { BottleVisual, RailList, RailListItem } from "@peated/web/components";
+import { RailListSection } from "./railListSection.stylex";
 
 export type BottleRailItem = {
   end?: ReactNode;
@@ -34,9 +28,13 @@ export function BottleRailSection({
   moreLabel?: string;
 }) {
   return (
-    <section {...stylex.props(styles.section)}>
-      <h2 {...stylex.props(styles.heading)}>{heading}</h2>
-      {intro ? <p {...stylex.props(styles.intro)}>{intro}</p> : null}
+    <RailListSection
+      action={
+        moreHref && moreLabel ? { href: moreHref, label: moreLabel } : undefined
+      }
+      heading={heading}
+      intro={intro}
+    >
       {items.length ? (
         <RailList ariaLabel={heading}>
           {items.map((item) => (
@@ -52,62 +50,6 @@ export function BottleRailSection({
         </RailList>
       ) : null}
       {children}
-      {moreHref && moreLabel ? (
-        <AppLink href={moreHref} {...stylex.props(styles.moreLink)}>
-          {moreLabel} →
-        </AppLink>
-      ) : null}
-    </section>
+    </RailListSection>
   );
 }
-
-const styles = stylex.create({
-  section: {
-    display: "flex",
-    minWidth: 0,
-    flexDirection: "column",
-    gap: space.x2,
-  },
-  heading: {
-    margin: 0,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
-  },
-  intro: {
-    margin: 0,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.4,
-  },
-  moreLink: {
-    display: "block",
-    boxSizing: "border-box",
-    width: "100%",
-    marginTop: "6px",
-    paddingTop: space.x3,
-    paddingRight: 0,
-    paddingBottom: space.x3,
-    paddingLeft: 0,
-    borderRadius: 0,
-    outline: "none",
-    backgroundColor: {
-      default: "transparent",
-      ":hover": colors.surface,
-      ":active": colors.surface,
-    },
-    color: colors.accentDeep,
-    fontFamily: fonts.display,
-    fontSize: "13px",
-    fontWeight: 700,
-    lineHeight: 1.3,
-    textDecoration: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
-  },
-});

--- a/apps/web/src/components/pages/railListSection.stories.tsx
+++ b/apps/web/src/components/pages/railListSection.stories.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import * as stylex from "@stylexjs/stylex";
+import { useState } from "react";
+
+import { RailList, RailListItem } from "..";
+import { StoryCanvas } from "../storyFixtures.stylex";
+import { BottleRailSection } from "./bottleRailSection.stylex";
+import { RailListSection } from "./railListSection.stylex";
+
+const distilleries = [
+  { bottles: 9, name: "Bruichladdich" },
+  { bottles: 9, name: "Port Charlotte" },
+  { bottles: 8, name: "Octomore" },
+  { bottles: 2, name: "Bowmore" },
+  { bottles: 1, name: "Bunnahabhain" },
+  { bottles: 1, name: "Caol Ila" },
+  { bottles: 1, name: "Springbank" },
+] as const;
+
+function ExpandableDistilleries() {
+  const [expanded, setExpanded] = useState(false);
+  const visibleDistilleries = expanded
+    ? distilleries
+    : distilleries.slice(0, 5);
+
+  return (
+    <RailListSection
+      action={{
+        ariaControls: "story-distilleries",
+        expanded,
+        label: expanded
+          ? "Show fewer distilleries"
+          : `View all ${distilleries.length} distilleries`,
+        onClick: () => setExpanded((value) => !value),
+      }}
+      heading="Distilleries"
+    >
+      <div id="story-distilleries">
+        <RailList ariaLabel="Series distilleries">
+          {visibleDistilleries.map((distillery) => (
+            <RailListItem
+              end={`${distillery.bottles} ${
+                distillery.bottles === 1 ? "bottle" : "bottles"
+              }`}
+              href={`#${distillery.name.toLowerCase().replaceAll(" ", "-")}`}
+              key={distillery.name}
+              title={distillery.name}
+            />
+          ))}
+        </RailList>
+      </div>
+    </RailListSection>
+  );
+}
+
+const meta = {
+  title: "Components/Layout/Rail List Section",
+  component: RailListSection,
+  args: {
+    children: null,
+    heading: "Distilleries",
+  },
+  argTypes: {
+    action: { control: false },
+    children: { control: false },
+  },
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="compact">
+        <div {...stylex.props(styles.rail)}>
+          <Story />
+        </div>
+      </StoryCanvas>
+    ),
+  ],
+} satisfies Meta<typeof RailListSection>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ExpandableCollection: Story = {
+  render: () => <ExpandableDistilleries />,
+};
+
+export const LinkedBottleCollection: Story = {
+  render: () => (
+    <BottleRailSection
+      heading="Other bottles in this series"
+      items={[
+        {
+          href: "#port-charlotte",
+          metadata: "Single Malt · Sep 2024",
+          name: "Port Charlotte 9.2",
+        },
+        {
+          href: "#bruichladdich",
+          metadata: "Single Malt · Sep 2024",
+          name: "Bruichladdich 9.1",
+        },
+        {
+          href: "#octomore",
+          metadata: "Single Malt · 2024",
+          name: "Octomore 8.3",
+        },
+      ]}
+      moreHref="#series"
+      moreLabel="See all 27 bottles"
+    />
+  ),
+};
+
+const styles = stylex.create({
+  rail: {
+    width: "336px",
+    maxWidth: "100%",
+  },
+});

--- a/apps/web/src/components/pages/railListSection.stylex.tsx
+++ b/apps/web/src/components/pages/railListSection.stylex.tsx
@@ -1,0 +1,112 @@
+import * as stylex from "@stylexjs/stylex";
+import type { ReactNode } from "react";
+
+import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
+import { AppLink } from "../appLink";
+
+export type RailListSectionAction =
+  | {
+      href: string;
+      label: string;
+    }
+  | {
+      ariaControls: string;
+      expanded: boolean;
+      label: string;
+      onClick: () => void;
+    };
+
+/** Presents a compact linked collection in a page rail. */
+export function RailListSection({
+  action,
+  children,
+  heading,
+  intro,
+}: {
+  action?: RailListSectionAction;
+  children: ReactNode;
+  heading: string;
+  intro?: string;
+}) {
+  return (
+    <section {...stylex.props(styles.section)}>
+      <h2 {...stylex.props(styles.heading)}>{heading}</h2>
+      {intro ? <p {...stylex.props(styles.intro)}>{intro}</p> : null}
+      {children}
+      {action ? (
+        "href" in action ? (
+          <AppLink href={action.href} {...stylex.props(styles.more)}>
+            {action.label} <span aria-hidden="true">→</span>
+          </AppLink>
+        ) : (
+          <button
+            aria-controls={action.ariaControls}
+            aria-expanded={action.expanded}
+            onClick={action.onClick}
+            type="button"
+            {...stylex.props(styles.more, styles.moreButton)}
+          >
+            {action.label}
+          </button>
+        )
+      ) : null}
+    </section>
+  );
+}
+
+const styles = stylex.create({
+  section: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x2,
+  },
+  heading: {
+    margin: 0,
+    fontFamily: fonts.display,
+    fontSize: "18px",
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
+    lineHeight: 1.2,
+  },
+  intro: {
+    margin: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "10px",
+    lineHeight: 1.4,
+  },
+  more: {
+    display: "block",
+    boxSizing: "border-box",
+    width: "100%",
+    marginTop: "6px",
+    paddingTop: space.x3,
+    paddingRight: 0,
+    paddingBottom: space.x3,
+    paddingLeft: 0,
+    borderRadius: 0,
+    outline: "none",
+    backgroundColor: {
+      default: "transparent",
+      ":hover": colors.surface,
+      ":active": colors.surface,
+    },
+    color: colors.accentDeep,
+    fontFamily: fonts.display,
+    fontSize: "13px",
+    fontWeight: 700,
+    lineHeight: 1.3,
+    textAlign: "left",
+    textDecoration: "none",
+    boxShadow: {
+      default: "none",
+      ":focus-visible": effects.focusRing,
+    },
+  },
+  moreButton: {
+    appearance: "none",
+    borderWidth: 0,
+    cursor: "pointer",
+  },
+});

--- a/apps/web/src/components/pages/railListSection.stylex.tsx
+++ b/apps/web/src/components/pages/railListSection.stylex.tsx
@@ -1,8 +1,9 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
-import { AppLink } from "../appLink";
+import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { TextLink } from "../textLink.stylex";
+import { textLinkStyles } from "../textLinkStyles.stylex";
 
 export type RailListSectionAction =
   | {
@@ -32,24 +33,26 @@ export function RailListSection({
     <section {...stylex.props(styles.section)}>
       <h2 {...stylex.props(styles.heading)}>{heading}</h2>
       {intro ? <p {...stylex.props(styles.intro)}>{intro}</p> : null}
-      {children}
       {action ? (
         "href" in action ? (
-          <AppLink href={action.href} {...stylex.props(styles.more)}>
-            {action.label} <span aria-hidden="true">→</span>
-          </AppLink>
+          <TextLink href={action.href}>{action.label}</TextLink>
         ) : (
           <button
             aria-controls={action.ariaControls}
             aria-expanded={action.expanded}
             onClick={action.onClick}
             type="button"
-            {...stylex.props(styles.more, styles.moreButton)}
+            {...stylex.props(
+              textLinkStyles.link,
+              textLinkStyles.small,
+              styles.actionButton,
+            )}
           >
             {action.label}
           </button>
         )
       ) : null}
+      {children}
     </section>
   );
 }
@@ -76,37 +79,12 @@ const styles = stylex.create({
     fontSize: "10px",
     lineHeight: 1.4,
   },
-  more: {
-    display: "block",
-    boxSizing: "border-box",
-    width: "100%",
-    marginTop: "6px",
-    paddingTop: space.x3,
-    paddingRight: 0,
-    paddingBottom: space.x3,
-    paddingLeft: 0,
-    borderRadius: 0,
-    outline: "none",
-    backgroundColor: {
-      default: "transparent",
-      ":hover": colors.surface,
-      ":active": colors.surface,
-    },
-    color: colors.accentDeep,
-    fontFamily: fonts.display,
-    fontSize: "13px",
-    fontWeight: 700,
-    lineHeight: 1.3,
-    textAlign: "left",
-    textDecoration: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
-  },
-  moreButton: {
+  actionButton: {
     appearance: "none",
+    margin: 0,
+    padding: 0,
     borderWidth: 0,
+    backgroundColor: "transparent",
     cursor: "pointer",
   },
 });

--- a/apps/web/src/components/scoring.stylex.tsx
+++ b/apps/web/src/components/scoring.stylex.tsx
@@ -221,7 +221,7 @@ export type BottleRatingsProps = {
   scoreCount?: number;
 };
 
-/** Combines tasting ratings and the published review score for one bottle row. */
+/** Combines available tasting ratings and the published review score for one bottle row. */
 export function BottleRatings({
   counts = {},
   high = null,
@@ -234,6 +234,8 @@ export function BottleRatings({
   const maxBandCount = Math.max(...bandCounts, 0);
   const sampleHeight = getRatingSampleHeight(tastingCount);
   const hasRange = low !== null && high !== null;
+  if (tastingCount === 0 && median === null) return null;
+
   const label = [
     median === null
       ? "No published score"
@@ -247,7 +249,7 @@ export function BottleRatings({
   return (
     <span
       aria-label={label}
-      data-state={tastingCount === 0 && median === null ? "empty" : "populated"}
+      data-state="populated"
       role="img"
       title={label}
       {...stylex.props(styles.bottleRatings)}

--- a/apps/web/src/components/scoring.test.tsx
+++ b/apps/web/src/components/scoring.test.tsx
@@ -4,7 +4,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { ReviewScore } from "./scoring.stylex";
+import { BottleRatings, ReviewScore } from "./scoring.stylex";
 
 describe("ReviewScore", () => {
   let container: HTMLDivElement;
@@ -30,5 +30,17 @@ describe("ReviewScore", () => {
     expect(container.textContent).toContain("median of 1 score");
     expect(container.textContent).not.toContain("Only 1 score so far");
     expect(container.textContent).not.toContain("low 92");
+  });
+
+  it("omits Bottle ratings when there is nothing to show", () => {
+    act(() => root.render(<BottleRatings />));
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows Bottle ratings when tasting ratings exist", () => {
+    act(() => root.render(<BottleRatings counts={{ very_good: 2 }} />));
+
+    expect(container.querySelector('[data-state="populated"]')).not.toBeNull();
   });
 });

--- a/openspec/changes/add-public-bottle-series-pages/design.md
+++ b/openspec/changes/add-public-bottle-series-pages/design.md
@@ -52,7 +52,7 @@ The page uses the shared page header, Bottle list, sort control, cursor pager, e
 
 Series identity and counts sit above the Bottle list instead of in a side rail. Signed-in members also see the number of Series Bottles in their Library and can filter the list to Bottles in or outside their Library. These counts use the complete filtered result, not the current page. Signed-out visitors see only public facts.
 
-The side rail shows Distilleries derived from every active Bottle in the Series. Each linked Distillery includes its Bottle count. Long lists show five Distilleries until the person chooses “View more.” No new Distillery filter or Series endpoint is added.
+The side rail shows Distilleries derived from every active Bottle in the Series. Each linked Distillery includes its Bottle count. Long lists show five Distilleries until the person chooses to view all of them. The breakdown uses the same section heading, compact rows, and quiet footer action as Bottle-side collections. No new Distillery filter or Series endpoint is added.
 
 The shared Bottle list omits its ratings block when a Bottle has neither tasting ratings nor a published review score. Long page titles use a smaller narrow-screen size and may wrap long words so they do not leave the viewport.
 

--- a/openspec/changes/add-public-bottle-series-pages/design.md
+++ b/openspec/changes/add-public-bottle-series-pages/design.md
@@ -13,6 +13,7 @@ The new surface crosses catalog identity, search, moderation lifecycle, API seri
 - Make Series discoverable from Bottle pages, canonical IDs, and global search.
 - Preserve old public references when duplicate Series merge.
 - Reuse the existing page layout, Bottle list, Bottle rail, ratings, pager, error, and empty-state components.
+- Keep public Series facts and signed-in Library progress visible before the Bottle list on every screen size.
 
 **Non-Goals:**
 
@@ -49,6 +50,10 @@ Add a `series` search scope, result group, nearest result, exact Peated ID resul
 
 The page uses the shared page header, Bottle list, sort control, cursor pager, error, and empty-state components. It shows a Brand link, Series name, optional description, Peated ID, and total Bottle count. Membership defaults to newest release and supports the existing relevant Bottle sort choices. Category and age filters are omitted because this page is already a scoped collection.
 
+Series identity and counts sit above the Bottle list instead of in a side rail. Signed-in members also see the number of Series Bottles in their Library and can filter the list to Bottles in or outside their Library. These counts use the complete filtered result, not the current page. Signed-out visitors see only public facts.
+
+The shared Bottle list omits its ratings block when a Bottle has neither tasting ratings nor a published review score. Long page titles use a smaller narrow-screen size and may wrap long words so they do not leave the viewport.
+
 ### Bottle pages use a shared Bottle rail section
 
 Extract the current recommendation rail markup into a small reusable Bottle rail section inside the Bottle overview component. The Series widget uses the same Bottle visual, metadata, and rating presentation. It requests up to four Series Bottles, removes the current Bottle, shows at most three other Bottles, and links “See all N bottles” to the canonical Series page. It renders only when the Series contains another Bottle and does not show an empty shell.
@@ -60,6 +65,7 @@ The existing Series fact remains and links to the same canonical page.
 - **Series search adds another global-search scope and query.** → Run it only when requested, retain the existing per-scope limit, and use the current indexed Series search vector.
 - **Merging a large Series can update many Bottle groups.** → Reuse the transactional Bottle update boundary and finalize affected search/stat work after commit, as current Series deletion does.
 - **Some Series have incomplete descriptions or release dates.** → Omit missing description text and use existing Bottle list fallbacks; do not infer Series prose or sequence.
+- **Peated may not contain every official Series release.** → Say "In your library" and show a count against the currently cataloged Bottles. Do not call the Series complete or show a completion percentage.
 - **Adding `S` changes Peated ID parsing exhaustiveness.** → Update exact-ID search and route tests at the same cutover.
 - **A Series can become empty after all Bottles are reassigned.** → The page remains valid while the Series exists; moderators may delete it explicitly, producing a destination-less tombstone and a not-found response.
 

--- a/openspec/changes/add-public-bottle-series-pages/design.md
+++ b/openspec/changes/add-public-bottle-series-pages/design.md
@@ -52,7 +52,7 @@ The page uses the shared page header, Bottle list, sort control, cursor pager, e
 
 Series identity and counts sit above the Bottle list instead of in a side rail. Signed-in members also see the number of Series Bottles in their Library and can filter the list to Bottles in or outside their Library. These counts use the complete filtered result, not the current page. Signed-out visitors see only public facts.
 
-The side rail shows Distilleries derived from every active Bottle in the Series. Each linked Distillery includes its Bottle count. Long lists show five Distilleries until the person chooses to view all of them. The breakdown uses the same section heading, compact rows, and quiet footer action as Bottle-side collections. No new Distillery filter or Series endpoint is added.
+The side rail shows Distilleries derived from every active Bottle in the Series. Each linked Distillery includes its Bottle count. Long lists show five Distilleries until the person chooses to view all of them. The breakdown uses the same section heading, compact rows, and small action below the heading as other collection sections. No new Distillery filter or Series endpoint is added.
 
 The shared Bottle list omits its ratings block when a Bottle has neither tasting ratings nor a published review score. Long page titles use a smaller narrow-screen size and may wrap long words so they do not leave the viewport.
 

--- a/openspec/changes/add-public-bottle-series-pages/design.md
+++ b/openspec/changes/add-public-bottle-series-pages/design.md
@@ -52,6 +52,8 @@ The page uses the shared page header, Bottle list, sort control, cursor pager, e
 
 Series identity and counts sit above the Bottle list instead of in a side rail. Signed-in members also see the number of Series Bottles in their Library and can filter the list to Bottles in or outside their Library. These counts use the complete filtered result, not the current page. Signed-out visitors see only public facts.
 
+The side rail shows Distilleries derived from every active Bottle in the Series. Each linked Distillery includes its Bottle count. Long lists show five Distilleries until the person chooses “View more.” No new Distillery filter or Series endpoint is added.
+
 The shared Bottle list omits its ratings block when a Bottle has neither tasting ratings nor a published review score. Long page titles use a smaller narrow-screen size and may wrap long words so they do not leave the viewport.
 
 ### Bottle pages use a shared Bottle rail section

--- a/openspec/changes/add-public-bottle-series-pages/proposal.md
+++ b/openspec/changes/add-public-bottle-series-pages/proposal.md
@@ -8,6 +8,9 @@ Bottle Series are durable catalog records, but people can only encounter them as
 - Add a dedicated Series page with Brand context, description, Bottle count, and a paginated Bottle list.
 - Link Series references and global search results to the dedicated page.
 - Add an "Other bottles in this series" section to Bottle pages, built from existing Bottle rail and list components, with a link to the complete Series page.
+- Put Series facts before the Bottle list and show signed-in members how many Series Bottles are in their Library.
+- Let signed-in members show all Series Bottles, Bottles in their Library, or Bottles not in their Library.
+- Omit empty ratings from Bottle lists and keep long page titles inside narrow screens.
 - Preserve public Series identity when duplicate Series are merged. **BREAKING**: populated Series can no longer be deleted without a destination.
 
 ## Capabilities
@@ -24,5 +27,6 @@ None.
 
 - Bottle Series schemas, serializers, API routes, search, Peated ID parsing, and catalog lifecycle behavior.
 - Web catalog URLs, canonical routing, metadata, sitemaps, search results, Series pages, and Bottle overview composition.
+- Shared Bottle-list ratings and narrow page-title presentation.
 - Database schema and generated migration metadata for Series tombstones.
 - Focused server and web tests plus desktop and mobile UI verification.

--- a/openspec/changes/add-public-bottle-series-pages/proposal.md
+++ b/openspec/changes/add-public-bottle-series-pages/proposal.md
@@ -9,6 +9,7 @@ Bottle Series are durable catalog records, but people can only encounter them as
 - Link Series references and global search results to the dedicated page.
 - Add an "Other bottles in this series" section to Bottle pages, built from existing Bottle rail and list components, with a link to the complete Series page.
 - Put Series facts before the Bottle list and show signed-in members how many Series Bottles are in their Library.
+- Show a compact Distilleries breakdown beside the Series Bottle list.
 - Let signed-in members show all Series Bottles, Bottles in their Library, or Bottles not in their Library.
 - Omit empty ratings from Bottle lists and keep long page titles inside narrow screens.
 - Preserve public Series identity when duplicate Series are merged. **BREAKING**: populated Series can no longer be deleted without a destination.

--- a/openspec/changes/add-public-bottle-series-pages/specs/bottle-series-catalog/spec.md
+++ b/openspec/changes/add-public-bottle-series-pages/specs/bottle-series-catalog/spec.md
@@ -37,6 +37,22 @@ The system SHALL provide a responsive Series page that explains the Series and l
 - **WHEN** a person opens an active Series with no Bottles
 - **THEN** the page shows the Series identity and a clear empty state without an inactive Bottle list shell
 
+#### Scenario: Signed-in Library progress
+
+- **WHEN** a signed-in member opens a Series page
+- **THEN** the page shows how many cataloged Series Bottles are in their Library before the Bottle list
+- **AND** the member can show all Bottles, Bottles in their Library, or Bottles not in their Library
+
+#### Scenario: Signed-out Series page
+
+- **WHEN** a signed-out person opens a Series page
+- **THEN** the page shows the public Series facts without personal Library counts or filters
+
+#### Scenario: Bottle without ratings
+
+- **WHEN** a Bottle list row has no tasting ratings and no published review score
+- **THEN** the row omits the empty ratings block
+
 ### Requirement: Bottle-to-Series navigation
 
 The system SHALL make the assigned Series and other member Bottles discoverable from a Bottle page.

--- a/openspec/changes/add-public-bottle-series-pages/specs/bottle-series-catalog/spec.md
+++ b/openspec/changes/add-public-bottle-series-pages/specs/bottle-series-catalog/spec.md
@@ -48,6 +48,12 @@ The system SHALL provide a responsive Series page that explains the Series and l
 - **WHEN** a signed-out person opens a Series page
 - **THEN** the page shows the public Series facts without personal Library counts or filters
 
+#### Scenario: Series distilleries
+
+- **WHEN** a Series contains Bottles with assigned Distilleries
+- **THEN** the page shows a linked Distillery breakdown beside the Bottle list
+- **AND** a long breakdown starts with a short preview that the person can expand
+
 #### Scenario: Bottle without ratings
 
 - **WHEN** a Bottle list row has no tasting ratings and no published review score

--- a/openspec/changes/add-public-bottle-series-pages/tasks.md
+++ b/openspec/changes/add-public-bottle-series-pages/tasks.md
@@ -40,3 +40,4 @@
 
 - [x] 8.1 Add the full-Series Distillery breakdown to the side rail with a short expandable preview, focused tests, and desktop and mobile UI checks.
 - [x] 8.2 Match the established Bottle rail collection pattern and add Storybook examples for linked and expandable rail sections.
+- [x] 8.3 Place rail collection actions below their headings and match the established text-link treatment.

--- a/openspec/changes/add-public-bottle-series-pages/tasks.md
+++ b/openspec/changes/add-public-bottle-series-pages/tasks.md
@@ -35,3 +35,7 @@
 ## 7. Series overview facts
 
 - [x] 7.1 Present Series counts with the compact overview facts used on Bottle and Entity pages, then verify desktop and mobile layouts.
+
+## 8. Series Distilleries
+
+- [x] 8.1 Add the full-Series Distillery breakdown to the side rail with a short expandable preview, focused tests, and desktop and mobile UI checks.

--- a/openspec/changes/add-public-bottle-series-pages/tasks.md
+++ b/openspec/changes/add-public-bottle-series-pages/tasks.md
@@ -24,3 +24,10 @@
 - [x] 5.1 Update the Peated ID architecture documentation for Series identity and lifecycle.
 - [x] 5.2 Run focused server and web tests, typechecks, lint, formatting, and OpenSpec validation.
 - [x] 5.3 Verify the Series page and Bottle widget at desktop and mobile widths with production-shaped Series data.
+
+## 6. Series overview and Library progress
+
+- [x] 6.1 Add signed-in Library filtering to the Bottle list API with focused tests.
+- [x] 6.2 Move Series identity and counts above the Bottle list, then add the Library count and filters.
+- [x] 6.3 Omit empty ratings from shared Bottle lists and keep long page titles inside narrow screens.
+- [x] 6.4 Run focused tests, typechecks, lint, formatting, and desktop and mobile UI checks.

--- a/openspec/changes/add-public-bottle-series-pages/tasks.md
+++ b/openspec/changes/add-public-bottle-series-pages/tasks.md
@@ -39,3 +39,4 @@
 ## 8. Series Distilleries
 
 - [x] 8.1 Add the full-Series Distillery breakdown to the side rail with a short expandable preview, focused tests, and desktop and mobile UI checks.
+- [x] 8.2 Match the established Bottle rail collection pattern and add Storybook examples for linked and expandable rail sections.

--- a/openspec/changes/add-public-bottle-series-pages/tasks.md
+++ b/openspec/changes/add-public-bottle-series-pages/tasks.md
@@ -31,3 +31,7 @@
 - [x] 6.2 Move Series identity and counts above the Bottle list, then add the Library count and filters.
 - [x] 6.3 Omit empty ratings from shared Bottle lists and keep long page titles inside narrow screens.
 - [x] 6.4 Run focused tests, typechecks, lint, formatting, and desktop and mobile UI checks.
+
+## 7. Series overview facts
+
+- [x] 7.1 Present Series counts with the compact overview facts used on Bottle and Entity pages, then verify desktop and mobile layouts.


### PR DESCRIPTION
Series pages now put compact Bottle and Library facts above the catalog. Signed-in members can see how many Series bottles they own and switch between all bottles, bottles in their Library, and bottles they are missing. Signed-out pages keep the public-only view, and long Series names stay within narrow screens.

A Distilleries sidebar now summarizes every active bottle in the Series, links each Distillery, and shows its bottle count. Long lists start with five rows and expand through “View all N distilleries.” The action sits directly below the section heading and uses the same small text-link treatment as entity collection sections. The rail stacks below the catalog on narrow screens.

The shared rail collection pattern also covers linked Bottle collections, with Storybook examples for both linked and expandable states. The Series details response supplies the full Distillery breakdown so counts do not depend on the current page. The shared bottle list omits empty rating blocks when a bottle has no tasting ratings or published score.
