### PR TITLE
fix(web): stabilize series page transitions

### DIFF
--- a/apps/web/src/app/(app)/series/[seriesId]/layout.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/layout.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+import { getCurrentUser } from "@peated/web/lib/auth.server";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
+import { serializeSeriesStructuredData } from "@peated/web/lib/catalogStructuredData";
+import { getSeriesPage } from "@peated/web/lib/seriesPage.server";
+
+import { SeriesPageFrame } from "./seriesPageFrame.stylex";
+
+export default async function SeriesLayout(props: {
+  children: ReactNode;
+  params: Promise<{ seriesId: string }>;
+}) {
+  const { seriesId } = await props.params;
+  const [series, currentUser] = await Promise.all([
+    getSeriesPage(parseCatalogRouteId(seriesId)),
+    getCurrentUser(),
+  ]);
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: serializeSeriesStructuredData(series),
+        }}
+      />
+      <SeriesPageFrame
+        hasCurrentUser={Boolean(currentUser)}
+        initialSeries={series}
+      >
+        {props.children}
+      </SeriesPageFrame>
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/series/[seriesId]/loading.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/loading.tsx
@@ -1,5 +1,5 @@
-import { CatalogPageLoading } from "@peated/web/components/pages/catalogPage.stylex";
+import { SeriesPageLoading } from "./seriesPageFrame.stylex";
 
 export default function SeriesLoading() {
-  return <CatalogPageLoading title="Series" />;
+  return <SeriesPageLoading />;
 }

--- a/apps/web/src/app/(app)/series/[seriesId]/page.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/page.tsx
@@ -1,16 +1,19 @@
+import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { BOTTLE_LIST_SORT_OPTIONS } from "@peated/server/constants";
 import { getCurrentUser } from "@peated/web/lib/auth.server";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
-import { serializeSeriesStructuredData } from "@peated/web/lib/catalogStructuredData";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getQueryClient } from "@peated/web/lib/orpc/query";
 import { getSeriesSeoMetadata } from "@peated/web/lib/seoMetadata";
 import { getSeriesPage } from "@peated/web/lib/seriesPage.server";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import type { Metadata } from "next";
 
+import { SeriesPageClient } from "./seriesPageClient.stylex";
 import {
-  SeriesPageClient,
+  seriesPageQueries,
   type SeriesLibraryFilter,
-} from "./seriesPageClient.stylex";
+} from "./seriesPageQueries";
 
 type SearchParams = Record<string, string | string[] | undefined>;
 
@@ -42,7 +45,6 @@ export async function generateMetadata(props: {
     searchParams: await props.searchParams,
   });
 }
