### PR TITLE
docs: document public whisky data and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Peated
 
-The application that powers peated.com.
+Peated is a public record of whisky. Our goal is to document as much whisky as
+possible and make that data freely accessible to everyone.
 
-For more details, take a look at <https://peated.com/about>
+Browse the catalog at <https://peated.com> or read it through the public API at
+<https://peated.com/about/api>.
 
 A Discord is available if you want to contribute: <https://discord.gg/d7GFPfy88Z>
 

--- a/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
@@ -4,6 +4,7 @@ import { SiteFooter, type SiteFooterProps } from "@peated/web/components";
 
 const links = [
   { href: "/about", label: "About" },
+  { href: "/about/api", label: "API" },
   { href: "/about/categories", label: "Whisky categories" },
   { href: "/about/ratings", label: "Rating guide" },
   { href: "/events", label: "Whisky events" },
@@ -40,7 +41,7 @@ export function ApplicationFooter({ stats }: { stats?: Outputs["stats"] }) {
         },
       ]}
       responsibility="Drink responsibly"
-      statement="A record of whisky bottles, critic scores, and tasting notes from the people who drank them."
+      statement="A public record of whisky bottles, critic scores, and tasting notes from the people who drank them."
     />
   );
 }

--- a/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
+++ b/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
@@ -13,6 +13,7 @@ const MOBILE = "@media (max-width: 559px)";
 
 const aboutTabs = [
   { href: "/about", label: "About" },
+  { href: "/about/api", label: "API" },
   { href: "/about/categories", label: "Whisky categories" },
   { href: "/about/ratings", label: "Rating guide" },
   { href: "/updates", label: "Recent changes" },
@@ -64,6 +65,21 @@ export function AboutLink({ children, ...props }: TextLinkProps) {
 export function AboutTextStack({ children }: { children: ReactNode }) {
   return <div {...stylex.props(styles.textStack)}>{children}</div>;
 }
+
+/* oxlint-disable jsx-a11y/no-noninteractive-tabindex -- Overflowing code must be keyboard-scrollable. */
+export function AboutCode({ children }: { children: string }) {
+  return (
+    <pre
+      aria-label="Example API request"
+      role="region"
+      tabIndex={0}
+      {...stylex.props(styles.codeBlock)}
+    >
+      <code>{children}</code>
+    </pre>
+  );
+}
+/* oxlint-enable jsx-a11y/no-noninteractive-tabindex */
 
 export function ReviewSteps({
   steps,
@@ -119,6 +135,18 @@ const styles = stylex.create({
     fontFamily: fonts.reading,
     fontSize: "15px",
     lineHeight: 1.7,
+  },
+  codeBlock: {
+    maxWidth: "100%",
+    margin: 0,
+    padding: space.x4,
+    overflowX: "auto",
+    borderRadius: "3px",
+    backgroundColor: colors.inset,
+    color: colors.ink,
+    fontFamily: fonts.data,
+    fontSize: "12px",
+    lineHeight: 1.55,
   },
   steps: {
     display: "grid",

--- a/apps/web/src/app/(app)/about/api/page.tsx
+++ b/apps/web/src/app/(app)/about/api/page.tsx
@@ -1,0 +1,109 @@
+import { RailList, RailListItem } from "@peated/web/components";
+import {
+  PageSection,
+  RailSection,
+} from "@peated/web/components/pages/pageLayout.stylex";
+import config from "@peated/web/config";
+import type { Metadata } from "next";
+import {
+  AboutCode,
+  AboutLink,
+  AboutPage,
+  AboutText,
+  AboutTextStack,
+} from "../aboutPage.stylex";
+
+export const dynamic = "force-static";
+
+export const metadata: Metadata = {
+  title: "Peated API",
+  description:
+    "How to read Peated's public whisky catalog through its JSON API.",
+};
+
+const bottleSearch =
+  'curl "https://api.peated.com/v1/bottles?query=Ardbeg&limit=10"';
+
+export default function ApiPage() {
+  return (
+    <AboutPage
+      currentHref="/about/api"
+      description="Peated publishes its whisky catalog through a JSON API."
+      eyebrow="Reference · JSON over HTTPS"
+      rail={
+        <RailSection heading="API resources">
+          <RailList ariaLabel="Peated API resources">
+            <RailListItem
+              href="https://api.peated.com"
+              metadata="Browse paths and response fields"
+              title="Live API reference"
+            />
+            <RailListItem
+              href="https://api.peated.com/spec.json"
+              metadata="OpenAPI 3.1 JSON"
+              title="OpenAPI specification"
+            />
+            <RailListItem href={config.GITHUB_REPO} title="Source on GitHub" />
+            <RailListItem
+              href={config.DISCORD_LINK}
+              metadata="Ask about access or integrations"
+              title="Peated on Discord"
+            />
+          </RailList>
+        </RailSection>
+      }
+      title="Peated API"
+    >
+      <PageSection heading="Read the catalog">
+        <AboutTextStack>
+          <AboutText>
+            The API lives at{" "}
+            <AboutLink href="https://api.peated.com/v1">
+              api.peated.com/v1
+            </AboutLink>
+            . Call it from a command line or server. Public catalog GET requests
+            return JSON without a token.
+          </AboutText>
+          <AboutCode>{bottleSearch}</AboutCode>
+          <AboutText>
+            This searches bottle names for “Ardbeg” and returns up to 10
+            matches. Bottle lists put records in <code>results</code>. When
+            <code> rel.nextCursor</code> contains a number, pass that number as
+            <code> cursor</code> to read the next page. A page can contain up to
+            100 records.
+          </AboutText>
+        </AboutTextStack>
+      </PageSection>
+
+      <PageSection heading="API reference">
+        <AboutText>
+          The{" "}
+          <AboutLink href="https://api.peated.com">
+            live API reference
+          </AboutLink>{" "}
+          lists every path, query parameter, and response field. Tools that read
+          OpenAPI can use the{" "}
+          <AboutLink href="https://api.peated.com/spec.json">
+            JSON specification
+          </AboutLink>
+          .
+        </AboutText>
+      </PageSection>
+
+      <PageSection heading="Account access">
+        <AboutTextStack>
+          <AboutText>
+            Actions tied to a member need an OAuth bearer token. Peated
+            registers OAuth clients manually; ask in{" "}
+            <AboutLink href={config.DISCORD_LINK}>Discord</AboutLink> if you are
+            building an integration.
+          </AboutText>
+          <AboutText>
+            Identify automated clients when possible, keep request rates
+            reasonable, and do not degrade the service.
+          </AboutText>
+        </AboutTextStack>
+      </PageSection>
+    </AboutPage>
+  );
+}

--- a/apps/web/src/app/(app)/about/page.tsx
+++ b/apps/web/src/app/(app)/about/page.tsx
@@ -23,7 +23,7 @@ export const dynamic = "force-static";
 export const metadata: Metadata = {
   title: "About",
   description:
-    "How Peated records whisky bottles, the people who make them, and what drinkers thought.",
+    "Peated is a public record of whisky bottles, the people who make them, and what drinkers thought.",
 };
 
 export default async function AboutRoute() {
@@ -32,7 +32,7 @@ export default async function AboutRoute() {
   return (
     <AboutPage
       currentHref="/about"
-      description="A community-maintained record of whisky bottles, the people who make them, and what the people who drank them thought."
+      description="A public record of whisky bottles, the people who make them, and what the people who drank them thought."
       eyebrow="Reference · edited by members"
       rail={
         <>
@@ -91,14 +91,14 @@ export default async function AboutRoute() {
       <PageSection heading="Why Peated exists">
         <AboutTextStack>
           <AboutText>
-            Peated is a social record for tasting and collecting whisky. It
-            gives you one place to identify a bottle, record what you drank, and
-            leave useful notes.
+            Peated exists to document as much whisky as possible and make that
+            record freely accessible to everyone. You can browse the catalog,
+            suggest a correction, or read the data through the public API.
           </AboutText>
           <AboutText>
-            The catalog is central to that work. It combines public sources with
-            corrections from members. The same API that serves the site is open
-            to anyone building on top of it.
+            The catalog combines public sources with corrections from members.
+            Members can also record what they drank and add tasting notes and
+            reviews.
           </AboutText>
         </AboutTextStack>
       </PageSection>
@@ -122,7 +122,7 @@ export default async function AboutRoute() {
           facts={[
             { label: "Started", value: "2023" },
             { label: "Maintained by", value: "Members" },
-            { label: "License", value: "Apache 2.0" },
+            { label: "Source code license", value: "Apache 2.0" },
             { label: "API", value: "Public" },
           ]}
           layout="grid"


### PR DESCRIPTION
Peated now states its goal plainly in the README and About page: document as much whisky as possible and keep the record freely accessible. The About copy also distinguishes the Apache 2.0 source-code license from the public API.

The site footer and About navigation now link to `/about/api`. That guide uses the existing About page layout and explains anonymous catalog reads, pagination, the live OpenAPI reference, and OAuth access for member actions.
