### PR TITLE
feat(profiles): add overview and separate tastings

### DIFF
--- a/apps/server/src/orpc/contracts/users/tasting-stats.ts
+++ b/apps/server/src/orpc/contracts/users/tasting-stats.ts
@@ -2,12 +2,19 @@ import { AgeStatsSchema } from "@peated/server/schemas";
 import { z } from "zod";
 import { contract } from "../base";
 
+const ProducerStatSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  count: z.number(),
+});
+
 export default contract
   .route({
     method: "GET",
     path: "/users/{user}/tasting-stats",
     summary: "Get user tasting statistics",
-    description: "Get rating, bottle, and age totals for a user's tastings",
+    description:
+      "Get rating, bottle, producer, and age totals for a user's tastings",
     operationId: "getUserTastingStats",
   })
   .input(
@@ -26,6 +33,11 @@ export default contract
         very_good: z.number(),
         outstanding: z.number(),
         unicorn: z.number(),
+      }),
+      producers: z.object({
+        brands: z.array(ProducerStatSchema),
+        bottlers: z.array(ProducerStatSchema),
+        distillers: z.array(ProducerStatSchema),
       }),
       mostTastedBottle: z
         .object({

--- a/apps/server/src/orpc/mock/fixtures/user-stats.ts
+++ b/apps/server/src/orpc/mock/fixtures/user-stats.ts
@@ -2,6 +2,7 @@ import type { MockOutputs } from "../contract";
 import { mockBottle } from "./bottles";
 import {
   mockBuffaloTraceEntity,
+  mockEntities,
   mockEntity,
   mockMacallanEntity,
   mockMidletonEntity,
@@ -94,6 +95,24 @@ export const mockUserTastingStats = {
     very_good: 10,
     outstanding: 15,
     unicorn: 7,
+  },
+  producers: {
+    brands: [
+      { id: mockRedbreastEntity.id, name: mockRedbreastEntity.name, count: 7 },
+    ],
+    bottlers: [
+      { id: mockEntities[7]!.id, name: mockEntities[7]!.name, count: 5 },
+      { id: mockEntities[8]!.id, name: mockEntities[8]!.name, count: 3 },
+    ],
+    distillers: [
+      { id: mockEntity.id, name: mockEntity.name, count: 15 },
+      { id: mockMacallanEntity.id, name: mockMacallanEntity.name, count: 8 },
+      {
+        id: mockSpringbankEntity.id,
+        name: mockSpringbankEntity.name,
+        count: 6,
+      },
+    ],
   },
   mostTastedBottle: {
     id: mockBottle.id,

--- a/apps/server/src/orpc/routes/users/details.ts
+++ b/apps/server/src/orpc/routes/users/details.ts
@@ -49,6 +49,7 @@ async function aggregateCollectionStats(userId: number) {
         bottle: {
           id: bottles.id,
           groupId: bottles.groupId,
+          bottlerId: bottles.bottlerId,
           brandId: bottles.brandId,
           category: bottles.category,
           flavorProfile: bottles.flavorProfile,

--- a/apps/server/src/orpc/routes/users/library-stats.ts
+++ b/apps/server/src/orpc/routes/users/library-stats.ts
@@ -206,6 +206,7 @@ export default implement(libraryStatsContract).handler(async function ({
           bottle: {
             id: bottles.id,
             groupId: bottles.groupId,
+            bottlerId: bottles.bottlerId,
             brandId: bottles.brandId,
             category: bottles.category,
             flavorProfile: bottles.flavorProfile,

--- a/apps/server/src/orpc/routes/users/tasting-bottle-scan.test.ts
+++ b/apps/server/src/orpc/routes/users/tasting-bottle-scan.test.ts
@@ -11,6 +11,7 @@ test("fails closed when a stored Bottle has no BottleGroup", () => {
       bottle: {
         id: 42,
         groupId: null,
+        bottlerId: null,
         brandId: 1,
         category: null,
         flavorProfile: null,

--- a/apps/server/src/orpc/routes/users/tasting-bottle-scan.ts
+++ b/apps/server/src/orpc/routes/users/tasting-bottle-scan.ts
@@ -7,7 +7,13 @@ const TASTING_BOTTLE_SCAN_BATCH_SIZE = 200;
 
 export type UserBottleRead = Pick<
   typeof bottles.$inferSelect,
-  "brandId" | "category" | "flavorProfile" | "groupId" | "id" | "statedAge"
+  | "bottlerId"
+  | "brandId"
+  | "category"
+  | "flavorProfile"
+  | "groupId"
+  | "id"
+  | "statedAge"
 >;
 
 export type TastingBottleScanRow = {
@@ -72,6 +78,7 @@ export async function* scanUserTastingBottles(
         bottle: {
           id: bottles.id,
           groupId: bottles.groupId,
+          bottlerId: bottles.bottlerId,
           brandId: bottles.brandId,
           category: bottles.category,
           flavorProfile: bottles.flavorProfile,

--- a/apps/server/src/orpc/routes/users/tasting-stats.test.ts
+++ b/apps/server/src/orpc/routes/users/tasting-stats.test.ts
@@ -37,6 +37,11 @@ describe("GET /users/:user/tasting-stats", () => {
         outstanding: 0,
         unicorn: 0,
       },
+      producers: {
+        brands: expect.any(Array),
+        bottlers: [],
+        distillers: [],
+      },
       mostTastedBottle: null,
       age: {
         knownCount: 4,
@@ -73,12 +78,89 @@ describe("GET /users/:user/tasting-stats", () => {
       unicorn: 0,
     });
     expect(data.mostTastedBottle).toBeNull();
+    expect(data.producers).toEqual({
+      brands: [],
+      bottlers: [],
+      distillers: [],
+    });
     expect(data.age).toMatchObject({
       knownCount: 0,
       median: null,
       oldest: null,
     });
     expect(data.age.buckets.every((bucket) => bucket.count === 0)).toBe(true);
+  });
+
+  test("ranks the producers represented in tastings", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const brandA = await fixtures.Entity({
+      kind: "brand",
+      name: "Alpha Brand",
+    });
+    const brandB = await fixtures.Entity({
+      kind: "brand",
+      name: "Bravo Brand",
+    });
+    const bottlerA = await fixtures.Entity({
+      kind: "bottler",
+      name: "Alpha Bottler",
+    });
+    const bottlerB = await fixtures.Entity({
+      kind: "bottler",
+      name: "Bravo Bottler",
+    });
+    const distillerA = await fixtures.Entity({
+      kind: "distillery",
+      name: "Alpha Distillery",
+    });
+    const distillerB = await fixtures.Entity({
+      kind: "distillery",
+      name: "Bravo Distillery",
+    });
+    const bottleA = await fixtures.Bottle({
+      brandId: brandA.id,
+      bottlerId: bottlerA.id,
+      distillerIds: [distillerA.id],
+    });
+    const bottleB = await fixtures.Bottle({
+      brandId: brandA.id,
+      bottlerId: bottlerA.id,
+      distillerIds: [distillerA.id, distillerB.id],
+    });
+    const bottleC = await fixtures.Bottle({
+      brandId: brandB.id,
+      bottlerId: bottlerB.id,
+      distillerIds: [distillerB.id],
+    });
+
+    for (const bottleId of [bottleA.id, bottleA.id, bottleB.id, bottleC.id]) {
+      await fixtures.Tasting({
+        bottleId,
+        createdById: defaults.user.id,
+      });
+    }
+
+    const data = await routerClient.users.tastingStats(
+      { user: defaults.user.id },
+      { context: { user: defaults.user } },
+    );
+
+    expect(data.producers).toEqual({
+      brands: [
+        { id: brandA.id, name: brandA.name, count: 3 },
+        { id: brandB.id, name: brandB.name, count: 1 },
+      ],
+      bottlers: [
+        { id: bottlerA.id, name: bottlerA.name, count: 3 },
+        { id: bottlerB.id, name: bottlerB.name, count: 1 },
+      ],
+      distillers: [
+        { id: distillerA.id, name: distillerA.name, count: 3 },
+        { id: distillerB.id, name: distillerB.name, count: 2 },
+      ],
+    });
   });
 
   test("summarizes bands and repeated Bottles", async ({

--- a/apps/server/src/orpc/routes/users/tasting-stats.ts
+++ b/apps/server/src/orpc/routes/users/tasting-stats.ts
@@ -1,16 +1,42 @@
 import { EMPTY_TASTING_BAND_COUNTS } from "@peated/server/constants";
 import { db } from "@peated/server/db";
-import { bottles } from "@peated/server/db/schema";
+import {
+  bottles,
+  bottlesToDistillers,
+  entities,
+} from "@peated/server/db/schema";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { implement } from "@peated/server/orpc";
 import userTastingStatsContract from "@peated/server/orpc/contracts/users/tasting-stats";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { buildAgeStats } from "./age-stats";
 import {
   scanUserTastingBottles,
   UserBottleReadIntegrityError,
 } from "./tasting-bottle-scan";
+
+type ProducerStat = { id: number; name: string; count: number };
+
+function incrementCount(counts: Map<number, number>, id: number) {
+  counts.set(id, (counts.get(id) ?? 0) + 1);
+}
+
+function rankProducers(
+  counts: Map<number, number>,
+  entitiesById: Map<number, { id: number; name: string }>,
+): ProducerStat[] {
+  return Array.from(counts, ([id, count]) => {
+    const entity = entitiesById.get(id);
+    if (!entity) throw new Error(`Bottle references missing Entity ${id}.`);
+    return { id, name: entity.name, count };
+  })
+    .sort(
+      (left, right) =>
+        right.count - left.count || left.name.localeCompare(right.name),
+    )
+    .slice(0, 5);
+}
 
 export default implement(userTastingStatsContract).handler(async function ({
   input,
@@ -32,6 +58,9 @@ export default implement(userTastingStatsContract).handler(async function ({
 
   const ages: number[] = [];
   const bottleCounts = new Map<number, number>();
+  const brandCounts = new Map<number, number>();
+  const bottlerCounts = new Map<number, number>();
+  const distillerCounts = new Map<number, number>();
   const bands = { total: 0, ...EMPTY_TASTING_BAND_COUNTS };
   let total = 0;
   let unstatedCount = 0;
@@ -39,6 +68,22 @@ export default implement(userTastingStatsContract).handler(async function ({
   try {
     for await (const rows of scanUserTastingBottles(user.id)) {
       total += rows.length;
+      const bottleIds = Array.from(
+        new Set(rows.flatMap(({ bottle }) => (bottle ? [bottle.id] : []))),
+      );
+      const distillerRows = bottleIds.length
+        ? await db
+            .select()
+            .from(bottlesToDistillers)
+            .where(inArray(bottlesToDistillers.bottleId, bottleIds))
+        : [];
+      const distillerIdsByBottleId = new Map<number, number[]>();
+      for (const { bottleId, distillerId } of distillerRows) {
+        const ids = distillerIdsByBottleId.get(bottleId) ?? [];
+        ids.push(distillerId);
+        distillerIdsByBottleId.set(bottleId, ids);
+      }
+
       for (const { bottle, ratingBand } of rows) {
         if (ratingBand !== null) {
           bands[ratingBand] += 1;
@@ -47,6 +92,14 @@ export default implement(userTastingStatsContract).handler(async function ({
 
         if (bottle) {
           bottleCounts.set(bottle.id, (bottleCounts.get(bottle.id) ?? 0) + 1);
+          incrementCount(brandCounts, bottle.brandId);
+          if (bottle.bottlerId !== null) {
+            incrementCount(bottlerCounts, bottle.bottlerId);
+          }
+          for (const distillerId of distillerIdsByBottleId.get(bottle.id) ??
+            []) {
+            incrementCount(distillerCounts, distillerId);
+          }
         }
         if (bottle?.statedAge === null || !bottle) {
           unstatedCount += 1;
@@ -75,11 +128,32 @@ export default implement(userTastingStatsContract).handler(async function ({
           where: eq(bottles.id, mostTastedBottleId),
           with: { brand: true, group: true, series: true },
         });
+  const producerIds = Array.from(
+    new Set([
+      ...brandCounts.keys(),
+      ...bottlerCounts.keys(),
+      ...distillerCounts.keys(),
+    ]),
+  );
+  const producerEntities = producerIds.length
+    ? await db
+        .select({ id: entities.id, name: entities.name })
+        .from(entities)
+        .where(inArray(entities.id, producerIds))
+    : [];
+  const producersById = new Map(
+    producerEntities.map((entity) => [entity.id, entity]),
+  );
 
   return {
     total,
     uniqueBottles: bottleCounts.size,
     bands,
+    producers: {
+      brands: rankProducers(brandCounts, producersById),
+      bottlers: rankProducers(bottlerCounts, producersById),
+      distillers: rankProducers(distillerCounts, producersById),
+    },
     mostTastedBottle: mostTastedBottle
       ? {
           id: mostTastedBottle.id,

--- a/apps/web/e2e/profile-header.spec.ts
+++ b/apps/web/e2e/profile-header.spec.ts
@@ -3,27 +3,28 @@ import { expect, test } from "./test";
 import { adminUser, testAccessToken, testUser } from "./rpc-fixtures.mjs";
 import { signIn } from "./session";
 
-test("refreshes the profile after an administrator changes the moderator role", async ({
+test("updates the profile actions after an administrator changes the moderator role", async ({
   context,
   page,
 }, testInfo) => {
   await signIn(context, {
-    accessToken: `${testAccessToken}-profile-role-update-${testInfo.project.name}`,
+    accessToken: `${testAccessToken}-profile-role-update-${testInfo.project.name}-${testInfo.retry}`,
     user: adminUser,
   });
 
-  await page.goto(`/users/${testUser.username}/activity`, {
-    waitUntil: "commit",
+  await page.goto(`/users/${testUser.username}/activity`);
+  const profileActions = page.getByRole("button", {
+    name: `Actions for ${testUser.username}`,
   });
-  await page
-    .getByRole("button", { name: `Actions for ${testUser.username}` })
-    .click();
+  await profileActions.click();
   await page.getByRole("menuitem", { name: "Add moderator role" }).click();
 
-  const moderatorRole = page
-    .getByRole("main")
-    .getByText("Moderator", { exact: true });
-  await expect(moderatorRole).toBeVisible();
+  const removeModeratorRole = page.getByRole("menuitem", {
+    name: "Remove moderator role",
+  });
+  await profileActions.click();
+  await expect(removeModeratorRole).toBeVisible();
   await page.reload();
-  await expect(moderatorRole).toBeVisible();
+  await profileActions.click();
+  await expect(removeModeratorRole).toBeVisible();
 });

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -189,13 +189,13 @@ function getTasting(tasting: Tasting, bottle: Bottle): TastingEntryProps {
   const member = {
     color: tasting.color === null ? undefined : formatColor(tasting.color),
     comments: tasting.comments,
-    description: tasting.notes ?? undefined,
-    descriptionHref: `/tastings/${tasting.id}`,
+    notes: tasting.notes ?? undefined,
+    notesHref: `/tastings/${tasting.id}`,
     hasToasted: tasting.hasToasted,
     imageKind: tasting.imageUrl ? ("photo" as const) : ("bottle" as const),
     imageUrl: tasting.imageUrl ?? bottle.imageUrl,
     name: formatBottleDisplayName(bottle, { includeBrand: false }),
-    notes: tasting.tags,
+    tags: tasting.tags,
     ratingBand: tasting.ratingBand ?? undefined,
     servingStyle: tasting.servingStyle
       ? formatServingStyle(tasting.servingStyle)

--- a/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
+++ b/apps/web/src/app/(app)/tastings/[tastingId]/tastingDetail.stylex.tsx
@@ -82,7 +82,7 @@ export function TastingDetail({ tasting }: { tasting: Tasting }) {
           imageUrl={tasting.imageUrl ?? tasting.bottle.imageUrl}
           size="detail"
         />
-        <div {...stylex.props(styles.verdict)}>
+        <div {...stylex.props(styles.ratingSummary)}>
           <strong {...stylex.props(styles.ratingLabel)}>
             {rating?.label ?? "Not rated"}
           </strong>
@@ -97,9 +97,9 @@ export function TastingDetail({ tasting }: { tasting: Tasting }) {
         </div>
       </div>
 
-      <p {...stylex.props(styles.notes, !tasting.notes && styles.emptyNotes)}>
-        {tasting.notes || "No notes."}
-      </p>
+      {tasting.notes ? (
+        <p {...stylex.props(styles.notes)}>{tasting.notes}</p>
+      ) : null}
 
       {tasting.tags.length ? (
         <div {...stylex.props(styles.tags)}>
@@ -218,7 +218,7 @@ const styles = stylex.create({
       gap: space.x4,
     },
   },
-  verdict: {
+  ratingSummary: {
     display: "flex",
     minWidth: 0,
     flex: 1,
@@ -251,9 +251,6 @@ const styles = stylex.create({
     fontSize: "15px",
     lineHeight: 1.6,
     whiteSpace: "pre-wrap",
-  },
-  emptyNotes: {
-    color: colors.inkMuted,
   },
   tags: {
     display: "flex",

--- a/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
@@ -9,28 +9,14 @@ import {
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
-import {
-  CursorPager,
-  LoadingList,
-  MemberAvatar,
-  SectionError,
-  type TastingEntryMember,
-} from "@peated/web/components";
-import {
-  MemberActivityList,
-  type MemberActivityItem,
-} from "@peated/web/components/pages/memberProfileContent.stylex";
+import { CursorPager, LoadingList, SectionError } from "@peated/web/components";
+import { MemberActivityList } from "@peated/web/components/pages/memberProfileContent.stylex";
 import { PageColumns } from "@peated/web/components/pages/pageLayout.stylex";
-import { getTastingEntryMember } from "@peated/web/components/tastingRecordEntry";
-import TimeSince from "@peated/web/components/timeSince";
-import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
+import { toActivityItem } from "../profileActivity";
 import { useProfile } from "../profileContext";
 
-type Activity = Outputs["users"]["activity"]["list"]["results"][number];
 type ActivityList = Outputs["users"]["activity"]["list"];
 
 export function ProfileActivityPageClient({
@@ -137,62 +123,4 @@ export function ProfileActivityPageClient({
       </section>
     </PageColumns>
   );
-}
-
-function toActivityItem(activity: Activity): MemberActivityItem {
-  if (activity.type === "collection_add") {
-    return {
-      activity: {
-        author: activity.createdBy.username,
-        authorHref: `/users/${activity.createdBy.username}`,
-        collectionHref: activity.collection.href ?? undefined,
-        collectionName: activity.collection.name,
-        date: <TimeSince date={activity.createdAt} />,
-        id: activity.id,
-        items: activity.items.map((entry) => ({
-          brand: entry.bottle.brand.shortName || entry.bottle.brand.name,
-          brandHref: getEntityUrl({
-            id: entry.bottle.brand.id,
-            kind: "brand",
-            name: entry.bottle.brand.name,
-          }),
-          href: getBottleUrl(entry.bottle),
-          id: String(entry.id),
-          imageUrl: entry.imageUrl ?? entry.bottle.imageUrl,
-          metadata: getBottleMetadata(entry.bottle).split(" · "),
-          name: formatBottleDisplayName(entry.bottle, {
-            includeBrand: false,
-          }),
-        })),
-        totalItems: activity.totalItems,
-      },
-      id: activity.id,
-      kind: "collection",
-    };
-  }
-
-  const [firstTasting, ...remainingTastings] = activity.tastings;
-  if (!firstTasting)
-    throw new Error("A tasting session must contain a tasting");
-  const members: [TastingEntryMember, ...TastingEntryMember[]] = [
-    getTastingEntryMember(firstTasting),
-    ...remainingTastings.map(getTastingEntryMember),
-  ];
-  return {
-    id: activity.id,
-    kind: "tasting",
-    tasting: {
-      author: activity.createdBy.username,
-      authorHref: `/users/${activity.createdBy.username}`,
-      authorId: activity.createdBy.id,
-      date: <TimeSince date={activity.lastActivityAt} />,
-      leading: (
-        <MemberAvatar
-          pictureUrl={activity.createdBy.pictureUrl}
-          username={activity.createdBy.username}
-        />
-      ),
-      members,
-    },
-  };
 }

--- a/apps/web/src/app/(app)/users/[username]/page.tsx
+++ b/apps/web/src/app/(app)/users/[username]/page.tsx
@@ -1,32 +1,42 @@
-import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
+import type { Outputs } from "@peated/server/orpc/router";
 import { createServerClient } from "@peated/web/lib/orpc/client.server";
 import { getProfilePage } from "@peated/web/lib/profilePage.server";
 
-import { ProfileTastingsPageClient } from "./profileTastingsPageClient.stylex";
+import { ProfileOverviewPageClient } from "./profileOverviewPageClient.stylex";
 
 export const fetchCache = "default-no-store";
 
-export default async function ProfilePageRoute(props: {
+export default async function ProfileOverviewPage(props: {
   params: Promise<{ username: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { username } = await props.params;
   const { client } = await createServerClient();
   const user = await getProfilePage(username);
-  const tastingInput = getApiQueryParams(await props.searchParams, {
-    defaults: { cursor: 1 },
-    numericFields: ["cursor"],
-    overrides: { limit: 10, user: user.id },
-  });
-  const [regionList, tastingList] = await Promise.all([
-    client.users.regionList({ user: user.id }),
-    client.tastings.list(tastingInput),
+  const [activityList, badgePage, tastingStats] = await Promise.all([
+    client.users.activity.list({ limit: 3, user: user.id }),
+    client.users.badgeList({ cursor: 1, limit: 100, user: user.id }),
+    client.users.tastingStats({ user: user.id }),
   ]);
+  const badgeAwards: Outputs["users"]["badgeList"]["results"] = [
+    ...badgePage.results,
+  ];
+  let badgeCursor = badgePage.rel.nextCursor;
+
+  while (badgeCursor) {
+    const nextBadgePage = await client.users.badgeList({
+      cursor: badgeCursor,
+      limit: 100,
+      user: user.id,
+    });
+    badgeAwards.push(...nextBadgePage.results);
+    badgeCursor = nextBadgePage.rel.nextCursor;
+  }
 
   return (
-    <ProfileTastingsPageClient
-      initialRegionList={regionList}
-      initialTastingList={tastingList}
+    <ProfileOverviewPageClient
+      initialActivityList={activityList}
+      initialBadgeAwards={badgeAwards}
+      initialTastingStats={tastingStats}
     />
   );
 }

--- a/apps/web/src/app/(app)/users/[username]/profileActivity.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileActivity.tsx
@@ -1,0 +1,72 @@
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
+import type { Outputs } from "@peated/server/orpc/router";
+
+import { MemberAvatar, type TastingEntryMember } from "@peated/web/components";
+import type { MemberActivityItem } from "@peated/web/components/pages/memberProfileContent.stylex";
+import { getTastingEntryMember } from "@peated/web/components/tastingRecordEntry";
+import TimeSince from "@peated/web/components/timeSince";
+import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
+import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
+
+type Activity = Outputs["users"]["activity"]["list"]["results"][number];
+
+/** Maps one API activity item to the shared profile activity presentation. */
+export function toActivityItem(activity: Activity): MemberActivityItem {
+  if (activity.type === "collection_add") {
+    return {
+      activity: {
+        author: activity.createdBy.username,
+        authorHref: `/users/${activity.createdBy.username}`,
+        collectionHref: activity.collection.href ?? undefined,
+        collectionName: activity.collection.name,
+        date: <TimeSince date={activity.createdAt} />,
+        id: activity.id,
+        items: activity.items.map((entry) => ({
+          brand: entry.bottle.brand.shortName || entry.bottle.brand.name,
+          brandHref: getEntityUrl({
+            id: entry.bottle.brand.id,
+            kind: "brand",
+            name: entry.bottle.brand.name,
+          }),
+          href: getBottleUrl(entry.bottle),
+          id: String(entry.id),
+          imageUrl: entry.imageUrl ?? entry.bottle.imageUrl,
+          metadata: getBottleMetadata(entry.bottle).split(" · "),
+          name: formatBottleDisplayName(entry.bottle, {
+            includeBrand: false,
+          }),
+        })),
+        totalItems: activity.totalItems,
+      },
+      id: activity.id,
+      kind: "collection",
+    };
+  }
+
+  const [firstTasting, ...remainingTastings] = activity.tastings;
+  if (!firstTasting) {
+    throw new Error("A tasting session must contain a tasting");
+  }
+  const members: [TastingEntryMember, ...TastingEntryMember[]] = [
+    getTastingEntryMember(firstTasting),
+    ...remainingTastings.map(getTastingEntryMember),
+  ];
+
+  return {
+    id: activity.id,
+    kind: "tasting",
+    tasting: {
+      author: activity.createdBy.username,
+      authorHref: `/users/${activity.createdBy.username}`,
+      authorId: activity.createdBy.id,
+      date: <TimeSince date={activity.lastActivityAt} />,
+      leading: (
+        <MemberAvatar
+          pictureUrl={activity.createdBy.pictureUrl}
+          username={activity.createdBy.username}
+        />
+      ),
+      members,
+    },
+  };
+}

--- a/apps/web/src/app/(app)/users/[username]/profileLayoutClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileLayoutClient.stylex.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation } from "@tanstack/react-query";
 import { usePathname } from "next/navigation";
 import { useState, type ReactNode } from "react";
 
@@ -12,14 +11,12 @@ import {
   EmptyState,
   PageTabs,
   RowMenu,
-  SummaryStrip,
 } from "@peated/web/components";
 import { MemberProfileHeader } from "@peated/web/components/pages/memberProfileHeader.stylex";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { space } from "../../../../styles/tokens.stylex";
 import { ProfileProvider, type ProfileUser } from "./profileContext";
 
-type TastingStats = Outputs["users"]["tastingStats"];
 type FriendStatus = NonNullable<ProfileUser["friendStatus"]>;
 
 export function ProfileLayoutClient({
@@ -37,22 +34,7 @@ export function ProfileLayoutClient({
 }) {
   const orpc = useORPC();
   const pathname = usePathname();
-  const isCurrentUser = currentUserId === initialUser.id;
   const [isModerator, setIsModerator] = useState(Boolean(initialUser.mod));
-  const ratingQuery = useQuery({
-    ...orpc.users.tastingStats.queryOptions({
-      input: { user: initialUser.id },
-    }),
-    enabled: !privateRecord,
-  });
-  const metadata = initialUser.createdAt
-    ? [`Joined ${formatJoinDate(initialUser.createdAt)}`]
-    : [];
-  const badges = initialUser.admin
-    ? ["Admin"]
-    : isModerator
-      ? ["Moderator"]
-      : [];
 
   return (
     <div {...stylex.props(styles.page)}>
@@ -66,13 +48,8 @@ export function ProfileLayoutClient({
             onModeratorChange={setIsModerator}
           />
         }
-        badges={badges}
-        metadata={metadata}
         pictureUrl={initialUser.pictureUrl}
         privateProfile={privateRecord}
-        ratingLabel={isCurrentUser ? "How you rate" : "How they rate"}
-        bands={getBands(ratingQuery.data)}
-        ratingsLoading={!privateRecord && ratingQuery.isPending}
         username={initialUser.username}
       />
 
@@ -85,36 +62,23 @@ export function ProfileLayoutClient({
         </div>
       ) : (
         <ProfileProvider currentUserId={currentUserId} user={initialUser}>
-          <div {...stylex.props(styles.summary)}>
-            <SummaryStrip
-              cells={[
-                { label: "Tastings", value: initialUser.stats.tastings },
-                { label: "Unique bottles", value: initialUser.stats.bottles },
-                { label: "In Library", value: initialUser.stats.library.total },
-                {
-                  label: "Contributions",
-                  value: initialUser.stats.contributions,
-                },
-              ]}
-            />
-          </div>
           <PageTabs
             ariaLabel={`${initialUser.username}'s profile`}
             currentHref={pathname}
             items={[
               {
-                count: initialUser.stats.tastings,
                 href: `/users/${initialUser.username}`,
+                label: "Overview",
+              },
+              {
+                count: initialUser.stats.tastings,
+                href: `/users/${initialUser.username}/tastings`,
                 label: "Tastings",
               },
               {
                 count: initialUser.stats.library.total,
                 href: `/users/${initialUser.username}/library`,
                 label: "Library",
-              },
-              {
-                href: `/users/${initialUser.username}/activity`,
-                label: "Activity",
               },
             ]}
           />
@@ -218,28 +182,8 @@ function ProfileActions({
   );
 }
 
-function getBands(stats?: TastingStats) {
-  if (!stats?.bands.total) return undefined;
-  return {
-    good: stats.bands.good,
-    mediocre: stats.bands.mediocre,
-    outstanding: stats.bands.outstanding,
-    unicorn: stats.bands.unicorn,
-    very_good: stats.bands.very_good,
-  };
-}
-
-function formatJoinDate(createdAt: string) {
-  return new Intl.DateTimeFormat("en-US", {
-    month: "long",
-    timeZone: "UTC",
-    year: "numeric",
-  }).format(new Date(createdAt));
-}
-
 const styles = stylex.create({
   page: { minWidth: 0 },
-  summary: { marginTop: "6px", marginBottom: space.x6 },
-  content: { marginTop: space.x6 },
+  content: { marginTop: space.x8 },
   privateState: { maxWidth: "760px", marginTop: space.x6 },
 });

--- a/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+import type { Outputs } from "@peated/server/orpc/router";
+import * as stylex from "@stylexjs/stylex";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  AppLink,
+  FactList,
+  LoadingPlaceholder,
+  RailList,
+  RailListItem,
+  SectionHeading,
+  TastingRatingDistribution,
+  type FactListItem,
+  type TastingRatingCounts,
+} from "@peated/web/components";
+import { MemberActivityList } from "@peated/web/components/pages/memberProfileContent.stylex";
+import {
+  PageColumns,
+  RailSection,
+} from "@peated/web/components/pages/pageLayout.stylex";
+import { useORPC } from "@peated/web/lib/orpc/context";
+import { getEntityUrl } from "@peated/web/lib/urls";
+import { colors, space } from "../../../../styles/tokens.stylex";
+import { toActivityItem } from "./profileActivity";
+import { useProfile } from "./profileContext";
+import { ProfilePassport } from "./profilePassport.stylex";
+
+type ActivityList = Outputs["users"]["activity"]["list"];
+type BadgeAward = Outputs["users"]["badgeList"]["results"][number];
+type TastingStats = Outputs["users"]["tastingStats"];
+type ProducerKind = "brand" | "bottler" | "distillery";
+type ProducerStat = TastingStats["producers"]["brands"][number];
+type ProducerGroup = {
+  heading: string;
+  items: readonly ProducerStat[];
+  kind: ProducerKind;
+};
+
+export function ProfileOverviewPageClient({
+  initialActivityList,
+  initialBadgeAwards,
+  initialTastingStats,
+}: {
+  initialActivityList: ActivityList;
+  initialBadgeAwards: readonly BadgeAward[];
+  initialTastingStats: TastingStats;
+}) {
+  const orpc = useORPC();
+  const { isCurrentUser, user } = useProfile();
+  const statsQuery = useQuery({
+    ...orpc.users.tastingStats.queryOptions({ input: { user: user.id } }),
+    initialData: initialTastingStats,
+  });
+  const bands = getBands(statsQuery.data);
+  const producerGroups = getProducerGroups(statsQuery.data?.producers);
+  const facts: readonly [FactListItem, ...FactListItem[]] = user.createdAt
+    ? [
+        { label: "Tastings", value: formatCount(user.stats.tastings) },
+        { label: "Bottles tasted", value: formatCount(user.stats.bottles) },
+        { label: "In library", value: formatCount(user.stats.library.total) },
+        {
+          label: "Catalog changes",
+          value: formatCount(user.stats.contributions),
+        },
+        { label: "Joined", value: formatJoinDate(user.createdAt) },
+      ]
+    : [
+        { label: "Tastings", value: formatCount(user.stats.tastings) },
+        { label: "Bottles tasted", value: formatCount(user.stats.bottles) },
+        { label: "In library", value: formatCount(user.stats.library.total) },
+        {
+          label: "Catalog changes",
+          value: formatCount(user.stats.contributions),
+        },
+      ];
+  const activity = initialActivityList.results
+    .filter(
+      (item) =>
+        item.type !== "collection_add" ||
+        !item.collection.href?.endsWith("/favorites"),
+    )
+    .slice(0, 3)
+    .map(toActivityItem);
+
+  return (
+    <div {...stylex.props(styles.overview)}>
+      <PageColumns
+        rail={
+          <>
+            {producerGroups.length ? (
+              <ProducerSections groups={producerGroups} />
+            ) : null}
+            <RailSection heading="Passport">
+              <ProfilePassport awards={initialBadgeAwards} />
+            </RailSection>
+            {statsQuery.isPending || bands ? (
+              <RatingSummary
+                bands={bands}
+                label={isCurrentUser ? "Your ratings" : "Their ratings"}
+                loading={statsQuery.isPending}
+              />
+            ) : null}
+          </>
+        }
+        railBehavior="stack"
+      >
+        <div {...stylex.props(styles.main)}>
+          <FactList facts={facts} layout="grid" />
+          <section aria-label="Recent activity">
+            <div {...stylex.props(styles.sectionHeader)}>
+              <SectionHeading>Recent activity</SectionHeading>
+              <AppLink href={`/users/${user.username}/activity`}>
+                View all
+              </AppLink>
+            </div>
+            <MemberActivityList
+              emptyDescription={
+                isCurrentUser
+                  ? "Your tastings and library additions will appear here."
+                  : `${user.username} has no recent activity.`
+              }
+              items={activity}
+            />
+          </section>
+        </div>
+      </PageColumns>
+    </div>
+  );
+}
+
+function ProducerSections({ groups }: { groups: readonly ProducerGroup[] }) {
+  return (
+    <>
+      {groups.map((group) => (
+        <RailSection heading={group.heading} key={group.kind}>
+          <RailList ariaLabel={`${group.heading} tasted often`}>
+            {group.items.map((producer) => (
+              <RailListItem
+                end={formatCount(producer.count)}
+                href={getEntityUrl({
+                  id: producer.id,
+                  kind: group.kind,
+                  name: producer.name,
+                })}
+                key={producer.id}
+                title={producer.name}
+              />
+            ))}
+          </RailList>
+        </RailSection>
+      ))}
+    </>
+  );
+}
+
+function RatingSummary({
+  bands,
+  label,
+  loading,
+}: {
+  bands?: TastingRatingCounts;
+  label: string;
+  loading: boolean;
+}) {
+  return (
+    <RailSection heading={label}>
+      {bands ? (
+        <TastingRatingDistribution counts={bands} showCounts />
+      ) : (
+        <div
+          aria-busy="true"
+          aria-label="Loading ratings"
+          role="status"
+          {...stylex.props(styles.ratingLoading)}
+        >
+          <LoadingPlaceholder preset="heading" />
+          <LoadingPlaceholder delay={1} preset="text" />
+          <LoadingPlaceholder delay={2} preset="metadata" />
+        </div>
+      )}
+    </RailSection>
+  );
+}
+
+function getBands(stats?: TastingStats): TastingRatingCounts | undefined {
+  if (!stats?.bands.total) return undefined;
+  return {
+    good: stats.bands.good,
+    mediocre: stats.bands.mediocre,
+    outstanding: stats.bands.outstanding,
+    unicorn: stats.bands.unicorn,
+    very_good: stats.bands.very_good,
+  };
+}
+
+function getProducerGroups(
+  producers?: TastingStats["producers"],
+): ProducerGroup[] {
+  if (!producers) return [];
+
+  const groups: ProducerGroup[] = [];
+  if (producers.distillers.length) {
+    groups.push({
+      heading: "Distillers",
+      items: producers.distillers.slice(0, 3),
+      kind: "distillery",
+    });
+  }
+  if (producers.bottlers.length) {
+    groups.push({
+      heading: "Bottlers",
+      items: producers.bottlers.slice(0, 3),
+      kind: "bottler",
+    });
+  }
+  if (groups.length < 2 && producers.brands.length) {
+    groups.push({
+      heading: "Brands",
+      items: producers.brands.slice(0, 3),
+      kind: "brand",
+    });
+  }
+  return groups;
+}
+
+function formatJoinDate(createdAt: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    timeZone: "UTC",
+    year: "numeric",
+  }).format(new Date(createdAt));
+}
+
+function formatCount(count: number) {
+  return count.toLocaleString("en-US");
+}
+
+const styles = stylex.create({
+  overview: {
+    minWidth: 0,
+  },
+  main: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x8,
+  },
+  sectionHeader: {
+    display: "flex",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: space.x4,
+    paddingBottom: space.x3,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.sectionRule,
+  },
+  ratingLoading: {
+    display: "flex",
+    minHeight: "66px",
+    flexDirection: "column",
+    gap: space.x2,
+  },
+});

--- a/apps/web/src/app/(app)/users/[username]/profilePassport.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profilePassport.stylex.tsx
@@ -1,0 +1,81 @@
+import type { Outputs } from "@peated/server/orpc/router";
+import * as stylex from "@stylexjs/stylex";
+
+import { AppLink, BadgeImage } from "@peated/web/components";
+import { colors, fonts, space } from "../../../../styles/tokens.stylex";
+
+type BadgeAward = Outputs["users"]["badgeList"]["results"][number];
+
+export function ProfilePassport({ awards }: { awards: readonly BadgeAward[] }) {
+  if (!awards.length) {
+    return <p {...stylex.props(styles.empty)}>No stamps yet.</p>;
+  }
+
+  return (
+    <ul aria-label="Passport stamps" {...stylex.props(styles.list)}>
+      {awards.map((award) => (
+        <li key={award.id}>
+          <AppLink
+            href={`/badges/${award.badge.id}`}
+            {...stylex.props(styles.stamp)}
+          >
+            <BadgeImage badge={award.badge} level={award.level} size={40} />
+            <span {...stylex.props(styles.copy)}>
+              <strong {...stylex.props(styles.name)}>{award.badge.name}</strong>
+              <span {...stylex.props(styles.status)}>
+                {award.level ? "Stamped" : "In progress"}
+              </span>
+            </span>
+          </AppLink>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+const styles = stylex.create({
+  list: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space.x3,
+    margin: 0,
+    padding: 0,
+    listStyle: "none",
+  },
+  stamp: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "center",
+    gap: space.x3,
+    color: colors.ink,
+    textDecoration: "none",
+  },
+  copy: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x1,
+  },
+  name: {
+    overflow: "hidden",
+    fontFamily: fonts.display,
+    fontSize: "14px",
+    fontWeight: 700,
+    lineHeight: 1.25,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  status: {
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "10px",
+    lineHeight: 1.3,
+  },
+  empty: {
+    margin: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.5,
+  },
+});

--- a/apps/web/src/app/(app)/users/[username]/tastings/page.tsx
+++ b/apps/web/src/app/(app)/users/[username]/tastings/page.tsx
@@ -1,0 +1,32 @@
+import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
+import { createServerClient } from "@peated/web/lib/orpc/client.server";
+import { getProfilePage } from "@peated/web/lib/profilePage.server";
+
+import { ProfileTastingsPageClient } from "./profileTastingsPageClient.stylex";
+
+export const fetchCache = "default-no-store";
+
+export default async function ProfilePageRoute(props: {
+  params: Promise<{ username: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const { username } = await props.params;
+  const { client } = await createServerClient();
+  const user = await getProfilePage(username);
+  const tastingInput = getApiQueryParams(await props.searchParams, {
+    defaults: { cursor: 1 },
+    numericFields: ["cursor"],
+    overrides: { limit: 10, user: user.id },
+  });
+  const [regionList, tastingList] = await Promise.all([
+    client.users.regionList({ user: user.id }),
+    client.tastings.list(tastingInput),
+  ]);
+
+  return (
+    <ProfileTastingsPageClient
+      initialRegionList={regionList}
+      initialTastingList={tastingList}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsPageClient.stylex.tsx
@@ -22,7 +22,7 @@ import {
 import { TastingRecordEntry } from "@peated/web/components/tastingRecordEntry";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { useProfile } from "./profileContext";
+import { useProfile } from "../profileContext";
 
 type TastingList = Outputs["tastings"]["list"];
 type RegionList = Outputs["users"]["regionList"];
@@ -51,7 +51,9 @@ export function ProfileTastingsPageClient({
   });
 
   return (
-    <PageColumns rail={getRegionRail(regionQuery, user.username)}>
+    <PageColumns
+      rail={getRegionRail(regionQuery, user.username, isCurrentUser)}
+    >
       <section aria-label={`${user.username}'s tastings`}>
         {tastingQuery.isPending ? (
           <LoadingList label="Loading member tastings" rows={4} />
@@ -60,8 +62,8 @@ export function ProfileTastingsPageClient({
             heading="Tastings are unavailable"
             onRetry={() => void tastingQuery.refetch()}
           >
-            The member profile is still available. Try loading their tastings
-            again.
+            The profile is still available. Try loading{" "}
+            {isCurrentUser ? "your" : "their"} tastings again.
           </SectionError>
         ) : tastingQuery.data.results.length ? (
           <ItemList ariaLabel={`${user.username}'s tasting records`}>
@@ -113,10 +115,12 @@ export function ProfileTastingsPageClient({
 function getRegionRail(
   query: ReturnType<typeof useQuery<RegionList>>,
   username: string,
+  isCurrentUser: boolean,
 ) {
+  const heading = isCurrentUser ? "What you pour" : "What they pour";
   if (query.isPending) {
     return (
-      <RailSection heading="What they pour">
+      <RailSection heading={heading}>
         <LoadingList label="Loading member regions" rows={3} />
       </RailSection>
     );
@@ -133,7 +137,7 @@ function getRegionRail(
   }
   if (!query.data.results.length) return undefined;
   return (
-    <RailSection heading="What they pour">
+    <RailSection heading={heading}>
       <RailList ariaLabel={`${username}'s most tasted regions`}>
         {query.data.results.slice(0, 6).map((item) => (
           <RailListItem

--- a/apps/web/src/components/pages/memberProfileHeader.stories.tsx
+++ b/apps/web/src/components/pages/memberProfileHeader.stories.tsx
@@ -11,13 +11,6 @@ const meta = {
   title: "Components/Members/Profile Header",
   component: MemberProfileHeader,
   args: {
-    bands: {
-      good: 15,
-      mediocre: 4,
-      outstanding: 44,
-      unicorn: 10,
-      very_good: 31,
-    },
     username: "dcramer",
   },
   decorators: [
@@ -35,7 +28,6 @@ type Story = StoryObj<MemberProfileHeaderProps>;
 export const AnotherMember: Story = {
   args: {
     actions: <Button variant="accent">Add friend</Button>,
-    ratingLabel: "How they rate",
   },
 };
 
@@ -51,8 +43,6 @@ export const YourProfile: Story = {
         </ButtonLink>
       </>
     ),
-    metadata: ["Joined August 2026"],
-    ratingLabel: "How you rate",
   },
 };
 
@@ -60,14 +50,5 @@ export const Private: Story = {
   args: {
     actions: <Button variant="accent">Add friend</Button>,
     privateProfile: true,
-    bands: undefined,
-  },
-};
-
-export const RatingLoading: Story = {
-  args: {
-    actions: <Button variant="accent">Add friend</Button>,
-    bands: undefined,
-    ratingsLoading: true,
   },
 };

--- a/apps/web/src/components/pages/memberProfileHeader.stylex.tsx
+++ b/apps/web/src/components/pages/memberProfileHeader.stylex.tsx
@@ -1,12 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import {
-  Chip,
-  LoadingPlaceholder,
-  TastingRatingDistribution,
-  type TastingRatingCounts,
-} from "..";
+import { Chip } from "..";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import {
   colors,
@@ -15,85 +10,38 @@ import {
   space,
 } from "../../styles/tokens.stylex";
 
-const FOLDED = "@media (max-width: 899px)";
 const PHONE = "@media (max-width: 559px)";
 
 export type MemberProfileHeaderProps = {
   actions?: ReactNode;
-  badges?: readonly string[];
-  metadata?: readonly string[];
   pictureUrl?: string | null;
   privateProfile?: boolean;
-  ratingLabel?: "How they rate" | "How you rate";
-  bands?: TastingRatingCounts;
-  ratingsLoading?: boolean;
   username: string;
 };
 
-/** Presents API-owned member identity, actions, and rating distribution. */
+/** Presents member identity, private status, and profile actions. */
 export function MemberProfileHeader({
   actions,
-  badges = [],
-  metadata = [],
   pictureUrl,
   privateProfile = false,
-  ratingLabel = "How they rate",
-  bands,
-  ratingsLoading = false,
   username,
 }: MemberProfileHeaderProps) {
-  const showRatings = Boolean(bands || ratingsLoading);
-
   return (
     <header {...stylex.props(styles.header)}>
       <ProfileAvatar pictureUrl={pictureUrl} username={username} />
       <div {...stylex.props(styles.copy)}>
-        {privateProfile || badges.length ? (
-          <div {...stylex.props(styles.badges)}>
-            {privateProfile ? (
-              <Chip variant="tinted">Private profile</Chip>
-            ) : null}
-            {badges.map((badge) => (
-              <Chip key={badge}>{badge}</Chip>
-            ))}
+        {privateProfile ? (
+          <div {...stylex.props(styles.status)}>
+            <Chip variant="tinted">Private profile</Chip>
           </div>
         ) : null}
         <h1 {...stylex.props(foundationStyles.pageTitle, styles.title)}>
           {username}
         </h1>
-        {metadata.length ? (
-          <div {...stylex.props(styles.metadata)}>
-            {metadata.map((item, index) => (
-              <span key={item}>
-                {index ? <span aria-hidden="true"> · </span> : null}
-                {item}
-              </span>
-            ))}
-          </div>
-        ) : null}
         {actions ? (
           <div {...stylex.props(styles.actions)}>{actions}</div>
         ) : null}
       </div>
-      {showRatings ? (
-        <section aria-label={ratingLabel} {...stylex.props(styles.ratings)}>
-          <h2 {...stylex.props(styles.ratingLabel)}>{ratingLabel}</h2>
-          {bands ? (
-            <TastingRatingDistribution counts={bands} showCounts />
-          ) : (
-            <div
-              aria-busy="true"
-              aria-label="Loading member rating distribution"
-              role="status"
-              {...stylex.props(styles.ratingLoading)}
-            >
-              <LoadingPlaceholder preset="heading" />
-              <LoadingPlaceholder delay={1} preset="text" />
-              <LoadingPlaceholder delay={2} preset="metadata" />
-            </div>
-          )}
-        </section>
-      ) : null}
     </header>
   );
 }
@@ -130,15 +78,12 @@ const styles = stylex.create({
   header: {
     display: "grid",
     minWidth: 0,
-    gridTemplateColumns: "76px minmax(0, 1fr) 336px",
+    gridTemplateColumns: "76px minmax(0, 1fr)",
     alignItems: "start",
     gap: space.x6,
     paddingTop: space.x6,
     paddingBottom: space.x6,
     backgroundColor: "transparent",
-    [FOLDED]: {
-      gridTemplateColumns: "76px minmax(0, 1fr)",
-    },
     [PHONE]: {
       gridTemplateColumns: "64px minmax(0, 1fr)",
       gap: space.x4,
@@ -164,7 +109,7 @@ const styles = stylex.create({
   copy: {
     minWidth: 0,
   },
-  badges: {
+  status: {
     display: "flex",
     gap: space.x2,
     marginBottom: space.x2,
@@ -173,48 +118,11 @@ const styles = stylex.create({
   title: {
     overflowWrap: "anywhere",
   },
-  metadata: {
-    marginTop: space.x2,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.45,
-  },
   actions: {
     display: "flex",
     alignItems: "center",
     gap: space.x2,
     marginTop: space.x4,
     flexWrap: "wrap",
-  },
-  ratings: {
-    minWidth: 0,
-    [FOLDED]: {
-      gridColumn: 2,
-    },
-    [PHONE]: {
-      gridColumn: "1 / -1",
-      paddingTop: space.x4,
-      borderTopWidth: "1px",
-      borderTopStyle: "solid",
-      borderTopColor: colors.hairline,
-    },
-  },
-  ratingLabel: {
-    margin: 0,
-    marginBottom: space.x2,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 400,
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
-  },
-  ratingLoading: {
-    display: "flex",
-    minHeight: "66px",
-    flexDirection: "column",
-    gap: space.x2,
   },
 });

--- a/apps/web/src/components/tastingEntry.stories.tsx
+++ b/apps/web/src/components/tastingEntry.stories.tsx
@@ -17,15 +17,15 @@ const meta = {
         href: "/bottles/lagavulin-16",
         metadata: "Islay · 16 years · 43% ABV",
         name: "Lagavulin 16-year-old",
-        notes: ["Smoke", "Dried fruit", "Sea salt"],
         ratingBand: "outstanding",
+        tags: ["Smoke", "Dried fruit", "Sea salt"],
       },
       {
         href: "/bottles/ardbeg-uigeadail",
         metadata: "Islay · No age statement · 54.2% ABV",
         name: "Ardbeg Uigeadail",
-        notes: ["Tar", "Raisin", "Espresso"],
         ratingBand: "good",
+        tags: ["Tar", "Raisin", "Espresso"],
       },
     ],
     menu: (
@@ -74,18 +74,18 @@ export const Overview: Story = {
   ),
 };
 
-export const LongDescription: Story = {
+export const LongNotes: Story = {
   args: {
     members: [
       {
-        description:
+        notes:
           "The nose starts with wood smoke, dried orange, and old leather before moving into dark chocolate and sea salt. The palate adds roasted coffee, black pepper, and a little raisin sweetness. With time, the smoke softens and more fruit comes through. The finish is long, dry, and smoky, with espresso and orange peel lingering after the last sip.",
-        descriptionHref: "/tastings/42",
+        notesHref: "/tastings/42",
         href: "/bottles/lagavulin-16",
         metadata: "Islay · 16 years · 43% ABV",
         name: "Lagavulin 16-year-old",
-        notes: ["Smoke", "Dried fruit", "Sea salt"],
         ratingBand: "outstanding",
+        tags: ["Smoke", "Dried fruit", "Sea salt"],
       },
     ],
   },

--- a/apps/web/src/components/tastingEntry.stylex.tsx
+++ b/apps/web/src/components/tastingEntry.stylex.tsx
@@ -21,17 +21,17 @@ export type TastingMediaKind = "bottle" | "photo";
 export type TastingEntryMember = {
   color?: string;
   comments?: number;
-  description?: string;
-  descriptionHref?: string;
   hasToasted?: boolean;
   href?: string;
   imageKind?: TastingMediaKind;
   imageUrl?: string | null;
   metadata?: string;
   name: string;
-  notes?: readonly string[];
+  notes?: string;
+  notesHref?: string;
   ratingBand?: RatingBand;
   servingStyle?: string;
+  tags?: readonly string[];
   tastingId?: number;
   toasts?: number;
 };
@@ -133,26 +133,19 @@ export function TastingEntry({
                 </div>
                 {menu ? <div {...stylex.props(styles.menu)}>{menu}</div> : null}
               </div>
-              <p
-                {...stylex.props(
-                  styles.description,
-                  !member.description && styles.emptyDescription,
-                )}
-              >
-                {member.description ? (
-                  <TastingDescription member={member} />
-                ) : (
-                  "No notes."
-                )}
-              </p>
-              {member.notes?.length ? (
-                <div {...stylex.props(styles.notes)}>
-                  {member.notes.map((note, index) => (
+              {member.notes?.trim() ? (
+                <p {...stylex.props(styles.notes)}>
+                  <TastingNotes member={member} />
+                </p>
+              ) : null}
+              {member.tags?.length ? (
+                <div {...stylex.props(styles.tags)}>
+                  {member.tags.map((tag, index) => (
                     <Chip
-                      key={`${note}-${index}`}
+                      key={`${tag}-${index}`}
                       variant={index < 2 ? "tinted" : "neutral"}
                     >
-                      {note}
+                      {tag}
                     </Chip>
                   ))}
                 </div>
@@ -235,32 +228,28 @@ export function TastingMedia({
   );
 }
 
-const DESCRIPTION_PREVIEW_LENGTH = 180;
+const NOTES_PREVIEW_LENGTH = 180;
 
-function TastingDescription({ member }: { member: TastingEntryMember }) {
-  const description = member.description?.trim().replace(/\s+/g, " ");
+function TastingNotes({ member }: { member: TastingEntryMember }) {
+  const notes = member.notes?.trim().replace(/\s+/g, " ");
 
-  if (
-    !member.descriptionHref ||
-    !description ||
-    description.length <= DESCRIPTION_PREVIEW_LENGTH
-  ) {
-    return member.description;
+  if (!member.notesHref || !notes || notes.length <= NOTES_PREVIEW_LENGTH) {
+    return member.notes;
   }
 
-  const wordBoundary = description
-    .slice(0, DESCRIPTION_PREVIEW_LENGTH + 1)
+  const wordBoundary = notes
+    .slice(0, NOTES_PREVIEW_LENGTH + 1)
     .lastIndexOf(" ");
-  const cutoff = wordBoundary > 0 ? wordBoundary : DESCRIPTION_PREVIEW_LENGTH;
-  const preview = `${description.slice(0, cutoff).trimEnd()}…`;
+  const cutoff = wordBoundary > 0 ? wordBoundary : NOTES_PREVIEW_LENGTH;
+  const preview = `${notes.slice(0, cutoff).trimEnd()}…`;
 
   return (
     <>
       {preview}{" "}
       <AppLink
         aria-label={`Read the full tasting notes for ${member.name}`}
-        href={member.descriptionHref}
-        {...stylex.props(styles.descriptionLink)}
+        href={member.notesHref}
+        {...stylex.props(styles.notesLink)}
       >
         Read more <span aria-hidden="true">→</span>
       </AppLink>
@@ -403,7 +392,7 @@ const styles = stylex.create({
     textOverflow: { default: "ellipsis", [COMPACT]: "clip" },
     whiteSpace: { default: "nowrap", [COMPACT]: "normal" },
   },
-  description: {
+  notes: {
     margin: 0,
     marginTop: "14px",
     color: colors.ink,
@@ -412,10 +401,7 @@ const styles = stylex.create({
     lineHeight: 1.6,
     whiteSpace: "pre-wrap",
   },
-  emptyDescription: {
-    color: colors.inkMuted,
-  },
-  descriptionLink: {
+  notesLink: {
     color: colors.accentDeep,
     fontWeight: 600,
     textDecoration: {
@@ -429,7 +415,7 @@ const styles = stylex.create({
     },
     whiteSpace: "nowrap",
   },
-  notes: {
+  tags: {
     display: "flex",
     flexWrap: "wrap",
     gap: "6px",

--- a/apps/web/src/components/tastingEntry.test.tsx
+++ b/apps/web/src/components/tastingEntry.test.tsx
@@ -3,35 +3,32 @@ import { describe, expect, it } from "vitest";
 
 import { TastingEntry } from "./tastingEntry.stylex";
 
-function renderDescription(description: string, descriptionHref?: string) {
+function renderNotes(notes: string, notesHref?: string) {
   return renderToStaticMarkup(
     <TastingEntry
       author="peatfan"
       date="Today"
       members={[
         {
-          description,
-          descriptionHref,
           name: "Lagavulin 16-year-old",
+          notes,
+          notesHref,
         },
       ]}
     />,
   );
 }
 
-describe("TastingEntry descriptions", () => {
+describe("TastingEntry notes", () => {
   it("shows short tasting notes without a details link", () => {
-    const html = renderDescription(
-      "Smoke, fruit, and sea salt.",
-      "/tastings/1",
-    );
+    const html = renderNotes("Smoke, fruit, and sea salt.", "/tastings/1");
 
     expect(html).toContain("Smoke, fruit, and sea salt.");
     expect(html).not.toContain("Read more");
   });
 
   it("shortens long tasting notes and links to the tasting details", () => {
-    const html = renderDescription(
+    const html = renderNotes(
       `${"Smoke, fruit, and sea salt. ".repeat(12)}The final sentence.`,
       "/tastings/42",
     );
@@ -45,14 +42,14 @@ describe("TastingEntry descriptions", () => {
   });
 
   it("shows the full tasting notes when no details link is provided", () => {
-    const description = `${"Smoke, fruit, and sea salt. ".repeat(12)}The final sentence.`;
-    const html = renderDescription(description);
+    const notes = `${"Smoke, fruit, and sea salt. ".repeat(12)}The final sentence.`;
+    const html = renderNotes(notes);
 
     expect(html).toContain("The final sentence.");
     expect(html).not.toContain("Read more");
   });
 
-  it("shows the recorded tasting details and discussion link", () => {
+  it("omits missing tasting notes and shows the recorded details", () => {
     const html = renderToStaticMarkup(
       <TastingEntry
         author="peatfan"
@@ -64,9 +61,9 @@ describe("TastingEntry descriptions", () => {
             imageKind: "photo",
             imageUrl: "/tasting.jpg",
             name: "Springbank 15",
-            notes: ["wax", "coal smoke"],
             ratingBand: "outstanding",
             servingStyle: "Neat",
+            tags: ["wax", "coal smoke"],
             tastingId: 42,
           },
         ]}
@@ -74,7 +71,7 @@ describe("TastingEntry descriptions", () => {
     );
 
     expect(html).toContain('src="/tasting.jpg"');
-    expect(html).toContain("No notes.");
+    expect(html).not.toContain("No notes.");
     expect(html).toContain("wax");
     expect(html).toContain("Neat");
     expect(html).toContain("Deep gold");

--- a/apps/web/src/components/tastingRecordEntry.tsx
+++ b/apps/web/src/components/tastingRecordEntry.tsx
@@ -43,15 +43,15 @@ export function getTastingEntryMember(
         ? undefined
         : formatColor(tasting.color),
     comments: tasting.comments,
-    description: tasting.notes ?? undefined,
-    descriptionHref: `/tastings/${tasting.id}`,
+    notes: tasting.notes ?? undefined,
+    notesHref: `/tastings/${tasting.id}`,
     hasToasted: tasting.hasToasted,
     href: getBottleUrl(tasting.bottle),
     imageKind: tasting.imageUrl ? "photo" : "bottle",
     imageUrl: tasting.imageUrl ?? tasting.bottle.imageUrl,
     metadata: getBottleMetadata(tasting.bottle),
     name: formatBottleDisplayName(tasting.bottle),
-    notes: tasting.tags ?? undefined,
+    tags: tasting.tags ?? undefined,
     ratingBand: tasting.ratingBand ?? undefined,
     servingStyle: tasting.servingStyle
       ? formatServingStyle(tasting.servingStyle)


### PR DESCRIPTION
Profiles now open on an Overview page with compact facts and recent activity, while Tastings moves to its own route and Library remains separate. The Overview rail shows frequently tasted distillers and bottlers as independent sections, followed by Passport stamps and a viewer-aware rating distribution. The profile header no longer carries oversized statistics or admin and moderator labels.

The tasting statistics response now includes ranked brands, bottlers, and distillers derived during its existing bottle scan. Tasting cards and details also omit missing notes instead of rendering a placeholder. Producer aggregation has integration coverage, and the shared tasting entry behavior is covered across the web test suite.
