### PR TITLE
fix(tasting): use standard bottle rows and clarify wheel copy

### DIFF
--- a/apps/server/src/orpc/contracts/bottles/flavor-profile.ts
+++ b/apps/server/src/orpc/contracts/bottles/flavor-profile.ts
@@ -8,7 +8,7 @@ export default contract
     path: "/bottles/{bottle}/flavor-profile",
     summary: "Get a bottle flavor profile",
     description:
-      "Count public tastings of one active Bottle with each tasting-note family. Each tasting counts once per family. Only tastings with recognized notes enter the denominator; private and suggested notes are excluded.",
+      "Count public tastings of one active Bottle with each tasting-note category. Each tasting counts once per category. Only tastings with recognized notes enter the denominator; private and suggested notes are excluded.",
     spec: (spec) => ({ ...spec, operationId: "getBottleFlavorProfile" }),
   })
   .input(z.object({ bottle: z.coerce.number().int().positive() }))

--- a/apps/server/src/orpc/routes/bottles/flavor-profile.test.ts
+++ b/apps/server/src/orpc/routes/bottles/flavor-profile.test.ts
@@ -4,7 +4,7 @@ import { bottleTombstones, tastings } from "@peated/server/db/schema";
 import { routerClient } from "@peated/server/orpc/router";
 
 describe("GET /bottles/{bottle}/flavor-profile", () => {
-  test("counts public tastings once per family and keeps exact Bottle scope", async ({
+  test("counts public tastings once per category and keeps exact Bottle scope", async ({
     fixtures,
     defaults,
   }) => {

--- a/apps/server/src/orpc/routes/bottles/flavor-profile.ts
+++ b/apps/server/src/orpc/routes/bottles/flavor-profile.ts
@@ -17,7 +17,7 @@ export default implement(flavorProfileContract).handler(
         await resolveActiveBottleIds(tx, [input.bottle]);
 
         // Bottle flavor profiles are public: this route excludes private notes,
-        // even for their author, and counts each tasting once per family.
+        // even for their author, and counts each tasting once per category.
         const result = await tx.execute<BottleFlavorProfile>(sql`
         WITH public_notes AS MATERIALIZED (
           SELECT DISTINCT ${tastings.id} AS tasting_id,

--- a/apps/web/e2e/routes.spec.ts
+++ b/apps/web/e2e/routes.spec.ts
@@ -93,11 +93,16 @@ test("public routes load", async ({ page, snapshot }) => {
           });
           await expect(panel).toHaveAttribute("aria-modal", "true");
           await expect(
-            panel.getByRole("heading", { name: "Bottles across Peated" }),
+            panel.getByRole("heading", { name: "Bottles with these notes" }),
           ).toBeVisible();
-          await expect(panel.getByRole("link").first()).toHaveAttribute(
+          await expect(
+            panel.getByRole("link", {
+              name: existingBottle.group.name,
+              exact: true,
+            }),
+          ).toHaveAttribute(
             "href",
-            `/bottles/${existingBottle.id}`,
+            new RegExp(`^/bottles/${existingBottle.id}-`),
           );
           await page.keyboard.press("Escape");
           await expect(panel).toHaveCount(0);

--- a/apps/web/src/app/(app)/about/tasting-wheel/page.tsx
+++ b/apps/web/src/app/(app)/about/tasting-wheel/page.tsx
@@ -3,7 +3,7 @@ import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import type { Metadata } from "next";
 import { AboutPage, AboutText, AboutTextStack } from "../aboutPage.stylex";
 import {
-  TastingWheelFamilies,
+  TastingWheelCategories,
   TastingWheelIntroduction,
 } from "./tastingWheel.stylex";
 
@@ -21,38 +21,42 @@ export default function TastingWheelPage() {
     <TastingWheelProvider>
       <AboutPage
         currentHref="/about/tasting-wheel"
-        description="Find words for what you smell and taste."
+        description="Know the taste, but can’t quite name it? The wheel gives you a few words to try."
         title="Tasting wheel"
       >
         <TastingWheelIntroduction />
 
         <PageSection
           heading="Tasting notes"
-          intro="Browse the flavor families below. These words are suggestions, not a checklist."
+          intro="These are the notes you can choose when you log a tasting."
         >
-          <TastingWheelFamilies />
+          <TastingWheelCategories />
         </PageSection>
 
         <PageSection heading="About this wheel">
           <AboutTextStack>
             <AboutText>
-              Peated uses the Wine &amp; Spirit Education Trust&apos;s 2025
-              tasting guide as its main source. We also looked at tasting wheels
-              for Scotch, American whiskey, and Canadian whisky. None uses these
-              exact flavor families.
+              Our starting point was the Wine &amp; Spirit Education
+              Trust&apos;s 2025 tasting guide, alongside wheels for Scotch,
+              American whiskey, and Canadian whisky. The 9 categories here are
+              our own arrangement of those ideas.
             </AboutText>
             <AboutText>
-              Some guides put words together because they can have the same
-              cause. Peated puts words together when they smell or taste alike.
-              One note can have more than one cause.
+              The categories reflect what the notes remind you of. You
+              don&apos;t need to know whether a flavor came from the grain, the
+              still, or the cask to put a name to it.
             </AboutText>
             <AboutText>
-              The flavor profile on a bottle page shows how often its public
-              tastings mention each family. On distillery and region pages, it
-              shows how common each family is across bottles with notes. These
-              profiles show commonality, not intensity.
+              On a bottle page, a larger slice means more public tastings
+              mention that category. On distillery and region pages, it means
+              more bottles have those notes. Neither tells you how strong a
+              flavor tastes, and your notes don&apos;t have to match anyone
+              else&apos;s.
             </AboutText>
           </AboutTextStack>
+        </PageSection>
+
+        <PageSection heading="Sources and references">
           <RailList ariaLabel="Tasting wheel sources">
             <RailListItem
               href="https://www.wsetglobal.com/media/16506/wset_l3spirits_sat_en_feb2025_issue3.pdf"

--- a/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
+++ b/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
@@ -66,11 +66,13 @@ export function TastingWheelIntroduction() {
           Start with what you notice
         </SectionHeading>
         <p {...stylex.props(styles.directionText)}>
-          Start with something broad, like fruit or spice, then look outward for
-          a more specific note. Choose only what fits what you smell and taste.
+          Does it remind you of fruit? Follow that part of the wheel outward.
+          Maybe it&apos;s a crisp apple, a little citrus, or a handful of
+          raisins. A couple of words is plenty. Leave out anything you
+          don&apos;t taste.
         </p>
         <p {...stylex.props(styles.directionText)}>
-          Select a note to read its description and see bottle examples.
+          Pick a note to find out more and see bottles with that flavor.
         </p>
       </div>
     </section>
@@ -92,8 +94,8 @@ function TastingWheelGraphic() {
         >
           <title id="tasting-wheel-title">Peated tasting wheel</title>
           <desc id="tasting-wheel-description">
-            Explore a flavor family or a note to find related words and example
-            bottles.
+            Explore a flavor category or a note to find related words and
+            example bottles.
           </desc>
           {WHEEL_CATEGORIES.map((category, categoryIndex) => {
             const startAngle = categoryIndex * categorySpan;
@@ -202,15 +204,15 @@ function TastingWheelGraphic() {
   );
 }
 
-export function TastingWheelFamilies() {
+export function TastingWheelCategories() {
   const { select } = useTastingWheel();
   return (
-    <div {...stylex.props(styles.familyGrid)}>
+    <div {...stylex.props(styles.categoryGrid)}>
       {WHEEL_CATEGORIES.map((category) => (
         <article
           id={`tasting-note-${category.key}`}
           key={category.key}
-          {...stylex.props(styles.family)}
+          {...stylex.props(styles.category)}
         >
           <SectionHeading level={3}>{category.name}</SectionHeading>
           <button
@@ -226,7 +228,7 @@ export function TastingWheelFamilies() {
           >
             See examples
           </button>
-          <p {...stylex.props(styles.familyDescription)}>
+          <p {...stylex.props(styles.categoryDescription)}>
             {category.description}
           </p>
           <div {...stylex.props(styles.notes)}>
@@ -338,7 +340,7 @@ const styles = stylex.create({
     fontWeight: 600,
     pointerEvents: "none",
   },
-  familyGrid: {
+  categoryGrid: {
     display: "grid",
     gridTemplateColumns: {
       default: "repeat(3, minmax(0, 1fr))",
@@ -348,7 +350,7 @@ const styles = stylex.create({
     columnGap: space.x6,
     rowGap: space.x8,
   },
-  family: {
+  category: {
     minWidth: 0,
     paddingTop: space.x3,
     borderTopWidth: "1px",
@@ -356,7 +358,7 @@ const styles = stylex.create({
     borderTopColor: colors.hairline,
     scrollMarginTop: space.x8,
   },
-  familyDescription: {
+  categoryDescription: {
     margin: 0,
     marginTop: space.x2,
     color: colors.inkMuted,

--- a/apps/web/src/components/flavorWheel.stylex.tsx
+++ b/apps/web/src/components/flavorWheel.stylex.tsx
@@ -36,11 +36,11 @@ const label = (category: string) =>
   category.charAt(0).toUpperCase() + category.slice(1);
 
 /**
- * Distribution of public tasting-note families across bottles or one bottle's tastings.
+ * Distribution of public tasting-note categories across bottles or one bottle's tastings.
  * Each wedge has a fixed position and an independent 0–100% area scale.
- * Hover or keyboard focus previews a family's share and two leading notes.
+ * Hover or keyboard focus previews a category's share and two leading notes.
  * The center keeps the last preview when the pointer or focus leaves the wheel.
- * Activating a wedge calls onExplore to open that family's notes and bottles.
+ * Activating a wedge calls onExplore to open that category's notes and bottles.
  * The parent supplies the heading and centered reference links through footer.
  * Any recognized notes render a chart; empty data shows a short message.
  */
@@ -99,7 +99,7 @@ export function FlavorWheel({
             <svg
               viewBox="0 0 336 292"
               role="group"
-              aria-label="Flavor families"
+              aria-label="Flavor categories"
               {...stylex.props(styles.wheel)}
             >
               {categories.map((item, index) => {

--- a/apps/web/src/components/flavorWheel.test.tsx
+++ b/apps/web/src/components/flavorWheel.test.tsx
@@ -9,7 +9,7 @@ import { createRoot } from "react-dom/client";
 import { expect, test } from "vitest";
 import { FlavorWheel } from "./flavorWheel.stylex";
 
-test("previews families on hover and focus, and explores only on activation", async () => {
+test("previews categories on hover and focus, and explores only on activation", async () => {
   const container = document.createElement("div");
   document.body.append(container);
   const root = createRoot(container);

--- a/apps/web/src/features/tastingWheel/tastingWheelDetails.stylex.tsx
+++ b/apps/web/src/features/tastingWheel/tastingWheelDetails.stylex.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import type { TagCategory } from "@peated/server/types";
-import { BottleIdentityRow, Button, Slideout } from "@peated/web/components";
+import { BottleList, Button, Slideout } from "@peated/web/components";
 import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
+import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
@@ -118,13 +118,10 @@ function TastingWheelDetails({
         </div>
       </section>
       <section aria-busy={query.isPending}>
-        <SectionHeading level={3}>Bottles across Peated</SectionHeading>
+        <SectionHeading level={3}>Bottles with these notes</SectionHeading>
         <p {...stylex.props(styles.explanation)}>
-          Ranked by the share of public tastings with notes that mention{" "}
-          {selection.note
-            ? selection.note
-            : `a note in the ${category.name.toLowerCase()} family`}
-          .
+          Ordered by how often people mention these notes in their public
+          tastings.
         </p>
         <div aria-live="polite">
           {query.isPending ? (
@@ -137,28 +134,16 @@ function TastingWheelDetails({
               </Button>
             </div>
           ) : query.data.results.length ? (
-            <ul {...stylex.props(styles.bottles)}>
-              {query.data.results.map(
-                ({ bottle, matchingTastings, taggedTastings }) => (
-                  <li key={bottle.id} {...stylex.props(styles.bottle)}>
-                    <BottleIdentityRow
-                      name={formatBottleDisplayName(bottle, {
-                        includeBrand: false,
-                      })}
-                      brand={bottle.brand.name}
-                      href={`/bottles/${bottle.id}`}
-                      imageUrl={bottle.imageUrl}
-                      subtitle={`${matchingTastings.toLocaleString()} of ${taggedTastings.toLocaleString()} ${taggedTastings === 1 ? "tasting" : "tastings"}`}
-                      metadata={[...(bottle.abv ? [`${bottle.abv}% ABV`] : [])]}
-                    />
-                  </li>
-                ),
+            <BottleList
+              ariaLabel="Bottles with these tasting notes"
+              items={query.data.results.map(({ bottle }) =>
+                toBottleListItem(bottle),
               )}
-            </ul>
+            />
           ) : (
             <p {...stylex.props(styles.status)}>
               No bottles have recorded tastings for{" "}
-              {selection.note ?? `this family`} yet. Try another note.
+              {selection.note ?? `this category`} yet. Try another note.
             </p>
           )}
         </div>
@@ -198,11 +183,4 @@ const styles = stylex.create({
     textWrap: "pretty",
   },
   status: { marginTop: space.x4, color: colors.inkMuted },
-  bottles: { margin: 0, marginTop: space.x3, padding: 0, listStyle: "none" },
-  bottle: {
-    borderBottom: {
-      default: `1px solid ${colors.hairline}`,
-      ":last-child": "none",
-    },
-  },
 });

--- a/docs/features/bottle-presentation.md
+++ b/docs/features/bottle-presentation.md
@@ -140,17 +140,17 @@ token. The conflict belongs in verification or moderation workflows.
 
 ## Tasting-note flavor profile
 
-Bottle overview pages show a flavor-family wheel below the bottle image. Each
-family measures its occurrence in that exact Bottle's public tastings with
-recognized notes. Each tasting counts once per family; repeat tastings remain
+Bottle overview pages show a flavor-category wheel below the bottle image. Each
+category measures its occurrence in that exact Bottle's public tastings with
+recognized notes. Each tasting counts once per category; repeat tastings remain
 separate observations. Private tastings and suggested tags are excluded, even
 for signed-in authors. Do not combine sibling releases or use summed tag counts
-as family counts.
+as category counts.
 
-Distillery and region wheels instead count each active Bottle once per family.
-Both show commonality, not intensity. Keep family positions fixed. Hovering or
-focusing a family previews its share and leading notes in the center, keeping
-the last preview when the pointer or focus leaves. Clicking a family opens the
+Distillery and region wheels instead count each active Bottle once per category.
+Both show commonality, not intensity. Keep category positions fixed. Hovering or
+focusing a category previews its share and leading notes in the center, keeping
+the last preview when the pointer or focus leaves. Clicking a category opens the
 shared tasting-wheel panel with note descriptions and matching bottles. Omit
 instructional text, raw bottle counts, and contribution CTAs. Any recognized
 public notes produce a chart; none produces a short empty message. The


### PR DESCRIPTION
Tasting-wheel bottle examples now use the standard bottle list, keeping the three lines for brand, bottle name, and metadata instead of inserting counts such as “3 of 3 tastings.” Bottle and brand links use the shared URL helpers.

The guide uses concrete tasting examples and calls the wheel’s sections “categories” throughout. Sources and references have their own section at the bottom of the page.

The focused unit tests and web typecheck pass. The public-route browser check passes the bottle-wheel steps but hits its overall timeout on later pages locally; the full browser run still needs CI verification.
