### PR TITLE
feat(scrapers): prepare Whiskey Reviewer for saved rules

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -65,6 +65,15 @@ function prepareWhiskySaga(input: { apply?: boolean } = {}) {
   );
 }
 
+function prepareWhiskeyReviewer(input: { apply?: boolean } = {}) {
+  return routerClient.externalSites.scrapeSources.prepare(
+    { site: "whiskeyreviewer", ...input },
+    {
+      context: { user: admin },
+    },
+  );
+}
+
 function prepareCompassBox(input: { apply?: boolean } = {}) {
   return routerClient.externalSites.scrapeSources.prepare(
     { site: "compassbox", ...input },
@@ -115,6 +124,18 @@ const whiskySagaRegistry = createScraperRegistry({
     {
       ...scraperRegistry.sources.get("whiskysaga")!,
       externalSiteKey: "whiskysaga",
+    },
+  ],
+});
+
+const whiskeyReviewerCanonicalUrl =
+  "https://whiskeyreviewer.com/2026/08/example-bourbon-review-081026";
+const whiskeyReviewerRegistry = createScraperRegistry({
+  targets: [scraperRegistry.targets.get("whiskeyreviewer")!],
+  sources: [
+    {
+      ...scraperRegistry.sources.get("whiskeyreviewer")!,
+      externalSiteKey: "whiskeyreviewer",
     },
   ],
 });
@@ -278,6 +299,59 @@ async function setupWhiskySagaMigration(bottleId: number | null = null) {
       nativeScoreDisplay: "89/100",
       clip: "An existing clip.",
       tags: ["orchard fruit"],
+    })
+    .returning();
+  await db.insert(externalReviewBodies).values({
+    externalReviewId: review.id,
+    body: "Synthetic old review body.",
+    fetchedAt: new Date(),
+  });
+  await db.insert(externalReviewPublications).values({
+    externalSiteId: site.id,
+    approvedAt: null,
+  });
+  await db.insert(externalSiteRuns).values({
+    externalSiteId: site.id,
+    status: "succeeded",
+    trigger: "scheduled",
+    completedAt: new Date(),
+  });
+  return { site, article, review };
+}
+
+async function setupWhiskeyReviewerMigration(bottleId: number | null = null) {
+  const [site] = await db
+    .insert(externalSites)
+    .values({
+      type: "whiskeyreviewer",
+      name: "The Whiskey Reviewer",
+      runEvery: null,
+    })
+    .returning();
+  await syncScraperDefinitions(whiskeyReviewerRegistry);
+  const [article] = await db
+    .insert(externalReviewArticles)
+    .values({
+      externalSiteId: site.id,
+      canonicalUrl: whiskeyReviewerCanonicalUrl,
+      title: "Example Bourbon Review",
+      publishedAt: new Date("2026-08-10"),
+    })
+    .returning();
+  const [review] = await db
+    .insert(externalReviews)
+    .values({
+      articleId: article.id,
+      sourceKey: `whiskeyreviewer:${createHash("sha256").update(whiskeyReviewerCanonicalUrl).digest("hex")}`,
+      name: "Example Bourbon",
+      bottleId,
+      hidden: true,
+      reviewerName: "Rowan Hill",
+      nativeScoreValue: 87,
+      nativeScoreScale: 100,
+      nativeScoreDisplay: "B+",
+      clip: "An existing clip.",
+      tags: ["vanilla"],
     })
     .returning();
   await db.insert(externalReviewBodies).values({
@@ -592,6 +666,62 @@ describe("POST /admin/scrape-sources/prepare", () => {
     ]);
   });
 
+  test("prepares The Whiskey Reviewer without replacing its records", async ({
+    fixtures,
+  }) => {
+    const bottle = await fixtures.Bottle();
+    const { site, article, review } = await setupWhiskeyReviewerMigration(
+      bottle.id,
+    );
+    const bodies = await db.select().from(externalReviewBodies);
+    const publications = await db.select().from(externalReviewPublications);
+    const runs = await db.select().from(externalSiteRuns);
+    const [target] = await db.select().from(scrapeTargets);
+
+    await expect(prepareWhiskeyReviewer()).resolves.toEqual({
+      siteId: site.id,
+      scrapeSourceId: null,
+      reviewCount: 1,
+      applied: false,
+    });
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+    expect(await db.select().from(externalReviews)).toEqual([review]);
+
+    const applied = await prepareWhiskeyReviewer({ apply: true });
+    expect(applied).toEqual({
+      siteId: site.id,
+      scrapeSourceId: expect.any(Number),
+      reviewCount: 1,
+      applied: true,
+    });
+    await syncScraperDefinitions(whiskeyReviewerRegistry);
+    expect(await db.select().from(externalReviewArticles)).toEqual([article]);
+    expect(await db.select().from(externalReviews)).toEqual([
+      {
+        ...review,
+        sourceKey: `${whiskeyReviewerCanonicalUrl}#review-1`,
+      },
+    ]);
+    expect(await db.select().from(externalReviewBodies)).toEqual(bodies);
+    expect(await db.select().from(externalReviewPublications)).toEqual(
+      publications,
+    );
+    expect(await db.select().from(externalSiteRuns)).toEqual(runs);
+    expect(await db.select().from(scrapeTargets)).toEqual([
+      { ...target, managedBy: "admin", updatedAt: expect.any(Date) },
+    ]);
+    expect(await db.select().from(scrapeSources)).toEqual([
+      expect.objectContaining({
+        id: applied.scrapeSourceId,
+        externalSiteId: site.id,
+        kind: "review",
+        listUrl: "https://whiskeyreviewer.com/",
+        enabled: false,
+        createdById: admin.id,
+      }),
+    ]);
+  });
+
   test("prepares Compass Box without replacing prices or Bottle matches", async ({
     fixtures,
   }) => {
@@ -827,6 +957,28 @@ describe("POST /admin/scrape-sources/prepare", () => {
         "Check the URL and review records for The Whisky Study article",
       ),
     });
+    expect(await db.select().from(externalReviews)).toEqual(reviews);
+    expect(await db.select().from(scrapeTargets)).toEqual(targets);
+    expect(await db.select().from(scrapeSources)).toEqual([]);
+  });
+
+  test("refuses an unexpected The Whiskey Reviewer article URL", async () => {
+    const { article } = await setupWhiskeyReviewerMigration();
+    await db
+      .update(externalReviewArticles)
+      .set({ canonicalUrl: `${whiskeyReviewerCanonicalUrl}/` })
+      .where(eq(externalReviewArticles.id, article.id));
+    const reviews = await db.select().from(externalReviews);
+    const targets = await db.select().from(scrapeTargets);
+
+    await expect(prepareWhiskeyReviewer({ apply: true })).rejects.toMatchObject(
+      {
+        code: "BAD_REQUEST",
+        message: expect.stringContaining(
+          "Check the URL and review records for The Whiskey Reviewer article",
+        ),
+      },
+    );
     expect(await db.select().from(externalReviews)).toEqual(reviews);
     expect(await db.select().from(scrapeTargets)).toEqual(targets);
     expect(await db.select().from(scrapeSources)).toEqual([]);

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.ts
@@ -4,6 +4,7 @@ import { ExternalSiteKeySchema } from "@peated/server/schemas";
 import { prepareBourbonCultureSource } from "@peated/server/scraper/configured/prepareBourbonCulture";
 import { prepareCompassBoxSource } from "@peated/server/scraper/configured/prepareCompassBox";
 import { prepareKilchomanSource } from "@peated/server/scraper/configured/prepareKilchoman";
+import { prepareWhiskeyReviewerSource } from "@peated/server/scraper/configured/prepareWhiskeyReviewer";
 import { prepareWhiskySagaSource } from "@peated/server/scraper/configured/prepareWhiskySaga";
 import { prepareWhiskyStudySource } from "@peated/server/scraper/configured/prepareWhiskyStudy";
 import {
@@ -30,7 +31,7 @@ export default procedure
     z
       .object({
         site: ExternalSiteKeySchema.describe(
-          "The existing site's key. Currently supports bourbonculture, compassbox, kilchoman, whiskysaga, and whiskystudy.",
+          "The existing site's key. Currently supports bourbonculture, compassbox, kilchoman, whiskeyreviewer, whiskysaga, and whiskystudy.",
         ),
         apply: z
           .boolean()
@@ -64,6 +65,7 @@ export default procedure
       bourbonculture: prepareBourbonCultureSource,
       compassbox: prepareCompassBoxSource,
       kilchoman: prepareKilchomanSource,
+      whiskeyreviewer: prepareWhiskeyReviewerSource,
       whiskysaga: prepareWhiskySagaSource,
       whiskystudy: prepareWhiskyStudySource,
     }[input.site];

--- a/apps/server/src/scraper/README.md
+++ b/apps/server/src/scraper/README.md
@@ -82,13 +82,16 @@ product database. Only a revision that passes its preview can become active. An
 admin can return to any older revision that passed. Pausing a source stops
 collection but keeps its revisions and run history.
 
-Rules formats 1 and 2 support same-origin HTML list and detail pages, an item
+Rules formats 1 through 3 support same-origin HTML list and detail pages, an item
 limit, an optional next-page link, CSS selectors, and fixed date, number, price,
 and volume conversions. Version 2 also supports bounded value cleanup, fixed
 values, joined labeled text, and list-card exclusion. An `item` selector scopes
 each `detailLink`; `excludeWhen` skips that item when its selector finds text,
 optionally beginning with one of the configured literal labels. Code follows at
-most five list pages. Rules do not support
+most five list pages. Version 3 also lets review sources select and clean their
+canonical URL, read a publication date from a URL path with bounded `yyyy`, `yy`,
+`MM`, `dd`, and `*` tokens, and map up to 25 finite text grades to numeric values.
+Rules do not support
 scripts, custom code, arbitrary request headers, browser automation, numbered
 page templates, infinite scrolling, or cross-origin discovery. Add a code-owned
 adapter when a source needs those capabilities.
@@ -154,12 +157,12 @@ pnpm cli scrapers preview --site whiskystudy --input /tmp/revision.json --limit 
 ```
 
 The input has the same `listUrl` and `rules` fields accepted by the revision
-API. Set `rulesVersion` to `2` when testing version 2 operations. An omitted
+API. Set `rulesVersion` to `3` when testing current operations. An omitted
 version means version 1 so existing preview files keep their original behavior:
 
 ```json
 {
-  "rulesVersion": 2,
+  "rulesVersion": 3,
   "listUrl": "https://example.com/reviews",
   "rules": {}
 }

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -444,6 +444,39 @@ describe("scrape source parser", () => {
     });
   });
 
+  it.each([
+    ["is missing", "", "Required value was not found."],
+    [
+      "points to another website",
+      '<link rel="canonical" href="https://other.test/review">',
+      "Pages must stay on the source website.",
+    ],
+  ])(
+    "reports one canonical URL issue when the configured value %s",
+    (_, canonicalMarkup, message) => {
+      const result = parseScrapeDetail(
+        {
+          ...reviewConfig,
+          detail: {
+            ...reviewConfig.detail,
+            canonicalUrl: {
+              selector: 'link[rel="canonical"]',
+              attribute: "href",
+            },
+          },
+        },
+        `${canonicalMarkup}<h1>Review</h1><time datetime="2026-04-02"></time><article class="review"><h2>Example</h2></article>`,
+        new URL("https://reviews.test/review"),
+      );
+
+      expect(result.kind).toBe("review");
+      expect(result.value).toBeNull();
+      expect(
+        result.issues.filter(({ field }) => field === "detail.canonicalUrl"),
+      ).toEqual([{ field: "detail.canonicalUrl", message }]);
+    },
+  );
+
   it("matches Whiskey Reviewer identity, URL date, grade, and evidence", async () => {
     const pageUrl = new URL(
       "https://whiskeyreviewer.com/2026/08/example-bourbon-review-081026/",

--- a/apps/server/src/scraper/configured/parser.test.ts
+++ b/apps/server/src/scraper/configured/parser.test.ts
@@ -6,6 +6,10 @@ import {
 } from "../adapters/bourbonCulture";
 import { parseCompassBoxProducts } from "../adapters/legacy/scrapeCompassBox";
 import { parseKilchomanProducts } from "../adapters/legacy/scrapeKilchoman";
+import {
+  discoverWhiskeyReviewerArticles,
+  parseWhiskeyReviewerArticle,
+} from "../adapters/whiskeyReviewer";
 import { parseWhiskySagaArticle } from "../adapters/whiskySaga";
 import { parseWhiskyStudyArticle } from "../adapters/whiskyStudy";
 import { parseScrapeDetail, parseScrapeList } from "./parser";
@@ -187,6 +191,65 @@ const kilchomanRules = {
   },
 } satisfies ScrapeRules;
 
+const whiskeyReviewerRules = {
+  kind: "review",
+  list: {
+    detailLink: {
+      selector:
+        '.widget.posts-list:contains("Recent Reviews") a.post-title[href^="/"]:not([href*="?"]), .widget.posts-list:contains("Recent Reviews") a.post-title[href^="https://whiskeyreviewer.com/"]:not([href*="?"])',
+      attribute: "href",
+    },
+    maxItems: 5,
+  },
+  detail: {
+    canonicalUrl: {
+      selector: 'link[rel="canonical"]',
+      attribute: "href",
+      removeSuffixes: ["/"],
+    },
+    title: { selector: "#the-post h1.entry-title" },
+    publishedAt: { urlDateFormat: "/yyyy/MM/*-MMddyy" },
+    reviewItem: "#the-post .entry-content",
+    name: {
+      selector: "#the-post h1.entry-title",
+      removeSuffixes: ["Review", "Rview"],
+    },
+    reviewerName: {
+      selector: "p",
+      startsWith: ["By "],
+      removePrefixes: ["By "],
+    },
+    reviewText: {
+      selector:
+        'p:contains("nose"), p:contains("Nose"), p:contains("palate"), p:contains("Palate"), p:contains("finish"), p:contains("Finish")',
+      all: true,
+    },
+    score: {
+      value: {
+        selector: "#the-post .entry-content > p",
+        startsWith: ["Rating:"],
+        removePrefixes: ["Rating:"],
+      },
+      scale: 100,
+      map: [
+        { text: "A+", value: 100 },
+        { text: "A", value: 95 },
+        { text: "A-", value: 90 },
+        { text: "B+", value: 87 },
+        { text: "B", value: 83 },
+        { text: "B-", value: 80 },
+        { text: "C+", value: 77 },
+        { text: "C", value: 73 },
+        { text: "C-", value: 70 },
+        { text: "D+", value: 67 },
+        { text: "D", value: 63 },
+        { text: "D-", value: 60 },
+        { text: "F", value: 0 },
+      ],
+    },
+  },
+} satisfies ScrapeRules;
+
 function expectReviewFactsAndEvidenceToMatch(
   configured: ReturnType<typeof parseScrapeDetail>,
   legacy: NonNullable<ReturnType<typeof parseWhiskyStudyArticle>>,
@@ -312,6 +375,28 @@ describe("scrape source parser", () => {
     });
   });
 
+  it("matches the current Whiskey Reviewer article links", async () => {
+    const pageUrl = new URL("https://whiskeyreviewer.com/");
+    const html = await loadFixture("whiskeyreviewer", "index.html");
+    const legacyLinks = discoverWhiskeyReviewerArticles(html).map(
+      (url) => url.href,
+    );
+
+    expect(parseScrapeList(whiskeyReviewerRules, html, pageUrl)).toEqual({
+      links: [
+        "https://whiskeyreviewer.com/2026/08/example-bourbon-review-081026/",
+        "https://whiskeyreviewer.com/2026/08/example-scotch-review-080626/",
+      ],
+      nextPageUrl: null,
+      issues: [],
+    });
+    expect(
+      parseScrapeList(whiskeyReviewerRules, html, pageUrl).links.map((url) =>
+        url.replace(/\/$/u, ""),
+      ),
+    ).toEqual(legacyLinks);
+  });
+
   it("rejects a next page on another website", () => {
     const result = parseScrapeList(
       {
@@ -357,6 +442,59 @@ describe("scrape source parser", () => {
       reviewerName: "Ada",
       nativeScore: { value: 91, scale: 100, display: "91 / 100" },
     });
+  });
+
+  it("matches Whiskey Reviewer identity, URL date, grade, and evidence", async () => {
+    const pageUrl = new URL(
+      "https://whiskeyreviewer.com/2026/08/example-bourbon-review-081026/",
+    );
+    const html = await loadFixture("whiskeyreviewer", "review.html");
+    const legacy = parseWhiskeyReviewerArticle(html, pageUrl);
+    const configured = parseScrapeDetail(whiskeyReviewerRules, html, pageUrl);
+
+    expect(configured.kind).toBe("review");
+    expect(configured.issues).toEqual([]);
+    if (configured.kind !== "review" || !configured.value) {
+      throw new Error("Expected configured review output.");
+    }
+    expect(configured.value.article).toMatchObject({
+      canonicalUrl: legacy.article.canonicalUrl,
+      title: legacy.article.title,
+      publishedAt: legacy.article.publishedAt,
+    });
+    expect(configured.value.article.externalReviews[0]).toMatchObject({
+      name: legacy.article.externalReviews[0]?.name,
+      reviewerName: legacy.article.externalReviews[0]?.reviewerName,
+      nativeScore: legacy.article.externalReviews[0]?.nativeScore,
+    });
+    expect(Object.values(configured.value.externalReviewTexts)).toEqual(
+      Object.values(legacy.externalReviewTexts),
+    );
+    expect(Object.values(configured.value.externalReviewBodies)).toEqual(
+      Object.values(legacy.externalReviewBodies),
+    );
+  });
+
+  it("rejects conflicting URL dates and unmapped scores", async () => {
+    const html = (await loadFixture("whiskeyreviewer", "review.html"))
+      .replace("/2026/08/example-bourbon", "/2025/08/example-bourbon")
+      .replace("Rating: B+", "Rating: E");
+    const result = parseScrapeDetail(
+      whiskeyReviewerRules,
+      html,
+      new URL(
+        "https://whiskeyreviewer.com/2025/08/example-bourbon-review-081026/",
+      ),
+    );
+
+    expect(result).toMatchObject({ kind: "review", value: null });
+    expect(result.issues).toEqual([
+      { field: "detail.publishedAt", message: "Date is not valid." },
+      {
+        field: "detail.score",
+        message: "Score is not in the configured map.",
+      },
+    ]);
   });
 
   it("removes Whisky Study title suffixes and finds a labeled score", () => {

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -75,7 +75,9 @@ function readValue(root: ReturnType<typeof load>, rule: ScrapeReadableValue) {
       ? rule.startsWith?.map((value) => value.toLowerCase())
       : undefined;
   root(rule.selector).each((_, element) => {
-    const value = normalizeValue(root(element).text());
+    const selected = root(element).clone();
+    selected.find("br").replaceWith(" ");
+    const value = normalizeValue(selected.text());
     if (!value) return;
     if (
       startsWith &&
@@ -183,6 +185,58 @@ function parseDate(value: string | null) {
   return Number.isFinite(timestamp) ? new Date(timestamp) : null;
 }
 
+function parseDateFromUrl(url: URL, format: string) {
+  // Rules v3 owns this token grammar; literals are escaped so saved rules cannot run regex code.
+  const tokens: string[] = [];
+  let pattern = "^";
+  let offset = 0;
+  for (const match of format.matchAll(/yyyy|yy|MM|dd|\*/g)) {
+    const index = match.index;
+    pattern += format
+      .slice(offset, index)
+      .replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const token = match[0];
+    if (token === "*") {
+      pattern += "[^/?#]*";
+    } else {
+      tokens.push(token);
+      pattern += token === "yyyy" ? "(\\d{4})" : "(\\d{2})";
+    }
+    offset = index + token.length;
+  }
+  pattern += format.slice(offset).replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  pattern += "$";
+
+  const match = new RegExp(pattern, "u").exec(url.pathname);
+  if (!match) return null;
+  const values = new Map<string, number>();
+  for (const [index, token] of tokens.entries()) {
+    const value = Number(match[index + 1]);
+    const prior = values.get(token);
+    if (prior !== undefined && prior !== value) return null;
+    values.set(token, value);
+  }
+  const fullYear = values.get("yyyy");
+  const shortYear = values.get("yy");
+  if (
+    fullYear !== undefined &&
+    shortYear !== undefined &&
+    fullYear % 100 !== shortYear
+  ) {
+    return null;
+  }
+  const year = fullYear ?? (shortYear === undefined ? null : 2000 + shortYear);
+  const month = values.get("MM");
+  const day = values.get("dd");
+  if (year === null || month === undefined || day === undefined) return null;
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+    ? date
+    : null;
+}
+
 function parseNumber(value: string | null) {
   if (!value) return null;
   const match = value.replaceAll(",", "").match(/-?\d+(?:\.\d+)?/);
@@ -221,6 +275,7 @@ function validationIssues(
 
 function reviewField(path: PropertyKey[]) {
   if (path[0] !== "article") return "detail";
+  if (path[1] === "canonicalUrl") return "detail.canonicalUrl";
   if (path[1] === "title") return "detail.title";
   if (path[1] === "publishedAt") return "detail.publishedAt";
   if (path[1] !== "externalReviews") return "detail";
@@ -253,12 +308,45 @@ function parseReviewDetail(
 ): ScrapeDetailResult {
   const $ = load(html);
   const issues: ScrapeIssue[] = [];
+  let canonicalUrl: URL | null = pageUrl;
+  const canonicalUrlRule =
+    "canonicalUrl" in rules.detail ? rules.detail.canonicalUrl : undefined;
+  if (canonicalUrlRule) {
+    const canonicalUrlText = readValue($, canonicalUrlRule);
+    if (!canonicalUrlText) {
+      canonicalUrl = null;
+      issues.push({
+        field: "detail.canonicalUrl",
+        message: "Required value was not found.",
+      });
+    } else {
+      try {
+        canonicalUrl = new URL(absoluteHttpUrl(canonicalUrlText, pageUrl));
+      } catch (error) {
+        canonicalUrl = null;
+        issues.push({
+          field: "detail.canonicalUrl",
+          message: error instanceof Error ? error.message : "URL is not valid.",
+        });
+      }
+    }
+  }
   const title = readValue($, rules.detail.title);
-  const publishedAtText = rules.detail.publishedAt
-    ? readValue($, rules.detail.publishedAt)
-    : null;
-  const publishedAt = parseDate(publishedAtText);
-  if (!publishedAtText) {
+  const publishedAtRule = rules.detail.publishedAt;
+  const publishedAtText =
+    publishedAtRule && !("urlDateFormat" in publishedAtRule)
+      ? readValue($, publishedAtRule)
+      : null;
+  const publishedAt =
+    publishedAtRule && "urlDateFormat" in publishedAtRule
+      ? canonicalUrl
+        ? parseDateFromUrl(canonicalUrl, publishedAtRule.urlDateFormat)
+        : null
+      : parseDate(publishedAtText);
+  if (
+    !publishedAtRule ||
+    (!publishedAtText && !("urlDateFormat" in publishedAtRule))
+  ) {
     issues.push({
       field: "detail.publishedAt",
       message: "Required value was not found.",
@@ -316,7 +404,7 @@ function parseReviewDetail(
         });
         return;
       }
-      const sourceKey = `${pageUrl.toString()}#review-${index + 1}`;
+      const sourceKey = `${canonicalUrl?.toString() ?? pageUrl.toString()}#review-${index + 1}`;
       const body = readReviewBody($(element));
       if (body) externalReviewBodies[sourceKey] = body;
       const reviewerName = reviewerSelector
@@ -325,11 +413,24 @@ function parseReviewDetail(
       const scoreText = rules.detail.score
         ? readReviewValue(item, rules.detail.score.value)
         : null;
-      const scoreValue = parseNumber(scoreText);
+      const scoreMap =
+        rules.detail.score && "map" in rules.detail.score
+          ? rules.detail.score.map
+          : undefined;
+      const mappedScore = scoreMap?.find(
+        (entry) =>
+          entry.text.toLocaleLowerCase("en") ===
+          scoreText?.toLocaleLowerCase("en"),
+      )?.value;
+      const scoreValue = scoreMap
+        ? (mappedScore ?? null)
+        : parseNumber(scoreText);
       if (scoreText && scoreValue === null) {
         issues.push({
           field: "detail.score",
-          message: "Score is not a number.",
+          message: scoreMap
+            ? "Score is not in the configured map."
+            : "Score is not a number.",
         });
       }
       externalReviews.push({
@@ -361,7 +462,7 @@ function parseReviewDetail(
 
   const result = ExternalReviewArticleIngestionSchema.safeParse({
     article: {
-      canonicalUrl: pageUrl.toString(),
+      canonicalUrl: canonicalUrl?.toString() ?? null,
       title,
       issue: null,
       publishedAt,

--- a/apps/server/src/scraper/configured/parser.ts
+++ b/apps/server/src/scraper/configured/parser.ts
@@ -308,6 +308,14 @@ function parseReviewDetail(
 ): ScrapeDetailResult {
   const $ = load(html);
   const issues: ScrapeIssue[] = [];
+  const parsedArticleFieldIssues = new Set<string>();
+  const reportArticleFieldIssue = (
+    field: "detail.canonicalUrl" | "detail.publishedAt",
+    message: string,
+  ) => {
+    parsedArticleFieldIssues.add(field);
+    issues.push({ field, message });
+  };
   let canonicalUrl: URL | null = pageUrl;
   const canonicalUrlRule =
     "canonicalUrl" in rules.detail ? rules.detail.canonicalUrl : undefined;
@@ -315,19 +323,19 @@ function parseReviewDetail(
     const canonicalUrlText = readValue($, canonicalUrlRule);
     if (!canonicalUrlText) {
       canonicalUrl = null;
-      issues.push({
-        field: "detail.canonicalUrl",
-        message: "Required value was not found.",
-      });
+      reportArticleFieldIssue(
+        "detail.canonicalUrl",
+        "Required value was not found.",
+      );
     } else {
       try {
         canonicalUrl = new URL(absoluteHttpUrl(canonicalUrlText, pageUrl));
       } catch (error) {
         canonicalUrl = null;
-        issues.push({
-          field: "detail.canonicalUrl",
-          message: error instanceof Error ? error.message : "URL is not valid.",
-        });
+        reportArticleFieldIssue(
+          "detail.canonicalUrl",
+          error instanceof Error ? error.message : "URL is not valid.",
+        );
       }
     }
   }
@@ -347,12 +355,12 @@ function parseReviewDetail(
     !publishedAtRule ||
     (!publishedAtText && !("urlDateFormat" in publishedAtRule))
   ) {
-    issues.push({
-      field: "detail.publishedAt",
-      message: "Required value was not found.",
-    });
+    reportArticleFieldIssue(
+      "detail.publishedAt",
+      "Required value was not found.",
+    );
   } else if (!publishedAt) {
-    issues.push({ field: "detail.publishedAt", message: "Date is not valid." });
+    reportArticleFieldIssue("detail.publishedAt", "Date is not valid.");
   }
   const externalReviews: Array<{
     sourceKey: string;
@@ -475,7 +483,7 @@ function parseReviewDetail(
   if (!result.success) {
     issues.push(
       ...validationIssues(result.error, reviewField).filter(
-        ({ field }) => field !== "detail.publishedAt",
+        ({ field }) => !parsedArticleFieldIssues.has(field),
       ),
     );
     return { kind: "review", value: null, issues };

--- a/apps/server/src/scraper/configured/prepareWhiskeyReviewer.ts
+++ b/apps/server/src/scraper/configured/prepareWhiskeyReviewer.ts
@@ -1,0 +1,24 @@
+import { createHash } from "node:crypto";
+import {
+  prepareReviewSource,
+  type PrepareReviewSourceInput,
+} from "./prepareReviewSource";
+
+/** Checks one source by default; applying keeps record IDs and leaves collection paused. */
+export async function prepareWhiskeyReviewerSource(
+  input: PrepareReviewSourceInput,
+) {
+  return prepareReviewSource(input, {
+    siteKey: "whiskeyreviewer",
+    siteName: "The Whiskey Reviewer",
+    targetKey: "whiskeyreviewer",
+    origin: "https://whiskeyreviewer.com",
+    listUrl: "https://whiskeyreviewer.com/",
+    isCanonicalArticleUrl: (url) =>
+      /^https:\/\/whiskeyreviewer\.com\/\d{4}\/\d{2}\/[a-z0-9][a-z0-9-]*-\d{6}$/.test(
+        url,
+      ),
+    legacyReviewKey: (url) =>
+      `whiskeyreviewer:${createHash("sha256").update(url).digest("hex")}`,
+  });
+}

--- a/apps/server/src/scraper/configured/rules.test.ts
+++ b/apps/server/src/scraper/configured/rules.test.ts
@@ -6,6 +6,7 @@ import {
   SCRAPE_SOURCE_MAX_LIST_PAGES,
   ScrapeRulesSchema,
   ScrapeRulesV1Schema,
+  ScrapeRulesV2Schema,
   ScrapeValueSchema,
 } from "./rules";
 
@@ -37,8 +38,8 @@ test("bounds list and detail pages", () => {
 
 test("rejects rules for an unsupported stored format", () => {
   const rules = ScrapeRulesSchema.parse(reviewConfig(25));
-  expect(() => parseScrapeRules(3, rules)).toThrow(
-    "Unsupported scrape rules version: 3.",
+  expect(() => parseScrapeRules(4, rules)).toThrow(
+    "Unsupported scrape rules version: 4.",
   );
 });
 
@@ -51,7 +52,86 @@ test("loads old rules only through the version 1 contract", () => {
       list: { ...rules.list, item: ".card" },
     }),
   ).toThrow();
-  expect(SCRAPE_RULES_VERSION).toBe(2);
+  expect(SCRAPE_RULES_VERSION).toBe(3);
+});
+
+test("loads version 2 rules only through their original contract", () => {
+  const rules = ScrapeRulesV2Schema.parse(reviewConfig(25));
+  expect(parseScrapeRules(2, rules)).toEqual(rules);
+  expect(() =>
+    parseScrapeRules(2, {
+      ...rules,
+      detail: {
+        ...rules.detail,
+        canonicalUrl: {
+          selector: 'link[rel="canonical"]',
+          attribute: "href",
+        },
+      },
+    }),
+  ).toThrow();
+});
+
+test("accepts bounded canonical URLs, URL dates, and score maps", () => {
+  const rules = ScrapeRulesSchema.parse({
+    ...reviewConfig(25),
+    detail: {
+      ...reviewConfig(25).detail,
+      canonicalUrl: {
+        selector: 'link[rel="canonical"]',
+        attribute: "href",
+        removeSuffixes: ["/"],
+      },
+      publishedAt: { urlDateFormat: "/yyyy/MM/*-MMddyy" },
+      score: {
+        value: { selector: ".rating", removePrefixes: ["Rating:"] },
+        scale: 100,
+        map: [
+          { text: "A", value: 95 },
+          { text: "B+", value: 87 },
+        ],
+      },
+    },
+  });
+
+  expect(parseScrapeRules(3, rules)).toEqual(rules);
+});
+
+test.each([
+  ["missing URL year", "/reviews/MM/dd/*"],
+  ["missing URL month", "/reviews/yyyy/dd/*"],
+  ["missing URL day", "/reviews/yyyy/MM/*"],
+  ["unknown URL token", "/reviews/yyyy/MM/DD/*"],
+])("rejects invalid URL date formats: %s", (_, urlDateFormat) => {
+  expect(() =>
+    ScrapeRulesSchema.parse({
+      ...reviewConfig(25),
+      detail: {
+        ...reviewConfig(25).detail,
+        publishedAt: { urlDateFormat },
+      },
+    }),
+  ).toThrow();
+});
+
+test("rejects duplicate or out-of-range score mappings", () => {
+  const config = reviewConfig(25);
+  expect(() =>
+    ScrapeRulesSchema.parse({
+      ...config,
+      detail: {
+        ...config.detail,
+        score: {
+          value: { selector: ".rating" },
+          scale: 10,
+          map: [
+            { text: "A", value: 9 },
+            { text: "a", value: 11 },
+          ],
+        },
+      },
+    }),
+  ).toThrow();
 });
 
 test("accepts bounded list-card exclusion only with an item selector", () => {

--- a/apps/server/src/scraper/configured/rules.ts
+++ b/apps/server/src/scraper/configured/rules.ts
@@ -3,7 +3,8 @@ import type { JsonValue } from "@peated/server/scraper/types";
 import { z } from "zod";
 
 export const SCRAPE_RULES_VERSION_1 = 1;
-export const SCRAPE_RULES_VERSION = 2;
+export const SCRAPE_RULES_VERSION_2 = 2;
+export const SCRAPE_RULES_VERSION = 3;
 // TODO(scraper-platform): Add event after scraped-event match and update rules are defined.
 export const SCRAPE_SOURCE_KIND_LIST = ["review", "price"] as const;
 export type ScrapeSourceKind = (typeof SCRAPE_SOURCE_KIND_LIST)[number];
@@ -14,6 +15,7 @@ export const SCRAPE_SOURCE_MAX_ITEMS = 99;
 const SCRAPE_VALUE_MAX_LENGTH = 200;
 const SCRAPE_LITERAL_MAX_LENGTH = 100;
 const SCRAPE_LITERAL_MAX_ITEMS = 10;
+const SCRAPE_SCORE_MAP_MAX_ITEMS = 25;
 
 export const ScrapeSelectorSchema = z
   .string()
@@ -143,6 +145,99 @@ function reviewRulesSchema<T extends z.ZodType, U extends z.ZodType>(
     .strict();
 }
 
+export const ScrapeUrlDateSchema = z
+  .object({
+    urlDateFormat: z
+      .string()
+      .trim()
+      .min(1)
+      .max(SCRAPE_VALUE_MAX_LENGTH)
+      .superRefine((format, context) => {
+        const tokens: string[] = format.match(/yyyy|yy|MM|dd|\*/g) ?? [];
+        const literal = format.replaceAll(/yyyy|yy|MM|dd|\*/g, "");
+        if (!tokens.includes("yyyy") && !tokens.includes("yy")) {
+          context.addIssue({
+            code: "custom",
+            message: "URL date format requires yyyy or yy.",
+          });
+        }
+        if (!tokens.includes("MM") || !tokens.includes("dd")) {
+          context.addIssue({
+            code: "custom",
+            message: "URL date format requires MM and dd.",
+          });
+        }
+        if (/[A-Za-z0-9]/.test(literal)) {
+          context.addIssue({
+            code: "custom",
+            message: "URL date format contains an unsupported token.",
+          });
+        }
+      }),
+  })
+  .strict();
+
+const ScrapeScoreMapEntrySchema = z
+  .object({
+    text: ScrapeLiteralSchema,
+    value: z.number().nonnegative(),
+  })
+  .strict();
+
+const ScrapeScoreSchema = z
+  .object({
+    value: ScrapeValueSchema,
+    scale: z.number().positive(),
+    map: z
+      .array(ScrapeScoreMapEntrySchema)
+      .min(1)
+      .max(SCRAPE_SCORE_MAP_MAX_ITEMS)
+      .optional(),
+  })
+  .strict()
+  .superRefine((score, context) => {
+    const labels = new Set<string>();
+    for (const [index, entry] of (score.map ?? []).entries()) {
+      if (entry.value > score.scale) {
+        context.addIssue({
+          code: "custom",
+          path: ["map", index, "value"],
+          message: "Mapped score cannot exceed its scale.",
+        });
+      }
+      const label = entry.text.toLocaleLowerCase("en");
+      if (labels.has(label)) {
+        context.addIssue({
+          code: "custom",
+          path: ["map", index, "text"],
+          message: "Mapped score labels must be unique.",
+        });
+      }
+      labels.add(label);
+    }
+  });
+
+const ReviewRulesSchema = z
+  .object({
+    kind: z.literal("review"),
+    list: ListRulesSchema,
+    detail: z
+      .object({
+        canonicalUrl: ScrapeValueSchema.optional(),
+        title: ScrapeValueSchema,
+        publishedAt: z
+          .union([ScrapeValueSchema, ScrapeUrlDateSchema])
+          .optional(),
+        reviewItem: ScrapeSelectorSchema,
+        name: ScrapeValueSchema,
+        reviewerName: ScrapeValueSchema.optional(),
+        reviewText: ScrapeValueSchema.optional(),
+        score: ScrapeScoreSchema.optional(),
+      })
+      .strict(),
+  })
+  .strict();
+
 function priceRulesSchema<T extends z.ZodType, U extends z.ZodType>(
   valueSchema: T,
   listSchema: U,
@@ -172,13 +267,19 @@ export const ScrapeRulesV1Schema = z.discriminatedUnion("kind", [
   priceRulesSchema(ScrapeValueSelectorV1Schema, ListRulesV1Schema),
 ]);
 
-export const ScrapeRulesSchema = z.discriminatedUnion("kind", [
+export const ScrapeRulesV2Schema = z.discriminatedUnion("kind", [
   reviewRulesSchema(ScrapeValueSchema, ListRulesSchema),
+  priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
+]);
+
+export const ScrapeRulesSchema = z.discriminatedUnion("kind", [
+  ReviewRulesSchema,
   priceRulesSchema(ScrapeValueSchema, ListRulesSchema),
 ]);
 
 export const StoredScrapeRulesSchema = z.union([
   ScrapeRulesV1Schema,
+  ScrapeRulesV2Schema,
   ScrapeRulesSchema,
 ]);
 
@@ -196,6 +297,9 @@ export function parseScrapeRules(
 ) {
   if (rulesVersion === SCRAPE_RULES_VERSION_1) {
     return ScrapeRulesV1Schema.parse(rules);
+  }
+  if (rulesVersion === SCRAPE_RULES_VERSION_2) {
+    return ScrapeRulesV2Schema.parse(rules);
   }
   if (rulesVersion === SCRAPE_RULES_VERSION) {
     return ScrapeRulesSchema.parse(rules);

--- a/apps/server/src/scraper/configured/service.test.ts
+++ b/apps/server/src/scraper/configured/service.test.ts
@@ -185,7 +185,7 @@ test("database constraints keep source and revision identity valid", async () =>
     createdById: user.id,
   });
   expect(first.revision).toBe(1);
-  expect(first.rulesVersion).toBe(2);
+  expect(first.rulesVersion).toBe(3);
 
   await expect(
     db.insert(scrapeSources).values({

--- a/apps/server/src/scraper/configured/setupAgent.test.ts
+++ b/apps/server/src/scraper/configured/setupAgent.test.ts
@@ -51,8 +51,14 @@ function reviewCandidate(
         nextPage: null,
       },
       detail: {
+        canonicalUrl: null,
         title: suggestedValue("h1"),
-        publishedAt: suggestedValue("time", "datetime"),
+        publishedAt: {
+          input: "selector" as const,
+          selector: "time",
+          attribute: "datetime",
+          urlDateFormat: null,
+        },
         reviewItem: "article.review",
         name: suggestedValue(nameSelector, null, {
           removeSuffixes: ["Review"],
@@ -68,10 +74,7 @@ function reviewCandidate(
   };
 }
 
-function toolCallResponse(
-  callId: string,
-  candidate: ReturnType<typeof reviewCandidate>,
-) {
+function toolCallResponse<T extends object>(callId: string, candidate: T) {
   return {
     model: "test-setup-model",
     output: [
@@ -229,6 +232,77 @@ test("returns rules only after the rule check passes", async () => {
   expect(secondRequest?.instructions).toContain(
     "Your work is complete only when check_rules accepts the rules.",
   );
+});
+
+test("accepts canonical cleanup, URL dates, and finite score maps", async () => {
+  const base = reviewCandidate("h1");
+  const candidate = {
+    ...base,
+    rules: {
+      ...base.rules,
+      detail: {
+        ...base.rules.detail,
+        canonicalUrl: suggestedValue('link[rel="canonical"]', "href", {
+          removeSuffixes: ["/"],
+        }),
+        publishedAt: {
+          input: "url_date" as const,
+          selector: null,
+          attribute: null,
+          urlDateFormat: "/yyyy/MM/*-MMddyy",
+        },
+        score: {
+          value: suggestedValue(".rating", null, {
+            removePrefixes: ["Rating:"],
+          }),
+          scale: 100,
+          map: [
+            { text: "A", value: 95 },
+            { text: "B+", value: 87 },
+          ],
+        },
+      },
+    },
+  };
+  const checkRules = vi.fn(async () => ({
+    status: "passed" as const,
+    checked: "parsed mapped review",
+  }));
+
+  const result = await runScrapeSourceSetupAgent({
+    conversationId: "scrape_source:1",
+    externalSiteRunId: 10,
+    kind: "review",
+    scrapeSourceId: 1,
+    listPages: [
+      {
+        url: "https://example.test/reviews",
+        html: '<a class="review" href="/reviews/one">Review</a>',
+      },
+    ],
+    detailPages: [],
+    request: vi.fn().mockResolvedValue(toolCallResponse("mapped", candidate)),
+    checkRules,
+  });
+
+  expect(result.rules).toMatchObject({
+    detail: {
+      canonicalUrl: {
+        selector: 'link[rel="canonical"]',
+        attribute: "href",
+        removeSuffixes: ["/"],
+      },
+      publishedAt: { urlDateFormat: "/yyyy/MM/*-MMddyy" },
+      score: {
+        scale: 100,
+        map: [
+          { text: "A", value: 95 },
+          { text: "B+", value: 87 },
+        ],
+      },
+    },
+  });
+  expect(checkRules).toHaveBeenCalledOnce();
 });
 
 test("stops after the rule-check limit", async () => {

--- a/apps/server/src/scraper/configured/setupAgent.ts
+++ b/apps/server/src/scraper/configured/setupAgent.ts
@@ -15,6 +15,7 @@ import {
   ScrapeAttributeSchema,
   ScrapeRulesSchema,
   ScrapeSelectorSchema,
+  ScrapeUrlDateSchema,
   ScrapeValueSchema,
   type ScrapeListExclusion,
   type ScrapeRules,
@@ -26,7 +27,7 @@ import {
   type ScrapeSourceSetupFeedback,
 } from "./setupError";
 
-export const AI_INSTRUCTIONS_VERSION = "scrape-source-v10";
+export const AI_INSTRUCTIONS_VERSION = "scrape-source-v11";
 const MAX_AI_INPUT_CHARS = 200_000;
 export const MAX_SUGGESTION_DETAIL_PAGES = 3;
 const MAX_RULE_CHECKS = 3;
@@ -105,6 +106,44 @@ const SuggestedLinkSelectorSchema = z
   })
   .strict();
 
+const SuggestedPublishedAtSchema = z
+  .object({
+    input: z.enum(["selector", "url_date"]),
+    selector: ScrapeSelectorSchema.nullable(),
+    attribute: ScrapeAttributeSchema.nullable(),
+    urlDateFormat: z.string().trim().min(1).max(200).nullable(),
+  })
+  .strict()
+  .superRefine((rule, context) => {
+    if (
+      rule.input === "selector" &&
+      (!rule.selector || rule.urlDateFormat !== null)
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "A date selector requires selector and no URL date format.",
+      });
+    }
+    if (
+      rule.input === "url_date" &&
+      (rule.urlDateFormat === null ||
+        rule.selector !== null ||
+        rule.attribute !== null)
+    ) {
+      context.addIssue({
+        code: "custom",
+        message: "A URL date requires its format and no selector.",
+      });
+    }
+  });
+
+const SuggestedScoreMapEntrySchema = z
+  .object({
+    text: z.string().trim().min(1).max(100),
+    value: z.number().nonnegative(),
+  })
+  .strict();
+
 const SuggestedListExclusionSchema = z
   .object({
     selector: ScrapeSelectorSchema,
@@ -136,8 +175,9 @@ const SuggestedReviewRulesSchema = z
     list: SuggestedListRulesSchema,
     detail: z
       .object({
+        canonicalUrl: SuggestedValueSelectorSchema.nullable(),
         title: SuggestedValueSelectorSchema,
-        publishedAt: SuggestedValueSelectorSchema,
+        publishedAt: SuggestedPublishedAtSchema,
         reviewItem: ScrapeSelectorSchema,
         name: SuggestedValueSelectorSchema,
         reviewerName: SuggestedValueSelectorSchema.nullable(),
@@ -146,6 +186,7 @@ const SuggestedReviewRulesSchema = z
           .object({
             value: SuggestedValueSelectorSchema,
             scale: z.number().positive(),
+            map: z.array(SuggestedScoreMapEntrySchema).max(25).nullable(),
           })
           .strict()
           .nullable(),
@@ -239,6 +280,8 @@ const RULE_INSTRUCTIONS = [
   "Identify the content and attributes that represent each output field.",
   "Selectors must match the same field across the supplied detail pages.",
   "Review rules must read the publisher's publication date.",
+  "When a review date exists only in the canonical URL path, use url_date with a format made from yyyy, yy, MM, dd, and * tokens. Literal characters must match the path. Repeated date tokens must agree.",
+  "Set canonicalUrl only when the article's stored canonical URL needs to come from page markup or bounded cleanup such as removing a trailing slash. Otherwise set it to null.",
   "For reviews, reviewItem must select the complete content container for each reviewed bottle, including its introduction, tasting notes, and conclusion. Its text is retained internally for later parsing. Exclude navigation, comments, related articles, and other bottles' reviews.",
   "Use reviewText for a narrower tasting-notes container when available; otherwise select the review body. This text is used for flavor matching and short clips.",
   "Include an optional field when the supplied pages clearly and consistently provide it.",
@@ -256,6 +299,7 @@ const RULE_INSTRUCTIONS = [
   "For visible text, startsWith can keep elements beginning with one of up to 10 literal labels and all can join the matches in document order. Attribute selectors cannot use startsWith or all.",
   "After reading a value, removePrefixes and removeSuffixes can remove the first matching literal beginning or ending, then prefix and suffix can add literal text. Matching is case-insensitive. Set unused lists, prefix, and suffix to null and all to false.",
   "Use fixed values only for a fact that is stable and unambiguous across the selected source pages.",
+  "For a numeric score, set score map to null. For a publisher's finite text grades, map every accepted label to its numeric value on the declared scale.",
   "Use only fields allowed by check_rules.",
   "The listPages are the main page and likely list pages from the same website.",
   "The detailPages are optional examples of review or product pages.",
@@ -296,6 +340,19 @@ function toScrapeValue(value: SuggestedValueSelector): ScrapeValue {
   return ScrapeValueSchema.parse(rule);
 }
 
+function toPublishedAt(
+  value: z.infer<typeof SuggestedPublishedAtSchema>,
+): ReviewRules["detail"]["publishedAt"] {
+  if (value.input === "url_date") {
+    return ScrapeUrlDateSchema.parse({ urlDateFormat: value.urlDateFormat });
+  }
+  const rule: ScrapeSelectorCandidate = {
+    selector: value.selector,
+  };
+  if (value.attribute !== null) rule.attribute = value.attribute;
+  return ScrapeValueSchema.parse(rule);
+}
+
 function toScrapeLinkSelector(
   value: z.infer<typeof SuggestedLinkSelectorSchema>,
 ): ScrapeValueSelectorV1 {
@@ -326,11 +383,14 @@ function toScrapeList(input: SuggestedListRules): ReviewRules["list"] {
 function toReviewRules(input: SuggestedReviewRules): ScrapeRules {
   const detail: ReviewRules["detail"] = {
     title: toScrapeValue(input.detail.title),
-    publishedAt: toScrapeValue(input.detail.publishedAt),
+    publishedAt: toPublishedAt(input.detail.publishedAt),
     reviewItem: input.detail.reviewItem,
     name: toScrapeValue(input.detail.name),
   };
   const list = toScrapeList(input.list);
+  if (input.detail.canonicalUrl !== null) {
+    detail.canonicalUrl = toScrapeValue(input.detail.canonicalUrl);
+  }
   if (input.detail.reviewerName !== null) {
     detail.reviewerName = toScrapeValue(input.detail.reviewerName);
   }
@@ -342,6 +402,9 @@ function toReviewRules(input: SuggestedReviewRules): ScrapeRules {
       scale: input.detail.score.scale,
       value: toScrapeValue(input.detail.score.value),
     };
+    if (input.detail.score.map?.length) {
+      detail.score.map = input.detail.score.map;
+    }
   }
   return ScrapeRulesSchema.parse({ kind: input.kind, list, detail });
 }

--- a/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
+++ b/apps/server/src/scraper/configured/suggestion.price.eval.test.ts
@@ -17,6 +17,7 @@ import {
   createScrapeSourceSuggestionRun,
 } from "./runs";
 import { createSiteWithScrapeSource } from "./service";
+import { AI_INSTRUCTIONS_VERSION } from "./setupAgent";
 
 const SITE_ORIGIN = "https://price-fixture.test";
 const HOME_URL = `${SITE_ORIGIN}/`;
@@ -196,7 +197,7 @@ describe.skipIf(!isAIGatewayConfigured("scraper"))(
         .from(scrapeSourceRevisions)
         .where(eq(scrapeSourceRevisions.scrapeSourceId, source.id));
       expect(suggestedRevision).toMatchObject({
-        aiInstructionsVersion: "scrape-source-v7",
+        aiInstructionsVersion: AI_INSTRUCTIONS_VERSION,
         author: "ai",
         listUrl: LIST_URL,
         previewStatus: "pending",

--- a/docs/operations/configured-scraper-migration.md
+++ b/docs/operations/configured-scraper-migration.md
@@ -107,6 +107,29 @@ same review IDs recorded before applying without adding duplicate articles or
 reviews. Check the run and Sentry before restoring the saved schedule.
 Preparation must not change the source's publication setting.
 
+## The Whiskey Reviewer
+
+Use the preparation endpoint with `{"site": "whiskeyreviewer"}`. The check-only
+request verifies that each stored article has one review, uses the expected
+dated Whiskey Reviewer URL without a trailing slash, and still has the key
+written by the code scraper. Applying changes those review keys in place and
+adds a paused source whose list page is `https://whiskeyreviewer.com/`.
+
+Before applying, save the same review and run records and stop the
+`whiskeyreviewer` schedule. Version 3 rules must select only the five links in
+the Recent Reviews widget. They must read and remove the ending slash from the
+canonical link, derive the publication date from the dated URL, remove `Review`
+or the publisher's known `Rview` typo from the Bottle name, and map every
+publisher letter grade from A+ through F to its existing 100-point value. Run a
+full local no-write preview and compare all five current names, writers, dates,
+grade displays, selected tasting evidence, and review bodies with the code
+scraper.
+
+After applying, save and preview the reviewed version 3 revision. Activate only
+exact output, trigger one manual collection, and confirm that it updates the
+same article and review IDs without adding trailing-slash duplicates. Check
+Bottle matches, the run, and Sentry before restoring the saved schedule.
+
 ## Compass Box
 
 Use the same preparation endpoint with `{"site": "compassbox"}`. The check-only
@@ -163,9 +186,9 @@ handles reviews added after the switch. Do not delete source or run history.
 ## Other sources
 
 The preparation API is shared. It currently supports Bourbon Culture, Compass
-Box, Kilchoman, Whisky Saga, and The Whisky Study. Other sites are rejected
-without changing records. Add each site's conversion behind this route as its
-existing records are reviewed.
+Box, Kilchoman, The Whiskey Reviewer, Whisky Saga, and The Whisky Study. Other
+sites are rejected without changing records. Add each site's conversion behind
+this route as its existing records are reviewed.
 
 Prepare each source using its own rules for recognizing existing records.
 Articles with several reviews need a verified match for each review. Store


### PR DESCRIPTION
Saved review rules can now preserve a publisher-cleaned canonical URL, derive publication dates from a bounded URL-path format, and map a finite set of text grades to numeric scores. These additions are stored as rules version 3; existing version 1 and 2 revisions keep their original strict interpreters.

The Whiskey Reviewer can use those rules through the existing administrator preparation flow. Check-only validates every stored article and legacy review key, while apply changes keys in place and creates a paused source without replacing article or review IDs, Bottle matches, publication state, bodies, or run history. A full live no-write preview parsed the five current reviews in six controlled requests with exact names, writers, URL-derived dates, and A-through-F score semantics; activation and schedule restoration remain separate operator-reviewed steps.
