### PR TITLE
fix(web): restore compact search and sidebar layouts

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -48,7 +48,7 @@ typography:
     letterSpacing: -0.04em
   section-heading:
     fontFamily: Space Grotesk
-    fontSize: 24px
+    fontSize: 20px
     fontWeight: 700
     lineHeight: 1.2
     letterSpacing: -0.025em
@@ -60,7 +60,7 @@ typography:
     letterSpacing: -0.025em
   compact-row-title:
     fontFamily: Space Grotesk
-    fontSize: 16px
+    fontSize: 15px
     fontWeight: 700
     lineHeight: 1.25
     letterSpacing: -0.025em
@@ -234,6 +234,9 @@ sentiment poles.
 - Section headings use `SectionHeading` in every column. Heading levels express
   document structure and share one visual treatment. Do not add compact,
   uppercase, or page-specific section heading variants.
+- Typeahead group names are control labels, not page sections. Use the field
+  label role for these groups and compact row titles for their results. Bottle
+  suggestions keep standard thumbnails and identity details with 8px row padding.
 - Browse headings should name the content or its relationship to the page.
   State the ranking only when it helps people choose; sort controls should
   still name their order.
@@ -242,9 +245,9 @@ sentiment poles.
 | ------------------- | ------- | ------ | -------------------- | -------- |
 | Page title          | Display | 700    | 40–72px / 0.95       | -0.05em  |
 | Compact page title  | Display | 700    | 32–40px / 1.1        | -0.04em  |
-| Section heading     | Display | 700    | 24px / 1.2           | -0.025em |
+| Section heading     | Display | 700    | 20px / 1.2           | -0.025em |
 | Row title           | Display | 700    | 18px / 1.25          | -0.025em |
-| Compact row title   | Display | 700    | 16px / 1.25          | -0.025em |
+| Compact row title   | Display | 700    | 15px / 1.25          | -0.025em |
 | Prose               | Reading | 400    | 16px / 1.65          | normal   |
 | Body                | Reading | 400    | 15px / 1.6           | normal   |
 | Input               | Reading | 400    | 16px / 1.45          | normal   |
@@ -346,8 +349,9 @@ JSDoc.
 - Standard three-line rows share one thumbnail size across bottle lists,
   activity, search, selection, and loading states. Keep the full bottle visible;
   never crop it to an avatar square. Single-line library additions use smaller
-  thumbnails. Sidebar bottle lists use the same standard rows and thumbnails as
-  other bottle lists.
+  thumbnails. Sidebar bottle lists use the shared sidebar variant with smaller
+  thumbnails, compact titles limited to two lines, and trailing details below
+  the identity. Recent tastings show their date and rating as supporting details.
 - State precise values. Do not replace known numbers with vague labels.
 - Do not invent data, rankings, totals, ranges, or derived values in a visual
   component.

