### PR TITLE
feat(scrapers): prepare Whisky Study for saved rules

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -45,6 +45,15 @@ function prepare(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareWhiskyStudy(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "whiskystudy", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 const canonicalUrl =
   "https://thebourbonculture.com/whiskey-reviews/example-review/";
 const registry = createScraperRegistry({
@@ -53,6 +62,18 @@ const registry = createScraperRegistry({
     {
       ...scraperRegistry.sources.get("bourbonculture")!,
       externalSiteKey: "bourbonculture",
+    },
+  ],
+});
+
+const whiskyStudyCanonicalUrl =
+  "https://thewhiskystudy.com/reviews-3/example-scotch-review";
+const whiskyStudyRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("whiskystudy")!],
+  sources: [
+    {
+      ...scraperRegistry.sources.get("whiskystudy")!,
+      externalSiteKey: "whiskystudy",
     },
   ],
 });
@@ -100,6 +121,59 @@ async function setupMigration(bottleId: number | null = null) {
   await db.insert(externalReviewPublications).values({
     externalSiteId: site.id,
     approvedAt: new Date(),
+  });
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return { site, article, review };
+}
+
+async function setupWhiskyStudyMigration(bottleId: number | null = null) {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "whiskystudy",
+      name: "The Whisky Study",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(whiskyStudyRegistry);
+  const [article] = await db
+    .insert(externalReviewArticles)
+    .values({
+      externalSiteId: site.id,
+      canonicalUrl: whiskyStudyCanonicalUrl,
+      title: "Example Scotch 18 Year Shelf Review",
+      publishedAt: new Date("2026-07-04"),
+    })
+    .returning();
+  const [review] = await db
+    .insert(externalReviews)
+    .values({
+      articleId: article.id,
+      sourceKey: `whiskystudy:${createHash("sha256").update(whiskyStudyCanonicalUrl).digest("hex")}`,
+      name: "Example Scotch 18 Year",
+      bottleId,
+      hidden: true,
+      reviewerName: "Chris Ellis",
+      nativeScoreValue: 92,
+      nativeScoreScale: 100,
+      nativeScoreDisplay: "92/100",
+      clip: "An existing clip.",
+      tags: ["orchard fruit"],
+    })
+    .returning();
+  await db.insert(externalReviewBodies).values({
+    externalReviewId: review.id,
+    body: "Synthetic old review body.",
+    fetchedAt: new Date(),
+  });
+  await db.insert(externalReviewPublications).values({
+    externalSiteId: site.id,
+    approvedAt: null,
   });
   await db.insert(externalSiteRuns).values({
     externalSiteId: site.id,
@@ -254,6 +328,82 @@ describe("POST /admin/scrape-sources/prepare", () => {
       code: "CONFLICT",
       message: "Bourbon Culture is already prepared for saved scraping rules.",
     });
+  });
+
+  test("prepares The Whisky Study without replacing its records", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const { site, article, review } = await setupWhiskyStudyMigration(
+      bottle.id,
+    );
+    const bodies = await db.select().from(externalReviewBodies);
+    const publications = await db.select().from(externalReviewPublications);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareWhiskyStudy()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      reviewCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(externalReviews)).toEqual([review]);
+
+    const applied = await prepareWhiskyStudy({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      reviewCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(whiskyStudyRegistry);
+    expect(await db.select().from(externalReviewArticles)).toEqual([article]);
+    expect(await db.select().from(externalReviews)).toEqual([
+      {
+        ...review,
+        sourceKey: `${whiskyStudyCanonicalUrl}#review-1`,
+      },
+    ]);
+    expect(await db.select().from(externalReviewBodies)).toEqual(bodies);
+    expect(await db.select().from(externalReviewPublications)).toEqual(
+      publications,
+    );
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "review",
+        listUrl: "https://thewhiskystudy.com/reviews-3",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+  });
+
+  test("refuses an unexpected The Whisky Study article URL", async () => {
+    const { article } = await setupWhiskyStudyMigration();
+    await db
+      .update(externalReviewArticles)
+      .set({ canonicalUrl: `${whiskyStudyCanonicalUrl}/` })
+      .where(eq(externalReviewArticles.id, article.id));
+    const reviews = await db.select().from(externalReviews);
+    const targets = await db.select().from(scrapeTargets);
+
+    await expect(prepareWhiskyStudy({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining(
+        "Check the URL and review records for The Whisky Study article",
+      ),
+    });
+    expect(await db.select().from(externalReviews)).toEqual(reviews);
+    expect(await db.select().from(scrapeTargets)).toEqual(targets);
+    expect(await db.select().from(scrapeSources)).toEqual([]);
   });
 
   test.each([

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -2,6 +2,7 @@ import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
 import { ExternalSiteKeySchema } from "@peated/server/schemas";
 import { prepareBourbonCultureSource } from "@peated/server/scraper/configured/prepareBourbonCulture";
+import { prepareWhiskyStudySource } from "@peated/server/scraper/configured/prepareWhiskyStudy";
 import {
   ScrapeSourceConflictError,
   ScrapeSourceNotFoundError,
@@ -26,7 +27,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture.",
+          "The existing site's key. Currently supports bourbonculture and whiskystudy.",
         ),
         apply: z
           .boolean()
@@ -53,13 +54,17 @@ export default procedure
       .strict(),
   )
   .handler(async ({ input, context, errors }) => {
-    if (input.site !== "bourbonculture") {
+    if (!["bourbonculture", "whiskystudy"].includes(input.site)) {
       throw errors.BAD_REQUEST({
         message: "This scraper cannot move to saved rules yet.",
       });
     }
     try {
-      return await prepareBourbonCultureSource({
+      const prepareSource =
+        input.site === "bourbonculture"
+          ? prepareBourbonCultureSource
+          : prepareWhiskyStudySource;
+      return await prepareSource({
         apply: input.apply,
         createdById: context.user.id,
       });

--- a/apps/server/src/scraper/configured/prepareReviewSource.ts
+++ b/apps/server/src/scraper/configured/prepareReviewSource.ts
@@ -1,0 +1,214 @@
+import { db } from "@peated/server/db";
+import {
+  externalReviewArticles,
+  externalReviews,
+  externalSiteRuns,
+  externalSites,
+  externalSiteScrapeTargets,
+  scrapeOrigins,
+  scrapeSources,
+  scrapeTargets,
+} from "@peated/server/db/schema";
+import { and, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+import {
+  ScrapeSourceConflictError,
+  ScrapeSourceNotFoundError,
+  ScrapeSourceValidationError,
+} from "./service";
+
+const InputSchema = z
+  .object({
+    apply: z.boolean().default(false),
+    createdById: z.number().int().positive(),
+  })
+  .strict();
+
+export type PrepareReviewSourceInput = z.input<typeof InputSchema>;
+
+type ReviewSourceDefinition = {
+  siteKey: string;
+  siteName: string;
+  targetKey: string;
+  origin: string;
+  listUrl: string;
+  isCanonicalArticleUrl: (url: string) => boolean;
+  legacyReviewKey: (url: string) => string;
+};
+
+/** Checks one single-review source by default; applying preserves records and leaves collection paused. */
+export async function prepareReviewSource(
+  input: PrepareReviewSourceInput,
+  definition: ReviewSourceDefinition,
+) {
+  const { apply, createdById } = InputSchema.parse(input);
+  return db.transaction(async (tx) => {
+    // The scraper lifecycle also locks this site before choosing its scraper.
+    const [site] = await tx
+      .select()
+      .from(externalSites)
+      .where(eq(externalSites.type, definition.siteKey))
+      .for("update");
+    if (!site) {
+      throw new ScrapeSourceNotFoundError(
+        `${definition.siteName} was not found.`,
+      );
+    }
+    if (site.runEvery !== null) {
+      throw new ScrapeSourceConflictError(
+        `Stop the ${definition.siteName} schedule before continuing.`,
+      );
+    }
+    const [activeRun] = await tx
+      .select({ id: externalSiteRuns.id })
+      .from(externalSiteRuns)
+      .where(
+        and(
+          eq(externalSiteRuns.externalSiteId, site.id),
+          inArray(externalSiteRuns.status, ["queued", "running"]),
+        ),
+      )
+      .limit(1);
+    if (activeRun) {
+      throw new ScrapeSourceConflictError(
+        `Wait for the active ${definition.siteName} run to finish.`,
+      );
+    }
+    const [source] = await tx
+      .select({ id: scrapeSources.id })
+      .from(scrapeSources)
+      .where(eq(scrapeSources.externalSiteId, site.id));
+    if (source) {
+      throw new ScrapeSourceConflictError(
+        `${definition.siteName} is already prepared for saved scraping rules.`,
+      );
+    }
+
+    const siteTargets = await tx
+      .select()
+      .from(externalSiteScrapeTargets)
+      .where(eq(externalSiteScrapeTargets.externalSiteId, site.id))
+      .for("update");
+    const targetSites = await tx
+      .select()
+      .from(externalSiteScrapeTargets)
+      .where(eq(externalSiteScrapeTargets.targetKey, definition.targetKey))
+      .for("update");
+    const origins = await tx
+      .select()
+      .from(scrapeOrigins)
+      .where(eq(scrapeOrigins.targetKey, definition.targetKey))
+      .for("update");
+    const [target] = await tx
+      .select()
+      .from(scrapeTargets)
+      .where(eq(scrapeTargets.key, definition.targetKey))
+      .for("update");
+    // This operation handles only the review source's own request settings.
+    if (
+      siteTargets.length !== 1 ||
+      siteTargets[0].targetKey !== definition.targetKey ||
+      !siteTargets[0].active ||
+      siteTargets[0].managedBy !== "code" ||
+      targetSites.length !== 1 ||
+      targetSites[0].externalSiteId !== site.id ||
+      origins.length !== 1 ||
+      origins[0].origin !== definition.origin ||
+      !origins[0].active ||
+      origins[0].managedBy !== "code" ||
+      origins[0].robotsMode !== "enforce" ||
+      !target?.enabled ||
+      target.managedBy !== "code"
+    ) {
+      throw new ScrapeSourceValidationError(
+        `${definition.siteName} has unexpected request settings. Check them before continuing.`,
+      );
+    }
+
+    const articles = await tx
+      .select({
+        id: externalReviewArticles.id,
+        url: externalReviewArticles.canonicalUrl,
+      })
+      .from(externalReviewArticles)
+      .where(eq(externalReviewArticles.externalSiteId, site.id))
+      .for("update");
+    const reviews = await tx
+      .select({
+        id: externalReviews.id,
+        articleId: externalReviews.articleId,
+        sourceKey: externalReviews.sourceKey,
+      })
+      .from(externalReviews)
+      .innerJoin(
+        externalReviewArticles,
+        eq(externalReviewArticles.id, externalReviews.articleId),
+      )
+      .where(eq(externalReviewArticles.externalSiteId, site.id))
+      .for("update");
+    const reviewsByArticle = new Map<number, typeof reviews>();
+    for (const review of reviews) {
+      const group = reviewsByArticle.get(review.articleId) ?? [];
+      group.push(review);
+      reviewsByArticle.set(review.articleId, group);
+    }
+    const changes = articles.map((article) => {
+      const articleReviews = reviewsByArticle.get(article.id) ?? [];
+      // Review imports own these keys. One verified review per article avoids guessing.
+      if (
+        !definition.isCanonicalArticleUrl(article.url) ||
+        articleReviews.length !== 1 ||
+        articleReviews[0].sourceKey !== definition.legacyReviewKey(article.url)
+      ) {
+        throw new ScrapeSourceValidationError(
+          `Check the URL and review records for ${definition.siteName} article ${article.id} before continuing.`,
+        );
+      }
+      return { id: articleReviews[0].id, sourceKey: `${article.url}#review-1` };
+    });
+
+    let scrapeSourceId: number | null = null;
+    if (apply) {
+      for (const change of changes) {
+        await tx
+          .update(externalReviews)
+          .set({ sourceKey: change.sourceKey })
+          .where(eq(externalReviews.id, change.id));
+      }
+      await tx
+        .update(externalSiteScrapeTargets)
+        .set({ managedBy: "admin", updatedAt: new Date() })
+        .where(
+          and(
+            eq(externalSiteScrapeTargets.externalSiteId, site.id),
+            eq(externalSiteScrapeTargets.targetKey, definition.targetKey),
+          ),
+        );
+      await tx
+        .update(scrapeOrigins)
+        .set({ managedBy: "admin", updatedAt: new Date() })
+        .where(eq(scrapeOrigins.origin, definition.origin));
+      await tx
+        .update(scrapeTargets)
+        .set({ managedBy: "admin", updatedAt: new Date() })
+        .where(eq(scrapeTargets.key, definition.targetKey));
+      const [created] = await tx
+        .insert(scrapeSources)
+        .values({
+          externalSiteId: site.id,
+          kind: "review",
+          listUrl: definition.listUrl,
+          createdById,
+        })
+        .returning({ id: scrapeSources.id });
+      if (!created) throw new Error("Failed to prepare the scrape source.");
+      scrapeSourceId = created.id;
+    }
+    return {
+      siteId: site.id,
+      scrapeSourceId,
+      reviewCount: changes.length,
+      applied: apply,
+    };
+  });
+}

--- a/apps/server/src/scraper/configured/prepareWhiskyStudy.ts
+++ b/apps/server/src/scraper/configured/prepareWhiskyStudy.ts
@@ -5,20 +5,20 @@ import {
 } from "./prepareReviewSource";
 
 /** Checks one source by default; applying keeps record IDs and leaves collection paused. */
-export async function prepareBourbonCultureSource(
+export async function prepareWhiskyStudySource(
   input: PrepareReviewSourceInput,
 ) {
   return prepareReviewSource(input, {
-    siteKey: "bourbonculture",
-    siteName: "Bourbon Culture",
-    targetKey: "bourbonculture",
-    origin: "https://thebourbonculture.com",
-    listUrl: "https://thebourbonculture.com/",
+    siteKey: "whiskystudy",
+    siteName: "The Whisky Study",
+    targetKey: "whiskystudy",
+    origin: "https://thewhiskystudy.com",
+    listUrl: "https://thewhiskystudy.com/reviews-3",
     isCanonicalArticleUrl: (url) =>
-      /^https:\/\/thebourbonculture\.com\/whiskey-reviews\/[a-z0-9][a-z0-9-]*\/$/.test(
+      /^https:\/\/thewhiskystudy\.com\/reviews-3\/[a-z0-9][a-z0-9-]*$/.test(
         url,
       ),
     legacyReviewKey: (url) =>
-      `bourbonculture:${createHash("sha256").update(url).digest("hex")}`,
+      `whiskystudy:${createHash("sha256").update(url).digest("hex")}`,
   });
 }

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -83,6 +83,29 @@ Publication settings stay the same. Follow
 [External Review Sources](external-review-sources.md) for publication decisions
 and current publisher access checks.
 
+## The Whisky Study
+
+Use the same process for The Whisky Study with `{"site": "whiskystudy"}`.
+The check-only request verifies that every stored article uses the expected
+`https://thewhiskystudy.com/reviews-3/...` URL without a trailing slash, has
+exactly one review, and still has the key written by the code scraper. Applying
+the preparation changes those review keys in place and adds a paused source
+whose list page is `https://thewhiskystudy.com/reviews-3`.
+
+Before applying, save the same records and stop the `whiskystudy` schedule as
+described above. Compare all stored records after applying. Keep the existing
+limit of 20 latest articles and one review per article when checking suggested
+rules. Verify each article URL, name, writer, date, score, selected review text,
+Bottle match, hidden state, and publication setting. The old scraper removes
+`Review` or `Shelf Review` from the end of Bottle names; saved rules do not do
+text cleanup, so review any name change before activation.
+
+Preview and activate the chosen revision, run one manual collection through
+`POST /v1/external-sites/whiskystudy/trigger`, and confirm that it updates the
+same review IDs recorded before applying without adding duplicate articles or
+reviews. Check the run and Sentry before restoring the saved schedule.
+Preparation must not change the source's publication setting.
+
 ## If something goes wrong
 
 A request without `apply: true` leaves records unchanged. After applying, keep the
@@ -92,9 +115,9 @@ handles reviews added after the switch. Do not delete source or run history.
 
 ## Other sources
 
-The preparation API is shared. Bourbon Culture is the first supported source;
-other sites are rejected without changing records. Add each site's conversion
-behind this route as its existing records are reviewed.
+The preparation API is shared. It currently supports Bourbon Culture and The
+Whisky Study. Other sites are rejected without changing records. Add each
+site's conversion behind this route as its existing records are reviewed.
 
 Prepare each source using its own rules for recognizing existing records.
 Articles with several reviews need a verified match for each review. Store


### PR DESCRIPTION
The scraper preparation API can now move The Whisky Study from its code-owned adapter to database-configured rules while preserving existing article and review IDs, Bottle matches, visibility, publication settings, stored bodies, and run history. It validates the source's canonical URLs, legacy review keys, one-review-per-article shape, stopped schedule, inactive runs, and exclusive request ownership before creating a paused source.

Bourbon Culture now uses the extracted single-review preparation path, so both migrations share the same transaction and safety checks. The operating guide covers The Whisky Study's rollout and its Bottle-name cleanup difference. Deployment alone changes no source data: an admin must still inspect the dry run, explicitly apply it, preview the saved rules, and activate a passing revision.
