### PR TITLE
fix(home): simplify distilleries heading

### DIFF
--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -307,9 +307,9 @@ export function HomeDistilleries({
 }) {
   return (
     <section {...stylex.props(styles.section)}>
-      <HomeModuleHeading title="Most recorded distilleries" />
+      <HomeModuleHeading title="Distilleries" />
       <div {...stylex.props(styles.distilleries)}>
-        <ItemList ariaLabel="Most recorded distilleries">
+        <ItemList ariaLabel="Distilleries">
           {distilleries.map((distillery) => (
             <ItemRow
               href={distillery.href}


### PR DESCRIPTION
The homepage distillery section now uses “Distilleries” for its heading and accessible list label, replacing “Most recorded distilleries.”
