### PR TITLE
perf(server): reduce repeated test setup work

### DIFF
--- a/apps/server/src/externalReviews/ingest.ts
+++ b/apps/server/src/externalReviews/ingest.ts
@@ -7,7 +7,7 @@ import { ExternalReviewArticleIngestionSchema } from "@peated/server/externalRev
 import { storeExternalReviewArticle } from "@peated/server/externalReviews/store";
 import { findBottleReferenceAssignment } from "@peated/server/lib/bottleFinder";
 import { logTelemetryError } from "@peated/server/lib/log";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 

--- a/apps/server/src/lib/bottleReferences.ts
+++ b/apps/server/src/lib/bottleReferences.ts
@@ -27,7 +27,7 @@ import {
   resolveActiveBottleIds,
   type ActiveBottleRejectionReason,
 } from "@peated/server/lib/resolveActiveBottleIds";
-import { pushJob, pushUniqueJob } from "@peated/server/worker/client";
+import { pushJob, pushUniqueJob } from "@peated/server/worker/dispatch";
 import { and, asc, eq, inArray, isNull, or, sql } from "drizzle-orm";
 
 /** Lists unresolved, non-ignored references for bounded maintenance output. */

--- a/apps/server/src/lib/catalogVerification.ts
+++ b/apps/server/src/lib/catalogVerification.ts
@@ -7,7 +7,7 @@ import {
 import { db } from "@peated/server/db";
 import { changes } from "@peated/server/db/schema";
 import { getPeatedSystemActor } from "@peated/server/lib/actors";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 
 export function getCatalogVerificationCreationMetadata(
   creationSource: CatalogVerificationCreationSource,

--- a/apps/server/src/lib/createBottle.ts
+++ b/apps/server/src/lib/createBottle.ts
@@ -43,7 +43,7 @@ import type { Context } from "@peated/server/orpc/context";
 import { bottleNormalize } from "@peated/server/orpc/routes/bottles/validation";
 import type { BottleInputSchema } from "@peated/server/schemas";
 import type { BottlePreviewResult } from "@peated/server/types";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { and, eq, sql } from "drizzle-orm";
 import type { z } from "zod";
 import {

--- a/apps/server/src/lib/createStorePrices.ts
+++ b/apps/server/src/lib/createStorePrices.ts
@@ -25,7 +25,7 @@ import {
   ExternalSiteKeySchema,
   StorePriceInputSchema,
 } from "@peated/server/schemas";
-import { pushJob, pushUniqueJob } from "@peated/server/worker/client";
+import { pushJob, pushUniqueJob } from "@peated/server/worker/dispatch";
 import { and, eq, inArray, or, sql } from "drizzle-orm";
 import { createHash } from "node:crypto";
 import { z } from "zod";

--- a/apps/server/src/lib/dispatchBottleStatsRecompute.ts
+++ b/apps/server/src/lib/dispatchBottleStatsRecompute.ts
@@ -1,5 +1,5 @@
 import { logError } from "@peated/server/lib/log";
-import { pushJob } from "@peated/server/worker/client";
+import { pushJob } from "@peated/server/worker/dispatch";
 import type { UpdateBottleStatsJobArgs } from "@peated/server/worker/jobs/updateBottleStats";
 
 type BottleStatsSource = "externalReview" | "memberReview" | "tasting";

--- a/apps/server/src/lib/mergeBottles.ts
+++ b/apps/server/src/lib/mergeBottles.ts
@@ -35,7 +35,7 @@ import { logError } from "@peated/server/lib/log";
 import { recomputeBottleGroupStatsInTransaction } from "@peated/server/lib/recomputeBottleGroupStats";
 import { recomputeBottleStatsInTransaction } from "@peated/server/lib/recomputeBottleStats";
 import type { Context } from "@peated/server/orpc/context";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { and, asc, eq, inArray, or, sql } from "drizzle-orm";
 import { z } from "zod";
 

--- a/apps/server/src/lib/priceMatchingProposals.ts
+++ b/apps/server/src/lib/priceMatchingProposals.ts
@@ -82,7 +82,7 @@ import {
   StorePriceBottleRepairDraftSchema,
   StorePriceMatchDecisionSchema,
 } from "@peated/server/schemas";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { isDeepStrictEqual } from "node:util";
 import type { z } from "zod";

--- a/apps/server/src/lib/storePriceMatchRetryRuns.ts
+++ b/apps/server/src/lib/storePriceMatchRetryRuns.ts
@@ -134,7 +134,7 @@ export async function enqueueStorePriceMatchRetryRunJob({
   delayMs?: number;
   runId: number;
 }) {
-  const { pushJob } = await import("@peated/server/worker/client");
+  const { pushJob } = await import("@peated/server/worker/dispatch");
 
   await pushJob(
     "ProcessStorePriceMatchRetryRun",

--- a/apps/server/src/lib/test/workerDispatch.ts
+++ b/apps/server/src/lib/test/workerDispatch.ts
@@ -1,7 +1,7 @@
 import {
   configureWorkerDispatch,
   type WorkerDispatch,
-} from "@peated/server/worker/client";
+} from "@peated/server/worker/dispatch";
 import { vi } from "vitest";
 
 export const pushJob = vi.fn<WorkerDispatch["pushJob"]>();

--- a/apps/server/src/lib/updateBottle.ts
+++ b/apps/server/src/lib/updateBottle.ts
@@ -53,7 +53,7 @@ import { formatBottleName } from "@peated/server/lib/format";
 import { logError } from "@peated/server/lib/log";
 import type { Context } from "@peated/server/orpc/context";
 import { EntityChoiceInputSchema } from "@peated/server/schemas";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { and, asc, eq, inArray, isNull, ne, sql } from "drizzle-orm";
 import { z } from "zod";
 

--- a/apps/server/src/lib/updateEntity.ts
+++ b/apps/server/src/lib/updateEntity.ts
@@ -33,7 +33,7 @@ import {
   type BottleUpdateFinalizationManifest,
 } from "@peated/server/lib/updateBottle";
 import { EntityInputFields } from "@peated/server/schemas/entities";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { asc, eq, or, sql } from "drizzle-orm";
 import { z } from "zod";
 

--- a/apps/server/src/orpc/middleware/rateLimit.ts
+++ b/apps/server/src/orpc/middleware/rateLimit.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { base } from "..";
-import { getConnection } from "../../worker/client";
+import { getConnection } from "../../worker/redis";
 import type { Context } from "../context";
 
 interface RateLimitOptions {

--- a/apps/server/src/orpc/routes/admin/moderation/automation.ts
+++ b/apps/server/src/orpc/routes/admin/moderation/automation.ts
@@ -7,7 +7,7 @@ import {
 } from "@peated/server/db/schema";
 import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
-import { getQueue } from "@peated/server/worker/client";
+import { getQueue } from "@peated/server/worker/queue";
 import { desc, eq, gte, inArray, sql } from "drizzle-orm";
 import { ModerationAutomationResponseSchema } from "./schemas";
 

--- a/apps/server/src/orpc/routes/bottleAliases/create.ts
+++ b/apps/server/src/orpc/routes/bottleAliases/create.ts
@@ -9,7 +9,7 @@ import {
 import { logError } from "@peated/server/lib/log";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { z } from "zod";
 
 export default procedure

--- a/apps/server/src/orpc/routes/bottleAliases/delete.ts
+++ b/apps/server/src/orpc/routes/bottleAliases/delete.ts
@@ -5,7 +5,7 @@ import {
 import { logError } from "@peated/server/lib/log";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { z } from "zod";
 
 export default procedure

--- a/apps/server/src/orpc/routes/bottleSeries/create.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/create.ts
@@ -13,7 +13,7 @@ import {
 } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
 import { BottleSeriesSerializer } from "@peated/server/serializers/bottleSeries";
-import { pushJob } from "@peated/server/worker/client";
+import { pushJob } from "@peated/server/worker/dispatch";
 import { eq, sql } from "drizzle-orm";
 
 export default procedure

--- a/apps/server/src/orpc/routes/bottleSeries/update.ts
+++ b/apps/server/src/orpc/routes/bottleSeries/update.ts
@@ -10,7 +10,7 @@ import {
 } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
 import { BottleSeriesSerializer } from "@peated/server/serializers/bottleSeries";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { and, eq, ne, sql } from "drizzle-orm";
 import { z } from "zod";
 

--- a/apps/server/src/orpc/routes/comments/create.ts
+++ b/apps/server/src/orpc/routes/comments/create.ts
@@ -15,7 +15,7 @@ import {
 import { CommentInputSchema, CommentSchema } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
 import { CommentSerializer } from "@peated/server/serializers/comment";
-import { pushJob } from "@peated/server/worker/client";
+import { pushJob } from "@peated/server/worker/dispatch";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 

--- a/apps/server/src/orpc/routes/entities/aliases/create.ts
+++ b/apps/server/src/orpc/routes/entities/aliases/create.ts
@@ -6,7 +6,7 @@ import {
 } from "@peated/server/lib/entityAliases";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { z } from "zod";
 
 export default procedure

--- a/apps/server/src/orpc/routes/entities/aliases/delete.ts
+++ b/apps/server/src/orpc/routes/entities/aliases/delete.ts
@@ -1,7 +1,7 @@
 import { deleteEntityAlias } from "@peated/server/lib/entityAliases";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { z } from "zod";
 
 export default procedure

--- a/apps/server/src/orpc/routes/entities/create.ts
+++ b/apps/server/src/orpc/routes/entities/create.ts
@@ -24,7 +24,7 @@ import {
 } from "@peated/server/orpc/middleware/auth";
 import { serialize } from "@peated/server/serializers";
 import { EntitySerializer } from "@peated/server/serializers/entity";
-import { pushJob } from "@peated/server/worker/client";
+import { pushJob } from "@peated/server/worker/dispatch";
 import { eq, sql } from "drizzle-orm";
 
 export default implement(contract)

--- a/apps/server/src/orpc/routes/entities/merge.ts
+++ b/apps/server/src/orpc/routes/entities/merge.ts
@@ -5,7 +5,7 @@ import { requireMod } from "@peated/server/orpc/middleware";
 import { EntitySchema } from "@peated/server/schemas";
 import { serialize } from "@peated/server/serializers";
 import { EntitySerializer } from "@peated/server/serializers/entity";
-import { pushJob } from "@peated/server/worker/client";
+import { pushJob } from "@peated/server/worker/dispatch";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 

--- a/apps/server/src/orpc/routes/entities/references/create.ts
+++ b/apps/server/src/orpc/routes/entities/references/create.ts
@@ -5,7 +5,7 @@ import { changes, entities, entityReferences } from "@peated/server/db/schema";
 import { getUserActorForDatabase } from "@peated/server/lib/actors";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { and, eq, isNull, sql } from "drizzle-orm";
 import { z } from "zod";
 

--- a/apps/server/src/orpc/routes/entities/references/delete.ts
+++ b/apps/server/src/orpc/routes/entities/references/delete.ts
@@ -3,7 +3,7 @@ import { entityReferences } from "@peated/server/db/schema";
 import { requiredEntityReferenceNames } from "@peated/server/lib/db";
 import { procedure } from "@peated/server/orpc";
 import { requireMod } from "@peated/server/orpc/middleware";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 

--- a/apps/server/src/orpc/routes/external-sites/review-scoring/update.ts
+++ b/apps/server/src/orpc/routes/external-sites/review-scoring/update.ts
@@ -16,7 +16,7 @@ import {
   ExternalSiteKeySchema,
   REVIEW_SCORING_CONFIG_KEY,
 } from "@peated/server/schemas";
-import { pushJob } from "@peated/server/worker/client";
+import { pushJob } from "@peated/server/worker/dispatch";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
 

--- a/apps/server/src/orpc/routes/prices/matchQueue/retry-utils.ts
+++ b/apps/server/src/orpc/routes/prices/matchQueue/retry-utils.ts
@@ -2,7 +2,7 @@ import {
   claimStorePriceMatchProposalProcessingLease,
   releaseStorePriceMatchProposalProcessingLease,
 } from "@peated/server/lib/priceMatching";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 
 export type StorePriceMatchRetryEnqueueResult =
   | {

--- a/apps/server/src/orpc/routes/tastings/create.ts
+++ b/apps/server/src/orpc/routes/tastings/create.ts
@@ -29,7 +29,7 @@ import { serialize } from "@peated/server/serializers";
 import { BadgeSerializer } from "@peated/server/serializers/badge";
 import { BadgeAwardSerializer } from "@peated/server/serializers/badgeAward";
 import { TastingSerializer } from "@peated/server/serializers/tasting";
-import { pushJob } from "@peated/server/worker/client";
+import { pushJob } from "@peated/server/worker/dispatch";
 import { and, eq, inArray, sql } from "drizzle-orm";
 import { dispatchTastingStatsRecompute } from "./dispatchStatsRecompute";
 import { isTastingIdentityConflict } from "./isTastingIdentityConflict";

--- a/apps/server/src/scraper/index.ts
+++ b/apps/server/src/scraper/index.ts
@@ -25,7 +25,7 @@ import { syncScraperDefinitions } from "./syncDefinitions";
 import type { ScraperRunPayload } from "./types";
 
 const enqueueScraperRun: ScraperEnqueue = async (jobName, args, options) => {
-  const { pushJob } = await import("@peated/server/worker/client");
+  const { pushJob } = await import("@peated/server/worker/dispatch");
   await pushJob(jobName, args, options);
 };
 

--- a/apps/server/src/test/setup-test-env.ts
+++ b/apps/server/src/test/setup-test-env.ts
@@ -15,6 +15,7 @@ import {
   installInMemoryWorkerDispatch,
   resetInMemoryWorkerDispatch,
 } from "../lib/test/workerDispatch";
+import { getConnection } from "../worker/redis";
 
 process.env.DISABLE_HTTP_CACHE = "1";
 
@@ -25,10 +26,6 @@ installInMemoryWorkerDispatch();
 beforeEach(() => {
   resetInMemoryWorkerDispatch();
 });
-
-// XXX: doing this causes the module to catch and more or less all mocks to break
-// force registration of all jobs
-// import "../worker/jobs";
 
 const pgTables = pgTable("pg_tables", {
   schemaname: text("schemaname").notNull(),
@@ -107,8 +104,7 @@ beforeEach(async (ctx) => {
 beforeEach(async (ctx) => {
   // Clear rate limit keys from Redis
   try {
-    const oJobs = await import("../worker/client");
-    const redis = await oJobs.getConnection();
+    const redis = await getConnection();
     if (redis) {
       const rateLimitPrefixes = [
         "rl:*",

--- a/apps/server/src/worker/client.ts
+++ b/apps/server/src/worker/client.ts
@@ -1,13 +1,13 @@
 import { context, propagation } from "@opentelemetry/api";
 import { scheduledJob, scheduler } from "@peated/server/lib/cron";
 import * as Sentry from "@sentry/node";
-import { Queue, Worker, type JobsOptions } from "bullmq";
-import IORedis from "ioredis";
+import { Worker, type JobsOptions, type Queue } from "bullmq";
 import { createHash } from "node:crypto";
 import config from "../config";
 import { syncExternalSites } from "../lib/externalSites";
 import { logError, logInfo, logTelemetryError } from "../lib/log";
 import { initializeScraperRuntime } from "../scraper";
+import { runJob, type WorkerDispatch } from "./dispatch";
 import "./jobs";
 import createNextRepeatingEvents from "./jobs/createNextRepeatingEvents";
 import scheduleScrapers from "./jobs/scheduleScrapers";
@@ -16,8 +16,21 @@ import {
   buildQueuedJobData,
   parseQueuedJobData,
 } from "./payload";
+import { getQueue } from "./queue";
+import { disconnectConnection, getConnection } from "./redis";
 import registry from "./registry";
 import { type JobArgs, type JobName, type QueuedJobInput } from "./types";
+
+export {
+  configureWorkerDispatch,
+  pushJob,
+  pushUniqueJob,
+  runJob,
+  useQueueWorkerDispatch,
+} from "./dispatch";
+export type { WorkerDispatch } from "./dispatch";
+export { getQueue } from "./queue";
+export { getConnection } from "./redis";
 
 export function generateUniqIdentifier(name: string, args?: JobArgs) {
   let hash = createHash("md5");
@@ -92,86 +105,16 @@ async function pushJobToQueue(
   );
 }
 
-export type WorkerDispatch = {
-  pushJob: typeof pushJobToQueue;
-  pushUniqueJob: typeof pushUniqueJobToQueue;
-  runJob: typeof runRegisteredJob;
-};
-
-const queueDispatch: WorkerDispatch = {
+export const queueWorkerDispatch: WorkerDispatch = {
   pushJob: pushJobToQueue,
   pushUniqueJob: pushUniqueJobToQueue,
   runJob: runRegisteredJob,
 };
-let workerDispatch = queueDispatch;
-
-export function configureWorkerDispatch(dispatch: WorkerDispatch) {
-  workerDispatch = dispatch;
-}
-
-/** Restore the production Redis-backed dispatch after a test-owned override. */
-export function useQueueWorkerDispatch() {
-  workerDispatch = queueDispatch;
-}
-
-export async function runJob(jobName: JobName, args?: JobArgs) {
-  return args === undefined
-    ? await workerDispatch.runJob(jobName)
-    : await workerDispatch.runJob(jobName, args);
-}
-
-export async function pushUniqueJob(
-  jobName: JobName,
-  args?: JobArgs,
-  opts?: JobsOptions,
-) {
-  if (opts !== undefined) {
-    return await workerDispatch.pushUniqueJob(jobName, args, opts);
-  }
-  return args === undefined
-    ? await workerDispatch.pushUniqueJob(jobName)
-    : await workerDispatch.pushUniqueJob(jobName, args);
-}
-
-export async function pushJob(
-  jobName: JobName,
-  args?: JobArgs,
-  opts?: JobsOptions,
-) {
-  if (opts !== undefined) {
-    return await workerDispatch.pushJob(jobName, args, opts);
-  }
-  return args === undefined
-    ? await workerDispatch.pushJob(jobName)
-    : await workerDispatch.pushJob(jobName, args);
-}
-
-let connection: IORedis | null = null;
 const SCRAPER_JOB_LOCK_DURATION_MS = 60 * 60_000;
-
-export async function getQueue(
-  name = "default",
-  connection: Awaited<ReturnType<typeof getConnection>> | null = null,
-) {
-  return new Queue(name, {
-    connection: connection || (await getConnection()),
-  });
-}
-
-export async function getConnection() {
-  if (connection) return connection;
-
-  connection = new IORedis(config.REDIS_URL, {
-    maxRetriesPerRequest: null,
-  });
-
-  return connection;
-}
 
 export async function gracefulShutdown(signal?: string, worker?: Worker) {
   scheduler.stop();
-  if (connection) connection.disconnect();
-  connection = null;
+  disconnectConnection();
 }
 
 export type WorkerRuntime = {

--- a/apps/server/src/worker/dispatch.ts
+++ b/apps/server/src/worker/dispatch.ts
@@ -1,0 +1,77 @@
+import type { JobsOptions } from "bullmq";
+import type { JobArgs, JobName } from "./types";
+
+type DispatchJob = (
+  jobName: JobName,
+  args?: JobArgs,
+  opts?: JobsOptions,
+) => Promise<void>;
+
+type RunJob = (jobName: JobName, args?: JobArgs) => Promise<void>;
+
+export type WorkerDispatch = {
+  pushJob: DispatchJob;
+  pushUniqueJob: DispatchJob;
+  runJob: RunJob;
+};
+
+async function loadQueueWorkerDispatch() {
+  // Load the full worker only when the app actually sends or runs a job.
+  const { queueWorkerDispatch } = await import("./client");
+  return queueWorkerDispatch;
+}
+
+const queueDispatch: WorkerDispatch = {
+  async pushJob(...args) {
+    await (await loadQueueWorkerDispatch()).pushJob(...args);
+  },
+  async pushUniqueJob(...args) {
+    await (await loadQueueWorkerDispatch()).pushUniqueJob(...args);
+  },
+  async runJob(...args) {
+    await (await loadQueueWorkerDispatch()).runJob(...args);
+  },
+};
+
+let workerDispatch = queueDispatch;
+
+export function configureWorkerDispatch(dispatch: WorkerDispatch) {
+  workerDispatch = dispatch;
+}
+
+/** Use the normal Redis queues again after a test replaced them. */
+export function useQueueWorkerDispatch() {
+  workerDispatch = queueDispatch;
+}
+
+export async function runJob(jobName: JobName, args?: JobArgs) {
+  return args === undefined
+    ? await workerDispatch.runJob(jobName)
+    : await workerDispatch.runJob(jobName, args);
+}
+
+export async function pushUniqueJob(
+  jobName: JobName,
+  args?: JobArgs,
+  opts?: JobsOptions,
+) {
+  if (opts !== undefined) {
+    return await workerDispatch.pushUniqueJob(jobName, args, opts);
+  }
+  return args === undefined
+    ? await workerDispatch.pushUniqueJob(jobName)
+    : await workerDispatch.pushUniqueJob(jobName, args);
+}
+
+export async function pushJob(
+  jobName: JobName,
+  args?: JobArgs,
+  opts?: JobsOptions,
+) {
+  if (opts !== undefined) {
+    return await workerDispatch.pushJob(jobName, args, opts);
+  }
+  return args === undefined
+    ? await workerDispatch.pushJob(jobName)
+    : await workerDispatch.pushJob(jobName, args);
+}

--- a/apps/server/src/worker/entityMerge.ts
+++ b/apps/server/src/worker/entityMerge.ts
@@ -1,4 +1,4 @@
-import { pushJob } from "@peated/server/worker/client";
+import { pushJob } from "@peated/server/worker/dispatch";
 import { z } from "zod";
 import type { JobPayload } from "./types";
 

--- a/apps/server/src/worker/jobs/capturePriceImage.test.ts
+++ b/apps/server/src/worker/jobs/capturePriceImage.test.ts
@@ -2,7 +2,7 @@ import { db } from "@peated/server/db";
 import { bottles, storePrices } from "@peated/server/db/schema";
 import type * as uploads from "@peated/server/lib/uploads";
 import { compressAndResizeImage } from "@peated/server/lib/uploads";
-import type * as workerClient from "@peated/server/worker/client";
+import type * as workerClient from "@peated/server/worker/dispatch";
 import { eq } from "drizzle-orm";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import capturePriceImageWithServices, {

--- a/apps/server/src/worker/jobs/capturePriceImage.ts
+++ b/apps/server/src/worker/jobs/capturePriceImage.ts
@@ -3,7 +3,7 @@ import { db } from "@peated/server/db";
 import { storePrices } from "@peated/server/db/schema";
 import { logInfo, logTelemetryError } from "@peated/server/lib/log";
 import { compressAndResizeImage, storeFile } from "@peated/server/lib/uploads";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import type { JobContext, JobPayload } from "@peated/server/worker/types";
 import { eq } from "drizzle-orm";
 import { Readable } from "stream";

--- a/apps/server/src/worker/jobs/indexBottleSeriesSearchVectors.ts
+++ b/apps/server/src/worker/jobs/indexBottleSeriesSearchVectors.ts
@@ -2,7 +2,7 @@ import { db } from "@peated/server/db";
 import { bottleSeries, bottles, entities } from "@peated/server/db/schema";
 import { logInfo } from "@peated/server/lib/log";
 import { buildBottleSeriesSearchVector } from "@peated/server/lib/search";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import type { JobPayload } from "@peated/server/worker/types";
 import { eq } from "drizzle-orm";
 import { z } from "zod";

--- a/apps/server/src/worker/jobs/mergeEntity.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.ts
@@ -50,7 +50,7 @@ import {
   updateBottleInTransaction,
   type BottleUpdateFinalizationManifest,
 } from "@peated/server/lib/updateBottle";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import {
   EntityMergeJobInputSchema,
   isOperationEntityMergeJobInput,

--- a/apps/server/src/worker/jobs/onBottleChange.ts
+++ b/apps/server/src/worker/jobs/onBottleChange.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { pushUniqueJob, runJob } from "@peated/server/worker/client";
+import { pushUniqueJob, runJob } from "@peated/server/worker/dispatch";
 import { z } from "zod";
 import type { JobPayload } from "../types";
 import type { UpdateBottleStatsJobArgs } from "./updateBottleStats";

--- a/apps/server/src/worker/jobs/onBottleReferenceChange.ts
+++ b/apps/server/src/worker/jobs/onBottleReferenceChange.ts
@@ -1,5 +1,5 @@
 import { syncBottleReferenceConsumersForReferenceChange } from "@peated/server/lib/bottleReferences";
-import { runJob } from "@peated/server/worker/client";
+import { runJob } from "@peated/server/worker/dispatch";
 import { z } from "zod";
 import type { JobPayload } from "../types";
 

--- a/apps/server/src/worker/jobs/onEntityChange.ts
+++ b/apps/server/src/worker/jobs/onEntityChange.ts
@@ -1,5 +1,5 @@
 import { db } from "@peated/server/db";
-import { pushUniqueJob, runJob } from "@peated/server/worker/client";
+import { pushUniqueJob, runJob } from "@peated/server/worker/dispatch";
 import type { JobPayload } from "@peated/server/worker/types";
 import { z } from "zod";
 

--- a/apps/server/src/worker/jobs/queueBottleEntityStats.ts
+++ b/apps/server/src/worker/jobs/queueBottleEntityStats.ts
@@ -1,6 +1,6 @@
 import { db } from "@peated/server/db";
 import { notEmpty, uniq } from "@peated/server/lib/filter";
-import { pushJob } from "@peated/server/worker/client";
+import { pushJob } from "@peated/server/worker/dispatch";
 
 async function queueEntityStats(owner: {
   brandId: number;

--- a/apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.ts
+++ b/apps/server/src/worker/jobs/reconcileStorePriceMatchProposals.ts
@@ -4,7 +4,7 @@ import {
   storePrices,
 } from "@peated/server/db/schema";
 import { logError, logInfo } from "@peated/server/lib/log";
-import { pushJob } from "@peated/server/worker/client";
+import { pushJob } from "@peated/server/worker/dispatch";
 import { desc, eq, sql } from "drizzle-orm";
 
 type ReconcileStorePriceMatchProposalsArgs = {

--- a/apps/server/src/worker/jobs/runScraper.ts
+++ b/apps/server/src/worker/jobs/runScraper.ts
@@ -18,7 +18,7 @@ export type RunScraperServices = {
 const defaultServices: RunScraperServices = {
   executeRun: executeScraperRun,
   enqueueRun: async (runId, options) => {
-    const { pushJob } = await import("@peated/server/worker/client");
+    const { pushJob } = await import("@peated/server/worker/dispatch");
     await pushJob("RunScraper", { runId }, options);
   },
 };

--- a/apps/server/src/worker/jobs/updateEntityStats.ts
+++ b/apps/server/src/worker/jobs/updateEntityStats.ts
@@ -6,7 +6,7 @@ import {
   entities,
   tastings,
 } from "@peated/server/db/schema";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { eq, sql } from "drizzle-orm";
 import { z } from "zod";
 import type { JobPayload } from "../types";

--- a/apps/server/src/worker/queue.ts
+++ b/apps/server/src/worker/queue.ts
@@ -1,0 +1,11 @@
+import { Queue } from "bullmq";
+import { getConnection } from "./redis";
+
+export async function getQueue(
+  name = "default",
+  connection: Awaited<ReturnType<typeof getConnection>> | null = null,
+) {
+  return new Queue(name, {
+    connection: connection || (await getConnection()),
+  });
+}

--- a/apps/server/src/worker/redis.ts
+++ b/apps/server/src/worker/redis.ts
@@ -1,0 +1,19 @@
+import IORedis from "ioredis";
+import config from "../config";
+
+let connection: IORedis | null = null;
+
+export async function getConnection() {
+  if (connection) return connection;
+
+  connection = new IORedis(config.REDIS_URL, {
+    maxRetriesPerRequest: null,
+  });
+
+  return connection;
+}
+
+export function disconnectConnection() {
+  if (connection) connection.disconnect();
+  connection = null;
+}


### PR DESCRIPTION
Server tests no longer load every background job and scraper before each test file. They load only the small pieces needed to replace job sending and clear Redis. Production still loads the full worker the first time a real job is sent, and existing imports from the worker client keep working.

In a controlled three-file run, setup time fell from 7.01 seconds to 3.88 seconds, while total test time fell from 11.62 seconds to 10.63 seconds. Per-file isolation remains enabled because disabling it caused tests to affect one another. A real Redis check confirmed that jobs can still be sent, read, and removed through the production path.
