### PR TITLE
fix(auth)!: restrict token use and enforce login limits

### DIFF
--- a/apps/server/src/lib/auth.test.ts
+++ b/apps/server/src/lib/auth.test.ts
@@ -1,5 +1,14 @@
+import config from "@peated/server/config";
+import jsonwebtoken from "jsonwebtoken";
 import { db } from "../db";
-import { createAccessToken, createUser, getUserFromHeader } from "./auth";
+import {
+  createAccessToken,
+  createUser,
+  generateMagicLink,
+  getUserFromHeader,
+  signToken,
+  verifyToken,
+} from "./auth";
 
 test("creates user with no username conflict", async () => {
   const data = {
@@ -41,3 +50,44 @@ test("gets user from a valid authorization header", async ({ fixtures }) => {
 test("returns null for an invalid authorization header token", async () => {
   await expect(getUserFromHeader("Bearer invalid-token")).resolves.toBeNull();
 });
+
+test("does not accept a magic link as an API access token", async ({
+  fixtures,
+}) => {
+  const user = await fixtures.User();
+  const { token } = await generateMagicLink(user);
+
+  await expect(getUserFromHeader(`Bearer ${token}`)).resolves.toBeNull();
+});
+
+for (const purpose of ["recovery", "email-verification"] as const) {
+  test(`does not accept a ${purpose} token as an API access token`, async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User();
+    const token = await signToken({ id: user.id, email: user.email }, purpose);
+
+    await expect(getUserFromHeader(`Bearer ${token}`)).resolves.toBeNull();
+  });
+}
+
+test("does not accept tokens without a purpose", async ({ fixtures }) => {
+  const user = await fixtures.User();
+  const token = jsonwebtoken.sign({ id: user.id }, config.JWT_SECRET, {
+    expiresIn: "7d",
+  });
+
+  await expect(getUserFromHeader(`Bearer ${token}`)).resolves.toBeNull();
+});
+
+test.each(["magic-link", "recovery", "webauthn-challenge"] as const)(
+  "%s JWTs expire after ten minutes",
+  async (purpose) => {
+    const token = await signToken(
+      { iat: Math.floor(Date.now() / 1000) - 601 },
+      purpose,
+    );
+
+    await expect(verifyToken(token, purpose)).rejects.toThrow("jwt expired");
+  },
+);

--- a/apps/server/src/lib/auth.ts
+++ b/apps/server/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { hashSync } from "bcrypt";
 import { eq } from "drizzle-orm";
+import jsonwebtoken from "jsonwebtoken";
 import { z } from "zod";
 import config from "../config";
 import type { AnyDatabase } from "../db";
@@ -9,15 +10,11 @@ import { users } from "../db/schema";
 import { random } from "../lib/rand";
 import { serialize } from "../serializers";
 import { UserSerializer } from "../serializers/user";
+import { sendVerificationEmail } from "./email";
 import { logWarn } from "./log";
 import { absoluteUrl } from "./urls";
 
-// I love to ESM.
-import type { JwtPayload } from "jsonwebtoken";
-import { default as jsonwebtoken } from "jsonwebtoken";
-import { sendVerificationEmail } from "./email";
-const { sign, verify } = jsonwebtoken;
-type JsonWebTokenPayload = Parameters<typeof sign>[0];
+const TokenDataSchema = z.record(z.string(), z.json());
 const UserTokenSchema = z.object({ id: z.number().int().positive() });
 const ChallengeTokenSchema = z.object({
   challenge: z.string().min(1),
@@ -26,41 +23,36 @@ const ChallengeTokenSchema = z.object({
 
 export const ACCESS_TOKEN_EXPIRES_IN_SECONDS = 7 * 24 * 60 * 60;
 
-export function signPayload(payload: JsonWebTokenPayload): Promise<string> {
-  return new Promise<string>((res, rej) => {
-    sign(payload, config.JWT_SECRET, { expiresIn: "7d" }, (err, token) => {
-      if (err) rej(err);
-      if (!token) throw new Error("Unknown error signing token.");
-      res(token);
-    });
+export const TOKEN_LIFETIME_SECONDS = {
+  access: ACCESS_TOKEN_EXPIRES_IN_SECONDS,
+  "magic-link": 10 * 60,
+  recovery: 10 * 60,
+  "email-verification": 7 * 24 * 60 * 60,
+  "webauthn-challenge": 10 * 60,
+  "photo-identification-create": 7 * 24 * 60 * 60,
+} as const;
+
+type TokenPurpose = keyof typeof TOKEN_LIFETIME_SECONDS;
+
+/** Creates a signed token with the lifetime assigned to its purpose. */
+export async function signToken(
+  payload: z.infer<typeof TokenDataSchema>,
+  purpose: TokenPurpose,
+): Promise<string> {
+  return jsonwebtoken.sign(payload, config.JWT_SECRET, {
+    audience: purpose,
+    expiresIn: TOKEN_LIFETIME_SECONDS[purpose],
   });
 }
 
-export function verifyPayload(
-  token: string | undefined,
-): Promise<string | JwtPayload | undefined> {
-  return new Promise((res, rej) => {
-    if (!token) {
-      rej("invalid token");
-      return;
-    }
-
-    verify(token, config.JWT_SECRET, {}, (err, decoded) => {
-      if (err) {
-        rej("invalid token");
-        return;
-      }
-      const payload = z.record(z.string(), z.json()).safeParse(decoded);
-      if (!payload.success) {
-        rej("invalid token");
-        return;
-      }
-      res(payload.data);
-    });
+/** Checks the signature, expiration, and purpose before returning the token's data. */
+export async function verifyToken(token: string, purpose: TokenPurpose) {
+  // Account access rule: a token may only be used for its signed purpose (`aud`).
+  const payload = jsonwebtoken.verify(token, config.JWT_SECRET, {
+    audience: purpose,
   });
+  return TokenDataSchema.parse(payload);
 }
-
-export { verifyPayload as verifyToken };
 
 export async function getUserFromHeader(
   authorizationHeader: string | undefined,
@@ -68,9 +60,9 @@ export async function getUserFromHeader(
   const token = authorizationHeader?.replace(/^Bearer /i, "");
   if (!token) return null;
 
-  let payload: Awaited<ReturnType<typeof verifyPayload>>;
+  let payload: Awaited<ReturnType<typeof verifyToken>>;
   try {
-    payload = await verifyPayload(token);
+    payload = await verifyToken(token, "access");
   } catch {
     logWarn("Invalid Bearer token", {});
     return null;
@@ -106,7 +98,7 @@ export async function getUserFromHeader(
 
 export async function createAccessToken(user: User): Promise<string> {
   const payload = await serialize(UserSerializer, user, user);
-  return await signPayload(payload);
+  return await signToken(payload, "access");
 }
 
 // OWASP recommends 10+ rounds for bcrypt
@@ -173,7 +165,7 @@ export async function generateMagicLink(user: User, redirectTo = "/") {
     createdAt: new Date().toISOString(),
   };
 
-  const signedToken = await signPayload(token);
+  const signedToken = await signToken(token, "magic-link");
   const url = absoluteUrl(
     config.URL_PREFIX,
     `/auth/magic-link?token=${signedToken}&redirectTo=${encodeURIComponent(redirectTo)}`,
@@ -185,46 +177,40 @@ export async function generateMagicLink(user: User, redirectTo = "/") {
   };
 }
 
-/**
- * Sign a WebAuthn challenge to prevent tampering and replay attacks
- * The signed token includes the challenge and creation timestamp
- */
+/** Signs a passkey challenge that expires in ten minutes. */
 export async function signChallenge(challenge: string): Promise<string> {
   const payload = {
     challenge,
     createdAt: new Date().toISOString(),
   };
-  return await signPayload(payload);
+  return await signToken(payload, "webauthn-challenge");
 }
 
-/**
- * Verify a signed WebAuthn challenge
- * Ensures the challenge hasn't been tampered with and is recent (within 5 minutes)
- * Returns the original challenge value if valid
- */
+/** Rejects expired, modified, or mismatched passkey challenges. */
 export async function verifyChallenge(
   signedChallenge: string,
   expectedChallenge: string,
 ): Promise<void> {
   let payload: z.infer<typeof ChallengeTokenSchema>;
   try {
-    payload = ChallengeTokenSchema.parse(await verifyPayload(signedChallenge));
+    payload = ChallengeTokenSchema.parse(
+      await verifyToken(signedChallenge, "webauthn-challenge"),
+    );
   } catch (err) {
     throw new Error("Challenge signature is invalid or has expired", {
       cause: err,
     });
   }
 
-  // Verify the challenge matches what we expect
   if (payload.challenge !== expectedChallenge) {
     throw new Error("Challenge does not match");
   }
 
-  // Verify challenge is recent (within 10 minutes)
-  const CHALLENGE_TTL = 10 * 60 * 1000; // 10 minutes
   const createdAt = new Date(payload.createdAt).getTime();
-  const now = new Date().getTime();
-  if (now - createdAt > CHALLENGE_TTL) {
+  if (
+    Date.now() - createdAt >
+    TOKEN_LIFETIME_SECONDS["webauthn-challenge"] * 1000
+  ) {
     throw new Error("Challenge expired");
   }
 }

--- a/apps/server/src/lib/email.ts
+++ b/apps/server/src/lib/email.ts
@@ -20,7 +20,7 @@ import {
   type User,
 } from "../db/schema";
 import type { EmailVerifySchema, PasswordResetSchema } from "../schemas";
-import { generateMagicLink, signPayload } from "./auth";
+import { generateMagicLink, signToken } from "./auth";
 import { formatBottleDisplayName } from "./bottleDisplayName";
 import { logError, logInfo } from "./log";
 import { resolveActiveBottleIds } from "./resolveActiveBottleIds";
@@ -204,10 +204,13 @@ export async function sendVerificationEmail({
     transport = mailTransport;
   }
 
-  const token = await signPayload({
-    email: user.email,
-    id: user.id,
-  } satisfies z.infer<typeof EmailVerifySchema>);
+  const token = await signToken(
+    {
+      email: user.email,
+      id: user.id,
+    } satisfies z.infer<typeof EmailVerifySchema>,
+    "email-verification",
+  );
 
   const verifyUrl = `${config.URL_PREFIX}/verify?token=${token}`;
 
@@ -247,12 +250,15 @@ export async function sendPasswordResetEmail({
     .update(user.passwordHash || "")
     .digest("hex");
 
-  const token = await signPayload({
-    email: user.email,
-    id: user.id,
-    createdAt: new Date().toISOString(),
-    digest,
-  } satisfies z.infer<typeof PasswordResetSchema>);
+  const token = await signToken(
+    {
+      email: user.email,
+      id: user.id,
+      createdAt: new Date().toISOString(),
+      digest,
+    } satisfies z.infer<typeof PasswordResetSchema>,
+    "recovery",
+  );
 
   const resetUrl = `${config.URL_PREFIX}/recover-account?token=${token}`;
 

--- a/apps/server/src/lib/photoIdentificationCreateToken.ts
+++ b/apps/server/src/lib/photoIdentificationCreateToken.ts
@@ -2,7 +2,7 @@ import {
   BottleClassificationDecisionSchema,
   ImagePhotoSuitabilitySchema,
 } from "@peated/server/agents/bottleClassifier";
-import { signPayload, verifyPayload } from "@peated/server/lib/auth";
+import { signToken, verifyToken } from "@peated/server/lib/auth";
 import { z } from "zod";
 
 export const PhotoIdentificationCreateTokenPayloadSchema = z
@@ -12,6 +12,7 @@ export const PhotoIdentificationCreateTokenPayloadSchema = z
     pendingImageId: z.string().trim().min(1),
     decision: BottleClassificationDecisionSchema,
     photoSuitability: ImagePhotoSuitabilitySchema,
+    aud: z.literal("photo-identification-create").optional(),
     iat: z.number().optional(),
     exp: z.number().optional(),
   })
@@ -25,14 +26,15 @@ export type PhotoIdentificationCreateTokenPayload = z.infer<
 export async function signPhotoIdentificationCreateToken(
   payload: PhotoIdentificationCreateTokenPayload,
 ) {
-  return await signPayload(
+  return await signToken(
     PhotoIdentificationCreateTokenPayloadSchema.parse(payload),
+    "photo-identification-create",
   );
 }
 
 /** Verifies the create token and returns the user-owned create proposal it authorizes. */
 export async function verifyPhotoIdentificationCreateToken(token: string) {
   return PhotoIdentificationCreateTokenPayloadSchema.parse(
-    await verifyPayload(token),
+    await verifyToken(token, "photo-identification-create"),
   );
 }

--- a/apps/server/src/orpc/middleware/rateLimit.ts
+++ b/apps/server/src/orpc/middleware/rateLimit.ts
@@ -1,7 +1,5 @@
-import { ORPCError } from "@orpc/server";
 import { z } from "zod";
 import { base } from "..";
-import { logError } from "../../lib/log";
 import { getConnection } from "../../worker/client";
 import type { Context } from "../context";
 
@@ -58,25 +56,12 @@ export function createRateLimit<TContext extends Context = Context>(
 
       const key = `${keyPrefix}:${identifier}`;
 
-      try {
-        const count = await incrementCounter(key, windowMs);
+      // Rate-limit rule: stop the request if its count cannot be checked.
+      const count = await incrementCounter(key, windowMs);
 
-        if (count > maxRequests) {
-          throw errors.FORBIDDEN({
-            message: "Too many requests. Please try again later.",
-          });
-        }
-      } catch (error) {
-        if (error instanceof ORPCError) {
-          throw error;
-        }
-
-        logError(error, {
-          extra: {
-            keyPrefix,
-            maxRequests,
-            windowMs,
-          },
+      if (count > maxRequests) {
+        throw errors.FORBIDDEN({
+          message: "Too many requests. Please try again later.",
         });
       }
 

--- a/apps/server/src/orpc/routes/auth/magic-link/confirm.test.ts
+++ b/apps/server/src/orpc/routes/auth/magic-link/confirm.test.ts
@@ -1,104 +1,97 @@
-import { createRouterClient } from "@orpc/server";
-import waitError from "@peated/server/lib/test/waitError";
 import {
-  createMagicLinkConfirmProcedure,
-  type MagicLinkAuthServices,
-} from "@peated/server/orpc/routes/auth/magic-link/confirm";
-import { beforeEach, describe, expect, test, vi } from "vitest";
+  generateMagicLink,
+  getUserFromHeader,
+  signToken,
+} from "@peated/server/lib/auth";
+import { routerClient } from "@peated/server/orpc/router";
 
-const createAccessToken = vi.fn<MagicLinkAuthServices["createToken"]>();
-const verifyPayload = vi.fn<MagicLinkAuthServices["verifyToken"]>();
-const confirmClient = createRouterClient(
-  {
-    confirm: createMagicLinkConfirmProcedure({
-      createToken: createAccessToken,
-      verifyToken: verifyPayload,
-    }),
-  },
-  { context: { ip: "127.0.0.1", user: null } },
-);
+const context = { ip: "127.0.0.1", user: null };
 
 describe("POST /auth/magic-link/confirm", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  test("confirms magic link for active user", async ({ fixtures }) => {
+  test("confirms magic link and issues a usable access token", async ({
+    fixtures,
+  }) => {
     const user = await fixtures.User({ active: true, verified: false });
-    const token = "valid-token";
+    const { token } = await generateMagicLink(user);
 
-    verifyPayload.mockResolvedValue({
-      id: user.id,
-      email: user.email,
-      createdAt: new Date().toISOString(),
-    });
-
-    createAccessToken.mockResolvedValue("mocked-access-token");
-
-    const result = await confirmClient.confirm({ token });
+    const result = await routerClient.auth.magicLink.confirm(
+      { token },
+      { context },
+    );
 
     expect(result.user.id).toBe(user.id);
     expect(result.user.verified).toBe(true);
-    expect(result.accessToken).toBe("mocked-access-token");
-    expect(createAccessToken).toHaveBeenCalledWith(
-      expect.objectContaining({ id: user.id }),
+    await expect(
+      getUserFromHeader(`Bearer ${result.accessToken}`),
+    ).resolves.toMatchObject({ id: user.id });
+  });
+
+  test("rejects invalid token", async () => {
+    await expect(
+      routerClient.auth.magicLink.confirm(
+        { token: "invalid-token" },
+        { context },
+      ),
+    ).rejects.toThrow("Invalid magic link token.");
+  });
+
+  test("rejects expired token", async ({ fixtures }) => {
+    const user = await fixtures.User();
+    const token = await signToken(
+      {
+        id: user.id,
+        email: user.email,
+        createdAt: new Date(Date.now() - 11 * 60 * 1000).toISOString(),
+      },
+      "magic-link",
     );
+
+    await expect(
+      routerClient.auth.magicLink.confirm({ token }, { context }),
+    ).rejects.toThrow("Invalid magic link token.");
   });
 
-  test("throws error for invalid token", async ({ fixtures }) => {
-    const token = "invalid-token";
-
-    verifyPayload.mockRejectedValue(new Error("Invalid token"));
-
-    const error = await waitError(confirmClient.confirm({ token }));
-
-    expect(error).toMatchInlineSnapshot(`[Error: Invalid magic link token.]`);
-  });
-
-  test("throws error for expired token", async ({ fixtures }) => {
-    const user = await fixtures.User({ active: true });
-    const token = "expired-token";
-
-    const expiredDate = new Date();
-    expiredDate.setMinutes(expiredDate.getMinutes() - 11); // 11 minutes ago
-
-    verifyPayload.mockResolvedValue({
-      id: user.id,
-      email: user.email,
-      createdAt: expiredDate.toISOString(),
-    });
-
-    const error = await waitError(confirmClient.confirm({ token }));
-
-    expect(error).toMatchInlineSnapshot(`[Error: Invalid magic link token.]`);
-  });
-
-  test("throws error for inactive user", async ({ fixtures }) => {
+  test("rejects inactive user", async ({ fixtures }) => {
     const user = await fixtures.User({ active: false });
-    const token = "valid-token";
+    const { token } = await generateMagicLink(user);
 
-    verifyPayload.mockResolvedValue({
-      id: user.id,
-      email: user.email,
-      createdAt: new Date().toISOString(),
-    });
-
-    const error = await waitError(confirmClient.confirm({ token }));
-
-    expect(error).toMatchInlineSnapshot(`[Error: Invalid magic link token.]`);
+    await expect(
+      routerClient.auth.magicLink.confirm({ token }, { context }),
+    ).rejects.toThrow("Invalid magic link token.");
   });
 
-  test("throws error for non-existent user", async ({ fixtures }) => {
-    const token = "valid-token";
+  test("rejects non-existent user", async () => {
+    const token = await signToken(
+      {
+        id: 999999,
+        email: "nonexistent@example.com",
+        createdAt: new Date().toISOString(),
+      },
+      "magic-link",
+    );
 
-    verifyPayload.mockResolvedValue({
-      id: "non-existent-id",
-      email: "nonexistent@example.com",
-      createdAt: new Date().toISOString(),
-    });
-
-    const error = await waitError(confirmClient.confirm({ token }));
-
-    expect(error).toMatchInlineSnapshot(`[Error: Invalid magic link token.]`);
+    await expect(
+      routerClient.auth.magicLink.confirm({ token }, { context }),
+    ).rejects.toThrow("Invalid magic link token.");
   });
+
+  for (const purpose of ["access", "recovery", "email-verification"] as const) {
+    test(`rejects a ${purpose} token even when its payload matches a magic link`, async ({
+      fixtures,
+    }) => {
+      const user = await fixtures.User({ verified: false });
+      const token = await signToken(
+        {
+          id: user.id,
+          email: user.email,
+          createdAt: new Date().toISOString(),
+        },
+        purpose,
+      );
+
+      await expect(
+        routerClient.auth.magicLink.confirm({ token }, { context }),
+      ).rejects.toThrow("Invalid magic link token.");
+    });
+  }
 });

--- a/apps/server/src/orpc/routes/auth/magic-link/confirm.ts
+++ b/apps/server/src/orpc/routes/auth/magic-link/confirm.ts
@@ -1,7 +1,11 @@
 import { db } from "@peated/server/db";
 import { users } from "@peated/server/db/schema";
 import { AuditEvent, auditLog } from "@peated/server/lib/auditLog";
-import { createAccessToken, verifyPayload } from "@peated/server/lib/auth";
+import {
+  createAccessToken,
+  TOKEN_LIFETIME_SECONDS,
+  verifyToken,
+} from "@peated/server/lib/auth";
 import { procedure } from "@peated/server/orpc";
 import { authRateLimit } from "@peated/server/orpc/middleware";
 import { AuthSchema } from "@peated/server/schemas";
@@ -11,113 +15,80 @@ import { UserSerializer } from "@peated/server/serializers/user";
 import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
-const TOKEN_CUTOFF = 600; // 10 minutes
-
-export type MagicLinkAuthServices = {
-  createToken: typeof createAccessToken;
-  verifyToken: typeof verifyPayload;
-};
-
-const defaultServices: MagicLinkAuthServices = {
-  createToken: createAccessToken,
-  verifyToken: verifyPayload,
-};
-
-export function createMagicLinkConfirmProcedure(
-  services: MagicLinkAuthServices = defaultServices,
-) {
-  return procedure
-    .use(authRateLimit)
-    .route({
-      method: "POST",
-      path: "/auth/magic-link/confirm",
-      summary: "Confirm magic link",
-      description:
-        "Confirm magic link authentication and return access token. Automatically verifies the user account",
-      spec: (spec) => ({
-        ...spec,
-        operationId: "confirmMagicLink",
-      }),
-    })
-    .input(
-      z.object({
-        token: z.string(),
-      }),
-    )
-    .output(AuthSchema)
-    .handler(async function ({ input, context, errors }) {
-      let payload;
-      try {
-        payload = await services.verifyToken(input.token);
-      } catch (err) {
-        throw errors.BAD_REQUEST({
-          message: "Invalid magic link token.",
-          cause: err,
-        });
-      }
-
-      let parsedPayload;
-      try {
-        parsedPayload = MagicLinkSchema.parse(payload);
-      } catch (err) {
-        throw errors.BAD_REQUEST({
-          message: "Invalid magic link token.",
-          cause: err,
-        });
-      }
-
-      if (
-        new Date(parsedPayload.createdAt).getTime() <
-        new Date().getTime() - TOKEN_CUTOFF * 1000
-      ) {
-        throw errors.BAD_REQUEST({
-          message: "Invalid magic link token.",
-        });
-      }
-
-      const [user] = await db
-        .select()
-        .from(users)
-        .where(
-          and(
-            eq(users.id, parsedPayload.id),
-            eq(sql`LOWER(${users.email})`, parsedPayload.email.toLowerCase()),
-          ),
-        );
-      if (!user) {
-        throw errors.BAD_REQUEST({
-          message: "Invalid magic link token.",
-        });
-      }
-
-      if (!user.active) {
-        throw errors.BAD_REQUEST({
-          message: "Invalid magic link token.",
-        });
-      }
-
-      // Update user as verified
-      const [updatedUser] = await db
-        .update(users)
-        .set({
-          verified: true,
-        })
-        .where(eq(users.id, user.id))
-        .returning();
-
-      auditLog({
-        event: AuditEvent.LOGIN_SUCCESS,
-        userId: user.id,
-        ip: context.ip,
-        userAgent: context.userAgent,
-        metadata: { method: "magic_link" },
+export default procedure
+  .use(authRateLimit)
+  .route({
+    method: "POST",
+    path: "/auth/magic-link/confirm",
+    summary: "Confirm magic link",
+    description:
+      "Confirm magic link authentication and return access token. Automatically verifies the user account",
+    spec: (spec) => ({
+      ...spec,
+      operationId: "confirmMagicLink",
+    }),
+  })
+  .input(
+    z.object({
+      token: z.string(),
+    }),
+  )
+  .output(AuthSchema)
+  .handler(async function ({ input, context, errors }) {
+    let token;
+    try {
+      token = MagicLinkSchema.parse(
+        await verifyToken(input.token, "magic-link"),
+      );
+    } catch (err) {
+      throw errors.BAD_REQUEST({
+        message: "Invalid magic link token.",
+        cause: err,
       });
+    }
 
-      return {
-        user: await serialize(UserSerializer, updatedUser, updatedUser),
-        accessToken: await services.createToken(updatedUser),
-      };
+    if (
+      new Date(token.createdAt).getTime() <
+      Date.now() - TOKEN_LIFETIME_SECONDS["magic-link"] * 1000
+    ) {
+      throw errors.BAD_REQUEST({
+        message: "Invalid magic link token.",
+      });
+    }
+
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(
+        and(
+          eq(users.id, token.id),
+          eq(sql`LOWER(${users.email})`, token.email.toLowerCase()),
+        ),
+      );
+    if (!user?.active) {
+      throw errors.BAD_REQUEST({
+        message: "Invalid magic link token.",
+      });
+    }
+
+    const [updatedUser] = await db
+      .update(users)
+      .set({
+        verified: true,
+      })
+      .where(eq(users.id, user.id))
+      .returning();
+
+    auditLog({
+      event: AuditEvent.LOGIN_SUCCESS,
+      userId: user.id,
+      ip: context.ip,
+      userAgent: context.userAgent,
+      metadata: { method: "magic_link" },
     });
-}
 
-export default createMagicLinkConfirmProcedure();
+    return {
+      user: await serialize(UserSerializer, updatedUser, updatedUser),
+      accessToken: await createAccessToken(updatedUser),
+    };
+  });

--- a/apps/server/src/orpc/routes/auth/magic-link/create.test.ts
+++ b/apps/server/src/orpc/routes/auth/magic-link/create.test.ts
@@ -1,5 +1,4 @@
 import { createRouterClient } from "@orpc/server";
-import waitError from "@peated/server/lib/test/waitError";
 import {
   createMagicLinkProcedure,
   type MagicLinkSender,
@@ -26,39 +25,31 @@ describe("POST /auth/magic-link", () => {
     expect(sendMagicLinkEmail).toHaveBeenCalledWith({ user });
   });
 
-  test("throws error when magic link email delivery fails", async ({
-    fixtures,
-  }) => {
+  test("does not reveal email delivery failures", async ({ fixtures }) => {
     const user = await fixtures.User({ active: true });
     vi.mocked(sendMagicLinkEmail).mockRejectedValueOnce(
       new Error("SMTP credentials are not configured"),
     );
 
-    const error = await waitError(
+    await expect(
       magicLinkClient.create({ email: user.email }),
-    );
-
-    expect(error).toMatchInlineSnapshot(
-      `[Error: Unable to send magic link email.]`,
-    );
+    ).resolves.toEqual({});
   });
 
-  test("throws error when user is not found", async ({ fixtures }) => {
-    const error = await waitError(
+  test("does not reveal when user is not found", async () => {
+    await expect(
       magicLinkClient.create({ email: "nonexistent@example.com" }),
-    );
-
-    expect(error).toMatchInlineSnapshot(`[Error: Account not found.]`);
+    ).resolves.toEqual({});
+    expect(sendMagicLinkEmail).not.toHaveBeenCalled();
   });
 
-  test("throws error when user is not active", async ({ fixtures }) => {
+  test("does not reveal when user is not active", async ({ fixtures }) => {
     const user = await fixtures.User({ active: false });
 
-    const error = await waitError(
+    await expect(
       magicLinkClient.create({ email: user.email }),
-    );
-
-    expect(error).toMatchInlineSnapshot(`[Error: Account not found.]`);
+    ).resolves.toEqual({});
+    expect(sendMagicLinkEmail).not.toHaveBeenCalled();
   });
 
   test("is case-insensitive for email", async ({ fixtures }) => {

--- a/apps/server/src/orpc/routes/auth/magic-link/create.ts
+++ b/apps/server/src/orpc/routes/auth/magic-link/create.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 
 export type MagicLinkSender = typeof sendMagicLinkEmail;
 
+/** Attempts email delivery and returns success even if no account exists or delivery fails. */
 export function createMagicLinkProcedure(
   sendEmail: MagicLinkSender = sendMagicLinkEmail,
 ) {
@@ -31,23 +32,14 @@ export function createMagicLinkProcedure(
       }),
     )
     .output(z.object({}))
-    .handler(async function ({ input: { email }, errors }) {
+    .handler(async function ({ input: { email } }) {
       const [user] = await db
         .select()
         .from(users)
         .where(eq(sql`LOWER(${users.email})`, email));
 
-      if (!user) {
-        throw errors.NOT_FOUND({
-          message: "Account not found.",
-        });
-      }
-
-      if (!user.active) {
-        throw errors.NOT_FOUND({
-          message: "Account not found.",
-        });
-      }
+      // Account access rule: the response must not reveal whether an account exists.
+      if (!user?.active) return {};
 
       try {
         await sendEmail({ user });
@@ -57,9 +49,6 @@ export function createMagicLinkProcedure(
             name: "auth/magic-link/create",
             userId: user.id,
           },
-        });
-        throw errors.INTERNAL_SERVER_ERROR({
-          message: "Unable to send magic link email.",
         });
       }
 

--- a/apps/server/src/orpc/routes/auth/recovery/challenge.test.ts
+++ b/apps/server/src/orpc/routes/auth/recovery/challenge.test.ts
@@ -1,4 +1,4 @@
-import { signPayload } from "@peated/server/lib/auth";
+import { signToken } from "@peated/server/lib/auth";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { createHash } from "crypto";
@@ -11,12 +11,15 @@ describe("POST /auth/recovery/challenge", () => {
       .update(user.passwordHash || "")
       .digest("hex");
 
-    const token = await signPayload({
-      id: user.id,
-      email: user.email,
-      digest,
-      createdAt: new Date().toISOString(),
-    });
+    const token = await signToken(
+      {
+        id: user.id,
+        email: user.email,
+        digest,
+        createdAt: new Date().toISOString(),
+      },
+      "recovery",
+    );
 
     const result = await routerClient.auth.recovery.challenge(
       { token },
@@ -38,12 +41,15 @@ describe("POST /auth/recovery/challenge", () => {
     // Token created 15 minutes ago (expired, limit is 10 min)
     const expiredDate = new Date(Date.now() - 15 * 60 * 1000);
 
-    const token = await signPayload({
-      id: user.id,
-      email: user.email,
-      digest,
-      createdAt: expiredDate.toISOString(),
-    });
+    const token = await signToken(
+      {
+        id: user.id,
+        email: user.email,
+        digest,
+        createdAt: expiredDate.toISOString(),
+      },
+      "recovery",
+    );
 
     const err = await waitError(
       routerClient.auth.recovery.challenge(
@@ -58,12 +64,15 @@ describe("POST /auth/recovery/challenge", () => {
   test("rejects token with invalid digest", async ({ fixtures }) => {
     const user = await fixtures.User();
 
-    const token = await signPayload({
-      id: user.id,
-      email: user.email,
-      digest: "0".repeat(64), // Wrong digest
-      createdAt: new Date().toISOString(),
-    });
+    const token = await signToken(
+      {
+        id: user.id,
+        email: user.email,
+        digest: "0".repeat(64), // Wrong digest
+        createdAt: new Date().toISOString(),
+      },
+      "recovery",
+    );
 
     const err = await waitError(
       routerClient.auth.recovery.challenge(
@@ -78,12 +87,15 @@ describe("POST /auth/recovery/challenge", () => {
   test("rejects token for non-existent user", async () => {
     const digest = createHash("sha256").update("").digest("hex");
 
-    const token = await signPayload({
-      id: 99999,
-      email: "nonexistent@example.com",
-      digest,
-      createdAt: new Date().toISOString(),
-    });
+    const token = await signToken(
+      {
+        id: 99999,
+        email: "nonexistent@example.com",
+        digest,
+        createdAt: new Date().toISOString(),
+      },
+      "recovery",
+    );
 
     const err = await waitError(
       routerClient.auth.recovery.challenge(

--- a/apps/server/src/orpc/routes/auth/recovery/challenge.ts
+++ b/apps/server/src/orpc/routes/auth/recovery/challenge.ts
@@ -1,7 +1,7 @@
 import { ORPCError } from "@orpc/server";
 import { db } from "@peated/server/db";
 import { passkeys, users } from "@peated/server/db/schema";
-import { verifyPayload } from "@peated/server/lib/auth";
+import { TOKEN_LIFETIME_SECONDS, verifyToken } from "@peated/server/lib/auth";
 import { logError } from "@peated/server/lib/log";
 import {
   AuthenticatorTransportsSchema,
@@ -14,8 +14,6 @@ import type { PublicKeyCredentialCreationOptionsJSON } from "@simplewebauthn/ser
 import { createHash, timingSafeEqual } from "crypto";
 import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
-
-const TOKEN_CUTOFF = 600; // 10 minutes
 
 export default procedure
   .use(authRateLimit)
@@ -46,7 +44,7 @@ export default procedure
       // Verify the recovery token
       let payload;
       try {
-        payload = await verifyPayload(input.token);
+        payload = await verifyToken(input.token, "recovery");
       } catch (err) {
         throw errors.BAD_REQUEST({
           message: "Invalid verification token.",
@@ -56,7 +54,7 @@ export default procedure
       const token = PasswordResetSchema.parse(payload);
       if (
         new Date(token.createdAt).getTime() <
-        new Date().getTime() - TOKEN_CUTOFF * 1000
+        Date.now() - TOKEN_LIFETIME_SECONDS["recovery"] * 1000
       ) {
         throw errors.BAD_REQUEST({
           message: "Token has expired.",

--- a/apps/server/src/orpc/routes/auth/recovery/confirm-passkey.test.ts
+++ b/apps/server/src/orpc/routes/auth/recovery/confirm-passkey.test.ts
@@ -10,14 +10,14 @@ import { createHash } from "crypto";
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
-const verifyPayload = vi.fn<RecoveryPasskeyServices["verifyToken"]>();
+const verifyToken = vi.fn<RecoveryPasskeyServices["verifyToken"]>();
 const verifyPasskeyRegistration =
   vi.fn<RecoveryPasskeyServices["verifyRegistration"]>();
 const confirmPasskeyClient = createRouterClient(
   {
     confirmPasskey: createRecoveryPasskeyConfirmProcedure({
       verifyRegistration: verifyPasskeyRegistration,
-      verifyToken: verifyPayload,
+      verifyToken,
     }),
   },
   { context: { ip: "127.0.0.1", user: null } },
@@ -47,7 +47,7 @@ describe("POST /auth/recovery/passkey/confirm", () => {
       },
     };
 
-    verifyPayload.mockResolvedValue({
+    verifyToken.mockResolvedValue({
       id: user.id,
       email: user.email,
       digest,
@@ -95,7 +95,7 @@ describe("POST /auth/recovery/passkey/confirm", () => {
     const expiredDate = new Date();
     expiredDate.setMinutes(expiredDate.getMinutes() - 11); // 11 minutes ago
 
-    verifyPayload.mockResolvedValue({
+    verifyToken.mockResolvedValue({
       id: user.id,
       email: user.email,
       digest,
@@ -123,7 +123,7 @@ describe("POST /auth/recovery/passkey/confirm", () => {
   });
 
   test("rejects invalid token", async ({ fixtures }) => {
-    verifyPayload.mockRejectedValue(new Error("Invalid token"));
+    verifyToken.mockRejectedValue(new Error("Invalid token"));
 
     const err = await waitError(
       confirmPasskeyClient.confirmPasskey({
@@ -146,7 +146,7 @@ describe("POST /auth/recovery/passkey/confirm", () => {
   });
 
   test("rejects user not found", async ({ fixtures }) => {
-    verifyPayload.mockResolvedValue({
+    verifyToken.mockResolvedValue({
       id: 99999,
       email: "nonexistent@example.com",
       digest: "mock-digest",
@@ -193,7 +193,7 @@ describe("POST /auth/recovery/passkey/confirm", () => {
       },
     };
 
-    verifyPayload.mockResolvedValue({
+    verifyToken.mockResolvedValue({
       id: user.id,
       email: user.email,
       digest,

--- a/apps/server/src/orpc/routes/auth/recovery/confirm-passkey.ts
+++ b/apps/server/src/orpc/routes/auth/recovery/confirm-passkey.ts
@@ -5,7 +5,8 @@ import { AuditEvent, auditLog } from "@peated/server/lib/auditLog";
 import {
   createAccessToken,
   generatePasswordHash,
-  verifyPayload,
+  TOKEN_LIFETIME_SECONDS,
+  verifyToken,
 } from "@peated/server/lib/auth";
 import { logError } from "@peated/server/lib/log";
 import {
@@ -22,16 +23,14 @@ import { createHash, randomBytes, timingSafeEqual } from "crypto";
 import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
 
-const TOKEN_CUTOFF = 600; // 10 minutes
-
 export type RecoveryPasskeyServices = {
   verifyRegistration: typeof verifyPasskeyRegistration;
-  verifyToken: typeof verifyPayload;
+  verifyToken: typeof verifyToken;
 };
 
 const defaultServices: RecoveryPasskeyServices = {
   verifyRegistration: verifyPasskeyRegistration,
-  verifyToken: verifyPayload,
+  verifyToken,
 };
 
 export function createRecoveryPasskeyConfirmProcedure(
@@ -67,7 +66,7 @@ export function createRecoveryPasskeyConfirmProcedure(
         // Verify the recovery token
         let payload;
         try {
-          payload = await services.verifyToken(input.token);
+          payload = await services.verifyToken(input.token, "recovery");
         } catch (err) {
           throw errors.BAD_REQUEST({
             message: "Invalid verification token.",
@@ -77,7 +76,7 @@ export function createRecoveryPasskeyConfirmProcedure(
         const token = PasswordResetSchema.parse(payload);
         if (
           new Date(token.createdAt).getTime() <
-          new Date().getTime() - TOKEN_CUTOFF * 1000
+          Date.now() - TOKEN_LIFETIME_SECONDS["recovery"] * 1000
         ) {
           throw errors.BAD_REQUEST({
             message: "Token has expired.",

--- a/apps/server/src/orpc/routes/auth/recovery/confirm.test.ts
+++ b/apps/server/src/orpc/routes/auth/recovery/confirm.test.ts
@@ -1,6 +1,6 @@
 import { db } from "@peated/server/db";
 import { users } from "@peated/server/db/schema";
-import { signPayload } from "@peated/server/lib/auth";
+import { signToken } from "@peated/server/lib/auth";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { compareSync } from "bcrypt";
@@ -8,17 +8,74 @@ import { createHash } from "crypto";
 import { eq } from "drizzle-orm";
 
 describe("POST /auth/password-reset/confirm", () => {
+  test("rejects magic-link tokens across recovery flows", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ verified: false });
+    const token = await signToken(
+      {
+        id: user.id,
+        email: user.email,
+        createdAt: new Date().toISOString(),
+        digest: createHash("sha256")
+          .update(user.passwordHash || "")
+          .digest("hex"),
+      },
+      "magic-link",
+    );
+    const options = { context: { ip: "127.0.0.1" } };
+
+    await expect(
+      routerClient.auth.recovery.confirm(
+        { token, password: "newpassword" },
+        options,
+      ),
+    ).rejects.toThrow("Invalid verification token.");
+    await expect(
+      routerClient.auth.recovery.challenge({ token }, options),
+    ).rejects.toThrow("Invalid verification token.");
+    await expect(
+      routerClient.auth.recovery.confirmPasskey(
+        {
+          token,
+          signedChallenge: "unused-challenge",
+          passkeyResponse: {
+            id: "unused-credential",
+            rawId: "unused-credential",
+            type: "public-key",
+            clientExtensionResults: {},
+            response: {
+              clientDataJSON: "unused-client-data",
+              attestationObject: "unused-attestation",
+            },
+          },
+        },
+        options,
+      ),
+    ).rejects.toThrow("Invalid verification token.");
+
+    const [storedUser] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, user.id));
+    expect(storedUser.passwordHash).toBe(user.passwordHash);
+    expect(storedUser.verified).toBe(false);
+  });
+
   test("valid token", async ({ fixtures }) => {
     const user = await fixtures.User();
 
-    const token = await signPayload({
-      id: user.id,
-      email: user.email,
-      createdAt: new Date(),
-      digest: createHash("sha256")
-        .update(user.passwordHash || "")
-        .digest("hex"),
-    });
+    const token = await signToken(
+      {
+        id: user.id,
+        email: user.email,
+        createdAt: new Date().toISOString(),
+        digest: createHash("sha256")
+          .update(user.passwordHash || "")
+          .digest("hex"),
+      },
+      "recovery",
+    );
 
     await routerClient.auth.recovery.confirm(
       {
@@ -38,12 +95,15 @@ describe("POST /auth/password-reset/confirm", () => {
   test("invalid digest", async ({ fixtures }) => {
     const user = await fixtures.User();
 
-    const token = await signPayload({
-      id: user.id,
-      email: user.email,
-      createdAt: new Date(),
-      digest: "abc",
-    });
+    const token = await signToken(
+      {
+        id: user.id,
+        email: user.email,
+        createdAt: new Date().toISOString(),
+        digest: "abc",
+      },
+      "recovery",
+    );
 
     const err = await waitError(
       routerClient.auth.recovery.confirm(
@@ -67,14 +127,17 @@ describe("POST /auth/password-reset/confirm", () => {
   test("expired token", async ({ fixtures }) => {
     const user = await fixtures.User();
 
-    const token = await signPayload({
-      id: user.id,
-      email: user.email,
-      createdAt: new Date("2023-12-01T12:56:36Z"),
-      digest: createHash("sha256")
-        .update(user.passwordHash || "")
-        .digest("hex"),
-    });
+    const token = await signToken(
+      {
+        id: user.id,
+        email: user.email,
+        createdAt: "2023-12-01T12:56:36Z",
+        digest: createHash("sha256")
+          .update(user.passwordHash || "")
+          .digest("hex"),
+      },
+      "recovery",
+    );
 
     const err = await waitError(
       routerClient.auth.recovery.confirm(

--- a/apps/server/src/orpc/routes/auth/recovery/confirm.ts
+++ b/apps/server/src/orpc/routes/auth/recovery/confirm.ts
@@ -4,7 +4,8 @@ import { AuditEvent, auditLog } from "@peated/server/lib/auditLog";
 import {
   createAccessToken,
   generatePasswordHash,
-  verifyPayload,
+  TOKEN_LIFETIME_SECONDS,
+  verifyToken,
 } from "@peated/server/lib/auth";
 import { procedure } from "@peated/server/orpc";
 import { authRateLimit } from "@peated/server/orpc/middleware";
@@ -14,8 +15,6 @@ import { UserSerializer } from "@peated/server/serializers/user";
 import { createHash, timingSafeEqual } from "crypto";
 import { and, eq, sql } from "drizzle-orm";
 import { z } from "zod";
-
-const TOKEN_CUTOFF = 600; // 10 minutes
 
 export default procedure
   .use(authRateLimit)
@@ -40,7 +39,7 @@ export default procedure
   .handler(async function ({ input, context, errors }) {
     let payload;
     try {
-      payload = await verifyPayload(input.token);
+      payload = await verifyToken(input.token, "recovery");
     } catch (err) {
       throw errors.BAD_REQUEST({
         message: "Invalid verification token.",
@@ -50,7 +49,7 @@ export default procedure
     const token = PasswordResetSchema.parse(payload);
     if (
       new Date(token.createdAt).getTime() <
-      new Date().getTime() - TOKEN_CUTOFF * 1000
+      Date.now() - TOKEN_LIFETIME_SECONDS["recovery"] * 1000
     ) {
       throw errors.BAD_REQUEST({
         message: "Token has expired.",

--- a/apps/server/src/orpc/routes/auth/recovery/create.test.ts
+++ b/apps/server/src/orpc/routes/auth/recovery/create.test.ts
@@ -93,4 +93,47 @@ describe("POST /auth/password-reset", () => {
     );
     expect(sendPasswordResetEmail).not.toHaveBeenCalled();
   });
+
+  test("stops requests when the rate-limit counter fails", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User();
+    const counterError = new Error("Redis unavailable");
+    const client = createRouterClient(
+      {
+        create: createRecoveryProcedure(
+          sendPasswordResetEmail,
+          createAuthRateLimit(async () => {
+            throw counterError;
+          }),
+        ),
+      },
+      { context: { ip: "127.0.0.1", user: null } },
+    );
+
+    await expect(client.create({ email: user.email })).rejects.toThrow(
+      counterError,
+    );
+    expect(sendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  test("allows 15 requests per IP and rejects the next request", async () => {
+    for (let count = 0; count < 15; count++) {
+      await expect(
+        recoveryClient.create({ email: "nonexistent@example.com" }),
+      ).resolves.toEqual({});
+    }
+
+    await expect(
+      recoveryClient.create({ email: "nonexistent@example.com" }),
+    ).rejects.toThrow("Too many requests. Please try again later.");
+
+    const otherClient = createRouterClient(
+      { create: createRecoveryProcedure(sendPasswordResetEmail) },
+      { context: { ip: "127.0.0.2", user: null } },
+    );
+    await expect(
+      otherClient.create({ email: "nonexistent@example.com" }),
+    ).resolves.toEqual({});
+  });
 });

--- a/apps/server/src/orpc/routes/email/verify.test.ts
+++ b/apps/server/src/orpc/routes/email/verify.test.ts
@@ -1,6 +1,6 @@
 import { db } from "@peated/server/db";
 import { users } from "@peated/server/db/schema";
-import { signPayload } from "@peated/server/lib/auth";
+import { createAccessToken, signToken } from "@peated/server/lib/auth";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { eq } from "drizzle-orm";
@@ -10,10 +10,13 @@ describe("POST /email/verify", () => {
   test("valid token", async ({ fixtures }) => {
     const user = await fixtures.User({ verified: false });
 
-    const token = await signPayload({
-      id: user.id,
-      email: user.email,
-    });
+    const token = await signToken(
+      {
+        id: user.id,
+        email: user.email,
+      },
+      "email-verification",
+    );
 
     await routerClient.email.verify({ token });
 
@@ -30,5 +33,20 @@ describe("POST /email/verify", () => {
     );
 
     expect(err).toMatchInlineSnapshot(`[Error: Invalid verification token.]`);
+  });
+
+  test("cannot verify email with an API access token", async ({ fixtures }) => {
+    const user = await fixtures.User({ verified: false });
+    const token = await createAccessToken(user);
+
+    await expect(routerClient.email.verify({ token })).rejects.toThrow(
+      "Invalid verification token.",
+    );
+
+    const [storedUser] = await db
+      .select()
+      .from(users)
+      .where(eq(users.id, user.id));
+    expect(storedUser.verified).toBe(false);
   });
 });

--- a/apps/server/src/orpc/routes/email/verify.ts
+++ b/apps/server/src/orpc/routes/email/verify.ts
@@ -1,6 +1,6 @@
 import { db } from "@peated/server/db";
 import { users } from "@peated/server/db/schema";
-import { verifyPayload } from "@peated/server/lib/auth";
+import { verifyToken } from "@peated/server/lib/auth";
 import { procedure } from "@peated/server/orpc";
 import { EmailVerifySchema } from "@peated/server/schemas";
 import { and, eq, sql } from "drizzle-orm";
@@ -20,7 +20,7 @@ export default procedure
   .handler(async function ({ input, errors }) {
     let payload;
     try {
-      payload = await verifyPayload(input.token);
+      payload = await verifyToken(input.token, "email-verification");
     } catch (err) {
       throw errors.BAD_REQUEST({
         message: "Invalid verification token.",

--- a/apps/web/src/components/loginForm.tsx
+++ b/apps/web/src/components/loginForm.tsx
@@ -107,11 +107,12 @@ export default function LoginForm() {
   if (result?.magicLink) {
     return (
       <AuthenticationPanel
-        description="Use the secure link we sent to finish signing in."
+        description="Use the link in your email to finish signing in."
         title="Check your email"
       >
         <AuthenticationNotice>
-          The link is on its way{email ? ` to ${email}` : ""}.
+          If an account uses this email, we'll send a sign-in link. If it
+          doesn't arrive, check your spam folder or try again.
         </AuthenticationNotice>
         <AccountLinks email={email} />
       </AuthenticationPanel>

--- a/docs/architecture/account-access.md
+++ b/docs/architecture/account-access.md
@@ -1,6 +1,6 @@
 # Account Access
 
-This document records the product rules for Terms of Service acceptance and
+This document records the rules for sign-in, Terms of Service acceptance, and
 email verification. Middleware, route schemas, and tests define exact behavior.
 
 ## Terms Of Service
@@ -38,9 +38,34 @@ addition to their other authorization middleware. The UI may prompt unverified
 users without presenting verification as a requirement for operations that do
 not enforce it.
 
+## Authentication Safeguards
+
+Sign-in, registration, and recovery routes share a limit of 15 requests per
+hour per signed-in user or IP address. Redis stores the request count. If that
+count cannot be checked, the request stops and the error handler reports the
+failure.
+
+Magic-link requests return the same empty success response for active,
+inactive, and unknown accounts. Email delivery failures are reported internally
+without changing the response. Neither the status code nor the response body
+reveals whether an account exists. Response times can still differ.
+
+Each signed token records its purpose in the JWT `aud` (audience) field.
+`verifyToken` checks that purpose, the signature, and the expiration time before
+returning the token's data. API requests using `Authorization: Bearer` require
+an access token.
+Email sign-in links, recovery links, email verification links, passkey
+challenges, and proposals to create a Bottle from a photo each have a separate
+purpose. Email sign-in links, recovery links, and passkey challenges expire
+after 10 minutes; access tokens expire after 7 days.
+
+Tokens without a purpose are rejected. When this check is first deployed,
+users must sign in again and request new emailed links.
+
 ## Ownership
 
 - user fields: `apps/server/src/db/schema/users.ts`
+- token signing and verification: `apps/server/src/lib/auth.ts`
 - authentication middleware: `apps/server/src/orpc/middleware/auth.ts`
 - acceptance route: `apps/server/src/orpc/routes/auth/tos/accept.ts`
 - registration and authentication: `apps/server/src/orpc/routes/auth/`


### PR DESCRIPTION
Authentication now stops when Redis cannot enforce the request limit. Requesting an email sign-in link returns the same response for active, inactive, and unknown accounts, including when email delivery fails.

Signed tokens now record their purpose, and each route checks it before using the token. This prevents magic-link, recovery, and email-verification tokens from being accepted as API credentials or used in another authentication flow. Token lifetimes are defined in one place; email sign-in links, recovery links, and passkey challenges expire after ten minutes.

**Deployment invalidates existing sessions and previously issued tokens.** Users must sign in again, request fresh emailed links, and retry any pending Bottle creation from a photo. Tokens without a purpose are rejected.

Regression coverage checks token misuse, expiration, rate-limit failures, and identical responses to email sign-in requests, alongside successful authentication and OAuth flows. All 127 targeted tests passed, along with server and web typechecks, lint, and formatting. Full-suite and browser QA were not run.
