### PR TITLE
feat(scrapers): prepare Kilchoman for saved rules

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -74,6 +74,15 @@ function prepareCompassBox(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareKilchoman(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "kilchoman", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 const canonicalUrl =
   "https://thebourbonculture.com/whiskey-reviews/example-review/";
 const registry = createScraperRegistry({
@@ -116,6 +125,16 @@ const compassBoxRegistry = createScraperRegistry({
     {
       ...scraperRegistry.sources.get("compassbox")!,
       externalSiteKey: "compassbox",
+    },
+  ],
+});
+
+const kilchomanRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("kilchoman")!],
+  sources: [
+    {
+      ...scraperRegistry.sources.get("kilchoman")!,
+      externalSiteKey: "kilchoman",
     },
   ],
 });
@@ -289,6 +308,25 @@ async function setupCompassBoxMigration() {
     })
     .returning();
   await syncScraperDefinitions(compassBoxRegistry);
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return site;
+}
+
+async function setupKilchomanMigration() {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "kilchoman",
+      name: "Kilchoman",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(kilchomanRegistry);
   await db.insert(externalSiteRuns).values({
     externalSiteId: site.id,
     status: "succeeded",
@@ -664,6 +702,112 @@ describe("POST /admin/scrape-sources/prepare", () => {
     await expect(prepareCompassBox({ apply: true })).rejects.toMatchObject({
       code: "BAD_REQUEST",
       message: "Compass Box has no stored prices to verify.",
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("prepares Kilchoman without replacing prices or Bottle matches", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const site = await setupKilchomanMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Kilchoman Machir Bay 70cl",
+      price: 4990,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.kilchomandistillery.com/our-whisky/machir-bay/",
+      bottleId: bottle.id,
+    });
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Kilchoman Rockside 11 Years Old",
+      price: 5500,
+      currency: "gbp",
+      volume: 700,
+      url: "https://www.kilchomandistillery.com/our-whisky/rockside-11-years-old/",
+      bottleId: null,
+      hidden: true,
+    });
+    const prices = await db.select().from(storePrices);
+    const histories = await db.select().from(storePriceHistories);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareKilchoman()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+
+    const applied = await prepareKilchoman({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      priceCount: 2,
+      visiblePriceCount: 1,
+      matchedPriceCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(kilchomanRegistry);
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(storePriceHistories)).toEqual(histories);
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "price",
+        listUrl: "https://www.kilchomandistillery.com/whisky-shop/",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+    await expect(prepareKilchoman({ apply: true })).rejects.toMatchObject({
+      code: "CONFLICT",
+      message: "Kilchoman is already prepared for saved scraping rules.",
+    });
+  });
+
+  test("refuses an unexpected Kilchoman price without changing records", async ({
+    fixtures,
+  }) => {
+    const site = await setupKilchomanMigration();
+    await fixtures.StorePrice({
+      externalSiteId: site.id,
+      name: "Kilchoman Machir Bay 70cl",
+      currency: "gbp",
+      volume: 700,
+      url: "https://example.com/our-whisky/machir-bay/",
+      bottleId: null,
+    });
+    const prices = await db.select().from(storePrices);
+    const targets = await db.select().from(scrapeTargets);
+
+    await expect(prepareKilchoman({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: expect.stringContaining("Check Kilchoman price"),
+    });
+    expect(await db.select().from(storePrices)).toEqual(prices);
+    expect(await db.select().from(scrapeTargets)).toEqual(targets);
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("refuses Kilchoman without stored prices", async () => {
+    await setupKilchomanMigration();
+
+    await expect(prepareKilchoman({ apply: true })).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+      message: "Kilchoman has no stored prices to verify.",
     });
     expect(await db.select().from(scrapeSources)).toEqual([]);
   });

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -3,6 +3,7 @@ import { requireAdmin } from "@peated/server/orpc/middleware";
 import { ExternalSiteKeySchema } from "@peated/server/schemas";
 import { prepareBourbonCultureSource } from "@peated/server/scraper/configured/prepareBourbonCulture";
 import { prepareCompassBoxSource } from "@peated/server/scraper/configured/prepareCompassBox";
+import { prepareKilchomanSource } from "@peated/server/scraper/configured/prepareKilchoman";
 import { prepareWhiskySagaSource } from "@peated/server/scraper/configured/prepareWhiskySaga";
 import { prepareWhiskyStudySource } from "@peated/server/scraper/configured/prepareWhiskyStudy";
 import {
@@ -29,7 +30,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, compassbox, whiskysaga, and whiskystudy.",
+          "The existing site's key. Currently supports bourbonculture, compassbox, kilchoman, whiskysaga, and whiskystudy.",
         ),
         apply: z
           .boolean()
@@ -62,6 +63,7 @@ export default procedure
     const prepareSource = {
       bourbonculture: prepareBourbonCultureSource,
       compassbox: prepareCompassBoxSource,
+      kilchoman: prepareKilchomanSource,
       whiskysaga: prepareWhiskySagaSource,
       whiskystudy: prepareWhiskyStudySource,
     }[input.site];

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -5,6 +5,7 @@ import {
   parseBourbonCultureArticle,
 } from "../adapters/bourbonCulture";
 import { parseCompassBoxProducts } from "../adapters/legacy/scrapeCompassBox";
+import { parseKilchomanProducts } from "../adapters/legacy/scrapeKilchoman";
 import { parseWhiskySagaArticle } from "../adapters/whiskySaga";
 import { parseWhiskyStudyArticle } from "../adapters/whiskyStudy";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
@@ -164,6 +165,28 @@ const compassBoxRules = {
   },
 } satisfies ScrapeRules;
 
+const kilchomanRules = {
+  kind: "price",
+  list: {
+    item: "ul.grid-products > li.product",
+    detailLink: { selector: 'a[href*="/our-whisky/"]', attribute: "href" },
+    excludeWhen: {
+      selector: '.product_soldout, h3:contains("Gift Pack")',
+    },
+    maxItems: 99,
+  },
+  detail: {
+    name: { selector: "h1", prefix: "Kilchoman " },
+    price: { selector: ".price" },
+    currency: "gbp",
+    volume: { value: "700 ml" },
+    imageUrl: {
+      selector: 'meta[property="og:image"]',
+      attribute: "content",
+    },
+  },
+} satisfies ScrapeRules;
+
 function expectReviewFactsAndEvidenceToMatch(
   configured: ReturnType<typeof parseScrapeDetail>,
   legacy: NonNullable<ReturnType<typeof parseWhiskyStudyArticle>>,
@@ -255,6 +278,20 @@ describe("scrape source parser", () => {
     );
 
     expect(parseScrapeList(compassBoxRules, html, pageUrl)).toEqual({
+      links: legacyLinks,
+      nextPageUrl: null,
+      issues: [],
+    });
+  });
+
+  it("matches the current Kilchoman parser's available product links", async () => {
+    const pageUrl = new URL("https://www.kilchomandistillery.com/whisky-shop/");
+    const html = await loadFixture("kilchoman", "bottle-list.html");
+    const legacyLinks = parseKilchomanProducts(html, pageUrl.toString()).map(
+      ({ url }) => url,
+    );
+
+    expect(parseScrapeList(kilchomanRules, html, pageUrl)).toEqual({
       links: legacyLinks,
       nextPageUrl: null,
       issues: [],

--- a/apps/server/src/scraper/configured/prepareKilchoman.ts
+++ b/apps/server/src/scraper/configured/prepareKilchoman.ts
@@ -1,0 +1,23 @@
+import {
+  preparePriceSource,
+  type PreparePriceSourceInput,
+} from "./preparePriceSource";
+
+/** Checks Kilchoman by default; applying keeps price IDs and leaves collection paused. */
+export async function prepareKilchomanSource(input: PreparePriceSourceInput) {
+  return preparePriceSource(input, {
+    siteKey: "kilchoman",
+    siteName: "Kilchoman",
+    targetKey: "kilchoman",
+    origin: "https://www.kilchomandistillery.com",
+    listUrl: "https://www.kilchomandistillery.com/whisky-shop/",
+    isExpectedPrice: (price) =>
+      /^https:\/\/www\.kilchomandistillery\.com\/our-whisky\/[a-z0-9][a-z0-9-]*\/$/.test(
+        price.url,
+      ) &&
+      price.externalProductId === null &&
+      price.name.startsWith("Kilchoman ") &&
+      price.currency === "gbp" &&
+      price.volume === 700,
+  });
+}

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -130,6 +130,29 @@ preview. Activate only exact output, trigger one manual collection, and confirm
 that it updates the same price IDs and Bottle matches. Check the run and Sentry
 before restoring the saved schedule.
 
+## Kilchoman
+
+Use the preparation endpoint with `{"site": "kilchoman"}`. The check-only
+request locks and inventories every stored price without changing it. It reports
+the total, visible, and Bottle-matched price counts. It stops if a price does not
+use the expected Kilchoman product URL, null external product ID, `Kilchoman`
+name prefix, GBP currency, or 700 ml volume. Applying transfers the existing
+request settings to administrator ownership and adds a paused price source whose
+list page is `https://www.kilchomandistillery.com/whisky-shop/`. It does not
+update price rows or history.
+
+Before applying, stop the `kilchoman` schedule and wait for active runs. Save
+the same price and run records listed for Compass Box. Run the version 2 rules
+through the local no-write preview without an item limit. Compare every current
+product with the code scraper. The list rules must omit sold-out products and
+gift packs; the detail rules must keep the `Kilchoman` name prefix, GBP price,
+700 ml volume, canonical product URL, and product image.
+
+After applying, save the reviewed version 2 revision and run its production
+preview. Activate only exact output, trigger one manual collection, and confirm
+that it updates the same price IDs and Bottle matches. Check the run and Sentry
+before restoring the saved schedule.
+
 ## If something goes wrong
 
 A request without `apply: true` leaves records unchanged. After applying, keep the
@@ -140,9 +163,9 @@ handles reviews added after the switch. Do not delete source or run history.
 ## Other sources
 
 The preparation API is shared. It currently supports Bourbon Culture, Compass
-Box, and The Whisky Study. Other sites are rejected without changing records.
-Add each site's conversion behind this route as its existing records are
-reviewed.
+Box, Kilchoman, Whisky Saga, and The Whisky Study. Other sites are rejected
+without changing records. Add each site's conversion behind this route as its
+existing records are reviewed.
 
 Prepare each source using its own rules for recognizing existing records.
 Articles with several reviews need a verified match for each review. Store


### PR DESCRIPTION
Kilchoman can now be prepared for saved parsing rules through the existing administrator handoff. The default check inventories all stored prices and rejects unexpected URLs, product IDs, names, currencies, or volumes. Explicit apply transfers only the source's request settings and creates a paused price source without replacing price rows, history, Bottle matches, or run history.

The accepted version 2 rules preserve the current product links and omit sold-out products and gift packs. A full local no-write preview against the public shop completed all eight current products in nine controlled requests with no retries, rate limits, or product writes. Activation and schedule restoration remain separate operator-reviewed steps.
