### PR TITLE
fix(web): place tasting wheel guidance above the graphic

### DIFF
--- a/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
+++ b/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
@@ -60,7 +60,6 @@ export function TastingWheelIntroduction() {
       aria-labelledby="tasting-wheel-introduction"
       {...stylex.props(styles.introduction)}
     >
-      <TastingWheelGraphic />
       <div {...stylex.props(styles.directions)}>
         <SectionHeading id="tasting-wheel-introduction">
           Start with what you notice
@@ -73,6 +72,7 @@ export function TastingWheelIntroduction() {
           Select a note to read its description and see bottle examples.
         </p>
       </div>
+      <TastingWheelGraphic />
     </section>
   );
 }
@@ -251,14 +251,10 @@ export function TastingWheelFamilies() {
 const styles = stylex.create({
   introduction: {
     display: "grid",
-    gridTemplateColumns: {
-      default: "minmax(0, 520px) minmax(0, 1fr)",
-      [TABLET]: "minmax(0, 1fr)",
-    },
-    alignItems: "center",
+    gridTemplateColumns: "minmax(0, 1fr)",
     gap: space.x6,
   },
-  directions: { display: "grid", gap: space.x3, maxWidth: "44ch" },
+  directions: { display: "grid", gap: space.x3, maxWidth: "74ch" },
   directionText: {
     margin: 0,
     fontFamily: fonts.reading,
@@ -267,7 +263,12 @@ const styles = stylex.create({
     color: colors.inkMuted,
     textWrap: "pretty",
   },
-  figure: { margin: 0, maxWidth: "520px" },
+  figure: {
+    margin: 0,
+    width: "100%",
+    maxWidth: "520px",
+    justifySelf: "center",
+  },
   wheelFrame: {
     width: "100%",
     minWidth: 0,


### PR DESCRIPTION
Move the tasting-wheel guidance above the graphic on desktop and mobile, so readers see how to use the wheel before exploring it. Center the wheel beneath the left-aligned introduction and give the text a wider reading measure. The wording and note-selection behavior stay unchanged.
