### PR TITLE
fix(web): stabilize direct tasting loading

### DIFF
--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -696,16 +696,14 @@ function AddBottleFlowContent() {
       setTastingLoadError(undefined);
 
       try {
-        const [bottle, collectionStatus] = await Promise.all([
-          orpc.bottles.details.call({
-            bottle: bottleId,
-          }),
-          orpc.collections.bottles.list.call({
-            user: "me",
-            collection: "library",
-            bottle: bottleId,
-          }),
-        ]);
+        const bottle = await orpc.bottles.details.call({
+          bottle: bottleId,
+        });
+        const collectionStatus = await orpc.collections.bottles.list.call({
+          user: "me",
+          collection: "library",
+          bottle: bottle.id,
+        });
 
         if (cancelled) return;
         const libraryEntry = collectionStatus.results[0] ?? null;

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -28,6 +28,7 @@ import type { CreateBottlePrefill } from "@peated/web/components/search/createBo
 import { getCreateBottleHref } from "@peated/web/components/search/createBottleHref";
 import { Search as BottleSearch } from "@peated/web/components/search/search.stylex";
 import TastingForm, {
+  TastingFormLoading,
   type MemberReviewFormSubmitData,
   type TastingCreateFormSubmitData,
 } from "@peated/web/components/tastingForm";
@@ -160,7 +161,17 @@ function CollectionBottlePanel({ entry }: { entry: CollectionBottle }) {
   );
 }
 
-function LoadingBottlePanel({ title }: { title: string }) {
+function LoadingBottlePanel({
+  intent,
+  title,
+}: {
+  intent: AddBottleIntent;
+  title: string;
+}) {
+  if (intent === "tasting") {
+    return <TastingFormLoading title={title} />;
+  }
+
   return (
     <WorkflowScreen title={title}>
       <LoadingList label="Loading bottle" rows={3} />
@@ -607,8 +618,7 @@ function AddBottleFlowContent() {
     requestedResultSource,
   ]);
 
-  const [loadedBottleKey, setLoadedBottleKey] = useState<string | null>(null);
-  const [loadingBottle, setLoadingBottle] = useState(false);
+  const [handledBottleKey, setHandledBottleKey] = useState<string | null>(null);
   const [bottleLoadError, setBottleLoadError] = useState<string | null>(null);
   const [selectedBottle, setSelectedBottle] = useState<FlowBottle | null>(null);
   const [libraryError, setLibraryError] = useState<string | undefined>();
@@ -671,7 +681,7 @@ function AddBottleFlowContent() {
 
   useEffect(() => {
     if (!requestedBottleKey || !requestedBottleId) {
-      setLoadedBottleKey(null);
+      setHandledBottleKey(null);
       return;
     }
 
@@ -679,7 +689,6 @@ function AddBottleFlowContent() {
     let cancelled = false;
 
     async function loadRequestedBottle() {
-      setLoadingBottle(true);
       setBottleLoadError(null);
       setAddedEntry(null);
       setAddedEntryPhotoTrace(null);
@@ -687,14 +696,16 @@ function AddBottleFlowContent() {
       setTastingLoadError(undefined);
 
       try {
-        const bottle = await orpc.bottles.details.call({
-          bottle: bottleId,
-        });
-        const collectionStatus = await orpc.collections.bottles.list.call({
-          user: "me",
-          collection: "library",
-          bottle: bottle.id,
-        });
+        const [bottle, collectionStatus] = await Promise.all([
+          orpc.bottles.details.call({
+            bottle: bottleId,
+          }),
+          orpc.collections.bottles.list.call({
+            user: "me",
+            collection: "library",
+            bottle: bottleId,
+          }),
+        ]);
 
         if (cancelled) return;
         const libraryEntry = collectionStatus.results[0] ?? null;
@@ -730,21 +741,19 @@ function AddBottleFlowContent() {
         } else {
           setSelectedBottle(selection);
         }
-        setLoadedBottleKey(requestedBottleKey);
+        setHandledBottleKey(requestedBottleKey);
       } catch (err) {
         logError(err);
         if (cancelled) return;
         setSelectedBottle(null);
-        setLoadedBottleKey(null);
+        setHandledBottleKey(requestedBottleKey);
         setBottleLoadError(
           "We couldn't load that bottle. Search again or start over.",
         );
-      } finally {
-        if (!cancelled) setLoadingBottle(false);
       }
     }
 
-    if (loadedBottleKey !== requestedBottleKey) {
+    if (handledBottleKey !== requestedBottleKey) {
       void loadRequestedBottle();
     }
 
@@ -753,7 +762,7 @@ function AddBottleFlowContent() {
     };
   }, [
     intent,
-    loadedBottleKey,
+    handledBottleKey,
     orpc,
     requestedBottleId,
     requestedPendingImage,
@@ -769,7 +778,7 @@ function AddBottleFlowContent() {
     setTastingDraft(null);
     setTastingLoadError(undefined);
     setBottleLoadError(null);
-    setLoadedBottleKey(requestedBottleKey);
+    setHandledBottleKey(requestedBottleKey);
     router.replace(getAddBottleHref({ intent: nextIntent }));
   }
 
@@ -1039,8 +1048,8 @@ function AddBottleFlowContent() {
     router.push(getBottleUrl(tastingDraft.bottle));
   }
 
-  if (loadingBottle) {
-    return <LoadingBottlePanel title={flowTitle} />;
+  if (requestedBottleKey && handledBottleKey !== requestedBottleKey) {
+    return <LoadingBottlePanel intent={intent} title={flowTitle} />;
   }
 
   if (bottleLoadError) {

--- a/apps/web/src/components/tastingForm.tsx
+++ b/apps/web/src/components/tastingForm.tsx
@@ -65,6 +65,37 @@ export type {
   TastingEditFormSubmitData,
 } from "@peated/web/lib/tastingForm";
 
+function RecordTypeSection({
+  disabled,
+  onChange,
+  value,
+}: {
+  disabled: boolean;
+  onChange: (value: RecordType) => void;
+  value: RecordType | null;
+}) {
+  return (
+    <FormSection
+      description="A tasting records one pour. A review is your overall opinion of the bottle."
+      title="What do you want to log?"
+    >
+      <RecordTypeInput disabled={disabled} onChange={onChange} value={value} />
+    </FormSection>
+  );
+}
+
+/** Reserves the first-step tasting form while its bottle data loads. */
+export function TastingFormLoading({ title }: { title: string }) {
+  return (
+    <WorkflowScreen mobileSaveBar title={title}>
+      <FormStack>
+        <LoadingList label="Loading bottle" rows={1} />
+        <RecordTypeSection disabled onChange={() => undefined} value={null} />
+      </FormStack>
+    </WorkflowScreen>
+  );
+}
+
 type TastingCreateFormProps = {
   initialData: Partial<z.infer<typeof TastingSchema>> &
     Pick<z.infer<typeof TastingSchema>, "bottle">;
@@ -396,16 +427,11 @@ export default function TastingForm(
             <FormNotice>{submitError ?? errorMessage}</FormNotice>
           ) : null}
           {recordType === null ? (
-            <FormSection
-              description="A tasting records one pour. A review is your overall opinion of the bottle."
-              title="What do you want to log?"
-            >
-              <RecordTypeInput
-                disabled={saving}
-                onChange={selectRecordType}
-                value={recordType}
-              />
-            </FormSection>
+            <RecordTypeSection
+              disabled={saving}
+              onChange={selectRecordType}
+              value={recordType}
+            />
           ) : null}
           {recordType !== null ? (
             <FormSteps currentStep={currentStep} steps={steps} />


### PR DESCRIPTION
Direct tasting links now show the first tasting-form step while bottle data loads. They no longer flash the bottle finder or use a short generic list. The loading screen uses the form's record-choice section and reserves the bottle row.

The flow resolves a merged Bottle ID before it checks Library membership, so old direct links use the canonical Bottle. It stays client-side and behind the existing auth boundary. Server caching and session behavior do not change. I checked slow loading at 390×844 and 1440×900, and ran the web tests, typecheck, and production build.
