### PR TITLE
feat(scrapers): prepare Whisky Saga for saved rules

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -54,6 +54,15 @@ function prepareWhiskyStudy(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareWhiskySaga(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "whiskysaga", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 const canonicalUrl =
   "https://thebourbonculture.com/whiskey-reviews/example-review/";
 const registry = createScraperRegistry({
@@ -74,6 +83,18 @@ const whiskyStudyRegistry = createScraperRegistry({
     {
       ...scraperRegistry.sources.get("whiskystudy")!,
       externalSiteKey: "whiskystudy",
+    },
+  ],
+});
+
+const whiskySagaCanonicalUrl =
+  "https://www.whiskysaga.com/blog/example-scotch-review";
+const whiskySagaRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("whiskysaga")!],
+  sources: [
+    {
+      ...scraperRegistry.sources.get("whiskysaga")!,
+      externalSiteKey: "whiskysaga",
     },
   ],
 });
@@ -162,6 +183,59 @@ async function setupWhiskyStudyMigration(bottleId: number | null = null) {
       nativeScoreValue: 92,
       nativeScoreScale: 100,
       nativeScoreDisplay: "92/100",
+      clip: "An existing clip.",
+      tags: ["orchard fruit"],
+    })
+    .returning();
+  await db.insert(externalReviewBodies).values({
+    externalReviewId: review.id,
+    body: "Synthetic old review body.",
+    fetchedAt: new Date(),
+  });
+  await db.insert(externalReviewPublications).values({
+    externalSiteId: site.id,
+    approvedAt: null,
+  });
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return { site, article, review };
+}
+
+async function setupWhiskySagaMigration(bottleId: number | null = null) {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "whiskysaga",
+      name: "Whisky Saga",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(whiskySagaRegistry);
+  const [article] = await db
+    .insert(externalReviewArticles)
+    .values({
+      externalSiteId: site.id,
+      canonicalUrl: whiskySagaCanonicalUrl,
+      title: "Example Scotch Review",
+      publishedAt: new Date("2026-07-05"),
+    })
+    .returning();
+  const [review] = await db
+    .insert(externalReviews)
+    .values({
+      articleId: article.id,
+      sourceKey: `whiskysaga:${createHash("sha256").update(whiskySagaCanonicalUrl).digest("hex")}`,
+      name: "Example Scotch",
+      bottleId,
+      hidden: true,
+      reviewerName: "Thomas Øhrbom",
+      nativeScoreValue: 89,
+      nativeScoreScale: 100,
+      nativeScoreDisplay: "89/100",
       clip: "An existing clip.",
       tags: ["orchard fruit"],
     })
@@ -380,6 +454,60 @@ describe("POST /admin/scrape-sources/prepare", () => {
         externalSiteId: site.id,
         kind: "review",
         listUrl: "https://thewhiskystudy.com/reviews-3",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+  });
+
+  test("prepares Whisky Saga without replacing its records", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const { site, article, review } = await setupWhiskySagaMigration(bottle.id);
+    const bodies = await db.select().from(externalReviewBodies);
+    const publications = await db.select().from(externalReviewPublications);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareWhiskySaga()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      reviewCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(externalReviews)).toEqual([review]);
+
+    const applied = await prepareWhiskySaga({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      reviewCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(whiskySagaRegistry);
+    expect(await db.select().from(externalReviewArticles)).toEqual([article]);
+    expect(await db.select().from(externalReviews)).toEqual([
+      {
+        ...review,
+        sourceKey: `${whiskySagaCanonicalUrl}#review-1`,
+      },
+    ]);
+    expect(await db.select().from(externalReviewBodies)).toEqual(bodies);
+    expect(await db.select().from(externalReviewPublications)).toEqual(
+      publications,
+    );
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "review",
+        listUrl: "https://www.whiskysaga.com/blog/category/Scotland",
         enabled: false,
         createdById: admin.id,
       }),

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -2,6 +2,7 @@ import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
 import { ExternalSiteKeySchema } from "@peated/server/schemas";
 import { prepareBourbonCultureSource } from "@peated/server/scraper/configured/prepareBourbonCulture";
+import { prepareWhiskySagaSource } from "@peated/server/scraper/configured/prepareWhiskySaga";
 import { prepareWhiskyStudySource } from "@peated/server/scraper/configured/prepareWhiskyStudy";
 import {
   ScrapeSourceConflictError,
@@ -27,7 +28,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture and whiskystudy.",
+          "The existing site's key. Currently supports bourbonculture, whiskysaga, and whiskystudy.",
         ),
         apply: z
           .boolean()
@@ -54,16 +55,17 @@ export default procedure
       .strict(),
   )
   .handler(async ({ input, context, errors }) => {
-    if (!["bourbonculture", "whiskystudy"].includes(input.site)) {
+    const prepareSource = {
+      bourbonculture: prepareBourbonCultureSource,
+      whiskysaga: prepareWhiskySagaSource,
+      whiskystudy: prepareWhiskyStudySource,
+    }[input.site];
+    if (!prepareSource) {
       throw errors.BAD_REQUEST({
         message: "This scraper cannot move to saved rules yet.",
       });
     }
     try {
-      const prepareSource =
-        input.site === "bourbonculture"
-          ? prepareBourbonCultureSource
-          : prepareWhiskyStudySource;
       return await prepareSource({
         apply: input.apply,
         createdById: context.user.id,

--- a/apps/server/src/scraper/configured/prepareWhiskySaga.ts
+++ b/apps/server/src/scraper/configured/prepareWhiskySaga.ts
@@ -1,0 +1,20 @@
+import { createHash } from "node:crypto";
+import {
+  prepareReviewSource,
+  type PrepareReviewSourceInput,
+} from "./prepareReviewSource";
+
+/** Checks one source by default; applying keeps record IDs and leaves collection paused. */
+export async function prepareWhiskySagaSource(input: PrepareReviewSourceInput) {
+  return prepareReviewSource(input, {
+    siteKey: "whiskysaga",
+    siteName: "Whisky Saga",
+    targetKey: "whiskysaga",
+    origin: "https://www.whiskysaga.com",
+    listUrl: "https://www.whiskysaga.com/blog/category/Scotland",
+    isCanonicalArticleUrl: (url) =>
+      /^https:\/\/www\.whiskysaga\.com\/blog\/[a-z0-9][a-z0-9-]*$/.test(url),
+    legacyReviewKey: (url) =>
+      `whiskysaga:${createHash("sha256").update(url).digest("hex")}`,
+  });
+}


### PR DESCRIPTION
## Why

Whisky Saga is a good review-source pilot for saved parsing rules, but its 179 existing reviews and 97 Bottle matches must keep their IDs, links, publication state, and history during the ownership change.

## What

- Add Whisky Saga to the guarded review-source preparation endpoint.
- Validate canonical article URLs and existing URL-derived review keys before changing ownership.
- Rewrite review keys in place and create a paused configured source without replacing review records, matches, publication state, or request settings.
- Keep dry-run inventory and apply behavior explicit; production activation remains a separate step.

This PR is stacked on #1018. A full local no-write preview of the proposed v2 rules passed against 20 current Whisky Saga pages with no issues, complete names/reviewers/dates/scores, normalized `NN/100` displays, and zero emitted items. The production schedule remains unchanged by this PR.

## Testing

- Full CI passed
- Guarded prepare-route tests cover inventory, in-place key changes, preserved IDs and relationships, and unsafe-state rejection
- Full live local no-write preview: 20 pages, 21 requests across a deferred resume, no parsing issues, zero writes

## AI assistance

AI assisted with the implementation, tests, production-safety review, and reviewer-facing documentation. Existing IDs and relationship invariants are enforced by deterministic integration tests.
