### PR TITLE
ci(web): capture Storybook screenshots

### DIFF
--- a/.github/workflows/web-visual.yml
+++ b/.github/workflows/web-visual.yml
@@ -65,6 +65,8 @@ jobs:
           VISUAL_SOURCE_SHA: ${{ github.sha }}
           VISUAL_OUTPUT_DIR: ${{ github.workspace }}/visual-output/candidate
         run: pnpm test:e2e
+      - name: Build Storybook for screenshots
+        run: pnpm storybook:screenshots:build
       - name: Capture Storybook stories
         env:
           VISUAL_OUTPUT_DIR: ${{ github.workspace }}/visual-output/candidate

--- a/.github/workflows/web-visual.yml
+++ b/.github/workflows/web-visual.yml
@@ -65,6 +65,10 @@ jobs:
           VISUAL_SOURCE_SHA: ${{ github.sha }}
           VISUAL_OUTPUT_DIR: ${{ github.workspace }}/visual-output/candidate
         run: pnpm test:e2e
+      - name: Capture Storybook stories
+        env:
+          VISUAL_OUTPUT_DIR: ${{ github.workspace }}/visual-output/candidate
+        run: pnpm storybook:screenshots
       # Every main commit can become a pull request base, so each gets an exact artifact.
       - name: Store baseline by source revision
         if: github.event_name != 'pull_request'

--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -2,6 +2,7 @@ import type { StorybookConfig } from "@storybook/nextjs-vite";
 import stylex from "@stylexjs/unplugin";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import svgr from "vite-plugin-svgr";
 
 const webRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 
