### PR TITLE
feat(activity): show all activity types with shared bottle rows

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -290,8 +290,8 @@ JSDoc.
   source images have useful transparency.
 - Standard three-line rows share one thumbnail size across bottle lists,
   activity, search, selection, and loading states. Keep the full bottle visible;
-  never crop it to an avatar square. Compact two-line rails may use a smaller
-  thumbnail.
+  never crop it to an avatar square. Single-line bottle rows and compact
+  two-line rails may use smaller thumbnails.
 - State precise values. Do not replace known numbers with vague labels.
 - Do not invent data, rankings, totals, ranges, or derived values in a visual
   component.

--- a/apps/server/src/lib/activityFeed.ts
+++ b/apps/server/src/lib/activityFeed.ts
@@ -1,10 +1,24 @@
 import { db } from "@peated/server/db";
-import type { Collection, Tasting, User } from "@peated/server/db/schema";
-import { collectionBottles, tastings, users } from "@peated/server/db/schema";
+import type {
+  Bottle,
+  Collection,
+  MemberReview,
+  Tasting,
+  User,
+} from "@peated/server/db/schema";
+import {
+  bottles,
+  collectionBottles,
+  memberReviews,
+  tastings,
+  users,
+} from "@peated/server/db/schema";
 import { getReservedCollection } from "@peated/server/lib/db";
 import { serialize } from "@peated/server/serializers";
+import { BottleSerializer } from "@peated/server/serializers/bottle";
 import { CollectionSerializer } from "@peated/server/serializers/collection";
 import { CollectionBottleSerializer } from "@peated/server/serializers/collectionBottle";
