### PR TITLE
feat(web): enrich country and region overviews

### DIFF
--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -54,6 +54,7 @@ import {
   tastingNotes,
   testBottler,
   testBrand,
+  testCountry,
   testOwnedEntity,
   testOwner,
   testRegion,
@@ -301,6 +302,13 @@ async function handleRpcRequest({ request, response, url }) {
       }
       sendRpcResponse(response, testRegion);
       return true;
+    case "countries/details":
+      if (input?.country !== testCountry.slug) {
+        sendRpcError(response, "Unexpected country details payload");
+        return true;
+      }
+      sendRpcResponse(response, testCountry);
+      return true;
     case "countries/categories":
       if (input?.country !== testRegion.country.slug) {
         sendRpcError(response, "Unexpected country categories payload");
@@ -327,8 +335,15 @@ async function handleRpcRequest({ request, response, url }) {
     case "bottlers/list":
     case "companies/list":
     case "countries/list":
-    case "regions/list":
       sendRpcResponse(response, emptyList);
+      return true;
+    case "regions/list":
+      sendRpcResponse(
+        response,
+        input?.country === testCountry.slug
+          ? { ...emptyList, results: [testRegion] }
+          : emptyList,
+      );
       return true;
     case "bottles/editContext":
       if (input?.bottle !== unifiedBottleEditContext.bottleId) {
@@ -771,9 +786,12 @@ async function handleRpcRequest({ request, response, url }) {
         input?.country === testRegion.country.slug &&
         (input?.region === undefined || input.region === testRegion.slug) &&
         input?.limit === 5 &&
-        input?.sort === "-tastings"
+        input?.sort === "-release"
       ) {
-        sendRpcResponse(response, buildBottleListResponse([existingBottle]));
+        sendRpcResponse(
+          response,
+          buildBottleListResponse([bottleGroupRepresentative]),
+        );
         return true;
       }
       if (

--- a/apps/web/e2e/routes.spec.ts
+++ b/apps/web/e2e/routes.spec.ts
@@ -7,6 +7,7 @@ import {
   priceSite,
   testBottler,
   testBrand,
+  testCountry,
   testOwnedEntity,
   testOwner,
   testRegion,
@@ -29,6 +30,11 @@ const publicRoutes = [
     heading: existingBottleDetails.group.fullName,
     name: "Bottle",
     path: `/bottles/${existingBottle.id}`,
+  },
+  {
+    heading: testCountry.name,
+    name: "Country",
+    path: `/locations/${testCountry.slug}`,
   },
   {
     heading: testRegion.name,
@@ -117,6 +123,34 @@ test(
     await snapshot("Menu", { fullPage: false, ready: navigation });
     await navigation.getByRole("link", { name: "Bottles" }).click();
     await expect(page).toHaveURL(/\/bottles$/);
+  },
+);
+
+test(
+  "location overviews expose discovery sections on mobile",
+  { tag: "@mobile" },
+  async ({ page, snapshot }) => {
+    await page.goto(`/locations/${testCountry.slug}`);
+
+    const regions = page.getByRole("heading", { name: "Regions" });
+    await expect(regions).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Most recorded distilleries" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Latest releases" }),
+    ).toBeVisible();
+    await snapshot("Country overview", { ready: regions });
+
+    await page.goto(
+      `/locations/${testRegion.country.slug}/regions/${testRegion.slug}`,
+    );
+
+    const releases = page.getByRole("heading", { name: "Latest releases" });
+    await expect(
+      page.getByRole("heading", { name: "Most recorded distilleries" }),
+    ).toBeVisible();
+    await snapshot("Region overview", { ready: releases });
   },
 );
 

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/page.tsx
@@ -4,7 +4,9 @@ import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import { LocationOverview } from "../../locationOverview.stylex";
 import {
   getLocationCategoryItems,
-  getLocationPopularBottles,
+  getLocationDistilleries,
+  getLocationLatestReleases,
+  getLocationRegions,
 } from "../../locationPage";
 
 export default async function CountryOverviewPage(props: {
@@ -12,21 +14,38 @@ export default async function CountryOverviewPage(props: {
 }) {
   const { countrySlug } = await props.params;
   const { client } = await getPublicPageServerClient();
-  const [country, categories, popularBottles] = await Promise.all([
-    getCountryPage(countrySlug),
-    client.countries.categories({ country: countrySlug }),
-    client.bottles.list({
-      country: countrySlug,
-      limit: 5,
-      sort: "-tastings",
-    }),
-  ]);
+  const [country, categories, latestReleases, distilleries, regions] =
+    await Promise.all([
+      getCountryPage(countrySlug),
+      client.countries.categories({ country: countrySlug }),
+      client.bottles.list({
+        country: countrySlug,
+        limit: 5,
+        sort: "-release",
+      }),
+      client.distilleries.list({
+        country: countrySlug,
+        limit: 5,
+        sort: "-bottles",
+      }),
+      client.regions.list({
+        country: countrySlug,
+        hasBottles: true,
+        limit: 4,
+        sort: "-bottles",
+      }),
+    ]);
+  const rootHref = `/locations/${countrySlug}`;
 
   return (
     <LocationOverview
       categories={getLocationCategoryItems(categories.results)}
-      popularBottles={getLocationPopularBottles(popularBottles.results)}
+      distilleries={getLocationDistilleries(distilleries.results)}
+      distillersHref={`${rootHref}/distillers`}
+      latestReleases={getLocationLatestReleases(latestReleases.results)}
       productionRules={country.summary}
+      regions={getLocationRegions(regions.results)}
+      releasesHref={`${rootHref}/bottles?sort=-release`}
       totalBottles={country.totalBottles}
       totalDistillers={country.totalDistillers}
       visual={{ kind: "country", slug: country.slug }}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
@@ -4,7 +4,8 @@ import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import { LocationOverview } from "../../../locationOverview.stylex";
 import {
   getLocationCategoryItems,
-  getLocationPopularBottles,
+  getLocationDistilleries,
+  getLocationLatestReleases,
 } from "../../../locationPage";
 
 export default async function RegionOverviewPage(props: {
@@ -12,22 +13,32 @@ export default async function RegionOverviewPage(props: {
 }) {
   const { countrySlug, regionSlug } = await props.params;
   const { client } = await getPublicPageServerClient();
-  const [region, categories, popularBottles] = await Promise.all([
+  const [region, categories, latestReleases, distilleries] = await Promise.all([
     getRegionPage(countrySlug, regionSlug),
     client.regions.categories({ country: countrySlug, region: regionSlug }),
     client.bottles.list({
       country: countrySlug,
       region: regionSlug,
       limit: 5,
-      sort: "-tastings",
+      sort: "-release",
+    }),
+    client.distilleries.list({
+      country: countrySlug,
+      region: regionSlug,
+      limit: 5,
+      sort: "-bottles",
     }),
   ]);
   const isUsState = countrySlug === "united-states";
+  const rootHref = `/locations/${countrySlug}/regions/${regionSlug}`;
 
   return (
     <LocationOverview
       categories={getLocationCategoryItems(categories.results)}
-      popularBottles={getLocationPopularBottles(popularBottles.results)}
+      distilleries={getLocationDistilleries(distilleries.results)}
+      distillersHref={`${rootHref}/distillers`}
+      latestReleases={getLocationLatestReleases(latestReleases.results)}
+      releasesHref={`${rootHref}/bottles?sort=-release`}
       totalBottles={region.totalBottles}
       totalDistillers={region.totalDistillers}
       visual={

--- a/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
@@ -1,8 +1,18 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { DistributionList, FactList } from "@peated/web/components";
-import type { BottleRailItem } from "@peated/web/components/pages/bottleRailSection.stylex";
-import { BottleRailSection } from "@peated/web/components/pages/bottleRailSection.stylex";
+import {
+  BottleList,
+  type BottleListItem,
+  DistributionList,
+  FactList,
+  RailList,
+  RailListItem,
+  TextLink,
+} from "@peated/web/components";
+import {
+  type HomeOrigin,
+  HomeRegionGrid,
+} from "@peated/web/components/pages/homeBrowse.stylex";
 import {
   PageColumns,
   PageSection,
@@ -14,16 +24,29 @@ import { LocationVisual } from "./locationPageFrame.stylex";
 
 export function LocationOverview({
   categories,
-  popularBottles,
+  distilleries,
+  distillersHref,
+  latestReleases,
   productionRules,
+  regions = [],
+  releasesHref,
   totalBottles,
   totalDistillers,
   visual,
   visualHeading = "Map",
 }: {
   categories: readonly { count: number; label: string }[];
-  popularBottles: readonly BottleRailItem[];
+  distilleries: readonly {
+    href: string;
+    location?: string;
+    name: string;
+    totalBottles: number;
+  }[];
+  distillersHref: string;
+  latestReleases: readonly BottleListItem[];
   productionRules?: string | null;
+  regions?: readonly HomeOrigin[];
+  releasesHref: string;
   totalBottles: number;
   totalDistillers: number;
   visual: { kind: "country" | "state"; slug: string };
@@ -41,12 +64,6 @@ export function LocationOverview({
               <p {...stylex.props(styles.copy)}>{productionRules}</p>
             </RailSection>
           ) : null}
-          {popularBottles.length ? (
-            <BottleRailSection
-              heading="Popular bottles"
-              items={popularBottles}
-            />
-          ) : null}
         </>
       }
       railBehavior="stack"
@@ -61,6 +78,49 @@ export function LocationOverview({
         ]}
         layout="grid"
       />
+      {regions.length ? (
+        <PageSection heading="Regions">
+          <HomeRegionGrid regions={regions} />
+        </PageSection>
+      ) : null}
+      {distilleries.length ? (
+        <PageSection
+          heading="Most recorded distilleries"
+          intro={
+            <TextLink href={distillersHref}>
+              {totalDistillers === 1
+                ? "View 1 distillery"
+                : `View all ${totalDistillers.toLocaleString("en-US")} distilleries`}
+            </TextLink>
+          }
+        >
+          <RailList ariaLabel="Most recorded distilleries">
+            {distilleries.map((distillery) => (
+              <RailListItem
+                href={distillery.href}
+                key={distillery.href}
+                metadata={[
+                  distillery.location,
+                  `${distillery.totalBottles.toLocaleString("en-US")} ${
+                    distillery.totalBottles === 1 ? "bottle" : "bottles"
+                  }`,
+                ]
+                  .filter(Boolean)
+                  .join(" · ")}
+                title={distillery.name}
+              />
+            ))}
+          </RailList>
+        </PageSection>
+      ) : null}
+      {latestReleases.length ? (
+        <PageSection
+          heading="Latest releases"
+          intro={<TextLink href={releasesHref}>View all releases</TextLink>}
+        >
+          <BottleList ariaLabel="Latest releases" items={latestReleases} />
+        </PageSection>
+      ) : null}
       {categories.length ? (
         <PageSection heading="Bottles by category">
           <DistributionList items={categories} />

--- a/apps/web/src/app/(app)/locations/locationPage.ts
+++ b/apps/web/src/app/(app)/locations/locationPage.ts
@@ -1,12 +1,13 @@
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
 import type { PageTabItem } from "@peated/web/components";
-import type { BottleRailItem } from "@peated/web/components/pages/bottleRailSection.stylex";
-import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
-import { getBottleUrl } from "@peated/web/lib/urls";
+import type { HomeOrigin } from "@peated/web/components/pages/homeBrowse.stylex";
+import { toBottleListItem } from "@peated/web/lib/bottleListItem";
+import { getEntityUrl } from "@peated/web/lib/urls";
 
 type Bottle = Outputs["bottles"]["list"]["results"][number];
+type Distillery = Outputs["distilleries"]["list"]["results"][number];
+type Region = Outputs["regions"]["list"]["results"][number];
 
 export function getCountryLocationTabs({
   rootHref,
@@ -59,13 +60,36 @@ export function getLocationCategoryItems(
   );
 }
 
-export function getLocationPopularBottles(
-  bottles: readonly Bottle[],
-): BottleRailItem[] {
-  return bottles.map((bottle) => ({
-    href: getBottleUrl(bottle),
-    imageUrl: bottle.imageUrl,
-    metadata: getBottleMetadata(bottle),
-    name: formatBottleDisplayName(bottle),
+export function getLocationLatestReleases(bottles: readonly Bottle[]) {
+  return bottles.flatMap((bottle) =>
+    bottle.releaseYear === null
+      ? []
+      : [
+          toBottleListItem(bottle, {
+            includeRatings: true,
+            includeRelatedReleases: true,
+          }),
+        ],
+  );
+}
+
+export function getLocationDistilleries(distilleries: readonly Distillery[]) {
+  return distilleries.map((distillery) => ({
+    href: getEntityUrl(distillery),
+    location: [distillery.region?.name, distillery.country?.name]
+      .filter(Boolean)
+      .join(", "),
+    name: distillery.name,
+    totalBottles: distillery.totalBottles,
+  }));
+}
+
+export function getLocationRegions(regions: readonly Region[]): HomeOrigin[] {
+  return regions.map((region) => ({
+    description: region.description ?? undefined,
+    href: `/locations/${region.country.slug}/regions/${region.slug}`,
+    name: region.name,
+    slug: region.slug,
+    totalBottles: region.totalBottles,
   }));
 }

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -188,6 +188,21 @@ function RegionCard({ region }: { region: HomeOrigin }) {
   );
 }
 
+/** Keeps the homepage and country overview region cards identical. */
+export function HomeRegionGrid({
+  regions,
+}: {
+  regions: readonly HomeOrigin[];
+}) {
+  return (
+    <div {...stylex.props(styles.regionGrid)}>
+      {regions.map((region) => (
+        <RegionCard key={region.href} region={region} />
+      ))}
+    </div>
+  );
+}
+
 export function HomeOrigins({
   countries,
   remainingCountries,
@@ -269,11 +284,7 @@ export function HomeOrigins({
       {regions.length ? (
         <>
           <div {...stylex.props(styles.regionHeading)}>By region</div>
-          <div {...stylex.props(styles.regionGrid)}>
-            {regions.map((region) => (
-              <RegionCard key={region.href} region={region} />
-            ))}
-          </div>
+          <HomeRegionGrid regions={regions} />
         </>
       ) : null}
     </section>

--- a/openspec/changes/improve-location-catalog-pages/design.md
+++ b/openspec/changes/improve-location-catalog-pages/design.md
@@ -41,7 +41,11 @@ Alternative: add a configurable `CatalogPage` component that owns queries and na
 
 ### Overview content stays compact and evidence-based
 
-Each overview shows bottle and distillery facts, a category distribution, a location visual, and popular bottles. Country pages also show the existing production-rules summary when present. Widgets with no data are omitted; numeric facts still show zero.
+Each overview shows bottle and distillery facts, a category distribution, a location visual, latest releases, and the distilleries with the most recorded bottles. Country pages also show the existing production-rules summary and leading regions when present. Widgets with no data are omitted; numeric facts still show zero.
+
+The country region list reuses the homepage region-card renderer. The homepage and country overview therefore keep the same card markup, styles, truncation, and responsive grid. The location route only supplies country-scoped region data and the link to the complete Regions section.
+
+Other overview lists use the catalog-page `PageSection`, `BottleList`, `RailList`, and `TextLink` components. Homepage section wrappers remain owned by the homepage.
 
 The implementation will not add events, tasting demographics, or inferred regional facts because current APIs do not establish those relationships.
 
@@ -58,7 +62,7 @@ Changing the stored count job changes future calculations but does not rewrite p
 - [Stored totals can temporarily use old semantics] → Do not claim that deployment recomputes them. Record the required follow-up operation and keep queries internally consistent where they calculate live results.
 - [Moving distiller lists from root URLs changes bookmarked content] → Preserve the root URLs as useful overviews and expose clear Distillers tabs at stable child URLs.
 - [Multi-distillery bottles can appear in several locations] → Treat each location page as a production relationship, not a partition of the global bottle count.
-- [More overview queries can increase page work] → Run independent queries in parallel and keep the first slice to categories and popular bottles.
+- [More overview queries can increase page work] → Run independent queries in parallel and keep each discovery list to a small first slice.
 
 ## Migration Plan
 

--- a/openspec/changes/improve-location-catalog-pages/proposal.md
+++ b/openspec/changes/improve-location-catalog-pages/proposal.md
@@ -7,7 +7,8 @@ Country and region pages use a one-off layout and expose less catalog context th
 - Define bottle production location from the assigned producing distilleries. Brand and bottler addresses do not establish origin.
 - Add country and region bottle queries and category summaries that use the same production-location rule.
 - Give country and region pages a shared detail structure with overview, bottles, and distillers sections. Keep the existing country regions section.
-- Add compact overview content: catalog facts, bottle categories, a map, production rules when available, and popular bottles.
+- Add compact overview content: catalog facts, bottle categories, a map, production rules when available, latest releases, and the most recorded distilleries.
+- Show a country's leading regions in the main overview column with the same region cards used on the homepage.
 - Add a Storybook example for catalog detail pages using the existing page components.
 - Keep the production count update outside this change. It requires the catalog operation inventory, approval, and verification gates.
 

--- a/openspec/changes/improve-location-catalog-pages/specs/location-catalog-pages/spec.md
+++ b/openspec/changes/improve-location-catalog-pages/specs/location-catalog-pages/spec.md
@@ -54,7 +54,8 @@ The country detail page SHALL provide Overview, Bottles, Distillers, and Regions
 #### Scenario: View country overview
 
 - **WHEN** a visitor opens a country root URL
-- **THEN** the page shows catalog facts, available category data, a country visual, available production rules, and available popular bottles
+- **THEN** the page shows catalog facts, available category data, a country visual, available production rules, latest releases, the most recorded distilleries, and available leading regions
+- **AND** leading regions use the same region-card renderer as the homepage
 
 #### Scenario: Browse country collections
 
@@ -68,7 +69,7 @@ The region detail page SHALL provide Overview, Bottles, and Distillers sections 
 #### Scenario: View region overview
 
 - **WHEN** a visitor opens a region root URL
-- **THEN** the page shows catalog facts, available category data, a location visual, and available popular bottles
+- **THEN** the page shows catalog facts, available category data, a location visual, latest releases, and the most recorded distilleries
 
 #### Scenario: Browse region collections
 
@@ -81,5 +82,5 @@ Location overviews SHALL omit optional widgets that have no data and SHALL retai
 
 #### Scenario: View a location with little information
 
-- **WHEN** a location has no category, summary, or popular-bottle data
+- **WHEN** a location has no category, summary, region, latest-release, or distillery data
 - **THEN** the page omits those widgets and still shows its zero bottle and distillery facts

--- a/openspec/changes/improve-location-catalog-pages/tasks.md
+++ b/openspec/changes/improve-location-catalog-pages/tasks.md
@@ -16,9 +16,15 @@
 - [x] 3.2 Add country Overview, Bottles, Distillers, and existing Regions sections under one route layout
 - [x] 3.3 Add region Overview, Bottles, and Distillers sections under one route layout
 - [x] 3.4 Add focused web tests for location tab and optional-section logic
+- [x] 3.5 Reuse the homepage region cards on country overviews
+- [x] 3.6 Add latest releases and the most recorded distilleries to country and region overviews
+- [x] 3.7 Update location route fixtures and coverage for the added overview reads
+- [x] 3.8 Align discovery sections with catalog page components while preserving the homepage region renderer
 
 ## 4. Verification
 
 - [x] 4.1 Run focused server and web tests, typechecks, lint, and format checks
 - [x] 4.2 Run Storybook and desktop/mobile browser QA for representative country and region pages
 - [x] 4.3 Record the separate production count update without performing production writes
+- [x] 4.4 Re-run focused web tests, typecheck, lint, format, and desktop/mobile browser QA
+- [x] 4.5 Verify the catalog-aligned follow-up with focused checks and browser QA


### PR DESCRIPTION
Country and region overviews now help visitors move from broad origin context into useful catalog discovery.

Country pages show leading regions in the main column with the exact `HomeRegionGrid` renderer used on the homepage. This keeps the card markup, responsive layout, descriptions, counts, and links in one shared implementation. Both country and region pages also show the distilleries with the most recorded bottles and the latest dated releases. Their links retain the active location filters.

The other discovery blocks use the same `PageSection`, `BottleList`, `RailList`, and `TextLink` composition as entity catalog pages. Homepage section wrappers stay private to the homepage; only the explicitly shared region renderer crosses that boundary.

The existing facts, category distribution, location map, and production rules remain in place. Optional sections stay hidden when their queries return no usable data. The route fixture now covers a country page and verifies the new discovery sections on mobile as well as the existing desktop route suite.

Review focus: shared homepage region rendering, existing catalog-page composition, location-scoped query inputs, and the main-column section order.
