### PR TITLE
fix(web): simplify bottle browse headings

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -202,6 +202,9 @@ sentiment poles.
 - Section headings use `SectionHeading` in every column. Heading levels express
   document structure and share one visual treatment. Do not add compact,
   uppercase, or page-specific section heading variants.
+- Browse headings should name the content or its relationship to the page.
+  State the ranking only when it helps people choose; sort controls should
+  still name their order.
 
 | Role            | Family  | Weight | Size and line height | Tracking |
 | --------------- | ------- | ------ | -------------------- | -------- |

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -618,7 +618,6 @@ export function BottleOverviewClient() {
         }}
         mainState={mainState}
         moreTastingsHref={`${getBottleUrl(bottle)}/tastings`}
-        recommendationIntro={recommendationsQuery.data?.reason}
         recommendationState={
           recommendationsQuery.isPending ? (
             <LoadingList label="Loading bottle recommendations" rows={3} />

--- a/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityBottleOverview.tsx
@@ -40,7 +40,7 @@ export function EntityBottleOverview({
   const presentation = getEntityPresentation(entity);
   const entityHref = getEntityUrl(entity);
   const isDistillery = entity.kind === "distillery";
-  const heading = isDistillery ? "Popular other bottlings" : "Popular bottles";
+  const heading = isDistillery ? "Other bottlings" : "Bottles";
   const viewAllParams = new URLSearchParams({ sort: "-tastings" });
   if (isDistillery) viewAllParams.set("view", "other");
 
@@ -108,8 +108,8 @@ export function EntityBottleOverview({
       <BottleList
         ariaLabel={
           isDistillery
-            ? `${entity.name} popular other bottlings`
-            : `${entity.name} popular bottles`
+            ? `${entity.name} other bottlings`
+            : `${entity.name} bottles`
         }
         items={bottleList.results.map((bottle) =>
           toBottleListItem(bottle, {

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewLayout.stylex.tsx
@@ -69,7 +69,7 @@ export function EntityOverviewLoading() {
         catalogSections={
           <div aria-hidden="true" {...stylex.props(styles.loadingSections)}>
             <LoadingSection label="Loading entity releases" rows={4} />
-            <LoadingSection label="Loading popular bottles" rows={4} />
+            <LoadingSection label="Loading bottles" rows={4} />
           </div>
         }
         relationships={

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -42,7 +42,6 @@ export type BottleOverviewProps = {
   mainState?: ReactNode;
   moreTastingsHref?: string;
   recommendationHeading?: string;
-  recommendationIntro?: string;
   recommendationState?: ReactNode;
   recommendations?: readonly BottleRecommendation[];
   railSections?: ReactNode;
@@ -59,7 +58,6 @@ export function BottleOverview({
   mainState,
   moreTastingsHref,
   recommendationHeading = "If you liked this",
-  recommendationIntro,
   recommendationState,
   recommendations = [],
   railSections,
@@ -153,7 +151,6 @@ export function BottleOverview({
             {recommendations.length ? (
               <BottleRailSection
                 heading={recommendationHeading}
-                intro={recommendationIntro}
                 items={recommendations}
               />
             ) : recommendationState ? (

--- a/apps/web/src/components/pages/catalogDetailComposition.stories.tsx
+++ b/apps/web/src/components/pages/catalogDetailComposition.stories.tsx
@@ -54,8 +54,8 @@ export const Overview: Story = {
       <PageColumns
         rail={
           <div>
-            <PageSection heading="Popular bottles">
-              <RailList ariaLabel="Popular bottles">
+            <PageSection heading="Bottles">
+              <RailList ariaLabel="Bottles">
                 <RailListItem
                   href="#"
                   metadata="Single malt"

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -64,10 +64,10 @@ export function HomeHighestRated({
             <span aria-hidden="true">→</span>
           </Link>
         }
-        title="Highest rated"
+        title="Bottles to try"
       />
       <div {...stylex.props(styles.rows)}>
-        <BottleList ariaLabel="Highest rated bottles" items={bottles} />
+        <BottleList ariaLabel="Bottles to try" items={bottles} />
       </div>
     </section>
   );


### PR DESCRIPTION
Simplifies bottle browsing headings to “Other bottlings” on distillery pages, “Bottles” on brand and bottler pages, and “Bottles to try” in the home browse component. Removes the repeated explanation below “If you liked this,” aligns accessible labels and the catalog story, and records the heading guidance in DESIGN.md.
