### PR TITLE
fix(web): build entity links from their stored kind

### DIFF
--- a/apps/server/src/orpc/contracts/users/tasting-stats.ts
+++ b/apps/server/src/orpc/contracts/users/tasting-stats.ts
@@ -1,10 +1,12 @@
-import { AgeStatsSchema } from "@peated/server/schemas";
+import { AgeStatsSchema, EntitySchema } from "@peated/server/schemas";
 import { z } from "zod";
 import { contract } from "../base";
 
-const ProducerStatSchema = z.object({
-  id: z.number(),
-  name: z.string(),
+const ProducerStatSchema = EntitySchema.pick({
+  id: true,
+  name: true,
+  kind: true,
+}).extend({
   count: z.number(),
 });
 

--- a/apps/server/src/orpc/mock/fixtures/user-stats.ts
+++ b/apps/server/src/orpc/mock/fixtures/user-stats.ts
@@ -98,18 +98,44 @@ export const mockUserTastingStats = {
   },
   producers: {
     brands: [
-      { id: mockRedbreastEntity.id, name: mockRedbreastEntity.name, count: 7 },
+      {
+        id: mockRedbreastEntity.id,
+        name: mockRedbreastEntity.name,
+        kind: mockRedbreastEntity.kind,
+        count: 7,
+      },
     ],
     bottlers: [
-      { id: mockEntities[7]!.id, name: mockEntities[7]!.name, count: 5 },
-      { id: mockEntities[8]!.id, name: mockEntities[8]!.name, count: 3 },
+      {
+        id: mockEntities[7]!.id,
+        name: mockEntities[7]!.name,
+        kind: mockEntities[7]!.kind,
+        count: 5,
+      },
+      {
+        id: mockEntities[8]!.id,
+        name: mockEntities[8]!.name,
+        kind: mockEntities[8]!.kind,
+        count: 3,
+      },
     ],
     distillers: [
-      { id: mockEntity.id, name: mockEntity.name, count: 15 },
-      { id: mockMacallanEntity.id, name: mockMacallanEntity.name, count: 8 },
+      {
+        id: mockEntity.id,
+        name: mockEntity.name,
+        kind: mockEntity.kind,
+        count: 15,
+      },
+      {
+        id: mockMacallanEntity.id,
+        name: mockMacallanEntity.name,
+        kind: mockMacallanEntity.kind,
+        count: 8,
+      },
       {
         id: mockSpringbankEntity.id,
         name: mockSpringbankEntity.name,
+        kind: mockSpringbankEntity.kind,
         count: 6,
       },
     ],

--- a/apps/server/src/orpc/routes/users/tasting-stats.test.ts
+++ b/apps/server/src/orpc/routes/users/tasting-stats.test.ts
@@ -91,21 +91,21 @@ describe("GET /users/:user/tasting-stats", () => {
     expect(data.age.buckets.every((bucket) => bucket.count === 0)).toBe(true);
   });
 
-  test("ranks the producers represented in tastings", async ({
+  test("ranks producers by Bottle role while preserving their Entity kind", async ({
     defaults,
     fixtures,
   }) => {
     const brandA = await fixtures.Entity({
-      kind: "brand",
-      name: "Alpha Brand",
+      kind: "distillery",
+      name: "Alpha Distillery Brand",
     });
     const brandB = await fixtures.Entity({
       kind: "brand",
       name: "Bravo Brand",
     });
     const bottlerA = await fixtures.Entity({
-      kind: "bottler",
-      name: "Alpha Bottler",
+      kind: "company",
+      name: "Alpha Bottling Company",
     });
     const bottlerB = await fixtures.Entity({
       kind: "bottler",
@@ -116,8 +116,8 @@ describe("GET /users/:user/tasting-stats", () => {
       name: "Alpha Distillery",
     });
     const distillerB = await fixtures.Entity({
-      kind: "distillery",
-      name: "Bravo Distillery",
+      kind: "brand",
+      name: "Bravo Distiller Brand",
     });
     const bottleA = await fixtures.Bottle({
       brandId: brandA.id,
@@ -149,16 +149,26 @@ describe("GET /users/:user/tasting-stats", () => {
 
     expect(data.producers).toEqual({
       brands: [
-        { id: brandA.id, name: brandA.name, count: 3 },
-        { id: brandB.id, name: brandB.name, count: 1 },
+        { id: brandA.id, name: brandA.name, kind: brandA.kind, count: 3 },
+        { id: brandB.id, name: brandB.name, kind: brandB.kind, count: 1 },
       ],
       bottlers: [
-        { id: bottlerA.id, name: bottlerA.name, count: 3 },
-        { id: bottlerB.id, name: bottlerB.name, count: 1 },
+        { id: bottlerA.id, name: bottlerA.name, kind: bottlerA.kind, count: 3 },
+        { id: bottlerB.id, name: bottlerB.name, kind: bottlerB.kind, count: 1 },
       ],
       distillers: [
-        { id: distillerA.id, name: distillerA.name, count: 3 },
-        { id: distillerB.id, name: distillerB.name, count: 2 },
+        {
+          id: distillerA.id,
+          name: distillerA.name,
+          kind: distillerA.kind,
+          count: 3,
+        },
+        {
+          id: distillerB.id,
+          name: distillerB.name,
+          kind: distillerB.kind,
+          count: 2,
+        },
       ],
     });
   });

--- a/apps/server/src/orpc/routes/users/tasting-stats.ts
+++ b/apps/server/src/orpc/routes/users/tasting-stats.ts
@@ -9,6 +9,7 @@ import { getUserFromId, profileVisible } from "@peated/server/lib/api";
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { implement } from "@peated/server/orpc";
 import userTastingStatsContract from "@peated/server/orpc/contracts/users/tasting-stats";
+import type { Entity } from "@peated/server/types";
 import { eq, inArray } from "drizzle-orm";
 import { buildAgeStats } from "./age-stats";
 import {
@@ -16,20 +17,18 @@ import {
   UserBottleReadIntegrityError,
 } from "./tasting-bottle-scan";
 
-type ProducerStat = { id: number; name: string; count: number };
-
 function incrementCount(counts: Map<number, number>, id: number) {
   counts.set(id, (counts.get(id) ?? 0) + 1);
 }
 
 function rankProducers(
   counts: Map<number, number>,
-  entitiesById: Map<number, { id: number; name: string }>,
-): ProducerStat[] {
+  entitiesById: Map<number, Pick<Entity, "id" | "name" | "kind">>,
+) {
   return Array.from(counts, ([id, count]) => {
     const entity = entitiesById.get(id);
     if (!entity) throw new Error(`Bottle references missing Entity ${id}.`);
-    return { id, name: entity.name, count };
+    return { id, name: entity.name, kind: entity.kind, count };
   })
     .sort(
       (left, right) =>
@@ -137,7 +136,7 @@ export default implement(userTastingStatsContract).handler(async function ({
   );
   const producerEntities = producerIds.length
     ? await db
-        .select({ id: entities.id, name: entities.name })
+        .select({ id: entities.id, name: entities.name, kind: entities.kind })
         .from(entities)
         .where(inArray(entities.id, producerIds))
     : [];

--- a/apps/web/e2e/entity-page-redirects.spec.ts
+++ b/apps/web/e2e/entity-page-redirects.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "./test";
 
 import {
+  distilleryBrandBottleId,
   replacementSourceEntityId,
   testOwnedEntity,
   testOwner,
@@ -31,10 +32,18 @@ test.describe("Entity page routes", () => {
     }
   });
 
-  test("uses the canonical company link and completes client navigation", async ({
+  test("links a Bottle's distillery Brand and its owner to their canonical pages", async ({
     page,
   }) => {
-    await page.goto(`/distillers/${testOwnedEntity.id}`);
+    await page.goto(`/bottles/${distilleryBrandBottleId}`);
+
+    const brandLink = page
+      .getByRole("link", { name: testOwnedEntity.name, exact: true })
+      .first();
+    const distilleryUrl = `/distillers/${testOwnedEntity.id}-lagavulin-distillery`;
+    await expect(brandLink).toHaveAttribute("href", distilleryUrl);
+    await brandLink.click();
+    await expect(page).toHaveURL(distilleryUrl);
 
     const companyLink = page.getByRole("link", { name: "View company" });
     await expect(companyLink).toHaveAttribute(

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -26,6 +26,7 @@ import {
   createdTastingId,
   destinationBottleGroup,
   destinationBottleGroupId,
+  distilleryBrandBottleId,
   emptyEntityCatalog,
   emptyList,
   exactMatchedBottle,
@@ -2388,6 +2389,10 @@ function hasBottleInCollection(collection, bottleId) {
 }
 
 function buildBottleForId(id) {
+  if (id === distilleryBrandBottleId) {
+    return buildBottle({ id, brand: testOwnedEntity });
+  }
+
   if (id === createdBottleId) {
     return buildBottle({
       id: createdBottleId,

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -237,6 +237,7 @@ export const emptyEntityCatalog = {
 };
 
 export const existingBottleId = 9301;
+export const distilleryBrandBottleId = 9320;
 export const createdBottleId = 9302;
 export const exactMatchedBottleId = 9305;
 export const replacementSourceBottleId = 9307;

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -435,11 +435,7 @@ export function BottlePageFrameClient({
               : null
           }
           brand={bottle.brand.shortName || bottle.brand.name}
-          brandHref={getEntityUrl({
-            id: bottle.brand.id,
-            kind: "brand",
-            name: bottle.brand.name,
-          })}
+          brandHref={getEntityUrl(bottle.brand)}
           eyebrow={getBottleEyebrow(bottle)}
           menu={<BottleActions bottle={bottle} />}
           name={formatBottleDisplayName(bottle, { includeBrand: false })}

--- a/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
@@ -61,11 +61,7 @@ export default async function BottleReleasesPage(props: {
             <ItemListItem key={bottle.id}>
               <BottleIdentityRow
                 brand={bottle.brand.name}
-                brandHref={getEntityUrl({
-                  id: bottle.brand.id,
-                  kind: "brand",
-                  name: bottle.brand.name,
-                })}
+                brandHref={getEntityUrl(bottle.brand)}
                 end={
                   bottle.medianScore !== null && bottle.scoreCount >= 20
                     ? `${bottle.medianScore} / 100`

--- a/apps/web/src/app/(app)/entities/[entityId]/codes/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/codes/page.tsx
@@ -53,13 +53,7 @@ export default async function EntityCodesPage(props: {
       rows.push({
         code,
         country: distiller?.country?.name ?? null,
-        href: distiller
-          ? getEntityUrl({
-              id: distiller.id,
-              kind: "distillery",
-              name: distiller.name,
-            })
-          : undefined,
+        href: distiller ? getEntityUrl(distiller) : undefined,
         name: distiller?.name ?? distillerName ?? "Unknown",
       });
     }
@@ -73,11 +67,7 @@ export default async function EntityCodesPage(props: {
     <EntityCodes
       entityName={entity.name}
       example={{
-        href: getEntityUrl({
-          id: exampleDistiller.id,
-          kind: "distillery",
-          name: exampleDistiller.name,
-        }),
+        href: getEntityUrl(exampleDistiller),
         name: exampleDistiller.name,
       }}
       groups={groups}

--- a/apps/web/src/app/(app)/flights/[flightId]/page.tsx
+++ b/apps/web/src/app/(app)/flights/[flightId]/page.tsx
@@ -67,11 +67,7 @@ export default async function FlightPage(props: {
               <ItemListItem key={bottle.id}>
                 <BottleIdentityRow
                   brand={bottle.brand.name}
-                  brandHref={getEntityUrl({
-                    id: bottle.brand.id,
-                    kind: "brand",
-                    name: bottle.brand.name,
-                  })}
+                  brandHref={getEntityUrl(bottle.brand)}
                   end={
                     <ButtonLink
                       href={getAddBottleHref({

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
@@ -320,11 +320,7 @@ function toLibraryItem(
         ]
       : undefined,
     brand: bottle.brand.shortName || bottle.brand.name,
-    brandHref: getEntityUrl({
-      id: bottle.brand.id,
-      kind: "brand",
-      name: bottle.brand.name,
-    }),
+    brandHref: getEntityUrl(bottle.brand),
     href: getBottleUrl(bottle),
     id: String(entry.id),
     imageUrl: entry.imageUrl ?? bottle.imageUrl,

--- a/apps/web/src/app/(app)/users/[username]/profileActivity.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileActivity.tsx
@@ -23,11 +23,7 @@ export function toActivityItem(activity: Activity): MemberActivityItem {
         id: activity.id,
         items: activity.items.map((entry) => ({
           brand: entry.bottle.brand.shortName || entry.bottle.brand.name,
-          brandHref: getEntityUrl({
-            id: entry.bottle.brand.id,
-            kind: "brand",
-            name: entry.bottle.brand.name,
-          }),
+          brandHref: getEntityUrl(entry.bottle.brand),
           href: getBottleUrl(entry.bottle),
           id: String(entry.id),
           imageUrl: entry.imageUrl ?? entry.bottle.imageUrl,

--- a/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
@@ -30,12 +30,10 @@ import { profileQueries } from "./profileQueries";
 type ActivityList = Outputs["users"]["activity"]["list"];
 type BadgeAward = Outputs["users"]["badgeList"]["results"][number];
 type TastingStats = Outputs["users"]["tastingStats"];
-type ProducerKind = "brand" | "bottler" | "distillery";
 type ProducerStat = TastingStats["producers"]["brands"][number];
 type ProducerGroup = {
   heading: string;
   items: readonly ProducerStat[];
-  kind: ProducerKind;
 };
 
 export function ProfileOverviewPageClient({
@@ -121,16 +119,12 @@ function ProducerSections({ groups }: { groups: readonly ProducerGroup[] }) {
   return (
     <>
       {groups.map((group) => (
-        <RailSection heading={group.heading} key={group.kind}>
+        <RailSection heading={group.heading} key={group.heading}>
           <RailList ariaLabel={`${group.heading} tasted often`}>
             {group.items.map((producer) => (
               <RailListItem
                 end={formatCount(producer.count)}
-                href={getEntityUrl({
-                  id: producer.id,
-                  kind: group.kind,
-                  name: producer.name,
-                })}
+                href={getEntityUrl(producer)}
                 key={producer.id}
                 title={producer.name}
               />
@@ -192,21 +186,18 @@ function getProducerGroups(
     groups.push({
       heading: "Distillers",
       items: producers.distillers.slice(0, 3),
-      kind: "distillery",
     });
   }
   if (producers.bottlers.length) {
     groups.push({
       heading: "Bottlers",
       items: producers.bottlers.slice(0, 3),
-      kind: "bottler",
     });
   }
   if (groups.length < 2 && producers.brands.length) {
     groups.push({
       heading: "Brands",
       items: producers.brands.slice(0, 3),
-      kind: "brand",
     });
   }
   return groups;

--- a/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
+++ b/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
@@ -51,11 +51,7 @@ export function FlightOverlay({
                 <ItemListItem key={bottle.id}>
                   <BottleIdentityRow
                     brand={bottle.brand.name}
-                    brandHref={getEntityUrl({
-                      id: bottle.brand.id,
-                      kind: "brand",
-                      name: bottle.brand.name,
-                    })}
+                    brandHref={getEntityUrl(bottle.brand)}
                     href={getBottleUrl(bottle)}
                     imageUrl={bottle.imageUrl}
                     metadata={getBottleMetadata(bottle).split(" · ")}

--- a/apps/web/src/lib/bottleListItem.test.ts
+++ b/apps/web/src/lib/bottleListItem.test.ts
@@ -7,10 +7,26 @@ describe("toBottleListItem", () => {
   test("separates the brand from the expression in standard bottle lists", () => {
     expect(toBottleListItem(mockBottle)).toMatchObject({
       brand: "Lagavulin",
-      brandHref: "/brands/9201-lagavulin",
+      brandHref: "/distillers/9201-lagavulin",
       name: "16-year-old",
     });
   });
+
+  test.each([
+    ["brand", "brands"],
+    ["distillery", "distillers"],
+    ["bottler", "bottlers"],
+    ["company", "companies"],
+  ] as const)(
+    "links a %s used as the brand to its own collection",
+    (kind, collection) => {
+      const bottle = { ...mockBottle, brand: { ...mockBottle.brand, kind } };
+
+      expect(toBottleListItem(bottle).brandHref).toBe(
+        `/${collection}/9201-lagavulin`,
+      );
+    },
+  );
 
   test("keeps the brand in the name when the brand row is disabled", () => {
     expect(

--- a/apps/web/src/lib/bottleListItem.ts
+++ b/apps/web/src/lib/bottleListItem.ts
@@ -37,13 +37,7 @@ export function toBottleListItem(
     brand: includeBrandRow
       ? bottle.brand.shortName || bottle.brand.name
       : undefined,
-    brandHref: includeBrandRow
-      ? getEntityUrl({
-          id: bottle.brand.id,
-          kind: "brand",
-          name: bottle.brand.name,
-        })
-      : undefined,
+    brandHref: includeBrandRow ? getEntityUrl(bottle.brand) : undefined,
     hasTasted: bottle.hasTasted,
     href: getBottleUrl(bottle),
     id: bottle.peatedId,

--- a/apps/web/src/lib/urls.test.ts
+++ b/apps/web/src/lib/urls.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getBottleSeriesUrl, getBottleUrl, getEntityUrl } from "./urls";
+import {
+  getBottleSeriesUrl,
+  getBottleUrl,
+  getEntityKindSearchUrl,
+  getEntityUrl,
+} from "./urls";
 
 const bottle = {
   id: 123,
@@ -22,14 +27,15 @@ describe("public catalog URLs", () => {
   });
 
   it.each([
-    ["brand", "/brands/123"],
-    ["distillery", "/distillers/123"],
-    ["bottler", "/bottlers/123"],
-    ["company", "/companies/123"],
+    ["brand", "/brands"],
+    ["distillery", "/distillers"],
+    ["bottler", "/bottlers"],
+    ["company", "/companies"],
   ] as const)("uses the %s Entity collection", (kind, expected) => {
     expect(getEntityUrl({ id: 123, kind, name: "Lagavulin" })).toBe(
-      `${expected}-lagavulin`,
+      `${expected}/123-lagavulin`,
     );
+    expect(getEntityKindSearchUrl(kind)).toBe(expected);
   });
 
   it("uses the generic Entity route when kind is unavailable", () => {

--- a/apps/web/src/lib/urls.ts
+++ b/apps/web/src/lib/urls.ts
@@ -24,6 +24,7 @@ export function getBottleSeriesUrl(series: {
   return `/series/${series.id}-${createUrlSlug(series.fullName, "series")}`;
 }
 
+/** Entity identity owns the route: pass the stored kind, never a Bottle field's role. */
 export function getEntityUrl(entity: {
   id: number;
   kind: EntityKind | null;
@@ -52,22 +53,7 @@ function createUrlSlug(
 }
 
 export function getEntityKindSearchUrl(kind: EntityKind) {
-  let link: string;
-  switch (kind) {
-    case "bottler":
-      link = "/bottlers";
-      break;
-    case "brand":
-      link = "/brands";
-      break;
-    case "distillery":
-      link = "/distillers";
-      break;
-    case "company":
-      link = "/companies";
-      break;
-  }
-  return link;
+  return ENTITY_COLLECTION_BY_KIND[kind];
 }
 
 export function buildQueryString(

--- a/docs/architecture/peated-ids.md
+++ b/docs/architecture/peated-ids.md
@@ -20,6 +20,9 @@ Peated IDs are serialized in uppercase with at least four digits. Input and sear
 - Entity URLs use the collection for their primary kind: `/brands`,
   `/distillers`, `/bottlers`, or `/companies`, followed by the numeric ID and
   current name slug.
+  Web callers pass the Entity directly to `getEntityUrl` in
+  `apps/web/src/lib/urls.ts`. A Bottle's Brand, Bottler, or Distiller field does
+  not determine that Entity's kind or URL.
 - Series URLs use `/series/{numeric ID}-{current full-name slug}`. The full name
   includes the Brand.
 - The numeric ID identifies the object. The web app creates the slug when it


### PR DESCRIPTION
Entity links now follow the entity's stored kind across bottle pages and lists, flights, profile activity and libraries, producer statistics, and distillery codes. A distillery used as a bottle's brand now links directly to `/distillers/...` instead of `/brands/...`.

Callers pass the entity directly to `getEntityUrl`, and browse and detail URL helpers share the same kind-to-collection mapping. The tasting statistics API now includes each producer's `kind`, so profile links can use the stored identity without inferring it from the statistics group.

Regression coverage checks every entity kind used as a brand, preserves kinds across producer statistics groups, and follows a bottle's distillery brand and its owner in the browser. The web suite, focused backend tests, browser checks, both typechecks, and lint passed locally.
