### PR TITLE
fix(web): standardize typography across shared components

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -40,9 +40,15 @@ typography:
     fontWeight: 700
     lineHeight: 0.95
     letterSpacing: -0.05em
+  compact-page-title:
+    fontFamily: Space Grotesk
+    fontSize: 40px
+    fontWeight: 700
+    lineHeight: 1.1
+    letterSpacing: -0.04em
   section-heading:
     fontFamily: Space Grotesk
-    fontSize: 20px
+    fontSize: 24px
     fontWeight: 700
     lineHeight: 1.2
     letterSpacing: -0.025em
@@ -52,6 +58,22 @@ typography:
     fontWeight: 700
     lineHeight: 1.25
     letterSpacing: -0.025em
+  compact-row-title:
+    fontFamily: Space Grotesk
+    fontSize: 16px
+    fontWeight: 700
+    lineHeight: 1.25
+    letterSpacing: -0.025em
+  prose:
+    fontFamily: Karla
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.65
+  input:
+    fontFamily: Karla
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.45
   body:
     fontFamily: Karla
     fontSize: 15px
@@ -62,6 +84,16 @@ typography:
     fontSize: 15px
     fontWeight: 600
     lineHeight: 1.2
+  compact-interactive:
+    fontFamily: Karla
+    fontSize: 13px
+    fontWeight: 600
+    lineHeight: 1.3
+  code:
+    fontFamily: IBM Plex Mono
+    fontSize: 13px
+    fontWeight: 400
+    lineHeight: 1.45
   metadata:
     fontFamily: Karla
     fontSize: 13px
@@ -70,7 +102,7 @@ typography:
   field-label:
     fontFamily: Karla
     fontSize: 13px
-    fontWeight: 400
+    fontWeight: 600
     lineHeight: 1.4
     letterSpacing: 0
   micro-label:
@@ -206,16 +238,39 @@ sentiment poles.
   State the ranking only when it helps people choose; sort controls should
   still name their order.
 
-| Role            | Family  | Weight | Size and line height | Tracking |
-| --------------- | ------- | ------ | -------------------- | -------- |
-| Page title      | Display | 700    | 40–72px / 0.95       | -0.05em  |
-| Section heading | Display | 700    | 20px / 1.2           | -0.025em |
-| Row title       | Display | 700    | 18px / 1.25          | -0.025em |
-| Body            | Reading | 400    | 15px / 1.6           | normal   |
-| Interactive     | Reading | 600    | 15px / 1.2           | normal   |
-| Metadata        | Reading | 400    | 13px / 1.45          | normal   |
-| Field label     | Reading | 400    | 13px / 1.4           | normal   |
-| Micro label     | Reading | 400    | 13px / 1.4           | normal   |
+| Role                | Family  | Weight | Size and line height | Tracking |
+| ------------------- | ------- | ------ | -------------------- | -------- |
+| Page title          | Display | 700    | 40–72px / 0.95       | -0.05em  |
+| Compact page title  | Display | 700    | 32–40px / 1.1        | -0.04em  |
+| Section heading     | Display | 700    | 24px / 1.2           | -0.025em |
+| Row title           | Display | 700    | 18px / 1.25          | -0.025em |
+| Compact row title   | Display | 700    | 16px / 1.25          | -0.025em |
+| Prose               | Reading | 400    | 16px / 1.65          | normal   |
+| Body                | Reading | 400    | 15px / 1.6           | normal   |
+| Input               | Reading | 400    | 16px / 1.45          | normal   |
+| Interactive         | Reading | 600    | 15px / 1.2           | normal   |
+| Compact interactive | Reading | 600    | 13px / 1.3           | normal   |
+| Metadata            | Reading | 400    | 13px / 1.45          | normal   |
+| Field label         | Reading | 600    | 13px / 1.4           | normal   |
+| Micro label         | Reading | 400    | 13px / 1.4           | normal   |
+| Code                | Mono    | 400    | 13px / 1.45          | normal   |
+
+Compose these roles from `foundationStyles`; do not copy their font recipes
+into page or component styles. Local styles own layout, color, and deliberate
+emphasis. Use the compact page title for task screens such as search, sign-in,
+and admin; catalog identities use the larger page title. Long descriptions and
+reviews use prose; short interface copy uses body. Inputs stay at 16px on every
+screen. Regular and compact rows each have one shared title size.
+
+Dates, counts, table headers, hints, and navigation use Karla. Selected controls
+keep the same font family and size; use weight, color, and the active indicator
+to show selection. Keep metadata at 13px instead of shrinking it to fit. Let it
+wrap or give the layout more room. Put useful page metadata below the title.
+
+Logos, avatar initials, numeric scores, prominent statistics, and labels inside
+scaled diagrams may have sizes suited to their geometry. Their owning shared
+component defines those exceptions; they do not create new body or heading
+styles.
 
 Use tabular numerals for aligned numbers. Use uppercase text only for short
 data labels. Do not use the display face for body copy.

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -20,9 +20,10 @@
 - Share add/edit forms. Routes supply data, auth checks, mutations, and redirects.
 - Keep StyleX with its markup. Use wrappers only when third-party markup cannot
   be styled safely otherwise. No Tailwind or catch-all folders like `product/`.