+import { MemberReviewSerializer } from "@peated/server/serializers/memberReview";
 import { TastingSerializer } from "@peated/server/serializers/tasting";
 import { UserSerializer } from "@peated/server/serializers/user";
 import type {
@@ -58,7 +72,7 @@ export function coerceActivityDate(value: Date | string) {
 
 /**
  * Returns per-source offsets for a logical feed page while keeping secondary
- * collection groups capped whenever primary tasting activity exists.
+ * collection groups capped whenever primary tasting or review activity exists.
  */
 export function getActivitySourceWindow({
   cursor,
@@ -128,7 +142,7 @@ export function getActivitySourceWindow({
   };
 }
 
-/** Interleaves primary tastings with capped secondary collection activity. */
+/** Interleaves primary tastings and member reviews with capped secondary collection activity. */
 export function composeActivity({
   primary,
   secondary,
@@ -218,8 +232,8 @@ function markedTastingsSql({
   `;
 }
 
-/** Counts logical tasting sessions inside one stable activity snapshot. */
-export async function countTastingSessions({
+/** Counts tasting sessions and member reviews inside one activity snapshot. */
+export async function countPrimaryActivity({
   userCondition,
   snapshotAt,
 }: {
@@ -227,22 +241,33 @@ export async function countTastingSessions({
   snapshotAt: Date;
 }) {
   const result = await db.execute<{ count: string }>(sql`
-    SELECT COALESCE(SUM(marked_tastings.is_session_start), 0) AS count
-    FROM (${markedTastingsSql({ userCondition, snapshotAt })}) marked_tastings
+    SELECT (
+      SELECT COALESCE(SUM(marked_tastings.is_session_start), 0)
+      FROM (${markedTastingsSql({ userCondition, snapshotAt })}) marked_tastings
+    ) + (
+      SELECT COUNT(*) FROM ${memberReviews}
+      INNER JOIN ${users} ON ${users.id} = ${memberReviews.createdById}
+      WHERE ${userCondition} AND ${memberReviews.createdAt} <= ${snapshotAt}
+    ) AS count
   `);
   return Number(result.rows[0]?.count ?? 0);
 }
 
-type TastingSessionRow = {
-  session_id: string;
+type PrimaryActivityRow = {
+  type: "tasting_session" | "member_review";
+  id: string;
   created_by_id: string;
   started_at: Date | string;
   last_activity_at: Date | string;
   tasting_ids: (number | string)[];
 };
 
-/** Returns complete tasting sessions, so feed pagination never splits one. */
-export async function getTastingSessions({
+type PrimaryActivity =
+  | (TastingSessionGroup & { type: "tasting_session" })
+  | { type: "member_review"; review: MemberReview; bottle: Bottle };
+
+/** Pages sessions and member reviews together, without splitting a session. */
+export async function getPrimaryActivity({
   userCondition,
   snapshotAt,
   offset,
@@ -252,14 +277,14 @@ export async function getTastingSessions({
   snapshotAt: Date;
   offset: number;
   limit: number;
-}): Promise<TastingSessionGroup[]> {
+}): Promise<PrimaryActivity[]> {
   if (!limit) return [];
 
   // Session membership and hydration must share one MVCC snapshot so a
   // concurrent deletion cannot leave an aggregate referencing a missing row.
   return await db.transaction(
     async (tx) => {
-      const result = await tx.execute<TastingSessionRow>(sql`
+      const result = await tx.execute<PrimaryActivityRow>(sql`
         WITH marked_tastings AS (
           ${markedTastingsSql({ userCondition, snapshotAt })}
         ),
@@ -288,9 +313,21 @@ export async function getTastingSessions({
             numbered_tastings.created_by_id,
             numbered_tastings.session_number
         )
-        SELECT *
-        FROM tasting_sessions
-        ORDER BY tasting_sessions.last_activity_at DESC, tasting_sessions.session_id DESC
+        SELECT * FROM (
+          SELECT 'tasting_session' AS type, session_id AS id, created_by_id,
+            started_at, last_activity_at, tasting_ids
+          FROM tasting_sessions
+          UNION ALL
+          SELECT 'member_review' AS type, ${memberReviews.id} AS id,
+            ${memberReviews.createdById} AS created_by_id,
+            ${memberReviews.createdAt} AS started_at,
+            ${memberReviews.createdAt} AS last_activity_at,
+            ARRAY[]::bigint[] AS tasting_ids
+          FROM ${memberReviews}
+          INNER JOIN ${users} ON ${users.id} = ${memberReviews.createdById}
+          WHERE ${userCondition} AND ${memberReviews.createdAt} <= ${snapshotAt}
+        ) primary_activity
+        ORDER BY last_activity_at DESC, id DESC, type
         OFFSET ${offset}
         LIMIT ${limit}
       `);
@@ -308,28 +345,52 @@ export async function getTastingSessions({
         tastingRows.map((tasting) => [tasting.id, tasting]),
       );
 
-      return result.rows.map((row) => ({
-        id: Number(row.session_id),
-        createdById: Number(row.created_by_id),
-        startedAt: coerceActivityDate(row.started_at),
-        lastActivityAt: coerceActivityDate(row.last_activity_at),
-        tastings: row.tasting_ids.map((id) => {
-          const tasting = tastingsById.get(Number(id));
-          if (!tasting) {
+      const reviewIds = result.rows
+        .filter((row) => row.type === "member_review")
+        .map((row) => Number(row.id));
+      const reviewRows = reviewIds.length
+        ? await tx
+            .select({ review: memberReviews, bottle: bottles })
+            .from(memberReviews)
+            .innerJoin(bottles, eq(bottles.id, memberReviews.bottleId))
+            .where(inArray(memberReviews.id, reviewIds))
+        : [];
+      const reviewsById = new Map(
+        reviewRows.map((row) => [row.review.id, row]),
+      );
+
+      return result.rows.map((row): PrimaryActivity => {
+        if (row.type === "member_review") {
+          const review = reviewsById.get(Number(row.id));
+          if (!review)
             throw new Error(
-              `Activity session references missing Tasting ${id}.`,
+              `Activity references missing member review ${row.id}.`,
             );
-          }
-          return tasting;
-        }),
-      }));
+          return { type: "member_review", ...review };
+        }
+        return {
+          type: "tasting_session",
+          id: Number(row.id),
+          createdById: Number(row.created_by_id),
+          startedAt: coerceActivityDate(row.started_at),
+          lastActivityAt: coerceActivityDate(row.last_activity_at),
+          tastings: row.tasting_ids.map((id) => {
+            const tasting = tastingsById.get(Number(id));
+            if (!tasting)
+              throw new Error(
+                `Activity session references missing Tasting ${id}.`,
+              );
+            return tasting;
+          }),
+        };
+      });
     },
     { accessMode: "read only", isolationLevel: "repeatable read" },
   );
 }
 
 /** Serializes logical tasting sessions into the shared activity contract. */
-export async function serializeTastingSessionEntries(
+async function serializeTastingSessionEntries(
   sessions: TastingSessionGroup[],
   currentUser?: User | null,
 ) {
@@ -371,6 +432,52 @@ export async function serializeTastingSessionEntries(
       tastings: sessionTastings,
     };
   });
+}
+
+/** Serializes both primary sources with the same bottle and member contracts. */
+export async function serializePrimaryActivityEntries(
+  items: PrimaryActivity[],
+  currentUser?: User | null,
+): Promise<ActivityEntry[]> {
+  const sessions = items.filter((item) => item.type === "tasting_session");
+  const reviews = items.filter((item) => item.type === "member_review");
+  const [sessionEntries, serializedReviews, serializedBottles] =
+    await Promise.all([
+      serializeTastingSessionEntries(sessions, currentUser),
+      serialize(
+        MemberReviewSerializer,
+        reviews.map((item) => item.review),
+        currentUser,
+      ),
+      serialize(
+        BottleSerializer,
+        reviews.map((item) => item.bottle),
+        currentUser,
+        [],
+        { includeGroupSummary: true },
+      ),
+    ]);
+  const entries = new Map(sessionEntries.map((entry) => [entry.id, entry]));
+  reviews.forEach((item, index) => {
+    const review = serializedReviews[index]!;
+    const id = `member_review:${review.id}`;
+    entries.set(id, {
+      id,
+      type: "member_review",
+      priority: "primary",
+      createdAt: review.createdAt,
+      createdBy: review.createdBy,
+      review: { ...review, bottle: serializedBottles[index]! },
+    });
+  });
+  return items.map(
+    (item) =>
+      entries.get(
+        item.type === "member_review"
+          ? `member_review:${item.review.id}`
+          : `tasting_session:${item.createdById}:${item.id}`,
+      )!,
+  );
 }
 
 async function getCollectionHref(collection: Collection, user: User) {

--- a/apps/server/src/orpc/contracts/activity/list.ts
+++ b/apps/server/src/orpc/contracts/activity/list.ts
@@ -8,7 +8,8 @@ export default contract
     method: "GET",
     path: "/activity",
     summary: "List activity",
-    description: "Get recent tastings and grouped collection additions",
+    description:
+      "Get recent tastings, member reviews, and grouped collection additions",
     operationId: "listActivity",
   })
   .input(

--- a/apps/server/src/orpc/mock/fixtures/README.md
+++ b/apps/server/src/orpc/mock/fixtures/README.md
@@ -14,6 +14,14 @@ catalog totals are synthetic UI samples, not observations about real people or
 current production data. The database test builders in `lib/test/fixtures.ts`
 and the CLI's database seed command are separate from this in-memory catalog.
 
+## Activity examples
+
+`activity.ts` includes tasting sessions, member reviews, and single and grouped
+library additions. The activity page combines these with the critic reviews in
+`externalReviews.ts`. The shared component stories use the same examples and
+also cover a critic review without a reviewer byline. Library status stays in
+the library data but is not shown in activity rows.
+
 ## Adding catalog data
 
 - Give each producer its own kind, country, region, address, and ownership.

--- a/apps/server/src/orpc/mock/fixtures/activity.ts
+++ b/apps/server/src/orpc/mock/fixtures/activity.ts
@@ -2,6 +2,7 @@ import type { MockOutputs } from "../contract";
 import { mockBottles } from "./bottles";
 import { mockCollectionBottle, mockCollectionBottles } from "./collections";
 import { timestamp } from "./constants";
+import { mockMemberReviews } from "./memberReviews";
 import { mockTasting, mockTastings } from "./tastings";
 import { mockFriends, mockPublicUser } from "./users";
 
@@ -26,6 +27,33 @@ export const mockActivity = [
     createdBy: mockFriends[0]!,
     tastings: [mockTastings[2]!],
   },
+  ...mockMemberReviews.map((review) => ({
+    id: `member-review-${review.id}`,
+    type: "member_review" as const,
+    priority: "primary" as const,
+    createdAt: review.createdAt,
+    createdBy: review.createdBy,
+    review,
+  })),
+  {
+    id: "library-add-9703",
+    type: "collection_add",
+    priority: "secondary",
+    createdAt: "2026-08-25T17:00:00.000Z",
+    windowStart: "2026-08-25T17:00:00.000Z",
+    windowEnd: "2026-08-25T17:00:00.000Z",
+    createdBy: mockFriends[0]!,
+    collection: {
+      id: 9803,
+      name: "Library",
+      totalBottles: 1,
+      createdAt: "2026-07-01T12:00:00.000Z",
+      createdBy: mockFriends[0]!,
+      href: `/users/${mockFriends[0]!.username}/library`,
+    },
+    items: [mockCollectionBottles[2]!],
+    totalItems: 1,
+  },
   {
     id: "collection-add-9701",
     type: "collection_add",
@@ -36,11 +64,11 @@ export const mockActivity = [
     createdBy: mockPublicUser,
     collection: {
       id: 9801,
-      name: "Islay Favorites",
+      name: "Library",
       totalBottles: 3,
       createdAt: "2026-07-01T12:00:00.000Z",
       createdBy: mockPublicUser,
-      href: `/users/${mockPublicUser.username}/collections/9801`,
+      href: `/users/${mockPublicUser.username}/library`,
     },
     items: [
       mockCollectionBottle,

--- a/apps/server/src/orpc/routes/activity/list.test.ts
+++ b/apps/server/src/orpc/routes/activity/list.test.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { collectionBottles } from "@peated/server/db/schema";
+import { collectionBottles, memberReviews } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { describe, expect, test } from "vitest";
@@ -361,4 +361,114 @@ describe("GET /activity", () => {
       tastings: [{ id: interleaved.id }],
     });
   });
+});
+
+test("member reviews respect public and accepted-follow visibility", async ({
+  fixtures,
+  defaults,
+}) => {
+  const publicUser = await fixtures.User();
+  const friend = await fixtures.User({ private: true });
+  const pending = await fixtures.User({ private: true });
+  await fixtures.Follow({
+    fromUserId: defaults.user.id,
+    toUserId: friend.id,
+    status: "following",
+  });
+  await fixtures.Follow({
+    fromUserId: defaults.user.id,
+    toUserId: pending.id,
+    status: "pending",
+  });
+  const bottle = await fixtures.Bottle();
+  await db.insert(memberReviews).values(
+    [publicUser, friend, pending].map((user) => ({
+      bottleId: bottle.id,
+      createdById: user.id,
+      score: 90,
+      createdAt: new Date("2026-01-03T12:00:00Z"),
+    })),
+  );
+  const publicFeed = await routerClient.activity.list({ filter: "global" });
+  expect(publicFeed.results.map((item) => item.createdBy.id)).toEqual([
+    publicUser.id,
+  ]);
+  const friendFeed = await routerClient.activity.list(
+    { filter: "friends" },
+    { context: { user: defaults.user } },
+  );
+  expect(friendFeed.results.map((item) => item.createdBy.id)).toEqual([
+    friend.id,
+  ]);
+  const signedIn = await routerClient.activity.list(
+    { filter: "global" },
+    { context: { user: defaults.user } },
+  );
+  expect(
+    signedIn.results.map((item) => item.createdBy.id).sort((a, b) => a - b),
+  ).toEqual([friend.id, publicUser.id].sort((a, b) => a - b));
+  const profile = await routerClient.users.activity.list(
+    { user: friend.username },
+    { context: { user: defaults.user } },
+  );
+  expect(profile.results).toMatchObject([
+    {
+      type: "member_review",
+      review: {
+        score: 90,
+        bottle: { id: bottle.id },
+        createdBy: { id: friend.id },
+      },
+    },
+  ]);
+});
+
+test("pages member reviews and tasting sessions together without duplicates", async ({
+  fixtures,
+}) => {
+  const user = await fixtures.User();
+  const bottle = await fixtures.Bottle();
+  const early = await fixtures.Tasting({
+    createdById: user.id,
+    createdAt: new Date("2026-01-03T12:00:00Z"),
+  });
+  const latest = await fixtures.Tasting({
+    createdById: user.id,
+    createdAt: new Date("2026-01-03T13:00:00Z"),
+  });
+  const [review] = await db
+    .insert(memberReviews)
+    .values({
+      bottleId: bottle.id,
+      createdById: user.id,
+      score: 0,
+      notes: "Review notes",
+      createdAt: new Date("2026-01-03T14:00:00Z"),
+    })
+    .returning();
+  const first = await routerClient.activity.list({ limit: 1 });
+  expect(first.results).toMatchObject([
+    {
+      id: `member_review:${review.id}`,
+      type: "member_review",
+      review: { score: 0, notes: "Review notes", bottle: { id: bottle.id } },
+    },
+  ]);
+  expect(first.rel.nextCursor).not.toBeNull();
+  const second = await routerClient.activity.list({
+    limit: 1,
+    cursor: first.rel.nextCursor!,
+  });
+  expect(second.results).toMatchObject([
+    {
+      type: "tasting_session",
+      tastings: [{ id: latest.id }, { id: early.id }],
+    },
+  ]);
+  expect(second.rel.nextCursor).toBeNull();
+  const previous = await routerClient.activity.list({
+    limit: 1,
+    cursor: second.rel.prevCursor!,
+  });
+  expect(previous.results).toEqual(first.results);
 });

--- a/apps/server/src/orpc/routes/activity/list.ts
+++ b/apps/server/src/orpc/routes/activity/list.ts
@@ -8,13 +8,13 @@ import {
 import {
   coerceActivityDate,
   composeActivity,
-  countTastingSessions,
+  countPrimaryActivity,
   encodeActivityCursor,
   getActivitySourceWindow,
-  getTastingSessions,
+  getPrimaryActivity,
   parseActivityCursor,
   serializeCollectionAddEntries,
-  serializeTastingSessionEntries,
+  serializePrimaryActivityEntries,
   type CollectionAddGroup,
 } from "@peated/server/lib/activityFeed";
 import { implement } from "@peated/server/orpc";
@@ -88,7 +88,7 @@ export default implement(activityListContract).handler(async function ({
   const collectionGroupCreatedAt = sql<Date>`MAX(${collectionBottles.createdAt})`;
 
   const [totalPrimary, secondaryCountResult] = await Promise.all([
-    countTastingSessions({
+    countPrimaryActivity({
       userCondition,
       snapshotAt: activityCursor.snapshotAt,
     }),
@@ -115,8 +115,8 @@ export default implement(activityListContract).handler(async function ({
     totalSecondary,
   });
 
-  const [tastingRows, collectionGroupRows] = await Promise.all([
-    getTastingSessions({
+  const [primaryRows, collectionGroupRows] = await Promise.all([
+    getPrimaryActivity({
       userCondition,
       snapshotAt: activityCursor.snapshotAt,
       limit: sourceWindow.primaryLimit,
@@ -148,8 +148,8 @@ export default implement(activityListContract).handler(async function ({
       .offset(sourceWindow.secondaryOffset),
   ]);
 
-  const primaryEntries = await serializeTastingSessionEntries(
-    tastingRows,
+  const primaryEntries = await serializePrimaryActivityEntries(
+    primaryRows,
     context.user,
   );
   const secondaryEntries = await serializeCollectionAddEntries({

--- a/apps/server/src/orpc/routes/users/activity/list.ts
+++ b/apps/server/src/orpc/routes/users/activity/list.ts
@@ -7,13 +7,13 @@ import {
 import {
   coerceActivityDate,
   composeActivity,
-  countTastingSessions,
+  countPrimaryActivity,
   encodeActivityCursor,
   getActivitySourceWindow,
-  getTastingSessions,
+  getPrimaryActivity,
   parseActivityCursor,
   serializeCollectionAddEntries,
-  serializeTastingSessionEntries,
+  serializePrimaryActivityEntries,
   type CollectionAddGroup,
 } from "@peated/server/lib/activityFeed";
 import { getUserFromId, profileVisible } from "@peated/server/lib/api";
@@ -56,7 +56,7 @@ export default implement(userActivityListContract).handler(async function ({
   const collectionBucket = sql<Date>`DATE_TRUNC('day', ${collectionBottles.createdAt})`;
   const collectionGroupCreatedAt = sql<Date>`MAX(${collectionBottles.createdAt})`;
   const [totalPrimary, secondaryCountResult] = await Promise.all([
-    countTastingSessions({
+    countPrimaryActivity({
       userCondition,
       snapshotAt: activityCursor.snapshotAt,
     }),
@@ -81,8 +81,8 @@ export default implement(userActivityListContract).handler(async function ({
     totalSecondary,
   });
 
-  const [tastingRows, collectionGroupRows] = await Promise.all([
-    getTastingSessions({
+  const [primaryRows, collectionGroupRows] = await Promise.all([
+    getPrimaryActivity({
       userCondition,
       snapshotAt: activityCursor.snapshotAt,
       limit: sourceWindow.primaryLimit,
@@ -110,8 +110,8 @@ export default implement(userActivityListContract).handler(async function ({
       .offset(sourceWindow.secondaryOffset),
   ]);
 
-  const primaryEntries = await serializeTastingSessionEntries(
-    tastingRows,
+  const primaryEntries = await serializePrimaryActivityEntries(
+    primaryRows,
     context.user,
   );
   const secondaryEntries = await serializeCollectionAddEntries({

--- a/apps/server/src/schemas/profileActivity.ts
+++ b/apps/server/src/schemas/profileActivity.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { CollectionBottleSchema, CollectionSchema } from "./collections";
+import { MemberReviewDetailsSchema } from "./memberReviews";
 import { TastingSchema } from "./tastings";
 import { UserSchema } from "./users";
 
@@ -66,9 +67,19 @@ export const ActivityCollectionAddEntrySchema = z.object({
     .describe("Total collection items represented by this entry"),
 });
 
+export const ActivityMemberReviewEntrySchema = z.object({
+  id: z.string().describe("Stable activity entry identifier"),
+  type: z.literal("member_review"),
+  priority: z.literal("primary"),
+  createdAt: z.string().datetime().readonly(),
+  createdBy: UserSchema.readonly(),
+  review: MemberReviewDetailsSchema,
+});
+
 export const ActivityEntrySchema = z.discriminatedUnion("type", [
   ActivityTastingSessionEntrySchema,
   ActivityCollectionAddEntrySchema,
+  ActivityMemberReviewEntrySchema,
 ]);
 
 export const ActivityCursorSchema = z.object({

--- a/apps/web/e2e/activity-feed.spec.ts
+++ b/apps/web/e2e/activity-feed.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test } from "./test";
 
-import { activityReview, tastingNotes, testUser } from "./rpc-fixtures.mjs";
+import {
+  activityReview,
+  createdMemberReview,
+  tastingNotes,
+  testUser,
+} from "./rpc-fixtures.mjs";
 import { signIn } from "./session";
 
 test.describe("activity feed", () => {
@@ -23,17 +28,17 @@ test.describe("activity feed", () => {
 
     await page.goto("/");
     const homeFeed = page.getByRole("list", {
-      name: "Recent tastings and reviews",
+      name: "Recent activity",
     });
     const homeReview = homeFeed
       .getByRole("listitem")
       .filter({ hasText: activityReview.clip });
     await expect(homeReview).toBeVisible();
     const reviewTitle = await homeReview
-      .locator(`a[title][href="${activityReview.url}"]`)
+      .locator(`a[href^="/bottles/"]`)
       .innerText();
     const bottleHref = await homeReview
-      .getByRole("link", { name: "View bottle" })
+      .locator('a[href^="/bottles/"]')
       .getAttribute("href");
 
     await page
@@ -43,7 +48,7 @@ test.describe("activity feed", () => {
       .click();
     await expect(page).toHaveURL(/\/activity$/);
     const feed = page.getByRole("list", {
-      name: "Latest tastings and reviews",
+      name: "Latest activity",
     });
 
     await expect(
@@ -59,16 +64,32 @@ test.describe("activity feed", () => {
     await expect(
       feed.getByText("A tasting from the wider community."),
     ).toBeVisible();
+    await expect(feed.getByText(createdMemberReview.notes)).toBeVisible();
+    await expect(
+      feed.getByRole("link", { name: "Read review", exact: true }),
+    ).toHaveAttribute("href", `/reviews/${createdMemberReview.id}`);
+    await expect(
+      feed.getByText("their library", { exact: true }),
+    ).toBeVisible();
+    await expect(feed.getByText("Sealed", { exact: true })).toHaveCount(0);
+    await expect(
+      page
+        .getByRole("complementary")
+        .getByRole("link", { name: "Add a tasting", exact: true }),
+    ).toBeVisible();
+    await expect(
+      feed.getByRole("link", { name: "Add a tasting", exact: true }),
+    ).toHaveCount(0);
     await snapshot("Activity / Everyone", { ready: feed });
 
     const review = feed
       .getByRole("listitem")
       .filter({ hasText: activityReview.clip });
-    const bottleLink = review.getByRole("link", { name: "View bottle" });
+    const bottleLink = review.locator('a[href^="/bottles/"]');
     await expect(bottleLink).toHaveAttribute("href", bottleHref!);
-    await expect(
-      review.locator(`a[title][href="${activityReview.url}"]`),
-    ).toHaveText(reviewTitle);
+    await expect(review.locator(`a[href^="/bottles/"]`)).toHaveText(
+      reviewTitle,
+    );
     await bottleLink.click();
     await expect(page).toHaveURL(/\/bottles\//);
 
@@ -80,7 +101,10 @@ test.describe("activity feed", () => {
       }),
     );
     await review
-      .getByRole("link", { name: activityReview.site.name, exact: true })
+      .getByRole("link", {
+        name: `Read at ${activityReview.site.name} ↗`,
+        exact: true,
+      })
       .click();
     await expect(page).toHaveURL(activityReview.url);
   });

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -17,6 +17,7 @@ import {
   buildBottle,
   buildBottleGroup,
   buildCollectionBottle,
+  buildCommunityActivity,
   buildFavoriteActivity,
   buildTasting,
   createdBottleId,
@@ -186,9 +187,7 @@ async function handleRpcRequest({ request, response, url }) {
     case "activity/list":
       sendRpcResponse(
         response,
-        input?.cursor
-          ? buildActivity()
-          : buildFavoriteActivity({ nextCursor: "2:1780833600000" }),
+        buildCommunityActivity({ following: input?.filter === "friends" }),
       );
       return true;
     case "users/activity/list":

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -997,6 +997,33 @@ export function buildActivity({
   };
 }
 
+export function buildCommunityActivity({ following = false } = {}) {
+  const activity = buildActivity({
+    tastingSession: [
+      buildTasting({
+        notes: following
+          ? "A tasting from someone you follow."
+          : "A tasting from the wider community.",
+      }),
+    ],
+    collectionBottle: buildCollectionBottle({ status: "sealed" }),
+  });
+  return {
+    ...activity,
+    results: [
+      ...activity.results,
+      {
+        id: `member_review:${createdMemberReview.id}`,
+        type: "member_review",
+        priority: "primary",
+        createdAt: timestamp,
+        createdBy: testUser,
+        review: { ...createdMemberReview, bottle: existingBottle },
+      },
+    ],
+  };
+}
+
 export function buildFavoriteActivity({ nextCursor = null } = {}) {
   return {
     results: Array.from({ length: 10 }, (_, index) => ({

--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -181,9 +181,9 @@ function LatestReleases() {
 function Activity() {
   const orpc = useORPC();
   const externalReviews = useQuery(publicHomeQueries.recentReviews(orpc));
-  const tastings = useQuery(publicHomeQueries.memberTastings(orpc));
+  const activity = useQuery(publicHomeQueries.memberActivity(orpc));
 
-  if (tastings.isPending && externalReviews.isPending) {
+  if (activity.isPending && externalReviews.isPending) {
     return (
       <HomeSectionLoading>
         <LoadingList label="Loading activity" rows={3} />
@@ -191,32 +191,31 @@ function Activity() {
     );
   }
 
-  if (tastings.error && externalReviews.error) {
+  if (activity.error && externalReviews.error) {
     return (
       <SectionError
         heading="Activity is unavailable"
         onRetry={() => {
-          void tastings.refetch();
+          void activity.refetch();
           void externalReviews.refetch();
         }}
       >
-        We couldn't load the latest tastings and reviews. The rest of the
-        database is still available.
+        We couldn't load the latest activity. The rest of the database is still
+        available.
       </SectionError>
     );
   }
 
-  const memberTastings = tastings.data?.results ?? [];
+  const memberActivity = activity.data?.results ?? [];
   const criticReviews = externalReviews.data?.results ?? [];
-  const items = getCommunityFeedItems({ criticReviews, memberTastings });
+  const items = getCommunityFeedItems({
+    criticReviews,
+    activity: memberActivity,
+  });
 
   return items.length ? (
     <HomeActivityFeed>
-      <CommunityFeed
-        ariaLabel="Recent tastings and reviews"
-        items={items}
-        limit={3}
-      />
+      <CommunityFeed ariaLabel="Recent activity" items={items} limit={3} />
     </HomeActivityFeed>
   ) : null;
 }

--- a/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
@@ -1,14 +1,14 @@
 import {
+  mockActivity,
   mockExternalReview,
   mockFriendships,
-  mockTasting,
 } from "@peated/server/orpc/mock/fixtures";
 import { beforeEach, expect, test, vi } from "vitest";
 import { loadActivityFeed } from "./loadActivityFeed";
 
 type Options = Parameters<typeof loadActivityFeed>[0];
 const publicClient = {
-  tastings: { list: vi.fn<Options["publicClient"]["tastings"]["list"]>() },
+  activity: { list: vi.fn<Options["publicClient"]["activity"]["list"]>() },
   externalReviews: {
     list: vi.fn<Options["publicClient"]["externalReviews"]["list"]>(),
   },
@@ -17,8 +17,8 @@ const memberClient = {
   friends: {
     list: vi.fn<NonNullable<Options["memberClient"]>["friends"]["list"]>(),
   },
-  tastings: {
-    list: vi.fn<NonNullable<Options["memberClient"]>["tastings"]["list"]>(),
+  activity: {
+    list: vi.fn<NonNullable<Options["memberClient"]>["activity"]["list"]>(),
   },
 };
 const rel = { nextCursor: null, prevCursor: null };
@@ -29,8 +29,11 @@ beforeEach(() => {
     results: mockFriendships,
     rel,
   });
-  memberClient.tastings.list.mockResolvedValue({ results: [], rel });
-  publicClient.tastings.list.mockResolvedValue({ results: [mockTasting], rel });
+  memberClient.activity.list.mockResolvedValue({ results: [], rel });
+  publicClient.activity.list.mockResolvedValue({
+    results: [mockActivity[0]],
+    rel,
+  });
   publicClient.externalReviews.list.mockResolvedValue({
     results: [mockExternalReview],
     rel,
@@ -48,13 +51,13 @@ test("keeps Following empty when followed people have no activity", async () => 
     filter: "active",
     limit: 1,
   });
-  expect(memberClient.tastings.list).toHaveBeenCalledWith({
+  expect(memberClient.activity.list).toHaveBeenCalledWith({
     filter: "friends",
     limit: 20,
   });
   expect(feed.items).toEqual([]);
   expect(feed.note).toBeUndefined();
-  expect(publicClient.tastings.list).not.toHaveBeenCalled();
+  expect(publicClient.activity.list).not.toHaveBeenCalled();
   expect(publicClient.externalReviews.list).not.toHaveBeenCalled();
 });
 
@@ -70,7 +73,7 @@ test("falls back to Everyone only when there are no accepted follows", async () 
     "You're not following anyone yet. Showing everyone's activity.",
   );
   expect(feed.items).toHaveLength(2);
-  expect(memberClient.tastings.list).not.toHaveBeenCalled();
+  expect(memberClient.activity.list).not.toHaveBeenCalled();
   expect(publicClient.externalReviews.list).toHaveBeenCalled();
 });
 
@@ -81,7 +84,7 @@ test("does not hide a failed follow lookup by showing Everyone", async () => {
   await expect(
     loadActivityFeed({ following: true, memberClient, publicClient }),
   ).rejects.toBe(error);
-  expect(publicClient.tastings.list).not.toHaveBeenCalled();
+  expect(publicClient.activity.list).not.toHaveBeenCalled();
 });
 
 test("uses public activity for Everyone even when signed in", async () => {
@@ -93,7 +96,7 @@ test("uses public activity for Everyone even when signed in", async () => {
 
   expect(feed.items).toHaveLength(2);
   expect(memberClient.friends.list).not.toHaveBeenCalled();
-  expect(memberClient.tastings.list).not.toHaveBeenCalled();
+  expect(memberClient.activity.list).not.toHaveBeenCalled();
 });
 
 test("anonymous Following uses public activity and explains sign-in", async () => {

--- a/apps/web/src/app/(app)/activity/loadActivityFeed.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.ts
@@ -3,7 +3,7 @@ import type { Router } from "@peated/server/orpc/router";
 import { getCommunityFeedItems } from "@peated/web/lib/communityFeed";
 
 type Client = RouterClient<Router>;
-type TastingClient = { tastings: Pick<Client["tastings"], "list"> };
+type ActivityClient = { activity: Pick<Client["activity"], "list"> };
 
 /** Falls back to public activity only when there are no accepted follows. */
 export async function loadActivityFeed({
@@ -12,8 +12,8 @@ export async function loadActivityFeed({
   publicClient,
 }: {
   following: boolean;
-  memberClient?: TastingClient & { friends: Pick<Client["friends"], "list"> };
-  publicClient: TastingClient & {
+  memberClient?: ActivityClient & { friends: Pick<Client["friends"], "list"> };
+  publicClient: ActivityClient & {
     externalReviews: Pick<Client["externalReviews"], "list">;
   };
 }) {
@@ -25,14 +25,14 @@ export async function loadActivityFeed({
       limit: 1,
     });
     if (follows.results.length) {
-      const tastings = await memberClient.tastings.list({
+      const activity = await memberClient.activity.list({
         filter: "friends",
         limit: 20,
       });
       return {
         items: getCommunityFeedItems({
           criticReviews: [],
-          memberTastings: tastings.results,
+          activity: activity.results,
         }),
         note,
       };
@@ -42,15 +42,15 @@ export async function loadActivityFeed({
     note = "Sign in to follow people. Showing everyone's activity.";
   }
 
-  const [tastings, reviews] = await Promise.all([
-    publicClient.tastings.list({ limit: 20 }),
+  const [activity, reviews] = await Promise.all([
+    publicClient.activity.list({ limit: 20 }),
     publicClient.externalReviews.list({ limit: 20, sort: "recent" }),
   ]);
 
   return {
     items: getCommunityFeedItems({
       criticReviews: reviews.results,
-      memberTastings: tastings.results,
+      activity: activity.results,
     }),
     note,
   };

--- a/apps/web/src/app/(app)/activity/page.tsx
+++ b/apps/web/src/app/(app)/activity/page.tsx
@@ -1,16 +1,20 @@
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { PageTabs } from "@peated/web/components";
 import { ActivityPage } from "@peated/web/components/pages/activityPage.stylex";
 import { getCurrentUser } from "@peated/web/lib/auth.server";
+import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import {
   getAnonymousServerClient,
   getServerClient,
 } from "@peated/web/lib/orpc/client.server";
+import { getBottleUrl } from "@peated/web/lib/urls";
 import type { Metadata } from "next";
 import { loadActivityFeed } from "./loadActivityFeed";
 
 export const metadata: Metadata = {
   title: "Activity",
-  description: "Recent whisky tastings and reviews on Peated.",
+  description:
+    "Recent whisky tastings, reviews, and library additions on Peated.",
 };
 
 export default async function Activity({
@@ -21,17 +25,30 @@ export default async function Activity({
   const [{ feed }, user] = await Promise.all([searchParams, getCurrentUser()]);
   const following = feed === "following" || (feed !== "everyone" && !!user);
   const { client: publicClient } = await getAnonymousServerClient();
-  const memberClient =
-    following && user ? (await getServerClient()).client : undefined;
-  const { items, note } = await loadActivityFeed({
-    following,
-    memberClient,
-    publicClient,
-  });
+  const memberClient = user ? (await getServerClient()).client : undefined;
+  const [{ items, note }, library] = await Promise.all([
+    loadActivityFeed({ following, memberClient, publicClient }),
+    memberClient?.collections.bottles.list({
+      user: "me",
+      collection: "library",
+      limit: 25,
+    }),
+  ]);
+  const libraryBottles = (library?.results ?? [])
+    .filter((item) => !item.hasTasted)
+    .slice(0, 3)
+    .map((item) => ({
+      href: getBottleUrl(item.bottle),
+      imageUrl: item.imageUrl ?? item.bottle.imageUrl,
+      name: formatBottleDisplayName(item.bottle),
+      metadata: getBottleMetadata(item.bottle),
+    }));
 
   return (
     <ActivityPage
       items={items}
+      libraryBottles={libraryBottles}
+      libraryHref={user ? `/users/${user.username}/library` : undefined}
       note={note}
       selector={
         <PageTabs

--- a/apps/web/src/app/(app)/page.tsx
+++ b/apps/web/src/app/(app)/page.tsx
@@ -36,7 +36,7 @@ export default async function Page() {
       queryFn: getPublicStats,
     }),
     queryClient.prefetchQuery(publicHomeQueries.events(orpc)),
-    queryClient.prefetchQuery(publicHomeQueries.memberTastings(orpc)),
+    queryClient.prefetchQuery(publicHomeQueries.memberActivity(orpc)),
     queryClient.prefetchQuery(publicHomeQueries.recentReviews(orpc)),
     queryClient.prefetchQuery(publicHomeQueries.releases(orpc)),
     ...(session.user

--- a/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/activity/profileActivityPageClient.stylex.tsx
@@ -69,7 +69,7 @@ export function ProfileActivityPageClient() {
           <MemberActivityList
             emptyDescription={
               isCurrentUser
-                ? "Your tastings and library additions will appear here."
+                ? "Your tastings, reviews, and library additions will appear here."
                 : `${user.username} has no recent activity.`
             }
             items={visibleActivity.map(toActivityItem)}

--- a/apps/web/src/app/(app)/users/[username]/profileActivity.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileActivity.tsx
@@ -1,5 +1,6 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";
+import { getCommunityFeedItems } from "@peated/web/lib/communityFeed";
 
 import { MemberAvatar, type TastingEntryMember } from "@peated/web/components";
 import type { MemberActivityItem } from "@peated/web/components/pages/memberProfileContent.stylex";
@@ -11,6 +12,16 @@ type Activity = Outputs["users"]["activity"]["list"]["results"][number];
 
 /** Maps one API activity item to the shared profile activity presentation. */
 export function toActivityItem(activity: Activity): MemberActivityItem {
+  if (activity.type === "member_review") {
+    return {
+      id: activity.id,
+      kind: "review",
+      review: getCommunityFeedItems({
+        activity: [activity],
+        criticReviews: [],
+      })[0]!,
+    };
+  }
   if (activity.type === "collection_add") {
     return {
       activity: {

--- a/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
@@ -86,7 +86,7 @@ export function ProfileOverviewPageClient({
             <MemberActivityList
               emptyDescription={
                 isCurrentUser
-                  ? "Your tastings and library additions will appear here."
+                  ? "Your tastings, reviews, and library additions will appear here."
                   : `${user.username} has no recent activity.`
               }
               items={activity}

--- a/apps/web/src/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stories.tsx
@@ -45,6 +45,9 @@ const meta = {
       </StoryCanvas>
     ),
   ],
+  argTypes: {
+    variant: { control: "inline-radio", options: ["standard", "compact"] },
+  },
   args: {
     ...toBottleListItem(rowBottle),
     href: "/bottles/19936",
@@ -53,8 +56,16 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component:
-          "Use Bottle Identity Row wherever a standard bottle row appears. toBottleListItem and getBottleIdentityProps supply the same marketed name, provenance, and release facts used on the homepage and in Library. Rows share a 48 × 64px thumbnail on desktop and 42 × 58px on mobile. Producer links, related releases, and action menus remain separate controls.",
+        component: `Use BottleIdentityRow for one bottle, BottleList for a catalog list, and CommunityFeed for activity. Build props with toBottleListItem (API Bottles) or getBottleIdentityProps (partial reads). Both variants take the same full marketed name.
+
+| Variant | Use | Content |
+| --- | --- | --- |
+| standard (default) | Catalog, search, tastings, reviews, and selection | Name, provenance, and release facts; 48 × 64px thumbnail (42 × 58px on mobile). |
+| compact | Single or grouped library additions | One name line, 24 × 32px thumbnail, and a 44px hit area. |
+
+Compact omits provenance, metadata, subtitle, status, and related releases. Long compact names truncate visually and retain their full accessible name and title. Use layout="cell" inside an existing control; end holds independent actions or scores. BottleVisual owns the image frame and fallback; the row chooses its size.
+
+Use Row Layouts to compare these components at desktop and phone widths.`,
       },
     },
   },
@@ -124,12 +135,39 @@ export const Overview: Story = {
   ),
 };
 
+export const Compact: Story = {
+  args: { variant: "compact" },
+  render: (args) => (
+    <ItemList ariaLabel="Compact bottle examples">
+      <ItemListItem>
+        <BottleIdentityRow {...args} />
+      </ItemListItem>
+      <ItemListItem>
+        <BottleIdentityRow
+          {...args}
+          name="Lagavulin 16-year-old"
+          href="/bottles/42"
+          imageUrl={null}
+        />
+      </ItemListItem>
+      <ItemListItem>
+        <BottleIdentityRow
+          {...args}
+          name="Bruichladdich Octomore Edition 15.3 Islay Barley Super Heavily Peated"
+          href="/bottles/18481"
+          imageUrl={null}
+        />
+      </ItemListItem>
+    </ItemList>
+  ),
+};
+
 export const RowLayouts: Story = {
   parameters: {
     docs: {
       description: {
         story:
-          "Compare the actual bottle, activity, tasting, search, selection, and loading components at wide and phone widths. They share thumbnail geometry and row typography. Use BottleVisual's small size only for compact two-line rails; BottleIdentityRow always uses the standard size.",
+          "Compare the actual bottle, activity, tasting, search, selection, and loading components at wide and phone widths. They share thumbnail geometry and row typography. Standard rows use the shared medium thumbnail; compact library additions use the extra-small thumbnail, and two-line rails use the small thumbnail.",
       },
     },
   },
@@ -142,6 +180,10 @@ export const RowLayouts: Story = {
           <SectionHeading level={3}>Bottle list</SectionHeading>
           <BottleIdentityRow {...args} />
         </section>
+        <section aria-label="Library addition">
+          <SectionHeading level={3}>Library addition</SectionHeading>
+          <BottleIdentityRow {...args} variant="compact" />
+        </section>
         <section aria-label="Activity">
           <SectionHeading level={3}>
             Activity on the homepage and activity page
@@ -150,16 +192,20 @@ export const RowLayouts: Story = {
             items={[
               {
                 actor: "Whiskyfun",
-                bottle: args,
                 actorHref: "https://example.com/review",
-                bottleHref: args.href!,
+                action: "published a review",
+                kind: "critic_review",
                 date: "2026-08-24T12:00:00.000Z",
-                href: "https://example.com/review",
                 id: "review",
-                imageUrl: args.imageUrl,
-                metadata,
-                score: 88,
-                title,
+                bottles: [
+                  {
+                    ...args,
+                    id: "bottle",
+                    score: 88,
+                    activityHref: "https://example.com/review",
+                    activityLabel: "Read at Whiskyfun ↗",
+                  },
+                ],
               },
             ]}
           />

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -3,16 +3,14 @@ import type { MouseEventHandler, ReactNode } from "react";
 
 import { foundationStyles } from "../styles/foundations.stylex";
 import {
-  bottleThumbnailMetrics,
   colors,
-  controlMetrics,
   effects,
   fonts,
   space,
   zIndices,
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
-import { ImageViewer } from "./imageViewer.stylex";
+import { BottleVisual } from "./bottleVisual.stylex";
 import Join from "./join";
 import { linkedRowStyles } from "./linkedRow.stylex";
 import { MatchedText } from "./matchedText.stylex";
@@ -20,67 +18,8 @@ import { MemberStatus } from "./memberStatus.stylex";
 import { TextLink } from "./textLink.stylex";
 import { getTextTitle } from "./textTitle";
 
-const COMPACT = "@media (max-width: 639px)";
-const bottleIconUrl = "/assets/bottle.svg";
-
-export type BottleVisualSize = "sm" | "md" | "lg" | "xl";
-
-export type BottleVisualProps = {
-  expandable?: boolean;
-  imageUrl?: string | null;
-  label?: string;
-  size?: BottleVisualSize;
-};
-
-/**
- * Shows a bottle image or Peated's bottle glyph when no image exists.
- * Use the default medium size beside three-line identities, including activity entries.
- * Fixed-size frames cap both dimensions so source images cannot enlarge a row.
- */
-export function BottleVisual({
-  expandable = false,
-  imageUrl,
-  label,
-  size = "md",
-}: BottleVisualProps) {
-  const hasExpandableImage = Boolean(imageUrl && expandable && label);
-
-  return (
-    <span
-      aria-hidden={!label ? "true" : undefined}
-      aria-label={label && !hasExpandableImage ? label : undefined}
-      role={label && !hasExpandableImage ? "img" : undefined}
-      {...stylex.props(
-        styles.visual,
-        Boolean(imageUrl) && styles.imageVisual,
-        visualSizeStyles[size],
-        hasExpandableImage && styles.expandableVisual,
-      )}
-    >
-      {hasExpandableImage && imageUrl && label ? (
-        <ImageViewer alt="" fill label={label} src={imageUrl}>
-          <img
-            alt=""
-            src={imageUrl}
-            {...stylex.props(styles.image, expandableImagePaddingStyles[size])}
-          />
-        </ImageViewer>
-      ) : imageUrl ? (
-        <img alt="" src={imageUrl} {...stylex.props(styles.image)} />
-      ) : (
-        <span
-          style={{
-            maskImage: `url("${bottleIconUrl}")`,
-            WebkitMaskImage: `url("${bottleIconUrl}")`,
-          }}
-          {...stylex.props(styles.fallbackAsset)}
-        />
-      )}
-    </span>
-  );
-}
-
 export type BottleIdentityRowProps = {
+  /** Aligns standard row content; compact rows always center their single line. */
   align?: "center" | "start";
   end?: ReactNode;
   hasTasted?: boolean;
@@ -98,11 +37,17 @@ export type BottleIdentityRowProps = {
     href: string;
   };
   subtitle?: ReactNode;
+  /** Standard: three identity lines. Compact: one name line for library additions. */
+  variant?: "standard" | "compact";
 };
 
 /**
- * Owns the standard three-line bottle row: marketed name, provenance, then release facts.
- * Use toBottleListItem for API Bottles so pages cannot drift from the home/Library identity.
+ * Bottle identity for lists and activity. Standard shows name, provenance, then
+ * release facts; compact shows one name line for library additions.
+ * Use toBottleListItem for API Bottles or getBottleIdentityProps for partial reads.
+ * Both variants take the same full marketed name and own their thumbnail size.
+ * Use layout="cell" inside an existing row/selection control. Compact omits
+ * provenance, metadata, subtitle, status, and related releases; end remains available.
  */
 export function BottleIdentityRow({
   align = "center",
@@ -119,20 +64,25 @@ export function BottleIdentityRow({
   provenance = [],
   relatedReleases,
   subtitle,
+  variant = "standard",
 }: BottleIdentityRowProps) {
+  const compact = variant === "compact";
   return (
     <div
       {...stylex.props(
         styles.row,
-        align === "start" && styles.startAlignedRow,
+        compact && styles.compactRow,
+        !compact && align === "start" && styles.startAlignedRow,
         layout === "cell" && styles.cellLayout,
         Boolean(href) && layout === "row" && linkedRowStyles.container,
         Boolean(href) && layout === "row" && linkedRowStyles.onGround,
       )}
     >
-      <BottleVisual imageUrl={imageUrl} />
+      <BottleVisual imageUrl={imageUrl} size={compact ? "xs" : "md"} />
       <div {...stylex.props(styles.copy)}>
-        <div {...stylex.props(styles.nameLine)}>
+        <div
+          {...stylex.props(styles.nameLine, compact && styles.compactNameLine)}
+        >
           {href ? (
             <AppLink
               href={href}
@@ -141,20 +91,28 @@ export function BottleIdentityRow({
               {...stylex.props(
                 foundationStyles.rowTitle,
                 styles.name,
+                compact && styles.compactName,
                 linkedRowStyles.primaryLink,
               )}
             >
               <MatchedText query={query} text={name} />
             </AppLink>
           ) : (
-            <span {...stylex.props(foundationStyles.rowTitle, styles.name)}>
+            <span
+              title={name}
+              {...stylex.props(
+                foundationStyles.rowTitle,
+                styles.name,
+                compact && styles.compactName,
+              )}
+            >
               <MatchedText query={query} text={name} />
             </span>
           )}
-          {isLibrary ? <MemberStatus kind="library" /> : null}
-          {hasTasted ? <MemberStatus kind="tasted" /> : null}
+          {!compact && isLibrary ? <MemberStatus kind="library" /> : null}
+          {!compact && hasTasted ? <MemberStatus kind="tasted" /> : null}
         </div>
-        {provenance.length ? (
+        {!compact && provenance.length ? (
           <div {...stylex.props(foundationStyles.metadata, styles.subtitle)}>
             <Join divider=" · ">
               {provenance.map((item, index) =>
@@ -169,7 +127,7 @@ export function BottleIdentityRow({
             </Join>
           </div>
         ) : null}
-        {subtitle ? (
+        {!compact && subtitle ? (
           <div
             title={getTextTitle(subtitle)}
             {...stylex.props(foundationStyles.metadata, styles.subtitle)}
@@ -177,7 +135,7 @@ export function BottleIdentityRow({
             {subtitle}
           </div>
         ) : null}
-        {metadata.length ? (
+        {!compact && metadata.length ? (
           <div
             title={metadata.join(" · ")}
             {...stylex.props(foundationStyles.metadata, styles.metadata)}
@@ -190,7 +148,7 @@ export function BottleIdentityRow({
             ))}
           </div>
         ) : null}
-        {relatedReleases && relatedReleases.count > 1 ? (
+        {!compact && relatedReleases && relatedReleases.count > 1 ? (
           <AppLink
             href={relatedReleases.href}
             {...stylex.props(
@@ -208,91 +166,6 @@ export function BottleIdentityRow({
 }
 
 const styles = stylex.create({
-  visual: {
-    boxSizing: "border-box",
-    display: "inline-flex",
-    minWidth: 0,
-    minHeight: 0,
-    flexGrow: 0,
-    flexShrink: 0,
-    alignItems: "center",
-    justifyContent: "center",
-    overflow: "hidden",
-    borderRadius: controlMetrics.radiusSmall,
-    backgroundColor: "transparent",
-    color: colors.inkMuted,
-  },
-  imageVisual: {
-    backgroundColor: colors.imageBackground,
-    boxShadow: `inset 0 0 0 1px ${colors.hairline}`,
-  },
-  expandableVisual: {
-    padding: 0,
-  },
-  visualSmall: {
-    width: "32px",
-    maxWidth: "32px",
-    height: "46px",
-    maxHeight: "46px",
-    padding: space.x1,
-  },
-  visualMedium: {
-    width: bottleThumbnailMetrics.width,
-    maxWidth: bottleThumbnailMetrics.width,
-    height: bottleThumbnailMetrics.height,
-    maxHeight: bottleThumbnailMetrics.height,
-    padding: space.x2,
-  },
-  visualLarge: {
-    width: { default: "132px", [COMPACT]: "80px" },
-    maxWidth: { default: "132px", [COMPACT]: "80px" },
-    height: { default: "176px", [COMPACT]: "120px" },
-    maxHeight: { default: "176px", [COMPACT]: "120px" },
-    padding: { default: space.x2, [COMPACT]: space.x1 },
-  },
-  visualExtraLarge: {
-    width: "100%",
-    maxWidth: "100%",
-    aspectRatio: "4 / 5",
-    padding: space.x4,
-  },
-  image: {
-    boxSizing: "border-box",
-    display: "block",
-    width: "100%",
-    maxWidth: "100%",
-    minWidth: 0,
-    height: "100%",
-    maxHeight: "100%",
-    minHeight: 0,
-    objectFit: "contain",
-  },
-  expandableImageSmall: {
-    padding: space.x1,
-  },
-  expandableImageMedium: {
-    padding: space.x2,
-  },
-  expandableImageLarge: {
-    padding: { default: space.x2, [COMPACT]: space.x1 },
-  },
-  expandableImageExtraLarge: {
-    padding: space.x4,
-  },
-  fallbackAsset: {
-    display: "block",
-    width: "100%",
-    maxWidth: "100%",
-    height: "100%",
-    maxHeight: "100%",
-    backgroundColor: "currentColor",
-    maskPosition: "center",
-    maskRepeat: "no-repeat",
-    maskSize: "contain",
-    WebkitMaskPosition: "center",
-    WebkitMaskRepeat: "no-repeat",
-    WebkitMaskSize: "contain",
-  },
   row: {
     boxSizing: "border-box",
     display: "flex",
@@ -309,6 +182,20 @@ const styles = stylex.create({
   },
   startAlignedRow: {
     alignItems: "flex-start",
+  },
+  compactRow: {
+    minHeight: "44px",
+    gap: space.x2,
+    paddingTop: space.x1,
+    paddingBottom: space.x1,
+  },
+  compactNameLine: { marginTop: 0 },
+  compactName: {
+    display: "block",
+    overflow: "hidden",
+    fontSize: "15px",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
   },
   cellLayout: {
     width: "100%",
@@ -392,17 +279,3 @@ const styles = stylex.create({
     justifyContent: "flex-end",
   },
 });
-
-const visualSizeStyles = {
-  sm: styles.visualSmall,
-  md: styles.visualMedium,
-  lg: styles.visualLarge,
-  xl: styles.visualExtraLarge,
-} satisfies Record<BottleVisualSize, stylex.StyleXStyles>;
-
-const expandableImagePaddingStyles = {
-  sm: styles.expandableImageSmall,
-  md: styles.expandableImageMedium,
-  lg: styles.expandableImageLarge,
-  xl: styles.expandableImageExtraLarge,
-} satisfies Record<BottleVisualSize, stylex.StyleXStyles>;

--- a/apps/web/src/components/bottleList.stories.tsx
+++ b/apps/web/src/components/bottleList.stories.tsx
@@ -69,6 +69,14 @@ const meta = {
     items,
   },
   argTypes: { items: { control: false } },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Use for catalog results and other lists of bottles. Build items with toBottleListItem; BottleIdentityRow owns each identity and thumbnail. Ratings are optional, and an explicit end action takes their place. Use CommunityFeed for grouped activity and BottleRailSection for a sidebar list. See Bottle Identity Row / Row Layouts for the shared layout reference.",
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <StoryCanvas width="wide">

--- a/apps/web/src/components/bottleList.stylex.tsx
+++ b/apps/web/src/components/bottleList.stylex.tsx
@@ -18,7 +18,11 @@ export type BottleListProps = {
   items: readonly BottleListItem[];
 };
 
-/** Owns the standard bottle-list structure and delegates identity to one row. */
+/**
+ * Catalog list of BottleIdentityRow items. Build items with toBottleListItem;
+ * end overrides the optional rating summary. Use CommunityFeed when the author,
+ * action, or event grouping matters, and SelectedBottleSummary inside forms.
+ */
 export function BottleList({ ariaLabel, items }: BottleListProps) {
   return (
     <ItemList ariaLabel={ariaLabel}>

--- a/apps/web/src/components/bottleVisual.stories.tsx
+++ b/apps/web/src/components/bottleVisual.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import BottleImage from "../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
+import { BottleVisual } from "./bottleVisual.stylex";
+import { StoryCanvas, StoryRow } from "./storyFixtures.stylex";
+
+const meta = {
+  title: "Components/Bottles/Bottle Visual",
+  component: BottleVisual,
+  args: {
+    imageUrl: BottleImage.src,
+    label: "Laphroaig Elements L 2.0",
+    size: "md",
+  },
+  argTypes: {
+    size: { control: "inline-radio", options: ["xs", "sm", "md", "lg", "xl"] },
+  },
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="compact">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component: `Bottle image primitive: contains the full image on white and uses Peated's bottle glyph when imageUrl is absent. Use BottleIdentityRow for a bottle row; it chooses the thumbnail size for you.
+
+| Size | Use |
+| --- | --- |
+| xs | Single-line library additions (24 × 32px). |
+| sm | Two-line sidebar rails (32 × 46px). |
+| md (default) | Standard rows, search, and selection (48 × 64px; 42 × 58px on mobile). |
+| lg | Detail media (132 × 176px; 80 × 120px on mobile). |
+| xl | Full-width detail media with a 4:5 frame. |
+
+Omit label when adjacent text already names the bottle. Supply label for a standalone image. expandable requires both an image and a label; use it in detail media, outside another link or button.`,
+      },
+    },
+  },
+} satisfies Meta<typeof BottleVisual>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {
+  render: (args) => (
+    <StoryRow>
+      <BottleVisual {...args} />
+      <BottleVisual {...args} imageUrl={null} />
+    </StoryRow>
+  ),
+};
+
+export const Expandable: Story = {
+  args: { expandable: true, size: "lg" },
+};

--- a/apps/web/src/components/bottleVisual.stylex.tsx
+++ b/apps/web/src/components/bottleVisual.stylex.tsx
@@ -1,0 +1,185 @@
+import * as stylex from "@stylexjs/stylex";
+
+import {
+  bottleThumbnailMetrics,
+  colors,
+  controlMetrics,
+  space,
+} from "../styles/tokens.stylex";
+import { ImageViewer } from "./imageViewer.stylex";
+
+const COMPACT = "@media (max-width: 639px)";
+const bottleIconUrl = "/assets/bottle.svg";
+
+export type BottleVisualSize = "xs" | "sm" | "md" | "lg" | "xl";
+
+export type BottleVisualProps = {
+  expandable?: boolean;
+  imageUrl?: string | null;
+  label?: string;
+  size?: BottleVisualSize;
+};
+
+/**
+ * Shows a bottle image or Peated's bottle glyph when no image exists.
+ * BottleIdentityRow chooses its own size. Use this primitive directly only when
+ * composing another layout: sm for two-line rails, md for standard rows, lg/xl
+ * for detail media. Omit label beside visible bottle text; expandable needs a label.
+ * Fixed-size frames cap both dimensions so source images cannot enlarge a row.
+ */
+export function BottleVisual({
+  expandable = false,
+  imageUrl,
+  label,
+  size = "md",
+}: BottleVisualProps) {
+  const hasExpandableImage = Boolean(imageUrl && expandable && label);
+
+  return (
+    <span
+      aria-hidden={!label ? "true" : undefined}
+      aria-label={label && !hasExpandableImage ? label : undefined}
+      role={label && !hasExpandableImage ? "img" : undefined}
+      {...stylex.props(
+        styles.visual,
+        Boolean(imageUrl) && styles.imageVisual,
+        visualSizeStyles[size],
+        hasExpandableImage && styles.expandableVisual,
+      )}
+    >
+      {hasExpandableImage && imageUrl && label ? (
+        <ImageViewer alt="" fill label={label} src={imageUrl}>
+          <img
+            alt=""
+            src={imageUrl}
+            {...stylex.props(styles.image, expandableImagePaddingStyles[size])}
+          />
+        </ImageViewer>
+      ) : imageUrl ? (
+        <img alt="" src={imageUrl} {...stylex.props(styles.image)} />
+      ) : (
+        <span
+          style={{
+            maskImage: `url("${bottleIconUrl}")`,
+            WebkitMaskImage: `url("${bottleIconUrl}")`,
+          }}
+          {...stylex.props(styles.fallbackAsset)}
+        />
+      )}
+    </span>
+  );
+}
+
+const styles = stylex.create({
+  visual: {
+    boxSizing: "border-box",
+    display: "inline-flex",
+    minWidth: 0,
+    minHeight: 0,
+    flexGrow: 0,
+    flexShrink: 0,
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+    borderRadius: controlMetrics.radiusSmall,
+    backgroundColor: "transparent",
+    color: colors.inkMuted,
+  },
+  imageVisual: {
+    backgroundColor: colors.imageBackground,
+    boxShadow: `inset 0 0 0 1px ${colors.hairline}`,
+  },
+  expandableVisual: {
+    padding: 0,
+  },
+  visualExtraSmall: {
+    width: "24px",
+    maxWidth: "24px",
+    height: "32px",
+    maxHeight: "32px",
+    padding: "2px",
+  },
+  visualSmall: {
+    width: "32px",
+    maxWidth: "32px",
+    height: "46px",
+    maxHeight: "46px",
+    padding: space.x1,
+  },
+  visualMedium: {
+    width: bottleThumbnailMetrics.width,
+    maxWidth: bottleThumbnailMetrics.width,
+    height: bottleThumbnailMetrics.height,
+    maxHeight: bottleThumbnailMetrics.height,
+    padding: space.x2,
+  },
+  visualLarge: {
+    width: { default: "132px", [COMPACT]: "80px" },
+    maxWidth: { default: "132px", [COMPACT]: "80px" },
+    height: { default: "176px", [COMPACT]: "120px" },
+    maxHeight: { default: "176px", [COMPACT]: "120px" },
+    padding: { default: space.x2, [COMPACT]: space.x1 },
+  },
+  visualExtraLarge: {
+    width: "100%",
+    maxWidth: "100%",
+    aspectRatio: "4 / 5",
+    padding: space.x4,
+  },
+  image: {
+    boxSizing: "border-box",
+    display: "block",
+    width: "100%",
+    maxWidth: "100%",
+    minWidth: 0,
+    height: "100%",
+    maxHeight: "100%",
+    minHeight: 0,
+    objectFit: "contain",
+  },
+  expandableImageExtraSmall: {
+    padding: "2px",
+  },
+  expandableImageSmall: {
+    padding: space.x1,
+  },
+  expandableImageMedium: {
+    padding: space.x2,
+  },
+  expandableImageLarge: {
+    padding: { default: space.x2, [COMPACT]: space.x1 },
+  },
+  expandableImageExtraLarge: {
+    padding: space.x4,
+  },
+  fallbackAsset: {
+    display: "block",
+    width: "100%",
+    maxWidth: "100%",
+    height: "100%",
+    maxHeight: "100%",
+    backgroundColor: "currentColor",
+    maskPosition: "center",
+    maskRepeat: "no-repeat",
+    maskSize: "contain",
+    WebkitMaskPosition: "center",
+    WebkitMaskRepeat: "no-repeat",
+    WebkitMaskSize: "contain",
+  },
+});
+
+const visualSizeStyles = {
+  xs: styles.visualExtraSmall,
+  sm: styles.visualSmall,
+  md: styles.visualMedium,
+  lg: styles.visualLarge,
+  xl: styles.visualExtraLarge,
+} satisfies Record<BottleVisualSize, stylex.StyleXStyles>;
+
+const expandableImagePaddingStyles = {
+  xs: styles.expandableImageExtraSmall,
+  sm: styles.expandableImageSmall,
+  md: styles.expandableImageMedium,
+  lg: styles.expandableImageLarge,
+  xl: styles.expandableImageExtraLarge,
+} satisfies Record<BottleVisualSize, stylex.StyleXStyles>;

--- a/apps/web/src/components/communityFeed.stories.tsx
+++ b/apps/web/src/components/communityFeed.stories.tsx
@@ -1,6 +1,9 @@
+import {
+  mockActivity,
+  mockExternalReview,
+} from "@peated/server/orpc/mock/fixtures";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
-
-import BottleImage from "../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
+import { getCommunityFeedItems } from "../lib/communityFeed";
 import { CommunityFeed } from "./communityFeed.stylex";
 import { StoryCanvas } from "./storyFixtures.stylex";
 
@@ -11,7 +14,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "A mixed feed with reviews as the primary destination and separate bottle links. Review scores and tasting ratings are centered beside the bottle name, author, and details; italic previews sit below that header.",
+          "Tastings, critic reviews, member reviews, and library additions share an author header. Tastings and reviews use the standard three-line bottle identity; library additions use compact, single-line bottle rows. Critic bylines are optional; library status is omitted.",
       },
     },
   },
@@ -22,39 +25,21 @@ const meta = {
       </StoryCanvas>
     ),
   ],
+  args: {
+    items: getCommunityFeedItems({
+      activity: mockActivity,
+      criticReviews: [mockExternalReview],
+    }),
+  },
 } satisfies Meta<typeof CommunityFeed>;
-
 export default meta;
 type Story = StoryObj<typeof meta>;
-
-export const Overview: Story = {
+export const Overview: Story = {};
+export const WithoutCriticByline: Story = {
   args: {
-    items: [
-      {
-        actor: "stillroom",
-        actorHref: "/users/stillroom",
-        bottleHref: "/bottles/7-lagavulin-16-year-old",
-        date: "2026-08-28T12:00:00.000Z",
-        description: "Smoke, dried fruit, sea salt, and a long finish.",
-        href: "/tastings/42",
-        id: "tasting-42",
-        imageUrl: BottleImage.src,
-        metadata: "Single malt · 16 years · 43% ABV",
-        ratingBand: "outstanding",
-        title: "Lagavulin 16-year-old",
-      },
-      {
-        actor: "Words of Whisky",
-        actorHref: "https://example.com/reviews/lagavulin-16",
-        bottleHref: "/bottles/7-lagavulin-16-year-old",
-        date: "2026-08-27T12:00:00.000Z",
-        description: "Revisiting Lagavulin 16-year-old",
-        href: "https://example.com/reviews/lagavulin-16",
-        id: "critic-91",
-        metadata: "Single malt · 16 years · 43% ABV",
-        score: 90,
-        title: "Lagavulin 16-year-old",
-      },
-    ],
+    items: getCommunityFeedItems({
+      activity: [],
+      criticReviews: [{ ...mockExternalReview, reviewerName: null }],
+    }),
   },
 };

--- a/apps/web/src/components/communityFeed.stylex.tsx
+++ b/apps/web/src/components/communityFeed.stylex.tsx
@@ -1,36 +1,46 @@
 import * as stylex from "@stylexjs/stylex";
 import { foundationStyles } from "../styles/foundations.stylex";
-
 import { colors, fonts, space } from "../styles/tokens.stylex";
+import { Avatar } from "./avatar.stylex";
 import {
   BottleIdentityRow,
   type BottleIdentityRowProps,
 } from "./bottleIdentityRow.stylex";
 import { ItemList, ItemListItem } from "./itemList.stylex";
-import { linkedRowStyles } from "./linkedRow.stylex";
 import { RATING_BANDS, TastingRating, type RatingBand } from "./scoring.stylex";
 import { TextLink } from "./textLink.stylex";
 import TimeSince from "./timeSince";
 
-export type CommunityFeedItem = {
-  bottle?: Pick<BottleIdentityRowProps, "name" | "provenance" | "metadata">;
-  actor: string;
-  actorHref?: string;
-  bottleHref: string;
-  date: string;
-  description?: string;
-  href: string;
+export type CommunityFeedBottle = Pick<
+  BottleIdentityRowProps,
+  "provenance" | "href" | "imageUrl" | "metadata" | "name"
+> & {
   id: string;
-  imageUrl?: string | null;
-  metadata?: string;
+  description?: string;
+  activityHref?: string;
+  activityLabel?: string;
+  byline?: string;
   ratingBand?: RatingBand | null;
   score?: number;
-  title: string;
+};
+
+export type CommunityFeedItem = {
+  id: string;
+  kind: "tasting" | "critic_review" | "member_review" | "collection_add";
+  actor: string;
+  actorHref?: string;
+  actorImageUrl?: string | null;
+  action: string;
+  date: string;
+  bottles: readonly CommunityFeedBottle[];
+  destination?: { href: string; label: string };
+  more?: { href: string; label: string };
 };
 
 /**
- * Owns activity rows on the homepage and /activity, including ratings and independent bottle links.
- * Callers supply items and limits; row markup and styling stay here.
+ * Activity list for the homepage and /activity. Map API entries with
+ * getCommunityFeedItems; this component owns author context, event grouping,
+ * and the standard/compact bottle choice. Routes own queries and actions.
  */
 export function CommunityFeed({
   ariaLabel = "Activity",
@@ -42,158 +52,194 @@ export function CommunityFeed({
   limit?: number;
 }) {
   const visibleItems = limit === undefined ? items : items.slice(0, limit);
-
   return (
     <ItemList ariaLabel={ariaLabel}>
       {visibleItems.map((item) => (
         <ItemListItem key={item.id}>
-          <article
-            {...stylex.props(
-              styles.entry,
-              linkedRowStyles.container,
-              linkedRowStyles.onGround,
-            )}
-          >
-            <div {...stylex.props(styles.heading)}>
-              <div {...stylex.props(styles.identity)}>
-                <BottleIdentityRow
-                  {...item.bottle}
-                  align="start"
-                  layout="cell"
-                  href={item.href}
-                  imageUrl={item.imageUrl}
-                  metadata={
-                    item.bottle?.metadata ??
-                    (item.metadata ? item.metadata.split(" · ") : [])
-                  }
-                  name={item.bottle?.name ?? item.title}
-                />
-                <div
-                  {...stylex.props(foundationStyles.metadata, styles.context)}
-                >
-                  {item.actorHref ? (
-                    <TextLink href={item.actorHref} size="inherit">
-                      {item.actor}
-                    </TextLink>
-                  ) : (
-                    item.actor
-                  )}
-                  <span aria-hidden="true"> · </span>
-                  <TimeSince date={item.date} />
-                </div>
-                <div
-                  {...stylex.props(foundationStyles.metadata, styles.metadata)}
-                >
-                  <TextLink href={item.bottleHref} size="inherit">
-                    View bottle
-                  </TextLink>
-                </div>
-              </div>
-              {item.score !== undefined || item.ratingBand ? (
-                <div {...stylex.props(styles.facts)}>
-                  {item.score !== undefined ? (
-                    <strong
-                      aria-label={`Review score: ${item.score} out of 100`}
-                      {...stylex.props(styles.score)}
-                    >
-                      {item.score}
-                    </strong>
-                  ) : null}
-                  {item.ratingBand ? (
-                    <>
-                      <strong {...stylex.props(styles.rating)}>
-                        {
-                          RATING_BANDS.find(
-                            (band) => band.key === item.ratingBand,
-                          )?.label
-                        }
-                      </strong>
-                      <TastingRating band={item.ratingBand} />
-                    </>
-                  ) : null}
-                </div>
-              ) : null}
-            </div>
-            {item.description ? (
-              <p {...stylex.props(foundationStyles.body, styles.excerpt)}>
-                {item.description}
-              </p>
-            ) : null}
-          </article>
+          <CommunityFeedEntry item={item} />
         </ItemListItem>
       ))}
     </ItemList>
   );
 }
 
-const MOBILE = "@media (max-width: 559px)";
+/** One event for an existing activity list, including member profile reviews. */
+export function CommunityFeedEntry({ item }: { item: CommunityFeedItem }) {
+  return (
+    <article {...stylex.props(styles.entry)}>
+      <header {...stylex.props(styles.author)}>
+        <Avatar
+          imageUrl={item.actorImageUrl}
+          initials={item.actor.slice(0, 2).toUpperCase()}
+          size="xs"
+        />
+        <div {...stylex.props(foundationStyles.metadata, styles.context)}>
+          {item.actorHref ? (
+            <TextLink href={item.actorHref} size="inherit">
+              {item.actor}
+            </TextLink>
+          ) : (
+            <strong>{item.actor}</strong>
+          )}{" "}
+          {item.action}
+          {item.destination ? (
+            <>
+              {" "}
+              <TextLink href={item.destination.href} size="inherit">
+                {item.destination.label}
+              </TextLink>
+            </>
+          ) : null}
+          <span {...stylex.props(styles.date)}>
+            <span aria-hidden="true"> · </span>
+            <TimeSince date={item.date} />
+          </span>
+        </div>
+      </header>
+      <div
+        {...stylex.props(
+          styles.content,
+          item.kind === "collection_add" && styles.compactContent,
+        )}
+      >
+        {item.bottles.map((bottle) => (
+          <div key={bottle.id} {...stylex.props(styles.bottle)}>
+            <BottleIdentityRow
+              variant={item.kind === "collection_add" ? "compact" : "standard"}
+              provenance={bottle.provenance}
+              name={bottle.name}
+              href={bottle.href}
+              imageUrl={bottle.imageUrl}
+              metadata={bottle.metadata}
+              end={
+                bottle.score !== undefined || bottle.ratingBand ? (
+                  <div {...stylex.props(styles.facts)}>
+                    {bottle.score !== undefined ? (
+                      <strong
+                        aria-label={`Review score: ${bottle.score} out of 100`}
+                        {...stylex.props(styles.score)}
+                      >
+                        {bottle.score}
+                        <span {...stylex.props(styles.scoreScale)}>/100</span>
+                      </strong>
+                    ) : null}
+                    {bottle.ratingBand ? (
+                      <>
+                        <strong {...stylex.props(styles.rating)}>
+                          {
+                            RATING_BANDS.find(
+                              (band) => band.key === bottle.ratingBand,
+                            )?.label
+                          }
+                        </strong>
+                        <TastingRating band={bottle.ratingBand} />
+                      </>
+                    ) : null}
+                  </div>
+                ) : undefined
+              }
+            />
+            {bottle.description || bottle.activityHref || bottle.byline ? (
+              <div {...stylex.props(styles.details)}>
+                {bottle.description ? (
+                  <p {...stylex.props(foundationStyles.body, styles.excerpt)}>
+                    {bottle.description}
+                  </p>
+                ) : null}
+                {bottle.byline || bottle.activityHref ? (
+                  <div
+                    {...stylex.props(foundationStyles.metadata, styles.footer)}
+                  >
+                    {bottle.byline ? <span>By {bottle.byline}</span> : null}
+                    {bottle.byline && bottle.activityHref ? (
+                      <span aria-hidden="true"> · </span>
+                    ) : null}
+                    {bottle.activityHref ? (
+                      <TextLink href={bottle.activityHref} size="inherit">
+                        {bottle.activityLabel}
+                      </TextLink>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+        ))}
+        {item.more ? (
+          <TextLink href={item.more.href} size="sm">
+            {item.more.label}
+          </TextLink>
+        ) : null}
+      </div>
+    </article>
+  );
+}
 
+const MOBILE = "@media (max-width: 559px)";
 const styles = stylex.create({
-  entry: {
-    boxSizing: "border-box",
-    display: "grid",
-    gridTemplateColumns: "minmax(0, 1fr)",
-    alignItems: "center",
-    columnGap: space.x3,
-    rowGap: space.x2,
-    width: "calc(100% + 24px)",
-    marginLeft: "-12px",
-    marginRight: "-12px",
-    padding: "14px 12px",
-  },
-  heading: {
+  entry: { paddingTop: space.x4, paddingBottom: space.x4 },
+  author: {
     display: "flex",
-    minWidth: 0,
     alignItems: "center",
     gap: space.x3,
+    [MOBILE]: { gap: space.x2 },
   },
-  identity: {
-    flex: 1,
+  context: { minWidth: 0, color: colors.inkMuted },
+  date: { whiteSpace: "nowrap" },
+  content: {
     minWidth: 0,
+    marginLeft: "38px",
+    marginTop: space.x2,
+    display: "flex",
+    flexDirection: "column",
+    gap: space.x3,
+    [MOBILE]: { marginLeft: "34px" },
   },
-  context: {
-    marginTop: "3px",
-    color: colors.inkMuted,
-  },
-  metadata: {
-    marginTop: "3px",
-    color: colors.inkMuted,
+  bottle: { minWidth: 0 },
+  compactContent: { gap: 0 },
+  details: {
+    marginLeft: "60px",
+    ["@media (max-width: 639px)"]: { marginLeft: "54px" },
   },
   facts: {
     display: "flex",
-    maxWidth: "112px",
     flexShrink: 0,
     alignItems: "flex-end",
     flexDirection: "column",
     gap: space.x2,
   },
   rating: {
-    maxWidth: "120px",
     color: colors.ink,
     fontFamily: fonts.display,
-    fontSize: "18px",
+    fontSize: "15px",
     fontWeight: 700,
     lineHeight: 1.2,
     textAlign: "right",
-    [MOBILE]: {
-      maxWidth: "88px",
-      fontSize: "15px",
-    },
+    [MOBILE]: { fontSize: "13px" },
   },
   score: {
     color: colors.ink,
     fontFamily: fonts.display,
-    fontSize: "40px",
+    fontSize: "32px",
     fontVariantNumeric: "tabular-nums",
     fontWeight: 700,
     letterSpacing: "-0.045em",
-    lineHeight: 0.9,
-    textAlign: "right",
+    lineHeight: 1,
+    whiteSpace: "nowrap",
+    [MOBILE]: { fontSize: "26px" },
+  },
+  scoreScale: {
+    color: colors.inkMuted,
+    fontSize: "12px",
+    fontWeight: 400,
+    letterSpacing: "normal",
+    marginLeft: "3px",
   },
   excerpt: {
-    gridColumn: "1",
-    margin: 0,
+    marginTop: 0,
+    marginBottom: space.x2,
     color: colors.ink,
     fontStyle: "italic",
   },
+  footer: { color: colors.inkMuted },
 });

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -16,14 +16,15 @@ export { Avatar } from "./avatar.stylex";
 export type { AvatarProps, AvatarSize } from "./avatar.stylex";
 export { BadgeImage } from "./badgeImage.stylex";
 export type { BadgeImageProps } from "./badgeImage.stylex";
-export { BottleIdentityRow, BottleVisual } from "./bottleIdentityRow.stylex";
-export type {
-  BottleIdentityRowProps,
-  BottleVisualProps,
-  BottleVisualSize,
-} from "./bottleIdentityRow.stylex";
+export { BottleIdentityRow } from "./bottleIdentityRow.stylex";
+export type { BottleIdentityRowProps } from "./bottleIdentityRow.stylex";
 export { BottleList } from "./bottleList.stylex";
 export type { BottleListItem, BottleListProps } from "./bottleList.stylex";
+export { BottleVisual } from "./bottleVisual.stylex";
+export type {
+  BottleVisualProps,
+  BottleVisualSize,
+} from "./bottleVisual.stylex";
 export { Button, ButtonLink, IconButton } from "./button.stylex";
 export type {
   ButtonLinkProps,

--- a/apps/web/src/components/itemList.stories.tsx
+++ b/apps/web/src/components/itemList.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import * as stylex from "@stylexjs/stylex";
 
 import { colors, fonts, zIndices } from "../styles/tokens.stylex";
-import { BottleVisual } from "./bottleIdentityRow.stylex";
+import { BottleVisual } from "./bottleVisual.stylex";
 import { ItemList, ItemRow } from "./itemList.stylex";
 import { BottleRatings } from "./scoring.stylex";
 import { StoryCanvas, StoryStack } from "./storyFixtures.stylex";

--- a/apps/web/src/components/pages/activityPage.stories.tsx
+++ b/apps/web/src/components/pages/activityPage.stories.tsx
@@ -1,8 +1,11 @@
+import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import {
+  mockActivity,
+  mockCollectionBottles,
   mockExternalReview,
-  mockTasting,
 } from "@peated/server/orpc/mock/fixtures";
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { getBottleUrl } from "../../lib/urls";
 
 import { getCommunityFeedItems } from "../../lib/communityFeed";
 import { PageTabs } from "../pageTabs.stylex";
@@ -23,15 +26,24 @@ const meta = {
     docs: {
       description: {
         component:
-          "Activity uses the catalog columns, with Following/Everyone beside the page title and aligned with the feed column. The sidebar has the contribution action and rating guidance, and is hidden on mobile. A short notice explains when Following shows everyone's activity because there are no accepted follows.",
+          "Activity uses the catalog columns, with Following/Everyone beside the page title and aligned with the feed column. The sidebar has the tasting action and bottles from the member’s library, and is hidden on mobile. A short notice explains when Following shows everyone's activity because there are no accepted follows.",
       },
     },
   },
   args: {
     items: getCommunityFeedItems({
       criticReviews: [mockExternalReview],
-      memberTastings: [mockTasting],
+      activity: mockActivity,
     }),
+    libraryBottles: mockCollectionBottles
+      .filter((item) => !item.hasTasted)
+      .slice(0, 3)
+      .map((item) => ({
+        href: getBottleUrl(item.bottle),
+        name: formatBottleDisplayName(item.bottle),
+        imageUrl: item.bottle.imageUrl,
+      })),
+    libraryHref: "/users/mock-user/library",
     selector: (
       <PageTabs
         ariaLabel="Activity feeds"

--- a/apps/web/src/components/pages/activityPage.stylex.tsx
+++ b/apps/web/src/components/pages/activityPage.stylex.tsx
@@ -4,6 +4,10 @@ import type { ReactNode } from "react";
 import { ButtonLink, EmptyState, TextLink } from "..";
 import { colors, fonts, space } from "../../styles/tokens.stylex";
 import { CommunityFeed, type CommunityFeedItem } from "../communityFeed.stylex";
+import {
+  BottleRailSection,
+  type BottleRailItem,
+} from "./bottleRailSection.stylex";
 import { PageColumns, PageHeader } from "./pageLayout.stylex";
 import { RailListSection } from "./railListSection.stylex";
 
@@ -12,9 +16,13 @@ export function ActivityPage({
   items,
   note,
   selector,
+  libraryBottles = [],
+  libraryHref,
 }: {
   items: readonly CommunityFeedItem[];
   note?: string;
+  libraryBottles?: readonly BottleRailItem[];
+  libraryHref?: string;
   selector: ReactNode;
 }) {
   return (
@@ -31,8 +39,7 @@ export function ActivityPage({
           <div {...stylex.props(styles.rail)}>
             <RailListSection heading="What have you tried?">
               <p {...stylex.props(styles.railText)}>
-                Choose a bottle, add a rating, and keep a note of what you
-                tasted.
+                Add a rating and a few notes to remember what you tasted.
               </p>
               <div>
                 <ButtonLink
@@ -44,26 +51,25 @@ export function ActivityPage({
                 </ButtonLink>
               </div>
             </RailListSection>
-            <RailListSection heading="Tastings and reviews">
-              <p {...stylex.props(styles.railText)}>
-                Tastings use five ratings, from Mediocre to Unicorn. Reviews can
-                include a score out of 100.
-              </p>
-              <TextLink href="/about/ratings">How ratings work →</TextLink>
-            </RailListSection>
+            {libraryBottles.length ? (
+              <BottleRailSection
+                heading="From your library"
+                intro="A few bottles you haven’t tasted on Peated."
+                items={libraryBottles}
+                moreHref={libraryHref}
+                moreLabel="View library →"
+              />
+            ) : null}
+            <TextLink href="/about/ratings">How ratings work →</TextLink>
           </div>
         }
       >
         {note ? <p {...stylex.props(styles.note)}>{note}</p> : null}
         {items.length ? (
-          <CommunityFeed
-            ariaLabel="Latest tastings and reviews"
-            items={items}
-            limit={20}
-          />
+          <CommunityFeed ariaLabel="Latest activity" items={items} limit={20} />
         ) : (
           <EmptyState heading="Nothing here yet">
-            New tastings and reviews will appear here.
+            Tastings, reviews, and library additions will appear here.
           </EmptyState>
         )}
       </PageColumns>

--- a/apps/web/src/components/pages/memberProfileContent.stylex.tsx
+++ b/apps/web/src/components/pages/memberProfileContent.stylex.tsx
@@ -4,6 +4,11 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import {
+  CommunityFeedEntry,
+  type CommunityFeedItem,
+} from "../communityFeed.stylex";
+
+import {
   BottleIdentityRow,
   Button,
   Chip,
@@ -181,6 +186,7 @@ export type MemberCollectionActivity = {
 };
 
 export type MemberActivityItem =
+  | { id: string; kind: "review"; review: CommunityFeedItem }
   | { id: string; kind: "tasting"; tasting: TastingEntryProps }
   | { activity: MemberCollectionActivity; id: string; kind: "collection" };
 
@@ -200,7 +206,11 @@ export function MemberActivityList({
   return (
     <ItemList ariaLabel="Member activity">
       {items.map((item) =>
-        item.kind === "tasting" ? (
+        item.kind === "review" ? (
+          <ItemListItem key={item.id}>
+            <CommunityFeedEntry item={item.review} />
+          </ItemListItem>
+        ) : item.kind === "tasting" ? (
           <ItemListItem key={item.id}>
             <TastingEntry {...item.tasting} />
           </ItemListItem>
@@ -245,7 +255,7 @@ function CollectionActivity({
           <ItemList ariaLabel={`${activity.collectionName} additions`}>
             {activity.items.map(({ id, ...identity }) => (
               <ItemListItem key={id}>
-                <BottleIdentityRow {...identity} />
+                <BottleIdentityRow {...identity} variant="compact" />
               </ItemListItem>
             ))}
             {hiddenCount ? (

--- a/apps/web/src/components/searchResults.stylex.tsx
+++ b/apps/web/src/components/searchResults.stylex.tsx
@@ -13,9 +13,9 @@ import { AppLink } from "./appLink";
 import { Avatar } from "./avatar.stylex";
 import {
   BottleIdentityRow,
-  BottleVisual,
   type BottleIdentityRowProps,
 } from "./bottleIdentityRow.stylex";
+import { BottleVisual } from "./bottleVisual.stylex";
 import { Button, ButtonLink } from "./button.stylex";
 import { FloatingPanel } from "./feedback.stylex";
 import { MatchedText } from "./matchedText.stylex";

--- a/apps/web/src/components/tastingEntry.stylex.tsx
+++ b/apps/web/src/components/tastingEntry.stylex.tsx
@@ -12,9 +12,9 @@ import {
 import { AppLink } from "./appLink";
 import {
   BottleIdentityRow,
-  BottleVisual,
   type BottleIdentityRowProps,
 } from "./bottleIdentityRow.stylex";
+import { BottleVisual } from "./bottleVisual.stylex";
 import { Chip } from "./chip.stylex";
 import { TastingRating, type RatingBand } from "./scoring.stylex";
 import { TastingToastSummary } from "./tastingToastButton.stylex";

--- a/apps/web/src/lib/communityFeed.test.ts
+++ b/apps/web/src/lib/communityFeed.test.ts
@@ -1,4 +1,5 @@
 import {
+  mockActivity,
   mockExternalReview,
   mockTasting,
 } from "@peated/server/orpc/mock/fixtures";
@@ -6,24 +7,28 @@ import { describe, expect, test } from "vitest";
 
 import { getCommunityFeedItems } from "./communityFeed";
 
+const session = mockActivity.find((item) => item.type === "tasting_session")!;
+
 describe("getCommunityFeedItems", () => {
   test("uses the review clip as the preview", () => {
     const [item] = getCommunityFeedItems({
       criticReviews: [mockExternalReview],
-      memberTastings: [],
+      activity: [],
     });
 
-    expect(item?.description).toBe(mockExternalReview.clip);
+    expect(item?.bottles[0]?.description).toBe(mockExternalReview.clip);
     expect(item?.actorHref).toBe(mockExternalReview.url);
   });
 
   test("uses the article title when the review has no clip", () => {
     const [item] = getCommunityFeedItems({
       criticReviews: [{ ...mockExternalReview, clip: null }],
-      memberTastings: [],
+      activity: [],
     });
 
-    expect(item?.description).toBe(mockExternalReview.article.title);
+    expect(item?.bottles[0]?.description).toBe(
+      mockExternalReview.article.title,
+    );
   });
 
   test("uses concise bottle identity for both review and tasting links", () => {
@@ -39,17 +44,17 @@ describe("getCommunityFeedItems", () => {
     };
     const items = getCommunityFeedItems({
       criticReviews: [{ ...mockExternalReview, bottle }],
-      memberTastings: [{ ...mockTasting, bottle }],
+      activity: [{ ...session, tastings: [{ ...mockTasting, bottle }] }],
     });
 
-    expect(items.map((item) => item.title)).toEqual([
+    expect(items.map((item) => item.bottles[0]?.name)).toEqual([
       "Example Barrel Proof",
       "Example Barrel Proof",
     ]);
-    expect(items.every((item) => item.metadata?.includes("Batch C923"))).toBe(
-      true,
-    );
-    expect(items.map((item) => item.href)).toEqual([
+    expect(
+      items.every((item) => item.bottles[0]?.metadata?.includes("Batch C923")),
+    ).toBe(true);
+    expect(items.map((item) => item.bottles[0]?.activityHref)).toEqual([
       mockExternalReview.url,
       `/tastings/${mockTasting.id}`,
     ]);
@@ -68,10 +73,76 @@ describe("getCommunityFeedItems", () => {
           nativeScore: { value: 9, scale: 10, display: "9/10" },
         },
       ],
-      memberTastings: [mockTasting],
+      activity: [{ ...session, tastings: [mockTasting] }],
     });
 
-    expect(items.map((item) => item.score)).toEqual([0, undefined, undefined]);
-    expect(items[2]?.ratingBand).toBe(mockTasting.ratingBand);
+    expect(items.map((item) => item.bottles[0]?.score)).toEqual([
+      0,
+      undefined,
+      undefined,
+    ]);
+    expect(items[2]?.bottles[0]?.ratingBand).toBe(mockTasting.ratingBand);
   });
+});
+
+test("includes all four activity types, preserves groups, and omits library status", () => {
+  const items = getCommunityFeedItems({
+    activity: mockActivity,
+    criticReviews: [mockExternalReview],
+  });
+  expect(new Set(items.map((item) => item.kind))).toEqual(
+    new Set(["tasting", "critic_review", "member_review", "collection_add"]),
+  );
+  expect(items.find((item) => item.id === session.id)?.bottles).toHaveLength(
+    session.tastings.length,
+  );
+  const additions = items.filter((item) => item.kind === "collection_add");
+  expect(additions.map((item) => item.bottles.length)).toEqual([1, 3]);
+  for (const item of additions) {
+    expect(item.destination?.href).toMatch(/\/library$/);
+    expect(
+      item.bottles.every(
+        (bottle) => !("status" in bottle) && !("isLibrary" in bottle),
+      ),
+    ).toBe(true);
+  }
+  const dates = items.map((item) => Date.parse(item.date));
+  expect(dates).toEqual([...dates].sort((a, b) => b - a));
+});
+
+test.each([null, "Whisky Advocate", "Alex Sample"])(
+  "critic byline is optional and does not repeat the publication: %s",
+  (reviewerName) => {
+    const [item] = getCommunityFeedItems({
+      activity: [],
+      criticReviews: [
+        {
+          ...mockExternalReview,
+          site: { ...mockExternalReview.site!, name: "Whisky Advocate" },
+          reviewerName,
+        },
+      ],
+    });
+    expect(item?.actor).toBe("Whisky Advocate");
+    expect(item?.bottles[0]?.byline).toBe(
+      reviewerName === "Alex Sample" ? reviewerName : undefined,
+    );
+  },
+);
+
+test("does not show favorites as library additions", () => {
+  const addition = mockActivity.find((item) => item.type === "collection_add")!;
+  const items = getCommunityFeedItems({
+    criticReviews: [],
+    activity: [
+      {
+        ...addition,
+        collection: {
+          ...addition.collection,
+          href: "/users/someone/favorites",
+        },
+      },
+    ],
+  });
+  expect(items).toEqual([]);
 });

--- a/apps/web/src/lib/communityFeed.ts
+++ b/apps/web/src/lib/communityFeed.ts
@@ -1,74 +1,151 @@
 import type { Outputs } from "@peated/server/orpc/router";
-
-import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
-import type { CommunityFeedItem } from "@peated/web/components/communityFeed.stylex";
+import type {
+  CommunityFeedBottle,
+  CommunityFeedItem,
+} from "@peated/web/components/communityFeed.stylex";
 import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";
-import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getBottleUrl } from "@peated/web/lib/urls";
 
 type CriticReview = Outputs["externalReviews"]["list"]["results"][number];
-type MemberTasting = Outputs["tastings"]["list"]["results"][number];
+type Activity = Outputs["activity"]["list"]["results"][number];
+type Bottle = Outputs["bottles"]["list"]["results"][number];
+
+function feedBottle(bottle: Bottle): CommunityFeedBottle {
+  return {
+    id: bottle.peatedId,
+    ...getBottleIdentityProps(bottle),
+    href: getBottleUrl(bottle),
+    imageUrl: bottle.imageUrl,
+  };
+}
 
 export function getCommunityFeedItems({
   criticReviews,
-  memberTastings,
+  activity,
 }: {
   criticReviews: readonly CriticReview[];
-  memberTastings: readonly MemberTasting[];
+  activity: readonly Activity[];
 }): CommunityFeedItem[] {
   const criticItems = criticReviews.flatMap((review): CommunityFeedItem[] => {
     if (!review.bottle) return [];
-
     const source = review.site?.name ?? review.reviewerName ?? "Critic";
     return [
       {
-        actor: source,
-        bottle: getBottleIdentityProps(review.bottle),
-        actorHref: review.url,
-        bottleHref: getBottleUrl(review.bottle),
-        date: review.article.publishedAt ?? review.createdAt,
-        description: getPreview(review.clip ?? review.article.title),
-        href: review.url,
         id: `critic-${review.id}`,
-        imageUrl: review.bottle.imageUrl,
-        metadata: getBottleMetadata(review.bottle),
-        score:
-          review.nativeScore?.scale === 100
-            ? review.nativeScore.value
-            : undefined,
-        title: formatBottleDisplayName(review.bottle),
+        kind: "critic_review",
+        actor: source,
+        actorHref: review.url,
+        actorImageUrl: review.site?.imageUrl,
+        action: "published a review",
+        date: review.article.publishedAt ?? review.createdAt,
+        bottles: [
+          {
+            ...feedBottle(review.bottle),
+            description: getPreview(review.clip ?? review.article.title),
+            activityHref: review.url,
+            activityLabel: `Read at ${source} ↗`,
+            byline:
+              review.reviewerName && review.reviewerName !== source
+                ? review.reviewerName
+                : undefined,
+            score:
+              review.nativeScore?.scale === 100
+                ? review.nativeScore.value
+                : undefined,
+          },
+        ],
       },
     ];
   });
-  const tastingItems = memberTastings.map(
-    (tasting): CommunityFeedItem => ({
-      actor: tasting.createdBy.username,
-      bottle: getBottleIdentityProps(tasting.bottle),
-      actorHref: `/users/${tasting.createdBy.username}`,
-      bottleHref: getBottleUrl(tasting.bottle),
-      date: tasting.createdAt,
-      description: getPreview(tasting.notes),
-      href: `/tastings/${tasting.id}`,
-      id: `tasting-${tasting.id}`,
-      imageUrl: tasting.bottle.imageUrl,
-      metadata: getBottleMetadata(tasting.bottle),
-      ratingBand: tasting.ratingBand,
-      title: formatBottleDisplayName(tasting.bottle),
-    }),
-  );
-
-  return [...criticItems, ...tastingItems].sort(
+  const memberItems = activity.flatMap((entry): CommunityFeedItem[] => {
+    const actor = {
+      id: entry.id,
+      actor: entry.createdBy.username,
+      actorHref: `/users/${entry.createdBy.username}`,
+      actorImageUrl: entry.createdBy.pictureUrl,
+    };
+    if (entry.type === "tasting_session") {
+      return [
+        {
+          ...actor,
+          kind: "tasting",
+          action:
+            entry.tastings.length === 1
+              ? "tasted"
+              : `tasted ${entry.tastings.length} bottles`,
+          date: entry.lastActivityAt,
+          bottles: entry.tastings.map((tasting) => ({
+            ...feedBottle(tasting.bottle),
+            id: String(tasting.id),
+            description: getPreview(tasting.notes),
+            ratingBand: tasting.ratingBand,
+            activityHref: `/tastings/${tasting.id}`,
+            activityLabel: "View tasting",
+          })),
+        },
+      ];
+    }
+    if (entry.type === "member_review") {
+      return [
+        {
+          ...actor,
+          kind: "member_review",
+          action: "reviewed",
+          date: entry.createdAt,
+          bottles: [
+            {
+              ...feedBottle(entry.review.bottle),
+              score: entry.review.score,
+              description: getPreview(entry.review.notes),
+              activityHref: `/reviews/${entry.review.id}`,
+              activityLabel: "Read review",
+            },
+          ],
+        },
+      ];
+    }
+    // Peated activity follows the profile rule: favorites are not feed events.
+    if (entry.collection.href?.endsWith("/favorites")) return [];
+    const isLibrary = entry.collection.href?.endsWith("/library");
+    const destinationLabel = isLibrary
+      ? "their library"
+      : entry.collection.name;
+    const count = entry.totalItems;
+    const hiddenCount = Math.max(0, count - entry.items.length);
+    return [
+      {
+        ...actor,
+        kind: "collection_add",
+        date: entry.createdAt,
+        action: `added ${count === 1 ? "a bottle" : `${count} bottles`} to${entry.collection.href ? "" : ` ${destinationLabel}`}`,
+        destination: entry.collection.href
+          ? { href: entry.collection.href, label: destinationLabel }
+          : undefined,
+        bottles: entry.items.map((item) => ({
+          ...feedBottle(item.bottle),
+          id: String(item.id),
+          imageUrl: item.imageUrl ?? item.bottle.imageUrl,
+        })),
+        more:
+          hiddenCount && entry.collection.href
+            ? {
+                href: entry.collection.href,
+                label: `View ${hiddenCount} more ${hiddenCount === 1 ? "bottle" : "bottles"} →`,
+              }
+            : undefined,
+      },
+    ];
+  });
+  return [...criticItems, ...memberItems].sort(
     (left, right) => Date.parse(right.date) - Date.parse(left.date),
   );
 }
 
 const PREVIEW_LENGTH = 160;
-
 function getPreview(value?: string | null) {
   const normalized = value?.trim().replace(/\s+/g, " ");
   if (!normalized) return undefined;
   if (normalized.length <= PREVIEW_LENGTH) return normalized;
-
   const wordBoundary = normalized.slice(0, PREVIEW_LENGTH + 1).lastIndexOf(" ");
   const cutoff = wordBoundary > 0 ? wordBoundary : PREVIEW_LENGTH;
   return `${normalized.slice(0, cutoff).trimEnd()}…`;

--- a/apps/web/src/lib/orpc/homeQueries.ts
+++ b/apps/web/src/lib/orpc/homeQueries.ts
@@ -16,8 +16,8 @@ export const publicHomeQueries = {
     orpc.events.list.queryOptions({
       input: { limit: 1, onlyUpcoming: true, sort: "date" },
     }),
-  memberTastings: (orpc: ORPCQueryUtils) =>
-    orpc.tastings.list.queryOptions({
+  memberActivity: (orpc: ORPCQueryUtils) =>
+    orpc.activity.list.queryOptions({
       input: { limit: 3 },
     }),
   releases: (orpc: ORPCQueryUtils) =>

--- a/docs/features/bottle-presentation.md
+++ b/docs/features/bottle-presentation.md
@@ -355,6 +355,46 @@ the implementation.
 
 ## Implementation Map
 
+### Choosing a web component
+
+The components live in `apps/web/src/components/`, with stories beside them.
+Storybook's **Components / Bottles / Bottle Identity Row / Row Layouts** is the
+shared visual reference for desktop and phone layouts.
+
+| Need                        | Component                             | Responsibility                                                                                               |
+| --------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| One standard bottle row     | `BottleIdentityRow`                   | Full marketed name, provenance, release facts, thumbnail, and linked hit area.                               |
+| One-line library addition   | `BottleIdentityRow variant="compact"` | Same name, smaller thumbnail, and a 44px hit area; long names truncate visually.                             |
+| Catalog list                | `BottleList`                          | List semantics and optional ratings or row actions.                                                          |
+| Mixed activity              | `CommunityFeed`                       | Author, action, date, grouped bottles, scores, and review links; chooses compact rows for library additions. |
+| Selected bottle in a form   | `SelectedBottleSummary`               | Standard identity and optional change action.                                                                |
+| Sidebar bottle suggestions  | `pages/BottleRailSection`             | Two-line rail with smaller thumbnails and optional section action.                                           |
+| Image within another layout | `BottleVisual`                        | Image sizing, white frame, missing-image glyph, and optional expansion.                                      |
+
+Use `toBottleListItem` from `apps/web/src/lib/bottleListItem.ts` for full API
+Bottles. For partial reads, `getBottleIdentityProps` supplies the name,
+provenance, and release facts; the caller supplies the image and destination.
+API reads must include the BottleGroup summary needed by the name formatter.
+
+```tsx
+const item = toBottleListItem(bottle);
+
+<BottleIdentityRow {...item} />
+<BottleIdentityRow {...item} variant="compact" />
+```
+
+Both variants accept the full marketed name, including brand context. Compact
+rows omit provenance, metadata, subtitles, membership status, and related-release
+links. The optional `end` slot remains available. `layout="cell"` fits the identity
+inside an existing table or selection control; it does not change content density.
+The row owns thumbnail size, so callers do not build a second image/name layout.
+
+Routes own queries, authentication, and mutations. Keep API-to-feed mapping in
+`getCommunityFeedItems`; pass its output to `CommunityFeed`. Component JSDoc and
+Storybook controls document supported props and states.
+
+### Other presentation branches
+
 The contract is applied at the presentation site that owns each branch:
 
 - Bottle headers, result rows, previews, and tasting identities compose their


### PR DESCRIPTION
The homepage and Activity page now combine tastings, critic reviews, member reviews, and library additions. Each event puts its author, action, and date above the shared bottle rows. Library additions use compact single-line rows with small thumbnails; reviews and tastings retain the standard identity. Critic bylines are optional, library status stays out of the feed, and the page's tasting action lives in the sidebar alongside untasted library bottles.

Member reviews are now a primary activity source in the global and profile APIs. They share pagination with complete tasting sessions and follow the existing visibility rules. Regression coverage checks private profiles, accepted follows, and pagination without duplicate or split sessions; dev fixtures and component stories cover all four activity types.

BottleIdentityRow owns the standard and compact variants, while BottleVisual now lives in its own module. Storybook documents their intended uses, image sizes, missing-image behavior, and responsive layouts. The Bottle Presentation guide maps each use case to the existing row, list, feed, selection, or sidebar component.
