### PR TITLE
fix(web): unify catalog identity rows and component naming

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -180,7 +180,8 @@ components:
 This document defines Peated's durable visual system. It does not inventory
 React components or define product data and route behavior. Storybook owns
 component usage and visible states. Feature and architecture documents own
-product behavior and data rules.
+product behavior and data rules. The [naming policy](docs/policies/naming.md#ui-components)
+owns component names, roles, and file placement.
 
 ## Overview
 
@@ -341,6 +342,21 @@ JSDoc.
 - Use the same visual foundations in the public product and admin.
 - Keep errors inside the section that failed when the rest of the page still
   works.
+
+### Catalog rows
+
+- Each core catalog kind owns its identity row. Use that same identity in lists,
+  sidebars, search results, and selection controls.
+- Brand and producer rows show the name, known kind and location, and following
+  status. Series rows show the series name and brand; region rows show the name
+  and country. Leave unavailable facts absent.
+- Keep Peated IDs, descriptions, ownership explanations, and aggregate statistics
+  out of row identity. IDs remain useful on detail and maintenance screens.
+- Place contextual counts and independent actions beside the identity. Give menu
+  cells 12px padding on both sides and enough width for the complete touch target.
+  Keep row actions available on narrow screens.
+- Names and metadata wrap when needed. Use the compact title for sidebars and
+  search, with the same identity facts as a standard row.
 
 ### Images and data
 

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -8,6 +8,9 @@
   facts in the content. Do not add this pattern to components or stories.
 - Search `src/components/` before adding components. Query `peated-storybook` MCP
   when running; use documented props and states.
+- Follow `../../docs/policies/naming.md` for component roles, domain names,
+  file names, shared type ownership, and placement. Review the name and all
+  affected uses when a component's responsibility changes.
 - Keep stories beside components; page-sized, render-only components go in `pages/`.
 - Document usage, states, and examples in Storybook; expose the same guidance
   through concise component JSDoc.
@@ -27,6 +30,10 @@
   `/activity`, and member profiles.
   Use `formatBottleDisplayName` or `toBottleListItem` for displayed bottle names.
   API responses used by these helpers must include the BottleGroup summary.
+- `EntityIdentityRow`, `SeriesIdentityRow`, and `LocationIdentityRow` own other
+  catalog row identities across lists, sidebars, search, and selection. Keep IDs,
+  descriptions, and counts out of identity metadata; place contextual counts and
+  actions beside it. Use `getEntityIdentityProps` for partial or full Entity reads.
 - Every bottle row, including sidebar, picker, selected, and admin rows, uses
   `BottleIdentityRow`. Use `toBottlePickerOption` for selection controls. Do not
   recreate bottle identity with generic text rows, chips, or image/name markup.
@@ -45,9 +52,6 @@
   “entity,” “measure,” or “canonical ID.”
 - Say “rating” or show its name/range (`Very good · 85–89`), not “tasting band.”
   Use “review score” for an exact 0–100 score.
-- Name components for their Peated concept, task, or standard UI control. Avoid
-  `Product`, `Experience`, `Surface`, `Shell`, `Widget`, `Module`, `Structure`,
-  or `Record` unless it is the product term.
 
 ## Routes
 

--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
+
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
@@ -311,11 +313,7 @@ function Distilleries({ totalDistilleries }: { totalDistilleries?: number }) {
     <HomeDistilleries
       distilleries={distilleries.data.results.map((distillery) => ({
         href: getEntityUrl(distillery),
-        location: [distillery.region?.name, distillery.country?.name]
-          .filter(Boolean)
-          .join(", "),
-        name: distillery.name,
-        totalBottles: distillery.totalBottles,
+        ...getEntityIdentityProps(distillery),
       }))}
       totalDistilleries={totalDistilleries}
     />

--- a/apps/web/src/app/(app)/entities/[entityId]/codes/entityCodes.stylex.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/codes/entityCodes.stylex.tsx
@@ -1,7 +1,7 @@
 import * as stylex from "@stylexjs/stylex";
 
-import { Card, TextLink } from "@peated/web/components";
-import { CatalogTable } from "@peated/web/components/pages/catalogTable.stylex";
+import { Card, EntityIdentityRow, TextLink } from "@peated/web/components";
+import { CatalogTable } from "@peated/web/components/catalogTable.stylex";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import { foundationStyles } from "../../../../../styles/foundations.stylex";
 import { colors, space } from "../../../../../styles/tokens.stylex";
@@ -70,29 +70,15 @@ export function EntityCodes({
               },
               {
                 key: "distillery",
+                padding: "flush",
                 header: "Distillery",
                 cell: (row) => (
-                  <div {...stylex.props(styles.distillery)}>
-                    <div {...stylex.props(foundationStyles.rowTitle)}>
-                      {row.href ? (
-                        <TextLink href={row.href} size="inherit">
-                          {row.name}
-                        </TextLink>
-                      ) : (
-                        row.name
-                      )}
-                    </div>
-                    {row.country ? (
-                      <div
-                        {...stylex.props(
-                          foundationStyles.metadata,
-                          styles.country,
-                        )}
-                      >
-                        {row.country}
-                      </div>
-                    ) : null}
-                  </div>
+                  <EntityIdentityRow
+                    href={row.href}
+                    location={row.country ?? undefined}
+                    name={row.name}
+                    layout="cell"
+                  />
                 ),
               },
             ]}
@@ -123,12 +109,5 @@ const styles = stylex.create({
     color: colors.ink,
     fontVariantNumeric: "tabular-nums",
     fontWeight: 600,
-  },
-  distillery: {
-    minWidth: 0,
-    overflowWrap: "anywhere",
-  },
-  country: {
-    color: colors.inkMuted,
   },
 });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.test.tsx
@@ -72,7 +72,7 @@ describe("EntityCatalogRelationships", () => {
     });
 
     expect(html).toContain("Bottled by");
-    expect(html).toContain("SMWS");
+    expect(html).toContain("The Scotch Malt Whisky Society");
     expect(html).not.toContain("Unused Brand");
     expect(html).not.toContain(">Brands<");
   });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityCatalogRelationships.tsx
@@ -1,9 +1,11 @@
 import type { Outputs } from "@peated/server/orpc/router";
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 
 import {
+  EntityIdentityRow,
+  ItemListItem,
   LoadingList,
   RailList,
-  RailListItem,
   SectionError,
 } from "@peated/web/components";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
