### PR TITLE
feat(catalog): improve country and region pages

### DIFF
--- a/apps/server/src/lib/bottleProductionLocation.ts
+++ b/apps/server/src/lib/bottleProductionLocation.ts
@@ -1,0 +1,61 @@
+import { db } from "@peated/server/db";
+import {
+  bottleTombstones,
+  bottles,
+  bottlesToDistillers,
+  entities,
+} from "@peated/server/db/schema";
+import {
+  and,
+  asc,
+  isNotNull,
+  sql,
+  type SQL,
+  type SQLWrapper,
+} from "drizzle-orm";
+
+type ProductionLocation =
+  | { countryId: number | SQLWrapper; regionId?: never }
+  | { countryId?: never; regionId: number | SQLWrapper };
+
+// Bottle origin follows the producing distillery. Brand and bottler addresses
+// describe business relationships and do not establish production location.
+export function bottleProducedIn(location: ProductionLocation): SQL<unknown> {
+  const locationWhere =
+    location.countryId !== undefined
+      ? sql`${entities.countryId} = ${location.countryId}`
+      : sql`${entities.regionId} = ${location.regionId}`;
+
+  return sql`EXISTS(
+    SELECT FROM ${bottlesToDistillers}
+    INNER JOIN ${entities}
+      ON ${bottlesToDistillers.distillerId} = ${entities.id}
+    WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
+      AND ${locationWhere}
+  )`;
+}
+
+export async function listBottleCategoriesByProductionLocation(
+  location: ProductionLocation,
+) {
+  const rows = await db
+    .select({
+      category: bottles.category,
+      count: sql<string>`COUNT(*)`,
+    })
+    .from(bottles)
+    .where(
+      and(
+        isNotNull(bottles.groupId),
+        sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
+        bottleProducedIn(location),
+      ),
+    )
+    .groupBy(bottles.category)
+    .orderBy(asc(bottles.category));
+
+  return rows.map(({ count, category }) => ({
+    count: Number(count),
+    category,
+  }));
+}

--- a/apps/server/src/orpc/contracts/bottles/list.ts
+++ b/apps/server/src/orpc/contracts/bottles/list.ts
@@ -38,6 +38,18 @@ export default contract
       distiller: z.coerce.number().nullish(),
       bottler: z.coerce.number().nullish(),
       entity: z.coerce.number().nullish(),
+      country: z.coerce
+        .string()
+        .nullish()
+        .describe(
+          "Filter by the country of an assigned distillery. Accepts a slug or numeric ID.",
+        ),
+      region: z.coerce
+        .string()
+        .nullish()
+        .describe(
+          "Filter by the region of an assigned distillery. Accepts a slug or numeric ID and requires `country`.",
+        ),
       distilleryView: z
         .enum(DISTILLERY_BOTTLE_VIEW_LIST)
         .nullish()

--- a/apps/server/src/orpc/routes/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/bottles/list.test.ts
@@ -1238,6 +1238,73 @@ describe("GET /bottles", () => {
     expect(results.length).toBe(0);
   });
 
