### PR TITLE
fix(web): align catalog header action sizes

### DIFF
--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -43,7 +43,7 @@ function EntityFollowAction({ entity }: { entity: Entity }) {
       <ButtonLink
         aria-label={`Follow ${entity.name}`}
         href={`/login?redirectTo=${encodeURIComponent(getEntityUrl(entity))}`}
-        size="md"
+        size="lg"
         variant="accent"
       >
         Follow
@@ -63,7 +63,7 @@ function EntityFollowAction({ entity }: { entity: Entity }) {
       loading={pending}
       loadingLabel={isFollowing ? "Unfollowing…" : "Following…"}
       onClick={() => followControls.toggle(entity)}
-      size="md"
+      size="lg"
       variant="accent"
     >
       {isFollowing ? "Unfollow" : "Follow"}
@@ -191,7 +191,7 @@ export function EntityPageFrameClient({
               {createBottleHref ? (
                 <ButtonLink
                   href={createBottleHref}
-                  size="md"
+                  size="lg"
                   variant={canFollow ? "tonal" : "accent"}
                 >
                   {bottleActionLabel}


### PR DESCRIPTION
Entity detail headers now render Follow/Unfollow and Add a bottle at the same large size as the page overflow menu. This removes the 4 px height mismatch across distiller, brand, and bottler detail pages for both signed-in and signed-out states.

Browser checks at 1280×900 and 390×844 confirmed that all three header controls are 44 px high. Bottle detail headers already use the same sizing.
