### PR TITLE
fix(web): contain bottle links in scraper lists

### DIFF
--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -52,6 +52,7 @@ import {
   priceSiteRuns,
   replacementSourceBottleId,
   replacementSourceEntityId,
+  siteReviewList,
   storePriceList,
   suggestedTags,
   tastingNotes,
@@ -1485,6 +1486,10 @@ async function handleRpcRequest({ request, response, url }) {
       sendRpcResponse(response, createdMemberReview);
       return true;
     case "externalReviews/list":
+      if (input?.site === priceSite.type) {
+        sendRpcResponse(response, siteReviewList);
+        return true;
+      }
       if (input?.bottle !== undefined && !isNumber(input.bottle)) {
         sendRpcError(response, "Unexpected external review list payload");
         return true;

--- a/apps/web/e2e/routes.spec.ts
+++ b/apps/web/e2e/routes.spec.ts
@@ -8,6 +8,8 @@ import {
   existingBottleDetails,
   mockApiServer,
   priceSite,
+  siteReviewList,
+  storePriceList,
   testBottler,
   testBrand,
   testCountry,
@@ -399,15 +401,29 @@ test("browse from the homepage through a country and its regions", async ({
   await snapshot("Region overview", { ready: regionHeading });
 });
 
-test("site administration route loads for an administrator", async ({
+test("scraper lists keep bottle links and navigation independently clickable", async ({
   context,
   page,
 }) => {
   await signIn(context, { user: { ...testUser, admin: true } });
 
-  const response = await page.goto(`/admin/sites/${priceSite.type}`, {
-    waitUntil: "commit",
-  });
+  const root = `/admin/sites/${priceSite.type}`;
+  await page.goto(`${root}/reviews`);
+  const table = page.getByRole("table");
+  await expect(table.locator("tbody tr")).toHaveCount(
+    siteReviewList.results.length,
+  );
 
-  expect(response?.status()).toBeLessThan(400);
+  await page
+    .getByRole("navigation", { name: "Scraper", exact: true })
+    .getByRole("link", { name: "Prices", exact: true })
+    .click();
+  await expect(page).toHaveURL(`${root}/prices`);
+  const firstPriceBottle = storePriceList.results[0]!.bottle!;
+  await table.locator(bottleHrefSelector(firstPriceBottle.id)).click();
+  await expect(page).toHaveURL(bottlePathPattern(firstPriceBottle.id));
+
+  await page.goto(`${root}/reviews`);
+  await table.locator(bottleHrefSelector(existingBottle.id)).click();
+  await expect(page).toHaveURL(bottlePathPattern(existingBottle.id));
 });

--- a/apps/web/e2e/routes.spec.ts
+++ b/apps/web/e2e/routes.spec.ts
@@ -419,6 +419,9 @@ test("scraper lists keep bottle links and navigation independently clickable", a
     .getByRole("link", { name: "Prices", exact: true })
     .click();
   await expect(page).toHaveURL(`${root}/prices`);
+  await expect(table.locator("tbody tr")).toHaveCount(
+    storePriceList.results.length,
+  );
   const firstPriceBottle = storePriceList.results[0]!.bottle!;
   await table.locator(bottleHrefSelector(firstPriceBottle.id)).click();
   await expect(page).toHaveURL(bottlePathPattern(firstPriceBottle.id));

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -701,8 +701,8 @@ export const priceSite = {
   nextRunAt: null,
   runEvery: 60,
   externalReviews: {
-    total: 0,
-    matched: 0,
+    total: 2,
+    matched: 2,
     unmatched: 0,
   },
   priceListings: {
@@ -920,6 +920,20 @@ export const activityReview = {
   bottle: existingBottle,
   createdAt: timestamp,
   updatedAt: timestamp,
+};
+
+export const siteReviewList = {
+  rel: { nextCursor: null, prevCursor: null },
+  results: [
+    activityReview,
+    {
+      ...activityReview,
+      id: 9803,
+      name: exactMatchedBottle.fullName,
+      url: "https://example.com/reviews/second-whisky",
+      bottle: exactMatchedBottle,
+    },
+  ],
 };
 
 export const homeAwards = [

--- a/apps/web/src/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stories.tsx
@@ -1,4 +1,7 @@
-import { mockBottle } from "@peated/server/orpc/mock/fixtures";
+import {
+  mockBottle,
+  mockExternalReviews,
+} from "@peated/server/orpc/mock/fixtures";
 import {
   toBottleListItem,
   toBottlePickerOption,
@@ -8,6 +11,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import type { BottleRowActionControls } from "@peated/web/hooks/useBottleRowActions";
 
 import BottleImage from "../../../../packages/bottle-classifier/src/eval-fixtures/assets/photo-add-bottle-misses/laphroaig-elements-l2.0.webp";
+import { ReviewRows } from "./admin/reviewTable.stylex";
 import { BottleIdentityRow } from "./bottleIdentityRow.stylex";
 import { BottleRowActions } from "./bottleRowActions.stylex";
 import { CommunityFeed } from "./communityFeed.stylex";
@@ -73,7 +77,7 @@ const meta = {
 | sidebar | Sidebar bottle lists | 15px title limited to two lines, 32 × 46px thumbnail, and trailing content below the identity. |
 | compact | Single or grouped library additions | One name line, 24 × 32px thumbnail, and a 44px hit area. |
 
-Sidebar omits membership status icons and keeps full accessible names when its two-line titles truncate. Compact omits provenance, metadata, subtitle, status, and related releases. Long compact names truncate visually and retain their full accessible name and title. Use layout="cell" inside an existing control; end holds independent actions or scores. BottleVisual owns the image frame and fallback; the row chooses its size.
+Sidebar omits membership status icons and keeps full accessible names when its two-line titles truncate. Compact omits provenance, metadata, subtitle, status, and related releases. Long compact names truncate visually and retain their full accessible name and title. Use layout="cell" inside an existing control; linked cells keep their hit area inside the bottle identity. The end slot holds independent actions or scores. BottleVisual owns the image frame and fallback; the row chooses its size.
 
 Use Row Layouts to compare these components at desktop and phone widths.`,
       },
@@ -292,6 +296,17 @@ export const RowLayouts: Story = {
               },
             ]}
             query=""
+          />
+        </section>
+        <section aria-label="Scraper reviews">
+          <SectionHeading level={3}>Scraper reviews</SectionHeading>
+          <ReviewRows
+            reviews={mockExternalReviews.slice(0, 2).map((review) => ({
+              ...review,
+              bottle: review.bottle
+                ? { ...review.bottle, imageUrl: null }
+                : null,
+            }))}
           />
         </section>
         <section aria-label="Selection">

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -44,7 +44,8 @@ export type BottleIdentityRowProps = {
  * Use toBottleListItem for API Bottles or getBottleIdentityProps for partial reads.
  * All variants take the same full marketed name and own their thumbnail size.
  * The name line owns title typography so surrounding body leading cannot shift it.
- * Use layout="cell" inside an existing row/selection control. Compact omits
+ * Use layout="cell" inside an existing row/selection control. Linked cells keep
+ * their hit area inside the bottle identity. Compact omits
  * provenance, metadata, subtitle, status, and related releases; end remains available.
  */
 export function BottleIdentityRow({
@@ -87,7 +88,7 @@ export function BottleIdentityRow({
         compact && styles.compactRow,
         !compact && align === "start" && styles.startAlignedRow,
         layout === "cell" && styles.cellLayout,
-        Boolean(href) && layout === "row" && linkedRowStyles.container,
+        Boolean(href) && linkedRowStyles.container,
         Boolean(href) && layout === "row" && linkedRowStyles.onGround,
       )}
     >


### PR DESCRIPTION
Bottle links in scraper reviews and prices now stay within their own bottle row. The cell layout applied an absolutely positioned click area without a containing block, allowing the final bottle link to cover the viewport and intercept other links and controls. The shared bottle row now owns that boundary in both layouts.

The existing scraper browser test now checks navigation between lists and opening the first bottle in each list. Manual desktop and mobile checks confirmed the click areas stay within their rows, with light and dark layouts reviewed.
