### PR TITLE
fix(web): clarify bottler distilleries heading

### DIFF
--- a/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.test.tsx
@@ -77,27 +77,27 @@ describe("EntityCatalogRelationships", () => {
     expect(html).not.toContain(">Brands<");
   });
 
-  test.each(["brand", "bottler"] as const)(
-    "shows distilleries on a %s page",
-    (kind) => {
-      const html = renderRelationships(kind, {
-        brands: [],
-        bottlers: [],
-        distillers: [
-          {
-            id: 4,
-            name: "Caol Ila",
-            shortName: null,
-            kind: "distillery",
-            count: 5,
-          },
-        ],
-      });
+  test.each([
+    ["brand", "Distilled at"],
+    ["bottler", "Distilleries"],
+  ] as const)("shows distilleries on a %s page", (kind, heading) => {
+    const html = renderRelationships(kind, {
+      brands: [],
+      bottlers: [],
+      distillers: [
+        {
+          id: 4,
+          name: "Caol Ila",
+          shortName: null,
+          kind: "distillery",
+          count: 5,
+        },
+      ],
+    });
 
-      expect(html).toContain("Distilled at");
-      expect(html).toContain("Caol Ila");
-    },
-  );
+    expect(html).toContain(heading);
+    expect(html).toContain("Caol Ila");
+  });
 
   test("shows bottlers on a brand page when no distillery is known", () => {
     const html = renderRelationships("brand", {

--- a/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
@@ -47,7 +47,7 @@ function getRelationshipGroup(entity: Entity, catalog?: EntityCatalog) {
           ]
         : [
             {
-              heading: "Distilled at",
+              heading: "Distilleries",
               itemLabel: "distilleries",
               items: catalog.related.distillers,
             },
@@ -81,7 +81,7 @@ export function EntityCatalogRelationships({
         }
       : entity.kind === "distillery"
         ? { heading: "Bottled by", itemLabel: "bottlers" }
-        : { heading: "Distilled at", itemLabel: "distilleries" });
+        : { heading: "Distilleries", itemLabel: "distilleries" });
 
   if (pending) {
     return (


### PR DESCRIPTION
The bottler details page now labels its related distillery list “Distilleries” instead of “Distilled at,” which describes the list clearly in the bottler context. Brand pages keep the existing “Distilled at” heading.

The relationship component test now verifies the heading for each entity kind.
