### PR TITLE
fix(web): unify bottle rows across the app

### DIFF
--- a/apps/web/e2e/routes.spec.ts
+++ b/apps/web/e2e/routes.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "./test";
 
+import { bottlePathPattern } from "./assertions";
 import {
   bottleGroupRepresentative,
   existingBottle,
@@ -97,13 +98,10 @@ test("public routes load", async ({ page, snapshot }) => {
           ).toBeVisible();
           await expect(
             panel.getByRole("link", {
-              name: existingBottle.group.name,
+              name: existingBottle.group.fullName,
               exact: true,
             }),
-          ).toHaveAttribute(
-            "href",
-            new RegExp(`^/bottles/${existingBottle.id}-`),
-          );
+          ).toHaveAttribute("href", bottlePathPattern(existingBottle.id));
           await page.keyboard.press("Escape");
           await expect(panel).toHaveCount(0);
           await expect(smoke).toBeFocused();

--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -1,15 +1,11 @@
 "use client";
 
-import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
-import { formatCategoryName } from "@peated/server/lib/format";
 import { ButtonLink, LoadingList, SectionError } from "@peated/web/components";
 import { CommunityFeed } from "@peated/web/components/communityFeed.stylex";
-import { EntityLinks } from "@peated/web/components/entityLinks";
-import Join from "@peated/web/components/join";
 import {
   HomeActivityFeed,
   HomeContributionPrompt,
@@ -34,8 +30,6 @@ import {
 import { getEntityUrl } from "@peated/web/lib/urls";
 import { space } from "../../../../styles/tokens.stylex";
 import { HomeEventCallout } from "./homeEventCallout.stylex";
-
-type Bottle = Outputs["bottles"]["list"]["results"][number];
 
 export function PublicHome({
   searchPlaceholder,
@@ -168,26 +162,7 @@ function LatestReleases() {
   const items = releases.results.flatMap((bottle) => {
     if (bottle.releaseYear === null) return [];
 
-    const distillers = bottle.distillers.filter(
-      (distiller) => distiller.id !== bottle.brand.id,
-    );
-    const subtitle = [
-      distillers.length ? (
-        <EntityLinks entities={distillers} key="distillers" />
-      ) : null,
-      bottle.category ? formatCategoryName(bottle.category) : null,
-    ].filter((value) => value !== null);
-
-    return [
-      {
-        ...toBottleListItem(bottle, { includeBrandRow: false }),
-        align: "start" as const,
-        metadata: getReleaseMetadata(bottle),
-        subtitle: subtitle.length ? (
-          <Join divider=" · ">{subtitle}</Join>
-        ) : undefined,
-      },
-    ];
+    return [toBottleListItem(bottle)];
   });
 
   return items.length ? (
@@ -346,14 +321,6 @@ function Distilleries({ totalDistilleries }: { totalDistilleries?: number }) {
       totalDistilleries={totalDistilleries}
     />
   ) : null;
-}
-
-function getReleaseMetadata(bottle: Bottle) {
-  return [
-    bottle.releaseYear === null ? null : `${bottle.releaseYear} release`,
-    bottle.statedAge === null ? null : `${bottle.statedAge} years`,
-    bottle.abv === null ? null : `${bottle.abv.toFixed(1)}% ABV`,
-  ].filter((value): value is string => Boolean(value));
 }
 
 const NARROW = "@media (max-width: 759px)";

--- a/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
@@ -1,4 +1,3 @@
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import {
   BottleIdentityRow,
   CursorPager,
@@ -6,7 +5,7 @@ import {
   ItemList,
   ItemListItem,
 } from "@peated/web/components";
-import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
+import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
@@ -16,7 +15,7 @@ import {
   requireReleaseFamilyAnchor,
   requireReleaseFamilyGroup,
 } from "@peated/web/lib/releaseFamily";
-import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
+import { getBottleUrl } from "@peated/web/lib/urls";
 
 import { BottleSection } from "../bottleSection.stylex";
 
@@ -60,19 +59,12 @@ export default async function BottleReleasesPage(props: {
           {bottleList.results.map((bottle) => (
             <ItemListItem key={bottle.id}>
               <BottleIdentityRow
-                brand={bottle.brand.name}
-                brandHref={getEntityUrl(bottle.brand)}
+                {...toBottleListItem(bottle)}
                 end={
                   bottle.medianScore !== null && bottle.scoreCount >= 20
                     ? `${bottle.medianScore} / 100`
                     : undefined
                 }
-                href={getBottleUrl(bottle)}
-                imageUrl={bottle.imageUrl}
-                metadata={getBottleMetadata(bottle).split(" · ")}
-                name={formatBottleDisplayName(bottle, {
-                  includeBrand: false,
-                })}
               />
             </ItemListItem>
           ))}

--- a/apps/web/src/app/(app)/flights/[flightId]/page.tsx
+++ b/apps/web/src/app/(app)/flights/[flightId]/page.tsx
@@ -1,4 +1,3 @@
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import {
   BottleIdentityRow,
   ButtonLink,
@@ -11,11 +10,10 @@ import {
   PageSection,
 } from "@peated/web/components/pages/pageLayout.stylex";
 import { getAddBottleHref } from "@peated/web/lib/addBottle";
-import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
+import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { summarize } from "@peated/web/lib/markdown";
 import { getServerClient } from "@peated/web/lib/orpc/client.server";
 import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
-import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 import { cache } from "react";
 
 import { FlightActions } from "./flightActions";
@@ -66,8 +64,7 @@ export default async function FlightPage(props: {
             {flight.bottles.map(({ bottle, hasTasted, isLibrary }) => (
               <ItemListItem key={bottle.id}>
                 <BottleIdentityRow
-                  brand={bottle.brand.name}
-                  brandHref={getEntityUrl(bottle.brand)}
+                  {...toBottleListItem(bottle)}
                   end={
                     <ButtonLink
                       href={getAddBottleHref({
@@ -82,13 +79,7 @@ export default async function FlightPage(props: {
                     </ButtonLink>
                   }
                   hasTasted={hasTasted}
-                  href={getBottleUrl(bottle)}
-                  imageUrl={bottle.imageUrl}
                   isLibrary={isLibrary}
-                  metadata={getBottleMetadata(bottle).split(" · ")}
-                  name={formatBottleDisplayName(bottle, {
-                    includeBrand: false,
-                  })}
                 />
               </ItemListItem>
             ))}

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -206,7 +206,6 @@ export function SeriesPageClient({
                   controls: bottleActions,
                   item: toBottleListItem(bottle, {
                     includeBrandInName: false,
-                    includeBrandRow: false,
                     includeRatings: true,
                     includeRelatedReleases: true,
                     includeSeriesInName: false,

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
@@ -1,13 +1,11 @@
 "use client";
 
-import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useState, useTransition } from "react";
 
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { ButtonLink, LoadingList, SectionError } from "@peated/web/components";
 import {
   MemberLibraryFilters,
@@ -15,9 +13,9 @@ import {
   type MemberLibraryFilterGroup,
   type MemberLibraryItem,
 } from "@peated/web/components/pages/memberProfileContent.stylex";
+import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
 import { colors, fonts, space } from "../../../../../styles/tokens.stylex";
 import { useProfile } from "../profileContext";
 import { getProfileLibraryInput, profileQueries } from "../profileQueries";
@@ -283,6 +281,9 @@ function toLibraryItem(
 ): MemberLibraryItem {
   const bottle = entry.bottle;
   return {
+    ...toBottleListItem(bottle),
+    hasTasted: false,
+    isLibrary: false,
     actions: canEdit
       ? [
           {
@@ -319,29 +320,10 @@ function toLibraryItem(
           },
         ]
       : undefined,
-    brand: bottle.brand.shortName || bottle.brand.name,
-    brandHref: getEntityUrl(bottle.brand),
-    href: getBottleUrl(bottle),
     id: String(entry.id),
     imageUrl: entry.imageUrl ?? bottle.imageUrl,
-    metadata: getLibraryMetadata(bottle),
-    name: formatBottleDisplayName(bottle, { includeBrand: false }),
     status: entry.status ? capitalize(entry.status) : undefined,
   };
-}
-
-function getLibraryMetadata(bottle: LibraryEntry["bottle"]) {
-  return [
-    bottle.category ? formatCategoryName(bottle.category) : null,
-    bottle.statedAge !== null
-      ? `${bottle.statedAge} years`
-      : bottle.noAgeStatement
-        ? "No age statement"
-        : null,
-    bottle.abv !== null
-      ? `${bottle.abv.toFixed(1).replace(/\.0$/, "")}% ABV`
-      : null,
-  ].filter((value): value is string => Boolean(value));
 }
 
 function getFilterGroups({

--- a/apps/web/src/app/(app)/users/[username]/profileActivity.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileActivity.tsx
@@ -1,12 +1,11 @@
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { Outputs } from "@peated/server/orpc/router";
+import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";
 
 import { MemberAvatar, type TastingEntryMember } from "@peated/web/components";
 import type { MemberActivityItem } from "@peated/web/components/pages/memberProfileContent.stylex";
 import { getTastingEntryMember } from "@peated/web/components/tastingRecordEntry";
 import TimeSince from "@peated/web/components/timeSince";
-import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
-import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
+import { getBottleUrl } from "@peated/web/lib/urls";
 
 type Activity = Outputs["users"]["activity"]["list"]["results"][number];
 
@@ -22,15 +21,10 @@ export function toActivityItem(activity: Activity): MemberActivityItem {
         date: <TimeSince date={activity.createdAt} />,
         id: activity.id,
         items: activity.items.map((entry) => ({
-          brand: entry.bottle.brand.shortName || entry.bottle.brand.name,
-          brandHref: getEntityUrl(entry.bottle.brand),
+          ...getBottleIdentityProps(entry.bottle),
           href: getBottleUrl(entry.bottle),
           id: String(entry.id),
           imageUrl: entry.imageUrl ?? entry.bottle.imageUrl,
-          metadata: getBottleMetadata(entry.bottle).split(" · "),
-          name: formatBottleDisplayName(entry.bottle, {
-            includeBrand: false,
-          }),
         })),
         totalItems: activity.totalItems,
       },

--- a/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
+++ b/apps/web/src/app/(layout-free)/addBottle/addBottleFlow.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { Outputs } from "@peated/server/orpc/router";
 import type { Bottle } from "@peated/server/types";
 import {
@@ -40,7 +39,6 @@ import {
   getPendingImageFromParams,
 } from "@peated/web/lib/addBottle";
 import { toBlob } from "@peated/web/lib/blobs";
-import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { uploadImageAfterSave } from "@peated/web/lib/imageUpload";
 import { logError } from "@peated/web/lib/log";
@@ -142,10 +140,8 @@ function BottlePanel({
 }) {
   return (
     <SelectedBottleSummary
-      brand={bottle.brand.shortName || bottle.brand.name}
+      bottle={bottle}
       imageUrl={previewUrl ?? bottle.imageUrl}
-      metadata={getBottleMetadata(bottle)}
-      name={formatBottleDisplayName(bottle, { includeBrand: false })}
     />
   );
 }
@@ -153,10 +149,8 @@ function BottlePanel({
 function CollectionBottlePanel({ entry }: { entry: CollectionBottle }) {
   return (
     <SelectedBottleSummary
-      brand={entry.bottle.brand.shortName || entry.bottle.brand.name}
+      bottle={entry.bottle}
       imageUrl={entry.imageUrl ?? entry.bottle.imageUrl}
-      metadata={getBottleMetadata(entry.bottle)}
-      name={formatBottleDisplayName(entry.bottle, { includeBrand: false })}
     />
   );
 }

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/audit/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/audit/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import {
   Field,
   FormNotice,
@@ -12,7 +11,6 @@ import {
 import { moderationHrefForAudit } from "@peated/web/components/admin/moderation/auditHref";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import { ModRequired } from "@peated/web/hooks/useAuthRequired";
-import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { getBottleUrl } from "@peated/web/lib/urls";
@@ -84,12 +82,7 @@ function AuditBottleForm({ bottleId }: { bottleId: string }) {
     >
       <form onSubmit={runAudit}>
         <FormStack>
-          <SelectedBottleSummary
-            brand={bottle.brand.shortName || bottle.brand.name}
-            imageUrl={bottle.imageUrl}
-            metadata={getBottleMetadata(bottle)}
-            name={formatBottleDisplayName(bottle, { includeBrand: false })}
-          />
+          <SelectedBottleSummary bottle={bottle} />
           {error ? <FormNotice>{error}</FormNotice> : null}
           {summary ? (
             <FormNotice>No changes proposed. {summary}</FormNotice>

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
@@ -133,12 +133,7 @@ function MergeBottleForm({ bottleId }: { bottleId: string }) {
     >
       <form onSubmit={handleSubmit(submit)}>
         <FormStack>
-          <SelectedBottleSummary
-            brand={bottle.brand.shortName || bottle.brand.name}
-            imageUrl={bottle.imageUrl}
-            metadata={getBottleMetadata(bottle)}
-            name={formatBottleDisplayName(bottle, { includeBrand: false })}
-          />
+          <SelectedBottleSummary bottle={bottle} />
           {submitError ? <FormNotice>{submitError}</FormNotice> : null}
           <FormSection title="Duplicate bottle">
             <Controller

--- a/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
+++ b/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { Bottle } from "@peated/server/types";
 import {
   BottleIdentityRow,
@@ -10,8 +9,7 @@ import {
 } from "@peated/web/components";
 import { ClientOnly } from "@peated/web/components/clientOnly";
 import QRCodeClient from "@peated/web/components/qrcode.client.stylex";
-import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
-import { getBottleUrl, getEntityUrl } from "@peated/web/lib/urls";
+import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import * as stylex from "@stylexjs/stylex";
 import { foundationStyles } from "../../../../../styles/foundations.stylex";
 import { colors, space } from "../../../../../styles/tokens.stylex";
@@ -49,16 +47,7 @@ export function FlightOverlay({
             <ItemList ariaLabel="Flight bottles">
               {bottles.map(({ bottle }) => (
                 <ItemListItem key={bottle.id}>
-                  <BottleIdentityRow
-                    brand={bottle.brand.name}
-                    brandHref={getEntityUrl(bottle.brand)}
-                    href={getBottleUrl(bottle)}
-                    imageUrl={bottle.imageUrl}
-                    metadata={getBottleMetadata(bottle).split(" · ")}
-                    name={formatBottleDisplayName(bottle, {
-                      includeBrand: false,
-                    })}
-                  />
+                  <BottleIdentityRow {...toBottleListItem(bottle)} />
                 </ItemListItem>
               ))}
             </ItemList>

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -39,6 +39,7 @@ import {
 } from "@peated/web/components";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
+import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";
 import {
   getFormErrorMessage,
   toChoiceValue,
@@ -47,7 +48,7 @@ import { useORPC } from "@peated/web/lib/orpc/context";
 import { zodResolver } from "@peated/web/lib/zodResolver";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { WandSparkles } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import type { SubmitHandler } from "react-hook-form";
 import { Controller, useForm } from "react-hook-form";
 import { z } from "zod";
@@ -412,19 +413,8 @@ export default function BottleForm({
   const statedAge = watch("statedAge");
   const noAgeStatement = watch("noAgeStatement");
   const abv = watch("abv");
-  const previewMetadata = useMemo(
-    () =>
-      [
-        category ? formatCategoryName(category) : null,
-        noAgeStatement
-          ? "No age statement"
-          : statedAge != null
-            ? `${statedAge} years`
-            : null,
-        abv != null ? `${abv}% ABV` : null,
-      ].filter((item): item is string => Boolean(item)),
-    [abv, category, noAgeStatement, statedAge],
-  );
+  const edition = watch("edition");
+  const releaseYear = watch("releaseYear");
 
   useEffect(() => {
     return () => {
@@ -482,9 +472,16 @@ export default function BottleForm({
           </FormNotice>
           {name || brand ? (
             <BottleIdentityRow
-              brand={brand?.name}
-              metadata={previewMetadata}
-              name={name || "Bottle preview"}
+              {...getBottleIdentityProps({
+                name: name || "Bottle preview",
+                brand: { name: brand?.name ?? "" },
+                category: category ?? null,
+                statedAge: statedAge ?? null,
+                noAgeStatement: noAgeStatement ?? null,
+                abv: abv ?? null,
+                edition,
+                releaseYear,
+              })}
             />
           ) : null}
           {submitError ? (

--- a/apps/web/src/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stories.tsx
@@ -1,3 +1,5 @@
+import { mockBottle } from "@peated/server/orpc/mock/fixtures";
+import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import type { BottleRowActionControls } from "@peated/web/hooks/useBottleRowActions";
@@ -22,6 +24,17 @@ const bottleActions = {
   isLibrary: () => true,
 } satisfies BottleRowActionControls;
 
+const rowBottle = {
+  ...mockBottle,
+  brand: { ...mockBottle.brand, name: "Laphroaig", shortName: null },
+  name: "Elements L 2.0",
+  group: undefined,
+  releaseYear: 2024,
+  statedAge: null,
+  abv: 59.6,
+  imageUrl: BottleImage.src,
+};
+
 const meta = {
   title: "Components/Bottles/Bottle Identity Row",
   component: BottleIdentityRow,
@@ -33,18 +46,15 @@ const meta = {
     ),
   ],
   args: {
-    brand: "Laphroaig",
-    brandHref: "/entities/809",
+    ...toBottleListItem(rowBottle),
     href: "/bottles/19936",
     imageUrl: BottleImage.src,
-    metadata: ["Single malt", "Islay"],
-    name: "Elements L 2.0",
   },
   parameters: {
     docs: {
       description: {
         component:
-          "Use Bottle Identity Row in bottle lists. Three-line identities, activity entries, and selected-bottle summaries share the default medium BottleVisual size: 48 × 64px on desktop and 42 × 58px on mobile. The bottle name is the main destination. Brand links, related releases, and action menus remain separate controls.",
+          "Use Bottle Identity Row wherever a standard bottle row appears. toBottleListItem and getBottleIdentityProps supply the same marketed name, provenance, and release facts used on the homepage and in Library. Rows share a 48 × 64px thumbnail on desktop and 42 × 58px on mobile. Producer links, related releases, and action menus remain separate controls.",
       },
     },
   },
@@ -71,12 +81,11 @@ export const Overview: Story = {
       </ItemListItem>
       <ItemListItem>
         <BottleIdentityRow
-          brand="Lagavulin"
-          brandHref="/entities/245"
+          provenance={[{ name: "Single Malt" }]}
           href="/bottles/42"
           imageUrl={null}
           metadata={["16 years", "43.0% ABV", "Distillers Edition"]}
-          name="16-year-old"
+          name="Lagavulin 16-year-old"
           relatedReleases={{ count: 3, href: "/bottles/42/releases" }}
         />
       </ItemListItem>
@@ -104,12 +113,11 @@ export const Overview: Story = {
       </ItemListItem>
       <ItemListItem>
         <BottleIdentityRow
-          brand="Bruichladdich"
-          brandHref="/entities/213"
+          provenance={[{ name: "Single Malt" }]}
           href="/bottles/18481"
           imageUrl={null}
           metadata={["61.5% ABV", "2024 release", "Islay barley"]}
-          name="Octomore Edition 15.3 Islay Barley Super Heavily Peated"
+          name="Bruichladdich Octomore Edition 15.3 Islay Barley Super Heavily Peated"
         />
       </ItemListItem>
     </ItemList>
@@ -126,7 +134,7 @@ export const RowLayouts: Story = {
     },
   },
   render: (args) => {
-    const title = [args.brand, args.name].filter(Boolean).join(" ");
+    const title = args.name;
     const metadata = args.metadata?.join(" · ") ?? "";
     return (
       <StoryStack>
@@ -142,6 +150,7 @@ export const RowLayouts: Story = {
             items={[
               {
                 actor: "Whiskyfun",
+                bottle: args,
                 actorHref: "https://example.com/review",
                 bottleHref: args.href!,
                 date: "2026-08-24T12:00:00.000Z",
@@ -163,6 +172,7 @@ export const RowLayouts: Story = {
             members={[
               {
                 href: args.href,
+                bottle: args,
                 imageUrl: args.imageUrl,
                 metadata,
                 name: title,
@@ -182,6 +192,7 @@ export const RowLayouts: Story = {
                 items: [
                   {
                     href: args.href!,
+                    bottle: args,
                     id: "bottle",
                     metadata,
                     title,
@@ -200,10 +211,8 @@ export const RowLayouts: Story = {
         <section aria-label="Selection">
           <SectionHeading level={3}>Selected bottle</SectionHeading>
           <SelectedBottleSummary
-            brand={args.brand!}
+            bottle={rowBottle}
             imageUrl={args.imageUrl}
-            metadata={metadata}
-            name={args.name}
             onChange={() => undefined}
           />
         </section>

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -1,5 +1,5 @@
 import * as stylex from "@stylexjs/stylex";
-import type { ReactNode } from "react";
+import type { MouseEventHandler, ReactNode } from "react";
 
 import { foundationStyles } from "../styles/foundations.stylex";
 import {
@@ -13,8 +13,11 @@ import {
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { ImageViewer } from "./imageViewer.stylex";
+import Join from "./join";
 import { linkedRowStyles } from "./linkedRow.stylex";
+import { MatchedText } from "./matchedText.stylex";
 import { MemberStatus } from "./memberStatus.stylex";
+import { TextLink } from "./textLink.stylex";
 import { getTextTitle } from "./textTitle";
 
 const COMPACT = "@media (max-width: 639px)";
@@ -78,8 +81,6 @@ export function BottleVisual({
 
 export type BottleIdentityRowProps = {
   align?: "center" | "start";
-  brand?: string;
-  brandHref?: string;
   end?: ReactNode;
   hasTasted?: boolean;
   href?: string;
@@ -88,6 +89,9 @@ export type BottleIdentityRowProps = {
   layout?: "cell" | "row";
   metadata?: readonly string[];
   name: string;
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
+  query?: string;
+  provenance?: readonly { name: string; href?: string }[];
   relatedReleases?: {
     count: number;
     href: string;
@@ -96,13 +100,11 @@ export type BottleIdentityRowProps = {
 };
 
 /**
- * Owns the standard bottle row and its thumbnail size. Supply a name from
- * formatBottleDisplayName (or toBottleListItem), with brand context if omitted there.
+ * Owns the standard three-line bottle row: marketed name, provenance, then release facts.
+ * Use toBottleListItem for API Bottles so pages cannot drift from the home/Library identity.
  */
 export function BottleIdentityRow({
   align = "center",
-  brand,
-  brandHref,
   end,
   hasTasted = false,
   href,
@@ -111,6 +113,9 @@ export function BottleIdentityRow({
   layout = "row",
   metadata = [],
   name,
+  onClick,
+  query,
+  provenance = [],
   relatedReleases,
   subtitle,
 }: BottleIdentityRowProps) {
@@ -126,49 +131,43 @@ export function BottleIdentityRow({
     >
       <BottleVisual imageUrl={imageUrl} />
       <div {...stylex.props(styles.copy)}>
-        {brand ? (
-          brandHref ? (
-            <AppLink
-              href={brandHref}
-              title={brand}
-              {...stylex.props(
-                foundationStyles.metadata,
-                styles.brand,
-                styles.brandLink,
-                linkedRowStyles.nestedAction,
-              )}
-            >
-              {brand}
-            </AppLink>
-          ) : (
-            <span
-              title={brand}
-              {...stylex.props(foundationStyles.metadata, styles.brand)}
-            >
-              {brand}
-            </span>
-          )
-        ) : null}
         <div {...stylex.props(styles.nameLine)}>
           {href ? (
             <AppLink
               href={href}
+              onClick={onClick}
+              title={name}
               {...stylex.props(
                 foundationStyles.rowTitle,
                 styles.name,
                 linkedRowStyles.primaryLink,
               )}
             >
-              {name}
+              <MatchedText query={query} text={name} />
             </AppLink>
           ) : (
             <span {...stylex.props(foundationStyles.rowTitle, styles.name)}>
-              {name}
+              <MatchedText query={query} text={name} />
             </span>
           )}
           {isLibrary ? <MemberStatus kind="library" /> : null}
           {hasTasted ? <MemberStatus kind="tasted" /> : null}
         </div>
+        {provenance.length ? (
+          <div {...stylex.props(foundationStyles.metadata, styles.subtitle)}>
+            <Join divider=" · ">
+              {provenance.map((item, index) =>
+                item.href ? (
+                  <TextLink href={item.href} key={index} size="inherit">
+                    {item.name}
+                  </TextLink>
+                ) : (
+                  <span key={index}>{item.name}</span>
+                ),
+              )}
+            </Join>
+          </div>
+        ) : null}
         {subtitle ? (
           <div
             title={getTextTitle(subtitle)}
@@ -307,35 +306,6 @@ const styles = stylex.create({
     flex: 1,
     flexDirection: "column",
     alignItems: "flex-start",
-  },
-  brand: {
-    maxWidth: "100%",
-    overflow: "hidden",
-    outline: "none",
-    color: colors.inkMuted,
-    textDecoration: "none",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
-  },
-  brandLink: {
-    color: {
-      default: colors.inkMuted,
-      ":hover": colors.accentDeep,
-      ":active": colors.accentDeep,
-      ":focus-visible": colors.accentDeep,
-    },
-    textDecorationLine: {
-      default: "none",
-      ":hover": "underline",
-      ":active": "underline",
-      ":focus-visible": "underline",
-    },
-    textDecorationThickness: "1px",
-    textUnderlineOffset: "2px",
   },
   nameLine: {
     display: "block",

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -35,6 +35,7 @@ export type BottleVisualProps = {
 /**
  * Shows a bottle image or Peated's bottle glyph when no image exists.
  * Use the default medium size beside three-line identities, including activity entries.
+ * Fixed-size frames cap both dimensions so source images cannot enlarge a row.
  */
 export function BottleVisual({
   expandable = false,
@@ -210,6 +211,9 @@ const styles = stylex.create({
   visual: {
     boxSizing: "border-box",
     display: "inline-flex",
+    minWidth: 0,
+    minHeight: 0,
+    flexGrow: 0,
     flexShrink: 0,
     alignItems: "center",
     justifyContent: "center",
@@ -227,21 +231,28 @@ const styles = stylex.create({
   },
   visualSmall: {
     width: "32px",
+    maxWidth: "32px",
     height: "46px",
+    maxHeight: "46px",
     padding: space.x1,
   },
   visualMedium: {
     width: bottleThumbnailMetrics.width,
+    maxWidth: bottleThumbnailMetrics.width,
     height: bottleThumbnailMetrics.height,
+    maxHeight: bottleThumbnailMetrics.height,
     padding: space.x2,
   },
   visualLarge: {
     width: { default: "132px", [COMPACT]: "80px" },
+    maxWidth: { default: "132px", [COMPACT]: "80px" },
     height: { default: "176px", [COMPACT]: "120px" },
+    maxHeight: { default: "176px", [COMPACT]: "120px" },
     padding: { default: space.x2, [COMPACT]: space.x1 },
   },
   visualExtraLarge: {
     width: "100%",
+    maxWidth: "100%",
     aspectRatio: "4 / 5",
     padding: space.x4,
   },
@@ -249,7 +260,11 @@ const styles = stylex.create({
     boxSizing: "border-box",
     display: "block",
     width: "100%",
+    maxWidth: "100%",
+    minWidth: 0,
     height: "100%",
+    maxHeight: "100%",
+    minHeight: 0,
     objectFit: "contain",
   },
   expandableImageSmall: {
@@ -267,7 +282,9 @@ const styles = stylex.create({
   fallbackAsset: {
     display: "block",
     width: "100%",
+    maxWidth: "100%",
     height: "100%",
+    maxHeight: "100%",
     backgroundColor: "currentColor",
     maskPosition: "center",
     maskRepeat: "no-repeat",

--- a/apps/web/src/components/bottleResolver/states.tsx
+++ b/apps/web/src/components/bottleResolver/states.tsx
@@ -1,5 +1,3 @@
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
-import { formatCategoryName } from "@peated/server/lib/format";
 import type { Bottle } from "@peated/server/types";
 import {
   Button,
@@ -19,7 +17,6 @@ import {
   BottleResolverSection,
 } from "./layout.stylex";
 import {
-  FallbackActions,
   getPhotoFailureCopyPayload,
   LabelFacts,
   PhotoFailurePanel,
@@ -248,14 +245,7 @@ export function PhotoMatchCreateState({
               title="Label photo"
             />
           ) : null}
-          <SelectedBottleSummary
-            brand={matchedBottle.brand.shortName || matchedBottle.brand.name}
-            imageUrl={matchedBottle.imageUrl}
-            metadata={getMatchedBottleMetadata(matchedBottle)}
-            name={formatBottleDisplayName(matchedBottle, {
-              includeBrand: false,
-            })}
-          />
+          <SelectedBottleSummary bottle={matchedBottle} />
           <LabelFacts result={result} />
           {renderMatchedResultActions ? (
             renderMatchedResultActions({
@@ -332,22 +322,4 @@ export function PhotoMatchCreateState({
       </BottleResolverSection>
     </BottleResolverColumn>
   );
-}
-
-function getMatchedBottleMetadata(bottle: Bottle) {
-  const release =
-    bottle.releaseYear !== null &&
-    !bottle.edition
-      ?.toLocaleLowerCase()
-      .includes(`${bottle.releaseYear} release`)
-      ? `${bottle.releaseYear} release`
-      : null;
-
-  return [
-    bottle.category ? formatCategoryName(bottle.category) : "Bottle",
-    bottle.edition,
-    release,
-  ]
-    .filter((value): value is string => Boolean(value))
-    .join(" · ");
 }

--- a/apps/web/src/components/communityFeed.stylex.tsx
+++ b/apps/web/src/components/communityFeed.stylex.tsx
@@ -2,8 +2,10 @@ import * as stylex from "@stylexjs/stylex";
 import { foundationStyles } from "../styles/foundations.stylex";
 
 import { colors, fonts, space } from "../styles/tokens.stylex";
-import { AppLink } from "./appLink";
-import { BottleVisual } from "./bottleIdentityRow.stylex";
+import {
+  BottleIdentityRow,
+  type BottleIdentityRowProps,
+} from "./bottleIdentityRow.stylex";
 import { ItemList, ItemListItem } from "./itemList.stylex";
 import { linkedRowStyles } from "./linkedRow.stylex";
 import { RATING_BANDS, TastingRating, type RatingBand } from "./scoring.stylex";
@@ -11,6 +13,7 @@ import { TextLink } from "./textLink.stylex";
 import TimeSince from "./timeSince";
 
 export type CommunityFeedItem = {
+  bottle?: Pick<BottleIdentityRowProps, "name" | "provenance" | "metadata">;
   actor: string;
   actorHref?: string;
   bottleHref: string;
@@ -51,20 +54,20 @@ export function CommunityFeed({
               linkedRowStyles.onGround,
             )}
           >
-            <BottleVisual imageUrl={item.imageUrl} />
             <div {...stylex.props(styles.heading)}>
               <div {...stylex.props(styles.identity)}>
-                <AppLink
+                <BottleIdentityRow
+                  {...item.bottle}
+                  align="start"
+                  layout="cell"
                   href={item.href}
-                  title={item.title}
-                  {...stylex.props(
-                    foundationStyles.rowTitle,
-                    styles.title,
-                    linkedRowStyles.primaryLink,
-                  )}
-                >
-                  {item.title}
-                </AppLink>
+                  imageUrl={item.imageUrl}
+                  metadata={
+                    item.bottle?.metadata ??
+                    (item.metadata ? item.metadata.split(" · ") : [])
+                  }
+                  name={item.bottle?.name ?? item.title}
+                />
                 <div
                   {...stylex.props(foundationStyles.metadata, styles.context)}
                 >
@@ -81,7 +84,6 @@ export function CommunityFeed({
                 <div
                   {...stylex.props(foundationStyles.metadata, styles.metadata)}
                 >
-                  {item.metadata ? <>{item.metadata} · </> : null}
                   <TextLink href={item.bottleHref} size="inherit">
                     View bottle
                   </TextLink>
@@ -130,7 +132,7 @@ const styles = stylex.create({
   entry: {
     boxSizing: "border-box",
     display: "grid",
-    gridTemplateColumns: "auto minmax(0, 1fr)",
+    gridTemplateColumns: "minmax(0, 1fr)",
     alignItems: "center",
     columnGap: space.x3,
     rowGap: space.x2,
@@ -148,13 +150,6 @@ const styles = stylex.create({
   identity: {
     flex: 1,
     minWidth: 0,
-  },
-  title: {
-    display: "block",
-    color: colors.ink,
-    textDecoration: "none",
-    whiteSpace: "normal",
-    textWrap: "pretty",
   },
   context: {
     marginTop: "3px",
@@ -196,7 +191,7 @@ const styles = stylex.create({
     textAlign: "right",
   },
   excerpt: {
-    gridColumn: "2",
+    gridColumn: "1",
     margin: 0,
     color: colors.ink,
     fontStyle: "italic",

--- a/apps/web/src/components/matchedText.stylex.tsx
+++ b/apps/web/src/components/matchedText.stylex.tsx
@@ -1,0 +1,32 @@
+import * as stylex from "@stylexjs/stylex";
+import { colors } from "../styles/tokens.stylex";
+
+export function MatchedText({
+  query = "",
+  text,
+}: {
+  query?: string;
+  text: string;
+}) {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const start = normalizedQuery
+    ? text.toLocaleLowerCase().indexOf(normalizedQuery)
+    : -1;
+  if (start < 0) return text;
+  const end = start + normalizedQuery.length;
+  return (
+    <>
+      {text.slice(0, start)}
+      <mark {...stylex.props(styles.match)}>{text.slice(start, end)}</mark>
+      {text.slice(end)}
+    </>
+  );
+}
+
+const styles = stylex.create({
+  match: {
+    borderRadius: "1px",
+    backgroundColor: colors.accentTint,
+    color: "inherit",
+  },
+});

--- a/apps/web/src/components/pages/memberReviewForm.stories.tsx
+++ b/apps/web/src/components/pages/memberReviewForm.stories.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { mockBottle } from "@peated/server/orpc/mock/fixtures";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { useEffect, useState } from "react";
 
@@ -60,11 +61,7 @@ export const Default: Story = {
       >
         <form>
           <FormStack>
-            <SelectedBottleSummary
-              brand="Springbank"
-              metadata="46% ABV · 15 years · Campbeltown single malt"
-              name="15-year-old"
-            />
+            <SelectedBottleSummary bottle={mockBottle} />
             <RecordTypeInput
               disabled={false}
               onChange={setRecordType}

--- a/apps/web/src/components/pages/workflowScreen.stories.tsx
+++ b/apps/web/src/components/pages/workflowScreen.stories.tsx
@@ -1,3 +1,4 @@
+import { mockBottle } from "@peated/server/orpc/mock/fixtures";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import { Field, Textarea, TextInput } from "../field.stylex";
@@ -24,11 +25,7 @@ export const Overview: Story = {
   render: (args) => (
     <WorkflowScreen {...args} saveHint="Step 2 of 3">
       <FormStack>
-        <SelectedBottleSummary
-          brand="Ardbeg"
-          metadata="54.2% ABV · NAS · Islay"
-          name="Uigeadail"
-        />
+        <SelectedBottleSummary bottle={mockBottle} />
         <FormSection title="Your tasting">
           <FormGrid>
             <Field htmlFor="workflow-date" label="Date">
@@ -55,11 +52,7 @@ export const Saving: Story = {
   args: { saving: true },
   render: (args) => (
     <WorkflowScreen {...args} saveHint="Saving this tasting">
-      <SelectedBottleSummary
-        brand="Ardbeg"
-        metadata="54.2% ABV · NAS · Islay"
-        name="Uigeadail"
-      />
+      <SelectedBottleSummary bottle={mockBottle} />
     </WorkflowScreen>
   ),
 };

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { Outputs } from "@peated/server/orpc/router";
 import type {
   SearchResultGroup,
@@ -9,7 +8,7 @@ import type {
 import { Button, SearchBox } from "@peated/web/components";
 import { getCreateBottleHref } from "@peated/web/components/search/createBottleHref";
 import useAuth from "@peated/web/hooks/useAuth";
-import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
+import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import {
   addRecentSearch,
@@ -170,7 +169,9 @@ function bottleItem(
     showRatings: boolean;
   },
 ) {
+  const identity = getBottleIdentityProps(bottle);
   return {
+    bottle: identity,
     href: getBottleHref(bottle),
     id: `bottle-${bottle.id}`,
     ratings: showRatings
@@ -182,12 +183,11 @@ function bottleItem(
           bands: bottle.tastingBandCounts,
         }
       : undefined,
-    metadata: getBottleMetadata(bottle),
-    title: formatBottleDisplayName(bottle),
+    title: identity.name,
     visual: {
       kind: "bottle",
       imageUrl: bottle.imageUrl,
-      label: `${formatBottleDisplayName(bottle)} bottle`,
+      label: `${identity.name} bottle`,
     },
   } satisfies SearchResultItem;
 }

--- a/apps/web/src/components/searchResults.stylex.tsx
+++ b/apps/web/src/components/searchResults.stylex.tsx
@@ -11,9 +11,14 @@ import {
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { Avatar } from "./avatar.stylex";
-import { BottleVisual } from "./bottleIdentityRow.stylex";
+import {
+  BottleIdentityRow,
+  BottleVisual,
+  type BottleIdentityRowProps,
+} from "./bottleIdentityRow.stylex";
 import { Button, ButtonLink } from "./button.stylex";
 import { FloatingPanel } from "./feedback.stylex";
+import { MatchedText } from "./matchedText.stylex";
 import { MemberStatus } from "./memberStatus.stylex";
 import { BottleRatings, type TastingRatingCounts } from "./scoring.stylex";
 
@@ -28,6 +33,7 @@ export type SearchResultRatings = {
 };
 
 export type SearchResultItem = {
+  bottle?: Pick<BottleIdentityRowProps, "provenance" | "metadata">;
   href: string;
   id: string;
   isFollowing?: boolean;
@@ -271,57 +277,98 @@ function SearchResultsGroup({
       <ul {...stylex.props(styles.list)}>
         {group.items.map((item) => (
           <li key={item.id} {...stylex.props(styles.listItem)}>
-            <AppLink
-              href={item.href}
-              id={
-                optionIdPrefix
-                  ? `${optionIdPrefix}-${encodeURIComponent(item.id)}`
-                  : undefined
-              }
-              onClick={(event) => {
-                if (onItemSelect) {
-                  event.preventDefault();
-                  onItemSelect(item);
+            {item.visual?.kind === "bottle" ? (
+              <div
+                id={
+                  optionIdPrefix
+                    ? `${optionIdPrefix}-${encodeURIComponent(item.id)}`
+                    : undefined
                 }
-              }}
-              {...stylex.props(
-                styles.result,
-                variant === "database" && styles.databaseResult,
-                item.id === activeId && styles.activeResult,
-              )}
-            >
-              {item.visual ? <ResultVisual visual={item.visual} /> : null}
-              <span {...stylex.props(styles.copy)}>
-                <strong
-                  title={item.title}
-                  {...stylex.props(foundationStyles.rowTitle, styles.title)}
-                >
-                  <MatchedText query={query} text={item.title} />
-                  {item.isFollowing ? <MemberStatus kind="following" /> : null}
-                </strong>
-                {item.metadata ? (
-                  <span
-                    title={item.metadata}
-                    {...stylex.props(
-                      foundationStyles.metadata,
-                      styles.metadata,
-                    )}
+                {...stylex.props(
+                  styles.result,
+                  variant === "database" && styles.databaseResult,
+                  item.id === activeId && styles.activeResult,
+                )}
+              >
+                <BottleIdentityRow
+                  {...item.bottle}
+                  align="start"
+                  href={item.href}
+                  imageUrl={item.visual.imageUrl}
+                  metadata={
+                    item.bottle?.metadata ??
+                    (item.metadata ? item.metadata.split(" · ") : [])
+                  }
+                  name={item.title}
+                  query={query}
+                  onClick={(event) => {
+                    if (onItemSelect) {
+                      event.preventDefault();
+                      onItemSelect(item);
+                    }
+                  }}
+                  end={
+                    item.ratings ? (
+                      <ResultRatings ratings={item.ratings} />
+                    ) : undefined
+                  }
+                />
+              </div>
+            ) : (
+              <AppLink
+                href={item.href}
+                id={
+                  optionIdPrefix
+                    ? `${optionIdPrefix}-${encodeURIComponent(item.id)}`
+                    : undefined
+                }
+                onClick={(event) => {
+                  if (onItemSelect) {
+                    event.preventDefault();
+                    onItemSelect(item);
+                  }
+                }}
+                {...stylex.props(
+                  styles.result,
+                  variant === "database" && styles.databaseResult,
+                  item.id === activeId && styles.activeResult,
+                )}
+              >
+                {item.visual ? <ResultVisual visual={item.visual} /> : null}
+                <span {...stylex.props(styles.copy)}>
+                  <strong
+                    title={item.title}
+                    {...stylex.props(foundationStyles.rowTitle, styles.title)}
                   >
-                    {item.metadata}
-                  </span>
-                ) : null}
+                    <MatchedText query={query} text={item.title} />
+                    {item.isFollowing ? (
+                      <MemberStatus kind="following" />
+                    ) : null}
+                  </strong>
+                  {item.metadata ? (
+                    <span
+                      title={item.metadata}
+                      {...stylex.props(
+                        foundationStyles.metadata,
+                        styles.metadata,
+                      )}
+                    >
+                      {item.metadata}
+                    </span>
+                  ) : null}
+                  {item.ratings ? (
+                    <span {...stylex.props(styles.compactRatings)}>
+                      <ResultRatings ratings={item.ratings} />
+                    </span>
+                  ) : null}
+                </span>
                 {item.ratings ? (
-                  <span {...stylex.props(styles.compactRatings)}>
+                  <span {...stylex.props(styles.wideRatings)}>
                     <ResultRatings ratings={item.ratings} />
                   </span>
                 ) : null}
-              </span>
-              {item.ratings ? (
-                <span {...stylex.props(styles.wideRatings)}>
-                  <ResultRatings ratings={item.ratings} />
-                </span>
-              ) : null}
-            </AppLink>
+              </AppLink>
+            )}
           </li>
         ))}
       </ul>
@@ -367,24 +414,6 @@ function ResultRatings({ ratings }: { ratings: SearchResultRatings }) {
       scoreCount={ratings.score?.count}
     />
   ) : null;
-}
-
-function MatchedText({ query, text }: { query: string; text: string }) {
-  const normalizedQuery = query.trim().toLocaleLowerCase();
-  const start = normalizedQuery
-    ? text.toLocaleLowerCase().indexOf(normalizedQuery)
-    : -1;
-
-  if (start < 0) return text;
-
-  const end = start + normalizedQuery.length;
-  return (
-    <>
-      {text.slice(0, start)}
-      <mark {...stylex.props(styles.match)}>{text.slice(start, end)}</mark>
-      {text.slice(end)}
-    </>
-  );
 }
 
 const styles = stylex.create({
@@ -560,11 +589,6 @@ const styles = stylex.create({
     color: "inherit",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
-  },
-  match: {
-    borderRadius: "1px",
-    backgroundColor: colors.accentTint,
-    color: "inherit",
   },
   metadata: {
     maxWidth: "100%",

--- a/apps/web/src/components/selectedBottleSummary.stories.tsx
+++ b/apps/web/src/components/selectedBottleSummary.stories.tsx
@@ -1,3 +1,4 @@
+import { mockBottle } from "@peated/server/orpc/mock/fixtures";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
 import BottleImage from "../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
@@ -8,10 +9,8 @@ const meta = {
   title: "Components/Bottles/Selected Bottle Summary",
   component: SelectedBottleSummary,
   args: {
-    brand: "Lagavulin",
+    bottle: mockBottle,
     imageUrl: BottleImage.src,
-    metadata: "Islay · 16 years · 43.0% ABV · ex-bourbon",
-    name: "16-year-old",
     onChange: () => undefined,
   },
   argTypes: {
@@ -35,10 +34,21 @@ export const Overview: Story = {
       <SelectedBottleSummary {...args} />
       <SelectedBottleSummary {...args} onChange={undefined} />
       <SelectedBottleSummary
-        brand="Bruichladdich"
+        bottle={{
+          ...mockBottle,
+          brand: {
+            ...mockBottle.brand,
+            name: "Bruichladdich",
+            shortName: null,
+          },
+          name: "Octomore Edition 15.3 Islay Barley Super Heavily Peated",
+          group: null,
+          statedAge: null,
+          noAgeStatement: true,
+          abv: 61.5,
+          imageUrl: null,
+        }}
         imageUrl={null}
-        metadata="Islay · No age statement · 61.5% ABV · oloroso and bourbon casks"
-        name="Octomore Edition 15.3 Islay Barley Super Heavily Peated"
       />
     </StoryStack>
   ),

--- a/apps/web/src/components/selectedBottleSummary.stylex.tsx
+++ b/apps/web/src/components/selectedBottleSummary.stylex.tsx
@@ -1,27 +1,27 @@
+import {
+  getBottleIdentityProps,
+  type BottleIdentitySource,
+} from "@peated/web/lib/bottleListItem";
 import { BottleIdentityRow } from "./bottleIdentityRow.stylex";
 import { Button } from "./button.stylex";
 
 export type SelectedBottleSummaryProps = {
-  brand: string;
+  bottle: BottleIdentitySource & { imageUrl?: string | null };
   imageUrl?: string | null;
-  metadata: string;
-  name: string;
   /** Shows a change action when the owning workflow allows bottle selection. */
   onChange?: () => void;
 };
 
 /** Keeps the selected bottle visible while a member completes a related form. */
 export function SelectedBottleSummary({
-  brand,
+  bottle,
   imageUrl,
-  metadata,
-  name,
   onChange,
 }: SelectedBottleSummaryProps) {
   return (
     <section aria-label="Selected bottle">
       <BottleIdentityRow
-        brand={brand}
+        {...getBottleIdentityProps(bottle)}
         end={
           onChange ? (
             <Button onClick={onChange} size="sm" variant="text">
@@ -29,10 +29,8 @@ export function SelectedBottleSummary({
             </Button>
           ) : undefined
         }
-        imageUrl={imageUrl}
+        imageUrl={imageUrl ?? bottle.imageUrl}
         layout="cell"
-        metadata={metadata ? metadata.split(" · ") : []}
-        name={name}
       />
     </section>
   );

--- a/apps/web/src/components/tastingEntry.stylex.tsx
+++ b/apps/web/src/components/tastingEntry.stylex.tsx
@@ -10,7 +10,11 @@ import {
   space,
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
-import { BottleVisual } from "./bottleIdentityRow.stylex";
+import {
+  BottleIdentityRow,
+  BottleVisual,
+  type BottleIdentityRowProps,
+} from "./bottleIdentityRow.stylex";
 import { Chip } from "./chip.stylex";
 import { TastingRating, type RatingBand } from "./scoring.stylex";
 import { TastingToastSummary } from "./tastingToastButton.stylex";
@@ -21,6 +25,7 @@ const bottleIconUrl = "/assets/bottle.svg";
 export type TastingMediaKind = "bottle" | "photo";
 
 export type TastingEntryMember = {
+  bottle?: Pick<BottleIdentityRowProps, "name" | "provenance" | "metadata">;
   color?: string;
   comments?: number;
   hasToasted?: boolean;
@@ -70,11 +75,6 @@ export function TastingEntry({
             key={`${member.tastingId ?? member.href ?? member.name}-${member.name}`}
             {...stylex.props(styles.member)}
           >
-            <TastingMedia
-              imageKind={member.imageKind}
-              imageUrl={member.imageUrl}
-              size="card"
-            />
             <div {...stylex.props(styles.memberBody)}>
               <div {...stylex.props(styles.headingRow)}>
                 <div {...stylex.props(styles.memberCopy)}>
@@ -109,37 +109,17 @@ export function TastingEntry({
                       </span>
                     </div>
                   </header>
-                  {member.href ? (
-                    <AppLink
-                      href={member.href}
-                      title={member.name}
-                      {...stylex.props(
-                        foundationStyles.rowTitle,
-                        styles.name,
-                        styles.nameLink,
-                      )}
-                    >
-                      {member.name}
-                    </AppLink>
-                  ) : (
-                    <span
-                      title={member.name}
-                      {...stylex.props(foundationStyles.rowTitle, styles.name)}
-                    >
-                      {member.name}
-                    </span>
-                  )}
-                  {member.metadata ? (
-                    <span
-                      title={member.metadata}
-                      {...stylex.props(
-                        foundationStyles.metadata,
-                        styles.metadata,
-                      )}
-                    >
-                      {member.metadata}
-                    </span>
-                  ) : null}
+                  <BottleIdentityRow
+                    {...member.bottle}
+                    align="start"
+                    href={member.href}
+                    imageUrl={member.imageUrl}
+                    metadata={
+                      member.bottle?.metadata ??
+                      (member.metadata ? member.metadata.split(" · ") : [])
+                    }
+                    name={member.bottle?.name ?? member.name}
+                  />
                 </div>
                 <div {...stylex.props(styles.rating)}>
                   {member.ratingBand ? (
@@ -373,41 +353,6 @@ const styles = stylex.create({
   menu: {
     display: "flex",
     flexShrink: 0,
-  },
-  name: {
-    display: "block",
-    marginTop: space.x2,
-    overflow: "hidden",
-    color: colors.ink,
-    textDecoration: "none",
-    textOverflow: { default: "ellipsis", [COMPACT]: "clip" },
-    whiteSpace: { default: "nowrap", [COMPACT]: "normal" },
-    outline: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
-  },
-  nameLink: {
-    color: {
-      default: colors.ink,
-      ":hover": colors.accentDeep,
-      ":active": colors.accentDeep,
-      ":focus-visible": colors.accentDeep,
-    },
-    textDecorationLine: {
-      default: "none",
-      ":hover": "underline",
-      ":active": "underline",
-      ":focus-visible": "underline",
-    },
-  },
-  metadata: {
-    marginTop: space.x1,
-    overflow: "hidden",
-    color: colors.inkMuted,
-    textOverflow: { default: "ellipsis", [COMPACT]: "clip" },
-    whiteSpace: { default: "nowrap", [COMPACT]: "normal" },
   },
   notes: {
     margin: 0,

--- a/apps/web/src/components/tastingForm.tsx
+++ b/apps/web/src/components/tastingForm.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { toTitleCase } from "@peated/server/lib/strings";
 import type { TastingSchema } from "@peated/server/schemas";
 import type { User } from "@peated/server/types";
@@ -32,7 +31,6 @@ import {
   type RecordType,
 } from "@peated/web/components/recordTypeInput.stylex";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
-import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import type { ImageUploadValue } from "@peated/web/lib/imageUpload";
 import {
@@ -411,18 +409,11 @@ export default function TastingForm(
       <form onSubmit={formAction}>
         <FormStack>
           <SelectedBottleSummary
-            brand={
-              initialData.bottle.brand.shortName ||
-              initialData.bottle.brand.name
-            }
+            bottle={initialData.bottle}
             imageUrl={
               (isReview ? effectiveReviewImagePreview : imagePreview) ??
               initialData.bottle.imageUrl
             }
-            metadata={getBottleMetadata(initialData.bottle)}
-            name={formatBottleDisplayName(initialData.bottle, {
-              includeBrand: false,
-            })}
           />
           {submitError || errorMessage ? (
             <FormNotice>{submitError ?? errorMessage}</FormNotice>

--- a/apps/web/src/components/tastingRecordEntry.tsx
+++ b/apps/web/src/components/tastingRecordEntry.tsx
@@ -1,9 +1,6 @@
 import type { Outputs } from "@peated/server/orpc/router";
 
-import {
-  formatBottleDisplayName,
-  type BottleDisplayNameSource,
-} from "@peated/server/lib/bottleDisplayName";
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { formatColor, formatServingStyle } from "@peated/server/lib/format";
 import {
   MemberAvatar,
@@ -12,16 +9,16 @@ import {
 } from "@peated/web/components";
 import TimeSince from "@peated/web/components/timeSince";
 import {
-  getBottleMetadata,
-  type BottleMetadata,
-} from "@peated/web/lib/bottleMetadata";
+  getBottleIdentityProps,
+  type BottleIdentitySource,
+} from "@peated/web/lib/bottleListItem";
+import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getBottleUrl } from "@peated/web/lib/urls";
 
 type Tasting = Outputs["tastings"]["list"]["results"][number];
 
 type TastingEntryRecord = {
-  bottle: BottleDisplayNameSource &
-    BottleMetadata & { id: number; imageUrl?: string | null };
+  bottle: BottleIdentitySource & { id: number; imageUrl?: string | null };
   color?: number | null;
   comments?: number;
   hasToasted?: boolean;
@@ -38,6 +35,7 @@ export function getTastingEntryMember(
   tasting: TastingEntryRecord,
 ): TastingEntryMember {
   return {
+    bottle: getBottleIdentityProps(tasting.bottle),
     color:
       tasting.color === null || tasting.color === undefined
         ? undefined

--- a/apps/web/src/lib/bottleListItem.test.ts
+++ b/apps/web/src/lib/bottleListItem.test.ts
@@ -4,11 +4,11 @@ import { describe, expect, test } from "vitest";
 import { toBottleListItem } from "./bottleListItem";
 
 describe("toBottleListItem", () => {
-  test("separates the brand from the expression in standard bottle lists", () => {
+  test("uses the full marketed name and separates provenance from release facts", () => {
     expect(toBottleListItem(mockBottle)).toMatchObject({
-      brand: "Lagavulin",
-      brandHref: "/distillers/9201-lagavulin",
-      name: "16-year-old",
+      name: "Lagavulin 16-year-old",
+      provenance: [{ name: "Single Malt" }],
+      metadata: ["16 years", "43.0% ABV"],
     });
   });
 
@@ -18,35 +18,34 @@ describe("toBottleListItem", () => {
     ["bottler", "bottlers"],
     ["company", "companies"],
   ] as const)(
-    "links a %s used as the brand to its own collection",
+    "links a %s used as a distinct distiller to its own collection",
     (kind, collection) => {
-      const bottle = { ...mockBottle, brand: { ...mockBottle.brand, kind } };
+      const bottle = {
+        ...mockBottle,
+        brand: { ...mockBottle.brand, id: 999 },
+        distillers: [{ ...mockBottle.brand, kind }],
+      };
 
-      expect(toBottleListItem(bottle).brandHref).toBe(
-        `/${collection}/9201-lagavulin`,
-      );
+      expect(toBottleListItem(bottle).provenance).toContainEqual({
+        name: "Lagavulin",
+        href: `/${collection}/9201-lagavulin`,
+      });
     },
   );
 
-  test("keeps the brand in the name when the brand row is disabled", () => {
+  test("does not repeat a distiller already identified by the brand", () => {
     expect(
-      toBottleListItem(mockBottle, { includeBrandRow: false }),
-    ).toMatchObject({
-      brand: undefined,
-      brandHref: undefined,
-      name: "Lagavulin 16-year-old",
-    });
+      toBottleListItem({ ...mockBottle, distillers: [mockBottle.brand] })
+        .provenance,
+    ).toEqual([{ name: "Single Malt" }]);
   });
 
   test("can omit the brand from a list owned by that brand", () => {
     expect(
       toBottleListItem(mockBottle, {
         includeBrandInName: false,
-        includeBrandRow: false,
       }),
     ).toMatchObject({
-      brand: undefined,
-      brandHref: undefined,
       name: "16-year-old",
     });
   });
@@ -63,8 +62,11 @@ describe("toBottleListItem", () => {
 
     expect(
       toBottleListItem({ ...mockBottle, bottler }, { includeBottler: true })
-        .subtitle,
-    ).toBe("Bottled by SMWS");
+        .provenance,
+    ).toContainEqual({
+      name: "Bottled by SMWS",
+      href: "/bottlers/4263-the-scotch-malt-whisky-society",
+    });
   });
 
   test("does not repeat the brand when it also fills the bottler role", () => {
@@ -72,7 +74,30 @@ describe("toBottleListItem", () => {
       toBottleListItem(
         { ...mockBottle, bottler: mockBottle.brand },
         { includeBottler: true },
-      ).subtitle,
-    ).toBeUndefined();
+      ).provenance,
+    ).toEqual([{ name: "Single Malt" }]);
+  });
+
+  test("uses only known release facts without manufacturing missing dates or ages", () => {
+    expect(
+      toBottleListItem({
+        ...mockBottle,
+        releaseYear: 2026,
+        releaseMonth: null,
+        releaseDay: null,
+        statedAge: null,
+        noAgeStatement: null,
+        abv: null,
+      }).metadata,
+    ).toEqual(["2026 release"]);
+    expect(
+      toBottleListItem({
+        ...mockBottle,
+        releaseYear: null,
+        statedAge: null,
+        noAgeStatement: true,
+        abv: null,
+      }).metadata,
+    ).toEqual(["No age statement"]);
   });
 });

--- a/apps/web/src/lib/bottleListItem.ts
+++ b/apps/web/src/lib/bottleListItem.ts
@@ -1,8 +1,14 @@
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
-import { formatReleaseDate } from "@peated/server/lib/bottleRelease";
+import {
+  formatBottleDisplayName,
+  getBottleReleaseMetadata,
+  type BottleDisplayNameSource,
+} from "@peated/server/lib/bottleDisplayName";
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
-import type { BottleListItem } from "@peated/web/components";
+import type {
+  BottleIdentityRowProps,
+  BottleListItem,
+} from "@peated/web/components";
 
 import { getReleaseFamilyHref } from "./releaseFamily";
 import { getBottleUrl, getEntityUrl } from "./urls";
@@ -12,51 +18,95 @@ type Bottle = Outputs["bottles"]["list"]["results"][number];
 export type BottleListItemOptions = {
   includeBottler?: boolean;
   includeBrandInName?: boolean;
-  includeBrandRow?: boolean;
   includeRatings?: boolean;
   includeRelatedReleases?: boolean;
   includeSeriesInName?: boolean;
 };
 
-/** Maps one API Bottle to the shared standard list presentation. */
-export function toBottleListItem(
-  bottle: Bottle,
+export type BottleIdentitySource = BottleDisplayNameSource & {
+  brand: BottleDisplayNameSource["brand"] & { id?: number };
+} & Pick<Bottle, "abv" | "category" | "noAgeStatement" | "statedAge"> &
+  Partial<Pick<Bottle, "bottler" | "distillers">>;
+
+/** The same three identity lines apply to lists, selections, and partial Bottle reads. */
+export function getBottleIdentityProps(
+  bottle: BottleIdentitySource,
   {
     includeBottler = false,
-    includeBrandInName,
-    includeBrandRow = true,
-    includeRatings = false,
-    includeRelatedReleases = false,
+    includeBrandInName = true,
     includeSeriesInName = true,
-  }: BottleListItemOptions = {},
-): BottleListItem {
-  const releaseDate = formatReleaseDate(bottle);
-  const relatedReleaseCount = bottle.group?.totalBottles ?? 1;
-
+  }: Pick<
+    BottleListItemOptions,
+    "includeBottler" | "includeBrandInName" | "includeSeriesInName"
+  > = {},
+): Pick<BottleIdentityRowProps, "align" | "name" | "provenance" | "metadata"> {
+  const releaseFact = getBottleReleaseMetadata(bottle);
+  const releaseYear =
+    bottle.releaseYear == null ? null : `${bottle.releaseYear} release`;
   return {
-    brand: includeBrandRow
-      ? bottle.brand.shortName || bottle.brand.name
-      : undefined,
-    brandHref: includeBrandRow ? getEntityUrl(bottle.brand) : undefined,
-    hasTasted: bottle.hasTasted,
-    href: getBottleUrl(bottle),
-    id: bottle.peatedId,
-    imageUrl: bottle.imageUrl,
-    isLibrary: bottle.isLibrary,
+    align: "start",
+    name: formatBottleDisplayName(bottle, {
+      includeBrand: includeBrandInName,
+      includeSeries: includeSeriesInName,
+    }),
+    provenance: [
+      ...(bottle.distillers ?? [])
+        .filter((distiller) => distiller.id !== bottle.brand.id)
+        .map((distiller) => ({
+          name: distiller.name,
+          href: getEntityUrl(distiller),
+        })),
+      ...(includeBottler &&
+      bottle.bottler &&
+      bottle.bottler.id !== bottle.brand.id
+        ? [
+            {
+              name: `Bottled by ${bottle.bottler.shortName || bottle.bottler.name}`,
+              href: getEntityUrl(bottle.bottler),
+            },
+          ]
+        : []),
+      ...(bottle.category
+        ? [{ name: formatCategoryName(bottle.category) }]
+        : []),
+    ],
     metadata: [
-      releaseDate ? `${releaseDate} release` : null,
-      bottle.category ? formatCategoryName(bottle.category) : null,
+      releaseFact !== releaseYear ? releaseFact : null,
+      releaseYear,
       bottle.statedAge !== null
         ? `${bottle.statedAge} years`
         : bottle.noAgeStatement
           ? "No age statement"
           : null,
-      bottle.abv !== null ? `${formatAbv(bottle.abv)}% ABV` : null,
+      bottle.abv !== null ? `${bottle.abv.toFixed(1)}% ABV` : null,
     ].filter((value): value is string => value !== null),
-    name: formatBottleDisplayName(bottle, {
-      includeBrand: includeBrandInName ?? !includeBrandRow,
-      includeSeries: includeSeriesInName,
+  };
+}
+
+/** Owns the three-line identity used by every standard bottle row, including home and Library. */
+export function toBottleListItem(
+  bottle: Bottle,
+  {
+    includeBottler = false,
+    includeBrandInName = true,
+    includeRatings = false,
+    includeRelatedReleases = false,
+    includeSeriesInName = true,
+  }: BottleListItemOptions = {},
+): BottleListItem {
+  const relatedReleaseCount = bottle.group?.totalBottles ?? 1;
+
+  return {
+    ...getBottleIdentityProps(bottle, {
+      includeBottler,
+      includeBrandInName,
+      includeSeriesInName,
     }),
+    hasTasted: bottle.hasTasted,
+    href: getBottleUrl(bottle),
+    id: bottle.peatedId,
+    imageUrl: bottle.imageUrl,
+    isLibrary: bottle.isLibrary,
     ratings: includeRatings
       ? {
           counts: bottle.tastingBandCounts,
@@ -73,13 +123,5 @@ export function toBottleListItem(
             href: getReleaseFamilyHref(bottle),
           }
         : undefined,
-    subtitle:
-      includeBottler && bottle.bottler && bottle.bottler.id !== bottle.brand.id
-        ? `Bottled by ${bottle.bottler.shortName || bottle.bottler.name}`
-        : undefined,
   };
-}
-
-function formatAbv(abv: number) {
-  return abv.toFixed(1).replace(/\.0$/, "");
 }

--- a/apps/web/src/lib/communityFeed.ts
+++ b/apps/web/src/lib/communityFeed.ts
@@ -2,6 +2,7 @@ import type { Outputs } from "@peated/server/orpc/router";
 
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { CommunityFeedItem } from "@peated/web/components/communityFeed.stylex";
+import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getBottleUrl } from "@peated/web/lib/urls";
 
@@ -22,6 +23,7 @@ export function getCommunityFeedItems({
     return [
       {
         actor: source,
+        bottle: getBottleIdentityProps(review.bottle),
         actorHref: review.url,
         bottleHref: getBottleUrl(review.bottle),
         date: review.article.publishedAt ?? review.createdAt,
@@ -41,6 +43,7 @@ export function getCommunityFeedItems({
   const tastingItems = memberTastings.map(
     (tasting): CommunityFeedItem => ({
       actor: tasting.createdBy.username,
+      bottle: getBottleIdentityProps(tasting.bottle),
       actorHref: `/users/${tasting.createdBy.username}`,
       bottleHref: getBottleUrl(tasting.bottle),
       date: tasting.createdAt,

--- a/docs/features/bottle-presentation.md
+++ b/docs/features/bottle-presentation.md
@@ -205,6 +205,21 @@ identity into `fullName`.
 Use for search results, bottle tables, activity cards, selection results, and
 similar repeated items that support a title plus secondary metadata.
 
+`BottleIdentityRow` owns the shared three-line layout used by the homepage's
+New for you list, Library, catalog lists, search results, activity, and selected
+bottle summaries. `getBottleIdentityProps` supplies its identity fields;
+`toBottleListItem` adds links, images, and optional list actions and ratings.
+Do not rebuild these lines in a page-specific mapper:
+
+1. The marketed bottle name, including brand context.
+2. Distillers not already identified by the brand, followed by the category.
+3. Known release facts, stated age, and ABV.
+
+Missing facts do not create placeholder lines. Activity context, Library status,
+personal images, and actions belong to their owning view, not a competing bottle
+identity layout. Compact rails and primary page headings remain separate display
+contexts.
+
 - Show enough producer, series, and expression context to recognize the Bottle
   outside its detail page.
 - Include a named release marker in the title.


### PR DESCRIPTION
Library and other standard bottle displays now use the same three-line row as the homepage's “New for you”: marketed name, producer/category context, then known release facts, age, and ABV.

The shared row previously allowed competing layouts and page-specific formatting. One identity mapper now feeds that component across Library, catalog and flight lists, search, activity, tastings, and selected-bottle summaries. Library photos, status, and actions remain view-specific; search highlighting and independent review/bottle links are preserved. Sorting is unchanged.

The row-layout story uses one bottle across each context for comparison. Browser checks covered desktop/mobile and light/dark, while focused regression tests exercised Library edits, flight actions, activity links, and bottle selection. The web test suite and typecheck pass; the full repository suite remains for CI.
