### PR TITLE
feat(navigation): put activity first in the header

### DIFF
--- a/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
@@ -3,6 +3,8 @@ import type { Outputs } from "@peated/server/orpc/router";
 import { SiteFooter, type SiteFooterProps } from "@peated/web/components";
 
 const links = [
+  { href: "/locations", label: "Locations" },
+  { href: "/brands", label: "Brands" },
   { href: "/about", label: "About" },
   { href: "/about/api", label: "API" },
   { href: "/about/categories", label: "Whisky categories" },

--- a/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
@@ -19,10 +19,9 @@ import { publicHomeQueries } from "@peated/web/lib/orpc/homeQueries";
 import { ApplicationFooter } from "./applicationFooter.stylex";
 
 const databaseItems = [
+  { href: "/activity", label: "Activity" },
   { href: "/bottles", label: "Bottles" },
-  { href: "/locations", label: "Locations" },
   { href: "/distillers", label: "Distillers" },
-  { href: "/brands", label: "Brands" },
   { href: "/bottlers", label: "Bottlers" },
 ] as const;
 
@@ -58,12 +57,12 @@ export function ApplicationLayout({ children }: { children: ReactNode }) {
         },
         { href: "/tastings", label: "Tastings" },
         { href: "/following", label: "Following" },
-        { href: "/friends", label: "Friends" },
       ]
     : [];
   const accountItems = user
     ? [
         { href: `/users/${user.username}`, label: "Profile" },
+        { href: "/friends", label: "Friends" },
         { href: "/settings", label: "Settings" },
         {
           disabled: logoutPending,

--- a/apps/web/src/components/navigation.stories.tsx
+++ b/apps/web/src/components/navigation.stories.tsx
@@ -4,17 +4,16 @@ import { NavigationTabs } from "./navigation.stylex";
 import { StoryCanvas, StoryStack } from "./storyFixtures.stylex";
 
 const databaseItems = [
+  { href: "/activity", label: "Activity" },
   { href: "/bottles", label: "Bottles" },
-  { href: "/locations", label: "Locations" },
   { href: "/distillers", label: "Distillers" },
-  { href: "/brands", label: "Brands" },
   { href: "/bottlers", label: "Bottlers" },
 ] as const;
 
 const personalItems = [
   { href: "/library", label: "Library" },
   { href: "/tastings", label: "Tastings" },
-  { href: "/friends", label: "Friends" },
+  { href: "/following", label: "Following" },
 ] as const;
 
 const meta = {

--- a/apps/web/src/components/pages/applicationHeader.stories.tsx
+++ b/apps/web/src/components/pages/applicationHeader.stories.tsx
@@ -9,17 +9,16 @@ import { SearchBox } from "../searchBox.stylex";
 import { searchResultGroups } from "../storyData";
 
 const databaseItems = [
+  { href: "/activity", label: "Activity" },
   { href: "/bottles", label: "Bottles" },
-  { href: "/locations", label: "Locations" },
   { href: "/distillers", label: "Distillers" },
-  { href: "/brands", label: "Brands" },
   { href: "/bottlers", label: "Bottlers" },
 ] as const;
 
 const personalItems = [
   { count: 41, href: "/library", label: "Library" },
   { count: 412, href: "/tastings", label: "Tastings" },
-  { count: 38, href: "/friends", label: "Friends" },
+  { href: "/following", label: "Following" },
 ] as const;
 
 const scopes = [
@@ -49,6 +48,7 @@ function HeaderExample({
         signedIn
           ? [
               { href: "/profile", label: "Profile" },
+              { href: "/friends", label: "Friends" },
               { href: "/settings", label: "Settings" },
               { label: "Sign out", onSelect: () => undefined },
             ]

--- a/apps/web/src/components/siteFooter.stories.tsx
+++ b/apps/web/src/components/siteFooter.stories.tsx
@@ -4,6 +4,8 @@ import { SiteFooter, type SiteFooterProps } from "./siteFooter.stylex";
 import { StoryCanvas } from "./storyFixtures.stylex";
 
 const links: SiteFooterProps["links"] = [
+  { href: "/locations", label: "Locations" },
+  { href: "/brands", label: "Brands" },
   { href: "/about", label: "About" },
   { href: "/updates", label: "Recent changes" },
   { href: "https://github.com/peated/peated", label: "Source" },


### PR DESCRIPTION
Activity is now the first header link and opens `/activity`. Locations and Brands move to the footer, and Friends moves into the profile dropdown on desktop and mobile. Storybook examples reflect the same navigation.
