### PR TITLE
feat(tasting): add bottle flavor profiles and simplify the wheel guide

### DIFF
--- a/apps/server/src/orpc/contracts/bottles/flavor-profile.ts
+++ b/apps/server/src/orpc/contracts/bottles/flavor-profile.ts
@@ -1,0 +1,15 @@
+import { BottleFlavorProfileSchema } from "@peated/server/schemas/flavorProfile";
+import { z } from "zod";
+import { contract } from "../base";
+
+export default contract
+  .route({
+    method: "GET",
+    path: "/bottles/{bottle}/flavor-profile",
+    summary: "Get a bottle flavor profile",
+    description:
+      "Count public tastings of one active Bottle with each tasting-note family. Each tasting counts once per family. Only tastings with recognized notes enter the denominator; private and suggested notes are excluded.",
+    spec: (spec) => ({ ...spec, operationId: "getBottleFlavorProfile" }),
+  })
+  .input(z.object({ bottle: z.coerce.number().int().positive() }))
+  .output(BottleFlavorProfileSchema);

--- a/apps/server/src/orpc/mock/contract.ts
+++ b/apps/server/src/orpc/mock/contract.ts
@@ -7,6 +7,7 @@ import bottleGroupBottles from "@peated/server/orpc/contracts/bottleGroups/bottl
 import bottleGroupDetails from "@peated/server/orpc/contracts/bottleGroups/details";
 import bottlerList from "@peated/server/orpc/contracts/bottlers/list";
 import bottleDetails from "@peated/server/orpc/contracts/bottles/details";
+import bottleFlavorProfile from "@peated/server/orpc/contracts/bottles/flavor-profile";
 import bottleList from "@peated/server/orpc/contracts/bottles/list";
 import bottlePriceList from "@peated/server/orpc/contracts/bottles/prices/list";
 import bottleRecommendations from "@peated/server/orpc/contracts/bottles/recommendations";
@@ -84,6 +85,7 @@ export const mockContract = {
   },
   bottles: {
     details: bottleDetails,
+    flavorProfile: bottleFlavorProfile,
     list: bottleList,
     prices: {
       list: bottlePriceList,

--- a/apps/server/src/orpc/mock/fixtures/flavorProfile.ts
+++ b/apps/server/src/orpc/mock/fixtures/flavorProfile.ts
@@ -1,5 +1,8 @@
 import { TAG_CATEGORIES } from "@peated/server/constants";
-import type { FlavorProfile } from "@peated/server/schemas/flavorProfile";
+import type {
+  BottleFlavorProfile,
+  FlavorProfile,
+} from "@peated/server/schemas/flavorProfile";
 
 export const mockFlavorProfile: FlavorProfile = {
   totalBottles: 40,
@@ -18,5 +21,27 @@ export const mockFlavorProfile: FlavorProfile = {
       ["pepper", "clove"],
       ["oak", "sherry"],
     ][index]!.map((name) => ({ name, bottleCount: 1 })),
+  })),
+};
+
+export const mockBottleFlavorProfile: BottleFlavorProfile = {
+  notedTastings: 12,
+  categories: TAG_CATEGORIES.map((category, index) => ({
+    category,
+    tastingCount: [4, 5, 1, 10, 3, 0, 6, 2, 4][index]!,
+    notes: [
+      [{ name: "malt", tastingCount: 4 }],
+      [{ name: "lemon zest", tastingCount: 5 }],
+      [{ name: "heather", tastingCount: 1 }],
+      [
+        { name: "peat", tastingCount: 8 },
+        { name: "bonfire", tastingCount: 6 },
+      ],
+      [{ name: "leather", tastingCount: 3 }],
+      [],
+      [{ name: "honey", tastingCount: 6 }],
+      [{ name: "clove", tastingCount: 2 }],
+      [{ name: "oak", tastingCount: 4 }],
+    ][index]!,
   })),
 };

--- a/apps/server/src/orpc/mock/router.ts
+++ b/apps/server/src/orpc/mock/router.ts
@@ -7,6 +7,7 @@ import bottleGroupBottles from "./routes/bottleGroups/bottles";
 import bottleGroupDetails from "./routes/bottleGroups/details";
 import bottlerList from "./routes/bottlers/list";
 import bottleDetails from "./routes/bottles/details";
+import bottleFlavorProfile from "./routes/bottles/flavor-profile";
 import bottleList from "./routes/bottles/list";
 import bottlePriceList from "./routes/bottles/prices/list";
 import bottleRecommendations from "./routes/bottles/recommendations";
