### PR TITLE
fix(server): use Render commit for the release version

### DIFF
--- a/apps/server/src/config.test.ts
+++ b/apps/server/src/config.test.ts
@@ -1,0 +1,50 @@
+describe("server version", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  test.each([
+    {
+      name: "prefers an explicit version over the Render commit",
+      version: "release-1",
+      renderCommit: "0123456789abcdef0123456789abcdef01234567",
+      expected: "release-1",
+    },
+    {
+      name: "uses the Render commit when VERSION is unset",
+      version: undefined,
+      renderCommit: "0123456789abcdef0123456789abcdef01234567",
+      expected: "0123456789abcdef0123456789abcdef01234567",
+    },
+    {
+      name: "uses the Render commit when VERSION is empty",
+      version: "",
+      renderCommit: "0123456789abcdef0123456789abcdef01234567",
+      expected: "0123456789abcdef0123456789abcdef01234567",
+    },
+    {
+      name: "keeps the version empty when deployment metadata is unset",
+      version: undefined,
+      renderCommit: undefined,
+      expected: "",
+    },
+    {
+      name: "keeps the version empty when deployment metadata is empty",
+      version: "",
+      renderCommit: "",
+      expected: "",
+    },
+  ])("$name", async ({ version, renderCommit, expected }) => {
+    vi.stubEnv("VERSION", version);
+    vi.stubEnv("RENDER_GIT_COMMIT", renderCommit);
+
+    const { default: config } = await import("./config");
+
+    expect(config.VERSION).toBe(expected);
+  });
+});

--- a/apps/server/src/config.ts
+++ b/apps/server/src/config.ts
@@ -31,7 +31,7 @@ export default {
   SMTP_PASS: process.env.SMTP_PASS,
   SMTP_FROM_NAME: "Peated",
 
-  VERSION: process.env.VERSION || "",
+  VERSION: process.env.VERSION || process.env.RENDER_GIT_COMMIT || "",
 
   SENTRY_DSN: process.env.SENTRY_DSN || "",
   SENTRY_SERVICE: process.env.SENTRY_SERVICE || "@peated/server",

--- a/docs/operations/deployments.md
+++ b/docs/operations/deployments.md
@@ -6,6 +6,10 @@ Peated production has three parts:
 - Render runs the API at `https://api.peated.com` and the worker.
 - PlanetScale hosts the production database.
 
+The API and worker use `VERSION` as their release identifier when it is non-empty.
+Otherwise, they use Render's `RENDER_GIT_COMMIT`. The API exposes this value at
+`/v1/version`, and both services use it for Sentry releases.
+
 Before a deploy, identify which parts change and whether they must remain
 compatible during the rollout. Never assume that a database, API, worker, and
 web change become active at the same time.

--- a/turbo.json
+++ b/turbo.json
@@ -38,6 +38,7 @@
     "API_SERVER",
     "URL_PREFIX",
     "VERSION",
+    "RENDER_GIT_COMMIT",
     "GOOGLE_CLIENT_ID",
     "SENTRY_DSN",
     "SENTRY_ORG",


### PR DESCRIPTION
The API and worker now use `RENDER_GIT_COMMIT` when `VERSION` is unset or empty, so `/v1/version` reports the deployed SHA and Sentry receives the same release identifier. Explicit `VERSION` overrides and the empty version used without deployment metadata are unchanged. Turbo also forwards the Render variable for root start commands. Regression tests cover override precedence and unset or empty environment values.
