### PR TITLE
ci(server): use native pnpm setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,19 +232,14 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+      - name: Setup pnpm, Node, and dependencies
+        uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
-          run_install: false
-      - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24.18.0
-          cache: pnpm
+          runtime: node@24.18.0
+          cache: true
+          require-lockfile: true
       - name: Run docker images
         run: docker compose up -d
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
       - name: Run server tests
         run: pnpm --filter @peated/server test:ci -- --shard=${{ matrix.shard }}/${{ matrix.total }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -232,14 +232,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Setup pnpm, Node, and dependencies
+      - name: Setup pnpm and Node
         uses: pnpm/setup@703c52620218391530e48b9e8870d5c0082e1b9b # v2.1.0
         with:
           runtime: node@24.18.0
           cache: true
-          require-lockfile: true
+          install: false
       - name: Run docker images
         run: docker compose up -d
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
       - name: Run server tests
         run: pnpm --filter @peated/server test:ci -- --shard=${{ matrix.shard }}/${{ matrix.total }}
 


### PR DESCRIPTION
Server test jobs now use the pnpm 11 setup action, which downloads the ready-to-run pnpm binary instead of installing an older pnpm through npm and upgrading it. The action also installs Node 24.18.0 and restores the package cache. Dependency installation remains after Docker startup and keeps the existing frozen-lockfile check.

The successful comparison completed pnpm and Node setup in 12–15 seconds on every slice. The previous pnpm installer alone took 27 seconds to 3:40, and total server job times ranged from 6:35 to 10:00; with this change they ranged from 5:07 to 6:56. This limits the migration to server tests so it can be proven before applying it to other CI jobs; test commands and four-way splitting are unchanged.
