### PR TITLE
fix(footer): group links and collapse navigation on mobile

### DIFF
--- a/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationFooter.stylex.tsx
@@ -2,19 +2,34 @@ import type { Outputs } from "@peated/server/orpc/router";
 
 import { SiteFooter, type SiteFooterProps } from "@peated/web/components";
 
-const links = [
-  { href: "/locations", label: "Locations" },
-  { href: "/brands", label: "Brands" },
-  { href: "/about", label: "About" },
-  { href: "/about/api", label: "API" },
-  { href: "/about/categories", label: "Whisky categories" },
-  { href: "/about/tasting-wheel", label: "Tasting wheel" },
-  { href: "/about/ratings", label: "Rating guide" },
-  { href: "/events", label: "Whisky events" },
-  { href: "/updates", label: "Recent changes" },
-  { href: "https://github.com/peated/peated", label: "Source" },
-  { href: "/terms", label: "Terms" },
-] as const satisfies SiteFooterProps["links"];
+const groups = [
+  {
+    label: "Explore",
+    links: [
+      { href: "/locations", label: "Locations" },
+      { href: "/brands", label: "Brands" },
+      { href: "/events", label: "Whisky events" },
+    ],
+  },
+  {
+    label: "Reference",
+    links: [
+      { href: "/about/categories", label: "Whisky categories" },
+      { href: "/about/tasting-wheel", label: "Tasting wheel" },
+      { href: "/about/ratings", label: "Rating guide" },
+      { href: "/bottlers/4263/codes", label: "SMWS distillery codes" },
+    ],
+  },
+  {
+    label: "Project",
+    links: [
+      { href: "/about", label: "About" },
+      { href: "/updates", label: "Recent changes" },
+      { href: "/about/api", label: "API" },
+      { href: "https://github.com/peated/peated", label: "Source" },
+    ],
+  },
+] as const satisfies SiteFooterProps["groups"];
 
 function formatCount(value: number, noun: string) {
   return `${value.toLocaleString("en-US")} ${noun}`;
@@ -35,14 +50,9 @@ export function ApplicationFooter({ stats }: { stats?: Outputs["stats"] }) {
   return (
     <SiteFooter
       coverage={coverage}
-      links={links}
+      groups={groups}
+      legalLinks={[{ href: "/terms", label: "Terms" }]}
       provenance="Edited by members · corrections welcome"
-      referenceLinks={[
-        {
-          href: "/bottlers/4263/codes",
-          label: "SMWS distillery codes",
-        },
-      ]}
       responsibility="Drink responsibly"
       statement="A public record of whisky bottles, critic scores, and tasting notes from the people who drank them."
     />

--- a/apps/web/src/components/siteFooter.stories.tsx
+++ b/apps/web/src/components/siteFooter.stories.tsx
@@ -3,13 +3,33 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { SiteFooter, type SiteFooterProps } from "./siteFooter.stylex";
 import { StoryCanvas } from "./storyFixtures.stylex";
 
-const links: SiteFooterProps["links"] = [
-  { href: "/locations", label: "Locations" },
-  { href: "/brands", label: "Brands" },
-  { href: "/about", label: "About" },
-  { href: "/updates", label: "Recent changes" },
-  { href: "https://github.com/peated/peated", label: "Source" },
-  { href: "/terms", label: "Terms" },
+const groups: SiteFooterProps["groups"] = [
+  {
+    label: "Explore",
+    links: [
+      { href: "/locations", label: "Locations" },
+      { href: "/brands", label: "Brands" },
+      { href: "/events", label: "Whisky events" },
+    ],
+  },
+  {
+    label: "Reference",
+    links: [
+      { href: "/about/categories", label: "Whisky categories" },
+      { href: "/about/tasting-wheel", label: "Tasting wheel" },
+      { href: "/about/ratings", label: "Rating guide" },
+      { href: "/bottlers/4263/codes", label: "SMWS distillery codes" },
+    ],
+  },
+  {
+    label: "Project",
+    links: [
+      { href: "/about", label: "About" },
+      { href: "/updates", label: "Recent changes" },
+      { href: "/about/api", label: "API" },
+      { href: "https://github.com/peated/peated", label: "Source" },
+    ],
+  },
 ];
 
 const meta = {
@@ -18,21 +38,28 @@ const meta = {
   args: {
     coverage:
       "47,402 bottles · 3,102 distilleries · 1,891 brands · 431 bottlers · 312,000 tastings",
-    links,
-    provenance: "Community-edited · corrections welcome",
-    referenceLinks: [
-      { href: "/bottlers/4263/codes", label: "SMWS distillery codes" },
-    ],
+    groups,
+    legalLinks: [{ href: "/terms", label: "Terms" }],
+    provenance: "Edited by members · corrections welcome",
+    responsibility: "Drink responsibly",
     statement:
-      "A record of whisky bottles, critic scores, and tasting notes from the people who drank them.",
+      "A public record of whisky bottles, critic scores, and tasting notes from the people who drank them.",
   },
   argTypes: {
-    links: { control: false },
-    referenceLinks: { control: false },
+    groups: { control: false },
+    legalLinks: { control: false },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Footer links form three columns on desktop. Below 640px, each group becomes a collapsed native disclosure; description, coverage, and provenance are hidden. Legal links and responsible-drinking copy remain visible. Links and disclosure summaries show hover, pressed, and keyboard-focus states.",
+      },
+    },
   },
   decorators: [
     (Story) => (
-      <StoryCanvas width="wide">
+      <StoryCanvas width="page">
         <Story />
       </StoryCanvas>
     ),
@@ -42,4 +69,4 @@ const meta = {
 export default meta;
 type Story = StoryObj<SiteFooterProps>;
 
-export const ReferenceFooter: Story = {};
+export const Overview: Story = {};

--- a/apps/web/src/components/siteFooter.stylex.tsx
+++ b/apps/web/src/components/siteFooter.stylex.tsx
@@ -1,12 +1,12 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
-import { SectionHeading } from "./sectionHeading.stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
-import { colors, effects, fonts, space } from "../styles/tokens.stylex";
+import { colors, fonts, space } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 
 const COMPACT = "@media (max-width: 639px)";
+const NARROW = "@media (max-width: 959px)";
 
 export type FooterLink = {
   href: string;
@@ -16,20 +16,26 @@ export type FooterLink = {
 export type SiteFooterProps = {
   brand?: string;
   coverage?: ReactNode;
-  links: readonly [FooterLink, ...FooterLink[]];
+  groups: readonly {
+    label: string;
+    links: readonly FooterLink[];
+  }[];
+  legalLinks: readonly FooterLink[];
   provenance: ReactNode;
-  referenceLinks: readonly FooterLink[];
   responsibility?: ReactNode;
   statement: ReactNode;
 };
 
-/** Closes reference pages with durable destinations and data provenance. */
+/**
+ * Groups footer destinations into columns. On small screens, native disclosures
+ * keep every destination available while secondary copy and totals stay hidden.
+ */
 export function SiteFooter({
   brand = "Peated",
   coverage,
-  links,
+  groups,
+  legalLinks,
   provenance,
-  referenceLinks,
   responsibility = "Drink responsibly.",
   statement,
 }: SiteFooterProps) {
@@ -42,40 +48,68 @@ export function SiteFooter({
             {statement}
           </p>
         </div>
-        <nav aria-label="Footer">
-          <ul {...stylex.props(styles.footerLinks)}>
-            {links.map((link) => (
-              <li key={link.href}>
-                <FooterAnchor link={link} />
-              </li>
-            ))}
-          </ul>
-        </nav>
-      </div>
-      {referenceLinks.length ? (
-        <div {...stylex.props(styles.referenceSection)}>
-          <SectionHeading>Reference</SectionHeading>
-          <p {...stylex.props(styles.referenceLinks)}>
-            {referenceLinks.map((link) => (
-              <FooterAnchor key={link.href} link={link} />
-            ))}
-          </p>
+        <div {...stylex.props(styles.footerGroups)}>
+          {groups.map((group) => (
+            <nav key={group.label} aria-label={group.label}>
+              <p
+                {...stylex.props(
+                  foundationStyles.fieldLabel,
+                  styles.groupLabel,
+                )}
+              >
+                {group.label}
+              </p>
+              <FooterLinks links={group.links} />
+            </nav>
+          ))}
         </div>
+      </div>
+      <nav aria-label="Footer" {...stylex.props(styles.mobileNavigation)}>
+        {groups.map((group) => (
+          <details key={group.label} {...stylex.props(styles.disclosure)}>
+            <summary
+              {...stylex.props(foundationStyles.interactive, styles.summary)}
+            >
+              {group.label}
+            </summary>
+            <FooterLinks links={group.links} />
+          </details>
+        ))}
+      </nav>
+      {coverage ? (
+        <p {...stylex.props(foundationStyles.metadata, styles.coverage)}>
+          {coverage}
+        </p>
       ) : null}
-      <div {...stylex.props(styles.footerMeta)}>
-        {coverage ? (
-          <p {...stylex.props(foundationStyles.metadata, styles.coverage)}>
-            {coverage}
-          </p>
-        ) : null}
+      <div
+        {...stylex.props(
+          styles.footerMeta,
+          !!coverage && styles.metaWithCoverage,
+        )}
+      >
         <p {...stylex.props(foundationStyles.metadata, styles.provenance)}>
           {provenance}
         </p>
         <p {...stylex.props(foundationStyles.metadata, styles.responsibility)}>
           {responsibility}
         </p>
+        {legalLinks.map((link) => (
+          <FooterAnchor key={link.href} link={link} />
+        ))}
       </div>
     </footer>
+  );
+}
+
+function FooterLinks({ links }: { links: readonly FooterLink[] }) {
+  return (
+    <ul {...stylex.props(styles.footerLinks)}>
+      {links.map((link) => (
+        <li key={link.href}>
+          <FooterAnchor link={link} />
+        </li>
+      ))}
+    </ul>
   );
 }
 
@@ -100,15 +134,19 @@ const styles = stylex.create({
   },
   footerMain: {
     display: "grid",
-    gridTemplateColumns: "minmax(220px, 260px) minmax(0, 1fr)",
+    gridTemplateColumns: "minmax(200px, 260px) minmax(0, 1fr)",
     gap: space.x12,
-    [COMPACT]: {
+    [NARROW]: {
       gridTemplateColumns: "minmax(0, 1fr)",
-      gap: space.x8,
+      gap: space.x6,
+    },
+    [COMPACT]: {
+      display: "none",
     },
   },
   footerIdentity: {
     maxWidth: "260px",
+    [NARROW]: { maxWidth: "460px" },
   },
   footerBrand: {
     color: colors.ink,
@@ -123,64 +161,113 @@ const styles = stylex.create({
     marginTop: space.x2,
     color: colors.inkMuted,
   },
+  footerGroups: {
+    display: "grid",
+    gridTemplateColumns: "minmax(0, 0.8fr) minmax(0, 1.2fr) minmax(0, 1fr)",
+    gap: space.x8,
+  },
+  groupLabel: {
+    margin: 0,
+    marginBottom: space.x2,
+    color: colors.ink,
+  },
   footerLinks: {
-    display: "flex",
-    alignItems: "baseline",
-    justifyContent: "flex-end",
-    columnGap: space.x6,
-    rowGap: space.x3,
-    flexWrap: "wrap",
     margin: 0,
     padding: 0,
     listStyle: "none",
     [COMPACT]: {
-      justifyContent: "flex-start",
+      paddingBottom: space.x3,
     },
   },
   footerLink: {
+    display: "inline-flex",
+    alignItems: "center",
+    minHeight: "32px",
     color: {
       default: colors.inkMuted,
-      ":hover": colors.ink,
+      ":hover": colors.accent,
+      ":active": colors.accent,
+      ":focus-visible": colors.accent,
     },
-    fontWeight: 600,
-    textDecoration: "none",
-    outline: "none",
-    boxShadow: {
+    textDecorationLine: {
       default: "none",
-      ":focus-visible": effects.focusRing,
+      ":hover": "underline",
+      ":active": "underline",
+      ":focus-visible": "underline",
+    },
+    textUnderlineOffset: "3px",
+    outline: "none",
+    [COMPACT]: {
+      minHeight: "44px",
+      minWidth: "44px",
+      fontSize: "16px",
     },
   },
-  referenceSection: {
-    marginTop: space.x8,
+  mobileNavigation: {
+    display: "none",
+    [COMPACT]: { display: "block" },
   },
-  referenceLinks: {
-    display: "flex",
-    flexWrap: "wrap",
-    gap: space.x4,
-    margin: 0,
-    marginTop: space.x2,
+  disclosure: {
+    borderBottomWidth: { default: "1px", ":last-child": 0 },
+    borderBottomStyle: "solid",
+    borderBottomColor: colors.hairline,
+  },
+  summary: {
+    boxSizing: "border-box",
+    minHeight: "44px",
+    paddingTop: space.x3,
+    paddingBottom: space.x3,
+    cursor: "pointer",
+    color: {
+      default: colors.ink,
+      ":hover": colors.accent,
+      ":active": colors.accent,
+      ":focus-visible": colors.accent,
+    },
+    textDecorationLine: {
+      default: "none",
+      ":hover": "underline",
+      ":active": "underline",
+      ":focus-visible": "underline",
+    },
+    textUnderlineOffset: "3px",
+    outline: "none",
+    fontSize: "16px",
   },
   footerMeta: {
     display: "flex",
-    alignItems: "baseline",
-    gap: space.x4,
-    marginTop: space.x8,
+    alignItems: "center",
+    columnGap: space.x6,
+    rowGap: space.x2,
+    marginTop: space.x6,
+    paddingTop: space.x4,
     paddingBottom: space.x4,
     flexWrap: "wrap",
+    borderTopWidth: "1px",
+    borderTopStyle: "solid",
+    borderTopColor: colors.hairline,
+    [COMPACT]: { marginTop: space.x4 },
+  },
+  metaWithCoverage: {
+    marginTop: space.x3,
+    [COMPACT]: { marginTop: space.x4 },
   },
   coverage: {
-    minWidth: "280px",
+    margin: 0,
+    marginTop: space.x6,
+    color: colors.inkMuted,
+    fontVariantNumeric: "tabular-nums",
+    [COMPACT]: { display: "none" },
+  },
+  provenance: {
     flex: 1,
     margin: 0,
     color: colors.inkMuted,
-    fontVariantNumeric: "tabular-nums",
-  },
-  provenance: {
-    margin: 0,
-    color: colors.inkMuted,
+    [COMPACT]: { display: "none" },
   },
   responsibility: {
     margin: 0,
     color: colors.inkMuted,
+    [COMPACT]: { flex: 1 },
   },
 });


### PR DESCRIPTION
The footer now groups its existing links into Explore, Reference, and Project columns, with Terms beside the small print. Below 640px, the groups become collapsed native disclosures and the description, totals, and editing note are hidden. Terms and “Drink responsibly” remain visible, and all 12 existing destinations remain available.

Checked desktop and mobile layouts, dark mode, keyboard expansion, and the transition back to columns. Lint and formatting passed. The full web typecheck was interrupted after more than ten minutes under heavy local load and still needs CI verification.