@@ -84,6 +85,7 @@ export const mockRouter = mockOS.router({
   },
   bottles: {
     details: bottleDetails,
+    flavorProfile: bottleFlavorProfile,
     list: bottleList,
     prices: {
       list: bottlePriceList,

--- a/apps/server/src/orpc/mock/routes/bottles/flavor-profile.ts
+++ b/apps/server/src/orpc/mock/routes/bottles/flavor-profile.ts
@@ -1,0 +1,12 @@
+import { mockBottles } from "@peated/server/orpc/mock/fixtures";
+import { mockBottleFlavorProfile } from "@peated/server/orpc/mock/fixtures/flavorProfile";
+import { mockOS } from "@peated/server/orpc/mock/implementer";
+
+export default mockOS.bottles.flavorProfile.handler(
+  async ({ input, errors }) => {
+    if (!mockBottles.some((bottle) => bottle.id === input.bottle)) {
+      throw errors.NOT_FOUND({ message: "Mock bottle not found." });
+    }
+    return mockBottleFlavorProfile;
+  },
+);

--- a/apps/server/src/orpc/routes/bottles/flavor-profile.test.ts
+++ b/apps/server/src/orpc/routes/bottles/flavor-profile.test.ts
@@ -1,0 +1,165 @@
+import { TAG_CATEGORIES } from "@peated/server/constants";
+import { db } from "@peated/server/db";
+import { bottleTombstones, tastings } from "@peated/server/db/schema";
+import { routerClient } from "@peated/server/orpc/router";
+
+describe("GET /bottles/{bottle}/flavor-profile", () => {
+  test("counts public tastings once per family and keeps exact Bottle scope", async ({
+    fixtures,
+    defaults,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const sibling = await fixtures.BottleGroupMember({
+      groupId: bottle.groupId,
+      edition: "Another release",
+    });
+    const privateUser = await fixtures.User({ private: true });
+    for (const [name, tagCategory] of [
+      ["smoke", "smoke"],
+      ["ash", "smoke"],
+      ["bonfire", "smoke"],
+      ["vanilla", "sweet"],
+      ["iodine", "smoke"],
+      ["oak", "wood"],
+    ] as const) {
+      await fixtures.Tag({ name, tagCategory });
+    }
+    await db.insert(tastings).values([
+      {
+        bottleId: bottle.id,
+        createdById: defaults.user.id,
+        tags: ["smoke", "smoke", "ash", "bonfire", "vanilla"],
+        createdAt: new Date("2026-01-01"),
+      },
+      {
+        bottleId: bottle.id,
+        createdById: defaults.user.id,
+        tags: ["smoke"],
+        createdAt: new Date("2026-01-02"),
+      },
+      {
+        bottleId: bottle.id,
+        createdById: defaults.user.id,
+        tags: ["vanilla"],
+        createdAt: new Date("2026-01-03"),
+      },
+      {
+        bottleId: bottle.id,
+        createdById: defaults.user.id,
+        tags: [],
+        createdAt: new Date("2026-01-04"),
+      },
+      {
+        bottleId: bottle.id,
+        createdById: defaults.user.id,
+        tags: ["unrecognized"],
+        createdAt: new Date("2026-01-05"),
+      },
+      {
+        bottleId: bottle.id,
+        createdById: privateUser.id,
+        tags: ["iodine", "oak"],
+      },
+      { bottleId: sibling.id, createdById: defaults.user.id, tags: ["oak"] },
+    ]);
+
+    const result = await routerClient.bottles.flavorProfile(
+      { bottle: bottle.id },
+      { context: { user: privateUser } },
+    );
+    expect(result).toEqual(
+      await routerClient.bottles.flavorProfile({ bottle: bottle.id }),
+    );
+    expect(result.notedTastings).toBe(3);
+    expect(result.categories.map((item) => item.category)).toEqual(
+      TAG_CATEGORIES,
+    );
+    expect(result.categories.find((item) => item.category === "smoke")).toEqual(
+      {
+        category: "smoke",
+        tastingCount: 2,
+        notes: [
+          { name: "smoke", tastingCount: 2 },
+          { name: "ash", tastingCount: 1 },
+        ],
+      },
+    );
+    expect(result.categories.find((item) => item.category === "sweet")).toEqual(
+      {
+        category: "sweet",
+        tastingCount: 2,
+        notes: [{ name: "vanilla", tastingCount: 2 }],
+      },
+    );
+    expect(result.categories.find((item) => item.category === "wood")).toEqual({
+      category: "wood",
+      tastingCount: 0,
+      notes: [],
+    });
+  });
+
+  test("returns no distribution for private-only or unrecognized notes", async ({
+    fixtures,
+    defaults,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const privateUser = await fixtures.User({ private: true });
+    await fixtures.Tag({ name: "smoke", tagCategory: "smoke" });
+    await db.insert(tastings).values([
+      { bottleId: bottle.id, createdById: privateUser.id, tags: ["smoke"] },
+      {
+        bottleId: bottle.id,
+        createdById: defaults.user.id,
+        tags: ["unrecognized"],
+      },
+    ]);
+    const result = await routerClient.bottles.flavorProfile({
+      bottle: bottle.id,
+    });
+    expect(result.notedTastings).toBe(0);
+    expect(
+      result.categories.every(
+        (item) => item.tastingCount === 0 && item.notes.length === 0,
+      ),
+    ).toBe(true);
+  });
+
+  test("returns an empty profile without tastings", async ({ fixtures }) => {
+    const bottle = await fixtures.Bottle();
+    const result = await routerClient.bottles.flavorProfile({
+      bottle: bottle.id,
+    });
+    expect(result.notedTastings).toBe(0);
+    expect(
+      result.categories.every(
+        (item) => item.tastingCount === 0 && item.notes.length === 0,
+      ),
+    ).toBe(true);
+  });
+
+  test("rejects missing, retired, and unassigned Bottles", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const replacement = await fixtures.Bottle();
+    const legacy = await fixtures.LegacyBottle();
+    await db
+      .insert(bottleTombstones)
+      .values({ bottleId: bottle.id, newBottleId: replacement.id });
+    await expect(
+      routerClient.bottles.flavorProfile({ bottle: 999_999_999 }),
+    ).rejects.toMatchObject({ status: 404 });
+    await expect(
+      routerClient.bottles.flavorProfile({ bottle: bottle.id }),
+    ).rejects.toMatchObject({ status: 409 });
+    await expect(
+      routerClient.bottles.flavorProfile({ bottle: legacy.id }),
+    ).rejects.toMatchObject({ status: 409 });
+  });
+
+  test("requires a positive integer Bottle ID", async () => {
+    await expect(
+      routerClient.bottles.flavorProfile({ bottle: -1 }),
+    ).rejects.toMatchObject({ status: 400 });
+  });
+});

--- a/apps/server/src/orpc/routes/bottles/flavor-profile.ts
+++ b/apps/server/src/orpc/routes/bottles/flavor-profile.ts
@@ -1,0 +1,85 @@
+import { TAG_CATEGORIES } from "@peated/server/constants";
+import { db } from "@peated/server/db";
+import { tags, tastings, users } from "@peated/server/db/schema";
+import {
+  ActiveBottleSelectionError,
+  resolveActiveBottleIds,
+} from "@peated/server/lib/resolveActiveBottleIds";
+import { implement } from "@peated/server/orpc";
+import flavorProfileContract from "@peated/server/orpc/contracts/bottles/flavor-profile";
+import type { BottleFlavorProfile } from "@peated/server/schemas/flavorProfile";
+import { sql } from "drizzle-orm";
+
+export default implement(flavorProfileContract).handler(
+  async ({ input, errors }) => {
+    try {
+      return await db.transaction(async (tx) => {
+        await resolveActiveBottleIds(tx, [input.bottle]);
+
+        // Bottle flavor profiles are public: this route excludes private notes,
+        // even for their author, and counts each tasting once per family.
+        const result = await tx.execute<BottleFlavorProfile>(sql`
+        WITH public_notes AS MATERIALIZED (
+          SELECT DISTINCT ${tastings.id} AS tasting_id,
+            ${tags.name} AS name, ${tags.tagCategory} AS category
+          FROM ${tastings}
+          INNER JOIN ${users} ON ${users.id} = ${tastings.createdById}
+            AND ${users.private} = FALSE
+          CROSS JOIN LATERAL unnest(${tastings.tags}) AS note(name)
+          INNER JOIN ${tags} ON ${tags.name} = note.name
+          WHERE ${tastings.bottleId} = ${input.bottle}
+        ), category_counts AS (
+          SELECT category, COUNT(DISTINCT tasting_id)::integer AS tasting_count
+          FROM public_notes GROUP BY category
+        ), ranked_notes AS (
+          SELECT category, name, COUNT(*)::integer AS tasting_count,
+            ROW_NUMBER() OVER (
+              PARTITION BY category ORDER BY COUNT(*) DESC, name ASC
+            ) AS rank
+          FROM public_notes GROUP BY category, name
+        )
+        SELECT
+          (SELECT COUNT(DISTINCT tasting_id)::integer FROM public_notes) AS "notedTastings",
+          COALESCE((
+            SELECT jsonb_agg(jsonb_build_object(
+              'category', category_counts.category,
+              'tastingCount', category_counts.tasting_count,
+              'notes', (
+                SELECT jsonb_agg(jsonb_build_object(
+                  'name', ranked_notes.name,
+                  'tastingCount', ranked_notes.tasting_count
+                ) ORDER BY ranked_notes.rank)
+                FROM ranked_notes
+                WHERE ranked_notes.category = category_counts.category
+                  AND ranked_notes.rank <= 2
+              )
+            )) FROM category_counts
+          ), '[]'::jsonb) AS categories
+      `);
+        const profile = result.rows[0];
+        if (!profile)
+          throw new Error("Bottle flavor profile query returned no result");
+
+        return {
+          ...profile,
+          categories: TAG_CATEGORIES.map(
+            (category) =>
+              profile.categories.find((item) => item.category === category) ?? {
+                category,
+                tastingCount: 0,
+                notes: [],
+              },
+          ),
+        };
+      });
+    } catch (error) {
+      if (error instanceof ActiveBottleSelectionError) {
+        if (error.reason === "missing") {
+          throw errors.NOT_FOUND({ message: error.message, cause: error });
+        }
+        throw errors.CONFLICT({ message: error.message, cause: error });
+      }
+      throw error;
+    }
+  },
+);

--- a/apps/server/src/orpc/routes/bottles/index.ts
+++ b/apps/server/src/orpc/routes/bottles/index.ts
@@ -7,6 +7,7 @@ import create from "./create";
 import delete_ from "./delete";
 import details from "./details";
 import editContext from "./edit-context";
+import flavorProfile from "./flavor-profile";
 import imageUpdate from "./image-update";
 import list from "./list";
 import merge from "./merge";
@@ -21,6 +22,7 @@ import validation from "./validation";
 
 export default base.tag("bottles").router({
   details,
+  flavorProfile,
   list,
   create,
   update,

--- a/apps/server/src/schemas/flavorProfile.ts
+++ b/apps/server/src/schemas/flavorProfile.ts
@@ -21,3 +21,23 @@ export const FlavorProfileSchema = z.object({
 });
 
 export type FlavorProfile = z.infer<typeof FlavorProfileSchema>;
+
+export const BottleFlavorProfileSchema = z.object({
+  notedTastings: z.number().int().nonnegative(),
+  categories: z.array(
+    z.object({
+      category: z.enum(TAG_CATEGORIES),
+      tastingCount: z.number().int().nonnegative(),
+      notes: z
+        .array(
+          z.object({
+            name: z.string(),
+            tastingCount: z.number().int().positive(),
+          }),
+        )
+        .max(2),
+    }),
+  ),
+});
+
+export type BottleFlavorProfile = z.infer<typeof BottleFlavorProfileSchema>;

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -1331,6 +1331,30 @@ async function handleRpcRequest({ request, response, url }) {
       mutateCollectionBottle(request, input, "delete");
       sendRpcResponse(response, {});
       return true;
+    case "bottles/flavorProfile":
+      sendRpcResponse(response, {
+        notedTastings: 4,
+        categories: [
+          {
+            category: "smoke",
+            tastingCount: 3,
+            notes: [{ name: "peat", tastingCount: 3 }],
+          },
+          {
+            category: "fruit",
+            tastingCount: 1,
+            notes: [{ name: "apple", tastingCount: 1 }],
+          },
+        ],
+      });
+      return true;
+    case "tags/bottles":
+      sendRpcResponse(response, {
+        results: [
+          { bottle: existingBottle, matchingTastings: 3, taggedTastings: 4 },
+        ],
+      });
+      return true;
     case "bottles/tags":
       if (!isNumber(input?.bottle)) {
         sendRpcError(response, "Unexpected bottle tags payload");

--- a/apps/web/e2e/routes.spec.ts
+++ b/apps/web/e2e/routes.spec.ts
@@ -82,6 +82,27 @@ test("public routes load", async ({ page, snapshot }) => {
           .getByRole("heading", { exact: true, name: route.heading })
           .first();
         await expect(heading).toBeVisible();
+        if (route.name === "Bottle") {
+          const smoke = page.getByRole("button", {
+            name: /^Smoke, 75% of tastings with notes/,
+          });
+          await smoke.click();
+          const panel = page.getByRole("dialog", {
+            name: "Smoke",
+            exact: true,
+          });
+          await expect(panel).toHaveAttribute("aria-modal", "true");
+          await expect(
+            panel.getByRole("heading", { name: "Bottles across Peated" }),
+          ).toBeVisible();
+          await expect(panel.getByRole("link").first()).toHaveAttribute(
+            "href",
+            `/bottles/${existingBottle.id}`,
+          );
+          await page.keyboard.press("Escape");
+          await expect(panel).toHaveCount(0);
+          await expect(smoke).toBeFocused();
+        }
         await snapshot(route.name, { ready: heading });
       }
     });

--- a/apps/web/src/app/(app)/about/tasting-wheel/page.tsx
+++ b/apps/web/src/app/(app)/about/tasting-wheel/page.tsx
@@ -1,24 +1,13 @@
 import { RailList, RailListItem } from "@peated/web/components";
-import {
-  PageSection,
-  RailSection,
-} from "@peated/web/components/pages/pageLayout.stylex";
+import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import type { Metadata } from "next";
-import {
-  AboutPage,
-  AboutText,
-  AboutTextStack,
-  ReviewSteps,
-} from "../aboutPage.stylex";
+import { AboutPage, AboutText, AboutTextStack } from "../aboutPage.stylex";
 import {
   TastingWheelFamilies,
-  TastingWheelGraphic,
+  TastingWheelIntroduction,
 } from "./tastingWheel.stylex";
 
-import {
-  TastingWheelCategoryLinks,
-  TastingWheelProvider,
-} from "@peated/web/features/tastingWheel/tastingWheelDetails.stylex";
+import { TastingWheelProvider } from "@peated/web/features/tastingWheel/tastingWheelDetails.stylex";
 
 export const dynamic = "force-static";
 
@@ -32,118 +21,70 @@ export default function TastingWheelPage() {
     <TastingWheelProvider>
       <AboutPage
         currentHref="/about/tasting-wheel"
-        description="Start with 1 of 9 groups. Then choose a more specific smell or flavor. Every example below appears in Peated's tasting form."
-        rail={
-          <>
-            <RailSection heading="Sources">
-              <RailList ariaLabel="Tasting wheel sources">
-                <RailListItem
-                  href="https://www.wsetglobal.com/media/16506/wset_l3spirits_sat_en_feb2025_issue3.pdf"
-                  metadata="Tasting guide for spirits, 2025"
-                  title="Wine & Spirit Education Trust"
-                />
-                <RailListItem
-                  href="https://www.scotch-whisky.org.uk/media/1714/swa-tasting-toolkit_2020.pdf"
-                  metadata="Scotch whisky tasting wheel, 2020"
-                  title="Scotch Whisky Research Institute"
-                />
-                <RailListItem
-                  href="https://whiskymag.com/articles/tasting-wheel/"
-                  metadata="Charles MacLean's whisky tasting wheel"
-                  title="Whisky Magazine"
-                />
-                <RailListItem
-                  href="https://www.woodfordreserve.com/flavor-wheels/"
-                  metadata="American whiskey tasting wheels"
-                  title="Woodford Reserve"
-                />
-                <RailListItem
-                  href="https://www.jpwisers.com/wp-content/uploads/Whisky-Wheel-Dr-Don-Livermore.pdf"
-                  metadata="Canadian whisky flavor wheel"
-                  title="J.P. Wiser's"
-                />
-                <RailListItem
-                  href="https://www.drjimswan.com/flavour-wheel/"
-                  metadata="How the first whisky tasting wheel was made"
-                  title="Dr Jim Swan"
-                />
-              </RailList>
-            </RailSection>
-            <RailSection heading="Groups">
-              <TastingWheelCategoryLinks />
-            </RailSection>
-            <RailSection heading="Use the wheel">
-              <RailList ariaLabel="Use the tasting wheel">
-                <RailListItem
-                  href="/addBottle?intent=tasting"
-                  metadata="Add your tasting notes"
-                  title="Log a tasting"
-                />
-                <RailListItem href="/about/ratings" title="Rating guide" />
-              </RailList>
-            </RailSection>
-          </>
-        }
+        description="Find words for what you smell and taste."
         title="Tasting wheel"
       >
-        <PageSection heading="Find the right words">
-          <TastingWheelGraphic />
-        </PageSection>
-
-        <PageSection heading="Use the wheel">
-          <ReviewSteps
-            steps={[
-              {
-                body: "Choose the group that best matches what you smell, taste, or notice after a sip.",
-                title: "Start broad",
-              },
-              {
-                body: "Choose a more specific word if one fits.",
-                title: "Choose a word",
-              },
-              {
-                body: "Use only the words you notice. You do not need one from every group.",
-                title: "Stop when it fits",
-              },
-            ]}
-          />
-        </PageSection>
+        <TastingWheelIntroduction />
 
         <PageSection
-          heading="The 9 groups"
-          intro="These are words you can choose in Peated's tasting form. They are examples, not a checklist."
+          heading="Tasting notes"
+          intro="Browse the flavor families below. These words are suggestions, not a checklist."
         >
           <TastingWheelFamilies />
         </PageSection>
 
-        <PageSection heading="How we chose the groups">
+        <PageSection heading="About this wheel">
           <AboutTextStack>
             <AboutText>
               Peated uses the Wine &amp; Spirit Education Trust&apos;s 2025
               tasting guide as its main source. We also looked at tasting wheels
               for Scotch, American whiskey, and Canadian whisky. None uses these
-              exact 9 groups.
+              exact flavor families.
             </AboutText>
             <AboutText>
               Some guides put words together because they can have the same
               cause. Peated puts words together when they smell or taste alike.
               One note can have more than one cause.
             </AboutText>
-          </AboutTextStack>
-        </PageSection>
-
-        <PageSection heading="The wheel and bottle pages">
-          <AboutTextStack>
             <AboutText>
-              Use the wheel to describe one tasting. Choose words from any part
-              of it, in any order.
-            </AboutText>
-            <AboutText>
-              A bottle page can also show one broad flavor, such as Light &amp;
-              Delicate or Heavily Peated. That broad flavor does not limit the
-              words you can choose.
+              The flavor profile on a bottle page shows how often its public
+              tastings mention each family. On distillery and region pages, it
+              shows how common each family is across bottles with notes. These
+              profiles show commonality, not intensity.
             </AboutText>
           </AboutTextStack>
+          <RailList ariaLabel="Tasting wheel sources">
+            <RailListItem
+              href="https://www.wsetglobal.com/media/16506/wset_l3spirits_sat_en_feb2025_issue3.pdf"
+              metadata="Tasting guide for spirits, 2025"
+              title="Wine & Spirit Education Trust"
+            />
+            <RailListItem
+              href="https://www.scotch-whisky.org.uk/media/1714/swa-tasting-toolkit_2020.pdf"
+              metadata="Scotch whisky tasting wheel, 2020"
+              title="Scotch Whisky Research Institute"
+            />
+            <RailListItem
+              href="https://whiskymag.com/articles/tasting-wheel/"
+              metadata="Charles MacLean's whisky tasting wheel"
+              title="Whisky Magazine"
+            />
+            <RailListItem
+              href="https://www.woodfordreserve.com/flavor-wheels/"
+              metadata="American whiskey tasting wheels"
+              title="Woodford Reserve"
+            />
+            <RailListItem
+              href="https://www.jpwisers.com/wp-content/uploads/Whisky-Wheel-Dr-Don-Livermore.pdf"
+              metadata="Canadian whisky flavor wheel"
+              title="J.P. Wiser's"
+            />
+            <RailListItem
+              href="https://www.drjimswan.com/flavour-wheel/"
+              metadata="How the first whisky tasting wheel was made"
+              title="Dr Jim Swan"
+            />
+          </RailList>
         </PageSection>
       </AboutPage>
     </TastingWheelProvider>

--- a/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
+++ b/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
@@ -11,6 +11,7 @@ import { Fragment } from "react";
 import { colors, fonts, space } from "../../../../styles/tokens.stylex";
 
 const MOBILE = "@media (max-width: 559px)";
+const TABLET = "@media (max-width: 899px)";
 
 const CENTER = 260;
 const HUB_RADIUS = 88;
@@ -53,7 +54,30 @@ function labelTransform(radius: number, angle: number) {
   return `translate(${x} ${y}) rotate(${rotation})`;
 }
 
-export function TastingWheelGraphic() {
+export function TastingWheelIntroduction() {
+  return (
+    <section
+      aria-labelledby="tasting-wheel-introduction"
+      {...stylex.props(styles.introduction)}
+    >
+      <TastingWheelGraphic />
+      <div {...stylex.props(styles.directions)}>
+        <SectionHeading id="tasting-wheel-introduction">
+          Start with what you notice
+        </SectionHeading>
+        <p {...stylex.props(styles.directionText)}>
+          Start with something broad, like fruit or spice, then look outward for
+          a more specific note. Choose only what fits what you smell and taste.
+        </p>
+        <p {...stylex.props(styles.directionText)}>
+          Select a note to read its description and see bottle examples.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function TastingWheelGraphic() {
   const { select, selection } = useTastingWheel();
   const categorySpan = 360 / WHEEL_CATEGORIES.length;
 
@@ -68,8 +92,8 @@ export function TastingWheelGraphic() {
         >
           <title id="tasting-wheel-title">Peated tasting wheel</title>
           <desc id="tasting-wheel-description">
-            Explore a tasting category or a note to find related words and
-            example bottles.
+            Explore a flavor family or a note to find related words and example
+            bottles.
           </desc>
           {WHEEL_CATEGORIES.map((category, categoryIndex) => {
             const startAngle = categoryIndex * categorySpan;
@@ -225,6 +249,24 @@ export function TastingWheelFamilies() {
 }
 
 const styles = stylex.create({
+  introduction: {
+    display: "grid",
+    gridTemplateColumns: {
+      default: "minmax(0, 520px) minmax(0, 1fr)",
+      [TABLET]: "minmax(0, 1fr)",
+    },
+    alignItems: "center",
+    gap: space.x6,
+  },
+  directions: { display: "grid", gap: space.x3, maxWidth: "44ch" },
+  directionText: {
+    margin: 0,
+    fontFamily: fonts.reading,
+    fontSize: "16px",
+    lineHeight: 1.6,
+    color: colors.inkMuted,
+    textWrap: "pretty",
+  },
   figure: { margin: 0, maxWidth: "520px" },
   wheelFrame: {
     width: "100%",
@@ -299,7 +341,8 @@ const styles = stylex.create({
   familyGrid: {
     display: "grid",
     gridTemplateColumns: {
-      default: "repeat(2, minmax(0, 1fr))",
+      default: "repeat(3, minmax(0, 1fr))",
+      [TABLET]: "repeat(2, minmax(0, 1fr))",
       [MOBILE]: "minmax(0, 1fr)",
     },
     columnGap: space.x6,

--- a/apps/web/src/app/(app)/bottles/[bottleId]/(overview)/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/(overview)/page.tsx
@@ -28,6 +28,9 @@ export default async function BottlePage(props: {
   const orpc = createTanstackQueryUtils(client);
 
   await Promise.all([
+    queryClient.prefetchQuery(
+      orpc.bottles.flavorProfile.queryOptions({ input: { bottle: bottle.id } }),
+    ),
     queryClient.prefetchQuery(bottleOverviewQueries.reviews(orpc, bottle.id)),
     queryClient.prefetchQuery(bottleOverviewQueries.tastings(orpc, bottle.id)),
     ...(bottle.series

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -35,6 +35,7 @@ import { BottleOverview } from "@peated/web/components/pages/bottleOverview.styl
 import { BottlePageHeader } from "@peated/web/components/pages/bottlePageHeader.stylex";
 import { BottleRailSection } from "@peated/web/components/pages/bottleRailSection.stylex";
 import TimeSince from "@peated/web/components/timeSince";
+import { FlavorProfileSection } from "@peated/web/features/flavorProfile/flavorProfileSection";
 import useAuth from "@peated/web/hooks/useAuth";
 import {
   getAddBottleHref,
@@ -625,6 +626,12 @@ export function BottleOverviewClient() {
           ) : undefined
         }
         recommendations={recommendations}
+        flavorProfile={
+          <FlavorProfileSection
+            key={bottle.id}
+            scope={{ kind: "bottle", bottle: bottle.id }}
+          />
+        }
         railSections={seriesRail}
         tastingCount={bottle.totalTastings}
         tastings={tastings}

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -3,8 +3,7 @@
 import * as stylex from "@stylexjs/stylex";
 import { space } from "../../../../styles/tokens.stylex";
 
-import { PlaceFlavorProfile } from "@peated/web/features/flavorProfile/placeFlavorProfile";
-import { getEntityUrl } from "@peated/web/lib/urls";
+import { FlavorProfileSection } from "@peated/web/features/flavorProfile/flavorProfileSection";
 import { useQuery } from "@tanstack/react-query";
 
 import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";
@@ -102,10 +101,9 @@ export function EntityOverviewClient() {
           <EntityMap entity={entity} />
           {entity.kind === "distillery" ? (
             <div {...stylex.props(styles.flavorProfile)}>
-              <PlaceFlavorProfile
+              <FlavorProfileSection
                 key={entity.id}
                 scope={{ kind: "distillery", entity: entity.id }}
-                bottlesHref={`${getEntityUrl(entity)}/bottles`}
               />
             </div>
           ) : null}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
@@ -1,4 +1,4 @@
-import { PlaceFlavorProfile } from "@peated/web/features/flavorProfile/placeFlavorProfile";
+import { FlavorProfileSection } from "@peated/web/features/flavorProfile/flavorProfileSection";
 import { getRegionMap } from "@peated/web/lib/locationMap";
 import { getRegionPage } from "@peated/web/lib/locationPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
@@ -52,9 +52,8 @@ export default async function RegionOverviewPage(props: {
       distilleries={getLocationDistilleries(distilleries.results)}
       distillersHref={`${rootHref}/distillers`}
       flavorProfile={
-        <PlaceFlavorProfile
+        <FlavorProfileSection
           scope={{ kind: "region", country: countrySlug, region: regionSlug }}
-          bottlesHref={`${rootHref}/bottles`}
         />
       }
       latestReleases={getLocationLatestReleases(latestReleases.results)}

--- a/apps/web/src/components/flavorWheel.stories.tsx
+++ b/apps/web/src/components/flavorWheel.stories.tsx
@@ -1,4 +1,7 @@
-import { mockFlavorProfile as profile } from "@peated/server/orpc/mock/fixtures/flavorProfile";
+import {
+  mockBottleFlavorProfile,
+  mockFlavorProfile as profile,
+} from "@peated/server/orpc/mock/fixtures/flavorProfile";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { FlavorWheel } from "./flavorWheel.stylex";
 import { RailSection } from "./pages/pageLayout.stylex";
@@ -30,6 +33,7 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Overview: Story = {};
+export const Bottle: Story = { args: { profile: mockBottleFlavorProfile } };
 export const Sparse: Story = {
   args: {
     profile: {

--- a/apps/web/src/components/flavorWheel.stylex.tsx
+++ b/apps/web/src/components/flavorWheel.stylex.tsx
@@ -38,7 +38,8 @@ const label = (category: string) =>
 /**
  * Distribution of public tasting-note families across bottles or one bottle's tastings.
  * Each wedge has a fixed position and an independent 0–100% area scale.
- * Selection reveals its share and two leading notes in the center, without bars.
+ * Hover or keyboard focus previews a family's share and two leading notes.
+ * The center keeps the last preview when the pointer or focus leaves the wheel.
  * Activating a wedge calls onExplore to open that family's notes and bottles.
  * The parent supplies the heading and centered reference links through footer.
  * Any recognized notes render a chart; empty data shows a short message.
@@ -122,8 +123,12 @@ export function FlavorWheel({
                     aria-label={`${label(item.category)}, ${percentage(item.count)}% of ${sample} with notes${item.notes.length ? `; ${item.notes.map((note) => note.name).join(", ")}` : "; no notes recorded"}`}
                     aria-pressed={isSelected}
                     aria-haspopup={onExplore ? "dialog" : undefined}
+                    onMouseEnter={() => setSelection(item.category)}
                     onClick={() => explore(item.category)}
-                    onFocus={() => setFocused(item.category)}
+                    onFocus={() => {
+                      setFocused(item.category);
+                      setSelection(item.category);
+                    }}
                     onBlur={() => setFocused(null)}
                     onKeyDown={(event) => {
                       if (event.key === "Enter" || event.key === " ") {

--- a/apps/web/src/components/flavorWheel.stylex.tsx
+++ b/apps/web/src/components/flavorWheel.stylex.tsx
@@ -1,14 +1,15 @@
 "use client";
 
 import { TAG_CATEGORIES } from "@peated/server/constants";
-import type { FlavorProfile } from "@peated/server/schemas/flavorProfile";
+import type {
+  BottleFlavorProfile,
+  FlavorProfile,
+} from "@peated/server/schemas/flavorProfile";
 import type { TagCategory } from "@peated/server/types";
 import * as stylex from "@stylexjs/stylex";
-import { Info } from "lucide-react";
-import { useId, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import { colors, fonts, space } from "../styles/tokens.stylex";
-import { Button } from "./button.stylex";
 
 const CENTER_X = 168;
 const CENTER_Y = 148;
@@ -33,83 +34,71 @@ function segment(radius: number, start: number, end: number) {
 
 const label = (category: string) =>
   category.charAt(0).toUpperCase() + category.slice(1);
-const formatCount = (count: number) => count.toLocaleString("en-US");
 
 /**
- * Sidebar distribution of public tasting-note families across bottles.
+ * Distribution of public tasting-note families across bottles or one bottle's tastings.
  * Each wedge has a fixed position and an independent 0–100% area scale.
  * Selection reveals its share and two leading notes in the center, without bars.
- * Optional onExplore opens the selected family in the caller’s tasting guide.
- * The parent supplies the heading, reference links through footer,
- * and any contribution action for empty data.
+ * Activating a wedge calls onExplore to open that family's notes and bottles.
+ * The parent supplies the heading and centered reference links through footer.
+ * Any recognized notes render a chart; empty data shows a short message.
  */
 export function FlavorWheel({
   profile,
   onExplore,
   footer,
 }: {
-  profile: FlavorProfile;
+  profile: FlavorProfile | BottleFlavorProfile;
   footer?: ReactNode;
   onExplore?: (category: TagCategory) => void;
 }) {
-  const descriptionId = useId();
   const [selection, setSelection] = useState<string | null>(null);
   const [focused, setFocused] = useState<string | null>(null);
+  const isBottle = "notedTastings" in profile;
+  const sampleCount = isBottle ? profile.notedTastings : profile.notedBottles;
+  const sample = isBottle ? "tastings" : "bottles";
+  const values = isBottle
+    ? profile.categories.map((item) => ({
+        category: item.category,
+        count: item.tastingCount,
+        notes: item.notes,
+      }))
+    : profile.categories.map((item) => ({
+        category: item.category,
+        count: item.bottleCount,
+        notes: item.notes,
+      }));
   const categories = TAG_CATEGORIES.map(
     (category) =>
-      profile.categories.find((item) => item.category === category) ?? {
+      values.find((item) => item.category === category) ?? {
         category,
-        bottleCount: 0,
+        count: 0,
         notes: [],
       },
   );
   const mostCommon = categories.reduce((best, item) =>
-    item.bottleCount > best.bottleCount ? item : best,
+    item.count > best.count ? item : best,
   );
   const selected =
     categories.find((item) => item.category === selection) ?? mostCommon;
   const percentage = (count: number) =>
-    profile.notedBottles ? Math.round((count / profile.notedBottles) * 100) : 0;
-  const sparse = profile.notedBottles > 0 && profile.notedBottles < 5;
+    sampleCount ? Math.round((count / sampleCount) * 100) : 0;
+  function explore(category: TagCategory) {
+    setSelection(category);
+    onExplore?.(category);
+  }
 
   return (
     <div {...stylex.props(styles.root)}>
-      {profile.notedBottles === 0 ? (
-        <p {...stylex.props(styles.message)}>
-          No public tasting notes yet. Add tasting notes to a bottle to help
-          describe its flavor.
-        </p>
-      ) : sparse ? (
-        <div {...stylex.props(styles.early)}>
-          <p {...stylex.props(styles.message)}>
-            A few early notes from {formatCount(profile.notedBottles)}{" "}
-            {profile.notedBottles === 1 ? "bottle" : "bottles"}. More bottles
-            need notes before showing a distribution.
-          </p>
-          <p {...stylex.props(styles.earlyNotes)}>
-            {categories
-              .flatMap((item) => item.notes)
-              .sort(
-                (a, b) =>
-                  b.bottleCount - a.bottleCount || a.name.localeCompare(b.name),
-              )
-              .slice(0, 4)
-              .map((note) => note.name)
-              .join(" · ")}
-          </p>
-        </div>
+      {sampleCount === 0 ? (
+        <p {...stylex.props(styles.message)}>No public tasting notes yet.</p>
       ) : (
         <>
-          <div {...stylex.props(styles.context)}>
-            <span>Bottles with these notes</span>
-            <span>{formatCount(profile.notedBottles)} bottles</span>
-          </div>
           <div {...stylex.props(styles.chart)}>
             <svg
               viewBox="0 0 336 292"
               role="group"
               aria-label="Flavor families"
-              aria-describedby={descriptionId}
               {...stylex.props(styles.wheel)}
             >
               {categories.map((item, index) => {
@@ -117,12 +106,11 @@ export function FlavorWheel({
                 const start = index * span + 2;
                 const end = (index + 1) * span - 2;
                 const [x, y] = point(128, (start + end) / 2);
-                // Area, rather than radius, is proportional to bottle occurrence.
+                // FlavorWheel uses area, rather than radius, to show commonality.
                 const radius = Math.sqrt(
                   INNER_RADIUS ** 2 +
-                    ((OUTER_RADIUS ** 2 - INNER_RADIUS ** 2) *
-                      item.bottleCount) /
-                      profile.notedBottles,
+                    ((OUTER_RADIUS ** 2 - INNER_RADIUS ** 2) * item.count) /
+                      sampleCount,
                 );
                 const isSelected = selected.category === item.category;
                 const isFocused = focused === item.category;
@@ -131,15 +119,16 @@ export function FlavorWheel({
                     key={item.category}
                     role="button"
                     tabIndex={0}
-                    aria-label={`${label(item.category)}, ${percentage(item.bottleCount)}% of bottles${item.notes.length ? `; ${item.notes.map((note) => note.name).join(", ")}` : "; no notes recorded"}`}
+                    aria-label={`${label(item.category)}, ${percentage(item.count)}% of ${sample} with notes${item.notes.length ? `; ${item.notes.map((note) => note.name).join(", ")}` : "; no notes recorded"}`}
                     aria-pressed={isSelected}
-                    onClick={() => setSelection(item.category)}
+                    aria-haspopup={onExplore ? "dialog" : undefined}
+                    onClick={() => explore(item.category)}
                     onFocus={() => setFocused(item.category)}
                     onBlur={() => setFocused(null)}
                     onKeyDown={(event) => {
                       if (event.key === "Enter" || event.key === " ") {
                         event.preventDefault();
-                        setSelection(item.category);
+                        explore(item.category);
                       }
                     }}
                     {...stylex.props(styles.segment)}
@@ -148,7 +137,7 @@ export function FlavorWheel({
                       d={segment(OUTER_RADIUS, start, end)}
                       {...stylex.props(styles.track)}
                     />
-                    {item.bottleCount > 0 ? (
+                    {item.count > 0 ? (
                       <path
                         d={segment(radius, start, end)}
                         {...stylex.props(styles.fill)}
@@ -183,7 +172,7 @@ export function FlavorWheel({
                 {label(selected.category)}
               </strong>
               <span {...stylex.props(styles.centerValue)}>
-                {percentage(selected.bottleCount)}%
+                {percentage(selected.count)}%
               </span>
               <div {...stylex.props(styles.centerNotes)}>
                 {selected.notes.length ? (
@@ -202,59 +191,17 @@ export function FlavorWheel({
               </div>
             </div>
           </div>
-          <p id={descriptionId} {...stylex.props(styles.hint)}>
-            Select a family to explore its notes.
-          </p>
-          {onExplore ? (
-            <Button
-              variant="text"
-              size="sm"
-              fullWidth
-              aria-haspopup="dialog"
-              onClick={() => onExplore(selected.category)}
-            >
-              Explore {label(selected.category).toLowerCase()} notes
-            </Button>
-          ) : null}
         </>
       )}
-      <details {...stylex.props(styles.coverage)}>
-        <summary {...stylex.props(styles.coverageSummary)}>
-          <span>
-            Notes cover {formatCount(profile.notedBottles)} of{" "}
-            {formatCount(profile.totalBottles)} bottles
-          </span>
-          <Info size={14} aria-hidden="true" />
-        </summary>
-        <p {...stylex.props(styles.explanation)}>
-          Each family shows the share of bottles with a matching public tasting
-          note, among bottles with recognized notes. Each bottle counts once per
-          family. Private tastings and suggested notes are excluded.
-        </p>
-        <p {...stylex.props(styles.explanation)}>
-          Families can overlap. Missing notes do not mean a flavor is absent,
-          and more frequently tasted bottles have more chances to collect notes.
-          This shows occurrence, not intensity.
-        </p>
-      </details>
-      {footer}
+      {footer ? <div {...stylex.props(styles.footer)}>{footer}</div> : null}
     </div>
   );
 }
 
 const styles = stylex.create({
   root: { width: "100%", maxWidth: "336px", marginInline: "auto", minWidth: 0 },
-  context: {
-    display: "flex",
-    justifyContent: "space-between",
-    gap: space.x2,
-    color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
-    fontVariantNumeric: "tabular-nums",
-  },
   chart: { position: "relative" },
+  footer: { textAlign: "center" },
   wheel: {
     display: "block",
     width: "100%",
@@ -333,54 +280,11 @@ const styles = stylex.create({
     overflow: "hidden",
     textOverflow: "ellipsis",
   },
-  hint: {
-    margin: 0,
-    textAlign: "center",
-    color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
-  },
-  coverage: {
-    marginTop: space.x2,
-    color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
-  },
-  coverageSummary: {
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: space.x2,
-    minHeight: "44px",
-    cursor: "pointer",
-    listStyle: "none",
-    backgroundColor: {
-      default: "transparent",
-      ":hover": colors.surface,
-      ":active": colors.inset,
-    },
-    outline: {
-      default: "none",
-      ":focus-visible": `2px solid ${colors.accent}`,
-    },
-    outlineOffset: "-2px",
-  },
-  explanation: { margin: 0, paddingBottom: space.x2 },
   message: {
     margin: 0,
     fontFamily: fonts.reading,
     fontSize: "15px",
     lineHeight: 1.6,
     color: colors.inkMuted,
-  },
-  early: { display: "grid", gap: space.x3 },
-  earlyNotes: {
-    margin: 0,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.6,
-    color: colors.ink,
   },
 });

--- a/apps/web/src/components/flavorWheel.test.tsx
+++ b/apps/web/src/components/flavorWheel.test.tsx
@@ -1,6 +1,9 @@
 // @vitest-environment jsdom
 
-import { mockFlavorProfile } from "@peated/server/orpc/mock/fixtures/flavorProfile";
+import {
+  mockBottleFlavorProfile,
+  mockFlavorProfile,
+} from "@peated/server/orpc/mock/fixtures/flavorProfile";
 import { act } from "react";
 import { createRoot } from "react-dom/client";
 import { expect, test } from "vitest";
@@ -44,14 +47,64 @@ test("selects flavor families with the keyboard and pointer", async () => {
       ),
     );
     expect(fruit.getAttribute("aria-pressed")).toBe("true");
-    await act(() =>
-      container
-        .querySelector("button[aria-haspopup=dialog]")!
-        .dispatchEvent(new MouseEvent("click", { bubbles: true })),
-    );
-    expect(explored).toEqual(["fruit"]);
+    expect(fruit.getAttribute("aria-haspopup")).toBe("dialog");
+    expect(explored).toEqual(["fruit", "smoke", "fruit"]);
+    expect(container.querySelector("button")).toBeNull();
   } finally {
     act(() => root.unmount());
     container.remove();
+  }
+});
+
+test("uses tasting commonality for a bottle and keeps sparse notes interactive", () => {
+  const container = document.createElement("div");
+  const root = createRoot(container);
+  try {
+    act(() => root.render(<FlavorWheel profile={mockBottleFlavorProfile} />));
+    expect(
+      container.querySelector(
+        '[aria-label^="Smoke, 83% of tastings with notes"]',
+      ),
+    ).not.toBeNull();
+    expect(container.textContent).not.toMatch(/\d+ bottles|Notes cover/);
+    act(() =>
+      root.render(
+        <FlavorWheel
+          profile={{
+            notedTastings: 1,
+            categories: [
+              {
+                category: "smoke",
+                tastingCount: 1,
+                notes: [{ name: "peat", tastingCount: 1 }],
+              },
+            ],
+          }}
+        />,
+      ),
+    );
+    expect(
+      container.querySelector(
+        '[aria-label^="Smoke, 100% of tastings with notes"]',
+      ),
+    ).not.toBeNull();
+    expect(
+      container.querySelector(
+        '[aria-label^="Wood, 0% of tastings with notes"]',
+      ),
+    ).not.toBeNull();
+    act(() =>
+      root.render(
+        <FlavorWheel
+          profile={{ ...mockFlavorProfile, notedBottles: 0, categories: [] }}
+        />,
+      ),
+    );
+    expect(container.querySelector("svg")).toBeNull();
+    expect(container.querySelector("button")).toBeNull();
+    expect(container.querySelector("details")).toBeNull();
+    expect(container.textContent).toBe("No public tasting notes yet.");
+  } finally {
+    act(() => root.unmount());
   }
 });

--- a/apps/web/src/components/flavorWheel.test.tsx
+++ b/apps/web/src/components/flavorWheel.test.tsx
@@ -9,7 +9,7 @@ import { createRoot } from "react-dom/client";
 import { expect, test } from "vitest";
 import { FlavorWheel } from "./flavorWheel.stylex";
 
-test("selects flavor families with the keyboard and pointer", async () => {
+test("previews families on hover and focus, and explores only on activation", async () => {
   const container = document.createElement("div");
   document.body.append(container);
   const root = createRoot(container);
@@ -29,26 +29,43 @@ test("selects flavor families with the keyboard and pointer", async () => {
     const smoke = container.querySelector(
       '[role="button"][aria-label^="Smoke,"]',
     )!;
-    expect(smoke.getAttribute("aria-pressed")).toBe("true");
+    const center = container.querySelector('[aria-hidden="true"]')!;
+    expect(center.textContent).toBe("Smoke83%brineash");
+    await act(() =>
+      fruit.dispatchEvent(new MouseEvent("mouseover", { bubbles: true })),
+    );
+    expect(center.textContent).toBe("Fruit79%applelemon zest");
+    expect(explored).toEqual([]);
     await act(() =>
       fruit.dispatchEvent(
+        new MouseEvent("mouseout", {
+          bubbles: true,
+          relatedTarget: document.body,
+        }),
+      ),
+    );
+    expect(center.textContent).toBe("Fruit79%applelemon zest");
+    await act(() =>
+      fruit.dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+    expect(explored).toEqual(["fruit"]);
+    await act(() =>
+      smoke.dispatchEvent(new FocusEvent("focusin", { bubbles: true })),
+    );
+    expect(center.textContent).toBe("Smoke83%brineash");
+    expect(explored).toEqual(["fruit"]);
+    await act(() =>
+      smoke.dispatchEvent(
         new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
       ),
     );
-    expect(fruit.getAttribute("aria-pressed")).toBe("true");
-    expect(smoke.getAttribute("aria-pressed")).toBe("false");
     await act(() =>
-      smoke.dispatchEvent(new MouseEvent("click", { bubbles: true })),
-    );
-    expect(smoke.getAttribute("aria-pressed")).toBe("true");
-    await act(() =>
-      fruit.dispatchEvent(
+      smoke.dispatchEvent(
         new KeyboardEvent("keydown", { key: " ", bubbles: true }),
       ),
     );
-    expect(fruit.getAttribute("aria-pressed")).toBe("true");
-    expect(fruit.getAttribute("aria-haspopup")).toBe("dialog");
-    expect(explored).toEqual(["fruit", "smoke", "fruit"]);
+    expect(smoke.getAttribute("aria-haspopup")).toBe("dialog");
+    expect(explored).toEqual(["fruit", "smoke", "smoke"]);
     expect(container.querySelector("button")).toBeNull();
   } finally {
     act(() => root.unmount());

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -38,6 +38,7 @@ export type BottleOverviewProps = {
   criticReviewDetail?: string;
   criticReviews?: readonly CriticReviewProps[];
   declaredFacts: readonly [FactListItem, ...FactListItem[]];
+  flavorProfile?: ReactNode;
   image: BottleOverviewImage;
   mainState?: ReactNode;
   moreTastingsHref?: string;
@@ -50,11 +51,12 @@ export type BottleOverviewProps = {
   tastings?: readonly TastingEntryProps[];
 };
 
-/** Composes the bottle facts, image, reviews, tastings, and recommendations. */
+/** Composes bottle facts, image, reviews, and tastings, with its flavor profile above related bottles. */
 export function BottleOverview({
   criticReviewDetail,
   criticReviews = [],
   declaredFacts,
+  flavorProfile,
   image,
   mainState,
   moreTastingsHref,
@@ -128,7 +130,7 @@ export function BottleOverview({
       </div>
 
       <aside
-        aria-label="Bottle media and recommendations"
+        aria-label="Bottle image, flavor profile, and recommendations"
         {...stylex.props(styles.rail)}
       >
         <figure {...stylex.props(styles.media)}>
@@ -148,8 +150,12 @@ export function BottleOverview({
           ) : null}
         </figure>
 
-        {recommendations.length || recommendationState || railSections ? (
+        {flavorProfile ||
+        recommendations.length ||
+        recommendationState ||
+        railSections ? (
           <div {...stylex.props(styles.railSections)}>
+            {flavorProfile}
             {recommendations.length ? (
               <BottleRailSection
                 heading={recommendationHeading}

--- a/apps/web/src/features/flavorProfile/flavorProfileSection.tsx
+++ b/apps/web/src/features/flavorProfile/flavorProfileSection.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import type {
+  BottleFlavorProfile,
+  FlavorProfile,
+} from "@peated/server/schemas/flavorProfile";
 import {
   FlavorWheel,
   LoadingPlaceholder,
@@ -14,35 +18,36 @@ import {
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useQuery } from "@tanstack/react-query";
 
-type PlaceFlavorProfileProps = {
+type FlavorProfileSectionProps = {
   scope:
+    | { kind: "bottle"; bottle: number }
     | { kind: "distillery"; entity: number }
     | { kind: "region"; country: string; region: string };
-  bottlesHref: string;
 };
 
-export function PlaceFlavorProfile(props: PlaceFlavorProfileProps) {
+export function FlavorProfileSection(props: FlavorProfileSectionProps) {
   return (
     <TastingWheelProvider>
-      <PlaceFlavorProfileContent {...props} />
+      <FlavorProfileContent {...props} />
     </TastingWheelProvider>
   );
 }
 
-function PlaceFlavorProfileContent({
-  scope,
-  bottlesHref,
-}: PlaceFlavorProfileProps) {
+function FlavorProfileContent({ scope }: FlavorProfileSectionProps) {
   const { select } = useTastingWheel();
   const orpc = useORPC();
-  const query = useQuery(
-    scope.kind === "distillery"
-      ? orpc.entities.flavorProfile.queryOptions({
-          input: { entity: scope.entity },
+  const query = useQuery<FlavorProfile | BottleFlavorProfile>(
+    scope.kind === "bottle"
+      ? orpc.bottles.flavorProfile.queryOptions({
+          input: { bottle: scope.bottle },
         })
-      : orpc.regions.flavorProfile.queryOptions({
-          input: { country: scope.country, region: scope.region },
-        }),
+      : scope.kind === "distillery"
+        ? orpc.entities.flavorProfile.queryOptions({
+            input: { entity: scope.entity },
+          })
+        : orpc.regions.flavorProfile.queryOptions({
+            input: { country: scope.country, region: scope.region },
+          }),
   );
 
   return (
@@ -59,22 +64,15 @@ function PlaceFlavorProfileContent({
           Try loading the tasting notes again.
         </SectionError>
       ) : (
-        <>
-          <FlavorWheel
-            footer={
-              <TextLink href="/about/tasting-wheel" tone="muted">
-                About the tasting wheel
-              </TextLink>
-            }
-            profile={query.data}
-            onExplore={(category) => select({ category })}
-          />
-          {query.data.notedBottles < 5 ? (
-            <TextLink href={bottlesHref}>
-              Browse bottles to add tasting notes
+        <FlavorWheel
+          footer={
+            <TextLink href="/about/tasting-wheel" tone="muted">
+              About the tasting wheel
             </TextLink>
-          ) : null}
-        </>
+          }
+          profile={query.data}
+          onExplore={(category) => select({ category })}
+        />
       )}
     </RailSection>
   );

--- a/apps/web/src/features/tastingWheel/tastingWheelDetails.stylex.tsx
+++ b/apps/web/src/features/tastingWheel/tastingWheelDetails.stylex.tsx
@@ -10,11 +10,7 @@ import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { createContext, useContext, useState, type ReactNode } from "react";
 import { colors, space } from "../../styles/tokens.stylex";
-import {
-  CATEGORY_DEFINITIONS,
-  NOTE_DESCRIPTIONS,
-  WHEEL_CATEGORIES,
-} from "./tastingWheelData";
+import { CATEGORY_DEFINITIONS, NOTE_DESCRIPTIONS } from "./tastingWheelData";
 
 type Selection = {
   category: TagCategory;
@@ -68,26 +64,6 @@ export function TastingWheelProvider({ children }: { children: ReactNode }) {
         ) : null}
       </Slideout>
     </TastingWheelContext>
-  );
-}
-
-export function TastingWheelCategoryLinks() {
-  const { select } = useTastingWheel();
-  return (
-    <div {...stylex.props(styles.categoryLinks)}>
-      {WHEEL_CATEGORIES.map((category) => (
-        <Button
-          key={category.key}
-          variant="text"
-          align="start"
-          fullWidth
-          aria-haspopup="dialog"
-          onClick={() => select({ category: category.key })}
-        >
-          {category.name}
-        </Button>
-      ))}
-    </div>
   );
 }
 
@@ -147,7 +123,7 @@ function TastingWheelDetails({
           Ranked by the share of public tastings with notes that mention{" "}
           {selection.note
             ? selection.note
-            : `a note in the ${category.name.toLowerCase()} category`}
+            : `a note in the ${category.name.toLowerCase()} family`}
           .
         </p>
         <div aria-live="polite">
@@ -182,7 +158,7 @@ function TastingWheelDetails({
           ) : (
             <p {...stylex.props(styles.status)}>
               No bottles have recorded tastings for{" "}
-              {selection.note ?? `this category`} yet. Try another note.
+              {selection.note ?? `this family`} yet. Try another note.
             </p>
           )}
         </div>
@@ -228,11 +204,5 @@ const styles = stylex.create({
       default: `1px solid ${colors.hairline}`,
       ":last-child": "none",
     },
-  },
-  categoryLinks: {
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "stretch",
-    marginLeft: "-16px",
   },
 });

--- a/docs/features/bottle-presentation.md
+++ b/docs/features/bottle-presentation.md
@@ -138,6 +138,23 @@ When stored fields conflict, concise presentation should prefer the explicit
 human-facing marketed designation and avoid displaying a contradictory second
 token. The conflict belongs in verification or moderation workflows.
 
+## Tasting-note flavor profile
+
+Bottle overview pages show a flavor-family wheel below the bottle image. Each
+family measures its occurrence in that exact Bottle's public tastings with
+recognized notes. Each tasting counts once per family; repeat tastings remain
+separate observations. Private tastings and suggested tags are excluded, even
+for signed-in authors. Do not combine sibling releases or use summed tag counts
+as family counts.
+
+Distillery and region wheels instead count each active Bottle once per family.
+Both show commonality, not intensity. Keep family positions fixed and show the
+selected family's leading notes in the center. Clicking a family opens the
+shared tasting-wheel panel with note descriptions and matching bottles. Omit
+instructional text, raw bottle counts, and contribution CTAs. Any recognized
+public notes produce a chart; none produces a short empty message. The
+whole-bottle style classification is separate from this distribution.
+
 ## Presentation Branches
 
 Choose the branch from the needs and context of the surface, not from the

--- a/docs/features/bottle-presentation.md
+++ b/docs/features/bottle-presentation.md
@@ -148,8 +148,9 @@ for signed-in authors. Do not combine sibling releases or use summed tag counts
 as family counts.
 
 Distillery and region wheels instead count each active Bottle once per family.
-Both show commonality, not intensity. Keep family positions fixed and show the
-selected family's leading notes in the center. Clicking a family opens the
+Both show commonality, not intensity. Keep family positions fixed. Hovering or
+focusing a family previews its share and leading notes in the center, keeping
+the last preview when the pointer or focus leaves. Clicking a family opens the
 shared tasting-wheel panel with note descriptions and matching bottles. Omit
 instructional text, raw bottle counts, and contribution CTAs. Any recognized
 public notes produce a chart; none produces a short empty message. The


### PR DESCRIPTION
Bottle overview pages now show the tasting-note flavor wheel, alongside the existing distillery and region profiles. Hovering or focusing a family previews its share and leading notes in the center; clicking opens the shared panel of note descriptions and matching bottles. The profiles omit bottle coverage counts, instructional copy, and the contribution CTA, and center the reference link beneath the wheel.

The tasting-wheel guide uses flavor-family language and a wider layout without the duplicate sidebar navigation. Sources remain available at the bottom of the page, and existing note anchors are preserved.

The new bottle profile endpoint counts each public tasting once per family, scoped to the exact bottle. Private tastings, unrecognized notes, and sibling releases do not contribute. Existing distillery and region profiles keep their distinct-bottle calculation. Any recognized public notes now produce a chart; no database migration is required.

Regression coverage checks the privacy and counting rules, sparse and empty profiles, keyboard activation, and the bottle-page panel flow. The proposed bottle-specific per-note distribution panel is not included; clicks still open the shared flavor reference and bottle examples.
