### PR TITLE
fix(web): improve tasting form hierarchy

### DIFF
--- a/apps/web/e2e/add-bottle.spec.ts
+++ b/apps/web/e2e/add-bottle.spec.ts
@@ -604,12 +604,10 @@ test.describe("add bottle flow", () => {
     expect(addBottleUrl.searchParams.get("pendingImageUrl")).toBe(
       pendingScanImageUrl,
     );
-    await expect(
-      getSelectedBottleImage(
-        page,
-        formatBottleDisplayName(existingBottleDetails),
-      ),
-    ).toHaveAttribute("src", pendingScanImageUrl);
+    await expect(getSelectedBottleImage(page)).toHaveAttribute(
+      "src",
+      pendingScanImageUrl,
+    );
     await expect(
       page.getByRole("link", { name: "Search Bottles" }),
     ).toHaveAttribute(
@@ -645,7 +643,12 @@ test.describe("add bottle flow", () => {
       page.getByRole("heading", { name: "Added to Library" }),
     ).toBeVisible();
     await expect(
-      getSelectedBottle(page, formatBottleDisplayName(existingBottleDetails)),
+      getSelectedBottle(
+        page,
+        formatBottleDisplayName(existingBottleDetails, {
+          includeBrand: false,
+        }),
+      ),
     ).toBeVisible();
   });
 
@@ -736,14 +739,17 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("heading", { name: "Added to Library" }),
     ).toBeVisible();
+    await expect(getSelectedBottleImage(page)).toHaveAttribute(
+      "src",
+      /library\.webp$/,
+    );
     await expect(
-      getSelectedBottleImage(
+      getSelectedBottle(
         page,
-        formatBottleDisplayName(existingBottleDetails),
+        formatBottleDisplayName(existingBottleDetails, {
+          includeBrand: false,
+        }),
       ),
-    ).toHaveAttribute("src", /library\.webp$/);
-    await expect(
-      getSelectedBottle(page, formatBottleDisplayName(existingBottleDetails)),
     ).toBeVisible();
     await expect(
       page.getByRole("button", { name: "Add another to Library" }),
@@ -799,12 +805,10 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("heading", { name: "Added to Library" }),
     ).toBeVisible();
-    await expect(
-      getSelectedBottleImage(
-        page,
-        formatBottleDisplayName(existingBottleDetails),
-      ),
-    ).toHaveAttribute("src", /library\.webp$/);
+    await expect(getSelectedBottleImage(page)).toHaveAttribute(
+      "src",
+      /library\.webp$/,
+    );
   });
 
   test("redirects to login when a scan hits an expired session", async ({
@@ -1075,9 +1079,7 @@ test.describe("add bottle flow", () => {
     await expect(
       page.getByRole("heading", { name: "Log a tasting" }),
     ).toBeVisible();
-    await expect(
-      page.getByText(`${testBrand.name} ${createdBottleName}`),
-    ).toBeVisible();
+    await expect(getSelectedBottle(page, createdBottleName)).toBeVisible();
     await page.getByRole("button", { name: /^Log a tasting/ }).click();
     await page
       .getByRole("radio", { name: /^Very good/ })
@@ -1138,7 +1140,12 @@ test.describe("add bottle flow", () => {
       page.getByRole("heading", { name: "Added to Library" }),
     ).toBeVisible();
     await expect(
-      getSelectedBottle(page, formatBottleDisplayName(existingBottleDetails)),
+      getSelectedBottle(
+        page,
+        formatBottleDisplayName(existingBottleDetails, {
+          includeBrand: false,
+        }),
+      ),
     ).toBeVisible();
   });
 
@@ -1164,7 +1171,10 @@ test.describe("add bottle flow", () => {
       page.getByRole("heading", { name: "Log a tasting" }),
     ).toBeVisible();
     await expect(
-      page.getByText(formatBottleDisplayName(existingBottle)),
+      getSelectedBottle(
+        page,
+        formatBottleDisplayName(existingBottle, { includeBrand: false }),
+      ),
     ).toBeVisible();
   });
 
@@ -1384,9 +1394,10 @@ test.describe("add bottle flow", () => {
       page.getByRole("heading", { name: "Bottle added" }),
     ).toBeVisible();
     await expect(page.getByRole("link", { name: "Add Similar" })).toBeHidden();
-    await expect(
-      getSelectedBottleImage(page, createdBottleName),
-    ).toHaveAttribute("src", pendingScanImageUrl);
+    await expect(getSelectedBottleImage(page)).toHaveAttribute(
+      "src",
+      pendingScanImageUrl,
+    );
     await expect(getSelectedBottle(page, createdBottleName)).toBeVisible();
 
     const libraryRequestPromise = waitForCollectionBottleCreate(page);
@@ -1425,7 +1436,7 @@ test.describe("add bottle flow", () => {
     const createdUrl = new URL(page.url());
     expect(createdUrl.searchParams.get("pendingImageId")).toBeNull();
     expect(createdUrl.searchParams.get("pendingImageUrl")).toBeNull();
-    await expect(getSelectedBottleImage(page, createdBottleName)).toBeHidden();
+    await expect(getSelectedBottleImage(page)).toBeHidden();
 
     const libraryRequestPromise = waitForCollectionBottleCreate(page);
     await page.getByRole("button", { name: "Add to Library" }).click();
@@ -1454,11 +1465,8 @@ function getSelectedBottle(page: Page, name: string) {
     .getByText(name, { exact: false });
 }
 
-function getSelectedBottleImage(page: Page, name: string) {
-  return page
-    .getByRole("region", { name: "Selected bottle" })
-    .getByRole("img", { name: `${name} bottle` })
-    .locator("img");
+function getSelectedBottleImage(page: Page) {
+  return page.getByRole("region", { name: "Selected bottle" }).locator("img");
 }
 
 async function toggleBottleBoolean(page: Page, label: string) {

--- a/apps/web/e2e/record-tasting.spec.ts
+++ b/apps/web/e2e/record-tasting.spec.ts
@@ -115,7 +115,7 @@ test.describe("log tasting", () => {
     );
     await chooseVeryGood(page);
     await snapshot("Tasting form / Tasting / 1 Rating", {
-      ready: page.getByRole("heading", { name: "Your rating" }),
+      ready: page.getByRole("heading", { name: "How was it?" }),
     });
     await fillComments(page, tastingNotes);
     await snapshot("Tasting form / Tasting / 2 Notes", {

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -141,10 +141,10 @@ function BottlePanel({
 }) {
   return (
     <SelectedBottleSummary
-      bottleId={bottle.peatedId}
+      brand={bottle.brand.shortName || bottle.brand.name}
       imageUrl={previewUrl ?? bottle.imageUrl}
       metadata={getBottleMetadata(bottle)}
-      name={formatBottleDisplayName(bottle)}
+      name={formatBottleDisplayName(bottle, { includeBrand: false })}
     />
   );
 }
@@ -152,10 +152,10 @@ function BottlePanel({
 function CollectionBottlePanel({ entry }: { entry: CollectionBottle }) {
   return (
     <SelectedBottleSummary
-      bottleId={entry.bottle.peatedId}
+      brand={entry.bottle.brand.shortName || entry.bottle.brand.name}
       imageUrl={entry.imageUrl ?? entry.bottle.imageUrl}
       metadata={getBottleMetadata(entry.bottle)}
-      name={formatBottleDisplayName(entry.bottle)}
+      name={formatBottleDisplayName(entry.bottle, { includeBrand: false })}
     />
   );
 }

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/audit/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/audit/page.tsx
@@ -85,10 +85,10 @@ function AuditBottleForm({ bottleId }: { bottleId: string }) {
       <form onSubmit={runAudit}>
         <FormStack>
           <SelectedBottleSummary
-            bottleId={bottle.peatedId}
+            brand={bottle.brand.shortName || bottle.brand.name}
             imageUrl={bottle.imageUrl}
             metadata={getBottleMetadata(bottle)}
-            name={formatBottleDisplayName(bottle)}
+            name={formatBottleDisplayName(bottle, { includeBrand: false })}
           />
           {error ? <FormNotice>{error}</FormNotice> : null}
           {summary ? (

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
@@ -134,10 +134,10 @@ function MergeBottleForm({ bottleId }: { bottleId: string }) {
       <form onSubmit={handleSubmit(submit)}>
         <FormStack>
           <SelectedBottleSummary
-            bottleId={bottle.peatedId}
+            brand={bottle.brand.shortName || bottle.brand.name}
             imageUrl={bottle.imageUrl}
             metadata={getBottleMetadata(bottle)}
-            name={formatBottleDisplayName(bottle)}
+            name={formatBottleDisplayName(bottle, { includeBrand: false })}
           />
           {submitError ? <FormNotice>{submitError}</FormNotice> : null}
           <FormSection title="Duplicate bottle">

--- a/apps/web/src/components/bottleResolver/states.tsx
+++ b/apps/web/src/components/bottleResolver/states.tsx
@@ -249,10 +249,12 @@ export function PhotoMatchCreateState({
             />
           ) : null}
           <SelectedBottleSummary
-            bottleId={matchedBottle.peatedId}
+            brand={matchedBottle.brand.shortName || matchedBottle.brand.name}
             imageUrl={matchedBottle.imageUrl}
             metadata={getMatchedBottleMetadata(matchedBottle)}
-            name={formatBottleDisplayName(matchedBottle)}
+            name={formatBottleDisplayName(matchedBottle, {
+              includeBrand: false,
+            })}
           />
           <LabelFacts result={result} />
           {renderMatchedResultActions ? (

--- a/apps/web/src/components/formLayout.stylex.tsx
+++ b/apps/web/src/components/formLayout.stylex.tsx
@@ -64,6 +64,15 @@ export type FormStepsProps = {
 export function FormSteps({ currentStep, steps }: FormStepsProps) {
   return (
     <nav aria-label="Form progress" {...stylex.props(styles.steps)}>
+      <div {...stylex.props(styles.stepSummary)}>
+        <strong {...stylex.props(styles.stepSummaryLabel)}>
+          {steps[currentStep]}
+        </strong>
+        <span aria-hidden="true">·</span>
+        <span>
+          {currentStep + 1} of {steps.length}
+        </span>
+      </div>
       <ol {...stylex.props(styles.stepList)}>
         {steps.map((step, index) => (
           <li
@@ -75,16 +84,20 @@ export function FormSteps({ currentStep, steps }: FormStepsProps) {
               index === currentStep && styles.currentStep,
             )}
           >
-            <span aria-hidden="true">{index + 1}</span>
             <span title={step} {...stylex.props(styles.stepLabel)}>
               {step}
             </span>
+            <span
+              aria-hidden="true"
+              {...stylex.props(
+                styles.stepSegment,
+                index < currentStep && styles.completedStepSegment,
+                index === currentStep && styles.currentStepSegment,
+              )}
+            />
           </li>
         ))}
       </ol>
-      <span {...stylex.props(styles.stepCount)}>
-        Step {currentStep + 1} of {steps.length}
-      </span>
     </nav>
   );
 }
@@ -211,35 +224,47 @@ const styles = stylex.create({
     boxSizing: "border-box",
     display: "flex",
     minWidth: 0,
-    alignItems: "center",
-    gap: space.x4,
+    flexDirection: "column",
+    rowGap: space.x2,
     paddingTop: 0,
     paddingRight: 0,
     paddingBottom: space.x3,
     paddingLeft: 0,
     backgroundColor: "transparent",
-    "@media (max-width: 559px)": {
-      gap: space.x3,
-    },
+  },
+  stepSummary: {
+    display: "none",
+    alignItems: "baseline",
+    columnGap: space.x1,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    lineHeight: 1.4,
+    "@media (max-width: 559px)": { display: "flex" },
+  },
+  stepSummaryLabel: {
+    color: colors.ink,
+    fontFamily: fonts.display,
+    fontWeight: 700,
+    letterSpacing: "-0.02em",
   },
   stepList: {
     display: "flex",
     minWidth: 0,
-    flex: 1,
-    gap: space.x4,
+    gap: space.x2,
     margin: 0,
     padding: 0,
     listStyle: "none",
-    "@media (max-width: 559px)": { gap: space.x3 },
   },
   step: {
     display: "flex",
     minWidth: 0,
-    alignItems: "baseline",
+    flex: 1,
+    flexDirection: "column",
     gap: space.x2,
     color: colors.inkMuted,
     fontFamily: fonts.reading,
-    fontSize: "14px",
+    fontSize: "13px",
     fontWeight: 600,
     letterSpacing: 0,
     lineHeight: 1.3,
@@ -255,14 +280,17 @@ const styles = stylex.create({
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
+    "@media (max-width: 559px)": { display: "none" },
   },
-  stepCount: {
-    flexShrink: 0,
-    color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.3,
+  stepSegment: {
+    display: "block",
+    width: "100%",
+    height: "4px",
+    borderRadius: "2px",
+    backgroundColor: colors.hairline,
   },
+  completedStepSegment: { backgroundColor: colors.accent },
+  currentStepSegment: { backgroundColor: colors.accent },
   notice: {
     boxSizing: "border-box",
     padding: 0,

--- a/apps/web/src/components/pages/memberReviewForm.stories.tsx
+++ b/apps/web/src/components/pages/memberReviewForm.stories.tsx
@@ -54,18 +54,16 @@ export const Default: Story = {
         mobileSaveBar
         onClose={() => undefined}
         onSave={() => undefined}
-        saveHint={
-          isReview ? "Saving updates your existing review." : "Step 1 of 3"
-        }
+        saveHint={isReview ? "Saving updates your existing review." : undefined}
         saveLabel={isReview ? "Update review" : "Continue"}
         title={isReview ? "Edit your review" : "Log a tasting"}
       >
         <form>
           <FormStack>
             <SelectedBottleSummary
-              bottleId="B-14829"
+              brand="Springbank"
               metadata="46% ABV · 15 years · Campbeltown single malt"
-              name="Springbank 15"
+              name="15-year-old"
             />
             <RecordTypeInput
               disabled={false}
@@ -123,7 +121,7 @@ export const Default: Story = {
                   currentStep={0}
                   steps={["Rating", "Notes", "Details"]}
                 />
-                <FormSection title="Your rating">
+                <FormSection title="How was it?">
                   <RatingBandInput
                     id="tasting-rating"
                     name="rating"

--- a/apps/web/src/components/pages/workflowScreen.stories.tsx
+++ b/apps/web/src/components/pages/workflowScreen.stories.tsx
@@ -25,9 +25,9 @@ export const Overview: Story = {
     <WorkflowScreen {...args} saveHint="Step 2 of 3">
       <FormStack>
         <SelectedBottleSummary
-          bottleId="B00872"
+          brand="Ardbeg"
           metadata="54.2% ABV · NAS · Islay"
-          name="Ardbeg Uigeadail"
+          name="Uigeadail"
         />
         <FormSection title="Your tasting">
           <FormGrid>
@@ -56,9 +56,9 @@ export const Saving: Story = {
   render: (args) => (
     <WorkflowScreen {...args} saveHint="Saving this tasting">
       <SelectedBottleSummary
-        bottleId="B00872"
+        brand="Ardbeg"
         metadata="54.2% ABV · NAS · Islay"
-        name="Ardbeg Uigeadail"
+        name="Uigeadail"
       />
     </WorkflowScreen>
   ),

--- a/apps/web/src/components/selectedBottleSummary.stories.tsx
+++ b/apps/web/src/components/selectedBottleSummary.stories.tsx
@@ -8,10 +8,10 @@ const meta = {
   title: "Components/Bottles/Selected Bottle Summary",
   component: SelectedBottleSummary,
   args: {
-    bottleId: "B00872",
+    brand: "Lagavulin",
     imageUrl: BottleImage.src,
     metadata: "Islay · 16 years · 43.0% ABV · ex-bourbon",
-    name: "Lagavulin 16",
+    name: "16-year-old",
     onChange: () => undefined,
   },
   argTypes: {
@@ -35,7 +35,7 @@ export const Overview: Story = {
       <SelectedBottleSummary {...args} />
       <SelectedBottleSummary {...args} onChange={undefined} />
       <SelectedBottleSummary
-        bottleId="B104281"
+        brand="Bruichladdich"
         imageUrl={null}
         metadata="Islay · No age statement · 61.5% ABV · oloroso and bourbon casks"
         name="Octomore Edition 15.3 Islay Barley Super Heavily Peated"

--- a/apps/web/src/components/selectedBottleSummary.stylex.tsx
+++ b/apps/web/src/components/selectedBottleSummary.stylex.tsx
@@ -1,11 +1,8 @@
-import * as stylex from "@stylexjs/stylex";
-
-import { colors, fonts, space } from "../styles/tokens.stylex";
-import { BottleVisual } from "./bottleIdentityRow.stylex";
+import { BottleIdentityRow } from "./bottleIdentityRow.stylex";
 import { Button } from "./button.stylex";
 
 export type SelectedBottleSummaryProps = {
-  bottleId: string;
+  brand: string;
   imageUrl?: string | null;
   metadata: string;
   name: string;
@@ -15,74 +12,29 @@ export type SelectedBottleSummaryProps = {
 
 /** Keeps the selected bottle visible while a member completes a related form. */
 export function SelectedBottleSummary({
-  bottleId,
+  brand,
   imageUrl,
   metadata,
   name,
   onChange,
 }: SelectedBottleSummaryProps) {
   return (
-    <section aria-label="Selected bottle" {...stylex.props(styles.summary)}>
-      <BottleVisual imageUrl={imageUrl} label={`${name} bottle`} size="sm" />
-      <div {...stylex.props(styles.copy)}>
-        <strong title={name} {...stylex.props(styles.name)}>
-          {name}
-        </strong>
-        <span
-          title={`${bottleId} · ${metadata}`}
-          {...stylex.props(styles.metadata)}
-        >
-          {bottleId} · {metadata}
-        </span>
-      </div>
-      {onChange ? (
-        <Button onClick={onChange} size="sm" variant="text">
-          Change bottle
-        </Button>
-      ) : null}
+    <section aria-label="Selected bottle">
+      <BottleIdentityRow
+        brand={brand}
+        end={
+          onChange ? (
+            <Button onClick={onChange} size="sm" variant="text">
+              Change bottle
+            </Button>
+          ) : undefined
+        }
+        imageUrl={imageUrl}
+        layout="cell"
+        metadata={metadata ? metadata.split(" · ") : []}
+        name={name}
+        size="sm"
+      />
     </section>
   );
 }
-
-const styles = stylex.create({
-  summary: {
-    boxSizing: "border-box",
-    display: "flex",
-    width: "100%",
-    minWidth: 0,
-    alignItems: "center",
-    gap: space.x3,
-    paddingTop: space.x3,
-    paddingRight: 0,
-    paddingBottom: space.x3,
-    paddingLeft: 0,
-    backgroundColor: "transparent",
-  },
-  copy: {
-    display: "flex",
-    minWidth: 0,
-    flex: 1,
-    flexDirection: "column",
-    rowGap: space.x1,
-  },
-  name: {
-    overflow: "hidden",
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 700,
-    letterSpacing: "-0.025em",
-    lineHeight: 1.25,
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-  },
-  metadata: {
-    overflow: "hidden",
-    color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-  },
-});

--- a/apps/web/src/components/servingStyleInput.stories.tsx
+++ b/apps/web/src/components/servingStyleInput.stories.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { useState } from "react";
+
+import { StoryCanvas, StoryStack } from "./storyFixtures.stylex";
+import { ServingStyleInput, type ServingStyle } from "./tastingInputs.stylex";
+
+const meta = {
+  title: "Components/Forms/Serving Style",
+  component: ServingStyleInput,
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="compact">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+  args: {
+    id: "serving",
+    name: "servingStyle",
+    onChange: () => undefined,
+    value: "neat",
+  },
+} satisfies Meta<typeof ServingStyleInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {
+  render: (args) => (
+    <StoryStack>
+      <ControlledServingStyleInput {...args} />
+      <ServingStyleInput
+        {...args}
+        disabled
+        id="disabled-serving"
+        name="disabled-serving"
+      />
+    </StoryStack>
+  ),
+};
+
+function ControlledServingStyleInput(
+  props: React.ComponentProps<typeof ServingStyleInput>,
+) {
+  const [value, setValue] = useState<ServingStyle | null>(props.value);
+
+  return <ServingStyleInput {...props} onChange={setValue} value={value} />;
+}

--- a/apps/web/src/components/tastingForm.tsx
+++ b/apps/web/src/components/tastingForm.tsx
@@ -318,10 +318,10 @@ export default function TastingForm(
         ? "Your review could not be loaded."
         : reviewScore === null
           ? "Enter a score to save."
-          : `Step ${currentStep + 1} of ${steps.length}`
+          : undefined
     : needsRating
       ? "Pick a rating to continue."
-      : `Step ${currentStep + 1} of ${steps.length}`;
+      : undefined;
   const saveLabel = isReview
     ? isLastStep
       ? reviewQuery.data
@@ -379,13 +379,18 @@ export default function TastingForm(
       <form onSubmit={formAction}>
         <FormStack>
           <SelectedBottleSummary
-            bottleId={initialData.bottle.peatedId}
+            brand={
+              initialData.bottle.brand.shortName ||
+              initialData.bottle.brand.name
+            }
             imageUrl={
               (isReview ? effectiveReviewImagePreview : imagePreview) ??
               initialData.bottle.imageUrl
             }
             metadata={getBottleMetadata(initialData.bottle)}
-            name={formatBottleDisplayName(initialData.bottle)}
+            name={formatBottleDisplayName(initialData.bottle, {
+              includeBrand: false,
+            })}
           />
           {submitError || errorMessage ? (
             <FormNotice>{submitError ?? errorMessage}</FormNotice>
@@ -585,7 +590,7 @@ export default function TastingForm(
             )
           ) : null}
           {recordType === "tasting" && currentStep === 0 ? (
-            <FormSection title="Your rating">
+            <FormSection title="How was it?">
               <Controller
                 control={control}
                 name="ratingBand"
@@ -593,7 +598,6 @@ export default function TastingForm(
                   <RatingBandInput
                     disabled={isSubmitting}
                     id="tasting-rating"
-                    label="How was it"
                     name={field.name}
                     onChange={field.onChange}
                     required={props.mode !== "edit"}

--- a/apps/web/src/components/tastingInputs.stylex.tsx
+++ b/apps/web/src/components/tastingInputs.stylex.tsx
@@ -2,7 +2,15 @@
 
 import { COLOR_SCALE, type SERVING_STYLE_LIST } from "@peated/server/constants";
 import * as stylex from "@stylexjs/stylex";
-import { Box, Droplets, GlassWater, Minus, Plus, Upload } from "lucide-react";
+import {
+  Box,
+  Check,
+  Droplets,
+  GlassWater,
+  Minus,
+  Plus,
+  Upload,
+} from "lucide-react";
 import { useRef } from "react";
 
 import {
@@ -176,26 +184,8 @@ export function RatingBandInput({
   required = false,
   value,
 }: RatingBandInputProps) {
-  const selectedBand = RATING_BANDS.find((band) => band.key === value);
-
   return (
     <div {...stylex.props(styles.scoreRoot, disabled && styles.disabled)}>
-      <div {...stylex.props(styles.ratingHeading)}>
-        <span {...stylex.props(styles.ratingLabel)}>{label}</span>
-        {required ? (
-          <span {...stylex.props(styles.requiredLabel)}>Required</span>
-        ) : null}
-      </div>
-      <div {...stylex.props(styles.bandSelectionHeading)}>
-        <strong {...stylex.props(styles.selectedBandLabel)}>
-          {selectedBand?.label ?? "Pick a rating"}
-        </strong>
-        {selectedBand ? (
-          <span {...stylex.props(styles.selectedBandRange)}>
-            {selectedBand.range}
-          </span>
-        ) : null}
-      </div>
       <div
         aria-label={label}
         role="radiogroup"
@@ -223,17 +213,30 @@ export function RatingBandInput({
                 value={band.key}
                 {...stylex.props(styles.visuallyHiddenInput)}
               />
-              <span {...stylex.props(styles.visuallyHiddenText)}>
-                {band.label}, {band.range}
-              </span>
               <span
-                aria-hidden="true"
                 {...stylex.props(
-                  styles.bandInputBracket,
-                  checked && bandInputBracketSelectedStyles[band.key],
+                  styles.bandInputName,
+                  checked && bandInputTextSelectedStyles[band.key],
                 )}
               >
-                {band.shortRange}
+                <Check
+                  aria-hidden="true"
+                  size={13}
+                  strokeWidth={2.5}
+                  {...stylex.props(
+                    styles.bandInputCheck,
+                    !checked && styles.bandInputCheckHidden,
+                  )}
+                />
+                {band.label}
+              </span>
+              <span
+                {...stylex.props(
+                  styles.bandInputRange,
+                  checked && bandInputTextSelectedStyles[band.key],
+                )}
+              >
+                {band.range}
               </span>
             </label>
           );
@@ -636,53 +639,46 @@ const styles = stylex.create({
   scoreRoot: {
     width: "100%",
   },
-  bandSelectionHeading: {
-    display: "flex",
-    alignItems: "baseline",
-    columnGap: space.x2,
-    marginTop: space.x3,
-  },
-  selectedBandLabel: {
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
-  },
-  selectedBandRange: {
-    color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
-  },
   bandInputTrack: {
     display: "grid",
     width: "100%",
-    height: "52px",
+    height: "64px",
     gridTemplateColumns: "repeat(5, minmax(0, 1fr))",
-    gap: "2px",
-    marginTop: space.x3,
+    gap: space.x1,
+    "@media (max-width: 559px)": {
+      height: "auto",
+      gridTemplateColumns: "minmax(0, 1fr)",
+      gap: space.x2,
+    },
   },
   bandInputCell: {
     position: "relative",
     minWidth: 0,
     display: "flex",
-    height: "52px",
+    height: "64px",
+    flexDirection: "column",
     alignItems: "center",
     justifyContent: "center",
+    rowGap: space.x1,
     overflow: "hidden",
     borderRadius: controlMetrics.radiusSmall,
-    backgroundColor: "transparent",
+    backgroundColor: colors.fieldBackground,
     cursor: "pointer",
     boxShadow: {
-      default: `inset 0 0 0 2px ${colors.fieldRule}`,
-      ":hover": `inset 0 0 0 2px ${colors.inkMuted}`,
+      default: `inset 0 0 0 1px ${colors.fieldRule}`,
+      ":hover": `inset 0 0 0 1px ${colors.inkMuted}`,
       ":focus-within": effects.focusRing,
     },
     opacity: {
       default: 1,
       ":hover": 0.86,
+    },
+    "@media (max-width: 559px)": {
+      height: "48px",
+      flexDirection: "row",
+      justifyContent: "space-between",
+      paddingRight: space.x3,
+      paddingLeft: space.x3,
     },
   },
   bandInputCellSelected: {
@@ -707,28 +703,38 @@ const styles = stylex.create({
   band5Selected: {
     backgroundColor: colors.band5,
   },
-  bandInputBracket: {
-    position: "relative",
+  bandInputName: {
+    display: "flex",
+    minWidth: 0,
+    alignItems: "center",
+    columnGap: space.x1,
     color: colors.ink,
     fontFamily: fonts.display,
-    fontSize: "19px",
-    fontVariantNumeric: "tabular-nums",
+    fontSize: "14px",
     fontWeight: 700,
-    letterSpacing: "-0.03em",
-    lineHeight: 1,
-    opacity: 0.26,
+    letterSpacing: "-0.02em",
+    lineHeight: 1.2,
     pointerEvents: "none",
   },
-  bandInputBracketSelectedLight: {
-    opacity: 0.5,
+  bandInputRange: {
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "11px",
+    fontVariantNumeric: "tabular-nums",
+    lineHeight: 1.2,
+    pointerEvents: "none",
   },
-  bandInputBracketSelectedDark: {
-    color: colors.ground,
-    opacity: 0.5,
+  bandInputCheck: {
+    flexShrink: 0,
   },
-  bandInputBracketSelectedDarkest: {
+  bandInputCheckHidden: {
+    visibility: "hidden",
+  },
+  bandInputTextSelectedLight: {
+    color: colors.ink,
+  },
+  bandInputTextSelectedDark: {
     color: colors.ground,
-    opacity: 0.62,
   },
   servingStyleTrack: {
     display: "grid",
@@ -759,21 +765,13 @@ const styles = stylex.create({
     },
   },
   servingStyleCellSelected: {
-    backgroundColor: colors.ground,
+    backgroundColor: colors.accentTint,
     color: colors.ink,
     boxShadow: {
-      default: `inset 0 0 0 2px ${colors.ink}`,
-      ":hover": `inset 0 0 0 2px ${colors.ink}`,
+      default: `inset 0 0 0 2px ${colors.accent}`,
+      ":hover": `inset 0 0 0 2px ${colors.accent}`,
       ":focus-within": effects.focusRing,
     },
-  },
-  visuallyHiddenText: {
-    position: "absolute",
-    width: "1px",
-    height: "1px",
-    overflow: "hidden",
-    clipPath: "inset(50%)",
-    whiteSpace: "nowrap",
   },
   colorRoot: {
     width: "100%",
@@ -916,12 +914,12 @@ const bandInputSelectedStyles = {
   unicorn: styles.band5Selected,
 } satisfies Record<RatingBand, stylex.StyleXStyles>;
 
-const bandInputBracketSelectedStyles = {
-  mediocre: styles.bandInputBracketSelectedLight,
-  good: styles.bandInputBracketSelectedLight,
-  very_good: styles.bandInputBracketSelectedDark,
-  outstanding: styles.bandInputBracketSelectedDark,
-  unicorn: styles.bandInputBracketSelectedDarkest,
+const bandInputTextSelectedStyles = {
+  mediocre: styles.bandInputTextSelectedLight,
+  good: styles.bandInputTextSelectedLight,
+  very_good: styles.bandInputTextSelectedLight,
+  outstanding: styles.bandInputTextSelectedDark,
+  unicorn: styles.bandInputTextSelectedDark,
 } satisfies Record<RatingBand, stylex.StyleXStyles>;
 
 const SERVING_STYLE_OPTIONS = [


### PR DESCRIPTION
Logging a tasting now has a clear hierarchy: a compact segmented progress trail, one “How was it?” prompt, rating labels inside their choices, and a quieter selected state for serving style. Mobile uses the same structure without duplicate progress copy.

The selected bottle summary now reuses the standard three-line identity row for brand, bottle name, and release facts. It no longer exposes the Peated ID. The audit, merge, photo resolution, and add-bottle flows use the same summary contract.
