### PR TITLE
fix(home): restore wide activity column

### DIFF
--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -54,7 +54,6 @@ export function PublicHome({
     <HomePage
       content={
         <PageColumns
-          equal
           rail={
             <>
               {upcomingEvent ? (
@@ -66,7 +65,6 @@ export function PublicHome({
                 </div>
               ) : null}
               <div {...stylex.props(styles.secondaryRail)}>
-                <Activity />
                 <Distilleries totalDistilleries={stats.data?.distilleries} />
                 <HomeContributionPrompt
                   primaryAction={
@@ -99,6 +97,7 @@ export function PublicHome({
               </div>
             ) : null}
             <LatestReleases />
+            <Activity />
             <div {...stylex.props(styles.desktopOnly)}>
               <Origins />
             </div>

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -407,7 +407,7 @@ const styles = stylex.create({
   },
   regionGrid: {
     display: "grid",
-    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
     gap: "6px",
     marginTop: space.x2,
     [NARROW]: {
@@ -468,7 +468,7 @@ const styles = stylex.create({
   },
   countryGrid: {
     display: "grid",
-    gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
     gap: "6px",
     marginTop: space.x4,
     [NARROW]: {


### PR DESCRIPTION
The homepage returns to its wide main column and narrow rail. Activity now appears with recent releases in the main column, while distilleries and the contribution prompt remain in the rail. Country and region cards also use the four-column desktop grid again; mobile stacking is unchanged.
