### PR TITLE
fix(web): show loading feedback during browse navigation

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -50,6 +50,8 @@
 
 ## Routes
 
+- Follow `../../docs/development/web-loading.md` for loading boundaries,
+  navigation feedback, and query updates.
 - Nest pages under their parent layout when tabs, headers, or navigation should
   remain. Keep the parent tab active.
 - Load only the nested page's data.

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -97,6 +97,8 @@ const appliedQueueProposalTokens = new Set();
 const ignoredInconclusiveProposalTokens = new Set();
 let collectionBottleId = 1;
 let pendingUploadId = 1;
+let releasePageReady = Promise.resolve();
+let releasePage = () => {};
 
 const bottleCheckMock = createBottleCheckMock({
   exactMatchedBottleId,
@@ -118,6 +120,24 @@ const server = http.createServer(async (request, response) => {
   }
 
   const url = new URL(request.url ?? "/", `http://${host}:${port}`);
+  if (
+    request.method === "POST" &&
+    url.pathname === "/__test/release-pages/hold"
+  ) {
+    releasePageReady = new Promise((resolve) => {
+      releasePage = resolve;
+    });
+    response.writeHead(204, corsHeaders).end();
+    return;
+  }
+  if (
+    request.method === "POST" &&
+    url.pathname === "/__test/release-pages/resume"
+  ) {
+    releasePage();
+    response.writeHead(204, corsHeaders).end();
+    return;
+  }
   if (url.pathname.startsWith("/uploads/")) {
     response
       .writeHead(200, {
@@ -700,9 +720,16 @@ async function handleRpcRequest({ request, response, url }) {
     }
     case "bottleGroups/bottles":
       if (input?.group === bottleGroupId) {
+        if (input.cursor === 2) await releasePageReady;
         sendRpcResponse(response, {
-          results: bottleGroupMembers,
-          rel: { nextCursor: null, prevCursor: null },
+          results:
+            input.cursor === 2
+              ? bottleGroupMembers.slice(1)
+              : bottleGroupMembers,
+          rel:
+            input.cursor === 2
+              ? { nextCursor: null, prevCursor: 1 }
+              : { nextCursor: 2, prevCursor: null },
         });
         return true;
       }
@@ -889,6 +916,19 @@ async function handleRpcRequest({ request, response, url }) {
           results: [homeBottle, existingBottle],
           rel: { nextCursor: null, prevCursor: null },
         });
+        return true;
+      }
+      if (input?.limit === 50 && input?.entity === undefined) {
+        sendRpcResponse(
+          response,
+          buildBottleListResponse(
+            input.query === "no-matching-whisky"
+              ? []
+              : input.sort === "name"
+                ? [existingBottle, homeBottle]
+                : [homeBottle, existingBottle],
+          ),
+        );
         return true;
       }
       if (!getAccessToken(request).includes("flight-bottles")) return false;

--- a/apps/web/e2e/profile-library.spec.ts
+++ b/apps/web/e2e/profile-library.spec.ts
@@ -78,18 +78,46 @@ test.describe("profile library", () => {
       page.getByRole("heading", { name: "Added to Library" }),
     ).toBeVisible();
 
-    await page.goto(`/users/${testUser.username}/library?cursor=2`, {
-      waitUntil: "commit",
-    });
+    await page.goto(`/users/${testUser.username}/library?cursor=2`);
     await expect(libraryBottleLink(page, bottleId)).toBeVisible();
 
     const sort = page.getByRole("combobox", { name: "Sort bottles" });
     await expect(sort).toHaveValue("name");
-    await sort.selectOption({ label: "Recently added" });
+    const navigation = `/users/${testUser.username}/library?sort=-created*`;
+    let releaseNavigation!: () => void;
+    const navigationReady = new Promise<void>((resolve) => {
+      releaseNavigation = resolve;
+    });
+    await page.route(`**${navigation}`, async (route) => {
+      await navigationReady;
+      await route.continue();
+    });
+    try {
+      await sort.focus();
+      await sort.selectOption({ label: "Recently added" });
+      await expect(sort).toHaveValue("-created");
+      await expect(sort).toBeFocused();
+      await expect(
+        page.getByRole("status").filter({ hasText: "Updating…" }),
+      ).toBeVisible();
+      await page.screenshot({
+        path: testInfo.outputPath("library-sort-pending.png"),
+      });
+      await expect(libraryBottleLink(page, bottleId)).toBeVisible();
+      await expect(
+        page.getByRole("heading", { name: testUser.username, exact: true }),
+      ).toBeVisible();
+    } finally {
+      releaseNavigation();
+    }
     await expect(page).toHaveURL(
       `/users/${testUser.username}/library?sort=-created`,
     );
-    await page.reload({ waitUntil: "commit" });
+    await expect(
+      page.getByRole("status").filter({ hasText: "Updating…" }),
+    ).toHaveCount(0);
+    await page.unroute(`**${navigation}`);
+    await page.reload();
     await expect(sort).toHaveValue("-created");
 
     await page
@@ -109,19 +137,40 @@ test.describe("profile library", () => {
     await expect(page).toHaveURL(
       `/users/${testUser.username}/library?sort=name`,
     );
+    await page.goBack();
+    await expect(sort).toHaveValue("-created");
+    await page.goForward();
+    await expect(sort).toHaveValue("name");
 
-    await page.goto(`/users/${testUser.username}/library?cursor=2`, {
-      waitUntil: "commit",
+    await page.goto(`/users/${testUser.username}/library?cursor=2`);
+    const brandNavigation = `**/users/${testUser.username}/library?brand=*`;
+    let releaseBrandNavigation!: () => void;
+    const brandNavigationReady = new Promise<void>((resolve) => {
+      releaseBrandNavigation = resolve;
     });
-    await page
-      .getByRole("button", {
-        name: new RegExp(`^${existingBottle.brand.name}\\b`),
-      })
-      .click();
+    await page.route(brandNavigation, async (route) => {
+      await brandNavigationReady;
+      await route.continue();
+    });
+    try {
+      await page
+        .getByRole("button", {
+          name: new RegExp(`^${existingBottle.brand.name}\\b`),
+        })
+        .click();
+      await expect(
+        page.getByRole("status").filter({ hasText: "Updating…" }),
+      ).toBeVisible();
+      await sort.selectOption({ label: "Recently added" });
+      await expect(sort).toHaveValue("-created");
+    } finally {
+      releaseBrandNavigation();
+    }
     await expect(page).toHaveURL(
-      `/users/${testUser.username}/library?brand=${existingBottle.brand.id}`,
+      `/users/${testUser.username}/library?brand=${existingBottle.brand.id}&sort=-created`,
     );
     await expect(libraryBottleLink(page, bottleId)).toBeVisible();
+    await page.unroute(brandNavigation);
   });
 
   test("lets the owner remove a Library entry", async ({

--- a/apps/web/e2e/routes.spec.ts
+++ b/apps/web/e2e/routes.spec.ts
@@ -1,10 +1,12 @@
 import { expect, test } from "./test";
 
-import { bottlePathPattern } from "./assertions";
+import { bottleHrefSelector, bottlePathPattern } from "./assertions";
 import {
+  bottleGroupMembers,
   bottleGroupRepresentative,
   existingBottle,
   existingBottleDetails,
+  mockApiServer,
   priceSite,
   testBottler,
   testBrand,
@@ -66,11 +68,7 @@ const publicRoutes = [
   },
 ] as const;
 
-const otherPublicRoutes = [
-  ["Bottle releases", `/bottles/${bottleGroupRepresentative.id}/releases`],
-  ["distillers", "/distillers"],
-  ["company", `/companies/${testOwner.id}`],
-] as const;
+const otherPublicRoutes = [["company", `/companies/${testOwner.id}`]] as const;
 
 test("public routes load", async ({ page, snapshot }) => {
   for (const route of publicRoutes) {
@@ -120,6 +118,104 @@ for (const [name, path] of otherPublicRoutes) {
   });
 }
 
+test("bottle releases stream new pages without replacing the bottle header", async ({
+  page,
+  request,
+}, testInfo) => {
+  await page.goto(`/bottles/${bottleGroupRepresentative.id}/releases`);
+  const releases = page.getByRole("list", { name: "Bottle releases" });
+  await expect(releases).toBeVisible();
+  const heading = page.getByRole("heading", { level: 1 });
+  const title = await heading.textContent();
+  const next = page
+    .getByRole("navigation", { name: "Release pages" })
+    .locator('a[rel="next"]');
+  const nextHref = await next.getAttribute("href");
+  expect(nextHref).toBeTruthy();
+  const navigation = `**${nextHref}*`;
+  let releaseNavigation!: () => void;
+  const navigationReady = new Promise<void>((resolve) => {
+    releaseNavigation = resolve;
+  });
+  await page.route(navigation, async (route) => {
+    await navigationReady;
+    await route.continue();
+  });
+  await request.post(`${mockApiServer}/__test/release-pages/hold`);
+  try {
+    await next.click();
+    await expect(next.getByRole("status")).toHaveText("Loading…");
+    await expect(releases).toBeVisible();
+    releaseNavigation();
+    await expect(
+      page.getByRole("status", { name: "Loading releases", exact: true }),
+    ).toBeVisible();
+    await expect(heading).toHaveText(title!);
+    await expect(
+      page.getByRole("heading", { name: "Releases", exact: true }),
+    ).toBeVisible();
+    await page.screenshot({
+      path: testInfo.outputPath("release-page-loading.png"),
+    });
+  } finally {
+    releaseNavigation();
+    await request.post(`${mockApiServer}/__test/release-pages/resume`);
+    await page.unroute(navigation);
+  }
+  await expect(page).toHaveURL(nextHref!);
+  await expect(
+    releases.locator(bottleHrefSelector(bottleGroupMembers[1]!.id)),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("status", { name: "Loading releases", exact: true }),
+  ).toHaveCount(0);
+});
+
+test("distillers filters keep controls responsive while results update", async ({
+  page,
+}) => {
+  await page.goto("/distillers?cursor=2");
+  const producer = page.getByRole("link", {
+    name: testOwnedEntity.name,
+    exact: true,
+  });
+  await expect(producer).toBeVisible();
+  const sort = page.getByRole("combobox", { name: "Sort distillers" });
+  const navigation = "**/distillers?country=japan*";
+  let releaseNavigation!: () => void;
+  const navigationReady = new Promise<void>((resolve) => {
+    releaseNavigation = resolve;
+  });
+  await page.route(navigation, async (route) => {
+    await navigationReady;
+    await route.continue();
+  });
+  try {
+    const country = page.getByRole("button", { name: "Japan", exact: true });
+    await country.click();
+    await expect(country).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      page.getByRole("status").filter({ hasText: "Updating…" }),
+    ).toBeVisible();
+    await expect(producer).toBeVisible();
+    await sort.selectOption({ label: "Name" });
+    await expect(sort).toHaveValue("name");
+  } finally {
+    releaseNavigation();
+  }
+  await expect(page).toHaveURL("/distillers?country=japan&sort=name");
+  await expect(
+    page.getByRole("heading", { name: "No distillers found" }),
+  ).toBeVisible();
+  await expect(sort).toBeVisible();
+  await page.unroute(navigation);
+  await page
+    .getByRole("button", { name: "Clear filters", exact: true })
+    .click();
+  await expect(page).toHaveURL("/distillers?sort=name");
+  await expect(producer).toBeVisible();
+});
+
 test("Add Entity route loads for a signed-in member", async ({
   context,
   page,
@@ -148,6 +244,58 @@ test(
     await snapshot("Menu", { fullPage: false, ready: navigation });
     await navigation.getByRole("link", { name: "Bottles" }).click();
     await expect(page).toHaveURL(/\/bottles$/);
+
+    const sort = page.getByRole("combobox", { name: "Sort bottles" });
+    await expect(sort).toHaveValue("-release");
+    const sortNavigation = "**/bottles?sort=name*";
+    let releaseNavigation!: () => void;
+    const navigationReady = new Promise<void>((resolve) => {
+      releaseNavigation = resolve;
+    });
+    await page.route(sortNavigation, async (route) => {
+      await navigationReady;
+      await route.continue();
+    });
+    try {
+      await sort.selectOption({ label: "Bottle name" });
+      await expect(sort).toHaveValue("name");
+      await expect(
+        page.getByRole("status").filter({ hasText: "Updating…" }),
+      ).toBeVisible();
+      await expect(
+        page.locator(bottleHrefSelector(existingBottle.id)),
+      ).toBeVisible();
+    } finally {
+      releaseNavigation();
+    }
+    await expect(page).toHaveURL("/bottles?sort=name");
+    await expect(
+      page.getByRole("status").filter({ hasText: "Updating…" }),
+    ).toHaveCount(0);
+    await page.unroute(sortNavigation);
+    await expect(
+      page
+        .getByRole("list", { name: "Bottle records" })
+        .getByRole("listitem")
+        .first()
+        .locator(bottleHrefSelector(existingBottle.id)),
+    ).toBeVisible();
+
+    const search = page.getByRole("searchbox", { name: "Find a bottle" });
+    await search.fill("no-matching-whisky");
+    await search.press("Enter");
+    await expect(
+      page.getByRole("heading", { name: "No bottles found" }),
+    ).toBeVisible();
+    await expect(sort).toBeVisible();
+    await expect(search).toBeFocused();
+    await page
+      .getByRole("button", { name: "Clear filters", exact: true })
+      .click();
+    await expect(page).toHaveURL("/bottles?sort=name");
+    await expect(
+      page.locator(bottleHrefSelector(existingBottle.id)),
+    ).toBeVisible();
   },
 );
 

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -1,5 +1,5 @@
 const timestamp = "2026-06-07T12:00:00.000Z";
-const mockApiServer = `http://127.0.0.1:${process.env.PLAYWRIGHT_API_PORT ?? 4999}`;
+export const mockApiServer = `http://127.0.0.1:${process.env.PLAYWRIGHT_API_PORT ?? 4999}`;
 
 export const createdBottleName = "Playwright Reserve";
 export const tastingNotes = "Smoke, lemon peel, and sea salt.";

--- a/apps/web/src/app/(admin)/admin/(default)/loading.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingList } from "@peated/web/components";
+
+export default function Loading() {
+  return <LoadingList label="Loading records" rows={4} />;
+}

--- a/apps/web/src/app/(admin)/admin/(default)/locations/[countrySlug]/(tabs)/loading.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/locations/[countrySlug]/(tabs)/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingList } from "@peated/web/components";
+
+export default function Loading() {
+  return <LoadingList label="Loading location records" rows={4} />;
+}

--- a/apps/web/src/app/(admin)/admin/(default)/moderation/loading.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/moderation/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingList } from "@peated/web/components";
+
+export default function Loading() {
+  return <LoadingList label="Loading moderation records" rows={4} />;
+}

--- a/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/loading.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/sites/[siteId]/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingList } from "@peated/web/components";
+
+export default function Loading() {
+  return <LoadingList label="Loading site records" rows={4} />;
+}

--- a/apps/web/src/app/(admin)/admin/(layout-free)/loading.tsx
+++ b/apps/web/src/app/(admin)/admin/(layout-free)/loading.tsx
@@ -1,0 +1,1 @@
+export { default } from "@peated/web/components/defaultLoading";

--- a/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/(entity-catalog)/entityCatalogPageClient.tsx
@@ -6,6 +6,7 @@ import type { Outputs } from "@peated/server/orpc/router";
 import type { EntityKind } from "@peated/server/types";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useOptimistic, useTransition } from "react";
 
 import { ButtonLink, PageTabs } from "@peated/web/components";
 import { CatalogPage } from "@peated/web/components/pages/catalogPage.stylex";
@@ -62,6 +63,11 @@ export function EntityCatalogPageClient({
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [isNavigating, startTransition] = useTransition();
+  const [displayedParams, setDisplayedParams] = useOptimistic(
+    searchParams.toString(),
+  );
+  const displayedSearchParams = new URLSearchParams(displayedParams);
   const queryParams = useApiQueryParams({
     numericFields: ["cursor", "limit"],
   });
@@ -73,15 +79,15 @@ export function EntityCatalogPageClient({
         : kind === "bottler"
           ? orpc.bottlers.list.queryOptions({ input: queryParams })
           : orpc.companies.list.queryOptions({ input: queryParams });
-  const { data: entityList } = useSuspenseQuery({
+  const { data: entityList, isFetching } = useSuspenseQuery({
     ...listQueryOptions,
     initialData: initialEntityList,
   });
   const page = Number(searchParams.get("cursor") ?? "1") || 1;
-  const sort = searchParams.get("sort") ?? DEFAULT_SORT;
-  const country = searchParams.get("country") ?? "";
-  const query = searchParams.get("query") ?? "";
-  const region = searchParams.get("region") ?? "";
+  const sort = displayedSearchParams.get("sort") ?? DEFAULT_SORT;
+  const country = displayedSearchParams.get("country") ?? "";
+  const query = displayedSearchParams.get("query") ?? "";
+  const region = displayedSearchParams.get("region") ?? "";
   const hasFilters = Boolean(country || query || region);
   const filter =
     searchParams.get("filter") === "following" ? "following" : "all";
@@ -89,8 +95,16 @@ export function EntityCatalogPageClient({
   const followingHref = getScopeHref(pathname, searchParams, "following");
   const showFollowing = Boolean(user && kind !== "company");
 
+  function navigate(nextParams: URLSearchParams) {
+    startTransition(() => {
+      // Catalog queries follow the committed URL; only controls anticipate navigation.
+      setDisplayedParams(nextParams.toString());
+      router.push(buildSearchHref(pathname, nextParams), { scroll: false });
+    });
+  }
+
   function updateParams(updates: Record<string, string>) {
-    const nextParams = new URLSearchParams(searchParams);
+    const nextParams = new URLSearchParams(displayedParams);
 
     Object.entries(updates).forEach(([name, value]) => {
       if (value) nextParams.set(name, value);
@@ -98,15 +112,15 @@ export function EntityCatalogPageClient({
     });
     if ("country" in updates) nextParams.delete("region");
     nextParams.delete("cursor");
-    router.push(buildSearchHref(pathname, nextParams));
+    navigate(nextParams);
   }
 
   function clearFilters() {
-    const nextParams = new URLSearchParams(searchParams);
+    const nextParams = new URLSearchParams(displayedParams);
     ["country", "cursor", "query", "region"].forEach((name) =>
       nextParams.delete(name),
     );
-    router.push(buildSearchHref(pathname, nextParams));
+    navigate(nextParams);
   }
 
   const addHref = `/addEntity?kind=${kind}`;
@@ -130,7 +144,6 @@ export function EntityCatalogPageClient({
           ariaLabel={`${config.title} filters`}
           countries={countryOptions}
           country={country}
-          key={query}
           onClear={clearFilters}
           onCountryChange={(value) => updateParams({ country: value })}
           onQuerySubmit={(value) => updateParams({ query: value })}
@@ -195,6 +208,7 @@ export function EntityCatalogPageClient({
         }
         onSortChange={(value) => updateParams({ sort: value })}
         page={page}
+        pending={isNavigating || isFetching}
         pendingIds={followControls.pendingIds}
         previousHref={getCursorHref(
           pathname,

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -5,6 +5,7 @@ import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useOptimistic, useTransition } from "react";
 
 import { ButtonLink } from "@peated/web/components";
 import { addBottleRowActions } from "@peated/web/components/bottleRowActions.stylex";
@@ -89,6 +90,11 @@ export function BottleCatalogPageClient({
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [isNavigating, startTransition] = useTransition();
+  const [displayedParams, setDisplayedParams] = useOptimistic(
+    searchParams.toString(),
+  );
+  const displayedSearchParams = new URLSearchParams(displayedParams);
   const queryParams = normalizeBottleCatalogQueryParams(
     useApiQueryParams({
       defaults: { sort: DEFAULT_SORT },
@@ -108,19 +114,30 @@ export function BottleCatalogPageClient({
       overrides: { limit: 50 },
     }),
   );
-  const { data: bottleList } = useSuspenseQuery({
+  const { data: bottleList, isFetching } = useSuspenseQuery({
     ...orpc.bottles.list.queryOptions({ input: queryParams }),
     initialData: initialBottleList,
   });
   const page = Number(searchParams.get("cursor") ?? "1") || 1;
-  const sort = String(queryParams.sort ?? DEFAULT_SORT);
+  const sort =
+    sortOptions.find(
+      (option) => option.value === displayedSearchParams.get("sort"),
+    )?.value ?? DEFAULT_SORT;
   const filter =
     searchParams.get("filter") === "following" ? "following" : "all";
   const allHref = getScopeHref(pathname, searchParams, "all");
   const followingHref = getScopeHref(pathname, searchParams, "following");
 
+  function navigate(nextParams: URLSearchParams) {
+    startTransition(() => {
+      // Catalog queries follow the committed URL; only controls anticipate navigation.
+      setDisplayedParams(nextParams.toString());
+      router.push(buildSearchHref(pathname, nextParams), { scroll: false });
+    });
+  }
+
   function updateParams(updates: Record<string, string>) {
-    const nextParams = new URLSearchParams(searchParams);
+    const nextParams = new URLSearchParams(displayedParams);
 
     Object.entries(updates).forEach(([name, value]) => {
       if (value) nextParams.set(name, value);
@@ -130,13 +147,13 @@ export function BottleCatalogPageClient({
     if ("age" in updates) nextParams.delete("ageBand");
     nextParams.delete("cursor");
     nextParams.delete("minScore");
-    router.push(buildSearchHref(pathname, nextParams));
+    navigate(nextParams);
   }
 
   function clearFilters() {
-    const nextParams = new URLSearchParams(searchParams);
+    const nextParams = new URLSearchParams(displayedParams);
     clearedFilterKeys.forEach((name) => nextParams.delete(name));
-    router.push(buildSearchHref(pathname, nextParams));
+    navigate(nextParams);
   }
 
   const items = bottleList.results.map((bottle) =>
@@ -162,16 +179,15 @@ export function BottleCatalogPageClient({
       }
       filters={
         <BottleCatalogFilters
-          age={searchParams.get("age") ?? ""}
-          ageBand={searchParams.get("ageBand") ?? ""}
+          age={displayedSearchParams.get("age") ?? ""}
+          ageBand={displayedSearchParams.get("ageBand") ?? ""}
           ageBandOptions={ageBandOptions}
-          category={searchParams.get("category") ?? ""}
+          category={displayedSearchParams.get("category") ?? ""}
           categoryOptions={categoryOptions}
-          key={searchParams.get("query") ?? ""}
           onChange={(name, value) => updateParams({ [name]: value })}
           onClear={clearFilters}
           onQuerySubmit={(value) => updateParams({ query: value.trim() })}
-          query={searchParams.get("query") ?? ""}
+          query={displayedSearchParams.get("query") ?? ""}
         />
       }
       navigation={
@@ -212,6 +228,7 @@ export function BottleCatalogPageClient({
         onClear={clearFilters}
         onSortChange={(value) => updateParams({ sort: value })}
         page={page}
+        pending={isNavigating || isFetching}
         previousHref={getCursorHref(
           pathname,
           searchParams,

--- a/apps/web/src/app/(app)/bottles/[bottleId]/loading.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingList } from "@peated/web/components";
+
+export default function Loading() {
+  return <LoadingList label="Loading bottle details" rows={4} />;
+}

--- a/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/releases/page.tsx
@@ -4,6 +4,7 @@ import {
   EmptyState,
   ItemList,
   ItemListItem,
+  LoadingList,
 } from "@peated/web/components";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getBottlePage } from "@peated/web/lib/bottlePage.server";
@@ -16,6 +17,7 @@ import {
   requireReleaseFamilyGroup,
 } from "@peated/web/lib/releaseFamily";
 import { getBottleUrl } from "@peated/web/lib/urls";
+import { Suspense } from "react";
 
 import { BottleSection } from "../bottleSection.stylex";
 
@@ -40,6 +42,32 @@ export default async function BottleReleasesPage(props: {
   ]);
   const anchorId = parseCatalogRouteId(bottleId);
   const cursor = Number(searchParams.cursor ?? 1) || 1;
+
+  return (
+    <BottleSection heading="Releases">
+      <Suspense
+        key={`${anchorId}:${cursor}`}
+        fallback={<LoadingList label="Loading releases" />}
+      >
+        <ReleaseResults
+          anchorId={anchorId}
+          cursor={cursor}
+          searchParams={searchParams}
+        />
+      </Suspense>
+    </BottleSection>
+  );
+}
+
+async function ReleaseResults({
+  anchorId,
+  cursor,
+  searchParams,
+}: {
+  anchorId: number;
+  cursor: number;
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
   const { anchorBottle, client, group } = await getReleaseGroup(anchorId);
   const bottleList = await resolveOrNotFound(
     client.bottleGroups.bottles({
@@ -53,7 +81,7 @@ export default async function BottleReleasesPage(props: {
   const pathname = `${getBottleUrl(anchorBottle)}/releases`;
 
   return (
-    <BottleSection heading="Releases">
+    <>
       {bottleList.results.length ? (
         <ItemList ariaLabel="Bottle releases">
           {bottleList.results.map((bottle) => (
@@ -88,7 +116,7 @@ export default async function BottleReleasesPage(props: {
           bottleList.rel.prevCursor,
         )}
       />
-    </BottleSection>
+    </>
   );
 }
 

--- a/apps/web/src/app/(app)/bottles/[bottleId]/tastings/page.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/tastings/page.tsx
@@ -4,6 +4,7 @@ import {
   EmptyState,
   ItemList,
   ItemListItem,
+  LoadingList,
 } from "@peated/web/components";
 import { TastingRecordEntry } from "@peated/web/components/tastingRecordEntry";
 import { getAddBottleHref } from "@peated/web/lib/addBottle";
@@ -12,6 +13,7 @@ import { parseCatalogRouteId } from "@peated/web/lib/catalogRoute";
 import { getCursorHref } from "@peated/web/lib/cursorHref";
 import { getAnonymousServerClient } from "@peated/web/lib/orpc/client.server";
 import { getBottleUrl } from "@peated/web/lib/urls";
+import { Suspense } from "react";
 
 import { BottleSection } from "../bottleSection.stylex";
 
@@ -25,6 +27,28 @@ export default async function BottleTastingsPage(props: {
   ]);
   const id = parseCatalogRouteId(bottleId);
   const cursor = Number(searchParams.cursor ?? 1) || 1;
+
+  return (
+    <BottleSection heading="Tastings">
+      <Suspense
+        key={`${id}:${cursor}`}
+        fallback={<LoadingList label="Loading tastings" />}
+      >
+        <TastingResults id={id} cursor={cursor} searchParams={searchParams} />
+      </Suspense>
+    </BottleSection>
+  );
+}
+
+async function TastingResults({
+  id,
+  cursor,
+  searchParams,
+}: {
+  id: number;
+  cursor: number;
+  searchParams: Record<string, string | string[] | undefined>;
+}) {
   const [bottle, { client }] = await Promise.all([
     getBottlePage(id),
     getAnonymousServerClient(),
@@ -37,7 +61,7 @@ export default async function BottleTastingsPage(props: {
   const pathname = `${getBottleUrl(bottle)}/tastings`;
 
   return (
-    <BottleSection heading="Tastings">
+    <>
       {tastingList.results.length ? (
         <ItemList ariaLabel="Bottle tasting records">
           {tastingList.results.map((tasting) => (
@@ -76,6 +100,6 @@ export default async function BottleTastingsPage(props: {
           tastingList.rel.prevCursor,
         )}
       />
-    </BottleSection>
+    </>
   );
 }

--- a/apps/web/src/app/(app)/entities/[entityId]/bottles/entityBottleListClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/bottles/entityBottleListClient.stylex.tsx
@@ -4,7 +4,7 @@ import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import type { ReactNode } from "react";
+import { useOptimistic, useTransition, type ReactNode } from "react";
 
 import { PageTabs } from "@peated/web/components";
 import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
@@ -80,12 +80,15 @@ export function EntityBottleListClient({
       },
     }),
   );
-  const { data: bottleList } = useSuspenseQuery({
+  const { data: bottleList, isFetching } = useSuspenseQuery({
     ...orpc.bottles.list.queryOptions({ input: queryParams }),
     initialData: initialBottleList,
   });
   const page = Number(searchParams.get("cursor") ?? "1") || 1;
-  const sort = String(queryParams.sort ?? DEFAULT_SORT);
+  const [isNavigating, startTransition] = useTransition();
+  const [sort, setSort] = useOptimistic(
+    String(queryParams.sort ?? DEFAULT_SORT),
+  );
 
   function getViewHref(view: "other" | "releases") {
     const nextParams = new URLSearchParams(searchParams);
@@ -98,7 +101,10 @@ export function EntityBottleListClient({
     const nextParams = new URLSearchParams(searchParams);
     nextParams.set("sort", value);
     nextParams.delete("cursor");
-    router.push(buildSearchHref(pathname, nextParams));
+    startTransition(() => {
+      setSort(value);
+      router.push(buildSearchHref(pathname, nextParams), { scroll: false });
+    });
   }
 
   return (
@@ -148,6 +154,7 @@ export function EntityBottleListClient({
         )}
         onSortChange={updateSort}
         page={page}
+        pending={isNavigating || isFetching}
         previousHref={getCursorHref(
           pathname,
           searchParams,

--- a/apps/web/src/app/(app)/events/loading.tsx
+++ b/apps/web/src/app/(app)/events/loading.tsx
@@ -1,0 +1,11 @@
+import { LoadingList } from "@peated/web/components";
+import { PageHeader } from "@peated/web/components/pages/pageLayout.stylex";
+
+export default function Loading() {
+  return (
+    <>
+      <PageHeader title="Whisky events" />
+      <LoadingList label="Loading events" rows={4} />
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/flights/[flightId]/loading.tsx
+++ b/apps/web/src/app/(app)/flights/[flightId]/loading.tsx
@@ -1,0 +1,11 @@
+import { LoadingList, LoadingPlaceholder } from "@peated/web/components";
+import { PageHeader } from "@peated/web/components/pages/pageLayout.stylex";
+
+export default function Loading() {
+  return (
+    <>
+      <PageHeader title={<LoadingPlaceholder preset="heading" />} />
+      <LoadingList label="Loading flight bottles" rows={4} />
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/flights/loading.tsx
+++ b/apps/web/src/app/(app)/flights/loading.tsx
@@ -1,0 +1,11 @@
+import { LoadingList } from "@peated/web/components";
+import { PageHeader } from "@peated/web/components/pages/pageLayout.stylex";
+
+export default function Loading() {
+  return (
+    <>
+      <PageHeader title="Flights" />
+      <LoadingList label="Loading flights" rows={4} />
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/following/followingPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/following/followingPageClient.stylex.tsx
@@ -3,6 +3,7 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useOptimistic, useTransition } from "react";
 
 import {
   ButtonLink,
@@ -44,11 +45,18 @@ export function FollowingPageClient({
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [isNavigating, startTransition] = useTransition();
+  const [displayedParams, setDisplayedParams] = useOptimistic(
+    searchParams.toString(),
+  );
+  const controls = getFollowingPageState(
+    Object.fromEntries(new URLSearchParams(displayedParams)),
+  );
   const state = getFollowingPageState(Object.fromEntries(searchParams));
   const listQueryOptions = orpc.entities.list.queryOptions({
     input: state.input,
   });
-  const { data: entityList } = useSuspenseQuery({
+  const { data: entityList, isFetching } = useSuspenseQuery({
     ...listQueryOptions,
     initialData: initialEntityList,
   });
@@ -62,20 +70,27 @@ export function FollowingPageClient({
     toEntityCatalogItem(entity, followControls.isFollowing(entity)),
   );
 
+  function navigate(nextParams: URLSearchParams) {
+    startTransition(() => {
+      setDisplayedParams(nextParams.toString());
+      router.push(buildSearchHref(pathname, nextParams), { scroll: false });
+    });
+  }
+
   function updateParams(updates: Record<string, string>) {
-    const nextParams = new URLSearchParams(searchParams);
+    const nextParams = new URLSearchParams(displayedParams);
     Object.entries(updates).forEach(([name, value]) => {
       if (value) nextParams.set(name, value);
       else nextParams.delete(name);
     });
     nextParams.delete("cursor");
-    router.push(buildSearchHref(pathname, nextParams));
+    navigate(nextParams);
   }
 
   function clearFilters() {
-    const nextParams = new URLSearchParams(searchParams);
+    const nextParams = new URLSearchParams(displayedParams);
     ["cursor", "query", "type"].forEach((name) => nextParams.delete(name));
-    router.push(buildSearchHref(pathname, nextParams));
+    navigate(nextParams);
   }
 
   const noMatches = state.hasFilters;
@@ -85,19 +100,19 @@ export function FollowingPageClient({
       filters={
         <FilterPanel
           ariaLabel="Following filters"
-          onClear={state.hasFilters ? clearFilters : undefined}
+          onClear={controls.hasFilters ? clearFilters : undefined}
           query={{
             label: "Name",
             onSubmit: (value) => updateParams({ query: value }),
             placeholder: "Distiller, brand, or bottler",
-            query: state.query,
+            query: controls.query,
           }}
         >
           <FacetGroup
             label="Type"
             onChange={(value) => updateParams({ type: value })}
             options={typeOptions}
-            selected={state.type === "all" ? "" : state.type}
+            selected={controls.type === "all" ? "" : controls.type}
           />
         </FilterPanel>
       }
@@ -151,6 +166,7 @@ export function FollowingPageClient({
           })
         }
         page={state.cursor}
+        pending={isNavigating || isFetching}
         pendingIds={followControls.pendingIds}
         previousHref={getCursorHref(
           pathname,
@@ -158,7 +174,7 @@ export function FollowingPageClient({
           entityList.rel.prevCursor,
         )}
         showFollowingMarks={state.view === "find"}
-        sort={state.sort}
+        sort={controls.sort}
         sortOptions={sortOptions}
         total={visibleList.total}
       />

--- a/apps/web/src/app/(app)/locations/(index)/loading.tsx
+++ b/apps/web/src/app/(app)/locations/(index)/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingList } from "@peated/web/components";
+
+export default function Loading() {
+  return <LoadingList label="Loading locations" rows={4} />;
+}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/(country)/loading.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/(country)/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingList } from "@peated/web/components";
+
+export default function Loading() {
+  return <LoadingList label="Loading country details" rows={4} />;
+}

--- a/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/loading.tsx
+++ b/apps/web/src/app/(app)/locations/[countrySlug]/regions/[regionSlug]/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingList } from "@peated/web/components";
+
+export default function Loading() {
+  return <LoadingList label="Loading region details" rows={4} />;
+}

--- a/apps/web/src/app/(app)/locations/loading.tsx
+++ b/apps/web/src/app/(app)/locations/loading.tsx
@@ -1,0 +1,11 @@
+import { LoadingList } from "@peated/web/components";
+import { PageHeader } from "@peated/web/components/pages/pageLayout.stylex";
+
+export default function Loading() {
+  return (
+    <>
+      <PageHeader title="Locations" />
+      <LoadingList label="Loading locations" rows={4} />
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/locations/locationBottleListClient.tsx
+++ b/apps/web/src/app/(app)/locations/locationBottleListClient.tsx
@@ -3,6 +3,7 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useOptimistic, useTransition } from "react";
 
 import { BottleCatalogList } from "@peated/web/components/pages/bottleCatalog.stylex";
 import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
@@ -46,18 +47,24 @@ export function LocationBottleListClient({
       overrides: { country, limit: 25, region },
     }),
   );
-  const { data: bottleList } = useSuspenseQuery({
+  const { data: bottleList, isFetching } = useSuspenseQuery({
     ...orpc.bottles.list.queryOptions({ input: queryParams }),
     initialData: initialBottleList,
   });
   const page = Number(searchParams.get("cursor") ?? "1") || 1;
-  const sort = String(queryParams.sort ?? LOCATION_BOTTLE_DEFAULT_SORT);
+  const [isNavigating, startTransition] = useTransition();
+  const [sort, setSort] = useOptimistic(
+    String(queryParams.sort ?? LOCATION_BOTTLE_DEFAULT_SORT),
+  );
 
   function updateSort(value: string) {
     const nextParams = new URLSearchParams(searchParams);
     nextParams.set("sort", value);
     nextParams.delete("cursor");
-    router.push(buildSearchHref(pathname, nextParams));
+    startTransition(() => {
+      setSort(value);
+      router.push(buildSearchHref(pathname, nextParams), { scroll: false });
+    });
   }
 
   return (
@@ -77,6 +84,7 @@ export function LocationBottleListClient({
       )}
       onSortChange={updateSort}
       page={page}
+      pending={isNavigating || isFetching}
       previousHref={getCursorHref(
         pathname,
         searchParams,

--- a/apps/web/src/app/(app)/search/loading.tsx
+++ b/apps/web/src/app/(app)/search/loading.tsx
@@ -1,0 +1,11 @@
+import { LoadingList } from "@peated/web/components";
+import { PageHeader } from "@peated/web/components/pages/pageLayout.stylex";
+
+export default function Loading() {
+  return (
+    <>
+      <PageHeader title="Search" />
+      <LoadingList label="Loading search results" rows={4} />
+    </>
+  );
+}

--- a/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/search/searchPageClient.stylex.tsx
@@ -3,7 +3,7 @@
 import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback } from "react";
+import { useCallback, useOptimistic, useTransition } from "react";
 
 import { getCreateBottleHref } from "@peated/web/components/search/createBottleHref";
 import {
@@ -111,6 +111,10 @@ export function SearchPageClient({
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [isNavigating, startTransition] = useTransition();
+  const [displayedParams, setDisplayedParams] = useOptimistic(
+    searchParams.toString(),
+  );
   const query = searchParams.get("q") ?? "";
   const intent = getAddBottleIntent(searchParams.get("intent"));
   const directToTasting = searchParams.has("tasting");
@@ -160,14 +164,14 @@ export function SearchPageClient({
   );
 
   function submitSearch(nextQuery: string) {
-    const nextParams = new URLSearchParams(searchParams);
+    const nextParams = new URLSearchParams(displayedParams);
     if (nextQuery) nextParams.set("q", nextQuery);
     else nextParams.delete("q");
     replaceSearch(nextParams);
   }
 
   function updateScope(nextScope: SearchScope, nextQuery: string) {
-    const nextParams = new URLSearchParams(searchParams);
+    const nextParams = new URLSearchParams(displayedParams);
     if (nextQuery) nextParams.set("q", nextQuery);
     else nextParams.delete("q");
     if (nextScope === "all") nextParams.delete("type");
@@ -177,7 +181,12 @@ export function SearchPageClient({
 
   function replaceSearch(nextParams: URLSearchParams) {
     const nextQuery = nextParams.toString();
-    router.replace(nextQuery ? `/search?${nextQuery}` : "/search");
+    startTransition(() => {
+      setDisplayedParams(nextQuery);
+      router.replace(nextQuery ? `/search?${nextQuery}` : "/search", {
+        scroll: false,
+      });
+    });
   }
 
   return (
@@ -210,6 +219,7 @@ export function SearchPageClient({
           limit={databaseSearch ? 5 : 50}
           onScopeChange={databaseSearch ? updateScope : undefined}
           onSubmit={submitSearch}
+          pending={isNavigating}
           placement={databaseSearch ? "database" : "page"}
           placeholder={
             databaseSearch ? "Ardbeg 10, Supernova, Lagavulin…" : undefined

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -5,7 +5,7 @@ import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useState } from "react";
+import { useOptimistic, useState, useTransition } from "react";
 
 import {
   Button,
@@ -74,6 +74,11 @@ export function SeriesPageClient({
   const pathname = usePathname();
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [isNavigating, startTransition] = useTransition();
+  const [displayedParams, setDisplayedParams] = useOptimistic(
+    searchParams.toString(),
+  );
+  const displayedSearchParams = new URLSearchParams(displayedParams);
   const bottleListQuery = useQuery({
     ...orpc.bottles.list.queryOptions({
       input: {
@@ -88,13 +93,16 @@ export function SeriesPageClient({
   });
 
   function updateParams(updates: Record<string, string>) {
-    const nextParams = new URLSearchParams(searchParams);
+    const nextParams = new URLSearchParams(displayedParams);
     for (const [name, value] of Object.entries(updates)) {
       if (value) nextParams.set(name, value);
       else nextParams.delete(name);
     }
     nextParams.delete("cursor");
-    router.push(buildSearchHref(pathname, nextParams));
+    startTransition(() => {
+      setDisplayedParams(nextParams.toString());
+      router.push(buildSearchHref(pathname, nextParams), { scroll: false });
+    });
   }
 
   const facts =
@@ -159,7 +167,9 @@ export function SeriesPageClient({
             {...stylex.props(styles.filters)}
           >
             {libraryOptions.map((option) => {
-              const selected = option.value === initialLibrary;
+              const selected =
+                option.value ===
+                (displayedSearchParams.get("library") ?? "all");
               return (
                 <Chip
                   aria-pressed={selected}
@@ -219,12 +229,13 @@ export function SeriesPageClient({
               )}
               onSortChange={(value) => updateParams({ sort: value })}
               page={initialCursor}
+              pending={isNavigating || bottleListQuery.isFetching}
               previousHref={getCursorHref(
                 pathname,
                 searchParams,
                 bottleList.rel.prevCursor,
               )}
-              sort={initialSort}
+              sort={displayedSearchParams.get("sort") ?? initialSort}
               sortOptions={sortOptions}
               total={bottleList.total}
             />

--- a/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/library/profileLibraryPageClient.stylex.tsx
@@ -4,7 +4,7 @@ import type { Outputs } from "@peated/server/orpc/router";
 import * as stylex from "@stylexjs/stylex";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
-import { useState, useTransition } from "react";
+import { useOptimistic, useState, useTransition } from "react";
 
 import { ButtonLink, LoadingList, SectionError } from "@peated/web/components";
 import {
@@ -39,12 +39,19 @@ export function ProfileLibraryPageClient() {
   const searchParams = useSearchParams();
   const { isCurrentUser, user } = useProfile();
   const [isNavigating, startTransition] = useTransition();
+  const [displayedParams, setDisplayedParams] = useOptimistic(
+    searchParams.toString(),
+  );
   const [entryChanges, setEntryChanges] = useState<
     Record<number, LibraryEntryChange>
   >({});
   const [mutationError, setMutationError] = useState(false);
   const input = getProfileLibraryInput(searchParams, user.id);
-  const { brand, cursor, distiller, query, sort, status } = input;
+  const { cursor } = input;
+  const { brand, distiller, query, sort, status } = getProfileLibraryInput(
+    new URLSearchParams(displayedParams),
+    user.id,
+  );
   const libraryQueryOptions = profileQueries.library(orpc, input);
   const libraryListQueryKey = orpc.collections.bottles.list.key({
     type: "query",
@@ -67,16 +74,20 @@ export function ProfileLibraryPageClient() {
 
   function navigate(nextParams: URLSearchParams) {
     const nextQuery = nextParams.toString();
-    startTransition(() =>
-      router.push(nextQuery ? `${pathname}?${nextQuery}` : pathname),
-    );
+    startTransition(() => {
+      // Library queries follow the committed URL; only controls anticipate navigation.
+      setDisplayedParams(nextQuery);
+      router.push(nextQuery ? `${pathname}?${nextQuery}` : pathname, {
+        scroll: false,
+      });
+    });
   }
 
   function setFilter(
     name: "brand" | "distiller" | "status" | "sort",
     value: string,
   ) {
-    const next = new URLSearchParams(searchParams);
+    const next = new URLSearchParams(displayedParams);
     next.delete("cursor");
     if (value) next.set(name, value);
     else next.delete(name);
@@ -84,7 +95,7 @@ export function ProfileLibraryPageClient() {
   }
 
   function setQuery(value: string) {
-    const next = new URLSearchParams(searchParams);
+    const next = new URLSearchParams(displayedParams);
     next.delete("cursor");
     if (value) next.set("query", value);
     else next.delete("query");
@@ -92,7 +103,7 @@ export function ProfileLibraryPageClient() {
   }
 
   function clearFilters() {
-    const next = new URLSearchParams(searchParams);
+    const next = new URLSearchParams(displayedParams);
     ["brand", "cursor", "distiller", "query", "status"].forEach((name) =>
       next.delete(name),
     );
@@ -194,7 +205,7 @@ export function ProfileLibraryPageClient() {
       }
       rail={filterPanel}
     >
-      <div aria-busy={isNavigating || mutationPending || undefined}>
+      <div aria-busy={mutationPending || undefined}>
         {mutationError ? (
           <p
             role="alert"
@@ -258,6 +269,7 @@ export function ProfileLibraryPageClient() {
             )}
             page={cursor}
             onSortChange={(value) => setFilter("sort", value)}
+            pending={isNavigating || libraryQuery.isFetching}
             previousHref={getCursorHref(
               pathname,
               searchParams,

--- a/apps/web/src/components/admin/adminTable.stylex.tsx
+++ b/apps/web/src/components/admin/adminTable.stylex.tsx
@@ -17,6 +17,7 @@ import {
   space,
 } from "../../styles/tokens.stylex";
 import { linkedRowStyles } from "../linkedRow.stylex";
+import { LinkPending } from "../linkPending.stylex";
 import { AdminPager } from "./adminUtility.stylex";
 
 export type AdminTableColumn<Item extends object> = {
@@ -251,6 +252,7 @@ function SortLink({
       {...stylex.props(styles.sortLink)}
     >
       {label}
+      <LinkPending />
       {sort === name ? <ArrowDown aria-hidden="true" size={12} /> : null}
       {sort === inverted ? <ArrowUp aria-hidden="true" size={12} /> : null}
     </Link>
@@ -364,6 +366,7 @@ const styles = stylex.create({
     boxShadow: { default: "none", ":focus-visible": effects.focusRing },
   },
   sortLink: {
+    position: "relative",
     display: "inline-flex",
     alignItems: "center",
     gap: space.x1,

--- a/apps/web/src/components/appLink.tsx
+++ b/apps/web/src/components/appLink.tsx
@@ -10,7 +10,7 @@ import {
 import { textLinkStyles } from "./textLinkStyles.stylex";
 
 export type AppLinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
-  prefetch?: boolean;
+  prefetch?: boolean | null;
 };
 
 export function isInternalAppHref(href: string) {

--- a/apps/web/src/components/button.stylex.tsx
+++ b/apps/web/src/components/button.stylex.tsx
@@ -9,7 +9,8 @@ import {
   effects,
   space,
 } from "../styles/tokens.stylex";
-import { AppLink, type AppLinkProps } from "./appLink";
+import { AppLink, isInternalAppHref, type AppLinkProps } from "./appLink";
+import { LinkPending } from "./linkPending.stylex";
 
 const REDUCED_MOTION = "@media (prefers-reduced-motion: reduce)";
 
@@ -73,7 +74,7 @@ export type ButtonLinkProps = Omit<AppLinkProps, "className" | "style"> & {
   variant?: ButtonVariant;
 };
 
-/** Uses the button treatment for navigation without hiding its link semantics. */
+/** Keeps native link semantics; internal links show Next.js navigation progress. */
 export function ButtonLink({
   align = "center",
   children,
@@ -100,6 +101,11 @@ export function ButtonLink({
       )}
     >
       {children}
+      {props.href &&
+      isInternalAppHref(props.href) &&
+      props.download === undefined ? (
+        <LinkPending />
+      ) : null}
     </AppLink>
   );
 }
@@ -243,6 +249,7 @@ const styles = stylex.create({
     textAlign: "left",
   },
   link: {
+    position: "relative",
     textDecoration: "none",
   },
   iconButton: {

--- a/apps/web/src/components/linkPending.stories.tsx
+++ b/apps/web/src/components/linkPending.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { ButtonLink } from "./button.stylex";
+import { LinkPendingIndicator } from "./linkPending.stylex";
+import { StoryCanvas } from "./storyFixtures.stylex";
+
+const meta = {
+  title: "Components/Messages & Status/Link Pending",
+  component: LinkPendingIndicator,
+  args: { pending: true },
+  render: (args) => (
+    <StoryCanvas>
+      <ButtonLink href="#next" variant="tonal">
+        Next →
+        <LinkPendingIndicator {...args} />
+      </ButtonLink>
+    </StoryCanvas>
+  ),
+} satisfies Meta<typeof LinkPendingIndicator>;
+
+export default meta;
+export const Overview: StoryObj<typeof meta> = {};

--- a/apps/web/src/components/linkPending.stylex.tsx
+++ b/apps/web/src/components/linkPending.stylex.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import * as stylex from "@stylexjs/stylex";
+import { useLinkStatus } from "next/link";
+
+/** Place inside a Next Link with a positioned parent; Next owns its pending state. */
+export function LinkPending() {
+  const { pending } = useLinkStatus();
+  return <LinkPendingIndicator pending={pending} />;
+}
+
+/** Shows navigation progress without changing the link's label, size, or native behavior. */
+export function LinkPendingIndicator({ pending }: { pending: boolean }) {
+  return (
+    <>
+      <span role="status" {...stylex.props(styles.status)}>
+        {pending ? "Loading…" : null}
+      </span>
+      {pending ? (
+        <span aria-hidden="true" {...stylex.props(styles.track)}>
+          <span {...stylex.props(styles.progress)} />
+        </span>
+      ) : null}
+    </>
+  );
+}
+
+const sweep = stylex.keyframes({
+  "0%": { transform: "translateX(-100%)" },
+  "100%": { transform: "translateX(300%)" },
+});
+
+const styles = stylex.create({
+  status: {
+    position: "absolute",
+    width: "1px",
+    height: "1px",
+    overflow: "hidden",
+    clipPath: "inset(50%)",
+    whiteSpace: "nowrap",
+  },
+  track: {
+    position: "absolute",
+    right: 0,
+    bottom: 0,
+    left: 0,
+    height: "2px",
+    overflow: "hidden",
+    pointerEvents: "none",
+  },
+  progress: {
+    display: "block",
+    width: "33%",
+    height: "2px",
+    backgroundColor: "currentColor",
+    animationName: {
+      default: sweep,
+      "@media (prefers-reduced-motion: reduce)": "none",
+    },
+    animationDuration: "1.15s",
+    animationTimingFunction: "cubic-bezier(0.4, 0, 0.2, 1)",
+    animationIterationCount: "infinite",
+  },
+});

--- a/apps/web/src/components/lists.stories.tsx
+++ b/apps/web/src/components/lists.stories.tsx
@@ -73,3 +73,17 @@ export const Overview: Story = {
     </StoryStack>
   ),
 };
+
+export const UpdatingResults: Story = {
+  render: () => (
+    <ListToolbar
+      count={12}
+      noun="bottle"
+      onSortChange={() => undefined}
+      pending
+      sort="name"
+      sortOptions={sortOptions}
+      total={41}
+    />
+  ),
+};

--- a/apps/web/src/components/lists.stylex.tsx
+++ b/apps/web/src/components/lists.stylex.tsx
@@ -26,17 +26,19 @@ export type ListToolbarProps = {
   noun: string;
   onExport?: () => void;
   onSortChange: (value: string) => void;
+  pending?: boolean;
   sort: string;
   sortOptions: readonly [ListSortOption, ...ListSortOption[]];
   total?: number;
 };
 
-/** Pairs an item count with sorting and optional export actions. */
+/** Keeps sorting available while pending results retain their last settled count. */
 export function ListToolbar({
   count,
   noun,
   onExport,
   onSortChange,
+  pending = false,
   sort,
   sortOptions,
   total,
@@ -56,6 +58,12 @@ export function ListToolbar({
         ) : null}
       </p>
       <div {...stylex.props(styles.actions)}>
+        <span
+          role="status"
+          {...stylex.props(foundationStyles.metadata, styles.status)}
+        >
+          {pending ? "Updating…" : null}
+        </span>
         <label {...stylex.props(foundationStyles.fieldLabel, styles.sortLabel)}>
           <span>Sort</span>
           <CompactSelect
@@ -113,7 +121,7 @@ export type CursorPagerProps = {
   previousHref?: string;
 };
 
-/** Presents only the cursor actions supplied by the owning API. */
+/** Prefetches API-owned page links and shows their Next.js navigation progress. */
 export function CursorPager({
   ariaLabel = "Pages",
   nextHref,
@@ -131,12 +139,24 @@ export function CursorPager({
         )}
       >
         {previousHref ? (
-          <ButtonLink href={previousHref} rel="prev" size="sm" variant="tonal">
+          <ButtonLink
+            href={previousHref}
+            prefetch={null}
+            rel="prev"
+            size="sm"
+            variant="tonal"
+          >
             ← Previous
           </ButtonLink>
         ) : null}
         {nextHref ? (
-          <ButtonLink href={nextHref} rel="next" size="sm" variant="tonal">
+          <ButtonLink
+            href={nextHref}
+            prefetch={null}
+            rel="next"
+            size="sm"
+            variant="tonal"
+          >
             Next →
           </ButtonLink>
         ) : null}
@@ -263,6 +283,9 @@ const styles = stylex.create({
     display: "flex",
     alignItems: "center",
     gap: space.x2,
+  },
+  status: {
+    minWidth: "9ch",
   },
   sortLabel: {
     display: "flex",

--- a/apps/web/src/components/pageTabs.stylex.tsx
+++ b/apps/web/src/components/pageTabs.stylex.tsx
@@ -1,5 +1,6 @@
 import * as stylex from "@stylexjs/stylex";
 import Link from "next/link";
+import { LinkPending } from "./linkPending.stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
 import {
@@ -33,13 +34,13 @@ export function PageTabs({ ariaLabel, currentHref, items }: PageTabsProps) {
             aria-current={current ? "page" : undefined}
             href={item.href}
             key={item.href}
-            prefetch={false}
             {...stylex.props(
               foundationStyles.interactive,
               styles.tab,
               current && [foundationStyles.interactive, styles.currentTab],
             )}
           >
+            <LinkPending />
             <span>{item.label}</span>
             {item.count !== undefined ? (
               <span {...stylex.props(foundationStyles.metadata, styles.count)}>
@@ -71,6 +72,7 @@ const styles = stylex.create({
     },
   },
   tab: {
+    position: "relative",
     display: "inline-flex",
     minHeight: "40px",
     flexShrink: 0,

--- a/apps/web/src/components/pages/bottleCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/bottleCatalog.stylex.tsx
@@ -26,6 +26,7 @@ export type BottleCatalogListProps = {
   onClear?: () => void;
   onSortChange: (value: string) => void;
   page: number;
+  pending?: boolean;
   previousHref?: string;
   sort: string;
   sortOptions: readonly [ListSortOption, ...ListSortOption[]];
@@ -42,6 +43,7 @@ export function BottleCatalogList({
   onClear,
   onSortChange,
   page,
+  pending = false,
   previousHref,
   sort,
   sortOptions,
@@ -49,41 +51,42 @@ export function BottleCatalogList({
 }: BottleCatalogListProps) {
   return (
     <section aria-label="Bottle catalog" {...stylex.props(styles.catalog)}>
-      {items.length ? (
-        <>
-          <ListToolbar
-            count={items.length}
-            noun="bottle"
-            onSortChange={onSortChange}
-            sort={sort}
-            sortOptions={sortOptions}
-            total={total}
-          />
+      <ListToolbar
+        count={items.length}
+        noun="bottle"
+        onSortChange={onSortChange}
+        pending={pending}
+        sort={sort}
+        sortOptions={sortOptions}
+        total={total}
+      />
+      <div aria-busy={pending || undefined}>
+        {items.length ? (
           <BottleList ariaLabel="Bottle records" items={items} />
-        </>
-      ) : (
-        <EmptyState
-          action={
-            emptyAction ??
-            (onClear ? (
-              <Button onClick={onClear} size="sm" variant="tonal">
-                Clear filters
-              </Button>
-            ) : (
-              <ButtonLink
-                href="/addBottle?intent=catalog"
-                size="sm"
-                variant="tonal"
-              >
-                Add a bottle
-              </ButtonLink>
-            ))
-          }
-          heading={emptyHeading}
-        >
-          {emptyDescription}
-        </EmptyState>
-      )}
+        ) : (
+          <EmptyState
+            action={
+              emptyAction ??
+              (onClear ? (
+                <Button onClick={onClear} size="sm" variant="tonal">
+                  Clear filters
+                </Button>
+              ) : (
+                <ButtonLink
+                  href="/addBottle?intent=catalog"
+                  size="sm"
+                  variant="tonal"
+                >
+                  Add a bottle
+                </ButtonLink>
+              ))
+            }
+            heading={emptyHeading}
+          >
+            {emptyDescription}
+          </EmptyState>
+        )}
+      </div>
       <CursorPager
         ariaLabel="Bottle pages"
         nextHref={nextHref}

--- a/apps/web/src/components/pages/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/entityCatalog.stylex.tsx
@@ -82,6 +82,7 @@ export type EntityCatalogListProps = {
   onToggleFollowing?: (item: EntityCatalogItem) => void;
   onSortChange: (value: string) => void;
   page: number;
+  pending?: boolean;
   pendingIds?: ReadonlySet<number>;
   previousHref?: string;
   showFollowingMarks?: boolean;
@@ -103,6 +104,7 @@ export function EntityCatalogList({
   onToggleFollowing,
   onSortChange,
   page,
+  pending = false,
   pendingIds,
   previousHref,
   showFollowingMarks = true,
@@ -112,16 +114,17 @@ export function EntityCatalogList({
 }: EntityCatalogListProps) {
   return (
     <section aria-label={`${noun} catalog`} {...stylex.props(styles.catalog)}>
-      {items.length ? (
-        <>
-          <ListToolbar
-            count={items.length}
-            noun={noun}
-            onSortChange={onSortChange}
-            sort={sort}
-            sortOptions={sortOptions}
-            total={total}
-          />
+      <ListToolbar
+        count={items.length}
+        noun={noun}
+        onSortChange={onSortChange}
+        pending={pending}
+        sort={sort}
+        sortOptions={sortOptions}
+        total={total}
+      />
+      <div aria-busy={pending || undefined}>
+        {items.length ? (
           <EntityCatalogTable
             items={items}
             noun={noun}
@@ -129,26 +132,26 @@ export function EntityCatalogList({
             pendingIds={pendingIds}
             showFollowingMarks={showFollowingMarks}
           />
-        </>
-      ) : (
-        <EmptyState
-          action={
-            emptyAction ??
-            (onClear ? (
-              <Button onClick={onClear} size="sm" variant="tonal">
-                Clear filters
-              </Button>
-            ) : addHref ? (
-              <ButtonLink href={addHref} size="sm" variant="tonal">
-                Add {noun}
-              </ButtonLink>
-            ) : undefined)
-          }
-          heading={emptyHeading ?? `No ${noun}s found`}
-        >
-          {emptyDescription}
-        </EmptyState>
-      )}
+        ) : (
+          <EmptyState
+            action={
+              emptyAction ??
+              (onClear ? (
+                <Button onClick={onClear} size="sm" variant="tonal">
+                  Clear filters
+                </Button>
+              ) : addHref ? (
+                <ButtonLink href={addHref} size="sm" variant="tonal">
+                  Add {noun}
+                </ButtonLink>
+              ) : undefined)
+            }
+            heading={emptyHeading ?? `No ${noun}s found`}
+          >
+            {emptyDescription}
+          </EmptyState>
+        )}
+      </div>
       <CursorPager
         ariaLabel={`${noun} pages`}
         nextHref={nextHref}

--- a/apps/web/src/components/pages/memberProfileContent.stylex.tsx
+++ b/apps/web/src/components/pages/memberProfileContent.stylex.tsx
@@ -45,6 +45,7 @@ export type MemberLibraryListProps = {
   items: readonly MemberLibraryItem[];
   nextHref?: string;
   onSortChange: (value: string) => void;
+  pending?: boolean;
   page: number;
   previousHref?: string;
   sort: string;
@@ -60,6 +61,7 @@ export function MemberLibraryList({
   items,
   nextHref,
   onSortChange,
+  pending = false,
   page,
   previousHref,
   sort,
@@ -72,35 +74,38 @@ export function MemberLibraryList({
         count={items.length}
         noun="bottle"
         onSortChange={onSortChange}
+        pending={pending}
         sort={sort}
         sortOptions={sortOptions}
         total={total}
       />
-      {items.length ? (
-        <ItemList ariaLabel="Library bottles">
-          {items.map(({ actions, id, status, ...identity }) => (
-            <ItemListItem key={id}>
-              <BottleIdentityRow
-                {...identity}
-                end={
-                  status || actions?.length ? (
-                    <div {...stylex.props(styles.libraryEnd)}>
-                      {status ? <Chip>{status}</Chip> : null}
-                      {actions?.length ? (
-                        <RowMenu groups={actions} label={identity.name} />
-                      ) : null}
-                    </div>
-                  ) : undefined
-                }
-              />
-            </ItemListItem>
-          ))}
-        </ItemList>
-      ) : (
-        <EmptyState action={emptyAction} heading={emptyHeading}>
-          {emptyDescription}
-        </EmptyState>
-      )}
+      <div aria-busy={pending || undefined}>
+        {items.length ? (
+          <ItemList ariaLabel="Library bottles">
+            {items.map(({ actions, id, status, ...identity }) => (
+              <ItemListItem key={id}>
+                <BottleIdentityRow
+                  {...identity}
+                  end={
+                    status || actions?.length ? (
+                      <div {...stylex.props(styles.libraryEnd)}>
+                        {status ? <Chip>{status}</Chip> : null}
+                        {actions?.length ? (
+                          <RowMenu groups={actions} label={identity.name} />
+                        ) : null}
+                      </div>
+                    ) : undefined
+                  }
+                />
+              </ItemListItem>
+            ))}
+          </ItemList>
+        ) : (
+          <EmptyState action={emptyAction} heading={emptyHeading}>
+            {emptyDescription}
+          </EmptyState>
+        )}
+      </div>
       <CursorPager
         ariaLabel="Library pages"
         nextHref={nextHref}

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -104,6 +104,8 @@ export type SearchProps = {
   limit?: number;
   onScopeChange?: (scope: SearchScope, query: string) => void;
   onSubmit?: (query: string) => void;
+  /** Includes a containing route's server navigation in the search status. */
+  pending?: boolean;
   placement?: "database" | "overlay" | "page";
   placeholder?: string;
   scopeValues?: readonly SearchScope[];
@@ -464,6 +466,7 @@ export function Search({
   limit = 3,
   onScopeChange,
   onSubmit,
+  pending = false,
   placement = "overlay",
   placeholder = "bottles, series, distillers, brands…",
   scopeValues,
@@ -686,9 +689,9 @@ export function Search({
       scope={effectiveScope}
       scopeFacets={availableScopeFacets}
       scopes={availableScopes}
-      status={status}
+      status={pending ? "searching" : status}
       statusText={
-        status === "searching"
+        pending || status === "searching"
           ? getSearchingText(effectiveScope, Boolean(user))
           : undefined
       }

--- a/docs/development/web-loading.md
+++ b/docs/development/web-loading.md
@@ -1,0 +1,94 @@
+# Web Loading
+
+Use Next.js loading boundaries for route data and React transitions for feedback
+while navigating. Keep the page header, filters, and navigation available while
+the results change. The URL owns committed filters and pagination.
+
+## Route Loading
+
+Place `loading.tsx` below the layout that should remain visible. A segment's
+loading file covers its page and nested segments, not its own layout. Keep
+fallbacks free of data fetching and reuse the existing loading components.
+
+For independently loading server content, put the asynchronous read inside a
+component beneath `Suspense`. Awaiting the read before returning the boundary
+prevents that boundary from streaming its fallback.
+
+When a new query should replace the results with skeletons, key the results
+boundary using the normalized inputs that identify those results. Keep controls
+outside that boundary. Do not key the whole page: that also resets controls,
+focus, and unrelated local state.
+
+Server-render public records even when their HTML is streamed. Moving a read
+into a client effect solely to get a loading indicator loses that rendering.
+See [Web Caching](../architecture/web-caching.md) for session and caching rules.
+
+## Updating Existing Results
+
+For sorting an already visible list, keep the rows and show pending feedback.
+The route wraps `router.push` or `router.replace` in `useTransition` and passes
+the pending flag to `ListToolbar`. Use `scroll: false` for in-place filter and
+sort changes; pagination can retain Next.js's normal scroll behavior.
+
+Use `useOptimistic` for the controls' requested values when waiting for the URL
+would make them revert to their old selection. Build subsequent filter changes
+from those requested values so rapid changes compose. Reset the cursor when the
+sort or filters change. Keep query inputs and cached results tied to the
+committed URL until navigation completes.
+
+The profile library demonstrates this distinction: its controls anticipate the
+new URL, while its hydrated TanStack query continues to display the current
+entries. `ListToolbar` exposes a live updating status outside the busy results
+region. Keep the same distinction for empty results and errors.
+
+`useTransition` tracks transitions started through that hook. It is not a
+global router status and does not track unrelated links or browser history.
+Use Next.js's `useLinkStatus` inside a link for feedback on that link's pending
+navigation. Preserve native link behavior, including modifier clicks.
+
+`PageTabs`, internal `ButtonLink` targets, and admin sort links compose
+`LinkPending` inside their Next link. Its progress bar preserves the control's
+size and has a static reduced-motion state. It ends when Next commits the
+navigation; a streamed results boundary can remain pending after that.
+
+Prefer Next.js's default prefetch behavior for small navigation groups and
+adjacent pages. Dense lists of record links can disable prefetching. Pending
+feedback must also work when a destination has not been prefetched.
+
+Bottle releases and tastings demonstrate server results beneath a keyed
+`Suspense` boundary. Their section headings sit outside the boundary, and the
+bottle layout keeps identity and tabs mounted. The results component owns its
+asynchronous read. Sortable client catalogs demonstrate retained results with
+`ListToolbar pending` instead.
+
+## Client Queries
+
+Use TanStack's query state for client fetching. `isPending` covers a query
+without data; `isFetching` also covers refetching with data. A route transition
+can be pending while the current client query is idle, so query state alone
+does not cover server navigation.
+
+Use `keepPreviousData` with `useQuery` only when the old results are useful
+during a query-key change. `useSuspenseQuery` does not support that placeholder
+option. Do not change query ownership or introduce a second fetch solely to
+make a loading state appear.
+
+## Verification
+
+Extend the browser workflow that owns the interaction. Hold its navigation
+response to verify immediate feedback, the selected control value, retained
+content, and focus; release it and verify the final URL and results. Include
+rapid changes and Back/Forward when changing URL-state handling.
+
+Check streaming fallbacks with a delayed upstream response, rather than
+buffering the whole Next.js response. Review skeleton geometry and pending
+feedback in a browser, including empty results, narrow screens, both color
+schemes, and reduced motion. Do not add appearance assertions.
+
+## References
+
+- [Next.js loading files](https://nextjs.org/docs/app/api-reference/file-conventions/loading)
+- [Next.js search and pagination](https://nextjs.org/learn/dashboard-app/adding-search-and-pagination)
+- [Next.js link status](https://nextjs.org/docs/app/api-reference/functions/use-link-status)
+- [React transitions](https://react.dev/reference/react/useTransition)
+- [TanStack pagination](https://tanstack.com/query/latest/docs/framework/react/guides/paginated-queries)

--- a/docs/research/web-loading-audit-2026-09.md
+++ b/docs/research/web-loading-audit-2026-09.md
@@ -1,0 +1,37 @@
+# Web Loading Audit — September 2026
+
+The reported profile Library sort delay also reproduced on the bottle catalog.
+Both kept the old selection and results visible while Next.js requested the
+new server render. The Library already had a route skeleton and a transition,
+but its only navigation signal was `aria-busy`, which provided no visible
+feedback. Query loading flags stayed idle during this server round trip.
+
+This audit follows browse pages, search, sort controls, tabs, and pagination.
+It does not change query ownership, caching policy, or mutation workflows.
+
+## Findings and Changes
+
+| Area                                                  | Finding                                                                                     | Change                                                                                                        |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Profile Library                                       | Server-prefetched data meant client query state did not cover sort navigation.              | Optimistic control values and visible transition status; retained rows and existing initial skeleton.         |
+| Bottle and producer catalogs                          | Sort and filter controls waited for committed URL state; empty lists removed their toolbar. | Same transition pattern, stable controls for empty results, and no filter-panel remount on query changes.     |
+| Following, series, producer bottles, location bottles | The same direct `router.push` gap appeared in their source.                                 | Pending toolbar state and optimistic control values, with queries still using committed inputs.               |
+| Tabs, paging, admin sort                              | Native links had no pending treatment; tabs and paging disabled prefetch.                   | Next link status in tabs, button links, and admin sort links; default prefetch for tabs and adjacent pages.   |
+| Bottle releases and tastings                          | Server reads completed before returning results, without a local streaming boundary.        | Async results under a boundary keyed by bottle and cursor; section headings and bottle layout remain mounted. |
+| Location, bottle, flight, event, admin sections       | Several routes fell back to a broader boundary above their persistent layout.               | Local loading files beneath the relevant layouts, using existing loading primitives.                          |
+| Search submission                                     | Client search status did not cover the containing route's `router.replace`.                 | Include the route transition in the existing search status.                                                   |
+
+## Verification
+
+The owning browser workflows now hold navigation requests to check immediate
+feedback, retained content, control values, and completion. Library coverage
+also checks rapid filter/sort changes and browser history. Catalog coverage
+checks empty results and clearing filters. A controlled upstream release-page
+request distinguishes streamed skeletons from the earlier navigation delay.
+
+The source audit identifies shared paths; it is not a claim that every route
+and network failure was separately reproduced. Mutation redirects and Search's
+existing client/server data ownership remain outside this loading cleanup.
+
+See [Web Loading](../development/web-loading.md) for the reusable patterns and
+framework references.


### PR DESCRIPTION
Changing Library sort or catalog filters now updates the controls immediately and shows progress while the next server render loads. Previously, client query loading flags stayed idle during that navigation, leaving the page looking unresponsive. The same fix covers bottle and producer catalogs, Following, series, location lists, and search; empty results keep their controls available.

The implementation follows three Next.js patterns: route-local React transitions retain existing results, keyed Suspense streams bottle release and tasting pages beneath persistent headers, and native links expose pending feedback with default prefetch for tabs and pagers. Local loading files keep nested bottle, location, flight, event, and admin navigation within the appropriate layout. Shared feedback components and documented recipes make these patterns composable without changing data ownership or caching policy.

Regression coverage holds navigation and upstream responses to verify immediate feedback, rapid filter/sort composition, history, focus, empty-state recovery, and streamed skeletons. The web unit tests, typecheck, lint, and seven targeted browser workflows passed, with desktop and mobile visual checks. Full repository validation remains for CI.
