### PR TITLE
ci(server): stop collecting unused coverage

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,7 +15,7 @@
     "typecheck": "tsc --noEmit",
     "test": "sh -c 'if [ \"$1\" = \"--\" ]; then shift; fi; if [ -f .env.test.local ]; then dotenv -e .env.test -e .env.test.local -- vitest run \"$@\"; else dotenv -e .env.test -- vitest run \"$@\"; fi' --",
     "test:watch": "sh -c 'if [ \"$1\" = \"--\" ]; then shift; fi; if [ -f .env.test.local ]; then dotenv -e .env.test -e .env.test.local -- vitest watch \"$@\"; else dotenv -e .env.test -- vitest watch \"$@\"; fi' --",
-    "test:ci": "sh -c 'if [ \"$1\" = \"--\" ]; then shift; fi; if [ -f .env.test.local ]; then dotenv -e .env.test -e .env.test.local -- vitest run --coverage --reporter=junit --reporter=default --outputFile=junit.xml \"$@\"; else dotenv -e .env.test -- vitest run --coverage --reporter=junit --reporter=default --outputFile=junit.xml \"$@\"; fi' --"
+    "test:ci": "sh -c 'if [ \"$1\" = \"--\" ]; then shift; fi; if [ -f .env.test.local ]; then dotenv -e .env.test -e .env.test.local -- vitest run --reporter=junit --reporter=default --outputFile=junit.xml \"$@\"; else dotenv -e .env.test -- vitest run --reporter=junit --reporter=default --outputFile=junit.xml \"$@\"; fi' --"
   },
   "dependencies": {
     "@faker-js/faker": "^10.6.0",
@@ -42,7 +42,6 @@
     "@sentry/node": "catalog:",
     "@simplewebauthn/server": "^13.3.0",
     "@sindresorhus/slugify": "^2.2.1",
-    "@vitest/coverage-v8": "catalog:",
     "axios": "~1.19.0",
     "bcrypt": "^6.0.0",
     "bullmq": "^5.40.3",

--- a/apps/server/vitest.config.mts
+++ b/apps/server/vitest.config.mts
@@ -10,10 +10,6 @@ export default defineConfig({
     },
   },
   test: {
-    coverage: {
-      provider: "v8",
-      reporter: ["json"],
-    },
     maxConcurrency: 1,
     pool: "forks",
     fileParallelism: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,9 +72,6 @@ catalogs:
     '@types/react-dom':
       specifier: ^19.2.3
       version: 19.2.3
-    '@vitest/coverage-v8':
-      specifier: ~4.1.4
-      version: 4.1.4
     dotenv:
       specifier: ^16.4.7
       version: 16.6.1
@@ -312,9 +309,6 @@ importers:
       '@sindresorhus/slugify':
         specifier: ^2.2.1
         version: 2.2.1
-      '@vitest/coverage-v8':
-        specifier: 'catalog:'
-        version: 4.1.4(vitest@4.1.4)
       axios:
         specifier: ~1.19.0
         version: 1.19.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
@@ -11911,7 +11905,8 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@bcoe/v8-coverage@1.0.2': {}
+  '@bcoe/v8-coverage@1.0.2':
+    optional: true
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -15588,6 +15583,7 @@ snapshots:
       std-env: 4.1.0
       tinyrainbow: 3.1.0
       vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.4)(jsdom@25.0.1(supports-color@8.1.1))(vite@8.2.1(@types/node@24.13.2)(esbuild@0.27.7)(jiti@2.7.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+    optional: true
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -15929,6 +15925,7 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
       js-tokens: 10.0.0
+    optional: true
 
   astring@1.9.0: {}
 
@@ -17734,7 +17731,8 @@ snapshots:
 
   html-enumerated-attributes@1.1.1: {}
 
-  html-escaper@2.0.2: {}
+  html-escaper@2.0.2:
+    optional: true
 
   html-to-text@9.0.5:
     dependencies:
@@ -18100,18 +18098,21 @@ snapshots:
 
   isomorphic-timers-promises@1.0.1: {}
 
-  istanbul-lib-coverage@3.2.2: {}
+  istanbul-lib-coverage@3.2.2:
+    optional: true
 
   istanbul-lib-report@3.0.1:
     dependencies:
       istanbul-lib-coverage: 3.2.2
       make-dir: 4.0.0
       supports-color: 7.2.0
+    optional: true
 
   istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
+    optional: true
 
   jackspeak@3.4.3:
     dependencies:
@@ -18142,7 +18143,8 @@ snapshots:
 
   js-cookie@3.0.5: {}
 
-  js-tokens@10.0.0: {}
+  js-tokens@10.0.0:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -18577,10 +18579,12 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
       source-map-js: 1.2.1
+    optional: true
 
   make-dir@4.0.0:
     dependencies:
       semver: 7.8.5
+    optional: true
 
   make-error@1.3.6:
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,7 +48,6 @@ catalog:
   "@types/pg": ^8.18.0
   vite: ^8.2.1
   vitest: "~4.1.4"
-  "@vitest/coverage-v8": "~4.1.4"
   "@playwright/test": "^1.60.0"
   zod: ^4.5.4
 


### PR DESCRIPTION
Server CI now runs the same tests without generating a coverage file that was never uploaded, combined, or checked. This removes the server-only coverage setting and dependency; test selection, four-way splitting, and test reports remain unchanged.
