### PR TITLE
fix(activity): restore library addition bottle previews

### DIFF
--- a/apps/server/src/lib/activityFeed.ts
+++ b/apps/server/src/lib/activityFeed.ts
@@ -45,11 +45,12 @@ export type TastingSessionGroup = {
   tastings: Tasting[];
 };
 
+/** Keeps PostgreSQL timestamp text so preview bounds retain microsecond precision. */
 export type CollectionAddGroup = {
   collection: Collection;
   user: User;
-  windowStart: Date;
-  windowEnd: Date;
+  windowStart: string;
+  windowEnd: string;
   totalItems: number;
 };
 
@@ -545,26 +546,32 @@ export async function serializeCollectionAddEntries({
       serializedCollectionsById.set(group.collection.id, collection);
     }
 
+    // Activity previews must use exact database bounds; JS dates truncate microseconds.
     const previewRows = await db
       .select()
       .from(collectionBottles)
       .where(
         and(
           eq(collectionBottles.collectionId, group.collection.id),
-          gte(collectionBottles.createdAt, group.windowStart),
-          lte(collectionBottles.createdAt, group.windowEnd),
+          gte(
+            collectionBottles.createdAt,
+            sql`${group.windowStart}::timestamp`,
+          ),
+          lte(collectionBottles.createdAt, sql`${group.windowEnd}::timestamp`),
         ),
       )
       .orderBy(desc(collectionBottles.createdAt))
       .limit(COLLECTION_PREVIEW_LIMIT);
 
+    const windowStart = coerceActivityDate(group.windowStart);
+    const windowEnd = coerceActivityDate(group.windowEnd);
     entries.push({
-      id: `collection_add:${group.user.id}:${group.collection.id}:${group.windowEnd.getTime()}`,
+      id: `collection_add:${group.user.id}:${group.collection.id}:${windowEnd.getTime()}`,
       type: "collection_add",
       priority: "secondary",
-      createdAt: group.windowEnd.toISOString(),
-      windowStart: group.windowStart.toISOString(),
-      windowEnd: group.windowEnd.toISOString(),
+      createdAt: windowEnd.toISOString(),
+      windowStart: windowStart.toISOString(),
+      windowEnd: windowEnd.toISOString(),
       createdBy,
       collection,
       items: await serialize(

--- a/apps/server/src/orpc/routes/activity/list.test.ts
+++ b/apps/server/src/orpc/routes/activity/list.test.ts
@@ -2,6 +2,7 @@ import { db } from "@peated/server/db";
 import { collectionBottles, memberReviews } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
+import { sql } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
 
 async function insertCollectionBottles(
@@ -15,6 +16,56 @@ async function insertCollectionBottles(
 }
 
 describe("GET /activity", () => {
+  for (const feed of ["global", "profile"] as const) {
+    test(`includes microsecond-precision additions in ${feed} feed previews`, async ({
+      fixtures,
+    }) => {
+      const user = await fixtures.User();
+      const collection = await fixtures.Collection({
+        name: "Library",
+        createdById: user.id,
+      });
+      const addedBottles = await Promise.all(
+        Array.from({ length: 6 }, () => fixtures.Bottle()),
+      );
+      await db.insert(collectionBottles).values(
+        addedBottles.map((bottle, index) => ({
+          collectionId: collection.id,
+          bottleId: bottle.id,
+          createdAt:
+            index === 0
+              ? sql`TIMESTAMP '2026-01-04 12:00:00.123456'`
+              : sql`TIMESTAMP '2026-01-03 12:00:00.123000' + ${index} * INTERVAL '1 microsecond'`,
+        })),
+      );
+
+      const result =
+        feed === "global"
+          ? await routerClient.activity.list({ filter: "global", limit: 10 })
+          : await routerClient.users.activity.list({
+              user: user.username,
+              limit: 10,
+            });
+
+      expect(result.results).toMatchObject([
+        {
+          type: "collection_add",
+          totalItems: 1,
+          createdAt: "2026-01-04T12:00:00.123Z",
+          items: [{ bottle: { id: addedBottles[0].id } }],
+        },
+        {
+          type: "collection_add",
+          totalItems: 5,
+          createdAt: "2026-01-03T12:00:00.123Z",
+          items: [5, 4, 3, 2].map((index) => ({
+            bottle: { id: addedBottles[index].id },
+          })),
+        },
+      ]);
+    });
+  }
+
   test("returns tastings and grouped collection additions", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/activity/list.ts
+++ b/apps/server/src/orpc/routes/activity/list.ts
@@ -6,7 +6,6 @@ import {
   users,
 } from "@peated/server/db/schema";
 import {
-  coerceActivityDate,
   composeActivity,
   countPrimaryActivity,
   encodeActivityCursor,
@@ -31,8 +30,8 @@ type ActivityFilter = "global" | "friends" | "local";
 type CollectionAddGroupRow = {
   collection: typeof collections.$inferSelect;
   user: typeof users.$inferSelect;
-  windowStart: Date | string;
-  windowEnd: Date | string;
+  windowStart: string;
+  windowEnd: string;
   totalItems: string;
 };
 
@@ -126,8 +125,8 @@ export default implement(activityListContract).handler(async function ({
       .select({
         collection: collections,
         user: users,
-        windowStart: sql<Date>`MIN(${collectionBottles.createdAt})`,
-        windowEnd: sql<Date>`MAX(${collectionBottles.createdAt})`,
+        windowStart: sql<string>`MIN(${collectionBottles.createdAt})::text`,
+        windowEnd: sql<string>`MAX(${collectionBottles.createdAt})::text`,
         totalItems: sql<string>`COUNT(${collectionBottles.id})`,
       })
       .from(collectionBottles)
@@ -157,8 +156,8 @@ export default implement(activityListContract).handler(async function ({
       (row: CollectionAddGroupRow): CollectionAddGroup => ({
         collection: row.collection,
         user: row.user,
-        windowStart: coerceActivityDate(row.windowStart),
-        windowEnd: coerceActivityDate(row.windowEnd),
+        windowStart: row.windowStart,
+        windowEnd: row.windowEnd,
         totalItems: Number(row.totalItems),
       }),
     ),

--- a/apps/server/src/orpc/routes/users/activity/list.ts
+++ b/apps/server/src/orpc/routes/users/activity/list.ts
@@ -5,7 +5,6 @@ import {
   users,
 } from "@peated/server/db/schema";
 import {
-  coerceActivityDate,
   composeActivity,
   countPrimaryActivity,
   encodeActivityCursor,
@@ -23,8 +22,8 @@ import { and, desc, eq, lte, sql } from "drizzle-orm";
 
 type CollectionAddGroupRow = {
   collection: typeof collections.$inferSelect;
-  windowStart: Date | string;
-  windowEnd: Date | string;
+  windowStart: string;
+  windowEnd: string;
   totalItems: string;
 };
 
@@ -91,8 +90,8 @@ export default implement(userActivityListContract).handler(async function ({
     db
       .select({
         collection: collections,
-        windowStart: sql<Date>`MIN(${collectionBottles.createdAt})`,
-        windowEnd: sql<Date>`MAX(${collectionBottles.createdAt})`,
+        windowStart: sql<string>`MIN(${collectionBottles.createdAt})::text`,
+        windowEnd: sql<string>`MAX(${collectionBottles.createdAt})::text`,
         totalItems: sql<string>`COUNT(${collectionBottles.id})`,
       })
       .from(collectionBottles)
@@ -119,8 +118,8 @@ export default implement(userActivityListContract).handler(async function ({
       (row: CollectionAddGroupRow): CollectionAddGroup => ({
         collection: row.collection,
         user,
-        windowStart: coerceActivityDate(row.windowStart),
-        windowEnd: coerceActivityDate(row.windowEnd),
+        windowStart: row.windowStart,
+        windowEnd: row.windowEnd,
         totalItems: Number(row.totalItems),
       }),
     ),


### PR DESCRIPTION
Restore bottle previews for library additions in the global and profile activity feeds. A single addition displays its bottle; larger groups show up to four bottles, with a "View N more bottles" link only for the remainder.

The preview lookup converted PostgreSQL timestamps to JavaScript dates, truncating microseconds and excluding the newest addition from its own group. Keep the exact database timestamps for lookup bounds and convert them only when building the response. Public timestamps, entry IDs, and stored data are unchanged.

Regression coverage exercises single additions and capped, newest-first groups with microsecond timestamps through both feed routes.
