### PR TITLE
fix(web): use valid sort for admin locations

### DIFF
--- a/apps/web/src/app/(admin)/admin/(default)/locations/page.tsx
+++ b/apps/web/src/app/(admin)/admin/(default)/locations/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Inputs } from "@peated/server/orpc/router";
 import {
   AdminBreadcrumbs,
   AdminPage,
@@ -10,10 +11,12 @@ import useApiQueryParams from "@peated/web/hooks/useApiQueryParams";
 import { useORPC } from "@peated/web/lib/orpc/context";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
+const DEFAULT_SORT: NonNullable<Inputs["countries"]["list"]>["sort"] = "name";
+
 export default function Page() {
   const queryParams = useApiQueryParams({
     defaults: {
-      sort: "-created",
+      sort: DEFAULT_SORT,
     },
     numericFields: ["cursor", "limit"],
   });
@@ -45,7 +48,7 @@ export default function Page() {
       <Table
         items={countryList.results}
         rel={countryList.rel}
-        defaultSort="-created"
+        defaultSort={DEFAULT_SORT}
         url={(item) => `/admin/locations/${item.slug}`}
         columns={[{ name: "name", sort: "name", sortDefaultOrder: "asc" }]}
         withSearch


### PR DESCRIPTION
The admin Locations page now requests countries using the supported `name` sort, so opening `/admin/locations` no longer fails with a 422 `INPUT_VALIDATION_FAILED` response. The table uses the same default, and the value is typed from the oRPC contract so future contract drift fails the web typecheck.

Refs Sentry event `ec71261f613448c3ab9d59bd783147f1` and `PEATED-49M`.

Web lint, formatting, and typechecking pass. The focused server test could not start because the shared test database migration reports that `review_body` already exists.
