### PR TITLE
feat(scrapers): prepare Compass Box for saved rules

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -9,6 +9,8 @@ import {
   scrapeSourceRuns,
   scrapeSources,
   scrapeTargets,
+  storePriceHistories,
+  storePrices,
   type User,
 } from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
@@ -63,6 +65,15 @@ function prepareWhiskySaga(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareCompassBox(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "compassbox", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 const canonicalUrl =
   "https://thebourbonculture.com/whiskey-reviews/example-review/";
 const registry = createScraperRegistry({
@@ -95,6 +106,16 @@ const whiskySagaRegistry = createScraperRegistry({
     {
       ...scraperRegistry.sources.get("whiskysaga")!,
       externalSiteKey: "whiskysaga",
+    },
+  ],
+});
+
+const compassBoxRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("compassbox")!],
+  sources: [
+    {
+      ...scraperRegistry.sources.get("compassbox")!,
+      externalSiteKey: "compassbox",
     },
   ],
 });
@@ -256,6 +277,25 @@ async function setupWhiskySagaMigration(bottleId: number | null = null) {
     completedAt: new Date(),
   });
   return { site, article, review };
+}
+
+async function setupCompassBoxMigration() {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "compassbox",
+      name: "Compass Box",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(compassBoxRegistry);
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return site;
 }
 
 describe("POST /admin/scrape-sources/prepare", () => {
@@ -512,6 +552,120 @@ describe("POST /admin/scrape-sources/prepare", () => {
         createdById: admin.id,
       }),
     ]);
