### PR TITLE
fix(activity): default feed to everyone

### DIFF
--- a/apps/web/e2e/activity-feed.spec.ts
+++ b/apps/web/e2e/activity-feed.spec.ts
@@ -9,7 +9,7 @@ import {
 import { signIn } from "./session";
 
 test.describe("activity feed", () => {
-  test("filters activity and keeps review and bottle links independent", async ({
+  test("shows activity and keeps review and bottle links independent", async ({
     context,
     page,
     snapshot,
@@ -69,12 +69,6 @@ test.describe("activity feed", () => {
       name: "Latest activity",
     });
 
-    await expect(
-      feed.getByText("A tasting from someone you follow."),
-    ).toBeVisible();
-    await expect(feed.getByText(activityReview.clip)).toHaveCount(0);
-
-    await page.getByRole("link", { name: "Everyone", exact: true }).click();
     await expect(feed.getByText(activityReview.clip)).toBeVisible();
     await expect(
       feed.getByRole("link", { name: activityReview.site.name, exact: true }),

--- a/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
@@ -4,7 +4,7 @@ import {
   mockFriendships,
 } from "@peated/server/orpc/mock/fixtures";
 import { beforeEach, expect, test, vi } from "vitest";
-import { loadActivityFeed } from "./loadActivityFeed";
+import { getActivityFeedSelection, loadActivityFeed } from "./loadActivityFeed";
 
 type Options = Parameters<typeof loadActivityFeed>[0];
 const publicClient = {
@@ -38,6 +38,13 @@ beforeEach(() => {
     results: [mockExternalReview],
     rel,
   });
+});
+
+test("defaults the activity feed selection to Everyone", () => {
+  expect(getActivityFeedSelection()).toBe("everyone");
+  expect(getActivityFeedSelection("everyone")).toBe("everyone");
+  expect(getActivityFeedSelection("unknown")).toBe("everyone");
+  expect(getActivityFeedSelection("following")).toBe("following");
 });
 
 test("keeps Following empty when followed people have no activity", async () => {

--- a/apps/web/src/app/(app)/activity/loadActivityFeed.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.ts
@@ -5,6 +5,10 @@ import { getCommunityFeedItems } from "@peated/web/lib/communityFeed";
 type Client = RouterClient<Router>;
 type ActivityClient = { activity: Pick<Client["activity"], "list"> };
 
+export function getActivityFeedSelection(feed?: string) {
+  return feed === "following" ? "following" : "everyone";
+}
+
 /** Falls back to public activity only when there are no accepted follows. */
 export async function loadActivityFeed({
   following,

--- a/apps/web/src/app/(app)/activity/page.tsx
+++ b/apps/web/src/app/(app)/activity/page.tsx
@@ -7,7 +7,7 @@ import {
   getServerClient,
 } from "@peated/web/lib/orpc/client.server";
 import type { Metadata } from "next";
-import { loadActivityFeed } from "./loadActivityFeed";
+import { getActivityFeedSelection, loadActivityFeed } from "./loadActivityFeed";
 
 export const metadata: Metadata = {
   title: "Activity",
@@ -21,7 +21,8 @@ export default async function Activity({
   searchParams: Promise<{ feed?: string }>;
 }) {
   const [{ feed }, user] = await Promise.all([searchParams, getCurrentUser()]);
-  const following = feed === "following" || (feed !== "everyone" && !!user);
+  const selectedFeed = getActivityFeedSelection(feed);
+  const following = selectedFeed === "following";
   const { client: publicClient } = await getAnonymousServerClient();
   const memberClient = user ? (await getServerClient()).client : undefined;
   const [{ items, note }, library] = await Promise.all([
@@ -49,7 +50,7 @@ export default async function Activity({
       selector={
         <PageTabs
           ariaLabel="Activity feeds"
-          currentHref={`/activity?feed=${following ? "following" : "everyone"}`}
+          currentHref={`/activity?feed=${selectedFeed}`}
           items={[
             { href: "/activity?feed=following", label: "Following" },
             { href: "/activity?feed=everyone", label: "Everyone" },


### PR DESCRIPTION
The activity page now shows Everyone by default for signed-in and anonymous visitors. Following remains available when explicitly selected, and missing or invalid feed values fall back to Everyone.

The route-selection rule has focused Vitest coverage. The existing browser workflow now checks the default public feed without using browser coverage for deterministic query parsing.
