### PR TITLE
feat(scrapers): extend configured parsing rules

### DIFF
--- a/apps/cli/src/commands/scrapers.test.ts
+++ b/apps/cli/src/commands/scrapers.test.ts
@@ -1,5 +1,19 @@
 import { describe, expect, test } from "vitest";
-import { parsePreviewLimit } from "./scrapers";
+import { parsePreviewInput, parsePreviewLimit } from "./scrapers";
+
+const rules = {
+  kind: "price",
+  list: {
+    detailLink: { selector: "a.product", attribute: "href" },
+    maxItems: 10,
+  },
+  detail: {
+    name: { selector: "h1" },
+    price: { selector: ".price" },
+    currency: "usd",
+    volume: { value: "700 ml" },
+  },
+};
 
 describe("parsePreviewLimit", () => {
   test("accepts a bounded whole number", () => {
@@ -10,5 +24,29 @@ describe("parsePreviewLimit", () => {
     expect(() => parsePreviewLimit(value)).toThrow(
       "Preview limit must be an integer from 1 to 99.",
     );
+  });
+});
+
+describe("parsePreviewInput", () => {
+  test("defaults existing files to rules version 1", () => {
+    expect(
+      parsePreviewInput({
+        listUrl: "https://example.test/products",
+        rules: {
+          ...rules,
+          detail: { ...rules.detail, volume: { selector: ".volume" } },
+        },
+      }).rulesVersion,
+    ).toBe(1);
+  });
+
+  test("accepts an explicit rules version for the runtime parser", () => {
+    expect(
+      parsePreviewInput({
+        rulesVersion: 2,
+        listUrl: "https://example.test/products",
+        rules,
+      }),
+    ).toMatchObject({ rulesVersion: 2, rules });
   });
 });

--- a/apps/cli/src/commands/scrapers.ts
+++ b/apps/cli/src/commands/scrapers.ts
@@ -1,5 +1,4 @@
 import program from "@peated/cli/program";
-import { ScrapeRulesSchema } from "@peated/server/scraper/configured/rules";
 import { runLocalScrapeSourcePreview } from "@peated/server/scraper/localPreview";
 import { readFile } from "node:fs/promises";
 import { z } from "zod";
@@ -7,9 +6,16 @@ import { z } from "zod";
 const PreviewFileSchema = z
   .object({
     listUrl: z.url(),
-    rules: ScrapeRulesSchema,
+    rulesVersion: z.number().int().positive().default(1),
+    rules: z.json(),
   })
   .strict();
+
+type PreviewFileInput = z.input<typeof PreviewFileSchema>;
+
+export function parsePreviewInput(value: PreviewFileInput) {
+  return PreviewFileSchema.parse(value);
+}
 
 export function parsePreviewLimit(value: string) {
   const limit = Number(value);
@@ -22,7 +28,7 @@ export function parsePreviewLimit(value: string) {
 async function readPreviewFile(path: string) {
   const contents = await readFile(path, "utf8");
   try {
-    return PreviewFileSchema.parse(JSON.parse(contents));
+    return parsePreviewInput(JSON.parse(contents));
   } catch {
     throw new Error(`Invalid scraper preview file: ${path}`);
   }

--- a/apps/server/__fixtures__/bourbonculture/index.html
+++ b/apps/server/__fixtures__/bourbonculture/index.html
@@ -2,7 +2,11 @@
 <html>
   <body>
     <main>
-      <h2>Latest Whiskey Reviews</h2>
+      <h2
+        class="wp-block-heading has-text-align-center has-white-background-color has-background"
+      >
+        Latest Whiskey Reviews
+      </h2>
       <ul class="wp-block-latest-posts">
         <li>
           <a

--- a/apps/server/src/db/schema/scrapeSources.ts
+++ b/apps/server/src/db/schema/scrapeSources.ts
@@ -17,8 +17,8 @@ import {
 } from "drizzle-orm/pg-core";
 import type { ScrapeSourcePreviewResult } from "../../scraper/configured/preview";
 import {
-  type ScrapeRules,
   SCRAPE_SOURCE_KIND_LIST,
+  type StoredScrapeRules,
 } from "../../scraper/configured/rules";
 import { externalSiteRuns, externalSites } from "./externalSites";
 import { users } from "./users";
@@ -76,7 +76,7 @@ export const scrapeSourceRevisions = pgTable(
     revision: integer("revision").notNull(),
     rulesVersion: integer("rules_version").notNull(),
     listUrl: text("list_url").notNull(),
-    rules: jsonb("rules").$type<ScrapeRules>().notNull(),
+    rules: jsonb("rules").$type<StoredScrapeRules>().notNull(),
     author: scrapeSourceRevisionAuthorEnum("author").notNull(),
     aiModel: text("ai_model"),
     aiInstructionsVersion: text("ai_instructions_version"),

--- a/apps/server/src/schemas/scrapeSources.ts
+++ b/apps/server/src/schemas/scrapeSources.ts
@@ -3,6 +3,7 @@ import { ScrapeSourcePreviewResultSchema } from "../scraper/configured/preview";
 import {
   SCRAPE_SOURCE_KIND_LIST,
   ScrapeRulesSchema,
+  StoredScrapeRulesSchema,
 } from "../scraper/configured/rules";
 import { ExternalSiteSchema } from "./externalSites";
 
@@ -30,7 +31,7 @@ const ScrapeSourceRevisionBaseSchema = z
     revision: z.number().int().positive(),
     rulesVersion: z.number().int().positive(),
     listUrl: ScrapeSourceUrlSchema,
-    rules: ScrapeRulesSchema,
+    rules: StoredScrapeRulesSchema,
     active: z.boolean(),
     previewStatus: z.enum(["pending", "passed", "failed"]),
     previewResult: ScrapeSourcePreviewResultSchema,

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -150,10 +150,21 @@ pnpm cli scrapers preview --site whiskystudy --input /tmp/revision.json --limit 
 ```
 
 The input has the same `listUrl` and `rules` fields accepted by the revision
-API. Omit `--limit` for a full acceptance preview. A bounded preview is useful
-while editing rules; the complete rules still need a full local acceptance run
-before production activation. If request controls pause a run, the command
-prints the next eligible time and resumes from its saved page automatically.
+API. Set `rulesVersion` to `2` when testing version 2 operations. An omitted
+version means version 1 so existing preview files keep their original behavior:
+
+```json
+{
+  "rulesVersion": 2,
+  "listUrl": "https://example.com/reviews",
+  "rules": {}
+}
+```
+
+Omit `--limit` for a full acceptance preview. A bounded preview is useful while
+editing rules; the complete rules still need a full local acceptance run before
+production activation. If request controls pause a run, the command prints the
+next eligible time and resumes from its saved page automatically.
 
 ## Source acceptance rules
 

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -82,9 +82,13 @@ product database. Only a revision that passes its preview can become active. An
 admin can return to any older revision that passed. Pausing a source stops
 collection but keeps its revisions and run history.
 
-Rules format 1 supports same-origin HTML list and detail pages, an item limit,
-an optional next-page link, CSS selectors, and fixed date, number, price, and
-volume conversions. Code follows at most five list pages. It does not support
+Rules formats 1 and 2 support same-origin HTML list and detail pages, an item
+limit, an optional next-page link, CSS selectors, and fixed date, number, price,
+and volume conversions. Version 2 also supports bounded value cleanup, fixed
+values, joined labeled text, and list-card exclusion. An `item` selector scopes
+each `detailLink`; `excludeWhen` skips that item when its selector finds text,
+optionally beginning with one of the configured literal labels. Code follows at
+most five list pages. Rules do not support
 scripts, custom code, arbitrary request headers, browser automation, numbered
 page templates, infinite scrolling, or cross-origin discovery. Add a code-owned
 adapter when a source needs those capabilities.

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
+import { parseScrapeRules } from "./rules";
 
 const reviewConfig = {
   kind: "review" as const,
@@ -95,6 +96,168 @@ describe("scrape source parser", () => {
       name: "Example 12 Year",
       reviewerName: "Ada",
       nativeScore: { value: 91, scale: 100, display: "91 / 100" },
+    });
+  });
+
+  it("removes Whisky Study title suffixes and finds a labeled score", () => {
+    const result = parseScrapeDetail(
+      {
+        ...reviewConfig,
+        detail: {
+          ...reviewConfig.detail,
+          name: {
+            selector: "h2",
+            removeSuffixes: ["Shelf Review", "Review"],
+          },
+          score: {
+            value: {
+              selector: "p, strong",
+              startsWith: ["Score"],
+              removePrefixes: ["Score:"],
+              suffix: "/100",
+            },
+            scale: 100,
+          },
+        },
+      },
+      '<h1>Reviews</h1><time datetime="2026-04-02"></time><article class="review"><h2>Aberfeldy 18 Year Shelf Review</h2><p>Price: $120</p><strong>Score: 90</strong></article>',
+      new URL("https://reviews.test/aberfeldy"),
+    );
+
+    expect(result).toMatchObject({
+      kind: "review",
+      issues: [],
+      value: {
+        article: {
+          externalReviews: [
+            {
+              name: "Aberfeldy 18 Year",
+              nativeScore: { value: 90, display: "90/100" },
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  it("joins only Whisky Saga tasting sections in document order", () => {
+    const result = parseScrapeDetail(
+      {
+        ...reviewConfig,
+        detail: {
+          ...reviewConfig.detail,
+          reviewText: {
+            selector: ".body p",
+            startsWith: ["Nose:", "Palate:", "Taste:", "Finish:"],
+            all: true,
+          },
+          score: {
+            value: {
+              selector: ".body p",
+              startsWith: ["Score"],
+              removePrefixes: ["Score"],
+            },
+            scale: 100,
+          },
+        },
+      },
+      '<h1>Review</h1><time datetime="2026-04-02"></time><article class="review"><h2>Port Ellen</h2><div class="body"><p>An introduction.</p><p>Nose: smoke.</p><p>Price: high.</p><p>Palate: citrus.</p><p>Finish: long.</p><p>Score 90/100</p></div></article>',
+      new URL("https://reviews.test/port-ellen"),
+    );
+    if (result.kind !== "review" || !result.value)
+      throw new Error("Expected review output.");
+    expect(Object.values(result.value.externalReviewTexts)).toEqual([
+      "Nose: smoke. Palate: citrus. Finish: long.",
+    ]);
+    expect(result.value.article.externalReviews[0]?.nativeScore).toMatchObject({
+      value: 90,
+      display: "90/100",
+    });
+  });
+
+  it("uses fixed values and literal prefixes before price validation", () => {
+    const result = parseScrapeDetail(
+      {
+        kind: "price",
+        list: {
+          detailLink: { selector: "a.product", attribute: "href" },
+          maxItems: 10,
+        },
+        detail: {
+          name: { selector: "h1", prefix: "Kilchoman " },
+          price: { selector: ".price" },
+          currency: "gbp",
+          volume: { value: "700 ml" },
+        },
+      },
+      '<h1>Machir Bay</h1><span class="price">£49.95</span>',
+      new URL("https://store.test/products/machir-bay"),
+    );
+    expect(result).toMatchObject({
+      kind: "price",
+      issues: [],
+      value: [{ name: "Kilchoman Machir Bay", price: 4995, volume: 700 }],
+    });
+  });
+
+  it("reports joined values over the element bound", () => {
+    const result = parseScrapeDetail(
+      {
+        ...reviewConfig,
+        detail: {
+          ...reviewConfig.detail,
+          reviewText: { selector: ".body p", all: true },
+        },
+      },
+      `<h1>Review</h1><time datetime="2026-04-02"></time><article class="review"><h2>Bottle</h2><div class="body">${Array.from({ length: 101 }, () => "<p>Nose: smoke.</p>").join("")}</div></article>`,
+      new URL("https://reviews.test/too-many"),
+    );
+    expect(result).toMatchObject({
+      kind: "review",
+      issues: [
+        {
+          field: "detail.reviewItem",
+          message: "Value matched more than 100 elements.",
+        },
+      ],
+    });
+  });
+
+  it("treats values emptied by literal cleanup as missing", () => {
+    const result = parseScrapeDetail(
+      {
+        ...reviewConfig,
+        detail: {
+          ...reviewConfig.detail,
+          name: { selector: "h2", removeSuffixes: ["Review"] },
+        },
+      },
+      '<h1>Reviews</h1><time datetime="2026-04-02"></time><article class="review"><h2>Review</h2></article>',
+      new URL("https://reviews.test/empty-name"),
+    );
+    expect(result.issues).toContainEqual({
+      field: "detail.name",
+      message: "Required value was not found.",
+    });
+  });
+
+  it("keeps version 1 parsing output unchanged", () => {
+    const rules = parseScrapeRules(1, reviewConfig);
+    const result = parseScrapeDetail(
+      rules,
+      '<h1>Spring reviews</h1><time datetime="2026-04-02"></time><article class="review"><h2>Example 12 Year</h2><span class="score">91 / 100</span><div class="body">Rich and balanced.</div></article>',
+      new URL("https://reviews.test/spring"),
+    );
+    expect(result).toMatchObject({
+      kind: "review",
+      issues: [],
+      value: {
+        article: {
+          externalReviews: [
+            { name: "Example 12 Year", nativeScore: { value: 91 } },
+          ],
+        },
+      },
     });
   });
 

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -1,5 +1,6 @@
 import { loadFixture } from "@peated/server/lib/test/fixtures";
 import { describe, expect, it } from "vitest";
+import { parseCompassBoxProducts } from "../adapters/legacy/scrapeCompassBox";
 import { parseWhiskySagaArticle } from "../adapters/whiskySaga";
 import { parseWhiskyStudyArticle } from "../adapters/whiskyStudy";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
@@ -101,6 +102,22 @@ const whiskySagaRules = {
   },
 } satisfies ScrapeRules;
 
+const compassBoxRules = {
+  kind: "price",
+  list: {
+    item: ".card-wrapper.product-card-wrapper",
+    detailLink: { selector: ".card__heading a[href]", attribute: "href" },
+    excludeWhen: { selector: ".badge", startsWith: ["Sold out"] },
+    maxItems: 99,
+  },
+  detail: {
+    name: { selector: "h1", prefix: "Compass Box " },
+    price: { selector: ".price" },
+    currency: "gbp",
+    volume: { value: "700 ml" },
+  },
+} satisfies ScrapeRules;
+
 function expectReviewFactsAndEvidenceToMatch(
   configured: ReturnType<typeof parseScrapeDetail>,
   legacy: NonNullable<ReturnType<typeof parseWhiskyStudyArticle>>,
@@ -159,6 +176,41 @@ describe("scrape source parser", () => {
     expect(result).toEqual({
       links: ["https://reviews.test/one"],
       nextPageUrl: "https://reviews.test/archive?page=2",
+      issues: [],
+    });
+  });
+
+  it("excludes unavailable list cards with bounded text matching", () => {
+    const result = parseScrapeList(
+      {
+        ...reviewConfig,
+        list: {
+          ...reviewConfig.list,
+          item: ".product-card",
+          excludeWhen: { selector: ".badge", startsWith: ["Sold out"] },
+        },
+      },
+      '<article class="product-card"><span class="badge">New</span><a class="review" href="/one">One</a></article><article class="product-card"><span class="badge">SOLD OUT</span><a class="review" href="/two">Two</a></article><article class="product-card"><a class="review" href="/three">Three</a></article>',
+      new URL("https://reviews.test/archive"),
+    );
+
+    expect(result).toEqual({
+      links: ["https://reviews.test/one", "https://reviews.test/three"],
+      nextPageUrl: null,
+      issues: [],
+    });
+  });
+
+  it("matches the current Compass Box parser's available product links", async () => {
+    const pageUrl = new URL("https://www.compassboxwhisky.com/collections");
+    const html = await loadFixture("compassbox", "bottle-list.html");
+    const legacyLinks = parseCompassBoxProducts(html, pageUrl.toString()).map(
+      ({ url }) => url,
+    );
+
+    expect(parseScrapeList(compassBoxRules, html, pageUrl)).toEqual({
+      links: legacyLinks,
+      nextPageUrl: null,
       issues: [],
     });
   });

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -1,6 +1,9 @@
+import { loadFixture } from "@peated/server/lib/test/fixtures";
 import { describe, expect, it } from "vitest";
+import { parseWhiskySagaArticle } from "../adapters/whiskySaga";
+import { parseWhiskyStudyArticle } from "../adapters/whiskyStudy";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
-import { parseScrapeRules } from "./rules";
+import { parseScrapeRules, type ScrapeRules } from "./rules";
 
 const reviewConfig = {
   kind: "review" as const,
@@ -18,6 +21,114 @@ const reviewConfig = {
     score: { value: { selector: ".score" }, scale: 100 },
   },
 };
+
+const whiskyStudyRules = {
+  kind: "review",
+  list: {
+    detailLink: {
+      selector: "article.blog-item h1.blog-title a[href]",
+      attribute: "href",
+    },
+    maxItems: 20,
+  },
+  detail: {
+    title: { selector: "h1.entry-title" },
+    publishedAt: {
+      selector: 'meta[itemprop="datePublished"]',
+      attribute: "content",
+    },
+    reviewItem: "article.h-entry .blog-item-content.e-content",
+    name: {
+      selector: "h1.entry-title",
+      removeSuffixes: ["Shelf Review", "Review"],
+    },
+    reviewerName: {
+      selector: 'meta[itemprop="author"]',
+      attribute: "content",
+    },
+    reviewText: {
+      selector: "article.h-entry .blog-item-content.e-content p",
+      startsWith: ["Nose:", "Palate:", "Taste:", "Finish:"],
+      all: true,
+    },
+    score: {
+      value: {
+        selector:
+          "article.h-entry .blog-item-content.e-content h1, article.h-entry .blog-item-content.e-content h2, article.h-entry .blog-item-content.e-content h3, article.h-entry .blog-item-content.e-content h4, article.h-entry .blog-item-content.e-content p",
+        startsWith: ["Score"],
+        removePrefixes: ["Score:"],
+        suffix: "/100",
+      },
+      scale: 100,
+    },
+  },
+} satisfies ScrapeRules;
+
+const whiskySagaRules = {
+  kind: "review",
+  list: {
+    detailLink: {
+      selector: "article.blog-item a.blog-more-link[href]",
+      attribute: "href",
+    },
+    maxItems: 20,
+  },
+  detail: {
+    title: { selector: "h1.entry-title" },
+    publishedAt: {
+      selector: 'meta[itemprop="datePublished"]',
+      attribute: "content",
+    },
+    reviewItem: "article.h-entry .blog-item-content",
+    name: { selector: "h1.entry-title" },
+    reviewerName: {
+      selector: 'meta[itemprop="author"]',
+      attribute: "content",
+    },
+    reviewText: {
+      selector: "article.h-entry .blog-item-content p",
+      startsWith: ["Nose:", "Palate:", "Taste:", "Finish:"],
+      all: true,
+    },
+    score: {
+      value: {
+        selector: "article.h-entry .blog-item-content p",
+        startsWith: ["Score"],
+        removePrefixes: ["Score:", "Score"],
+      },
+      scale: 100,
+    },
+  },
+} satisfies ScrapeRules;
+
+function expectReviewFactsAndEvidenceToMatch(
+  configured: ReturnType<typeof parseScrapeDetail>,
+  legacy: NonNullable<ReturnType<typeof parseWhiskyStudyArticle>>,
+) {
+  expect(configured.kind).toBe("review");
+  expect(configured.issues).toEqual([]);
+  if (configured.kind !== "review" || !configured.value) {
+    throw new Error("Expected configured review output.");
+  }
+  const configuredReview = configured.value.article.externalReviews[0];
+  const legacyReview = legacy.article.externalReviews[0];
+  expect(configured.value.article).toMatchObject({
+    canonicalUrl: legacy.article.canonicalUrl,
+    title: legacy.article.title,
+    publishedAt: legacy.article.publishedAt,
+  });
+  expect(configuredReview).toMatchObject({
+    name: legacyReview?.name,
+    reviewerName: legacyReview?.reviewerName,
+    nativeScore: legacyReview?.nativeScore,
+  });
+  expect(Object.values(configured.value.externalReviewTexts)).toEqual(
+    Object.values(legacy.externalReviewTexts),
+  );
+  expect(Object.values(configured.value.externalReviewBodies)).toEqual(
+    Object.values(legacy.externalReviewBodies),
+  );
+}
 
 describe("scrape source parser", () => {
   it("limits detail links to the same website", () => {
@@ -173,6 +284,40 @@ describe("scrape source parser", () => {
       value: 90,
       display: "90/100",
     });
+  });
+
+  it("matches the current Whisky Study parser facts and evidence", async () => {
+    const url = new URL(
+      "https://thewhiskystudy.com/reviews-3/example-scotch-review",
+    );
+    const html = (await loadFixture("whiskystudy", "review.html")).replace(
+      "<head>",
+      '<head><meta itemprop="datePublished" content="2026-07-04T12:03:15-0700"><meta itemprop="author" content="Chris Ellis">',
+    );
+    const legacy = parseWhiskyStudyArticle(html, url);
+    expect(legacy).not.toBeNull();
+    if (!legacy) throw new Error("Expected legacy review output.");
+
+    expectReviewFactsAndEvidenceToMatch(
+      parseScrapeDetail(whiskyStudyRules, html, url),
+      legacy,
+    );
+  });
+
+  it("matches the current Whisky Saga parser facts and evidence", async () => {
+    const url = new URL("https://www.whiskysaga.com/blog/example-scotch");
+    const html = (await loadFixture("whiskysaga", "review.html")).replace(
+      "<head>",
+      '<head><meta itemprop="datePublished" content="2026-08-17T22:36:08+0200"><meta itemprop="author" content="Thomas Øhrbom">',
+    );
+    const legacy = parseWhiskySagaArticle(html, url);
+    expect(legacy).not.toBeNull();
+    if (!legacy) throw new Error("Expected legacy review output.");
+
+    expectReviewFactsAndEvidenceToMatch(
+      parseScrapeDetail(whiskySagaRules, html, url),
+      legacy,
+    );
   });
 
   it("uses fixed values and literal prefixes before price validation", () => {

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -1,5 +1,9 @@
 import { loadFixture } from "@peated/server/lib/test/fixtures";
 import { describe, expect, it } from "vitest";
+import {
+  discoverBourbonCultureArticles,
+  parseBourbonCultureArticle,
+} from "../adapters/bourbonCulture";
 import { parseCompassBoxProducts } from "../adapters/legacy/scrapeCompassBox";
 import { parseWhiskySagaArticle } from "../adapters/whiskySaga";
 import { parseWhiskyStudyArticle } from "../adapters/whiskyStudy";
@@ -98,6 +102,48 @@ const whiskySagaRules = {
         removePrefixes: ["Score:", "Score"],
       },
       scale: 100,
+    },
+  },
+} satisfies ScrapeRules;
+
+const bourbonCultureRules = {
+  kind: "review",
+  list: {
+    detailLink: {
+      selector:
+        "h2.wp-block-heading.has-white-background-color + ul.wp-block-latest-posts a.wp-block-latest-posts__post-title[href]",
+      attribute: "href",
+    },
+    maxItems: 6,
+  },
+  detail: {
+    title: { selector: "article h1.entry-title" },
+    publishedAt: {
+      selector: "article time.entry-date",
+      attribute: "datetime",
+    },
+    reviewItem: "article .entry-content",
+    name: {
+      selector: "article h1.entry-title",
+      removeSuffixes: ["Review"],
+    },
+    reviewerName: {
+      selector: 'meta[name="author"]',
+      attribute: "content",
+    },
+    reviewText: {
+      selector: "article .entry-content p",
+      startsWith: ["Nose:", "Palate:", "Finish:"],
+      all: true,
+    },
+    score: {
+      value: {
+        selector:
+          "article .entry-content h1, article .entry-content h2, article .entry-content h3, article .entry-content h4, article .entry-content p",
+        startsWith: ["Score:"],
+        removePrefixes: ["Score:"],
+      },
+      scale: 10,
     },
   },
 } satisfies ScrapeRules;
@@ -209,6 +255,20 @@ describe("scrape source parser", () => {
     );
 
     expect(parseScrapeList(compassBoxRules, html, pageUrl)).toEqual({
+      links: legacyLinks,
+      nextPageUrl: null,
+      issues: [],
+    });
+  });
+
+  it("matches the current Bourbon Culture parser's latest review links", async () => {
+    const pageUrl = new URL("https://thebourbonculture.com/");
+    const html = await loadFixture("bourbonculture", "index.html");
+    const legacyLinks = discoverBourbonCultureArticles(html).map(
+      (url) => url.href,
+    );
+
+    expect(parseScrapeList(bourbonCultureRules, html, pageUrl)).toEqual({
       links: legacyLinks,
       nextPageUrl: null,
       issues: [],
@@ -368,6 +428,20 @@ describe("scrape source parser", () => {
 
     expectReviewFactsAndEvidenceToMatch(
       parseScrapeDetail(whiskySagaRules, html, url),
+      legacy,
+    );
+  });
+
+  it("matches the current Bourbon Culture parser facts and evidence", async () => {
+    const url = new URL(
+      "https://thebourbonculture.com/whiskey-reviews/example-bourbon-review/",
+    );
+    const html = await loadFixture("bourbonculture", "review.html");
+    const legacy = parseBourbonCultureArticle(html, url);
+    expect(legacy.article.externalReviews).toHaveLength(1);
+
+    expectReviewFactsAndEvidenceToMatch(
+      parseScrapeDetail(bourbonCultureRules, html, url),
       legacy,
     );
   });

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -116,21 +116,30 @@ export function parseScrapeList(
   const links = new Set<string>();
   try {
     const $ = load(html);
-    for (const element of $(rules.list.detailLink.selector).toArray()) {
-      const raw = rules.list.detailLink.attribute
-        ? $(element).attr(rules.list.detailLink.attribute)
-        : $(element).text();
-      if (!raw?.trim()) continue;
-      try {
-        links.add(absoluteHttpUrl(raw.trim(), pageUrl));
-      } catch (error) {
-        issues.push({
-          field: "list.detailLink",
-          message:
-            error instanceof Error
-              ? error.message
-              : "Unable to parse selector.",
-        });
+    const itemSelector = "item" in rules.list ? rules.list.item : undefined;
+    const excludeWhen =
+      "excludeWhen" in rules.list ? rules.list.excludeWhen : undefined;
+    const items = itemSelector ? $(itemSelector).toArray() : [null];
+    for (const itemElement of items) {
+      const item = itemElement ? load($.html(itemElement)) : $;
+      if (excludeWhen && readValue(item, excludeWhen)) continue;
+      for (const element of item(rules.list.detailLink.selector).toArray()) {
+        const raw = rules.list.detailLink.attribute
+          ? item(element).attr(rules.list.detailLink.attribute)
+          : item(element).text();
+        if (!raw?.trim()) continue;
+        try {
+          links.add(absoluteHttpUrl(raw.trim(), pageUrl));
+        } catch (error) {
+          issues.push({
+            field: "list.detailLink",
+            message:
+              error instanceof Error
+                ? error.message
+                : "Unable to parse selector.",
+          });
+        }
+        if (links.size >= rules.list.maxItems) break;
       }
       if (links.size >= rules.list.maxItems) break;
     }

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -6,7 +6,11 @@ import { createHash } from "node:crypto";
 import type { z } from "zod";
 import { readReviewBody } from "../adapters/reviewBody";
 import type { ScrapeIssue } from "./preview";
-import type { ScrapeRules, ScrapeValueSelector } from "./rules";
+import type {
+  ScrapeValue,
+  ScrapeValueSelectorV1,
+  StoredScrapeRules,
+} from "./rules";
 
 export type ScrapeListResult = {
   links: string[];
@@ -26,16 +30,69 @@ export type ScrapeDetailResult =
       issues: ScrapeIssue[];
     };
 
-function readValue(
-  root: ReturnType<typeof load>,
-  selector: ScrapeValueSelector,
-) {
-  const element = root(selector.selector).first();
-  const raw = selector.attribute
-    ? element.attr(selector.attribute)
-    : element.text();
-  const value = raw?.replaceAll(/\s+/g, " ").trim();
-  return value || null;
+type ScrapeReadableValue = ScrapeValue | ScrapeValueSelectorV1;
+
+function normalizeValue(value: string | undefined) {
+  return value?.replaceAll(/\s+/g, " ").trim() || null;
+}
+
+function cleanValue(value: string | null, rule: ScrapeReadableValue) {
+  if (!value) return null;
+  let result = value;
+  if ("removePrefixes" in rule && rule.removePrefixes) {
+    const normalized = result.toLowerCase();
+    const prefix = rule.removePrefixes.find((candidate) =>
+      normalized.startsWith(candidate.toLowerCase()),
+    );
+    if (prefix) result = result.slice(prefix.length).trim();
+  }
+  if ("removeSuffixes" in rule && rule.removeSuffixes) {
+    const normalized = result.toLowerCase();
+    const suffix = rule.removeSuffixes.find((candidate) =>
+      normalized.endsWith(candidate.toLowerCase()),
+    );
+    if (suffix) result = result.slice(0, -suffix.length).trim();
+  }
+  if (!result) return null;
+  if ("prefix" in rule && rule.prefix) result = `${rule.prefix}${result}`;
+  if ("suffix" in rule && rule.suffix) result = `${result}${rule.suffix}`;
+  return normalizeValue(result);
+}
+
+function readValue(root: ReturnType<typeof load>, rule: ScrapeReadableValue) {
+  if ("value" in rule) return cleanValue(normalizeValue(rule.value), rule);
+
+  if ("attribute" in rule && rule.attribute) {
+    return cleanValue(
+      normalizeValue(root(rule.selector).first().attr(rule.attribute)),
+      rule,
+    );
+  }
+
+  const values: string[] = [];
+  const startsWith =
+    "startsWith" in rule
+      ? rule.startsWith?.map((value) => value.toLowerCase())
+      : undefined;
+  root(rule.selector).each((_, element) => {
+    const value = normalizeValue(root(element).text());
+    if (!value) return;
+    if (
+      startsWith &&
+      !startsWith.some((prefix) => value.toLowerCase().startsWith(prefix))
+    ) {
+      return;
+    }
+    values.push(value);
+    if (!("all" in rule && rule.all) || values.length > 100) return false;
+  });
+  if (values.length > 100) {
+    throw new Error("Value matched more than 100 elements.");
+  }
+  return cleanValue(
+    normalizeValue("all" in rule && rule.all ? values.join(" ") : values[0]),
+    rule,
+  );
 }
 
 function absoluteHttpUrl(value: string, baseUrl: URL) {
@@ -51,7 +108,7 @@ function absoluteHttpUrl(value: string, baseUrl: URL) {
 }
 
 export function parseScrapeList(
-  rules: ScrapeRules,
+  rules: StoredScrapeRules,
   html: string,
   pageUrl: URL,
 ): ScrapeListResult {
@@ -181,7 +238,7 @@ function priceField(path: PropertyKey[]) {
 }
 
 function parseReviewDetail(
-  rules: Extract<ScrapeRules, { kind: "review" }>,
+  rules: Extract<StoredScrapeRules, { kind: "review" }>,
   html: string,
   pageUrl: URL,
 ): ScrapeDetailResult {
@@ -212,28 +269,34 @@ function parseReviewDetail(
   const reviewItems = $(rules.detail.reviewItem).toArray();
   const readReviewValue = (
     item: ReturnType<typeof load>,
-    selector: ScrapeValueSelector,
+    selector: ScrapeReadableValue,
   ) =>
     readValue(item, selector) ??
     (reviewItems.length === 1 ? readValue($, selector) : null);
 
   try {
     const reviewerSelector = rules.detail.reviewerName;
-    const pageBylines = reviewerSelector
-      ? $(reviewerSelector.selector).filter(
-          (_, element) =>
-            $(element).closest(rules.detail.reviewItem).length === 0,
-        )
-      : null;
-    // Scraper parsing shares only one explicit page byline; a review's writer stays local.
-    const pageReviewerText =
-      reviewerSelector && pageBylines?.length === 1
-        ? reviewerSelector.attribute
-          ? pageBylines.attr(reviewerSelector.attribute)
-          : pageBylines.text()
+    const pageBylines =
+      reviewerSelector && !("value" in reviewerSelector)
+        ? $(reviewerSelector.selector).filter(
+            (_, element) =>
+              $(element).closest(rules.detail.reviewItem).length === 0,
+          )
         : null;
+    // Scraper parsing shares only one explicit page byline; a review's writer stays local.
     const pageReviewerName =
-      pageReviewerText?.replaceAll(/\s+/g, " ").trim() || null;
+      reviewerSelector && "value" in reviewerSelector
+        ? readValue($, reviewerSelector)
+        : reviewerSelector && pageBylines?.length === 1
+          ? cleanValue(
+              normalizeValue(
+                "attribute" in reviewerSelector && reviewerSelector.attribute
+                  ? pageBylines.attr(reviewerSelector.attribute)
+                  : pageBylines.text(),
+              ),
+              reviewerSelector,
+            )
+          : null;
     reviewItems.forEach((element, index) => {
       const item = load($.html(element));
       const name = readReviewValue(item, rules.detail.name);
@@ -311,7 +374,7 @@ function parseReviewDetail(
 }
 
 function parseStorePriceDetail(
-  rules: Extract<ScrapeRules, { kind: "price" }>,
+  rules: Extract<StoredScrapeRules, { kind: "price" }>,
   html: string,
   pageUrl: URL,
 ): ScrapeDetailResult {
@@ -349,7 +412,7 @@ function parseStorePriceDetail(
 }
 
 export function parseScrapeDetail(
-  rules: ScrapeRules,
+  rules: StoredScrapeRules,
   html: string,
   pageUrl: URL,
 ): ScrapeDetailResult {

--- a/apps/server/src/scraper/configured/rules.test.ts
+++ b/apps/server/src/scraper/configured/rules.test.ts
@@ -45,7 +45,38 @@ test("rejects rules for an unsupported stored format", () => {
 test("loads old rules only through the version 1 contract", () => {
   const rules = ScrapeRulesV1Schema.parse(reviewConfig(25));
   expect(parseScrapeRules(1, rules)).toEqual(rules);
+  expect(() =>
+    parseScrapeRules(1, {
+      ...rules,
+      list: { ...rules.list, item: ".card" },
+    }),
+  ).toThrow();
   expect(SCRAPE_RULES_VERSION).toBe(2);
+});
+
+test("accepts bounded list-card exclusion only with an item selector", () => {
+  expect(
+    ScrapeRulesSchema.parse({
+      ...reviewConfig(25),
+      list: {
+        ...reviewConfig(25).list,
+        item: ".product-card",
+        excludeWhen: { selector: ".badge", startsWith: ["Sold out"] },
+      },
+    }).list,
+  ).toMatchObject({
+    item: ".product-card",
+    excludeWhen: { selector: ".badge", startsWith: ["Sold out"] },
+  });
+  expect(() =>
+    ScrapeRulesSchema.parse({
+      ...reviewConfig(25),
+      list: {
+        ...reviewConfig(25).list,
+        excludeWhen: { selector: ".badge" },
+      },
+    }),
+  ).toThrow("List exclusion requires an item selector.");
 });
 
 test("accepts bounded selector and fixed value operations", () => {

--- a/apps/server/src/scraper/configured/rules.test.ts
+++ b/apps/server/src/scraper/configured/rules.test.ts
@@ -1,9 +1,12 @@
 import { expect, test } from "vitest";
 import {
   parseScrapeRules,
+  SCRAPE_RULES_VERSION,
   SCRAPE_SOURCE_MAX_ITEMS,
   SCRAPE_SOURCE_MAX_LIST_PAGES,
   ScrapeRulesSchema,
+  ScrapeRulesV1Schema,
+  ScrapeValueSchema,
 } from "./rules";
 
 function reviewConfig(maxItems: number) {
@@ -34,7 +37,78 @@ test("bounds list and detail pages", () => {
 
 test("rejects rules for an unsupported stored format", () => {
   const rules = ScrapeRulesSchema.parse(reviewConfig(25));
-  expect(() => parseScrapeRules(2, rules)).toThrow(
-    "Unsupported scrape rules version: 2.",
+  expect(() => parseScrapeRules(3, rules)).toThrow(
+    "Unsupported scrape rules version: 3.",
   );
+});
+
+test("loads old rules only through the version 1 contract", () => {
+  const rules = ScrapeRulesV1Schema.parse(reviewConfig(25));
+  expect(parseScrapeRules(1, rules)).toEqual(rules);
+  expect(SCRAPE_RULES_VERSION).toBe(2);
+});
+
+test("accepts bounded selector and fixed value operations", () => {
+  expect(
+    ScrapeValueSchema.parse({
+      selector: ".notes p",
+      startsWith: ["Nose:", "Finish:"],
+      all: true,
+      removePrefixes: ["Score:"],
+      removeSuffixes: [" Review"],
+      prefix: "Kilchoman ",
+      suffix: "/100",
+    }),
+  ).toEqual({
+    selector: ".notes p",
+    startsWith: ["Nose:", "Finish:"],
+    all: true,
+    removePrefixes: ["Score:"],
+    removeSuffixes: ["Review"],
+    prefix: "Kilchoman ",
+    suffix: "/100",
+  });
+  expect(ScrapeValueSchema.parse({ value: "700 ml" })).toEqual({
+    value: "700 ml",
+  });
+});
+
+test.each([
+  ["both inputs", { selector: "h1", value: "700 ml" }],
+  ["no input", { prefix: "Kilchoman " }],
+  ["unknown operation", { selector: "h1", regex: "Review$" }],
+  [
+    "attribute prefix filter",
+    { selector: "meta", attribute: "content", startsWith: ["Score"] },
+  ],
+  ["attribute joining", { selector: "meta", attribute: "content", all: true }],
+  ["fixed value length", { value: "x".repeat(201) }],
+  ["prefix length", { selector: "h1", prefix: "x".repeat(201) }],
+  ["suffix length", { selector: "h1", suffix: "x".repeat(201) }],
+  [
+    "prefix count",
+    { selector: "p", startsWith: Array.from({ length: 11 }, () => "Nose") },
+  ],
+  ["prefix length", { selector: "p", startsWith: ["x".repeat(101)] }],
+  [
+    "suffix count",
+    {
+      selector: "h1",
+      removeSuffixes: Array.from({ length: 11 }, () => "Review"),
+    },
+  ],
+  ["suffix length", { selector: "h1", removeSuffixes: ["x".repeat(101)] }],
+  [
+    "removed prefix count",
+    {
+      selector: "h1",
+      removePrefixes: Array.from({ length: 11 }, () => "Score"),
+    },
+  ],
+  [
+    "removed prefix length",
+    { selector: "h1", removePrefixes: ["x".repeat(101)] },
+  ],
+])("rejects invalid or unbounded value rules: %s", (_, rule) => {
+  expect(() => ScrapeValueSchema.parse(rule)).toThrow();
 });

--- a/apps/server/src/scraper/configured/rules.ts
+++ b/apps/server/src/scraper/configured/rules.ts
@@ -79,7 +79,7 @@ export const ScrapeValueSchema = z.union([
   ScrapeFixedValueSchema,
 ]);
 
-const ListRulesSchema = z
+const ListRulesV1Schema = z
   .object({
     detailLink: ScrapeValueSelectorV1Schema,
     nextPage: ScrapeValueSelectorV1Schema.optional(),
@@ -92,11 +92,36 @@ const ListRulesSchema = z
   })
   .strict();
 
-function reviewRulesSchema<T extends z.ZodType>(valueSchema: T) {
+export const ScrapeListExclusionSchema = z
+  .object({
+    selector: ScrapeSelectorSchema,
+    startsWith: ScrapeLiteralListSchema.optional(),
+  })
+  .strict();
+
+const ListRulesSchema = ListRulesV1Schema.extend({
+  item: ScrapeSelectorSchema.optional(),
+  excludeWhen: ScrapeListExclusionSchema.optional(),
+})
+  .strict()
+  .superRefine((rules, context) => {
+    if (rules.excludeWhen && !rules.item) {
+      context.addIssue({
+        code: "custom",
+        path: ["excludeWhen"],
+        message: "List exclusion requires an item selector.",
+      });
+    }
+  });
+
+function reviewRulesSchema<T extends z.ZodType, U extends z.ZodType>(
+  valueSchema: T,
+  listSchema: U,
+) {
   return z
     .object({
       kind: z.literal("review"),
-      list: ListRulesSchema,
+      list: listSchema,
       detail: z
         .object({
           title: valueSchema,
@@ -118,11 +143,14 @@ function reviewRulesSchema<T extends z.ZodType>(valueSchema: T) {
     .strict();
 }
 
-function priceRulesSchema<T extends z.ZodType>(valueSchema: T) {
+function priceRulesSchema<T extends z.ZodType, U extends z.ZodType>(
+  valueSchema: T,
+  listSchema: U,
+) {
   return z
     .object({
       kind: z.literal("price"),
-      list: ListRulesSchema,
+      list: listSchema,
       detail: z
         .object({
           name: valueSchema,
@@ -140,13 +168,13 @@ function priceRulesSchema<T extends z.ZodType>(valueSchema: T) {
 }
 
 export const ScrapeRulesV1Schema = z.discriminatedUnion("kind", [
-  reviewRulesSchema(ScrapeValueSelectorV1Schema),
-  priceRulesSchema(ScrapeValueSelectorV1Schema),
+  reviewRulesSchema(ScrapeValueSelectorV1Schema, ListRulesV1Schema),
+  priceRulesSchema(ScrapeValueSelectorV1Schema, ListRulesV1Schema),
 ]);
 
 export const ScrapeRulesSchema = z.discriminatedUnion("kind", [
-  reviewRulesSchema(ScrapeValueSchema),
-  priceRulesSchema(ScrapeValueSchema),
+  reviewRulesSchema(ScrapeValueSchema, ListRulesSchema),
+  priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
 ]);
 
 export const StoredScrapeRulesSchema = z.union([
@@ -159,6 +187,7 @@ export type ScrapeRules = z.infer<typeof ScrapeRulesSchema>;
 export type StoredScrapeRules = z.infer<typeof StoredScrapeRulesSchema>;
 export type ScrapeValueSelectorV1 = z.infer<typeof ScrapeValueSelectorV1Schema>;
 export type ScrapeValue = z.infer<typeof ScrapeValueSchema>;
+export type ScrapeListExclusion = z.infer<typeof ScrapeListExclusionSchema>;
 
 /** Parses rules only with the interpreter contract that owns their stored version. */
 export function parseScrapeRules(

--- a/apps/server/src/scraper/configured/rules.ts
+++ b/apps/server/src/scraper/configured/rules.ts
@@ -1,13 +1,19 @@
 import { CURRENCY_LIST } from "@peated/server/constants";
+import type { JsonValue } from "@peated/server/scraper/types";
 import { z } from "zod";
 
-export const SCRAPE_RULES_VERSION = 1;
+export const SCRAPE_RULES_VERSION_1 = 1;
+export const SCRAPE_RULES_VERSION = 2;
 // TODO(scraper-platform): Add event after scraped-event match and update rules are defined.
 export const SCRAPE_SOURCE_KIND_LIST = ["review", "price"] as const;
 export type ScrapeSourceKind = (typeof SCRAPE_SOURCE_KIND_LIST)[number];
 export const SCRAPE_SOURCE_MAX_LIST_PAGES = 5;
 export const SCRAPE_SOURCE_DEFAULT_MAX_ITEMS = 25;
 export const SCRAPE_SOURCE_MAX_ITEMS = 99;
+
+const SCRAPE_VALUE_MAX_LENGTH = 200;
+const SCRAPE_LITERAL_MAX_LENGTH = 100;
+const SCRAPE_LITERAL_MAX_ITEMS = 10;
 
 export const ScrapeSelectorSchema = z
   .string()
@@ -20,17 +26,63 @@ export const ScrapeSelectorSchema = z
 
 export const ScrapeAttributeSchema = z.string().trim().min(1).max(100);
 
-const ScrapeValueSelectorSchema = z
+const ScrapeLiteralSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(SCRAPE_LITERAL_MAX_LENGTH);
+const ScrapeLiteralListSchema = z
+  .array(ScrapeLiteralSchema)
+  .min(1)
+  .max(SCRAPE_LITERAL_MAX_ITEMS);
+const ScrapeCleanupSchema = {
+  removePrefixes: ScrapeLiteralListSchema.optional(),
+  removeSuffixes: ScrapeLiteralListSchema.optional(),
+  prefix: z.string().min(1).max(SCRAPE_VALUE_MAX_LENGTH).optional(),
+  suffix: z.string().min(1).max(SCRAPE_VALUE_MAX_LENGTH).optional(),
+};
+
+export const ScrapeValueSelectorV1Schema = z
   .object({
     selector: ScrapeSelectorSchema,
     attribute: ScrapeAttributeSchema.optional(),
   })
   .strict();
 
+const ScrapeTextValueSelectorSchema = z
+  .object({
+    selector: ScrapeSelectorSchema,
+    startsWith: ScrapeLiteralListSchema.optional(),
+    all: z.literal(true).optional(),
+    ...ScrapeCleanupSchema,
+  })
+  .strict();
+
+const ScrapeAttributeValueSelectorSchema = z
+  .object({
+    selector: ScrapeSelectorSchema,
+    attribute: ScrapeAttributeSchema,
+    ...ScrapeCleanupSchema,
+  })
+  .strict();
+
+const ScrapeFixedValueSchema = z
+  .object({
+    value: z.string().trim().min(1).max(SCRAPE_VALUE_MAX_LENGTH),
+    ...ScrapeCleanupSchema,
+  })
+  .strict();
+
+export const ScrapeValueSchema = z.union([
+  ScrapeTextValueSelectorSchema,
+  ScrapeAttributeValueSelectorSchema,
+  ScrapeFixedValueSchema,
+]);
+
 const ListRulesSchema = z
   .object({
-    detailLink: ScrapeValueSelectorSchema,
-    nextPage: ScrapeValueSelectorSchema.optional(),
+    detailLink: ScrapeValueSelectorV1Schema,
+    nextPage: ScrapeValueSelectorV1Schema.optional(),
     maxItems: z
       .number()
       .int()
@@ -40,61 +92,84 @@ const ListRulesSchema = z
   })
   .strict();
 
-const ReviewRulesSchema = z
-  .object({
-    kind: z.literal("review"),
-    list: ListRulesSchema,
-    detail: z
-      .object({
-        title: ScrapeValueSelectorSchema,
-        publishedAt: ScrapeValueSelectorSchema.optional(),
-        reviewItem: ScrapeSelectorSchema,
-        name: ScrapeValueSelectorSchema,
-        reviewerName: ScrapeValueSelectorSchema.optional(),
-        reviewText: ScrapeValueSelectorSchema.optional(),
-        score: z
-          .object({
-            value: ScrapeValueSelectorSchema,
-            scale: z.number().positive(),
-          })
-          .strict()
-          .optional(),
-      })
-      .strict(),
-  })
-  .strict();
+function reviewRulesSchema<T extends z.ZodType>(valueSchema: T) {
+  return z
+    .object({
+      kind: z.literal("review"),
+      list: ListRulesSchema,
+      detail: z
+        .object({
+          title: valueSchema,
+          publishedAt: valueSchema.optional(),
+          reviewItem: ScrapeSelectorSchema,
+          name: valueSchema,
+          reviewerName: valueSchema.optional(),
+          reviewText: valueSchema.optional(),
+          score: z
+            .object({
+              value: valueSchema,
+              scale: z.number().positive(),
+            })
+            .strict()
+            .optional(),
+        })
+        .strict(),
+    })
+    .strict();
+}
 
-const PriceRulesSchema = z
-  .object({
-    kind: z.literal("price"),
-    list: ListRulesSchema,
-    detail: z
-      .object({
-        name: ScrapeValueSelectorSchema,
-        price: ScrapeValueSelectorSchema,
-        currency: z.enum(CURRENCY_LIST),
-        volume: ScrapeValueSelectorSchema,
-        url: ScrapeValueSelectorSchema.optional(),
-        externalProductId: ScrapeValueSelectorSchema.optional(),
-        imageUrl: ScrapeValueSelectorSchema.optional(),
-        barcode: ScrapeValueSelectorSchema.optional(),
-      })
-      .strict(),
-  })
-  .strict();
+function priceRulesSchema<T extends z.ZodType>(valueSchema: T) {
+  return z
+    .object({
+      kind: z.literal("price"),
+      list: ListRulesSchema,
+      detail: z
+        .object({
+          name: valueSchema,
+          price: valueSchema,
+          currency: z.enum(CURRENCY_LIST),
+          volume: valueSchema,
+          url: valueSchema.optional(),
+          externalProductId: valueSchema.optional(),
+          imageUrl: valueSchema.optional(),
+          barcode: valueSchema.optional(),
+        })
+        .strict(),
+    })
+    .strict();
+}
 
-export const ScrapeRulesSchema = z.discriminatedUnion("kind", [
-  ReviewRulesSchema,
-  PriceRulesSchema,
+export const ScrapeRulesV1Schema = z.discriminatedUnion("kind", [
+  reviewRulesSchema(ScrapeValueSelectorV1Schema),
+  priceRulesSchema(ScrapeValueSelectorV1Schema),
 ]);
 
-export type ScrapeRules = z.infer<typeof ScrapeRulesSchema>;
-export type ScrapeValueSelector = z.infer<typeof ScrapeValueSelectorSchema>;
+export const ScrapeRulesSchema = z.discriminatedUnion("kind", [
+  reviewRulesSchema(ScrapeValueSchema),
+  priceRulesSchema(ScrapeValueSchema),
+]);
 
-/** Parses rules only with the interpreter that owns their stored version. */
-export function parseScrapeRules(rulesVersion: number, rules: ScrapeRules) {
-  if (rulesVersion !== SCRAPE_RULES_VERSION) {
-    throw new Error(`Unsupported scrape rules version: ${rulesVersion}.`);
+export const StoredScrapeRulesSchema = z.union([
+  ScrapeRulesV1Schema,
+  ScrapeRulesSchema,
+]);
+
+export type ScrapeRulesV1 = z.infer<typeof ScrapeRulesV1Schema>;
+export type ScrapeRules = z.infer<typeof ScrapeRulesSchema>;
+export type StoredScrapeRules = z.infer<typeof StoredScrapeRulesSchema>;
+export type ScrapeValueSelectorV1 = z.infer<typeof ScrapeValueSelectorV1Schema>;
+export type ScrapeValue = z.infer<typeof ScrapeValueSchema>;
+
+/** Parses rules only with the interpreter contract that owns their stored version. */
+export function parseScrapeRules(
+  rulesVersion: number,
+  rules: StoredScrapeRules | JsonValue,
+) {
+  if (rulesVersion === SCRAPE_RULES_VERSION_1) {
+    return ScrapeRulesV1Schema.parse(rules);
   }
-  return ScrapeRulesSchema.parse(rules);
+  if (rulesVersion === SCRAPE_RULES_VERSION) {
+    return ScrapeRulesSchema.parse(rules);
+  }
+  throw new Error(`Unsupported scrape rules version: ${rulesVersion}.`);
 }

--- a/apps/server/src/scraper/configured/runtime.ts
+++ b/apps/server/src/scraper/configured/runtime.ts
@@ -33,7 +33,7 @@ import {
 import {
   SCRAPE_SOURCE_MAX_LIST_PAGES,
   parseScrapeRules,
-  type ScrapeRules,
+  type StoredScrapeRules,
 } from "./rules";
 import { recordScrapeSourcePreview } from "./service";
 import {
@@ -136,7 +136,7 @@ function createScrapeSourceAdapter(
   input: {
     targetKey: string;
     listUrl: string;
-    rules: ScrapeRules;
+    rules: StoredScrapeRules;
   } & (
     | { purpose: "collect" }
     | { purpose: "preview"; recordPreview: RecordScrapeSourcePreview }
@@ -267,7 +267,7 @@ export function createLocalScrapeSourcePreview(input: {
   siteKey: string;
   targetKey: string;
   listUrl: string;
-  rules: ScrapeRules;
+  rules: StoredScrapeRules;
   recordPreview: RecordScrapeSourcePreview;
 }): ScraperSourceDefinition<ConfiguredScrapeCursor, unknown> {
   return {
@@ -299,7 +299,7 @@ function createScrapeSourceDefinition(input: {
   targetKey: string;
   listUrl: string;
   purpose: "collect" | "preview";
-  rules: ScrapeRules;
+  rules: StoredScrapeRules;
 }): ScraperSourceDefinition<ConfiguredScrapeCursor, unknown> {
   const observationSchema =
     input.rules.kind === "review"

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -185,6 +185,7 @@ test("database constraints keep source and revision identity valid", async () =>
     createdById: user.id,
   });
   expect(first.revision).toBe(1);
+  expect(first.rulesVersion).toBe(2);
 
   await expect(
     db.insert(scrapeSources).values({

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -33,13 +33,21 @@ function suggestedValue(
   };
 }
 
-function reviewCandidate(nameSelector: string) {
+function reviewCandidate(
+  nameSelector: string,
+  listOptions: {
+    item?: string;
+    excludeWhen?: { selector: string; startsWith: string[] | null };
+  } = {},
+) {
   return {
     listPageUrl: "https://example.test/reviews",
     rules: {
       kind: "review" as const,
       list: {
+        item: listOptions.item ?? null,
         detailLink: { selector: "a.review", attribute: "href" as const },
+        excludeWhen: listOptions.excludeWhen ?? null,
         nextPage: null,
       },
       detail: {
@@ -136,7 +144,13 @@ test("returns rules only after the rule check passes", async () => {
     .fn()
     .mockResolvedValueOnce(toolCallResponse("first", reviewCandidate(".bad")))
     .mockResolvedValueOnce(
-      toolCallResponse("second", reviewCandidate(".bottle-name")),
+      toolCallResponse(
+        "second",
+        reviewCandidate(".bottle-name", {
+          item: ".product-card",
+          excludeWhen: { selector: ".badge", startsWith: ["Sold out"] },
+        }),
+      ),
     );
   const checkRules = vi.fn(async ({ rules }) => {
     if (rules.kind !== "review") throw new Error("Expected review rules.");
@@ -186,7 +200,11 @@ test("returns rules only after the rule check passes", async () => {
   expect(result.model).toBe("test-setup-model");
   expect(result.rules).toMatchObject({
     kind: "review",
-    list: { maxItems: SCRAPE_SOURCE_DEFAULT_MAX_ITEMS },
+    list: {
+      item: ".product-card",
+      excludeWhen: { selector: ".badge", startsWith: ["Sold out"] },
+      maxItems: SCRAPE_SOURCE_DEFAULT_MAX_ITEMS,
+    },
     detail: {
       name: { selector: ".bottle-name", removeSuffixes: ["Review"] },
       reviewText: {

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -7,6 +7,32 @@ import {
   suggestionRequestLimit,
 } from "./setupAgent";
 
+function suggestedValue(
+  selector: string,
+  attribute: string | null = null,
+  operations: {
+    startsWith?: string[];
+    all?: boolean;
+    removePrefixes?: string[];
+    removeSuffixes?: string[];
+    prefix?: string;
+    suffix?: string;
+  } = {},
+) {
+  return {
+    input: "selector" as const,
+    selector,
+    attribute,
+    value: null,
+    startsWith: operations.startsWith ?? null,
+    all: operations.all ?? false,
+    removePrefixes: operations.removePrefixes ?? null,
+    removeSuffixes: operations.removeSuffixes ?? null,
+    prefix: operations.prefix ?? null,
+    suffix: operations.suffix ?? null,
+  };
+}
+
 function reviewCandidate(nameSelector: string) {
   return {
     listPageUrl: "https://example.test/reviews",
@@ -17,12 +43,17 @@ function reviewCandidate(nameSelector: string) {
         nextPage: null,
       },
       detail: {
-        title: { selector: "h1", attribute: null },
-        publishedAt: { selector: "time", attribute: "datetime" },
+        title: suggestedValue("h1"),
+        publishedAt: suggestedValue("time", "datetime"),
         reviewItem: "article.review",
-        name: { selector: nameSelector, attribute: null },
+        name: suggestedValue(nameSelector, null, {
+          removeSuffixes: ["Review"],
+        }),
         reviewerName: null,
-        reviewText: { selector: ".body", attribute: null },
+        reviewText: suggestedValue(".body p", null, {
+          startsWith: ["Nose:", "Finish:"],
+          all: true,
+        }),
         score: null,
       },
     },
@@ -109,7 +140,10 @@ test("returns rules only after the rule check passes", async () => {
     );
   const checkRules = vi.fn(async ({ rules }) => {
     if (rules.kind !== "review") throw new Error("Expected review rules.");
-    if (rules.detail.name.selector === ".bad") {
+    if (
+      "selector" in rules.detail.name &&
+      rules.detail.name.selector === ".bad"
+    ) {
       return {
         status: "failed" as const,
         feedback: {
@@ -153,7 +187,14 @@ test("returns rules only after the rule check passes", async () => {
   expect(result.rules).toMatchObject({
     kind: "review",
     list: { maxItems: SCRAPE_SOURCE_DEFAULT_MAX_ITEMS },
-    detail: { name: { selector: ".bottle-name" } },
+    detail: {
+      name: { selector: ".bottle-name", removeSuffixes: ["Review"] },
+      reviewText: {
+        selector: ".body p",
+        startsWith: ["Nose:", "Finish:"],
+        all: true,
+      },
+    },
   });
   expect(request).toHaveBeenCalledTimes(2);
   const firstRequest = request.mock.calls[0]?.[0];
@@ -164,7 +205,6 @@ test("returns rules only after the rule check passes", async () => {
     parameters: { type: "object" },
   });
   expect(JSON.stringify(firstRequest?.tools[0])).not.toContain('"oneOf"');
-  expect(JSON.stringify(firstRequest?.tools[0])).not.toContain('"maxItems"');
   const secondRequest = request.mock.calls[1]?.[0];
   expect(JSON.stringify(secondRequest?.input)).toContain("detail.name");
   expect(JSON.stringify(secondRequest?.input)).toContain("North Coast 12");

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -15,15 +15,17 @@ import {
   ScrapeAttributeSchema,
   ScrapeRulesSchema,
   ScrapeSelectorSchema,
+  ScrapeValueSchema,
   type ScrapeRules,
-  type ScrapeValueSelector,
+  type ScrapeValue,
+  type ScrapeValueSelectorV1,
 } from "./rules";
 import {
   ScrapeSourceSetupError,
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v8";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v9";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_SUGGESTION_DETAIL_PAGES = 3;
 const MAX_RULE_CHECKS = 3;
@@ -49,10 +51,51 @@ export function suggestionRequestLimit(samplePageCount: number) {
 // The AI API requires every field. Null means that the suggested rule omits it.
 const SuggestedValueSelectorSchema = z
   .object({
-    selector: ScrapeSelectorSchema,
+    input: z.enum(["selector", "fixed"]),
+    selector: ScrapeSelectorSchema.nullable(),
     attribute: ScrapeAttributeSchema.nullable(),
+    value: z.string().trim().min(1).max(200).nullable(),
+    startsWith: z.array(z.string().trim().min(1).max(100)).max(10).nullable(),
+    all: z.boolean(),
+    removePrefixes: z
+      .array(z.string().trim().min(1).max(100))
+      .max(10)
+      .nullable(),
+    removeSuffixes: z
+      .array(z.string().trim().min(1).max(100))
+      .max(10)
+      .nullable(),
+    prefix: z.string().min(1).max(200).nullable(),
+    suffix: z.string().min(1).max(200).nullable(),
   })
-  .strict();
+  .strict()
+  .superRefine((rule, context) => {
+    if (rule.input === "selector" && (!rule.selector || rule.value !== null)) {
+      context.addIssue({
+        code: "custom",
+        message: "A selector input requires selector and no fixed value.",
+      });
+    }
+    if (
+      rule.input === "fixed" &&
+      (rule.value === null ||
+        rule.selector !== null ||
+        rule.attribute !== null ||
+        rule.startsWith !== null ||
+        rule.all)
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "A fixed input requires value and no selector.",
+      });
+    }
+    if (rule.attribute !== null && (rule.startsWith !== null || rule.all)) {
+      context.addIssue({
+        code: "custom",
+        message: "Attribute selectors cannot filter or join text.",
+      });
+    }
+  });
 
 const SuggestedLinkSelectorSchema = z
   .object({
@@ -130,6 +173,18 @@ type SuggestedReviewRules = z.infer<typeof SuggestedReviewRulesSchema>;
 type SuggestedPriceRules = z.infer<typeof SuggestedPriceRulesSchema>;
 type ReviewRules = Extract<ScrapeRules, { kind: "review" }>;
 type PriceRules = Extract<ScrapeRules, { kind: "price" }>;
+type ScrapeCleanupOperations = {
+  removePrefixes?: string[];
+  removeSuffixes?: string[];
+  prefix?: string;
+  suffix?: string;
+};
+type ScrapeSelectorCandidate = ScrapeCleanupOperations & {
+  selector: string | null;
+  attribute?: string;
+  startsWith?: string[];
+  all?: true;
+};
 
 type SetupAgentCheckResult<T> =
   | { status: "passed"; checked: T }
@@ -175,6 +230,10 @@ const RULE_INSTRUCTIONS = [
   'Set list nextPage to an anchor selector with the "href" attribute when the list has a next-page link. Otherwise set it to null.',
   'Use "src" for image URLs and "datetime" for machine-readable time values when those attributes exist.',
   "Use an attribute whenever the required value is stored in that attribute instead of visible text.",
+  'For every detail value, set input to "selector" with selector and optional attribute, or set input to "fixed" with value. Set the unused selector, attribute, or value fields to null.',
+  "For visible text, startsWith can keep elements beginning with one of up to 10 literal labels and all can join the matches in document order. Attribute selectors cannot use startsWith or all.",
+  "After reading a value, removePrefixes and removeSuffixes can remove the first matching literal beginning or ending, then prefix and suffix can add literal text. Matching is case-insensitive. Set unused lists, prefix, and suffix to null and all to false.",
+  "Use fixed values only for a fact that is stable and unambiguous across the selected source pages.",
   "Use only fields allowed by check_rules.",
   "The listPages are the main page and likely list pages from the same website.",
   "The detailPages are optional examples of review or product pages.",
@@ -185,38 +244,66 @@ const RULE_INSTRUCTIONS = [
   "</rules>",
 ].join("\n");
 
-function toScrapeValueSelector(
-  value: SuggestedValueSelector,
-): ScrapeValueSelector {
-  return value.attribute === null
-    ? { selector: value.selector }
-    : { attribute: value.attribute, selector: value.selector };
+function cleanupOperations(value: SuggestedValueSelector) {
+  const operations: ScrapeCleanupOperations = {};
+  if (value.removePrefixes?.length) {
+    operations.removePrefixes = value.removePrefixes;
+  }
+  if (value.removeSuffixes?.length) {
+    operations.removeSuffixes = value.removeSuffixes;
+  }
+  if (value.prefix !== null) operations.prefix = value.prefix;
+  if (value.suffix !== null) operations.suffix = value.suffix;
+  return operations;
+}
+
+function toScrapeValue(value: SuggestedValueSelector): ScrapeValue {
+  if (value.input === "fixed") {
+    return ScrapeValueSchema.parse({
+      value: value.value,
+      ...cleanupOperations(value),
+    });
+  }
+  const rule: ScrapeSelectorCandidate = {
+    selector: value.selector,
+    ...cleanupOperations(value),
+  };
+  if (value.attribute !== null) rule.attribute = value.attribute;
+  if (value.startsWith?.length) rule.startsWith = value.startsWith;
+  if (value.all) rule.all = true;
+  return ScrapeValueSchema.parse(rule);
+}
+
+function toScrapeLinkSelector(
+  value: z.infer<typeof SuggestedLinkSelectorSchema>,
+): ScrapeValueSelectorV1 {
+  return { attribute: value.attribute, selector: value.selector };
 }
 
 function toReviewRules(input: SuggestedReviewRules): ScrapeRules {
   const detail: ReviewRules["detail"] = {
-    title: toScrapeValueSelector(input.detail.title),
-    publishedAt: toScrapeValueSelector(input.detail.publishedAt),
+    title: toScrapeValue(input.detail.title),
+    publishedAt: toScrapeValue(input.detail.publishedAt),
     reviewItem: input.detail.reviewItem,
-    name: toScrapeValueSelector(input.detail.name),
+    name: toScrapeValue(input.detail.name),
   };
   const list: ReviewRules["list"] = {
-    detailLink: toScrapeValueSelector(input.list.detailLink),
+    detailLink: toScrapeLinkSelector(input.list.detailLink),
     maxItems: SCRAPE_SOURCE_DEFAULT_MAX_ITEMS,
   };
   if (input.list.nextPage !== null) {
-    list.nextPage = toScrapeValueSelector(input.list.nextPage);
+    list.nextPage = toScrapeLinkSelector(input.list.nextPage);
   }
   if (input.detail.reviewerName !== null) {
-    detail.reviewerName = toScrapeValueSelector(input.detail.reviewerName);
+    detail.reviewerName = toScrapeValue(input.detail.reviewerName);
   }
   if (input.detail.reviewText !== null) {
-    detail.reviewText = toScrapeValueSelector(input.detail.reviewText);
+    detail.reviewText = toScrapeValue(input.detail.reviewText);
   }
   if (input.detail.score !== null) {
     detail.score = {
       scale: input.detail.score.scale,
-      value: toScrapeValueSelector(input.detail.score.value),
+      value: toScrapeValue(input.detail.score.value),
     };
   }
   return ScrapeRulesSchema.parse({ kind: input.kind, list, detail });
@@ -224,31 +311,29 @@ function toReviewRules(input: SuggestedReviewRules): ScrapeRules {
 
 function toPriceRules(input: SuggestedPriceRules): ScrapeRules {
   const detail: PriceRules["detail"] = {
-    name: toScrapeValueSelector(input.detail.name),
-    price: toScrapeValueSelector(input.detail.price),
+    name: toScrapeValue(input.detail.name),
+    price: toScrapeValue(input.detail.price),
     currency: input.detail.currency,
-    volume: toScrapeValueSelector(input.detail.volume),
+    volume: toScrapeValue(input.detail.volume),
   };
   const list: PriceRules["list"] = {
-    detailLink: toScrapeValueSelector(input.list.detailLink),
+    detailLink: toScrapeLinkSelector(input.list.detailLink),
     maxItems: SCRAPE_SOURCE_DEFAULT_MAX_ITEMS,
   };
   if (input.list.nextPage !== null) {
-    list.nextPage = toScrapeValueSelector(input.list.nextPage);
+    list.nextPage = toScrapeLinkSelector(input.list.nextPage);
   }
   if (input.detail.url !== null) {
-    detail.url = toScrapeValueSelector(input.detail.url);
+    detail.url = toScrapeValue(input.detail.url);
   }
   if (input.detail.externalProductId !== null) {
-    detail.externalProductId = toScrapeValueSelector(
-      input.detail.externalProductId,
-    );
+    detail.externalProductId = toScrapeValue(input.detail.externalProductId);
   }
   if (input.detail.imageUrl !== null) {
-    detail.imageUrl = toScrapeValueSelector(input.detail.imageUrl);
+    detail.imageUrl = toScrapeValue(input.detail.imageUrl);
   }
   if (input.detail.barcode !== null) {
-    detail.barcode = toScrapeValueSelector(input.detail.barcode);
+    detail.barcode = toScrapeValue(input.detail.barcode);
   }
   return ScrapeRulesSchema.parse({ kind: input.kind, list, detail });
 }

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -16,6 +16,7 @@ import {
   ScrapeRulesSchema,
   ScrapeSelectorSchema,
   ScrapeValueSchema,
+  type ScrapeListExclusion,
   type ScrapeRules,
   type ScrapeValue,
   type ScrapeValueSelectorV1,
@@ -25,7 +26,7 @@ import {
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v9";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v10";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_SUGGESTION_DETAIL_PAGES = 3;
 const MAX_RULE_CHECKS = 3;
@@ -104,12 +105,30 @@ const SuggestedLinkSelectorSchema = z
   })
   .strict();
 
-const SuggestedListRulesSchema = z
+const SuggestedListExclusionSchema = z
   .object({
-    detailLink: SuggestedLinkSelectorSchema,
-    nextPage: SuggestedLinkSelectorSchema.nullable(),
+    selector: ScrapeSelectorSchema,
+    startsWith: z.array(z.string().trim().min(1).max(100)).max(10).nullable(),
   })
   .strict();
+
+const SuggestedListRulesSchema = z
+  .object({
+    item: ScrapeSelectorSchema.nullable(),
+    detailLink: SuggestedLinkSelectorSchema,
+    excludeWhen: SuggestedListExclusionSchema.nullable(),
+    nextPage: SuggestedLinkSelectorSchema.nullable(),
+  })
+  .strict()
+  .superRefine((rules, context) => {
+    if (rules.excludeWhen && !rules.item) {
+      context.addIssue({
+        code: "custom",
+        path: ["excludeWhen"],
+        message: "List exclusion requires an item selector.",
+      });
+    }
+  });
 
 const SuggestedReviewRulesSchema = z
   .object({
@@ -169,6 +188,7 @@ const SuggestedPriceRevisionSchema = z
   .strict();
 
 type SuggestedValueSelector = z.infer<typeof SuggestedValueSelectorSchema>;
+type SuggestedListRules = z.infer<typeof SuggestedListRulesSchema>;
 type SuggestedReviewRules = z.infer<typeof SuggestedReviewRulesSchema>;
 type SuggestedPriceRules = z.infer<typeof SuggestedPriceRulesSchema>;
 type ReviewRules = Extract<ScrapeRules, { kind: "review" }>;
@@ -226,7 +246,9 @@ const RULE_INSTRUCTIONS = [
   "</success_criteria>",
   "<rules>",
   "Use short, stable CSS selectors.",
+  "When list items need independent checks, set list item to their shared container selector. Otherwise set it to null.",
   'The list detailLink must select anchor elements and use the "href" attribute.',
+  "Set list excludeWhen to a selector inside each list item, with optional startsWith labels, only when a matching value means that item must be skipped. Otherwise set it to null.",
   'Set list nextPage to an anchor selector with the "href" attribute when the list has a next-page link. Otherwise set it to null.',
   'Use "src" for image URLs and "datetime" for machine-readable time values when those attributes exist.',
   "Use an attribute whenever the required value is stored in that attribute instead of visible text.",
@@ -280,6 +302,27 @@ function toScrapeLinkSelector(
   return { attribute: value.attribute, selector: value.selector };
 }
 
+function toScrapeList(input: SuggestedListRules): ReviewRules["list"] {
+  const list: ReviewRules["list"] = {
+    detailLink: toScrapeLinkSelector(input.detailLink),
+    maxItems: SCRAPE_SOURCE_DEFAULT_MAX_ITEMS,
+  };
+  if (input.item !== null) list.item = input.item;
+  if (input.excludeWhen !== null) {
+    const excludeWhen: ScrapeListExclusion = {
+      selector: input.excludeWhen.selector,
+    };
+    if (input.excludeWhen.startsWith?.length) {
+      excludeWhen.startsWith = input.excludeWhen.startsWith;
+    }
+    list.excludeWhen = excludeWhen;
+  }
+  if (input.nextPage !== null) {
+    list.nextPage = toScrapeLinkSelector(input.nextPage);
+  }
+  return list;
+}
+
 function toReviewRules(input: SuggestedReviewRules): ScrapeRules {
   const detail: ReviewRules["detail"] = {
     title: toScrapeValue(input.detail.title),
@@ -287,13 +330,7 @@ function toReviewRules(input: SuggestedReviewRules): ScrapeRules {
     reviewItem: input.detail.reviewItem,
     name: toScrapeValue(input.detail.name),
   };
-  const list: ReviewRules["list"] = {
-    detailLink: toScrapeLinkSelector(input.list.detailLink),
-    maxItems: SCRAPE_SOURCE_DEFAULT_MAX_ITEMS,
-  };
-  if (input.list.nextPage !== null) {
-    list.nextPage = toScrapeLinkSelector(input.list.nextPage);
-  }
+  const list = toScrapeList(input.list);
   if (input.detail.reviewerName !== null) {
     detail.reviewerName = toScrapeValue(input.detail.reviewerName);
   }
@@ -316,13 +353,7 @@ function toPriceRules(input: SuggestedPriceRules): ScrapeRules {
     currency: input.detail.currency,
     volume: toScrapeValue(input.detail.volume),
   };
-  const list: PriceRules["list"] = {
-    detailLink: toScrapeLinkSelector(input.list.detailLink),
-    maxItems: SCRAPE_SOURCE_DEFAULT_MAX_ITEMS,
-  };
-  if (input.list.nextPage !== null) {
-    list.nextPage = toScrapeLinkSelector(input.list.nextPage);
-  }
+  const list = toScrapeList(input.list);
   if (input.detail.url !== null) {
     detail.url = toScrapeValue(input.detail.url);
   }

--- a/apps/server/src/scraper/localPreview.test.ts
+++ b/apps/server/src/scraper/localPreview.test.ts
@@ -34,7 +34,7 @@ test("previews configured rules through the runtime without product writes", asy
         <article>
           <h1>Example Whisky</h1>
           <time datetime="2026-09-01"></time>
-          <div class="review"><p>Tasting notes.</p><strong>88</strong></div>
+          <div class="review"><h2>Example Whisky Review</h2><p>Tasting notes.</p><strong>88</strong></div>
         </article>
       `);
     }
@@ -45,6 +45,7 @@ test("previews configured rules through the runtime without product writes", asy
     {
       site: "whiskystudy",
       listUrl: "https://thewhiskystudy.com/reviews-3",
+      rulesVersion: 2,
       rules: {
         kind: "review",
         list: {
@@ -55,7 +56,7 @@ test("previews configured rules through the runtime without product writes", asy
           title: { selector: "h1" },
           publishedAt: { selector: "time", attribute: "datetime" },
           reviewItem: ".review",
-          name: { selector: "h1" },
+          name: { selector: "h2", removeSuffixes: ["Review"] },
           reviewText: { selector: "p" },
           score: { value: { selector: "strong" }, scale: 100 },
         },

--- a/apps/server/src/scraper/localPreview.ts
+++ b/apps/server/src/scraper/localPreview.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import type { ScrapeSourcePreviewResult } from "./configured/preview";
 import {
   SCRAPE_SOURCE_MAX_LIST_PAGES,
-  ScrapeRulesSchema,
+  parseScrapeRules,
 } from "./configured/rules";
 import { createLocalScrapeSourcePreview } from "./configured/runtime";
 import { findScraperSourceBySiteKey } from "./definitions";
@@ -19,7 +19,8 @@ const InputSchema = z
   .object({
     site: z.string().trim().min(1),
     listUrl: z.url(),
-    rules: ScrapeRulesSchema,
+    rulesVersion: z.number().int().positive().default(1),
+    rules: z.json(),
     limit: z.number().int().positive().max(99).optional(),
   })
   .strict();
@@ -37,15 +38,16 @@ export async function runLocalScrapeSourcePreview(
 ) {
   const parsed = InputSchema.parse(input);
   const clock = options.clock ?? scraperSystemClock;
+  const parsedRules = parseScrapeRules(parsed.rulesVersion, parsed.rules);
   const rules = parsed.limit
     ? {
-        ...parsed.rules,
+        ...parsedRules,
         list: {
-          ...parsed.rules.list,
-          maxItems: Math.min(parsed.rules.list.maxItems, parsed.limit),
+          ...parsedRules.list,
+          maxItems: Math.min(parsedRules.list.maxItems, parsed.limit),
         },
       }
-    : parsed.rules;
+    : parsedRules;
 
   await syncExternalSites();
   await syncScraperDefinitions(scraperRegistry);

--- a/apps/web/e2e/review-scoring.spec.ts
+++ b/apps/web/e2e/review-scoring.spec.ts
@@ -51,11 +51,6 @@ test("moderator previews and saves score rules; readers keep the original score"
   await expect(
     page.getByLabel(`${priceSite.name} score 3.5 out of 5`),
   ).toBeVisible();
-  await expect(
-    page.getByText("Counts as an estimated 86/100 in the bottle score.", {
-      exact: false,
-    }),
-  ).toBeVisible();
   await snapshot("Bottles/Original critic score", {
     ready: page.getByLabel(`${priceSite.name} score 3.5 out of 5`),
   });

--- a/apps/web/src/components/admin/scraperParsingEditor.stylex.tsx
+++ b/apps/web/src/components/admin/scraperParsingEditor.stylex.tsx
@@ -319,6 +319,7 @@ export function ScraperParsingEditor({
                       {revision.author === "ai"
                         ? "Created with AI"
                         : "Created by a person"}
+                      {` · Rules v${revision.rulesVersion}`}
                     </span>
                   </span>
                 }

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -97,8 +97,9 @@ described above. Compare all stored records after applying. Keep the existing
 limit of 20 latest articles and one review per article when checking suggested
 rules. Verify each article URL, name, writer, date, score, selected review text,
 Bottle match, hidden state, and publication setting. The old scraper removes
-`Review` or `Shelf Review` from the end of Bottle names; saved rules do not do
-text cleanup, so review any name change before activation.
+`Review` or `Shelf Review` from the end of Bottle names; version 1 rules cannot
+do that cleanup. Use version 2 literal suffix cleanup and confirm the names
+remain unchanged before activation.
 
 Preview and activate the chosen revision, run one manual collection through
 `POST /v1/external-sites/whiskystudy/trigger`, and confirm that it updates the

--- a/openspec/changes/extend-configured-scraper-values/.openspec.yaml
+++ b/openspec/changes/extend-configured-scraper-values/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/extend-configured-scraper-values/design.md
+++ b/openspec/changes/extend-configured-scraper-values/design.md
@@ -1,0 +1,128 @@
+## Context
+
+Configured scraper rules version 1 reads the first value matched by each CSS
+selector. That is enough for simple pages, but local previews found three
+repeatable gaps:
+
+- The Whisky Study needs to remove `Review` or `Shelf Review` from article
+  titles and find a score element by its text rather than its position.
+- Whisky Saga needs to join only paragraphs beginning with tasting-section
+  labels so clips and tags keep the same evidence as the code adapter.
+- Small price sources commonly publish a fixed 700 ml size or omit a producer
+  prefix from each product heading.
+
+The revision table already stores `rulesVersion`, so new behavior can be added
+without changing saved version 1 revisions. Preview and collection already use
+the same parser and network controls.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Express the observed value cleanup with bounded data, not source code.
+- Keep version 1 revisions byte-for-byte and behaviorally compatible.
+- Make local preview, production preview, AI setup, manual editing, and
+  collection interpret version 2 identically.
+- Preserve source evidence used for names, scores, clips, tags, volumes, and
+  matching.
+
+**Non-Goals:**
+
+- Arbitrary regular expressions, JavaScript, templates, or per-source plugins.
+- Cross-origin requests, authentication, browser rendering, JSON APIs, or
+  changing request policy.
+- General product filtering beyond CSS selectors and bounded text-prefix
+  selection.
+- Migrating a source whose complete local and production previews do not match
+  its stored coverage and identity.
+
+## Decisions
+
+### Add rules version 2 and retain a separate version 1 interpreter
+
+New revisions use version 2. Loading a revision dispatches to the schema and
+value reader for its stored version. Version 1 parsing remains frozen instead
+of silently acquiring new defaults.
+
+This is preferred to extending the version 1 object in place because a future
+parser change must not alter replay or rollback behavior for an immutable
+revision.
+
+### Use one bounded value expression instead of field-specific transforms
+
+A version 2 value expression has exactly one input:
+
+- `selector` plus optional `attribute`; or
+- fixed `value` text.
+
+Selector input can optionally filter normalized element text with a bounded
+`startsWith` list and set `all: true` to join every remaining match in document
+order with one space. The resulting text can remove the first matching literal
+from bounded `removePrefixes` and `removeSuffixes` lists and then add bounded
+`prefix` and `suffix` literals.
+
+Operations run in that order: read, normalize, filter, choose or join, remove a
+prefix, remove a suffix, add a prefix, add a suffix. Comparisons for
+`startsWith`, `removePrefixes`, and `removeSuffixes` are case-insensitive;
+output keeps the source's original spelling. Empty results remain missing
+values and use the existing field validation.
+
+One expression shape keeps review and price rules understandable in the JSON
+editor. Literal operations cover the observed sources without admitting code
+or regular-expression denial-of-service risks. Fixed values are source claims,
+so preview must display them alongside scraped fields for human verification.
+
+### Bound every new operation
+
+Fixed values and added prefixes or suffixes are limited to 200 characters.
+Removed prefix and suffix lists contain at most 10 non-empty values of at most
+100 characters. `all` can
+join at most 100 selected elements, and the existing 50,000-character review
+text limit is applied after joining.
+
+AI setup receives the same schema and plain-language operation order. It must
+prefer source text and use fixed values only when the source makes that fact
+stable and unambiguous, such as a shop that sells only 700 ml bottles in the
+selected list.
+
+### Put the rules version in local preview input
+
+The local preview file accepts `rulesVersion` and requires it for version 2
+rules. Omitting it continues to mean version 1 for existing files. The command
+passes the version through the same runtime parser used by stored revisions.
+
+## Risks / Trade-offs
+
+- [A fixed value becomes false when a shop changes its catalog] → Preview shows
+  the fixed output; source migration notes must record the public evidence, and
+  normal health checks still surface invalid or changed pages.
+- [Text-prefix filtering misses a new label spelling] → A missing required
+  value fails preview or collection; optional review text remains visible in
+  preview comparison before activation.
+- [Joining matches captures navigation or repeated mobile markup] → CSS scope,
+  a 100-element limit, document-order joining, and local no-write preview bound
+  and expose the result.
+- [Two rule versions increase parser complexity] → Keep separate schemas and
+  value readers with shared final validators and fixtures proving version 1
+  output does not change.
+- [AI overuses cleanup operations] → Code validates only bounded literals, AI
+  review sees final parsed values, and activation still requires a fresh
+  production preview.
+
+## Migration Plan
+
+1. Deploy version 2 schema, interpreter, editor, suggestion, and local preview
+   support while leaving all active revisions on version 1.
+2. Re-run local no-write previews for Whisky Study, Whisky Saga, and one small
+   price source with version 2 rules.
+3. Compare full output with stored URLs, names, scores or prices, Bottle
+   matches, and item counts before preparing or activating any source.
+4. Create new inactive version 2 revisions and use normal production preview
+   and activation controls.
+5. Roll back by activating the previous passing revision or pausing the source;
+   version 1 interpretation remains available.
+
+## Open Questions
+
+None. The operations are limited to cases demonstrated by current public
+sources; further transforms require another rules version.

--- a/openspec/changes/extend-configured-scraper-values/design.md
+++ b/openspec/changes/extend-configured-scraper-values/design.md
@@ -10,6 +10,8 @@ repeatable gaps:
   labels so clips and tags keep the same evidence as the code adapter.
 - Small price sources commonly publish a fixed 700 ml size or omit a producer
   prefix from each product heading.
+- Compass Box marks sold-out products inside each card, so a safe selector
+  cannot exclude their links without the unsupported relational `:has` syntax.
 
 The revision table already stores `rulesVersion`, so new behavior can be added
 without changing saved version 1 revisions. Preview and collection already use
@@ -31,8 +33,7 @@ the same parser and network controls.
 - Arbitrary regular expressions, JavaScript, templates, or per-source plugins.
 - Cross-origin requests, authentication, browser rendering, JSON APIs, or
   changing request policy.
-- General product filtering beyond CSS selectors and bounded text-prefix
-  selection.
+- General product filtering beyond a bounded list-item text exclusion.
 - Migrating a source whose complete local and production previews do not match
   its stored coverage and identity.
 
@@ -84,6 +85,18 @@ AI setup receives the same schema and plain-language operation order. It must
 prefer source text and use fixed values only when the source makes that fact
 stable and unambiguous, such as a shop that sells only 700 ml bottles in the
 selected list.
+
+### Scope optional exclusion to one list item
+
+Version 2 list rules can set an `item` CSS selector. When present, the detail
+link selector is evaluated independently inside each item. An optional
+`excludeWhen` selector can skip that item when it finds non-empty text,
+optionally limited to text beginning with one of the same bounded literal
+prefixes used by value rules.
+
+This makes a card-local fact such as `Sold out` usable without admitting
+relational CSS, regular expressions, or cross-item state. `excludeWhen` is
+invalid without `item`; version 1 retains its original global link selection.
 
 ### Put the rules version in local preview input
 

--- a/openspec/changes/extend-configured-scraper-values/proposal.md
+++ b/openspec/changes/extend-configured-scraper-values/proposal.md
@@ -3,13 +3,16 @@
 Live local previews show that configured rules can find the right pages but
 cannot preserve several common source-owned values. Review sources need bounded
 text selection and simple title cleanup, while small shops often publish a
-fixed bottle volume or omit a producer prefix from each product heading.
+fixed bottle volume, omit a producer prefix from each product heading, or mark
+availability inside a product card rather than on its link.
 
 ## What Changes
 
 - Add safe, declarative value operations for fixed text, literal text cleanup
   and additions at either end, and joining selected elements whose text starts
   with an allowed prefix.
+- Add a bounded list-item scope and text-based exclusion so unavailable product
+  cards can be skipped without relational selectors or source code.
 - Store these rules under a new rules version so existing revisions keep their
   current parsing behavior.
 - Teach manual editing, AI suggestions, previews, and collection to use the new

--- a/openspec/changes/extend-configured-scraper-values/proposal.md
+++ b/openspec/changes/extend-configured-scraper-values/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+Live local previews show that configured rules can find the right pages but
+cannot preserve several common source-owned values. Review sources need bounded
+text selection and simple title cleanup, while small shops often publish a
+fixed bottle volume or omit a producer prefix from each product heading.
+
+## What Changes
+
+- Add safe, declarative value operations for fixed text, literal text cleanup
+  and additions at either end, and joining selected elements whose text starts
+  with an allowed prefix.
+- Store these rules under a new rules version so existing revisions keep their
+  current parsing behavior.
+- Teach manual editing, AI suggestions, previews, and collection to use the new
+  version through the same parser and validators.
+- Cover the exact Whisky Study, Whisky Saga, and small price-source cases found
+  by local no-write previews.
+- Keep arbitrary scripts, regular expressions, cross-origin reads, and
+  source-specific code out of saved rules.
+
+## Capabilities
+
+### New Capabilities
+
+- `configured-scraper-value-rules`: Safe value selection and small text
+  operations for database-managed scraper revisions.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+This affects configured scraper rule schemas, versioned parsing, AI setup
+schemas and prompts, the admin rules editor, preview output, and deterministic
+parser/runtime tests. Existing version 1 revisions remain unchanged. No
+database migration or new network permission is required.

--- a/openspec/changes/extend-configured-scraper-values/specs/configured-scraper-value-rules/spec.md
+++ b/openspec/changes/extend-configured-scraper-values/specs/configured-scraper-value-rules/spec.md
@@ -46,6 +46,24 @@ text-prefix filtering or multi-element joining.
 - **WHEN** more than 100 elements remain after selector and prefix filtering
 - **THEN** parsing reports a bounded value error instead of reading or storing a partial joined value
 
+### Requirement: List items can exclude unavailable entries
+
+The system SHALL let a version 2 list rule scope its detail-link selector to a
+CSS-selected item. It SHALL optionally skip an item when a selector inside that
+item finds normalized text, limited when configured to a bounded list of
+case-insensitive literal prefixes. An exclusion rule MUST require an item
+selector. Version 1 list selection MUST remain unchanged.
+
+#### Scenario: A product card is sold out
+
+- **WHEN** a list item contains a badge beginning with `Sold out` and `excludeWhen` selects badges with that literal prefix
+- **THEN** the parser skips that item's detail link and continues with the remaining cards in document order
+
+#### Scenario: An exclusion has no item scope
+
+- **WHEN** a version 2 list rule supplies `excludeWhen` without an `item` selector
+- **THEN** strict rule validation rejects the complete revision
+
 ### Requirement: Value rules can apply literal cleanup
 
 The system SHALL let a version 2 value remove the first matching literal from

--- a/openspec/changes/extend-configured-scraper-values/specs/configured-scraper-value-rules/spec.md
+++ b/openspec/changes/extend-configured-scraper-values/specs/configured-scraper-value-rules/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: Saved value rules use versioned bounded operations
+
+The system SHALL support configured scraper rules version 2 without changing
+the schema or behavior of stored version 1 revisions. A version 2 value rule
+MUST use exactly one CSS selector or one fixed value and MUST reject arbitrary
+regular expressions, scripts, templates, and values beyond the documented
+limits.
+
+#### Scenario: A version 1 revision runs after version 2 is deployed
+
+- **WHEN** preview, collection, replay, or rollback loads a stored version 1 revision
+- **THEN** the system validates and reads it with the version 1 schema and interpreter
+
+#### Scenario: A value rule has conflicting inputs
+
+- **WHEN** a version 2 value rule contains both a selector and a fixed value, or neither input
+- **THEN** strict rule validation rejects the complete revision
+
+#### Scenario: A value rule contains executable matching logic
+
+- **WHEN** a version 2 rule contains a regular expression, script, template, or unsupported key
+- **THEN** strict rule validation rejects the complete revision
+
+### Requirement: Selector values can filter and join source text
+
+The system SHALL let a version 2 selector value filter normalized element text
+by a bounded list of case-insensitive literal prefixes. It SHALL read the first
+remaining element by default or, when `all` is true, join at most 100 remaining
+elements in document order with one space. An attribute selector MUST NOT use
+text-prefix filtering or multi-element joining.
+
+#### Scenario: Review evidence uses named tasting sections
+
+- **WHEN** a review-text selector matches paragraphs and filters for `Nose:`, `Palate:`, `Taste:`, and `Finish:` with `all` true
+- **THEN** the parser joins only matching paragraph text in document order and excludes introductions, prices, scores, and signatures
+
+#### Scenario: A score changes position in an article
+
+- **WHEN** a score selector matches several headings and paragraphs but filters for the literal prefix `Score`
+- **THEN** the parser reads the first matching score text regardless of its element position
+
+#### Scenario: Too many elements match a joined value
+
+- **WHEN** more than 100 elements remain after selector and prefix filtering
+- **THEN** parsing reports a bounded value error instead of reading or storing a partial joined value
+
+### Requirement: Value rules can apply literal cleanup
+
+The system SHALL let a version 2 value remove the first matching literal from
+bounded ordered prefix and suffix lists and then add bounded literal prefix and
+suffix text. Matching MUST be case-insensitive, MUST remove text only at the
+matching end of the value, and MUST preserve the source spelling of all
+remaining text.
+
+#### Scenario: A review title carries an editorial suffix
+
+- **WHEN** the source value ends with `Shelf Review` or `Review` and those literals are configured as removable suffixes
+- **THEN** the parser removes only the matching final literal and returns the remaining trimmed bottle name
+
+#### Scenario: A shop heading omits its producer
+
+- **WHEN** a product name value has the prefix `Kilchoman `
+- **THEN** the parser prepends that literal once to the selected source text before product validation
+
+#### Scenario: A score display includes an editorial label
+
+- **WHEN** a score begins with `Score:` and the configured output adds `/100`
+- **THEN** the parser preserves the numeric source text and emits the existing `90/100` display form
+
+#### Scenario: A cleanup result is empty
+
+- **WHEN** literal cleanup leaves no non-whitespace text
+- **THEN** the parser treats the field as missing and existing output validation rejects it when required
+
+### Requirement: Fixed values remain visible source claims
+
+The system SHALL let a version 2 rule provide bounded fixed text for a value
+that is stable across the selected source, and SHALL pass it through the same
+conversion and output validation as selected text. Production and local
+previews MUST show the converted output before activation.
+
+#### Scenario: A selected shop list has one fixed bottle size
+
+- **WHEN** a price rule supplies the fixed value `700 ml` for volume
+- **THEN** preview and collection validate and emit 700 milliliters for each selected product
+
+#### Scenario: A fixed value cannot be converted
+
+- **WHEN** a fixed price, score, date, or volume value does not satisfy the field conversion and output schema
+- **THEN** preview or collection reports the owning detail field and writes no product output for the failed run
+
+### Requirement: Every rule-authoring path uses the version 2 contract
+
+The system SHALL let admins author version 2 rules manually and through AI
+setup. AI setup SHALL receive the same strict schema and operation order as the
+runtime, and SHALL use fixed values only for stable facts supported by the
+selected public source. The local preview command MUST accept a rules version
+and run it through the same versioned parser, validators, request controls, and
+no-write sink as production preview.
+
+#### Scenario: AI proposes value operations
+
+- **WHEN** AI setup needs bounded literal cleanup or addition, a fixed value, or joined filtered text to parse supplied pages
+- **THEN** it can propose only the bounded version 2 operations and code checks their final output before AI review
+
+#### Scenario: An admin previews a version 2 file locally
+
+- **WHEN** the admin runs the local preview command with a version 2 rules file
+- **THEN** the command reports production-shaped output and issues without writing reviews or prices
+
+#### Scenario: A new revision is saved
+
+- **WHEN** an admin saves valid version 2 rules from AI setup or manual editing
+- **THEN** the immutable revision records rules version 2 and activation still requires a passing production preview

--- a/openspec/changes/extend-configured-scraper-values/tasks.md
+++ b/openspec/changes/extend-configured-scraper-values/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Versioned rule contract
 
-- [x] 1.1 Add strict version 2 value and scrape-rule schemas with bounded selector, fixed value, prefix filtering, joining, and literal cleanup or additions at either end
+- [x] 1.1 Add strict version 2 value and scrape-rule schemas with bounded selector, fixed value, prefix filtering, joining, literal cleanup or additions at either end, and list-item exclusion
 - [x] 1.2 Keep version 1 schema and interpretation frozen, and dispatch stored revisions by `rulesVersion`
 - [x] 1.3 Add schema tests for valid operations, conflicting inputs, unsupported keys, and every size or count bound
 
@@ -8,7 +8,7 @@
 
 - [x] 2.1 Implement the documented value-operation order with case-insensitive literal matching and source-spelling preservation
 - [x] 2.2 Report bounded errors for excessive joined matches and treat empty cleanup results as missing values
-- [x] 2.3 Add parser fixtures for Whisky Study title and score layouts, Whisky Saga tasting paragraphs, and a fixed-volume prefixed price
+- [x] 2.3 Add parser fixtures for Whisky Study title and score layouts, Whisky Saga tasting paragraphs, a fixed-volume prefixed price, and sold-out list-card exclusion
 - [x] 2.4 Prove existing version 1 parser fixtures produce unchanged output
 
 ## 3. Authoring and runtime
@@ -22,5 +22,5 @@
 
 - [x] 4.1 Run focused parser, service, runtime, route, CLI, typecheck, lint, and formatting checks
 - [x] 4.2 Run local no-write full previews for Whisky Study and Whisky Saga and compare URLs, names, reviewers, dates, scores, review evidence, and item counts with stored records
-- [ ] 4.3 Run a local no-write full preview for one small price source and compare names, prices, currency, volume, URLs, images, Bottle matches, and item count with its current scraper
+- [x] 4.3 Run a local no-write full preview for one small price source and compare names, prices, currency, volume, URLs, images, Bottle matches, and item count with its current scraper
 - [ ] 4.4 Only after exact parity, create inactive production revisions, pass production previews, activate the pilot sources, restore their prior schedules, run once, and verify stored IDs and relationships remain unchanged

--- a/openspec/changes/extend-configured-scraper-values/tasks.md
+++ b/openspec/changes/extend-configured-scraper-values/tasks.md
@@ -21,6 +21,6 @@
 ## 4. Verification and pilots
 
 - [x] 4.1 Run focused parser, service, runtime, route, CLI, typecheck, lint, and formatting checks
-- [ ] 4.2 Run local no-write full previews for Whisky Study and Whisky Saga and compare URLs, names, reviewers, dates, scores, review evidence, and item counts with stored records
+- [x] 4.2 Run local no-write full previews for Whisky Study and Whisky Saga and compare URLs, names, reviewers, dates, scores, review evidence, and item counts with stored records
 - [ ] 4.3 Run a local no-write full preview for one small price source and compare names, prices, currency, volume, URLs, images, Bottle matches, and item count with its current scraper
 - [ ] 4.4 Only after exact parity, create inactive production revisions, pass production previews, activate the pilot sources, restore their prior schedules, run once, and verify stored IDs and relationships remain unchanged

--- a/openspec/changes/extend-configured-scraper-values/tasks.md
+++ b/openspec/changes/extend-configured-scraper-values/tasks.md
@@ -1,0 +1,26 @@
+## 1. Versioned rule contract
+
+- [x] 1.1 Add strict version 2 value and scrape-rule schemas with bounded selector, fixed value, prefix filtering, joining, and literal cleanup or additions at either end
+- [x] 1.2 Keep version 1 schema and interpretation frozen, and dispatch stored revisions by `rulesVersion`
+- [x] 1.3 Add schema tests for valid operations, conflicting inputs, unsupported keys, and every size or count bound
+
+## 2. Version 2 parsing
+
+- [x] 2.1 Implement the documented value-operation order with case-insensitive literal matching and source-spelling preservation
+- [x] 2.2 Report bounded errors for excessive joined matches and treat empty cleanup results as missing values
+- [x] 2.3 Add parser fixtures for Whisky Study title and score layouts, Whisky Saga tasting paragraphs, and a fixed-volume prefixed price
+- [x] 2.4 Prove existing version 1 parser fixtures produce unchanged output
+
+## 3. Authoring and runtime
+
+- [x] 3.1 Save new manual and AI revisions as version 2 while continuing to load and activate version 1 revisions
+- [x] 3.2 Extend AI setup schemas, instructions, and checks to generate only supported version 2 operations
+- [x] 3.3 Update the admin rules editor and revision display for version 2 rules without hiding the stored version
+- [x] 3.4 Extend the local no-write preview input with `rulesVersion`, defaulting omitted input to version 1
+
+## 4. Verification and pilots
+
+- [x] 4.1 Run focused parser, service, runtime, route, CLI, typecheck, lint, and formatting checks
+- [ ] 4.2 Run local no-write full previews for Whisky Study and Whisky Saga and compare URLs, names, reviewers, dates, scores, review evidence, and item counts with stored records
+- [ ] 4.3 Run a local no-write full preview for one small price source and compare names, prices, currency, volume, URLs, images, Bottle matches, and item count with its current scraper
+- [ ] 4.4 Only after exact parity, create inactive production revisions, pass production previews, activate the pilot sources, restore their prior schedules, run once, and verify stored IDs and relationships remain unchanged


### PR DESCRIPTION
## Why

Live configured-rule pilots showed that version 1's first-value selectors cannot safely reproduce several existing sources. Whisky Study needs literal name cleanup and multiple review sections; Whisky Saga needs the same multi-section support; price sources may need fixed values, producer prefixes, or card-local availability checks. Without those operations, migration would change public names, displayed scores, captured evidence, or current product coverage.

## What

- Add immutable version 2 value rules while keeping stored version 1 revisions strict and loadable.
- Support one selector or a fixed value, optional case-insensitive `startsWith` filtering, bounded `all` joins, literal prefix/suffix removal, and literal prefix/suffix additions.
- Scope detail links to list items and skip an item through a bounded, text-based `excludeWhen` rule, without relational selectors or custom code.
- Cap fixed/addition values, cleanup arrays, cleanup literals, and joined output.
- Save new manual and AI-assisted revisions as version 2 and teach the setup agent the bounded operations.
- Accept `rulesVersion` in local preview input, defaulting omitted versions to version 1 for compatibility.
- Display a revision's rule version in the admin editor.
- Document the behavior and its source-migration acceptance criteria in OpenSpec and the scraper guide.

Full live no-write previews passed for Whisky Study and Whisky Saga: 20 current pages each, no parsing issues, complete names/reviewers/dates/scores, normalized `NN/100` displays, and zero emitted items. Both runs also resumed correctly after request-control deferral. Fixture parity tests compare the configured and hardcoded parsers' public facts, selected tasting evidence, and review bodies.

A bounded Bourbon Culture no-write preview passed for the two newest reviews with exact article facts and zero emitted items. The scoped live selector resolves exactly the six reviews in the publisher's Latest Whiskey Reviews section. Fixture parity tests compare both selected links and the configured parser's facts and evidence with the hardcoded parser. Production inventory confirms six current records and preserves their article URLs, review IDs, and Bottle matches for the later preparation workflow.

A full Compass Box no-write preview also passed: 24 current products in 25 requests, no parsing issues, and zero emitted items. Names, prices, currency, volume, URLs, source image paths, Bottle-match identities, and item count match the current scraper and stored records; three sold-out products are excluded. A fixture parity test compares available links with the hardcoded parser. Kilchoman and Fine Drams remain rejected migration candidates because their configured output did not exactly preserve existing price behavior or coverage.

## Testing

- 76 focused server tests covering rules, parsing, hardcoded-parser parity, setup, service, runtime, and local previews
- 27 CLI tests
- `pnpm --filter @peated/server typecheck`
- `pnpm --filter @peated/cli typecheck`
- Focused oxlint and Prettier checks
- `pnpm exec openspec validate extend-configured-scraper-values --strict`
- Live no-write previews against Whisky Study, Whisky Saga, Bourbon Culture, Compass Box, Kilchoman, and Fine Drams

## AI assistance

AI assisted with the rule-language design, implementation, tests, OpenSpec artifacts, and reviewer-facing documentation. Deterministic tests and live local previews were used to verify the resulting behavior.
