### PR TITLE
feat(scrapers): add local configured-rule previews

### DIFF
--- a/apps/cli/src/commands/index.ts
+++ b/apps/cli/src/commands/index.ts
@@ -11,5 +11,6 @@ export * from "./labels";
 export * from "./mocks";
 export * from "./prices";
 export * from "./regions";
+export * from "./scrapers";
 export * from "./tastings";
 export * from "./users";

--- a/apps/cli/src/commands/scrapers.test.ts
+++ b/apps/cli/src/commands/scrapers.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from "vitest";
+import { parsePreviewLimit } from "./scrapers";
+
+describe("parsePreviewLimit", () => {
+  test("accepts a bounded whole number", () => {
+    expect(parsePreviewLimit("3")).toBe(3);
+  });
+
+  test.each(["0", "100", "1.5", "nope"])("rejects %s", (value) => {
+    expect(() => parsePreviewLimit(value)).toThrow(
+      "Preview limit must be an integer from 1 to 99.",
+    );
+  });
+});

--- a/apps/cli/src/commands/scrapers.ts
+++ b/apps/cli/src/commands/scrapers.ts
@@ -1,0 +1,53 @@
+import program from "@peated/cli/program";
+import { runLocalScrapeSourcePreview } from "@peated/server/scraper";
+import { ScrapeRulesSchema } from "@peated/server/scraper/configured/rules";
+import { readFile } from "node:fs/promises";
+import { z } from "zod";
+
+const PreviewFileSchema = z
+  .object({
+    listUrl: z.url(),
+    rules: ScrapeRulesSchema,
+  })
+  .strict();
+
+export function parsePreviewLimit(value: string) {
+  const limit = Number(value);
+  if (!Number.isInteger(limit) || limit < 1 || limit > 99) {
+    throw new Error("Preview limit must be an integer from 1 to 99.");
+  }
+  return limit;
+}
+
+async function readPreviewFile(path: string) {
+  const contents = await readFile(path, "utf8");
+  try {
+    return PreviewFileSchema.parse(JSON.parse(contents));
+  } catch {
+    throw new Error(`Invalid scraper preview file: ${path}`);
+  }
+}
+
+const subcommand = program
+  .command("scrapers")
+  .description("Test scraper parsing rules through the local runtime");
+
+subcommand
+  .command("preview")
+  .description("Preview saved parsing rules without writing products")
+  .requiredOption("--site <key>", "Existing code-owned external site key")
+  .requiredOption("--input <file>", "JSON file containing listUrl and rules")
+  .option(
+    "--limit <count>",
+    "Read at most this many detail pages",
+    parsePreviewLimit,
+  )
+  .action(async (options) => {
+    const input = await readPreviewFile(options.input);
+    const result = await runLocalScrapeSourcePreview({
+      site: options.site,
+      ...input,
+      limit: options.limit,
+    });
+    console.log(JSON.stringify(result, null, 2));
+  });

--- a/apps/cli/src/commands/scrapers.ts
+++ b/apps/cli/src/commands/scrapers.ts
@@ -44,10 +44,19 @@ subcommand
   )
   .action(async (options) => {
     const input = await readPreviewFile(options.input);
-    const result = await runLocalScrapeSourcePreview({
-      site: options.site,
-      ...input,
-      limit: options.limit,
-    });
+    const result = await runLocalScrapeSourcePreview(
+      {
+        site: options.site,
+        ...input,
+        limit: options.limit,
+      },
+      {
+        onDeferred: (nextAttemptAt) => {
+          console.error(
+            `Request controls paused the preview. Continuing after ${nextAttemptAt.toISOString()}.`,
+          );
+        },
+      },
+    );
     console.log(JSON.stringify(result, null, 2));
   });

--- a/apps/cli/src/commands/scrapers.ts
+++ b/apps/cli/src/commands/scrapers.ts
@@ -1,6 +1,6 @@
 import program from "@peated/cli/program";
-import { runLocalScrapeSourcePreview } from "@peated/server/scraper";
 import { ScrapeRulesSchema } from "@peated/server/scraper/configured/rules";
+import { runLocalScrapeSourcePreview } from "@peated/server/scraper/localPreview";
 import { readFile } from "node:fs/promises";
 import { z } from "zod";
 

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -152,7 +152,8 @@ pnpm cli scrapers preview --site whiskystudy --input /tmp/revision.json --limit 
 The input has the same `listUrl` and `rules` fields accepted by the revision
 API. Omit `--limit` for a full acceptance preview. A bounded preview is useful
 while editing rules; the complete rules still need a full local acceptance run