+  test("filters production location through distilleries", async ({
+    fixtures,
+  }) => {
+    const country = await fixtures.Country({ slug: "scotland" });
+    const otherCountry = await fixtures.Country({ slug: "japan" });
+    const region = await fixtures.Region({
+      countryId: country.id,
+      slug: "islay",
+    });
+    const otherRegion = await fixtures.Region({
+      countryId: otherCountry.id,
+      slug: "islay",
+    });
+    const brand = await fixtures.Entity({ countryId: country.id });
+    const distiller = await fixtures.Entity({
+      countryId: country.id,
+      regionId: region.id,
+      kind: "distillery",
+    });
+    const otherDistiller = await fixtures.Entity({
+      countryId: otherCountry.id,
+      regionId: otherRegion.id,
+      kind: "distillery",
+    });
+    const localBottle = await fixtures.Bottle({
+      name: "Local bottle",
+      distillerIds: [distiller.id],
+    });
+    await fixtures.Bottle({
+      name: "Local brand only",
+      brandId: brand.id,
+      distillerIds: [otherDistiller.id],
+    });
+
+    const countryResults = await routerClient.bottles.list({
+      country: country.slug,
+    });
+    const regionResults = await routerClient.bottles.list({
+      country: country.slug,
+      region: region.slug,
+    });
+
+    expect(countryResults.results.map(({ id }) => id)).toEqual([
+      localBottle.id,
+    ]);
+    expect(regionResults.results.map(({ id }) => id)).toEqual([localBottle.id]);
+  });
+
+  test("requires and validates a region country", async ({ fixtures }) => {
+    const country = await fixtures.Country({ slug: "scotland" });
+    const otherCountry = await fixtures.Country({ slug: "japan" });
+    const region = await fixtures.Region({
+      countryId: otherCountry.id,
+      slug: "islay",
+    });
+
+    await expect(
+      routerClient.bottles.list({ region: region.slug }),
+    ).rejects.toThrow("Region requires country.");
+    await expect(
+      routerClient.bottles.list({
+        country: country.slug,
+        region: region.id.toString(),
+      }),
+    ).rejects.toThrow("Invalid region.");
+  });
+
   test("validates input parameters", async () => {
     const err = await waitError(
       routerClient.bottles.list({

--- a/apps/server/src/orpc/routes/bottles/list.ts
+++ b/apps/server/src/orpc/routes/bottles/list.ts
@@ -6,12 +6,15 @@ import {
   bottlesToDistillers,
   bottleTombstones,
   collectionBottles,
+  countries,
   entities,
   entityFollows,
   flightBottles,
   flights,
+  regions,
   tastings,
 } from "@peated/server/db/schema";
+import { bottleProducedIn } from "@peated/server/lib/bottleProductionLocation";
 import { getReservedCollection } from "@peated/server/lib/db";
 import { bottlesForDistilleryView } from "@peated/server/lib/distilleryBottleView";
 import {
@@ -57,8 +60,18 @@ export default implement(bottleListContract).handler(async function ({
   context,
   errors,
 }) {
-  const { query, cursor, limit, filter, library, category, ageBand, ...rest } =
-    input;
+  const {
+    query,
+    cursor,
+    limit,
+    filter,
+    library,
+    category,
+    ageBand,
+    country,
+    region,
+    ...rest
+  } = input;
   const offset = (cursor - 1) * limit;
   const textQuery = plainTextSearchQuery(query);
   const prefixQuery = prefixTextSearchQuery(query);
@@ -173,6 +186,42 @@ export default implement(bottleListContract).handler(async function ({
           : undefined,
       ),
     );
+  }
+  if (region && !country) {
+    throw errors.BAD_REQUEST({ message: "Region requires country." });
+  }
+  if (country) {
+    let countryId: number;
+    if (Number.isFinite(+country)) {
+      countryId = Number(country);
+    } else {
+      const [result] = await db
+        .select({ id: countries.id })
+        .from(countries)
+        .where(eq(sql`LOWER(${countries.slug})`, country.toLowerCase()))
+        .limit(1);
+      if (!result) {
+        throw errors.BAD_REQUEST({ message: "Invalid country." });
+      }
+      countryId = result.id;
+    }
+
+    if (region) {
+      const regionWhere = Number.isFinite(+region)
+        ? eq(regions.id, Number(region))
+        : eq(sql`LOWER(${regions.slug})`, region.toLowerCase());
+      const [result] = await db
+        .select({ id: regions.id })
+        .from(regions)
+        .where(and(eq(regions.countryId, countryId), regionWhere))
+        .limit(1);
+      if (!result) {
+        throw errors.BAD_REQUEST({ message: "Invalid region." });
+      }
+      where.push(bottleProducedIn({ regionId: result.id }));
+    } else {
+      where.push(bottleProducedIn({ countryId }));
+    }
   }
   if (rest.brand) {
     where.push(eq(bottles.brandId, rest.brand));

--- a/apps/server/src/orpc/routes/countries/categories.ts
+++ b/apps/server/src/orpc/routes/countries/categories.ts
@@ -1,14 +1,9 @@
 import { db } from "@peated/server/db";
-import {
-  bottleTombstones,
-  bottles,
-  bottlesToDistillers,
-  countries,
-  entities,
-} from "@peated/server/db/schema";
+import { countries } from "@peated/server/db/schema";
+import { listBottleCategoriesByProductionLocation } from "@peated/server/lib/bottleProductionLocation";
 import { procedure } from "@peated/server/orpc";
 import { CategoryEnum } from "@peated/server/schemas";
-import { and, asc, eq, isNotNull, sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
 export default procedure
@@ -57,32 +52,9 @@ export default procedure
       countryId = result.id;
     }
 
-    const rows = await db
-      .select({
-        category: bottles.category,
-        count: sql<string>`COUNT(*)`,
-      })
-      .from(bottles)
-      .where(
-        and(
-          isNotNull(bottles.groupId),
-          sql`NOT EXISTS(SELECT FROM ${bottleTombstones} WHERE ${bottleTombstones.bottleId} = ${bottles.id})`,
-          sql`EXISTS(
-            SELECT FROM ${bottlesToDistillers}
-            INNER JOIN ${entities}
-              ON ${bottlesToDistillers.distillerId} = ${entities.id}
-            WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
-              AND ${entities.countryId} = ${countryId}
-          )`,
-        ),
-      )
-      .groupBy(bottles.category)
-      .orderBy(asc(bottles.category));
-
-    const results = rows.map(({ count, category }) => ({
-      count: Number(count),
-      category,
-    }));
+    const results = await listBottleCategoriesByProductionLocation({
+      countryId,
+    });
 
     return {
       results,

--- a/apps/server/src/orpc/routes/regions/categories.test.ts
+++ b/apps/server/src/orpc/routes/regions/categories.test.ts
@@ -1,0 +1,70 @@
+import { routerClient } from "@peated/server/orpc/router";
+
+describe("GET /countries/:country/regions/:region/categories", () => {
+  test("lists active Bottle categories by producing distillery", async ({
+    fixtures,
+  }) => {
+    const country = await fixtures.Country({ slug: "scotland" });
+    const region = await fixtures.Region({
+      countryId: country.id,
+      slug: "islay",
+    });
+    const otherRegion = await fixtures.Region({
+      countryId: country.id,
+      slug: "speyside",
+    });
+    const distiller = await fixtures.Entity({
+      countryId: country.id,
+      regionId: region.id,
+      kind: "distillery",
+    });
+    const otherDistiller = await fixtures.Entity({
+      countryId: country.id,
+      regionId: otherRegion.id,
+      kind: "distillery",
+    });
+    await fixtures.Bottle({
+      category: "single_malt",
+      distillerIds: [distiller.id],
+    });
+    await fixtures.Bottle({
+      category: "blend",
+      distillerIds: [otherDistiller.id],
+    });
+
+    const data = await routerClient.regions.categories({
+      country: country.slug,
+      region: region.slug,
+    });
+
+    expect(data).toEqual({
+      results: [{ category: "single_malt", count: 1 }],
+      totalCount: 1,
+    });
+  });
+
+  test("returns an empty summary", async ({ fixtures }) => {
+    const country = await fixtures.Country();
+    const region = await fixtures.Region({ countryId: country.id });
+
+    await expect(
+      routerClient.regions.categories({
+        country: country.id,
+        region: region.id,
+      }),
+    ).resolves.toEqual({ results: [], totalCount: 0 });
+  });
+
+  test("rejects a region outside the country", async ({ fixtures }) => {
+    const country = await fixtures.Country();
+    const otherCountry = await fixtures.Country();
+    const region = await fixtures.Region({ countryId: otherCountry.id });
+
+    await expect(
+      routerClient.regions.categories({
+        country: country.id,
+        region: region.id,
+      }),
+    ).rejects.toThrow("Invalid region.");
+  });
+});

--- a/apps/server/src/orpc/routes/regions/categories.ts
+++ b/apps/server/src/orpc/routes/regions/categories.ts
@@ -1,0 +1,70 @@
+import { db } from "@peated/server/db";
+import { countries, regions } from "@peated/server/db/schema";
+import { listBottleCategoriesByProductionLocation } from "@peated/server/lib/bottleProductionLocation";
+import { procedure } from "@peated/server/orpc";
+import { CategoryEnum } from "@peated/server/schemas";
+import { and, eq, sql } from "drizzle-orm";
+import { z } from "zod";
+
+export default procedure
+  .route({
+    method: "GET",
+    path: "/countries/{country}/regions/{region}/categories",
+    summary: "Get region categories",
+    description:
+      "Retrieve whisky categories and their counts for a region based on distillery locations",
+    operationId: "listRegionCategories",
+  })
+  .input(
+    z.object({
+      country: z.coerce.string(),
+      region: z.coerce.string(),
+    }),
+  )
+  .output(
+    z.object({
+      results: z.array(
+        z.object({
+          count: z.number(),
+          category: CategoryEnum.nullable(),
+        }),
+      ),
+      totalCount: z.number(),
+    }),
+  )
+  .handler(async function ({ input, errors }) {
+    let countryId: number;
+    if (Number.isFinite(+input.country)) {
+      countryId = Number(input.country);
+    } else {
+      const [country] = await db
+        .select({ id: countries.id })
+        .from(countries)
+        .where(eq(sql`LOWER(${countries.slug})`, input.country.toLowerCase()))
+        .limit(1);
+      if (!country) {
+        throw errors.BAD_REQUEST({ message: "Invalid country." });
+      }
+      countryId = country.id;
+    }
+
+    const regionWhere = Number.isFinite(+input.region)
+      ? eq(regions.id, Number(input.region))
+      : eq(sql`LOWER(${regions.slug})`, input.region.toLowerCase());
+    const [region] = await db
+      .select({ id: regions.id })
+      .from(regions)
+      .where(and(eq(regions.countryId, countryId), regionWhere))
+      .limit(1);
+    if (!region) {
+      throw errors.BAD_REQUEST({ message: "Invalid region." });
+    }
+
+    const results = await listBottleCategoriesByProductionLocation({
+      regionId: region.id,
+    });
+    return {
+      results,
+      totalCount: results.reduce((total, { count }) => total + count, 0),
+    };
+  });

--- a/apps/server/src/orpc/routes/regions/index.ts
+++ b/apps/server/src/orpc/routes/regions/index.ts
@@ -1,4 +1,5 @@
 import { base } from "@peated/server/orpc";
+import categories from "./categories";
 import create from "./create";
 import delete_ from "./delete";
 import details from "./details";
@@ -6,6 +7,7 @@ import list from "./list";
 import update from "./update";
 
 export default base.tag("regions").router({
+  categories,
   details,
   list,
   create,

--- a/apps/server/src/worker/jobs/updateCountryStats.test.ts
+++ b/apps/server/src/worker/jobs/updateCountryStats.test.ts
@@ -3,9 +3,7 @@ import { bottleTombstones, countries } from "@peated/server/db/schema";
 import { eq } from "drizzle-orm";
 import updateCountryStats from "./updateCountryStats";
 
-test("counts active independently complete Bottles once", async ({
-  fixtures,
-}) => {
+test("counts active Bottles by producing distillery", async ({ fixtures }) => {
   const country1 = await fixtures.Country({ name: "United States" });
   const country2 = await fixtures.Country({ name: "Canada" });
 
@@ -41,7 +39,8 @@ test("counts active independently complete Bottles once", async ({
     .from(countries)
     .where(eq(countries.id, country1.id));
   expect(newCountry1).toBeDefined();
-  expect(newCountry1.totalBottles).toEqual(3);
+  expect(newCountry1.totalBottles).toEqual(1);
+  expect(newCountry1.totalDistillers).toEqual(2);
 });
 
 test.each([

--- a/apps/server/src/worker/jobs/updateCountryStats.ts
+++ b/apps/server/src/worker/jobs/updateCountryStats.ts
@@ -6,6 +6,7 @@ import {
   countries,
   entities,
 } from "@peated/server/db/schema";
+import { bottleProducedIn } from "@peated/server/lib/bottleProductionLocation";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import type { JobPayload } from "../types";
@@ -40,18 +41,7 @@ export default async function updateCountryStats(input: JobPayload) {
       totalBottles: sql<string>`(
         SELECT COUNT(*)
         FROM ${bottles}
-        WHERE EXISTS (
-          SELECT FROM ${entities}
-          WHERE (
-            ${bottles.brandId} = ${entities.id}
-            OR ${bottles.bottlerId} = ${entities.id}
-            OR EXISTS(
-                SELECT FROM ${bottlesToDistillers}
-                WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
-                AND ${bottlesToDistillers.distillerId} = ${entities.id}
-            )
-          ) AND ${entities.countryId} = ${countries.id}
-        )
+        WHERE ${bottleProducedIn({ countryId: countries.id })}
         AND ${bottles.groupId} IS NOT NULL
         AND NOT EXISTS (
           SELECT 1

--- a/apps/server/src/worker/jobs/updateRegionStats.test.ts
+++ b/apps/server/src/worker/jobs/updateRegionStats.test.ts
@@ -3,9 +3,7 @@ import { bottleTombstones, regions } from "@peated/server/db/schema";
 import { eq } from "drizzle-orm";
 import updateRegionStats from "./updateRegionStats";
 
-test("counts active independently complete Bottles once", async ({
-  fixtures,
-}) => {
+test("counts active Bottles by producing distillery", async ({ fixtures }) => {
   const region1 = await fixtures.Region({ name: "Region 1" });
   const region2 = await fixtures.Region({ name: "Region 2" });
 
@@ -53,7 +51,8 @@ test("counts active independently complete Bottles once", async ({
     .from(regions)
     .where(eq(regions.id, region1.id));
   expect(newRegion1).toBeDefined();
-  expect(newRegion1.totalBottles).toEqual(3);
+  expect(newRegion1.totalBottles).toEqual(1);
+  expect(newRegion1.totalDistillers).toEqual(2);
 });
 
 test.each([

--- a/apps/server/src/worker/jobs/updateRegionStats.ts
+++ b/apps/server/src/worker/jobs/updateRegionStats.ts
@@ -6,6 +6,7 @@ import {
   entities,
   regions,
 } from "@peated/server/db/schema";
+import { bottleProducedIn } from "@peated/server/lib/bottleProductionLocation";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import type { JobPayload } from "../types";
@@ -40,18 +41,7 @@ export default async function updateRegionStats(input: JobPayload) {
       totalBottles: sql<string>`(
         SELECT COUNT(*)
         FROM ${bottles}
-        WHERE EXISTS (
-          SELECT FROM ${entities}
-          WHERE (
-            ${bottles.brandId} = ${entities.id}
-            OR ${bottles.bottlerId} = ${entities.id}
-            OR EXISTS(
-                SELECT FROM ${bottlesToDistillers}
-                WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
-                AND ${bottlesToDistillers.distillerId} = ${entities.id}
-            )
-          ) AND ${entities.regionId} = ${regions.id}
-        )
+        WHERE ${bottleProducedIn({ regionId: regions.id })}
         AND ${bottles.groupId} IS NOT NULL
         AND NOT EXISTS (
           SELECT 1

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -9,6 +9,7 @@
 - Put component usage, visible states, and examples in Storybook. Use concise component JSDoc so Storybook Docs and MCP expose the same guidance.
 - Start with one Overview story. Add another story only for a meaningful behavior, async state, permission boundary, error, or responsive composition.
 - Keep complete routes out of Storybook. Review them in the application.
+- Use the Catalog Detail Page story when building a catalog detail route.
 - Keep API queries, auth state, mutations, server actions, and navigation out of reusable components. Put route-only behavior beside the route and shared behavior in a narrowly named feature folder.
 - Do not add catch-all component folders such as `product/`.
 - Use StyleX for web styling. Do not add Tailwind utilities or configuration.

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -301,6 +301,29 @@ async function handleRpcRequest({ request, response, url }) {
       }
       sendRpcResponse(response, testRegion);
       return true;
+    case "countries/categories":
+      if (input?.country !== testRegion.country.slug) {
+        sendRpcError(response, "Unexpected country categories payload");
+        return true;
+      }
+      sendRpcResponse(response, {
+        results: [{ category: "single_malt", count: 1 }],
+        totalCount: 1,
+      });
+      return true;
+    case "regions/categories":
+      if (
+        input?.country !== testRegion.country.slug ||
+        input?.region !== testRegion.slug
+      ) {
+        sendRpcError(response, "Unexpected region categories payload");
+        return true;
+      }
+      sendRpcResponse(response, {
+        results: [{ category: "single_malt", count: 1 }],
+        totalCount: 1,
+      });
+      return true;
     case "bottlers/list":
     case "companies/list":
     case "countries/list":
@@ -742,6 +765,15 @@ async function handleRpcRequest({ request, response, url }) {
           results: [existingBottle, exactMergeOtherBottle],
           rel: { nextCursor: null, prevCursor: null },
         });
+        return true;
+      }
+      if (
+        input?.country === testRegion.country.slug &&
+        (input?.region === undefined || input.region === testRegion.slug) &&
+        input?.limit === 5 &&
+        input?.sort === "-tastings"
+      ) {
+        sendRpcResponse(response, buildBottleListResponse([existingBottle]));
         return true;
       }
       if (

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/bottles/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/bottles/page.tsx
@@ -1,0 +1,45 @@
+import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
+import {
+  BOTTLE_CATALOG_ALLOWED_VALUES,
+  normalizeBottleCatalogQueryParams,
+} from "@peated/web/lib/bottleCatalogQueryParams";
+import { getCountryPage } from "@peated/web/lib/locationPage.server";
+import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+
+import {
+  LOCATION_BOTTLE_DEFAULT_SORT,
+  LOCATION_BOTTLE_QUERY_FIELDS,
+} from "../../../locationBottleList";
+import { LocationBottleListClient } from "../../../locationBottleListClient";
+
+export default async function CountryBottlesPage(props: {
+  params: Promise<{ countrySlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ countrySlug }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const queryParams = normalizeBottleCatalogQueryParams(
+    getApiQueryParams(searchParams, {
+      defaults: { sort: LOCATION_BOTTLE_DEFAULT_SORT },
+      allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
+      fields: LOCATION_BOTTLE_QUERY_FIELDS,
+      numericFields: ["cursor"],
+      overrides: { country: countrySlug, limit: 25 },
+    }),
+  );
+  const { client } = await getPublicPageServerClient();
+  const [country, bottleList] = await Promise.all([
+    getCountryPage(countrySlug),
+    client.bottles.list(queryParams),
+  ]);
+
+  return (
+    <LocationBottleListClient
+      country={countrySlug}
+      initialBottleList={bottleList}
+      locationName={country.name}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/distillers/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/distillers/page.tsx
@@ -1,0 +1,46 @@
+import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
+import { getCursorHref } from "@peated/web/lib/cursorHref";
+import { getCountryPage } from "@peated/web/lib/locationPage.server";
+import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+
+import { LocationDistillerList } from "../../../locationLists";
+
+export default async function CountryDistillersPage(props: {
+  params: Promise<{ countrySlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ countrySlug }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const queryParams = getApiQueryParams(searchParams, {
+    defaults: { sort: "-bottles" },
+    numericFields: ["cursor", "limit"],
+    overrides: { country: countrySlug, limit: 50 },
+  });
+  const { client } = await getPublicPageServerClient();
+  const [country, distillerList] = await Promise.all([
+    getCountryPage(countrySlug),
+    client.distilleries.list(queryParams),
+  ]);
+  const pathname = `/locations/${countrySlug}/distillers`;
+  const page = Number(queryParams.cursor ?? 1) || 1;
+
+  return (
+    <LocationDistillerList
+      items={distillerList.results}
+      name={country.name}
+      nextHref={getCursorHref(
+        pathname,
+        searchParams,
+        distillerList.rel.nextCursor,
+      )}
+      page={page}
+      previousHref={getCursorHref(
+        pathname,
+        searchParams,
+        distillerList.rel.prevCursor,
+      )}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/layout.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/layout.tsx
@@ -1,23 +1,16 @@
 import { ButtonLink, ExpandableDescription } from "@peated/web/components";
 import { getCurrentUser } from "@peated/web/lib/auth.server";
-import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
-import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
-import { cache, type ReactNode } from "react";
+import { getCountryPage } from "@peated/web/lib/locationPage.server";
+import type { ReactNode } from "react";
 
+import { getCountryLocationTabs } from "../../locationPage";
 import { LocationPageFrame } from "../../locationPageFrame.stylex";
-
-const getCountry = cache(async (countrySlug: string) => {
-  const { client } = await getPublicPageServerClient();
-  return await resolveOrNotFound(
-    client.countries.details({ country: countrySlug }),
-  );
-});
 
 export async function generateMetadata(props: {
   params: Promise<{ countrySlug: string }>;
 }) {
   const { countrySlug } = await props.params;
-  const country = await getCountry(countrySlug);
+  const country = await getCountryPage(countrySlug);
 
   return {
     title: `Whisky from ${country.name}`,
@@ -31,7 +24,7 @@ export default async function CountryLayout(props: {
 }) {
   const { countrySlug } = await props.params;
   const [country, user] = await Promise.all([
-    getCountry(countrySlug),
+    getCountryPage(countrySlug),
     getCurrentUser(),
   ]);
   const rootHref = `/locations/${country.slug}`;
@@ -49,22 +42,17 @@ export default async function CountryLayout(props: {
           </ButtonLink>
         ) : undefined
       }
-      country={undefined}
       description={
         country.description ? (
           <ExpandableDescription content={country.description} noLinks />
         ) : undefined
       }
-      name={country.name}
-      tabs={[
-        {
-          count: country.totalDistillers,
-          href: rootHref,
-          label: "Distillers",
-        },
-        { href: `${rootHref}/regions`, label: "Regions" },
-      ]}
-      visual={{ kind: "country", slug: country.slug }}
+      location={{ kind: "country", name: country.name }}
+      tabs={getCountryLocationTabs({
+        rootHref,
+        totalBottles: country.totalBottles,
+        totalDistillers: country.totalDistillers,
+      })}
     >
       {props.children}
     </LocationPageFrame>

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/page.tsx
@@ -1,42 +1,35 @@
-import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
-import { getCursorHref } from "@peated/web/lib/cursorHref";
+import { getCountryPage } from "@peated/web/lib/locationPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 
-import { LocationDistillerList } from "../../locationLists";
+import { LocationOverview } from "../../locationOverview.stylex";
+import {
+  getLocationCategoryItems,
+  getLocationPopularBottles,
+} from "../../locationPage";
 
-export default async function CountryDistillersPage(props: {
+export default async function CountryOverviewPage(props: {
   params: Promise<{ countrySlug: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  const [{ countrySlug }, searchParams] = await Promise.all([
-    props.params,
-    props.searchParams,
-  ]);
-  const queryParams = getApiQueryParams(searchParams, {
-    defaults: { sort: "-bottles" },
-    numericFields: ["cursor", "limit"],
-    overrides: { country: countrySlug, limit: 50 },
-  });
+  const { countrySlug } = await props.params;
   const { client } = await getPublicPageServerClient();
-  const distillerList = await client.distilleries.list(queryParams);
-  const pathname = `/locations/${countrySlug}`;
-  const page = Number(queryParams.cursor ?? 1) || 1;
+  const [country, categories, popularBottles] = await Promise.all([
+    getCountryPage(countrySlug),
+    client.countries.categories({ country: countrySlug }),
+    client.bottles.list({
+      country: countrySlug,
+      limit: 5,
+      sort: "-tastings",
+    }),
+  ]);
 
   return (
-    <LocationDistillerList
-      items={distillerList.results}
-      name={countrySlug.replaceAll("-", " ")}
-      nextHref={getCursorHref(
-        pathname,
-        searchParams,
-        distillerList.rel.nextCursor,
-      )}
-      page={page}
-      previousHref={getCursorHref(
-        pathname,
-        searchParams,
-        distillerList.rel.prevCursor,
-      )}
+    <LocationOverview
+      categories={getLocationCategoryItems(categories.results)}
+      popularBottles={getLocationPopularBottles(popularBottles.results)}
+      productionRules={country.summary}
+      totalBottles={country.totalBottles}
+      totalDistillers={country.totalDistillers}
+      visual={{ kind: "country", slug: country.slug }}
     />
   );
 }

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/bottles/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/bottles/page.tsx
@@ -1,0 +1,50 @@
+import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
+import {
+  BOTTLE_CATALOG_ALLOWED_VALUES,
+  normalizeBottleCatalogQueryParams,
+} from "@peated/web/lib/bottleCatalogQueryParams";
+import { getRegionPage } from "@peated/web/lib/locationPage.server";
+import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+
+import {
+  LOCATION_BOTTLE_DEFAULT_SORT,
+  LOCATION_BOTTLE_QUERY_FIELDS,
+} from "../../../../locationBottleList";
+import { LocationBottleListClient } from "../../../../locationBottleListClient";
+
+export default async function RegionBottlesPage(props: {
+  params: Promise<{ countrySlug: string; regionSlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ countrySlug, regionSlug }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const queryParams = normalizeBottleCatalogQueryParams(
+    getApiQueryParams(searchParams, {
+      defaults: { sort: LOCATION_BOTTLE_DEFAULT_SORT },
+      allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
+      fields: LOCATION_BOTTLE_QUERY_FIELDS,
+      numericFields: ["cursor"],
+      overrides: {
+        country: countrySlug,
+        limit: 25,
+        region: regionSlug,
+      },
+    }),
+  );
+  const { client } = await getPublicPageServerClient();
+  const [region, bottleList] = await Promise.all([
+    getRegionPage(countrySlug, regionSlug),
+    client.bottles.list(queryParams),
+  ]);
+
+  return (
+    <LocationBottleListClient
+      country={countrySlug}
+      initialBottleList={bottleList}
+      locationName={region.name}
+      region={regionSlug}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/distillers/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/distillers/page.tsx
@@ -1,0 +1,46 @@
+import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
+import { getCursorHref } from "@peated/web/lib/cursorHref";
+import { getRegionPage } from "@peated/web/lib/locationPage.server";
+import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+
+import { LocationDistillerList } from "../../../../locationLists";
+
+export default async function RegionDistillersPage(props: {
+  params: Promise<{ countrySlug: string; regionSlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ countrySlug, regionSlug }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const queryParams = getApiQueryParams(searchParams, {
+    defaults: { sort: "-bottles" },
+    numericFields: ["cursor", "limit"],
+    overrides: { country: countrySlug, limit: 50, region: regionSlug },
+  });
+  const { client } = await getPublicPageServerClient();
+  const [region, distillerList] = await Promise.all([
+    getRegionPage(countrySlug, regionSlug),
+    client.distilleries.list(queryParams),
+  ]);
+  const pathname = `/locations/${countrySlug}/regions/${regionSlug}/distillers`;
+  const page = Number(queryParams.cursor ?? 1) || 1;
+
+  return (
+    <LocationDistillerList
+      items={distillerList.results}
+      name={region.name}
+      nextHref={getCursorHref(
+        pathname,
+        searchParams,
+        distillerList.rel.nextCursor,
+      )}
+      page={page}
+      previousHref={getCursorHref(
+        pathname,
+        searchParams,
+        distillerList.rel.prevCursor,
+      )}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/layout.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/layout.tsx
@@ -1,0 +1,67 @@
+import { ButtonLink, ExpandableDescription } from "@peated/web/components";
+import { getCurrentUser } from "@peated/web/lib/auth.server";
+import { getRegionPage } from "@peated/web/lib/locationPage.server";
+import type { ReactNode } from "react";
+
+import { getRegionLocationTabs } from "../../../locationPage";
+import { LocationPageFrame } from "../../../locationPageFrame.stylex";
+
+export async function generateMetadata(props: {
+  params: Promise<{ countrySlug: string; regionSlug: string }>;
+}) {
+  const { countrySlug, regionSlug } = await props.params;
+  const region = await getRegionPage(countrySlug, regionSlug);
+
+  return {
+    title: `Whisky from ${region.name}, ${region.country.name}`,
+    description: region.description,
+  };
+}
+
+export default async function RegionLayout(props: {
+  children: ReactNode;
+  params: Promise<{ countrySlug: string; regionSlug: string }>;
+}) {
+  const { countrySlug, regionSlug } = await props.params;
+  const [region, user] = await Promise.all([
+    getRegionPage(countrySlug, regionSlug),
+    getCurrentUser(),
+  ]);
+  const rootHref = `/locations/${countrySlug}/regions/${regionSlug}`;
+
+  return (
+    <LocationPageFrame
+      actions={
+        user?.mod ? (
+          <ButtonLink
+            href={`/admin/locations/${countrySlug}/regions/${regionSlug}/edit?returnTo=${rootHref}`}
+            size="sm"
+            variant="tonal"
+          >
+            Edit location
+          </ButtonLink>
+        ) : undefined
+      }
+      description={
+        region.description ? (
+          <ExpandableDescription content={region.description} noLinks />
+        ) : undefined
+      }
+      location={{
+        country: {
+          href: `/locations/${region.country.slug}`,
+          name: region.country.name,
+        },
+        kind: "region",
+        name: region.name,
+      }}
+      tabs={getRegionLocationTabs({
+        rootHref,
+        totalBottles: region.totalBottles,
+        totalDistillers: region.totalDistillers,
+      })}
+    >
+      {props.children}
+    </LocationPageFrame>
+  );
+}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
@@ -1,106 +1,41 @@
-import { ButtonLink, ExpandableDescription } from "@peated/web/components";
-import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
-import { getCurrentUser } from "@peated/web/lib/auth.server";
-import { getCursorHref } from "@peated/web/lib/cursorHref";
+import { getRegionPage } from "@peated/web/lib/locationPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
-import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
-import { cache } from "react";
 
-import { LocationDistillerList } from "../../../locationLists";
-import { LocationPageFrame } from "../../../locationPageFrame.stylex";
+import { LocationOverview } from "../../../locationOverview.stylex";
+import {
+  getLocationCategoryItems,
+  getLocationPopularBottles,
+} from "../../../locationPage";
 
-const getRegion = cache(async (countrySlug: string, regionSlug: string) => {
-  const { client } = await getPublicPageServerClient();
-  return await resolveOrNotFound(
-    client.regions.details({ country: countrySlug, region: regionSlug }),
-  );
-});
-
-export async function generateMetadata(props: {
+export default async function RegionOverviewPage(props: {
   params: Promise<{ countrySlug: string; regionSlug: string }>;
 }) {
   const { countrySlug, regionSlug } = await props.params;
-  const region = await getRegion(countrySlug, regionSlug);
-
-  return {
-    title: `Whisky from ${region.name}, ${region.country.name}`,
-    description: region.description,
-  };
-}
-
-export default async function RegionPage(props: {
-  params: Promise<{ countrySlug: string; regionSlug: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
-}) {
-  const [{ countrySlug, regionSlug }, searchParams] = await Promise.all([
-    props.params,
-    props.searchParams,
-  ]);
   const { client } = await getPublicPageServerClient();
-  const region = await getRegion(countrySlug, regionSlug);
-  const queryParams = getApiQueryParams(searchParams, {
-    defaults: { sort: "-bottles" },
-    numericFields: ["cursor", "limit"],
-    overrides: { country: countrySlug, limit: 50, region: regionSlug },
-  });
-  const [distillerList, user] = await Promise.all([
-    client.distilleries.list(queryParams),
-    getCurrentUser(),
+  const [region, categories, popularBottles] = await Promise.all([
+    getRegionPage(countrySlug, regionSlug),
+    client.regions.categories({ country: countrySlug, region: regionSlug }),
+    client.bottles.list({
+      country: countrySlug,
+      region: regionSlug,
+      limit: 5,
+      sort: "-tastings",
+    }),
   ]);
-  const pathname = `/locations/${countrySlug}/regions/${regionSlug}`;
-  const page = Number(queryParams.cursor ?? 1) || 1;
+  const isUsState = countrySlug === "united-states";
 
   return (
-    <LocationPageFrame
-      actions={
-        user?.mod ? (
-          <ButtonLink
-            href={`/admin/locations/${countrySlug}/regions/${regionSlug}/edit?returnTo=${pathname}`}
-            size="sm"
-            variant="tonal"
-          >
-            Edit location
-          </ButtonLink>
-        ) : undefined
-      }
-      country={{
-        href: `/locations/${region.country.slug}`,
-        name: region.country.name,
-      }}
-      description={
-        region.description ? (
-          <ExpandableDescription content={region.description} noLinks />
-        ) : undefined
-      }
-      name={region.name}
-      tabs={[
-        {
-          count: region.totalDistillers,
-          href: pathname,
-          label: "Distillers",
-        },
-      ]}
+    <LocationOverview
+      categories={getLocationCategoryItems(categories.results)}
+      popularBottles={getLocationPopularBottles(popularBottles.results)}
+      totalBottles={region.totalBottles}
+      totalDistillers={region.totalDistillers}
       visual={
-        countrySlug === "united-states"
+        isUsState
           ? { kind: "state", slug: region.slug }
           : { kind: "country", slug: region.country.slug }
       }
-    >
-      <LocationDistillerList
-        items={distillerList.results}
-        name={region.name}
-        nextHref={getCursorHref(
-          pathname,
-          searchParams,
-          distillerList.rel.nextCursor,
-        )}
-        page={page}
-        previousHref={getCursorHref(
-          pathname,
-          searchParams,
-          distillerList.rel.prevCursor,
-        )}
-      />
-    </LocationPageFrame>
+      visualHeading={isUsState ? "Map" : `In ${region.country.name}`}
+    />
   );
 }

--- a/apps/web/src/app/(app)/locations/locationBottleList.ts
+++ b/apps/web/src/app/(app)/locations/locationBottleList.ts
@@ -1,0 +1,11 @@
+export const LOCATION_BOTTLE_DEFAULT_SORT = "-release";
+
+export const LOCATION_BOTTLE_QUERY_FIELDS = ["cursor", "sort"] as const;
+
+export const LOCATION_BOTTLE_SORT_OPTIONS = [
+  { label: "Newest release", value: "-release" },
+  { label: "Most tasted", value: "-tastings" },
+  { label: "Highest score", value: "-score" },
+  { label: "Bottle name", value: "name" },
+  { label: "Oldest age", value: "-age" },
+] as const;

--- a/apps/web/src/app/(app)/locations/locationBottleListClient.tsx
+++ b/apps/web/src/app/(app)/locations/locationBottleListClient.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import type { Outputs } from "@peated/server/orpc/router";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
+import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
+import {
+  BOTTLE_CATALOG_ALLOWED_VALUES,
+  normalizeBottleCatalogQueryParams,
+} from "@peated/web/lib/bottleCatalogQueryParams";
+import { toBottleListItem } from "@peated/web/lib/bottleListItem";
+import { buildSearchHref, getCursorHref } from "@peated/web/lib/cursorHref";
+import { useORPC } from "@peated/web/lib/orpc/context";
+
+import {
+  LOCATION_BOTTLE_DEFAULT_SORT,
+  LOCATION_BOTTLE_QUERY_FIELDS,
+  LOCATION_BOTTLE_SORT_OPTIONS,
+} from "./locationBottleList";
+
+type BottleList = Outputs["bottles"]["list"];
+
+export function LocationBottleListClient({
+  country,
+  initialBottleList,
+  locationName,
+  region,
+}: {
+  country: string;
+  initialBottleList: BottleList;
+  locationName: string;
+  region?: string;
+}) {
+  const orpc = useORPC();
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const queryParams = normalizeBottleCatalogQueryParams(
+    useApiQueryParams({
+      defaults: { sort: LOCATION_BOTTLE_DEFAULT_SORT },
+      allowedValues: BOTTLE_CATALOG_ALLOWED_VALUES,
+      fields: LOCATION_BOTTLE_QUERY_FIELDS,
+      numericFields: ["cursor"],
+      overrides: { country, limit: 25, region },
+    }),
+  );
+  const { data: bottleList } = useSuspenseQuery({
+    ...orpc.bottles.list.queryOptions({ input: queryParams }),
+    initialData: initialBottleList,
+  });
+  const page = Number(searchParams.get("cursor") ?? "1") || 1;
+  const sort = String(queryParams.sort ?? LOCATION_BOTTLE_DEFAULT_SORT);
+
+  function updateSort(value: string) {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set("sort", value);
+    nextParams.delete("cursor");
+    router.push(buildSearchHref(pathname, nextParams));
+  }
+
+  return (
+    <BottleCatalogList
+      emptyDescription={`No bottles produced in ${locationName} have been added yet.`}
+      emptyHeading="No bottles yet"
+      items={bottleList.results.map((bottle) =>
+        toBottleListItem(bottle, {
+          includeRatings: true,
+          includeRelatedReleases: true,
+        }),
+      )}
+      nextHref={getCursorHref(
+        pathname,
+        searchParams,
+        bottleList.rel.nextCursor,
+      )}
+      onSortChange={updateSort}
+      page={page}
+      previousHref={getCursorHref(
+        pathname,
+        searchParams,
+        bottleList.rel.prevCursor,
+      )}
+      sort={sort}
+      sortOptions={LOCATION_BOTTLE_SORT_OPTIONS}
+      total={bottleList.total}
+    />
+  );
+}

--- a/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
@@ -1,0 +1,81 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { DistributionList, FactList } from "@peated/web/components";
+import type { BottleRailItem } from "@peated/web/components/pages/bottleRailSection.stylex";
+import { BottleRailSection } from "@peated/web/components/pages/bottleRailSection.stylex";
+import {
+  PageColumns,
+  PageSection,
+  RailSection,
+} from "@peated/web/components/pages/pageLayout.stylex";
+import { colors, fonts } from "../../../styles/tokens.stylex";
+
+import { LocationVisual } from "./locationPageFrame.stylex";
+
+export function LocationOverview({
+  categories,
+  popularBottles,
+  productionRules,
+  totalBottles,
+  totalDistillers,
+  visual,
+  visualHeading = "Map",
+}: {
+  categories: readonly { count: number; label: string }[];
+  popularBottles: readonly BottleRailItem[];
+  productionRules?: string | null;
+  totalBottles: number;
+  totalDistillers: number;
+  visual: { kind: "country" | "state"; slug: string };
+  visualHeading?: string;
+}) {
+  return (
+    <PageColumns
+      rail={
+        <>
+          <RailSection heading={visualHeading}>
+            <LocationVisual visual={visual} />
+          </RailSection>
+          {productionRules ? (
+            <RailSection heading="Production rules">
+              <p {...stylex.props(styles.copy)}>{productionRules}</p>
+            </RailSection>
+          ) : null}
+          {popularBottles.length ? (
+            <BottleRailSection
+              heading="Popular bottles"
+              items={popularBottles}
+            />
+          ) : null}
+        </>
+      }
+      railBehavior="stack"
+    >
+      <FactList
+        facts={[
+          { label: "Bottles", value: totalBottles.toLocaleString("en-US") },
+          {
+            label: "Distilleries",
+            value: totalDistillers.toLocaleString("en-US"),
+          },
+        ]}
+        layout="grid"
+      />
+      {categories.length ? (
+        <PageSection heading="Bottles by category">
+          <DistributionList items={categories} />
+        </PageSection>
+      ) : null}
+    </PageColumns>
+  );
+}
+
+const styles = stylex.create({
+  copy: {
+    margin: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.reading,
+    fontSize: "14px",
+    lineHeight: 1.55,
+  },
+});

--- a/apps/web/src/app/(app)/locations/locationPage.test.ts
+++ b/apps/web/src/app/(app)/locations/locationPage.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  getCountryLocationTabs,
+  getLocationCategoryItems,
+  getRegionLocationTabs,
+} from "./locationPage";
+
+describe("locationPage", () => {
+  test("builds stable country and region sections", () => {
+    expect(
+      getCountryLocationTabs({
+        rootHref: "/locations/scotland",
+        totalBottles: 12,
+        totalDistillers: 3,
+      }),
+    ).toEqual([
+      { href: "/locations/scotland", label: "Overview" },
+      { count: 12, href: "/locations/scotland/bottles", label: "Bottles" },
+      {
+        count: 3,
+        href: "/locations/scotland/distillers",
+        label: "Distillers",
+      },
+      { href: "/locations/scotland/regions", label: "Regions" },
+    ]);
+    expect(
+      getRegionLocationTabs({
+        rootHref: "/locations/scotland/regions/islay",
+        totalBottles: 4,
+        totalDistillers: 2,
+      }),
+    ).toHaveLength(3);
+  });
+
+  test("omits missing and zero category sections", () => {
+    expect(
+      getLocationCategoryItems([
+        { category: "single_malt", count: 8 },
+        { category: null, count: 2 },
+        { category: "blend", count: 0 },
+      ]),
+    ).toEqual([{ count: 8, label: "Single Malt" }]);
+    expect(getLocationCategoryItems([])).toEqual([]);
+  });
+});

--- a/apps/web/src/app/(app)/locations/locationPage.ts
+++ b/apps/web/src/app/(app)/locations/locationPage.ts
@@ -1,0 +1,71 @@
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
+import { formatCategoryName } from "@peated/server/lib/format";
+import type { Outputs } from "@peated/server/orpc/router";
+import type { PageTabItem } from "@peated/web/components";
+import type { BottleRailItem } from "@peated/web/components/pages/bottleRailSection.stylex";
+import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
+import { getBottleUrl } from "@peated/web/lib/urls";
+
+type Bottle = Outputs["bottles"]["list"]["results"][number];
+
+export function getCountryLocationTabs({
+  rootHref,
+  totalBottles,
+  totalDistillers,
+}: {
+  rootHref: string;
+  totalBottles: number;
+  totalDistillers: number;
+}): readonly [PageTabItem, ...PageTabItem[]] {
+  return [
+    { href: rootHref, label: "Overview" },
+    { count: totalBottles, href: `${rootHref}/bottles`, label: "Bottles" },
+    {
+      count: totalDistillers,
+      href: `${rootHref}/distillers`,
+      label: "Distillers",
+    },
+    { href: `${rootHref}/regions`, label: "Regions" },
+  ];
+}
+
+export function getRegionLocationTabs({
+  rootHref,
+  totalBottles,
+  totalDistillers,
+}: {
+  rootHref: string;
+  totalBottles: number;
+  totalDistillers: number;
+}): readonly [PageTabItem, ...PageTabItem[]] {
+  return [
+    { href: rootHref, label: "Overview" },
+    { count: totalBottles, href: `${rootHref}/bottles`, label: "Bottles" },
+    {
+      count: totalDistillers,
+      href: `${rootHref}/distillers`,
+      label: "Distillers",
+    },
+  ];
+}
+
+export function getLocationCategoryItems(
+  results: readonly { category: string | null; count: number }[],
+) {
+  return results.flatMap(({ category, count }) =>
+    category && count > 0
+      ? [{ count, label: formatCategoryName(category) }]
+      : [],
+  );
+}
+
+export function getLocationPopularBottles(
+  bottles: readonly Bottle[],
+): BottleRailItem[] {
+  return bottles.map((bottle) => ({
+    href: getBottleUrl(bottle),
+    imageUrl: bottle.imageUrl,
+    metadata: getBottleMetadata(bottle),
+    name: formatBottleDisplayName(bottle),
+  }));
+}

--- a/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
@@ -6,7 +6,10 @@ import type { ReactNode } from "react";
 
 import { PageTabs, TextLink, type PageTabItem } from "@peated/web/components";
 import CountryMapIcon from "@peated/web/components/countryMapIcon";
-import { PageHeader } from "@peated/web/components/pages/pageLayout.stylex";
+import {
+  PageHeader,
+  TabbedPage,
+} from "@peated/web/components/pages/pageLayout.stylex";
 import UsStateMapIcon from "@peated/web/components/usStateMapIcon";
 import { colors, space } from "../../../styles/tokens.stylex";
 
@@ -34,57 +37,54 @@ export function LocationsIndexFrame({ children }: { children: ReactNode }) {
 export function LocationPageFrame({
   actions,
   children,
-  country,
   description,
-  name,
+  location,
   tabs,
-  visual,
 }: {
   actions?: ReactNode;
   children: ReactNode;
-  country?: { href: string; name: string };
   description?: ReactNode;
-  name: string;
+  location:
+    | { kind: "country"; name: string }
+    | {
+        country: { href: string; name: string };
+        kind: "region";
+        name: string;
+      };
   tabs: readonly [PageTabItem, ...PageTabItem[]];
-  visual?: { kind: "country" | "state"; slug: string };
 }) {
   const pathname = usePathname();
+  const country = location.kind === "region" ? location.country : undefined;
 
   return (
-    <div>
-      <PageHeader
-        actions={actions}
-        description={description}
-        eyebrow={country ? "Whisky region" : "Whisky country"}
-        parent={
-          country ? (
-            <TextLink href={country.href} size="inherit">
-              {country.name}
-            </TextLink>
-          ) : undefined
-        }
-        title={name}
-      />
-      <div {...stylex.props(styles.tabs)}>
-        <PageTabs
-          ariaLabel={`${name} sections`}
-          currentHref={pathname}
-          items={tabs}
+    <TabbedPage
+      currentHref={pathname}
+      header={
+        <PageHeader
+          actions={actions}
+          description={description}
+          eyebrow={
+            location.kind === "region" ? "Whisky region" : "Whisky country"
+          }
+          parent={
+            country ? (
+              <TextLink href={country.href} size="inherit">
+                {country.name}
+              </TextLink>
+            ) : undefined
+          }
+          title={location.name}
         />
-      </div>
-      <div {...stylex.props(styles.overviewGrid)}>
-        <div {...stylex.props(styles.content)}>{children}</div>
-        {visual ? (
-          <aside {...stylex.props(styles.details)}>
-            <LocationVisual visual={visual} />
-          </aside>
-        ) : null}
-      </div>
-    </div>
+      }
+      tabs={tabs}
+      tabsLabel={`${location.name} sections`}
+    >
+      {children}
+    </TabbedPage>
   );
 }
 
-function LocationVisual({
+export function LocationVisual({
   visual,
 }: {
   visual: { kind: "country" | "state"; slug: string };
@@ -105,35 +105,11 @@ function LocationVisual({
   );
 }
 
-const NARROW = "@media (max-width: 759px)";
-
 const styles = stylex.create({
   indexTabs: { marginTop: space.x6 },
-  tabs: { marginTop: 0 },
-  overviewGrid: {
-    display: "grid",
-    gridTemplateAreas: {
-      default: '"content details"',
-      [NARROW]: '"details" "content"',
-    },
-    gridTemplateColumns: {
-      default: "minmax(0, 1fr) 336px",
-      [NARROW]: "minmax(0, 1fr)",
-    },
-    columnGap: space.x12,
-  },
-  content: {
-    gridArea: "content",
-    minWidth: 0,
-    paddingTop: space.x4,
-  },
   indexContent: {
     minWidth: 0,
     marginTop: space.x6,
-  },
-  details: {
-    gridArea: "details",
-    minWidth: 0,
   },
   visual: {
     display: "flex",
@@ -141,7 +117,6 @@ const styles = stylex.create({
     alignItems: "center",
     justifyContent: "center",
     boxSizing: "border-box",
-    marginTop: space.x4,
     padding: space.x6,
     borderRadius: "3px",
     backgroundColor: colors.inset,

--- a/apps/web/src/components/distributionList.stories.tsx
+++ b/apps/web/src/components/distributionList.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { DistributionList } from "./distributionList.stylex";
+import { StoryCanvas } from "./storyFixtures.stylex";
+
+const meta = {
+  title: "Components/Lists & Tables/Distribution List",
+  component: DistributionList,
+  args: {
+    items: [
+      { count: 842, label: "Single malt" },
+      { count: 311, label: "Blend" },
+      { count: 126, label: "Single grain" },
+      { count: 0, label: "Unknown" },
+    ],
+  },
+  argTypes: { items: { control: "object" } },
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="compact">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+} satisfies Meta<typeof DistributionList>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {};

--- a/apps/web/src/components/distributionList.stylex.tsx
+++ b/apps/web/src/components/distributionList.stylex.tsx
@@ -1,0 +1,90 @@
+import * as stylex from "@stylexjs/stylex";
+
+import { colors, fonts, space } from "../styles/tokens.stylex";
+
+export type DistributionListItem = {
+  count: number;
+  label: string;
+};
+
+/** Shows labeled counts as bars. Use a different component for interactive rows. */
+export function DistributionList({
+  items,
+}: {
+  items: readonly DistributionListItem[];
+}) {
+  const visibleItems = items.filter(({ count }) => count > 0);
+  const largestCount = Math.max(...visibleItems.map(({ count }) => count), 0);
+
+  if (!visibleItems.length) return null;
+
+  return (
+    <ul {...stylex.props(styles.list)}>
+      {visibleItems.map(({ count, label }) => (
+        <li key={label} {...stylex.props(styles.item)}>
+          <div {...stylex.props(styles.copy)}>
+            <span {...stylex.props(styles.label)}>{label}</span>
+            <span {...stylex.props(styles.count)}>
+              {count.toLocaleString()}
+            </span>
+          </div>
+          <div aria-hidden="true" {...stylex.props(styles.track)}>
+            <span
+              style={{ width: `${(count / largestCount) * 100}%` }}
+              {...stylex.props(styles.fill)}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+const styles = stylex.create({
+  list: {
+    display: "flex",
+    flexDirection: "column",
+    gap: space.x3,
+    margin: 0,
+    padding: 0,
+    listStyle: "none",
+  },
+  item: {
+    minWidth: 0,
+  },
+  copy: {
+    display: "flex",
+    alignItems: "baseline",
+    justifyContent: "space-between",
+    gap: space.x4,
+  },
+  label: {
+    overflow: "hidden",
+    color: colors.ink,
+    fontFamily: fonts.reading,
+    fontSize: "14px",
+    lineHeight: 1.4,
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+  },
+  count: {
+    flexShrink: 0,
+    margin: 0,
+    color: colors.inkMuted,
+    fontFamily: fonts.data,
+    fontSize: "11px",
+    fontVariantNumeric: "tabular-nums",
+    lineHeight: 1.3,
+  },
+  track: {
+    height: "5px",
+    marginTop: space.x1,
+    overflow: "hidden",
+    backgroundColor: colors.inset,
+  },
+  fill: {
+    display: "block",
+    height: "100%",
+    backgroundColor: colors.dataAccent,
+  },
+});

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -63,6 +63,8 @@ export { CriticReview } from "./criticReview.stylex";
 export type { CriticReviewProps } from "./criticReview.stylex";
 export { DataTable } from "./dataTable.stylex";
 export type { DataTableColumn, DataTableProps } from "./dataTable.stylex";
+export { DistributionList } from "./distributionList.stylex";
+export type { DistributionListItem } from "./distributionList.stylex";
 export { ExpandableDescription } from "./expandableDescription.stylex";
 export { FacetRow } from "./facetRow.stylex";
 export type { FacetRowProps } from "./facetRow.stylex";

--- a/apps/web/src/components/pages/catalogDetailComposition.stories.tsx
+++ b/apps/web/src/components/pages/catalogDetailComposition.stories.tsx
@@ -1,0 +1,119 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { DistributionList, FactList, RailList, RailListItem } from "..";
+import { StoryCanvas } from "../storyFixtures.stylex";
+import {
+  PageColumns,
+  PageHeader,
+  PageSection,
+  RailSection,
+  TabbedPage,
+} from "./pageLayout.stylex";
+
+const meta = {
+  title: "Components/Layout/Catalog Detail Page",
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Use these components to build catalog detail pages. Keep data loading, sign-in state, navigation, and updates in the page route.",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="page">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+} satisfies Meta;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const tabs = [
+  { href: "/catalog/scotland", label: "Overview" },
+  { href: "/catalog/scotland/bottles", label: "Bottles", count: 1284 },
+  { href: "/catalog/scotland/distillers", label: "Distillers", count: 148 },
+] as const;
+
+export const Overview: Story = {
+  render: () => (
+    <TabbedPage
+      currentHref="/catalog/scotland"
+      header={
+        <PageHeader
+          description="A short description can sit here."
+          eyebrow="Country"
+          title="Scotland"
+        />
+      }
+      tabs={tabs}
+      tabsLabel="Scotland catalog sections"
+    >
+      <PageColumns
+        rail={
+          <>
+            <RailSection heading="Popular bottles">
+              <RailList ariaLabel="Popular bottles">
+                <RailListItem
+                  href="#"
+                  metadata="Single malt"
+                  title="Example 12-year-old"
+                />
+                <RailListItem
+                  href="#"
+                  metadata="Blend"
+                  title="Another bottle"
+                />
+              </RailList>
+            </RailSection>
+            <RailSection heading="Production rules">
+              Show established production facts when the page includes them.
+            </RailSection>
+          </>
+        }
+        railBehavior="stack"
+      >
+        <FactList
+          facts={[
+            { label: "Bottles", value: "1,284" },
+            { label: "Distilleries", value: 148 },
+          ]}
+          layout="grid"
+        />
+        <PageSection heading="Bottles by category">
+          <DistributionList
+            items={[
+              { count: 842, label: "Single malt" },
+              { count: 311, label: "Blend" },
+              { count: 126, label: "Single grain" },
+            ]}
+          />
+        </PageSection>
+      </PageColumns>
+    </TabbedPage>
+  ),
+};
+
+export const Minimal: Story = {
+  render: () => (
+    <TabbedPage
+      currentHref="/catalog/new-region"
+      header={<PageHeader eyebrow="Region" title="New region" />}
+      tabs={[{ href: "/catalog/new-region", label: "Overview" }]}
+      tabsLabel="New region catalog sections"
+    >
+      <PageColumns>
+        <FactList
+          facts={[
+            { label: "Bottles", value: 0 },
+            { label: "Distilleries", value: 0 },
+          ]}
+          layout="grid"
+        />
+      </PageColumns>
+    </TabbedPage>
+  ),
+};

--- a/apps/web/src/components/pages/pageLayout.stylex.tsx
+++ b/apps/web/src/components/pages/pageLayout.stylex.tsx
@@ -29,6 +29,7 @@ export function PageFrame({
   );
 }
 
+/** Places page content beside an optional side column. */
 export function PageColumns({
   children,
   rail,
@@ -104,6 +105,7 @@ export function PageHeader({
   );
 }
 
+/** Keeps a detail page header and its tab content aligned. */
 export function TabbedPage({
   children,
   currentHref,

--- a/apps/web/src/lib/locationPage.server.ts
+++ b/apps/web/src/lib/locationPage.server.ts
@@ -1,0 +1,22 @@
+"server only";
+
+import { cache } from "react";
+
+import { getPublicPageServerClient } from "./orpc/client.server";
+import { resolveOrNotFound } from "./orpc/notFound.server";
+
+export const getCountryPage = cache(async (countrySlug: string) => {
+  const { client } = await getPublicPageServerClient();
+  return await resolveOrNotFound(
+    client.countries.details({ country: countrySlug }),
+  );
+});
+
+export const getRegionPage = cache(
+  async (countrySlug: string, regionSlug: string) => {
+    const { client } = await getPublicPageServerClient();
+    return await resolveOrNotFound(
+      client.regions.details({ country: countrySlug, region: regionSlug }),
+    );
+  },
+);

--- a/openspec/changes/improve-location-catalog-pages/.openspec.yaml
+++ b/openspec/changes/improve-location-catalog-pages/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/improve-location-catalog-pages/design.md
+++ b/openspec/changes/improve-location-catalog-pages/design.md
@@ -1,0 +1,72 @@
+## Context
+
+Country and region detail pages predate the current `PageHeader`, `TabbedPage`, `PageColumns`, and section components. They repeat this structure, keep the map inside the page frame, and show less useful catalog information than entity and series pages.
+
+Location totals also use any related brand, bottler, or distiller address. Peated's identity model treats the distiller as the producer. The current rule can therefore assign a bottle to a place where it was only branded or bottled. Country category counts already use distillers, so the totals can disagree with the category list.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Use one explicit production-location rule for stored totals and location lists.
+- Add useful country and region overviews and browsable bottle sections.
+- Build location pages from the existing shared page components.
+- Give maintainers a small Storybook reference for this composition.
+- Preserve existing public country and region URLs.
+
+**Non-Goals:**
+
+- A universal catalog page component or configuration system.
+- New event, tasting, or inferred geography data.
+- Production data writes or stored count updates.
+- A redesign of entity, bottle, profile, or series routes.
+
+## Decisions
+
+### Production location follows distillers
+
+A bottle matches a country or region when at least one assigned distillery is in that location. Brand and bottler addresses are excluded. A multi-distillery bottle can match more than one location, and a bottle without a located distillery matches none.
+
+The server will keep this SQL rule in one small helper. Bottle lists, category summaries, and stored count jobs will use it. This keeps the rule consistent without adding a general catalog helper.
+
+Alternative: retain the current union of brand, bottler, and distiller addresses. Rejected because it describes business addresses, not production origin, and cannot reconcile with category summaries.
+
+### Route layouts own page behavior
+
+Country and region layouts will own data loading, edit actions, tabs, and location details. They will use the existing shared page components. Overview, bottle, and distiller pages will load and show their own content.
+
+The country root becomes Overview and keeps `/regions`. Distillers move to `/distillers`; bottles use `/bottles`. The region root becomes Overview, with `/bottles` and `/distillers` children. Existing root URLs remain valid.
+
+Alternative: add a configurable `CatalogPage` component that owns queries and navigation. Rejected because it would mix route behavior into the shared component layer and require options for unlike pages.
+
+### Overview content stays compact and evidence-based
+
+Each overview shows bottle and distillery facts, a category distribution, a location visual, and popular bottles. Country pages also show the existing production-rules summary when present. Widgets with no data are omitted; numeric facts still show zero.
+
+The implementation will not add events, tasting demographics, or inferred regional facts because current APIs do not establish those relationships.
+
+### Storybook documents the page structure
+
+A static Storybook story will assemble `PageHeader`, `TabbedPage`, `PageColumns`, facts, sections, and side content. It will show a normal overview and a page with only required information. It will not reproduce API requests, sign-in state, URL search settings, or navigation behavior.
+
+### Stored totals require a separate operation
+
+Changing the stored count job changes future calculations but does not rewrite production data. A later count update must follow the catalog enrichment inventory, evidence, approval, and verification gates. Deployment does not depend on performing that write in this change.
+
+## Risks / Trade-offs
+
+- [Stored totals can temporarily use old semantics] → Do not claim that deployment recomputes them. Record the required follow-up operation and keep queries internally consistent where they calculate live results.
+- [Moving distiller lists from root URLs changes bookmarked content] → Preserve the root URLs as useful overviews and expose clear Distillers tabs at stable child URLs.
+- [Multi-distillery bottles can appear in several locations] → Treat each location page as a production relationship, not a partition of the global bottle count.
+- [More overview queries can increase page work] → Run independent queries in parallel and keep the first slice to categories and popular bottles.
+
+## Migration Plan
+
+1. Deploy the origin rule, API filters, stored count job changes, and new pages together.
+2. Verify country and region pages with live read-only queries and browser QA.
+3. Prepare a separate count inventory and request approval before updating production counts.
+4. If the UI must roll back, restore the old route content. The additive API filters can remain.
+
+## Open Questions
+
+None.

--- a/openspec/changes/improve-location-catalog-pages/proposal.md
+++ b/openspec/changes/improve-location-catalog-pages/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Country and region pages use a one-off layout and expose less catalog context than other detail pages. Their bottle totals also use brand and bottler addresses as origin, which can make location pages internally inconsistent.
+
+## What Changes
+
+- Define bottle production location from the assigned producing distilleries. Brand and bottler addresses do not establish origin.
+- Add country and region bottle queries and category summaries that use the same production-location rule.
+- Give country and region pages a shared detail structure with overview, bottles, and distillers sections. Keep the existing country regions section.
+- Add compact overview content: catalog facts, bottle categories, a map, production rules when available, and popular bottles.
+- Add a Storybook example for catalog detail pages using the existing page components.
+- Keep the production count update outside this change. It requires the catalog operation inventory, approval, and verification gates.
+
+## Capabilities
+
+### New Capabilities
+
+- `location-catalog-pages`: Defines location origin, location catalog queries, and the country and region detail-page behavior.
+- `catalog-detail-composition`: Defines how catalog detail pages use the shared components and Storybook example.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Server bottle lists, country and region category lists, and stored count jobs.
+- Country and region web routes and their shared location page components.
+- Shared web page-layout documentation and Storybook stories.
+- Existing stored country and region bottle totals will need a separately approved recomputation after deployment.

--- a/openspec/changes/improve-location-catalog-pages/specs/catalog-detail-composition/spec.md
+++ b/openspec/changes/improve-location-catalog-pages/specs/catalog-detail-composition/spec.md
@@ -1,0 +1,24 @@
+## ADDED Requirements
+
+### Requirement: Catalog detail pages use shared layout components
+
+Catalog detail route layouts SHALL use shared headers, tabs, columns, facts, sections, and side content. Data loading, sign-in state, navigation, and search behavior remain in the route.
+
+#### Scenario: Build a catalog detail route
+
+- **WHEN** a maintainer builds a catalog detail page
+- **THEN** route code owns page behavior and passes display values to the shared components
+
+### Requirement: Storybook page example
+
+Storybook SHALL include a static catalog detail example built from the page components used in production.
+
+#### Scenario: Review the standard page
+
+- **WHEN** a maintainer opens the Catalog Detail Page story
+- **THEN** the story shows the standard header, tabs, main content, facts, sections, and side content
+
+#### Scenario: Review a minimal page
+
+- **WHEN** a maintainer opens the Minimal story
+- **THEN** the story shows that optional sections and side content can be omitted without empty placeholders

--- a/openspec/changes/improve-location-catalog-pages/specs/location-catalog-pages/spec.md
+++ b/openspec/changes/improve-location-catalog-pages/specs/location-catalog-pages/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Bottle production location uses assigned distilleries
+
+The system SHALL match a bottle to a country or region only through an assigned producing distillery in that location. Brand and bottler addresses MUST NOT establish production location.
+
+#### Scenario: Distillery establishes origin
+
+- **WHEN** a bottle has an assigned distillery in a location
+- **THEN** the bottle is included in that location's bottle results, category summary, and stored bottle total
+
+#### Scenario: Brand or bottler does not establish origin
+
+- **WHEN** a bottle has a brand or bottler in a location but no assigned distillery there
+- **THEN** the bottle is excluded from that location's bottle results, category summary, and stored bottle total
+
+#### Scenario: Bottle has several production locations
+
+- **WHEN** a bottle has assigned distilleries in more than one location
+- **THEN** the bottle can appear in each matching location
+
+### Requirement: Location bottle queries
+
+The bottle list API SHALL support country and region production-location filters. A region slug filter MUST be scoped by its country.
+
+#### Scenario: Browse country bottles
+
+- **WHEN** a client lists bottles for a country
+- **THEN** the API returns only active bottles produced by a distillery in that country
+
+#### Scenario: Browse region bottles
+
+- **WHEN** a client lists bottles for a region and its country
+- **THEN** the API returns only active bottles produced by a distillery in that region
+
+### Requirement: Location category summaries
+
+The system SHALL provide country and region bottle counts grouped by category using the production-location rule.
+
+#### Scenario: View category distribution
+
+- **WHEN** a location has active bottles with known categories
+- **THEN** the response contains each category count and a total count for the location
+
+#### Scenario: Location has no categorized bottles
+
+- **WHEN** a location has no active bottles with known categories
+- **THEN** the response contains an empty result and a zero total count
+
+### Requirement: Country catalog detail page
+
+The country detail page SHALL provide Overview, Bottles, Distillers, and Regions sections while preserving the existing country root and regions URLs.
+
+#### Scenario: View country overview
+
+- **WHEN** a visitor opens a country root URL
+- **THEN** the page shows catalog facts, available category data, a country visual, available production rules, and available popular bottles
+
+#### Scenario: Browse country collections
+
+- **WHEN** a visitor selects Bottles, Distillers, or Regions
+- **THEN** the page shows the selected country-scoped collection under the same detail header and tabs
+
+### Requirement: Region catalog detail page
+
+The region detail page SHALL provide Overview, Bottles, and Distillers sections while preserving the existing region root URL.
+
+#### Scenario: View region overview
+
+- **WHEN** a visitor opens a region root URL
+- **THEN** the page shows catalog facts, available category data, a location visual, and available popular bottles
+
+#### Scenario: Browse region collections
+
+- **WHEN** a visitor selects Bottles or Distillers
+- **THEN** the page shows the selected region-scoped collection under the same detail header and tabs
+
+### Requirement: Missing optional overview data
+
+Location overviews SHALL omit optional widgets that have no data and SHALL retain zero-valued catalog facts.
+
+#### Scenario: View a location with little information
+
+- **WHEN** a location has no category, summary, or popular-bottle data
+- **THEN** the page omits those widgets and still shows its zero bottle and distillery facts

--- a/openspec/changes/improve-location-catalog-pages/tasks.md
+++ b/openspec/changes/improve-location-catalog-pages/tasks.md
@@ -1,0 +1,24 @@
+## 1. Production Location Data
+
+- [x] 1.1 Add one distillery-based bottle-location rule and use it in country and region count jobs
+- [x] 1.2 Add country and region production-location filters to the bottle list API
+- [x] 1.3 Add a region category summary and align the country summary with the shared location rule
+- [x] 1.4 Add or update server tests for origin, bottle filters, category summaries, and count jobs
+
+## 2. Catalog Page Structure
+
+- [x] 2.1 Add the smallest shared static distribution component needed by both location overviews, with focused tests or stories
+- [x] 2.2 Add a Storybook catalog detail page example and a short maintainer pointer
+
+## 3. Location Pages
+
+- [x] 3.1 Refactor the location frame to use shared page components and explicit country or region inputs
+- [x] 3.2 Add country Overview, Bottles, Distillers, and existing Regions sections under one route layout
+- [x] 3.3 Add region Overview, Bottles, and Distillers sections under one route layout
+- [x] 3.4 Add focused web tests for location tab and optional-section logic
+
+## 4. Verification
+
+- [x] 4.1 Run focused server and web tests, typechecks, lint, and format checks
+- [x] 4.2 Run Storybook and desktop/mobile browser QA for representative country and region pages
+- [x] 4.3 Record the separate production count update without performing production writes


### PR DESCRIPTION
Country and region pages now use the shared catalog detail structure. Each page has an overview plus bottle and distiller sections, while country pages retain their Regions section. Overviews show available counts, bottle categories, maps, production rules, and popular bottles without rendering empty widgets.

Location bottle filters, category summaries, and stored count jobs now use assigned distilleries to determine production origin. Brand and bottler addresses no longer establish origin. Existing production counts are not rewritten by this PR; that update remains a separate catalog operation with its own inventory, approval, and verification.

The shared count-bar component and Catalog Detail Page Storybook example document the intended page structure without moving data loading or navigation into reusable components. Review should focus on the production-origin rule and the country and region route structure.
