### PR TITLE
fix(web): use one component for section headings

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -195,6 +195,9 @@ sentiment poles.
 - **Karla** is the reading face for prose, labels, and member input.
 - **IBM Plex Mono** is available for rare values that must align as code-like
   data. Normal metadata and field labels use Karla.
+- Section headings use `SectionHeading` in every column. Heading levels express
+  document structure and share one visual treatment. Do not add compact,
+  uppercase, or page-specific section heading variants.
 
 | Role            | Family  | Weight | Size and line height | Tracking |
 | --------------- | ------- | ------ | -------------------- | -------- |

--- a/apps/web/src/app/(app)/_components/home/homeEventCallout.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/homeEventCallout.stylex.tsx
@@ -1,4 +1,5 @@
 import type { Event } from "@peated/server/types";
+import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
 import * as stylex from "@stylexjs/stylex";
 
 import { TextLink } from "@peated/web/components";
@@ -17,9 +18,7 @@ export function HomeEventCallout({
 
   return (
     <section aria-labelledby={headingId} {...stylex.props(styles.root)}>
-      <h2 id={headingId} {...stylex.props(styles.heading)}>
-        Coming up
-      </h2>
+      <SectionHeading id={headingId}>Coming up</SectionHeading>
       <h3 {...stylex.props(styles.title)}>{event.name}</h3>
       <div {...stylex.props(styles.details)}>
         <DateRange start={event.dateStart} end={event.dateEnd} />
@@ -37,15 +36,6 @@ export function HomeEventCallout({
 const styles = stylex.create({
   root: {
     minWidth: 0,
-  },
-  heading: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "24px",
-    fontWeight: 700,
-    letterSpacing: "-0.03em",
-    lineHeight: 1.1,
   },
   title: {
     margin: 0,

--- a/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
+++ b/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
@@ -1,3 +1,4 @@
+import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
@@ -95,7 +96,9 @@ export function ReviewSteps({
           <span {...stylex.props(styles.stepNumber)}>
             {String(index + 1).padStart(2, "0")}
           </span>
-          <h3 {...stylex.props(styles.stepTitle)}>{step.title}</h3>
+          <div {...stylex.props(styles.stepTitle)}>
+            <SectionHeading level={3}>{step.title}</SectionHeading>
+          </div>
           <div {...stylex.props(styles.stepBody)}>{step.body}</div>
         </li>
       ))}
@@ -175,16 +178,7 @@ const styles = stylex.create({
     fontVariantNumeric: "tabular-nums",
     lineHeight: 1.3,
   },
-  stepTitle: {
-    margin: 0,
-    marginTop: space.x2,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "17px",
-    fontWeight: 700,
-    letterSpacing: "-0.015em",
-    lineHeight: 1.25,
-  },
+  stepTitle: { marginTop: space.x2 },
   stepBody: {
     marginTop: space.x2,
     color: colors.inkMuted,

--- a/apps/web/src/app/(app)/about/brand/brandVoicePage.stylex.tsx
+++ b/apps/web/src/app/(app)/about/brand/brandVoicePage.stylex.tsx
@@ -200,9 +200,9 @@ export function BrandVoicePage() {
               {...stylex.props(styles.ruleCard, rule.wide && styles.ruleWide)}
             >
               <div {...stylex.props(styles.ruleCopy)}>
-                <h3 {...stylex.props(styles.cardTitle)}>
+                <SectionHeading level={3}>
                   {index + 1} · {rule.title}
-                </h3>
+                </SectionHeading>
                 <p {...stylex.props(styles.cardBody)}>{rule.body}</p>
               </div>
               <div {...stylex.props(styles.example)}>{rule.example()}</div>
@@ -272,7 +272,7 @@ export function BrandVoicePage() {
         <div {...stylex.props(styles.mechanicsGrid)}>
           {mechanics.map((item) => (
             <div key={item.title} {...stylex.props(styles.mechanicCard)}>
-              <h3 {...stylex.props(styles.mechanicTitle)}>{item.title}</h3>
+              <SectionHeading level={3}>{item.title}</SectionHeading>
               <p {...stylex.props(styles.mechanicBody)}>{item.body}</p>
             </div>
           ))}
@@ -484,14 +484,6 @@ const styles = stylex.create({
   ruleCopy: {
     maxWidth: "680px",
   },
-  cardTitle: {
-    margin: 0,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
-  },
   cardBody: {
     marginTop: space.x2,
     marginBottom: 0,
@@ -675,14 +667,6 @@ const styles = stylex.create({
     paddingLeft: "18px",
     borderRadius: controlMetrics.radius,
     backgroundColor: colors.surface,
-  },
-  mechanicTitle: {
-    margin: 0,
-    fontFamily: fonts.display,
-    fontSize: "15px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.3,
   },
   mechanicBody: {
     marginTop: space.x1,

--- a/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
+++ b/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
@@ -1,6 +1,7 @@
 import { TAG_CATEGORIES } from "@peated/server/constants";
 import type { TagCategory } from "@peated/server/types";
 import { Chip } from "@peated/web/components";
+import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
 import * as stylex from "@stylexjs/stylex";
 
 import { colors, fonts, space } from "../../../../styles/tokens.stylex";
@@ -253,7 +254,9 @@ export function TastingWheelGraphic() {
       <figcaption {...stylex.props(styles.caption)}>
         <div>
           <div {...stylex.props(styles.captionEyebrow)}>How to use it</div>
-          <h3 {...stylex.props(styles.captionTitle)}>Start with a group</h3>
+          <div {...stylex.props(styles.captionTitle)}>
+            <SectionHeading level={3}>Start with a group</SectionHeading>
+          </div>
         </div>
         <p {...stylex.props(styles.captionText)}>
           Pick the group that is closest to what you notice. The lists below
@@ -277,7 +280,7 @@ export function TastingWheelFamilies() {
           key={category.key}
           {...stylex.props(styles.family)}
         >
-          <h3 {...stylex.props(styles.familyTitle)}>{category.name}</h3>
+          <SectionHeading level={3}>{category.name}</SectionHeading>
           <p {...stylex.props(styles.familyDescription)}>
             {category.description}
           </p>
@@ -400,16 +403,7 @@ const styles = stylex.create({
     lineHeight: 1.3,
     textTransform: "uppercase",
   },
-  captionTitle: {
-    margin: 0,
-    marginTop: space.x1,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "20px",
-    fontWeight: 700,
-    letterSpacing: "-0.025em",
-    lineHeight: 1.2,
-  },
+  captionTitle: { marginTop: space.x1 },
   captionText: {
     margin: 0,
     color: colors.inkMuted,
@@ -433,15 +427,6 @@ const styles = stylex.create({
     borderTopStyle: "solid",
     borderTopColor: colors.hairline,
     scrollMarginTop: space.x8,
-  },
-  familyTitle: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.25,
   },
   familyDescription: {
     margin: 0,

--- a/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
@@ -15,7 +15,6 @@ import { HomeRegionGrid } from "@peated/web/components/pages/homeBrowse.stylex";
 import {
   PageColumns,
   PageSection,
-  RailSection,
 } from "@peated/web/components/pages/pageLayout.stylex";
 import { colors, fonts } from "../../../styles/tokens.stylex";
 
@@ -56,27 +55,31 @@ export function LocationOverview({
   return (
     <PageColumns
       rail={
-        <>
+        <div>
           {visual ? (
-            <RailSection heading="Map">
+            <PageSection heading="Map">
               <LocationVisual visual={visual} />
-            </RailSection>
+            </PageSection>
           ) : null}
           {productionRules ? (
-            <RailSection heading="Production rules">
+            <PageSection heading="Production rules">
               <p {...stylex.props(styles.copy)}>{productionRules}</p>
-            </RailSection>
+            </PageSection>
           ) : null}
           {categories.length ? (
-            <RailSection heading="Bottles by category">
+            <PageSection heading="Bottles by category">
               <DistributionList items={categories} />
-            </RailSection>
+            </PageSection>
           ) : null}
           {otherRegions.length ? (
-            <RailSection heading="Other regions">
-              {otherRegionsHref ? (
-                <TextLink href={otherRegionsHref}>View all regions</TextLink>
-              ) : null}
+            <PageSection
+              heading="Other regions"
+              intro={
+                otherRegionsHref ? (
+                  <TextLink href={otherRegionsHref}>View all regions</TextLink>
+                ) : null
+              }
+            >
               <RailList ariaLabel="Other regions">
                 {otherRegions.map((region) => (
                   <RailListItem
@@ -89,9 +92,9 @@ export function LocationOverview({
                   />
                 ))}
               </RailList>
-            </RailSection>
+            </PageSection>
           ) : null}
-        </>
+        </div>
       }
       railBehavior="stack"
     >

--- a/apps/web/src/components/admin/adminContent.stylex.tsx
+++ b/apps/web/src/components/admin/adminContent.stylex.tsx
@@ -4,6 +4,7 @@ import * as stylex from "@stylexjs/stylex";
 import { ChevronRight, Home } from "lucide-react";
 import Link from "next/link";
 import type { HTMLAttributes, ReactNode } from "react";
+import { SectionHeading } from "../sectionHeading.stylex";
 
 import { TextLink } from "..";
 import { foundationStyles } from "../../styles/foundations.stylex";
@@ -130,11 +131,7 @@ export function AdminSection({
       {title || description || action ? (
         <div {...stylex.props(styles.sectionHeader)}>
           <div {...stylex.props(styles.sectionCopy)}>
-            {title ? (
-              <h2 {...stylex.props(foundationStyles.sectionHeading)}>
-                {title}
-              </h2>
-            ) : null}
+            {title ? <SectionHeading>{title}</SectionHeading> : null}
             {description ? (
               <div {...stylex.props(styles.description)}>{description}</div>
             ) : null}

--- a/apps/web/src/components/admin/adminLayout.stylex.tsx
+++ b/apps/web/src/components/admin/adminLayout.stylex.tsx
@@ -5,6 +5,7 @@ import { ArrowLeft, Menu } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
+import { SectionHeading } from "../sectionHeading.stylex";
 
 import { SkipLink } from "@peated/web/components/skipLink.stylex";
 import { foundationStyles } from "../../styles/foundations.stylex";
@@ -54,7 +55,9 @@ function AdminNavigation({
     <nav aria-label="Admin navigation" {...stylex.props(styles.navigation)}>
       {groups.map((group) => (
         <section key={group.label} {...stylex.props(styles.navigationGroup)}>
-          <h2 {...stylex.props(styles.groupLabel)}>{group.label}</h2>
+          <div {...stylex.props(styles.groupLabel)}>
+            <SectionHeading>{group.label}</SectionHeading>
+          </div>
           <ul {...stylex.props(styles.navigationList)}>
             {group.items.map((item) => {
               const current = isCurrentHref(currentHref, item);
@@ -290,18 +293,7 @@ const styles = stylex.create({
     flexDirection: "column",
     gap: space.x2,
   },
-  groupLabel: {
-    margin: 0,
-    paddingRight: space.x2,
-    paddingLeft: space.x2,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 500,
-    letterSpacing: "0.12em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
-  },
+  groupLabel: { paddingRight: space.x2, paddingLeft: space.x2 },
   navigationList: {
     display: "flex",
     margin: 0,

--- a/apps/web/src/components/admin/adminUtility.stylex.tsx
+++ b/apps/web/src/components/admin/adminUtility.stylex.tsx
@@ -5,18 +5,11 @@ import * as stylex from "@stylexjs/stylex";
 import { AlertTriangle } from "lucide-react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
-import type { ComponentPropsWithoutRef, ElementType, ReactNode } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 import { CursorPager } from "..";
 import { buildQueryString } from "../../lib/urls";
-import { foundationStyles } from "../../styles/foundations.stylex";
-import {
-  colors,
-  controlMetrics,
-  effects,
-  fonts,
-  space,
-} from "../../styles/tokens.stylex";
+import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
 
 export function AdminPager({
   ariaLabel = "Pagination",
@@ -84,22 +77,6 @@ export function AdminEmptyActivity({
     </Link>
   ) : (
     <div {...stylex.props(styles.empty)}>{children}</div>
-  );
-}
-
-export function AdminHeading({
-  as: Component = "h1",
-  children,
-}: {
-  as?: ElementType;
-  children?: ReactNode;
-}) {
-  return (
-    <Component
-      {...stylex.props(foundationStyles.sectionHeading, styles.heading)}
-    >
-      {children}
-    </Component>
   );
 }
 
@@ -187,7 +164,6 @@ const styles = stylex.create({
     textDecoration: "none",
     boxShadow: { default: "none", ":focus-visible": effects.focusRing },
   },
-  heading: { color: colors.ink },
   alert: {
     display: "flex",
     alignItems: "flex-start",

--- a/apps/web/src/components/admin/badgeCheckEditor.stylex.tsx
+++ b/apps/web/src/components/admin/badgeCheckEditor.stylex.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
+import { SectionHeading } from "../sectionHeading.stylex";
 
 import { colors, fonts, space } from "../../styles/tokens.stylex";
 import { AdminSection } from "./adminContent.stylex";
@@ -42,7 +43,9 @@ export function BadgeCheckItem({
       <article {...stylex.props(styles.card)}>
         <header {...stylex.props(styles.cardHeader)}>
           <span {...stylex.props(styles.number)}>#{index + 1}</span>
-          <h3 {...stylex.props(styles.title)}>{title}</h3>
+          <div {...stylex.props(styles.title)}>
+            <SectionHeading level={3}>{title}</SectionHeading>
+          </div>
           {removeAction}
         </header>
         <div {...stylex.props(styles.cardBody)}>{children}</div>
@@ -113,12 +116,6 @@ const styles = stylex.create({
     backgroundColor: colors.inset,
   },
   number: { color: colors.inkMuted, fontFamily: fonts.data, fontSize: "10px" },
-  title: {
-    flexGrow: 1,
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "14px",
-  },
+  title: { flexGrow: 1 },
   cardBody: { padding: space.x4 },
 });

--- a/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
@@ -14,6 +14,7 @@ import { Plus, X } from "lucide-react";
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useDebounceCallback } from "usehooks-ts";
+import { SectionHeading } from "../../sectionHeading.stylex";
 
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { IconButton, TextLink } from "../..";
@@ -124,8 +125,8 @@ export default function ModerationBottlePicker({
       <div {...stylex.props(styles.position)}>
         <DialogPanel {...stylex.props(styles.panel)}>
           <header {...stylex.props(styles.header)}>
-            <DialogTitle {...stylex.props(styles.title)}>
-              Choose bottle
+            <DialogTitle as="div">
+              <SectionHeading>Choose bottle</SectionHeading>
             </DialogTitle>
             <IconButton
               icon={<X aria-hidden="true" size={18} />}
@@ -265,13 +266,6 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
     backgroundColor: colors.ground,
-  },
-  title: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "20px",
-    fontWeight: 700,
   },
   searchRow: {
     padding: space.x4,

--- a/apps/web/src/components/admin/scraperSetting.stylex.tsx
+++ b/apps/web/src/components/admin/scraperSetting.stylex.tsx
@@ -1,7 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
+import { SectionHeading } from "../sectionHeading.stylex";
 
-import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, fonts, space } from "../../styles/tokens.stylex";
 
 export default function ScraperSetting({
@@ -19,7 +19,7 @@ export default function ScraperSetting({
     <div {...stylex.props(styles.stack)}>
       <div {...stylex.props(styles.header)}>
         <div {...stylex.props(styles.copy)}>
-          <h3 {...stylex.props(foundationStyles.sectionHeading)}>{title}</h3>
+          <SectionHeading level={3}>{title}</SectionHeading>
           <p {...stylex.props(styles.description)}>{description}</p>
         </div>
         {action}

--- a/apps/web/src/components/applicationHeader.stylex.tsx
+++ b/apps/web/src/components/applicationHeader.stylex.tsx
@@ -9,6 +9,7 @@ import {
 import * as stylex from "@stylexjs/stylex";
 import { Menu as MenuIcon, Search, X } from "lucide-react";
 import { Fragment, useEffect, useRef, useState, type ReactNode } from "react";
+import { SectionHeading } from "./sectionHeading.stylex";
 
 import {
   colors,
@@ -346,7 +347,9 @@ function HeaderDrawerGroup({
 }) {
   return (
     <section>
-      <h2 {...stylex.props(styles.drawerHeading)}>{label}</h2>
+      <div {...stylex.props(styles.drawerHeading)}>
+        <SectionHeading>{label}</SectionHeading>
+      </div>
       <ul {...stylex.props(styles.drawerList)}>
         {items.map((item) => (
           <li key={item.href} {...stylex.props(styles.drawerListItem)}>
@@ -670,17 +673,7 @@ const styles = stylex.create({
       rowGap: space.x4,
     },
   },
-  drawerHeading: {
-    margin: 0,
-    marginBottom: space.x2,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 400,
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
-  },
+  drawerHeading: { marginBottom: space.x2 },
   drawerList: {
     margin: 0,
     paddingTop: space.x1,

--- a/apps/web/src/components/bottleChecks/checkResult.stylex.tsx
+++ b/apps/web/src/components/bottleChecks/checkResult.stylex.tsx
@@ -7,6 +7,7 @@ import {
   fonts,
   space,
 } from "../../styles/tokens.stylex";
+import { SectionHeading } from "../sectionHeading.stylex";
 import {
   getBottleCheckFindings,
   getBottleCheckState,
@@ -29,7 +30,9 @@ export default function CheckResult({
     return (
       <section {...stylex.props(styles.panel, styles.warningPanel)}>
         <div {...stylex.props(styles.eyebrow)}>Unsupported schema</div>
-        <h2 {...stylex.props(styles.title)}>{title}</h2>
+        <div {...stylex.props(styles.title)}>
+          <SectionHeading>{title}</SectionHeading>
+        </div>
         <p {...stylex.props(styles.copy)}>
           This audit uses schema version {check.schemaVersion}. Its historical
           proposals cannot be reviewed safely
@@ -85,7 +88,7 @@ export default function CheckResult({
         <span {...stylex.props(styles.status)}>
           {getBottleCheckState(check)}
         </span>
-        <h2 {...stylex.props(styles.compactTitle)}>{title}</h2>
+        <SectionHeading>{title}</SectionHeading>
       </div>
       <p {...stylex.props(styles.copy)}>{getBottleCheckSummary(check)}</p>
 
@@ -97,7 +100,7 @@ export default function CheckResult({
 
       {findings.length > 0 ? (
         <div {...stylex.props(styles.findings)}>
-          <h3 {...stylex.props(styles.compactTitle)}>Findings</h3>
+          <SectionHeading level={3}>Findings</SectionHeading>
           <div {...stylex.props(styles.findingList)}>
             {findings.map((finding, index) => {
               return (
@@ -147,21 +150,7 @@ const styles = stylex.create({
     letterSpacing: "0.08em",
     textTransform: "uppercase",
   },
-  title: {
-    margin: 0,
-    marginTop: space.x2,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 600,
-  },
-  compactTitle: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "14px",
-    fontWeight: 600,
-  },
+  title: { marginTop: space.x2 },
   copy: {
     margin: 0,
     marginTop: space.x2,

--- a/apps/web/src/components/bottleChecks/operationCard.stylex.tsx
+++ b/apps/web/src/components/bottleChecks/operationCard.stylex.tsx
@@ -15,6 +15,7 @@ import {
   fonts,
   space,
 } from "../../styles/tokens.stylex";
+import { SectionHeading } from "../sectionHeading.stylex";
 
 type Details = Outputs["audits"]["details"];
 export type BottleOperation = Details["audit"]["operations"][number];
@@ -661,7 +662,6 @@ export default function OperationCard({
   const allFieldsExcluded =
     editableFields.length > 0 &&
     editableFields.every((field) => excludedFields.has(field));
-  const Heading = compact ? "h2" : "h3";
 
   useEffect(() => {
     return () => {
@@ -731,9 +731,9 @@ export default function OperationCard({
       <article {...stylex.props(styles.card, styles.warningCard)}>
         <div {...stylex.props(styles.cardHeader, styles.centeredHeader)}>
           <div>
-            <Heading {...stylex.props(styles.cardTitle)}>
+            <SectionHeading level={compact ? 2 : 3}>
               {OPERATION_LABELS[operation.proposal.type]}
-            </Heading>
+            </SectionHeading>
             <p {...stylex.props(styles.copy)} role="status">
               {savingRemoval
                 ? "Removing operation…"
@@ -754,9 +754,9 @@ export default function OperationCard({
     <article {...stylex.props(styles.card)}>
       <div {...stylex.props(styles.cardHeader)}>
         <div>
-          <Heading {...stylex.props(styles.cardTitle)}>
+          <SectionHeading level={compact ? 2 : 3}>
             {OPERATION_LABELS[operation.proposal.type]}
-          </Heading>
+          </SectionHeading>
           {!compact ||
           operation.status !== "pending_review" ||
           notApprovalReady ? (
@@ -958,13 +958,6 @@ const styles = stylex.create({
     flexWrap: "wrap",
   },
   centeredHeader: { alignItems: "center" },
-  cardTitle: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "16px",
-    fontWeight: 600,
-  },
   status: {
     display: "inline-block",
     marginTop: space.x2,

--- a/apps/web/src/components/bottleResolver/layout.stylex.tsx
+++ b/apps/web/src/components/bottleResolver/layout.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 import { Camera } from "lucide-react";
 import type { ReactNode } from "react";
+import { SectionHeading } from "../sectionHeading.stylex";
 
 import { Button } from "..";
 import { foundationStyles } from "../../styles/foundations.stylex";
@@ -50,9 +51,7 @@ export function BottleResolverSection({
     <section {...stylex.props(styles.section)}>
       {title || description ? (
         <div {...stylex.props(styles.sectionHeader)}>
-          {title ? (
-            <h2 {...stylex.props(foundationStyles.sectionHeading)}>{title}</h2>
-          ) : null}
+          {title ? <SectionHeading>{title}</SectionHeading> : null}
           {description ? (
             <div
               {...stylex.props(
@@ -84,14 +83,9 @@ export function BottlePhotoAction({
         <Camera size={30} strokeWidth={1.5} />
       </span>
       <div {...stylex.props(styles.photoCopy)}>
-        <h2
-          {...stylex.props(
-            foundationStyles.sectionHeading,
-            styles.photoHeading,
-          )}
-        >
-          Photograph the label
-        </h2>
+        <div {...stylex.props(styles.photoHeading)}>
+          <SectionHeading>Photograph the label</SectionHeading>
+        </div>
         <p
           {...stylex.props(foundationStyles.metadata, styles.photoDescription)}
         >

--- a/apps/web/src/components/confirmationDialog.stylex.tsx
+++ b/apps/web/src/components/confirmationDialog.stylex.tsx
@@ -8,6 +8,7 @@ import {
 } from "@headlessui/react";
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
+import { SectionHeading } from "./sectionHeading.stylex";
 
 import { Button } from ".";
 import {
@@ -38,7 +39,9 @@ export default function ConfirmationDialog({
       <DialogBackdrop {...stylex.props(styles.backdrop)} />
       <div {...stylex.props(styles.position)}>
         <DialogPanel {...stylex.props(styles.panel)}>
-          <DialogTitle {...stylex.props(styles.title)}>{title}</DialogTitle>
+          <DialogTitle as="div">
+            <SectionHeading>{title}</SectionHeading>
+          </DialogTitle>
           <div {...stylex.props(styles.message)}>{message}</div>
           <div {...stylex.props(styles.actions)}>
             <Button onClick={onCancel} variant="tonal">
@@ -80,13 +83,6 @@ const styles = stylex.create({
     borderColor: colors.hairline,
     backgroundColor: colors.ground,
     boxShadow: effects.overlayShadow,
-  },
-  title: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "20px",
-    fontWeight: 700,
   },
   message: {
     marginTop: space.x3,

--- a/apps/web/src/components/feedback.stylex.tsx
+++ b/apps/web/src/components/feedback.stylex.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import type { HTMLAttributes, ReactNode } from "react";
+import { SectionHeading } from "./sectionHeading.stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
 import {
@@ -169,7 +170,7 @@ export function EmptyState({
     <section {...stylex.props(styles.statePanel)}>
       <div {...stylex.props(styles.stateCopy)}>
         <div {...stylex.props(styles.stateHeadingRow)}>
-          <h2 {...stylex.props(foundationStyles.sectionHeading)}>{heading}</h2>
+          <SectionHeading>{heading}</SectionHeading>
           {status}
         </div>
         <div {...stylex.props(foundationStyles.body, styles.stateDescription)}>
@@ -217,7 +218,7 @@ export function SectionError({
               <span {...stylex.props(styles.errorDetail)}>{detail}</span>
             ) : null}
           </div>
-          <h2 {...stylex.props(foundationStyles.sectionHeading)}>{heading}</h2>
+          <SectionHeading>{heading}</SectionHeading>
         </div>
         <div {...stylex.props(foundationStyles.body, styles.stateDescription)}>
           {children}

--- a/apps/web/src/components/filterPanel.stylex.tsx
+++ b/apps/web/src/components/filterPanel.stylex.tsx
@@ -3,7 +3,9 @@
 import * as stylex from "@stylexjs/stylex";
 import { ListFilter, Search } from "lucide-react";
 import { useId, useState, type FormEvent, type ReactNode } from "react";
+import { SectionHeading } from "./sectionHeading.stylex";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
@@ -71,7 +73,7 @@ export function FilterPanel({
       >
         {query ? (
           <div {...stylex.props(styles.panelHeader)}>
-            <span {...stylex.props(styles.heading)}>Filters</span>
+            <SectionHeading>Filters</SectionHeading>
             {onClear ? (
               <Button onClick={onClear} size="sm" variant="text">
                 Clear all
@@ -140,7 +142,7 @@ function FilterQueryForm({
       )}
     >
       <label htmlFor={id} {...stylex.props(styles.field)}>
-        <span {...stylex.props(styles.heading)}>{label}</span>
+        <span {...stylex.props(foundationStyles.fieldLabel)}>{label}</span>
         <TextInput
           aria-label={label}
           controlSize="sm"
@@ -206,9 +208,9 @@ export function FacetGroup({
 
   return (
     <section aria-labelledby={id} {...stylex.props(styles.facetGroup)}>
-      <h3 id={id} {...stylex.props(styles.heading)}>
+      <SectionHeading id={id} level={3}>
         {label}
-      </h3>
+      </SectionHeading>
       <div {...stylex.props(styles.facetRows)}>
         {options.map((option) => {
           const isSelected = selected === option.value;
@@ -346,16 +348,6 @@ const styles = stylex.create({
     flex: 1,
     flexDirection: "column",
     gap: space.x2,
-  },
-  heading: {
-    margin: 0,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 400,
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   facetGroup: {
     minWidth: 0,

--- a/apps/web/src/components/formLayout.stylex.tsx
+++ b/apps/web/src/components/formLayout.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 import { ChevronDown } from "lucide-react";
 import type { HTMLAttributes, ReactNode } from "react";
+import { SectionHeading } from "./sectionHeading.stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, effects, fonts, space } from "../styles/tokens.stylex";
@@ -35,7 +36,7 @@ export function FormSection({
     <section {...props} {...stylex.props(styles.section)}>
       <div {...stylex.props(styles.header)}>
         <div {...stylex.props(styles.copy)}>
-          <h2 {...stylex.props(foundationStyles.sectionHeading)}>{title}</h2>
+          <SectionHeading>{title}</SectionHeading>
           {description ? (
             <div {...stylex.props(foundationStyles.body, styles.description)}>
               {description}

--- a/apps/web/src/components/imageField.stylex.tsx
+++ b/apps/web/src/components/imageField.stylex.tsx
@@ -18,6 +18,7 @@ import {
 } from "react";
 import AvatarEditor from "react-avatar-editor";
 import { z } from "zod";
+import { SectionHeading } from "./sectionHeading.stylex";
 
 import { Button, Field } from ".";
 import setRef from "../lib/setRef";
@@ -236,7 +237,9 @@ function ImageCropDialog({
       <DialogBackdrop {...stylex.props(styles.backdrop)} />
       <div {...stylex.props(styles.position)}>
         <DialogPanel {...stylex.props(styles.panel)}>
-          <DialogTitle {...stylex.props(styles.title)}>Crop image</DialogTitle>
+          <DialogTitle as="div">
+            <SectionHeading>Crop image</SectionHeading>
+          </DialogTitle>
           <div {...stylex.props(styles.editor)}>
             <AvatarEditor
               border={20}
@@ -345,13 +348,6 @@ const styles = stylex.create({
     borderColor: colors.hairline,
     backgroundColor: colors.ground,
     boxShadow: effects.overlayShadow,
-  },
-  title: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "20px",
-    fontWeight: 700,
   },
   editor: {
     display: "flex",

--- a/apps/web/src/components/notePicker.stylex.tsx
+++ b/apps/web/src/components/notePicker.stylex.tsx
@@ -4,6 +4,7 @@ import { Dialog, DialogBackdrop, DialogPanel } from "@headlessui/react";
 import * as stylex from "@stylexjs/stylex";
 import type { FocusEvent } from "react";
 import { useId, useMemo, useState } from "react";
+import { SectionHeading } from "./sectionHeading.stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
 import {
@@ -272,12 +273,9 @@ export function NotePicker({
   return (
     <div data-state="open" {...stylex.props(styles.picker)}>
       <div {...stylex.props(styles.header)}>
-        <h3
-          id={titleId}
-          {...stylex.props(foundationStyles.sectionHeading, styles.title)}
-        >
+        <SectionHeading id={titleId} level={3}>
           Notes
-        </h3>
+        </SectionHeading>
         <input
           aria-describedby={resultCountId}
           aria-label="Search notes"
@@ -587,9 +585,6 @@ const styles = stylex.create({
     paddingRight: { default: space.x4, [COMPACT]: space.x3 },
     paddingBottom: space.x3,
     paddingLeft: { default: space.x4, [COMPACT]: space.x3 },
-  },
-  title: {
-    color: colors.ink,
   },
   search: {
     boxSizing: "border-box",

--- a/apps/web/src/components/pages/authentication.stylex.tsx
+++ b/apps/web/src/components/pages/authentication.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 import NextLink from "next/link";
 import type { ComponentProps, ReactNode } from "react";
+import { SectionHeading } from "../sectionHeading.stylex";
 
 import { TextLink, type TextLinkProps } from "..";
 import { foundationStyles } from "../../styles/foundations.stylex";
@@ -116,7 +117,7 @@ export function AuthenticationPanel({
   return (
     <section {...stylex.props(styles.panel)}>
       {back ? <div {...stylex.props(styles.back)}>{back}</div> : null}
-      <h2 {...stylex.props(styles.panelTitle)}>{title}</h2>
+      <SectionHeading>{title}</SectionHeading>
       {description ? (
         <div {...stylex.props(styles.panelDescription)}>{description}</div>
       ) : null}
@@ -386,15 +387,6 @@ const styles = stylex.create({
   },
   back: {
     marginBottom: "14px",
-  },
-  panelTitle: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "34px",
-    fontWeight: 700,
-    letterSpacing: "-0.03em",
-    lineHeight: 1.08,
   },
   panelDescription: {
     marginTop: space.x2,

--- a/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
@@ -1,9 +1,10 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
+import { SectionHeading } from "../sectionHeading.stylex";
 
 import type { ReviewScoreProps, TastingRatingDistributionProps } from "..";
 import { AppLink, ReviewScore, TastingRatingDistribution } from "..";
-import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
+import { colors, effects, space } from "../../styles/tokens.stylex";
 import { PageHeader } from "./pageLayout.stylex";
 
 const NARROW = "@media (max-width: 900px)";
@@ -68,7 +69,9 @@ export function BottlePageHeader({
           ) : null}
           {bands ? (
             <section {...stylex.props(styles.rating)}>
-              <h2 {...stylex.props(styles.ratingLabel)}>Tasting ratings</h2>
+              <div {...stylex.props(styles.ratingLabel)}>
+                <SectionHeading>Tasting ratings</SectionHeading>
+              </div>
               <div {...stylex.props(styles.ratingContent)}>
                 <TastingRatingDistribution {...bands} />
               </div>
@@ -137,17 +140,7 @@ const styles = stylex.create({
     alignItems: "start",
     gap: { default: 0, [PHONE]: space.x3 },
   },
-  ratingLabel: {
-    margin: 0,
-    marginBottom: { default: space.x2, [PHONE]: 0 },
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 400,
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
-  },
+  ratingLabel: { marginBottom: { default: space.x2, [PHONE]: 0 } },
   ratingContent: {
     minWidth: 0,
   },

--- a/apps/web/src/components/pages/catalogDetailComposition.stories.tsx
+++ b/apps/web/src/components/pages/catalogDetailComposition.stories.tsx
@@ -6,7 +6,6 @@ import {
   PageColumns,
   PageHeader,
   PageSection,
-  RailSection,
   TabbedPage,
 } from "./pageLayout.stylex";
 
@@ -16,7 +15,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Use these components to build catalog detail pages. Keep data loading, sign-in state, navigation, and updates in the page route.",
+          "Use these components to build catalog detail pages. Use PageSection for section headings in both columns. Keep data loading, sign-in state, navigation, and updates in the page route.",
       },
     },
   },
@@ -54,8 +53,8 @@ export const Overview: Story = {
     >
       <PageColumns
         rail={
-          <>
-            <RailSection heading="Popular bottles">
+          <div>
+            <PageSection heading="Popular bottles">
               <RailList ariaLabel="Popular bottles">
                 <RailListItem
                   href="#"
@@ -68,11 +67,11 @@ export const Overview: Story = {
                   title="Another bottle"
                 />
               </RailList>
-            </RailSection>
-            <RailSection heading="Production rules">
+            </PageSection>
+            <PageSection heading="Production rules">
               Show established production facts when the page includes them.
-            </RailSection>
-          </>
+            </PageSection>
+          </div>
         }
         railBehavior="stack"
       >

--- a/apps/web/src/components/pages/contentPage.stylex.tsx
+++ b/apps/web/src/components/pages/contentPage.stylex.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
+import { SectionHeading } from "../sectionHeading.stylex";
 
 import { TextLink, type TextLinkProps } from "..";
 import { foundationStyles } from "../../styles/foundations.stylex";
@@ -39,7 +40,7 @@ export function ContentSection({
 }) {
   return (
     <section {...stylex.props(styles.section)}>
-      <h2 {...stylex.props(styles.sectionTitle)}>{title}</h2>
+      <SectionHeading>{title}</SectionHeading>
       {children}
     </section>
   );
@@ -54,7 +55,7 @@ export function ContentSubsection({
 }) {
   return (
     <section {...stylex.props(styles.subsection)}>
-      <h3 {...stylex.props(styles.subsectionTitle)}>{title}</h3>
+      <SectionHeading level={3}>{title}</SectionHeading>
       {children}
     </section>
   );
@@ -113,28 +114,10 @@ const styles = stylex.create({
     flexDirection: "column",
     rowGap: space.x3,
   },
-  sectionTitle: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "24px",
-    fontWeight: 700,
-    letterSpacing: "-0.025em",
-    lineHeight: 1.2,
-  },
   subsection: {
     display: "flex",
     flexDirection: "column",
     rowGap: space.x2,
-  },
-  subsectionTitle: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "17px",
-    fontWeight: 700,
-    letterSpacing: "-0.015em",
-    lineHeight: 1.25,
   },
   text: {
     maxWidth: "74ch",

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 import { needsRegionMapCredit } from "../../lib/locationMap";
 import { RegionMapCredit } from "../locationMapIcon/credit.stylex";
+import { SectionHeading } from "../sectionHeading.stylex";
 
 import {
   BottleList,
@@ -35,7 +36,7 @@ function HomeModuleHeading({
   return (
     <div {...stylex.props(styles.heading)}>
       <div {...stylex.props(styles.headingLine)}>
-        <h2 {...stylex.props(styles.title)}>{title}</h2>
+        <SectionHeading>{title}</SectionHeading>
         {action}
       </div>
       {detail ? <div {...stylex.props(styles.detail)}>{detail}</div> : null}
@@ -180,7 +181,9 @@ export function HomeOrigins({
       </div>
       {regions.length ? (
         <>
-          <div {...stylex.props(styles.regionHeading)}>By region</div>
+          <div {...stylex.props(styles.regionHeading)}>
+            <SectionHeading level={3}>By region</SectionHeading>
+          </div>
           <HomeRegionGrid regions={regions} />
         </>
       ) : null}
@@ -243,7 +246,7 @@ export function HomeContributionPrompt({
 }) {
   return (
     <section {...stylex.props(styles.prompt)}>
-      <h2 {...stylex.props(styles.promptTitle)}>Missing a bottle?</h2>
+      <SectionHeading>Missing a bottle?</SectionHeading>
       <p {...stylex.props(styles.promptCopy)}>
         Add it. Cask number, vintage, ABV, finish—as much as the label tells
         you.
@@ -275,15 +278,6 @@ const styles = stylex.create({
     justifyContent: "space-between",
     gap: space.x3,
   },
-  title: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "24px",
-    fontWeight: 700,
-    letterSpacing: "-0.03em",
-    lineHeight: 1.1,
-  },
   detail: {
     color: colors.inkMuted,
     fontFamily: fonts.data,
@@ -304,15 +298,7 @@ const styles = stylex.create({
     fontSize: "15px",
     lineHeight: 1.5,
   },
-  regionHeading: {
-    marginTop: space.x6,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    lineHeight: 1.4,
-    textTransform: "uppercase",
-  },
+  regionHeading: { marginTop: space.x6 },
   regionGrid: {
     display: "grid",
     gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
@@ -371,15 +357,6 @@ const styles = stylex.create({
     paddingTop: "18px",
     paddingBottom: "18px",
     backgroundColor: "transparent",
-  },
-  promptTitle: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "15px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
   },
   promptCopy: {
     margin: 0,

--- a/apps/web/src/components/pages/homeSummary.stylex.tsx
+++ b/apps/web/src/components/pages/homeSummary.stylex.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
+import { SectionHeading } from "../sectionHeading.stylex";
 
 import {
   CountChip,
@@ -31,9 +32,7 @@ export function HomeMemberSummary({
       {...stylex.props(styles.widget)}
     >
       <div {...stylex.props(styles.widgetHeading)}>
-        <h2 id="member-record-heading" {...stylex.props(styles.widgetTitle)}>
-          Your record
-        </h2>
+        <SectionHeading id="member-record-heading">Your record</SectionHeading>
         <CountChip count={totalTastings} />
       </div>
       <div {...stylex.props(styles.recordPanel)}>
@@ -84,15 +83,6 @@ const styles = stylex.create({
     display: "flex",
     alignItems: "center",
     gap: "10px",
-  },
-  widgetTitle: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
   },
   recordPanel: {
     paddingTop: "22px",

--- a/apps/web/src/components/pages/pageLayout.stylex.tsx
+++ b/apps/web/src/components/pages/pageLayout.stylex.tsx
@@ -153,6 +153,7 @@ export function TabbedPage({
   );
 }
 
+/** Groups catalog content under the standard section heading in either column. */
 export function PageSection({
   children,
   heading,
@@ -175,6 +176,7 @@ export function PageSection({
   );
 }
 
+/** Spaces sidebar content; headings use the same component as main-column sections. */
 export function RailSection({
   children,
   heading,
@@ -184,7 +186,7 @@ export function RailSection({
 }) {
   return (
     <section {...stylex.props(styles.railSection)}>
-      <h2 {...stylex.props(styles.railHeading)}>{heading}</h2>
+      <SectionHeading>{heading}</SectionHeading>
       {children}
     </section>
   );
@@ -366,15 +368,5 @@ const styles = stylex.create({
     display: "flex",
     flexDirection: "column",
     rowGap: space.x2,
-  },
-  railHeading: {
-    margin: 0,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 400,
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
 });

--- a/apps/web/src/components/pages/railListSection.stylex.tsx
+++ b/apps/web/src/components/pages/railListSection.stylex.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
+import { SectionHeading } from "../sectionHeading.stylex";
 
 import { colors, fonts, space } from "../../styles/tokens.stylex";
 import { TextLink } from "../textLink.stylex";
@@ -31,7 +32,7 @@ export function RailListSection({
 }) {
   return (
     <section {...stylex.props(styles.section)}>
-      <h2 {...stylex.props(styles.heading)}>{heading}</h2>
+      <SectionHeading>{heading}</SectionHeading>
       {intro ? <p {...stylex.props(styles.intro)}>{intro}</p> : null}
       {action ? (
         "href" in action ? (
@@ -63,14 +64,6 @@ const styles = stylex.create({
     minWidth: 0,
     flexDirection: "column",
     gap: space.x2,
-  },
-  heading: {
-    margin: 0,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
   },
   intro: {
     margin: 0,

--- a/apps/web/src/components/searchResults.stylex.tsx
+++ b/apps/web/src/components/searchResults.stylex.tsx
@@ -1,5 +1,5 @@
 import * as stylex from "@stylexjs/stylex";
-import type { ReactNode } from "react";
+import { SectionHeading } from "./sectionHeading.stylex";
 
 import {
   colors,
@@ -116,9 +116,7 @@ export function SearchResults({
       ) : null}
       {emptyText && variant === "database" ? (
         <div {...stylex.props(styles.databaseEmptyState)}>
-          <h2 {...stylex.props(styles.databaseEmptyHeading)}>
-            Nothing matches “{query}”
-          </h2>
+          <SectionHeading>Nothing matches “{query}”</SectionHeading>
           <p {...stylex.props(styles.databaseEmptyDescription)}>
             Check the spelling, or record the bottle if the database is missing
             it.
@@ -224,15 +222,18 @@ function SearchResultsGroup({
           variant === "database" && styles.databaseGroupHeading,
         )}
       >
-        <h2
-          id={`${optionIdPrefix ?? "search"}-group-${group.id}`}
+        <div
           {...stylex.props(
             styles.groupName,
             variant === "database" && styles.databaseGroupName,
           )}
         >
-          {group.label}
-        </h2>
+          <SectionHeading
+            id={`${optionIdPrefix ?? "search"}-group-${group.id}`}
+          >
+            {group.label}
+          </SectionHeading>
+        </div>
         {group.total !== undefined ? (
           <span
             {...stylex.props(
@@ -414,15 +415,6 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
   },
-  databaseEmptyHeading: {
-    margin: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "17px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
-  },
   databaseEmptyDescription: {
     maxWidth: "560px",
     marginTop: space.x2,
@@ -453,28 +445,8 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
   },
-  groupName: {
-    minWidth: 0,
-    flex: 1,
-    margin: 0,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 400,
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
-  },
-  databaseGroupName: {
-    flex: 0,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "14px",
-    fontWeight: 700,
-    letterSpacing: "-0.01em",
-    textTransform: "none",
-    whiteSpace: "nowrap",
-  },
+  groupName: { minWidth: 0, flex: 1 },
+  databaseGroupName: { flex: 0 },
   groupCount: {
     color: colors.inkMuted,
     fontFamily: fonts.data,

--- a/apps/web/src/components/sectionHeading.stories.tsx
+++ b/apps/web/src/components/sectionHeading.stories.tsx
@@ -7,6 +7,14 @@ const meta = {
   title: "Components/Layout/Section Heading",
   component: SectionHeading,
   args: { children: "Similar bottles" },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Use SectionHeading for every section heading, including sidebars. Heading levels change document structure, not appearance. Keep spacing in the containing layout; do not add local typography variants.",
+      },
+    },
+  },
 } satisfies Meta<typeof SectionHeading>;
 
 export default meta;

--- a/apps/web/src/components/sectionHeading.stylex.tsx
+++ b/apps/web/src/components/sectionHeading.stylex.tsx
@@ -2,19 +2,30 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import { foundationStyles } from "../styles/foundations.stylex";
+import { colors } from "../styles/tokens.stylex";
 
+/** The single visual treatment for section headings; level changes semantics only. */
 export function SectionHeading({
   children,
+  id,
   level = 2,
 }: {
   children: ReactNode;
+  id?: string;
   level?: 2 | 3;
 }) {
   const Heading = level === 2 ? "h2" : "h3";
 
   return (
-    <Heading {...stylex.props(foundationStyles.sectionHeading)}>
+    <Heading
+      id={id}
+      {...stylex.props(foundationStyles.sectionHeading, styles.heading)}
+    >
       {children}
     </Heading>
   );
 }
+
+const styles = stylex.create({
+  heading: { color: colors.ink },
+});

--- a/apps/web/src/components/siteFooter.stylex.tsx
+++ b/apps/web/src/components/siteFooter.stylex.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
+import { SectionHeading } from "./sectionHeading.stylex";
 
 import { colors, effects, fonts, space } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
@@ -50,7 +51,7 @@ export function SiteFooter({
       </div>
       {referenceLinks.length ? (
         <div {...stylex.props(styles.referenceSection)}>
-          <h2 {...stylex.props(styles.footerHeading)}>Reference</h2>
+          <SectionHeading>Reference</SectionHeading>
           <p {...stylex.props(styles.referenceLinks)}>
             {referenceLinks.map((link) => (
               <FooterAnchor key={link.href} link={link} />
@@ -110,16 +111,6 @@ const styles = stylex.create({
     fontFamily: fonts.reading,
     fontSize: "13px",
     lineHeight: 1.55,
-  },
-  footerHeading: {
-    margin: 0,
-    color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 400,
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   footerLinks: {
     display: "flex",


### PR DESCRIPTION
Country and region sections now use the same 20px section headings as entity details. The shared sidebar wrappers and section headings across the homepage, About pages, search, forms, dialogs, and admin now render `SectionHeading`, removing the separate uppercase and page-specific typography.

Heading levels and accessibility IDs are preserved, while surrounding layouts own spacing. The unused `AdminHeading` is removed, and the design guide and Storybook document the single heading treatment.

Verified country, region, and About layouts at desktop and mobile widths, including light and dark rendering. The web suite passed all 311 tests; typechecking and formatting passed. Lint reports two existing React effect warnings in the dialog files.
