### PR TITLE
fix(activity): align feed toggle with activity column

### DIFF
--- a/apps/web/src/components/pages/activityPage.stories.tsx
+++ b/apps/web/src/components/pages/activityPage.stories.tsx
@@ -23,7 +23,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Activity uses the catalog columns, with Following/Everyone beside the page title. The sidebar has the contribution action and rating guidance, and is hidden on mobile. A short notice explains when Following shows everyone's activity because there are no accepted follows.",
+          "Activity uses the catalog columns, with Following/Everyone beside the page title and aligned with the feed column. The sidebar has the contribution action and rating guidance, and is hidden on mobile. A short notice explains when Following shows everyone's activity because there are no accepted follows.",
       },
     },
   },

--- a/apps/web/src/components/pages/activityPage.stylex.tsx
+++ b/apps/web/src/components/pages/activityPage.stylex.tsx
@@ -7,7 +7,7 @@ import { CommunityFeed, type CommunityFeedItem } from "../communityFeed.stylex";
 import { PageColumns, PageHeader } from "./pageLayout.stylex";
 import { RailListSection } from "./railListSection.stylex";
 
-/** Uses the catalog columns for activity, with feed selection in the title row. */
+/** Keeps the title and feed selection aligned with the activity column. */
 export function ActivityPage({
   items,
   note,
@@ -19,14 +19,14 @@ export function ActivityPage({
 }) {
   return (
     <div>
-      <div {...stylex.props(styles.header)}>
-        <PageHeader
-          actions={selector}
-          actionsPosition="inline"
-          title="Activity"
-        />
-      </div>
       <PageColumns
+        header={
+          <PageHeader
+            actions={selector}
+            actionsPosition="inline"
+            title="Activity"
+          />
+        }
         rail={
           <div {...stylex.props(styles.rail)}>
             <RailListSection heading="What have you tried?">
@@ -72,9 +72,6 @@ export function ActivityPage({
 }
 
 const styles = stylex.create({
-  header: {
-    marginBottom: space.x4,
-  },
   rail: {
     display: "flex",
     minWidth: 0,

--- a/apps/web/src/components/pages/pageLayout.stylex.tsx
+++ b/apps/web/src/components/pages/pageLayout.stylex.tsx
@@ -29,15 +29,17 @@ export function PageFrame({
   );
 }
 
-/** Places page content beside an optional side column. */
+/** Places page content beside an optional side column, with a header above the main column. */
 export function PageColumns({
   children,
   equal = false,
+  header,
   rail,
   railBehavior = "hide",
 }: {
   children: ReactNode;
   equal?: boolean;
+  header?: ReactNode;
   rail?: ReactNode;
   railBehavior?: "hide" | "stack";
 }) {
@@ -45,10 +47,12 @@ export function PageColumns({
     <div
       {...stylex.props(
         styles.columns,
+        header ? styles.columnsWithHeader : null,
         equal && styles.equalColumns,
         !rail && styles.singleColumn,
       )}
     >
+      {header ? <div {...stylex.props(styles.mainColumn)}>{header}</div> : null}
       <div {...stylex.props(styles.mainColumn)}>{children}</div>
       {rail ? (
         <aside
@@ -240,11 +244,15 @@ const styles = stylex.create({
       gridTemplateColumns: "minmax(0, 1fr)",
     },
   },
+  columnsWithHeader: {
+    rowGap: space.x4,
+  },
   singleColumn: {
     gridTemplateColumns: "minmax(0, 960px)",
   },
   mainColumn: {
     minWidth: 0,
+    gridColumn: 1,
   },
   rail: {
     display: "flex",


### PR DESCRIPTION
Align the Following / Everyone toggle with the right edge of the activity feed column. The Activity header now shares the feed's column layout, keeping the sidebar aligned with the feed below it. Verified alignment from 320px to 1440px, including light and dark themes.
