### PR TITLE
fix(home): prevent event callout layout shift

### DIFF
--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -274,6 +274,9 @@ async function handleRpcRequest({ request, response, url }) {
       }
       sendRpcResponse(response, { results: [] });
       return true;
+    case "events/list":
+      sendRpcResponse(response, emptyList);
+      return true;
     case "brands/list":
       sendRpcResponse(response, {
         ...emptyList,

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -35,6 +35,7 @@ export default async function Page() {
       ...publicHomeQueries.stats(orpc),
       queryFn: getPublicStats,
     }),
+    queryClient.prefetchQuery(publicHomeQueries.events(orpc)),
     queryClient.prefetchQuery(publicHomeQueries.recentReviews(orpc)),
     queryClient.prefetchQuery(publicHomeQueries.releases(orpc)),
     ...(session.user


### PR DESCRIPTION
The homepage now prefetches the upcoming event during the server render, so the event callout is present before hydration and no longer shifts the rest of the page when its client query completes. The existing client query, event selection, and 30-day visibility rule remain unchanged.