@@ -15,7 +16,11 @@ const config: StorybookConfig = {
   ],
   framework: {
     name: "@storybook/nextjs-vite",
-    options: {},
+    options: {
+      image: {
+        excludeFiles: ["**/*.svg"],
+      },
+    },
   },
   core: {
     disableTelemetry: true,
@@ -37,6 +42,7 @@ const config: StorybookConfig = {
   },
   async viteFinal(config) {
     config.plugins = [
+      svgr({ include: "**/*.svg*" }),
       stylex.vite({
         devMode: "full",
         enableInlinedConditionalMerge: true,

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -12,7 +12,7 @@
 - Keep API queries, auth state, mutations, server actions, and navigation out of reusable components. Put route-only behavior beside the route and shared behavior in a narrowly named feature folder.
 - Do not add catch-all component folders such as `product/`.
 - Use StyleX for web styling. Do not add Tailwind utilities or configuration.
-- Do not add component snapshots or presentation tests. Use the accessibility panel and manual light, dark, desktop, and mobile review.
+- Do not add committed component snapshots or presentation tests. CI captures Storybook stories as non-blocking Frameshift review images. Use the accessibility panel and manual light, dark, desktop, and mobile review for component changes.
 
 ## Product language
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -87,6 +87,7 @@
     "storybook": "10.5.10",
     "storybook-addon-pseudo-states": "10.5.10",
     "typescript": "catalog:",
+    "vite": "catalog:",
     "vite-plugin-svgr": "5.2.0",
     "vitest": "catalog:"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,7 @@
     "start": "next start",
     "storybook": "storybook dev -p 6006 --no-open",
     "storybook:build": "storybook build",
+    "storybook:screenshots": "playwright test --config playwright.storybook.config.ts",
     "lint": "cd ../.. && oxlint apps/web",
     "test": "vitest run",
     "test:ci": "vitest run --reporter=junit --reporter=default --outputFile=junit.xml",
@@ -84,6 +85,7 @@
     "storybook": "10.5.10",
     "storybook-addon-pseudo-states": "10.5.10",
     "typescript": "catalog:",
+    "vite-plugin-svgr": "5.2.0",
     "vitest": "catalog:"
   },
   "volta": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,6 +8,8 @@
     "start": "next start",
     "storybook": "storybook dev -p 6006 --no-open",
     "storybook:build": "storybook build",
+    "storybook:preview": "vite preview --host 127.0.0.1 --port 6007 --strictPort --outDir storybook-static",
+    "storybook:screenshots:build": "storybook build --test --preview-only",
     "storybook:screenshots": "playwright test --config playwright.storybook.config.ts",
     "lint": "cd ../.. && oxlint apps/web",
     "test": "vitest run",

--- a/apps/web/playwright.storybook.config.ts
+++ b/apps/web/playwright.storybook.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const baseURL = process.env.STORYBOOK_URL ?? "http://127.0.0.1:6006";
+
+export default defineConfig({
+  testDir: "./visual",
+  testMatch: "storybook.playwright.ts",
+  outputDir: ".playwright/storybook-results",
+  timeout: 10 * 60_000,
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: "list",
+  expect: {
+    timeout: 60_000,
+  },
+  use: {
+    ...devices["Desktop Chrome"],
+    baseURL,
+    colorScheme: "light",
+    contextOptions: { reducedMotion: "reduce" },
+    locale: "en-US",
+    screenshot: "only-on-failure",
+    timezoneId: "America/Los_Angeles",
+    trace: "retain-on-failure",
+    viewport: { width: 1440, height: 900 },
+  },
+  webServer: process.env.STORYBOOK_URL
+    ? undefined
+    : {
+        command: "pnpm storybook",
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+        url: `${baseURL}/index.json`,
+      },
+});

--- a/apps/web/playwright.storybook.config.ts
+++ b/apps/web/playwright.storybook.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const baseURL = process.env.STORYBOOK_URL ?? "http://127.0.0.1:6006";
+const baseURL = process.env.STORYBOOK_URL ?? "http://127.0.0.1:6007";
 
 export default defineConfig({
   testDir: "./visual",
@@ -29,9 +29,9 @@ export default defineConfig({
   webServer: process.env.STORYBOOK_URL
     ? undefined
     : {
-        command: "pnpm storybook",
-        reuseExistingServer: !process.env.CI,
-        timeout: 120_000,
+        command: "pnpm storybook:preview",
+        reuseExistingServer: false,
+        timeout: 30_000,
         url: `${baseURL}/index.json`,
       },
 });

--- a/apps/web/visual/README.md
+++ b/apps/web/visual/README.md
@@ -9,6 +9,10 @@ Snapshots are checkpoints inside behavioral E2E tests. There is no separate
 visual scenario registry or visual test suite. Do not add a test whose only
 outcome is a screenshot.
 
+Storybook stories are the exception. The screenshot workflow captures each
+story in its isolated view after the E2E suite finishes. Storybook owns these
+component states, so the capture does not add another scenario registry.
+
 ## Capture a snapshot
 
 Import `test` and `expect` from the shared E2E fixture:
@@ -46,14 +50,24 @@ state. Use a number when workflow order matters.
 
 ## Run locally
 
-Run the normal E2E suite:
+Run the normal E2E suite, then capture the Storybook stories:
 
 ```sh
 pnpm test:e2e
+pnpm storybook:screenshots
 ```
 
-Images and `manifest.json` go to `apps/web/.playwright/visual/`. The directory
-is reset at the start of each Playwright run.
+Images and `manifest.json` go to `apps/web/.playwright/visual/`. The E2E suite
+resets the directory, and the Storybook command adds its screenshots.
+
+Storybook screenshot paths follow the story hierarchy. The story name is a
+Frameshift variant, so related states stay together. For example, the
+`Components/Layout/Workflow Screen` stories write:
+
+```text
+storybook/components/layout/workflow-screen__overview.png
+storybook/components/layout/workflow-screen__saving.png
+```
 
 ## Frameshift flow
 
@@ -65,7 +79,7 @@ merge commit's first parent and compares it with the candidate snapshots:
 ```text
 main commit --run E2E--> revision-keyed baseline artifact
                                       |
-pull request --run E2E----------------+--> Frameshift report
+pull request --run E2E + Storybook----+--> Frameshift report
 ```
 
 Before comparison, CI checks the source SHA, capture contract, platform,

--- a/apps/web/visual/README.md
+++ b/apps/web/visual/README.md
@@ -54,11 +54,13 @@ Run the normal E2E suite, then capture the Storybook stories:
 
 ```sh
 pnpm test:e2e
+pnpm storybook:screenshots:build
 pnpm storybook:screenshots
 ```
 
 Images and `manifest.json` go to `apps/web/.playwright/visual/`. The E2E suite
-resets the directory, and the Storybook command adds its screenshots.
+resets the directory, and the Storybook command adds its screenshots from the
+static build.
 
 Storybook screenshot paths follow the story hierarchy. The story name is a
 Frameshift variant, so related states stay together. For example, the

--- a/apps/web/visual/storybook-screenshots.mjs
+++ b/apps/web/visual/storybook-screenshots.mjs
@@ -76,15 +76,17 @@ export async function replaceStorybookScreenshotsInManifest({
   const manifest = manifestSchema.parse(
     JSON.parse(await fs.readFile(manifestFile, "utf8")),
   );
-  if (manifest.capture.browserVersion !== browserVersion) {
+  const routeScreenshots = manifest.screenshots.filter(
+    (screenshot) => !screenshot.file.startsWith("storybook/"),
+  );
+  if (
+    routeScreenshots.length > 0 &&
+    manifest.capture.browserVersion !== browserVersion
+  ) {
     throw new Error(
       "Storybook and E2E screenshots must use the same browser version.",
     );
   }
-
-  const routeScreenshots = manifest.screenshots.filter(
-    (screenshot) => !screenshot.file.startsWith("storybook/"),
-  );
   const files = new Set(routeScreenshots.map((screenshot) => screenshot.file));
 
   for (const screenshot of screenshots) {
@@ -98,6 +100,7 @@ export async function replaceStorybookScreenshotsInManifest({
   manifest.screenshots = [...routeScreenshots, ...screenshots].sort(
     (left, right) => left.file.localeCompare(right.file),
   );
+  manifest.capture.browserVersion = browserVersion;
   await fs.writeFile(manifestFile, `${JSON.stringify(manifest, null, 2)}\n`);
 }
 

--- a/apps/web/visual/storybook-screenshots.mjs
+++ b/apps/web/visual/storybook-screenshots.mjs
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+
+const entrySchema = z.object({ type: z.string() }).passthrough();
+const storySchema = z.object({
+  id: z.string().min(1),
+  name: z.string().min(1),
+  title: z.string().min(1),
+  type: z.literal("story"),
+});
+const indexSchema = z.object({
+  entries: z.record(z.string(), z.unknown()),
+});
+const screenshotSchema = z
+  .object({ file: z.string().min(1), label: z.string() })
+  .passthrough();
+const manifestSchema = z
+  .object({
+    capture: z.object({ browserVersion: z.string().nullable() }).passthrough(),
+    screenshots: z.array(screenshotSchema),
+  })
+  .passthrough();
+
+/** @typedef {z.infer<typeof storySchema>} Story */
+/** @typedef {z.infer<typeof screenshotSchema>} Screenshot */
+
+/**
+ * Return the stories from a generated Storybook index.
+ * @param {unknown} value
+ * @returns {Story[]}
+ */
+export function storiesFromIndex(value) {
+  const index = indexSchema.parse(value);
+  return Object.values(index.entries)
+    .flatMap((entry) =>
+      entrySchema.parse(entry).type === "story"
+        ? [storySchema.parse(entry)]
+        : [],
+    )
+    .sort((left, right) => left.id.localeCompare(right.id));
+}
+
+/**
+ * Use the Storybook hierarchy as Frameshift groups and the story as a variant.
+ * @param {Story} story
+ */
+export function screenshotFile(story) {
+  const title = story.title.split("/").map(slug);
+  const name = slug(story.name);
+  if (title.some((part) => !part) || !name) {
+    throw new Error("Story titles and names must contain a letter or number.");
+  }
+
+  const component = title.pop();
+  if (!component) {
+    throw new Error("Story title must contain a component name.");
+  }
+  return path.posix.join("storybook", ...title, `${component}__${name}.png`);
+}
+
+/**
+ * Replace the Storybook section of the existing E2E capture manifest.
+ * @param {{
+ *   browserVersion: string,
+ *   output: string,
+ *   screenshots: Screenshot[],
+ * }} options
+ */
+export async function replaceStorybookScreenshotsInManifest({
+  browserVersion,
+  output,
+  screenshots,
+}) {
+  const manifestFile = path.join(output, "manifest.json");
+  const manifest = manifestSchema.parse(
+    JSON.parse(await fs.readFile(manifestFile, "utf8")),
+  );
+  if (manifest.capture.browserVersion !== browserVersion) {
+    throw new Error(
+      "Storybook and E2E screenshots must use the same browser version.",
+    );
+  }
+
+  const routeScreenshots = manifest.screenshots.filter(
+    (screenshot) => !screenshot.file.startsWith("storybook/"),
+  );
+  const files = new Set(routeScreenshots.map((screenshot) => screenshot.file));
+
+  for (const screenshot of screenshots) {
+    if (files.has(screenshot.file)) {
+      throw new Error(`Duplicate visual screenshot: ${screenshot.file}`);
+    }
+    await fs.access(path.join(output, screenshot.file));
+    files.add(screenshot.file);
+  }
+
+  manifest.screenshots = [...routeScreenshots, ...screenshots].sort(
+    (left, right) => left.file.localeCompare(right.file),
+  );
+  await fs.writeFile(manifestFile, `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+/** @param {string} value */
+function slug(value) {
+  return value
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 100);
+}

--- a/apps/web/visual/storybook-screenshots.test.mjs
+++ b/apps/web/visual/storybook-screenshots.test.mjs
@@ -115,7 +115,7 @@ describe("replaceStorybookScreenshotsInManifest", () => {
       path.join(output, "manifest.json"),
       JSON.stringify({
         capture: { browserVersion: "1" },
-        screenshots: [],
+        screenshots: [{ file: "routes/home.png", label: "Home" }],
       }),
     );
 
@@ -128,6 +128,28 @@ describe("replaceStorybookScreenshotsInManifest", () => {
     ).rejects.toThrow(
       "Storybook and E2E screenshots must use the same browser version.",
     );
+  });
+
+  test("uses the Storybook browser version when there are no route screenshots", async () => {
+    const output = await temporaryDirectory();
+    await fs.writeFile(
+      path.join(output, "manifest.json"),
+      JSON.stringify({
+        capture: { browserVersion: null },
+        screenshots: [],
+      }),
+    );
+
+    await replaceStorybookScreenshotsInManifest({
+      browserVersion: "1",
+      output,
+      screenshots: [],
+    });
+
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(output, "manifest.json"), "utf8"),
+    );
+    expect(manifest.capture.browserVersion).toBe("1");
   });
 });
 

--- a/apps/web/visual/storybook-screenshots.test.mjs
+++ b/apps/web/visual/storybook-screenshots.test.mjs
@@ -1,0 +1,140 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "vitest";
+
+import {
+  replaceStorybookScreenshotsInManifest,
+  screenshotFile,
+  storiesFromIndex,
+} from "./storybook-screenshots.mjs";
+
+const temporaryDirectories = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      fs.rm(directory, {
+        force: true,
+        recursive: true,
+      }),
+    ),
+  );
+});
+
+describe("storiesFromIndex", () => {
+  test("returns only stories in stable order", () => {
+    expect(
+      storiesFromIndex({
+        entries: {
+          docs: { id: "components-button--docs", type: "docs" },
+          saving: {
+            id: "components-workflow--saving",
+            name: "Saving",
+            title: "Components/Layout/Workflow Screen",
+            type: "story",
+          },
+          overview: {
+            id: "components-button--overview",
+            name: "Overview",
+            title: "Components/Buttons & Menus/Button",
+            type: "story",
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        id: "components-button--overview",
+        name: "Overview",
+        title: "Components/Buttons & Menus/Button",
+        type: "story",
+      },
+      {
+        id: "components-workflow--saving",
+        name: "Saving",
+        title: "Components/Layout/Workflow Screen",
+        type: "story",
+      },
+    ]);
+  });
+});
+
+describe("screenshotFile", () => {
+  test("uses the story as a Frameshift variant", () => {
+    expect(
+      screenshotFile({
+        id: "components-workflow--saving",
+        name: "Saving",
+        title: "Components/Layout/Workflow Screen",
+        type: "story",
+      }),
+    ).toBe("storybook/components/layout/workflow-screen__saving.png");
+  });
+});
+
+describe("replaceStorybookScreenshotsInManifest", () => {
+  test("replaces Storybook screenshots and preserves route screenshots", async () => {
+    const output = await temporaryDirectory();
+    await fs.writeFile(
+      path.join(output, "manifest.json"),
+      JSON.stringify({
+        capture: { browserVersion: "1" },
+        screenshots: [
+          { file: "routes/home.png", label: "Home" },
+          {
+            file: "storybook/components/old-story.png",
+            label: "Old story",
+          },
+        ],
+      }),
+    );
+    const storyFile = "storybook/components/button__overview.png";
+    await fs.mkdir(path.join(output, "storybook/components"), {
+      recursive: true,
+    });
+    await fs.writeFile(path.join(output, storyFile), "screenshot");
+
+    await replaceStorybookScreenshotsInManifest({
+      browserVersion: "1",
+      output,
+      screenshots: [{ file: storyFile, label: "Button / Overview" }],
+    });
+
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(output, "manifest.json"), "utf8"),
+    );
+    expect(manifest.screenshots).toEqual([
+      { file: "routes/home.png", label: "Home" },
+      { file: storyFile, label: "Button / Overview" },
+    ]);
+  });
+
+  test("rejects a different browser version", async () => {
+    const output = await temporaryDirectory();
+    await fs.writeFile(
+      path.join(output, "manifest.json"),
+      JSON.stringify({
+        capture: { browserVersion: "1" },
+        screenshots: [],
+      }),
+    );
+
+    await expect(
+      replaceStorybookScreenshotsInManifest({
+        browserVersion: "2",
+        output,
+        screenshots: [],
+      }),
+    ).rejects.toThrow(
+      "Storybook and E2E screenshots must use the same browser version.",
+    );
+  });
+});
+
+async function temporaryDirectory() {
+  const directory = await fs.mkdtemp(
+    path.join(os.tmpdir(), "peated-storybook-screenshots-"),
+  );
+  temporaryDirectories.push(directory);
+  return directory;
+}

--- a/apps/web/visual/storybook.playwright.ts
+++ b/apps/web/visual/storybook.playwright.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -8,6 +8,8 @@ import {
   storiesFromIndex,
 } from "./storybook-screenshots.mjs";
 
+const capturePageCount = 4;
+
 test("capture Storybook stories", async ({ page, request }) => {
   const indexResponse = await request.get("/index.json");
   expect(indexResponse.ok()).toBe(true);
@@ -16,42 +18,26 @@ test("capture Storybook stories", async ({ page, request }) => {
 
   const output = visualOutputRoot();
   const screenshots: Array<{ file: string; label: string }> = [];
-  for (const story of stories) {
-    await test.step(`${story.title} / ${story.name}`, async () => {
-      const url = new URL("/iframe.html", storybookUrl());
-      url.searchParams.set("id", story.id);
-      url.searchParams.set("viewMode", "story");
-      url.searchParams.set("globals", "theme:light");
+  const extraPages = await Promise.all(
+    Array.from({ length: Math.min(capturePageCount, stories.length) - 1 }, () =>
+      page.context().newPage(),
+    ),
+  );
+  const pages = [page, ...extraPages];
+  let nextStory = 0;
 
-      await page.goto(url.href, { waitUntil: "domcontentloaded" });
-      await expect(page.locator("#storybook-root > *").first()).toBeVisible();
-      await page.evaluate(async () => {
-        await document.fonts.ready;
-        await Promise.all(
-          Array.from(document.images, (image) =>
-            image.decode().catch(() => {}),
-          ),
+  await Promise.all(
+    pages.map(async (capturePage) => {
+      while (nextStory < stories.length) {
+        const story = stories[nextStory++];
+        const label = `${story.title} / ${story.name}`;
+        const screenshot = await test.step(label, () =>
+          captureStory(capturePage, story, output),
         );
-        await new Promise((resolve) => requestAnimationFrame(resolve));
-      });
-
-      const file = screenshotFile(story);
-      await fs.mkdir(path.dirname(path.join(output, file)), {
-        recursive: true,
-      });
-      await page.screenshot({
-        animations: "disabled",
-        caret: "hide",
-        fullPage: true,
-        path: path.join(output, file),
-        type: "png",
-      });
-      screenshots.push({
-        file,
-        label: `${story.title} / ${story.name}`,
-      });
-    });
-  }
+        screenshots.push(screenshot);
+      }
+    }),
+  );
 
   const browserVersion = page.context().browser()?.version();
   if (!browserVersion) {
@@ -64,8 +50,42 @@ test("capture Storybook stories", async ({ page, request }) => {
   });
 });
 
-function storybookUrl() {
-  return process.env.STORYBOOK_URL ?? "http://127.0.0.1:6006";
+type Story = ReturnType<typeof storiesFromIndex>[number];
+
+async function captureStory(page: Page, story: Story, output: string) {
+  const search = new URLSearchParams({
+    globals: "theme:light",
+    id: story.id,
+    viewMode: "story",
+  });
+
+  await page.goto(`/iframe.html?${search}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.locator("#storybook-root > *").first()).toBeVisible();
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    await Promise.all(
+      Array.from(document.images, (image) => image.decode().catch(() => {})),
+    );
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+  });
+
+  const file = screenshotFile(story);
+  await fs.mkdir(path.dirname(path.join(output, file)), {
+    recursive: true,
+  });
+  await page.screenshot({
+    animations: "disabled",
+    caret: "hide",
+    fullPage: true,
+    path: path.join(output, file),
+    type: "png",
+  });
+  return {
+    file,
+    label: `${story.title} / ${story.name}`,
+  };
 }
 
 function visualOutputRoot() {

--- a/apps/web/visual/storybook.playwright.ts
+++ b/apps/web/visual/storybook.playwright.ts
@@ -1,0 +1,76 @@
+import { expect, test } from "@playwright/test";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import {
+  replaceStorybookScreenshotsInManifest,
+  screenshotFile,
+  storiesFromIndex,
+} from "./storybook-screenshots.mjs";
+
+test("capture Storybook stories", async ({ page, request }) => {
+  const indexResponse = await request.get("/index.json");
+  expect(indexResponse.ok()).toBe(true);
+  const stories = storiesFromIndex(await indexResponse.json());
+  expect(stories.length).toBeGreaterThan(0);
+
+  const output = visualOutputRoot();
+  const screenshots: Array<{ file: string; label: string }> = [];
+  for (const story of stories) {
+    await test.step(`${story.title} / ${story.name}`, async () => {
+      const url = new URL("/iframe.html", storybookUrl());
+      url.searchParams.set("id", story.id);
+      url.searchParams.set("viewMode", "story");
+      url.searchParams.set("globals", "theme:light");
+
+      await page.goto(url.href, { waitUntil: "domcontentloaded" });
+      await expect(page.locator("#storybook-root > *").first()).toBeVisible();
+      await page.evaluate(async () => {
+        await document.fonts.ready;
+        await Promise.all(
+          Array.from(document.images, (image) =>
+            image.decode().catch(() => {}),
+          ),
+        );
+        await new Promise((resolve) => requestAnimationFrame(resolve));
+      });
+
+      const file = screenshotFile(story);
+      await fs.mkdir(path.dirname(path.join(output, file)), {
+        recursive: true,
+      });
+      await page.screenshot({
+        animations: "disabled",
+        caret: "hide",
+        fullPage: true,
+        path: path.join(output, file),
+        type: "png",
+      });
+      screenshots.push({
+        file,
+        label: `${story.title} / ${story.name}`,
+      });
+    });
+  }
+
+  const browserVersion = page.context().browser()?.version();
+  if (!browserVersion) {
+    throw new Error("Storybook screenshot browser version is unavailable.");
+  }
+  await replaceStorybookScreenshotsInManifest({
+    browserVersion,
+    output,
+    screenshots,
+  });
+});
+
+function storybookUrl() {
+  return process.env.STORYBOOK_URL ?? "http://127.0.0.1:6006";
+}
+
+function visualOutputRoot() {
+  const configured = process.env.VISUAL_OUTPUT_DIR;
+  return configured
+    ? path.resolve(configured)
+    : path.resolve(process.cwd(), ".playwright/visual");
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev:web": "dotenv -e .env.local -- turbo dev --filter=\"./apps/web\"",
     "storybook": "pnpm --filter @peated/web storybook",
     "storybook:build": "pnpm --filter @peated/web storybook:build",
+    "storybook:screenshots:build": "pnpm --filter @peated/web storybook:screenshots:build",
     "storybook:screenshots": "pnpm --filter @peated/web storybook:screenshots",
     "dev:server": "dotenv -e .env.local -- turbo dev --filter=\"./apps/server\"",
     "dev:server:api": "dotenv -e .env.local -- pnpm --filter='./apps/server' dev:api",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dev:web": "dotenv -e .env.local -- turbo dev --filter=\"./apps/web\"",
     "storybook": "pnpm --filter @peated/web storybook",
     "storybook:build": "pnpm --filter @peated/web storybook:build",
+    "storybook:screenshots": "pnpm --filter @peated/web storybook:screenshots",
     "dev:server": "dotenv -e .env.local -- turbo dev --filter=\"./apps/server\"",
     "dev:server:api": "dotenv -e .env.local -- pnpm --filter='./apps/server' dev:api",
     "dev:worker": "dotenv -e .env.local -- pnpm --filter='./apps/server' dev:worker",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,6 +617,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vite:
+        specifier: 'catalog:'
+        version: 8.2.1(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-plugin-svgr:
         specifier: 5.2.0
         version: 5.2.0(rollup@4.62.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -617,6 +617,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vite-plugin-svgr:
+        specifier: 5.2.0
+        version: 5.2.0(rollup@4.62.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest:
         specifier: 'catalog:'
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1(supports-color@8.1.1))(vite@8.2.1(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -10315,6 +10318,11 @@ packages:
       storybook: ^0.0.0-0 || ^9.0.0 || ^10.0.0 || ^10.0.0-0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0 || ^10.5.0-0 || ^10.6.0-0
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  vite-plugin-svgr@5.2.0:
+    resolution: {integrity: sha512-qj2eAKF8C6PZWemVTvQA0xgQIcP1hHU6Buh7fl6BhvayWwnuxE+z417miKxeDvRWbDrupQ1oK99hfxElopJ3sQ==}
+    peerDependencies:
+      vite: '>=3.0.0'
+
   vite-tsconfig-paths@5.1.4:
     resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
     peerDependencies:
@@ -14339,7 +14347,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.62.2
 
@@ -21371,6 +21379,17 @@ snapshots:
       vite: 8.2.1(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       vite-tsconfig-paths: 5.1.4(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite-plugin-svgr@5.2.0(rollup@4.62.2)(supports-color@8.1.1)(typescript@5.9.3)(vite@8.2.1(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.62.2)
+      '@svgr/core': 8.1.0(supports-color@8.1.1)(typescript@5.9.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@5.9.3))(supports-color@8.1.1)
+      vite: 8.2.1(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - rollup
       - supports-color
       - typescript
 


### PR DESCRIPTION
Frameshift now captures every Storybook story after the route screenshots. The story hierarchy groups related component images, and each story name becomes a variant. The capture keeps the existing manifest metadata and verifies that both passes use the same browser.

The command can run again against a completed manifest without duplicate entries. It waits for fonts and images, disables motion, and fails when a story does not render.

Screenshot CI uses Storybook's test build and four bounded browser pages. A local run builds in 11 seconds and captures all stories in 32 seconds, down from about four minutes with the development server.

The first report will show all 125 stories as new. Storybook also handles map SVGs the same way as the application, which repairs the existing Location Card story.