-before production activation.
+before production activation. If request controls pause a run, the command
+prints the next eligible time and resumes from its saved page automatically.
 
 ## Source acceptance rules
 

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -140,6 +140,20 @@ label. Fork pull requests run the ordinary tests without secrets.
 live AI service, including the full creation scenarios. Normal test runs exclude
 these checks. The `trigger-evals` label runs the broader eval suite in CI.
 
+Before saving a migration candidate, run its revision input through the local
+runtime. The command uses `.env.local`, the registered target, robots policy,
+request controls, production parser, and validators. It records the local run
+for inspection but uses a no-op sink, so it does not write reviews or prices:
+
+```bash
+pnpm cli scrapers preview --site whiskystudy --input /tmp/revision.json --limit 3
+```
+
+The input has the same `listUrl` and `rules` fields accepted by the revision
+API. Omit `--limit` for a full acceptance preview. A bounded preview is useful
+while editing rules; the complete rules still need a full local acceptance run
+before production activation.
+
 ## Source acceptance rules
 
 Every new or changed source must satisfy this contract. Prove a rule at the

--- a/apps/server/src/scraper/configured/createScraper.eval.test.ts
+++ b/apps/server/src/scraper/configured/createScraper.eval.test.ts
@@ -148,11 +148,11 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         const revision = suggested.revisions[0];
         expect(revision).toMatchObject({
           author: "ai",
-          aiModel: config.SCRAPER_SETUP_MODEL,
           aiInstructionsVersion: AI_INSTRUCTIONS_VERSION,
           previewStatus: "pending",
           active: false,
         });
+        expect(revision.aiModel).toBeTruthy();
         expect(await db.select().from(externalReviews)).toEqual([]);
 
         const revisionInput = { id: source.id, revisionId: revision.id };

--- a/apps/server/src/scraper/configured/preview.ts
+++ b/apps/server/src/scraper/configured/preview.ts
@@ -54,7 +54,7 @@ const PricePageSchema = z
   })
   .strict();
 
-const ScrapeSourcePreviewPageSchema = z.discriminatedUnion("kind", [
+export const ScrapeSourcePreviewPageSchema = z.discriminatedUnion("kind", [
   ReviewPageSchema,
   PricePageSchema,
 ]);

--- a/apps/server/src/scraper/configured/runtime.test.ts
+++ b/apps/server/src/scraper/configured/runtime.test.ts
@@ -6,6 +6,7 @@ import {
   scrapeOrigins,
   scrapeSourceRevisions,
   scrapeSourceRuns,
+  scrapeTargets,
   users,
 } from "@peated/server/db/schema";
 import { eq } from "drizzle-orm";
@@ -33,6 +34,20 @@ function fixedClock(): ScraperHttpClock {
       now = new Date(now.getTime() + milliseconds);
     },
     random: () => 0,
+  };
+}
+
+function controllableClock() {
+  let now = new Date("2026-08-28T12:00:00Z");
+  return {
+    now: () => now,
+    sleep: async (milliseconds: number) => {
+      now = new Date(now.getTime() + milliseconds);
+    },
+    random: () => 0,
+    advanceTo: (value: Date) => {
+      now = value;
+    },
   };
 }
 
@@ -176,6 +191,67 @@ test("follows a bounded next-page selector", async () => {
       { url: "https://preview.example/two" },
     ],
   });