--- a/apps/web/src/components/applicationHeader.stylex.tsx
+++ b/apps/web/src/components/applicationHeader.stylex.tsx
@@ -380,10 +380,8 @@ function HeaderDrawerGroup({
               {...stylex.props(
                 foundationStyles.interactive,
                 styles.drawerLink,
-                isCurrentNavigationHref(currentHref, item.href) && [
-                  foundationStyles.interactiveSmall,
+                isCurrentNavigationHref(currentHref, item.href) &&
                   styles.currentMenuLink,
-                ],
               )}
             >
               {item.label}

--- a/apps/web/src/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stories.tsx
@@ -51,7 +51,10 @@ const meta = {
     ),
   ],
   argTypes: {
-    variant: { control: "inline-radio", options: ["standard", "compact"] },
+    variant: {
+      control: "inline-radio",
+      options: ["standard", "search", "sidebar", "compact"],
+    },
   },
   args: {
     ...toBottleListItem(rowBottle),
@@ -61,14 +64,16 @@ const meta = {
   parameters: {
     docs: {
       description: {
-        component: `Use BottleIdentityRow for one bottle, BottleList for a catalog list, and CommunityFeed for activity. Build props with toBottleListItem (API Bottles) or getBottleIdentityProps (partial reads). Both variants take the same full marketed name.
+        component: `Use BottleIdentityRow for one bottle, BottleList for a catalog list, and CommunityFeed for activity. Build props with toBottleListItem (API Bottles) or getBottleIdentityProps (partial reads). All variants take the same full marketed name.
 
 | Variant | Use | Content |
 | --- | --- | --- |
-| standard (default) | Catalog, search, tastings, reviews, and selection | Name, provenance, and release facts; 48 × 64px thumbnail (42 × 58px on mobile). |
+| standard (default) | Catalog, tastings, reviews, and selection | Name, provenance, and release facts; 48 × 64px thumbnail (42 × 58px on mobile). |
+| search | Typeahead results | Standard identity and thumbnail, 15px compact title, and 8px vertical padding. |
+| sidebar | Sidebar bottle lists | 15px title limited to two lines, 32 × 46px thumbnail, and trailing content below the identity. |
 | compact | Single or grouped library additions | One name line, 24 × 32px thumbnail, and a 44px hit area. |
 
-Compact omits provenance, metadata, subtitle, status, and related releases. Long compact names truncate visually and retain their full accessible name and title. Use layout="cell" inside an existing control; end holds independent actions or scores. BottleVisual owns the image frame and fallback; the row chooses its size.
+Sidebar omits membership status icons and keeps full accessible names when its two-line titles truncate. Compact omits provenance, metadata, subtitle, status, and related releases. Long compact names truncate visually and retain their full accessible name and title. Use layout="cell" inside an existing control; end holds independent actions or scores. BottleVisual owns the image frame and fallback; the row chooses its size.
 
 Use Row Layouts to compare these components at desktop and phone widths.`,
       },
@@ -172,7 +177,7 @@ export const RowLayouts: Story = {
     docs: {
       description: {
         story:
-          "Compare the actual bottle, sidebar, activity, tasting, search, selection, and loading components at wide and phone widths. Standard rows, including sidebars, use the same three identity lines and medium thumbnail. Compact library additions use the extra-small thumbnail.",
+          "Compare the actual bottle, sidebar, activity, tasting, search, selection, and loading components at wide and phone widths. Standard rows use three identity lines and a medium thumbnail. Sidebars use a small thumbnail, compact two-line titles, and trailing details below the identity. Compact library additions use the extra-small thumbnail.",
       },
     },
   },
@@ -201,7 +206,11 @@ export const RowLayouts: Story = {
               },
             ]}
           />
-          <LoadingList label="Loading sidebar bottles" rows={2} />
+          <LoadingList
+            label="Loading sidebar bottles"
+            rows={2}
+            variant="sidebar"
+          />
         </StoryCanvas>
         <section aria-label="Activity">
           <SectionHeading level={3}>
@@ -262,6 +271,21 @@ export const RowLayouts: Story = {
                       kind: "bottle",
                       imageUrl: args.imageUrl,
                       label: title,
+                    },
+                  },
+                  {
+                    href: "/bottles/18481",
+                    bottle: {
+                      provenance: [{ name: "Single Malt" }],
+                      metadata: ["61.5% ABV", "2024 release"],
+                    },
+                    id: "search-long-name",
+                    title:
+                      "Bruichladdich Octomore Edition 15.3 Islay Barley Super Heavily Peated",
+                    visual: {
+                      kind: "bottle",
+                      imageUrl: null,
+                      label: "Bruichladdich Octomore",
                     },
                   },
                 ],

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -31,15 +31,18 @@ export type BottleIdentityRowProps = {
     href: string;
   };
   subtitle?: ReactNode;
-  /** Standard: three identity lines. Compact: one name line for library additions. */
-  variant?: "standard" | "compact";
+  /** Sidebar uses a small thumbnail, a two-line name, and a footer for trailing content. */
+  variant?: "standard" | "search" | "sidebar" | "compact";
 };
 
 /**
  * Bottle identity for lists and activity. Standard shows name, provenance, then
- * release facts; compact shows one name line for library additions.
+ * release facts; search tightens the title and spacing for typeahead results;
+ * sidebar uses compact titles and small thumbnails; compact shows one name line
+ * for library additions. Sidebar names use two lines with the full name in title.
+ * Search places trailing ratings or actions below the identity on narrow screens.
  * Use toBottleListItem for API Bottles or getBottleIdentityProps for partial reads.
- * Both variants take the same full marketed name and own their thumbnail size.
+ * All variants take the same full marketed name and own their thumbnail size.
  * Use layout="cell" inside an existing row/selection control. Compact omits
  * provenance, metadata, subtitle, status, and related releases; end remains available.
  */
@@ -61,10 +64,25 @@ export function BottleIdentityRow({
   variant = "standard",
 }: BottleIdentityRowProps) {
   const compact = variant === "compact";
+  const sidebar = variant === "sidebar";
+  const compactTitle = variant !== "standard";
+  const trailingContent = end ? (
+    <div
+      {...stylex.props(
+        styles.end,
+        sidebar && styles.sidebarEnd,
+        variant === "search" && styles.searchEnd,
+      )}
+    >
+      {end}
+    </div>
+  ) : null;
   return (
     <div
       {...stylex.props(
         styles.row,
+        variant === "search" && styles.searchRow,
+        sidebar && styles.sidebarRow,
         compact && styles.compactRow,
         !compact && align === "start" && styles.startAlignedRow,
         layout === "cell" && styles.cellLayout,
@@ -72,10 +90,16 @@ export function BottleIdentityRow({
         Boolean(href) && layout === "row" && linkedRowStyles.onGround,
       )}
     >
-      <BottleVisual imageUrl={imageUrl} size={compact ? "xs" : "md"} />
+      <BottleVisual
+        imageUrl={imageUrl}
+        size={compact ? "xs" : sidebar ? "sm" : "md"}
+      />
       <div {...stylex.props(styles.copy)}>
         <div
-          {...stylex.props(styles.nameLine, compact && styles.compactNameLine)}
+          {...stylex.props(
+            styles.nameLine,
+            (compact || sidebar) && styles.compactNameLine,
+          )}
         >
           {href ? (
             <AppLink
@@ -84,7 +108,9 @@ export function BottleIdentityRow({
               title={name}
               {...stylex.props(
                 foundationStyles.rowTitle,
+                compactTitle && foundationStyles.compactRowTitle,
                 styles.name,
+                sidebar && styles.sidebarName,
                 compact && styles.compactName,
                 linkedRowStyles.primaryLink,
               )}
@@ -96,15 +122,21 @@ export function BottleIdentityRow({
               title={name}
               {...stylex.props(
                 foundationStyles.rowTitle,
+                compactTitle && foundationStyles.compactRowTitle,
                 styles.name,
+                sidebar && styles.sidebarName,
                 compact && styles.compactName,
               )}
             >
               <MatchedText query={query} text={name} />
             </span>
           )}
-          {!compact && isLibrary ? <MemberStatus kind="library" /> : null}
-          {!compact && hasTasted ? <MemberStatus kind="tasted" /> : null}
+          {!compact && !sidebar && isLibrary ? (
+            <MemberStatus kind="library" />
+          ) : null}
+          {!compact && !sidebar && hasTasted ? (
+            <MemberStatus kind="tasted" />
+          ) : null}
         </div>
         {!compact && provenance.length ? (
           <div {...stylex.props(foundationStyles.metadata, styles.subtitle)}>
@@ -154,8 +186,9 @@ export function BottleIdentityRow({
             {relatedReleases.count.toLocaleString("en-US")} related releases
           </AppLink>
         ) : null}
+        {sidebar ? trailingContent : null}
       </div>
-      {end ? <div {...stylex.props(styles.end)}>{end}</div> : null}
+      {!sidebar ? trailingContent : null}
     </div>
   );
 }
@@ -178,6 +211,37 @@ const styles = stylex.create({
   startAlignedRow: {
     alignItems: "flex-start",
   },
+  searchRow: {
+    paddingTop: space.x2,
+    paddingBottom: space.x2,
+    "@media (max-width: 559px)": {
+      display: "grid",
+      gridTemplateColumns: "auto minmax(0, 1fr)",
+      rowGap: space.x1,
+    },
+  },
+  searchEnd: {
+    "@media (max-width: 559px)": {
+      gridColumn: "2",
+      justifyContent: "flex-start",
+    },
+  },
+  sidebarRow: {
+    alignItems: "flex-start",
+    paddingTop: space.x2,
+    paddingBottom: space.x2,
+  },
+  sidebarName: {
+    display: "-webkit-box",
+    WebkitBoxOrient: "vertical",
+    WebkitLineClamp: 2,
+    overflow: "hidden",
+  },
+  sidebarEnd: {
+    maxWidth: "100%",
+    marginTop: space.x1,
+    justifyContent: "flex-start",
+  },
   compactRow: {
     minHeight: "44px",
     gap: space.x2,
@@ -188,7 +252,6 @@ const styles = stylex.create({
   compactName: {
     display: "block",
     overflow: "hidden",
-    fontSize: "15px",
     textOverflow: "ellipsis",
     whiteSpace: "nowrap",
   },

--- a/apps/web/src/components/bottleVisual.stylex.tsx
+++ b/apps/web/src/components/bottleVisual.stylex.tsx
@@ -23,7 +23,7 @@ export type BottleVisualProps = {
 /**
  * Shows a bottle image or Peated's bottle glyph when no image exists.
  * BottleIdentityRow chooses its own size. Use this primitive directly only when
- * composing another layout: md for standard rows including sidebars, lg/xl
+ * composing another layout: sm for sidebar rows, md for standard rows, lg/xl
  * for detail media. Omit label beside visible bottle text; expandable needs a label.
  * Fixed-size frames cap both dimensions so source images cannot enlarge a row.
  */

--- a/apps/web/src/components/factList.stylex.tsx
+++ b/apps/web/src/components/factList.stylex.tsx
@@ -52,9 +52,11 @@ export function FactList({ facts, layout = "list" }: FactListProps) {
           </dt>
           <dd
             {...stylex.props(
-              foundationStyles.compactRowTitle,
+              layout === "grid"
+                ? foundationStyles.body
+                : foundationStyles.compactRowTitle,
               styles.value,
-              layout === "grid" && [foundationStyles.body, styles.gridValue],
+              layout === "grid" && styles.gridValue,
             )}
           >
             {fact.value}

--- a/apps/web/src/components/feedback.stylex.tsx
+++ b/apps/web/src/components/feedback.stylex.tsx
@@ -148,6 +148,7 @@ type PlaceholderPreset =
   | "metadata"
   | "score"
   | "text"
+  | "smallThumbnail"
   | "thumbnail";
 
 type PlaceholderDelay = 0 | 1 | 2 | 3 | 4;
@@ -272,13 +273,16 @@ type LoadingRowCount = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
 export type LoadingListProps = {
   label?: string;
   rows?: LoadingRowCount;
+  variant?: "standard" | "sidebar";
 };
 
-/** Reserves standard three-line row and bottle-thumbnail geometry while a list loads. */
+/** Reserves standard or compact sidebar row geometry while a list loads. */
 export function LoadingList({
   label = "Loading records",
   rows = 3,
+  variant = "standard",
 }: LoadingListProps) {
+  const sidebar = variant === "sidebar";
   return (
     <div
       aria-busy="true"
@@ -290,30 +294,37 @@ export function LoadingList({
         <div
           aria-hidden="true"
           key={index}
-          {...stylex.props(styles.loadingRow)}
+          {...stylex.props(
+            styles.loadingRow,
+            sidebar && styles.loadingSidebarRow,
+          )}
         >
           <LoadingPlaceholder
             delay={getPlaceholderDelay(index)}
-            preset="thumbnail"
+            preset={sidebar ? "smallThumbnail" : "thumbnail"}
           />
           <span {...stylex.props(styles.loadingCopy)}>
             <LoadingPlaceholder
               delay={getPlaceholderDelay(index + 1)}
-              preset="metadata"
+              preset={sidebar ? "text" : "metadata"}
             />
             <LoadingPlaceholder
               delay={getPlaceholderDelay(index + 1)}
-              preset="text"
+              preset={sidebar ? "metadata" : "text"}
             />
-            <LoadingPlaceholder
-              delay={getPlaceholderDelay(index + 2)}
-              preset="metadata"
-            />
+            {!sidebar ? (
+              <LoadingPlaceholder
+                delay={getPlaceholderDelay(index + 2)}
+                preset="metadata"
+              />
+            ) : null}
           </span>
-          <LoadingPlaceholder
-            delay={getPlaceholderDelay(index + 3)}
-            preset="score"
-          />
+          {!sidebar ? (
+            <LoadingPlaceholder
+              delay={getPlaceholderDelay(index + 3)}
+              preset="score"
+            />
+          ) : null}
         </div>
       ))}
     </div>
@@ -494,6 +505,11 @@ const styles = stylex.create({
       borderBottomWidth: 0,
     },
   },
+  loadingSidebarRow: {
+    gridTemplateColumns: "auto minmax(0, 1fr)",
+    paddingTop: space.x2,
+    paddingBottom: space.x2,
+  },
   loadingCopy: {
     display: "flex",
     minWidth: 0,
@@ -526,6 +542,10 @@ const styles = stylex.create({
     width: bottleThumbnailMetrics.width,
     height: bottleThumbnailMetrics.height,
   },
+  smallThumbnail: {
+    width: "32px",
+    height: "46px",
+  },
   score: {
     width: "46px",
     height: "20px",
@@ -557,6 +577,7 @@ const presets = {
   score: styles.score,
   text: styles.text,
   thumbnail: styles.thumbnail,
+  smallThumbnail: styles.smallThumbnail,
 } satisfies Record<PlaceholderPreset, stylex.StyleXStyles>;
 const delays = {
   0: styles.delay0,

--- a/apps/web/src/components/filterPanel.stylex.tsx
+++ b/apps/web/src/components/filterPanel.stylex.tsx
@@ -16,7 +16,6 @@ import { Button, IconButton } from "./button.stylex";
 import { FacetRow } from "./facetRow.stylex";
 import { TextInput } from "./field.stylex";
 
-const COMPACT = "@media (max-width: 639px)";
 const NARROW = "@media (max-width: 759px)";
 
 export type FilterPanelProps = {
@@ -286,10 +285,7 @@ const styles = stylex.create({
   contentOpen: {
     [NARROW]: {
       display: "grid",
-      gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
-    },
-    [COMPACT]: {
-      gridTemplateColumns: "minmax(0, 1fr)",
+      gridTemplateColumns: "repeat(auto-fit, minmax(min(100%, 272px), 1fr))",
     },
   },
   panelHeader: {

--- a/apps/web/src/components/foundations.stylex.tsx
+++ b/apps/web/src/components/foundations.stylex.tsx
@@ -170,7 +170,7 @@ export default function Foundations({
               </ItemList>
               <p {...stylex.props(foundationStyles.metadata, styles.muted)}>
                 Space Grotesk: page titles, section headings, and names.
-                Sections use 24px; rows use 18px or 16px in compact lists.
+                Sections use 20px; rows use 18px or 15px in compact lists.
               </p>
             </article>
             <article {...stylex.props(styles.typeSpecimen)}>

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -214,7 +214,11 @@ export function BottleOverviewLoading() {
         <div {...stylex.props(styles.media, styles.loadingMedia)} />
         <div {...stylex.props(styles.railSections)}>
           <LoadingPlaceholder preset="heading" />
-          <LoadingList label="Loading bottle recommendations" rows={3} />
+          <LoadingList
+            label="Loading bottle recommendations"
+            rows={3}
+            variant="sidebar"
+          />
         </div>
       </aside>
     </div>

--- a/apps/web/src/components/pages/bottleRailSection.stylex.tsx
+++ b/apps/web/src/components/pages/bottleRailSection.stylex.tsx
@@ -3,7 +3,7 @@ import type { ReactNode } from "react";
 import { BottleList, type BottleListItem } from "@peated/web/components";
 import { RailListSection } from "./railListSection.stylex";
 
-/** Sidebar bottle lists use the standard three-line identity; build items with toBottleListItem. */
+/** Uses the compact sidebar identity; build items with toBottleListItem. */
 export function BottleRailSection({
   children,
   heading,
@@ -27,7 +27,12 @@ export function BottleRailSection({
       heading={heading}
       intro={intro}
     >
-      {items.length ? <BottleList ariaLabel={heading} items={items} /> : null}
+      {items.length ? (
+        <BottleList
+          ariaLabel={heading}
+          items={items.map((item) => ({ ...item, variant: "sidebar" }))}
+        />
+      ) : null}
       {children}
     </RailListSection>
   );

--- a/apps/web/src/components/pages/tastingReviewRail.stories.tsx
+++ b/apps/web/src/components/pages/tastingReviewRail.stories.tsx
@@ -1,0 +1,80 @@
+import { mockBottle, mockTasting } from "@peated/server/orpc/mock/fixtures";
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import * as stylex from "@stylexjs/stylex";
+
+import { space } from "../../styles/tokens.stylex";
+import { TastingReviewRail } from "./tastingReviewRail.stylex";
+
+const longNameBottle = {
+  ...mockBottle,
+  brand: { ...mockBottle.brand, name: "The Balvenie", shortName: null },
+  name: "A Collection of Curious Casks French Pineau Cask Finish - Cask No. 55",
+  group: undefined,
+  series: null,
+  imageUrl: null,
+};
+
+const meta = {
+  title: "Components/Reviews & Tastings/Tasting Review Rail",
+  component: TastingReviewRail,
+  decorators: [
+    (Story) => (
+      <aside {...stylex.props(styles.rail)}>
+        <Story />
+      </aside>
+    ),
+  ],
+  args: {
+    author: mockTasting.createdBy,
+    bottle: mockBottle,
+    currentTastingId: mockTasting.id,
+    externalReviews: [],
+    memberReviews: [],
+    memberTastings: [
+      mockTasting,
+      { ...mockTasting, id: 9611, bottle: longNameBottle },
+      {
+        ...mockTasting,
+        id: 9612,
+        ratingBand: null,
+        bottle: {
+          ...longNameBottle,
+          brand: {
+            ...mockBottle.brand,
+            name: "Bruichladdich",
+            shortName: null,
+          },
+          name: "Octomore Edition 15.3 Islay Barley Super Heavily Peated",
+        },
+      },
+      { ...mockTasting, id: 9613 },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "The sidebar used by tasting and review pages, shown at its 336px desktop width. Long names retain a full accessible label and title, with a two-line visual limit. Dates and optional ratings sit below the name. Includes long names, missing images, and an unrated tasting using fixture data.",
+      },
+    },
+  },
+} satisfies Meta<typeof TastingReviewRail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {};
+
+export const Empty: Story = {
+  args: { memberTastings: [] },
+};
+
+const styles = stylex.create({
+  rail: {
+    display: "flex",
+    width: "336px",
+    maxWidth: "100%",
+    flexDirection: "column",
+    gap: space.x8,
+  },
+});

--- a/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
+++ b/apps/web/src/components/pages/tastingReviewRail.stylex.tsx
@@ -82,6 +82,8 @@ export function TastingReviewRail({
         items={moreFromMember.map((tasting) => ({
           ...toBottleListItem(tasting.bottle),
           id: String(tasting.id),
+          provenance: [],
+          metadata: [],
           end: (
             <div {...stylex.props(styles.tastingMeta)}>
               {tasting.ratingBand ? (
@@ -156,9 +158,9 @@ function formatPublishedDate(review: ExternalReview) {
 const styles = stylex.create({
   tastingMeta: {
     display: "flex",
-    flexDirection: "column",
-    alignItems: "flex-end",
-    gap: space.x1,
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: space.x2,
   },
   tastingDate: {
     color: colors.inkMuted,

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -580,7 +580,7 @@ export function Search({
   useEffect(() => () => debouncedSearch.cancel(), [debouncedSearch]);
 
   useEffect(() => {
-    if (placement === "page") return;
+    if (placement !== "database") return;
     // Browser storage is unavailable during server rendering.
     // oxlint-disable-next-line react/set-state-in-effect
     setRecentSearches(readRecentSearches());
@@ -641,7 +641,9 @@ export function Search({
 
   const groups = query.trim()
     ? (currentSnapshot?.groups ?? [])
-    : recentSearchGroups(recentSearches);
+    : placement === "database"
+      ? recentSearchGroups(recentSearches)
+      : [];
 
   const searchBox = (
     <SearchBox

--- a/apps/web/src/components/searchPicker.stylex.tsx
+++ b/apps/web/src/components/searchPicker.stylex.tsx
@@ -472,6 +472,8 @@ const styles = stylex.create({
     flex: 1,
     flexDirection: "column",
     justifyContent: "center",
+    paddingTop: space.x2,
+    paddingBottom: space.x2,
   },
   selectedName: {
     overflow: "hidden",

--- a/apps/web/src/components/searchResults.stories.tsx
+++ b/apps/web/src/components/searchResults.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Use for both global search and database results. Bottle results require identity from getBottleIdentityProps and render BottleIdentityRow. Other results may show an Avatar or initial. Include real images and missing-image results when reviewing a change.",
+          "Use for both global search and database results. Bottle results require identity from getBottleIdentityProps and render BottleIdentityRow. Typeahead results use quiet group labels, compact titles, and inline links to see all matches. Database results retain page headings. Other results may show an Avatar or initial. Include real images and missing-image results when reviewing a change.",
       },
     },
   },

--- a/apps/web/src/components/searchResults.stylex.tsx
+++ b/apps/web/src/components/searchResults.stylex.tsx
@@ -91,6 +91,7 @@ export type SearchResultsProps = {
 /**
  * Presents search results without owning search, ranking, or navigation.
  * Bottle visuals use the standard row thumbnail; member visuals use Avatar.
+ * Default uses compact typeahead rows and group labels; database uses page headings.
  * Supply bottle titles from formatBottleDisplayName.
  */
 export function SearchResults({
@@ -251,11 +252,6 @@ function SearchResultsGroup({
   query: string;
   variant: "database" | "default";
 }) {
-  const remaining =
-    group.total === undefined
-      ? undefined
-      : Math.max(group.total - group.items.length, 0);
-
   return (
     <section
       aria-labelledby={`${optionIdPrefix ?? "search"}-group-${group.id}`}
@@ -266,38 +262,37 @@ function SearchResultsGroup({
           variant === "database" && styles.databaseGroupHeading,
         )}
       >
-        <div
-          {...stylex.props(
-            styles.groupName,
-            variant === "database" && styles.databaseGroupName,
+        <div {...stylex.props(styles.groupName)}>
+          {variant === "database" ? (
+            <SectionHeading
+              id={`${optionIdPrefix ?? "search"}-group-${group.id}`}
+            >
+              {group.label}
+            </SectionHeading>
+          ) : (
+            <span
+              id={`${optionIdPrefix ?? "search"}-group-${group.id}`}
+              {...stylex.props(foundationStyles.fieldLabel, styles.groupLabel)}
+            >
+              {group.label}
+            </span>
           )}
-        >
-          <SectionHeading
-            id={`${optionIdPrefix ?? "search"}-group-${group.id}`}
-          >
-            {group.label}
-          </SectionHeading>
         </div>
         {group.total !== undefined ? (
-          <span
-            {...stylex.props(
-              foundationStyles.metadata,
-              styles.groupCount,
-              variant === "database" && styles.databaseGroupCount,
-            )}
-          >
+          <span {...stylex.props(foundationStyles.metadata, styles.groupCount)}>
             {group.total.toLocaleString("en-US")}
           </span>
         ) : null}
-        {variant === "database" && group.moreHref ? (
+        {group.moreHref ? (
           <AppLink
+            aria-label={`See all ${group.total === undefined ? "" : `${group.total.toLocaleString("en-US")} `}${group.label.toLowerCase()}`}
             href={group.moreHref}
             {...stylex.props(
               foundationStyles.interactiveSmall,
-              styles.databaseMore,
+              styles.groupMore,
             )}
           >
-            See all {group.total?.toLocaleString("en-US")}
+            {group.moreLabel ?? "See all"} →
           </AppLink>
         ) : null}
       </div>
@@ -313,6 +308,7 @@ function SearchResultsGroup({
                 }
                 {...stylex.props(
                   styles.result,
+                  styles.bottleResult,
                   variant === "database" && styles.databaseResult,
                   item.id === activeId && styles.activeResult,
                 )}
@@ -324,6 +320,7 @@ function SearchResultsGroup({
                   imageUrl={item.visual.imageUrl}
                   name={item.title}
                   query={query}
+                  variant={variant === "database" ? "standard" : "search"}
                   onClick={(event) => {
                     if (onItemSelect) {
                       event.preventDefault();
@@ -361,7 +358,12 @@ function SearchResultsGroup({
                 <span {...stylex.props(styles.copy)}>
                   <strong
                     title={item.title}
-                    {...stylex.props(foundationStyles.rowTitle, styles.title)}
+                    {...stylex.props(
+                      variant === "database"
+                        ? foundationStyles.rowTitle
+                        : foundationStyles.compactRowTitle,
+                      styles.title,
+                    )}
                   >
                     <MatchedText query={query} text={item.title} />
                     {item.isFollowing ? (
@@ -395,19 +397,6 @@ function SearchResultsGroup({
           </li>
         ))}
       </ul>
-      {group.moreHref && variant === "default" ? (
-        <AppLink
-          href={group.moreHref}
-          {...stylex.props(foundationStyles.metadata, styles.more)}
-        >
-          <span>
-            {remaining === undefined || remaining === 0
-              ? "More results"
-              : `${remaining.toLocaleString("en-US")} more ${group.label.toLowerCase()}`}
-          </span>
-          <strong>{group.moreLabel ?? "See all"} →</strong>
-        </AppLink>
-      ) : null}
     </section>
   );
 }
@@ -453,10 +442,10 @@ const styles = stylex.create({
   },
   searchingText: {
     margin: 0,
-    paddingTop: "14px",
-    paddingRight: "14px",
+    paddingTop: space.x3,
+    paddingRight: space.x3,
     paddingBottom: space.x4,
-    paddingLeft: "14px",
+    paddingLeft: space.x3,
     color: colors.inkMuted,
   },
   stateText: {
@@ -466,9 +455,9 @@ const styles = stylex.create({
     alignItems: "center",
     margin: 0,
     paddingTop: space.x4,
-    paddingRight: "14px",
+    paddingRight: space.x3,
     paddingBottom: space.x4,
-    paddingLeft: "14px",
+    paddingLeft: space.x3,
     color: colors.inkMuted,
   },
   databaseEmptyState: {
@@ -488,12 +477,12 @@ const styles = stylex.create({
   },
   groupHeading: {
     display: "flex",
-    alignItems: "baseline",
-    gap: space.x3,
+    alignItems: "center",
+    gap: space.x2,
     paddingTop: space.x3,
-    paddingRight: "14px",
+    paddingRight: space.x3,
     paddingBottom: space.x1,
-    paddingLeft: "14px",
+    paddingLeft: space.x3,
   },
   databaseGroupHeading: {
     gap: space.x2,
@@ -505,21 +494,27 @@ const styles = stylex.create({
     borderBottomStyle: "solid",
     borderBottomColor: colors.hairline,
   },
-  groupName: { minWidth: 0, flex: 1 },
-  databaseGroupName: { flex: 0 },
+  groupName: { minWidth: 0 },
+  groupLabel: { color: colors.inkMuted },
   groupCount: {
     color: colors.inkMuted,
     fontVariantNumeric: "tabular-nums",
   },
-  databaseGroupCount: {
-    flex: 0,
-  },
-  databaseMore: {
+  groupMore: {
+    display: "inline-flex",
+    minHeight: "24px",
+    alignItems: "center",
     marginLeft: "auto",
     outline: "none",
     color: colors.accentDeep,
     fontWeight: 700,
-    textDecoration: "none",
+    textDecorationLine: {
+      default: "none",
+      ":hover": "underline",
+      ":active": "underline",
+      ":focus-visible": "underline",
+    },
+    [COMPACT]: { minHeight: "44px" },
     boxShadow: {
       default: "none",
       ":focus-visible": effects.focusRing,
@@ -527,8 +522,8 @@ const styles = stylex.create({
   },
   list: {
     margin: 0,
-    paddingRight: "14px",
-    paddingLeft: "14px",
+    paddingRight: space.x3,
+    paddingLeft: space.x3,
     listStyle: "none",
   },
   listItem: {
@@ -543,14 +538,15 @@ const styles = stylex.create({
     boxSizing: "border-box",
     display: "flex",
     minWidth: 0,
+    minHeight: "44px",
     alignItems: "center",
     gap: space.x3,
-    marginRight: "-14px",
-    marginLeft: "-14px",
-    paddingTop: "10px",
-    paddingRight: "14px",
-    paddingBottom: "10px",
-    paddingLeft: "14px",
+    marginRight: "-12px",
+    marginLeft: "-12px",
+    paddingTop: space.x2,
+    paddingRight: space.x3,
+    paddingBottom: space.x2,
+    paddingLeft: space.x3,
     outline: "none",
     color: colors.ink,
     textDecoration: "none",
@@ -564,6 +560,10 @@ const styles = stylex.create({
       default: "none",
       ":focus-visible": effects.focusRing,
     },
+  },
+  bottleResult: {
+    paddingTop: 0,
+    paddingBottom: 0,
   },
   databaseResult: {
     marginRight: 0,
@@ -632,37 +632,24 @@ const styles = stylex.create({
       display: "flex",
     },
   },
-  more: {
-    display: "flex",
-    alignItems: "baseline",
-    justifyContent: "space-between",
-    gap: space.x3,
-    marginRight: "14px",
-    marginLeft: "14px",
-    paddingTop: "10px",
-    paddingBottom: "10px",
-    borderTopWidth: "1px",
-    borderTopStyle: "solid",
-    borderTopColor: colors.hairline,
-    outline: "none",
-    color: colors.inkMuted,
-    textDecoration: "none",
-    boxShadow: {
-      default: "none",
-      ":focus-visible": effects.focusRing,
-    },
-  },
   contribution: {
+    boxSizing: "border-box",
     display: "flex",
+    minHeight: "44px",
     alignItems: "baseline",
     justifyContent: "space-between",
     gap: space.x3,
     paddingTop: space.x3,
-    paddingRight: "14px",
+    paddingRight: space.x3,
     paddingBottom: space.x3,
-    paddingLeft: "14px",
+    paddingLeft: space.x3,
     outline: "none",
     textDecoration: "none",
+    backgroundColor: {
+      default: "transparent",
+      ":hover": colors.surface,
+      ":active": colors.inset,
+    },
     boxShadow: {
       default: "none",
       ":focus-visible": effects.focusRing,
@@ -675,9 +662,8 @@ const styles = stylex.create({
   },
   contributionRule: {
     height: "1px",
-    marginTop: space.x2,
-    marginRight: "14px",
-    marginLeft: "14px",
+    marginRight: space.x3,
+    marginLeft: space.x3,
     backgroundColor: colors.hairline,
   },
   contributionDescription: {
@@ -696,9 +682,9 @@ const styles = stylex.create({
     gap: space.x3,
     marginTop: space.x2,
     paddingTop: space.x3,
-    paddingRight: "14px",
+    paddingRight: space.x3,
     paddingBottom: space.x3,
-    paddingLeft: "14px",
+    paddingLeft: space.x3,
     borderTopWidth: "1px",
     borderTopStyle: "solid",
     borderTopColor: colors.hairline,

--- a/apps/web/src/components/sectionHeading.stories.tsx
+++ b/apps/web/src/components/sectionHeading.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Use SectionHeading for every section heading, including sidebars. The shared 24px heading sits above 18px row titles. Heading levels change document structure, not appearance. Keep spacing in the containing layout; do not add local typography variants.",
+          "Use SectionHeading for every section heading, including sidebars. The shared 20px heading sits above 18px row titles. Heading levels change document structure, not appearance. Keep spacing in the containing layout; do not add local typography variants.",
       },
     },
   },

--- a/apps/web/src/components/sectionHeading.stylex.tsx
+++ b/apps/web/src/components/sectionHeading.stylex.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { foundationStyles } from "../styles/foundations.stylex";
 import { colors } from "../styles/tokens.stylex";
 
-/** Section headings sit above 18px row titles at 24px; level changes semantics only. */
+/** Section headings sit above 18px row titles at 20px; level changes semantics only. */
 export function SectionHeading({
   children,
   id,

--- a/apps/web/src/styles/foundations.stylex.ts
+++ b/apps/web/src/styles/foundations.stylex.ts
@@ -35,7 +35,7 @@ export const foundationStyles = stylex.create({
   sectionHeading: {
     margin: 0,
     fontFamily: fonts.display,
-    fontSize: "24px",
+    fontSize: "20px",
     fontWeight: 700,
     letterSpacing: "-0.025em",
     lineHeight: 1.2,
@@ -51,7 +51,7 @@ export const foundationStyles = stylex.create({
   compactRowTitle: {
     margin: 0,
     fontFamily: fonts.display,
-    fontSize: "16px",
+    fontSize: "15px",
     fontWeight: 700,
     letterSpacing: "-0.025em",
     lineHeight: 1.25,

--- a/docs/features/bottle-presentation.md
+++ b/docs/features/bottle-presentation.md
@@ -218,8 +218,10 @@ Do not rebuild these lines in a page-specific mapper:
 
 Missing facts do not create placeholder lines. Activity context, Library status,
 personal images, and actions belong to their owning view, not a competing bottle
-identity layout. Sidebar bottle lists use the same standard rows and thumbnail
-size. Primary page headings remain a separate display context.
+identity layout. Sidebar bottle lists use the shared sidebar variant with
+compact titles, smaller thumbnails, and trailing content below the identity.
+Recent tastings show the tasting date and rating instead of catalog facts.
+Primary page headings remain a separate display context.
 
 Picker options and selected bottles also use `BottleIdentityRow`. Build them
 with `toBottlePickerOption`; it retains the numeric database ID and removes
@@ -368,15 +370,15 @@ The components live in `apps/web/src/components/`, with stories beside them.
 Storybook's **Components / Bottles / Bottle Identity Row / Row Layouts** is the
 shared visual reference for desktop and phone layouts.
 
-| Need                        | Component                             | Responsibility                                                                                               |
-| --------------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| One standard bottle row     | `BottleIdentityRow`                   | Full marketed name, provenance, release facts, thumbnail, and linked hit area.                               |
-| One-line library addition   | `BottleIdentityRow variant="compact"` | Same name, smaller thumbnail, and a 44px hit area; long names truncate visually.                             |
-| Catalog list                | `BottleList`                          | List semantics and optional ratings or row actions.                                                          |
-| Mixed activity              | `CommunityFeed`                       | Author, action, date, grouped bottles, scores, and review links; chooses compact rows for library additions. |
-| Selected bottle in a form   | `SelectedBottleSummary`               | Standard identity and optional change action.                                                                |
-| Sidebar bottle suggestions  | `pages/BottleRailSection`             | Standard BottleList rows with three identity lines, the shared thumbnail, and an optional section action.    |
-| Image within another layout | `BottleVisual`                        | Image sizing, white frame, missing-image glyph, and optional expansion.                                      |
+| Need                        | Component                             | Responsibility                                                                                                                          |
+| --------------------------- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| One standard bottle row     | `BottleIdentityRow`                   | Full marketed name, provenance, release facts, thumbnail, and linked hit area.                                                          |
+| One-line library addition   | `BottleIdentityRow variant="compact"` | Same name, smaller thumbnail, and a 44px hit area; long names truncate visually.                                                        |
+| Catalog list                | `BottleList`                          | List semantics and optional ratings or row actions.                                                                                     |
+| Mixed activity              | `CommunityFeed`                       | Author, action, date, grouped bottles, scores, and review links; chooses compact rows for library additions.                            |
+| Selected bottle in a form   | `SelectedBottleSummary`               | Standard identity and optional change action.                                                                                           |
+| Sidebar bottle suggestions  | `pages/BottleRailSection`             | Shared sidebar rows with compact two-line names, small thumbnails, trailing details below the identity, and an optional section action. |
+| Image within another layout | `BottleVisual`                        | Image sizing, white frame, missing-image glyph, and optional expansion.                                                                 |
 
 Use `toBottleListItem` from `apps/web/src/lib/bottleListItem.ts` for full API
 Bottles. For partial reads, `getBottleIdentityProps` supplies the name,
@@ -390,7 +392,10 @@ const item = toBottleListItem(bottle);
 <BottleIdentityRow {...item} variant="compact" />
 ```
 
-Both variants accept the full marketed name, including brand context. Compact
+All variants accept the full marketed name, including brand context. Sidebar
+rows use compact two-line titles and smaller thumbnails, omit membership icons,
+and place trailing dates, ratings, or actions below the identity. Recent tasting
+rows show tasting dates and ratings instead of catalog provenance and facts. Compact
 rows omit provenance, metadata, subtitles, membership status, and related-release
 links. The optional `end` slot remains available. `layout="cell"` fits the identity
 inside an existing table or selection control; it does not change content density.


### PR DESCRIPTION
Search suggestions and tasting sidebars became oversized after the typography and shared-row updates. Restore 20px section headings and 15px compact titles. Header search opens without recent searches, uses compact result rows and group labels, and places “See all” beside each group.

Sidebar bottles use the shared renderer with small thumbnails and two-line names. Recent tastings put dates and ratings below the name, giving long bottle names the full text column. Matching loading states and a 336px tasting-sidebar story cover long names, missing images, and unrated tastings. The design guide and component documentation define these densities.

The accompanying audit fixes active mobile navigation shrinking, cramped selected-picker values, fact grids inheriting heading letter spacing, and mobile filter columns hiding labels. Review should start with the shared typography and Bottle Identity Row’s Row Layouts story.

Verified actual tasting routes with long-name fixtures at desktop and 320px in light and dark themes, plus shared search, sidebar, selection, and loading layouts. All 30 focused tests, web typecheck, lint, and formatting passed.
