### PR TITLE
fix(web): show NAS for bottles without age statements

### DIFF
--- a/apps/server/src/lib/bottleSchemas.ts
+++ b/apps/server/src/lib/bottleSchemas.ts
@@ -115,7 +115,7 @@ function validateBottleInput(
   ) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: "Choose an age or No age statement, not both.",
+      message: "Choose an age or NAS, not both.",
       path: ["noAgeStatement"],
     });
   }

--- a/apps/web/src/app/(app)/about/brand/brandVoicePage.stylex.tsx
+++ b/apps/web/src/app/(app)/about/brand/brandVoicePage.stylex.tsx
@@ -48,7 +48,7 @@ const rules: readonly VoiceRule[] = [
       <div {...stylex.props(styles.wordLists)}>
         <WordList
           label="Trade jargon"
-          words="expression · liquid · NAS without expansion · organoleptic · the water of life"
+          words="expression · liquid · organoleptic · the water of life"
         />
         <WordList
           accent

--- a/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
+++ b/apps/web/src/app/(app)/bottles/(index)/bottleCatalogPageClient.tsx
@@ -50,7 +50,7 @@ const categoryOptions = [
 ] satisfies readonly BottleCatalogFilterOption[];
 
 const ageBandLabels = {
-  nas: "No age statement",
+  nas: "NAS",
   under_12: "Under 12",
   "12_17": "12–17 years",
   "18_24": "18–24 years",

--- a/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
+++ b/apps/web/src/app/(app)/bottles/[bottleId]/bottlePageClient.stylex.tsx
@@ -109,7 +109,7 @@ function getDeclaredFacts(bottle: Bottle): [FactListItem, ...FactListItem[]] {
       value:
         bottle.statedAge === null
           ? bottle.noAgeStatement
-            ? "No age statement"
+            ? "NAS"
             : null
           : `${bottle.statedAge} years`,
     },

--- a/apps/web/src/components/bottleForm.tsx
+++ b/apps/web/src/components/bottleForm.tsx
@@ -65,7 +65,7 @@ type BooleanChoice = {
 
 const noAgeStatementChoices: BooleanChoice[] = [
   { id: "unknown", name: "Not known" },
-  { id: "yes", name: "No age statement" },
+  { id: "yes", name: "NAS" },
 ];
 
 const colorChoices: BooleanChoice[] = [

--- a/apps/web/src/components/bottleList.stories.tsx
+++ b/apps/web/src/components/bottleList.stories.tsx
@@ -28,7 +28,7 @@ const items: BottleListProps["items"] = [
   {
     href: "/bottles/2",
     id: "2",
-    metadata: ["Single Malt", "No age statement", "54.2% ABV"],
+    metadata: ["Single Malt", "NAS", "54.2% ABV"],
     name: "Ardbeg Uigeadail",
     ratings: {
       counts: {

--- a/apps/web/src/components/tastingEntry.stories.tsx
+++ b/apps/web/src/components/tastingEntry.stories.tsx
@@ -30,7 +30,7 @@ const meta = {
         bottle: {
           name: "Ardbeg Uigeadail",
           provenance: [{ name: "Single Malt" }],
-          metadata: ["No age statement", "54.2% ABV"],
+          metadata: ["NAS", "54.2% ABV"],
         },
         ratingBand: "good",
         tags: ["Tar", "Raisin", "Espresso"],

--- a/apps/web/src/lib/bottleListItem.test.ts
+++ b/apps/web/src/lib/bottleListItem.test.ts
@@ -113,6 +113,6 @@ describe("toBottleListItem", () => {
         noAgeStatement: true,
         abv: null,
       }).metadata,
-    ).toEqual(["No age statement"]);
+    ).toEqual(["NAS"]);
   });
 });

--- a/apps/web/src/lib/bottleListItem.ts
+++ b/apps/web/src/lib/bottleListItem.ts
@@ -95,7 +95,7 @@ export function getBottleIdentityProps(
       bottle.statedAge !== null
         ? `${bottle.statedAge} years`
         : bottle.noAgeStatement
-          ? "No age statement"
+          ? "NAS"
           : null,
       bottle.abv !== null ? `${bottle.abv.toFixed(1)}% ABV` : null,
     ].filter((value): value is string => value !== null),

--- a/docs/features/bottle-presentation.md
+++ b/docs/features/bottle-presentation.md
@@ -110,10 +110,11 @@ Show stated age when it is useful and is not already expressed by the visible
 name. Within a release family, an exact age override can be a meaningful
 distinction when it differs from the shared expression age.
 
-When `noAgeStatement` is true, use `No age statement` in ordinary metadata. A
-dedicated Age column can use `NAS` when it also provides the full term as an
-accessible label. Do not show both forms in the same layout. A missing
-`statedAge` with no confirmed NAS fact is unknown and must not be labeled NAS.
+When `noAgeStatement` is true, use `NAS` in metadata, forms, filters, and detail
+views. The surrounding age label or context should make its meaning clear; a
+learning-oriented surface can explain that NAS means no age statement. A
+missing `statedAge` with no confirmed NAS fact is unknown and must not be
+labeled NAS.
 
 ### Let ABV stand on its own
 

--- a/skills/peated-writing/SKILL.md
+++ b/skills/peated-writing/SKILL.md
@@ -42,8 +42,7 @@ general or about Peated.
 
 Avoid these terms in customer-facing copy:
 
-- Trade jargon: `expression`, `liquid`, unexplained `NAS`, `organoleptic`,
-  `the water of life`.
+- Trade jargon: `expression`, `liquid`, `organoleptic`, `the water of life`.
 - Internal terms: `aggregate`, `entity`, `canonical`, `verdict`, `grain`,
   `band`.
 - Product marketing: `curated`, `discover`, `journey`, `unlock`, `seamless`,
@@ -54,6 +53,10 @@ or `How people rated` instead of exposing an internal measure name.
 
 `Dram` is allowed at most once per screen. Do not use it in a heading or as a
 cute plural.
+
+Use `NAS` for a Bottle confirmed to have no age statement. Age labels and
+surrounding context normally explain the term; learning-oriented surfaces can
+spell it out once.
 
 ## Use Peated Mechanics
 


### PR DESCRIPTION
Confirmed no-age-statement bottles now appear as “NAS” in bottle metadata, detail facts, catalog filters, forms, and validation. Stories, regression coverage, presentation rules, and Peated’s writing guidance use the same term, while bottles with unknown age information remain unlabeled.