+  });
+
+  test("prepares Compass Box without replacing prices or Bottle matches", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const site = await setupCompassBoxMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Compass Box Orchard House",
+      price: 4500,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.compassboxwhisky.com/products/orchard-house",
+      bottleId: bottle.id,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Compass Box Hedonism",
+      price: 8500,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.compassboxwhisky.com/products/hedonism",
+      bottleId: null,
+      hidden: true,
+    });
+    const prices = await db.select().from(storePrices);
+    const histories = await db.select().from(storePriceHistories);
+    const runs = await db.select().from(externalSiteRuns);
+    await db.update(scrapeTargets).set({
+      blockedUntil: new Date(Date.now() + 60_000),
+      windowRequestCount: 3,
+    });
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareCompassBox()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+
+    const applied = await prepareCompassBox({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: true,
+    });
+    // A later definition sync must not reclaim the transferred target.
+    await syncScraperDefinitions(compassBoxRegistry);
+    await syncScraperDefinitions(
+      createScraperRegistry({ targets: [], sources: [] }),
+    );
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(storePriceHistories)).toEqual(histories);
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "price",
+        listUrl: "https://www.compassboxwhisky.com/collections",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+    await expect(prepareCompassBox({ apply: true })).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Compass Box is already prepared for saved scraping rules.",
+    });
+  });
+
+  test("refuses an unexpected Compass Box price without changing records", async ({
+    fixtures,
+  }) => {
+    const site = await setupCompassBoxMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Compass Box Orchard House",
+      currency: "gbp",
+      volume: 700,
+      url: "https://example.com/products/orchard-house",
+      bottleId: null,
+    });
+    const prices = await db.select().from(storePrices);
+    const targets = await db.select().from(scrapeTargets);
+
+    await expect(prepareCompassBox({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Check Compass Box price"),
+    });
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(scrapeTargets)).toEqual(targets);
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("refuses Compass Box without stored prices", async () => {
+    await setupCompassBoxMigration();
+
+    await expect(prepareCompassBox({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Compass Box has no stored prices to verify.",
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
   });
 
   test("refuses an unexpected The Whisky Study article URL", async () => {

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -2,6 +2,7 @@ import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
 import { ExternalSiteKeySchema } from "@peated/server/schemas";
 import { prepareBourbonCultureSource } from "@peated/server/scraper/configured/prepareBourbonCulture";
+import { prepareCompassBoxSource } from "@peated/server/scraper/configured/prepareCompassBox";
 import { prepareWhiskySagaSource } from "@peated/server/scraper/configured/prepareWhiskySaga";
 import { prepareWhiskyStudySource } from "@peated/server/scraper/configured/prepareWhiskyStudy";
 import {
@@ -18,7 +19,7 @@ export default procedure
     path: "/admin/scrape-sources/prepare",
     summary: "Prepare an existing scraper for saved rules",
     description:
-      "Check existing reviews without saving. Set apply to true to save the changes and leave collection paused. Requires an administrator and a stopped schedule with no active runs.",
+      "Check existing source records without saving. Set apply to true to transfer request settings and leave collection paused. Requires an administrator and a stopped schedule with no active runs.",
     spec: (spec) => ({
       ...spec,
       operationId: "prepareScrapeSource",
@@ -28,7 +29,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, whiskysaga, and whiskystudy.",
+          "The existing site's key. Currently supports bourbonculture, compassbox, whiskysaga, and whiskystudy.",
         ),
         apply: z
           .boolean()
@@ -49,7 +50,10 @@ export default procedure
           .describe(
             "The prepared source ID, or null when checking without saving.",
           ),
-        reviewCount: z.number().int().nonnegative(),
+        reviewCount: z.number().int().nonnegative().optional(),
+        priceCount: z.number().int().positive().optional(),
+        visiblePriceCount: z.number().int().nonnegative().optional(),
+        matchedPriceCount: z.number().int().nonnegative().optional(),
         applied: z.boolean(),
       })
       .strict(),
@@ -57,6 +61,7 @@ export default procedure
   .handler(async ({ input, context, errors }) => {
     const prepareSource = {
       bourbonculture: prepareBourbonCultureSource,
+      compassbox: prepareCompassBoxSource,
       whiskysaga: prepareWhiskySagaSource,
       whiskystudy: prepareWhiskyStudySource,
     }[input.site];

--- a/apps/server/src/scraper/configured/prepareCompassBox.ts
+++ b/apps/server/src/scraper/configured/prepareCompassBox.ts
@@ -1,0 +1,23 @@
+import {
+  preparePriceSource,
+  type PreparePriceSourceInput,
+} from "./preparePriceSource";
+
+/** Checks Compass Box by default; applying keeps price IDs and leaves collection paused. */
+export async function prepareCompassBoxSource(input: PreparePriceSourceInput) {
+  return preparePriceSource(input, {
+    siteKey: "compassbox",
+    siteName: "Compass Box",
+    targetKey: "compassbox",
+    origin: "https://www.compassboxwhisky.com",
+    listUrl: "https://www.compassboxwhisky.com/collections",
+    isExpectedPrice: (price) =>
+      /^https:\/\/www\.compassboxwhisky\.com\/products\/[a-z0-9][a-z0-9-]*$/.test(
+        price.url,
+      ) &&
+      price.externalProductId === null &&
+      price.name.startsWith("Compass Box ") &&
+      price.currency === "gbp" &&
+      price.volume === 700,
+  });
+}

--- a/apps/server/src/scraper/configured/prepareExistingSource.ts
+++ b/apps/server/src/scraper/configured/prepareExistingSource.ts
@@ -1,0 +1,152 @@
+import type { AnyTransaction } from "@peated/server/db";
+import {
+  externalSiteRuns,
+  externalSites,
+  externalSiteScrapeTargets,
+  scrapeOrigins,
+  scrapeSources,
+  scrapeTargets,
+} from "@peated/server/db/schema";
+import { and, eq, inArray } from "drizzle-orm";
+import {
+  ScrapeSourceConflictError,
+  ScrapeSourceNotFoundError,
+  ScrapeSourceValidationError,
+} from "./service";
+
+export type ExistingSourceDefinition = {
+  siteKey: string;
+  siteName: string;
+  targetKey: string;
+  origin: string;
+};
+
+/** Locks and checks one code-owned source before its records are inspected. */
+export async function inspectExistingSource(
+  tx: AnyTransaction,
+  definition: ExistingSourceDefinition,
+) {
+  // The scraper lifecycle also locks this site before choosing its scraper.
+  const [site] = await tx
+    .select()
+    .from(externalSites)
+    .where(eq(externalSites.type, definition.siteKey))
+    .for("update");
+  if (!site) {
+    throw new ScrapeSourceNotFoundError(
+      `${definition.siteName} was not found.`,
+    );
+  }
+  if (site.runEvery !== null) {
+    throw new ScrapeSourceConflictError(
+      `Stop the ${definition.siteName} schedule before continuing.`,
+    );
+  }
+  const [activeRun] = await tx
+    .select({ id: externalSiteRuns.id })
+    .from(externalSiteRuns)
+    .where(
+      and(
+        eq(externalSiteRuns.externalSiteId, site.id),
+        inArray(externalSiteRuns.status, ["queued", "running"]),
+      ),
+    )
+    .limit(1);
+  if (activeRun) {
+    throw new ScrapeSourceConflictError(
+      `Wait for the active ${definition.siteName} run to finish.`,
+    );
+  }
+  const [source] = await tx
+    .select({ id: scrapeSources.id })
+    .from(scrapeSources)
+    .where(eq(scrapeSources.externalSiteId, site.id));
+  if (source) {
+    throw new ScrapeSourceConflictError(
+      `${definition.siteName} is already prepared for saved scraping rules.`,
+    );
+  }
+
+  const siteTargets = await tx
+    .select()
+    .from(externalSiteScrapeTargets)
+    .where(eq(externalSiteScrapeTargets.externalSiteId, site.id))
+    .for("update");
+  const targetSites = await tx
+    .select()
+    .from(externalSiteScrapeTargets)
+    .where(eq(externalSiteScrapeTargets.targetKey, definition.targetKey))
+    .for("update");
+  const origins = await tx
+    .select()
+    .from(scrapeOrigins)
+    .where(eq(scrapeOrigins.targetKey, definition.targetKey))
+    .for("update");
+  const [target] = await tx
+    .select()
+    .from(scrapeTargets)
+    .where(eq(scrapeTargets.key, definition.targetKey))
+    .for("update");
+  // A preparation operation can take ownership only of this site's request settings.
+  if (
+    siteTargets.length !== 1 ||
+    siteTargets[0].targetKey !== definition.targetKey ||
+    !siteTargets[0].active ||
+    siteTargets[0].managedBy !== "code" ||
+    targetSites.length !== 1 ||
+    targetSites[0].externalSiteId !== site.id ||
+    origins.length !== 1 ||
+    origins[0].origin !== definition.origin ||
+    !origins[0].active ||
+    origins[0].managedBy !== "code" ||
+    origins[0].robotsMode !== "enforce" ||
+    !target?.enabled ||
+    target.managedBy !== "code"
+  ) {
+    throw new ScrapeSourceValidationError(
+      `${definition.siteName} has unexpected request settings. Check them before continuing.`,
+    );
+  }
+  return site;
+}
+
+/** Transfers checked request settings and creates an inactive saved-rule source. */
+export async function createPreparedSource(
+  tx: AnyTransaction,
+  input: {
+    externalSiteId: number;
+    createdById: number;
+    kind: "review" | "price";
+    listUrl: string;
+  },
+  definition: ExistingSourceDefinition,
+) {
+  await tx
+    .update(externalSiteScrapeTargets)
+    .set({ managedBy: "admin", updatedAt: new Date() })
+    .where(
+      and(
+        eq(externalSiteScrapeTargets.externalSiteId, input.externalSiteId),
+        eq(externalSiteScrapeTargets.targetKey, definition.targetKey),
+      ),
+    );
+  await tx
+    .update(scrapeOrigins)
+    .set({ managedBy: "admin", updatedAt: new Date() })
+    .where(eq(scrapeOrigins.origin, definition.origin));
+  await tx
+    .update(scrapeTargets)
+    .set({ managedBy: "admin", updatedAt: new Date() })
+    .where(eq(scrapeTargets.key, definition.targetKey));
+  const [created] = await tx
+    .insert(scrapeSources)
+    .values({
+      externalSiteId: input.externalSiteId,
+      kind: input.kind,
+      listUrl: input.listUrl,
+      createdById: input.createdById,
+    })
+    .returning({ id: scrapeSources.id });
+  if (!created) throw new Error("Failed to prepare the scrape source.");
+  return created.id;
+}

--- a/apps/server/src/scraper/configured/preparePriceSource.ts
+++ b/apps/server/src/scraper/configured/preparePriceSource.ts
@@ -1,0 +1,74 @@
+import { db } from "@peated/server/db";
+import { storePrices, type StorePrice } from "@peated/server/db/schema";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import {
+  createPreparedSource,
+  inspectExistingSource,
+  type ExistingSourceDefinition,
+} from "./prepareExistingSource";
+import { ScrapeSourceValidationError } from "./service";
+
+const InputSchema = z
+  .object({
+    apply: z.boolean().default(false),
+    createdById: z.number().int().positive(),
+  })
+  .strict();
+
+export type PreparePriceSourceInput = z.input<typeof InputSchema>;
+
+type PriceSourceDefinition = ExistingSourceDefinition & {
+  listUrl: string;
+  isExpectedPrice: (price: StorePrice) => boolean;
+};
+
+/** Checks one price source by default; applying preserves price rows and leaves collection paused. */
+export async function preparePriceSource(
+  input: PreparePriceSourceInput,
+  definition: PriceSourceDefinition,
+) {
+  const { apply, createdById } = InputSchema.parse(input);
+  return db.transaction(async (tx) => {
+    const site = await inspectExistingSource(tx, definition);
+    const prices = await tx
+      .select()
+      .from(storePrices)
+      .where(eq(storePrices.externalSiteId, site.id))
+      .for("update");
+    if (prices.length === 0) {
+      throw new ScrapeSourceValidationError(
+        `${definition.siteName} has no stored prices to verify.`,
+      );
+    }
+    for (const price of prices) {
+      if (!definition.isExpectedPrice(price)) {
+        throw new ScrapeSourceValidationError(
+          `Check ${definition.siteName} price ${price.id} before continuing.`,
+        );
+      }
+    }
+
+    const scrapeSourceId = apply
+      ? await createPreparedSource(
+          tx,
+          {
+            externalSiteId: site.id,
+            kind: "price",
+            listUrl: definition.listUrl,
+            createdById,
+          },
+          definition,
+        )
+      : null;
+    return {
+      siteId: site.id,
+      scrapeSourceId,
+      priceCount: prices.length,
+      visiblePriceCount: prices.filter(({ hidden }) => !hidden).length,
+      matchedPriceCount: prices.filter(({ bottleId }) => bottleId !== null)
+        .length,
+      applied: apply,
+    };
+  });
+}

--- a/apps/server/src/scraper/configured/prepareReviewSource.ts
+++ b/apps/server/src/scraper/configured/prepareReviewSource.ts
@@ -2,20 +2,15 @@ import { db } from "@peated/server/db";
 import {
   externalReviewArticles,
   externalReviews,
-  externalSiteRuns,
-  externalSites,
-  externalSiteScrapeTargets,
-  scrapeOrigins,
-  scrapeSources,
-  scrapeTargets,
 } from "@peated/server/db/schema";
-import { and, eq, inArray } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { z } from "zod";
 import {
-  ScrapeSourceConflictError,
-  ScrapeSourceNotFoundError,
-  ScrapeSourceValidationError,
-} from "./service";
+  createPreparedSource,
+  inspectExistingSource,
+  type ExistingSourceDefinition,
+} from "./prepareExistingSource";
+import { ScrapeSourceValidationError } from "./service";
 
 const InputSchema = z
   .object({
@@ -26,11 +21,7 @@ const InputSchema = z
 
 export type PrepareReviewSourceInput = z.input<typeof InputSchema>;
 
-type ReviewSourceDefinition = {
-  siteKey: string;
-  siteName: string;
-  targetKey: string;
-  origin: string;
+type ReviewSourceDefinition = ExistingSourceDefinition & {
   listUrl: string;
   isCanonicalArticleUrl: (url: string) => boolean;
   legacyReviewKey: (url: string) => string;
@@ -43,87 +34,7 @@ export async function prepareReviewSource(
 ) {
   const { apply, createdById } = InputSchema.parse(input);
   return db.transaction(async (tx) => {
-    // The scraper lifecycle also locks this site before choosing its scraper.
-    const [site] = await tx
-      .select()
-      .from(externalSites)
-      .where(eq(externalSites.type, definition.siteKey))
-      .for("update");
-    if (!site) {
-      throw new ScrapeSourceNotFoundError(
-        `${definition.siteName} was not found.`,
-      );
-    }
-    if (site.runEvery !== null) {
-      throw new ScrapeSourceConflictError(
-        `Stop the ${definition.siteName} schedule before continuing.`,
-      );
-    }
-    const [activeRun] = await tx
-      .select({ id: externalSiteRuns.id })
-      .from(externalSiteRuns)
-      .where(
-        and(
-          eq(externalSiteRuns.externalSiteId, site.id),
-          inArray(externalSiteRuns.status, ["queued", "running"]),
-        ),
-      )
-      .limit(1);
-    if (activeRun) {
-      throw new ScrapeSourceConflictError(
-        `Wait for the active ${definition.siteName} run to finish.`,
-      );
-    }
-    const [source] = await tx
-      .select({ id: scrapeSources.id })
-      .from(scrapeSources)
-      .where(eq(scrapeSources.externalSiteId, site.id));
-    if (source) {
-      throw new ScrapeSourceConflictError(
-        `${definition.siteName} is already prepared for saved scraping rules.`,
-      );
-    }
-
-    const siteTargets = await tx
-      .select()
-      .from(externalSiteScrapeTargets)
-      .where(eq(externalSiteScrapeTargets.externalSiteId, site.id))
-      .for("update");
-    const targetSites = await tx
-      .select()
-      .from(externalSiteScrapeTargets)
-      .where(eq(externalSiteScrapeTargets.targetKey, definition.targetKey))
-      .for("update");
-    const origins = await tx
-      .select()
-      .from(scrapeOrigins)
-      .where(eq(scrapeOrigins.targetKey, definition.targetKey))
-      .for("update");
-    const [target] = await tx
-      .select()
-      .from(scrapeTargets)
-      .where(eq(scrapeTargets.key, definition.targetKey))
-      .for("update");
-    // This operation handles only the review source's own request settings.
-    if (
-      siteTargets.length !== 1 ||
-      siteTargets[0].targetKey !== definition.targetKey ||
-      !siteTargets[0].active ||
-      siteTargets[0].managedBy !== "code" ||
-      targetSites.length !== 1 ||
-      targetSites[0].externalSiteId !== site.id ||
-      origins.length !== 1 ||
-      origins[0].origin !== definition.origin ||
-      !origins[0].active ||
-      origins[0].managedBy !== "code" ||
-      origins[0].robotsMode !== "enforce" ||
-      !target?.enabled ||
-      target.managedBy !== "code"
-    ) {
-      throw new ScrapeSourceValidationError(
-        `${definition.siteName} has unexpected request settings. Check them before continuing.`,
-      );
-    }
+    const site = await inspectExistingSource(tx, definition);
 
     const articles = await tx
       .select({
@@ -175,34 +86,16 @@ export async function prepareReviewSource(
           .set({ sourceKey: change.sourceKey })
           .where(eq(externalReviews.id, change.id));
       }
-      await tx
-        .update(externalSiteScrapeTargets)
-        .set({ managedBy: "admin", updatedAt: new Date() })
-        .where(
-          and(
-            eq(externalSiteScrapeTargets.externalSiteId, site.id),
-            eq(externalSiteScrapeTargets.targetKey, definition.targetKey),
-          ),
-        );
-      await tx
-        .update(scrapeOrigins)
-        .set({ managedBy: "admin", updatedAt: new Date() })
-        .where(eq(scrapeOrigins.origin, definition.origin));
-      await tx
-        .update(scrapeTargets)
-        .set({ managedBy: "admin", updatedAt: new Date() })
-        .where(eq(scrapeTargets.key, definition.targetKey));
-      const [created] = await tx
-        .insert(scrapeSources)
-        .values({
+      scrapeSourceId = await createPreparedSource(
+        tx,
+        {
           externalSiteId: site.id,
           kind: "review",
           listUrl: definition.listUrl,
           createdById,
-        })
-        .returning({ id: scrapeSources.id });
-      if (!created) throw new Error("Failed to prepare the scrape source.");
-      scrapeSourceId = created.id;
+        },
+        definition,
+      );
     }
     return {
       siteId: site.id,

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -107,6 +107,29 @@ same review IDs recorded before applying without adding duplicate articles or
 reviews. Check the run and Sentry before restoring the saved schedule.
 Preparation must not change the source's publication setting.
 
+## Compass Box
+
+Use the same preparation endpoint with `{"site": "compassbox"}`. The check-only
+request locks and inventories every stored price without changing it. It reports
+the total, visible, and Bottle-matched price counts. It stops if a price has an
+unexpected product URL, external product ID, name prefix, currency, or volume.
+Applying transfers the existing request settings to administrator ownership and
+adds a paused price source whose list page is
+`https://www.compassboxwhisky.com/collections`. It does not update price rows or
+history.
+
+Before applying, stop the `compassbox` schedule and wait for active runs. Save
+the price IDs, product URLs, names, prices, currencies, volumes, image URLs,
+Bottle matches, hidden states, histories, request limits, and run history. Run
+the version 2 rules through the local no-write preview without an item limit.
+The current catalog must match the code scraper, including excluding sold-out
+cards.
+
+After applying, save the reviewed version 2 revision and run its production
+preview. Activate only exact output, trigger one manual collection, and confirm
+that it updates the same price IDs and Bottle matches. Check the run and Sentry
+before restoring the saved schedule.
+
 ## If something goes wrong
 
 A request without `apply: true` leaves records unchanged. After applying, keep the
@@ -116,9 +139,10 @@ handles reviews added after the switch. Do not delete source or run history.
 
 ## Other sources
 
-The preparation API is shared. It currently supports Bourbon Culture and The
-Whisky Study. Other sites are rejected without changing records. Add each
-site's conversion behind this route as its existing records are reviewed.
+The preparation API is shared. It currently supports Bourbon Culture, Compass
+Box, and The Whisky Study. Other sites are rejected without changing records.
+Add each site's conversion behind this route as its existing records are
+reviewed.
 
 Prepare each source using its own rules for recognizing existing records.
 Articles with several reviews need a verified match for each review. Store


### PR DESCRIPTION
## Why

Compass Box now has exact local parity with version 2 saved rules, but the existing code-owned site cannot use the new-source endpoint without replacing its identity. It needs a guarded handoff that preserves the current price rows, Bottle assignments, request state, and run history.

## What

- Add a reusable preparation boundary for checking one stopped, code-owned source and transferring only its existing request settings.
- Add price-source preparation that locks and inventories every stored price before applying.
- Support `compassbox` in the administrator preparation endpoint.
- Require every Compass Box row to retain its canonical product URL, null external product ID, `Compass Box` name prefix, GBP currency, and 700 ml volume.
- Report total, visible, and Bottle-matched price counts during the default no-write check.
- On explicit apply, create a paused saved-rule source while leaving price rows and histories unchanged.
- Document the Compass Box inventory, preview, activation, verification, and schedule-restoration procedure.

This PR is intentionally based on #1020 because the accepted Compass Box rules use its version 2 value and list-item operations.

## Testing

- 16 preparation route integration tests
- 35 preparation and OpenAPI integration tests together
- `pnpm --filter @peated/server typecheck`
- Focused oxlint and Prettier checks

## AI assistance

AI assisted with the preparation boundary, tests, and reviewer-facing documentation. Deterministic integration tests verify the no-write check and the transactional apply path.
