### PR TITLE
fix(scrapers): preserve page content in setup input

### DIFF
--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -104,6 +104,11 @@ pass. The AI provider does not store request content. An admin must still
 preview and activate the inactive revision. AI never changes the active
 revision directly.
 
+Before limiting model input, setup removes script and style elements from its
+HTML copies so large page headers do not crowd out links and article content.
+It keeps the page structure and attributes used by selectors. Rule checks and
+collection still parse the original fetched HTML.
+
 For reviews, `reviewItem` selects the full body to save internally; optional
 `reviewText` selects tasting notes for tags and clips. [External Reviews](../../../../docs/features/external-reviews.md)
 defines what is saved, who can read it, and when it is deleted.

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -1,3 +1,4 @@
+import { load } from "cheerio";
 import { expect, test, vi } from "vitest";
 import { SCRAPE_SOURCE_DEFAULT_MAX_ITEMS } from "./rules";
 import {
@@ -62,6 +63,41 @@ test("bounds total AI input while keeping every sample page", () => {
   expect(
     prepared.reduce((total, page) => total + page.html.length, 0),
   ).toBeLessThanOrEqual(200_000);
+});
+
+test("keeps links and review facts after a large page header", () => {
+  const pages = [
+    {
+      url: "https://example.test/reviews/one",
+      html: `<html><head>
+      <script>${"/* page script */".repeat(10_000)}</script>
+      <style>${".page { color: black; }".repeat(10_000)}</style>
+      <meta name="author" content="Example Writer">
+    </head><body>
+      <h2>Latest Reviews</h2>
+      <ul class="reviews"><li><a href="/reviews/one">Example Bourbon</a></li></ul>
+      <article class="review">
+        <h1>Example Bourbon</h1>
+        <time datetime="2026-08-01T12:00:00Z">August 1</time>
+        <div class="body"><p>Review introduction.</p><h2>Score: 8/10</h2></div>
+      </article>
+    </body></html>`,
+    },
+  ];
+  const [prepared] = prepareAiPages(pages);
+  const $ = load(prepared!.html);
+
+  expect(prepared!.url).toBe(pages[0]!.url);
+  expect(prepared!.html.length).toBeLessThanOrEqual(75_000);
+  expect($("h2 + ul.reviews a").attr("href")).toBe("/reviews/one");
+  expect($("article.review > h1").text()).toBe("Example Bourbon");
+  expect($("article.review time").attr("datetime")).toBe(
+    "2026-08-01T12:00:00Z",
+  );
+  expect($('meta[name="author"]').attr("content")).toBe("Example Writer");
+  expect($("article.review .body h2").text()).toBe("Score: 8/10");
+  expect($("article.review .body p").text()).toBe("Review introduction.");
+  expect(pages[0]!.html).toContain("/* page script */");
 });
 
 test("returns rules only after the rule check passes", async () => {

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -1,5 +1,6 @@
 import { CURRENCY_LIST } from "@peated/server/constants";
 import { runAgent, runTool } from "@peated/server/lib/agentTrace";
+import { load } from "cheerio";
 import { zodResponsesFunction } from "openai/helpers/zod";
 import type {
   ResponseInput,
@@ -22,7 +23,7 @@ import {
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v7";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v8";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_SUGGESTION_DETAIL_PAGES = 3;
 const MAX_RULE_CHECKS = 3;
@@ -272,10 +273,15 @@ export function prepareAiPages(pages: AiPage[]) {
     MAX_AI_PAGE_CHARS,
     Math.floor(MAX_AI_INPUT_CHARS / pages.length),
   );
-  return pages.map((page) => ({
-    url: page.url,
-    html: page.html.slice(0, charsPerPage),
-  }));
+  return pages.map((page) => {
+    const $ = load(page.html);
+    // Scraper setup needs selectable content before the shared input limit cuts it off.
+    $("script, style").remove();
+    return {
+      url: page.url,
+      html: $.html().slice(0, charsPerPage),
+    };
+  });
 }
 
 export function modelOutputIssues(error: Error): ScrapeIssue[] {


### PR DESCRIPTION
Scraper setup could receive only a page’s headers when inline scripts and styles filled the HTML size limit. Its rules then guessed at content the model had never seen and failed validation. This blocked the first production switch to saved rules.

Remove script and style elements from the model’s HTML copies before applying the existing limits. Keep page structure, selector attributes, and metadata; rule checks and collection still use the original fetched pages. Record the changed setup input as version 8.

Regression coverage puts links, a publication date, writer, score, and review body after an oversized header and verifies they reach setup. All 11 focused setup tests, server type checking, lint, and formatting passed. The production setup retry remains pending deployment to the worker; the migrated source is paused and its six existing reviews are unchanged.
