### PR TITLE
fix(web): hide flavor profiles without tasting notes

### DIFF
--- a/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOverviewClient.stylex.tsx
@@ -128,5 +128,8 @@ export function EntityOverviewClient() {
 }
 
 const styles = stylex.create({
-  flavorProfile: { paddingTop: space.x6 },
+  flavorProfile: {
+    display: { default: "block", ":empty": "none" },
+    paddingTop: space.x6,
+  },
 });

--- a/apps/web/src/components/pages/bottleOverview.stylex.tsx
+++ b/apps/web/src/components/pages/bottleOverview.stylex.tsx
@@ -277,7 +277,7 @@ const styles = stylex.create({
   },
   railSections: {
     gridArea: "railSections",
-    display: "flex",
+    display: { default: "flex", ":empty": "none" },
     minWidth: 0,
     flexDirection: "column",
     gap: space.x8,

--- a/apps/web/src/features/flavorProfile/flavorProfileSection.tsx
+++ b/apps/web/src/features/flavorProfile/flavorProfileSection.tsx
@@ -16,7 +16,7 @@ import {
   useTastingWheel,
 } from "@peated/web/features/tastingWheel/tastingWheelDetails.stylex";
 import { useORPC } from "@peated/web/lib/orpc/context";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, type UseQueryResult } from "@tanstack/react-query";
 
 type FlavorProfileSectionProps = {
   scope:
@@ -25,16 +25,7 @@ type FlavorProfileSectionProps = {
     | { kind: "region"; country: string; region: string };
 };
 
-export function FlavorProfileSection(props: FlavorProfileSectionProps) {
-  return (
-    <TastingWheelProvider>
-      <FlavorProfileContent {...props} />
-    </TastingWheelProvider>
-  );
-}
-
-function FlavorProfileContent({ scope }: FlavorProfileSectionProps) {
-  const { select } = useTastingWheel();
+export function FlavorProfileSection({ scope }: FlavorProfileSectionProps) {
   const orpc = useORPC();
   const query = useQuery<FlavorProfile | BottleFlavorProfile>(
     scope.kind === "bottle"
@@ -49,6 +40,29 @@ function FlavorProfileContent({ scope }: FlavorProfileSectionProps) {
             input: { country: scope.country, region: scope.region },
           }),
   );
+
+  if (
+    query.isSuccess &&
+    ("notedTastings" in query.data
+      ? query.data.notedTastings
+      : query.data.notedBottles) === 0
+  ) {
+    return null;
+  }
+
+  return (
+    <TastingWheelProvider>
+      <FlavorProfileContent query={query} />
+    </TastingWheelProvider>
+  );
+}
+
+function FlavorProfileContent({
+  query,
+}: {
+  query: UseQueryResult<FlavorProfile | BottleFlavorProfile>;
+}) {
+  const { select } = useTastingWheel();
 
   return (
     <RailSection heading="Flavor profile">


### PR DESCRIPTION
Hide the flavor profile section when it has no public tasting notes, including its heading and reference link. The shared behavior covers bottle, distillery, and region pages; empty bottle and distillery sidebar containers also collapse so they leave no extra spacing. Loading and retryable error states remain available.

Browser QA remains outstanding because agent-browser is unavailable locally.
