### PR TITLE
fix(web): restore admin link in profile dropdown

### DIFF
--- a/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/applicationLayout.stylex.tsx
@@ -64,6 +64,7 @@ export function ApplicationLayout({ children }: { children: ReactNode }) {
         { href: `/users/${user.username}`, label: "Profile" },
         { href: "/friends", label: "Friends" },
         { href: "/settings", label: "Settings" },
+        ...(user.admin ? [{ href: "/admin", label: "Admin" }] : []),
         {
           disabled: logoutPending,
           label: logoutPending ? "Signing out…" : "Sign out",


### PR DESCRIPTION
Restores the Admin link in the profile dropdown for users with admin access. The link uses the same `user.admin` check as the admin routes and opens `/admin`.
