### PR TITLE
feat(activity): paginate the community feed

### DIFF
--- a/apps/server/src/lib/activityFeed.ts
+++ b/apps/server/src/lib/activityFeed.ts
@@ -2,6 +2,7 @@ import { db } from "@peated/server/db";
 import type {
   Bottle,
   Collection,
+  ExternalReview,
   MemberReview,
   Tasting,
   User,
@@ -9,15 +10,20 @@ import type {
 import {
   bottles,
   collectionBottles,
+  externalReviewArticles,
+  externalReviewPublications,
+  externalReviews,
   memberReviews,
   tastings,
   users,
 } from "@peated/server/db/schema";
+import { visibleExternalReviewWhere } from "@peated/server/externalReviews/visibility";
 import { getReservedCollection } from "@peated/server/lib/db";
 import { serialize } from "@peated/server/serializers";
 import { BottleSerializer } from "@peated/server/serializers/bottle";
 import { CollectionSerializer } from "@peated/server/serializers/collection";
 import { CollectionBottleSerializer } from "@peated/server/serializers/collectionBottle";
+import { ExternalReviewSerializer } from "@peated/server/serializers/externalReview";
 import { MemberReviewSerializer } from "@peated/server/serializers/memberReview";
 import { TastingSerializer } from "@peated/server/serializers/tasting";
 import { UserSerializer } from "@peated/server/serializers/user";
@@ -233,14 +239,30 @@ function markedTastingsSql({
   `;
 }
 
-/** Counts tasting sessions and member reviews inside one activity snapshot. */
+/** Counts primary feed entries inside one activity snapshot. */
 export async function countPrimaryActivity({
+  includeCriticReviews = false,
   userCondition,
   snapshotAt,
 }: {
+  includeCriticReviews?: boolean;
   userCondition: SQL<unknown>;
   snapshotAt: Date;
 }) {
+  const criticReviewCount = includeCriticReviews
+    ? sql` + (
+        SELECT COUNT(*) FROM ${externalReviews}
+        INNER JOIN ${externalReviewArticles}
+          ON ${externalReviewArticles.id} = ${externalReviews.articleId}
+        LEFT JOIN ${externalReviewPublications}
+          ON ${externalReviewPublications.externalSiteId} = ${externalReviewArticles.externalSiteId}
+        WHERE ${visibleExternalReviewWhere()}
+          AND ${externalReviews.bottleId} IS NOT NULL
+          AND ${externalReviews.createdAt} <= ${snapshotAt}
+          AND ${externalReviewArticles.publishedAt} IS NOT NULL
+          AND ${externalReviewArticles.publishedAt} <= ${snapshotAt}
+      )`
+    : sql``;
   const result = await db.execute<{ count: string }>(sql`
     SELECT (
       SELECT COALESCE(SUM(marked_tastings.is_session_start), 0)
@@ -249,15 +271,15 @@ export async function countPrimaryActivity({
       SELECT COUNT(*) FROM ${memberReviews}
       INNER JOIN ${users} ON ${users.id} = ${memberReviews.createdById}
       WHERE ${userCondition} AND ${memberReviews.createdAt} <= ${snapshotAt}
-    ) AS count
+    ) ${criticReviewCount} AS count
   `);
   return Number(result.rows[0]?.count ?? 0);
 }
 
 type PrimaryActivityRow = {
-  type: "tasting_session" | "member_review";
+  type: "tasting_session" | "member_review" | "critic_review";
   id: string;
-  created_by_id: string;
+  created_by_id: string | null;
   started_at: Date | string;
   last_activity_at: Date | string;
   tasting_ids: (number | string)[];
@@ -265,15 +287,18 @@ type PrimaryActivityRow = {
 
 type PrimaryActivity =
   | (TastingSessionGroup & { type: "tasting_session" })
-  | { type: "member_review"; review: MemberReview; bottle: Bottle };
+  | { type: "member_review"; review: MemberReview; bottle: Bottle }
+  | { type: "critic_review"; review: ExternalReview };
 
-/** Pages sessions and member reviews together, without splitting a session. */
+/** Pages primary feed entries together, without splitting a tasting session. */
 export async function getPrimaryActivity({
+  includeCriticReviews = false,
   userCondition,
   snapshotAt,
   offset,
   limit,
 }: {
+  includeCriticReviews?: boolean;
   userCondition: SQL<unknown>;
   snapshotAt: Date;
   offset: number;
@@ -327,6 +352,28 @@ export async function getPrimaryActivity({
           FROM ${memberReviews}
           INNER JOIN ${users} ON ${users.id} = ${memberReviews.createdById}
           WHERE ${userCondition} AND ${memberReviews.createdAt} <= ${snapshotAt}
+          ${
+            includeCriticReviews
+              ? sql`
+                UNION ALL
+                SELECT 'critic_review' AS type, ${externalReviews.id} AS id,
+                  NULL::bigint AS created_by_id,
+                  ${externalReviewArticles.publishedAt} AS started_at,
+                  ${externalReviewArticles.publishedAt} AS last_activity_at,
+                  ARRAY[]::bigint[] AS tasting_ids
+                FROM ${externalReviews}
+                INNER JOIN ${externalReviewArticles}
+                  ON ${externalReviewArticles.id} = ${externalReviews.articleId}
+                LEFT JOIN ${externalReviewPublications}
+                  ON ${externalReviewPublications.externalSiteId} = ${externalReviewArticles.externalSiteId}
+                WHERE ${visibleExternalReviewWhere()}
+                  AND ${externalReviews.bottleId} IS NOT NULL
+                  AND ${externalReviews.createdAt} <= ${snapshotAt}
+                  AND ${externalReviewArticles.publishedAt} IS NOT NULL
+                  AND ${externalReviewArticles.publishedAt} <= ${snapshotAt}
+              `
+              : sql``
+          }
         ) primary_activity
         ORDER BY last_activity_at DESC, id DESC, type
         OFFSET ${offset}
@@ -360,7 +407,29 @@ export async function getPrimaryActivity({
         reviewRows.map((row) => [row.review.id, row]),
       );
 
+      const criticReviewIds = result.rows
+        .filter((row) => row.type === "critic_review")
+        .map((row) => Number(row.id));
+      const criticReviewRows = criticReviewIds.length
+        ? await tx
+            .select()
+            .from(externalReviews)
+            .where(inArray(externalReviews.id, criticReviewIds))
+        : [];
+      const criticReviewsById = new Map(
+        criticReviewRows.map((review) => [review.id, review]),
+      );
+
       return result.rows.map((row): PrimaryActivity => {
+        if (row.type === "critic_review") {
+          const review = criticReviewsById.get(Number(row.id));
+          if (!review) {
+            throw new Error(
+              `Activity references missing external review ${row.id}.`,
+            );
+          }
+          return { type: "critic_review", review };
+        }
         if (row.type === "member_review") {
           const review = reviewsById.get(Number(row.id));
           if (!review)
@@ -372,7 +441,7 @@ export async function getPrimaryActivity({
         return {
           type: "tasting_session",
           id: Number(row.id),
-          createdById: Number(row.created_by_id),
+          createdById: Number(row.created_by_id!),
           startedAt: coerceActivityDate(row.started_at),
           lastActivityAt: coerceActivityDate(row.last_activity_at),
           tastings: row.tasting_ids.map((id) => {
@@ -435,29 +504,39 @@ async function serializeTastingSessionEntries(
   });
 }
 
-/** Serializes both primary sources with the same bottle and member contracts. */
+/** Serializes primary feed sources with their public API contracts. */
 export async function serializePrimaryActivityEntries(
   items: PrimaryActivity[],
   currentUser?: User | null,
 ): Promise<ActivityEntry[]> {
   const sessions = items.filter((item) => item.type === "tasting_session");
   const reviews = items.filter((item) => item.type === "member_review");
-  const [sessionEntries, serializedReviews, serializedBottles] =
-    await Promise.all([
-      serializeTastingSessionEntries(sessions, currentUser),
-      serialize(
-        MemberReviewSerializer,
-        reviews.map((item) => item.review),
-        currentUser,
-      ),
-      serialize(
-        BottleSerializer,
-        reviews.map((item) => item.bottle),
-        currentUser,
-        [],
-        { includeGroupSummary: true },
-      ),
-    ]);
+  const criticReviews = items.filter((item) => item.type === "critic_review");
+  const [
+    sessionEntries,
+    serializedReviews,
+    serializedBottles,
+    serializedCriticReviews,
+  ] = await Promise.all([
+    serializeTastingSessionEntries(sessions, currentUser),
+    serialize(
+      MemberReviewSerializer,
+      reviews.map((item) => item.review),
+      currentUser,
+    ),
+    serialize(
+      BottleSerializer,
+      reviews.map((item) => item.bottle),
+      currentUser,
+      [],
+      { includeGroupSummary: true },
+    ),
+    serialize(
+      ExternalReviewSerializer,
+      criticReviews.map((item) => item.review),
+      currentUser,
+    ),
+  ]);
   const entries = new Map(sessionEntries.map((entry) => [entry.id, entry]));
   reviews.forEach((item, index) => {
     const review = serializedReviews[index]!;
@@ -471,12 +550,25 @@ export async function serializePrimaryActivityEntries(
       review: { ...review, bottle: serializedBottles[index]! },
     });
   });
+  criticReviews.forEach((item, index) => {
+    const review = serializedCriticReviews[index]!;
+    const id = `critic_review:${review.id}`;
+    entries.set(id, {
+      id,
+      type: "critic_review",
+      priority: "primary",
+      createdAt: review.article.publishedAt!,
+      review,
+    });
+  });
   return items.map(
     (item) =>
       entries.get(
         item.type === "member_review"
           ? `member_review:${item.review.id}`
-          : `tasting_session:${item.createdById}:${item.id}`,
+          : item.type === "critic_review"
+            ? `critic_review:${item.review.id}`
+            : `tasting_session:${item.createdById}:${item.id}`,
       )!,
   );
 }

--- a/apps/server/src/orpc/contracts/activity/list.ts
+++ b/apps/server/src/orpc/contracts/activity/list.ts
@@ -9,13 +9,19 @@ export default contract
     path: "/activity",
     summary: "List activity",
     description:
-      "Get recent tastings, member reviews, and grouped collection additions",
+      "Get recent tastings, reviews, and grouped collection additions",
     operationId: "listActivity",
   })
   .input(
     z
       .object({
         filter: z.enum(["global", "friends", "local"]).default("global"),
+        includeCriticReviews: z.coerce
+          .boolean()
+          .default(false)
+          .describe(
+            "Include published critic reviews in global and local activity",
+          ),
         cursor: z
           .string()
           .max(64)
@@ -25,6 +31,10 @@ export default contract
           .optional(),
         limit: z.coerce.number().gte(1).lte(100).default(10),
       })
-      .default({ filter: "global", limit: 10 }),
+      .default({
+        filter: "global",
+        includeCriticReviews: false,
+        limit: 10,
+      }),
   )
   .output(ActivityListResponseSchema);

--- a/apps/server/src/orpc/mock/router.test.ts
+++ b/apps/server/src/orpc/mock/router.test.ts
@@ -65,6 +65,17 @@ describe("mock oRPC router", () => {
       results: mockActivity,
       rel: { nextCursor: null, prevCursor: null },
     });
+    await expect(
+      anonymousClient.activity.list({ includeCriticReviews: true, limit: 1 }),
+    ).resolves.toMatchObject({
+      results: [
+        {
+          id: `critic_review:${mockExternalReview.id}`,
+          type: "critic_review",
+          review: { id: mockExternalReview.id },
+        },
+      ],
+    });
 
     const bottles = await anonymousClient.bottles.list({ query: "Lagavulin" });
     expect(bottles.results).toHaveLength(3);

--- a/apps/server/src/orpc/mock/routes/activity/list.ts
+++ b/apps/server/src/orpc/mock/routes/activity/list.ts
@@ -1,4 +1,7 @@
-import { mockActivity } from "@peated/server/orpc/mock/fixtures";
+import {
+  mockActivity,
+  mockExternalReview,
+} from "@peated/server/orpc/mock/fixtures";
 import { mockOS } from "@peated/server/orpc/mock/implementer";
 
 export default mockOS.activity.list.handler(
@@ -7,12 +10,24 @@ export default mockOS.activity.list.handler(
       throw errors.UNAUTHORIZED();
     }
 
-    const activity =
+    const memberActivity =
       input.filter === "friends"
         ? mockActivity.filter(
             (entry) => entry.createdBy.id !== context.user?.id,
           )
         : mockActivity;
+    const activity = input.includeCriticReviews
+      ? [
+          {
+            id: `critic_review:${mockExternalReview.id}`,
+            type: "critic_review" as const,
+            priority: "primary" as const,
+            createdAt: mockExternalReview.article.publishedAt!,
+            review: mockExternalReview,
+          },
+          ...memberActivity,
+        ]
+      : memberActivity;
 
     return {
       results: activity.slice(0, input.limit),

--- a/apps/server/src/orpc/routes/activity/list.test.ts
+++ b/apps/server/src/orpc/routes/activity/list.test.ts
@@ -1,8 +1,12 @@
 import { db } from "@peated/server/db";
-import { collectionBottles, memberReviews } from "@peated/server/db/schema";
+import {
+  collectionBottles,
+  externalReviewArticles,
+  memberReviews,
+} from "@peated/server/db/schema";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
-import { sql } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { describe, expect, test } from "vitest";
 
 async function insertCollectionBottles(
@@ -441,22 +445,30 @@ test("member reviews respect public and accepted-follow visibility", async ({
     })),
   );
   const publicFeed = await routerClient.activity.list({ filter: "global" });
-  expect(publicFeed.results.map((item) => item.createdBy.id)).toEqual([
-    publicUser.id,
-  ]);
+  expect(
+    publicFeed.results.flatMap((item) =>
+      item.type === "critic_review" ? [] : [item.createdBy.id],
+    ),
+  ).toEqual([publicUser.id]);
   const friendFeed = await routerClient.activity.list(
     { filter: "friends" },
     { context: { user: defaults.user } },
   );
-  expect(friendFeed.results.map((item) => item.createdBy.id)).toEqual([
-    friend.id,
-  ]);
+  expect(
+    friendFeed.results.flatMap((item) =>
+      item.type === "critic_review" ? [] : [item.createdBy.id],
+    ),
+  ).toEqual([friend.id]);
   const signedIn = await routerClient.activity.list(
     { filter: "global" },
     { context: { user: defaults.user } },
   );
   expect(
-    signedIn.results.map((item) => item.createdBy.id).sort((a, b) => a - b),
+    signedIn.results
+      .flatMap((item) =>
+        item.type === "critic_review" ? [] : [item.createdBy.id],
+      )
+      .sort((a, b) => a - b),
   ).toEqual([friend.id, publicUser.id].sort((a, b) => a - b));
   const profile = await routerClient.users.activity.list(
     { user: friend.username },
@@ -522,4 +534,81 @@ test("pages member reviews and tasting sessions together without duplicates", as
     cursor: second.rel.prevCursor!,
   });
   expect(previous.results).toEqual(first.results);
+});
+
+test("paginates critic reviews in the global activity stream", async ({
+  fixtures,
+}) => {
+  const bottle = await fixtures.Bottle();
+  const user = await fixtures.User();
+  const site = await fixtures.ExternalSite({ type: "whiskyadvocate" });
+  await fixtures.ApprovedExternalReviewPublication({
+    externalSiteId: site.id,
+  });
+  const review = await fixtures.ExternalReview({
+    bottleId: bottle.id,
+    createdAt: new Date("2026-01-03T14:00:00Z"),
+    externalSiteId: site.id,
+    url: "https://example.com/activity-review",
+  });
+  await db
+    .update(externalReviewArticles)
+    .set({
+      contentHash: "activity-review-content",
+      publishedAt: new Date("2026-01-03T14:00:00Z"),
+    })
+    .where(eq(externalReviewArticles.id, review.articleId!));
+  const tasting = await fixtures.Tasting({
+    createdById: user.id,
+    createdAt: new Date("2026-01-03T13:00:00Z"),
+  });
+
+  const first = await routerClient.activity.list({
+    includeCriticReviews: true,
+    limit: 1,
+  });
+  expect(first.results).toMatchObject([
+    {
+      id: `critic_review:${review.id}`,
+      type: "critic_review",
+      createdAt: "2026-01-03T14:00:00.000Z",
+      review: {
+        id: review.id,
+        url: "https://example.com/activity-review",
+        bottle: { id: bottle.id },
+      },
+    },
+  ]);
+
+  const laterImport = await fixtures.ExternalReview({
+    bottleId: bottle.id,
+    createdAt: new Date("2099-01-01T00:00:00Z"),
+    externalSiteId: site.id,
+    url: "https://example.com/later-import",
+  });
+  await db
+    .update(externalReviewArticles)
+    .set({
+      contentHash: "later-import-content",
+      publishedAt: new Date("2026-01-03T15:00:00Z"),
+    })
+    .where(eq(externalReviewArticles.id, laterImport.articleId!));
+
+  const second = await routerClient.activity.list({
+    cursor: first.rel.nextCursor!,
+    includeCriticReviews: true,
+    limit: 1,
+  });
+  expect(second.results).toMatchObject([
+    {
+      type: "tasting_session",
+      tastings: [{ id: tasting.id }],
+    },
+  ]);
+  expect(second.rel.prevCursor).not.toBeNull();
+
+  const memberOnly = await routerClient.activity.list({ limit: 10 });
+  expect(memberOnly.results.map((entry) => entry.type)).toEqual([
+    "tasting_session",
+  ]);
 });

--- a/apps/server/src/orpc/routes/activity/list.ts
+++ b/apps/server/src/orpc/routes/activity/list.ts
@@ -80,6 +80,8 @@ export default implement(activityListContract).handler(async function ({
     filter: input.filter,
     currentUserId: context.user?.id,
   });
+  const includeCriticReviews =
+    input.includeCriticReviews && input.filter !== "friends";
   const activityCursor = input.cursor
     ? parseActivityCursor(input.cursor)!
     : { page: 1, snapshotAt: new Date() };
@@ -88,6 +90,7 @@ export default implement(activityListContract).handler(async function ({
 
   const [totalPrimary, secondaryCountResult] = await Promise.all([
     countPrimaryActivity({
+      includeCriticReviews,
       userCondition,
       snapshotAt: activityCursor.snapshotAt,
     }),
@@ -116,6 +119,7 @@ export default implement(activityListContract).handler(async function ({
 
   const [primaryRows, collectionGroupRows] = await Promise.all([
     getPrimaryActivity({
+      includeCriticReviews,
       userCondition,
       snapshotAt: activityCursor.snapshotAt,
       limit: sourceWindow.primaryLimit,

--- a/apps/server/src/schemas/profileActivity.ts
+++ b/apps/server/src/schemas/profileActivity.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { CollectionBottleSchema, CollectionSchema } from "./collections";
+import { ExternalReviewSchema } from "./externalReviews";
 import { MemberReviewDetailsSchema } from "./memberReviews";
 import { TastingSchema } from "./tastings";
 import { UserSchema } from "./users";
@@ -76,10 +77,19 @@ export const ActivityMemberReviewEntrySchema = z.object({
   review: MemberReviewDetailsSchema,
 });
 
+export const ActivityCriticReviewEntrySchema = z.object({
+  id: z.string().describe("Stable activity entry identifier"),
+  type: z.literal("critic_review"),
+  priority: z.literal("primary"),
+  createdAt: z.string().datetime().readonly(),
+  review: ExternalReviewSchema,
+});
+
 export const ActivityEntrySchema = z.discriminatedUnion("type", [
   ActivityTastingSessionEntrySchema,
   ActivityCollectionAddEntrySchema,
   ActivityMemberReviewEntrySchema,
+  ActivityCriticReviewEntrySchema,
 ]);
 
 export const ActivityCursorSchema = z.object({
@@ -104,4 +114,8 @@ export const ProfileCollectionActivityCollectionSchema =
   ActivityCollectionSchema;
 export const ProfileCollectionAddActivitySchema =
   ActivityCollectionAddEntrySchema;
-export const ProfileActivityEntrySchema = ActivityEntrySchema;
+export const ProfileActivityEntrySchema = z.discriminatedUnion("type", [
+  ActivityTastingSessionEntrySchema,
+  ActivityCollectionAddEntrySchema,
+  ActivityMemberReviewEntrySchema,
+]);

--- a/apps/web/e2e/mock-rpc-server.mjs
+++ b/apps/web/e2e/mock-rpc-server.mjs
@@ -207,10 +207,21 @@ async function handleRpcRequest({ request, response, url }) {
       });
       return true;
     case "activity/list":
-      sendRpcResponse(
-        response,
-        buildCommunityActivity({ following: input?.filter === "friends" }),
-      );
+      {
+        const activity = buildCommunityActivity({
+          following: input?.filter === "friends",
+          includeCriticReviews: input?.includeCriticReviews === true,
+        });
+        sendRpcResponse(response, {
+          ...activity,
+          rel: {
+            nextCursor:
+              input?.cursor === "2:1780833600000" ? null : "2:1780833600000",
+            prevCursor:
+              input?.cursor === "2:1780833600000" ? "1:1780833600000" : null,
+          },
+        });
+      }
       return true;
     case "users/activity/list":
       sendRpcResponse(

--- a/apps/web/e2e/rpc-fixtures.mjs
+++ b/apps/web/e2e/rpc-fixtures.mjs
@@ -1012,7 +1012,10 @@ export function buildActivity({
   };
 }
 
-export function buildCommunityActivity({ following = false } = {}) {
+export function buildCommunityActivity({
+  following = false,
+  includeCriticReviews = false,
+} = {}) {
   const activity = buildActivity({
     tastingSession: [
       buildTasting({
@@ -1026,6 +1029,17 @@ export function buildCommunityActivity({ following = false } = {}) {
   return {
     ...activity,
     results: [
+      ...(includeCriticReviews
+        ? [
+            {
+              id: `critic_review:${activityReview.id}`,
+              type: "critic_review",
+              priority: "primary",
+              createdAt: activityReview.article.publishedAt,
+              review: activityReview,
+            },
+          ]
+        : []),
       ...activity.results,
       {
         id: `member_review:${createdMemberReview.id}`,

--- a/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
@@ -9,9 +9,6 @@ import { getActivityFeedSelection, loadActivityFeed } from "./loadActivityFeed";
 type Options = Parameters<typeof loadActivityFeed>[0];
 const publicClient = {
   activity: { list: vi.fn<Options["publicClient"]["activity"]["list"]>() },
-  externalReviews: {
-    list: vi.fn<Options["publicClient"]["externalReviews"]["list"]>(),
-  },
 };
 const memberClient = {
   friends: {
@@ -22,6 +19,13 @@ const memberClient = {
   },
 };
 const rel = { nextCursor: null, prevCursor: null };
+const criticActivity = {
+  id: `critic_review:${mockExternalReview.id}`,
+  type: "critic_review" as const,
+  priority: "primary" as const,
+  createdAt: mockExternalReview.article.publishedAt!,
+  review: mockExternalReview,
+};
 
 beforeEach(() => {
   vi.resetAllMocks();
@@ -31,11 +35,7 @@ beforeEach(() => {
   });
   memberClient.activity.list.mockResolvedValue({ results: [], rel });
   publicClient.activity.list.mockResolvedValue({
-    results: [mockActivity[0]],
-    rel,
-  });
-  publicClient.externalReviews.list.mockResolvedValue({
-    results: [mockExternalReview],
+    results: [mockActivity[0], criticActivity],
     rel,
   });
 });
@@ -59,13 +59,13 @@ test("keeps Following empty when followed people have no activity", async () => 
     limit: 1,
   });
   expect(memberClient.activity.list).toHaveBeenCalledWith({
+    cursor: undefined,
     filter: "friends",
     limit: 20,
   });
   expect(feed.items).toEqual([]);
   expect(feed.note).toBeUndefined();
   expect(publicClient.activity.list).not.toHaveBeenCalled();
-  expect(publicClient.externalReviews.list).not.toHaveBeenCalled();
 });
 
 test("falls back to Everyone only when there are no accepted follows", async () => {
@@ -81,7 +81,11 @@ test("falls back to Everyone only when there are no accepted follows", async () 
   );
   expect(feed.items).toHaveLength(2);
   expect(memberClient.activity.list).not.toHaveBeenCalled();
-  expect(publicClient.externalReviews.list).toHaveBeenCalled();
+  expect(publicClient.activity.list).toHaveBeenCalledWith({
+    cursor: undefined,
+    includeCriticReviews: true,
+    limit: 20,
+  });
 });
 
 test("does not hide a failed follow lookup by showing Everyone", async () => {
@@ -104,6 +108,29 @@ test("uses public activity for Everyone even when signed in", async () => {
   expect(feed.items).toHaveLength(2);
   expect(memberClient.friends.list).not.toHaveBeenCalled();
   expect(memberClient.activity.list).not.toHaveBeenCalled();
+});
+
+test("loads the requested activity page and returns its links", async () => {
+  publicClient.activity.list.mockResolvedValue({
+    results: [],
+    rel: { nextCursor: "3:1780833600000", prevCursor: "1:1780833600000" },
+  });
+
+  const feed = await loadActivityFeed({
+    cursor: "2:1780833600000",
+    following: false,
+    publicClient,
+  });
+
+  expect(publicClient.activity.list).toHaveBeenCalledWith({
+    cursor: "2:1780833600000",
+    includeCriticReviews: true,
+    limit: 20,
+  });
+  expect(feed.rel).toEqual({
+    nextCursor: "3:1780833600000",
+    prevCursor: "1:1780833600000",
+  });
 });
 
 test("anonymous Following uses public activity and explains sign-in", async () => {

--- a/apps/web/src/app/(app)/activity/loadActivityFeed.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.ts
@@ -11,15 +11,15 @@ export function getActivityFeedSelection(feed?: string) {
 
 /** Falls back to public activity only when there are no accepted follows. */
 export async function loadActivityFeed({
+  cursor,
   following,
   memberClient,
   publicClient,
 }: {
+  cursor?: string;
   following: boolean;
   memberClient?: ActivityClient & { friends: Pick<Client["friends"], "list"> };
-  publicClient: ActivityClient & {
-    externalReviews: Pick<Client["externalReviews"], "list">;
-  };
+  publicClient: ActivityClient;
 }) {
   let note: string | undefined;
 
@@ -30,6 +30,7 @@ export async function loadActivityFeed({
     });
     if (follows.results.length) {
       const activity = await memberClient.activity.list({
+        cursor,
         filter: "friends",
         limit: 20,
       });
@@ -39,6 +40,7 @@ export async function loadActivityFeed({
           activity: activity.results,
         }),
         note,
+        rel: activity.rel,
       };
     }
     note = "You're not following anyone yet. Showing everyone's activity.";
@@ -46,16 +48,18 @@ export async function loadActivityFeed({
     note = "Sign in to follow people. Showing everyone's activity.";
   }
 
-  const [activity, reviews] = await Promise.all([
-    publicClient.activity.list({ limit: 20 }),
-    publicClient.externalReviews.list({ limit: 20, sort: "recent" }),
-  ]);
+  const activity = await publicClient.activity.list({
+    cursor,
+    includeCriticReviews: true,
+    limit: 20,
+  });
 
   return {
     items: getCommunityFeedItems({
-      criticReviews: reviews.results,
+      criticReviews: [],
       activity: activity.results,
     }),
     note,
+    rel: activity.rel,
   };
 }

--- a/apps/web/src/app/(app)/activity/page.tsx
+++ b/apps/web/src/app/(app)/activity/page.tsx
@@ -1,7 +1,8 @@
-import { PageTabs } from "@peated/web/components";
+import { CursorPager, PageTabs } from "@peated/web/components";
 import { ActivityPage } from "@peated/web/components/pages/activityPage.stylex";
 import { getCurrentUser } from "@peated/web/lib/auth.server";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
+import { getCursorHref } from "@peated/web/lib/cursorHref";
 import {
   getAnonymousServerClient,
   getServerClient,
@@ -18,15 +19,21 @@ export const metadata: Metadata = {
 export default async function Activity({
   searchParams,
 }: {
-  searchParams: Promise<{ feed?: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  const [{ feed }, user] = await Promise.all([searchParams, getCurrentUser()]);
+  const [resolvedSearchParams, user] = await Promise.all([
+    searchParams,
+    getCurrentUser(),
+  ]);
+  const feed = getFirstValue(resolvedSearchParams.feed);
+  const cursor = getFirstValue(resolvedSearchParams.cursor);
+  const page = getPageNumber(getFirstValue(resolvedSearchParams.page));
   const selectedFeed = getActivityFeedSelection(feed);
   const following = selectedFeed === "following";
   const { client: publicClient } = await getAnonymousServerClient();
   const memberClient = user ? (await getServerClient()).client : undefined;
-  const [{ items, note }, library] = await Promise.all([
-    loadActivityFeed({ following, memberClient, publicClient }),
+  const [{ items, note, rel }, library] = await Promise.all([
+    loadActivityFeed({ cursor, following, memberClient, publicClient }),
     memberClient?.collections.bottles.list({
       user: "me",
       collection: "library",
@@ -47,6 +54,24 @@ export default async function Activity({
       libraryBottles={libraryBottles}
       libraryHref={user ? `/users/${user.username}/library` : undefined}
       note={note}
+      pagination={
+        <CursorPager
+          ariaLabel="Activity pages"
+          nextHref={getCursorHref(
+            "/activity",
+            resolvedSearchParams,
+            rel.nextCursor,
+            { page: page + 1 },
+          )}
+          page={page}
+          previousHref={getCursorHref(
+            "/activity",
+            resolvedSearchParams,
+            rel.prevCursor,
+            { page: Math.max(1, page - 1) },
+          )}
+        />
+      }
       selector={
         <PageTabs
           ariaLabel="Activity feeds"
@@ -59,4 +84,14 @@ export default async function Activity({
       }
     />
   );
+}
+
+function getFirstValue(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function getPageNumber(value?: string) {
+  if (!value) return 1;
+  const page = Number.parseInt(value, 10);
+  return Number.isSafeInteger(page) && page > 0 ? page : 1;
 }

--- a/apps/web/src/components/lists.stylex.tsx
+++ b/apps/web/src/components/lists.stylex.tsx
@@ -132,6 +132,11 @@ export function CursorPager({
 
   return (
     <nav aria-label={ariaLabel} {...stylex.props(styles.pagination)}>
+      {page !== undefined ? (
+        <span {...stylex.props(foundationStyles.metadata, styles.pageNumber)}>
+          Page {page}
+        </span>
+      ) : null}
       <div
         {...stylex.props(
           styles.paginationLinks,
@@ -161,11 +166,6 @@ export function CursorPager({
           </ButtonLink>
         ) : null}
       </div>
-      {page !== undefined ? (
-        <span {...stylex.props(foundationStyles.metadata, styles.pageNumber)}>
-          Page {page}
-        </span>
-      ) : null}
     </nav>
   );
 }

--- a/apps/web/src/components/lists.test.tsx
+++ b/apps/web/src/components/lists.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { CursorPager } from "./lists.stylex";
+
+describe("CursorPager", () => {
+  it("places page context before the navigation actions", () => {
+    const html = renderToStaticMarkup(
+      <CursorPager
+        nextHref="/activity?page=4"
+        page={3}
+        previousHref="/activity?page=2"
+      />,
+    );
+
+    expect(html.indexOf("Page 3")).toBeLessThan(html.indexOf("← Previous"));
+    expect(html.indexOf("← Previous")).toBeLessThan(html.indexOf("Next →"));
+  });
+});

--- a/apps/web/src/components/pages/activityPage.stories.tsx
+++ b/apps/web/src/components/pages/activityPage.stories.tsx
@@ -7,6 +7,7 @@ import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 import { toBottleListItem } from "../../lib/bottleListItem";
 
 import { getCommunityFeedItems } from "../../lib/communityFeed";
+import { CursorPager } from "../lists.stylex";
 import { PageTabs } from "../pageTabs.stylex";
 import { StoryCanvas } from "../storyFixtures.stylex";
 import { ActivityPage } from "./activityPage.stylex";
@@ -25,20 +26,36 @@ const meta = {
     docs: {
       description: {
         component:
-          "Activity uses the catalog columns, with Following/Everyone beside the page title and aligned with the feed column. The sidebar has the tasting action and bottles from the member’s library, and is hidden on mobile. A short notice explains when Following shows everyone's activity because there are no accepted follows.",
+          "Activity uses the catalog columns, with Following/Everyone beside the page title and aligned with the feed column. The cursor pager keeps the selected feed while moving through activity. The sidebar has the tasting action and bottles from the member’s library, and is hidden on mobile. A short notice explains when Following shows everyone's activity because there are no accepted follows.",
       },
     },
   },
   args: {
     items: getCommunityFeedItems({
-      criticReviews: [mockExternalReview],
-      activity: mockActivity,
+      criticReviews: [],
+      activity: [
+        {
+          id: `critic_review:${mockExternalReview.id}`,
+          type: "critic_review",
+          priority: "primary",
+          createdAt: mockExternalReview.article.publishedAt!,
+          review: mockExternalReview,
+        },
+        ...mockActivity,
+      ],
     }),
     libraryBottles: mockCollectionBottles
       .filter((item) => !item.hasTasted)
       .slice(0, 3)
       .map((item) => toBottleListItem(item.bottle)),
     libraryHref: "/users/mock-user/library",
+    pagination: (
+      <CursorPager
+        ariaLabel="Activity pages"
+        nextHref="/activity?feed=everyone&cursor=2%3A1780833600000&page=2"
+        page={1}
+      />
+    ),
     selector: (
       <PageTabs
         ariaLabel="Activity feeds"
@@ -60,6 +77,13 @@ export const Overview: Story = {};
 export const NoFollows: Story = {
   args: {
     note: "You're not following anyone yet. Showing everyone's activity.",
+    pagination: (
+      <CursorPager
+        ariaLabel="Activity pages"
+        nextHref="/activity?feed=following&cursor=2%3A1780833600000&page=2"
+        page={1}
+      />
+    ),
     selector: (
       <PageTabs
         ariaLabel="Activity feeds"

--- a/apps/web/src/components/pages/activityPage.stylex.tsx
+++ b/apps/web/src/components/pages/activityPage.stylex.tsx
@@ -13,12 +13,14 @@ import { RailListSection } from "./railListSection.stylex";
 export function ActivityPage({
   items,
   note,
+  pagination,
   selector,
   libraryBottles = [],
   libraryHref,
 }: {
   items: readonly CommunityFeedItem[];
   note?: string;
+  pagination?: ReactNode;
   libraryBottles?: readonly BottleListItem[];
   libraryHref?: string;
   selector: ReactNode;
@@ -74,6 +76,7 @@ export function ActivityPage({
             Tastings, reviews, and library additions will appear here.
           </EmptyState>
         )}
+        {pagination}
       </PageColumns>
     </div>
   );

--- a/apps/web/src/lib/communityFeed.test.ts
+++ b/apps/web/src/lib/communityFeed.test.ts
@@ -20,6 +20,33 @@ describe("getCommunityFeedItems", () => {
     expect(item?.actorHref).toBe(mockExternalReview.url);
   });
 
+  test("maps critic reviews returned as paginated activity", () => {
+    const [item] = getCommunityFeedItems({
+      criticReviews: [],
+      activity: [
+        {
+          id: `critic_review:${mockExternalReview.id}`,
+          type: "critic_review",
+          priority: "primary",
+          createdAt: mockExternalReview.article.publishedAt!,
+          review: mockExternalReview,
+        },
+      ],
+    });
+
+    expect(item).toMatchObject({
+      kind: "critic_review",
+      actor: mockExternalReview.site?.name,
+      actorHref: mockExternalReview.url,
+      bottles: [
+        {
+          description: mockExternalReview.clip,
+          activityHref: mockExternalReview.url,
+        },
+      ],
+    });
+  });
+
   test("uses the article title when the review has no clip", () => {
     const [item] = getCommunityFeedItems({
       criticReviews: [{ ...mockExternalReview, clip: null }],

--- a/apps/web/src/lib/communityFeed.ts
+++ b/apps/web/src/lib/communityFeed.ts
@@ -55,6 +55,35 @@ export function getCommunityFeedItems({
     ];
   });
   const memberItems = activity.flatMap((entry): CommunityFeedItem[] => {
+    if (entry.type === "critic_review") {
+      const review = entry.review;
+      if (!review.bottle) return [];
+      const source = review.site?.name ?? review.reviewerName ?? "Critic";
+      return [
+        {
+          id: entry.id,
+          kind: "critic_review",
+          actor: source,
+          actorHref: review.url,
+          actorImageUrl: review.site?.imageUrl,
+          action: "published a review",
+          date: entry.createdAt,
+          bottles: [
+            {
+              ...feedBottle(review.bottle),
+              description: getPreview(review.clip ?? review.article.title),
+              activityHref: review.url,
+              activityLabel: `Read at ${source} ↗`,
+              byline:
+                review.reviewerName && review.reviewerName !== source
+                  ? review.reviewerName
+                  : undefined,
+              score: review.nativeScore ?? undefined,
+            },
+          ],
+        },
+      ];
+    }
     const actor = {
       id: entry.id,
       actor: entry.createdBy.username,


### PR DESCRIPTION
The Activity page now uses cursor-based Previous and Next navigation while preserving the selected feed and a stable activity snapshot. Critic reviews join tastings, member reviews, and library additions in the same paginated query, so moving between pages cannot skip or repeat reviews because of a separate client-side merge. Existing API consumers retain their current member-only results unless they opt into critic reviews.

The shared pager presents `Page N` as left-aligned context and keeps its navigation actions grouped on the right across desktop and mobile. Following-feed behavior remains unchanged: critic reviews are included only for global and local activity. Regression coverage exercises cursor boundaries, the mock contract, critic-review mapping, pager ordering, and browser navigation.
