### PR TITLE
fix(web): improve bottle price listings

### DIFF
--- a/apps/web/src/app/(app)/bottles/[bottleId]/prices/bottleSellerList.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/prices/bottleSellerList.stylex.tsx
@@ -1,0 +1,125 @@
+import type { Outputs } from "@peated/server/orpc/router";
+import { AppLink } from "@peated/web/components/appLink";
+import Price from "@peated/web/components/price";
+import TimeSince from "@peated/web/components/timeSince";
+import * as stylex from "@stylexjs/stylex";
+
+import { colors, fonts, space } from "../../../../../styles/tokens.stylex";
+
+type Seller = Outputs["bottles"]["prices"]["list"]["results"][number];
+
+export function BottleSellerList({ sellers }: { sellers: readonly Seller[] }) {
+  return (
+    <ul aria-label="Bottle sellers" {...stylex.props(styles.list)}>
+      {sellers.map((seller) => {
+        const content = (
+          <>
+            <span {...stylex.props(styles.details)}>
+              <strong {...stylex.props(styles.seller)}>
+                {seller.site.name}
+              </strong>
+              <span {...stylex.props(styles.listing)}>{seller.name}</span>
+              <span {...stylex.props(styles.metadata)}>
+                {seller.volume.toLocaleString("en-US")} ml · Updated{" "}
+                <TimeSince date={seller.updatedAt} />
+              </span>
+            </span>
+            <span {...stylex.props(styles.price)}>
+              <Price currency={seller.currency} value={seller.price} />
+            </span>
+          </>
+        );
+
+        return (
+          <li
+            key={seller.id}
+            {...stylex.props(styles.item, !seller.isValid && styles.outdated)}
+          >
+            {seller.isValid ? (
+              <AppLink
+                href={seller.url}
+                {...stylex.props(styles.row, styles.link)}
+              >
+                {content}
+              </AppLink>
+            ) : (
+              <div {...stylex.props(styles.row)}>{content}</div>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+const styles = stylex.create({
+  list: {
+    width: "100%",
+    maxWidth: "800px",
+    margin: 0,
+    padding: 0,
+    listStyle: "none",
+  },
+  item: {
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+  },
+  row: {
+    display: "grid",
+    minWidth: 0,
+    gridTemplateColumns: "minmax(0, 1fr) auto",
+    alignItems: "start",
+    columnGap: space.x4,
+    paddingTop: "13px",
+    paddingRight: space.x3,
+    paddingBottom: "13px",
+    paddingLeft: space.x3,
+    color: colors.ink,
+    fontFamily: fonts.reading,
+    textDecorationLine: "none",
+  },
+  link: {
+    backgroundColor: {
+      default: "transparent",
+      ":hover": colors.surface,
+      ":active": colors.surface,
+    },
+  },
+  details: {
+    display: "block",
+    minWidth: 0,
+  },
+  seller: {
+    display: "block",
+    color: colors.accentDeep,
+    fontSize: "14px",
+    fontWeight: 700,
+    lineHeight: 1.35,
+  },
+  listing: {
+    display: "block",
+    marginTop: space.x1,
+    fontSize: "13px",
+    lineHeight: 1.4,
+  },
+  metadata: {
+    display: "block",
+    marginTop: space.x2,
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "11px",
+    lineHeight: 1.4,
+  },
+  price: {
+    paddingTop: "1px",
+    fontFamily: fonts.data,
+    fontSize: "13px",
+    fontWeight: 600,
+    lineHeight: 1.35,
+    whiteSpace: "nowrap",
+  },
+  outdated: {
+    opacity: 0.7,
+  },
+});

--- a/apps/web/src/app/(app)/bottles/[bottleId]/prices/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/prices/page.tsx
@@ -1,49 +1,9 @@
-import type { Outputs } from "@peated/server/orpc/router";
-import {
-  DataTable,
-  EmptyState,
-  type DataTableColumn,
-} from "@peated/web/components";
-import Price from "@peated/web/components/price";
-import TimeSince from "@peated/web/components/timeSince";
+import { EmptyState } from "@peated/web/components";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 
-import { BottleSection } from "../bottleSection.stylex";
-
-type PriceRow = Outputs["bottles"]["prices"]["list"]["results"][number];
-
-const columns: DataTableColumn<PriceRow>[] = [
-  {
-    cell: (item) =>
-      item.isValid
-        ? `${item.site?.name} — ${item.name}`
-        : `${item.site?.name} — ${item.name}`,
-    header: "Seller",
-    key: "seller",
-  },
-  {
-    align: "right",
-    cell: (item) => `${item.volume.toLocaleString("en-US")} ml`,
-    header: "Size",
-    key: "volume",
-    priority: "secondary",
-  },
-  {
-    align: "right",
-    cell: (item) => <TimeSince date={item.updatedAt} />,
-    header: "Updated",
-    key: "updated",
-    priority: "secondary",
-  },
-  {
-    align: "right",
-    cell: (item) => <Price currency={item.currency} value={item.price} />,
-    header: "Price",
-    key: "price",
-  },
-];
+import { BottleSellerList } from "./bottleSellerList.stylex";
 
 export default async function BottlePricesPage(props: {
   params: Promise<{ bottleId: string }>;
@@ -53,21 +13,11 @@ export default async function BottlePricesPage(props: {
   const { client } = await getAnonymousServerClient();
   const priceList = await client.bottles.prices.list({ bottle: bottle.id });
 
-  return (
-    <BottleSection heading="Sellers">
-      {priceList.results.length ? (
-        <DataTable
-          caption="Bottle sellers"
-          columns={columns}
-          getHref={(item) => (item.isValid ? item.url : undefined)}
-          getKey={(item) => item.id}
-          items={priceList.results}
-        />
-      ) : (
-        <EmptyState heading="No sellers found">
-          Peated does not have a current seller for this bottle.
-        </EmptyState>
-      )}
-    </BottleSection>
+  return priceList.results.length ? (
+    <BottleSellerList sellers={priceList.results} />
+  ) : (
+    <EmptyState heading="No prices found">
+      Peated does not have a price for this bottle.
+    </EmptyState>
   );
 }


### PR DESCRIPTION
The bottle Prices tab now renders each listing as a compact responsive row with the seller, original listing name, size, freshness, and price. Current offers remain linked, while outdated offers stay visible but subdued; the redundant Sellers heading is removed.

This replaces the generic table that compressed long store titles at mobile widths and separated related metadata across distant columns.