@@ -110,12 +112,14 @@ export function EntityCatalogRelationships({
     <PageSection heading={group.heading}>
       <RailList ariaLabel={`${entity.name} ${group.heading.toLowerCase()}`}>
         {group.items.map((related) => (
-          <RailListItem
-            end={related.count.toLocaleString("en-US")}
-            href={getEntityUrl(related)}
-            key={related.id}
-            title={related.shortName || related.name}
-          />
+          <ItemListItem key={related.id}>
+            <EntityIdentityRow
+              {...getEntityIdentityProps(related)}
+              variant="sidebar"
+              end={`${related.count.toLocaleString("en-US")} ${related.count === 1 ? "bottle" : "bottles"}`}
+              href={getEntityUrl(related)}
+            />
+          </ItemListItem>
         ))}
       </RailList>
     </PageSection>

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOperatedOverview.test.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOperatedOverview.test.tsx
@@ -55,7 +55,8 @@ describe("EntityOperatedOverview", () => {
     expect(html).toContain("Operates");
     expect(html).toContain("The Scotch Malt Whisky Society");
     expect(html).toContain('href="/bottlers/2-the-scotch-malt-whisky-society"');
-    expect(html).toContain("Bottler · 3,499 bottles");
+    expect(html).toContain("Bottler · Islay, Scotland");
+    expect(html).not.toContain("3,499 bottles");
     expect(html).toContain("Single Cask Nation");
     expect(html).toContain('href="/brands/3-single-cask-nation"');
   });

--- a/apps/web/src/app/(app)/entities/[entityId]/entityOperatedOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entityOperatedOverview.tsx
@@ -1,15 +1,17 @@
 import type { Outputs } from "@peated/server/orpc/router";
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 
 import {
+  EntityIdentityRow,
+  ItemListItem,
   LoadingList,
   RailList,
-  RailListItem,
   SectionError,
 } from "@peated/web/components";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
-import { getEntityPresentation, type Entity } from "./entityPageData";
+import { type Entity } from "./entityPageData";
 
 type EntityList = Outputs["entities"]["list"];
 
@@ -58,12 +60,13 @@ export function EntityOperatedOverview({
     <PageSection heading={heading}>
       <RailList ariaLabel={`${entity.name} brands and producers`}>
         {operated.map((item) => (
-          <RailListItem
-            href={getEntityUrl(item)}
-            key={item.id}
-            metadata={`${getEntityPresentation(item).label} · ${item.totalBottles.toLocaleString("en-US")} bottles`}
-            title={item.name}
-          />
+          <ItemListItem key={item.id}>
+            <EntityIdentityRow
+              {...getEntityIdentityProps(item)}
+              variant="sidebar"
+              href={getEntityUrl(item)}
+            />
+          </ItemListItem>
         ))}
       </RailList>
     </PageSection>

--- a/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
+++ b/apps/web/src/app/(app)/entities/[entityId]/entitySiblingOverview.tsx
@@ -1,16 +1,18 @@
 import type { Outputs } from "@peated/server/orpc/router";
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 
 import {
+  EntityIdentityRow,
+  ItemListItem,
   LoadingList,
   RailList,
-  RailListItem,
   SectionError,
   TextLink,
 } from "@peated/web/components";
 import { PageSection } from "@peated/web/components/pages/pageLayout.stylex";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
-import { getEntityPresentation, type Entity } from "./entityPageData";
+import { type Entity } from "./entityPageData";
 import { getEntitySiblings } from "./entitySiblingData";
 
 type EntityList = Outputs["entities"]["list"];
@@ -71,12 +73,13 @@ export function EntitySiblingOverview({
     <PageSection heading={heading} intro={companyLink}>
       <RailList ariaLabel={heading}>
         {siblings.map((sibling) => (
-          <RailListItem
-            href={getEntityUrl(sibling)}
-            key={sibling.id}
-            metadata={`${getEntityPresentation(sibling).label} · ${sibling.totalBottles.toLocaleString("en-US")} bottles`}
-            title={sibling.name}
-          />
+          <ItemListItem key={sibling.id}>
+            <EntityIdentityRow
+              {...getEntityIdentityProps(sibling)}
+              variant="sidebar"
+              href={getEntityUrl(sibling)}
+            />
+          </ItemListItem>
         ))}
       </RailList>
     </PageSection>

--- a/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
@@ -6,10 +6,13 @@ import {
   BottleList,
   type BottleListItem,
   DistributionList,
+  EntityIdentityRow,
+  type EntityListItem,
   FactList,
+  ItemListItem,
+  LocationIdentityRow,
   type LocationPreviewCardProps,
   RailList,
-  RailListItem,
   TextLink,
 } from "@peated/web/components";
 import { HomeRegionGrid } from "@peated/web/components/pages/homeBrowse.stylex";
@@ -38,12 +41,7 @@ export function LocationOverview({
   visual,
 }: {
   categories: readonly { count: number; label: string }[];
-  distilleries: readonly {
-    href: string;
-    location?: string;
-    name: string;
-    totalBottles: number;
-  }[];
+  distilleries: readonly EntityListItem[];
   distillersHref: string;
   flavorProfile?: ReactNode;
   latestReleases: readonly BottleListItem[];
@@ -89,14 +87,13 @@ export function LocationOverview({
             >
               <RailList ariaLabel="Other regions">
                 {otherRegions.map((region) => (
-                  <RailListItem
-                    href={region.href}
-                    key={region.href}
-                    metadata={`${region.totalBottles.toLocaleString("en-US")} ${
-                      region.totalBottles === 1 ? "bottle" : "bottles"
-                    }`}
-                    title={region.name}
-                  />
+                  <ItemListItem key={region.href}>
+                    <LocationIdentityRow
+                      href={region.href}
+                      name={region.name}
+                      variant="sidebar"
+                    />
+                  </ItemListItem>
                 ))}
               </RailList>
             </PageSection>
@@ -133,19 +130,9 @@ export function LocationOverview({
         >
           <RailList ariaLabel="Distilleries">
             {distilleries.map((distillery) => (
-              <RailListItem
-                href={distillery.href}
-                key={distillery.href}
-                metadata={[
-                  distillery.location,
-                  `${distillery.totalBottles.toLocaleString("en-US")} ${
-                    distillery.totalBottles === 1 ? "bottle" : "bottles"
-                  }`,
-                ]
-                  .filter(Boolean)
-                  .join(" · ")}
-                title={distillery.name}
-              />
+              <ItemListItem key={distillery.href}>
+                <EntityIdentityRow {...distillery} />
+              </ItemListItem>
             ))}
           </RailList>
         </PageSection>

--- a/apps/web/src/app/(app)/locations/locationPage.ts
+++ b/apps/web/src/app/(app)/locations/locationPage.ts
@@ -5,6 +5,7 @@ import type {
   PageTabItem,
 } from "@peated/web/components";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 import { getRegionMap } from "@peated/web/lib/locationMap";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
@@ -79,11 +80,7 @@ export function getLocationLatestReleases(bottles: readonly Bottle[]) {
 export function getLocationDistilleries(distilleries: readonly Distillery[]) {
   return distilleries.map((distillery) => ({
     href: getEntityUrl(distillery),
-    location: [distillery.region?.name, distillery.country?.name]
-      .filter(Boolean)
-      .join(", "),
-    name: distillery.name,
-    totalBottles: distillery.totalBottles,
+    ...getEntityIdentityProps(distillery),
   }));
 }
 

--- a/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/series/[seriesId]/seriesPageClient.stylex.tsx
@@ -2,6 +2,7 @@
 
 import type { BOTTLE_LIST_SORT_OPTIONS } from "@peated/server/constants";
 import type { Outputs } from "@peated/server/orpc/router";
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -10,10 +11,11 @@ import { useOptimistic, useState, useTransition } from "react";
 import {
   Button,
   Chip,
+  EntityIdentityRow,
   FactList,
+  ItemListItem,
   PeatedId,
   RailList,
-  RailListItem,
   SectionError,
   TextLink,
 } from "@peated/web/components";
@@ -276,14 +278,16 @@ function SeriesDistilleries({
       <div id="series-distilleries">
         <RailList ariaLabel="Series distilleries">
           {visibleDistillers.map((distiller) => (
-            <RailListItem
-              end={`${distiller.numBottles.toLocaleString("en-US")} ${
-                distiller.numBottles === 1 ? "bottle" : "bottles"
-              }`}
-              href={getEntityUrl(distiller)}
-              key={distiller.id}
-              title={distiller.name}
-            />
+            <ItemListItem key={distiller.id}>
+              <EntityIdentityRow
+                {...getEntityIdentityProps(distiller)}
+                variant="sidebar"
+                end={`${distiller.numBottles.toLocaleString("en-US")} ${
+                  distiller.numBottles === 1 ? "bottle" : "bottles"
+                }`}
+                href={getEntityUrl(distiller)}
+              />
+            </ItemListItem>
           ))}
         </RailList>
       </div>

--- a/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/profileOverviewPageClient.stylex.tsx
@@ -1,15 +1,17 @@
 "use client";
 
 import type { Outputs } from "@peated/server/orpc/router";
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 import * as stylex from "@stylexjs/stylex";
 import { useQuery } from "@tanstack/react-query";
 
 import {
   EmptyState,
+  EntityIdentityRow,
   FactList,
+  ItemListItem,
   LoadingPlaceholder,
   RailList,
-  RailListItem,
   TastingRatingDistribution,
   type FactListItem,
   type TastingRatingCounts,
@@ -120,12 +122,14 @@ function ProducerSections({ groups }: { groups: readonly ProducerGroup[] }) {
         <RailSection heading={group.heading} key={group.heading}>
           <RailList ariaLabel={`${group.heading} tasted often`}>
             {group.items.map((producer) => (
-              <RailListItem
-                end={formatCount(producer.count)}
-                href={getEntityUrl(producer)}
-                key={producer.id}
-                title={producer.name}
-              />
+              <ItemListItem key={producer.id}>
+                <EntityIdentityRow
+                  {...getEntityIdentityProps(producer)}
+                  variant="sidebar"
+                  end={formatCount(producer.count)}
+                  href={getEntityUrl(producer)}
+                />
+              </ItemListItem>
             ))}
           </RailList>
         </RailSection>

--- a/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsPageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/users/[username]/tastings/profileTastingsPageClient.stylex.tsx
@@ -11,8 +11,8 @@ import {
   ItemList,
   ItemListItem,
   LoadingList,
+  LocationIdentityRow,
   RailList,
-  RailListItem,
   SectionError,
 } from "@peated/web/components";
 import { RailSection } from "@peated/web/components/pages/pageLayout.stylex";
@@ -124,17 +124,21 @@ function getRegionRail(
     <RailSection heading={heading}>
       <RailList ariaLabel={`${username}'s most tasted regions`}>
         {query.data.results.slice(0, 6).map((item) => (
-          <RailListItem
-            end={item.count.toLocaleString("en-US")}
-            href={
-              item.region
-                ? `/locations/${item.country.slug}/regions/${item.region.slug}`
-                : `/locations/${item.country.slug}`
-            }
+          <ItemListItem
             key={`${item.country.slug}-${item.region?.slug ?? "country"}`}
-            metadata={item.region ? item.country.name : undefined}
-            title={item.region?.name ?? item.country.name}
-          />
+          >
+            <LocationIdentityRow
+              end={item.count.toLocaleString("en-US")}
+              href={
+                item.region
+                  ? `/locations/${item.country.slug}/regions/${item.region.slug}`
+                  : `/locations/${item.country.slug}`
+              }
+              country={item.region ? item.country.name : undefined}
+              name={item.region?.name ?? item.country.name}
+              variant="sidebar"
+            />
+          </ItemListItem>
         ))}
       </RailList>
     </RailSection>

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -6,7 +6,6 @@ import {
   formatCategoryName,
   formatFlavorProfile,
 } from "@peated/server/lib/format";
-import { toTitleCase } from "@peated/server/lib/strings";
 import {
   BottleInputFields,
   EntityChoiceSchema,
@@ -18,6 +17,7 @@ import type { Entity, EntityKind } from "@peated/server/types";
 import {
   BottleIdentityRow,
   Button,
+  EntityPicker,
   Field,
   FieldGroup,
   FormActions,
@@ -27,19 +27,19 @@ import {
   FormSection,
   FormStack,
   PictureInput,
-  ProducerPicker,
   SearchPicker,
   Select,
   Switch,
   Textarea,
   TextInput,
   UnitInput,
-  type ProducerPickerOption,
+  type EntityPickerOption,
   type SearchPickerOption,
 } from "@peated/web/components";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
 import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 import {
   getFormErrorMessage,
   toChoiceValue,
@@ -226,25 +226,15 @@ function choiceId(value: number | Entity | ChoiceLike) {
   return value.id ? String(value.id) : `new:${value.name}`;
 }
 
-function choiceDetail(value: number | Entity | ChoiceLike) {
-  if (isNumericChoice(value)) return "Existing catalog item";
-  if (isCatalogEntity(value)) {
-    return [toTitleCase(value.kind), value.region?.name ?? value.country?.name]
-      .filter(Boolean)
-      .join(" · ");
-  }
-  return value.id ? "Existing catalog item" : "New catalog item";
-}
-
-function toProducerPickerOption(
+function toEntityPickerOption(
   value: number | Entity | ChoiceLike | null | undefined,
-): ProducerPickerOption | null {
+): EntityPickerOption | null {
   if (value === null || value === undefined) return null;
   return {
-    detail: choiceDetail(value),
     id: choiceId(value),
-    meta: isCatalogEntity(value) ? value.peatedId : "Bottle form",
-    name: choiceName(value),
+    ...(isCatalogEntity(value)
+      ? getEntityIdentityProps(value)
+      : { name: choiceName(value) }),
   };
 }
 
@@ -252,31 +242,31 @@ function toSearchPickerOption(
   value: number | Entity | ChoiceLike,
 ): SearchPickerOption {
   return {
-    detail: choiceDetail(value),
+    entity: isCatalogEntity(value)
+      ? getEntityIdentityProps(value)
+      : { name: choiceName(value) },
     id: choiceId(value),
     label: choiceName(value),
   };
 }
 
-function producerPickerOption(entity: Entity): ProducerPickerOption {
+function entityPickerOption(entity: Entity): EntityPickerOption {
   return {
-    detail: choiceDetail(entity),
     id: String(entity.id),
-    meta: entity.peatedId,
-    name: entity.name,
+    ...getEntityIdentityProps(entity),
   };
 }
 
 function entitySearchOption(entity: Entity): SearchPickerOption {
   return {
-    detail: choiceDetail(entity),
+    entity: getEntityIdentityProps(entity),
     id: String(entity.id),
     label: entity.name,
   };
 }
 
 function entityChoiceFromOption(
-  option: ProducerPickerOption,
+  option: EntityPickerOption,
   kind: EntityKind,
 ): z.infer<typeof EntityChoiceSchema> {
   return option.id.startsWith("new:")
@@ -299,11 +289,10 @@ function draftSeries(name: string): NonNullable<FormSchemaType["series"]> {
 function makeDraftEntityOption(
   name: string,
   kind: EntityKind,
-): ProducerPickerOption {
+): EntityPickerOption {
   return {
-    detail: `New ${toTitleCase(kind).toLocaleLowerCase()}`,
     id: `new:${name}`,
-    meta: "Will be created on save",
+    kind,
     name,
   };
 }
@@ -335,11 +324,11 @@ export default function BottleForm({
   const [brandQuery, setBrandQuery] = useState("");
   const [bottlerQuery, setBottlerQuery] = useState("");
   const [distillerQuery, setDistillerQuery] = useState("");
-  const [brand, setBrand] = useState<ProducerPickerOption | null>(() =>
-    toProducerPickerOption(initialData.brand),
+  const [brand, setBrand] = useState<EntityPickerOption | null>(() =>
+    toEntityPickerOption(initialData.brand),
   );
-  const [bottler, setBottler] = useState<ProducerPickerOption | null>(() =>
-    toProducerPickerOption(initialData.bottler),
+  const [bottler, setBottler] = useState<EntityPickerOption | null>(() =>
+    toEntityPickerOption(initialData.bottler),
   );
   const [distillers, setDistillers] = useState<readonly SearchPickerOption[]>(
     () => initialData.distillers?.map(toSearchPickerOption) ?? [],
@@ -488,7 +477,7 @@ export default function BottleForm({
             <FormNotice role="alert">{submitError}</FormNotice>
           ) : null}
           <FormSection title="Bottle details">
-            <ProducerPicker
+            <EntityPicker
               error={errors.brand?.message}
               help="The main label the bottle is sold under."
               kind="brand"
@@ -521,7 +510,7 @@ export default function BottleForm({
               }}
               onQueryChange={setBrandQuery}
               options={(brandResults.data?.results ?? []).map(
-                producerPickerOption,
+                entityPickerOption,
               )}
               placeholder="Laphroaig"
               required
@@ -646,7 +635,7 @@ export default function BottleForm({
               }}
               onCreate={(query) => {
                 const option: SearchPickerOption = {
-                  detail: "New distillery",
+                  entity: { name: query, kind: "distillery" },
                   id: `new:${query}`,
                   label: query,
                 };
@@ -664,7 +653,7 @@ export default function BottleForm({
               placeholder="Search distilleries"
               value={distillers}
             />
-            <ProducerPicker
+            <EntityPicker
               help="The market-facing bottler or release imprint, when one is stated."
               kind="bottler"
               loading={bottlerResults.isFetching}
@@ -690,7 +679,7 @@ export default function BottleForm({
               }}
               onQueryChange={setBottlerQuery}
               options={(bottlerResults.data?.results ?? []).map(
-                producerPickerOption,
+                entityPickerOption,
               )}
               placeholder="Search bottlers"
               value={bottler}

--- a/apps/web/src/components/catalogTable.stylex.tsx
+++ b/apps/web/src/components/catalogTable.stylex.tsx
@@ -1,9 +1,9 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
 
-import { foundationStyles } from "../../styles/foundations.stylex";
-import { colors, space } from "../../styles/tokens.stylex";
-import { linkedRowStyles } from "../linkedRow.stylex";
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, space } from "../styles/tokens.stylex";
+import { linkedRowStyles } from "./linkedRow.stylex";
 
 const COMPACT = "@media (max-width: 639px)";
 
@@ -177,7 +177,10 @@ const styles = stylex.create({
     },
   },
   menuWidth: {
-    width: "40px",
+    // CatalogTable leaves 12px on each side of the 44px mobile action target.
+    width: "68px",
+    paddingRight: space.x3,
+    paddingLeft: space.x3,
   },
   ratingWidth: {
     width: "184px",

--- a/apps/web/src/components/entityField.tsx
+++ b/apps/web/src/components/entityField.tsx
@@ -1,6 +1,8 @@
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import SelectField, { type Option } from "./selectField";
 
+/** API-backed entity field for admin forms. Use EntityPicker for supplied options. */
 export default function EntityField({
   ...props
 }: React.ComponentProps<typeof SelectField<Option>>) {
@@ -12,7 +14,10 @@ export default function EntityField({
           query,
           limit: 25,
         });
-        return results;
+        return results.map((entity) => ({
+          ...entity,
+          entity: getEntityIdentityProps(entity),
+        }));
       }}
       {...props}
     />

--- a/apps/web/src/components/entityForm.tsx
+++ b/apps/web/src/components/entityForm.tsx
@@ -5,15 +5,15 @@ import { EntityInputSchema, EntityKindEnum } from "@peated/server/schemas";
 import type { Entity } from "@peated/server/types";
 import {
   Button,
+  EntityPicker,
   Field,
   FormNotice,
   FormSection,
   FormStack,
-  ProducerPicker,
   Select,
   Textarea,
   TextInput,
-  type ProducerPickerOption,
+  type EntityPickerOption,
 } from "@peated/web/components";
 import {
   entityImageDrafts,
@@ -22,6 +22,7 @@ import {
 } from "@peated/web/components/entityImageEditor.stylex";
 import { WorkflowScreen } from "@peated/web/components/workflowScreen.stylex";
 import useAuth from "@peated/web/hooks/useAuth";
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 import { getFormErrorMessage } from "@peated/web/lib/formHelpers";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { zodResolver } from "@peated/web/lib/zodResolver";
@@ -59,13 +60,11 @@ export default function EntityForm({
   const [images, setImages] = useState(() =>
     entityImageDrafts(initialData.images),
   );
-  const [owner, setOwner] = useState<ProducerPickerOption | null>(() =>
+  const [owner, setOwner] = useState<EntityPickerOption | null>(() =>
     initialData.owner
       ? {
-          detail: "Currently part of",
           id: String(initialData.owner.id),
-          meta: initialData.owner.peatedId,
-          name: initialData.owner.name,
+          ...getEntityIdentityProps(initialData.owner),
         }
       : null,
   );
@@ -280,9 +279,8 @@ export default function EntityForm({
             }
             title="Details"
           >
-            <ProducerPicker
+            <EntityPicker
               help="The company or organization this is part of, when known."
-              kind="producer"
               label="Part of"
               loading={ownerResults.isFetching}
               onChange={(value) => {
@@ -291,15 +289,8 @@ export default function EntityForm({
               }}
               onQueryChange={setOwnerQuery}
               options={(ownerResults.data?.results ?? []).map((item) => ({
-                detail: [
-                  toTitleCase(item.kind),
-                  item.region?.name ?? item.country?.name,
-                ]
-                  .filter(Boolean)
-                  .join(" · "),
                 id: String(item.id),
-                meta: item.peatedId,
-                name: item.name,
+                ...getEntityIdentityProps(item),
               }))}
               placeholder="Search brands and producers"
               value={owner}

--- a/apps/web/src/components/entityIdentityRow.stories.tsx
+++ b/apps/web/src/components/entityIdentityRow.stories.tsx
@@ -1,0 +1,178 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import * as stylex from "@stylexjs/stylex";
+import { useState } from "react";
+
+import { EntityIdentityRow } from "./entityIdentityRow.stylex";
+import { EntityPicker, type EntityPickerOption } from "./entityPicker.stylex";
+import { ItemList, ItemListItem } from "./itemList.stylex";
+import {
+  EntityCatalogList,
+  type EntityCatalogItem,
+} from "./pages/entityCatalog.stylex";
+import { SearchResults } from "./searchResults.stylex";
+import { SectionHeading } from "./sectionHeading.stylex";
+import { StoryCanvas, StoryStack } from "./storyFixtures.stylex";
+
+const entries: EntityCatalogItem[] = [
+  {
+    id: 1129,
+    href: "/entities/1129",
+    name: "Laphroaig",
+    kind: "distillery",
+    location: "Islay, Scotland",
+    isFollowing: true,
+    totalBottles: 207,
+    totalTastings: 22,
+    createBottleHref: "/bottles/new?distiller=1129",
+  },
+  {
+    id: 493,
+    href: "/entities/493",
+    name: "Yamazaki",
+    kind: "distillery",
+    location: "Osaka, Japan",
+    isFollowing: false,
+    totalBottles: 162,
+    totalTastings: 13,
+  },
+  {
+    id: 3,
+    href: "/entities/3",
+    name: "The Glasgow Distillery Company with a long catalog name",
+    kind: "company",
+    isFollowing: false,
+    totalBottles: 0,
+    totalTastings: 0,
+  },
+];
+const meta = {
+  title: "Components/Catalog/Brand and Producer Identity Row",
+  component: EntityIdentityRow,
+  args: {
+    name: "Laphroaig",
+    kind: "distillery",
+    location: "Islay, Scotland",
+    href: "/entities/1129",
+  },
+  decorators: [
+    (Story) => (
+      <StoryCanvas width="wide">
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Use this component for every brand or producer row. Identity contains its name, known kind and location, and following status. Use getEntityIdentityProps for API reads. Keep IDs and descriptions on detail screens; counts and actions belong in end or separate table cells. Standard rows use 18px titles; search and sidebar use 15px titles. Names and metadata wrap. Use layout=cell inside a table or selection control. Row Layouts compares the real catalog, sidebar, search, and picker components.",
+      },
+    },
+  },
+} satisfies Meta<typeof EntityIdentityRow>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {
+  render: (args) => (
+    <ItemList ariaLabel="Brand and producer identity examples">
+      <ItemListItem>
+        <EntityIdentityRow {...args} />
+      </ItemListItem>
+      <ItemListItem>
+        <EntityIdentityRow {...args} isFollowing />
+      </ItemListItem>
+      <ItemListItem>
+        <EntityIdentityRow
+          name="Producer with no location recorded"
+          kind="bottler"
+          href="/entities/3"
+        />
+      </ItemListItem>
+      <ItemListItem>
+        <EntityIdentityRow
+          name="A long brand or producer name that wraps while keeping its full identity available"
+          kind="company"
+          location="A long region name, Scotland"
+          href="/entities/4"
+        />
+      </ItemListItem>
+    </ItemList>
+  ),
+};
+export const RowLayouts: Story = { render: () => <RowLayoutsExample /> };
+function RowLayoutsExample() {
+  const [items, setItems] = useState(entries);
+  const [selection, setSelection] = useState<EntityPickerOption | null>({
+    id: String(entries[0].id),
+    name: entries[0].name,
+    kind: entries[0].kind,
+    location: entries[0].location,
+  });
+  return (
+    <StoryStack>
+      <SectionHeading>Catalog</SectionHeading>
+      <EntityCatalogList
+        items={items}
+        noun="distiller"
+        onSortChange={() => undefined}
+        onToggleFollowing={(item) =>
+          setItems(
+            items.map((entry) =>
+              entry.id === item.id
+                ? { ...entry, isFollowing: !entry.isFollowing }
+                : entry,
+            ),
+          )
+        }
+        page={1}
+        sort="name"
+        sortOptions={[{ label: "Name", value: "name" }]}
+        total={items.length}
+      />
+      <SectionHeading>Sidebar</SectionHeading>
+      <div {...stylex.props(styles.sidebar)}>
+        <ItemList ariaLabel="Related producers">
+          {items.map((item) => (
+            <ItemListItem key={item.id}>
+              <EntityIdentityRow {...item} variant="sidebar" />
+            </ItemListItem>
+          ))}
+        </ItemList>
+      </div>
+      <SectionHeading>Search</SectionHeading>
+      <SearchResults
+        query=""
+        groups={[
+          {
+            id: "distillers",
+            label: "Distillers",
+            items: items.map((item) => ({
+              id: String(item.id),
+              href: item.href,
+              title: item.name,
+              entity: {
+                name: item.name,
+                kind: item.kind,
+                location: item.location,
+              },
+            })),
+          },
+        ]}
+      />
+      <SectionHeading>Selection</SectionHeading>
+      <EntityPicker
+        options={items.map((item) => ({
+          id: String(item.id),
+          name: item.name,
+          kind: item.kind,
+          location: item.location,
+        }))}
+        value={selection}
+        onChange={setSelection}
+      />
+    </StoryStack>
+  );
+}
+
+const styles = stylex.create({ sidebar: { maxWidth: "320px" } });

--- a/apps/web/src/components/entityIdentityRow.stylex.tsx
+++ b/apps/web/src/components/entityIdentityRow.stylex.tsx
@@ -1,0 +1,54 @@
+import type { EntityKind } from "@peated/server/types";
+
+import { MemberStatus } from "./memberStatus.stylex";
+import {
+  TextIdentityRow,
+  type TextIdentityRowProps,
+} from "./textIdentityRow.stylex";
+
+/** Display facts shared by entity rows and selection controls. */
+export type EntityIdentity = {
+  name: string;
+  isFollowing?: boolean;
+  kind?: EntityKind;
+  location?: string;
+};
+
+export type EntityIdentityRowProps = Omit<
+  TextIdentityRowProps,
+  "metadata" | "status"
+> &
+  EntityIdentity;
+
+/** A linked brand or producer identity, independent of the page that lists it. */
+export type EntityListItem = EntityIdentity & { href: string };
+
+const kindLabels = {
+  brand: "Brand",
+  bottler: "Bottler",
+  distillery: "Distillery",
+  company: "Company",
+} satisfies Record<EntityKind, string>;
+
+/**
+ * Brand and producer identity in catalogs, sidebars, search, and selection.
+ * Shows the name, known kind and location, and following status. IDs, descriptions,
+ * and statistics do not belong in identity metadata. Put contextual counts or
+ * actions in end, or adjacent table cells. Use cell inside a table or picker.
+ */
+export function EntityIdentityRow({
+  isFollowing = false,
+  kind,
+  location,
+  ...props
+}: EntityIdentityRowProps) {
+  return (
+    <TextIdentityRow
+      {...props}
+      metadata={[kind ? kindLabels[kind] : null, location]
+        .filter(Boolean)
+        .join(" · ")}
+      status={isFollowing ? <MemberStatus kind="following" /> : undefined}
+    />
+  );
+}

--- a/apps/web/src/components/entityPicker.stories.tsx
+++ b/apps/web/src/components/entityPicker.stories.tsx
@@ -3,18 +3,15 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { useState } from "react";
 
-import {
-  ProducerPicker,
-  type ProducerPickerOption,
-} from "./producerPicker.stylex";
+import { EntityPicker, type EntityPickerOption } from "./entityPicker.stylex";
 import { distillerOptions } from "./storyData";
 import { StoryCanvas, StoryStack } from "./storyFixtures.stylex";
 
 const meta = {
   title: "Components/Catalog/Brand and Producer Picker",
-  component: ProducerPicker,
+  component: EntityPicker,
   args: {
-    kind: "distiller",
+    kind: "distillery",
     onChange: () => undefined,
     options: distillerOptions,
     value: null,
@@ -31,16 +28,16 @@ const meta = {
       </StoryCanvas>
     ),
   ],
-} satisfies Meta<typeof ProducerPicker>;
+} satisfies Meta<typeof EntityPicker>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const Search: Story = {
+export const Overview: Story = {
   render: (args) => (
     <StoryStack>
-      <ControlledProducerPicker {...args} />
-      <ControlledProducerPicker
+      <ControlledEntityPicker {...args} />
+      <ControlledEntityPicker
         {...args}
         error="Brand is required."
         kind="brand"
@@ -52,18 +49,18 @@ export const Search: Story = {
 
 export const Selected: Story = {
   args: { value: distillerOptions[0] },
-  render: (args) => <ControlledProducerPicker {...args} />,
+  render: (args) => <ControlledEntityPicker {...args} />,
 };
 
 export const WithCreateHandoff: Story = {
   render: (args) => (
-    <ControlledProducerPicker {...args} onCreate={() => undefined} />
+    <ControlledEntityPicker {...args} onCreate={() => undefined} />
   ),
 };
 
-function ControlledProducerPicker(
-  props: React.ComponentProps<typeof ProducerPicker>,
+function ControlledEntityPicker(
+  props: React.ComponentProps<typeof EntityPicker>,
 ) {
-  const [value, setValue] = useState<ProducerPickerOption | null>(props.value);
-  return <ProducerPicker {...props} onChange={setValue} value={value} />;
+  const [value, setValue] = useState<EntityPickerOption | null>(props.value);
+  return <EntityPicker {...props} onChange={setValue} value={value} />;
 }

--- a/apps/web/src/components/entityPicker.stylex.tsx
+++ b/apps/web/src/components/entityPicker.stylex.tsx
@@ -1,53 +1,52 @@
 "use client";
 
+import type { EntityKind } from "@peated/server/types";
 import { useMemo, type ReactNode } from "react";
+import type { EntityIdentity } from "./entityIdentityRow.stylex";
 
 import { SearchSelect, type SearchPickerOption } from "./searchPicker.stylex";
 
-export type ProducerPickerKind = "brand" | "bottler" | "distiller" | "producer";
+export type EntityPickerOption = Pick<
+  EntityIdentity,
+  "name" | "kind" | "location"
+> & { id: string };
 
-export type ProducerPickerOption = {
-  detail: string;
-  id: string;
-  meta: string;
-  name: string;
-};
-
-export type ProducerPickerProps = {
+export type EntityPickerProps = {
   error?: ReactNode;
   help?: string;
-  kind: ProducerPickerKind;
+  /** Stored entity kind for creation copy; omit when choosing across kinds. */
+  kind?: EntityKind;
   label?: string;
   loading?: boolean;
-  onChange: (value: ProducerPickerOption | null) => void;
+  onChange: (value: EntityPickerOption | null) => void;
   onCreate?: (query: string) => void;
   onQueryChange?: (query: string) => void;
-  options: readonly ProducerPickerOption[];
+  options: readonly EntityPickerOption[];
   placeholder?: string;
   required?: boolean;
-  value: ProducerPickerOption | null;
+  value: EntityPickerOption | null;
 };
 
 const kindCopy = {
   brand: { label: "Brand", plural: "brands", singular: "brand" },
   bottler: { label: "Bottler", plural: "bottlers", singular: "bottler" },
-  distiller: {
+  distillery: {
     label: "Distiller",
     plural: "distillers",
     singular: "distiller",
   },
-  producer: {
-    label: "Brand or producer",
-    plural: "brands and producers",
-    singular: "brand or producer",
-  },
+  company: { label: "Company", plural: "companies", singular: "company" },
 } satisfies Record<
-  ProducerPickerKind,
+  EntityKind,
   { label: string; plural: string; singular: string }
 >;
 
-/** Supplies brand and producer choices to the shared single-choice picker. */
-export function ProducerPicker({
+/**
+ * Selects one supplied brand, distillery, bottler, or company. Uses stored kinds;
+ * the caller owns queries, filtering, and creation. EntityField is the API-backed
+ * field adapter; EntityIdentityRow owns the identity displayed by this picker.
+ */
+export function EntityPicker({
   error,
   help,
   kind,
@@ -60,8 +59,14 @@ export function ProducerPicker({
   placeholder,
   required = false,
   value,
-}: ProducerPickerProps) {
-  const copy = kindCopy[kind];
+}: EntityPickerProps) {
+  const copy = kind
+    ? kindCopy[kind]
+    : {
+        label: "Brand or producer",
+        plural: "brands and producers",
+        singular: "brand or producer",
+      };
   const entitiesById = useMemo(
     () =>
       new Map(
@@ -73,12 +78,15 @@ export function ProducerPicker({
     [options, value],
   );
 
-  function toPickerOption(option: ProducerPickerOption): SearchPickerOption {
+  function toPickerOption(option: EntityPickerOption): SearchPickerOption {
     return {
-      detail: `${option.id} · ${option.meta}`,
+      entity: {
+        name: option.name,
+        kind: option.kind,
+        location: option.location,
+      },
       id: option.id,
       label: option.name,
-      selectedDetail: option.detail,
     };
   }
 

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -65,6 +65,17 @@ export { DataTable } from "./dataTable.stylex";
 export type { DataTableColumn, DataTableProps } from "./dataTable.stylex";
 export { DistributionList } from "./distributionList.stylex";
 export type { DistributionListItem } from "./distributionList.stylex";
+export { EntityIdentityRow } from "./entityIdentityRow.stylex";
+export type {
+  EntityIdentity,
+  EntityIdentityRowProps,
+  EntityListItem,
+} from "./entityIdentityRow.stylex";
+export { EntityPicker } from "./entityPicker.stylex";
+export type {
+  EntityPickerOption,
+  EntityPickerProps,
+} from "./entityPicker.stylex";
 export { ExpandableDescription } from "./expandableDescription.stylex";
 export { FacetRow } from "./facetRow.stylex";
 export type { FacetRowProps } from "./facetRow.stylex";
@@ -163,6 +174,8 @@ export type {
 } from "./lists.stylex";
 export { LocationCard } from "./locationCard.stylex";
 export type { LocationCardProps } from "./locationCard.stylex";
+export { LocationIdentityRow } from "./locationIdentityRow.stylex";
+export type { LocationIdentityRowProps } from "./locationIdentityRow.stylex";
 export { LocationPreviewCard } from "./locationPreviewCard.stylex";
 export type { LocationPreviewCardProps } from "./locationPreviewCard.stylex";
 export { MemberAvatar } from "./memberAvatar";
@@ -181,12 +194,6 @@ export type {
 } from "./notePicker.stylex";
 export { PageTabs } from "./pageTabs.stylex";
 export type { PageTabItem, PageTabsProps } from "./pageTabs.stylex";
-export { ProducerPicker } from "./producerPicker.stylex";
-export type {
-  ProducerPickerKind,
-  ProducerPickerOption,
-  ProducerPickerProps,
-} from "./producerPicker.stylex";
 export { RowMenu } from "./rowMenu.stylex";
 export type { RowMenuGroup, RowMenuItem, RowMenuProps } from "./rowMenu.stylex";
 export { ScopedSearch } from "./scopedSearch.stylex";
@@ -227,6 +234,8 @@ export type {
 export { SectionHeading } from "./sectionHeading.stylex";
 export { SelectedBottleSummary } from "./selectedBottleSummary.stylex";
 export type { SelectedBottleSummaryProps } from "./selectedBottleSummary.stylex";
+export { SeriesIdentityRow } from "./seriesIdentityRow.stylex";
+export type { SeriesIdentityRowProps } from "./seriesIdentityRow.stylex";
 export { SiteFooter } from "./siteFooter.stylex";
 export type { FooterLink, SiteFooterProps } from "./siteFooter.stylex";
 export { Slideout } from "./slideout.stylex";

--- a/apps/web/src/components/lists.stylex.tsx
+++ b/apps/web/src/components/lists.stylex.tsx
@@ -192,7 +192,7 @@ export type RailListItemProps = {
   title: string;
 };
 
-/** Generic sidebar links, such as reviewers or places. Use BottleList for bottles. */
+/** Generic sidebar links, such as help pages or reviewers. Catalog items use their domain IdentityRow inside ItemListItem. */
 export function RailListItem({
   end,
   href,

--- a/apps/web/src/components/locationIdentityRow.stories.tsx
+++ b/apps/web/src/components/locationIdentityRow.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { ItemList, ItemListItem } from "./itemList.stylex";
+import { LocationIdentityRow } from "./locationIdentityRow.stylex";
+import { StoryCanvas } from "./storyFixtures.stylex";
+const meta = {
+  title: "Components/Catalog/Location Identity Row",
+  component: LocationIdentityRow,
+  args: {
+    name: "Islay",
+    country: "Scotland",
+    href: "/locations/scotland/regions/islay",
+  },
+  decorators: [
+    (Story) => (
+      <StoryCanvas>
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+} satisfies Meta<typeof LocationIdentityRow>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Overview: Story = {
+  render: (args) => (
+    <ItemList ariaLabel="Locations">
+      <ItemListItem>
+        <LocationIdentityRow {...args} />
+      </ItemListItem>
+      <ItemListItem>
+        <LocationIdentityRow name="Scotland" href="/locations/scotland" />
+      </ItemListItem>
+    </ItemList>
+  ),
+};

--- a/apps/web/src/components/locationIdentityRow.stylex.tsx
+++ b/apps/web/src/components/locationIdentityRow.stylex.tsx
@@ -1,0 +1,19 @@
+import {
+  TextIdentityRow,
+  type TextIdentityRowProps,
+} from "./textIdentityRow.stylex";
+
+export type LocationIdentityRowProps = Omit<
+  TextIdentityRowProps,
+  "metadata" | "status"
+> & {
+  country?: string;
+};
+
+/** Country or region identity for lists and search; regions include their country when known. */
+export function LocationIdentityRow({
+  country,
+  ...props
+}: LocationIdentityRowProps) {
+  return <TextIdentityRow {...props} metadata={country} />;
+}

--- a/apps/web/src/components/pages/entityCatalog.stylex.tsx
+++ b/apps/web/src/components/pages/entityCatalog.stylex.tsx
@@ -8,28 +8,22 @@ import {
   ButtonLink,
   CursorPager,
   EmptyState,
+  EntityIdentityRow,
   FacetGroup,
   FilterPanel,
   ListToolbar,
-  MemberStatus,
   RowMenu,
+  type EntityListItem,
   type ListSortOption,
   type RowMenuItem,
 } from "..";
-import { foundationStyles } from "../../styles/foundations.stylex";
-import { colors } from "../../styles/tokens.stylex";
-import { AppLink } from "../appLink";
-import { linkedRowStyles } from "../linkedRow.stylex";
+import { CatalogTable, type CatalogTableColumn } from "../catalogTable.stylex";
 import { CatalogPageLoading } from "./catalogPage.stylex";
-import { CatalogTable, type CatalogTableColumn } from "./catalogTable.stylex";
 
-export type EntityCatalogItem = {
+export type EntityCatalogItem = EntityListItem & {
   createBottleHref?: string;
-  href: string;
   id: number;
   isFollowing: boolean;
-  metadata: readonly string[];
-  name: string;
   totalBottles: number;
   totalTastings: number;
 };
@@ -178,25 +172,16 @@ function EntityCatalogTable({
   const columns: CatalogTableColumn<EntityCatalogItem>[] = [
     {
       cell: (item) => (
-        <>
-          <AppLink
-            href={item.href}
-            {...stylex.props(
-              foundationStyles.rowTitle,
-              styles.title,
-              linkedRowStyles.primaryLink,
-            )}
-          >
-            {item.name}
-            {item.isFollowing && showFollowingMarks ? (
-              <MemberStatus kind="following" />
-            ) : null}
-          </AppLink>
-          <div {...stylex.props(foundationStyles.metadata, styles.metadata)}>
-            {item.metadata.join(" · ")}
-          </div>
-        </>
+        <EntityIdentityRow
+          href={item.href}
+          name={item.name}
+          kind={item.kind}
+          location={item.location}
+          isFollowing={item.isFollowing && showFollowingMarks}
+          layout="cell"
+        />
       ),
+      padding: "flush",
       header: "Name",
       key: "name",
     },
@@ -234,7 +219,6 @@ function EntityCatalogTable({
       header: <span {...stylex.props(styles.visuallyHidden)}>Actions</span>,
       interactive: true,
       key: "actions",
-      priority: "secondary",
       width: "menu",
     });
   }
@@ -325,20 +309,5 @@ const styles = stylex.create({
   },
   catalog: {
     minWidth: 0,
-  },
-  title: {
-    display: "block",
-    overflow: "hidden",
-    color: colors.ink,
-    textDecoration: "none",
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
-  },
-  metadata: {
-    marginTop: "3px",
-    overflow: "hidden",
-    color: colors.inkMuted,
-    textOverflow: "ellipsis",
-    whiteSpace: "nowrap",
   },
 });

--- a/apps/web/src/components/pages/entityCatalog.test.ts
+++ b/apps/web/src/components/pages/entityCatalog.test.ts
@@ -10,7 +10,7 @@ const item: EntityCatalogItem = {
   href: "/brands/42",
   id: 42,
   isFollowing: false,
-  metadata: ["Brand"],
+  kind: "brand",
   name: "Example Brand",
   totalBottles: 3,
   totalTastings: 8,

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -8,8 +8,10 @@ import { TextLink } from "../textLink.stylex";
 import {
   BottleList,
   type BottleListItem,
+  EntityIdentityRow,
+  type EntityListItem,
   ItemList,
-  ItemRow,
+  ItemListItem,
   LocationPreviewCard,
   type LocationPreviewCardProps,
 } from "..";
@@ -112,10 +114,6 @@ export function HomeActivityFeed({ children }: { children: ReactNode }) {
   );
 }
 
-function formatBottleCount(count: number) {
-  return `${count.toLocaleString("en-US")} ${count === 1 ? "bottle" : "bottles"}`;
-}
-
 /** Keeps homepage and country overview location previews identical. */
 export function HomeRegionGrid({
   regions,
@@ -187,18 +185,11 @@ export function HomeOrigins({
   );
 }
 
-export type HomeDistillery = {
-  href: string;
-  location?: string;
-  name: string;
-  totalBottles: number;
-};
-
 export function HomeDistilleries({
   distilleries,
   totalDistilleries,
 }: {
-  distilleries: readonly HomeDistillery[];
+  distilleries: readonly EntityListItem[];
   totalDistilleries?: number;
 }) {
   return (
@@ -207,17 +198,9 @@ export function HomeDistilleries({
       <div {...stylex.props(styles.distilleries)}>
         <ItemList ariaLabel="Distilleries">
           {distilleries.map((distillery) => (
-            <ItemRow
-              href={distillery.href}
-              key={distillery.href}
-              metadata={
-                <>
-                  {distillery.location ? `${distillery.location} · ` : null}
-                  {formatBottleCount(distillery.totalBottles)}
-                </>
-              }
-              title={distillery.name}
-            />
+            <ItemListItem key={distillery.href}>
+              <EntityIdentityRow {...distillery} />
+            </ItemListItem>
           ))}
         </ItemList>
       </div>

--- a/apps/web/src/components/search/search.stylex.tsx
+++ b/apps/web/src/components/search/search.stylex.tsx
@@ -9,6 +9,7 @@ import { Button, SearchBox } from "@peated/web/components";
 import { getCreateBottleHref } from "@peated/web/components/search/createBottleHref";
 import useAuth from "@peated/web/hooks/useAuth";
 import { getBottleIdentityProps } from "@peated/web/lib/bottleListItem";
+import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import {
   addRecentSearch,
@@ -198,14 +199,8 @@ function entityItem(entity: EntitySearchResult) {
   return {
     href: getEntityUrl(entity),
     id: `entity-${entity.id}`,
-    isFollowing: entity.isFollowing,
-    metadata: entity.region?.name,
+    entity: getEntityIdentityProps(entity),
     title: entity.name,
-    visual: {
-      kind: "initial",
-      fallback: entity.name.slice(0, 1).toLocaleUpperCase(),
-      label: entity.name,
-    },
   } satisfies SearchResultItem;
 }
 
@@ -213,13 +208,8 @@ function seriesItem(series: SeriesSearchResult) {
   return {
     href: getBottleSeriesUrl(series),
     id: `series-${series.id}`,
-    metadata: `${series.brand.name} · ${series.numReleases.toLocaleString("en-US")} ${series.numReleases === 1 ? "bottle" : "bottles"}`,
+    series: { brand: series.brand.name },
     title: series.name,
-    visual: {
-      kind: "initial",
-      fallback: "S",
-      label: series.fullName,
-    },
   } satisfies SearchResultItem;
 }
 
@@ -242,13 +232,8 @@ function regionItem(region: RegionSearchResult) {
   return {
     href: `/locations/${region.country.slug}/regions/${region.slug}`,
     id: `region-${region.id}`,
-    metadata: `${region.country.name} · ${region.totalDistillers.toLocaleString("en-US")} ${region.totalDistillers === 1 ? "distillery" : "distilleries"}`,
+    location: { country: region.country.name },
     title: region.name,
-    visual: {
-      kind: "initial",
-      fallback: region.name.slice(0, 1).toLocaleUpperCase(),
-      label: region.name,
-    },
   } satisfies SearchResultItem;
 }
 

--- a/apps/web/src/components/searchBox.stories.tsx
+++ b/apps/web/src/components/searchBox.stories.tsx
@@ -3,9 +3,9 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { useState } from "react";
 
-import { SearchBox } from "../searchBox.stylex";
-import { searchResultGroups } from "../storyData";
-import { StoryCanvas } from "../storyFixtures.stylex";
+import { SearchBox } from "./searchBox.stylex";
+import { searchResultGroups } from "./storyData";
+import { StoryCanvas } from "./storyFixtures.stylex";
 
 const scopes = [
   { count: 232808, label: "Everything", value: "everything" },

--- a/apps/web/src/components/searchPicker.stylex.tsx
+++ b/apps/web/src/components/searchPicker.stylex.tsx
@@ -4,6 +4,10 @@ import * as stylex from "@stylexjs/stylex";
 import { X } from "lucide-react";
 import type { FocusEvent, ReactNode } from "react";
 import { useId, useMemo, useState } from "react";
+import {
+  EntityIdentityRow,
+  type EntityIdentity,
+} from "./entityIdentityRow.stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
 import {
@@ -25,6 +29,7 @@ import { ValidationMessage } from "./field.stylex";
 import { useListboxNavigation } from "./useListboxNavigation";
 
 export type SearchPickerOption = {
+  entity?: Pick<EntityIdentity, "name" | "kind" | "location">;
   /** Build bottle selections with toBottlePickerOption to retain all identity lines. */
   bottle?: Pick<
     BottleIdentityRowProps,
@@ -33,7 +38,6 @@ export type SearchPickerOption = {
   detail?: string;
   id: number | string;
   label: string;
-  selectedDetail?: string;
 };
 
 export type SearchPickerProps = {
@@ -209,6 +213,12 @@ function PickerControl({
           <div {...stylex.props(styles.selectedCopy)}>
             {value[0].bottle ? (
               <BottleIdentityRow {...value[0].bottle} layout="cell" />
+            ) : value[0].entity ? (
+              <EntityIdentityRow
+                {...value[0].entity}
+                layout="cell"
+                variant="search"
+              />
             ) : (
               <>
                 <span
@@ -220,15 +230,15 @@ function PickerControl({
                 >
                   {value[0].label}
                 </span>
-                {(value[0].selectedDetail ?? value[0].detail) ? (
+                {value[0].detail ? (
                   <span
-                    title={value[0].selectedDetail ?? value[0].detail}
+                    title={value[0].detail}
                     {...stylex.props(
                       foundationStyles.metadata,
                       styles.selectedDetail,
                     )}
                   >
-                    {value[0].selectedDetail ?? value[0].detail}
+                    {value[0].detail}
                   </span>
                 ) : null}
               </>
@@ -252,10 +262,30 @@ function PickerControl({
         >
           {value.map((option) =>
             option.bottle ? (
-              <div key={option.id} {...stylex.props(styles.selectedBottle)}>
+              <div key={option.id} {...stylex.props(styles.selectedIdentity)}>
                 <BottleIdentityRow
                   {...option.bottle}
                   layout="cell"
+                  end={
+                    <IconButton
+                      disabled={disabled}
+                      icon={<X aria-hidden="true" size={16} />}
+                      label={`Remove ${option.label}`}
+                      onClick={() =>
+                        onChange(value.filter((item) => item.id !== option.id))
+                      }
+                      size="sm"
+                      variant="text"
+                    />
+                  }
+                />
+              </div>
+            ) : option.entity ? (
+              <div key={option.id} {...stylex.props(styles.selectedIdentity)}>
+                <EntityIdentityRow
+                  {...option.entity}
+                  layout="cell"
+                  variant="search"
                   end={
                     <IconButton
                       disabled={disabled}
@@ -347,7 +377,8 @@ function PickerControl({
                       type="button"
                       {...stylex.props(
                         styles.result,
-                        Boolean(option.bottle) && styles.bottleResult,
+                        Boolean(option.bottle || option.entity) &&
+                          styles.identityResult,
                         index === activeIndex && styles.activeResult,
                       )}
                     >
@@ -356,6 +387,13 @@ function PickerControl({
                           {...option.bottle}
                           layout="cell"
                           query={query}
+                        />
+                      ) : option.entity ? (
+                        <EntityIdentityRow
+                          {...option.entity}
+                          layout="cell"
+                          query={query}
+                          variant="search"
                         />
                       ) : (
                         <>
@@ -453,7 +491,7 @@ const styles = stylex.create({
   label: { color: colors.inkMuted },
   required: { color: colors.accentDeep },
   selected: { display: "flex", gap: space.x2, flexWrap: "wrap" },
-  selectedBottle: { width: "100%", minWidth: 0 },
+  selectedIdentity: { width: "100%", minWidth: 0 },
   selectedControl: {
     boxSizing: "border-box",
     display: "flex",
@@ -562,7 +600,7 @@ const styles = stylex.create({
     backgroundColor: colors.inset,
     boxShadow: effects.focusRing,
   },
-  bottleResult: { paddingTop: 0, paddingBottom: 0 },
+  identityResult: { paddingTop: 0, paddingBottom: 0 },
 
   detail: {
     color: colors.inkMuted,

--- a/apps/web/src/components/searchResults.stylex.tsx
+++ b/apps/web/src/components/searchResults.stylex.tsx
@@ -1,14 +1,21 @@
 import * as stylex from "@stylexjs/stylex";
+import {
+  EntityIdentityRow,
+  type EntityIdentity,
+} from "./entityIdentityRow.stylex";
+import {
+  LocationIdentityRow,
+  type LocationIdentityRowProps,
+} from "./locationIdentityRow.stylex";
 import { SectionHeading } from "./sectionHeading.stylex";
+import {
+  SeriesIdentityRow,
+  type SeriesIdentityRowProps,
+} from "./seriesIdentityRow.stylex";
+import type { TextIdentityRowProps } from "./textIdentityRow.stylex";
 
 import { foundationStyles } from "../styles/foundations.stylex";
-import {
-  colors,
-  controlMetrics,
-  effects,
-  fonts,
-  space,
-} from "../styles/tokens.stylex";
+import { colors, effects, space } from "../styles/tokens.stylex";
 import { AppLink } from "./appLink";
 import { Avatar } from "./avatar.stylex";
 import {
@@ -18,7 +25,6 @@ import {
 import { Button, ButtonLink } from "./button.stylex";
 import { FloatingPanel } from "./feedback.stylex";
 import { MatchedText } from "./matchedText.stylex";
-import { MemberStatus } from "./memberStatus.stylex";
 import { BottleRatings, type TastingRatingCounts } from "./scoring.stylex";
 
 const COMPACT = "@media (max-width: 559px)";
@@ -34,7 +40,9 @@ export type SearchResultRatings = {
 export type SearchResultItem = {
   href: string;
   id: string;
-  isFollowing?: boolean;
+  entity?: Pick<EntityIdentity, "kind" | "location" | "isFollowing">;
+  series?: Pick<SeriesIdentityRowProps, "brand">;
+  location?: Pick<LocationIdentityRowProps, "country">;
   ratings?: SearchResultRatings;
   title: string;
 } & (
@@ -47,7 +55,7 @@ export type SearchResultItem = {
       bottle?: never;
       metadata?: string;
       visual?: {
-        kind: "avatar" | "initial";
+        kind: "avatar";
         fallback: string;
         imageUrl?: string | null;
         label: string;
@@ -252,6 +260,26 @@ function SearchResultsGroup({
   query: string;
   variant: "database" | "default";
 }) {
+  function identityProps(
+    item: SearchResultItem,
+  ): Pick<
+    TextIdentityRowProps,
+    "href" | "name" | "query" | "variant" | "onClick"
+  > {
+    return {
+      href: item.href,
+      name: item.title,
+      query,
+      variant: variant === "database" ? "standard" : "search",
+      onClick: (event) => {
+        if (onItemSelect) {
+          event.preventDefault();
+          onItemSelect(item);
+        }
+      },
+    };
+  }
+
   return (
     <section
       aria-labelledby={`${optionIdPrefix ?? "search"}-group-${group.id}`}
@@ -308,7 +336,7 @@ function SearchResultsGroup({
                 }
                 {...stylex.props(
                   styles.result,
-                  styles.bottleResult,
+                  styles.identityResult,
                   variant === "database" && styles.databaseResult,
                   item.id === activeId && styles.activeResult,
                 )}
@@ -332,6 +360,37 @@ function SearchResultsGroup({
                     ) : undefined
                   }
                 />
+              </div>
+            ) : item.entity || item.series || item.location ? (
+              <div
+                id={
+                  optionIdPrefix
+                    ? `${optionIdPrefix}-${encodeURIComponent(item.id)}`
+                    : undefined
+                }
+                {...stylex.props(
+                  styles.result,
+                  styles.identityResult,
+                  variant === "database" && styles.databaseResult,
+                  item.id === activeId && styles.activeResult,
+                )}
+              >
+                {item.entity ? (
+                  <EntityIdentityRow
+                    {...item.entity}
+                    {...identityProps(item)}
+                  />
+                ) : item.series ? (
+                  <SeriesIdentityRow
+                    {...item.series}
+                    {...identityProps(item)}
+                  />
+                ) : (
+                  <LocationIdentityRow
+                    {...item.location}
+                    {...identityProps(item)}
+                  />
+                )}
               </div>
             ) : (
               <AppLink
@@ -365,9 +424,6 @@ function SearchResultsGroup({
                     )}
                   >
                     <MatchedText query={query} text={item.title} />
-                    {item.isFollowing ? (
-                      <MemberStatus kind="following" />
-                    ) : null}
                   </strong>
                   {item.metadata ? (
                     <span
@@ -405,15 +461,8 @@ function ResultVisual({
 }: {
   visual: Exclude<NonNullable<SearchResultItem["visual"]>, { kind: "bottle" }>;
 }) {
-  if (visual.kind === "avatar") {
-    return (
-      <Avatar imageUrl={visual.imageUrl} initials={visual.fallback} size="sm" />
-    );
-  }
   return (
-    <span aria-label={visual.label} role="img" {...stylex.props(styles.visual)}>
-      <span aria-hidden="true">{visual.fallback}</span>
-    </span>
+    <Avatar imageUrl={visual.imageUrl} initials={visual.fallback} size="sm" />
   );
 }
 
@@ -560,7 +609,7 @@ const styles = stylex.create({
       ":focus-visible": effects.focusRing,
     },
   },
-  bottleResult: {
+  identityResult: {
     paddingTop: 0,
     paddingBottom: 0,
   },
@@ -573,21 +622,6 @@ const styles = stylex.create({
   activeResult: {
     backgroundColor: colors.inset,
     boxShadow: effects.focusRing,
-  },
-  visual: {
-    display: "inline-flex",
-    width: "28px",
-    height: "28px",
-    flexShrink: 0,
-    alignItems: "center",
-    justifyContent: "center",
-    overflow: "hidden",
-    borderRadius: controlMetrics.radius,
-    backgroundColor: colors.inset,
-    color: colors.inkMuted,
-    fontFamily: fonts.display,
-    fontSize: "11px",
-    fontWeight: 700,
   },
   copy: {
     display: "flex",

--- a/apps/web/src/components/selectField/index.tsx
+++ b/apps/web/src/components/selectField/index.tsx
@@ -87,6 +87,7 @@ export default function SelectField<T extends Option>(props: Props<T>) {
   const byId = new Map(available.map((option) => [String(option.id), option]));
   const toPickerOption = (option: T): SearchPickerOption => ({
     bottle: option.bottle,
+    entity: option.entity,
     id: option.id ?? option.name,
     label: option.name,
   });

--- a/apps/web/src/components/selectField/types.ts
+++ b/apps/web/src/components/selectField/types.ts
@@ -2,6 +2,7 @@ import type { SearchPickerOption } from "../searchPicker.stylex";
 
 export type Option = {
   bottle?: SearchPickerOption["bottle"];
+  entity?: SearchPickerOption["entity"];
   description?: string | null;
   id?: string | number | null;
   name: string;

--- a/apps/web/src/components/seriesIdentityRow.stories.tsx
+++ b/apps/web/src/components/seriesIdentityRow.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { SeriesIdentityRow } from "./seriesIdentityRow.stylex";
+import { StoryCanvas } from "./storyFixtures.stylex";
+const meta = {
+  title: "Components/Catalog/Series Identity Row",
+  component: SeriesIdentityRow,
+  args: { name: "Elements", brand: "Laphroaig", href: "/series/1" },
+  decorators: [
+    (Story) => (
+      <StoryCanvas>
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+} satisfies Meta<typeof SeriesIdentityRow>;
+export default meta;
+type Story = StoryObj<typeof meta>;
+export const Overview: Story = {};

--- a/apps/web/src/components/seriesIdentityRow.stylex.tsx
+++ b/apps/web/src/components/seriesIdentityRow.stylex.tsx
@@ -1,0 +1,16 @@
+import {
+  TextIdentityRow,
+  type TextIdentityRowProps,
+} from "./textIdentityRow.stylex";
+
+export type SeriesIdentityRowProps = Omit<
+  TextIdentityRowProps,
+  "metadata" | "status"
+> & {
+  brand?: string;
+};
+
+/** Series identity for search and lists. Release counts belong outside the identity. */
+export function SeriesIdentityRow({ brand, ...props }: SeriesIdentityRowProps) {
+  return <TextIdentityRow {...props} metadata={brand} />;
+}

--- a/apps/web/src/components/storyData.ts
+++ b/apps/web/src/components/storyData.ts
@@ -1,28 +1,28 @@
+import type { EntityPickerOption } from "./entityPicker.stylex";
 import type { MemberPickerOption } from "./memberPicker.stylex";
 import type { NotePickerOption } from "./notePicker.stylex";
-import type { ProducerPickerOption } from "./producerPicker.stylex";
 import type { SearchResultGroup } from "./searchResults.stylex";
 
 export const distillerOptions = [
   {
-    detail: "Islay · 412 bottles · part of Rémy Cointreau",
     id: "D00192",
-    meta: "412 bottles",
     name: "Bruichladdich",
+    kind: "distillery",
+    location: "Islay, Scotland",
   },
   {
-    detail: "Islay · 86 bottles · part of Rémy Cointreau",
     id: "D00193",
-    meta: "86 bottles",
     name: "Bruichladdich (Port Charlotte)",
+    kind: "distillery",
+    location: "Islay, Scotland",
   },
   {
-    detail: "Islay · 64 bottles · part of Rémy Cointreau",
     id: "D00481",
-    meta: "64 bottles",
     name: "Bruichladdich (Octomore)",
+    kind: "distillery",
+    location: "Islay, Scotland",
   },
-] as const satisfies readonly ProducerPickerOption[];
+] as const satisfies readonly EntityPickerOption[];
 
 export const noteOptions = [
   { category: "Smoke", common: true, name: "Smoke", usageCount: 12880 },
@@ -107,9 +107,8 @@ export const searchResultGroups = [
       {
         href: "/entities/245",
         id: "entity-245",
-        metadata: "Islay",
+        entity: { kind: "distillery", location: "Islay, Scotland" },
         title: "Lagavulin",
-        visual: { kind: "initial", fallback: "L", label: "Lagavulin" },
       },
     ],
   },

--- a/apps/web/src/components/textIdentityRow.stylex.tsx
+++ b/apps/web/src/components/textIdentityRow.stylex.tsx
@@ -1,0 +1,131 @@
+import * as stylex from "@stylexjs/stylex";
+import type { MouseEventHandler, ReactNode } from "react";
+
+import { foundationStyles } from "../styles/foundations.stylex";
+import { colors, space } from "../styles/tokens.stylex";
+import { AppLink } from "./appLink";
+import { linkedRowStyles } from "./linkedRow.stylex";
+import { MatchedText } from "./matchedText.stylex";
+
+export type TextIdentityRowProps = {
+  end?: ReactNode;
+  href?: string;
+  layout?: "row" | "cell";
+  metadata?: string;
+  name: string;
+  onClick?: MouseEventHandler<HTMLAnchorElement>;
+  query?: string;
+  status?: ReactNode;
+  variant?: "standard" | "search" | "sidebar";
+};
+
+/**
+ * Internal text identity layout. Entity, series, and location rows own their
+ * domain metadata; callers use those components rather than this layout helper.
+ */
+export function TextIdentityRow({
+  end,
+  href,
+  layout = "row",
+  metadata,
+  name,
+  onClick,
+  query,
+  status,
+  variant = "standard",
+}: TextIdentityRowProps) {
+  const title = (
+    <>
+      <MatchedText query={query} text={name} />
+      {status}
+    </>
+  );
+  return (
+    <div
+      {...stylex.props(
+        styles.row,
+        variant !== "standard" && styles.compact,
+        layout === "cell" && styles.cell,
+        Boolean(href) && layout === "row" && linkedRowStyles.container,
+        Boolean(href) && layout === "row" && linkedRowStyles.onGround,
+      )}
+    >
+      <div {...stylex.props(styles.copy)}>
+        <div
+          {...stylex.props(
+            foundationStyles.rowTitle,
+            variant !== "standard" && foundationStyles.compactRowTitle,
+          )}
+        >
+          {href ? (
+            <AppLink
+              href={href}
+              onClick={onClick}
+              title={name}
+              {...stylex.props(styles.name, linkedRowStyles.primaryLink)}
+            >
+              {title}
+            </AppLink>
+          ) : (
+            <span title={name} {...stylex.props(styles.name)}>
+              {title}
+            </span>
+          )}
+        </div>
+        {metadata ? (
+          <div {...stylex.props(foundationStyles.metadata, styles.metadata)}>
+            {metadata}
+          </div>
+        ) : null}
+      </div>
+      {end ? (
+        <div
+          {...stylex.props(
+            foundationStyles.metadata,
+            styles.end,
+            linkedRowStyles.nestedAction,
+          )}
+        >
+          {end}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+const styles = stylex.create({
+  row: {
+    boxSizing: "border-box",
+    display: "flex",
+    width: "calc(100% + 24px)",
+    minWidth: 0,
+    minHeight: "44px",
+    alignItems: "center",
+    gap: space.x3,
+    marginRight: "-12px",
+    marginLeft: "-12px",
+    padding: space.x3,
+  },
+  compact: { paddingTop: space.x2, paddingBottom: space.x2 },
+  cell: {
+    width: "100%",
+    marginRight: 0,
+    marginLeft: 0,
+    paddingRight: 0,
+    paddingLeft: 0,
+  },
+  copy: { minWidth: 0, flex: 1 },
+  name: { color: colors.ink, overflowWrap: "anywhere", textDecoration: "none" },
+  metadata: {
+    marginTop: space.x1,
+    color: colors.inkMuted,
+    overflowWrap: "anywhere",
+  },
+  end: {
+    display: "flex",
+    flexShrink: 0,
+    alignItems: "center",
+    gap: space.x3,
+    fontVariantNumeric: "tabular-nums",
+  },
+});

--- a/apps/web/src/lib/entityCatalogItem.ts
+++ b/apps/web/src/lib/entityCatalogItem.ts
@@ -1,30 +1,21 @@
-import { toTitleCase } from "@peated/server/lib/strings";
 import type { Entity } from "@peated/server/types";
 
 import type { EntityCatalogItem } from "@peated/web/components/pages/entityCatalog.stylex";
 import { getEntityBottleCreateHref } from "@peated/web/lib/entityBottleCreateHref";
 import { getEntityUrl } from "@peated/web/lib/urls";
 
+import { getEntityIdentityProps } from "./entityIdentity";
+
 export function toEntityCatalogItem(
   entity: Entity,
   isFollowing = entity.isFollowing,
 ): EntityCatalogItem {
-  const location = [entity.region?.name, entity.country?.name]
-    .filter((value): value is string => Boolean(value))
-    .join(", ");
-  const metadata = [
-    entity.peatedId,
-    toTitleCase(entity.kind),
-    location || null,
-  ].filter((value): value is string => value !== null);
-
   return {
+    ...getEntityIdentityProps(entity),
     createBottleHref: getEntityBottleCreateHref(entity),
     href: getEntityUrl(entity),
     id: entity.id,
     isFollowing,
-    metadata,
-    name: entity.name,
     totalBottles: entity.totalBottles,
     totalTastings: entity.totalTastings,
   };

--- a/apps/web/src/lib/entityIdentity.ts
+++ b/apps/web/src/lib/entityIdentity.ts
@@ -1,0 +1,20 @@
+import type { Entity } from "@peated/server/types";
+import type { EntityIdentity } from "../components/entityIdentityRow.stylex";
+
+/** Uses only stored identity facts; partial reads leave missing facts absent. */
+export function getEntityIdentityProps(
+  entity: Pick<Entity, "name"> &
+    Partial<Pick<Entity, "kind" | "isFollowing">> & {
+      country?: { name: string } | null;
+      region?: { name: string } | null;
+    },
+): EntityIdentity {
+  return {
+    name: entity.name,
+    kind: entity.kind,
+    location:
+      [entity.region?.name, entity.country?.name].filter(Boolean).join(", ") ||
+      undefined,
+    isFollowing: entity.isFollowing,
+  };
+}

--- a/docs/policies/interfaces.md
+++ b/docs/policies/interfaces.md
@@ -12,7 +12,9 @@ An interface should expose the smallest useful action and make its owner clear.
 - Keep framework and outside-service types inside the module that owns them.
 - Add an exported interface only when it represents a stable boundary or
   removes real coupling.
-- Do not add wrappers that only rename or forward arguments.
+- Wrappers must own behavior or a narrower domain contract, such as the facts
+  allowed in an entity identity row. Do not add wrappers that only rename or
+  forward arguments.
 
 ## Exceptions
 

--- a/docs/policies/naming.md
+++ b/docs/policies/naming.md
@@ -17,6 +17,90 @@ Names should use Peated's domain terms and be clear where they are used.
 - Define an overloaded term once in its owning documentation. Do not reuse it
   for a nearby concept.
 
+## UI Components
+
+Web component authors and reviewers own these conventions. Apply them to new
+components and when changing an existing component's responsibility.
+
+### Names and roles
+
+Use a domain or task name followed by its UI role: `EntityIdentityRow`,
+`BottleForm`, or `PasskeyLoginButton`. Standard controls and established concepts
+can stand alone: `Button`, `Dialog`, or `FlavorWheel`. The roles below are shared
+terms, not a required suffix for every component.
+
+- Use PascalCase for components and `<ComponentName>Props` for their exported
+  props. Use the established domain noun in code. Visible copy and Storybook
+  titles use product language: `EntityPicker` appears as "Brand and Producer
+  Picker." A title change does not require a code rename.
+- Choose a name that describes what callers get. Add context such as `Home` or
+  `Moderation` only when the component owns behavior or composition specific to
+  that context. Reusing it elsewhere is a reason to review that name.
+- Use a prop for size, density, or appearance variations of the same component.
+  Use a separate component when it owns a different task or domain contract.
+  Do not use `New`, `V2`, `Custom`, or `Enhanced` to distinguish replacements.
+- Avoid `Product`, `Experience`, `Surface`, `Shell`, `Widget`, `Module`,
+  `Structure`, or `Record` unless it names an actual product concept. Describe
+  what a container holds or what its layout does.
+
+| Role          | Owns                                                                                                        |
+| ------------- | ----------------------------------------------------------------------------------------------------------- |
+| `IdentityRow` | One item's identifying content and row layout, reusable in a list, table cell, search result, or selection. |
+| `List`        | A collection of items, its order, and separators.                                                           |
+| `Table`       | A collection with shared column headers and aligned cells.                                                  |
+| `Card`        | A deliberately grouped container or preview. A horizontal row alone is not a card.                          |
+| `Input`       | Editing one value, such as text, a number, or a review score.                                               |
+| `Picker`      | Choosing from supplied options. Its contract states whether selection is single or multiple.                |
+| `Field`       | A form label, control, and validation, or an adapter that supplies a control's data.                        |
+| `Form`        | A related set of inputs and submission behavior.                                                            |
+| `Layout`      | Arrangement of supplied content, without owning the page's data or workflow.                                |
+| `Page`        | A complete page composition.                                                                                |
+
+### Files and ownership
+
+- Match the main component's name with a camelCase file stem:
+  `EntityIdentityRow` lives in `entityIdentityRow.stylex.tsx`, with stories in
+  `entityIdentityRow.stories.tsx`. Use `.stylex.tsx` for modules that define StyleX
+  styles and `.tsx` otherwise. Keep styling technology out of component names.
+- A module may export a closely related family, such as `Button`, `ButtonLink`,
+  and `IconButton` from `button.stylex.tsx`. Name the file for the family and avoid
+  adding one-file wrappers just to match every export.
+- Put shared components in `apps/web/src/components/`. Use a named feature folder
+  when related components need one. Put render-only page compositions and their
+  dedicated parts in `components/pages/`; keep route-specific data and behavior
+  beside the route. Framework-required names such as `page.tsx` stay unchanged.
+- Keep stories and tests beside their owning module. Component JSDoc and stories
+  explain what it owns and when to use it. Keep one public name per component in
+  imports and the component index; keep internal helpers out of that index.
+- Prefer a few domain-owned modules over folders for every suffix or visual
+  primitive. Do not create parallel component families in catch-all folders.
+
+### Props and shared types
+
+- Use stored kind names in data props. Keep contextual labels such as "Distiller"
+  separate from the stored kind `distillery`.
+- Name a shared layout helper for what it renders, such as `TextIdentityRow`.
+  Domain components own which facts appear.
+- Put shared types with their domain owner. A location page must not depend on a
+  homepage type to render an entity row. Name types for their contract, such as
+  `EntityIdentity`, `EntityListItem`, or `EntityPickerOption`; keep domain data
+  separate from rendering props such as `onClick` and `variant`.
+- Keep one value for each fact. A picker option must not store both `name` and
+  `entity.name`; adapters derive the control's label from its domain name.
+- Update names when use expands. A style shared by bottle and entity results is
+  an `identityResult`, not a `bottleResult`.
+
+### Review and changes
+
+Before adding a component, search for the domain and role in code and Storybook.
+Extend an existing owner when it already serves the task. Review the exported
+name, props, file, stories, types, styles, and imports together when changing its
+role. Rename all affected uses and remove obsolete exports in the same change.
+Correct mismatches in the area being changed; avoid unrelated rename sweeps.
+
+Review enforces semantic names. Typechecks and lint catch broken references;
+they do not prove that a name describes the right responsibility.
+
 ## Exceptions
 
 - Keep compatibility names at external boundaries and old storage keys when a


### PR DESCRIPTION
Brand and producer rows now show a consistent name, stored kind, known location, and following status across catalogs, sidebars, search, and selection. Peated IDs and incidental descriptions or totals no longer crowd the identity. Contextual counts stay in separate cells or trailing content, and action menus have proper cell padding and remain available on mobile.

Shared Entity, Series, and Location identity components own the allowed row content. The change also renames ProducerPicker to EntityPicker, moves the shared catalog table out of pages, removes redundant metadata and styles, and defines component naming and placement conventions. The existing two-column SMWS code table uses the shared identity inside its distillery cells.

The Brand and Producer Identity Row / Row Layouts story compares the real catalog, sidebar, search, and picker components. Desktop/mobile browser checks covered those layouts, action menus, and keyboard selection; 22 focused tests and the web typecheck passed. Full search-route browser QA was limited by the local mock API's unsupported combined search request.