-- Compose `foundationStyles` for standard typography instead of copying font
-  values into rows. `BottleIdentityRow` owns bottle rows; `BottleVisual` owns
-  bottle images; `CommunityFeed` owns activity on the homepage and `/activity`.
+- Compose `foundationStyles` for typography instead of copying font recipes
+  into components. Use Karla for metadata and labels, and reserve monospace for
+  code. Page metadata goes below its title. `BottleIdentityRow` owns bottle rows;
+  `BottleVisual` owns bottle images; `CommunityFeed` owns activity on the homepage and `/activity`.
   Use `formatBottleDisplayName` or `toBottleListItem` for displayed bottle names.
   API responses used by these helpers must include the BottleGroup summary.
 - Review changes to shared bottle layouts together in Bottle Identity Row's

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/layout.tsx
@@ -103,7 +103,7 @@ export default function Layout({
             size="lg"
           />
         }
-        eyebrow={site.type}
+        description={site.type}
         metadata={<ExternalSiteRunStatus site={site} />}
         actions={
           <AdminActions>

--- a/apps/web/src/app/(app)/_components/home/homeEventCallout.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/homeEventCallout.stylex.tsx
@@ -5,7 +5,8 @@ import * as stylex from "@stylexjs/stylex";
 import { TextLink } from "@peated/web/components";
 import DateRange from "@peated/web/components/dateRange";
 import { formatEventLocation } from "@peated/web/lib/eventLocation";
-import { colors, fonts, space } from "../../../../styles/tokens.stylex";
+import { foundationStyles } from "../../../../styles/foundations.stylex";
+import { colors, space } from "../../../../styles/tokens.stylex";
 
 export function HomeEventCallout({
   event,
@@ -18,9 +19,8 @@ export function HomeEventCallout({
 
   return (
     <section aria-labelledby={headingId} {...stylex.props(styles.root)}>
-      <SectionHeading id={headingId}>Coming up</SectionHeading>
-      <h3 {...stylex.props(styles.title)}>{event.name}</h3>
-      <div {...stylex.props(styles.details)}>
+      <SectionHeading id={headingId}>{event.name}</SectionHeading>
+      <div {...stylex.props(foundationStyles.metadata, styles.details)}>
         <DateRange start={event.dateStart} end={event.dateEnd} />
         {location ? <span>{location}</span> : null}
       </div>
@@ -37,25 +37,12 @@ const styles = stylex.create({
   root: {
     minWidth: 0,
   },
-  title: {
-    margin: 0,
-    marginTop: space.x3,
-    color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.25,
-  },
   details: {
     display: "flex",
     flexDirection: "column",
     gap: space.x1,
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
   },
   action: {
     marginTop: space.x3,

--- a/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
+++ b/apps/web/src/app/(app)/about/aboutPage.stylex.tsx
@@ -8,7 +8,8 @@ import {
   PageHeader,
   TabbedPage,
 } from "@peated/web/components/pages/pageLayout.stylex";
-import { colors, fonts, space } from "../../../styles/tokens.stylex";
+import { foundationStyles } from "../../../styles/foundations.stylex";
+import { colors, space } from "../../../styles/tokens.stylex";
 
 const MOBILE = "@media (max-width: 559px)";
 const STEPS_STACKED = "@media (max-width: 899px)";
@@ -50,7 +51,9 @@ export function AboutPage({
 }
 
 export function AboutText({ children }: { children: ReactNode }) {
-  return <p {...stylex.props(styles.text)}>{children}</p>;
+  return (
+    <p {...stylex.props(foundationStyles.body, styles.text)}>{children}</p>
+  );
 }
 
 export function AboutLink({ children, ...props }: TextLinkProps) {
@@ -72,7 +75,7 @@ export function AboutCode({ children }: { children: string }) {
       aria-label="Example API request"
       role="region"
       tabIndex={0}
-      {...stylex.props(styles.codeBlock)}
+      {...stylex.props(foundationStyles.code, styles.codeBlock)}
     >
       <code>{children}</code>
     </pre>
@@ -89,13 +92,15 @@ export function ReviewSteps({
     <ol {...stylex.props(styles.steps)}>
       {steps.map((step, index) => (
         <li key={step.title} {...stylex.props(styles.step)}>
-          <span {...stylex.props(styles.stepNumber)}>
+          <span {...stylex.props(foundationStyles.metadata, styles.stepNumber)}>
             {String(index + 1).padStart(2, "0")}
           </span>
           <div {...stylex.props(styles.stepTitle)}>
             <SectionHeading level={3}>{step.title}</SectionHeading>
           </div>
-          <div {...stylex.props(styles.stepBody)}>{step.body}</div>
+          <div {...stylex.props(foundationStyles.metadata, styles.stepBody)}>
+            {step.body}
+          </div>
         </li>
       ))}
     </ol>
@@ -112,12 +117,20 @@ export function ReviewDirections({
   return (
     <dl {...stylex.props(styles.directions)}>
       <div>
-        <dt {...stylex.props(styles.directionLabel)}>Move up for</dt>
-        <dd {...stylex.props(styles.directionBody)}>{up}</dd>
+        <dt {...stylex.props(foundationStyles.metadata, styles.directionLabel)}>
+          Move up for
+        </dt>
+        <dd {...stylex.props(foundationStyles.metadata, styles.directionBody)}>
+          {up}
+        </dd>
       </div>
       <div>
-        <dt {...stylex.props(styles.directionLabel)}>Move down for</dt>
-        <dd {...stylex.props(styles.directionBody)}>{down}</dd>
+        <dt {...stylex.props(foundationStyles.metadata, styles.directionLabel)}>
+          Move down for
+        </dt>
+        <dd {...stylex.props(foundationStyles.metadata, styles.directionBody)}>
+          {down}
+        </dd>
       </div>
     </dl>
   );
@@ -133,9 +146,6 @@ const styles = stylex.create({
     maxWidth: "74ch",
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.7,
   },
   codeBlock: {
     maxWidth: "100%",
@@ -145,9 +155,6 @@ const styles = stylex.create({
     borderRadius: "3px",
     backgroundColor: colors.inset,
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: "12px",
-    lineHeight: 1.55,
   },
   steps: {
     display: "grid",
@@ -169,18 +176,12 @@ const styles = stylex.create({
   },
   stepNumber: {
     color: colors.accentDeep,
-    fontFamily: fonts.data,
-    fontSize: "10px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.3,
   },
   stepTitle: { marginTop: space.x2 },
   stepBody: {
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.55,
   },
   directions: {
     display: "grid",
@@ -194,18 +195,10 @@ const styles = stylex.create({
   },
   directionLabel: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.04em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   directionBody: {
     margin: 0,
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.55,
   },
 });

--- a/apps/web/src/app/(app)/about/brand/brandVoicePage.stylex.tsx
+++ b/apps/web/src/app/(app)/about/brand/brandVoicePage.stylex.tsx
@@ -6,7 +6,6 @@ import { foundationStyles } from "../../../../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
-  fonts,
   space,
 } from "../../../../styles/tokens.stylex";
 
@@ -175,7 +174,7 @@ export function BrandVoicePage() {
           <br />
           Light about the drinking.
         </h1>
-        <p {...stylex.props(styles.lede)}>
+        <p {...stylex.props(foundationStyles.prose, styles.lede)}>
           The obvious way to sound relaxed is to dismiss whisky. The obvious way
           to sound credible is to revere it. Both are wrong. The database is not
           a joke. The hobby can be faintly ridiculous.
@@ -203,9 +202,13 @@ export function BrandVoicePage() {
                 <SectionHeading level={3}>
                   {index + 1} · {rule.title}
                 </SectionHeading>
-                <p {...stylex.props(styles.cardBody)}>{rule.body}</p>
+                <p {...stylex.props(foundationStyles.body, styles.cardBody)}>
+                  {rule.body}
+                </p>
               </div>
-              <div {...stylex.props(styles.example)}>{rule.example()}</div>
+              <div {...stylex.props(foundationStyles.body, styles.example)}>
+                {rule.example()}
+              </div>
             </li>
           ))}
         </ol>
@@ -216,7 +219,13 @@ export function BrandVoicePage() {
         intro="Preserve the useful fact. Remove the brochure voice, empty praise, and jokes that get in the way."
       >
         <div role="table" aria-label="Peated copy examples">
-          <div role="row" {...stylex.props(styles.comparisonHeader)}>
+          <div
+            role="row"
+            {...stylex.props(
+              foundationStyles.metadata,
+              styles.comparisonHeader,
+            )}
+          >
             <span role="columnheader">Don’t</span>
             <span role="columnheader">Do</span>
             <span role="columnheader">Why</span>
@@ -228,18 +237,43 @@ export function BrandVoicePage() {
               {...stylex.props(styles.comparisonRow)}
             >
               <div role="cell" {...stylex.props(styles.comparisonCell)}>
-                <span {...stylex.props(styles.mobileLabel)}>Don’t</span>
-                <s {...stylex.props(styles.before)}>{comparison.before}</s>
+                <span
+                  {...stylex.props(
+                    foundationStyles.metadata,
+                    styles.mobileLabel,
+                  )}
+                >
+                  Don’t
+                </span>
+                <s {...stylex.props(foundationStyles.body, styles.before)}>
+                  {comparison.before}
+                </s>
               </div>
               <div role="cell" {...stylex.props(styles.comparisonCell)}>
-                <span {...stylex.props(styles.mobileLabel)}>Do</span>
-                <strong {...stylex.props(styles.after)}>
+                <span
+                  {...stylex.props(
+                    foundationStyles.metadata,
+                    styles.mobileLabel,
+                  )}
+                >
+                  Do
+                </span>
+                <strong {...stylex.props(foundationStyles.body, styles.after)}>
                   {comparison.after}
                 </strong>
               </div>
               <div role="cell" {...stylex.props(styles.comparisonCell)}>
-                <span {...stylex.props(styles.mobileLabel)}>Why</span>
-                <span {...stylex.props(styles.reason)}>
+                <span
+                  {...stylex.props(
+                    foundationStyles.metadata,
+                    styles.mobileLabel,
+                  )}
+                >
+                  Why
+                </span>
+                <span
+                  {...stylex.props(foundationStyles.metadata, styles.reason)}
+                >
                   {comparison.reason}
                 </span>
               </div>
@@ -273,7 +307,14 @@ export function BrandVoicePage() {
           {mechanics.map((item) => (
             <div key={item.title} {...stylex.props(styles.mechanicCard)}>
               <SectionHeading level={3}>{item.title}</SectionHeading>
-              <p {...stylex.props(styles.mechanicBody)}>{item.body}</p>
+              <p
+                {...stylex.props(
+                  foundationStyles.metadata,
+                  styles.mechanicBody,
+                )}
+              >
+                {item.body}
+              </p>
             </div>
           ))}
         </div>
@@ -295,7 +336,11 @@ function VoiceSection({
     <section {...stylex.props(styles.section)}>
       <div {...stylex.props(styles.sectionHeader)}>
         <SectionHeading>{heading}</SectionHeading>
-        {intro ? <p {...stylex.props(styles.sectionIntro)}>{intro}</p> : null}
+        {intro ? (
+          <p {...stylex.props(foundationStyles.body, styles.sectionIntro)}>
+            {intro}
+          </p>
+        ) : null}
       </div>
       {children}
     </section>
@@ -314,11 +359,17 @@ function PositionCard({
   return (
     <div {...stylex.props(styles.positionCard)}>
       <div
-        {...stylex.props(styles.microLabel, accent && styles.accentMicroLabel)}
+        {...stylex.props(
+          foundationStyles.metadata,
+          styles.microLabel,
+          accent && styles.accentMicroLabel,
+        )}
       >
         {label}
       </div>
-      <p {...stylex.props(styles.positionBody)}>{children}</p>
+      <p {...stylex.props(foundationStyles.body, styles.positionBody)}>
+        {children}
+      </p>
     </div>
   );
 }
@@ -335,20 +386,28 @@ function WordList({
   return (
     <div {...stylex.props(styles.wordList)}>
       <div
-        {...stylex.props(styles.microLabel, accent && styles.accentMicroLabel)}
+        {...stylex.props(
+          foundationStyles.metadata,
+          styles.microLabel,
+          accent && styles.accentMicroLabel,
+        )}
       >
         {label}
       </div>
-      <div {...stylex.props(styles.words)}>{words}</div>
+      <div {...stylex.props(foundationStyles.metadata, styles.words)}>
+        {words}
+      </div>
     </div>
   );
 }
 
 function RegisterRow({ label, value }: { label: string; value: string }) {
   return (
-    <div {...stylex.props(styles.registerRow)}>
+    <div {...stylex.props(foundationStyles.metadata, styles.registerRow)}>
       <dt>{label}</dt>
-      <dd {...stylex.props(styles.registerValue)}>{value}</dd>
+      <dd {...stylex.props(foundationStyles.metadata, styles.registerValue)}>
+        {value}
+      </dd>
     </div>
   );
 }
@@ -370,14 +429,19 @@ function VoiceExample({
     >
       <div
         {...stylex.props(
+          foundationStyles.metadata,
           styles.microLabel,
           selected && styles.accentMicroLabel,
         )}
       >
         {label}
       </div>
-      <p {...stylex.props(styles.voiceQuote)}>{children}</p>
-      <div {...stylex.props(styles.voiceNote)}>{note}</div>
+      <p {...stylex.props(foundationStyles.body, styles.voiceQuote)}>
+        {children}
+      </p>
+      <div {...stylex.props(foundationStyles.metadata, styles.voiceNote)}>
+        {note}
+      </div>
     </div>
   );
 }
@@ -398,9 +462,6 @@ const styles = stylex.create({
     marginTop: space.x6,
     marginBottom: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "16px",
-    lineHeight: 1.6,
   },
   positionGrid: {
     display: "grid",
@@ -421,11 +482,6 @@ const styles = stylex.create({
   },
   microLabel: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   accentMicroLabel: {
     color: colors.accentDeep,
@@ -434,8 +490,6 @@ const styles = stylex.create({
     marginTop: "6px",
     marginBottom: 0,
     color: colors.ink,
-    fontSize: "14px",
-    lineHeight: 1.55,
   },
   section: {
     paddingTop: space.x12,
@@ -452,8 +506,6 @@ const styles = stylex.create({
     marginTop: space.x2,
     marginBottom: 0,
     color: colors.inkMuted,
-    fontSize: "14px",
-    lineHeight: 1.55,
   },
   ruleList: {
     display: "grid",
@@ -488,8 +540,6 @@ const styles = stylex.create({
     marginTop: space.x2,
     marginBottom: 0,
     color: colors.inkMuted,
-    fontSize: "14px",
-    lineHeight: 1.55,
   },
   example: {
     display: "flex",
@@ -500,8 +550,6 @@ const styles = stylex.create({
     borderRadius: controlMetrics.radius,
     backgroundColor: colors.ground,
     color: colors.ink,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
   wordLists: {
     display: "grid",
@@ -519,9 +567,6 @@ const styles = stylex.create({
   words: {
     marginTop: "6px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "12px",
-    lineHeight: 1.7,
   },
   registerList: {
     margin: 0,
@@ -536,7 +581,6 @@ const styles = stylex.create({
     borderBottomWidth: "1px",
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
-    fontSize: "13px",
     fontWeight: 600,
     ":last-child": {
       borderBottomWidth: 0,
@@ -550,10 +594,6 @@ const styles = stylex.create({
   registerValue: {
     margin: 0,
     color: colors.accentDeep,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    fontWeight: 400,
-    lineHeight: 1.3,
   },
   comparisonHeader: {
     display: "grid",
@@ -564,11 +604,6 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.sectionRule,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
     [NARROW]: {
       display: "none",
     },
@@ -594,30 +629,18 @@ const styles = stylex.create({
     display: "none",
     marginBottom: space.x1,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
     [NARROW]: {
       display: "block",
     },
   },
   before: {
     color: colors.inkMuted,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
   after: {
     color: colors.ink,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
   reason: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.5,
   },
   failureGrid: {
     display: "grid",
@@ -639,15 +662,10 @@ const styles = stylex.create({
     marginTop: space.x2,
     marginBottom: 0,
     color: colors.inkMuted,
-    fontSize: "15px",
-    lineHeight: 1.55,
   },
   voiceNote: {
     marginTop: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.4,
   },
   mechanicsGrid: {
     display: "grid",
@@ -672,7 +690,5 @@ const styles = stylex.create({
     marginTop: space.x1,
     marginBottom: 0,
     color: colors.inkMuted,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
 });

--- a/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
+++ b/apps/web/src/app/(app)/about/tasting-wheel/tastingWheel.stylex.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { foundationStyles } from "@peated/web/styles/foundations.stylex";
+
 import { Button } from "@peated/web/components";
 import { SectionHeading } from "@peated/web/components/sectionHeading.stylex";
 import { textLinkStyles } from "@peated/web/components/textLinkStyles.stylex";
@@ -64,13 +66,13 @@ export function TastingWheelIntroduction() {
         <SectionHeading id="tasting-wheel-introduction">
           Start with what you notice
         </SectionHeading>
-        <p {...stylex.props(styles.directionText)}>
+        <p {...stylex.props(foundationStyles.prose, styles.directionText)}>
           Does it remind you of fruit? Follow that part of the wheel outward.
           Maybe it&apos;s a crisp apple, a little citrus, or a handful of
           raisins. A couple of words is plenty. Leave out anything you
           don&apos;t taste.
         </p>
-        <p {...stylex.props(styles.directionText)}>
+        <p {...stylex.props(foundationStyles.prose, styles.directionText)}>
           Pick a note to find out more and see bottles with that flavor.
         </p>
       </div>
@@ -222,13 +224,18 @@ export function TastingWheelCategories() {
             onClick={() => select({ category: category.key })}
             {...stylex.props(
               textLinkStyles.link,
-              textLinkStyles.small,
+              foundationStyles.interactiveSmall,
               styles.examplesAction,
             )}
           >
             See examples
           </button>
-          <p {...stylex.props(styles.categoryDescription)}>
+          <p
+            {...stylex.props(
+              foundationStyles.metadata,
+              styles.categoryDescription,
+            )}
+          >
             {category.description}
           </p>
           <div {...stylex.props(styles.notes)}>
@@ -259,9 +266,6 @@ const styles = stylex.create({
   directions: { display: "grid", gap: space.x3, maxWidth: "74ch" },
   directionText: {
     margin: 0,
-    fontFamily: fonts.reading,
-    fontSize: "16px",
-    lineHeight: 1.6,
     color: colors.inkMuted,
     textWrap: "pretty",
   },
@@ -363,9 +367,6 @@ const styles = stylex.create({
     margin: 0,
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
   notes: {
     display: "flex",
@@ -374,7 +375,6 @@ const styles = stylex.create({
     marginTop: space.x3,
   },
 });
-
 const SEGMENT_STYLES = [
   styles.segmentSurface,
   styles.segmentInset,
@@ -386,7 +386,6 @@ const SEGMENT_STYLES = [
   styles.segmentAccent,
   styles.segmentSunken,
 ] as const;
-
 const OUTER_SEGMENT_STYLES = [
   styles.outerSurface,
   styles.outerInset,

--- a/apps/web/src/app/(app)/badges/[badgeId]/badgePage.stylex.tsx
+++ b/apps/web/src/app/(app)/badges/[badgeId]/badgePage.stylex.tsx
@@ -12,7 +12,8 @@ import {
   PageSection,
 } from "@peated/web/components/pages/pageLayout.stylex";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
-import { colors, fonts } from "../../../../styles/tokens.stylex";
+import { foundationStyles } from "../../../../styles/foundations.stylex";
+import { colors } from "../../../../styles/tokens.stylex";
 
 type Badge = Outputs["badges"]["details"];
 type AwardList = Outputs["badges"]["userList"];
@@ -38,14 +39,16 @@ export function BadgePage({
           {awardList.results.map((award, index) => (
             <ItemRow
               end={
-                <span {...stylex.props(styles.points)}>
+                <span
+                  {...stylex.props(foundationStyles.metadata, styles.points)}
+                >
                   {award.xp.toLocaleString("en-US")} points
                 </span>
               }
               href={`/users/${award.user.username}`}
               key={award.id}
               leading={
-                <span {...stylex.props(styles.rank)}>
+                <span {...stylex.props(foundationStyles.rowTitle, styles.rank)}>
                   #{(page - 1) * 25 + index + 1}
                 </span>
               }
@@ -77,14 +80,10 @@ const styles = stylex.create({
   page: { maxWidth: "900px" },
   rank: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "16px",
     fontVariantNumeric: "tabular-nums",
   },
   points: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
     whiteSpace: "nowrap",
   },

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogNavigation.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogNavigation.stylex.tsx
@@ -3,7 +3,8 @@
 import * as stylex from "@stylexjs/stylex";
 
 import { PageTabs, TextLink } from "@peated/web/components";
-import { colors, fonts, space } from "../../../../styles/tokens.stylex";
+import { foundationStyles } from "../../../../styles/foundations.stylex";
+import { colors, space } from "../../../../styles/tokens.stylex";
 
 export function BottleCatalogNavigation({
   allHref,
@@ -25,7 +26,7 @@ export function BottleCatalogNavigation({
         ]}
       />
       {scope === "following" ? (
-        <p {...stylex.props(styles.scopeHelp)}>
+        <p {...stylex.props(foundationStyles.body, styles.scopeHelp)}>
           Bottles from distillers, brands, and bottlers you follow. See followed{" "}
           <TextLink href="/distillers?filter=following" size="inherit">
             distillers
@@ -55,8 +56,5 @@ const styles = stylex.create({
   scopeHelp: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
 });

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -50,8 +50,9 @@ import {
   getBottleUrl,
   getEntityUrl,
 } from "@peated/web/lib/urls";
-import { colors, fonts, space } from "../../../../styles/tokens.stylex";
+import { colors, space } from "../../../../styles/tokens.stylex";
 
+import { foundationStyles } from "../../../../styles/foundations.stylex";
 import { bottleOverviewQueries } from "./bottleOverviewQueries";
 
 type Bottle = Outputs["bottles"]["details"];
@@ -67,7 +68,7 @@ const dateFormatter = new Intl.DateTimeFormat("en-US", {
   timeZone: "UTC",
 });
 
-function getBottleEyebrow(bottle: Bottle) {
+function getBottleDistillers(bottle: Bottle) {
   return bottle.distillers.length ? (
     <EntityLinks entities={bottle.distillers} />
   ) : null;
@@ -437,7 +438,7 @@ export function BottlePageFrameClient({
           }
           brand={bottle.brand.shortName || bottle.brand.name}
           brandHref={getEntityUrl(bottle.brand)}
-          eyebrow={getBottleEyebrow(bottle)}
+          metadata={getBottleDistillers(bottle)}
           menu={<BottleActions bottle={bottle} />}
           name={formatBottleDisplayName(bottle, { includeBrand: false })}
           score={
@@ -452,13 +453,13 @@ export function BottlePageFrameClient({
           }
         />
         {bottle.aliases.length ? (
-          <p {...stylex.props(styles.aliases)}>
+          <p {...stylex.props(foundationStyles.body, styles.aliases)}>
             <span {...stylex.props(styles.aliasLabel)}>Also known as</span>{" "}
             {bottle.aliases.join(" · ")}
           </p>
         ) : null}
         {bottle.description ? (
-          <div {...stylex.props(styles.description)}>
+          <div {...stylex.props(foundationStyles.body, styles.description)}>
             <ExpandableDescription content={bottle.description} />
           </div>
         ) : null}
@@ -634,7 +635,10 @@ export function BottleOverviewClient() {
 
       {recommendationsQuery.error ||
       (!mainFailed && (externalReviewsQuery.error || tastingsQuery.error)) ? (
-        <p role="status" {...stylex.props(styles.partialError)}>
+        <p
+          role="status"
+          {...stylex.props(foundationStyles.metadata, styles.partialError)}
+        >
           Some reviews, tastings, or recommendations could not be loaded. The
           rest of this page is still available.
         </p>
@@ -661,9 +665,6 @@ const styles = stylex.create({
     marginTop: space.x4,
     marginBottom: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
   aliasLabel: {
     color: colors.ink,
@@ -673,9 +674,6 @@ const styles = stylex.create({
     maxWidth: "680px",
     marginTop: space.x4,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.55,
   },
   overview: {
     minWidth: 0,
@@ -686,8 +684,5 @@ const styles = stylex.create({
     padding: space.x4,
     backgroundColor: colors.surface,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
 });

--- a/apps/web/src/app/(app)/bottles/[bottleId]/prices/bottleSellerList.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/prices/bottleSellerList.stylex.tsx
@@ -4,6 +4,7 @@ import Price from "@peated/web/components/price";
 import TimeSince from "@peated/web/components/timeSince";
 import * as stylex from "@stylexjs/stylex";
 
+import { foundationStyles } from "../../../../../styles/foundations.stylex";
 import { colors, fonts, space } from "../../../../../styles/tokens.stylex";
 
 type Seller = Outputs["bottles"]["prices"]["list"]["results"][number];
@@ -15,16 +16,24 @@ export function BottleSellerList({ sellers }: { sellers: readonly Seller[] }) {
         const content = (
           <>
             <span {...stylex.props(styles.details)}>
-              <strong {...stylex.props(styles.seller)}>
+              <strong
+                {...stylex.props(foundationStyles.interactive, styles.seller)}
+              >
                 {seller.site.name}
               </strong>
-              <span {...stylex.props(styles.listing)}>{seller.name}</span>
-              <span {...stylex.props(styles.metadata)}>
+              <span
+                {...stylex.props(foundationStyles.metadata, styles.listing)}
+              >
+                {seller.name}
+              </span>
+              <span
+                {...stylex.props(foundationStyles.metadata, styles.metadata)}
+              >
                 {seller.volume.toLocaleString("en-US")} ml · Updated{" "}
                 <TimeSince date={seller.updatedAt} />
               </span>
             </span>
-            <span {...stylex.props(styles.price)}>
+            <span {...stylex.props(foundationStyles.body, styles.price)}>
               <Price currency={seller.currency} value={seller.price} />
             </span>
           </>
@@ -93,30 +102,20 @@ const styles = stylex.create({
   seller: {
     display: "block",
     color: colors.accentDeep,
-    fontSize: "14px",
     fontWeight: 700,
-    lineHeight: 1.35,
   },
   listing: {
     display: "block",
     marginTop: space.x1,
-    fontSize: "13px",
-    lineHeight: 1.4,
   },
   metadata: {
     display: "block",
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.4,
   },
   price: {
     paddingTop: "1px",
-    fontFamily: fonts.data,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1.35,
     whiteSpace: "nowrap",
   },
   outdated: {

--- a/apps/web/src/app/(app)/entities/[entityId]/codes/entityCodes.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/codes/entityCodes.stylex.tsx
@@ -2,7 +2,8 @@ import * as stylex from "@stylexjs/stylex";
 
 import { Card, RailList, RailListItem, TextLink } from "@peated/web/components";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
-import { colors, fonts, space } from "../../../../../styles/tokens.stylex";
+import { foundationStyles } from "../../../../../styles/foundations.stylex";
+import { colors, space } from "../../../../../styles/tokens.stylex";
 
 type CodeGroup = {
   code: string;
@@ -29,13 +30,13 @@ export function EntityCodes({
       <PageSection heading="How the codes work">
         <Card appearance="plain" padding="sm">
           <div {...stylex.props(styles.intro)}>
-            <p {...stylex.props(styles.paragraph)}>
+            <p {...stylex.props(foundationStyles.body, styles.paragraph)}>
               {entityName} uses the number before the decimal point to identify
               the distillery. For example, cask 4.360 is the 360th cask from
               distillery 4,{" "}
               <TextLink href={example.href}>{example.name}</TextLink>.
             </p>
-            <p {...stylex.props(styles.paragraph)}>
+            <p {...stylex.props(foundationStyles.body, styles.paragraph)}>
               If a code is missing or incorrect, please report it in the{" "}
               <TextLink href="https://github.com/dcramer/peated/issues">
                 Peated issue tracker
@@ -56,7 +57,11 @@ export function EntityCodes({
           <RailList ariaLabel={`${group.heading} distillery codes`}>
             {group.rows.map((row) => (
               <RailListItem
-                end={<span {...stylex.props(styles.code)}>{row.code}</span>}
+                end={
+                  <span {...stylex.props(foundationStyles.code, styles.code)}>
+                    {row.code}
+                  </span>
+                }
                 href={row.href}
                 key={row.code}
                 metadata={row.country ?? undefined}
@@ -83,14 +88,9 @@ const styles = stylex.create({
   paragraph: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.6,
   },
   code: {
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: "12px",
     fontVariantNumeric: "tabular-nums",
     fontWeight: 600,
   },

--- a/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityImageGallery.stylex.tsx
@@ -8,10 +8,10 @@ import { ImageAttribution, ImageViewer } from "@peated/web/components";
 import {
   colors,
   controlMetrics,
-  fonts,
   space,
 } from "../../../../styles/tokens.stylex";
 
+import { foundationStyles } from "../../../../styles/foundations.stylex";
 import type { Entity } from "./entityPageData";
 
 function ImageNavigationButton({
@@ -112,7 +112,7 @@ export function EntityImageGallery({ entity }: { entity: Entity }) {
                 <span
                   aria-atomic="true"
                   aria-live="polite"
-                  {...stylex.props(styles.position)}
+                  {...stylex.props(foundationStyles.metadata, styles.position)}
                 >
                   {currentIndex + 1} / {images.length}
                 </span>
@@ -223,10 +223,7 @@ const styles = stylex.create({
   position: {
     minWidth: "40px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "12px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1,
     textAlign: "center",
   },
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityMap.stylex.tsx
@@ -2,8 +2,9 @@ import * as stylex from "@stylexjs/stylex";
 
 import { Card, TextLink } from "@peated/web/components";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
-import { colors, fonts, space } from "../../../../styles/tokens.stylex";
+import { colors, space } from "../../../../styles/tokens.stylex";
 
+import { foundationStyles } from "../../../../styles/foundations.stylex";
 import type { Entity } from "./entityPageData";
 
 function formatCoordinate(value: number, positive: string, negative: string) {
@@ -32,7 +33,9 @@ export function EntityMap({ entity }: { entity: Entity }) {
     <PageSection heading="Where">
       <Card appearance="plain" padding="sm">
         {entity.address ? (
-          <p {...stylex.props(styles.address)}>{entity.address}</p>
+          <p {...stylex.props(foundationStyles.metadata, styles.address)}>
+            {entity.address}
+          </p>
         ) : null}
         <iframe
           loading="lazy"
@@ -41,7 +44,9 @@ export function EntityMap({ entity }: { entity: Entity }) {
           {...stylex.props(styles.mapFrame)}
         />
         <div {...stylex.props(styles.mapFooter)}>
-          <span {...stylex.props(styles.coordinates)}>{coordinateLabel}</span>
+          <span {...stylex.props(foundationStyles.code, styles.coordinates)}>
+            {coordinateLabel}
+          </span>
           <TextLink href={mapHref} rel="noreferrer" target="_blank">
             Open in map →
           </TextLink>
@@ -56,9 +61,6 @@ const styles = stylex.create({
     margin: 0,
     marginBottom: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
   },
   mapFrame: {
     display: "block",
@@ -78,8 +80,5 @@ const styles = stylex.create({
   },
   coordinates: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.4,
   },
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityPageFrameClient.stylex.tsx
@@ -205,7 +205,7 @@ export function EntityPageFrameClient({
               <ExpandableDescription content={entity.description} />
             ) : null
           }
-          eyebrow={getEntityClassification(entity)}
+          metadata={getEntityClassification(entity)}
           menu={<EntityActions entity={entity} />}
           title={entity.name}
         />

--- a/apps/web/src/app/(app)/events/eventList.stylex.tsx
+++ b/apps/web/src/app/(app)/events/eventList.stylex.tsx
@@ -3,7 +3,8 @@ import * as stylex from "@stylexjs/stylex";
 
 import { ButtonLink, TextLink } from "@peated/web/components";
 import DateRange from "@peated/web/components/dateRange";
-import { colors, fonts, space } from "../../../styles/tokens.stylex";
+import { foundationStyles } from "../../../styles/foundations.stylex";
+import { colors, space } from "../../../styles/tokens.stylex";
 
 export function EventList({ events }: { events: Event[] }) {
   return (
@@ -14,11 +15,11 @@ export function EventList({ events }: { events: Event[] }) {
           .join(" · ");
         return (
           <article key={event.id} {...stylex.props(styles.event)}>
-            <div {...stylex.props(styles.date)}>
+            <div {...stylex.props(foundationStyles.metadata, styles.date)}>
               <DateRange start={event.dateStart} end={event.dateEnd} />
             </div>
             <div {...stylex.props(styles.details)}>
-              <h3 {...stylex.props(styles.name)}>
+              <h3 {...stylex.props(foundationStyles.rowTitle, styles.name)}>
                 {event.website ? (
                   <TextLink
                     href={event.website}
@@ -33,7 +34,11 @@ export function EventList({ events }: { events: Event[] }) {
                 )}
               </h3>
               {location ? (
-                <div {...stylex.props(styles.location)}>{location}</div>
+                <div
+                  {...stylex.props(foundationStyles.metadata, styles.location)}
+                >
+                  {location}
+                </div>
               ) : null}
             </div>
             <div {...stylex.props(styles.action)}>
@@ -78,24 +83,15 @@ const styles = stylex.create({
   },
   date: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "12px",
   },
   details: { minWidth: 0 },
   name: {
     margin: 0,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 650,
-    lineHeight: 1.25,
   },
   location: {
     marginTop: space.x1,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.4,
   },
   action: { whiteSpace: "nowrap" },
 });

--- a/apps/web/src/app/(app)/events/eventRegionFilter.stylex.tsx
+++ b/apps/web/src/app/(app)/events/eventRegionFilter.stylex.tsx
@@ -1,7 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
 
 import { ButtonLink } from "@peated/web/components";
-import { colors, fonts, space } from "../../../styles/tokens.stylex";
+import { foundationStyles } from "../../../styles/foundations.stylex";
+import { colors, space } from "../../../styles/tokens.stylex";
 import type { EventRegion, EventRegionOption } from "./eventRegionData";
 
 export function EventRegionFilter({
@@ -18,7 +19,11 @@ export function EventRegionFilter({
   return (
     <section aria-label="Event region" {...stylex.props(styles.root)}>
       <div {...stylex.props(styles.row)}>
-        <span {...stylex.props(styles.label)}>Show events in</span>
+        <span
+          {...stylex.props(foundationStyles.interactiveSmall, styles.label)}
+        >
+          Show events in
+        </span>
         <nav aria-label="World regions" {...stylex.props(styles.options)}>
           <ButtonLink
             aria-current={!selectedRegion ? "page" : undefined}
@@ -27,7 +32,9 @@ export function EventRegionFilter({
             variant={!selectedRegion ? "accent" : "tonal"}
           >
             <span>All regions</span>
-            <span {...stylex.props(styles.count)}>{total}</span>
+            <span {...stylex.props(foundationStyles.metadata, styles.count)}>
+              {total}
+            </span>
           </ButtonLink>
           {options.map((option) => {
             const current = selectedRegion?.slug === option.slug;
@@ -40,13 +47,17 @@ export function EventRegionFilter({
                 variant={current ? "accent" : "tonal"}
               >
                 <span>{option.label}</span>
-                <span {...stylex.props(styles.count)}>{option.count}</span>
+                <span
+                  {...stylex.props(foundationStyles.metadata, styles.count)}
+                >
+                  {option.count}
+                </span>
               </ButtonLink>
             );
           })}
         </nav>
       </div>
-      <div {...stylex.props(styles.summary)}>
+      <div {...stylex.props(foundationStyles.metadata, styles.summary)}>
         {selectedRegion
           ? `Showing ${visible} upcoming ${visible === 1 ? "event" : "events"} in ${selectedRegion.label}`
           : `Showing ${total} upcoming ${total === 1 ? "event" : "events"} worldwide`}
@@ -74,8 +85,6 @@ const styles = stylex.create({
   },
   label: {
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     fontWeight: 600,
   },
   options: {
@@ -84,15 +93,10 @@ const styles = stylex.create({
     flexWrap: "wrap",
   },
   count: {
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
   },
   summary: {
     marginTop: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
   },
 });

--- a/apps/web/src/app/(app)/flights/[flightId]/page.tsx
+++ b/apps/web/src/app/(app)/flights/[flightId]/page.tsx
@@ -54,7 +54,7 @@ export default async function FlightPage(props: {
           </ButtonLink>
         }
         description={flight.description}
-        eyebrow={flight.public ? "Public flight" : "Private flight"}
+        metadata={flight.public ? "Public flight" : "Private flight"}
         menu={<FlightActions flight={flight} />}
         title={flight.name}
       />

--- a/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
@@ -17,8 +17,9 @@ import {
   PageColumns,
   PageSection,
 } from "@peated/web/components/pages/pageLayout.stylex";
-import { colors, fonts } from "../../../styles/tokens.stylex";
+import { colors } from "../../../styles/tokens.stylex";
 
+import { foundationStyles } from "../../../styles/foundations.stylex";
 import { LocationVisual } from "./locationPageFrame.stylex";
 
 export function LocationOverview({
@@ -67,7 +68,9 @@ export function LocationOverview({
           {flavorProfile}
           {productionRules ? (
             <PageSection heading="Production rules">
-              <p {...stylex.props(styles.copy)}>{productionRules}</p>
+              <p {...stylex.props(foundationStyles.body, styles.copy)}>
+                {productionRules}
+              </p>
             </PageSection>
           ) : null}
           {categories.length ? (
@@ -163,8 +166,5 @@ const styles = stylex.create({
   copy: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.55,
   },
 });

--- a/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationPageFrame.stylex.tsx
@@ -67,9 +67,6 @@ export function LocationPageFrame({
         <PageHeader
           actions={actions}
           description={description}
-          eyebrow={
-            location.kind === "region" ? "Whisky region" : "Whisky country"
-          }
           parent={
             country ? (
               <TextLink href={country.href} size="inherit">

--- a/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
+++ b/apps/web/src/app/(app)/notifications/notificationList.stylex.tsx
@@ -22,12 +22,8 @@ import TimeSince from "@peated/web/components/timeSince";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { logError } from "@peated/web/lib/log";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import {
-  colors,
-  controlMetrics,
-  fonts,
-  space,
-} from "../../../styles/tokens.stylex";
+import { foundationStyles } from "../../../styles/foundations.stylex";
+import { colors, controlMetrics, space } from "../../../styles/tokens.stylex";
 
 export function NotificationList({
   emptyHeading,
@@ -144,7 +140,9 @@ export function NotificationList({
                   }
                 />
                 <div {...stylex.props(styles.copy)}>
-                  <div {...stylex.props(styles.message)}>
+                  <div
+                    {...stylex.props(foundationStyles.metadata, styles.message)}
+                  >
                     {from ? (
                       <TextLink href={`/users/${from.username}`} size="inherit">
                         {from.username}
@@ -162,14 +160,21 @@ export function NotificationList({
                       getNotificationMessage(notification)
                     )}
                   </div>
-                  <span {...stylex.props(styles.date)}>
+                  <span
+                    {...stylex.props(foundationStyles.metadata, styles.date)}
+                  >
                     <TimeSince date={notification.createdAt} />
                   </span>
                   {notification.type === "friend_request" &&
                   notification.ref ? (
                     <div {...stylex.props(styles.friendActions)}>
                       {notification.ref.status === "friends" ? (
-                        <span {...stylex.props(styles.friendStatus)}>
+                        <span
+                          {...stylex.props(
+                            foundationStyles.metadata,
+                            styles.friendStatus,
+                          )}
+                        >
                           Friends
                         </span>
                       ) : (
@@ -260,16 +265,11 @@ const styles = stylex.create({
   copy: { minWidth: 0, flex: 1 },
   message: {
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
   },
   date: {
     display: "block",
     marginTop: space.x1,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
   },
   friendActions: { display: "flex", marginTop: space.x3 },
   friendStatus: {
@@ -281,8 +281,5 @@ const styles = stylex.create({
     borderRadius: controlMetrics.radiusSmall,
     backgroundColor: colors.inset,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    textTransform: "uppercase",
   },
 });

--- a/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
@@ -17,7 +17,7 @@ import {
 } from "@peated/web/lib/addBottle";
 import { getBottleUrl } from "@peated/web/lib/urls";
 import { foundationStyles } from "../../../styles/foundations.stylex";
-import { colors, fonts, space } from "../../../styles/tokens.stylex";
+import { colors, space } from "../../../styles/tokens.stylex";
 
 type BottleUrlSource = Parameters<typeof getBottleUrl>[0];
 
@@ -46,10 +46,15 @@ function getDatabaseScope(value: string | null): SearchScope {
 function BrowseHeader({ bottleTotal }: { bottleTotal: number }) {
   return (
     <header {...stylex.props(styles.browseHeader)}>
-      <h1 {...stylex.props(foundationStyles.pageTitle, styles.browseTitle)}>
+      <h1
+        {...stylex.props(
+          foundationStyles.pageTitle,
+          foundationStyles.pageTitleCompact,
+        )}
+      >
         Search the database
       </h1>
-      <p {...stylex.props(styles.browseDescription)}>
+      <p {...stylex.props(foundationStyles.body, styles.browseDescription)}>
         {bottleTotal.toLocaleString("en-US")} bottles, and someone has probably
         logged yours. Search bottles, series, distillers, brands, and bottlers.
       </p>
@@ -179,7 +184,12 @@ export function SearchPageClient({
     <div {...stylex.props(styles.page, databaseSearch && styles.databasePage)}>
       {!databaseSearch ? (
         <header {...stylex.props(styles.header)}>
-          <h1 {...stylex.props(foundationStyles.pageTitle, styles.title)}>
+          <h1
+            {...stylex.props(
+              foundationStyles.pageTitle,
+              foundationStyles.pageTitleCompact,
+            )}
+          >
             {getTitle({ directToTasting, intent, memberSearch })}
           </h1>
         </header>
@@ -225,10 +235,7 @@ const styles = stylex.create({
     maxWidth: "none",
   },
   header: { marginBottom: space.x4 },
-  title: {
-    fontSize: "clamp(26px, 4vw, 32px)",
-    lineHeight: 1.1,
-  },
+
   search: {
     minWidth: 0,
   },
@@ -240,10 +247,7 @@ const styles = stylex.create({
     paddingTop: space.x6,
     textAlign: "center",
   },
-  browseTitle: {
-    fontSize: "clamp(28px, 5vw, 38px)",
-    lineHeight: 1.05,
-  },
+
   browseDescription: {
     maxWidth: "720px",
     marginTop: space.x4,
@@ -251,8 +255,5 @@ const styles = stylex.create({
     marginBottom: 0,
     marginLeft: "auto",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.5,
   },
 });

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -286,10 +286,6 @@ const styles = stylex.create({
   },
   title: {
     display: "block",
-    fontSize: {
-      default: null,
-      "@media (max-width: 480px)": "36px",
-    },
     overflowWrap: "anywhere",
   },
   filters: {

--- a/apps/web/src/app/(app)/terms/page.tsx
+++ b/apps/web/src/app/(app)/terms/page.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = { title: "Terms of Service" };
 export default function TermsPage() {
   return (
     <ContentPage
-      eyebrow="Effective Date: September 15, 2025"
+      metadata="Effective Date: September 15, 2025"
       intro="Welcome to peated.com (“Peated,” “we,” “our,” or “us”). By accessing or using our website, mobile application, or related services (collectively, the “Services”), you agree to be bound by these Terms of Service (“Terms”). If you do not agree, do not use our Services."
       title="Terms of Service"
     >

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryLayout.stylex.tsx
@@ -5,7 +5,8 @@ import type { ReactNode } from "react";
 
 import { LoadingList, LoadingPlaceholder } from "@peated/web/components";
 import { PageColumns } from "@peated/web/components/pages/pageLayout.stylex";
-import { colors, fonts, space } from "../../../../../styles/tokens.stylex";
+import { foundationStyles } from "../../../../../styles/foundations.stylex";
+import { colors, space } from "../../../../../styles/tokens.stylex";
 import { useProfile } from "../profileContext";
 import { getProfileLoadingRows } from "../profileLoading";
 
@@ -36,7 +37,13 @@ export function ProfileLibraryLoading() {
     <div aria-busy="true" aria-label="Loading member library" role="status">
       <ProfileLibraryLayout
         mobileFilters={
-          <div aria-hidden="true" {...stylex.props(styles.mobileFilters)}>
+          <div
+            aria-hidden="true"
+            {...stylex.props(
+              foundationStyles.interactiveSmall,
+              styles.mobileFilters,
+            )}
+          >
             Filter library
           </div>
         }
@@ -73,10 +80,7 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1.3,
     [NARROW]: { display: "block" },
   },
   loadingRail: {

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
@@ -16,7 +16,8 @@ import {
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { colors, fonts, space } from "../../../../../styles/tokens.stylex";
+import { foundationStyles } from "../../../../../styles/foundations.stylex";
+import { colors, space } from "../../../../../styles/tokens.stylex";
 import { useProfile } from "../profileContext";
 import { getProfileLibraryInput, profileQueries } from "../profileQueries";
 import { ProfileLibraryLayout } from "./profileLibraryLayout.stylex";
@@ -187,7 +188,10 @@ export function ProfileLibraryPageClient() {
     >
       <div aria-busy={isNavigating || mutationPending || undefined}>
         {mutationError ? (
-          <p role="alert" {...stylex.props(styles.actionError)}>
+          <p
+            role="alert"
+            {...stylex.props(foundationStyles.metadata, styles.actionError)}
+          >
             The library change failed. Try the action again.
           </p>
         ) : null}
@@ -413,7 +417,5 @@ const styles = stylex.create({
     borderRadius: "3px",
     backgroundColor: colors.accentTint,
     color: colors.accentDeep,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
   },
 });

--- a/apps/web/src/app/(app)/users/[username]/profilePassport.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profilePassport.stylex.tsx
@@ -2,13 +2,18 @@ import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 
 import { AppLink, BadgeImage } from "@peated/web/components";
-import { colors, fonts, space } from "../../../../styles/tokens.stylex";
+import { foundationStyles } from "../../../../styles/foundations.stylex";
+import { colors, space } from "../../../../styles/tokens.stylex";
 
 type BadgeAward = Outputs["users"]["badgeList"]["results"][number];
 
 export function ProfilePassport({ awards }: { awards: readonly BadgeAward[] }) {
   if (!awards.length) {
-    return <p {...stylex.props(styles.empty)}>No stamps yet.</p>;
+    return (
+      <p {...stylex.props(foundationStyles.metadata, styles.empty)}>
+        No stamps yet.
+      </p>
+    );
   }
 
   return (
@@ -21,8 +26,12 @@ export function ProfilePassport({ awards }: { awards: readonly BadgeAward[] }) {
           >
             <BadgeImage badge={award.badge} level={award.level} size={40} />
             <span {...stylex.props(styles.copy)}>
-              <strong {...stylex.props(styles.name)}>{award.badge.name}</strong>
-              <span {...stylex.props(styles.status)}>
+              <strong
+                {...stylex.props(foundationStyles.compactRowTitle, styles.name)}
+              >
+                {award.badge.name}
+              </strong>
+              <span {...stylex.props(foundationStyles.metadata, styles.status)}>
                 {award.level ? "Stamped" : "In progress"}
               </span>
             </span>
@@ -58,24 +67,14 @@ const styles = stylex.create({
   },
   name: {
     overflow: "hidden",
-    fontFamily: fonts.display,
-    fontSize: "14px",
-    fontWeight: 700,
-    lineHeight: 1.25,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
   status: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.3,
   },
   empty: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
 });

--- a/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
+++ b/apps/web/src/app/(layout-free)/flights/[flightId]/overlay/flightOverlay.stylex.tsx
@@ -32,9 +32,6 @@ export function FlightOverlay({
     <main {...stylex.props(foundationStyles.document, styles.screen)}>
       <div {...stylex.props(styles.content)}>
         <header {...stylex.props(styles.header)}>
-          <p {...stylex.props(foundationStyles.microLabel, styles.eyebrow)}>
-            Whisky flight
-          </p>
           <h1 {...stylex.props(foundationStyles.pageTitle)}>{name}</h1>
           {description ? (
             <p {...stylex.props(foundationStyles.body, styles.description)}>
@@ -93,7 +90,6 @@ const styles = stylex.create({
     rowGap: space.x3,
     marginBottom: space.x8,
   },
-  eyebrow: { margin: 0, color: colors.accentDeep },
   description: { margin: 0, color: colors.inkMuted },
   layout: {
     display: "grid",

--- a/apps/web/src/components/admin/adminContent.stylex.tsx
+++ b/apps/web/src/components/admin/adminContent.stylex.tsx
@@ -34,7 +34,7 @@ export function AdminBreadcrumbs({
           <Link
             aria-label="Admin"
             href="/admin"
-            {...stylex.props(styles.breadcrumbLink)}
+            {...stylex.props(foundationStyles.metadata, styles.breadcrumbLink)}
           >
             <Home aria-hidden="true" size={14} />
           </Link>
@@ -54,6 +54,7 @@ export function AdminBreadcrumbs({
               href={item.href}
               title={item.label}
               {...stylex.props(
+                foundationStyles.metadata,
                 styles.breadcrumbLink,
                 item.current && styles.currentBreadcrumb,
               )}
@@ -74,7 +75,6 @@ export function AdminPage({ children }: { children: ReactNode }) {
 export type AdminPageHeaderProps = {
   actions?: ReactNode;
   description?: ReactNode;
-  eyebrow?: ReactNode;
   metadata?: ReactNode;
   title: ReactNode;
 };
@@ -82,24 +82,30 @@ export type AdminPageHeaderProps = {
 export function AdminPageHeader({
   actions,
   description,
-  eyebrow,
   metadata,
   title,
 }: AdminPageHeaderProps) {
   return (
     <header {...stylex.props(styles.pageHeader)}>
       <div {...stylex.props(styles.pageHeaderCopy)}>
-        {eyebrow ? (
-          <div {...stylex.props(styles.eyebrow)}>{eyebrow}</div>
-        ) : null}
-        <h1 {...stylex.props(foundationStyles.pageTitle, styles.pageTitle)}>
+        <h1
+          {...stylex.props(
+            foundationStyles.pageTitle,
+            foundationStyles.pageTitleCompact,
+            styles.pageTitle,
+          )}
+        >
           {title}
         </h1>
         {description ? (
-          <div {...stylex.props(styles.description)}>{description}</div>
+          <div {...stylex.props(foundationStyles.body, styles.description)}>
+            {description}
+          </div>
         ) : null}
         {metadata ? (
-          <div {...stylex.props(styles.metadata)}>{metadata}</div>
+          <div {...stylex.props(foundationStyles.metadata, styles.metadata)}>
+            {metadata}
+          </div>
         ) : null}
       </div>
       {actions ? <div {...stylex.props(styles.actions)}>{actions}</div> : null}
@@ -133,7 +139,9 @@ export function AdminSection({
           <div {...stylex.props(styles.sectionCopy)}>
             {title ? <SectionHeading>{title}</SectionHeading> : null}
             {description ? (
-              <div {...stylex.props(styles.description)}>{description}</div>
+              <div {...stylex.props(foundationStyles.body, styles.description)}>
+                {description}
+              </div>
             ) : null}
           </div>
           {action ? (
@@ -165,9 +173,15 @@ export function AdminStat({
 }) {
   return (
     <div {...stylex.props(styles.stat)}>
-      <dt {...stylex.props(styles.statLabel)}>{label}</dt>
+      <dt {...stylex.props(foundationStyles.metadata, styles.statLabel)}>
+        {label}
+      </dt>
       <dd {...stylex.props(styles.statValue)}>{value}</dd>
-      {detail ? <div {...stylex.props(styles.statDetail)}>{detail}</div> : null}
+      {detail ? (
+        <div {...stylex.props(foundationStyles.metadata, styles.statDetail)}>
+          {detail}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -180,7 +194,13 @@ export function AdminStatus({
   tone?: "accent" | "danger" | "neutral" | "success" | "warning";
 }) {
   return (
-    <span {...stylex.props(styles.status, statusToneStyles[tone])}>
+    <span
+      {...stylex.props(
+        foundationStyles.metadata,
+        styles.status,
+        statusToneStyles[tone],
+      )}
+    >
       {children}
     </span>
   );
@@ -205,11 +225,19 @@ export function AdminTextLink({
 }
 
 export function AdminCode({ children }: { children: ReactNode }) {
-  return <code {...stylex.props(styles.code)}>{children}</code>;
+  return (
+    <code {...stylex.props(foundationStyles.code, styles.code)}>
+      {children}
+    </code>
+  );
 }
 
 export function AdminCodeBlock({ children }: { children: ReactNode }) {
-  return <pre {...stylex.props(styles.codeBlock)}>{children}</pre>;
+  return (
+    <pre {...stylex.props(foundationStyles.code, styles.codeBlock)}>
+      {children}
+    </pre>
+  );
 }
 
 export function AdminDetails({
@@ -223,8 +251,14 @@ export function AdminDetails({
 }) {
   return (
     <details open={open || undefined} {...stylex.props(styles.details)}>
-      <summary {...stylex.props(styles.detailsSummary)}>{summary}</summary>
-      <div {...stylex.props(styles.detailsBody)}>{children}</div>
+      <summary
+        {...stylex.props(foundationStyles.interactive, styles.detailsSummary)}
+      >
+        {summary}
+      </summary>
+      <div {...stylex.props(foundationStyles.metadata, styles.detailsBody)}>
+        {children}
+      </div>
     </details>
   );
 }
@@ -292,9 +326,6 @@ const styles = stylex.create({
       ":hover": colors.accentDeep,
       ":active": colors.accentDeep,
     },
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.3,
     textDecoration: "none",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
@@ -320,28 +351,13 @@ const styles = stylex.create({
     flexDirection: "column",
     rowGap: space.x2,
   },
-  eyebrow: {
-    color: colors.accentDeep,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 600,
-    letterSpacing: "0.1em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
-  },
-  pageTitle: { fontSize: "clamp(30px, 5vw, 40px)", overflowWrap: "anywhere" },
+  pageTitle: { overflowWrap: "anywhere" },
   description: {
     maxWidth: "68ch",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.55,
   },
   metadata: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.45,
   },
   actions: {
     display: "flex",
@@ -403,10 +419,6 @@ const styles = stylex.create({
   },
   statLabel: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    textTransform: "uppercase",
   },
   statValue: {
     margin: 0,
@@ -420,9 +432,6 @@ const styles = stylex.create({
   statDetail: {
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.4,
   },
   status: {
     display: "inline-flex",
@@ -431,10 +440,7 @@ const styles = stylex.create({
     paddingRight: space.x2,
     paddingLeft: space.x2,
     borderRadius: controlMetrics.radiusSmall,
-    fontFamily: fonts.data,
-    fontSize: "10px",
     fontWeight: 600,
-    lineHeight: 1.2,
   },
   statusNeutral: { backgroundColor: colors.inset, color: colors.inkMuted },
   statusAccent: {
@@ -449,8 +455,6 @@ const styles = stylex.create({
   },
   code: {
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: "0.92em",
     overflowWrap: "anywhere",
   },
   codeBlock: {
@@ -461,9 +465,6 @@ const styles = stylex.create({
     overflowX: "auto",
     backgroundColor: colors.inset,
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.5,
     whiteSpace: "pre-wrap",
   },
   details: {
@@ -475,7 +476,6 @@ const styles = stylex.create({
   detailsSummary: {
     padding: space.x4,
     color: colors.ink,
-    fontFamily: fonts.display,
     fontWeight: 700,
     listStyle: "none",
     cursor: "pointer",
@@ -492,9 +492,6 @@ const styles = stylex.create({
     paddingBottom: space.x4,
     paddingLeft: space.x4,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
   splitView: {
     display: "grid",
@@ -518,14 +515,12 @@ const styles = stylex.create({
   splitDetail: { minWidth: 0 },
   splitDetailHidden: { "@media (max-width: 839px)": { display: "none" } },
 });
-
 const toneStyles = {
   accent: styles.sectionAccent,
   danger: styles.sectionDanger,
   default: null,
   warning: styles.sectionWarning,
 } as const;
-
 const statusToneStyles = {
   accent: styles.statusAccent,
   danger: styles.statusDanger,

--- a/apps/web/src/components/admin/adminForm.stylex.tsx
+++ b/apps/web/src/components/admin/adminForm.stylex.tsx
@@ -17,6 +17,7 @@ import {
   Textarea,
   TextInput,
 } from "..";
+import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, fonts, space, zIndices } from "../../styles/tokens.stylex";
 import { WorkflowScreen } from "../workflowScreen.stylex";
 
@@ -61,7 +62,11 @@ export function AdminForm({
     <>
       {isSubmitting ? (
         <div aria-live="polite" role="status" {...stylex.props(styles.saving)}>
-          <span {...stylex.props(styles.savingLabel)}>Saving…</span>
+          <span
+            {...stylex.props(foundationStyles.interactive, styles.savingLabel)}
+          >
+            Saving…
+          </span>
         </div>
       ) : null}
       <form {...props} {...stylex.props(styles.form)}>
@@ -166,7 +171,9 @@ export const AdminTextField = forwardRef<HTMLInputElement, AdminTextFieldProps>(
               ref={ref}
               required={required}
             />
-            <span {...stylex.props(styles.suffix)}>{suffixLabel}</span>
+            <span {...stylex.props(foundationStyles.metadata, styles.suffix)}>
+              {suffixLabel}
+            </span>
           </span>
         ) : (
           <TextInput
@@ -308,7 +315,7 @@ export function AdminSwitchField<T extends FieldValues>({
 
 export function AdminFormError({ values }: { values: ReactNode[] }) {
   return (
-    <div role="alert" {...stylex.props(styles.error)}>
+    <div role="alert" {...stylex.props(foundationStyles.body, styles.error)}>
       <strong>There was an error with your submission.</strong>
       <ul {...stylex.props(styles.errorList)}>
         {values.map((value, index) => (
@@ -335,8 +342,6 @@ const styles = stylex.create({
     padding: space.x4,
     backgroundColor: colors.surface,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontWeight: 700,
   },
   suffixControl: {
     display: "grid",
@@ -347,8 +352,6 @@ const styles = stylex.create({
   suffix: {
     paddingRight: space.x4,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
   },
   error: {
     padding: space.x4,
@@ -357,9 +360,6 @@ const styles = stylex.create({
     borderColor: colors.criticalQuiet,
     backgroundColor: colors.accentTint,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.45,
   },
   errorList: { marginTop: space.x2, marginBottom: 0, paddingLeft: space.x6 },
 });

--- a/apps/web/src/components/admin/adminLayout.stylex.tsx
+++ b/apps/web/src/components/admin/adminLayout.stylex.tsx
@@ -67,6 +67,7 @@ function AdminNavigation({
                     aria-current={current ? "page" : undefined}
                     href={item.href}
                     {...stylex.props(
+                      foundationStyles.interactiveSmall,
                       styles.navigationLink,
                       current && styles.currentNavigationLink,
                     )}
@@ -97,16 +98,31 @@ export function AdminLayout({
       <header {...stylex.props(styles.mobileHeader)}>
         <Link href="/admin" {...stylex.props(styles.mobileBrand)}>
           <span {...stylex.props(styles.brandName)}>Peated</span>
-          <span {...stylex.props(styles.brandContext)}>Admin</span>
+          <span
+            {...stylex.props(foundationStyles.metadata, styles.brandContext)}
+          >
+            Admin
+          </span>
         </Link>
         <details {...stylex.props(styles.mobileMenu)}>
-          <summary {...stylex.props(styles.mobileMenuTrigger)}>
+          <summary
+            {...stylex.props(
+              foundationStyles.interactiveSmall,
+              styles.mobileMenuTrigger,
+            )}
+          >
             <Menu aria-hidden="true" size={18} />
             Menu
           </summary>
           <div {...stylex.props(styles.mobileMenuPanel)}>
             <AdminNavigation currentHref={activeHref} groups={groups} />
-            <Link href="/" {...stylex.props(styles.returnLink)}>
+            <Link
+              href="/"
+              {...stylex.props(
+                foundationStyles.interactiveSmall,
+                styles.returnLink,
+              )}
+            >
               <ArrowLeft aria-hidden="true" size={15} />
               Return to Peated
             </Link>
@@ -117,9 +133,19 @@ export function AdminLayout({
       <aside {...stylex.props(styles.sidebar)}>
         <Link href="/admin" {...stylex.props(styles.brand)}>
           <span {...stylex.props(styles.brandName)}>Peated</span>
-          <span {...stylex.props(styles.brandContext)}>Admin</span>
+          <span
+            {...stylex.props(foundationStyles.metadata, styles.brandContext)}
+          >
+            Admin
+          </span>
         </Link>
-        <Link href="/" {...stylex.props(styles.returnLink)}>
+        <Link
+          href="/"
+          {...stylex.props(
+            foundationStyles.interactiveSmall,
+            styles.returnLink,
+          )}
+        >
           <ArrowLeft aria-hidden="true" size={15} />
           Return to Peated
         </Link>
@@ -176,8 +202,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: colors.inset,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 700,
     listStyle: "none",
     cursor: "pointer",
@@ -245,12 +269,7 @@ const styles = stylex.create({
   },
   brandContext: {
     color: colors.accentDeep,
-    fontFamily: fonts.data,
-    fontSize: "10px",
     fontWeight: 600,
-    letterSpacing: "0.12em",
-    lineHeight: 1,
-    textTransform: "uppercase",
   },
   returnLink: {
     display: "inline-flex",
@@ -271,8 +290,6 @@ const styles = stylex.create({
       ":active": colors.inset,
     },
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "12px",
     fontWeight: 700,
     textDecoration: "none",
     boxShadow: {
@@ -313,8 +330,6 @@ const styles = stylex.create({
       ":active": colors.inset,
     },
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
     textDecoration: "none",
     boxShadow: {

--- a/apps/web/src/components/admin/adminTable.stylex.tsx
+++ b/apps/web/src/components/admin/adminTable.stylex.tsx
@@ -9,11 +9,11 @@ import { usePathname, useSearchParams } from "next/navigation";
 import type { ReactElement, ReactNode } from "react";
 
 import { buildQueryString } from "../../lib/urls";
+import { foundationStyles } from "../../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../../styles/tokens.stylex";
 import { linkedRowStyles } from "../linkedRow.stylex";
@@ -97,7 +97,7 @@ export function AdminTableContent<
             name="query"
             placeholder="Search"
             type="search"
-            {...stylex.props(styles.searchInput)}
+            {...stylex.props(foundationStyles.input, styles.searchInput)}
           />
         </form>
       ) : null}
@@ -115,6 +115,7 @@ export function AdminTableContent<
                       key={column.name}
                       scope="col"
                       {...stylex.props(
+                        foundationStyles.fieldLabel,
                         styles.header,
                         alignStyles[align],
                         index > 0 && styles.secondary,
@@ -154,7 +155,10 @@ export function AdminTableContent<
                     <th
                       colSpan={columns.length}
                       scope="colgroup"
-                      {...stylex.props(styles.groupCell)}
+                      {...stylex.props(
+                        foundationStyles.metadata,
+                        styles.groupCell,
+                      )}
                     >
                       {groupTo ? (
                         <Link
@@ -185,6 +189,7 @@ export function AdminTableContent<
                       <td
                         key={column.name}
                         {...stylex.props(
+                          foundationStyles.metadata,
                           styles.cell,
                           alignStyles[align],
                           column.fill && styles.fill,
@@ -198,7 +203,7 @@ export function AdminTableContent<
                             {...stylex.props(linkedRowStyles.primaryLink)}
                           />
                         ) : null}
-                        <span {...stylex.props(styles.cellContent)}>
+                        <span {...stylex.props()}>
                           {getColumnValue(item, column)}
                         </span>
                       </td>
@@ -305,8 +310,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: colors.fieldBackground,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     boxShadow: { default: "none", ":focus-visible": effects.focusRing },
     "::placeholder": { color: colors.inkMuted, opacity: 1 },
     "::-webkit-search-cancel-button": { appearance: "none" },
@@ -327,11 +330,6 @@ const styles = stylex.create({
   header: {
     padding: `${space.x2} ${space.x3}`,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 500,
-    letterSpacing: "0.08em",
-    textTransform: "uppercase",
     whiteSpace: "nowrap",
   },
   row: {
@@ -342,13 +340,10 @@ const styles = stylex.create({
   cell: {
     padding: `${space.x3} ${space.x3}`,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
     verticalAlign: "middle",
   },
   fill: { width: "100%", maxWidth: 0 },
-  cellContent: {},
+
   secondary: { "@media (max-width: 639px)": { display: "none" } },
   groupRow: {
     borderBottomWidth: "1px",
@@ -359,8 +354,6 @@ const styles = stylex.create({
   groupCell: {
     padding: `${space.x2} ${space.x3}`,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "13px",
     textAlign: "left",
   },
   groupLink: {
@@ -384,7 +377,6 @@ const styles = stylex.create({
   center: { textAlign: "center" },
   right: { textAlign: "right" },
 });
-
 const alignStyles = {
   center: styles.center,
   left: styles.left,

--- a/apps/web/src/components/admin/adminUtility.stylex.tsx
+++ b/apps/web/src/components/admin/adminUtility.stylex.tsx
@@ -9,7 +9,8 @@ import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 import { CursorPager } from "..";
 import { buildQueryString } from "../../lib/urls";
-import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, effects, space } from "../../styles/tokens.stylex";
 
 export function AdminPager({
   ariaLabel = "Pagination",
@@ -51,12 +52,22 @@ function AdminDefinitionListRoot(props: ComponentPropsWithoutRef<"dl">) {
 
 export function AdminDefinitionTerm(props: ComponentPropsWithoutRef<"dt">) {
   const { className: _className, ...rest } = props;
-  return <dt {...rest} {...stylex.props(styles.definitionTerm)} />;
+  return (
+    <dt
+      {...rest}
+      {...stylex.props(foundationStyles.metadata, styles.definitionTerm)}
+    />
+  );
 }
 
 export function AdminDefinitionDetails(props: ComponentPropsWithoutRef<"dd">) {
   const { className: _className, ...rest } = props;
-  return <dd {...rest} {...stylex.props(styles.definitionDetails)} />;
+  return (
+    <dd
+      {...rest}
+      {...stylex.props(foundationStyles.body, styles.definitionDetails)}
+    />
+  );
 }
 
 export const AdminDefinitionList = Object.assign(AdminDefinitionListRoot, {
@@ -72,11 +83,14 @@ export function AdminEmptyActivity({
   href?: string;
 }) {
   return href ? (
-    <Link href={href} {...stylex.props(styles.empty, styles.emptyLink)}>
+    <Link
+      href={href}
+      {...stylex.props(foundationStyles.body, styles.empty, styles.emptyLink)}
+    >
       {children}
     </Link>
   ) : (
-    <div {...stylex.props(styles.empty)}>{children}</div>
+    <div {...stylex.props(foundationStyles.body, styles.empty)}>{children}</div>
   );
 }
 
@@ -91,7 +105,11 @@ export function AdminAlert({
   return (
     <div
       role={type === "error" ? "alert" : "status"}
-      {...stylex.props(styles.alert, alertToneStyles[type])}
+      {...stylex.props(
+        foundationStyles.body,
+        styles.alert,
+        alertToneStyles[type],
+      )}
     >
       {type === "error" ? (
         <AlertTriangle
@@ -106,7 +124,11 @@ export function AdminAlert({
 }
 
 export function AdminMarkdown({ content }: { content: string }) {
-  return <div {...stylex.props(styles.markdown)}>{content}</div>;
+  return (
+    <div {...stylex.props(foundationStyles.prose, styles.markdown)}>
+      {content}
+    </div>
+  );
 }
 
 const styles = stylex.create({
@@ -125,10 +147,6 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    textTransform: "uppercase",
   },
   definitionDetails: {
     display: "flex",
@@ -142,8 +160,6 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     overflowWrap: "anywhere",
   },
   empty: {
@@ -154,8 +170,6 @@ const styles = stylex.create({
     padding: space.x8,
     borderWidth: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     textAlign: "center",
   },
   emptyLink: {
@@ -172,9 +186,6 @@ const styles = stylex.create({
     borderWidth: "1px",
     borderStyle: "solid",
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.45,
   },
   alertIcon: { flexShrink: 0 },
   alertDefault: {
@@ -195,13 +206,9 @@ const styles = stylex.create({
   },
   markdown: {
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.65,
     whiteSpace: "pre-wrap",
   },
 });
-
 const alertToneStyles = {
   default: styles.alertDefault,
   error: styles.alertError,

--- a/apps/web/src/components/admin/badgeCheckEditor.stylex.tsx
+++ b/apps/web/src/components/admin/badgeCheckEditor.stylex.tsx
@@ -2,7 +2,8 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 import { SectionHeading } from "../sectionHeading.stylex";
 
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 import { AdminSection } from "./adminContent.stylex";
 
 export function BadgeCheckEditor({
@@ -18,7 +19,9 @@ export function BadgeCheckEditor({
     <AdminSection title="Checks">
       {error}
       <div {...stylex.props(styles.actions)}>
-        <span {...stylex.props(styles.actionsLabel)}>Add check</span>
+        <span {...stylex.props(foundationStyles.metadata, styles.actionsLabel)}>
+          Add check
+        </span>
         {actions}
       </div>
       <ol {...stylex.props(styles.list)}>{children}</ol>
@@ -39,10 +42,16 @@ export function BadgeCheckItem({
 }) {
   return (
     <li {...stylex.props(styles.item)}>
-      {index ? <div {...stylex.props(styles.connector)}>And</div> : null}
+      {index ? (
+        <div {...stylex.props(foundationStyles.metadata, styles.connector)}>
+          And
+        </div>
+      ) : null}
       <article {...stylex.props(styles.card)}>
         <header {...stylex.props(styles.cardHeader)}>
-          <span {...stylex.props(styles.number)}>#{index + 1}</span>
+          <span {...stylex.props(foundationStyles.metadata, styles.number)}>
+            #{index + 1}
+          </span>
           <div {...stylex.props(styles.title)}>
             <SectionHeading level={3}>{title}</SectionHeading>
           </div>
@@ -64,11 +73,7 @@ const styles = stylex.create({
   },
   actionsLabel: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
     fontWeight: 600,
-    letterSpacing: "0.08em",
-    textTransform: "uppercase",
   },
   list: {
     display: "grid",
@@ -83,10 +88,6 @@ const styles = stylex.create({
     alignItems: "center",
     gap: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    textTransform: "uppercase",
     "::before": {
       content: "''",
       height: "1px",
@@ -115,7 +116,7 @@ const styles = stylex.create({
     borderBottomColor: colors.hairline,
     backgroundColor: colors.inset,
   },
-  number: { color: colors.inkMuted, fontFamily: fonts.data, fontSize: "10px" },
+  number: { color: colors.inkMuted },
   title: { flexGrow: 1 },
   cardBody: { padding: space.x4 },
 });

--- a/apps/web/src/components/admin/moderation/automationPage.tsx
+++ b/apps/web/src/components/admin/moderation/automationPage.tsx
@@ -89,7 +89,6 @@ export default function AutomationPage() {
       <ModerationNav />
       <AdminPage>
         <AdminPageHeader
-          eyebrow="Operational work"
           title="Automation"
           description="See what is moving, what is waiting, and what needs recovery. Human catalog decisions stay in Inbox."
           metadata={

--- a/apps/web/src/components/admin/moderation/historyPage.tsx
+++ b/apps/web/src/components/admin/moderation/historyPage.tsx
@@ -68,7 +68,7 @@ function HistoryDetails({ eventKey }: { eventKey: string }) {
       <ModerationStack>
         <AdminPageHeader
           title={event.title}
-          eyebrow={`${event.category} · ${event.kind.replaceAll("_", " ")}`}
+          metadata={`${event.category} · ${event.kind.replaceAll("_", " ")}`}
         />
         <AdminStatGrid>
           <AdminStat

--- a/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationBottlePicker.stylex.tsx
@@ -19,11 +19,11 @@ import { SectionHeading } from "../../sectionHeading.stylex";
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { IconButton, TextLink } from "../..";
 import { useORPC } from "../../../lib/orpc/context";
+import { foundationStyles } from "../../../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
   zIndices,
 } from "../../../styles/tokens.stylex";
@@ -152,10 +152,10 @@ export default function ModerationBottlePicker({
               placeholder="Search for a bottle"
               type="search"
               value={query}
-              {...stylex.props(styles.search)}
+              {...stylex.props(foundationStyles.input, styles.search)}
             />
           </div>
-          <div {...stylex.props(styles.context)}>
+          <div {...stylex.props(foundationStyles.metadata, styles.context)}>
             Select the bottle identified as <strong>{name}</strong>.
             {source ? (
               <>
@@ -174,12 +174,18 @@ export default function ModerationBottlePicker({
             ) : null}
           </div>
           {error ? (
-            <p role="alert" {...stylex.props(styles.error)}>
+            <p
+              role="alert"
+              {...stylex.props(foundationStyles.metadata, styles.error)}
+            >
               {error}
             </p>
           ) : null}
           {isLoading ? (
-            <p role="status" {...stylex.props(styles.status)}>
+            <p
+              role="status"
+              {...stylex.props(foundationStyles.body, styles.status)}
+            >
               Searching…
             </p>
           ) : null}
@@ -190,10 +196,12 @@ export default function ModerationBottlePicker({
                   disabled={isLoading}
                   onClick={() => void selectBottle(bottle)}
                   type="button"
-                  {...stylex.props(styles.result)}
+                  {...stylex.props(foundationStyles.body, styles.result)}
                 >
                   <strong>{formatBottleDisplayName(bottle)}</strong>
-                  <span {...stylex.props(styles.detail)}>
+                  <span
+                    {...stylex.props(foundationStyles.metadata, styles.detail)}
+                  >
                     {bottle.distillers
                       .map((distiller) => distiller.name)
                       .join(", ")}
@@ -205,12 +213,21 @@ export default function ModerationBottlePicker({
               <li {...stylex.props(styles.resultItem)}>
                 <Link
                   href={`/bottles/new?${newBottleParams.toString()}`}
-                  {...stylex.props(styles.result, styles.add)}
+                  {...stylex.props(
+                    foundationStyles.body,
+                    styles.result,
+                    styles.add,
+                  )}
                 >
                   <Plus aria-hidden="true" size={18} />
                   <span>
                     <strong>Can’t find it?</strong>
-                    <span {...stylex.props(styles.detail)}>
+                    <span
+                      {...stylex.props(
+                        foundationStyles.metadata,
+                        styles.detail,
+                      )}
+                    >
                       {query
                         ? `Add ${toTitleCase(query)} to the database.`
                         : "Add a new bottle to the database."}
@@ -284,8 +301,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: colors.inset,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     boxShadow: { default: "none", ":focus-visible": effects.focusRing },
     "::-webkit-search-cancel-button": { appearance: "none" },
   },
@@ -295,23 +310,16 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
   error: {
     margin: 0,
     padding: space.x4,
     color: colors.accentDeep,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
   },
   status: {
     margin: 0,
     padding: space.x6,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     textAlign: "center",
   },
   results: { margin: 0, padding: 0, listStyle: "none" },
@@ -332,8 +340,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: { default: "transparent", ":hover": colors.inset },
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     textAlign: "left",
     textDecoration: "none",
     cursor: "pointer",
@@ -344,8 +350,5 @@ const styles = stylex.create({
     display: "block",
     marginTop: space.x1,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.4,
   },
 });

--- a/apps/web/src/components/admin/moderation/moderationDetail.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationDetail.stylex.tsx
@@ -3,6 +3,7 @@
 import * as stylex from "@stylexjs/stylex";
 import { useEffect, useRef, type ReactNode } from "react";
 
+import { foundationStyles } from "../../../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
@@ -34,8 +35,12 @@ export function ModerationEmpty({
 }) {
   return (
     <div {...stylex.props(styles.empty)}>
-      <strong {...stylex.props(styles.emptyTitle)}>{title}</strong>
-      <p {...stylex.props(styles.emptyCopy)}>{children}</p>
+      <strong {...stylex.props(foundationStyles.rowTitle, styles.emptyTitle)}>
+        {title}
+      </strong>
+      <p {...stylex.props(foundationStyles.body, styles.emptyCopy)}>
+        {children}
+      </p>
       {action}
     </div>
   );
@@ -76,14 +81,20 @@ export function ModerationTaskHeader({
   useEffect(() => headingRef.current?.focus(), [taskKey]);
   return (
     <header {...stylex.props(styles.taskHeader)}>
-      <div {...stylex.props(styles.taskMeta)}>
+      <div {...stylex.props(foundationStyles.metadata, styles.taskMeta)}>
         {category} /{" "}
         <span {...stylex.props(blocked && styles.blocked)}>{status}</span>
       </div>
-      <h1 ref={headingRef} tabIndex={-1} {...stylex.props(styles.taskTitle)}>
+      <h1
+        ref={headingRef}
+        tabIndex={-1}
+        {...stylex.props(foundationStyles.sectionHeading, styles.taskTitle)}
+      >
         {question}
       </h1>
-      <p {...stylex.props(styles.taskCopy)}>{meta}</p>
+      <p {...stylex.props(foundationStyles.metadata, styles.taskCopy)}>
+        {meta}
+      </p>
     </header>
   );
 }
@@ -104,7 +115,9 @@ export function ModerationMedia({
           </ImageViewer>
         </div>
       ) : null}
-      <div {...stylex.props(styles.mediaCopy)}>{children}</div>
+      <div {...stylex.props(foundationStyles.body, styles.mediaCopy)}>
+        {children}
+      </div>
     </div>
   );
 }
@@ -115,7 +128,7 @@ export function ModerationActions({ children }: { children: ReactNode }) {
 
 export function ModerationLoading({ children }: { children: ReactNode }) {
   return (
-    <div role="status" {...stylex.props(styles.loading)}>
+    <div role="status" {...stylex.props(foundationStyles.body, styles.loading)}>
       {children}
     </div>
   );
@@ -153,10 +166,8 @@ const styles = stylex.create({
   },
   emptyTitle: {
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "18px",
   },
-  emptyCopy: { maxWidth: "42ch", margin: 0, fontSize: "14px", lineHeight: 1.5 },
+  emptyCopy: { maxWidth: "42ch", margin: 0 },
   srOnly: {
     position: "absolute",
     width: "1px",
@@ -171,11 +182,7 @@ const styles = stylex.create({
   },
   taskMeta: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
     fontWeight: 600,
-    letterSpacing: "0.08em",
-    textTransform: "uppercase",
   },
   blocked: { color: colors.accentDeep },
   taskTitle: {
@@ -183,16 +190,11 @@ const styles = stylex.create({
     marginTop: space.x3,
     outline: "none",
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "24px",
-    lineHeight: 1.15,
   },
   taskCopy: {
     margin: 0,
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
   },
   media: {
     display: "flex",
@@ -219,9 +221,6 @@ const styles = stylex.create({
   mediaCopy: {
     minWidth: 0,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
   taskActions: {
     display: "flex",
@@ -233,7 +232,5 @@ const styles = stylex.create({
   loading: {
     padding: space.x8,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
   },
 });

--- a/apps/web/src/components/admin/moderation/moderationInbox.stylex.tsx
+++ b/apps/web/src/components/admin/moderation/moderationInbox.stylex.tsx
@@ -10,11 +10,11 @@ import { usePathname, useSearchParams } from "next/navigation";
 import { useState } from "react";
 
 import { Button } from "../..";
+import { foundationStyles } from "../../../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../../../styles/tokens.stylex";
 
@@ -113,8 +113,14 @@ export function ModerationInboxContent({
     <section aria-label="Moderation inbox" {...stylex.props(styles.root)}>
       <header {...stylex.props(styles.header)}>
         <div {...stylex.props(styles.titleRow)}>
-          <h1 {...stylex.props(styles.title)}>Inbox</h1>
-          <span {...stylex.props(styles.count)}>{data.counts.all} open</span>
+          <h1
+            {...stylex.props(foundationStyles.pageTitleCompact, styles.title)}
+          >
+            Inbox
+          </h1>
+          <span {...stylex.props(foundationStyles.metadata, styles.count)}>
+            {data.counts.all} open
+          </span>
         </div>
         <form action={listPath} {...stylex.props(styles.searchForm)}>
           {category ? (
@@ -133,7 +139,7 @@ export function ModerationInboxContent({
             name="query"
             placeholder="Search decisions"
             type="search"
-            {...stylex.props(styles.search)}
+            {...stylex.props(foundationStyles.input, styles.search)}
           />
         </form>
         <nav aria-label="Inbox filters" {...stylex.props(styles.filters)}>
@@ -143,6 +149,7 @@ export function ModerationInboxContent({
               href={filter.href}
               key={filter.label}
               {...stylex.props(
+                foundationStyles.interactiveSmall,
                 styles.filter,
                 filter.active && styles.activeFilter,
               )}
@@ -162,14 +169,17 @@ export function ModerationInboxContent({
             >
               Ignore all {data.counts.inconclusive} inconclusive
             </Button>
-            <p {...stylex.props(styles.help)}>
+            <p {...stylex.props(foundationStyles.metadata, styles.help)}>
               These listings have no recommended bottle. Ignoring them removes
               them from the inbox without assigning one.
             </p>
           </div>
         ) : null}
         {bulkError ? (
-          <p role="alert" {...stylex.props(styles.error)}>
+          <p
+            role="alert"
+            {...stylex.props(foundationStyles.metadata, styles.error)}
+          >
             {bulkError}
           </p>
         ) : null}
@@ -199,23 +209,39 @@ export function ModerationInboxContent({
                     selected && styles.selectedTask,
                   )}
                 >
-                  <span {...stylex.props(styles.taskMeta)}>
+                  <span
+                    {...stylex.props(
+                      foundationStyles.metadata,
+                      styles.taskMeta,
+                    )}
+                  >
                     <span>{task.category}</span>
                     <TimeSince date={task.attentionAt} />
                   </span>
                   <strong
                     title={task.title}
-                    {...stylex.props(styles.taskTitle)}
+                    {...stylex.props(
+                      foundationStyles.compactRowTitle,
+                      styles.taskTitle,
+                    )}
                   >
                     {task.title}
                   </strong>
                   <span
                     title={task.question}
-                    {...stylex.props(styles.question)}
+                    {...stylex.props(
+                      foundationStyles.metadata,
+                      styles.question,
+                    )}
                   >
                     {task.question}
                   </span>
-                  <span {...stylex.props(styles.taskMeta)}>
+                  <span
+                    {...stylex.props(
+                      foundationStyles.metadata,
+                      styles.taskMeta,
+                    )}
+                  >
                     <span
                       title={task.sourceLabel}
                       {...stylex.props(styles.truncate)}
@@ -236,7 +262,7 @@ export function ModerationInboxContent({
           })}
         </ol>
       ) : (
-        <div {...stylex.props(styles.empty)}>
+        <div {...stylex.props(foundationStyles.metadata, styles.empty)}>
           <strong>Nothing needs a decision</strong>
           <span>
             Clear the filters or check Automation for operational work.
@@ -270,10 +296,8 @@ const styles = stylex.create({
   title: {
     margin: 0,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "20px",
   },
-  count: { color: colors.inkMuted, fontFamily: fonts.data, fontSize: "11px" },
+  count: { color: colors.inkMuted },
   searchForm: { marginTop: space.x4 },
   search: {
     boxSizing: "border-box",
@@ -288,8 +312,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: colors.fieldBackground,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     boxShadow: { default: "none", ":focus-visible": effects.focusRing },
     "::placeholder": { color: colors.inkMuted },
     "::-webkit-search-cancel-button": { appearance: "none" },
@@ -320,8 +342,6 @@ const styles = stylex.create({
     borderRadius: controlMetrics.radiusSmall,
     outline: "none",
     color: { default: colors.inkMuted, ":hover": colors.ink },
-    fontFamily: fonts.data,
-    fontSize: "10px",
     fontWeight: 600,
     textDecoration: "none",
     boxShadow: { default: "none", ":focus-visible": effects.focusRing },
@@ -335,16 +355,11 @@ const styles = stylex.create({
   help: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "12px",
-    lineHeight: 1.5,
   },
   error: {
     margin: 0,
     marginTop: space.x3,
     color: colors.accentDeep,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
   },
   taskList: {
     minHeight: 0,
@@ -381,15 +396,10 @@ const styles = stylex.create({
     justifyContent: "space-between",
     gap: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    textTransform: "uppercase",
     whiteSpace: "nowrap",
   },
   taskTitle: {
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "14px",
     overflow: "hidden",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
@@ -397,9 +407,6 @@ const styles = stylex.create({
   question: {
     display: "-webkit-box",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
     overflow: "hidden",
     WebkitBoxOrient: "vertical",
     WebkitLineClamp: 2,
@@ -415,8 +422,6 @@ const styles = stylex.create({
     gap: space.x2,
     padding: space.x8,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     textAlign: "center",
   },
 });

--- a/apps/web/src/components/admin/reviewTable.stylex.tsx
+++ b/apps/web/src/components/admin/reviewTable.stylex.tsx
@@ -3,7 +3,8 @@ import type { ExternalReview, PagingRel } from "@peated/server/types";
 import { getBottleUrl } from "@peated/web/lib/urls";
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 import { AdminTextLink } from "./adminContent.stylex";
 import { AdminTable } from "./adminTable.stylex";
 
@@ -63,7 +64,12 @@ export function ReviewRows({
                       {bottleName}
                     </span>
                   )}
-                  <span {...stylex.props(styles.metadata)}>
+                  <span
+                    {...stylex.props(
+                      foundationStyles.metadata,
+                      styles.metadata,
+                    )}
+                  >
                     {" · "}
                     {review.article.publishedAt ? (
                       <time dateTime={review.article.publishedAt}>
@@ -123,8 +129,6 @@ const styles = stylex.create({
   metadata: {
     flexShrink: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
   },
   score: {
     whiteSpace: "nowrap",

--- a/apps/web/src/components/admin/scraperParsingEditor.stylex.tsx
+++ b/apps/web/src/components/admin/scraperParsingEditor.stylex.tsx
@@ -8,7 +8,8 @@ import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { getFormErrorMessage } from "../../lib/formHelpers";
 import { useORPC } from "../../lib/orpc/context";
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 import { AdminButton } from "./adminButton.stylex";
 import {
   AdminActions,
@@ -193,13 +194,22 @@ export function ScraperParsingEditor({
         <ol {...stylex.props(styles.setupList)}>
           {setupSteps.map((step) => (
             <li key={step.name} {...stylex.props(styles.setupStep)}>
-              <span {...stylex.props(styles.setupStepName)}>{step.name}</span>
+              <span
+                {...stylex.props(
+                  foundationStyles.interactiveSmall,
+                  styles.setupStepName,
+                )}
+              >
+                {step.name}
+              </span>
               <AdminStatus tone={step.tone}>{step.status}</AdminStatus>
             </li>
           ))}
         </ol>
         {setup?.error ? (
-          <p {...stylex.props(styles.setupError)}>{setup.error}</p>
+          <p {...stylex.props(foundationStyles.metadata, styles.setupError)}>
+            {setup.error}
+          </p>
         ) : null}
       </AdminSection>
       {latest ? (
@@ -351,7 +361,13 @@ export function ScraperParsingEditor({
                     </AdminButton>
                   </AdminActions>
                   {previewRevisionId === revision.id ? (
-                    <p {...stylex.props(styles.previewStatus)} role="status">
+                    <p
+                      {...stylex.props(
+                        foundationStyles.metadata,
+                        styles.previewStatus,
+                      )}
+                      role="status"
+                    >
                       The test is running. Results will appear here when it
                       finishes.
                     </p>
@@ -490,8 +506,6 @@ const styles = stylex.create({
   },
   setupStepName: {
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
   },
   setupError: {
@@ -500,9 +514,6 @@ const styles = stylex.create({
     marginBottom: 0,
     marginLeft: 0,
     color: colors.accentDeep,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
   },
   revisionList: {
     display: "flex",
@@ -523,8 +534,6 @@ const styles = stylex.create({
   previewStatus: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
   },
   muted: { color: colors.inkMuted },
 });

--- a/apps/web/src/components/admin/scraperPreviewResult.stylex.tsx
+++ b/apps/web/src/components/admin/scraperPreviewResult.stylex.tsx
@@ -1,6 +1,7 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
-import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, effects, space } from "../../styles/tokens.stylex";
 import issueText from "./scraperIssueText";
 
 type Source = Outputs["externalSites"]["scrapeSources"]["list"][number];
@@ -63,7 +64,7 @@ export function ScraperPreviewResult({ result }: { result: Result }) {
   const morePages = pages.slice(VISIBLE_PAGE_COUNT);
 
   return (
-    <div {...stylex.props(styles.root)}>
+    <div {...stylex.props(foundationStyles.metadata, styles.root)}>
       {issues.length > 0 ? (
         <ul {...stylex.props(styles.issues)}>
           {issues.map((issue, index) => (
@@ -104,8 +105,6 @@ const styles = stylex.create({
     borderColor: colors.hairline,
     backgroundColor: "transparent",
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
   },
   issues: {
     margin: 0,

--- a/apps/web/src/components/admin/scraperScheduleSettings.stylex.tsx
+++ b/apps/web/src/components/admin/scraperScheduleSettings.stylex.tsx
@@ -8,7 +8,8 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { formatDuration } from "../../lib/format";
 import { getFormErrorMessage } from "../../lib/formHelpers";
 import { useORPC } from "../../lib/orpc/context";
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors } from "../../styles/tokens.stylex";
 import TimeSince from "../timeSince";
 import { AdminButton } from "./adminButton.stylex";
 import {
@@ -167,7 +168,7 @@ export default function ScraperScheduleSettings({ site }: { site: Site }) {
         ) : null}
       </AdminFormGrid>
       {automaticUnavailable ? (
-        <p {...stylex.props(styles.help)}>
+        <p {...stylex.props(foundationStyles.metadata, styles.help)}>
           Set up this scraper before you schedule automatic runs.
         </p>
       ) : null}
@@ -179,7 +180,5 @@ const styles = stylex.create({
   help: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
   },
 });

--- a/apps/web/src/components/admin/scraperSetting.stylex.tsx
+++ b/apps/web/src/components/admin/scraperSetting.stylex.tsx
@@ -2,7 +2,8 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 import { SectionHeading } from "../sectionHeading.stylex";
 
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 
 export default function ScraperSetting({
   action,
@@ -20,7 +21,9 @@ export default function ScraperSetting({
       <div {...stylex.props(styles.header)}>
         <div {...stylex.props(styles.copy)}>
           <SectionHeading level={3}>{title}</SectionHeading>
-          <p {...stylex.props(styles.description)}>{description}</p>
+          <p {...stylex.props(foundationStyles.body, styles.description)}>
+            {description}
+          </p>
         </div>
         {action}
       </div>
@@ -51,8 +54,5 @@ const styles = stylex.create({
     marginBottom: 0,
     marginLeft: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
 });

--- a/apps/web/src/components/appLink.tsx
+++ b/apps/web/src/components/appLink.tsx
@@ -1,3 +1,4 @@
+import { foundationStyles } from "@peated/web/styles/foundations.stylex";
 import * as stylex from "@stylexjs/stylex";
 import NextLink from "next/link";
 import {
@@ -36,7 +37,7 @@ export const AppLink = forwardRef(function AppLink(
 ) {
   const fallbackProps = className
     ? undefined
-    : stylex.props(textLinkStyles.link, textLinkStyles.small);
+    : stylex.props(textLinkStyles.link, foundationStyles.interactiveSmall);
   const linkProps = {
     ...props,
     className: className ?? fallbackProps?.className,

--- a/apps/web/src/components/applicationHeader.stylex.tsx
+++ b/apps/web/src/components/applicationHeader.stylex.tsx
@@ -11,6 +11,7 @@ import { Menu as MenuIcon, Search, X } from "lucide-react";
 import { Fragment, useEffect, useRef, useState, type ReactNode } from "react";
 import { SectionHeading } from "./sectionHeading.stylex";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
@@ -212,7 +213,12 @@ export function ApplicationHeader({
                       menuSurfaceStyles.surface,
                     )}
                   >
-                    <div {...stylex.props(styles.accountMenuHeader)}>
+                    <div
+                      {...stylex.props(
+                        foundationStyles.metadata,
+                        styles.accountMenuHeader,
+                      )}
+                    >
                       Account
                     </div>
                     <div {...stylex.props(styles.accountMenuSeparator)} />
@@ -235,6 +241,7 @@ export function ApplicationHeader({
               onClick={() => setSearchOpen(false)}
               type="button"
               {...stylex.props(
+                foundationStyles.interactiveSmall,
                 styles.mobileSearchCancel,
                 searchOpen && styles.mobileSearchCancelVisible,
               )}
@@ -289,7 +296,12 @@ function AccountMenuItem({
           <>
             <span>{item.label}</span>
             {item.count !== undefined ? (
-              <span {...stylex.props(styles.accountMenuCount)}>
+              <span
+                {...stylex.props(
+                  foundationStyles.metadata,
+                  styles.accountMenuCount,
+                )}
+              >
                 {item.count.toLocaleString("en-US")}
               </span>
             ) : null}
@@ -308,6 +320,7 @@ function AccountMenuItem({
               }}
               type="button"
               {...stylex.props(
+                foundationStyles.interactiveSmall,
                 styles.accountMenuItem,
                 styles.accountMenuAction,
                 focus && styles.focusedAccountMenuItem,
@@ -323,8 +336,12 @@ function AccountMenuItem({
             aria-current={current ? "page" : undefined}
             href={item.href}
             {...stylex.props(
+              foundationStyles.interactiveSmall,
               styles.accountMenuItem,
-              current && styles.currentMenuLink,
+              current && [
+                foundationStyles.interactiveSmall,
+                styles.currentMenuLink,
+              ],
               focus && styles.focusedAccountMenuItem,
             )}
           >
@@ -361,15 +378,20 @@ function HeaderDrawerGroup({
               }
               href={item.href}
               {...stylex.props(
+                foundationStyles.interactive,
                 styles.drawerLink,
-                isCurrentNavigationHref(currentHref, item.href) &&
+                isCurrentNavigationHref(currentHref, item.href) && [
+                  foundationStyles.interactiveSmall,
                   styles.currentMenuLink,
+                ],
               )}
             >
               {item.label}
             </AppLink>
             {item.count !== undefined ? (
-              <span {...stylex.props(styles.drawerCount)}>
+              <span
+                {...stylex.props(foundationStyles.metadata, styles.drawerCount)}
+              >
                 {item.count.toLocaleString("en-US")}
               </span>
             ) : null}
@@ -531,11 +553,6 @@ const styles = stylex.create({
     paddingRight: "48px",
     paddingLeft: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   accountMenuSeparator: {
     height: "1px",
@@ -556,10 +573,7 @@ const styles = stylex.create({
     paddingRight: space.x3,
     paddingLeft: space.x3,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1.2,
     textDecoration: "none",
     outline: "none",
     backgroundColor: {
@@ -592,15 +606,10 @@ const styles = stylex.create({
   },
   currentMenuLink: {
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "13px",
     fontWeight: 700,
   },
   accountMenuCount: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1,
   },
   mobileSearchButton: {
     display: "none",
@@ -616,10 +625,7 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: "transparent",
     color: colors.accentDeep,
-    fontFamily: fonts.display,
-    fontSize: "13px",
     fontWeight: 700,
-    lineHeight: 1,
     cursor: "pointer",
     boxShadow: {
       default: "none",
@@ -699,10 +705,7 @@ const styles = stylex.create({
   drawerLink: {
     flex: 1,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     fontWeight: 600,
-    lineHeight: 1.3,
     textDecoration: "none",
     outline: "none",
     boxShadow: {
@@ -713,10 +716,7 @@ const styles = stylex.create({
   drawerCount: {
     flexShrink: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1,
   },
   drawerAction: {
     display: "flex",

--- a/apps/web/src/components/bottleChecks/checkResult.stylex.tsx
+++ b/apps/web/src/components/bottleChecks/checkResult.stylex.tsx
@@ -1,10 +1,10 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../../styles/tokens.stylex";
 import { SectionHeading } from "../sectionHeading.stylex";
@@ -29,11 +29,13 @@ export default function CheckResult({
   if (!check.schemaSupported) {
     return (
       <section {...stylex.props(styles.panel, styles.warningPanel)}>
-        <div {...stylex.props(styles.eyebrow)}>Unsupported schema</div>
+        <div {...stylex.props(foundationStyles.fieldLabel, styles.label)}>
+          Unsupported schema
+        </div>
         <div {...stylex.props(styles.title)}>
           <SectionHeading>{title}</SectionHeading>
         </div>
-        <p {...stylex.props(styles.copy)}>
+        <p {...stylex.props(foundationStyles.body, styles.copy)}>
           This audit uses schema version {check.schemaVersion}. Its historical
           proposals cannot be reviewed safely
           {check.canClose
@@ -50,10 +52,18 @@ export default function CheckResult({
   if (compact) {
     return (
       <section aria-label="Review summary" {...stylex.props(styles.panel)}>
-        <p {...stylex.props(styles.copy)}>{getBottleCheckSummary(check)}</p>
+        <p {...stylex.props(foundationStyles.body, styles.copy)}>
+          {getBottleCheckSummary(check)}
+        </p>
 
         {clean ? (
-          <p {...stylex.props(styles.copy, styles.success)}>
+          <p
+            {...stylex.props(
+              foundationStyles.body,
+              styles.copy,
+              styles.success,
+            )}
+          >
             No catalog changes or unresolved findings were proposed.
           </p>
         ) : null}
@@ -62,12 +72,17 @@ export default function CheckResult({
           <div {...stylex.props(styles.findings)}>
             {findings.map((finding, index) => (
               <article
-                {...stylex.props(styles.finding)}
+                {...stylex.props(foundationStyles.body, styles.finding)}
                 key={`${finding.scope}:${finding.summary}:${index}`}
               >
                 <p>{finding.summary}</p>
                 {finding.evidenceRefs.length > 0 ? (
-                  <details {...stylex.props(styles.evidence)}>
+                  <details
+                    {...stylex.props(
+                      foundationStyles.metadata,
+                      styles.evidence,
+                    )}
+                  >
                     <summary {...stylex.props(styles.summary)}>
                       Evidence
                     </summary>
@@ -85,15 +100,19 @@ export default function CheckResult({
   return (
     <section {...stylex.props(styles.panel)}>
       <div {...stylex.props(styles.heading)}>
-        <span {...stylex.props(styles.status)}>
+        <span {...stylex.props(foundationStyles.metadata, styles.status)}>
           {getBottleCheckState(check)}
         </span>
         <SectionHeading>{title}</SectionHeading>
       </div>
-      <p {...stylex.props(styles.copy)}>{getBottleCheckSummary(check)}</p>
+      <p {...stylex.props(foundationStyles.body, styles.copy)}>
+        {getBottleCheckSummary(check)}
+      </p>
 
       {clean ? (
-        <div {...stylex.props(styles.copy, styles.success)}>
+        <div
+          {...stylex.props(foundationStyles.body, styles.copy, styles.success)}
+        >
           No catalog changes or unresolved findings were proposed.
         </div>
       ) : null}
@@ -105,12 +124,17 @@ export default function CheckResult({
             {findings.map((finding, index) => {
               return (
                 <article
-                  {...stylex.props(styles.finding)}
+                  {...stylex.props(foundationStyles.body, styles.finding)}
                   key={`${finding.scope}:${finding.summary}:${index}`}
                 >
                   <p>{finding.summary}</p>
                   {finding.evidenceRefs.length > 0 ? (
-                    <details {...stylex.props(styles.evidence)}>
+                    <details
+                      {...stylex.props(
+                        foundationStyles.metadata,
+                        styles.evidence,
+                      )}
+                    >
                       <summary {...stylex.props(styles.summary)}>
                         Evidence
                       </summary>
@@ -142,22 +166,14 @@ const styles = stylex.create({
     borderColor: colors.accent,
     backgroundColor: colors.accentTint,
   },
-  eyebrow: {
+  label: {
     color: colors.accentDeep,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    fontWeight: 600,
-    letterSpacing: "0.08em",
-    textTransform: "uppercase",
   },
   title: { marginTop: space.x2 },
   copy: {
     margin: 0,
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
   success: { color: colors.ink },
   heading: {
@@ -173,8 +189,6 @@ const styles = stylex.create({
     borderColor: colors.hairline,
     borderRadius: controlMetrics.radiusSmall,
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontWeight: 600,
   },
   findings: {
@@ -185,15 +199,10 @@ const styles = stylex.create({
   findingList: { display: "grid", gap: space.x3 },
   finding: {
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
   evidence: {
     marginTop: space.x1,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
   },
   summary: {
     cursor: "pointer",

--- a/apps/web/src/components/bottleChecks/operationCard.stylex.tsx
+++ b/apps/web/src/components/bottleChecks/operationCard.stylex.tsx
@@ -8,11 +8,11 @@ import * as stylex from "@stylexjs/stylex";
 import { ArrowRight, Copy } from "lucide-react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 import { z } from "zod";
+import { foundationStyles } from "../../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../../styles/tokens.stylex";
 import { SectionHeading } from "../sectionHeading.stylex";
@@ -134,7 +134,7 @@ function ImpactList({
   if (entries.length === 0) return null;
 
   return (
-    <dl {...stylex.props(styles.impactList)}>
+    <dl {...stylex.props(foundationStyles.metadata, styles.impactList)}>
       {entries.map(([label, value]) => (
         <div {...stylex.props(styles.impactItem)} key={label}>
           <dd {...stylex.props(styles.impactValue)}>{value}</dd>
@@ -154,9 +154,17 @@ function Warnings({
 }) {
   if (warnings.length === 0) return null;
   return (
-    <div {...stylex.props(styles.notice, styles.warningNotice)}>
-      <div {...stylex.props(styles.eyebrow)}>Warnings</div>
-      <ul {...stylex.props(styles.bulletList)}>
+    <div
+      {...stylex.props(
+        foundationStyles.body,
+        styles.notice,
+        styles.warningNotice,
+      )}
+    >
+      <div {...stylex.props(foundationStyles.metadata, styles.label)}>
+        Warnings
+      </div>
+      <ul {...stylex.props(foundationStyles.body, styles.bulletList)}>
         {warnings.map((warning) => (
           <li key={`${warning.code}:${warning.message}`}>{warning.message}</li>
         ))}
@@ -186,13 +194,18 @@ function FieldDiff({
     const editable = editableFields.includes(field);
     if (!onToggleField) return null;
     if (!editable) {
-      return <span {...stylex.props(styles.meta)}>Linked</span>;
+      return (
+        <span {...stylex.props(foundationStyles.metadata, styles.meta)}>
+          Linked
+        </span>
+      );
     }
     return (
       <button
         aria-label={`${excluded ? "Include" : "Exclude"} ${labelField(field)}`}
         aria-pressed={!excluded}
         {...stylex.props(
+          foundationStyles.interactiveSmall,
           styles.toggle,
           excluded ? styles.toggleExcluded : styles.toggleIncluded,
         )}
@@ -219,7 +232,11 @@ function FieldDiff({
             >
               <div {...stylex.props(styles.diffCardHeader)}>
                 <div
-                  {...stylex.props(styles.diffLabel, excluded && styles.struck)}
+                  {...stylex.props(
+                    foundationStyles.fieldLabel,
+                    styles.diffLabel,
+                    excluded && styles.struck,
+                  )}
                 >
                   {labelField(field)}
                 </div>
@@ -227,8 +244,12 @@ function FieldDiff({
               </div>
               <dl {...stylex.props(styles.diffValues)}>
                 <div {...stylex.props(styles.minWidth)}>
-                  <dt {...stylex.props(styles.meta)}>Current</dt>
-                  <dd {...stylex.props(styles.diffValue)}>
+                  <dt {...stylex.props(foundationStyles.metadata, styles.meta)}>
+                    Current
+                  </dt>
+                  <dd
+                    {...stylex.props(foundationStyles.body, styles.diffValue)}
+                  >
                     {formatValue(getPath(before, field))}
                   </dd>
                 </div>
@@ -237,8 +258,16 @@ function FieldDiff({
                   {...stylex.props(styles.arrow)}
                 />
                 <div {...stylex.props(styles.minWidth)}>
-                  <dt {...stylex.props(styles.meta)}>Proposed</dt>
-                  <dd {...stylex.props(styles.diffValue, styles.strong)}>
+                  <dt {...stylex.props(foundationStyles.metadata, styles.meta)}>
+                    Proposed
+                  </dt>
+                  <dd
+                    {...stylex.props(
+                      foundationStyles.body,
+                      styles.diffValue,
+                      styles.strong,
+                    )}
+                  >
                     {formatValue(getPath(after, field))}
                   </dd>
                 </div>
@@ -247,9 +276,11 @@ function FieldDiff({
           );
         })}
       </div>
-      <table {...stylex.props(styles.diffTable)}>
+      <table {...stylex.props(foundationStyles.body, styles.diffTable)}>
         <thead>
-          <tr {...stylex.props(styles.tableHeading)}>
+          <tr
+            {...stylex.props(foundationStyles.fieldLabel, styles.tableHeading)}
+          >
             {onToggleField ? (
               <th {...stylex.props(styles.applyCell)}>Apply</th>
             ) : null}
@@ -301,7 +332,13 @@ function Preview({
 }) {
   if (review.status === "blocked") {
     return (
-      <div {...stylex.props(styles.notice, styles.dangerNotice)}>
+      <div
+        {...stylex.props(
+          foundationStyles.body,
+          styles.notice,
+          styles.dangerNotice,
+        )}
+      >
         {review.preparationError.message}
       </div>
     );
@@ -311,7 +348,9 @@ function Preview({
     case "update_bottle":
       return (
         <div {...stylex.props(styles.preview)}>
-          <div {...stylex.props(styles.eyebrow)}>Live Bottle diff</div>
+          <div {...stylex.props(foundationStyles.metadata, styles.label)}>
+            Live Bottle diff
+          </div>
           <FieldDiff
             after={review.preview.after}
             before={review.preview.before}
@@ -334,7 +373,7 @@ function Preview({
     case "merge_bottles":
       return (
         <div {...stylex.props(styles.preview)}>
-          <div {...stylex.props(styles.copy)}>
+          <div {...stylex.props(foundationStyles.body, styles.copy)}>
             Retire{" "}
             <strong {...stylex.props(styles.strong)}>
               {review.preview.source.fullName}
@@ -352,7 +391,9 @@ function Preview({
     case "update_entity":
       return (
         <div {...stylex.props(styles.preview)}>
-          <div {...stylex.props(styles.eyebrow)}>Proposed changes</div>
+          <div {...stylex.props(foundationStyles.metadata, styles.label)}>
+            Proposed changes
+          </div>
           <FieldDiff
             after={review.preview.after}
             before={review.preview.before}
@@ -368,7 +409,7 @@ function Preview({
     case "merge_entities":
       return (
         <div {...stylex.props(styles.preview)}>
-          <div {...stylex.props(styles.copy)}>
+          <div {...stylex.props(foundationStyles.body, styles.copy)}>
             Retire{" "}
             <strong {...stylex.props(styles.strong)}>
               {review.preview.source.name}
@@ -456,7 +497,11 @@ function ResourceLinks({ operation }: { operation: BottleOperation }) {
       ];
       break;
   }
-  return <div {...stylex.props(styles.resourceLinks)}>{links}</div>;
+  return (
+    <div {...stylex.props(foundationStyles.metadata, styles.resourceLinks)}>
+      {links}
+    </div>
+  );
 }
 
 function ExecutionSummary({ operation }: { operation: BottleOperation }) {
@@ -495,7 +540,7 @@ function ExecutionSummary({ operation }: { operation: BottleOperation }) {
     "reconciled" in operation.result &&
     operation.result.reconciled === true;
   return (
-    <div {...stylex.props(styles.notice)}>
+    <div {...stylex.props(foundationStyles.body, styles.notice)}>
       {message}
       {reconciled ? " The prior execution was reconciled safely." : ""}
     </div>
@@ -509,7 +554,7 @@ export function EvidenceList({
 }) {
   if (evidence.length === 0) return null;
   return (
-    <ul {...stylex.props(styles.evidenceList)}>
+    <ul {...stylex.props(foundationStyles.body, styles.evidenceList)}>
       {evidence.map((ref) => {
         switch (ref.kind) {
           case "bottle":
@@ -734,7 +779,10 @@ export default function OperationCard({
             <SectionHeading level={compact ? 2 : 3}>
               {OPERATION_LABELS[operation.proposal.type]}
             </SectionHeading>
-            <p {...stylex.props(styles.copy)} role="status">
+            <p
+              {...stylex.props(foundationStyles.body, styles.copy)}
+              role="status"
+            >
               {savingRemoval
                 ? "Removing operation…"
                 : "Operation removed. This will be saved shortly."}
@@ -760,7 +808,7 @@ export default function OperationCard({
           {!compact ||
           operation.status !== "pending_review" ||
           notApprovalReady ? (
-            <span {...stylex.props(styles.status)}>
+            <span {...stylex.props(foundationStyles.metadata, styles.status)}>
               {notApprovalReady
                 ? "Not ready to approve"
                 : STATUS_LABELS[operation.status]}
@@ -782,7 +830,14 @@ export default function OperationCard({
       </div>
 
       {notApprovalReady ? (
-        <p {...stylex.props(styles.copy, styles.accentCopy)} role="status">
+        <p
+          {...stylex.props(
+            foundationStyles.body,
+            styles.copy,
+            styles.accentCopy,
+          )}
+          role="status"
+        >
           The current catalog state does not support applying this proposal.
         </p>
       ) : null}
@@ -799,7 +854,7 @@ export default function OperationCard({
       ) : null}
 
       {excludedFields.size > 0 ? (
-        <p {...stylex.props(styles.copy)}>
+        <p {...stylex.props(foundationStyles.body, styles.copy)}>
           {excludedFields.size} proposed field
           {excludedFields.size === 1 ? " is" : "s are"} struck out and will not
           be applied.
@@ -807,20 +862,32 @@ export default function OperationCard({
       ) : null}
 
       {operation.rejectionReason ? (
-        <div {...stylex.props(styles.copy)}>
+        <div {...stylex.props(foundationStyles.body, styles.copy)}>
           Removed: {operation.rejectionReason.replaceAll("_", " ")}
           {operation.reviewerNote ? ` — ${operation.reviewerNote}` : ""}
         </div>
       ) : null}
       <ExecutionSummary operation={operation} />
       {operation.error ? (
-        <div {...stylex.props(styles.notice, styles.dangerNotice)}>
+        <div
+          {...stylex.props(
+            foundationStyles.body,
+            styles.notice,
+            styles.dangerNotice,
+          )}
+        >
           {operation.error}
         </div>
       ) : null}
 
       {actionError ? (
-        <div {...stylex.props(styles.notice, styles.dangerNotice)}>
+        <div
+          {...stylex.props(
+            foundationStyles.body,
+            styles.notice,
+            styles.dangerNotice,
+          )}
+        >
           {actionError}
         </div>
       ) : null}
@@ -869,10 +936,14 @@ export default function OperationCard({
       ) : null}
 
       <details {...stylex.props(styles.details)}>
-        <summary {...stylex.props(styles.detailsSummary)}>
+        <summary
+          {...stylex.props(foundationStyles.interactive, styles.detailsSummary)}
+        >
           {compact ? "Evidence" : "Evidence and reasoning"}
         </summary>
-        <p {...stylex.props(styles.copy)}>{operation.proposal.rationale}</p>
+        <p {...stylex.props(foundationStyles.body, styles.copy)}>
+          {operation.proposal.rationale}
+        </p>
         <EvidenceList evidence={operation.proposal.evidenceRefs} />
         <ResourceLinks operation={operation} />
       </details>
@@ -880,7 +951,9 @@ export default function OperationCard({
       {rejecting && canReject ? (
         <div ref={rejectionPanel} {...stylex.props(styles.rejectionPanel)}>
           <div {...stylex.props(styles.rejectionFields)}>
-            <label {...stylex.props(styles.fieldLabel)}>
+            <label
+              {...stylex.props(foundationStyles.fieldLabel, styles.fieldLabel)}
+            >
               Reason
               <select
                 disabled={disabled}
@@ -891,7 +964,7 @@ export default function OperationCard({
                   if (reason) setRejectionReason(reason.id);
                 }}
                 value={rejectionReason}
-                {...stylex.props(styles.input)}
+                {...stylex.props(foundationStyles.input, styles.input)}
               >
                 {REJECTION_REASONS.map((reason) => (
                   <option key={reason.id} value={reason.id}>
@@ -900,7 +973,9 @@ export default function OperationCard({
                 ))}
               </select>
             </label>
-            <label {...stylex.props(styles.fieldLabel)}>
+            <label
+              {...stylex.props(foundationStyles.fieldLabel, styles.fieldLabel)}
+            >
               Note {rejectionReason === "other" ? "(required)" : "(optional)"}
               <input
                 disabled={disabled}
@@ -908,7 +983,7 @@ export default function OperationCard({
                   setRejectionNote(event.currentTarget.value)
                 }
                 value={rejectionNote}
-                {...stylex.props(styles.input)}
+                {...stylex.props(foundationStyles.input, styles.input)}
               />
             </label>
           </div>
@@ -967,37 +1042,24 @@ const styles = stylex.create({
     borderColor: colors.hairline,
     borderRadius: controlMetrics.radiusSmall,
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontWeight: 600,
   },
   preview: { marginTop: space.x4 },
-  eyebrow: {
+  label: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontWeight: 600,
-    letterSpacing: "0.08em",
-    textTransform: "uppercase",
   },
   copy: {
     margin: 0,
     marginTop: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
   accentCopy: { color: colors.accentDeep },
   strong: { color: colors.ink, fontWeight: 600 },
   muted: { color: colors.inkMuted },
   meta: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontWeight: 500,
-    letterSpacing: "0.05em",
-    textTransform: "uppercase",
   },
   impactList: {
     display: "flex",
@@ -1006,8 +1068,6 @@ const styles = stylex.create({
     padding: 0,
     gap: `${space.x1} ${space.x4}`,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     flexWrap: "wrap",
   },
   impactItem: { display: "flex", gap: space.x1 },
@@ -1022,9 +1082,6 @@ const styles = stylex.create({
     borderRadius: controlMetrics.radius,
     backgroundColor: colors.inset,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
   warningNotice: {
     borderColor: colors.accent,
@@ -1041,8 +1098,6 @@ const styles = stylex.create({
     paddingLeft: space.x6,
     gap: space.x1,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     listStyleType: "disc",
   },
   toggle: {
@@ -1052,8 +1107,6 @@ const styles = stylex.create({
     borderStyle: "solid",
     borderRadius: controlMetrics.radius,
     outline: "none",
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontWeight: 600,
     cursor: "pointer",
     boxShadow: { default: "none", ":focus-visible": effects.focusRing },
@@ -1093,9 +1146,6 @@ const styles = stylex.create({
   },
   diffLabel: {
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    fontWeight: 600,
   },
   diffValues: {
     display: "grid",
@@ -1109,8 +1159,6 @@ const styles = stylex.create({
     margin: 0,
     marginTop: space.x1,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     overflowWrap: "anywhere",
   },
   arrow: {
@@ -1124,16 +1172,10 @@ const styles = stylex.create({
     width: "100%",
     borderCollapse: "collapse",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
   },
   tableHeading: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    letterSpacing: "0.05em",
     textAlign: "left",
-    textTransform: "uppercase",
   },
   tableCell: {
     paddingTop: space.x2,
@@ -1163,8 +1205,6 @@ const styles = stylex.create({
     marginTop: space.x3,
     gap: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     flexWrap: "wrap",
   },
   link: {
@@ -1213,8 +1253,6 @@ const styles = stylex.create({
     padding: 0,
     gap: space.x1,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     listStyle: "none",
   },
   icon: { width: "20px", height: "20px" },
@@ -1248,8 +1286,6 @@ const styles = stylex.create({
   },
   detailsSummary: {
     color: { default: colors.inkMuted, ":hover": colors.ink },
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     fontWeight: 600,
     cursor: "pointer",
     outline: "none",
@@ -1278,8 +1314,6 @@ const styles = stylex.create({
   },
   fieldLabel: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
   },
   input: {
     boxSizing: "border-box",
@@ -1293,8 +1327,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: colors.surface,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     boxShadow: { default: "none", ":focus-visible": effects.focusRing },
   },
   rejectionActions: {

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -2,13 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import type { MouseEventHandler, ReactNode } from "react";
 
 import { foundationStyles } from "../styles/foundations.stylex";
-import {
-  colors,
-  effects,
-  fonts,
-  space,
-  zIndices,
-} from "../styles/tokens.stylex";
+import { colors, effects, space, zIndices } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { BottleVisual } from "./bottleVisual.stylex";
 import Join from "./join";
@@ -152,6 +146,7 @@ export function BottleIdentityRow({
           <AppLink
             href={relatedReleases.href}
             {...stylex.props(
+              foundationStyles.interactiveSmall,
               styles.relatedReleases,
               linkedRowStyles.nestedAction,
             )}
@@ -253,10 +248,7 @@ const styles = stylex.create({
       ":active": colors.accent,
       ":focus-visible": colors.accent,
     },
-    fontFamily: fonts.reading,
-    fontSize: "12px",
     fontWeight: 600,
-    lineHeight: 1.3,
     textDecorationLine: {
       default: "none",
       ":hover": "underline",

--- a/apps/web/src/components/bottleResolver/photoPreview.stylex.tsx
+++ b/apps/web/src/components/bottleResolver/photoPreview.stylex.tsx
@@ -1,11 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
-import {
-  colors,
-  controlMetrics,
-  fonts,
-  space,
-} from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, controlMetrics, space } from "../../styles/tokens.stylex";
 import { ImageViewer } from "../imageViewer.stylex";
 
 export type PhotoPreviewProps = {
@@ -54,10 +50,18 @@ export function PhotoPreview({
         ) : null}
       </span>
       <span {...stylex.props(styles.copy, loading && styles.loadingCopy)}>
-        <strong {...stylex.props(styles.title, loading && styles.loadingTitle)}>
+        <strong
+          {...stylex.props(
+            foundationStyles.compactRowTitle,
+            styles.title,
+            loading && foundationStyles.sectionHeading,
+          )}
+        >
           {title}
         </strong>
-        <span {...stylex.props(styles.metadata)}>{metadata}</span>
+        <span {...stylex.props(foundationStyles.metadata, styles.metadata)}>
+          {metadata}
+        </span>
       </span>
     </section>
   );
@@ -142,22 +146,10 @@ const styles = stylex.create({
   },
   title: {
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "14px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
   },
-  loadingTitle: {
-    fontSize: "24px",
-    letterSpacing: "-0.03em",
-    lineHeight: 1.08,
-  },
+
   metadata: {
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "12px",
-    lineHeight: 1.4,
   },
   progress: {
     position: "absolute",

--- a/apps/web/src/components/catalogDetails.stylex.tsx
+++ b/apps/web/src/components/catalogDetails.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, fonts, space } from "../styles/tokens.stylex";
 import { getTextTitle } from "./textTitle";
 
@@ -14,7 +15,7 @@ export type PeatedIdProps = {
 
 export function PeatedId({ detail, id }: PeatedIdProps) {
   return (
-    <div {...stylex.props(styles.idStamp)}>
+    <div {...stylex.props(foundationStyles.metadata, styles.idStamp)}>
       <span {...stylex.props(styles.idLabel)}>Peated ID</span>
       <span {...stylex.props(styles.idValue)}>{id}</span>
       {detail ? (
@@ -71,7 +72,10 @@ export function KeyFacts({ facts }: { facts: KeyFactList }) {
               styles.keyFactPhoneEven,
           )}
         >
-          <dt title={fact.label} {...stylex.props(styles.keyFactLabel)}>
+          <dt
+            title={fact.label}
+            {...stylex.props(foundationStyles.fieldLabel, styles.keyFactLabel)}
+          >
             {fact.label}
           </dt>
           <dd title={String(fact.value)} {...stylex.props(styles.keyFactValue)}>
@@ -91,10 +95,6 @@ const styles = stylex.create({
     flexWrap: { default: "nowrap", [COMPACT]: "wrap" },
     columnGap: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    letterSpacing: 0,
-    lineHeight: 1.4,
   },
   idLabel: {
     flexShrink: 0,
@@ -157,10 +157,6 @@ const styles = stylex.create({
     marginTop: "6px",
     overflow: "hidden",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    letterSpacing: 0,
-    lineHeight: 1.4,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
@@ -179,14 +175,12 @@ const styles = stylex.create({
     whiteSpace: "nowrap",
   },
 });
-
 const keyFactsColumnStyles = {
   1: styles.keyFactsOne,
   2: styles.keyFactsTwo,
   3: styles.keyFactsThree,
   4: styles.keyFactsFour,
 } satisfies Record<KeyFactList["length"], stylex.StyleXStyles>;
-
 function getKeyFactsColumnStyle(factCount: number) {
   if (factCount === 1) return keyFactsColumnStyles[1];
   if (factCount === 2) return keyFactsColumnStyles[2];

--- a/apps/web/src/components/chip.stylex.tsx
+++ b/apps/web/src/components/chip.stylex.tsx
@@ -1,12 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 
-import {
-  colors,
-  controlMetrics,
-  effects,
-  fonts,
-} from "../styles/tokens.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, controlMetrics, effects } from "../styles/tokens.stylex";
 
 export type ChipVariant = "neutral" | "tinted" | "solid";
 
@@ -31,7 +27,12 @@ export function Chip({
         data-variant={variant}
         onClick={onClick}
         type="button"
-        {...stylex.props(styles.chip, styles.interactive, variants[variant])}
+        {...stylex.props(
+          foundationStyles.interactiveSmall,
+          styles.chip,
+          styles.interactive,
+          variants[variant],
+        )}
       >
         {children}
       </button>
@@ -41,7 +42,11 @@ export function Chip({
   return (
     <span
       data-variant={variant}
-      {...stylex.props(styles.chip, variants[variant])}
+      {...stylex.props(
+        foundationStyles.interactiveSmall,
+        styles.chip,
+        variants[variant],
+      )}
     >
       {children}
     </span>
@@ -59,6 +64,7 @@ export function CountChip({
     <span
       data-tone={tone}
       {...stylex.props(
+        foundationStyles.metadata,
         styles.count,
         tone === "accent" ? styles.countAccent : styles.countNeutral,
       )}
@@ -81,10 +87,7 @@ const styles = stylex.create({
     paddingRight: "10px",
     paddingBottom: "5px",
     paddingLeft: "10px",
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1,
     whiteSpace: "nowrap",
   },
   interactive: {
@@ -130,11 +133,7 @@ const styles = stylex.create({
     justifyContent: "center",
     borderRadius: controlMetrics.radiusSmall,
     padding: 0,
-    fontFamily: fonts.data,
-    fontSize: "15px",
     fontVariantNumeric: "tabular-nums",
-    fontWeight: 400,
-    lineHeight: 1,
   },
   countAccent: {
     backgroundColor: "transparent",
@@ -145,7 +144,6 @@ const styles = stylex.create({
     color: colors.inkMuted,
   },
 });
-
 const variants = {
   neutral: styles.neutral,
   tinted: styles.tinted,

--- a/apps/web/src/components/collectionBottleStatus.stylex.tsx
+++ b/apps/web/src/components/collectionBottleStatus.stylex.tsx
@@ -2,11 +2,11 @@
 
 import * as stylex from "@stylexjs/stylex";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../styles/tokens.stylex";
 
@@ -49,6 +49,7 @@ export function CollectionBottleStatusChips({
             onClick={() => onChange(status)}
             type="button"
             {...stylex.props(
+              foundationStyles.interactiveSmall,
               styles.chip,
               selected && styles.selected,
               disabled && !selected && styles.disabled,
@@ -89,10 +90,7 @@ const styles = stylex.create({
       ":active": colors.surface,
     },
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "12px",
     fontWeight: 600,
-    lineHeight: 1,
     cursor: {
       default: "pointer",
       ":disabled": "default",

--- a/apps/web/src/components/confirmationDialog.stylex.tsx
+++ b/apps/web/src/components/confirmationDialog.stylex.tsx
@@ -11,13 +11,8 @@ import type { ReactNode } from "react";
 import { SectionHeading } from "./sectionHeading.stylex";
 
 import { Button } from ".";
-import {
-  colors,
-  effects,
-  fonts,
-  space,
-  zIndices,
-} from "../styles/tokens.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, effects, space, zIndices } from "../styles/tokens.stylex";
 
 export default function ConfirmationDialog({
   continueLabel = "Continue",
@@ -42,7 +37,9 @@ export default function ConfirmationDialog({
           <DialogTitle as="div">
             <SectionHeading>{title}</SectionHeading>
           </DialogTitle>
-          <div {...stylex.props(styles.message)}>{message}</div>
+          <div {...stylex.props(foundationStyles.body, styles.message)}>
+            {message}
+          </div>
           <div {...stylex.props(styles.actions)}>
             <Button onClick={onCancel} variant="tonal">
               Cancel
@@ -87,9 +84,6 @@ const styles = stylex.create({
   message: {
     marginTop: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
   actions: {
     display: "flex",

--- a/apps/web/src/components/criticReview.stylex.tsx
+++ b/apps/web/src/components/criticReview.stylex.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, fonts, space } from "../styles/tokens.stylex";
 import { TextLink } from "./textLink.stylex";
 
@@ -29,9 +30,18 @@ export function CriticReview({
     <article {...stylex.props(styles.review)}>
       <div {...stylex.props(styles.heading)}>
         <div {...stylex.props(styles.source)}>
-          <strong {...stylex.props(styles.publication)}>{publication}</strong>
+          <strong
+            {...stylex.props(
+              foundationStyles.compactRowTitle,
+              styles.publication,
+            )}
+          >
+            {publication}
+          </strong>
           {byline ? (
-            <span {...stylex.props(styles.byline)}>{byline}</span>
+            <span {...stylex.props(foundationStyles.metadata, styles.byline)}>
+              {byline}
+            </span>
           ) : null}
         </div>
         {rating !== null && rating !== undefined ? (
@@ -44,10 +54,14 @@ export function CriticReview({
         ) : null}
       </div>
 
-      {summary ? <p {...stylex.props(styles.summary)}>{summary}</p> : null}
+      {summary ? (
+        <p {...stylex.props(foundationStyles.prose, styles.summary)}>
+          {summary}
+        </p>
+      ) : null}
 
       {href ? (
-        <div {...stylex.props(styles.reviewLink)}>
+        <div {...stylex.props(foundationStyles.metadata, styles.reviewLink)}>
           <TextLink href={href} size="inherit">
             Read the full review on {publication} →
           </TextLink>
@@ -78,17 +92,9 @@ const styles = stylex.create({
   },
   publication: {
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "16px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.25,
   },
   byline: {
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
   },
   rating: {
     flexShrink: 0,
@@ -107,17 +113,9 @@ const styles = stylex.create({
     marginBottom: 0,
     marginLeft: 0,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "19px",
-    fontWeight: 400,
-    letterSpacing: "-0.015em",
-    lineHeight: 1.4,
     textWrap: "pretty",
   },
   reviewLink: {
     marginTop: space.x3,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.35,
   },
 });

--- a/apps/web/src/components/dataTable.stylex.tsx
+++ b/apps/web/src/components/dataTable.stylex.tsx
@@ -1,7 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { colors, fonts, space } from "../styles/tokens.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, space } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { linkedRowStyles } from "./linkedRow.stylex";
 
@@ -42,6 +43,7 @@ export function DataTable<Item>({
                 key={column.key}
                 scope="col"
                 {...stylex.props(
+                  foundationStyles.fieldLabel,
                   styles.header,
                   alignStyles[column.align ?? "left"],
                   column.priority === "secondary" && styles.secondary,
@@ -69,6 +71,7 @@ export function DataTable<Item>({
                   <td
                     key={column.key}
                     {...stylex.props(
+                      foundationStyles.metadata,
                       styles.cell,
                       alignStyles[column.align ?? "left"],
                       column.priority === "secondary" && styles.secondary,
@@ -130,12 +133,6 @@ const styles = stylex.create({
     paddingBottom: space.x2,
     paddingLeft: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 500,
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
     whiteSpace: "nowrap",
   },
   row: {
@@ -149,9 +146,6 @@ const styles = stylex.create({
     paddingBottom: "13px",
     paddingLeft: space.x3,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
     verticalAlign: "middle",
   },
   rowLink: {
@@ -166,7 +160,6 @@ const styles = stylex.create({
   center: { textAlign: "center" },
   right: { textAlign: "right" },
 });
-
 const alignStyles = {
   left: styles.left,
   center: styles.center,

--- a/apps/web/src/components/distributionList.stylex.tsx
+++ b/apps/web/src/components/distributionList.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, fonts, space } from "../styles/tokens.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, space } from "../styles/tokens.stylex";
 
 export type DistributionListItem = {
   count: number;
@@ -23,8 +24,10 @@ export function DistributionList({
       {visibleItems.map(({ count, label }) => (
         <li key={label} {...stylex.props(styles.item)}>
           <div {...stylex.props(styles.copy)}>
-            <span {...stylex.props(styles.label)}>{label}</span>
-            <span {...stylex.props(styles.count)}>
+            <span {...stylex.props(foundationStyles.metadata, styles.label)}>
+              {label}
+            </span>
+            <span {...stylex.props(foundationStyles.metadata, styles.count)}>
               {count.toLocaleString()}
             </span>
           </div>
@@ -61,9 +64,6 @@ const styles = stylex.create({
   label: {
     overflow: "hidden",
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.4,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
@@ -71,10 +71,7 @@ const styles = stylex.create({
     flexShrink: 0,
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.3,
   },
   track: {
     height: "5px",

--- a/apps/web/src/components/facetRow.stylex.tsx
+++ b/apps/web/src/components/facetRow.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ButtonHTMLAttributes } from "react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
@@ -60,9 +61,10 @@ export function FacetRow({
       <span
         title={label}
         {...stylex.props(
+          foundationStyles.interactiveSmall,
           styles.label,
           !counted && styles.labelWide,
-          selected && styles.selectedLabel,
+          selected && [foundationStyles.interactiveSmall, styles.selectedLabel],
         )}
       >
         {label}
@@ -80,7 +82,7 @@ export function FacetRow({
         </span>
       ) : null}
       {counted || !available ? (
-        <span {...stylex.props(styles.count)}>
+        <span {...stylex.props(foundationStyles.metadata, styles.count)}>
           {counted ? count.toLocaleString("en-US") : "–"}
         </span>
       ) : null}
@@ -136,9 +138,7 @@ const styles = stylex.create({
     minWidth: 0,
     flex: "0 1 128px",
     overflow: "hidden",
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1.3,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
@@ -153,9 +153,7 @@ const styles = stylex.create({
     borderBottomWidth: "2px",
     borderBottomStyle: "solid",
     borderBottomColor: colors.ink,
-    fontFamily: fonts.display,
     fontWeight: 700,
-    letterSpacing: "-0.02em",
   },
   trackSlot: {
     display: "flex",
@@ -185,10 +183,7 @@ const styles = stylex.create({
     width: "48px",
     flex: "0 0 48px",
     overflow: "hidden",
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.3,
     textAlign: "right",
     textOverflow: "clip",
     whiteSpace: "nowrap",
@@ -196,7 +191,7 @@ const styles = stylex.create({
   dismissSlot: {
     width: "14px",
     flex: "0 0 14px",
-    fontFamily: fonts.data,
+    fontFamily: fonts.reading,
     fontSize: "12px",
     lineHeight: 1,
     textAlign: "right",

--- a/apps/web/src/components/factList.stylex.tsx
+++ b/apps/web/src/components/factList.stylex.tsx
@@ -1,7 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { colors, fonts, space } from "../styles/tokens.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, space } from "../styles/tokens.stylex";
 
 export type FactListItem = {
   label: string;
@@ -42,6 +43,7 @@ export function FactList({ facts, layout = "list" }: FactListProps) {
         >
           <dt
             {...stylex.props(
+              foundationStyles.fieldLabel,
               styles.label,
               layout === "grid" && styles.gridLabel,
             )}
@@ -50,8 +52,9 @@ export function FactList({ facts, layout = "list" }: FactListProps) {
           </dt>
           <dd
             {...stylex.props(
+              foundationStyles.compactRowTitle,
               styles.value,
-              layout === "grid" && styles.gridValue,
+              layout === "grid" && [foundationStyles.body, styles.gridValue],
             )}
           >
             {fact.value}
@@ -101,38 +104,21 @@ const styles = stylex.create({
     width: "100px",
     flexShrink: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    letterSpacing: 0,
-    lineHeight: 1.4,
   },
   gridLabel: {
     width: "auto",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.04em",
-    lineHeight: 1.3,
   },
   value: {
     minWidth: 0,
     flex: 1,
     margin: 0,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "16px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.35,
     overflowWrap: "anywhere",
   },
   gridValue: {
     marginTop: space.x1,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     fontWeight: 700,
-    letterSpacing: 0,
-    lineHeight: 1.35,
   },
 });

--- a/apps/web/src/components/feedback.stylex.tsx
+++ b/apps/web/src/components/feedback.stylex.tsx
@@ -8,7 +8,6 @@ import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../styles/tokens.stylex";
 import { Button } from "./button.stylex";
@@ -60,10 +59,21 @@ export function FlashMessage({
     <div
       {...props}
       role={role ?? (tone === "error" ? "alert" : "status")}
-      {...stylex.props(styles.flashMessage, flashMessageTones[tone])}
+      {...stylex.props(
+        foundationStyles.body,
+        styles.flashMessage,
+        flashMessageTones[tone],
+      )}
     >
       {statusWord ? (
-        <span {...stylex.props(styles.flashStatus)}>{statusWord}</span>
+        <span
+          {...stylex.props(
+            foundationStyles.interactiveSmall,
+            styles.flashStatus,
+          )}
+        >
+          {statusWord}
+        </span>
       ) : null}
       {children}
     </div>
@@ -106,14 +116,26 @@ export function Notice({
       {...stylex.props(styles.notice, noticeTones[tone])}
     >
       {statusWord ? (
-        <span {...stylex.props(styles.noticeStatus, noticeStatusTones[tone])}>
+        <span
+          {...stylex.props(
+            foundationStyles.interactiveSmall,
+            styles.noticeStatus,
+            noticeStatusTones[tone],
+          )}
+        >
           {statusWord}
         </span>
       ) : null}
       {heading ? (
-        <strong {...stylex.props(styles.noticeHeading)}>{heading}</strong>
+        <strong
+          {...stylex.props(foundationStyles.rowTitle, styles.noticeHeading)}
+        >
+          {heading}
+        </strong>
       ) : null}
-      <div {...stylex.props(styles.noticeBody)}>{children}</div>
+      <div {...stylex.props(foundationStyles.body, styles.noticeBody)}>
+        {children}
+      </div>
       {action ? (
         <div {...stylex.props(styles.noticeAction)}>{action}</div>
       ) : null}
@@ -213,10 +235,19 @@ export function SectionError({
     >
       <div {...stylex.props(styles.stateCopy, styles.criticalStateCopy)}>
         <div {...stylex.props(styles.errorHeading)}>
-          <div {...stylex.props(styles.stateStatus)}>
+          <div
+            {...stylex.props(
+              foundationStyles.interactiveSmall,
+              styles.stateStatus,
+            )}
+          >
             <span>{status}</span>
             {detail ? (
-              <span {...stylex.props(styles.errorDetail)}>{detail}</span>
+              <span
+                {...stylex.props(foundationStyles.metadata, styles.errorDetail)}
+              >
+                {detail}
+              </span>
             ) : null}
           </div>
           <SectionHeading>{heading}</SectionHeading>
@@ -309,9 +340,6 @@ const styles = stylex.create({
     borderRadius: controlMetrics.radius,
     backgroundColor: colors.ground,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.6,
     boxShadow: effects.overlayShadow,
   },
   flashSuccess: {
@@ -327,11 +355,7 @@ const styles = stylex.create({
     display: "block",
     marginBottom: "2px",
     color: colors.inkMuted,
-    fontFamily: fonts.display,
-    fontSize: "13px",
     fontWeight: 700,
-    letterSpacing: "-0.01em",
-    lineHeight: 1.3,
   },
   notice: {
     boxSizing: "border-box",
@@ -353,29 +377,17 @@ const styles = stylex.create({
     display: "block",
     marginBottom: "2px",
     color: colors.inkMuted,
-    fontFamily: fonts.display,
-    fontSize: "13px",
     fontWeight: 700,
-    letterSpacing: "-0.01em",
-    lineHeight: 1.3,
   },
   noticeStatusWarning: { color: colors.accentDeep },
   noticeStatusCritical: { color: colors.critical },
   noticeHeading: {
     display: "block",
     marginBottom: "3px",
-    fontFamily: fonts.display,
-    fontSize: "17px",
-    fontWeight: 700,
-    letterSpacing: "-0.025em",
-    lineHeight: 1.25,
   },
   noticeBody: {
     maxWidth: "62ch",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.55,
   },
   noticeAction: {
     display: "flex",
@@ -451,12 +463,6 @@ const styles = stylex.create({
   },
   errorDetail: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "12px",
-    fontWeight: 400,
-    letterSpacing: "0.04em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   errorHeading: { width: "100%" },
   stateStatus: {
@@ -465,11 +471,7 @@ const styles = stylex.create({
     gap: space.x2,
     marginBottom: space.x1,
     color: colors.critical,
-    fontFamily: fonts.display,
-    fontSize: "13px",
     fontWeight: 700,
-    letterSpacing: "-0.01em",
-    lineHeight: 1.3,
   },
   loadingList: {
     boxSizing: "border-box",
@@ -534,25 +536,21 @@ const styles = stylex.create({
   delay3: { animationDelay: "250ms" },
   delay4: { animationDelay: "350ms" },
 });
-
 const flashMessageTones = {
   error: styles.flashError,
   info: styles.flashInfo,
   success: styles.flashSuccess,
 } satisfies Record<FlashMessageTone, stylex.StyleXStyles>;
-
 const noticeTones = {
   critical: styles.noticeCritical,
   notice: null,
   warning: styles.noticeWarning,
 } satisfies Record<NoticeTone, stylex.StyleXStyles | null>;
-
 const noticeStatusTones = {
   critical: styles.noticeStatusCritical,
   notice: null,
   warning: styles.noticeStatusWarning,
 } satisfies Record<NoticeTone, stylex.StyleXStyles | null>;
-
 const presets = {
   heading: styles.heading,
   metadata: styles.metadata,
@@ -560,7 +558,6 @@ const presets = {
   text: styles.text,
   thumbnail: styles.thumbnail,
 } satisfies Record<PlaceholderPreset, stylex.StyleXStyles>;
-
 const delays = {
   0: styles.delay0,
   1: styles.delay1,

--- a/apps/web/src/components/field.stylex.tsx
+++ b/apps/web/src/components/field.stylex.tsx
@@ -131,6 +131,7 @@ export const TextInput = forwardRef<HTMLInputElement, TextInputProps>(
         data-size={controlSize}
         ref={ref}
         {...stylex.props(
+          foundationStyles.input,
           styles.control,
           styles.input,
           inputSizeStyles[controlSize],
@@ -159,6 +160,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
         data-format={format}
         ref={ref}
         {...stylex.props(
+          foundationStyles.input,
           styles.control,
           styles.textarea,
           format === "data" && styles.data,
@@ -214,19 +216,13 @@ const styles = stylex.create({
   },
   label: {
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "14px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
   },
   required: {
     color: colors.accentDeep,
-    fontSize: "12px",
     fontStyle: "italic",
   },
   optional: {
     color: colors.inkMuted,
-    fontSize: "12px",
     fontStyle: "italic",
   },
   control: {
@@ -243,9 +239,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: colors.fieldBackground,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "16px",
-    lineHeight: 1.45,
     opacity: {
       default: 1,
       ":disabled": 0.45,
@@ -294,16 +287,13 @@ const styles = stylex.create({
   hint: {
     margin: 0,
     color: colors.inkMuted,
-    fontSize: "13px",
   },
   validation: {
     margin: 0,
     color: colors.critical,
-    fontSize: "13px",
     fontWeight: 600,
   },
 });
-
 const inputSizeStyles = {
   sm: styles.inputSmall,
   md: styles.inputMedium,

--- a/apps/web/src/components/filterPanel.stylex.tsx
+++ b/apps/web/src/components/filterPanel.stylex.tsx
@@ -10,7 +10,6 @@ import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../styles/tokens.stylex";
 import { Button, IconButton } from "./button.stylex";
@@ -57,7 +56,7 @@ export function FilterPanel({
           aria-expanded={open}
           onClick={() => setOpen((current) => !current)}
           type="button"
-          {...stylex.props(styles.toggle)}
+          {...stylex.props(foundationStyles.interactiveSmall, styles.toggle)}
         >
           <ListFilter aria-hidden="true" size={16} strokeWidth={1.75} />
           Filters
@@ -263,8 +262,6 @@ const styles = stylex.create({
       ":active": colors.surface,
     },
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "13px",
     fontWeight: 700,
     cursor: "pointer",
     boxShadow: {

--- a/apps/web/src/components/flavorWheel.stylex.tsx
+++ b/apps/web/src/components/flavorWheel.stylex.tsx
@@ -9,6 +9,7 @@ import type { TagCategory } from "@peated/server/types";
 import * as stylex from "@stylexjs/stylex";
 import { useState, type ReactNode } from "react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, fonts, space } from "../styles/tokens.stylex";
 
 const CENTER_X = 168;
@@ -92,7 +93,9 @@ export function FlavorWheel({
   return (
     <div {...stylex.props(styles.root)}>
       {sampleCount === 0 ? (
-        <p {...stylex.props(styles.message)}>No public tasting notes yet.</p>
+        <p {...stylex.props(foundationStyles.body, styles.message)}>
+          No public tasting notes yet.
+        </p>
       ) : (
         <>
           <div {...stylex.props(styles.chart)}>
@@ -162,6 +165,7 @@ export function FlavorWheel({
                       textAnchor="middle"
                       dominantBaseline="middle"
                       {...stylex.props(
+                        foundationStyles.metadata,
                         styles.label,
                         isSelected && styles.selectedLabel,
                       )}
@@ -173,13 +177,17 @@ export function FlavorWheel({
               })}
             </svg>
             <div aria-hidden="true" {...stylex.props(styles.center)}>
-              <strong {...stylex.props(styles.centerTitle)}>
+              <strong
+                {...stylex.props(foundationStyles.rowTitle, styles.centerTitle)}
+              >
                 {label(selected.category)}
               </strong>
               <span {...stylex.props(styles.centerValue)}>
                 {percentage(selected.count)}%
               </span>
-              <div {...stylex.props(styles.centerNotes)}>
+              <div
+                {...stylex.props(foundationStyles.metadata, styles.centerNotes)}
+              >
                 {selected.notes.length ? (
                   selected.notes.map((note) => (
                     <span
@@ -237,8 +245,6 @@ const styles = stylex.create({
   selected: { stroke: colors.ink },
   focused: { stroke: colors.ink, strokeWidth: 3, strokeDasharray: "3 2" },
   label: {
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fill: colors.inkMuted,
     pointerEvents: "none",
   },
@@ -256,10 +262,6 @@ const styles = stylex.create({
     pointerEvents: "none",
   },
   centerTitle: {
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    lineHeight: 1.2,
-    letterSpacing: "-0.02em",
     color: colors.ink,
   },
   centerValue: {
@@ -272,9 +274,6 @@ const styles = stylex.create({
     marginTop: space.x1,
   },
   centerNotes: {
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.3,
     color: colors.inkMuted,
     marginTop: space.x2,
     maxWidth: "100%",
@@ -287,9 +286,6 @@ const styles = stylex.create({
   },
   message: {
     margin: 0,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.6,
     color: colors.inkMuted,
   },
 });

--- a/apps/web/src/components/formControls.stylex.tsx
+++ b/apps/web/src/components/formControls.stylex.tsx
@@ -12,7 +12,6 @@ import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../styles/tokens.stylex";
 
@@ -36,6 +35,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
           disabled={disabled}
           ref={ref}
           {...stylex.props(
+            foundationStyles.input,
             styles.select,
             invalid && styles.invalid,
             disabled && styles.disabled,
@@ -272,9 +272,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: colors.fieldBackground,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "16px",
-    lineHeight: 1.45,
     cursor: {
       default: "pointer",
       ":disabled": "not-allowed",

--- a/apps/web/src/components/formLayout.stylex.tsx
+++ b/apps/web/src/components/formLayout.stylex.tsx
@@ -4,7 +4,7 @@ import type { HTMLAttributes, ReactNode } from "react";
 import { SectionHeading } from "./sectionHeading.stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
-import { colors, effects, fonts, space } from "../styles/tokens.stylex";
+import { colors, effects, space } from "../styles/tokens.stylex";
 
 export function FormStack({ children }: { children: ReactNode }) {
   return <div {...stylex.props(styles.stack)}>{children}</div>;
@@ -65,8 +65,13 @@ export type FormStepsProps = {
 export function FormSteps({ currentStep, steps }: FormStepsProps) {
   return (
     <nav aria-label="Form progress" {...stylex.props(styles.steps)}>
-      <div {...stylex.props(styles.stepSummary)}>
-        <strong {...stylex.props(styles.stepSummaryLabel)}>
+      <div {...stylex.props(foundationStyles.metadata, styles.stepSummary)}>
+        <strong
+          {...stylex.props(
+            foundationStyles.interactiveSmall,
+            styles.stepSummaryLabel,
+          )}
+        >
           {steps[currentStep]}
         </strong>
         <span aria-hidden="true">·</span>
@@ -80,9 +85,13 @@ export function FormSteps({ currentStep, steps }: FormStepsProps) {
             aria-current={index === currentStep ? "step" : undefined}
             key={step}
             {...stylex.props(
+              foundationStyles.interactiveSmall,
               styles.step,
               index < currentStep && styles.completedStep,
-              index === currentStep && styles.currentStep,
+              index === currentStep && [
+                foundationStyles.interactiveSmall,
+                styles.currentStep,
+              ],
             )}
           >
             <span title={step} {...stylex.props(styles.stepLabel)}>
@@ -116,7 +125,11 @@ export function FormNotice({
   ...props
 }: FormNoticeProps) {
   return (
-    <div {...props} role={role} {...stylex.props(styles.notice)}>
+    <div
+      {...props}
+      role={role}
+      {...stylex.props(foundationStyles.body, styles.notice)}
+    >
       {children}
     </div>
   );
@@ -238,16 +251,11 @@ const styles = stylex.create({
     alignItems: "baseline",
     columnGap: space.x1,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
     "@media (max-width: 559px)": { display: "flex" },
   },
   stepSummaryLabel: {
     color: colors.ink,
-    fontFamily: fonts.display,
     fontWeight: 700,
-    letterSpacing: "-0.02em",
   },
   stepList: {
     display: "flex",
@@ -264,18 +272,12 @@ const styles = stylex.create({
     flexDirection: "column",
     gap: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    letterSpacing: 0,
-    lineHeight: 1.3,
   },
   completedStep: { color: colors.ink },
   currentStep: {
     color: colors.ink,
-    fontFamily: fonts.display,
     fontWeight: 700,
-    letterSpacing: "-0.02em",
   },
   stepLabel: {
     overflow: "hidden",
@@ -298,9 +300,6 @@ const styles = stylex.create({
     borderWidth: 0,
     backgroundColor: "transparent",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.55,
   },
   details: {
     boxSizing: "border-box",

--- a/apps/web/src/components/foundations.stylex.tsx
+++ b/apps/web/src/components/foundations.stylex.tsx
@@ -1,3 +1,9 @@
+import { Button } from "./button.stylex";
+import { Field, TextInput } from "./field.stylex";
+import { ItemList, ItemRow } from "./itemList.stylex";
+import { SectionHeading } from "./sectionHeading.stylex";
+import { TextLink } from "./textLink.stylex";
+
 import type { StyleXStyles } from "@stylexjs/stylex";
 import * as stylex from "@stylexjs/stylex";
 import { foundationStyles } from "../styles/foundations.stylex";
@@ -5,7 +11,6 @@ import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../styles/tokens.stylex";
 
@@ -28,7 +33,7 @@ function TokenSwatch({ name, light, dark, use, colorStyle }: TokenSwatchProps) {
       </div>
       <h3 {...stylex.props(foundationStyles.rowTitle)}>{name}</h3>
       <p {...stylex.props(foundationStyles.body, styles.muted)}>{use}</p>
-      <p {...stylex.props(foundationStyles.metadata, styles.swatchValues)}>
+      <p {...stylex.props(foundationStyles.code, styles.swatchValues)}>
         {light} / {dark}
       </p>
     </article>
@@ -52,9 +57,7 @@ export default function Foundations({
   return (
     <main {...stylex.props(styles.page)}>
       <header {...stylex.props(styles.hero)}>
-        <h1 {...stylex.props(foundationStyles.pageTitle, styles.categoryTitle)}>
-          {title}
-        </h1>
+        <h1 {...stylex.props(foundationStyles.pageTitleCompact)}>{title}</h1>
       </header>
 
       {section === "color" ? (
@@ -147,83 +150,66 @@ export default function Foundations({
       {section === "typography" ? (
         <section {...stylex.props(styles.section)}>
           <div {...stylex.props(styles.typeGrid)}>
-            <article {...stylex.props(styles.typeSpecimen, styles.typeLead)}>
-              <span
-                {...stylex.props(
-                  foundationStyles.microLabel,
-                  styles.accentText,
-                )}
-              >
-                Display · Space Grotesk
-              </span>
-              <p
-                {...stylex.props(foundationStyles.pageTitle, styles.typeTitle)}
-              >
-                Lagavulin 16
-              </p>
-              <p {...stylex.props(foundationStyles.sectionHeading)}>
-                Similar bottles
-              </p>
-              <p {...stylex.props(foundationStyles.rowTitle)}>
-                Caol Ila 12-year-old
+            <article {...stylex.props(styles.typeSpecimen)}>
+              <p {...stylex.props(foundationStyles.pageTitleCompact)}>Whisky</p>
+              <SectionHeading>Distilleries</SectionHeading>
+              <ItemList ariaLabel="Standard row titles">
+                <ItemRow
+                  href="#lagavulin"
+                  title="Lagavulin"
+                  metadata="Islay · Scotland"
+                />
+              </ItemList>
+              <ItemList ariaLabel="Compact row titles">
+                <ItemRow
+                  href="#bruichladdich"
+                  title="Bruichladdich"
+                  metadata="Islay · Scotland"
+                  size="sm"
+                />
+              </ItemList>
+              <p {...stylex.props(foundationStyles.metadata, styles.muted)}>
+                Space Grotesk: page titles, section headings, and names.
+                Sections use 24px; rows use 18px or 16px in compact lists.
               </p>
             </article>
-
             <article {...stylex.props(styles.typeSpecimen)}>
-              <span
-                {...stylex.props(
-                  foundationStyles.microLabel,
-                  styles.accentText,
-                )}
-              >
-                Reading · Karla
-              </span>
-              <p {...stylex.props(foundationStyles.body, styles.readingSample)}>
+              <SectionHeading>Reading</SectionHeading>
+              <p {...stylex.props(foundationStyles.prose)}>
                 Smoke arrives first, followed by lemon peel, brine, and a dry
                 mineral finish. The texture stays light despite the long finish.
               </p>
-              <p {...stylex.props(foundationStyles.interactive)}>
-                Log a tasting
+              <p {...stylex.props(foundationStyles.body)}>
+                Browse bottles, read tasting notes, and add what you know.
               </p>
+              <p {...stylex.props(foundationStyles.metadata, styles.muted)}>
+                Islay · Single malt · 16 years · 43% ABV
+              </p>
+              <p {...stylex.props(foundationStyles.metadata, styles.muted)}>
+                Karla: 16px for longer reading, 15px for body copy, and 13px for
+                dates, counts, hints, and other supporting text.
+              </p>
+              <code {...stylex.props(foundationStyles.code)}>
+                GET /v1/bottles
+              </code>
             </article>
-
-            <article
-              {...stylex.props(styles.typeSpecimen, styles.dataSpecimen)}
-            >
-              <span
-                {...stylex.props(
-                  foundationStyles.microLabel,
-                  styles.accentText,
-                )}
+            <article {...stylex.props(styles.typeSpecimen)}>
+              <SectionHeading>Fields and actions</SectionHeading>
+              <Field
+                htmlFor="typography-name"
+                label="Bottle name"
+                hint="Use the name on the label."
+                required
               >
-                Labels · Karla; numerals · IBM Plex Mono
-              </span>
-              <dl {...stylex.props(styles.dataList)}>
-                <div {...stylex.props(styles.dataRow)}>
-                  <dt
-                    {...stylex.props(foundationStyles.fieldLabel, styles.muted)}
-                  >
-                    Peated ID
-                  </dt>
-                  <dd {...stylex.props(styles.dataValue)}>B00872</dd>
-                </div>
-                <div {...stylex.props(styles.dataRow)}>
-                  <dt
-                    {...stylex.props(foundationStyles.fieldLabel, styles.muted)}
-                  >
-                    ABV
-                  </dt>
-                  <dd {...stylex.props(styles.dataValue)}>43.0%</dd>
-                </div>
-                <div {...stylex.props(styles.dataRow)}>
-                  <dt
-                    {...stylex.props(foundationStyles.fieldLabel, styles.muted)}
-                  >
-                    Tastings
-                  </dt>
-                  <dd {...stylex.props(styles.dataValue)}>2,841</dd>
-                </div>
-              </dl>
+                <TextInput id="typography-name" defaultValue="Uigeadail" />
+              </Field>
+              <Button>Save bottle</Button>
+              <TextLink href="#bottles">View all bottles</TextLink>
+              <p {...stylex.props(foundationStyles.metadata, styles.muted)}>
+                Labels use 13px Karla with emphasis. Inputs stay at 16px on
+                every screen. Actions use 15px, or 13px in compact controls.
+                Monospace is reserved for code and technical identifiers.
+              </p>
             </article>
           </div>
         </section>
@@ -306,9 +292,6 @@ const styles = stylex.create({
   muted: {
     color: colors.inkMuted,
   },
-  categoryTitle: {
-    fontSize: { default: "40px", [COMPACT]: "32px" },
-  },
   section: {
     width: "100%",
     maxWidth: "1180px",
@@ -361,7 +344,6 @@ const styles = stylex.create({
   swatchValues: {
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontSize: "10px",
   },
   tonalExample: {
     display: "grid",
@@ -396,7 +378,10 @@ const styles = stylex.create({
   },
   typeGrid: {
     display: "grid",
-    gridTemplateColumns: { default: "1.35fr 1fr 1fr", [NARROW]: "1fr" },
+    gridTemplateColumns: {
+      default: "repeat(3, minmax(0, 1fr))",
+      [NARROW]: "1fr",
+    },
     columnGap: space.x2,
     rowGap: space.x2,
   },
@@ -412,41 +397,6 @@ const styles = stylex.create({
     borderTopStyle: "solid",
     borderTopColor: colors.sectionRule,
     backgroundColor: "transparent",
-  },
-  typeLead: {
-    backgroundColor: "transparent",
-  },
-  typeTitle: {
-    fontSize: { default: "44px", [COMPACT]: "36px" },
-  },
-  readingSample: {
-    maxWidth: "36ch",
-    fontSize: "17px",
-  },
-  dataSpecimen: {
-    backgroundColor: colors.ground,
-  },
-  dataList: {
-    display: "flex",
-    flexDirection: "column",
-    margin: 0,
-  },
-  dataRow: {
-    display: "flex",
-    alignItems: "baseline",
-    justifyContent: "space-between",
-    columnGap: space.x4,
-    paddingTop: space.x3,
-    paddingBottom: space.x3,
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
-    borderTopColor: colors.hairline,
-  },
-  dataValue: {
-    margin: 0,
-    fontFamily: fonts.data,
-    fontSize: "13px",
-    fontVariantNumeric: "tabular-nums",
   },
   foundationGrid: {
     display: "grid",

--- a/apps/web/src/components/historyTimeline.stylex.tsx
+++ b/apps/web/src/components/historyTimeline.stylex.tsx
@@ -1,7 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
-import { colors, fonts, space } from "../styles/tokens.stylex";
+import { colors, space } from "../styles/tokens.stylex";
 import { TextLink } from "./textLink.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
@@ -38,7 +38,9 @@ export function HistoryTimeline({ events, summary }: HistoryTimelineProps) {
               event.state === "operating" ? styles.operating : styles.silent,
             )}
           >
-            <time {...stylex.props(styles.date)}>{event.date}</time>
+            <time {...stylex.props(foundationStyles.metadata, styles.date)}>
+              {event.date}
+            </time>
             <div {...stylex.props(styles.content)}>
               <span {...stylex.props(styles.visuallyHidden)}>
                 {event.state === "operating"
@@ -61,7 +63,7 @@ export function HistoryTimeline({ events, summary }: HistoryTimelineProps) {
                 </span>
               ) : null}
               {event.source ? (
-                <span {...stylex.props(styles.source)}>
+                <span {...stylex.props(foundationStyles.metadata)}>
                   <TextLink
                     href={event.source.href}
                     rel="noreferrer"
@@ -121,10 +123,7 @@ const styles = stylex.create({
   },
   date: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "12px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.45,
   },
   content: {
     display: "flex",
@@ -136,11 +135,7 @@ const styles = stylex.create({
   note: {
     color: colors.inkMuted,
   },
-  source: {
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.45,
-  },
+
   summary: {
     marginTop: space.x3,
     color: colors.inkMuted,

--- a/apps/web/src/components/imageAttribution.stylex.tsx
+++ b/apps/web/src/components/imageAttribution.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, fonts } from "../styles/tokens.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors } from "../styles/tokens.stylex";
 
 export type ImageAttributionProps = {
   sourceUrl?: string | null;
@@ -15,7 +16,7 @@ export function ImageAttribution({
   if (!sourceUrl && !license) return null;
 
   return (
-    <span {...stylex.props(styles.root)}>
+    <span {...stylex.props(foundationStyles.metadata, styles.root)}>
       {sourceUrl ? (
         <a href={sourceUrl} rel="noreferrer" {...stylex.props(styles.link)}>
           Image source
@@ -31,9 +32,6 @@ const styles = stylex.create({
   root: {
     color: colors.inkMuted,
     display: "block",
-    fontFamily: fonts.data,
-    fontSize: "12px",
-    lineHeight: 1.4,
     overflowWrap: "anywhere",
   },
   link: {

--- a/apps/web/src/components/imageField.stylex.tsx
+++ b/apps/web/src/components/imageField.stylex.tsx
@@ -22,13 +22,8 @@ import { SectionHeading } from "./sectionHeading.stylex";
 
 import { Button, Field } from ".";
 import setRef from "../lib/setRef";
-import {
-  colors,
-  effects,
-  fonts,
-  space,
-  zIndices,
-} from "../styles/tokens.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, effects, space, zIndices } from "../styles/tokens.stylex";
 import { ImageViewer } from "./imageViewer.stylex";
 
 type Props = {
@@ -251,7 +246,9 @@ function ImageCropDialog({
               width={displayWidth}
             />
           </div>
-          <label {...stylex.props(styles.rangeLabel)}>
+          <label
+            {...stylex.props(foundationStyles.fieldLabel, styles.rangeLabel)}
+          >
             Zoom
             <input
               max={3}
@@ -360,9 +357,6 @@ const styles = stylex.create({
     gap: space.x2,
     marginTop: space.x4,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    textTransform: "uppercase",
   },
   range: { width: "100%", accentColor: colors.accent },
   dialogActions: {
@@ -373,5 +367,4 @@ const styles = stylex.create({
     flexWrap: "wrap",
   },
 });
-
 export default ImageField;

--- a/apps/web/src/components/imageViewer.stylex.tsx
+++ b/apps/web/src/components/imageViewer.stylex.tsx
@@ -10,10 +10,10 @@ import * as stylex from "@stylexjs/stylex";
 import { ExternalLink, Maximize2, X } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   controlMetrics,
   effects,
-  fonts,
   space,
   zIndices,
 } from "../styles/tokens.stylex";
@@ -59,14 +59,19 @@ export function ImageViewer({
               <img alt={alt} src={src} {...stylex.props(styles.fullImage)} />
             </div>
             <div {...stylex.props(styles.footer)}>
-              <DialogTitle {...stylex.props(styles.title)}>
+              <DialogTitle
+                {...stylex.props(foundationStyles.interactive, styles.title)}
+              >
                 {caption ?? label}
               </DialogTitle>
               <a
                 href={src}
                 rel="noreferrer"
                 target="_blank"
-                {...stylex.props(styles.originalLink)}
+                {...stylex.props(
+                  foundationStyles.interactiveSmall,
+                  styles.originalLink,
+                )}
               >
                 Open original
                 <ExternalLink aria-hidden="true" size={14} strokeWidth={1.75} />
@@ -207,10 +212,7 @@ const styles = stylex.create({
     overflow: "hidden",
     margin: 0,
     color: "white",
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     fontWeight: 600,
-    lineHeight: 1.35,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
@@ -222,10 +224,7 @@ const styles = stylex.create({
     borderRadius: controlMetrics.radiusSmall,
     outline: "none",
     color: "white",
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1.2,
     textDecorationLine: {
       default: "none",
       ":hover": "underline",

--- a/apps/web/src/components/itemList.stylex.tsx
+++ b/apps/web/src/components/itemList.stylex.tsx
@@ -97,7 +97,7 @@ export function ItemRow({
               {...stylex.props(
                 foundationStyles.rowTitle,
                 styles.title,
-                size === "sm" && styles.smallTitle,
+                size === "sm" && foundationStyles.compactRowTitle,
                 linkedRowStyles.primaryLink,
               )}
             >
@@ -109,7 +109,7 @@ export function ItemRow({
               {...stylex.props(
                 foundationStyles.rowTitle,
                 styles.title,
-                size === "sm" && styles.smallTitle,
+                size === "sm" && foundationStyles.compactRowTitle,
               )}
             >
               {title}
@@ -225,9 +225,7 @@ const styles = stylex.create({
       ":focus-visible": effects.focusRing,
     },
   },
-  smallTitle: {
-    fontSize: "16px",
-  },
+
   metadata: {
     marginTop: "3px",
     overflow: "hidden",

--- a/apps/web/src/components/lists.stylex.tsx
+++ b/apps/web/src/components/lists.stylex.tsx
@@ -2,6 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import { ChevronDown, Download } from "lucide-react";
 import type { ReactNode, SelectHTMLAttributes } from "react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
@@ -47,13 +48,15 @@ export function ListToolbar({
           {count.toLocaleString("en-US")} {count === 1 ? noun : `${noun}s`}
         </strong>
         {total !== undefined ? (
-          <span {...stylex.props(styles.countDetail)}>
+          <span
+            {...stylex.props(foundationStyles.metadata, styles.countDetail)}
+          >
             of {total.toLocaleString("en-US")}
           </span>
         ) : null}
       </p>
       <div {...stylex.props(styles.actions)}>
-        <label {...stylex.props(styles.sortLabel)}>
+        <label {...stylex.props(foundationStyles.fieldLabel, styles.sortLabel)}>
           <span>Sort</span>
           <CompactSelect
             aria-label={`Sort ${noun}s`}
@@ -87,7 +90,10 @@ function CompactSelect({
 }: SelectHTMLAttributes<HTMLSelectElement>) {
   return (
     <span {...stylex.props(styles.selectWrapper)}>
-      <select {...props} {...stylex.props(styles.select)}>
+      <select
+        {...props}
+        {...stylex.props(foundationStyles.input, styles.select)}
+      >
         {children}
       </select>
       <ChevronDown
@@ -136,7 +142,9 @@ export function CursorPager({
         ) : null}
       </div>
       {page !== undefined ? (
-        <span {...stylex.props(styles.pageNumber)}>Page {page}</span>
+        <span {...stylex.props(foundationStyles.metadata, styles.pageNumber)}>
+          Page {page}
+        </span>
       ) : null}
     </nav>
   );
@@ -180,22 +188,39 @@ export function RailListItem({
             <AppLink
               href={href}
               title={title}
-              {...stylex.props(styles.railTitle, styles.railTitleLink)}
+              {...stylex.props(
+                foundationStyles.compactRowTitle,
+                styles.railTitle,
+                styles.railTitleLink,
+              )}
             >
               {title}
             </AppLink>
           ) : (
-            <span title={title} {...stylex.props(styles.railTitle)}>
+            <span
+              title={title}
+              {...stylex.props(
+                foundationStyles.compactRowTitle,
+                styles.railTitle,
+              )}
+            >
               {title}
             </span>
           )}
           {metadata ? (
-            <span title={metadata} {...stylex.props(styles.railMetadata)}>
+            <span
+              title={metadata}
+              {...stylex.props(foundationStyles.metadata, styles.railMetadata)}
+            >
               {metadata}
             </span>
           ) : null}
         </div>
-        {end ? <span {...stylex.props(styles.railEnd)}>{end}</span> : null}
+        {end ? (
+          <span {...stylex.props(foundationStyles.metadata, styles.railEnd)}>
+            {end}
+          </span>
+        ) : null}
       </div>
     </ItemListItem>
   );
@@ -232,9 +257,6 @@ const styles = stylex.create({
   },
   countDetail: {
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.3,
   },
   actions: {
     display: "flex",
@@ -246,10 +268,6 @@ const styles = stylex.create({
     alignItems: "center",
     gap: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    letterSpacing: 0,
-    lineHeight: 1.3,
   },
   selectWrapper: {
     position: "relative",
@@ -270,10 +288,7 @@ const styles = stylex.create({
     backgroundImage: "none",
     backgroundColor: colors.fieldBackground,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
     fontWeight: 600,
-    lineHeight: 1,
     cursor: "pointer",
     boxShadow: {
       default: "none",
@@ -306,10 +321,7 @@ const styles = stylex.create({
   },
   pageNumber: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "13px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.4,
   },
   railList: {
     padding: 0,
@@ -332,11 +344,6 @@ const styles = stylex.create({
     display: "block",
     overflow: "hidden",
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "15px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.25,
     textDecoration: "none",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
@@ -358,9 +365,6 @@ const styles = stylex.create({
     marginTop: "2px",
     overflow: "hidden",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.35,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
@@ -371,9 +375,6 @@ const styles = stylex.create({
     alignItems: "center",
     justifyContent: "flex-end",
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.3,
   },
 });

--- a/apps/web/src/components/locationCard.stylex.tsx
+++ b/apps/web/src/components/locationCard.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, fonts, space } from "../styles/tokens.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, space } from "../styles/tokens.stylex";
 import { CardLink } from "./card.stylex";
 import CountryMapIcon from "./countryMapIcon";
 
@@ -33,9 +34,13 @@ export function LocationCard({
           {...stylex.props(styles.mapIcon)}
         />
       </div>
-      <h2 {...stylex.props(styles.title)}>{name}</h2>
-      {summary ? <p {...stylex.props(styles.summary)}>{summary}</p> : null}
-      <p {...stylex.props(styles.counts)}>
+      <h2 {...stylex.props(foundationStyles.rowTitle, styles.title)}>{name}</h2>
+      {summary ? (
+        <p {...stylex.props(foundationStyles.metadata, styles.summary)}>
+          {summary}
+        </p>
+      ) : null}
+      <p {...stylex.props(foundationStyles.metadata, styles.counts)}>
         {totalBottles.toLocaleString("en-US")} {bottleNoun} ·{" "}
         {totalDistillers.toLocaleString("en-US")} {distillerNoun}
       </p>
@@ -67,29 +72,16 @@ const styles = stylex.create({
   title: {
     margin: 0,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.25,
   },
   summary: {
     margin: 0,
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
   counts: {
     margin: 0,
     marginTop: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
     fontVariantNumeric: "tabular-nums",
-    letterSpacing: "0.04em",
-    lineHeight: 1.4,
-    textTransform: "uppercase",
   },
 });

--- a/apps/web/src/components/locationMapIcon/credit.stylex.tsx
+++ b/apps/web/src/components/locationMapIcon/credit.stylex.tsx
@@ -1,12 +1,13 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 import { TextLink } from "../textLink.stylex";
 
 /** Attribution for the adapted Scottish whisky region illustrations. */
 export function RegionMapCredit() {
   return (
-    <p {...stylex.props(styles.credit)}>
+    <p {...stylex.props(foundationStyles.metadata, styles.credit)}>
       Maps adapted from{" "}
       <TextLink
         href="https://commons.wikimedia.org/wiki/File:Scotch_regions.svg"
@@ -30,8 +31,5 @@ const styles = stylex.create({
     margin: 0,
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
   },
 });

--- a/apps/web/src/components/locationPreviewCard.stylex.tsx
+++ b/apps/web/src/components/locationPreviewCard.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
 import type { LocationMap } from "../lib/locationMap";
+import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, fonts, space } from "../styles/tokens.stylex";
 import { CardLink } from "./card.stylex";
 import { LocationMapIcon } from "./locationMapIcon";
@@ -40,15 +41,20 @@ export function LocationPreviewCard({
           )}
         </span>
       ) : null}
-      <strong title={name} {...stylex.props(styles.name)}>
+      <strong
+        title={name}
+        {...stylex.props(foundationStyles.compactRowTitle, styles.name)}
+      >
         {name}
       </strong>
-      <span {...stylex.props(styles.count)}>
+      <span {...stylex.props(foundationStyles.metadata, styles.count)}>
         {totalBottles.toLocaleString("en-US")}{" "}
         {totalBottles === 1 ? "bottle" : "bottles"}
       </span>
       {description ? (
-        <span {...stylex.props(styles.description)}>{description}</span>
+        <span {...stylex.props(foundationStyles.metadata, styles.description)}>
+          {description}
+        </span>
       ) : null}
     </CardLink>
   );
@@ -93,11 +99,6 @@ const styles = stylex.create({
   name: {
     gridRow: 2,
     overflow: "hidden",
-    fontFamily: fonts.display,
-    fontSize: "15px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
@@ -106,10 +107,7 @@ const styles = stylex.create({
     display: "block",
     marginTop: space.x1,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.4,
   },
   description: {
     gridRow: 4,
@@ -122,9 +120,6 @@ const styles = stylex.create({
     WebkitLineClamp: 3,
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
     textWrap: "pretty",
   },
 });

--- a/apps/web/src/components/navigation.stylex.tsx
+++ b/apps/web/src/components/navigation.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, effects, fonts, space } from "../styles/tokens.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, effects, space } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 
 const PERSONAL_FOLDS = "@media (max-width: 959px)";
@@ -42,7 +43,10 @@ export function NavigationTabs({
       </div>
       {personalItems.length > 0 ? (
         <div {...stylex.props(styles.personalGroup)}>
-          <span aria-hidden="true" {...stylex.props(styles.groupLabel)}>
+          <span
+            aria-hidden="true"
+            {...stylex.props(foundationStyles.fieldLabel, styles.groupLabel)}
+          >
             You
           </span>
           {personalItems.map((item) => (
@@ -69,7 +73,11 @@ function NavigationLink({
     <AppLink
       aria-current={current ? "page" : undefined}
       href={item.href}
-      {...stylex.props(styles.link, current && styles.currentLink)}
+      {...stylex.props(
+        foundationStyles.interactive,
+        styles.link,
+        current && [foundationStyles.interactive, styles.currentLink],
+      )}
     >
       {item.label}
     </AppLink>
@@ -120,11 +128,6 @@ const styles = stylex.create({
     alignItems: "center",
     paddingTop: "2px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   link: {
     display: "inline-flex",
@@ -136,10 +139,7 @@ const styles = stylex.create({
       default: colors.inkMuted,
       ":hover": colors.ink,
     },
-    fontFamily: fonts.reading,
-    fontSize: "14px",
     fontWeight: 600,
-    lineHeight: 1.2,
     textDecoration: "none",
     outline: "none",
     boxShadow: {
@@ -149,8 +149,6 @@ const styles = stylex.create({
   },
   currentLink: {
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "13px",
     fontWeight: 700,
   },
 });

--- a/apps/web/src/components/notePicker.stylex.tsx
+++ b/apps/web/src/components/notePicker.stylex.tsx
@@ -139,7 +139,7 @@ export function NotePickerField({
           role="combobox"
           type="search"
           value={query}
-          {...stylex.props(styles.fieldInput)}
+          {...stylex.props(foundationStyles.input, styles.fieldInput)}
         />
         <Button
           aria-expanded={isBrowserOpen}
@@ -176,17 +176,28 @@ export function NotePickerField({
                 >
                   <span
                     title={note.name}
-                    {...stylex.props(styles.suggestionName)}
+                    {...stylex.props(
+                      foundationStyles.interactiveSmall,
+                      styles.suggestionName,
+                    )}
                   >
                     {note.name}
                   </span>
-                  <span {...stylex.props(styles.suggestionCount)}>
+                  <span
+                    {...stylex.props(
+                      foundationStyles.metadata,
+                      styles.suggestionCount,
+                    )}
+                  >
                     used {note.usageCount.toLocaleString("en-US")} times
                   </span>
                 </button>
               ))
             ) : (
-              <p role="status" {...stylex.props(styles.fieldEmpty)}>
+              <p
+                role="status"
+                {...stylex.props(foundationStyles.metadata, styles.fieldEmpty)}
+              >
                 No existing notes match “{query.trim()}”.
               </p>
             )}
@@ -217,7 +228,10 @@ export function NotePickerField({
       ) : null}
 
       {value.length ? (
-        <p aria-live="polite" {...stylex.props(styles.fieldSummary)}>
+        <p
+          aria-live="polite"
+          {...stylex.props(foundationStyles.metadata, styles.fieldSummary)}
+        >
           {value.length} {value.length === 1 ? "note" : "notes"} selected
         </p>
       ) : null}
@@ -283,7 +297,7 @@ export function NotePicker({
           placeholder={`Search ${notes.length.toLocaleString("en-US")} notes`}
           type="search"
           value={query}
-          {...stylex.props(styles.search)}
+          {...stylex.props(foundationStyles.input, styles.search)}
         />
         {onClose ? (
           <button
@@ -310,6 +324,7 @@ export function NotePicker({
               }}
               type="button"
               {...stylex.props(
+                foundationStyles.interactiveSmall,
                 styles.category,
                 isActive && styles.activeCategory,
               )}
@@ -350,6 +365,7 @@ export function NotePicker({
                   title={`Used ${note.usageCount.toLocaleString("en-US")} times`}
                   type="button"
                   {...stylex.props(
+                    foundationStyles.interactiveSmall,
                     styles.note,
                     isSelected
                       ? styles.selectedNote
@@ -428,9 +444,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: "transparent",
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: { default: "12px", [COMPACT]: "16px" },
-    lineHeight: 1.4,
     "::placeholder": {
       color: colors.inkMuted,
       opacity: 1,
@@ -479,28 +492,18 @@ const styles = stylex.create({
   },
   suggestionName: {
     overflow: "hidden",
-    fontFamily: fonts.display,
-    fontSize: "13px",
     fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.25,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
   suggestionCount: {
     flexShrink: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.3,
   },
   fieldEmpty: {
     margin: 0,
     padding: space.x4,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
   },
   browserDialog: {
     position: "relative",
@@ -553,9 +556,6 @@ const styles = stylex.create({
     margin: 0,
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.3,
   },
   picker: {
     boxSizing: "border-box",
@@ -604,9 +604,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: colors.fieldBackground,
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: { default: "12px", [COMPACT]: "16px" },
-    lineHeight: 1.4,
     boxShadow: {
       default: "none",
       ":focus": `inset 0 0 0 1px ${colors.accent}`,
@@ -659,10 +656,7 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: { default: "transparent", ":hover": colors.surface },
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1,
     cursor: "pointer",
     boxShadow: {
       default: `inset 0 0 0 1px ${colors.sectionRule}`,
@@ -707,10 +701,7 @@ const styles = stylex.create({
     borderWidth: 0,
     borderRadius: controlMetrics.radiusSmall,
     outline: "none",
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1,
     cursor: "pointer",
     opacity: {
       default: 1,

--- a/apps/web/src/components/pageTabs.stylex.tsx
+++ b/apps/web/src/components/pageTabs.stylex.tsx
@@ -1,11 +1,11 @@
 import * as stylex from "@stylexjs/stylex";
 import Link from "next/link";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../styles/tokens.stylex";
 
@@ -34,11 +34,15 @@ export function PageTabs({ ariaLabel, currentHref, items }: PageTabsProps) {
             href={item.href}
             key={item.href}
             prefetch={false}
-            {...stylex.props(styles.tab, current && styles.currentTab)}
+            {...stylex.props(
+              foundationStyles.interactive,
+              styles.tab,
+              current && [foundationStyles.interactive, styles.currentTab],
+            )}
           >
             <span>{item.label}</span>
             {item.count !== undefined ? (
-              <span {...stylex.props(styles.count)}>
+              <span {...stylex.props(foundationStyles.metadata, styles.count)}>
                 {item.count.toLocaleString("en-US")}
               </span>
             ) : null}
@@ -77,10 +81,7 @@ const styles = stylex.create({
       default: colors.inkMuted,
       ":hover": colors.ink,
     },
-    fontFamily: fonts.reading,
-    fontSize: "15px",
     fontWeight: 600,
-    lineHeight: 1.2,
     textDecoration: "none",
     boxShadow: {
       default: "none",
@@ -89,8 +90,6 @@ const styles = stylex.create({
   },
   currentTab: {
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "15px",
     fontWeight: 700,
     boxShadow: {
       default: `inset 0 -2px 0 ${colors.ink}`,
@@ -106,11 +105,8 @@ const styles = stylex.create({
     paddingLeft: "6px",
     backgroundColor: colors.surface,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
     fontWeight: 600,
-    lineHeight: 1.2,
     textAlign: "center",
   },
 });

--- a/apps/web/src/components/pages/activityPage.stylex.tsx
+++ b/apps/web/src/components/pages/activityPage.stylex.tsx
@@ -2,7 +2,8 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import { ButtonLink, EmptyState, TextLink } from "..";
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 import { CommunityFeed, type CommunityFeedItem } from "../communityFeed.stylex";
 import {
   BottleRailSection,
@@ -38,7 +39,7 @@ export function ActivityPage({
         rail={
           <div {...stylex.props(styles.rail)}>
             <RailListSection heading="What have you tried?">
-              <p {...stylex.props(styles.railText)}>
+              <p {...stylex.props(foundationStyles.body, styles.railText)}>
                 Add a rating and a few notes to remember what you tasted.
               </p>
               <div>
@@ -64,7 +65,11 @@ export function ActivityPage({
           </div>
         }
       >
-        {note ? <p {...stylex.props(styles.note)}>{note}</p> : null}
+        {note ? (
+          <p {...stylex.props(foundationStyles.metadata, styles.note)}>
+            {note}
+          </p>
+        ) : null}
         {items.length ? (
           <CommunityFeed ariaLabel="Latest activity" items={items} limit={20} />
         ) : (
@@ -88,16 +93,10 @@ const styles = stylex.create({
   railText: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.6,
   },
   note: {
     marginTop: space.x4,
     marginBottom: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
 });

--- a/apps/web/src/components/pages/authentication.stylex.tsx
+++ b/apps/web/src/components/pages/authentication.stylex.tsx
@@ -57,16 +57,31 @@ export function AuthenticationIntro({
         Peated
       </NextLink>
       <div {...stylex.props(styles.introBody)}>
-        <h1 {...stylex.props(styles.introTitle)}>{title}</h1>
+        <h1
+          {...stylex.props(
+            foundationStyles.pageTitleCompact,
+            styles.introTitle,
+          )}
+        >
+          {title}
+        </h1>
         {description ? (
-          <div {...stylex.props(styles.introDescription)}>{description}</div>
+          <div
+            {...stylex.props(foundationStyles.prose, styles.introDescription)}
+          >
+            {description}
+          </div>
         ) : null}
         {facts ? (
           <dl {...stylex.props(styles.facts)}>
             {facts.map((fact) => (
               <div key={fact.label}>
                 <dd {...stylex.props(styles.factValue)}>{fact.value}</dd>
-                <dt {...stylex.props(styles.factLabel)}>{fact.label}</dt>
+                <dt
+                  {...stylex.props(foundationStyles.metadata, styles.factLabel)}
+                >
+                  {fact.label}
+                </dt>
               </div>
             ))}
           </dl>
@@ -74,7 +89,10 @@ export function AuthenticationIntro({
         {points ? (
           <ul {...stylex.props(styles.points)}>
             {points.map((point, index) => (
-              <li key={index} {...stylex.props(styles.point)}>
+              <li
+                key={index}
+                {...stylex.props(foundationStyles.body, styles.point)}
+              >
                 {point}
               </li>
             ))}
@@ -82,7 +100,9 @@ export function AuthenticationIntro({
         ) : null}
       </div>
       {footer ? (
-        <div {...stylex.props(styles.introFooter)}>{footer}</div>
+        <div {...stylex.props(foundationStyles.metadata, styles.introFooter)}>
+          {footer}
+        </div>
       ) : null}
     </aside>
   );
@@ -119,7 +139,9 @@ export function AuthenticationPanel({
       {back ? <div {...stylex.props(styles.back)}>{back}</div> : null}
       <SectionHeading>{title}</SectionHeading>
       {description ? (
-        <div {...stylex.props(styles.panelDescription)}>{description}</div>
+        <div {...stylex.props(foundationStyles.body, styles.panelDescription)}>
+          {description}
+        </div>
       ) : null}
       <div {...stylex.props(styles.panelContent)}>{children}</div>
     </section>
@@ -140,7 +162,11 @@ export function AuthenticationDivider({ label }: { label?: string }) {
       {label ? (
         <>
           <span {...stylex.props(styles.rule)} />
-          <span {...stylex.props(styles.dividerLabel)}>{label}</span>
+          <span
+            {...stylex.props(foundationStyles.metadata, styles.dividerLabel)}
+          >
+            {label}
+          </span>
           <span {...stylex.props(styles.rule)} />
         </>
       ) : null}
@@ -159,19 +185,26 @@ export function AuthenticationTextButton({
   ...props
 }: Omit<ComponentProps<"button">, "className" | "style">) {
   return (
-    <button {...props} {...stylex.props(styles.textButton)}>
+    <button
+      {...props}
+      {...stylex.props(foundationStyles.interactiveSmall, styles.textButton)}
+    >
       {children}
     </button>
   );
 }
 
 export function AuthenticationLinks({ children }: { children: ReactNode }) {
-  return <div {...stylex.props(styles.footerLinks)}>{children}</div>;
+  return (
+    <div {...stylex.props(foundationStyles.metadata, styles.footerLinks)}>
+      {children}
+    </div>
+  );
 }
 
 export function AuthenticationNotice({ children }: { children: ReactNode }) {
   return (
-    <div role="alert" {...stylex.props(styles.notice)}>
+    <div role="alert" {...stylex.props(foundationStyles.body, styles.notice)}>
       {children}
     </div>
   );
@@ -185,7 +218,10 @@ export function AuthenticationDetails({
   return (
     <ul {...stylex.props(styles.detailList)}>
       {items.map((item, index) => (
-        <li key={index} {...stylex.props(styles.detailListItem)}>
+        <li
+          key={index}
+          {...stylex.props(foundationStyles.body, styles.detailListItem)}
+        >
           {item}
         </li>
       ))}
@@ -263,19 +299,11 @@ const styles = stylex.create({
     maxWidth: "440px",
     margin: 0,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "clamp(34px, 5vw, 44px)",
-    fontWeight: 700,
-    letterSpacing: "-0.04em",
-    lineHeight: 1.02,
   },
   introDescription: {
     maxWidth: "440px",
     marginTop: space.x4,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "16px",
-    lineHeight: 1.55,
   },
   facts: {
     display: "grid",
@@ -304,11 +332,6 @@ const styles = stylex.create({
   factLabel: {
     marginTop: "2px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   points: {
     margin: 0,
@@ -323,8 +346,6 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
     color: colors.inkMuted,
-    fontSize: "15px",
-    lineHeight: 1.55,
     ":first-child": {
       paddingTop: 0,
     },
@@ -337,9 +358,6 @@ const styles = stylex.create({
     position: "relative",
     zIndex: zIndices.localContent,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.45,
     [NARROW]: {
       display: "none",
     },
@@ -391,8 +409,6 @@ const styles = stylex.create({
   panelDescription: {
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontSize: "14px",
-    lineHeight: 1.55,
   },
   panelContent: {
     marginTop: "22px",
@@ -424,11 +440,6 @@ const styles = stylex.create({
   },
   dividerLabel: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.1em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   textButton: {
     margin: 0,
@@ -437,10 +448,7 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: "transparent",
     color: colors.accentDeep,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1.4,
     cursor: "pointer",
     textAlign: "left",
     boxShadow: {
@@ -456,8 +464,6 @@ const styles = stylex.create({
     alignItems: "baseline",
     gap: "6px 8px",
     color: colors.inkMuted,
-    fontSize: "14px",
-    lineHeight: 1.55,
     flexWrap: "wrap",
   },
   notice: {
@@ -469,9 +475,7 @@ const styles = stylex.create({
     borderColor: colors.accentTint,
     backgroundColor: "transparent",
     color: colors.accentDeep,
-    fontSize: "14px",
     fontWeight: 600,
-    lineHeight: 1.45,
   },
   detailList: {
     margin: 0,
@@ -485,9 +489,6 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.45,
     ":first-child": {
       paddingTop: 0,
     },

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -16,7 +16,8 @@ import {
   SectionHeading,
   TastingEntry,
 } from "..";
-import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, effects, space } from "../../styles/tokens.stylex";
 import {
   BottleRailSection,
   type BottleRailItem,
@@ -83,7 +84,12 @@ export function BottleOverview({
               <div {...stylex.props(styles.sectionHeader)}>
                 <SectionHeading>Critic reviews</SectionHeading>
                 {criticReviewDetail ? (
-                  <span {...stylex.props(styles.sectionDetail)}>
+                  <span
+                    {...stylex.props(
+                      foundationStyles.metadata,
+                      styles.sectionDetail,
+                    )}
+                  >
                     {criticReviewDetail}
                   </span>
                 ) : null}
@@ -115,7 +121,10 @@ export function BottleOverview({
               tastingCount > tastings.length ? (
                 <AppLink
                   href={moreTastingsHref}
-                  {...stylex.props(styles.moreLink)}
+                  {...stylex.props(
+                    foundationStyles.interactiveSmall,
+                    styles.moreLink,
+                  )}
                 >
                   Show all {tastingCount.toLocaleString("en-US")} tastings →
                 </AppLink>
@@ -304,10 +313,6 @@ const styles = stylex.create({
   sectionDetail: {
     flexShrink: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.3,
-    textTransform: "lowercase",
   },
   moreLink: {
     display: "block",
@@ -326,10 +331,7 @@ const styles = stylex.create({
       ":active": colors.surface,
     },
     color: colors.accentDeep,
-    fontFamily: fonts.display,
-    fontSize: "13px",
     fontWeight: 700,
-    lineHeight: 1.3,
     textDecoration: "none",
     boxShadow: {
       default: "none",

--- a/apps/web/src/components/pages/bottlePageHeader.stories.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stories.tsx
@@ -20,7 +20,7 @@ const meta = {
     ),
     brand: "Laphroaig",
     brandHref: "/entities/809",
-    eyebrow: "Laphroaig Distillery",
+    metadata: "Laphroaig Distillery",
     menu: (
       <RowMenu
         groups={[
@@ -68,7 +68,7 @@ export const LongName: Story = {
   args: {
     brand: "The Scotch Malt Whisky Society",
     brandHref: "/entities/3417",
-    eyebrow: "Caol Ila Distillery",
+    metadata: "Caol Ila Distillery",
     name: "SMWS Highland peaty potion",
   },
 };
@@ -78,7 +78,7 @@ export const ThinData: Story = {
     actions: null,
     brand: "Port Ellen",
     brandHref: "/entities/214",
-    eyebrow: "Port Ellen Distillery",
+    metadata: "Port Ellen Distillery",
     menu: null,
     name: "Independent bottling",
     bands: null,

--- a/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
+++ b/apps/web/src/components/pages/bottlePageHeader.stylex.tsx
@@ -15,7 +15,7 @@ export type BottlePageHeaderProps = {
   bands?: TastingRatingDistributionProps | null;
   brand: string;
   brandHref?: string;
-  eyebrow?: ReactNode;
+  metadata?: ReactNode;
   menu?: ReactNode;
   name: string;
   score?: ReviewScoreProps | null;
@@ -27,7 +27,7 @@ export function BottlePageHeader({
   bands,
   brand,
   brandHref,
-  eyebrow,
+  metadata,
   menu,
   name,
   score,
@@ -39,7 +39,7 @@ export function BottlePageHeader({
       <PageHeader
         actions={actions}
         actionsPosition="start"
-        eyebrow={eyebrow}
+        metadata={metadata}
         menu={menu}
         title={
           <>

--- a/apps/web/src/components/pages/catalogDetailComposition.stories.tsx
+++ b/apps/web/src/components/pages/catalogDetailComposition.stories.tsx
@@ -44,7 +44,6 @@ export const Overview: Story = {
       header={
         <PageHeader
           description="A short description can sit here."
-          eyebrow="Country"
           title="Scotland"
         />
       }
@@ -100,7 +99,7 @@ export const Minimal: Story = {
   render: () => (
     <TabbedPage
       currentHref="/catalog/new-region"
-      header={<PageHeader eyebrow="Region" title="New region" />}
+      header={<PageHeader title="New region" />}
       tabs={[{ href: "/catalog/new-region", label: "Overview" }]}
       tabsLabel="New region catalog sections"
     >

--- a/apps/web/src/components/pages/catalogTable.stylex.tsx
+++ b/apps/web/src/components/pages/catalogTable.stylex.tsx
@@ -1,7 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 import { linkedRowStyles } from "../linkedRow.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
@@ -44,6 +45,7 @@ export function CatalogTable<Item>({
                 key={column.key}
                 scope="col"
                 {...stylex.props(
+                  foundationStyles.fieldLabel,
                   styles.header,
                   index === 0 && styles.firstColumn,
                   alignStyles[column.align ?? "left"],
@@ -77,7 +79,10 @@ export function CatalogTable<Item>({
                     column.padding === "flush" && styles.flushCell,
                     column.priority === "secondary" && styles.secondary,
                     column.width && widthStyles[column.width],
-                    column.width === "count" && styles.countCell,
+                    column.width === "count" && [
+                      foundationStyles.compactRowTitle,
+                      styles.countCell,
+                    ],
                     column.interactive && linkedRowStyles.nestedAction,
                   )}
                 >
@@ -125,12 +130,6 @@ const styles = stylex.create({
     paddingBottom: space.x2,
     paddingLeft: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 500,
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
     whiteSpace: "nowrap",
   },
   row: {
@@ -169,12 +168,7 @@ const styles = stylex.create({
   },
   countCell: {
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "15px",
     fontVariantNumeric: "tabular-nums",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1,
   },
   actionWidth: {
     width: "104px",
@@ -195,13 +189,11 @@ const styles = stylex.create({
   center: { textAlign: "center" },
   right: { textAlign: "right" },
 });
-
 const alignStyles = {
   left: styles.left,
   center: styles.center,
   right: styles.right,
 } as const;
-
 const widthStyles = {
   action: styles.actionWidth,
   count: styles.countWidth,

--- a/apps/web/src/components/pages/contentPage.stylex.tsx
+++ b/apps/web/src/components/pages/contentPage.stylex.tsx
@@ -4,27 +4,33 @@ import { SectionHeading } from "../sectionHeading.stylex";
 
 import { TextLink, type TextLinkProps } from "..";
 import { foundationStyles } from "../../styles/foundations.stylex";
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 
 export function ContentPage({
   children,
-  eyebrow,
+  metadata,
   intro,
   title,
 }: {
   children: ReactNode;
-  eyebrow?: ReactNode;
+  metadata?: ReactNode;
   intro?: ReactNode;
   title: ReactNode;
 }) {
   return (
     <article {...stylex.props(styles.page)}>
       <header {...stylex.props(styles.header)}>
-        {eyebrow ? (
-          <div {...stylex.props(styles.eyebrow)}>{eyebrow}</div>
-        ) : null}
         <h1 {...stylex.props(foundationStyles.pageTitle)}>{title}</h1>
-        {intro ? <div {...stylex.props(styles.intro)}>{intro}</div> : null}
+        {metadata ? (
+          <div {...stylex.props(foundationStyles.metadata, styles.metadata)}>
+            {metadata}
+          </div>
+        ) : null}
+        {intro ? (
+          <div {...stylex.props(foundationStyles.prose, styles.intro)}>
+            {intro}
+          </div>
+        ) : null}
       </header>
       <div {...stylex.props(styles.body)}>{children}</div>
     </article>
@@ -62,11 +68,15 @@ export function ContentSubsection({
 }
 
 export function ContentText({ children }: { children: ReactNode }) {
-  return <p {...stylex.props(styles.text)}>{children}</p>;
+  return (
+    <p {...stylex.props(foundationStyles.prose, styles.text)}>{children}</p>
+  );
 }
 
 export function ContentList({ children }: { children: ReactNode }) {
-  return <ul {...stylex.props(styles.list)}>{children}</ul>;
+  return (
+    <ul {...stylex.props(foundationStyles.prose, styles.list)}>{children}</ul>
+  );
 }
 
 export function ContentLink({ children, ...props }: TextLinkProps) {
@@ -86,22 +96,14 @@ const styles = stylex.create({
     maxWidth: "720px",
     paddingBottom: space.x6,
   },
-  eyebrow: {
-    marginBottom: space.x2,
+  metadata: {
+    marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   intro: {
     maxWidth: "680px",
     marginTop: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "16px",
-    lineHeight: 1.6,
   },
   body: {
     display: "flex",
@@ -123,9 +125,6 @@ const styles = stylex.create({
     maxWidth: "74ch",
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.7,
   },
   list: {
     display: "flex",
@@ -135,8 +134,5 @@ const styles = stylex.create({
     margin: 0,
     paddingLeft: "20px",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.6,
   },
 });

--- a/apps/web/src/components/pages/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/entityCatalog.stylex.tsx
@@ -16,7 +16,8 @@ import {
   type ListSortOption,
   type RowMenuItem,
 } from "..";
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors } from "../../styles/tokens.stylex";
 import { AppLink } from "../appLink";
 import { linkedRowStyles } from "../linkedRow.stylex";
 import { CatalogPageLoading } from "./catalogPage.stylex";
@@ -177,14 +178,18 @@ function EntityCatalogTable({
         <>
           <AppLink
             href={item.href}
-            {...stylex.props(styles.title, linkedRowStyles.primaryLink)}
+            {...stylex.props(
+              foundationStyles.rowTitle,
+              styles.title,
+              linkedRowStyles.primaryLink,
+            )}
           >
             {item.name}
             {item.isFollowing && showFollowingMarks ? (
               <MemberStatus kind="following" />
             ) : null}
           </AppLink>
-          <div {...stylex.props(styles.metadata)}>
+          <div {...stylex.props(foundationStyles.metadata, styles.metadata)}>
             {item.metadata.join(" · ")}
           </div>
         </>
@@ -322,11 +327,6 @@ const styles = stylex.create({
     display: "block",
     overflow: "hidden",
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "18px",
-    fontWeight: 700,
-    letterSpacing: "-0.025em",
-    lineHeight: 1.25,
     textDecoration: "none",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
@@ -335,9 +335,6 @@ const styles = stylex.create({
     marginTop: "3px",
     overflow: "hidden",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },

--- a/apps/web/src/components/pages/entityPageHeader.stories.tsx
+++ b/apps/web/src/components/pages/entityPageHeader.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
     description:
       "An Islay distillery known for heavily peated single malt whisky.",
     detail: "Distillery",
-    eyebrow: "Islay · Scotland",
+    metadata: "Islay · Scotland",
     id: "E9201",
     menu: (
       <RowMenu
@@ -58,7 +58,7 @@ export const ThinData: Story = {
     actions: undefined,
     description: undefined,
     detail: "Distillery",
-    eyebrow: "Scotland",
+    metadata: "Scotland",
     menu: undefined,
     parent: undefined,
     specs: [

--- a/apps/web/src/components/pages/entityPageHeader.stylex.tsx
+++ b/apps/web/src/components/pages/entityPageHeader.stylex.tsx
@@ -9,7 +9,7 @@ export type EntityPageHeaderProps = {
   actions?: ReactNode;
   description?: ReactNode;
   detail?: string;
-  eyebrow?: ReactNode;
+  metadata?: ReactNode;
   id: string;
   menu?: ReactNode;
   parent?: ReactNode;
@@ -22,7 +22,7 @@ export function EntityPageHeader({
   actions,
   description,
   detail,
-  eyebrow,
+  metadata,
   id,
   menu,
   parent,
@@ -35,7 +35,7 @@ export function EntityPageHeader({
         actions={actions}
         actionsPosition="start"
         description={description}
-        eyebrow={eyebrow}
+        metadata={metadata}
         identity={<PeatedId detail={detail} id={id} />}
         menu={menu}
         parent={parent}

--- a/apps/web/src/components/pages/errorPage.stylex.tsx
+++ b/apps/web/src/components/pages/errorPage.stylex.tsx
@@ -2,7 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
 import { foundationStyles } from "../../styles/foundations.stylex";
-import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
+import { colors, effects, space } from "../../styles/tokens.stylex";
 
 export type ErrorPageProps = {
   actions?: ReactNode;
@@ -38,9 +38,15 @@ export function ErrorPage({
 }: ErrorPageProps) {
   return (
     <section {...stylex.props(styles.root)}>
-      <div {...stylex.props(styles.status)}>{status}</div>
-      <h1 {...stylex.props(styles.title)}>{title}</h1>
-      <div {...stylex.props(styles.description)}>{children}</div>
+      <div {...stylex.props(foundationStyles.metadata, styles.status)}>
+        {status}
+      </div>
+      <h1 {...stylex.props(foundationStyles.pageTitleCompact, styles.title)}>
+        {title}
+      </h1>
+      <div {...stylex.props(foundationStyles.body, styles.description)}>
+        {children}
+      </div>
       {actions ? <ErrorPageActions>{actions}</ErrorPageActions> : null}
       {detail ? <div {...stylex.props(styles.detail)}>{detail}</div> : null}
       {support}
@@ -78,30 +84,53 @@ export function ErrorReference({
   return (
     <div {...stylex.props(styles.reference)}>
       <div {...stylex.props(styles.referenceRow)}>
-        <span {...stylex.props(styles.referenceLabel)}>{label}</span>
-        <span {...stylex.props(styles.referenceValue)}>{value}</span>
+        <span
+          {...stylex.props(foundationStyles.metadata, styles.referenceLabel)}
+        >
+          {label}
+        </span>
+        <span {...stylex.props(foundationStyles.code, styles.referenceValue)}>
+          {value}
+        </span>
         {action ? (
           <span {...stylex.props(styles.referenceAction)}>{action}</span>
         ) : null}
       </div>
       {description ? (
-        <div {...stylex.props(styles.referenceDescription)}>{description}</div>
+        <div
+          {...stylex.props(
+            foundationStyles.metadata,
+            styles.referenceDescription,
+          )}
+        >
+          {description}
+        </div>
       ) : null}
       {technicalDetail ? (
         <details
           open={technicalDetail.defaultOpen}
-          {...stylex.props(styles.technicalDetail)}
+          {...stylex.props(foundationStyles.code, styles.technicalDetail)}
         >
-          <summary {...stylex.props(styles.technicalSummary)}>
+          <summary
+            {...stylex.props(
+              foundationStyles.metadata,
+              styles.technicalSummary,
+            )}
+          >
             Technical detail
           </summary>
           <div {...stylex.props(styles.technicalBody)}>
             {technicalDetail.context ? (
-              <div {...stylex.props(styles.technicalContext)}>
+              <div
+                {...stylex.props(
+                  foundationStyles.code,
+                  styles.technicalContext,
+                )}
+              >
                 {technicalDetail.context}
               </div>
             ) : null}
-            <pre {...stylex.props(styles.stackTrace)}>
+            <pre {...stylex.props(foundationStyles.code, styles.stackTrace)}>
               {technicalDetail.stack}
             </pre>
           </div>
@@ -120,7 +149,9 @@ export function ErrorSupport({
 }) {
   return (
     <div {...stylex.props(styles.support)}>
-      <div {...stylex.props(styles.supportCopy)}>{children}</div>
+      <div {...stylex.props(foundationStyles.metadata, styles.supportCopy)}>
+        {children}
+      </div>
       <div {...stylex.props(styles.supportAction)}>{action}</div>
     </div>
   );
@@ -137,33 +168,18 @@ const styles = stylex.create({
   },
   status: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    fontWeight: 400,
-    letterSpacing: "0.1em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   title: {
     marginTop: space.x1,
     marginRight: 0,
     marginBottom: 0,
     marginLeft: 0,
-    fontFamily: fonts.display,
-    fontSize: "clamp(28px, 6vw, 34px)",
-    fontWeight: 700,
-    letterSpacing: "-0.03em",
-    lineHeight: 1.1,
     textWrap: "pretty",
   },
   description: {
     maxWidth: "560px",
     marginTop: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    fontWeight: 400,
-    lineHeight: 1.6,
     textWrap: "pretty",
   },
   actions: {
@@ -193,22 +209,12 @@ const styles = stylex.create({
   referenceLabel: {
     flexShrink: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    fontWeight: 400,
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   referenceValue: {
     minWidth: 0,
     flexGrow: 1,
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: "12px",
     fontVariantNumeric: "tabular-nums",
-    fontWeight: 400,
-    lineHeight: 1.45,
     overflowWrap: "anywhere",
   },
   referenceAction: {
@@ -218,22 +224,15 @@ const styles = stylex.create({
     maxWidth: "62ch",
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    fontWeight: 400,
-    lineHeight: 1.5,
   },
   technicalDetail: {
     marginTop: space.x3,
     color: colors.ink,
-    fontFamily: fonts.data,
   },
   technicalSummary: {
     width: "fit-content",
     color: colors.accent,
-    fontSize: "11px",
     fontWeight: 500,
-    lineHeight: 1.45,
     cursor: "pointer",
     outline: "none",
     boxShadow: {
@@ -254,9 +253,6 @@ const styles = stylex.create({
   },
   technicalContext: {
     color: colors.inkMuted,
-    fontSize: "11px",
-    fontWeight: 400,
-    lineHeight: 1.5,
     overflowWrap: "anywhere",
   },
   stackTrace: {
@@ -268,10 +264,6 @@ const styles = stylex.create({
     overflowX: "auto",
     overflowY: "auto",
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    fontWeight: 400,
-    lineHeight: 1.55,
     whiteSpace: "pre-wrap",
     overflowWrap: "anywhere",
   },
@@ -292,17 +284,12 @@ const styles = stylex.create({
     minWidth: "200px",
     flexGrow: 1,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    fontWeight: 400,
-    lineHeight: 1.55,
     textWrap: "pretty",
   },
   supportAction: {
     flexShrink: 0,
   },
 });
-
 const shellStyles = stylex.create({
   shell: {
     boxSizing: "border-box",

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -1,9 +1,9 @@
 import * as stylex from "@stylexjs/stylex";
-import Link from "next/link";
 import type { ReactNode } from "react";
 import { needsRegionMapCredit } from "../../lib/locationMap";
 import { RegionMapCredit } from "../locationMapIcon/credit.stylex";
 import { SectionHeading } from "../sectionHeading.stylex";
+import { TextLink } from "../textLink.stylex";
 
 import {
   BottleList,
@@ -13,13 +13,8 @@ import {
   LocationPreviewCard,
   type LocationPreviewCardProps,
 } from "..";
-import {
-  colors,
-  controlMetrics,
-  effects,
-  fonts,
-  space,
-} from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
 const NARROW = "@media (min-width: 640px) and (max-width: 899px)";
@@ -39,7 +34,11 @@ function HomeModuleHeading({
         <SectionHeading>{title}</SectionHeading>
         {action}
       </div>
-      {detail ? <div {...stylex.props(styles.detail)}>{detail}</div> : null}
+      {detail ? (
+        <div {...stylex.props(foundationStyles.metadata, styles.detail)}>
+          {detail}
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -56,13 +55,10 @@ export function HomeHighestRated({
     <section {...stylex.props(styles.section)}>
       <HomeModuleHeading
         action={
-          <Link
-            href="/bottles?sort=-score&minScore=0"
-            {...stylex.props(styles.moreLink)}
-          >
+          <TextLink href="/bottles?sort=-score&minScore=0">
             All {totalRated.toLocaleString("en-US")} rated{" "}
             <span aria-hidden="true">→</span>
-          </Link>
+          </TextLink>
         }
         title="Bottles to try"
       />
@@ -87,9 +83,9 @@ export function HomeLatestReleases({
     <section {...stylex.props(styles.section)}>
       <HomeModuleHeading
         action={
-          <Link href={seeAllHref} {...stylex.props(styles.moreLink)}>
+          <TextLink href={seeAllHref}>
             View all <span aria-hidden="true">→</span>
-          </Link>
+          </TextLink>
         }
         title={title}
       />
@@ -105,9 +101,9 @@ export function HomeActivityFeed({ children }: { children: ReactNode }) {
     <section {...stylex.props(styles.section)}>
       <HomeModuleHeading
         action={
-          <Link href="/activity" {...stylex.props(styles.moreLink)}>
+          <TextLink href="/activity">
             View all <span aria-hidden="true">→</span>
-          </Link>
+          </TextLink>
         }
         title="Activity"
       />
@@ -156,13 +152,13 @@ export function HomeOrigins({
     <section {...stylex.props(styles.section)}>
       <HomeModuleHeading
         action={
-          <Link href="/locations" {...stylex.props(styles.moreLink)}>
+          <TextLink href="/locations">
             Open the map <span aria-hidden="true">→</span>
-          </Link>
+          </TextLink>
         }
         title="Browse by origin"
       />
-      <p {...stylex.props(styles.originIntro)}>
+      <p {...stylex.props(foundationStyles.body, styles.originIntro)}>
         Mostly Scotch, a good deal of American, and a growing amount of
         everything else.
       </p>
@@ -226,12 +222,12 @@ export function HomeDistilleries({
         </ItemList>
       </div>
       <div {...stylex.props(styles.distilleryLink)}>
-        <Link href="/distillers" {...stylex.props(styles.moreLink)}>
+        <TextLink href="/distillers">
           {totalDistilleries === undefined
             ? "View all distilleries"
             : `View ${totalDistilleries.toLocaleString("en-US")} distilleries`}{" "}
           <span aria-hidden="true">→</span>
-        </Link>
+        </TextLink>
       </div>
     </section>
   );
@@ -247,7 +243,7 @@ export function HomeContributionPrompt({
   return (
     <section {...stylex.props(styles.prompt)}>
       <SectionHeading>Missing a bottle?</SectionHeading>
-      <p {...stylex.props(styles.promptCopy)}>
+      <p {...stylex.props(foundationStyles.metadata, styles.promptCopy)}>
         Add it. Cask number, vintage, ABV, finish—as much as the label tells
         you.
       </p>
@@ -280,11 +276,6 @@ const styles = stylex.create({
   },
   detail: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.06em",
-    lineHeight: 1.4,
-    textTransform: "uppercase",
   },
   rows: {
     marginTop: space.x2,
@@ -294,9 +285,6 @@ const styles = stylex.create({
     marginTop: space.x2,
     marginBottom: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.5,
   },
   regionHeading: { marginTop: space.x6 },
   regionGrid: {
@@ -326,30 +314,6 @@ const styles = stylex.create({
   distilleries: {
     marginTop: "14px",
   },
-  moreLink: {
-    display: "inline-block",
-    borderRadius: controlMetrics.radiusSmall,
-    outline: "none",
-    color: {
-      default: colors.accent,
-      ":hover": colors.accentDeep,
-      ":active": colors.accentDeep,
-    },
-    fontFamily: fonts.display,
-    fontSize: "13px",
-    fontWeight: 700,
-    lineHeight: 1.2,
-    textDecorationLine: {
-      default: "none",
-      ":hover": "underline",
-    },
-    textDecorationThickness: "1px",
-    textUnderlineOffset: "2px",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
-  },
   distilleryLink: {
     marginTop: space.x3,
   },
@@ -362,9 +326,6 @@ const styles = stylex.create({
     margin: 0,
     marginTop: space.x1,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
   promptActions: {
     display: "flex",

--- a/apps/web/src/components/pages/homeSections.stylex.tsx
+++ b/apps/web/src/components/pages/homeSections.stylex.tsx
@@ -1,7 +1,8 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 
 const NARROW = "@media (max-width: 759px)";
 
@@ -19,8 +20,14 @@ export function PublicHomeIntro({
 }: PublicHomeIntroProps) {
   return (
     <section {...stylex.props(styles.hero)}>
-      <h1 {...stylex.props(styles.heroTitle)}>{title}</h1>
-      <div {...stylex.props(styles.heroCopy)}>{description}</div>
+      <h1
+        {...stylex.props(foundationStyles.pageTitleCompact, styles.heroTitle)}
+      >
+        {title}
+      </h1>
+      <div {...stylex.props(foundationStyles.prose, styles.heroCopy)}>
+        {description}
+      </div>
       <div {...stylex.props(styles.heroSearch)}>{search}</div>
     </section>
   );
@@ -39,19 +46,11 @@ const styles = stylex.create({
     maxWidth: "760px",
     margin: 0,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "clamp(40px, 5vw, 44px)",
-    fontWeight: 700,
-    letterSpacing: "-0.04em",
-    lineHeight: 1.02,
   },
   heroCopy: {
     maxWidth: "620px",
     marginTop: "18px",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "17px",
-    lineHeight: 1.55,
   },
   heroSearch: {
     maxWidth: "760px",

--- a/apps/web/src/components/pages/homeSummary.stylex.tsx
+++ b/apps/web/src/components/pages/homeSummary.stylex.tsx
@@ -7,6 +7,7 @@ import {
   TastingRatingDistribution,
   type TastingRatingCounts,
 } from "..";
+import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, fonts, space } from "../../styles/tokens.stylex";
 
 export type HomeMemberFact = {
@@ -40,7 +41,12 @@ export function HomeMemberSummary({
           <strong {...stylex.props(styles.recordTotalValue)}>
             {totalTastings.toLocaleString("en-US")}
           </strong>
-          <span {...stylex.props(styles.recordTotalLabel)}>
+          <span
+            {...stylex.props(
+              foundationStyles.metadata,
+              styles.recordTotalLabel,
+            )}
+          >
             tastings you've recorded
           </span>
         </div>
@@ -53,7 +59,13 @@ export function HomeMemberSummary({
               <dd {...stylex.props(styles.recordFactValue)}>
                 {fact.value.toLocaleString("en-US")}
               </dd>
-              <dt title={fact.label} {...stylex.props(styles.recordFactLabel)}>
+              <dt
+                title={fact.label}
+                {...stylex.props(
+                  foundationStyles.metadata,
+                  styles.recordFactLabel,
+                )}
+              >
                 {fact.label}
               </dt>
             </div>
@@ -105,9 +117,6 @@ const styles = stylex.create({
   },
   recordTotalLabel: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.35,
   },
   recordDistribution: {
     marginTop: space.x4,
@@ -137,12 +146,7 @@ const styles = stylex.create({
     overflow: "hidden",
     marginTop: "2px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "9px",
-    letterSpacing: "0.06em",
-    lineHeight: 1.3,
     textOverflow: "ellipsis",
-    textTransform: "uppercase",
     whiteSpace: "nowrap",
   },
   loading: {

--- a/apps/web/src/components/pages/memberProfileContent.stylex.tsx
+++ b/apps/web/src/components/pages/memberProfileContent.stylex.tsx
@@ -25,7 +25,8 @@ import {
   type RowMenuGroup,
   type TastingEntryProps,
 } from "..";
-import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, effects, space } from "../../styles/tokens.stylex";
 
 const NARROW = "@media (max-width: 759px)";
 
@@ -59,7 +60,7 @@ export function MemberLibraryList({
 }: MemberLibraryListProps) {
   return (
     <section aria-label="Member library" {...stylex.props(styles.library)}>
-      <div {...stylex.props(styles.libraryCount)}>
+      <div {...stylex.props(foundationStyles.rowTitle, styles.libraryCount)}>
         <strong>
           {items.length.toLocaleString("en-US")}{" "}
           {items.length === 1 ? "bottle" : "bottles"}
@@ -166,7 +167,14 @@ export function MemberLibraryFilters({
 
   return mode === "mobile" ? (
     <details {...stylex.props(styles.mobileFilters)}>
-      <summary {...stylex.props(styles.mobileSummary)}>Filter library</summary>
+      <summary
+        {...stylex.props(
+          foundationStyles.interactiveSmall,
+          styles.mobileSummary,
+        )}
+      >
+        Filter library
+      </summary>
       {content}
     </details>
   ) : (
@@ -234,7 +242,12 @@ function CollectionActivity({
     <article {...stylex.props(styles.collectionActivity)}>
       <header {...stylex.props(styles.activityHeader)}>
         <div {...stylex.props(styles.activityCopy)}>
-          <div {...stylex.props(styles.activitySentence)}>
+          <div
+            {...stylex.props(
+              foundationStyles.metadata,
+              styles.activitySentence,
+            )}
+          >
             <TextLink href={activity.authorHref} size="inherit">
               {activity.author}
             </TextLink>
@@ -247,7 +260,11 @@ function CollectionActivity({
               <strong>{activity.collectionName}</strong>
             )}
           </div>
-          <span {...stylex.props(styles.activityDate)}>{activity.date}</span>
+          <span
+            {...stylex.props(foundationStyles.metadata, styles.activityDate)}
+          >
+            {activity.date}
+          </span>
         </div>
       </header>
       {activity.items.length ? (
@@ -260,7 +277,9 @@ function CollectionActivity({
             ))}
             {hiddenCount ? (
               <ItemListItem>
-                <div {...stylex.props(styles.moreItems)}>
+                <div
+                  {...stylex.props(foundationStyles.metadata, styles.moreItems)}
+                >
                   +{hiddenCount.toLocaleString("en-US")} more
                 </div>
               </ItemListItem>
@@ -284,10 +303,6 @@ const styles = stylex.create({
     gap: space.x2,
     paddingBottom: space.x3,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "17px",
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
   },
   libraryEnd: { display: "flex", alignItems: "center", gap: space.x2 },
   filterContent: { display: "flex", flexDirection: "column", gap: space.x6 },
@@ -307,8 +322,6 @@ const styles = stylex.create({
   mobileSummary: {
     padding: space.x3,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
     cursor: "pointer",
     outline: "none",
@@ -330,16 +343,10 @@ const styles = stylex.create({
   },
   activitySentence: {
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
   },
   activityDate: {
     marginTop: "2px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.35,
   },
   collectionItems: {
     marginTop: space.x3,
@@ -350,7 +357,5 @@ const styles = stylex.create({
     paddingBottom: space.x2,
     paddingLeft: "18px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
   },
 });

--- a/apps/web/src/components/pages/pageLayout.stylex.tsx
+++ b/apps/web/src/components/pages/pageLayout.stylex.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 
 import { PageTabs, SectionHeading, type PageTabItem } from "..";
 import { foundationStyles } from "../../styles/foundations.stylex";
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 
 const NARROW = "@media (max-width: 759px)";
 const MOBILE = "@media (max-width: 559px)";
@@ -71,7 +71,7 @@ export function PageHeader({
   actions,
   actionsPosition = "end",
   description,
-  eyebrow,
+  metadata,
   identity,
   menu,
   parent,
@@ -81,7 +81,7 @@ export function PageHeader({
   /** Inline actions stay beside the title and wrap to the right when space runs out. */
   actionsPosition?: "end" | "start" | "inline";
   description?: ReactNode;
-  eyebrow?: ReactNode;
+  metadata?: ReactNode;
   identity?: ReactNode;
   menu?: ReactNode;
   parent?: ReactNode;
@@ -98,13 +98,26 @@ export function PageHeader({
         )}
       >
         <div {...stylex.props(styles.pageHeaderCopy)}>
-          {eyebrow ? (
-            <div {...stylex.props(styles.eyebrow)}>{eyebrow}</div>
+          {parent ? (
+            <div
+              {...stylex.props(
+                foundationStyles.interactiveSmall,
+                styles.parent,
+              )}
+            >
+              {parent}
+            </div>
           ) : null}
-          {parent ? <div {...stylex.props(styles.parent)}>{parent}</div> : null}
           <h1 {...stylex.props(foundationStyles.pageTitle)}>{title}</h1>
+          {metadata ? (
+            <div {...stylex.props(foundationStyles.metadata, styles.metadata)}>
+              {metadata}
+            </div>
+          ) : null}
           {description ? (
-            <div {...stylex.props(styles.description)}>{description}</div>
+            <div {...stylex.props(foundationStyles.body, styles.description)}>
+              {description}
+            </div>
           ) : null}
         </div>
         {actions || menu ? (
@@ -167,7 +180,11 @@ export function PageSection({
       <div {...stylex.props(styles.sectionHeader)}>
         <SectionHeading>{heading}</SectionHeading>
         {intro ? (
-          <div {...stylex.props(styles.sectionIntro)}>{intro}</div>
+          <div
+            {...stylex.props(foundationStyles.metadata, styles.sectionIntro)}
+          >
+            {intro}
+          </div>
         ) : null}
       </div>
       {children}
@@ -305,30 +322,19 @@ const styles = stylex.create({
   inlineActions: {
     marginLeft: "auto",
   },
-  eyebrow: {
-    marginBottom: space.x2,
+  metadata: {
+    marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   parent: {
     marginBottom: space.x1,
     color: colors.accentDeep,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1.3,
   },
   description: {
     maxWidth: "680px",
     marginTop: space.x3,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.55,
   },
   headerActions: {
     display: "flex",
@@ -359,9 +365,6 @@ const styles = stylex.create({
     maxWidth: "620px",
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
   railSection: {
     display: "flex",

--- a/apps/web/src/components/pages/railListSection.stylex.tsx
+++ b/apps/web/src/components/pages/railListSection.stylex.tsx
@@ -2,7 +2,8 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 import { SectionHeading } from "../sectionHeading.stylex";
 
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 import { TextLink } from "../textLink.stylex";
 import { textLinkStyles } from "../textLinkStyles.stylex";
 
@@ -33,7 +34,11 @@ export function RailListSection({
   return (
     <section {...stylex.props(styles.section)}>
       <SectionHeading>{heading}</SectionHeading>
-      {intro ? <p {...stylex.props(styles.intro)}>{intro}</p> : null}
+      {intro ? (
+        <p {...stylex.props(foundationStyles.metadata, styles.intro)}>
+          {intro}
+        </p>
+      ) : null}
       {action ? (
         "href" in action ? (
           <TextLink href={action.href}>{action.label}</TextLink>
@@ -45,7 +50,7 @@ export function RailListSection({
             type="button"
             {...stylex.props(
               textLinkStyles.link,
-              textLinkStyles.small,
+              foundationStyles.interactiveSmall,
               styles.actionButton,
             )}
           >
@@ -68,9 +73,6 @@ const styles = stylex.create({
   intro: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.4,
   },
   actionButton: {
     appearance: "none",

--- a/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewDetail.stylex.tsx
@@ -15,6 +15,7 @@ import {
   type RatingBand,
 } from "@peated/web/components";
 import { getBottleUrl } from "@peated/web/lib/urls";
+import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, effects, fonts, space } from "../../styles/tokens.stylex";
 import { PageHeader } from "./pageLayout.stylex";
 
@@ -71,7 +72,7 @@ export function TastingReviewDetail({
   return (
     <article {...stylex.props(styles.detail)}>
       <PageHeader
-        eyebrow={`${rating.kind === "review" ? "Review" : "Tasting"} · ${fullDateFormatter.format(new Date(createdAt))}`}
+        metadata={`${rating.kind === "review" ? "Review" : "Tasting"} · ${fullDateFormatter.format(new Date(createdAt))}`}
         title={
           <AppLink
             aria-label={bottleName}
@@ -95,7 +96,12 @@ export function TastingReviewDetail({
               <TextLink href={`/users/${author.username}`}>
                 {author.username}
               </TextLink>
-              <span {...stylex.props(styles.authorMetadata)}>
+              <span
+                {...stylex.props(
+                  foundationStyles.metadata,
+                  styles.authorMetadata,
+                )}
+              >
                 {rating.kind === "review" ? "Member review" : "Tasting note"}
               </span>
             </div>
@@ -106,17 +112,31 @@ export function TastingReviewDetail({
               <strong {...stylex.props(styles.reviewScoreValue)}>
                 {rating.score}
               </strong>
-              <span {...stylex.props(styles.reviewScoreScale)}>/100</span>
+              <span
+                {...stylex.props(
+                  foundationStyles.metadata,
+                  styles.reviewScoreScale,
+                )}
+              >
+                /100
+              </span>
             </div>
           ) : rating.ratingBand && ratingBand ? (
             <div {...stylex.props(styles.tastingRatingSummary)}>
               <TastingRating band={rating.ratingBand} />
-              <span {...stylex.props(styles.tastingRatingCaption)}>
+              <span
+                {...stylex.props(
+                  foundationStyles.metadata,
+                  styles.tastingRatingCaption,
+                )}
+              >
                 {ratingBand.label} · {ratingBand.range}
               </span>
             </div>
           ) : (
-            <span {...stylex.props(styles.unrated)}>Not rated</span>
+            <span {...stylex.props(foundationStyles.metadata, styles.unrated)}>
+              Not rated
+            </span>
           )}
         </header>
 
@@ -126,7 +146,7 @@ export function TastingReviewDetail({
           </div>
         ) : null}
 
-        {notes ? <RecordNotes kind={rating.kind} notes={notes} /> : null}
+        {notes ? <RecordNotes notes={notes} /> : null}
 
         {tags.length ? (
           <div {...stylex.props(styles.tags)}>
@@ -142,7 +162,7 @@ export function TastingReviewDetail({
         ) : null}
 
         {friends.length ? (
-          <p {...stylex.props(styles.friends)}>
+          <p {...stylex.props(foundationStyles.metadata, styles.friends)}>
             {rating.kind === "review" ? "Shared with " : "Poured with "}
             {friends.map((friend, index) => (
               <span key={friend.id}>
@@ -167,16 +187,11 @@ export function TastingReviewDetail({
   );
 }
 
-function RecordNotes({ kind, notes }: { kind: Rating["kind"]; notes: string }) {
+function RecordNotes({ notes }: { notes: string }) {
   const paragraphs = notes.split(/\n\s*\n/).filter(Boolean);
 
   return (
-    <div
-      {...stylex.props(
-        styles.recordNotes,
-        kind === "review" ? styles.reviewNotes : styles.tastingNotes,
-      )}
-    >
+    <div {...stylex.props(foundationStyles.prose, styles.recordNotes)}>
       {paragraphs.map((paragraph, index) => (
         <p
           key={index}
@@ -205,8 +220,6 @@ const styles = stylex.create({
     },
     textDecoration: "none",
     textWrap: "balance",
-    fontSize: "clamp(36px, 4.5vw, 56px)",
-    lineHeight: 0.98,
     outline: "none",
     boxShadow: {
       default: "none",
@@ -240,9 +253,6 @@ const styles = stylex.create({
   },
   authorMetadata: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.35,
   },
   reviewScore: {
     display: "flex",
@@ -260,9 +270,6 @@ const styles = stylex.create({
   },
   reviewScoreScale: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.35,
   },
   tastingRatingSummary: {
     display: "flex",
@@ -273,16 +280,10 @@ const styles = stylex.create({
   },
   tastingRatingCaption: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.35,
   },
   unrated: {
     flexShrink: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.35,
   },
   facts: {
     minWidth: 0,
@@ -295,16 +296,8 @@ const styles = stylex.create({
     maxWidth: "62ch",
     marginTop: space.x6,
     color: colors.ink,
-    fontFamily: fonts.reading,
   },
-  reviewNotes: {
-    fontSize: "17px",
-    lineHeight: 1.72,
-  },
-  tastingNotes: {
-    fontSize: "16px",
-    lineHeight: 1.65,
-  },
+
   noteParagraph: {
     marginTop: 0,
     marginRight: 0,
@@ -325,9 +318,6 @@ const styles = stylex.create({
     margin: 0,
     marginTop: space.x4,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
   footer: {
     display: "flex",

--- a/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
@@ -10,7 +10,8 @@ import {
 } from "@peated/web/components";
 import { getBottleMetadata } from "@peated/web/lib/bottleMetadata";
 import { getBottleUrl } from "@peated/web/lib/urls";
-import { colors, fonts, space } from "../../styles/tokens.stylex";
+import { foundationStyles } from "../../styles/foundations.stylex";
+import { colors, space } from "../../styles/tokens.stylex";
 import { BottleRailSection } from "./bottleRailSection.stylex";
 import { RailListSection } from "./railListSection.stylex";
 
@@ -99,7 +100,9 @@ export function TastingReviewRail({
         moreLabel="See all tastings"
       >
         {!moreFromMember.length ? (
-          <p {...stylex.props(styles.empty)}>No other public tastings yet.</p>
+          <p {...stylex.props(foundationStyles.metadata, styles.empty)}>
+            No other public tastings yet.
+          </p>
         ) : null}
       </BottleRailSection>
 
@@ -134,7 +137,9 @@ export function TastingReviewRail({
             ))}
           </RailList>
         ) : (
-          <p {...stylex.props(styles.empty)}>No other reviews yet.</p>
+          <p {...stylex.props(foundationStyles.metadata, styles.empty)}>
+            No other reviews yet.
+          </p>
         )}
       </RailListSection>
     </>
@@ -155,8 +160,5 @@ const styles = stylex.create({
     margin: 0,
     paddingTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
   },
 });

--- a/apps/web/src/components/passport.stylex.tsx
+++ b/apps/web/src/components/passport.stylex.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, fonts } from "../styles/tokens.stylex";
 
 export type PassportStamp = {
@@ -32,7 +33,7 @@ export function Passport(props: PassportProps) {
       >
         <PassportCount count={props.count} detail={`${props.unit} stamped`} />
         {props.nextStampIn ? (
-          <p {...stylex.props(styles.note)}>
+          <p {...stylex.props(foundationStyles.metadata, styles.note)}>
             {formatSmallCount(props.nextStampIn)} more for the next stamp
           </p>
         ) : null}
@@ -80,11 +81,13 @@ export function Passport(props: PassportProps) {
           >
             <span {...stylex.props(styles.coverageFill(`${percentage}%`))} />
           </span>
-          <span {...stylex.props(styles.percentage)}>{percentage}%</span>
+          <span {...stylex.props(foundationStyles.metadata, styles.percentage)}>
+            {percentage}%
+          </span>
         </div>
       )}
       {missing.length > 0 ? (
-        <p {...stylex.props(styles.note)}>
+        <p {...stylex.props(foundationStyles.metadata, styles.note)}>
           not yet stamped: {missing.join(", ")}
         </p>
       ) : null}
@@ -98,7 +101,10 @@ function PassportCount({ count, detail }: { count: number; detail: string }) {
       <strong {...stylex.props(styles.count)}>
         {count.toLocaleString("en-US")}
       </strong>
-      <span title={detail} {...stylex.props(styles.countDetail)}>
+      <span
+        title={detail}
+        {...stylex.props(foundationStyles.metadata, styles.countDetail)}
+      >
         {detail}
       </span>
     </div>
@@ -138,9 +144,6 @@ const styles = stylex.create({
     minWidth: 0,
     overflow: "hidden",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
@@ -181,17 +184,11 @@ const styles = stylex.create({
   percentage: {
     flexShrink: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "13px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.4,
   },
   note: {
     margin: 0,
     marginTop: "12px",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
 });

--- a/apps/web/src/components/recordTypeInput.stylex.tsx
+++ b/apps/web/src/components/recordTypeInput.stylex.tsx
@@ -3,11 +3,11 @@
 import * as stylex from "@stylexjs/stylex";
 import { ArrowRight } from "lucide-react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../styles/tokens.stylex";
 
@@ -59,10 +59,15 @@ export function RecordTypeInput({
             )}
           >
             <span {...stylex.props(styles.choiceCopy)}>
-              <strong {...stylex.props(styles.choiceLabel)}>
+              <strong {...stylex.props(foundationStyles.compactRowTitle)}>
                 {choice.label}
               </strong>
-              <span {...stylex.props(styles.choiceDescription)}>
+              <span
+                {...stylex.props(
+                  foundationStyles.metadata,
+                  styles.choiceDescription,
+                )}
+              >
                 {choice.description}
               </span>
             </span>
@@ -126,18 +131,9 @@ const styles = stylex.create({
     flexDirection: "column",
     gap: space.x1,
   },
-  choiceLabel: {
-    fontFamily: fonts.display,
-    fontSize: "16px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
-  },
+
   choiceDescription: {
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
   },
   disabledChoice: { cursor: "not-allowed", opacity: 0.45 },
 });

--- a/apps/web/src/components/rowMenu.stylex.tsx
+++ b/apps/web/src/components/rowMenu.stylex.tsx
@@ -4,11 +4,11 @@ import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import * as stylex from "@stylexjs/stylex";
 import { Fragment } from "react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   zIndices,
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
@@ -81,6 +81,7 @@ export function RowMenu({
             <div
               title={label}
               {...stylex.props(
+                foundationStyles.fieldLabel,
                 styles.header,
                 variant === "page" && styles.pageHeader,
               )}
@@ -105,7 +106,14 @@ export function RowMenu({
                   <div {...stylex.props(styles.separator)} />
                 ) : null}
                 {group.label ? (
-                  <div {...stylex.props(styles.groupLabel)}>{group.label}</div>
+                  <div
+                    {...stylex.props(
+                      foundationStyles.fieldLabel,
+                      styles.groupLabel,
+                    )}
+                  >
+                    {group.label}
+                  </div>
                 ) : null}
                 {group.items.map((item, itemIndex) => (
                   <MenuItem
@@ -118,6 +126,7 @@ export function RowMenu({
                         <AppLink
                           href={item.href}
                           {...stylex.props(
+                            foundationStyles.interactive,
                             styles.item,
                             focus && styles.focusedItem,
                             disabled && styles.disabledItem,
@@ -130,6 +139,7 @@ export function RowMenu({
                           onClick={item.onSelect}
                           type="button"
                           {...stylex.props(
+                            foundationStyles.interactive,
                             styles.item,
                             focus && styles.focusedItem,
                             disabled && styles.disabledItem,
@@ -213,12 +223,7 @@ const styles = stylex.create({
     paddingRight: "48px",
     paddingLeft: "14px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
     textOverflow: "ellipsis",
-    textTransform: "uppercase",
     whiteSpace: "nowrap",
   },
   pageHeader: {
@@ -235,11 +240,6 @@ const styles = stylex.create({
     paddingBottom: "4px",
     paddingLeft: "14px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    letterSpacing: "0.08em",
-    lineHeight: 1.3,
-    textTransform: "uppercase",
   },
   separator: {
     height: "1px",
@@ -259,10 +259,7 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: "transparent",
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 500,
-    lineHeight: 1.25,
     textAlign: "left",
     textDecoration: "none",
     cursor: "pointer",

--- a/apps/web/src/components/scopedSearch.stylex.tsx
+++ b/apps/web/src/components/scopedSearch.stylex.tsx
@@ -5,11 +5,11 @@ import { Check, ChevronDown, X } from "lucide-react";
 import type { InputHTMLAttributes, Ref } from "react";
 import { useEffect, useId, useRef, useState } from "react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
   zIndices,
 } from "../styles/tokens.stylex";
@@ -117,6 +117,7 @@ export function ScopedSearch({
               }}
               type="button"
               {...stylex.props(
+                foundationStyles.interactiveSmall,
                 styles.scope,
                 scopeMenuOpen && styles.openScope,
                 hasAppliedScope && styles.appliedScope,
@@ -157,11 +158,19 @@ export function ScopedSearch({
                         }}
                         role="option"
                         type="button"
-                        {...stylex.props(styles.scopeMenuOption)}
+                        {...stylex.props(
+                          foundationStyles.interactiveSmall,
+                          styles.scopeMenuOption,
+                        )}
                       >
                         <span>{option.label}</span>
                         {option.count !== undefined ? (
-                          <span {...stylex.props(styles.scopeMenuCount)}>
+                          <span
+                            {...stylex.props(
+                              foundationStyles.metadata,
+                              styles.scopeMenuCount,
+                            )}
+                          >
                             {option.count.toLocaleString("en-US")}
                           </span>
                         ) : null}
@@ -191,7 +200,7 @@ export function ScopedSearch({
             inputProps.onPointerDown?.(event);
             setScopeMenuOpen(false);
           }}
-          {...stylex.props(styles.input)}
+          {...stylex.props(foundationStyles.input, styles.input)}
         />
         {hasQuery && onClear ? (
           <button
@@ -305,10 +314,7 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: colors.accentTint,
     color: colors.accentDeep,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontWeight: 500,
-    lineHeight: 1,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
     cursor: "pointer",
@@ -374,10 +380,7 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: "transparent",
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1.2,
     textAlign: "left",
     cursor: "pointer",
     boxShadow: {
@@ -388,10 +391,7 @@ const styles = stylex.create({
   scopeMenuCount: {
     marginLeft: "auto",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
-    fontWeight: 400,
   },
   scopeMenuCheck: {
     flexShrink: 0,
@@ -412,9 +412,6 @@ const styles = stylex.create({
       ":focus-visible": "none",
     },
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: { default: "13px", [COMPACT]: "16px" },
-    lineHeight: 1.4,
     "::placeholder": {
       color: colors.inkMuted,
       opacity: 1,

--- a/apps/web/src/components/scoring.stylex.tsx
+++ b/apps/web/src/components/scoring.stylex.tsx
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, controlMetrics, fonts, space } from "../styles/tokens.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
@@ -80,12 +81,18 @@ export function ReviewScore({
       data-state={hasScore ? "populated" : "withheld"}
       {...stylex.props(styles.score)}
     >
-      <div {...stylex.props(styles.reviewScoreLabel)}>Score</div>
+      <div
+        {...stylex.props(foundationStyles.fieldLabel, styles.reviewScoreLabel)}
+      >
+        Score
+      </div>
       {hasScore ? (
         <>
           <div {...stylex.props(styles.scoreHeading)}>
             <strong {...stylex.props(styles.scoreValue)}>{median}</strong>
-            <span {...stylex.props(styles.scoreMetadata)}>
+            <span
+              {...stylex.props(foundationStyles.metadata, styles.scoreMetadata)}
+            >
               / 100 · median of {formatCount(count)} {countNoun(count)}
             </span>
           </div>
@@ -96,13 +103,15 @@ export function ReviewScore({
             <span {...stylex.props(styles.scoreTick(median))} />
           </div>
           {hasRange ? (
-            <div {...stylex.props(styles.scoreCaption)}>
+            <div
+              {...stylex.props(foundationStyles.metadata, styles.scoreCaption)}
+            >
               low {low} · median {median} · high {high}
             </div>
           ) : null}
         </>
       ) : (
-        <div {...stylex.props(styles.scoreEmpty)}>
+        <div {...stylex.props(foundationStyles.body, styles.scoreEmpty)}>
           <span>
             {count === 0
               ? "No review scores yet."
@@ -158,7 +167,12 @@ export function TastingRatingDistribution({
           : null}
       </div>
       {showCounts && total > 0 ? (
-        <div {...stylex.props(styles.tastingRatingLabels)}>
+        <div
+          {...stylex.props(
+            foundationStyles.metadata,
+            styles.tastingRatingLabels,
+          )}
+        >
           {bins.map((bin, index) => (
             <span
               key={bin.key}
@@ -357,10 +371,6 @@ const styles = stylex.create({
   },
   reviewScoreLabel: {
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    letterSpacing: 0,
-    lineHeight: 1.4,
   },
   scoreHeading: {
     display: "flex",
@@ -406,10 +416,7 @@ const styles = stylex.create({
   scoreCaption: {
     marginTop: "8px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "12px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.45,
   },
   scoreEmpty: {
     display: "flex",
@@ -418,9 +425,6 @@ const styles = stylex.create({
     rowGap: space.x1,
     marginTop: space.x2,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.5,
     flexWrap: "wrap",
   },
   tastingRatingDistribution: {
@@ -469,10 +473,7 @@ const styles = stylex.create({
     gap: "2px",
     marginTop: "5px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.35,
   },
   tastingRatingLabel: (share: number) => ({
     minWidth: 0,
@@ -601,12 +602,8 @@ const styles = stylex.create({
   },
   scoreMetadata: {
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
   },
 });
-
 const bandFillStyles = {
   1: styles.band1Fill,
   2: styles.band2Fill,

--- a/apps/web/src/components/searchBox.stylex.tsx
+++ b/apps/web/src/components/searchBox.stylex.tsx
@@ -11,11 +11,11 @@ import {
   type ReactNode,
 } from "react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
   zIndices,
 } from "../styles/tokens.stylex";
@@ -332,7 +332,13 @@ export function SearchBox({
                 </div>
               ) : null}
               {status === "ready" && resultCount !== undefined ? (
-                <p aria-live="polite" {...stylex.props(styles.databaseCount)}>
+                <p
+                  aria-live="polite"
+                  {...stylex.props(
+                    foundationStyles.rowTitle,
+                    styles.databaseCount,
+                  )}
+                >
                   {resultCount.toLocaleString("en-US")}{" "}
                   {resultCount === 1 ? "result" : "results"}
                 </p>
@@ -464,11 +470,6 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "17px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
   },
   databaseFacets: {
     minWidth: 0,

--- a/apps/web/src/components/searchPicker.stylex.tsx
+++ b/apps/web/src/components/searchPicker.stylex.tsx
@@ -196,13 +196,22 @@ function PickerControl({
           )}
         >
           <span {...stylex.props(styles.selectedCopy)}>
-            <span title={value[0].label} {...stylex.props(styles.selectedName)}>
+            <span
+              title={value[0].label}
+              {...stylex.props(
+                foundationStyles.compactRowTitle,
+                styles.selectedName,
+              )}
+            >
               {value[0].label}
             </span>
             {(value[0].selectedDetail ?? value[0].detail) ? (
               <span
                 title={value[0].selectedDetail ?? value[0].detail}
-                {...stylex.props(styles.selectedDetail)}
+                {...stylex.props(
+                  foundationStyles.metadata,
+                  styles.selectedDetail,
+                )}
               >
                 {value[0].selectedDetail ?? value[0].detail}
               </span>
@@ -266,7 +275,11 @@ function PickerControl({
             type="search"
             value={query}
             disabled={disabled}
-            {...stylex.props(styles.input, Boolean(error) && styles.invalid)}
+            {...stylex.props(
+              foundationStyles.input,
+              styles.input,
+              Boolean(error) && styles.invalid,
+            )}
           />
           {isOpen && !disabled ? (
             <FloatingPanel {...stylex.props(styles.overlay)}>
@@ -277,7 +290,10 @@ function PickerControl({
                 {...stylex.props(styles.results)}
               >
                 {loading ? (
-                  <p role="status" {...stylex.props(styles.empty)}>
+                  <p
+                    role="status"
+                    {...stylex.props(foundationStyles.body, styles.empty)}
+                  >
                     Searching…
                   </p>
                 ) : availableOptions.length ? (
@@ -295,18 +311,26 @@ function PickerControl({
                         index === activeIndex && styles.activeResult,
                       )}
                     >
-                      <span {...stylex.props(styles.resultLabel)}>
+                      <span {...stylex.props(foundationStyles.compactRowTitle)}>
                         {option.label}
                       </span>
                       {option.detail ? (
-                        <span {...stylex.props(styles.detail)}>
+                        <span
+                          {...stylex.props(
+                            foundationStyles.metadata,
+                            styles.detail,
+                          )}
+                        >
                           {option.detail}
                         </span>
                       ) : null}
                     </button>
                   ))
                 ) : (
-                  <p role="status" {...stylex.props(styles.empty)}>
+                  <p
+                    role="status"
+                    {...stylex.props(foundationStyles.body, styles.empty)}
+                  >
                     {emptyText}
                   </p>
                 )}
@@ -321,13 +345,21 @@ function PickerControl({
                     setIsOpen(false);
                   }}
                   type="button"
-                  {...stylex.props(styles.createAction)}
+                  {...stylex.props(
+                    foundationStyles.interactiveSmall,
+                    styles.createAction,
+                  )}
                 >
                   <span>
                     {getCreateLabel?.(trimmedQuery) ?? `Add “${trimmedQuery}”`}
                   </span>
                   {createHint ? (
-                    <span {...stylex.props(styles.createHint)}>
+                    <span
+                      {...stylex.props(
+                        foundationStyles.metadata,
+                        styles.createHint,
+                      )}
+                    >
                       {createHint}
                     </span>
                   ) : null}
@@ -390,10 +422,6 @@ const styles = stylex.create({
   selectedName: {
     overflow: "hidden",
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    fontWeight: 600,
-    lineHeight: 1.25,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
@@ -401,9 +429,6 @@ const styles = stylex.create({
     overflow: "hidden",
     marginTop: "2px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.2,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
@@ -442,12 +467,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: colors.inset,
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: {
-      default: "14px",
-      "@media (max-width: 639px)": "16px",
-    },
-    lineHeight: 1.4,
     boxShadow: {
       default: "none",
       ":focus-visible": effects.focusRing,
@@ -487,25 +506,14 @@ const styles = stylex.create({
     backgroundColor: colors.inset,
     boxShadow: effects.focusRing,
   },
-  resultLabel: {
-    fontFamily: fonts.display,
-    fontSize: "14px",
-    fontWeight: 700,
-    lineHeight: 1.2,
-  },
+
   detail: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.3,
   },
   empty: {
     margin: 0,
     padding: space.x4,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.4,
   },
   createAction: {
     boxSizing: "border-box",
@@ -522,8 +530,6 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: { default: colors.surface, ":hover": colors.inset },
     color: colors.accentDeep,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 700,
     textAlign: "left",
     cursor: "pointer",
@@ -535,12 +541,7 @@ const styles = stylex.create({
   createHint: {
     flexShrink: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
     fontWeight: 500,
-    letterSpacing: "0.06em",
-    lineHeight: 1.2,
-    textTransform: "uppercase",
   },
   help: { margin: 0, color: colors.inkMuted },
 });

--- a/apps/web/src/components/searchResults.stylex.tsx
+++ b/apps/web/src/components/searchResults.stylex.tsx
@@ -135,12 +135,19 @@ export function SearchResults({
           {statusText ?? "Searching…"}
         </p>
       ) : emptyText && variant === "default" ? (
-        <p {...stylex.props(styles.stateText)}>{emptyText}</p>
+        <p {...stylex.props(foundationStyles.body, styles.stateText)}>
+          {emptyText}
+        </p>
       ) : null}
       {emptyText && variant === "database" ? (
         <div {...stylex.props(styles.databaseEmptyState)}>
           <SectionHeading>Nothing matches “{query}”</SectionHeading>
-          <p {...stylex.props(styles.databaseEmptyDescription)}>
+          <p
+            {...stylex.props(
+              foundationStyles.body,
+              styles.databaseEmptyDescription,
+            )}
+          >
             Check the spelling, or record the bottle if the database is missing
             it.
           </p>
@@ -173,7 +180,10 @@ export function SearchResults({
           : null}
       </div>
       {status === "error" ? (
-        <div role="alert" {...stylex.props(styles.error)}>
+        <div
+          role="alert"
+          {...stylex.props(foundationStyles.metadata, styles.error)}
+        >
           <span>
             {statusText ??
               "Search is temporarily unavailable. Existing navigation still works."}
@@ -192,10 +202,20 @@ export function SearchResults({
             href={visibleContribution.href}
             {...stylex.props(styles.contribution)}
           >
-            <span {...stylex.props(styles.contributionDescription)}>
+            <span
+              {...stylex.props(
+                foundationStyles.metadata,
+                styles.contributionDescription,
+              )}
+            >
               {visibleContribution.description}
             </span>
-            <strong {...stylex.props(styles.contributionAction)}>
+            <strong
+              {...stylex.props(
+                foundationStyles.interactiveSmall,
+                styles.contributionAction,
+              )}
+            >
               {visibleContribution.label} →
             </strong>
           </AppLink>
@@ -269,7 +289,13 @@ function SearchResultsGroup({
           </span>
         ) : null}
         {variant === "database" && group.moreHref ? (
-          <AppLink href={group.moreHref} {...stylex.props(styles.databaseMore)}>
+          <AppLink
+            href={group.moreHref}
+            {...stylex.props(
+              foundationStyles.interactiveSmall,
+              styles.databaseMore,
+            )}
+          >
             See all {group.total?.toLocaleString("en-US")}
           </AppLink>
         ) : null}
@@ -373,7 +399,10 @@ function SearchResultsGroup({
         ))}
       </ul>
       {group.moreHref && variant === "default" ? (
-        <AppLink href={group.moreHref} {...stylex.props(styles.more)}>
+        <AppLink
+          href={group.moreHref}
+          {...stylex.props(foundationStyles.metadata, styles.more)}
+        >
           <span>
             {remaining === undefined || remaining === 0
               ? "More results"
@@ -447,9 +476,6 @@ const styles = stylex.create({
     paddingBottom: space.x4,
     paddingLeft: "14px",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.55,
   },
   databaseEmptyState: {
     paddingTop: space.x6,
@@ -465,9 +491,6 @@ const styles = stylex.create({
     marginBottom: space.x4,
     marginLeft: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1.5,
   },
   groupHeading: {
     display: "flex",
@@ -501,10 +524,7 @@ const styles = stylex.create({
     marginLeft: "auto",
     outline: "none",
     color: colors.accentDeep,
-    fontFamily: fonts.reading,
-    fontSize: "12px",
     fontWeight: 700,
-    lineHeight: 1.3,
     textDecoration: "none",
     boxShadow: {
       default: "none",
@@ -632,9 +652,6 @@ const styles = stylex.create({
     borderTopColor: colors.hairline,
     outline: "none",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.35,
     textDecoration: "none",
     boxShadow: {
       default: "none",
@@ -672,18 +689,11 @@ const styles = stylex.create({
   contributionDescription: {
     minWidth: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
   },
   contributionAction: {
     flexShrink: 0,
     color: colors.accentDeep,
-    fontFamily: fonts.display,
-    fontSize: "13px",
     fontWeight: 700,
-    letterSpacing: "-0.01em",
-    lineHeight: 1.2,
   },
   error: {
     display: "flex",
@@ -699,9 +709,6 @@ const styles = stylex.create({
     borderTopStyle: "solid",
     borderTopColor: colors.hairline,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
     [COMPACT]: {
       alignItems: "flex-start",
       flexDirection: "column",

--- a/apps/web/src/components/sectionHeading.stories.tsx
+++ b/apps/web/src/components/sectionHeading.stories.tsx
@@ -1,17 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
+import { ItemList, ItemRow } from "./itemList.stylex";
 import { SectionHeading } from "./sectionHeading.stylex";
 import { StoryStack } from "./storyFixtures.stylex";
 
 const meta = {
   title: "Components/Layout/Section Heading",
   component: SectionHeading,
-  args: { children: "Similar bottles" },
+  args: { children: "Distilleries" },
   parameters: {
     docs: {
       description: {
         component:
-          "Use SectionHeading for every section heading, including sidebars. Heading levels change document structure, not appearance. Keep spacing in the containing layout; do not add local typography variants.",
+          "Use SectionHeading for every section heading, including sidebars. The shared 24px heading sits above 18px row titles. Heading levels change document structure, not appearance. Keep spacing in the containing layout; do not add local typography variants.",
       },
     },
   },
@@ -24,6 +25,9 @@ export const Overview: Story = {
   render: (args) => (
     <StoryStack>
       <SectionHeading {...args} />
+      <ItemList ariaLabel="Distilleries">
+        <ItemRow title="Ardbeg" metadata="Islay · Scotland" href="#ardbeg" />
+      </ItemList>
       <SectionHeading>History</SectionHeading>
       <SectionHeading level={3}>Details</SectionHeading>
     </StoryStack>

--- a/apps/web/src/components/sectionHeading.stylex.tsx
+++ b/apps/web/src/components/sectionHeading.stylex.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { foundationStyles } from "../styles/foundations.stylex";
 import { colors } from "../styles/tokens.stylex";
 
-/** The single visual treatment for section headings; level changes semantics only. */
+/** Section headings sit above 18px row titles at 24px; level changes semantics only. */
 export function SectionHeading({
   children,
   id,

--- a/apps/web/src/components/siteFooter.stylex.tsx
+++ b/apps/web/src/components/siteFooter.stylex.tsx
@@ -2,6 +2,7 @@ import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 import { SectionHeading } from "./sectionHeading.stylex";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, effects, fonts, space } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 
@@ -37,7 +38,9 @@ export function SiteFooter({
       <div {...stylex.props(styles.footerMain)}>
         <div {...stylex.props(styles.footerIdentity)}>
           <div {...stylex.props(styles.footerBrand)}>{brand}</div>
-          <p {...stylex.props(styles.statement)}>{statement}</p>
+          <p {...stylex.props(foundationStyles.metadata, styles.statement)}>
+            {statement}
+          </p>
         </div>
         <nav aria-label="Footer">
           <ul {...stylex.props(styles.footerLinks)}>
@@ -60,9 +63,17 @@ export function SiteFooter({
         </div>
       ) : null}
       <div {...stylex.props(styles.footerMeta)}>
-        {coverage ? <p {...stylex.props(styles.coverage)}>{coverage}</p> : null}
-        <p {...stylex.props(styles.provenance)}>{provenance}</p>
-        <p {...stylex.props(styles.responsibility)}>{responsibility}</p>
+        {coverage ? (
+          <p {...stylex.props(foundationStyles.metadata, styles.coverage)}>
+            {coverage}
+          </p>
+        ) : null}
+        <p {...stylex.props(foundationStyles.metadata, styles.provenance)}>
+          {provenance}
+        </p>
+        <p {...stylex.props(foundationStyles.metadata, styles.responsibility)}>
+          {responsibility}
+        </p>
       </div>
     </footer>
   );
@@ -70,7 +81,10 @@ export function SiteFooter({
 
 function FooterAnchor({ link }: { link: FooterLink }) {
   return (
-    <AppLink href={link.href} {...stylex.props(styles.footerLink)}>
+    <AppLink
+      href={link.href}
+      {...stylex.props(foundationStyles.interactiveSmall, styles.footerLink)}
+    >
       {link.label}
     </AppLink>
   );
@@ -108,9 +122,6 @@ const styles = stylex.create({
     margin: 0,
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.55,
   },
   footerLinks: {
     display: "flex",
@@ -131,10 +142,7 @@ const styles = stylex.create({
       default: colors.inkMuted,
       ":hover": colors.ink,
     },
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1.3,
     textDecoration: "none",
     outline: "none",
     boxShadow: {
@@ -165,23 +173,14 @@ const styles = stylex.create({
     flex: 1,
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.4,
   },
   provenance: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.4,
   },
   responsibility: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
-    lineHeight: 1.4,
   },
 });

--- a/apps/web/src/components/slideout.stylex.tsx
+++ b/apps/web/src/components/slideout.stylex.tsx
@@ -9,13 +9,8 @@ import {
 import * as stylex from "@stylexjs/stylex";
 import { X } from "lucide-react";
 import type { ReactNode } from "react";
-import {
-  colors,
-  effects,
-  fonts,
-  space,
-  zIndices,
-} from "../styles/tokens.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, effects, space, zIndices } from "../styles/tokens.stylex";
 import { IconButton } from "./button.stylex";
 
 export type SlideoutProps = {
@@ -51,7 +46,11 @@ export function Slideout({
               {navigation ? (
                 <div {...stylex.props(styles.navigation)}>{navigation}</div>
               ) : null}
-              <DialogTitle {...stylex.props(styles.title)}>{title}</DialogTitle>
+              <DialogTitle
+                {...stylex.props(foundationStyles.sectionHeading, styles.title)}
+              >
+                {title}
+              </DialogTitle>
             </div>
             <IconButton
               data-autofocus
@@ -62,7 +61,9 @@ export function Slideout({
               variant="text"
             />
           </header>
-          <div {...stylex.props(styles.body)}>{children}</div>
+          <div {...stylex.props(foundationStyles.body, styles.body)}>
+            {children}
+          </div>
           {footer ? (
             <footer {...stylex.props(styles.footer)}>{footer}</footer>
           ) : null}
@@ -124,11 +125,6 @@ const styles = stylex.create({
   },
   title: {
     margin: 0,
-    fontFamily: fonts.display,
-    fontSize: "32px",
-    fontWeight: 700,
-    lineHeight: 1.1,
-    letterSpacing: "-0.03em",
     overflowWrap: "anywhere",
   },
   body: {
@@ -138,9 +134,6 @@ const styles = stylex.create({
     padding: space.x6,
     flex: 1,
     paddingBottom: `max(${space.x6}, env(safe-area-inset-bottom))`,
-    fontFamily: fonts.reading,
-    fontSize: { default: "14px", [MOBILE]: "16px" },
-    lineHeight: 1.55,
   },
   footer: {
     flexShrink: 0,

--- a/apps/web/src/components/summaryStrip.stylex.tsx
+++ b/apps/web/src/components/summaryStrip.stylex.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, fonts, space } from "../styles/tokens.stylex";
 
 export type SummaryStripCell = {
@@ -34,13 +35,19 @@ export function SummaryStrip({ cells }: { cells: SummaryStripCells }) {
           key={`${cell.label}-${index}`}
           {...stylex.props(styles.cell)}
         >
-          <dt title={cell.label} {...stylex.props(styles.label)}>
+          <dt
+            title={cell.label}
+            {...stylex.props(foundationStyles.metadata, styles.label)}
+          >
             {cell.label}
           </dt>
           <dd {...stylex.props(styles.valueRow)}>
             <strong {...stylex.props(styles.value)}>{cell.value}</strong>
             {cell.detail ? (
-              <span title={cell.detail} {...stylex.props(styles.detail)}>
+              <span
+                title={cell.detail}
+                {...stylex.props(foundationStyles.metadata, styles.detail)}
+              >
                 {cell.detail}
               </span>
             ) : null}
@@ -71,10 +78,6 @@ const styles = stylex.create({
     marginTop: "6px",
     overflow: "hidden",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    letterSpacing: 0,
-    lineHeight: 1.4,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
@@ -100,9 +103,6 @@ const styles = stylex.create({
     minWidth: 0,
     overflow: "hidden",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },

--- a/apps/web/src/components/tastingEntry.stylex.tsx
+++ b/apps/web/src/components/tastingEntry.stylex.tsx
@@ -6,7 +6,6 @@ import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
@@ -84,12 +83,21 @@ export function TastingEntry({
                       {authorHref ? (
                         <AppLink
                           href={authorHref}
-                          {...stylex.props(styles.author, styles.authorLink)}
+                          {...stylex.props(
+                            foundationStyles.compactRowTitle,
+                            styles.author,
+                            styles.authorLink,
+                          )}
                         >
                           {author}
                         </AppLink>
                       ) : (
-                        <strong {...stylex.props(styles.author)}>
+                        <strong
+                          {...stylex.props(
+                            foundationStyles.compactRowTitle,
+                            styles.author,
+                          )}
+                        >
                           {author}
                         </strong>
                       )}
@@ -125,13 +133,20 @@ export function TastingEntry({
                   {member.ratingBand ? (
                     <TastingRating band={member.ratingBand} />
                   ) : (
-                    <span {...stylex.props(styles.unknown)}>–</span>
+                    <span
+                      {...stylex.props(
+                        foundationStyles.metadata,
+                        styles.unknown,
+                      )}
+                    >
+                      –
+                    </span>
                   )}
                 </div>
                 {menu ? <div {...stylex.props(styles.menu)}>{menu}</div> : null}
               </div>
               {member.notes?.trim() ? (
-                <p {...stylex.props(styles.notes)}>
+                <p {...stylex.props(foundationStyles.body, styles.notes)}>
                   <TastingNotes member={member} />
                 </p>
               ) : null}
@@ -169,7 +184,10 @@ export function TastingEntry({
                   {member.comments !== undefined ? (
                     <AppLink
                       href={`/tastings/${member.tastingId}#comments`}
-                      {...stylex.props(styles.commentsLink)}
+                      {...stylex.props(
+                        foundationStyles.interactiveSmall,
+                        styles.commentsLink,
+                      )}
                     >
                       {formatCommentCount(member.comments)}
                     </AppLink>
@@ -180,7 +198,11 @@ export function TastingEntry({
           </li>
         ))}
       </ul>
-      {comment ? <p {...stylex.props(styles.comment)}>{comment}</p> : null}
+      {comment ? (
+        <p {...stylex.props(foundationStyles.metadata, styles.comment)}>
+          {comment}
+        </p>
+      ) : null}
     </article>
   );
 }
@@ -323,11 +345,6 @@ const styles = stylex.create({
   author: {
     overflow: "hidden",
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "15px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.25,
     textDecoration: "none",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
@@ -358,9 +375,6 @@ const styles = stylex.create({
     margin: 0,
     marginTop: "14px",
     color: colors.ink,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
-    lineHeight: 1.6,
     whiteSpace: "pre-wrap",
   },
   notesLink: {
@@ -399,8 +413,6 @@ const styles = stylex.create({
   },
   unknown: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "12px",
   },
   footer: {
     display: "flex",
@@ -420,10 +432,7 @@ const styles = stylex.create({
   commentsLink: {
     flexShrink: 0,
     color: colors.accentDeep,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
     fontWeight: 600,
-    lineHeight: 1.4,
     textDecoration: {
       default: "none",
       ":hover": "underline",
@@ -438,9 +447,6 @@ const styles = stylex.create({
     margin: 0,
     marginBottom: space.x4,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.5,
   },
   media: {
     boxSizing: "border-box",

--- a/apps/web/src/components/tastingInputs.stylex.tsx
+++ b/apps/web/src/components/tastingInputs.stylex.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { useRef } from "react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
@@ -63,11 +64,18 @@ export function ReviewScoreInput({
   return (
     <div {...stylex.props(styles.reviewScoreRoot, disabled && styles.disabled)}>
       <div {...stylex.props(styles.ratingHeading)}>
-        <label htmlFor={id} {...stylex.props(styles.ratingLabel)}>
+        <label
+          htmlFor={id}
+          {...stylex.props(foundationStyles.fieldLabel, styles.ratingLabel)}
+        >
           {label}
         </label>
         {required ? (
-          <span {...stylex.props(styles.requiredLabel)}>Required</span>
+          <span
+            {...stylex.props(foundationStyles.microLabel, styles.requiredLabel)}
+          >
+            Required
+          </span>
         ) : null}
       </div>
       <div {...stylex.props(styles.reviewScoreHeading)}>
@@ -118,10 +126,20 @@ export function ReviewScoreInput({
           />
         </div>
         <div aria-live="polite" {...stylex.props(styles.reviewScoreBand)}>
-          <strong {...stylex.props(styles.reviewScoreBandLabel)}>
+          <strong
+            {...stylex.props(
+              foundationStyles.rowTitle,
+              styles.reviewScoreBandLabel,
+            )}
+          >
             {selectedBand?.label ?? "Choose a score"}
           </strong>
-          <span {...stylex.props(styles.reviewScoreBandRange)}>
+          <span
+            {...stylex.props(
+              foundationStyles.metadata,
+              styles.reviewScoreBandRange,
+            )}
+          >
             {selectedBand?.range ?? "0–100"}
           </span>
         </div>
@@ -147,7 +165,13 @@ export function ReviewScoreInput({
             />
           ) : null}
         </div>
-        <div aria-hidden="true" {...stylex.props(styles.reviewScoreAnchors)}>
+        <div
+          aria-hidden="true"
+          {...stylex.props(
+            foundationStyles.metadata,
+            styles.reviewScoreAnchors,
+          )}
+        >
           <span>60</span>
           <span {...stylex.props(styles.reviewScoreAnchor80)}>80 good</span>
           <span {...stylex.props(styles.reviewScoreAnchor90)}>
@@ -156,7 +180,7 @@ export function ReviewScoreInput({
           <span>100</span>
         </div>
       </div>
-      <p {...stylex.props(styles.reviewScoreHint)}>
+      <p {...stylex.props(foundationStyles.metadata, styles.reviewScoreHint)}>
         Whole numbers. Your score counts toward this bottle's review score and
         appears with your review.
       </p>
@@ -215,6 +239,7 @@ export function RatingBandInput({
               />
               <span
                 {...stylex.props(
+                  foundationStyles.compactRowTitle,
                   styles.bandInputName,
                   checked && bandInputTextSelectedStyles[band.key],
                 )}
@@ -232,6 +257,7 @@ export function RatingBandInput({
               </span>
               <span
                 {...stylex.props(
+                  foundationStyles.metadata,
                   styles.bandInputRange,
                   checked && bandInputTextSelectedStyles[band.key],
                 )}
@@ -275,6 +301,7 @@ export function ServingStyleInput({
           <label
             key={option}
             {...stylex.props(
+              foundationStyles.interactive,
               styles.servingStyleCell,
               checked && styles.servingStyleCellSelected,
             )}
@@ -324,7 +351,7 @@ export function ColorInput({
       <div {...stylex.props(styles.colorHeading)}>
         <strong
           title={selected?.[1] ?? "Unsure"}
-          {...stylex.props(styles.colorName)}
+          {...stylex.props(foundationStyles.rowTitle, styles.colorName)}
         >
           {selected?.[1] ?? "Unsure"}
         </strong>
@@ -367,13 +394,19 @@ export function ColorInput({
           {...stylex.props(styles.colorRange)}
         />
       </div>
-      <div aria-hidden="true" {...stylex.props(styles.colorAnchors)}>
+      <div
+        aria-hidden="true"
+        {...stylex.props(foundationStyles.metadata, styles.colorAnchors)}
+      >
         <span>clear</span>
         <span>gold</span>
         <span>amber</span>
         <span>dark</span>
       </div>
-      <p aria-live="polite" {...stylex.props(styles.colorHint)}>
+      <p
+        aria-live="polite"
+        {...stylex.props(foundationStyles.metadata, styles.colorHint)}
+      >
         {selected
           ? `${selected[1]} · ${selected[0]} of 20`
           : "Bar light can lie. Unsure is a real answer."}
@@ -478,19 +511,10 @@ const styles = stylex.create({
   },
   ratingLabel: {
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "14px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.4,
   },
   requiredLabel: {
     color: colors.accentDeep,
-    fontFamily: fonts.reading,
-    fontSize: "12px",
     fontStyle: "italic",
-    letterSpacing: 0,
-    lineHeight: 1.4,
   },
   reviewScoreHeading: {
     display: "flex",
@@ -526,7 +550,7 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: "transparent",
     color: colors.ink,
-    fontFamily: fonts.data,
+    fontFamily: fonts.display,
     fontSize: "42px",
     fontVariantNumeric: "tabular-nums",
     letterSpacing: "-0.04em",
@@ -549,18 +573,10 @@ const styles = stylex.create({
   },
   reviewScoreBandLabel: {
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "20px",
-    fontWeight: 700,
-    letterSpacing: "-0.025em",
-    lineHeight: 1.2,
   },
   reviewScoreBandRange: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "13px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.3,
   },
   reviewScoreScale: {
     paddingTop: space.x6,
@@ -596,10 +612,7 @@ const styles = stylex.create({
     height: "20px",
     justifyContent: "space-between",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "12px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.4,
     paddingTop: space.x1,
   },
   reviewScoreAnchor80: {
@@ -620,9 +633,6 @@ const styles = stylex.create({
     marginBottom: 0,
     marginLeft: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
   },
   visuallyHiddenInput: {
     position: "absolute",
@@ -709,19 +719,11 @@ const styles = stylex.create({
     alignItems: "center",
     columnGap: space.x1,
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "14px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
     pointerEvents: "none",
   },
   bandInputRange: {
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "11px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1.2,
     pointerEvents: "none",
   },
   bandInputCheck: {
@@ -753,10 +755,7 @@ const styles = stylex.create({
     borderRadius: controlMetrics.radius,
     backgroundColor: colors.fieldBackground,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "15px",
     fontWeight: 600,
-    lineHeight: 1,
     cursor: "pointer",
     boxShadow: {
       default: `inset 0 0 0 1px ${colors.fieldRule}`,
@@ -788,11 +787,6 @@ const styles = stylex.create({
     minWidth: 0,
     overflow: "hidden",
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "17px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
@@ -838,9 +832,6 @@ const styles = stylex.create({
     justifyContent: "space-between",
     marginTop: "6px",
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.3,
   },
   colorHint: {
     marginTop: space.x2,
@@ -848,9 +839,6 @@ const styles = stylex.create({
     marginBottom: 0,
     marginLeft: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.45,
   },
   pictureRoot: {
     width: "100%",
@@ -905,7 +893,6 @@ const styles = stylex.create({
     flexWrap: "wrap",
   },
 });
-
 const bandInputSelectedStyles = {
   mediocre: styles.band1Selected,
   good: styles.band2Selected,
@@ -913,7 +900,6 @@ const bandInputSelectedStyles = {
   outstanding: styles.band4Selected,
   unicorn: styles.band5Selected,
 } satisfies Record<RatingBand, stylex.StyleXStyles>;
-
 const bandInputTextSelectedStyles = {
   mediocre: styles.bandInputTextSelectedLight,
   good: styles.bandInputTextSelectedLight,
@@ -921,7 +907,6 @@ const bandInputTextSelectedStyles = {
   outstanding: styles.bandInputTextSelectedDark,
   unicorn: styles.bandInputTextSelectedDark,
 } satisfies Record<RatingBand, stylex.StyleXStyles>;
-
 const SERVING_STYLE_OPTIONS = [
   { icon: GlassWater, label: "Neat", value: "neat" },
   { icon: Box, label: "Rocks", value: "rocks" },

--- a/apps/web/src/components/tastingToastButton.stylex.tsx
+++ b/apps/web/src/components/tastingToastButton.stylex.tsx
@@ -6,7 +6,8 @@ import { useState } from "react";
 
 import useAuth from "@peated/web/hooks/useAuth";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { colors, fonts, space } from "../styles/tokens.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, space } from "../styles/tokens.stylex";
 import { Button, ButtonLink } from "./button.stylex";
 
 /** Owns the member-specific toast action and count for one tasting. */
@@ -61,11 +62,14 @@ export function TastingToastSummary({
           {toasted ? "Toasted" : "Toast"}
         </Button>
       ) : null}
-      <span {...stylex.props(styles.count)}>
+      <span {...stylex.props(foundationStyles.metadata, styles.count)}>
         {formatToastCount(count, toasted)}
       </span>
       {createToast.error ? (
-        <span aria-live="polite" {...stylex.props(styles.error)}>
+        <span
+          aria-live="polite"
+          {...stylex.props(foundationStyles.metadata, styles.error)}
+        >
           We couldn't save your toast. Try again.
         </span>
       ) : null}
@@ -92,16 +96,11 @@ const styles = stylex.create({
     minWidth: 0,
     overflow: "hidden",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.4,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },
   error: {
     flexShrink: 0,
     color: colors.critical,
-    fontFamily: fonts.reading,
-    fontSize: "12px",
   },
 });

--- a/apps/web/src/components/textLink.stylex.tsx
+++ b/apps/web/src/components/textLink.stylex.tsx
@@ -1,3 +1,4 @@
+import { foundationStyles } from "@peated/web/styles/foundations.stylex";
 import * as stylex from "@stylexjs/stylex";
 
 import { AppLink, type AppLinkProps } from "./appLink";
@@ -29,7 +30,7 @@ export function TextLink({
       {...props}
       {...stylex.props(
         textLinkStyles.link,
-        size === "sm" && textLinkStyles.small,
+        size === "sm" && foundationStyles.interactiveSmall,
         tone === "muted" && textLinkStyles.muted,
         truncate && textLinkStyles.truncate,
       )}

--- a/apps/web/src/components/textLinkStyles.stylex.ts
+++ b/apps/web/src/components/textLinkStyles.stylex.ts
@@ -1,6 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { colors, effects, fonts, zIndices } from "../styles/tokens.stylex";
+import { colors, effects, zIndices } from "../styles/tokens.stylex";
 
 /** Shared text-link interaction styles for TextLink and bare AppLink fallback. */
 export const textLinkStyles = stylex.create({
@@ -38,11 +38,6 @@ export const textLinkStyles = stylex.create({
     },
     fontWeight: 400,
     textDecorationLine: "underline",
-  },
-  small: {
-    fontFamily: fonts.reading,
-    fontSize: "13px",
-    lineHeight: 1.3,
   },
   truncate: {
     minWidth: 0,

--- a/apps/web/src/components/unitInput.stylex.tsx
+++ b/apps/web/src/components/unitInput.stylex.tsx
@@ -1,11 +1,11 @@
 import * as stylex from "@stylexjs/stylex";
 import type { InputHTMLAttributes } from "react";
 
+import { foundationStyles } from "../styles/foundations.stylex";
 import {
   colors,
   controlMetrics,
   effects,
-  fonts,
   space,
 } from "../styles/tokens.stylex";
 
@@ -39,9 +39,12 @@ export function UnitInput({
         aria-invalid={invalid || undefined}
         disabled={disabled}
         type={type}
-        {...stylex.props(styles.input)}
+        {...stylex.props(foundationStyles.input, styles.input)}
       />
-      <span aria-hidden="true" {...stylex.props(styles.unit)}>
+      <span
+        aria-hidden="true"
+        {...stylex.props(foundationStyles.metadata, styles.unit)}
+      >
         {unit}
       </span>
     </span>
@@ -90,10 +93,7 @@ const styles = stylex.create({
     outline: "none",
     backgroundColor: "transparent",
     color: colors.ink,
-    fontFamily: fonts.data,
-    fontSize: "16px",
     fontVariantNumeric: "tabular-nums",
-    lineHeight: 1,
     "::placeholder": {
       color: colors.inkMuted,
       opacity: 1,
@@ -103,8 +103,5 @@ const styles = stylex.create({
     flexShrink: 0,
     paddingRight: "13px",
     color: colors.inkMuted,
-    fontFamily: fonts.reading,
-    fontSize: "14px",
-    lineHeight: 1,
   },
 });

--- a/apps/web/src/components/workflowScreen.stylex.tsx
+++ b/apps/web/src/components/workflowScreen.stylex.tsx
@@ -73,7 +73,10 @@ export function WorkflowScreen({
               Peated
             </Link>
           </div>
-          <h1 title={title} {...stylex.props(styles.title)}>
+          <h1
+            title={title}
+            {...stylex.props(foundationStyles.compactRowTitle, styles.title)}
+          >
             {title}
           </h1>
           {onSave ? (
@@ -121,7 +124,9 @@ export function WorkflowScreen({
         <div {...stylex.props(styles.mobileSaveBar)}>
           <div {...stylex.props(styles.mobileSaveInner)}>
             {saveHint ? (
-              <p {...stylex.props(styles.saveHint)}>{saveHint}</p>
+              <p {...stylex.props(foundationStyles.metadata, styles.saveHint)}>
+                {saveHint}
+              </p>
             ) : null}
             <div
               {...stylex.props(
@@ -236,11 +241,6 @@ const styles = stylex.create({
     margin: 0,
     overflow: "hidden",
     color: colors.ink,
-    fontFamily: fonts.display,
-    fontSize: "15px",
-    fontWeight: 700,
-    letterSpacing: "-0.02em",
-    lineHeight: 1.2,
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
     textAlign: "center",
@@ -318,9 +318,6 @@ const styles = stylex.create({
   saveHint: {
     margin: 0,
     color: colors.inkMuted,
-    fontFamily: fonts.data,
-    fontSize: "10px",
-    lineHeight: 1.3,
     textAlign: "center",
   },
 });

--- a/apps/web/src/features/tastingWheel/tastingWheelDetails.stylex.tsx
+++ b/apps/web/src/features/tastingWheel/tastingWheelDetails.stylex.tsx
@@ -9,6 +9,7 @@ import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { createContext, useContext, useState, type ReactNode } from "react";
+import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
 import { CATEGORY_DEFINITIONS, NOTE_DESCRIPTIONS } from "./tastingWheelData";
 
@@ -87,7 +88,7 @@ function TastingWheelDetails({
   const notes = [...new Set([...category.wheelNotes, ...category.notes])];
   return (
     <div {...stylex.props(styles.details)}>
-      <p {...stylex.props(styles.description)}>
+      <p {...stylex.props(foundationStyles.prose, styles.description)}>
         {selection.note
           ? NOTE_DESCRIPTIONS[selection.note]
           : category.description}
@@ -119,7 +120,7 @@ function TastingWheelDetails({
       </section>
       <section aria-busy={query.isPending}>
         <SectionHeading level={3}>Bottles with these notes</SectionHeading>
-        <p {...stylex.props(styles.explanation)}>
+        <p {...stylex.props(foundationStyles.body, styles.explanation)}>
           Ordered by how often people mention these notes in their public
           tastings.
         </p>
@@ -160,8 +161,6 @@ const styles = stylex.create({
   details: { display: "flex", flexDirection: "column", gap: space.x6 },
   description: {
     margin: 0,
-    fontSize: "16px",
-    lineHeight: 1.6,
     textWrap: "pretty",
   },
   categoryDescription: {
@@ -179,7 +178,6 @@ const styles = stylex.create({
     margin: 0,
     marginTop: space.x2,
     color: colors.inkMuted,
-    fontSize: "14px",
     textWrap: "pretty",
   },
   status: { marginTop: space.x4, color: colors.inkMuted },

--- a/apps/web/src/styles/foundations.stylex.ts
+++ b/apps/web/src/styles/foundations.stylex.ts
@@ -1,6 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 import { colors, fonts } from "./tokens.stylex";
 
+/** Web typography roles. Components compose these with layout, color, and emphasis. */
 export const foundationStyles = stylex.create({
   document: {
     boxSizing: "border-box",
@@ -23,10 +24,18 @@ export const foundationStyles = stylex.create({
     letterSpacing: "-0.05em",
     lineHeight: 0.95,
   },
+  pageTitleCompact: {
+    margin: 0,
+    fontFamily: fonts.display,
+    fontSize: "clamp(32px, 4vw, 40px)",
+    fontWeight: 700,
+    letterSpacing: "-0.04em",
+    lineHeight: 1.1,
+  },
   sectionHeading: {
     margin: 0,
     fontFamily: fonts.display,
-    fontSize: "20px",
+    fontSize: "24px",
     fontWeight: 700,
     letterSpacing: "-0.025em",
     lineHeight: 1.2,
@@ -39,6 +48,14 @@ export const foundationStyles = stylex.create({
     letterSpacing: "-0.025em",
     lineHeight: 1.25,
   },
+  compactRowTitle: {
+    margin: 0,
+    fontFamily: fonts.display,
+    fontSize: "16px",
+    fontWeight: 700,
+    letterSpacing: "-0.025em",
+    lineHeight: 1.25,
+  },
   body: {
     margin: 0,
     fontFamily: fonts.reading,
@@ -46,11 +63,31 @@ export const foundationStyles = stylex.create({
     fontWeight: 400,
     lineHeight: 1.6,
   },
+  prose: {
+    margin: 0,
+    fontFamily: fonts.reading,
+    fontSize: "16px",
+    fontWeight: 400,
+    lineHeight: 1.65,
+    textWrap: "pretty",
+  },
+  input: {
+    fontFamily: fonts.reading,
+    fontSize: "16px",
+    fontWeight: 400,
+    lineHeight: 1.45,
+  },
   interactive: {
     fontFamily: fonts.reading,
     fontSize: "15px",
     fontWeight: 600,
     lineHeight: 1.2,
+  },
+  interactiveSmall: {
+    fontFamily: fonts.reading,
+    fontSize: "13px",
+    fontWeight: 600,
+    lineHeight: 1.3,
   },
   metadata: {
     fontFamily: fonts.reading,
@@ -61,7 +98,7 @@ export const foundationStyles = stylex.create({
   fieldLabel: {
     fontFamily: fonts.reading,
     fontSize: "13px",
-    fontWeight: 400,
+    fontWeight: 600,
     letterSpacing: 0,
     lineHeight: 1.4,
   },
@@ -71,5 +108,11 @@ export const foundationStyles = stylex.create({
     fontWeight: 400,
     letterSpacing: 0,
     lineHeight: 1.4,
+  },
+  code: {
+    fontFamily: fonts.data,
+    fontSize: "13px",
+    fontWeight: 400,
+    lineHeight: 1.45,
   },
 });


### PR DESCRIPTION
Restore a clear hierarchy between section headings and the items below them: headings use 24px, regular item names 18px, compact names 16px, and supporting details 13px. The homepage event callout uses the event name as its heading, removing the redundant “Coming up” label.

Centralize typography in `foundationStyles` across public pages, forms, search, lists, and admin. Normal labels and metadata use Karla, inputs stay at 16px, and monospace is reserved for code. Page metadata sits below its title, and homepage navigation links use `TextLink`.

Start review with `DESIGN.md`, the shared foundations, and Storybook’s Typography story, which now demonstrates the hierarchy with real components. Most of the broad diff replaces local font recipes with shared roles; wrapping and density in narrow layouts deserve the closest visual review.

Reviewed representative desktop/mobile layouts in light and dark themes. All 320 web tests, web typecheck, and the public-route smoke check passed after rebasing onto main. Mobile navigation and moderation workflow checks also passed. Lint reports only existing warnings.
