### PR TITLE
fix(web): extend SEO across public catalog pages

### DIFF
--- a/apps/web/e2e/bottle-checks.spec.ts
+++ b/apps/web/e2e/bottle-checks.spec.ts
@@ -98,7 +98,9 @@ test("runs a clean moderator Bottle audit inline and returns to the Bottle", asy
   );
   await page.getByRole("button", { name: "Run audit" }).click();
   await auditRequest;
-  await expect(page).toHaveURL(`/bottles/${existingBottleId}/audit`);
+  await expect(page).toHaveURL(
+    new RegExp(`/bottles/${existingBottleId}-[^/?#]+/audit$`),
+  );
   await expect(
     page.getByText(
       "No changes proposed. The Bottle identity is supported by the inspected evidence.",

--- a/apps/web/e2e/bottle-page-redirects.spec.ts
+++ b/apps/web/e2e/bottle-page-redirects.spec.ts
@@ -11,12 +11,16 @@ test.describe("Bottle page redirects", () => {
 
   test("permanently redirects an exact replacement and preserves its suffix", async ({
     page,
+    request,
   }) => {
     const sourcePath = `/bottles/${replacementSourceBottleId}/tastings?source=legacy&tag=one&tag=two`;
     const replacementPath = new RegExp(
       `/bottles/${exactMatchedBottleId}-[^/?#]+/tastings\\?source=legacy&tag=one&tag=two$`,
     );
 
+    const response = await request.get(sourcePath, { maxRedirects: 0 });
+    expect(response.status()).toBe(308);
+    expect(response.headers().location).toMatch(replacementPath);
     await page.goto(sourcePath, { waitUntil: "commit" });
     await expect(page).toHaveURL(replacementPath);
   });

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -62,6 +62,7 @@ import {
   testOwner,
   testRegion,
   testRegions,
+  testSeries,
   testUser,
   unifiedBottleEditContext,
 } from "./rpc-fixtures.mjs";
@@ -301,22 +302,36 @@ async function handleRpcRequest({ request, response, url }) {
     case "regions/details": {
       const region = testRegions.find(
         (region) =>
-          region.country.slug === input?.country &&
-          region.slug === input?.region,
+          region.country.slug === input?.country?.toLowerCase() &&
+          region.slug === input?.region?.toLowerCase(),
       );
       if (!region) {
-        sendRpcError(response, "Unexpected region details payload");
+        sendRpcNotFound(response, "Region not found.");
         return true;
       }
       sendRpcResponse(response, region);
       return true;
     }
+    case "bottleSeries/details":
+      if (![testSeries.id, 9402].includes(Number(input?.series))) {
+        sendRpcNotFound(response, "Series not found.");
+        return true;
+      }
+      sendRpcResponse(response, testSeries);
+      return true;
+    case "bottleSeries/list":
+      sendRpcResponse(response, {
+        ...emptyList,
+        results: [testSeries],
+        total: 1,
+      });
+      return true;
     case "countries/details": {
       const country = testCountries.find(
-        (country) => country.slug === input?.country,
+        (country) => country.slug === input?.country?.toLowerCase(),
       );
       if (!country) {
-        sendRpcError(response, "Unexpected country details payload");
+        sendRpcNotFound(response, "Country not found.");
         return true;
       }
       sendRpcResponse(response, country);
@@ -799,6 +814,10 @@ async function handleRpcRequest({ request, response, url }) {
       return true;
     }
     case "bottles/list":
+      if (Number(input?.series) === testSeries.id) {
+        sendRpcResponse(response, buildBottleListResponse([existingBottle]));
+        return true;
+      }
       if (getAccessToken(request).includes("exact-bottle-merge")) {
         sendRpcResponse(response, {
           results: [existingBottle, exactMergeOtherBottle],

--- a/apps/web/e2e/routes.spec.ts
+++ b/apps/web/e2e/routes.spec.ts
@@ -13,11 +13,17 @@ import {
   testOwnedEntity,
   testOwner,
   testRegion,
+  testSeries,
   testUser,
 } from "./rpc-fixtures.mjs";
 import { signIn } from "./session";
 
 const publicRoutes = [
+  {
+    heading: testSeries.name,
+    name: "Series",
+    path: `/series/${testSeries.id}`,
+  },
   {
     heading: "A record of whisky, bottle by bottle.",
     name: "Home",
@@ -72,7 +78,22 @@ const otherPublicRoutes = [
   ["company", `/companies/${testOwner.id}`],
 ] as const;
 
-test("public routes load", async ({ page, snapshot }) => {
+test("public routes load", async ({ page, request, snapshot }) => {
+  for (const source of [
+    `/series/${testSeries.id}`,
+    `/series/${testSeries.id}-old.name`,
+    "/series/9402-old",
+    `/S${testSeries.id}`,
+  ]) {
+    const response = await request.get(
+      `${source}?source=legacy&tag=one&tag=two`,
+      { maxRedirects: 0 },
+    );
+    expect(response.status()).toBe(308);
+    expect(response.headers().location).toBe(
+      `/series/${testSeries.id}-lagavulin-special-releases?source=legacy&tag=one&tag=two`,
+    );
+  }
   for (const route of publicRoutes) {
     await test.step(route.name, async () => {
       const response = await page.goto(route.path, { waitUntil: "commit" });
@@ -105,6 +126,24 @@ test("public routes load", async ({ page, snapshot }) => {
           await page.keyboard.press("Escape");
           await expect(panel).toHaveCount(0);
           await expect(smoke).toBeFocused();
+        }
+        if (["Series", "Country", "Region"].includes(route.name)) {
+          await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+            "href",
+            page.url(),
+          );
+          await expect(page.locator('meta[property="og:url"]')).toHaveAttribute(
+            "content",
+            page.url(),
+          );
+          const structured = await page
+            .locator('script[type="application/ld+json"]')
+            .allTextContents();
+          expect(
+            structured.some(
+              (value) => JSON.parse(value)["@type"] === "CollectionPage",
+            ),
+          ).toBe(true);
         }
         await snapshot(route.name, { ready: heading });
       }
@@ -153,8 +192,25 @@ test(
 
 test("browse from the homepage through a country and its regions", async ({
   page,
+  request,
   snapshot,
 }) => {
+  const source = `/locations/${testCountry.slug.toUpperCase()}/regions/${testRegion.slug.toUpperCase()}/bottles?source=legacy&tag=one&tag=two`;
+  const redirect = await request.get(source, { maxRedirects: 0 });
+  expect(redirect.status()).toBe(308);
+  expect(redirect.headers().location).toBe(
+    `/locations/${testCountry.slug}/regions/${testRegion.slug}/bottles?source=legacy&tag=one&tag=two`,
+  );
+  await page.goto(
+    `/locations/${testCountry.slug}/regions/${testRegion.slug}/bottles?cursor=2`,
+  );
+  await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+    "href",
+    page.url(),
+  );
+  await expect(page).toHaveTitle(
+    `Whisky bottles from ${testRegion.name}, ${testCountry.name} | Peated`,
+  );
   await page.goto("/");
   await page
     .getByRole("link", { name: new RegExp(`^${testCountry.name} `) })

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -1079,3 +1079,16 @@ export const emptyList = {
     prevCursor: null,
   },
 };
+
+export const testSeries = {
+  id: 9401,
+  peatedId: "S9401",
+  name: "Special Releases",
+  fullName: "Lagavulin Special Releases",
+  description: "Whisky from the Special Releases series.",
+  numReleases: 1,
+  brand: testBrand,
+  distillers: [],
+  createdAt: timestamp,
+  updatedAt: timestamp,
+};

--- a/apps/web/public/robots.txt
+++ b/apps/web/public/robots.txt
@@ -21,6 +21,9 @@ Host: https://peated.com
 
 # Sitemaps
 Sitemap: https://peated.com/sitemap.xml
+Sitemap: https://peated.com/sitemaps/series/sitemap.xml
+Sitemap: https://peated.com/sitemaps/locations.xml
+Sitemap: https://peated.com/sitemaps/regions/sitemap.xml
 Sitemap: https://peated.com/sitemaps/bottles/sitemap.xml
 Sitemap: https://peated.com/sitemaps/tastings/sitemap.xml
 Sitemap: https://peated.com/sitemaps/brands/sitemap.xml

--- a/apps/web/src/app/(app)/(entity-catalog)/bottlers/page.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/bottlers/page.tsx
@@ -1,11 +1,19 @@
-import type { Metadata } from "next";
+import { getCatalogSeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import { EntityCatalogPage } from "../entityCatalogPage";
 
-export const metadata: Metadata = {
-  title: "Whisky Bottlers",
-  description: "Browse whisky bottlers recorded in the Peated database.",
-};
+export async function generateMetadata(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return getCatalogSeoMetadata(
+    {
+      title: "Whisky bottlers",
+      description: "Browse whisky bottlers recorded in the Peated database.",
+      url: "/bottlers",
+    },
+    await props.searchParams,
+  );
+}
 
 export default function BottlerListPage(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/apps/web/src/app/(app)/(entity-catalog)/brands/page.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/brands/page.tsx
@@ -1,11 +1,19 @@
-import type { Metadata } from "next";
+import { getCatalogSeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import { EntityCatalogPage } from "../entityCatalogPage";
 
-export const metadata: Metadata = {
-  title: "Whisky Brands",
-  description: "Browse whisky brands recorded in the Peated database.",
-};
+export async function generateMetadata(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return getCatalogSeoMetadata(
+    {
+      title: "Whisky brands",
+      description: "Browse whisky brands recorded in the Peated database.",
+      url: "/brands",
+    },
+    await props.searchParams,
+  );
+}
 
 export default function BrandListPage(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/apps/web/src/app/(app)/(entity-catalog)/companies/page.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/companies/page.tsx
@@ -1,11 +1,19 @@
-import type { Metadata } from "next";
+import { getCatalogSeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import { EntityCatalogPage } from "../entityCatalogPage";
 
-export const metadata: Metadata = {
-  title: "Whisky Companies",
-  description: "Browse whisky companies recorded in the Peated database.",
-};
+export async function generateMetadata(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return getCatalogSeoMetadata(
+    {
+      title: "Whisky companies",
+      description: "Browse whisky companies recorded in the Peated database.",
+      url: "/companies",
+    },
+    await props.searchParams,
+  );
+}
 
 export default function CompanyListPage(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/apps/web/src/app/(app)/(entity-catalog)/distillers/page.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/distillers/page.tsx
@@ -1,11 +1,19 @@
-import type { Metadata } from "next";
+import { getCatalogSeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import { EntityCatalogPage } from "../entityCatalogPage";
 
-export const metadata: Metadata = {
-  title: "Whisky Distillers",
-  description: "Browse whisky distillers recorded in the Peated database.",
-};
+export async function generateMetadata(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return getCatalogSeoMetadata(
+    {
+      title: "Whisky distilleries",
+      description: "Browse whisky distilleries and the bottles they make.",
+      url: "/distillers",
+    },
+    await props.searchParams,
+  );
+}
 
 export default function DistillerListPage(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/apps/web/src/app/(app)/bottles/(index)/page.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/page.tsx
@@ -5,14 +5,22 @@ import {
   normalizeBottleCatalogQueryParams,
 } from "@peated/web/lib/bottleCatalogQueryParams";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
-import type { Metadata } from "next";
+import { getCatalogSeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import { BottleCatalogPageClient } from "./bottleCatalogPageClient";
 
-export const metadata: Metadata = {
-  title: "Whisky Bottles",
-  description: "Browse whisky bottles in the Peated database.",
-};
+export async function generateMetadata(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return getCatalogSeoMetadata(
+    {
+      title: "Whisky bottles",
+      description: "Browse whisky bottles in the Peated database.",
+      url: "/bottles",
+    },
+    await props.searchParams,
+  );
+}
 
 export default async function BottleListPage(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/apps/web/src/app/(app)/locations/(index)/all-regions/page.tsx
+++ b/apps/web/src/app/(app)/locations/(index)/all-regions/page.tsx
@@ -2,14 +2,22 @@ import { CursorPager } from "@peated/web/components";
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
-import type { Metadata } from "next";
+import { getCatalogSeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import { LocationTable } from "../../locationLists";
 
-export const metadata: Metadata = {
-  title: "Whisky Locations",
-  description: "Browse every whisky-producing country recorded by Peated.",
-};
+export async function generateMetadata(props: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  return getCatalogSeoMetadata(
+    {
+      title: "Whisky countries",
+      description: "Browse every whisky-producing country recorded by Peated.",
+      url: "/locations/all-regions",
+    },
+    await props.searchParams,
+  );
+}
 
 export default async function AllLocationsPage(props: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/apps/web/src/app/(app)/locations/(index)/page.tsx
+++ b/apps/web/src/app/(app)/locations/(index)/page.tsx
@@ -1,11 +1,13 @@
 import { CardGrid, LocationCard } from "@peated/web/components";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
-import type { Metadata } from "next";
+import { getCatalogSeoMetadata } from "@peated/web/lib/seoMetadata";
 
-export const metadata: Metadata = {
-  title: "Whisky Locations",
-  description: "Browse whisky-producing countries recorded by Peated.",
-};
+export const metadata = getCatalogSeoMetadata({
+  title: "Whisky locations",
+  description:
+    "Browse whisky countries and regions, with bottles, distilleries, ratings, and tasting notes.",
+  url: "/locations",
+});
 
 export default async function LocationsPage() {
   const { client } = await getAnonymousServerClient();

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/bottles/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/bottles/page.tsx
@@ -5,12 +5,25 @@ import {
 } from "@peated/web/lib/bottleCatalogQueryParams";
 import { getCountryPage } from "@peated/web/lib/locationPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getCountrySeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import {
   LOCATION_BOTTLE_DEFAULT_SORT,
   LOCATION_BOTTLE_QUERY_FIELDS,
 } from "../../../locationBottleList";
 import { LocationBottleListClient } from "../../../locationBottleListClient";
+
+export async function generateMetadata(props: {
+  params: Promise<{ countrySlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ countrySlug }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const location = await getCountryPage(countrySlug);
+  return getCountrySeoMetadata(location, { section: "bottles", searchParams });
+}
 
 export default async function CountryBottlesPage(props: {
   params: Promise<{ countrySlug: string }>;

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/distillers/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/distillers/page.tsx
@@ -2,8 +2,24 @@ import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { getCountryPage } from "@peated/web/lib/locationPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getCountrySeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import { LocationDistillerList } from "../../../locationLists";
+
+export async function generateMetadata(props: {
+  params: Promise<{ countrySlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ countrySlug }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const location = await getCountryPage(countrySlug);
+  return getCountrySeoMetadata(location, {
+    section: "distillers",
+    searchParams,
+  });
+}
 
 export default async function CountryDistillersPage(props: {
   params: Promise<{ countrySlug: string }>;

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/layout.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/layout.tsx
@@ -6,18 +6,6 @@ import type { ReactNode } from "react";
 import { getCountryLocationTabs } from "../../locationPage";
 import { LocationPageFrame } from "../../locationPageFrame.stylex";
 
-export async function generateMetadata(props: {
-  params: Promise<{ countrySlug: string }>;
-}) {
-  const { countrySlug } = await props.params;
-  const country = await getCountryPage(countrySlug);
-
-  return {
-    title: `Whisky from ${country.name}`,
-    description: country.description,
-  };
-}
-
 export default async function CountryLayout(props: {
   children: ReactNode;
   params: Promise<{ countrySlug: string }>;

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/page.tsx
@@ -1,5 +1,7 @@
+import { serializeCountryStructuredData } from "@peated/web/lib/catalogStructuredData";
 import { getCountryPage } from "@peated/web/lib/locationPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getCountrySeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import { LocationOverview } from "../../locationOverview.stylex";
 import {
@@ -8,6 +10,18 @@ import {
   getLocationLatestReleases,
   getLocationRegions,
 } from "../../locationPage";
+
+export async function generateMetadata(props: {
+  params: Promise<{ countrySlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ countrySlug }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const location = await getCountryPage(countrySlug);
+  return getCountrySeoMetadata(location, { searchParams });
+}
 
 export default async function CountryOverviewPage(props: {
   params: Promise<{ countrySlug: string }>;
@@ -38,17 +52,25 @@ export default async function CountryOverviewPage(props: {
   const rootHref = `/locations/${countrySlug}`;
 
   return (
-    <LocationOverview
-      categories={getLocationCategoryItems(categories.results)}
-      distilleries={getLocationDistilleries(distilleries.results)}
-      distillersHref={`${rootHref}/distillers`}
-      latestReleases={getLocationLatestReleases(latestReleases.results)}
-      productionRules={country.summary}
-      regions={getLocationRegions(regions.results)}
-      releasesHref={`${rootHref}/bottles?sort=-release`}
-      totalBottles={country.totalBottles}
-      totalDistillers={country.totalDistillers}
-      visual={{ kind: "country", slug: country.slug }}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: serializeCountryStructuredData(country),
+        }}
+      />
+      <LocationOverview
+        categories={getLocationCategoryItems(categories.results)}
+        distilleries={getLocationDistilleries(distilleries.results)}
+        distillersHref={`${rootHref}/distillers`}
+        latestReleases={getLocationLatestReleases(latestReleases.results)}
+        productionRules={country.summary}
+        regions={getLocationRegions(regions.results)}
+        releasesHref={`${rootHref}/bottles?sort=-release`}
+        totalBottles={country.totalBottles}
+        totalDistillers={country.totalDistillers}
+        visual={{ kind: "country", slug: country.slug }}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/regions/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/regions/page.tsx
@@ -1,7 +1,9 @@
 import { CursorPager, EmptyState } from "@peated/web/components";
 import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
+import { getCountryPage } from "@peated/web/lib/locationPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getCountrySeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import { REGION_LIST_SORT_OPTIONS } from "@peated/server/constants";
 import { LocationTable } from "../../../locationLists";
@@ -13,6 +15,18 @@ const REGION_QUERY_FIELDS = [
   "query",
   "sort",
 ] as const;
+export async function generateMetadata(props: {
+  params: Promise<{ countrySlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ countrySlug }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const location = await getCountryPage(countrySlug);
+  return getCountrySeoMetadata(location, { section: "regions", searchParams });
+}
+
 export default async function CountryRegionsPage(props: {
   params: Promise<{ countrySlug: string }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/bottles/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/bottles/page.tsx
@@ -5,12 +5,25 @@ import {
 } from "@peated/web/lib/bottleCatalogQueryParams";
 import { getRegionPage } from "@peated/web/lib/locationPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getRegionSeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import {
   LOCATION_BOTTLE_DEFAULT_SORT,
   LOCATION_BOTTLE_QUERY_FIELDS,
 } from "../../../../locationBottleList";
 import { LocationBottleListClient } from "../../../../locationBottleListClient";
+
+export async function generateMetadata(props: {
+  params: Promise<{ countrySlug: string; regionSlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ countrySlug, regionSlug }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const location = await getRegionPage(countrySlug, regionSlug);
+  return getRegionSeoMetadata(location, { section: "bottles", searchParams });
+}
 
 export default async function RegionBottlesPage(props: {
   params: Promise<{ countrySlug: string; regionSlug: string }>;

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/distillers/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/distillers/page.tsx
@@ -2,8 +2,24 @@ import { getApiQueryParams } from "@peated/web/lib/apiQueryParams";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { getRegionPage } from "@peated/web/lib/locationPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getRegionSeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import { LocationDistillerList } from "../../../../locationLists";
+
+export async function generateMetadata(props: {
+  params: Promise<{ countrySlug: string; regionSlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ countrySlug, regionSlug }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const location = await getRegionPage(countrySlug, regionSlug);
+  return getRegionSeoMetadata(location, {
+    section: "distillers",
+    searchParams,
+  });
+}
 
 export default async function RegionDistillersPage(props: {
   params: Promise<{ countrySlug: string; regionSlug: string }>;

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/layout.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/layout.tsx
@@ -6,18 +6,6 @@ import type { ReactNode } from "react";
 import { getRegionLocationTabs } from "../../../locationPage";
 import { LocationPageFrame } from "../../../locationPageFrame.stylex";
 
-export async function generateMetadata(props: {
-  params: Promise<{ countrySlug: string; regionSlug: string }>;
-}) {
-  const { countrySlug, regionSlug } = await props.params;
-  const region = await getRegionPage(countrySlug, regionSlug);
-
-  return {
-    title: `Whisky from ${region.name}, ${region.country.name}`,
-    description: region.description,
-  };
-}
-
 export default async function RegionLayout(props: {
   children: ReactNode;
   params: Promise<{ countrySlug: string; regionSlug: string }>;

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/page.tsx
@@ -1,7 +1,9 @@
 import { FlavorProfileSection } from "@peated/web/features/flavorProfile/flavorProfileSection";
+import { serializeRegionStructuredData } from "@peated/web/lib/catalogStructuredData";
 import { getRegionMap } from "@peated/web/lib/locationMap";
 import { getRegionPage } from "@peated/web/lib/locationPage.server";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
+import { getRegionSeoMetadata } from "@peated/web/lib/seoMetadata";
 
 import { LocationOverview } from "../../../locationOverview.stylex";
 import {
@@ -10,6 +12,18 @@ import {
   getLocationLatestReleases,
   getLocationRegions,
 } from "../../../locationPage";
+
+export async function generateMetadata(props: {
+  params: Promise<{ countrySlug: string; regionSlug: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) {
+  const [{ countrySlug, regionSlug }, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams,
+  ]);
+  const location = await getRegionPage(countrySlug, regionSlug);
+  return getRegionSeoMetadata(location, { searchParams });
+}
 
 export default async function RegionOverviewPage(props: {
   params: Promise<{ countrySlug: string; regionSlug: string }>;
@@ -47,22 +61,30 @@ export default async function RegionOverviewPage(props: {
   );
 
   return (
-    <LocationOverview
-      categories={getLocationCategoryItems(categories.results)}
-      distilleries={getLocationDistilleries(distilleries.results)}
-      distillersHref={`${rootHref}/distillers`}
-      flavorProfile={
-        <FlavorProfileSection
-          scope={{ kind: "region", country: countrySlug, region: regionSlug }}
-        />
-      }
-      latestReleases={getLocationLatestReleases(latestReleases.results)}
-      otherRegions={otherRegions}
-      otherRegionsHref={`/locations/${countrySlug}/regions`}
-      releasesHref={`${rootHref}/bottles?sort=-release`}
-      totalBottles={region.totalBottles}
-      totalDistillers={region.totalDistillers}
-      visual={getRegionMap(region.country.slug, region.slug)}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: serializeRegionStructuredData(region),
+        }}
+      />
+      <LocationOverview
+        categories={getLocationCategoryItems(categories.results)}
+        distilleries={getLocationDistilleries(distilleries.results)}
+        distillersHref={`${rootHref}/distillers`}
+        flavorProfile={
+          <FlavorProfileSection
+            scope={{ kind: "region", country: countrySlug, region: regionSlug }}
+          />
+        }
+        latestReleases={getLocationLatestReleases(latestReleases.results)}
+        otherRegions={otherRegions}
+        otherRegionsHref={`/locations/${countrySlug}/regions`}
+        releasesHref={`${rootHref}/bottles?sort=-release`}
+        totalBottles={region.totalBottles}
+        totalDistillers={region.totalDistillers}
+        visual={getRegionMap(region.country.slug, region.slug)}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/(app)/series/[seriesId]/page.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/page.tsx
@@ -1,6 +1,7 @@
 import { BOTTLE_LIST_SORT_OPTIONS } from "@peated/server/constants";
 import { getCurrentUser } from "@peated/web/lib/auth.server";
 import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
+import { serializeSeriesStructuredData } from "@peated/web/lib/catalogStructuredData";
 import { getPublicPageServerClient } from "@peated/web/lib/orpc/client.server";
 import { getSeriesSeoMetadata } from "@peated/web/lib/seoMetadata";
 import { getSeriesPage } from "@peated/web/lib/seriesPage.server";
@@ -32,10 +33,14 @@ function getLibraryFilter(value: string | undefined): SeriesLibraryFilter {
 
 export async function generateMetadata(props: {
   params: Promise<{ seriesId: string }>;
+  searchParams: Promise<SearchParams>;
 }): Promise<Metadata> {
   const { seriesId } = await props.params;
   const series = await getSeriesPage(parseCatalogRouteId(seriesId));
-  return getSeriesSeoMetadata(series, { canonical: true });
+  return getSeriesSeoMetadata(series, {
+    canonical: true,
+    searchParams: await props.searchParams,
+  });
 }
 
 export default async function SeriesPage(props: {
@@ -74,13 +79,21 @@ export default async function SeriesPage(props: {
   ]);
 
   return (
-    <SeriesPageClient
-      initialBottleList={bottleList}
-      initialCursor={cursor}
-      initialLibrary={library}
-      initialLibraryCount={libraryBottleList?.total ?? null}
-      initialSeries={series}
-      initialSort={sort}
-    />
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: serializeSeriesStructuredData(series),
+        }}
+      />
+      <SeriesPageClient
+        initialBottleList={bottleList}
+        initialCursor={cursor}
+        initialLibrary={library}
+        initialLibraryCount={libraryBottleList?.total ?? null}
+        initialSeries={series}
+        initialSort={sort}
+      />
+    </>
   );
 }

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/addRelease/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/addRelease/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
+
 import { use } from "react";
 
 import BottleForm from "@peated/web/components/bottleForm";
@@ -40,7 +42,9 @@ function AddSimilarBottleForm({ bottleId }: { bottleId: string }) {
   }
 
   const { data: sourceBottle } = useSuspenseQuery(
-    orpc.bottles.details.queryOptions({ input: { bottle: Number(bottleId) } }),
+    orpc.bottles.details.queryOptions({
+      input: { bottle: parseCatalogRouteId(bottleId) },
+    }),
   );
   const proposalQuery = useQuery({
     ...orpc.prices.matchQueue.details.queryOptions({

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/addTasting/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/addTasting/page.tsx
@@ -1,16 +1,9 @@
 import { getAddBottleHref } from "@peated/web/lib/addBottle";
-import { notFound, redirect } from "next/navigation";
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
+import { redirect } from "next/navigation";
 
 function getFirst(value: string | string[] | undefined) {
   return Array.isArray(value) ? value[0] : value;
-}
-
-function parseId(value: string) {
-  const id = Number(value);
-  if (!Number.isSafeInteger(id) || id < 1) {
-    notFound();
-  }
-  return id;
 }
 
 export default async function AddTasting(props: {
@@ -23,7 +16,7 @@ export default async function AddTasting(props: {
   ]);
   redirect(
     getAddBottleHref({
-      bottleId: parseId(bottleId),
+      bottleId: parseCatalogRouteId(bottleId),
       flightId: getFirst(searchParams.flight),
       intent: "tasting",
     }),

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/audit/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/audit/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
+
 import {
   Field,
   FormNotice,
@@ -33,7 +35,9 @@ function AuditBottleForm({ bottleId }: { bottleId: string }) {
   const orpc = useORPC();
   const router = useRouter();
   const { data: bottle } = useSuspenseQuery(
-    orpc.bottles.details.queryOptions({ input: { bottle: Number(bottleId) } }),
+    orpc.bottles.details.queryOptions({
+      input: { bottle: parseCatalogRouteId(bottleId) },
+    }),
   );
   const audit = useMutation(orpc.audits.create.mutationOptions());
   const [note, setNote] = useState("");

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/edit/page.tsx
@@ -1,4 +1,6 @@
 "use client";
+
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { use } from "react";
 
 import BottleForm from "@peated/web/components/bottleForm";
@@ -34,7 +36,7 @@ function BottleEditForm({ bottleId }: { bottleId: string }) {
   const { data: context } = useSuspenseQuery(
     formQueryOptions(
       orpc.bottles.editContext.queryOptions({
-        input: { bottle: Number(bottleId) },
+        input: { bottle: parseCatalogRouteId(bottleId) },
       }),
     ),
   );

--- a/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
+++ b/apps/web/src/app/(layout-free)/bottles/[bottleId]/merge/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
+
 import { formatBottleDisplayName } from "@peated/server/lib/bottleDisplayName";
 import { formatPeatedId } from "@peated/server/lib/peatedId";
 import { BottleMergeSchema } from "@peated/server/schemas";
@@ -53,7 +55,9 @@ function MergeBottleForm({ bottleId }: { bottleId: string }) {
   const searchParams = useSearchParams();
   const { flash } = useFlashMessages();
   const { data: bottle } = useSuspenseQuery(
-    orpc.bottles.details.queryOptions({ input: { bottle: Number(bottleId) } }),
+    orpc.bottles.details.queryOptions({
+      input: { bottle: parseCatalogRouteId(bottleId) },
+    }),
   );
   const prefilledId = Number(searchParams.get("other") ?? 0) || null;
   const prefilledDirection =

--- a/apps/web/src/app/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemap.xml/route.ts
@@ -12,6 +12,7 @@ export const dynamic = "force-static";
 export async function GET() {
   const sitemapIndexXML = await buildSitemapIndex([
     "/sitemaps/locations.xml",
+    "/sitemaps/regions/sitemap.xml",
     ...ENTITY_SITEMAP_COLLECTIONS.map(
       ({ collection }) => `/sitemaps/${collection}/sitemap.xml`,
     ),

--- a/apps/web/src/app/sitemaps/locations.xml/route.ts
+++ b/apps/web/src/app/sitemaps/locations.xml/route.ts
@@ -1,5 +1,9 @@
+import {
+  getCountrySitemapPages,
+  loadSitemapCountries,
+} from "@peated/web/lib/locationSitemaps";
 import { createAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
-import { buildPagesSitemap, type Sitemap } from "@peated/web/lib/sitemaps";
+import { buildPagesSitemap } from "@peated/web/lib/sitemaps";
 
 const SITEMAP_CACHE_CONTROL =
   "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800";
@@ -9,21 +13,8 @@ export const dynamic = "force-dynamic";
 export async function GET() {
   const { client } = await createAnonymousServerClient();
 
-  let cursor: number | null = 1;
-  const pages: Sitemap = [{ url: "/locations" }];
-  while (cursor) {
-    const { results, rel } = await client.countries.list({
-      cursor,
-    });
-
-    pages.push(
-      ...results.map((country) => ({
-        url: `/locations/${country.slug}`,
-      })),
-    );
-
-    cursor = rel?.nextCursor || null;
-  }
+  const countries = await loadSitemapCountries(client.countries.list);
+  const pages = getCountrySitemapPages(countries);
 
   const pagesSitemapXML = await buildPagesSitemap(pages);
 

--- a/apps/web/src/app/sitemaps/regions/[countrySlug]/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemaps/regions/[countrySlug]/sitemap.xml/route.ts
@@ -1,0 +1,25 @@
+import { loadRegionSitemap } from "@peated/web/lib/locationSitemaps";
+import { createAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
+import { resolveOrNotFound } from "@peated/web/lib/orpc/notFound.server";
+import { buildPagesSitemap } from "@peated/web/lib/sitemaps";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  _request: Request,
+  props: { params: Promise<{ countrySlug: string }> },
+) {
+  const { countrySlug } = await props.params;
+  const { client } = await createAnonymousServerClient();
+  const country = await resolveOrNotFound(
+    client.countries.details({ country: countrySlug }),
+  );
+  const pages = await loadRegionSitemap(country.slug, client.regions.list);
+  return new Response(await buildPagesSitemap(pages), {
+    headers: {
+      "Cache-Control":
+        "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800",
+      "Content-Type": "application/xml",
+    },
+  });
+}

--- a/apps/web/src/app/sitemaps/regions/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemaps/regions/sitemap.xml/route.ts
@@ -1,0 +1,22 @@
+import { loadSitemapCountries } from "@peated/web/lib/locationSitemaps";
+import { createAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
+import { buildSitemapIndex } from "@peated/web/lib/sitemaps";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const { client } = await createAnonymousServerClient();
+  const countries = await loadSitemapCountries(client.countries.list);
+  const xml = await buildSitemapIndex(
+    countries.map(
+      ({ slug }) => `/sitemaps/regions/${encodeURIComponent(slug)}/sitemap.xml`,
+    ),
+  );
+  return new Response(xml, {
+    headers: {
+      "Cache-Control":
+        "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800",
+      "Content-Type": "application/xml",
+    },
+  });
+}

--- a/apps/web/src/app/sitemaps/series/[id]/sitemap.xml/route.ts
+++ b/apps/web/src/app/sitemaps/series/[id]/sitemap.xml/route.ts
@@ -15,6 +15,9 @@ export async function GET(
 ) {
   const { id } = await props.params;
   const sitemapPage = Number(id);
+  if (!/^[1-9]\d*$/.test(id) || !Number.isSafeInteger(sitemapPage)) {
+    return new Response(null, { status: 404 });
+  }
   const { client } = await createAnonymousServerClient();
   const pages: Sitemap = [];
   let cursor = (sitemapPage - 1) * API_PAGES_PER_SITEMAP + 1;

--- a/apps/web/src/app/sitemaps/static.xml/route.ts
+++ b/apps/web/src/app/sitemaps/static.xml/route.ts
@@ -7,6 +7,12 @@ export const revalidate = 86400;
 
 export async function GET() {
   const pagesSitemapXML = await buildPagesSitemap([
+    { url: "/" },
+    { url: "/bottles" },
+    { url: "/brands" },
+    { url: "/distillers" },
+    { url: "/bottlers" },
+    { url: "/companies" },
     { url: "/about" },
     { url: "/about/tasting-wheel" },
     { url: "/bottlers/4263/codes" },

--- a/apps/web/src/lib/catalogPageRoutes.test.ts
+++ b/apps/web/src/lib/catalogPageRoutes.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import {
+  getBottleRouteRedirect,
+  getLocationRouteRedirect,
+  getSeriesRouteRedirect,
+  matchBottleRoute,
+  matchLocationRoute,
+  matchSeriesRoute,
+} from "./catalogPageRoutes";
+
+describe("catalog page redirects", () => {
+  it("redirects old bottle identities and preserves nested pages", () => {
+    const bottle = {
+      id: 43,
+      name: "16-year-old",
+      brand: { name: "Lagavulin" },
+    };
+    for (const path of ["/bottles/42", "/bottles/42-old.name", "/B0042"]) {
+      expect(getBottleRouteRedirect(matchBottleRoute(path)!, bottle)).toBe(
+        "/bottles/43-lagavulin-16-year-old",
+      );
+    }
+    expect(
+      getBottleRouteRedirect(
+        matchBottleRoute("/bottles/42-old/tastings")!,
+        bottle,
+      ),
+    ).toBe("/bottles/43-lagavulin-16-year-old/tastings");
+    expect(matchBottleRoute("/bottles/0")).toBeNull();
+  });
+  it("redirects numeric, stale, and Peated series IDs to the current identity", () => {
+    for (const path of ["/series/42", "/series/42-old.name", "/S0042"]) {
+      expect(
+        getSeriesRouteRedirect(matchSeriesRoute(path)!, {
+          id: 43,
+          fullName: "Ardbeg Supernova",
+        }),
+      ).toBe("/series/43-ardbeg-supernova");
+    }
+    expect(
+      getSeriesRouteRedirect(matchSeriesRoute("/series/42-old/edit")!, {
+        id: 42,
+        fullName: "Ardbeg Supernova",
+      }),
+    ).toBe("/series/42-ardbeg-supernova/edit");
+  });
+  it("leaves canonical Unicode series URLs alone", () => {
+    const path = "/series/42-山崎";
+    for (const pathname of [path, encodeURI(path)]) {
+      expect(
+        getSeriesRouteRedirect(matchSeriesRoute(pathname)!, {
+          id: 42,
+          fullName: "山崎",
+        }),
+      ).toBeNull();
+    }
+  });
+  it.each([
+    "/series",
+    "/series/0",
+    "/series/1.5",
+    "/series/1e2",
+    "/series/9007199254740992",
+    "/B0042",
+  ])("does not resolve %s as a series", (path) => {
+    expect(matchSeriesRoute(path)).toBeNull();
+  });
+  it("canonicalizes country and region paths while retaining tabs", () => {
+    const country = matchLocationRoute("/locations/SCOTLAND/regions")!;
+    expect(country).toMatchObject({
+      countrySlug: "SCOTLAND",
+      regionSlug: null,
+      suffix: "/regions",
+    });
+    expect(getLocationRouteRedirect(country, { slug: "scotland" })).toBe(
+      "/locations/scotland/regions",
+    );
+    const region = matchLocationRoute(
+      "/locations/SCOTLAND/regions/ISLAY/bottles",
+    )!;
+    expect(region).toMatchObject({
+      countrySlug: "SCOTLAND",
+      regionSlug: "ISLAY",
+      suffix: "/bottles",
+    });
+    expect(
+      getLocationRouteRedirect(region, {
+        slug: "islay",
+        country: { slug: "scotland" },
+      }),
+    ).toBe("/locations/scotland/regions/islay/bottles");
+    expect(
+      getLocationRouteRedirect(matchLocationRoute("/locations/scotland")!, {
+        slug: "scotland",
+      }),
+    ).toBeNull();
+  });
+  it("decodes location slugs without changing the browse routes", () => {
+    expect(
+      matchLocationRoute("/locations/c%C3%B4te-d-ivoire")?.countrySlug,
+    ).toBe("côte-d-ivoire");
+    for (const path of [
+      "/locations",
+      "/locations/all-regions",
+      "/locations/%ZZ",
+    ]) {
+      expect(matchLocationRoute(path)).toBeNull();
+    }
+  });
+});

--- a/apps/web/src/lib/catalogPageRoutes.test.ts
+++ b/apps/web/src/lib/catalogPageRoutes.test.ts
@@ -27,6 +27,31 @@ describe("catalog page redirects", () => {
       ),
     ).toBe("/bottles/43-lagavulin-16-year-old/tastings");
     expect(matchBottleRoute("/bottles/0")).toBeNull();
+    for (const suffix of [
+      "aliases",
+      "tastings",
+      "similar",
+      "prices",
+      "releases",
+      "edit",
+      "audit",
+      "merge",
+      "addTasting",
+      "addRelease",
+    ]) {
+      expect(matchBottleRoute(`/bottles/42-old/${suffix}`)?.suffix).toBe(
+        `/${suffix}`,
+      );
+    }
+    for (const suffix of [
+      "bottlings",
+      "bottlings/new",
+      "bottlings/9303",
+      "bottlings/9303/edit",
+      "releases/9303/edit",
+    ]) {
+      expect(matchBottleRoute(`/bottles/42/${suffix}`)).toBeNull();
+    }
   });
   it("redirects numeric, stale, and Peated series IDs to the current identity", () => {
     for (const path of ["/series/42", "/series/42-old.name", "/S0042"]) {

--- a/apps/web/src/lib/catalogPageRoutes.ts
+++ b/apps/web/src/lib/catalogPageRoutes.ts
@@ -1,0 +1,86 @@
+import { parsePeatedId } from "@peated/server/lib/peatedId";
+import {
+  getBottleSeriesUrl,
+  getBottleUrl,
+  getCountryUrl,
+  getRegionUrl,
+} from "./urls";
+
+export function matchBottleRoute(pathname: string) {
+  const shortId = /^\/([Bb]\d+)\/?$/.exec(pathname);
+  if (shortId) {
+    const parsed = parsePeatedId(shortId[1]);
+    return parsed?.type === "bottle"
+      ? { id: parsed.id, pathname, suffix: "" }
+      : null;
+  }
+  const match = /^\/bottles\/([1-9]\d*)(?:-[^/]+)?(\/.*)?$/.exec(pathname);
+  if (!match || !Number.isSafeInteger(Number(match[1]))) return null;
+  return { id: Number(match[1]), pathname, suffix: match[2] ?? "" };
+}
+
+export function getBottleRouteRedirect(
+  match: NonNullable<ReturnType<typeof matchBottleRoute>>,
+  bottle: Parameters<typeof getBottleUrl>[0],
+) {
+  return getRedirectPath(
+    match.pathname,
+    `${getBottleUrl(bottle)}${match.suffix}`,
+  );
+}
+
+export function matchSeriesRoute(pathname: string) {
+  const shortId = /^\/([Ss]\d+)\/?$/.exec(pathname);
+  if (shortId) {
+    const parsed = parsePeatedId(shortId[1]);
+    return parsed?.type === "series"
+      ? { id: parsed.id, pathname, suffix: "" }
+      : null;
+  }
+  const match = /^\/series\/([1-9]\d*)(?:-[^/]+)?(\/.*)?$/.exec(pathname);
+  if (!match || !Number.isSafeInteger(Number(match[1]))) return null;
+  return { id: Number(match[1]), pathname, suffix: match[2] ?? "" };
+}
+
+export function getSeriesRouteRedirect(
+  match: NonNullable<ReturnType<typeof matchSeriesRoute>>,
+  series: Parameters<typeof getBottleSeriesUrl>[0],
+) {
+  return getRedirectPath(
+    match.pathname,
+    `${getBottleSeriesUrl(series)}${match.suffix}`,
+  );
+}
+
+export function matchLocationRoute(pathname: string) {
+  const match = /^\/locations\/([^/]+)(?:\/regions\/([^/]+))?(\/.*)?$/.exec(
+    pathname,
+  );
+  if (!match || match[1] === "all-regions") return null;
+  try {
+    return {
+      countrySlug: decodeURIComponent(match[1]),
+      regionSlug: match[2] ? decodeURIComponent(match[2]) : null,
+      pathname,
+      suffix: match[3] ?? "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function getLocationRouteRedirect(
+  match: NonNullable<ReturnType<typeof matchLocationRoute>>,
+  location: { slug: string; country?: { slug: string } },
+) {
+  const path = location.country
+    ? getRegionUrl({ slug: location.slug, country: location.country })
+    : getCountryUrl(location);
+  return getRedirectPath(match.pathname, `${path}${match.suffix}`);
+}
+
+function getRedirectPath(pathname: string, canonicalPath: string) {
+  return pathname === canonicalPath || pathname === encodeURI(canonicalPath)
+    ? null
+    : canonicalPath;
+}

--- a/apps/web/src/lib/catalogPageRoutes.ts
+++ b/apps/web/src/lib/catalogPageRoutes.ts
@@ -14,7 +14,11 @@ export function matchBottleRoute(pathname: string) {
       ? { id: parsed.id, pathname, suffix: "" }
       : null;
   }
-  const match = /^\/bottles\/([1-9]\d*)(?:-[^/]+)?(\/.*)?$/.exec(pathname);
+  // Web routing keeps removed bottle pages as direct 404s.
+  const match =
+    /^\/bottles\/([1-9]\d*)(?:-[^/]+)?(\/(?:aliases|tastings|similar|prices|releases|edit|audit|merge|addTasting|addRelease)\/?|\/)?$/.exec(
+      pathname,
+    );
   if (!match || !Number.isSafeInteger(Number(match[1]))) return null;
   return { id: Number(match[1]), pathname, suffix: match[2] ?? "" };
 }

--- a/apps/web/src/lib/catalogStructuredData.test.ts
+++ b/apps/web/src/lib/catalogStructuredData.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+  serializeCountryStructuredData,
+  serializeRegionStructuredData,
+  serializeSeriesStructuredData,
+} from "./catalogStructuredData";
+
+describe("catalog structured data", () => {
+  const country = { name: "Scotland", slug: "scotland", description: null };
+  it("describes countries and regions with their browse hierarchy", () => {
+    const countryData = JSON.parse(serializeCountryStructuredData(country));
+    expect(countryData).toMatchObject({
+      "@type": "CollectionPage",
+      name: "Whisky from Scotland",
+      about: { "@type": "Country", name: "Scotland" },
+    });
+    const regionData = JSON.parse(
+      serializeRegionStructuredData({
+        name: "Islay",
+        slug: "islay",
+        country,
+        description: null,
+      }),
+    );
+    expect(
+      regionData.breadcrumb.itemListElement.map(
+        (item: { name: string; position: number }) => [
+          item.position,
+          item.name,
+        ],
+      ),
+    ).toEqual([
+      [1, "Locations"],
+      [2, "Scotland"],
+      [3, "Islay"],
+    ]);
+    expect(regionData.url).toMatch(/\/locations\/scotland\/regions\/islay$/);
+    expect(regionData.about["@type"]).toBe("AdministrativeArea");
+  });
+  it("links a series to its owning brand and safely embeds stored names", () => {
+    const serialized = serializeSeriesStructuredData({
+      id: 42,
+      fullName: "Ardbeg </script>",
+      description: null,
+      numReleases: 1,
+      brand: { id: 1, kind: "brand", name: "Ardbeg" },
+    });
+    expect(serialized).not.toContain("<");
+    const data = JSON.parse(serialized);
+    expect(data.name).toBe("Ardbeg </script> — Whisky series");
+    expect(data.breadcrumb.itemListElement[0].item).toMatch(
+      /\/brands\/1-ardbeg$/,
+    );
+    expect(data).not.toHaveProperty("aggregateRating");
+    expect(data).not.toHaveProperty("mainEntity");
+  });
+});

--- a/apps/web/src/lib/catalogStructuredData.ts
+++ b/apps/web/src/lib/catalogStructuredData.ts
@@ -1,0 +1,101 @@
+import config from "@peated/web/config";
+import {
+  getCountrySeoMetadata,
+  getRegionSeoMetadata,
+  getSeriesSeoMetadata,
+} from "./seoMetadata";
+import {
+  getBottleSeriesUrl,
+  getCountryUrl,
+  getEntityUrl,
+  getRegionUrl,
+} from "./urls";
+
+type Breadcrumb = { name: string; url: string };
+
+function serializeCollectionPage({
+  name,
+  description,
+  url,
+  breadcrumbs,
+  about,
+}: {
+  name: string;
+  description: string;
+  url: string;
+  breadcrumbs: Breadcrumb[];
+  about: { "@type": "Country" | "AdministrativeArea" | "Thing"; name: string };
+}) {
+  const absoluteUrl = new URL(url, config.URL_PREFIX).href;
+  const data = {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": absoluteUrl,
+    url: absoluteUrl,
+    name,
+    description,
+    about,
+    breadcrumb: {
+      "@type": "BreadcrumbList",
+      itemListElement: breadcrumbs.map((item, index) => ({
+        "@type": "ListItem",
+        position: index + 1,
+        name: item.name,
+        item: new URL(item.url, config.URL_PREFIX).href,
+      })),
+    },
+  };
+  // Catalog SEO embeds stored descriptions and names in HTML script elements.
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}
+
+export function serializeSeriesStructuredData(
+  series: Parameters<typeof getSeriesSeoMetadata>[0] & {
+    brand: Parameters<typeof getEntityUrl>[0];
+  },
+) {
+  const url = getBottleSeriesUrl(series);
+  return serializeCollectionPage({
+    name: `${series.fullName} — Whisky series`,
+    description: String(getSeriesSeoMetadata(series).description),
+    url,
+    about: { "@type": "Thing", name: series.fullName },
+    breadcrumbs: [
+      { name: series.brand.name, url: getEntityUrl(series.brand) },
+      { name: series.fullName, url },
+    ],
+  });
+}
+
+export function serializeCountryStructuredData(
+  country: Parameters<typeof getCountrySeoMetadata>[0],
+) {
+  const url = getCountryUrl(country);
+  return serializeCollectionPage({
+    name: `Whisky from ${country.name}`,
+    description: String(getCountrySeoMetadata(country).description),
+    url,
+    about: { "@type": "Country", name: country.name },
+    breadcrumbs: [
+      { name: "Locations", url: "/locations" },
+      { name: country.name, url },
+    ],
+  });
+}
+
+export function serializeRegionStructuredData(
+  region: Parameters<typeof getRegionSeoMetadata>[0],
+) {
+  const url = getRegionUrl(region);
+  return serializeCollectionPage({
+    name: `Whisky from ${region.name}, ${region.country.name}`,
+    description: String(getRegionSeoMetadata(region).description),
+    url,
+    about: { "@type": "AdministrativeArea", name: region.name },
+    breadcrumbs: [
+      { name: "Locations", url: "/locations" },
+      { name: region.country.name, url: getCountryUrl(region.country) },
+      { name: region.name, url },
+    ],
+  });
+}

--- a/apps/web/src/lib/locationPage.server.ts
+++ b/apps/web/src/lib/locationPage.server.ts
@@ -2,11 +2,11 @@
 
 import { cache } from "react";
 
-import { getPublicPageServerClient } from "./orpc/client.server";
+import { getAnonymousServerClient } from "./orpc/client.server";
 import { resolveOrNotFound } from "./orpc/notFound.server";
 
 export const getCountryPage = cache(async (countrySlug: string) => {
-  const { client } = await getPublicPageServerClient();
+  const { client } = await getAnonymousServerClient();
   return await resolveOrNotFound(
     client.countries.details({ country: countrySlug }),
   );
@@ -14,7 +14,7 @@ export const getCountryPage = cache(async (countrySlug: string) => {
 
 export const getRegionPage = cache(
   async (countrySlug: string, regionSlug: string) => {
-    const { client } = await getPublicPageServerClient();
+    const { client } = await getAnonymousServerClient();
     return await resolveOrNotFound(
       client.regions.details({ country: countrySlug, region: regionSlug }),
     );

--- a/apps/web/src/lib/locationSitemaps.test.ts
+++ b/apps/web/src/lib/locationSitemaps.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getCountrySitemapPages,
+  loadRegionSitemap,
+  loadSitemapCountries,
+} from "./locationSitemaps";
+
+describe("location sitemaps", () => {
+  it("reads every country page and includes their public tabs", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({
+        results: [{ slug: "scotland" }],
+        rel: { nextCursor: 2 },
+      })
+      .mockResolvedValueOnce({
+        results: [{ slug: "japan" }],
+        rel: { nextCursor: null },
+      });
+    const countries = await loadSitemapCountries(list);
+    expect(list.mock.calls.map(([input]) => input)).toEqual([
+      { cursor: 1, limit: 100, sort: "name" },
+      { cursor: 2, limit: 100, sort: "name" },
+    ]);
+    expect(getCountrySitemapPages(countries).map(({ url }) => url)).toEqual([
+      "/locations",
+      "/locations/all-regions",
+      "/locations/scotland",
+      "/locations/scotland/bottles",
+      "/locations/scotland/distillers",
+      "/locations/scotland/regions",
+      "/locations/japan",
+      "/locations/japan/bottles",
+      "/locations/japan/distillers",
+      "/locations/japan/regions",
+    ]);
+  });
+  it("paginates regions within one country and uses returned canonical slugs", async () => {
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({
+        results: [{ slug: "islay", country: { slug: "scotland" } }],
+        rel: { nextCursor: 2 },
+      })
+      .mockResolvedValueOnce({
+        results: [{ slug: "speyside", country: { slug: "scotland" } }],
+        rel: { nextCursor: null },
+      });
+    const pages = await loadRegionSitemap("scotland", list);
+    expect(pages).toEqual(
+      ["islay", "speyside"].flatMap((region) =>
+        ["", "/bottles", "/distillers"].map((suffix) => ({
+          url: `/locations/scotland/regions/${region}${suffix}`,
+        })),
+      ),
+    );
+    expect(list).toHaveBeenLastCalledWith({
+      country: "scotland",
+      cursor: 2,
+      limit: 100,
+      sort: "name",
+    });
+  });
+  it("leaves an empty region map empty and propagates API failures", async () => {
+    await expect(
+      loadRegionSitemap("japan", async () => ({
+        results: [],
+        rel: { nextCursor: null },
+      })),
+    ).resolves.toEqual([]);
+    await expect(
+      loadSitemapCountries(async () => {
+        throw new Error("API unavailable");
+      }),
+    ).rejects.toThrow("API unavailable");
+  });
+});

--- a/apps/web/src/lib/locationSitemaps.ts
+++ b/apps/web/src/lib/locationSitemaps.ts
@@ -1,0 +1,58 @@
+import type { Sitemap } from "./sitemaps";
+import { getCountryUrl, getRegionUrl } from "./urls";
+
+type Page<T> = { results: T[]; rel: { nextCursor: number | null } };
+
+export async function loadSitemapCountries(
+  list: (input: {
+    cursor: number;
+    limit: number;
+    sort: "name";
+  }) => Promise<Page<{ slug: string }>>,
+) {
+  const countries: { slug: string }[] = [];
+  let cursor: number | null = 1;
+  while (cursor) {
+    const page = await list({ cursor, limit: 100, sort: "name" });
+    countries.push(...page.results);
+    cursor = page.rel.nextCursor;
+  }
+  return countries;
+}
+
+export function getCountrySitemapPages(countries: { slug: string }[]): Sitemap {
+  return [
+    { url: "/locations" },
+    { url: "/locations/all-regions" },
+    ...countries.flatMap((country) =>
+      ["", "/bottles", "/distillers", "/regions"].map((suffix) => ({
+        url: `${getCountryUrl(country)}${suffix}`,
+      })),
+    ),
+  ];
+}
+
+export async function loadRegionSitemap(
+  country: string,
+  list: (input: {
+    country: string;
+    cursor: number;
+    limit: number;
+    sort: "name";
+  }) => Promise<Page<Parameters<typeof getRegionUrl>[0]>>,
+): Promise<Sitemap> {
+  const pages: Sitemap = [];
+  let cursor: number | null = 1;
+  while (cursor) {
+    const page = await list({ country, cursor, limit: 100, sort: "name" });
+    pages.push(
+      ...page.results.flatMap((region) =>
+        ["", "/bottles", "/distillers"].map((suffix) => ({
+          url: `${getRegionUrl(region)}${suffix}`,
+        })),
+      ),
+    );
+    cursor = page.rel.nextCursor;
+  }
+  return pages;
+}

--- a/apps/web/src/lib/peatedIdRoutes.test.ts
+++ b/apps/web/src/lib/peatedIdRoutes.test.ts
@@ -1,33 +1,7 @@
 import { describe, expect, it } from "vitest";
-import {
-  matchEntityRoute,
-  resolveCatalogPeatedIdRoute,
-  resolveEntityRoute,
-} from "./peatedIdRoutes";
+import { matchEntityRoute, resolveEntityRoute } from "./peatedIdRoutes";
 
 describe("Peated ID routes", () => {
-  it("redirects Bottle IDs to the Bottle collection route", () => {
-    expect(resolveCatalogPeatedIdRoute("/B0123")).toEqual({
-      action: "redirect",
-      pathname: "/bottles/123",
-    });
-    expect(resolveCatalogPeatedIdRoute("/b123")).toEqual({
-      action: "redirect",
-      pathname: "/bottles/123",
-    });
-  });
-
-  it("redirects Series IDs to the Series collection route", () => {
-    expect(resolveCatalogPeatedIdRoute("/S0421")).toEqual({
-      action: "redirect",
-      pathname: "/series/421",
-    });
-    expect(resolveCatalogPeatedIdRoute("/s421")).toEqual({
-      action: "redirect",
-      pathname: "/series/421",
-    });
-  });
-
   it("matches every route that can address an Entity", () => {
     expect(matchEntityRoute("/E0456")).toEqual({
       entityId: 456,
@@ -105,7 +79,6 @@ describe("Peated ID routes", () => {
   );
 
   it("does not claim unrelated or malformed routes", () => {
-    expect(resolveCatalogPeatedIdRoute("/bottles/123")).toBeNull();
     expect(matchEntityRoute("/bottles/123")).toBeNull();
     expect(matchEntityRoute("/distillers")).toBeNull();
     expect(matchEntityRoute("/entities/0")).toBeNull();

--- a/apps/web/src/lib/peatedIdRoutes.ts
+++ b/apps/web/src/lib/peatedIdRoutes.ts
@@ -44,26 +44,6 @@ function getEntityKind(collection: string): EntityKind | null {
   }
 }
 
-export function resolveCatalogPeatedIdRoute(
-  pathname: string,
-): PeatedIdRouteResolution | null {
-  const rootMatch = ROOT_PEATED_ID_PATTERN.exec(pathname);
-  if (rootMatch) {
-    const parsed = parsePeatedId(rootMatch[1]);
-    if (!parsed) return null;
-
-    if (parsed.type === "bottle") {
-      return { action: "redirect", pathname: `/bottles/${parsed.id}` };
-    }
-    if (parsed.type === "series") {
-      return { action: "redirect", pathname: `/series/${parsed.id}` };
-    }
-    return null;
-  }
-
-  return null;
-}
-
 export function matchEntityRoute(pathname: string): EntityRouteMatch | null {
   const rootMatch = ROOT_PEATED_ID_PATTERN.exec(pathname);
   if (rootMatch) {

--- a/apps/web/src/lib/seoMetadata.test.ts
+++ b/apps/web/src/lib/seoMetadata.test.ts
@@ -12,7 +12,7 @@ import {
 
 describe("SEO metadata", () => {
   it("provides plain location metadata and separate canonical URLs for tabs", () => {
-    const country = { name: "Scotland", slug: "scotland", description: null };
+    const country = { name: "Scotland", slug: "scotland" };
     expect(getCountrySeoMetadata(country)).toMatchObject({
       title: "Whisky from Scotland",
       description:

--- a/apps/web/src/lib/seoMetadata.test.ts
+++ b/apps/web/src/lib/seoMetadata.test.ts
@@ -2,12 +2,82 @@ import { describe, expect, it } from "vitest";
 
 import {
   getBottleSeoMetadata,
+  getCatalogSeoMetadata,
+  getCountrySeoMetadata,
   getEntitySeoMetadata,
+  getRegionSeoMetadata,
   getSeriesSeoMetadata,
   homeMetadata,
 } from "./seoMetadata";
 
 describe("SEO metadata", () => {
+  it("provides plain location metadata and separate canonical URLs for tabs", () => {
+    const country = { name: "Scotland", slug: "scotland", description: null };
+    expect(getCountrySeoMetadata(country)).toMatchObject({
+      title: "Whisky from Scotland",
+      description:
+        "Browse whisky bottles from Scotland, with ratings and tasting notes on Peated.",
+      alternates: { canonical: "/locations/scotland" },
+      openGraph: { title: "Whisky from Scotland", url: "/locations/scotland" },
+      twitter: { title: "Whisky from Scotland" },
+    });
+    expect(
+      getRegionSeoMetadata(
+        {
+          name: "Islay",
+          slug: "islay",
+          description: "**Smoky** whisky.\n\nMade on Islay.",
+          country,
+        },
+        {
+          section: "distillers",
+          searchParams: { cursor: "2", utm_source: "mail" },
+        },
+      ),
+    ).toMatchObject({
+      title: "Whisky distilleries in Islay, Scotland",
+      alternates: {
+        canonical: "/locations/scotland/regions/islay/distillers?cursor=2",
+      },
+      robots: undefined,
+    });
+    expect(
+      getCountrySeoMetadata({
+        ...country,
+        description: "**Scotch** whisky.\n\nMade in Scotland.",
+      }).description,
+    ).toBe("Scotch whisky. Made in Scotland.");
+  });
+  it("excludes filters and personal lists from indexing without losing pagination", () => {
+    const page = {
+      title: "Whisky bottles",
+      description: "Browse whisky bottles.",
+      url: "/bottles",
+    };
+    expect(getCatalogSeoMetadata(page, { cursor: "2" })).toMatchObject({
+      alternates: { canonical: "/bottles?cursor=2" },
+      robots: undefined,
+    });
+    for (const searchParams of [
+      { library: "in" },
+      { sort: "name" },
+      { query: "Islay" },
+    ]) {
+      expect(getCatalogSeoMetadata(page, searchParams).robots).toEqual({
+        index: false,
+        follow: true,
+      });
+    }
+    expect(
+      getCatalogSeoMetadata(page, { cursor: "1.5", _rsc: "abc" }).alternates,
+    ).toEqual({ canonical: "/bottles" });
+    expect(
+      getCatalogSeoMetadata({
+        ...page,
+        description: "A long description. ".repeat(20),
+      }).description?.length,
+    ).toBeLessThanOrEqual(160);
+  });
   it("defines the homepage search and social metadata", () => {
     expect(homeMetadata).toMatchObject({
       title: {

--- a/apps/web/src/lib/seoMetadata.ts
+++ b/apps/web/src/lib/seoMetadata.ts
@@ -5,7 +5,13 @@ import config from "@peated/web/config";
 import type { Metadata } from "next";
 
 import { summarize } from "./markdown";
-import { getBottleSeriesUrl, getBottleUrl, getEntityUrl } from "./urls";
+import {
+  getBottleSeriesUrl,
+  getBottleUrl,
+  getCountryUrl,
+  getEntityUrl,
+  getRegionUrl,
+} from "./urls";
 
 const HOME_TITLE = "Peated: Whisky bottles, reviews, and tasting notes";
 
@@ -52,6 +58,126 @@ type SeriesSeoMetadataSource = {
 type MetadataOptions = {
   canonical?: boolean;
 };
+
+export type SeoSearchParams = Record<string, string | string[] | undefined>;
+
+/** Catalog SEO keeps pagination crawlable and excludes filtered or personal lists. */
+export function getCatalogSeoMetadata(
+  {
+    title,
+    description,
+    url,
+  }: { title: string; description: string; url: string },
+  searchParams: SeoSearchParams = {},
+): Metadata {
+  description = description.replace(/\s+/g, " ").trim();
+  if (description.length > 160)
+    description = `${description.slice(0, 157).trimEnd()}...`;
+  const rawCursor = searchParams.cursor;
+  const cursor = Number(Array.isArray(rawCursor) ? rawCursor[0] : rawCursor);
+  const canonical =
+    Number.isSafeInteger(cursor) && cursor > 1
+      ? `${url}?cursor=${cursor}`
+      : url;
+  const filtered = Object.entries(searchParams).some(
+    ([key, value]) =>
+      key !== "cursor" &&
+      key !== "_rsc" &&
+      key !== "source" &&
+      key !== "ref" &&
+      !key.startsWith("utm_") &&
+      (Array.isArray(value) ? value.some(Boolean) : Boolean(value)),
+  );
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    robots: filtered ? { index: false, follow: true } : undefined,
+    openGraph: {
+      type: "website",
+      locale: "en_US",
+      siteName: "Peated",
+      title,
+      description,
+      url: canonical,
+    },
+    twitter: { card: "summary", title, description },
+  };
+}
+
+type CountrySeoSource = {
+  name: string;
+  slug: string;
+  description: string | null;
+};
+type RegionSeoSource = CountrySeoSource & {
+  country: { name: string; slug: string };
+};
+type LocationSeoOptions = {
+  section?: "bottles" | "distillers" | "regions";
+  searchParams?: SeoSearchParams;
+};
+
+function getLocationSeoMetadata(
+  name: string,
+  description: string | null,
+  url: string,
+  { section, searchParams }: LocationSeoOptions,
+): Metadata {
+  const title =
+    section === "distillers"
+      ? `Whisky distilleries in ${name}`
+      : section === "regions"
+        ? `Whisky regions in ${name}`
+        : section === "bottles"
+          ? `Whisky bottles from ${name}`
+          : `Whisky from ${name}`;
+  const fallback =
+    section === "distillers"
+      ? `Browse whisky distilleries in ${name} and the bottles they make.`
+      : section === "regions"
+        ? `Browse whisky regions in ${name}, with bottles and distilleries from each region.`
+        : `Browse whisky bottles from ${name}, with ratings and tasting notes on Peated.`;
+  return getCatalogSeoMetadata(
+    {
+      title,
+      description:
+        (!section &&
+          summarize(description || "", 160)
+            .replace(/\s+/g, " ")
+            .trim()) ||
+        fallback,
+      url: section ? `${url}/${section}` : url,
+    },
+    section ? searchParams : undefined,
+  );
+}
+
+export function getCountrySeoMetadata(
+  country: CountrySeoSource,
+  options: LocationSeoOptions = {},
+): Metadata {
+  return getLocationSeoMetadata(
+    country.name,
+    country.description,
+    getCountryUrl(country),
+    options,
+  );
+}
+
+export function getRegionSeoMetadata(
+  region: RegionSeoSource,
+  options: Omit<LocationSeoOptions, "section"> & {
+    section?: "bottles" | "distillers";
+  } = {},
+): Metadata {
+  return getLocationSeoMetadata(
+    `${region.name}, ${region.country.name}`,
+    region.description,
+    getRegionUrl(region),
+    options,
+  );
+}
 
 const ENTITY_KIND_LABELS = {
   bottler: "Whisky bottler",
@@ -134,31 +260,27 @@ export function getEntitySeoMetadata(
 
 export function getSeriesSeoMetadata(
   series: SeriesSeoMetadataSource,
-  { canonical = false }: MetadataOptions = {},
+  {
+    canonical = false,
+    searchParams,
+  }: MetadataOptions & { searchParams?: SeoSearchParams } = {},
 ): Metadata {
   const title = `${series.fullName} — Whisky series`;
   const bottleCount = series.numReleases.toLocaleString("en-US");
   const description =
-    summarize(series.description || "", 160) ||
+    summarize(series.description || "", 160)
+      .replace(/\s+/g, " ")
+      .trim() ||
     `See ${bottleCount} ${series.numReleases === 1 ? "bottle" : "bottles"} in the ${series.fullName} series.`;
   const url = getBottleSeriesUrl(series);
 
-  return {
-    title,
-    description,
-    alternates: canonical ? { canonical: url } : undefined,
-    openGraph: {
-      type: "website",
-      locale: "en_US",
-      siteName: "Peated",
-      title,
-      description,
-      url: canonical ? url : undefined,
-    },
-    twitter: {
-      card: "summary",
-      title,
-      description,
-    },
-  };
+  const metadata = getCatalogSeoMetadata(
+    { title, description, url },
+    searchParams,
+  );
+  if (!canonical) {
+    metadata.alternates = undefined;
+    metadata.openGraph = { ...metadata.openGraph, url: undefined };
+  }
+  return metadata;
 }

--- a/apps/web/src/lib/seoMetadata.ts
+++ b/apps/web/src/lib/seoMetadata.ts
@@ -108,7 +108,7 @@ export function getCatalogSeoMetadata(
 type CountrySeoSource = {
   name: string;
   slug: string;
-  description: string | null;
+  description?: string | null;
 };
 type RegionSeoSource = CountrySeoSource & {
   country: { name: string; slug: string };
@@ -120,7 +120,7 @@ type LocationSeoOptions = {
 
 function getLocationSeoMetadata(
   name: string,
-  description: string | null,
+  description: string | null | undefined,
   url: string,
   { section, searchParams }: LocationSeoOptions,
 ): Metadata {

--- a/apps/web/src/lib/urls.ts
+++ b/apps/web/src/lib/urls.ts
@@ -35,6 +35,19 @@ export function getBottleSeriesUrl(series: {
   return `/series/${series.id}-${createUrlSlug(series.fullName, "series")}`;
 }
 
+export function getCountryUrl(country: {
+  slug: string;
+}): `/locations/${string}` {
+  return `/locations/${encodeURIComponent(country.slug)}`;
+}
+
+export function getRegionUrl(region: {
+  slug: string;
+  country: { slug: string };
+}): `/locations/${string}/regions/${string}` {
+  return `${getCountryUrl(region.country)}/regions/${encodeURIComponent(region.slug)}`;
+}
+
 /** Entity identity owns the route: pass the stored kind, never a Bottle field's role. */
 export function getEntityUrl(entity: {
   id: number;

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,8 +1,16 @@
 import { isORPCNotFoundError } from "@peated/orpc/client/errors";
+import {
+  getBottleRouteRedirect,
+  getLocationRouteRedirect,
+  getSeriesRouteRedirect,
+  matchBottleRoute,
+  matchLocationRoute,
+  matchSeriesRoute,
+} from "@peated/web/lib/catalogPageRoutes";
 import { createAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 import {
   matchEntityRoute,
-  resolveCatalogPeatedIdRoute,
+  type PeatedIdRouteResolution,
   resolveEntityRoute,
 } from "@peated/web/lib/peatedIdRoutes";
 import {
@@ -23,7 +31,10 @@ export async function proxy(request: NextRequest) {
   );
   const entityMatch = matchEntityRoute(request.nextUrl.pathname);
   const tastingMatch = matchTastingRoute(request.nextUrl.pathname);
-  let resolution = resolveCatalogPeatedIdRoute(request.nextUrl.pathname);
+  const seriesMatch = matchSeriesRoute(request.nextUrl.pathname);
+  const bottleMatch = matchBottleRoute(request.nextUrl.pathname);
+  const locationMatch = matchLocationRoute(request.nextUrl.pathname);
+  let resolution: PeatedIdRouteResolution | null = null;
 
   if (entityMatch) {
     try {
@@ -49,6 +60,39 @@ export async function proxy(request: NextRequest) {
       if (pathname) resolution = { action: "redirect", pathname };
     } catch (error) {
       if (!isORPCNotFoundError(error)) throw error;
+    }
+  }
+  if (bottleMatch || seriesMatch || locationMatch) {
+    try {
+      // Catalog routing resolves public identities before Next starts streaming HTML.
+      const { client } = await createAnonymousServerClient();
+      let pathname: string | null;
+      if (bottleMatch) {
+        const bottle = await client.bottles.details({ bottle: bottleMatch.id });
+        pathname = getBottleRouteRedirect(bottleMatch, bottle);
+      } else if (seriesMatch) {
+        const series = await client.bottleSeries.details({
+          series: seriesMatch.id,
+        });
+        pathname = getSeriesRouteRedirect(seriesMatch, series);
+      } else if (locationMatch) {
+        const country = await client.countries.details({
+          country: locationMatch.countrySlug,
+        });
+        const location = locationMatch.regionSlug
+          ? await client.regions.details({
+              country: country.slug,
+              region: locationMatch.regionSlug,
+            })
+          : country;
+        pathname = getLocationRouteRedirect(locationMatch, location);
+      } else {
+        pathname = null;
+      }
+      resolution = pathname ? { action: "redirect", pathname } : null;
+    } catch (error) {
+      if (!isORPCNotFoundError(error)) throw error;
+      resolution = null;
     }
   }
   let response: NextResponse;
@@ -89,5 +133,8 @@ export const config = {
     "/sitemap.xml",
     "/sitemaps/:path*",
     "/tastings/:path*",
+    "/series/:path*",
+    "/bottles/:path*",
+    "/locations/:path*",
   ],
 };

--- a/docs/features/catalog-page-seo.md
+++ b/docs/features/catalog-page-seo.md
@@ -1,0 +1,33 @@
+# Catalog page SEO
+
+Public bottle, producer, series, country, and region pages have page-specific
+search and social metadata. The catalog browse pages use the same title,
+description, and canonical URL in search, Open Graph, and Twitter metadata.
+Generated descriptions use plain words; stored names and descriptions retain
+their meaning. Metadata contains no personal library counts or bottle lists.
+
+`apps/web/src/lib/seoMetadata.ts` owns catalog metadata. Country and region tabs
+each describe their own content. Paginated lists retain `cursor` in canonical
+URLs; filtered, sorted, and personal lists use `noindex, follow`. Tracking
+parameters do not change the canonical URL. This follows Google's
+[pagination guidance](https://developers.google.com/search/docs/specialty/ecommerce/pagination-and-incremental-page-loading).
+
+Series and location overviews use `CollectionPage` structured data with their
+browse hierarchy. They do not claim that a series is one product or publish
+invented ratings. `catalogStructuredData.ts` escapes stored text before embedding
+it in a script element.
+
+The request proxy resolves bottle and series IDs, merged records, stale name
+slugs, and location slug casing before HTML streaming starts. Redirects return HTTP 308 and
+preserve tabs and query parameters. Locations keep their existing country and
+region slug URLs. Unknown records follow the normal not-found path. All proxy
+identity reads and sitemap reads are anonymous.
+
+The root sitemap includes catalog browse pages, series, countries, and regions.
+Region sitemaps are split by country so a single request does not need to fetch
+every country's regions. They include overview and browse tabs, follow API
+pagination, and omit modification dates when the API has none.
+
+Bottle rows on these pages use the shared rendering described in
+[Bottle Presentation](bottle-presentation.md). SEO does not introduce a separate
+visual component.


### PR DESCRIPTION
Series, country, region, and catalog browse pages now have consistent search descriptions, social metadata, and canonical URLs. Country and region tabs describe their own content, paginated lists keep their page URLs, and filtered or personal views are excluded from indexing. Series and location overviews add structured data with their browse hierarchy, while the location sitemaps now include regions and public tabs.

Bottle and series IDs, merged records, and stale name slugs redirect directly to their current URLs before HTML streaming begins. Location URLs normalize stored slug casing. Redirects retain nested paths and query parameters. Bottle forms use the shared slug parser so edit, merge, audit, add-similar, and add-tasting links continue to work. Public identity and sitemap reads stay anonymous, and existing shared bottle rendering is preserved.

Regression coverage checks redirect status and destinations, rendered metadata, sitemap pagination, and safe structured data.