+});
+
+test("resumes configured previews without rereading completed pages", async () => {
+  const { pinned, revision, site } = await setupPreview("h1", true);
+  await db
+    .update(scrapeTargets)
+    .set({ requestsPerWindow: 3, windowMs: 60_000 })
+    .where(eq(scrapeTargets.key, site.type));
+  const fetchImpl = previewFetch(true);
+  const clock = controllableClock();
+
+  const first = await executeScraperRun(
+    { runId: pinned.run.id },
+    {
+      registry: createScraperRegistry({ targets: [], sources: [] }),
+      fetchImpl,
+      clock,
+      executionToken: "first-preview-owner",
+    },
+  );
+  expect(first.status).toBe("deferred");
+  if (!("nextAttemptAt" in first)) throw new Error("Expected deferral.");
+
+  const [deferred] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, pinned.run.id));
+  expect(deferred?.cursor).toMatchObject({
+    detailIndex: 1,
+    previewPages: [{ url: "https://preview.example/one" }],
+  });
+
+  clock.advanceTo(first.nextAttemptAt);
+  await expect(
+    executeScraperRun(
+      { runId: pinned.run.id },
+      {
+        registry: createScraperRegistry({ targets: [], sources: [] }),
+        fetchImpl,
+        clock,
+        executionToken: "second-preview-owner",
+      },
+    ),
+  ).resolves.toEqual({ status: "completed" });
+
+  const [storedRevision] = await db
+    .select()
+    .from(scrapeSourceRevisions)
+    .where(eq(scrapeSourceRevisions.id, revision.id));
+  expect(storedRevision?.previewResult).toMatchObject({
+    pages: [
+      { url: "https://preview.example/one" },
+      { url: "https://preview.example/two" },
+    ],
+  });
+  const requestedPaths = fetchImpl.mock.calls.map(
+    ([input]) => new URL(input instanceof Request ? input.url : input).pathname,
+  );
+  expect(requestedPaths.filter((path) => path === "/archive")).toHaveLength(2);
+  expect(requestedPaths.filter((path) => path === "/one")).toHaveLength(1);
+  expect(requestedPaths.filter((path) => path === "/two")).toHaveLength(1);
 });
 
 test("stores safe validation issues when a selector stops matching", async () => {

--- a/apps/server/src/scraper/configured/runtime.ts
+++ b/apps/server/src/scraper/configured/runtime.ts
@@ -108,13 +108,24 @@ function createPreviewPage(
   };
 }
 
-function createScrapeSourceAdapter(input: {
-  targetKey: string;
-  listUrl: string;
-  revisionId: number;
-  rules: ScrapeRules;
-  purpose: "collect" | "preview";
-}): ScraperAdapter<null, unknown> {
+type RecordScrapeSourcePreview = (input: {
+  status: "passed" | "failed";
+  result: {
+    issues: ScrapeIssue[];
+    pages: ScrapeSourcePreviewPage[];
+  };
+}) => Promise<void>;
+
+function createScrapeSourceAdapter(
+  input: {
+    targetKey: string;
+    listUrl: string;
+    rules: ScrapeRules;
+  } & (
+    | { purpose: "collect" }
+    | { purpose: "preview"; recordPreview: RecordScrapeSourcePreview }
+  ),
+): ScraperAdapter<null, unknown> {
   return async ({ session }) => {
     const pages: ScrapeSourcePreviewPage[] = [];
     try {
@@ -189,8 +200,7 @@ function createScrapeSourceAdapter(input: {
       }
 
       if (input.purpose === "preview") {
-        await recordScrapeSourcePreview({
-          revisionId: input.revisionId,
+        await input.recordPreview({
           status: pages.length > 0 ? "passed" : "failed",
           result: {
             issues:
@@ -211,14 +221,43 @@ function createScrapeSourceAdapter(input: {
         input.purpose === "preview" &&
         error instanceof ScrapeSourceParseError
       ) {
-        await recordScrapeSourcePreview({
-          revisionId: input.revisionId,
+        await input.recordPreview({
           status: "failed",
           result: { issues: error.issues, pages },
         });
       }
       throw error;
     }
+  };
+}
+
+/** Builds the no-write source used by local acceptance previews. */
+export function createLocalScrapeSourcePreview(input: {
+  siteKey: string;
+  targetKey: string;
+  listUrl: string;
+  rules: ScrapeRules;
+  recordPreview: RecordScrapeSourcePreview;
+}): ScraperSourceDefinition<null, unknown> {
+  return {
+    key: `local-preview-${input.siteKey}`,
+    externalSiteKey: input.siteKey,
+    targetKeys: [input.targetKey],
+    requestLimit: input.rules.list.maxItems + SCRAPE_SOURCE_MAX_LIST_PAGES,
+    resumeFromLastRun: false,
+    cursorSchema: z.null(),
+    observationSchema:
+      input.rules.kind === "review"
+        ? ExternalReviewArticleIngestionSchema
+        : z.array(StorePriceInputSchema),
+    adapter: createScrapeSourceAdapter({
+      targetKey: input.targetKey,
+      listUrl: input.listUrl,
+      rules: input.rules,
+      purpose: "preview",
+      recordPreview: input.recordPreview,
+    }),
+    sink: async () => {},
   };
 }
 
@@ -260,6 +299,28 @@ function createScrapeSourceDefinition(input: {
             });
           };
 
+  const adapter =
+    input.purpose === "preview"
+      ? createScrapeSourceAdapter({
+          targetKey: input.targetKey,
+          listUrl: input.listUrl,
+          rules: input.rules,
+          purpose: "preview",
+          recordPreview: async ({ status, result }) => {
+            await recordScrapeSourcePreview({
+              revisionId: input.revisionId,
+              status,
+              result,
+            });
+          },
+        })
+      : createScrapeSourceAdapter({
+          targetKey: input.targetKey,
+          listUrl: input.listUrl,
+          rules: input.rules,
+          purpose: "collect",
+        });
+
   return {
     key: `source-${input.scrapeSourceId}`,
     externalSiteKey: input.siteKey,
@@ -268,7 +329,7 @@ function createScrapeSourceDefinition(input: {
     resumeFromLastRun: false,
     cursorSchema: z.null(),
     observationSchema,
-    adapter: createScrapeSourceAdapter(input),
+    adapter,
     sink,
   };
 }

--- a/apps/server/src/scraper/configured/runtime.ts
+++ b/apps/server/src/scraper/configured/runtime.ts
@@ -25,11 +25,15 @@ import type {
 } from "../types";
 import { findLikelyDetailPages, findLikelyListPages } from "./discovery";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
-import type { ScrapeIssue, ScrapeSourcePreviewPage } from "./preview";
+import {
+  ScrapeSourcePreviewPageSchema,
+  type ScrapeIssue,
+  type ScrapeSourcePreviewPage,
+} from "./preview";
 import {
   SCRAPE_SOURCE_MAX_LIST_PAGES,
-  type ScrapeRules,
   parseScrapeRules,
+  type ScrapeRules,
 } from "./rules";
 import { recordScrapeSourcePreview } from "./service";
 import {
@@ -116,6 +120,18 @@ type RecordScrapeSourcePreview = (input: {
   };
 }) => Promise<void>;
 
+const ConfiguredScrapeCursorSchema = z
+  .object({
+    listUrls: z.array(z.url()).max(SCRAPE_SOURCE_MAX_LIST_PAGES),
+    detailUrls: z.array(z.url()).max(99),
+    nextListUrl: z.url().nullable(),
+    detailIndex: z.number().int().min(0).max(99),
+    previewPages: z.array(ScrapeSourcePreviewPageSchema).max(99),
+  })
+  .strict();
+
+type ConfiguredScrapeCursor = z.infer<typeof ConfiguredScrapeCursorSchema>;
+
 function createScrapeSourceAdapter(
   input: {
     targetKey: string;
@@ -125,19 +141,24 @@ function createScrapeSourceAdapter(
     | { purpose: "collect" }
     | { purpose: "preview"; recordPreview: RecordScrapeSourcePreview }
   ),
-): ScraperAdapter<null, unknown> {
-  return async ({ session }) => {
-    const pages: ScrapeSourcePreviewPage[] = [];
+): ScraperAdapter<ConfiguredScrapeCursor, unknown> {
+  return async ({ cursor, session }) => {
+    let state: ConfiguredScrapeCursor = cursor ?? {
+      listUrls: [],
+      detailUrls: [],
+      nextListUrl: new URL(input.listUrl).toString(),
+      detailIndex: 0,
+      previewPages: [],
+    };
     try {
-      const listUrls = new Set<string>();
-      const detailUrls = new Set<string>();
-      let nextListUrl: string | null = new URL(input.listUrl).toString();
+      const listUrls = new Set(state.listUrls);
+      const detailUrls = new Set(state.detailUrls);
       while (
-        nextListUrl &&
+        state.nextListUrl &&
         listUrls.size < SCRAPE_SOURCE_MAX_LIST_PAGES &&
         detailUrls.size < input.rules.list.maxItems
       ) {
-        if (listUrls.has(nextListUrl)) {
+        if (listUrls.has(state.nextListUrl)) {
           throw new ScrapeSourceParseError([
             {
               field: "list.nextPage",
@@ -145,10 +166,10 @@ function createScrapeSourceAdapter(
             },
           ]);
         }
-        listUrls.add(nextListUrl);
+        listUrls.add(state.nextListUrl);
         const listResponse = await session.request({
           target: input.targetKey,
-          url: new URL(nextListUrl),
+          url: new URL(state.nextListUrl),
         });
         const listResult = parseScrapeList(
           input.rules,
@@ -162,10 +183,18 @@ function createScrapeSourceAdapter(
           detailUrls.add(link);
           if (detailUrls.size >= input.rules.list.maxItems) break;
         }
-        nextListUrl = listResult.nextPageUrl;
+        state = {
+          ...state,
+          listUrls: [...listUrls],
+          detailUrls: [...detailUrls],
+          nextListUrl: listResult.nextPageUrl,
+        };
+        await session.checkpoint(state);
       }
 
-      for (const link of detailUrls) {
+      while (state.detailIndex < state.detailUrls.length) {
+        const link = state.detailUrls[state.detailIndex];
+        if (!link) throw new Error("Configured scraper detail URL is missing.");
         const response = await session.request({
           target: input.targetKey,
           url: new URL(link),
@@ -187,7 +216,7 @@ function createScrapeSourceAdapter(
               : parsed.value.length,
         };
         if (input.purpose === "preview") {
-          pages.push(
+          state.previewPages.push(
             createPreviewPage(
               observation,
               parsed.kind,
@@ -197,14 +226,16 @@ function createScrapeSourceAdapter(
         } else {
           await session.emit(observation);
         }
+        state = { ...state, detailIndex: state.detailIndex + 1 };
+        await session.checkpoint(state);
       }
 
       if (input.purpose === "preview") {
         await input.recordPreview({
-          status: pages.length > 0 ? "passed" : "failed",
+          status: state.previewPages.length > 0 ? "passed" : "failed",
           result: {
             issues:
-              pages.length > 0
+              state.previewPages.length > 0
                 ? []
                 : [
                     {
@@ -212,7 +243,7 @@ function createScrapeSourceAdapter(
                       message: "No pages produced valid output.",
                     },
                   ],
-            pages,
+            pages: state.previewPages,
           },
         });
       }
@@ -223,7 +254,7 @@ function createScrapeSourceAdapter(
       ) {
         await input.recordPreview({
           status: "failed",
-          result: { issues: error.issues, pages },
+          result: { issues: error.issues, pages: state.previewPages },
         });
       }
       throw error;
@@ -238,14 +269,14 @@ export function createLocalScrapeSourcePreview(input: {
   listUrl: string;
   rules: ScrapeRules;
   recordPreview: RecordScrapeSourcePreview;
-}): ScraperSourceDefinition<null, unknown> {
+}): ScraperSourceDefinition<ConfiguredScrapeCursor, unknown> {
   return {
     key: `local-preview-${input.siteKey}`,
     externalSiteKey: input.siteKey,
     targetKeys: [input.targetKey],
     requestLimit: input.rules.list.maxItems + SCRAPE_SOURCE_MAX_LIST_PAGES,
     resumeFromLastRun: false,
-    cursorSchema: z.null(),
+    cursorSchema: ConfiguredScrapeCursorSchema,
     observationSchema:
       input.rules.kind === "review"
         ? ExternalReviewArticleIngestionSchema
@@ -269,7 +300,7 @@ function createScrapeSourceDefinition(input: {
   listUrl: string;
   purpose: "collect" | "preview";
   rules: ScrapeRules;
-}): ScraperSourceDefinition<null, unknown> {
+}): ScraperSourceDefinition<ConfiguredScrapeCursor, unknown> {
   const observationSchema =
     input.rules.kind === "review"
       ? ExternalReviewArticleIngestionSchema
@@ -327,7 +358,7 @@ function createScrapeSourceDefinition(input: {
     targetKeys: [input.targetKey],
     requestLimit: input.rules.list.maxItems + SCRAPE_SOURCE_MAX_LIST_PAGES,
     resumeFromLastRun: false,
-    cursorSchema: z.null(),
+    cursorSchema: ConfiguredScrapeCursorSchema,
     observationSchema,
     adapter,
     sink,

--- a/apps/server/src/scraper/index.ts
+++ b/apps/server/src/scraper/index.ts
@@ -24,6 +24,9 @@ import {
 import { syncScraperDefinitions } from "./syncDefinitions";
 import type { ScraperRunPayload } from "./types";
 
+export { runLocalScrapeSourcePreview } from "./localPreview";
+export type { LocalScrapeSourcePreviewInput } from "./localPreview";
+
 const enqueueScraperRun: ScraperEnqueue = async (jobName, args, options) => {
   const { pushJob } = await import("@peated/server/worker/client");
   await pushJob(jobName, args, options);

--- a/apps/server/src/scraper/index.ts
+++ b/apps/server/src/scraper/index.ts
@@ -24,9 +24,6 @@ import {
 import { syncScraperDefinitions } from "./syncDefinitions";
 import type { ScraperRunPayload } from "./types";
 
-export { runLocalScrapeSourcePreview } from "./localPreview";
-export type { LocalScrapeSourcePreviewInput } from "./localPreview";
-
 const enqueueScraperRun: ScraperEnqueue = async (jobName, args, options) => {
   const { pushJob } = await import("@peated/server/worker/client");
   await pushJob(jobName, args, options);

--- a/apps/server/src/scraper/localPreview.test.ts
+++ b/apps/server/src/scraper/localPreview.test.ts
@@ -1,0 +1,180 @@
+import { db } from "@peated/server/db";
+import {
+  externalReviewArticles,
+  externalSiteRuns,
+  storePrices,
+} from "@peated/server/db/schema";
+import { eq } from "drizzle-orm";
+import { expect, test, vi } from "vitest";
+import type { ScraperHttpClock } from "./http";
+import { runLocalScrapeSourcePreview } from "./localPreview";
+
+function previewClock(): ScraperHttpClock {
+  let now = new Date("2026-09-03T12:00:00Z");
+  return {
+    now: () => now,
+    sleep: async (milliseconds) => {
+      now = new Date(now.getTime() + milliseconds);
+    },
+    random: () => 0,
+  };
+}
+
+test("previews configured rules through the runtime without product writes", async () => {
+  const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    if (url.pathname === "/robots.txt") {
+      return new Response("User-agent: *\nDisallow:");
+    }
+    if (url.pathname === "/reviews-3") {
+      return new Response('<a class="review" href="/reviews-3/one">One</a>');
+    }
+    if (url.pathname === "/reviews-3/one") {
+      return new Response(`
+        <article>
+          <h1>Example Whisky</h1>
+          <time datetime="2026-09-01"></time>
+          <div class="review"><p>Tasting notes.</p><strong>88</strong></div>
+        </article>
+      `);
+    }
+    return new Response(null, { status: 404 });
+  });
+
+  const result = await runLocalScrapeSourcePreview(
+    {
+      site: "whiskystudy",
+      listUrl: "https://thewhiskystudy.com/reviews-3",
+      rules: {
+        kind: "review",
+        list: {
+          detailLink: { selector: "a.review", attribute: "href" },
+          maxItems: 20,
+        },
+        detail: {
+          title: { selector: "h1" },
+          publishedAt: { selector: "time", attribute: "datetime" },
+          reviewItem: ".review",
+          name: { selector: "h1" },
+          reviewText: { selector: "p" },
+          score: { value: { selector: "strong" }, scale: 100 },
+        },
+      },
+      limit: 1,
+    },
+    {
+      fetchImpl,
+      clock: previewClock(),
+      executionToken: "local-preview-owner",
+    },
+  );
+
+  expect(result.run).toMatchObject({
+    status: "succeeded",
+    requestCount: 3,
+    emittedItemCount: 0,
+    itemCount: 0,
+  });
+  expect(result.preview).toEqual({
+    issues: [],
+    pages: [
+      {
+        kind: "review",
+        url: "https://thewhiskystudy.com/reviews-3/one",
+        title: "Example Whisky",
+        publishedAt: "2026-09-01T00:00:00.000Z",
+        reviews: [
+          {
+            name: "Example Whisky",
+            reviewerName: null,
+            nativeScore: { value: 88, scale: 100, display: "88" },
+          },
+        ],
+      },
+    ],
+  });
+  expect(await db.select().from(externalReviewArticles)).toHaveLength(0);
+  expect(await db.select().from(storePrices)).toHaveLength(0);
+
+  const [storedRun] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, result.run.id));
+  expect(storedRun?.status).toBe("succeeded");
+});
+
+test("previews price rules without storing prices", async () => {
+  const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+    const url = new URL(input instanceof Request ? input.url : input);
+    if (url.pathname === "/robots.txt") {
+      return new Response("User-agent: *\nDisallow:");
+    }
+    if (url.pathname === "/whisky") {
+      return new Response('<a class="product" href="/example.html">One</a>');
+    }
+    if (url.pathname === "/example.html") {
+      return new Response(`
+        <h1>Example Whisky</h1>
+        <span class="price">€42.50</span>
+        <span class="volume">70 cl</span>
+      `);
+    }
+    return new Response(null, { status: 404 });
+  });
+
+  const result = await runLocalScrapeSourcePreview(
+    {
+      site: "finedrams",
+      listUrl: "https://www.finedrams.com/whisky",
+      rules: {
+        kind: "price",
+        list: {
+          detailLink: { selector: "a.product", attribute: "href" },
+          maxItems: 20,
+        },
+        detail: {
+          name: { selector: "h1" },
+          price: { selector: ".price" },
+          currency: "eur",
+          volume: { selector: ".volume" },
+        },
+      },
+      limit: 1,
+    },
+    {
+      fetchImpl,
+      clock: previewClock(),
+      executionToken: "local-price-preview-owner",
+    },
+  );
+
+  expect(result.run).toMatchObject({
+    status: "succeeded",
+    requestCount: 3,
+    emittedItemCount: 0,
+    itemCount: 0,
+  });
+  expect(result.preview).toEqual({
+    issues: [],
+    pages: [
+      {
+        kind: "price",
+        url: "https://www.finedrams.com/example.html",
+        products: [
+          {
+            externalProductId: null,
+            name: "Example Whisky",
+            price: 4250,
+            currency: "eur",
+            volume: 700,
+            url: "https://www.finedrams.com/example.html",
+            imageUrl: null,
+            barcode: null,
+          },
+        ],
+      },
+    ],
+  });
+  expect(await db.select().from(externalReviewArticles)).toHaveLength(0);
+  expect(await db.select().from(storePrices)).toHaveLength(0);
+});

--- a/apps/server/src/scraper/localPreview.ts
+++ b/apps/server/src/scraper/localPreview.ts
@@ -10,7 +10,7 @@ import {
 } from "./configured/rules";
 import { createLocalScrapeSourcePreview } from "./configured/runtime";
 import { findScraperSourceBySiteKey } from "./definitions";
-import type { ScraperHttpClock } from "./http";
+import { scraperSystemClock, type ScraperHttpClock } from "./http";
 import { scraperRegistry } from "./registry";
 import { executeScraperRun } from "./runs";
 import { syncScraperDefinitions } from "./syncDefinitions";
@@ -32,9 +32,11 @@ export async function runLocalScrapeSourcePreview(
     fetchImpl?: typeof fetch;
     clock?: ScraperHttpClock;
     executionToken?: string;
+    onDeferred?: (nextAttemptAt: Date) => void;
   } = {},
 ) {
   const parsed = InputSchema.parse(input);
+  const clock = options.clock ?? scraperSystemClock;
   const rules = parsed.limit
     ? {
         ...parsed.rules,
@@ -108,15 +110,26 @@ export async function runLocalScrapeSourcePreview(
   if (!run) throw new Error("Failed to create the local scraper preview run.");
 
   try {
-    await executeScraperRun(
-      { runId: run.id },
-      {
-        registry,
-        fetchImpl: options.fetchImpl,
-        clock: options.clock,
-        executionToken: options.executionToken,
-      },
-    );
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const result = await executeScraperRun(
+        { runId: run.id },
+        {
+          registry,
+          fetchImpl: options.fetchImpl,
+          clock,
+          executionToken: options.executionToken,
+        },
+      );
+      if (result.status === "completed") break;
+      if ("nextAttemptAt" in result) {
+        options.onDeferred?.(result.nextAttemptAt);
+        await clock.sleep(
+          Math.max(0, result.nextAttemptAt.getTime() - clock.now().getTime()),
+        );
+        continue;
+      }
+      throw new Error("The local scraper preview is already running.");
+    }
   } catch (error) {
     if (!preview) throw error;
   }

--- a/apps/server/src/scraper/localPreview.ts
+++ b/apps/server/src/scraper/localPreview.ts
@@ -1,0 +1,130 @@
+import { db } from "@peated/server/db";
+import { externalSiteRuns, externalSites } from "@peated/server/db/schema";
+import { syncExternalSites } from "@peated/server/lib/externalSites";
+import { and, eq, inArray } from "drizzle-orm";
+import { z } from "zod";
+import type { ScrapeSourcePreviewResult } from "./configured/preview";
+import {
+  SCRAPE_SOURCE_MAX_LIST_PAGES,
+  ScrapeRulesSchema,
+} from "./configured/rules";
+import { createLocalScrapeSourcePreview } from "./configured/runtime";
+import { findScraperSourceBySiteKey } from "./definitions";
+import type { ScraperHttpClock } from "./http";
+import { scraperRegistry } from "./registry";
+import { executeScraperRun } from "./runs";
+import { syncScraperDefinitions } from "./syncDefinitions";
+
+const InputSchema = z
+  .object({
+    site: z.string().trim().min(1),
+    listUrl: z.url(),
+    rules: ScrapeRulesSchema,
+    limit: z.number().int().positive().max(99).optional(),
+  })
+  .strict();
+
+export type LocalScrapeSourcePreviewInput = z.input<typeof InputSchema>;
+
+export async function runLocalScrapeSourcePreview(
+  input: LocalScrapeSourcePreviewInput,
+  options: {
+    fetchImpl?: typeof fetch;
+    clock?: ScraperHttpClock;
+    executionToken?: string;
+  } = {},
+) {
+  const parsed = InputSchema.parse(input);
+  const rules = parsed.limit
+    ? {
+        ...parsed.rules,
+        list: {
+          ...parsed.rules.list,
+          maxItems: Math.min(parsed.rules.list.maxItems, parsed.limit),
+        },
+      }
+    : parsed.rules;
+
+  await syncExternalSites();
+  await syncScraperDefinitions(scraperRegistry);
+
+  const [site] = await db
+    .select()
+    .from(externalSites)
+    .where(eq(externalSites.type, parsed.site));
+  if (!site) throw new Error(`External site ${parsed.site} was not found.`);
+
+  const registeredSource = findScraperSourceBySiteKey(
+    scraperRegistry,
+    parsed.site,
+  );
+  if (!registeredSource) {
+    throw new Error(`External site ${parsed.site} has no code-owned scraper.`);
+  }
+  if (registeredSource.targetKeys.length !== 1) {
+    throw new Error(
+      `External site ${parsed.site} does not use one scrape target.`,
+    );
+  }
+  const [activeRun] = await db
+    .select({ id: externalSiteRuns.id })
+    .from(externalSiteRuns)
+    .where(
+      and(
+        eq(externalSiteRuns.externalSiteId, site.id),
+        inArray(externalSiteRuns.status, ["queued", "running"]),
+      ),
+    )
+    .limit(1);
+  if (activeRun) {
+    throw new Error(`External site ${parsed.site} already has an active run.`);
+  }
+
+  let preview: ScrapeSourcePreviewResult | null = null;
+  const previewSource = createLocalScrapeSourcePreview({
+    siteKey: parsed.site,
+    targetKey: registeredSource.targetKeys[0],
+    listUrl: parsed.listUrl,
+    rules,
+    recordPreview: async ({ result }) => {
+      preview = result;
+    },
+  });
+  const sources = new Map(scraperRegistry.sources);
+  for (const [key, source] of sources) {
+    if (source.externalSiteKey === parsed.site) sources.delete(key);
+  }
+  sources.set(previewSource.key, previewSource);
+  const registry = { sources, targets: scraperRegistry.targets };
+
+  const [run] = await db
+    .insert(externalSiteRuns)
+    .values({
+      externalSiteId: site.id,
+      trigger: "manual",
+      requestLimit: rules.list.maxItems + SCRAPE_SOURCE_MAX_LIST_PAGES,
+    })
+    .returning();
+  if (!run) throw new Error("Failed to create the local scraper preview run.");
+
+  try {
+    await executeScraperRun(
+      { runId: run.id },
+      {
+        registry,
+        fetchImpl: options.fetchImpl,
+        clock: options.clock,
+        executionToken: options.executionToken,
+      },
+    );
+  } catch (error) {
+    if (!preview) throw error;
+  }
+
+  const [storedRun] = await db
+    .select()
+    .from(externalSiteRuns)
+    .where(eq(externalSiteRuns.id, run.id));
+  if (!storedRun) throw new Error("Local scraper preview run was not found.");
+  return { run: storedRun, preview };
+}


### PR DESCRIPTION
## Why

Configured scraper revisions need to be exercised against current public pages before they can replace hardcoded sources. Until now, the only practical test path either stopped at fixtures or used the production write pipeline.

## What

- Add `pnpm cli scrapers preview` for running a configured revision locally.
- Use the registered target, robots policy, request coordinator, parser, and validators while replacing the product sink with a no-op.
- Accept the same `listUrl` and `rules` shape as the revision API, with an optional item limit for quick iterations.
- Return structured page summaries and request counts without storing publisher review prose or writing reviews and prices.
- Checkpoint list/detail progress and automatically resume after request-control deferrals in the same local process.
- Cover review and price previews, no-write behavior, request accounting, and deferred-run resumption.

Live local previews against Whisky Study, Whisky Saga, Compass Box, Kilchoman, and Fine Drams exposed real coverage and normalization differences before any production activation. Only Whisky Study and Whisky Saga are current candidates; the price-source candidates were rejected because their output did not exactly match the existing source behavior.

## Testing

- `pnpm --filter @peated/server test -- src/scraper/configured/runtime.test.ts src/scraper/configured/localPreview.test.ts`
- `pnpm --filter @peated/cli test`
- `pnpm --filter @peated/server typecheck`
- `pnpm --filter @peated/cli typecheck`
- Focused oxlint and Prettier checks
- Live no-write CLI previews against the public sources listed above

## AI assistance

AI assisted with the implementation, tests, and reviewer-facing documentation. The source behavior and live preview results were verified with deterministic tests and the local CLI.
