### PR TITLE
feat(library): add recently added sorting

### DIFF
--- a/apps/server/src/orpc/contracts/collections/bottles/list.ts
+++ b/apps/server/src/orpc/contracts/collections/bottles/list.ts
@@ -33,6 +33,12 @@ export default contract
         status: z
           .union([CollectionBottleStatusSchema, z.literal("unset")])
           .optional(),
+        sort: z
+          .enum(["name", "-created"])
+          .default("name")
+          .describe(
+            "Order by bottle name or by the date added to the collection, newest first.",
+          ),
         cursor: z.coerce.number().gte(1).default(1),
         limit: z.coerce.number().gte(1).lte(100).default(25),
       })

--- a/apps/server/src/orpc/mock/routes/collections/bottles/list.ts
+++ b/apps/server/src/orpc/mock/routes/collections/bottles/list.ts
@@ -58,6 +58,12 @@ export default mockOS.collections.bottles.list.handler(
           (input.status === "unset" && item.status === null)),
     );
 
+    collectionBottles.sort((a, b) =>
+      input.sort === "-created"
+        ? b.id - a.id
+        : a.bottle.fullName.localeCompare(b.bottle.fullName) || a.id - b.id,
+    );
+
     return mockPage(
       collectionBottles.map((item) => {
         const bottle = mockBottleFor(context.user, item.bottle);

--- a/apps/server/src/orpc/routes/collections/bottles/list.test.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/list.test.ts
@@ -62,6 +62,78 @@ describe("GET /users/:user/collections/:collection/bottles", () => {
     expect(response.results[0]).not.toHaveProperty("target");
   });
 
+  test("paginates recently added Library entries by membership date with stable ties", async ({
+    defaults,
+    fixtures,
+  }) => {
+    const collection = await fixtures.Collection({
+      name: "Library",
+      createdById: defaults.user.id,
+    });
+    const brand = await fixtures.Entity({ name: "Ordering Brand" });
+    const first = await fixtures.Bottle({ brandId: brand.id, name: "Zulu" });
+    const second = await fixtures.Bottle({ brandId: brand.id, name: "Beta" });
+    const oldest = await fixtures.Bottle({ brandId: brand.id, name: "Alpha" });
+    const excluded = await fixtures.Bottle({ brandId: brand.id });
+    const entries = await db
+      .insert(collectionBottles)
+      .values([
+        {
+          collectionId: collection.id,
+          bottleId: first.id,
+          status: "sealed",
+          createdAt: new Date("2026-08-02T12:00:00Z"),
+        },
+        {
+          collectionId: collection.id,
+          bottleId: second.id,
+          status: "sealed",
+          createdAt: new Date("2026-08-02T12:00:00Z"),
+        },
+        {
+          collectionId: collection.id,
+          bottleId: oldest.id,
+          status: "sealed",
+          createdAt: new Date("2026-08-01T12:00:00Z"),
+        },
+        {
+          collectionId: collection.id,
+          bottleId: excluded.id,
+          status: "open",
+          createdAt: new Date("2026-08-03T12:00:00Z"),
+        },
+      ])
+      .returning();
+
+    const input = {
+      user: "me",
+      collection: "library",
+      sort: "-created",
+      status: "sealed",
+      limit: 1,
+    } as const;
+    const context = { user: defaults.user };
+    const firstPage = await routerClient.collections.bottles.list(input, {
+      context,
+    });
+    const secondPage = await routerClient.collections.bottles.list(
+      { ...input, cursor: firstPage.rel.nextCursor! },
+      { context },
+    );
+    const lastPage = await routerClient.collections.bottles.list(
+      { ...input, cursor: secondPage.rel.nextCursor! },
+      { context },
+    );
+
+    expect(
+      [firstPage, secondPage, lastPage].flatMap((page) =>
+        page.results.map(({ id }) => id),
+      ),
+    ).toEqual([entries[1]!.id, entries[0]!.id, entries[2]!.id]);
+    expect(firstPage.rel).toEqual({ nextCursor: 2, prevCursor: null });
+    expect(lastPage.rel).toEqual({ nextCursor: null, prevCursor: 2 });
+  });
+
   test("filters direct membership by Bottle id", async ({
     defaults,
     fixtures,

--- a/apps/server/src/orpc/routes/collections/bottles/list.ts
+++ b/apps/server/src/orpc/routes/collections/bottles/list.ts
@@ -16,7 +16,7 @@ import collectionBottleListContract from "@peated/server/orpc/contracts/collecti
 import { serialize } from "@peated/server/serializers";
 import { CollectionBottleSerializer } from "@peated/server/serializers/collectionBottle";
 import type { SQL } from "drizzle-orm";
-import { and, asc, eq, isNull, sql } from "drizzle-orm";
+import { and, asc, desc, eq, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
 import { isLibraryCollection } from "./collectionBottleHelpers";
 
@@ -126,7 +126,11 @@ export default implement(collectionBottleListContract).handler(async function ({
     .where(and(...baseWhere))
     .limit(limit + 1)
     .offset(offset)
-    .orderBy(asc(bottles.fullName), asc(collectionBottles.id));
+    .orderBy(
+      ...(input.sort === "-created"
+        ? [desc(collectionBottles.createdAt), desc(collectionBottles.id)]
+        : [asc(bottles.fullName), asc(collectionBottles.id)]),
+    );
 
   return {
     results: await serialize(

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -2482,6 +2482,12 @@ function listCollectionBottles(request, input) {
     );
   }
 
+  results.sort((a, b) =>
+    input?.sort === "-created"
+      ? b.id - a.id
+      : a.bottle.fullName.localeCompare(b.bottle.fullName) || a.id - b.id,
+  );
+
   return {
     results,
     rel: {

--- a/apps/web/e2e/profile-library.spec.ts
+++ b/apps/web/e2e/profile-library.spec.ts
@@ -50,7 +50,7 @@ test.describe("profile library", () => {
     ).toBeVisible();
   });
 
-  test("filters Library entries from the profile tab", async ({
+  test("sorts and filters Library entries from the profile tab", async ({
     context,
     page,
   }, testInfo) => {
@@ -83,16 +83,32 @@ test.describe("profile library", () => {
     });
     await expect(libraryBottleLink(page, bottleId)).toBeVisible();
 
+    const sort = page.getByRole("combobox", { name: "Sort bottles" });
+    await expect(sort).toHaveValue("name");
+    await sort.selectOption({ label: "Recently added" });
+    await expect(page).toHaveURL(
+      `/users/${testUser.username}/library?sort=-created`,
+    );
+    await page.reload({ waitUntil: "commit" });
+    await expect(sort).toHaveValue("-created");
+
     await page
       .getByRole("searchbox", { name: "Find in this library" })
       .fill("zzzz");
     await page.getByRole("button", { name: "Find" }).click();
-    await expect(page).toHaveURL(/\/library\?query=zzzz$/);
+    await expect(page).toHaveURL(/\/library\?sort=-created&query=zzzz$/);
     await expect(libraryBottleLink(page, bottleId)).toHaveCount(0);
 
     await page.getByRole("button", { name: "Clear filters" }).click();
-    await expect(page).toHaveURL(`/users/${testUser.username}/library`);
+    await expect(page).toHaveURL(
+      `/users/${testUser.username}/library?sort=-created`,
+    );
     await expect(libraryBottleLink(page, bottleId)).toBeVisible();
+    await expect(sort).toHaveValue("-created");
+    await sort.selectOption({ label: "Alphabetical" });
+    await expect(page).toHaveURL(
+      `/users/${testUser.username}/library?sort=name`,
+    );
 
     await page.goto(`/users/${testUser.username}/library?cursor=2`, {
       waitUntil: "commit",

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
@@ -26,6 +26,11 @@ type LibraryEntry =
   Outputs["collections"]["bottles"]["list"]["results"][number];
 type LibraryEntryChange = LibraryEntry["status"] | "removed";
 
+const sortOptions = [
+  { label: "Alphabetical", value: "name" },
+  { label: "Recently added", value: "-created" },
+] as const;
+
 export function ProfileLibraryPageClient() {
   const orpc = useORPC();
   const queryClient = useQueryClient();
@@ -39,7 +44,7 @@ export function ProfileLibraryPageClient() {
   >({});
   const [mutationError, setMutationError] = useState(false);
   const input = getProfileLibraryInput(searchParams, user.id);
-  const { brand, cursor, distiller, query, status } = input;
+  const { brand, cursor, distiller, query, sort, status } = input;
   const libraryQueryOptions = profileQueries.library(orpc, input);
   const libraryListQueryKey = orpc.collections.bottles.list.key({
     type: "query",
@@ -67,7 +72,10 @@ export function ProfileLibraryPageClient() {
     );
   }
 
-  function setFilter(name: "brand" | "distiller" | "status", value: string) {
+  function setFilter(
+    name: "brand" | "distiller" | "status" | "sort",
+    value: string,
+  ) {
     const next = new URLSearchParams(searchParams);
     next.delete("cursor");
     if (value) next.set(name, value);
@@ -249,12 +257,15 @@ export function ProfileLibraryPageClient() {
               libraryQuery.data.rel.nextCursor,
             )}
             page={cursor}
+            onSortChange={(value) => setFilter("sort", value)}
             previousHref={getCursorHref(
               pathname,
               searchParams,
               libraryQuery.data.rel.prevCursor,
             )}
             total={statsQuery.data?.total}
+            sort={sort}
+            sortOptions={sortOptions}
           />
         )}
       </div>

--- a/apps/web/src/app/(app)/users/[username]/profileQueries.test.ts
+++ b/apps/web/src/app/(app)/users/[username]/profileQueries.test.ts
@@ -37,6 +37,7 @@ describe("profile route query state", () => {
           distiller: "19",
           internalRouteValue: "ignore-me",
           query: "peated",
+          sort: "-created",
           status: "open",
         },
         42,
@@ -48,6 +49,7 @@ describe("profile route query state", () => {
       distiller: 19,
       limit: 25,
       query: "peated",
+      sort: "-created",
       status: "open",
       user: 42,
     });
@@ -56,7 +58,13 @@ describe("profile route query state", () => {
   test("normalizes unsupported library filters", () => {
     expect(
       getProfileLibraryInput(
-        { brand: "-1", cursor: "0", distiller: "nan", status: "removed" },
+        {
+          brand: "-1",
+          cursor: "0",
+          distiller: "nan",
+          sort: "invalid",
+          status: "removed",
+        },
         42,
       ),
     ).toEqual({
@@ -66,8 +74,17 @@ describe("profile route query state", () => {
       distiller: undefined,
       limit: 25,
       query: "",
+      sort: "name",
       status: undefined,
       user: 42,
     });
+  });
+
+  test("uses the same library sort for server and browser params", () => {
+    const params = { sort: "-created", query: "peated", cursor: "2" };
+    expect(getProfileLibraryInput(new URLSearchParams(params), 42)).toEqual(
+      getProfileLibraryInput(params, 42),
+    );
+    expect(getProfileLibraryInput({}, 42).sort).toBe("name");
   });
 });

--- a/apps/web/src/app/(app)/users/[username]/profileQueries.ts
+++ b/apps/web/src/app/(app)/users/[username]/profileQueries.ts
@@ -16,6 +16,7 @@ export type ProfileLibraryInput = Inputs["collections"]["bottles"]["list"] & {
   distiller?: number;
   limit: 25;
   query: string;
+  sort: "name" | "-created";
   status?: "empty" | "open" | "sealed" | "unset";
   user: number;
 };
@@ -81,6 +82,7 @@ export function getProfileLibraryInput(
     distiller: parsePositiveNumber(getSearchParam(source, "distiller")),
     limit: 25,
     query: getSearchParam(source, "query") ?? "",
+    sort: getSearchParam(source, "sort") === "-created" ? "-created" : "name",
     status: parseLibraryStatus(getSearchParam(source, "status")),
     user: userId,
   };

--- a/apps/web/src/components/pages/memberProfileContent.stylex.tsx
+++ b/apps/web/src/components/pages/memberProfileContent.stylex.tsx
@@ -18,10 +18,12 @@ import {
   FilterQuery,
   ItemList,
   ItemListItem,
+  ListToolbar,
   RowMenu,
   TastingEntry,
   TextLink,
   type BottleIdentityRowProps,
+  type ListSortOption,
   type RowMenuGroup,
   type TastingEntryProps,
 } from "..";
@@ -42,8 +44,11 @@ export type MemberLibraryListProps = {
   emptyHeading: string;
   items: readonly MemberLibraryItem[];
   nextHref?: string;
+  onSortChange: (value: string) => void;
   page: number;
   previousHref?: string;
+  sort: string;
+  sortOptions: readonly [ListSortOption, ...ListSortOption[]];
   total?: number;
 };
 
@@ -54,21 +59,23 @@ export function MemberLibraryList({
   emptyHeading,
   items,
   nextHref,
+  onSortChange,
   page,
   previousHref,
+  sort,
+  sortOptions,
   total,
 }: MemberLibraryListProps) {
   return (
     <section aria-label="Member library" {...stylex.props(styles.library)}>
-      <div {...stylex.props(foundationStyles.rowTitle, styles.libraryCount)}>
-        <strong>
-          {items.length.toLocaleString("en-US")}{" "}
-          {items.length === 1 ? "bottle" : "bottles"}
-        </strong>
-        {total !== undefined ? (
-          <span>of {total.toLocaleString("en-US")}</span>
-        ) : null}
-      </div>
+      <ListToolbar
+        count={items.length}
+        noun="bottle"
+        onSortChange={onSortChange}
+        sort={sort}
+        sortOptions={sortOptions}
+        total={total}
+      />
       {items.length ? (
         <ItemList ariaLabel="Library bottles">
           {items.map(({ actions, id, status, ...identity }) => (
@@ -297,13 +304,6 @@ function formatBottleCount(count: number) {
 
 const styles = stylex.create({
   library: { minWidth: 0 },
-  libraryCount: {
-    display: "flex",
-    alignItems: "baseline",
-    gap: space.x2,
-    paddingBottom: space.x3,
-    color: colors.ink,
-  },
   libraryEnd: { display: "flex", alignItems: "center", gap: space.x2 },
   filterContent: { display: "flex", flexDirection: "column", gap: space.x6 },
   railFilters: { display: "block", [NARROW]: { display: "none" } },


### PR DESCRIPTION
The Library now offers Alphabetical and Recently added in the list toolbar. Recently added puts the bottles most recently saved to that collection first; alphabetical remains the default. The selection survives filtering, pagination, and reloads, and changing it returns to page one.

API regression coverage checks saved-date ordering and stable ties across filtered pages. The existing browser workflow now checks sort selection and persistence through filtering and reloads.
