### PR TITLE
fix(web): show relevant company page tabs

### DIFF
--- a/apps/web/e2e/entity-page-redirects.spec.ts
+++ b/apps/web/e2e/entity-page-redirects.spec.ts
@@ -34,6 +34,7 @@ test.describe("Entity page routes", () => {
 
   test("links a Bottle's distillery Brand and its owner to their canonical pages", async ({
     page,
+    snapshot,
   }) => {
     await page.goto(`/bottles/${distilleryBrandBottleId}`);
 
@@ -57,5 +58,21 @@ test.describe("Entity page routes", () => {
     await expect(
       page.getByRole("heading", { name: testOwner.name, exact: true }),
     ).toBeVisible();
+
+    const sections = page.getByRole("navigation", {
+      name: `${testOwner.name} sections`,
+    });
+    const bottlesLink = sections.getByRole("link", { name: "Bottles" });
+    await expect(bottlesLink).toBeVisible();
+    await expect(sections.getByRole("link", { name: "Tastings" })).toHaveCount(
+      0,
+    );
+    await snapshot("Company overview", { ready: sections });
+
+    await bottlesLink.click();
+    await expect(page).toHaveURL(`/companies/${testOwner.id}-diageo/bottles`);
+
+    await page.goto(`/companies/${testOwner.id}-diageo/tastings`);
+    await expect(page).toHaveURL(`/companies/${testOwner.id}-diageo`);
   });
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/page.tsx
@@ -10,8 +10,12 @@ import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHre
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import { getEntityUrl } from "@peated/web/lib/urls";
+import { redirect } from "next/navigation";
 
-import { getDistilleryBottleView } from "../entityPageData";
+import {
+  entityHasBottleCatalog,
+  getDistilleryBottleView,
+} from "../entityPageData";
 import { EntityBottleListClient } from "./entityBottleListClient.stylex";
 
 export default async function EntityBottlesPage(props: {
@@ -20,8 +24,12 @@ export default async function EntityBottlesPage(props: {
 }) {
   const { entityId } = await props.params;
   const searchParams = await props.searchParams;
-  const { client } = await getPublicPageServerClient();
   const entity = await getEntityPage(parseCatalogRouteId(entityId));
+  if (!entityHasBottleCatalog(entity) && entity.totalBottles === 0) {
+    redirect(getEntityUrl(entity));
+  }
+
+  const { client } = await getPublicPageServerClient();
   const createBottleHref = getEntityBottleCreateHref(entity);
   let distilleryView = getDistilleryBottleView(entity, searchParams.view);
   let queryParams = normalizeBottleCatalogQueryParams(

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.test.ts
@@ -61,6 +61,35 @@ describe("getEntityRelationshipOwnerIds", () => {
 });
 
 describe("getEntityTabs", () => {
+  it("keeps company bottles with stored counts but omits tastings", () => {
+    expect(
+      getEntityTabs({
+        id: 5558,
+        kind: "company",
+        name: "Diageo",
+        shortName: null,
+        totalBottles: 10,
+        totalTastings: 20,
+      }),
+    ).toEqual([
+      { href: "/companies/5558-diageo", label: "Overview" },
+      { href: "/companies/5558-diageo/bottles", label: "Bottles", count: 10 },
+    ]);
+  });
+
+  it("omits the bottle tab for companies with no bottles", () => {
+    expect(
+      getEntityTabs({
+        id: 5558,
+        kind: "company",
+        name: "Diageo",
+        shortName: null,
+        totalBottles: 0,
+        totalTastings: 0,
+      }),
+    ).toEqual([{ href: "/companies/5558-diageo", label: "Overview" }]);
+  });
+
   it("uses the canonical public Entity route", () => {
     expect(
       getEntityTabs({

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageData.ts
@@ -79,17 +79,23 @@ export function getEntityTabs(
   const baseUrl = getEntityUrl(entity);
   const tabs: [PageTabItem, ...PageTabItem[]] = [
     { href: baseUrl, label: "Overview" },
-    {
+  ];
+
+  if (entityHasBottleCatalog(entity) || entity.totalBottles > 0) {
+    tabs.push({
       count: entity.totalBottles,
       href: `${baseUrl}/bottles`,
       label: "Bottles",
-    },
-    {
+    });
+  }
+
+  if (entityHasBottleCatalog(entity)) {
+    tabs.push({
       count: entity.totalTastings,
       href: `${baseUrl}/tastings`,
       label: "Tastings",
-    },
-  ];
+    });
+  }
 
   if (entity.shortName === "SMWS") {
     tabs.push({ href: `${baseUrl}/codes`, label: "Distillery codes" });

--- a/apps/web/src/app/(app)/entities/[entityId]/tastings/page.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/tastings/page.tsx
@@ -2,7 +2,10 @@ import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getEntityPage } from "@peated/web/lib/entityPage.server";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
+import { getEntityUrl } from "@peated/web/lib/urls";
+import { redirect } from "next/navigation";
 
+import { entityHasBottleCatalog } from "../entityPageData";
 import { EntityTastingListClient } from "./entityTastingListClient.stylex";
 
 export default async function EntityTastingsPage(props: {
@@ -10,8 +13,10 @@ export default async function EntityTastingsPage(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
   const { entityId } = await props.params;
-  const { client } = await getAnonymousServerClient();
   const entity = await getEntityPage(parseCatalogRouteId(entityId));
+  if (!entityHasBottleCatalog(entity)) redirect(getEntityUrl(entity));
+
+  const { client } = await getAnonymousServerClient();
   const queryParams = getApiQueryParams(await props.searchParams, {
     numericFields: ["cursor"],
     overrides: { entity: entity.id, limit: 25 },


### PR DESCRIPTION
Company pages no longer show Tastings, and show Bottles only when they have directly linked bottles. Opening a hidden company tab redirects to its overview. Brands, distilleries, and bottlers keep their existing tabs.

Companies can have genuine bottle relationships, so this preserves populated company catalogs without treating ownership as a bottle link. No catalog records, ownership relationships, or database schemas change.