-
 export default async function SeriesPage(props: {
   params: Promise<{ seriesId: string }>;
   searchParams: Promise<SearchParams>;
@@ -61,14 +63,17 @@ export default async function SeriesPage(props: {
   const library = currentUser
     ? getLibraryFilter(firstValue(searchParams.library))
     : "all";
-  const [bottleList, libraryBottleList] = await Promise.all([
-    client.bottles.list({
-      cursor,
-      library: library === "all" ? undefined : library,
-      limit: 25,
-      series: series.id,
-      sort,
-    }),
+  const queryClient = getQueryClient();
+  const orpc = createTanstackQueryUtils(client);
+  const [, libraryBottleList] = await Promise.all([
+    queryClient.prefetchQuery(
+      seriesPageQueries.bottles(orpc, {
+        cursor,
+        library,
+        seriesId: series.id,
+        sort,
+      }),
+    ),
     currentUser
       ? client.bottles.list({
           library: "in",
@@ -79,21 +84,13 @@ export default async function SeriesPage(props: {
   ]);
 
   return (
-    <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{
-          __html: serializeSeriesStructuredData(series),
-        }}
-      />
+    <HydrationBoundary state={dehydrate(queryClient)}>
       <SeriesPageClient
-        initialBottleList={bottleList}
         initialCursor={cursor}
         initialLibrary={library}
         initialLibraryCount={libraryBottleList?.total ?? null}
-        initialSeries={series}
         initialSort={sort}
       />
-    </>
+    </HydrationBoundary>
   );
 }

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -1,43 +1,26 @@
 "use client";
 
-import type { BOTTLE_LIST_SORT_OPTIONS } from "@peated/server/constants";
-import type { Outputs } from "@peated/server/orpc/router";
-import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
-import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useOptimistic, useState, useTransition } from "react";
+import { useOptimistic, useTransition } from "react";
 
-import {
-  Button,
-  Chip,
-  EntityIdentityRow,
-  FactList,
-  ItemListItem,
-  PeatedId,
-  RailList,
-  SectionError,
-  TextLink,
-} from "@peated/web/components";
+import { Button, Chip, FactList, SectionError } from "@peated/web/components";
 import { addBottleRowActions } from "@peated/web/components/bottleRowActions.stylex";
-import Markdown from "@peated/web/components/markdown";
 import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
-import {
-  PageColumns,
-  PageHeader,
-} from "@peated/web/components/pages/pageLayout.stylex";
-import { RailListSection } from "@peated/web/components/pages/railListSection.stylex";
 import useBottleRowActions from "@peated/web/hooks/useBottleRowActions";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { getEntityUrl } from "@peated/web/lib/urls";
-import { space } from "../../../../styles/tokens.stylex";
 
-type BottleList = Outputs["bottles"]["list"];
-type Series = Outputs["bottleSeries"]["details"];
-type BottleSort = (typeof BOTTLE_LIST_SORT_OPTIONS)[number];
-export type SeriesLibraryFilter = "all" | "in" | "out";
+import {
+  SeriesPageContent,
+  useSeriesPageFrame,
+} from "./seriesPageFrame.stylex";
+import {
+  seriesPageQueries,
+  type SeriesBottleSort,
+  type SeriesLibraryFilter,
+} from "./seriesPageQueries";
 
 const sortOptions = [
   { label: "Latest release", value: "-release" },
@@ -54,24 +37,19 @@ const libraryOptions = [
   { label: "In your Library", value: "in" },
 ] as const;
 
-const DISTILLERY_PREVIEW_LIMIT = 5;
-
 export function SeriesPageClient({
-  initialBottleList,
   initialCursor,
   initialLibrary,
   initialLibraryCount,
-  initialSeries,
   initialSort,
 }: {
-  initialBottleList: BottleList;
   initialCursor: number;
   initialLibrary: SeriesLibraryFilter;
   initialLibraryCount: number | null;
-  initialSeries: Series;
-  initialSort: BottleSort;
+  initialSort: SeriesBottleSort;
 }) {
   const orpc = useORPC();
+  const { series } = useSeriesPageFrame();
   const bottleActions = useBottleRowActions();
   const pathname = usePathname();
   const router = useRouter();
@@ -81,18 +59,14 @@ export function SeriesPageClient({
     searchParams.toString(),
   );
   const displayedSearchParams = new URLSearchParams(displayedParams);
-  const bottleListQuery = useQuery({
-    ...orpc.bottles.list.queryOptions({
-      input: {
-        cursor: initialCursor,
-        library: initialLibrary === "all" ? undefined : initialLibrary,
-        limit: 25,
-        series: initialSeries.id,
-        sort: initialSort,
-      },
+  const bottleListQuery = useQuery(
+    seriesPageQueries.bottles(orpc, {
+      cursor: initialCursor,
+      library: initialLibrary,
+      seriesId: series.id,
+      sort: initialSort,
     }),
-    initialData: initialBottleList,
-  });
+  );
 
   function updateParams(updates: Record<string, string>) {
     const nextParams = new URLSearchParams(displayedParams);
@@ -109,12 +83,12 @@ export function SeriesPageClient({
 
   const facts =
     initialLibraryCount === null
-      ? ([{ label: "Bottles", value: initialSeries.numReleases }] as const)
+      ? ([{ label: "Bottles", value: series.numReleases }] as const)
       : ([
-          { label: "Bottles", value: initialSeries.numReleases },
+          { label: "Bottles", value: series.numReleases },
           {
             label: "In your Library",
-            value: `${initialLibraryCount.toLocaleString("en-US")} of ${initialSeries.numReleases.toLocaleString("en-US")}`,
+            value: `${initialLibraryCount.toLocaleString("en-US")} of ${series.numReleases.toLocaleString("en-US")}`,
           },
         ] as const);
   const bottleList = bottleListQuery.data;
@@ -122,52 +96,25 @@ export function SeriesPageClient({
   const emptyState =
     initialLibrary === "in"
       ? {
-          description: `None of the bottles from ${initialSeries.fullName} are in your Library.`,
+          description: `None of the bottles from ${series.fullName} are in your Library.`,
           heading: "No bottles in your Library",
         }
       : initialLibrary === "out"
         ? {
-            description: `Every bottle from ${initialSeries.fullName} on Peated is in your Library.`,
+            description: `Every bottle from ${series.fullName} on Peated is in your Library.`,
             heading: "Nothing missing",
           }
         : {
-            description: `No bottles have been added to ${initialSeries.fullName} yet.`,
+            description: `No bottles have been added to ${series.fullName} yet.`,
             heading: "No bottles in this series yet",
           };
 
   return (
-    <div {...stylex.props(styles.page)}>
-      <PageHeader
-        description={
-          initialSeries.description ? (
-            <Markdown content={initialSeries.description} />
-          ) : undefined
-        }
-        identity={<PeatedId id={initialSeries.peatedId} />}
-        parent={
-          <TextLink href={getEntityUrl(initialSeries.brand)}>
-            {initialSeries.brand.name}
-          </TextLink>
-        }
-        title={
-          <span {...stylex.props(styles.title)}>{initialSeries.name}</span>
-        }
-      />
-      <PageColumns
-        rail={
-          initialSeries.distillers.length ? (
-            <SeriesDistilleries distillers={initialSeries.distillers} />
-          ) : undefined
-        }
-        railBehavior="stack"
-      >
-        <FactList facts={facts} layout="grid" />
-        {initialLibraryCount !== null && initialSeries.numReleases > 0 ? (
-          <div
-            aria-label="Library filter"
-            role="group"
-            {...stylex.props(styles.filters)}
-          >
+    <SeriesPageContent
+      facts={<FactList facts={facts} layout="grid" />}
+      filters={
+        initialLibraryCount !== null && series.numReleases > 0 ? (
+          <>
             {libraryOptions.map((option) => {
               const selected =
                 option.value ===
@@ -187,9 +134,11 @@ export function SeriesPageClient({
                 </Chip>
               );
             })}
-          </div>
-        ) : null}
-        <div {...stylex.props(styles.bottles)}>
+          </>
+        ) : undefined
+      }
+      bottles={
+        <>
           {bottleListQuery.error ? (
             <SectionError
               heading="Bottles in this series are unavailable"
@@ -199,6 +148,7 @@ export function SeriesPageClient({
             </SectionError>
           ) : bottleList ? (
             <BottleCatalogList
+              key={`${initialCursor}:${initialLibrary}:${initialSort}`}
               emptyAction={
                 filtered ? (
                   <Button
@@ -242,75 +192,8 @@ export function SeriesPageClient({
               total={bottleList.total}
             />
           ) : null}
-        </div>
-      </PageColumns>
-    </div>
-  );
-}
-
-function SeriesDistilleries({
-  distillers,
-}: {
-  distillers: Series["distillers"];
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const hasMore = distillers.length > DISTILLERY_PREVIEW_LIMIT;
-  const visibleDistillers = expanded
-    ? distillers
-    : distillers.slice(0, DISTILLERY_PREVIEW_LIMIT);
-
-  return (
-    <RailListSection
-      action={
-        hasMore
-          ? {
-              ariaControls: "series-distilleries",
-              expanded,
-              label: expanded
-                ? "Show fewer distilleries"
-                : `View all ${distillers.length.toLocaleString("en-US")} distilleries`,
-              onClick: () => setExpanded((value) => !value),
-            }
-          : undefined
+        </>
       }
-      heading={distillers.length === 1 ? "Distillery" : "Distilleries"}
-    >
-      <div id="series-distilleries">
-        <RailList ariaLabel="Series distilleries">
-          {visibleDistillers.map((distiller) => (
-            <ItemListItem key={distiller.id}>
-              <EntityIdentityRow
-                {...getEntityIdentityProps(distiller)}
-                variant="sidebar"
-                end={`${distiller.numBottles.toLocaleString("en-US")} ${
-                  distiller.numBottles === 1 ? "bottle" : "bottles"
-                }`}
-                href={getEntityUrl(distiller)}
-              />
-            </ItemListItem>
-          ))}
-        </RailList>
-      </div>
-    </RailListSection>
+    />
   );
 }
-
-const styles = stylex.create({
-  page: {
-    minWidth: 0,
-  },
-  title: {
-    display: "block",
-    overflowWrap: "anywhere",
-  },
-  filters: {
-    display: "flex",
-    alignItems: "center",
-    gap: space.x2,
-    flexWrap: "wrap",
-  },
-  bottles: {
-    minWidth: 0,
-    paddingTop: space.x4,
-  },
-});

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageFrame.stylex.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import type { Outputs } from "@peated/server/orpc/router";
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
+import * as stylex from "@stylexjs/stylex";
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+import {
+  EntityIdentityRow,
+  FactList,
+  ItemListItem,
+  LoadingList,
+  LoadingPlaceholder,
+  PeatedId,
+  RailList,
+  TextLink,
+} from "@peated/web/components";
+import Markdown from "@peated/web/components/markdown";
+import {
+  PageColumns,
+  PageHeader,
+} from "@peated/web/components/pages/pageLayout.stylex";
+import { RailListSection } from "@peated/web/components/pages/railListSection.stylex";
+import { getEntityUrl } from "@peated/web/lib/urls";
+import { space } from "../../../../styles/tokens.stylex";
+
+type Series = Outputs["bottleSeries"]["details"];
+
+type SeriesPageFrameValue = {
+  hasCurrentUser: boolean;
+  series: Series;
+};
+
+const SeriesPageFrameContext = createContext<SeriesPageFrameValue | null>(null);
+const DISTILLERY_PREVIEW_LIMIT = 5;
+const COMPACT = "@media (max-width: 639px)";
+const loadingRowCounts = [1, 2, 3, 4, 5, 6, 7, 8] as const;
+
+export function SeriesPageFrame({
+  children,
+  hasCurrentUser,
+  initialSeries,
+}: {
+  children: ReactNode;
+  hasCurrentUser: boolean;
+  initialSeries: Series;
+}) {
+  return (
+    <SeriesPageFrameContext.Provider
+      value={{ hasCurrentUser, series: initialSeries }}
+    >
+      <div {...stylex.props(styles.page)}>
+        <PageHeader
+          description={
+            initialSeries.description ? (
+              <Markdown content={initialSeries.description} />
+            ) : undefined
+          }
+          identity={<PeatedId id={initialSeries.peatedId} />}
+          parent={
+            <TextLink href={getEntityUrl(initialSeries.brand)}>
+              {initialSeries.brand.name}
+            </TextLink>
+          }
+          title={
+            <span {...stylex.props(styles.title)}>{initialSeries.name}</span>
+          }
+        />
+        <PageColumns
+          rail={
+            initialSeries.distillers.length ? (
+              <SeriesDistilleries distillers={initialSeries.distillers} />
+            ) : undefined
+          }
+          railBehavior="stack"
+        >
+          {children}
+        </PageColumns>
+      </div>
+    </SeriesPageFrameContext.Provider>
+  );
+}
+
+export function SeriesPageContent({
+  bottles,
+  facts,
+  filters,
+}: {
+  bottles: ReactNode;
+  facts: ReactNode;
+  filters?: ReactNode;
+}) {
+  return (
+    <>
+      {facts}
+      {filters ? (
+        <div
+          aria-label="Library filter"
+          role="group"
+          {...stylex.props(styles.filters)}
+        >
+          {filters}
+        </div>
+      ) : null}
+      <div {...stylex.props(styles.bottles)}>{bottles}</div>
+    </>
+  );
+}
+
+/** Reserves the series content geometry inside the stable route frame. */
+export function SeriesPageLoading() {
+  const { hasCurrentUser, series } = useSeriesPageFrame();
+  const showLibrary = hasCurrentUser && series.numReleases > 0;
+  const loadingRows =
+    loadingRowCounts[
+      Math.min(Math.max(series.numReleases, 1), loadingRowCounts.length) - 1
+    ] ?? 1;
+  const facts = showLibrary
+    ? ([
+        {
+          label: "Bottles",
+          value: <LoadingPlaceholder preset="metadata" />,
+        },
+        {
+          label: "In your Library",
+          value: <LoadingPlaceholder preset="metadata" />,
+        },
+      ] as const)
+    : ([
+        {
+          label: "Bottles",
+          value: <LoadingPlaceholder preset="metadata" />,
+        },
+      ] as const);
+
+  return (
+    <div aria-busy="true" aria-label="Loading series bottles" role="status">
+      <SeriesPageContent
+        facts={<FactList facts={facts} layout="grid" />}
+        filters={
+          showLibrary ? <LoadingPlaceholder preset="heading" /> : undefined
+        }
+        bottles={
+          <div aria-hidden="true">
+            <div {...stylex.props(styles.loadingToolbar)}>
+              <LoadingPlaceholder preset="heading" />
+              <LoadingPlaceholder preset="metadata" />
+            </div>
+            <LoadingList
+              label="Loading bottles in this series"
+              rows={loadingRows}
+            />
+          </div>
+        }
+      />
+    </div>
+  );
+}
+
+export function useSeriesPageFrame() {
+  const value = useContext(SeriesPageFrameContext);
+  if (!value) throw new Error("Series content requires its route frame");
+  return value;
+}
+
+function SeriesDistilleries({
+  distillers,
+}: {
+  distillers: Series["distillers"];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const hasMore = distillers.length > DISTILLERY_PREVIEW_LIMIT;
+  const visibleDistillers = expanded
+    ? distillers
+    : distillers.slice(0, DISTILLERY_PREVIEW_LIMIT);
+
+  return (
+    <RailListSection
+      action={
+        hasMore
+          ? {
+              ariaControls: "series-distilleries",
+              expanded,
+              label: expanded
+                ? "Show fewer distilleries"
+                : `View all ${distillers.length.toLocaleString("en-US")} distilleries`,
+              onClick: () => setExpanded((value) => !value),
+            }
+          : undefined
+      }
+      heading={distillers.length === 1 ? "Distillery" : "Distilleries"}
+    >
+      <div id="series-distilleries">
+        <RailList ariaLabel="Series distilleries">
+          {visibleDistillers.map((distiller) => (
+            <ItemListItem key={distiller.id}>
+              <EntityIdentityRow
+                {...getEntityIdentityProps(distiller)}
+                variant="sidebar"
+                end={`${distiller.numBottles.toLocaleString("en-US")} ${
+                  distiller.numBottles === 1 ? "bottle" : "bottles"
+                }`}
+                href={getEntityUrl(distiller)}
+              />
+            </ItemListItem>
+          ))}
+        </RailList>
+      </div>
+    </RailListSection>
+  );
+}
+
+const styles = stylex.create({
+  page: {
+    minWidth: 0,
+  },
+  title: {
+    display: "block",
+    fontSize: {
+      default: null,
+      "@media (max-width: 480px)": "36px",
+    },
+    overflowWrap: "anywhere",
+  },
+  filters: {
+    display: "flex",
+    alignItems: "center",
+    gap: space.x2,
+    flexWrap: "wrap",
+  },
+  bottles: {
+    minWidth: 0,
+    paddingTop: space.x4,
+  },
+  loadingToolbar: {
+    display: "flex",
+    minHeight: { default: "32px", [COMPACT]: "64px" },
+    alignItems: { default: "center", [COMPACT]: "flex-start" },
+    justifyContent: "space-between",
+    flexDirection: { default: "row", [COMPACT]: "column" },
+    gap: space.x4,
+    paddingBottom: space.x3,
+  },
+});

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageQueries.ts
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageQueries.ts
@@ -1,0 +1,26 @@
+import type { BOTTLE_LIST_SORT_OPTIONS } from "@peated/server/constants";
+import type { ORPCQueryUtils } from "@peated/web/lib/orpc/context";
+
+export type SeriesBottleSort = (typeof BOTTLE_LIST_SORT_OPTIONS)[number];
+export type SeriesLibraryFilter = "all" | "in" | "out";
+
+type SeriesBottleQuery = {
+  cursor: number;
+  library: SeriesLibraryFilter;
+  seriesId: number;
+  sort: SeriesBottleSort;
+};
+
+/** Keeps the server prefetch and client read on the same request-specific key. */
+export const seriesPageQueries = {
+  bottles: (orpc: ORPCQueryUtils, query: SeriesBottleQuery) =>
+    orpc.bottles.list.queryOptions({
+      input: {
+        cursor: query.cursor,
+        library: query.library === "all" ? undefined : query.library,
+        limit: 25,
+        series: query.seriesId,
+        sort: query.sort,
+      },
+    }),
+};


### PR DESCRIPTION
Series detail navigation now keeps the real series header and distillery rail in a persistent route layout. The page fallback fills only the bottle-content slot, uses real labels instead of the placeholder title “Series,” and reserves rows from the known release count. Sorting also replaces the result set as one keyed unit so reused bottle rows do not slide to new positions.

The server and client now share the same bottle query options through request-scoped hydration. The route remains dynamic and session-aware; this adds no shared response cache and browser QA observed no duplicate bottle API request. On the audited series, route transitions and sorting measured CLS `0` at desktop and mobile widths; current production sorting measured about `0.185` and `0.283` respectively.

Refs #938
