### PR TITLE
fix(web): stabilize profile page transitions

### DIFF
--- a/apps/web/src/app/(app)/users/[username]/activity/loading.tsx
+++ b/apps/web/src/app/(app)/users/[username]/activity/loading.tsx
@@ -1,0 +1,5 @@
+import { ProfileActivityLoading } from "./profileActivityLayout";
+
+export default function ActivityLoading() {
+  return <ProfileActivityLoading />;
+}

--- a/apps/web/src/app/(app)/users/[username]/activity/page.tsx
+++ b/apps/web/src/app/(app)/users/[username]/activity/page.tsx
@@ -1,7 +1,13 @@
-import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
+import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { createServerClient } from "@peated/web/lib/orpc/client.server";
+import { getQueryClient } from "@peated/web/lib/orpc/query";
 import { getProfilePage } from "@peated/web/lib/profilePage.server";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
+import {
+  getProfileActivityRouteState,
+  profileQueries,
+} from "../profileQueries";
 import { ProfileActivityPageClient } from "./profileActivityPageClient.stylex";
 
 export default async function ProfileActivityPage(props: {
@@ -11,10 +17,16 @@ export default async function ProfileActivityPage(props: {
   const { username } = await props.params;
   const { client } = await createServerClient();
   const user = await getProfilePage(username);
-  const activityInput = getApiQueryParams(await props.searchParams, {
-    overrides: { limit: 10, user: user.id },
-  });
-  const activityList = await client.users.activity.list(activityInput);
+  const { cursor } = getProfileActivityRouteState(await props.searchParams);
+  const queryClient = getQueryClient();
+  const orpc = createTanstackQueryUtils(client);
+  await queryClient.prefetchInfiniteQuery(
+    profileQueries.activity(orpc, user.id, cursor),
+  );
 
-  return <ProfileActivityPageClient initialActivityList={activityList} />;
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ProfileActivityPageClient />
+    </HydrationBoundary>
+  );
 }

--- a/apps/web/src/app/(app)/users/[username]/activity/profileActivityLayout.tsx
+++ b/apps/web/src/app/(app)/users/[username]/activity/profileActivityLayout.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { LoadingList } from "@peated/web/components";
+import { PageColumns } from "@peated/web/components/pages/pageLayout.stylex";
+import { useProfile } from "../profileContext";
+import { getProfileLoadingRows } from "../profileLoading";
+
+export function ProfileActivityLayout({ children }: { children: ReactNode }) {
+  const { user } = useProfile();
+
+  return (
+    <PageColumns>
+      <section aria-label={`${user.username}'s activity`}>{children}</section>
+    </PageColumns>
+  );
+}
+
+export function ProfileActivityLoading() {
+  const { user } = useProfile();
+  const totalActivity = user.stats.tastings + user.stats.library.total;
+
+  return (
+    <ProfileActivityLayout>
+      <LoadingList
+        label="Loading member activity"
+        rows={getProfileLoadingRows(totalActivity)}
+      />
+    </ProfileActivityLayout>
+  );
+}

--- a/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
@@ -1,59 +1,30 @@
 "use client";
 
-import type { Outputs } from "@peated/server/orpc/router";
-import {
-  useInfiniteQuery,
-  type InfiniteData,
-  type QueryKey,
-} from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 
 import { CursorPager, LoadingList, SectionError } from "@peated/web/components";
 import { MemberActivityList } from "@peated/web/components/pages/memberProfileContent.stylex";
-import { PageColumns } from "@peated/web/components/pages/pageLayout.stylex";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { toActivityItem } from "../profileActivity";
 import { useProfile } from "../profileContext";
+import {
+  getProfileActivityRouteState,
+  profileQueries,
+} from "../profileQueries";
+import { ProfileActivityLayout } from "./profileActivityLayout";
 
-type ActivityList = Outputs["users"]["activity"]["list"];
-
-export function ProfileActivityPageClient({
-  initialActivityList,
-}: {
-  initialActivityList: ActivityList;
-}) {
+export function ProfileActivityPageClient() {
   const orpc = useORPC();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { isCurrentUser, user } = useProfile();
-  const cursor = searchParams.get("cursor") || undefined;
-  const page = Number(searchParams.get("page") ?? "1") || 1;
-  // Each page owns its cursor. ORPC does not expose an infinite query helper
-  // for this route, so keep the query function beside the pagination rules.
-  /* oxlint-disable @tanstack/query/prefer-query-options */
-  const activityQuery = useInfiniteQuery<
-    ActivityList,
-    Error,
-    InfiniteData<ActivityList>,
-    QueryKey,
-    string | undefined
-  >({
-    queryKey: orpc.users.activity.list.key({
-      input: { cursor, limit: 10, user: user.id },
-    }),
-    queryFn: ({ pageParam }) =>
-      orpc.users.activity.list.call({
-        cursor: pageParam,
-        limit: 10,
-        user: user.id,
-      }),
-    initialData: { pages: [initialActivityList], pageParams: [cursor] },
-    initialPageParam: cursor,
-    getNextPageParam: (lastPage) => lastPage.rel.nextCursor ?? undefined,
-  });
-  /* oxlint-enable @tanstack/query/prefer-query-options */
+  const { cursor, page } = getProfileActivityRouteState(searchParams);
+  const activityQuery = useInfiniteQuery(
+    profileQueries.activity(orpc, user.id, cursor),
+  );
   const {
     data,
     error,
@@ -63,15 +34,17 @@ export function ProfileActivityPageClient({
     isPending,
     refetch,
   } = activityQuery;
-  const visibleActivity = data.pages
-    .flatMap((activityPage) => activityPage.results)
-    .filter(
-      (activity) =>
-        activity.type !== "collection_add" ||
-        !activity.collection.href?.endsWith("/favorites"),
-    )
-    .slice(0, 10);
-  const lastPage = data.pages.at(-1) ?? initialActivityList;
+  const visibleActivity =
+    data?.pages
+      .flatMap((activityPage) => activityPage.results)
+      .filter(
+        (activity) =>
+          activity.type !== "collection_add" ||
+          !activity.collection.href?.endsWith("/favorites"),
+      )
+      .slice(0, 10) ?? [];
+  const firstPage = data?.pages[0];
+  const lastPage = data?.pages.at(-1);
 
   useEffect(() => {
     if (visibleActivity.length < 10 && hasNextPage && !isFetchingNextPage) {
@@ -80,47 +53,45 @@ export function ProfileActivityPageClient({
   }, [fetchNextPage, hasNextPage, isFetchingNextPage, visibleActivity.length]);
 
   return (
-    <PageColumns>
-      <section aria-label={`${user.username}'s activity`}>
-        {isPending ||
-        (!visibleActivity.length && (hasNextPage || isFetchingNextPage)) ? (
-          <LoadingList label="Loading member activity" rows={4} />
-        ) : error ? (
-          <SectionError
-            heading="Activity is unavailable"
-            onRetry={() => void refetch()}
-          >
-            The member profile is still available. Try loading activity again.
-          </SectionError>
-        ) : (
-          <>
-            <MemberActivityList
-              emptyDescription={
-                isCurrentUser
-                  ? "Your tastings and library additions will appear here."
-                  : `${user.username} has no recent activity.`
-              }
-              items={visibleActivity.map(toActivityItem)}
-            />
-            <CursorPager
-              ariaLabel={`${user.username} activity pages`}
-              nextHref={getCursorHref(
-                pathname,
-                searchParams,
-                lastPage.rel.nextCursor,
-                { page: page + 1 },
-              )}
-              page={page}
-              previousHref={getCursorHref(
-                pathname,
-                searchParams,
-                initialActivityList.rel.prevCursor,
-                { page: Math.max(1, page - 1) },
-              )}
-            />
-          </>
-        )}
-      </section>
-    </PageColumns>
+    <ProfileActivityLayout>
+      {isPending ||
+      (!visibleActivity.length && (hasNextPage || isFetchingNextPage)) ? (
+        <LoadingList label="Loading member activity" rows={4} />
+      ) : error ? (
+        <SectionError
+          heading="Activity is unavailable"
+          onRetry={() => void refetch()}
+        >
+          The member profile is still available. Try loading activity again.
+        </SectionError>
+      ) : (
+        <>
+          <MemberActivityList
+            emptyDescription={
+              isCurrentUser
+                ? "Your tastings and library additions will appear here."
+                : `${user.username} has no recent activity.`
+            }
+            items={visibleActivity.map(toActivityItem)}
+          />
+          <CursorPager
+            ariaLabel={`${user.username} activity pages`}
+            nextHref={getCursorHref(
+              pathname,
+              searchParams,
+              lastPage?.rel.nextCursor,
+              { page: page + 1 },
+            )}
+            page={page}
+            previousHref={getCursorHref(
+              pathname,
+              searchParams,
+              firstPage?.rel.prevCursor,
+              { page: Math.max(1, page - 1) },
+            )}
+          />
+        </>
+      )}
+    </ProfileActivityLayout>
   );
 }

--- a/apps/web/src/app/(app)/users/[username]/favorites/loading.tsx
+++ b/apps/web/src/app/(app)/users/[username]/favorites/loading.tsx
@@ -1,0 +1,5 @@
+import { ProfileLibraryLoading } from "../library/profileLibraryLayout.stylex";
+
+export default function FavoritesLoading() {
+  return <ProfileLibraryLoading />;
+}

--- a/apps/web/src/app/(app)/users/[username]/library/loading.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/loading.tsx
@@ -1,0 +1,5 @@
+import { ProfileLibraryLoading } from "./profileLibraryLayout.stylex";
+
+export default function LibraryLoading() {
+  return <ProfileLibraryLoading />;
+}

--- a/apps/web/src/app/(app)/users/[username]/library/page.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/page.tsx
@@ -1,10 +1,10 @@
-import {
-  getApiQueryParams,
-  type ApiQueryParamValue,
-} from "@peated/web/lib/apiQueryParams";
+import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { createServerClient } from "@peated/web/lib/orpc/client.server";
+import { getQueryClient } from "@peated/web/lib/orpc/query";
 import { getProfilePage } from "@peated/web/lib/profilePage.server";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
+import { getProfileLibraryInput, profileQueries } from "../profileQueries";
 import { ProfileLibraryPageClient } from "./profileLibraryPageClient.stylex";
 
 export default async function ProfileLibraryPage(props: {
@@ -14,47 +14,20 @@ export default async function ProfileLibraryPage(props: {
   const { username } = await props.params;
   const { client } = await createServerClient();
   const user = await getProfilePage(username);
-  const queryParams = getApiQueryParams(await props.searchParams, {
-    defaults: { cursor: 1, query: "" },
-    numericFields: ["brand", "cursor", "distiller"],
-  });
-  const status = parseLibraryStatus(queryParams.status);
-  const libraryInput = {
-    brand: queryParams.brand,
-    collection: "library" as const,
-    cursor: queryParams.cursor,
-    distiller: queryParams.distiller,
-    limit: 25,
-    query: queryParams.query,
-    status,
-    user: user.id,
-  };
-  const [libraryList, libraryStats] = await Promise.all([
-    client.collections.bottles.list(libraryInput),
-    client.users.libraryStats({ user: user.id }),
+  const libraryInput = getProfileLibraryInput(
+    await props.searchParams,
+    user.id,
+  );
+  const queryClient = getQueryClient();
+  const orpc = createTanstackQueryUtils(client);
+  await Promise.all([
+    queryClient.prefetchQuery(profileQueries.library(orpc, libraryInput)),
+    queryClient.prefetchQuery(profileQueries.libraryStats(orpc, user.id)),
   ]);
 
   return (
-    <ProfileLibraryPageClient
-      initialLibraryList={libraryList}
-      initialLibraryStats={libraryStats}
-    />
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ProfileLibraryPageClient />
+    </HydrationBoundary>
   );
-}
-
-function parseLibraryStatus(
-  value: ApiQueryParamValue,
-): "empty" | "open" | "sealed" | "unset" | undefined {
-  switch (String(value ?? "")) {
-    case "empty":
-      return "empty";
-    case "open":
-      return "open";
-    case "sealed":
-      return "sealed";
-    case "unset":
-      return "unset";
-    default:
-      return undefined;
-  }
 }

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryLayout.stylex.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import type { ReactNode } from "react";
+
+import { LoadingList, LoadingPlaceholder } from "@peated/web/components";
+import { PageColumns } from "@peated/web/components/pages/pageLayout.stylex";
+import { colors, fonts, space } from "../../../../../styles/tokens.stylex";
+import { useProfile } from "../profileContext";
+import { getProfileLoadingRows } from "../profileLoading";
+
+const NARROW = "@media (max-width: 759px)";
+
+export function ProfileLibraryLayout({
+  children,
+  mobileFilters,
+  rail,
+}: {
+  children: ReactNode;
+  mobileFilters: ReactNode;
+  rail: ReactNode;
+}) {
+  return (
+    <>
+      {mobileFilters}
+      <PageColumns rail={rail}>{children}</PageColumns>
+    </>
+  );
+}
+
+/** Keeps both Library filter layouts stable while data loads. */
+export function ProfileLibraryLoading() {
+  const { user } = useProfile();
+
+  return (
+    <div aria-busy="true" aria-label="Loading member library" role="status">
+      <ProfileLibraryLayout
+        mobileFilters={
+          <div aria-hidden="true" {...stylex.props(styles.mobileFilters)}>
+            Filter library
+          </div>
+        }
+        rail={
+          <div aria-hidden="true" {...stylex.props(styles.loadingRail)}>
+            <LoadingPlaceholder preset="heading" />
+            <LoadingList label="Loading library filters" rows={4} />
+          </div>
+        }
+      >
+        <div aria-hidden="true">
+          <div {...stylex.props(styles.loadingCount)}>
+            <LoadingPlaceholder preset="heading" />
+          </div>
+          <LoadingList
+            label="Loading library bottles"
+            rows={getProfileLoadingRows(user.stats.library.total)}
+          />
+        </div>
+      </ProfileLibraryLayout>
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  mobileFilters: {
+    display: "none",
+    marginBottom: space.x6,
+    padding: space.x3,
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.sectionRule,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+    color: colors.ink,
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    fontWeight: 600,
+    lineHeight: 1.3,
+    [NARROW]: { display: "block" },
+  },
+  loadingRail: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x4,
+  },
+  loadingCount: {
+    paddingBottom: space.x3,
+  },
+});

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
@@ -15,28 +15,19 @@ import {
   type MemberLibraryFilterGroup,
   type MemberLibraryItem,
 } from "@peated/web/components/pages/memberProfileContent.stylex";
-import { PageColumns } from "@peated/web/components/pages/pageLayout.stylex";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 import { colors, fonts, space } from "../../../../../styles/tokens.stylex";
 import { useProfile } from "../profileContext";
+import { getProfileLibraryInput, profileQueries } from "../profileQueries";
+import { ProfileLibraryLayout } from "./profileLibraryLayout.stylex";
 
 type LibraryEntry =
   Outputs["collections"]["bottles"]["list"]["results"][number];
-type LibraryList = Outputs["collections"]["bottles"]["list"];
-type LibraryStats = Outputs["users"]["libraryStats"];
-type LibraryStatus = NonNullable<LibraryEntry["status"]>;
 type LibraryEntryChange = LibraryEntry["status"] | "removed";
-const statusValues = new Set(["open", "sealed", "empty", "unset"]);
 
-export function ProfileLibraryPageClient({
-  initialLibraryList,
-  initialLibraryStats,
-}: {
-  initialLibraryList: LibraryList;
-  initialLibraryStats: LibraryStats;
-}) {
+export function ProfileLibraryPageClient() {
   const orpc = useORPC();
   const queryClient = useQueryClient();
   const pathname = usePathname();
@@ -48,35 +39,14 @@ export function ProfileLibraryPageClient({
     Record<number, LibraryEntryChange>
   >({});
   const [mutationError, setMutationError] = useState(false);
-  const cursor = Number(searchParams.get("cursor") ?? "1") || 1;
-  const query = searchParams.get("query") ?? "";
-  const brand = positiveNumber(searchParams.get("brand"));
-  const distiller = positiveNumber(searchParams.get("distiller"));
-  const status = parseStatus(searchParams.get("status"));
-  const input = {
-    brand,
-    collection: "library" as const,
-    cursor,
-    distiller,
-    limit: 25,
-    query,
-    status,
-    user: user.id,
-  };
-  const libraryQueryOptions = orpc.collections.bottles.list.queryOptions({
-    input,
-  });
+  const input = getProfileLibraryInput(searchParams, user.id);
+  const { brand, cursor, distiller, query, status } = input;
+  const libraryQueryOptions = profileQueries.library(orpc, input);
   const libraryListQueryKey = orpc.collections.bottles.list.key({
     type: "query",
   });
-  const libraryQuery = useQuery({
-    ...libraryQueryOptions,
-    initialData: initialLibraryList,
-  });
-  const statsQuery = useQuery({
-    ...orpc.users.libraryStats.queryOptions({ input: { user: user.id } }),
-    initialData: initialLibraryStats,
-  });
+  const libraryQuery = useQuery(libraryQueryOptions);
+  const statsQuery = useQuery(profileQueries.libraryStats(orpc, user.id));
   const updateMutation = useMutation(
     orpc.collections.bottles.update.mutationOptions(),
   );
@@ -203,88 +173,90 @@ export function ProfileLibraryPageClient({
   );
 
   return (
-    <>
-      <MemberLibraryFilters
-        groups={filters}
-        mode="mobile"
-        onChange={setFilter}
-        onClear={clearFilters}
-        onQuerySubmit={setQuery}
-        query={query}
-        total={statsQuery.data?.total}
-      />
-      <PageColumns rail={filterPanel}>
-        <div aria-busy={isNavigating || mutationPending || undefined}>
-          {mutationError ? (
-            <p role="alert" {...stylex.props(styles.actionError)}>
-              The library change failed. Try the action again.
-            </p>
-          ) : null}
-          {libraryQuery.isPending ? (
-            <LoadingList label="Loading member library" rows={4} />
-          ) : libraryQuery.error ? (
-            <SectionError
-              heading="Library is unavailable"
-              onRetry={() => void libraryQuery.refetch()}
-            >
-              The member profile is still available. Try loading the Library
-              again.
-            </SectionError>
-          ) : (
-            <MemberLibraryList
-              emptyAction={
-                isCurrentUser &&
-                !hasActiveFilters({ brand, distiller, query, status }) ? (
-                  <ButtonLink
-                    href="/addBottle?intent=library"
-                    size="sm"
-                    variant="accent"
-                  >
-                    Add your first bottle
-                  </ButtonLink>
-                ) : undefined
-              }
-              emptyDescription={
-                hasActiveFilters({ brand, distiller, query, status })
-                  ? "No library bottles match these filters."
-                  : isCurrentUser
-                    ? "Track what you own, what you have finished, and what you want to open next."
-                    : `${user.username} has not added any bottles to their Library.`
-              }
-              emptyHeading={
-                hasActiveFilters({ brand, distiller, query, status })
-                  ? "No matching bottles"
-                  : "No library bottles yet"
-              }
-              items={applyEntryChanges(
-                libraryQuery.data.results,
-                entryChanges,
-              ).map((entry) =>
-                toLibraryItem(
-                  entry,
-                  isCurrentUser,
-                  mutationPending,
-                  updateStatus,
-                  removeEntry,
-                ),
-              )}
-              nextHref={getCursorHref(
-                pathname,
-                searchParams,
-                libraryQuery.data.rel.nextCursor,
-              )}
-              page={cursor}
-              previousHref={getCursorHref(
-                pathname,
-                searchParams,
-                libraryQuery.data.rel.prevCursor,
-              )}
-              total={statsQuery.data?.total}
-            />
-          )}
-        </div>
-      </PageColumns>
-    </>
+    <ProfileLibraryLayout
+      mobileFilters={
+        <MemberLibraryFilters
+          groups={filters}
+          mode="mobile"
+          onChange={setFilter}
+          onClear={clearFilters}
+          onQuerySubmit={setQuery}
+          query={query}
+          total={statsQuery.data?.total}
+        />
+      }
+      rail={filterPanel}
+    >
+      <div aria-busy={isNavigating || mutationPending || undefined}>
+        {mutationError ? (
+          <p role="alert" {...stylex.props(styles.actionError)}>
+            The library change failed. Try the action again.
+          </p>
+        ) : null}
+        {libraryQuery.isPending ? (
+          <LoadingList label="Loading member library" rows={4} />
+        ) : libraryQuery.error ? (
+          <SectionError
+            heading="Library is unavailable"
+            onRetry={() => void libraryQuery.refetch()}
+          >
+            The member profile is still available. Try loading the Library
+            again.
+          </SectionError>
+        ) : (
+          <MemberLibraryList
+            emptyAction={
+              isCurrentUser &&
+              !hasActiveFilters({ brand, distiller, query, status }) ? (
+                <ButtonLink
+                  href="/addBottle?intent=library"
+                  size="sm"
+                  variant="accent"
+                >
+                  Add your first bottle
+                </ButtonLink>
+              ) : undefined
+            }
+            emptyDescription={
+              hasActiveFilters({ brand, distiller, query, status })
+                ? "No library bottles match these filters."
+                : isCurrentUser
+                  ? "Track what you own, what you have finished, and what you want to open next."
+                  : `${user.username} has not added any bottles to their Library.`
+            }
+            emptyHeading={
+              hasActiveFilters({ brand, distiller, query, status })
+                ? "No matching bottles"
+                : "No library bottles yet"
+            }
+            items={applyEntryChanges(
+              libraryQuery.data.results,
+              entryChanges,
+            ).map((entry) =>
+              toLibraryItem(
+                entry,
+                isCurrentUser,
+                mutationPending,
+                updateStatus,
+                removeEntry,
+              ),
+            )}
+            nextHref={getCursorHref(
+              pathname,
+              searchParams,
+              libraryQuery.data.rel.nextCursor,
+            )}
+            page={cursor}
+            previousHref={getCursorHref(
+              pathname,
+              searchParams,
+              libraryQuery.data.rel.prevCursor,
+            )}
+            total={statsQuery.data?.total}
+          />
+        )}
+      </div>
+    </ProfileLibraryLayout>
   );
 }
 
@@ -449,24 +421,6 @@ function hasActiveFilters(values: {
   return Boolean(
     values.brand || values.distiller || values.query || values.status,
   );
-}
-
-function positiveNumber(value: string | null) {
-  if (!value) return undefined;
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
-}
-
-function parseStatus(
-  value: string | null,
-): LibraryStatus | "unset" | undefined {
-  return value && statusValues.has(value)
-    ? value === "unset"
-      ? "unset"
-      : value === "open" || value === "sealed" || value === "empty"
-        ? value
-        : undefined
-    : undefined;
 }
 
 function capitalize(value: string) {

--- a/apps/web/src/app/(app)/users/[username]/loading.tsx
+++ b/apps/web/src/app/(app)/users/[username]/loading.tsx
@@ -1,5 +1,5 @@
-import { LoadingList } from "@peated/web/components";
+import { ProfileOverviewLoading } from "./profileOverviewLayout.stylex";
 
 export default function ProfileLoading() {
-  return <LoadingList label="Loading member profile" rows={4} />;
+  return <ProfileOverviewLoading />;
 }

--- a/apps/web/src/app/(app)/users/[username]/page.tsx
+++ b/apps/web/src/app/(app)/users/[username]/page.tsx
@@ -1,8 +1,12 @@
+import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import type { Outputs } from "@peated/server/orpc/router";
 import { createServerClient } from "@peated/web/lib/orpc/client.server";
+import { getQueryClient } from "@peated/web/lib/orpc/query";
 import { getProfilePage } from "@peated/web/lib/profilePage.server";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 import { ProfileOverviewPageClient } from "./profileOverviewPageClient.stylex";
+import { profileQueries } from "./profileQueries";
 
 export const fetchCache = "default-no-store";
 
@@ -12,10 +16,12 @@ export default async function ProfileOverviewPage(props: {
   const { username } = await props.params;
   const { client } = await createServerClient();
   const user = await getProfilePage(username);
-  const [activityList, badgePage, tastingStats] = await Promise.all([
+  const queryClient = getQueryClient();
+  const orpc = createTanstackQueryUtils(client);
+  const [activityList, badgePage] = await Promise.all([
     client.users.activity.list({ limit: 3, user: user.id }),
     client.users.badgeList({ cursor: 1, limit: 100, user: user.id }),
-    client.users.tastingStats({ user: user.id }),
+    queryClient.prefetchQuery(profileQueries.tastingStats(orpc, user.id)),
   ]);
   const badgeAwards: Outputs["users"]["badgeList"]["results"] = [
     ...badgePage.results,
@@ -33,10 +39,11 @@ export default async function ProfileOverviewPage(props: {
   }
 
   return (
-    <ProfileOverviewPageClient
-      initialActivityList={activityList}
-      initialBadgeAwards={badgeAwards}
-      initialTastingStats={tastingStats}
-    />
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ProfileOverviewPageClient
+        initialActivityList={activityList}
+        initialBadgeAwards={badgeAwards}
+      />
+    </HydrationBoundary>
   );
 }

--- a/apps/web/src/app/(app)/users/[username]/profileLoading.ts
+++ b/apps/web/src/app/(app)/users/[username]/profileLoading.ts
@@ -1,0 +1,6 @@
+const loadingRowCounts = [1, 2, 3, 4, 5, 6, 7, 8] as const;
+
+export function getProfileLoadingRows(total: number) {
+  const index = Math.min(Math.max(total, 1), loadingRowCounts.length) - 1;
+  return loadingRowCounts[index] ?? 1;
+}

--- a/apps/web/src/app/(app)/users/[username]/profileOverviewLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileOverviewLayout.stylex.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import type { ReactNode } from "react";
+
+import {
+  AppLink,
+  FactList,
+  type FactListItem,
+  LoadingList,
+  LoadingPlaceholder,
+  SectionHeading,
+} from "@peated/web/components";
+import {
+  PageColumns,
+  RailSection,
+} from "@peated/web/components/pages/pageLayout.stylex";
+import { colors, space } from "../../../../styles/tokens.stylex";
+import { useProfile } from "./profileContext";
+
+const loadingDelays = [0, 1, 2, 3, 4] as const;
+
+export function ProfileOverviewLayout({
+  main,
+  rail,
+}: {
+  main: ReactNode;
+  rail: ReactNode;
+}) {
+  return (
+    <div {...stylex.props(styles.overview)}>
+      <PageColumns rail={rail} railBehavior="stack">
+        <div {...stylex.props(styles.main)}>{main}</div>
+      </PageColumns>
+    </div>
+  );
+}
+
+export function ProfileActivitySection({
+  children,
+  username,
+}: {
+  children: ReactNode;
+  username: string;
+}) {
+  return (
+    <section aria-label="Recent activity">
+      <div {...stylex.props(styles.sectionHeader)}>
+        <SectionHeading>Recent activity</SectionHeading>
+        <AppLink href={`/users/${username}/activity`}>View all</AppLink>
+      </div>
+      {children}
+    </section>
+  );
+}
+
+/** Keeps the Overview page size stable while its data loads. */
+export function ProfileOverviewLoading() {
+  const { user } = useProfile();
+  const factLabels = user.createdAt
+    ? ["Tastings", "Bottles tasted", "In library", "Catalog changes", "Joined"]
+    : ["Tastings", "Bottles tasted", "In library", "Catalog changes"];
+  const facts: [FactListItem, ...FactListItem[]] = [
+    {
+      label: "Tastings",
+      value: <LoadingPlaceholder preset="metadata" />,
+    },
+    ...factLabels.slice(1).map((label, index) => ({
+      label,
+      value: (
+        <LoadingPlaceholder
+          delay={loadingDelays[(index + 1) % loadingDelays.length]}
+          preset="metadata"
+        />
+      ),
+    })),
+  ];
+
+  return (
+    <div aria-busy="true" aria-label="Loading profile overview" role="status">
+      <ProfileOverviewLayout
+        main={
+          <>
+            <FactList facts={facts} layout="grid" />
+            <ProfileActivitySection username={user.username}>
+              <LoadingList label="Loading recent member activity" rows={4} />
+            </ProfileActivitySection>
+          </>
+        }
+        rail={
+          <div aria-hidden="true" {...stylex.props(styles.loadingRail)}>
+            <LoadingRailSection />
+            <LoadingRailSection />
+            <LoadingRailSection />
+          </div>
+        }
+      />
+    </div>
+  );
+}
+
+function LoadingRailSection() {
+  return (
+    <RailSection heading={<LoadingPlaceholder preset="heading" />}>
+      <LoadingList label="Loading profile details" rows={3} />
+    </RailSection>
+  );
+}
+
+const styles = stylex.create({
+  overview: {
+    minWidth: 0,
+  },
+  main: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x8,
+  },
+  sectionHeader: {
+    display: "flex",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: space.x4,
+    paddingBottom: space.x3,
+    borderBottomWidth: "1px",
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.sectionRule,
+  },
+  loadingRail: {
+    display: "flex",
+    minWidth: 0,
+    flexDirection: "column",
+    gap: space.x8,
+  },
+});

--- a/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
@@ -5,27 +5,27 @@ import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 
 import {
-  AppLink,
   FactList,
   LoadingPlaceholder,
   RailList,
   RailListItem,
-  SectionHeading,
   TastingRatingDistribution,
   type FactListItem,
   type TastingRatingCounts,
 } from "@peated/web/components";
 import { MemberActivityList } from "@peated/web/components/pages/memberProfileContent.stylex";
-import {
-  PageColumns,
-  RailSection,
-} from "@peated/web/components/pages/pageLayout.stylex";
+import { RailSection } from "@peated/web/components/pages/pageLayout.stylex";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getEntityUrl } from "@peated/web/lib/urls";
-import { colors, space } from "../../../../styles/tokens.stylex";
+import { space } from "../../../../styles/tokens.stylex";
 import { toActivityItem } from "./profileActivity";
 import { useProfile } from "./profileContext";
+import {
+  ProfileActivitySection,
+  ProfileOverviewLayout,
+} from "./profileOverviewLayout.stylex";
 import { ProfilePassport } from "./profilePassport.stylex";
+import { profileQueries } from "./profileQueries";
 
 type ActivityList = Outputs["users"]["activity"]["list"];
 type BadgeAward = Outputs["users"]["badgeList"]["results"][number];
@@ -41,18 +41,13 @@ type ProducerGroup = {
 export function ProfileOverviewPageClient({
   initialActivityList,
   initialBadgeAwards,
-  initialTastingStats,
 }: {
   initialActivityList: ActivityList;
   initialBadgeAwards: readonly BadgeAward[];
-  initialTastingStats: TastingStats;
 }) {
   const orpc = useORPC();
   const { isCurrentUser, user } = useProfile();
-  const statsQuery = useQuery({
-    ...orpc.users.tastingStats.queryOptions({ input: { user: user.id } }),
-    initialData: initialTastingStats,
-  });
+  const statsQuery = useQuery(profileQueries.tastingStats(orpc, user.id));
   const bands = getBands(statsQuery.data);
   const producerGroups = getProducerGroups(statsQuery.data?.producers);
   const facts: readonly [FactListItem, ...FactListItem[]] = user.createdAt
@@ -85,36 +80,11 @@ export function ProfileOverviewPageClient({
     .map(toActivityItem);
 
   return (
-    <div {...stylex.props(styles.overview)}>
-      <PageColumns
-        rail={
-          <>
-            {producerGroups.length ? (
-              <ProducerSections groups={producerGroups} />
-            ) : null}
-            <RailSection heading="Passport">
-              <ProfilePassport awards={initialBadgeAwards} />
-            </RailSection>
-            {statsQuery.isPending || bands ? (
-              <RatingSummary
-                bands={bands}
-                label={isCurrentUser ? "Your ratings" : "Their ratings"}
-                loading={statsQuery.isPending}
-              />
-            ) : null}
-          </>
-        }
-        railBehavior="stack"
-      >
-        <div {...stylex.props(styles.main)}>
+    <ProfileOverviewLayout
+      main={
+        <>
           <FactList facts={facts} layout="grid" />
-          <section aria-label="Recent activity">
-            <div {...stylex.props(styles.sectionHeader)}>
-              <SectionHeading>Recent activity</SectionHeading>
-              <AppLink href={`/users/${user.username}/activity`}>
-                View all
-              </AppLink>
-            </div>
+          <ProfileActivitySection username={user.username}>
             <MemberActivityList
               emptyDescription={
                 isCurrentUser
@@ -123,10 +93,27 @@ export function ProfileOverviewPageClient({
               }
               items={activity}
             />
-          </section>
-        </div>
-      </PageColumns>
-    </div>
+          </ProfileActivitySection>
+        </>
+      }
+      rail={
+        <>
+          {producerGroups.length ? (
+            <ProducerSections groups={producerGroups} />
+          ) : null}
+          <RailSection heading="Passport">
+            <ProfilePassport awards={initialBadgeAwards} />
+          </RailSection>
+          {statsQuery.isPending || bands ? (
+            <RatingSummary
+              bands={bands}
+              label={isCurrentUser ? "Your ratings" : "Their ratings"}
+              loading={statsQuery.isPending}
+            />
+          ) : null}
+        </>
+      }
+    />
   );
 }
 
@@ -238,25 +225,6 @@ function formatCount(count: number) {
 }
 
 const styles = stylex.create({
-  overview: {
-    minWidth: 0,
-  },
-  main: {
-    display: "flex",
-    minWidth: 0,
-    flexDirection: "column",
-    gap: space.x8,
-  },
-  sectionHeader: {
-    display: "flex",
-    alignItems: "baseline",
-    justifyContent: "space-between",
-    gap: space.x4,
-    paddingBottom: space.x3,
-    borderBottomWidth: "1px",
-    borderBottomStyle: "solid",
-    borderBottomColor: colors.sectionRule,
-  },
   ratingLoading: {
     display: "flex",
     minHeight: "66px",

--- a/apps/web/src/app/(app)/users/[username]/profileQueries.test.ts
+++ b/apps/web/src/app/(app)/users/[username]/profileQueries.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  getProfileActivityRouteState,
+  getProfileLibraryInput,
+  getProfileTastingCursor,
+} from "./profileQueries";
+
+describe("profile route query state", () => {
+  test("uses the same activity state for server and browser params", () => {
+    const expected = { cursor: "next-page", page: 3 };
+
+    expect(
+      getProfileActivityRouteState({ cursor: "next-page", page: "3" }),
+    ).toEqual(expected);
+    expect(
+      getProfileActivityRouteState(
+        new URLSearchParams({ cursor: "next-page", page: "3" }),
+      ),
+    ).toEqual(expected);
+  });
+
+  test("normalizes invalid page values", () => {
+    expect(getProfileActivityRouteState({ page: "0" })).toEqual({
+      cursor: undefined,
+      page: 1,
+    });
+    expect(getProfileTastingCursor({ cursor: "not-a-page" })).toBe(1);
+  });
+
+  test("keeps only supported library filters", () => {
+    expect(
+      getProfileLibraryInput(
+        {
+          brand: "12",
+          cursor: "2",
+          distiller: "19",
+          internalRouteValue: "ignore-me",
+          query: "peated",
+          status: "open",
+        },
+        42,
+      ),
+    ).toEqual({
+      brand: 12,
+      collection: "library",
+      cursor: 2,
+      distiller: 19,
+      limit: 25,
+      query: "peated",
+      status: "open",
+      user: 42,
+    });
+  });
+
+  test("normalizes unsupported library filters", () => {
+    expect(
+      getProfileLibraryInput(
+        { brand: "-1", cursor: "0", distiller: "nan", status: "removed" },
+        42,
+      ),
+    ).toEqual({
+      brand: undefined,
+      collection: "library",
+      cursor: 1,
+      distiller: undefined,
+      limit: 25,
+      query: "",
+      status: undefined,
+      user: 42,
+    });
+  });
+});

--- a/apps/web/src/app/(app)/users/[username]/profileQueries.ts
+++ b/apps/web/src/app/(app)/users/[username]/profileQueries.ts
@@ -1,0 +1,114 @@
+import type { Inputs, Outputs } from "@peated/server/orpc/router";
+import {
+  infiniteQueryOptions,
+  type InfiniteData,
+  type QueryKey,
+} from "@tanstack/react-query";
+
+import type { SearchParamSource } from "@peated/web/lib/apiQueryParams";
+import type { ORPCQueryUtils } from "@peated/web/lib/orpc/context";
+
+type ActivityList = Outputs["users"]["activity"]["list"];
+export type ProfileLibraryInput = Inputs["collections"]["bottles"]["list"] & {
+  brand?: number;
+  collection: "library";
+  cursor: number;
+  distiller?: number;
+  limit: 25;
+  query: string;
+  status?: "empty" | "open" | "sealed" | "unset";
+  user: number;
+};
+
+/** The server and browser must use the same query keys. */
+export const profileQueries = {
+  activity: (orpc: ORPCQueryUtils, userId: number, cursor?: string) =>
+    infiniteQueryOptions<
+      ActivityList,
+      Error,
+      InfiniteData<ActivityList>,
+      QueryKey,
+      string | undefined
+    >({
+      queryKey: orpc.users.activity.list.key({
+        input: { cursor, limit: 10, user: userId },
+      }),
+      queryFn: ({ pageParam }) =>
+        orpc.users.activity.list.call({
+          cursor: pageParam,
+          limit: 10,
+          user: userId,
+        }),
+      initialPageParam: cursor,
+      getNextPageParam: (lastPage) => lastPage.rel.nextCursor ?? undefined,
+    }),
+  library: (orpc: ORPCQueryUtils, input: ProfileLibraryInput) =>
+    orpc.collections.bottles.list.queryOptions({ input }),
+  libraryStats: (orpc: ORPCQueryUtils, userId: number) =>
+    orpc.users.libraryStats.queryOptions({ input: { user: userId } }),
+  regions: (orpc: ORPCQueryUtils, userId: number) =>
+    orpc.users.regionList.queryOptions({ input: { user: userId } }),
+  tastingStats: (orpc: ORPCQueryUtils, userId: number) =>
+    orpc.users.tastingStats.queryOptions({ input: { user: userId } }),
+  tastings: (orpc: ORPCQueryUtils, userId: number, cursor: number) =>
+    orpc.tastings.list.queryOptions({
+      input: { cursor, limit: 10, user: userId },
+    }),
+};
+
+export function getProfileActivityRouteState(source: SearchParamSource) {
+  const cursor = getSearchParam(source, "cursor");
+  const page = parsePositiveNumber(getSearchParam(source, "page"));
+
+  return {
+    cursor: cursor || undefined,
+    page: page ?? 1,
+  };
+}
+
+export function getProfileTastingCursor(source: SearchParamSource) {
+  return parsePositiveNumber(getSearchParam(source, "cursor")) ?? 1;
+}
+
+export function getProfileLibraryInput(
+  source: SearchParamSource,
+  userId: number,
+): ProfileLibraryInput {
+  return {
+    brand: parsePositiveNumber(getSearchParam(source, "brand")),
+    collection: "library",
+    cursor: parsePositiveNumber(getSearchParam(source, "cursor")) ?? 1,
+    distiller: parsePositiveNumber(getSearchParam(source, "distiller")),
+    limit: 25,
+    query: getSearchParam(source, "query") ?? "",
+    status: parseLibraryStatus(getSearchParam(source, "status")),
+    user: userId,
+  };
+}
+
+function getSearchParam(source: SearchParamSource, name: string) {
+  if (Symbol.iterator in source) {
+    for (const [entryName, value] of source) {
+      if (entryName === name) return value;
+    }
+    return undefined;
+  }
+
+  const value = source[name];
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function parsePositiveNumber(value: string | undefined) {
+  if (!value) return undefined;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function parseLibraryStatus(value: string | undefined) {
+  return value === "empty" ||
+    value === "open" ||
+    value === "sealed" ||
+    value === "unset"
+    ? value
+    : undefined;
+}

--- a/apps/web/src/app/(app)/users/[username]/tastings/loading.tsx
+++ b/apps/web/src/app/(app)/users/[username]/tastings/loading.tsx
@@ -1,0 +1,5 @@
+import { ProfileTastingsLoading } from "./profileTastingsLayout";
+
+export default function TastingsLoading() {
+  return <ProfileTastingsLoading />;
+}

--- a/apps/web/src/app/(app)/users/[username]/tastings/page.tsx
+++ b/apps/web/src/app/(app)/users/[username]/tastings/page.tsx
@@ -1,7 +1,10 @@
-import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
+import { createTanstackQueryUtils } from "@orpc/tanstack-query";
 import { createServerClient } from "@peated/web/lib/orpc/client.server";
+import { getQueryClient } from "@peated/web/lib/orpc/query";
 import { getProfilePage } from "@peated/web/lib/profilePage.server";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
+import { getProfileTastingCursor, profileQueries } from "../profileQueries";
 import { ProfileTastingsPageClient } from "./profileTastingsPageClient.stylex";
 
 export const fetchCache = "default-no-store";
@@ -13,20 +16,17 @@ export default async function ProfilePageRoute(props: {
   const { username } = await props.params;
   const { client } = await createServerClient();
   const user = await getProfilePage(username);
-  const tastingInput = getApiQueryParams(await props.searchParams, {
-    defaults: { cursor: 1 },
-    numericFields: ["cursor"],
-    overrides: { limit: 10, user: user.id },
-  });
-  const [regionList, tastingList] = await Promise.all([
-    client.users.regionList({ user: user.id }),
-    client.tastings.list(tastingInput),
+  const cursor = getProfileTastingCursor(await props.searchParams);
+  const queryClient = getQueryClient();
+  const orpc = createTanstackQueryUtils(client);
+  await Promise.all([
+    queryClient.prefetchQuery(profileQueries.regions(orpc, user.id)),
+    queryClient.prefetchQuery(profileQueries.tastings(orpc, user.id, cursor)),
   ]);
 
   return (
-    <ProfileTastingsPageClient
-      initialRegionList={regionList}
-      initialTastingList={tastingList}
-    />
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <ProfileTastingsPageClient />
+    </HydrationBoundary>
   );
 }

--- a/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsLayout.tsx
+++ b/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsLayout.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import { LoadingList } from "@peated/web/components";
+import {
+  PageColumns,
+  RailSection,
+} from "@peated/web/components/pages/pageLayout.stylex";
+import { useProfile } from "../profileContext";
+import { getProfileLoadingRows } from "../profileLoading";
+
+export function ProfileTastingsLayout({
+  children,
+  rail,
+}: {
+  children: ReactNode;
+  rail?: ReactNode;
+}) {
+  return <PageColumns rail={rail}>{children}</PageColumns>;
+}
+
+export function ProfileTastingsLoading() {
+  const { isCurrentUser, user } = useProfile();
+
+  return (
+    <ProfileTastingsLayout
+      rail={
+        <RailSection
+          heading={isCurrentUser ? "What you pour" : "What they pour"}
+        >
+          <LoadingList label="Loading member regions" rows={3} />
+        </RailSection>
+      }
+    >
+      <LoadingList
+        label="Loading member tastings"
+        rows={getProfileLoadingRows(user.stats.tastings)}
+      />
+    </ProfileTastingsLayout>
+  );
+}

--- a/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsPageClient.stylex.tsx
@@ -15,43 +15,27 @@ import {
   RailListItem,
   SectionError,
 } from "@peated/web/components";
-import {
-  PageColumns,
-  RailSection,
-} from "@peated/web/components/pages/pageLayout.stylex";
+import { RailSection } from "@peated/web/components/pages/pageLayout.stylex";
 import { TastingRecordEntry } from "@peated/web/components/tastingRecordEntry";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useProfile } from "../profileContext";
+import { getProfileTastingCursor, profileQueries } from "../profileQueries";
+import { ProfileTastingsLayout } from "./profileTastingsLayout";
 
-type TastingList = Outputs["tastings"]["list"];
 type RegionList = Outputs["users"]["regionList"];
 
-export function ProfileTastingsPageClient({
-  initialRegionList,
-  initialTastingList,
-}: {
-  initialRegionList: RegionList;
-  initialTastingList: TastingList;
-}) {
+export function ProfileTastingsPageClient() {
   const orpc = useORPC();
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const { isCurrentUser, user } = useProfile();
-  const cursor = Number(searchParams.get("cursor") ?? "1") || 1;
-  const regionQuery = useQuery({
-    ...orpc.users.regionList.queryOptions({ input: { user: user.id } }),
-    initialData: initialRegionList,
-  });
-  const tastingQuery = useQuery({
-    ...orpc.tastings.list.queryOptions({
-      input: { cursor, limit: 10, user: user.id },
-    }),
-    initialData: initialTastingList,
-  });
+  const cursor = getProfileTastingCursor(searchParams);
+  const regionQuery = useQuery(profileQueries.regions(orpc, user.id));
+  const tastingQuery = useQuery(profileQueries.tastings(orpc, user.id, cursor));
 
   return (
-    <PageColumns
+    <ProfileTastingsLayout
       rail={getRegionRail(regionQuery, user.username, isCurrentUser)}
     >
       <section aria-label={`${user.username}'s tastings`}>
@@ -108,7 +92,7 @@ export function ProfileTastingsPageClient({
           )}
         />
       </section>
-    </PageColumns>
+    </ProfileTastingsLayout>
   );
 }
 

--- a/apps/web/src/components/feedback.stylex.tsx
+++ b/apps/web/src/components/feedback.stylex.tsx
@@ -234,7 +234,7 @@ export function SectionError({
   );
 }
 
-type LoadingRowCount = 1 | 2 | 3 | 4;
+type LoadingRowCount = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 
 export type LoadingListProps = {
   label?: string;


### PR DESCRIPTION
Each profile section now shows a loading state that matches its finished page. The member heading and tabs stay on screen, and the placeholders reserve space for lists, filters, and side content. Desktop and mobile tab changes recorded zero layout shift against a public profile. Library filters and the old Favorites link still work.

The server and browser now share one definition for each profile request. The existing private-profile behavior and no-cache policy remain unchanged. The browser does not make a second profile request after it receives the server result.

Refs #938
