### PR TITLE
ci(evals): gate paid scraper checks

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -2,6 +2,7 @@ name: Evals
 
 permissions:
   contents: read
+  pull-requests: read
 
 on:
   pull_request:
@@ -31,9 +32,18 @@ jobs:
       scraper_requested: ${{ steps.gate.outputs.scraper_requested }}
       scraper_should_run: ${{ steps.gate.outputs.scraper_should_run }}
     steps:
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: changes
+        with:
+          filters: |
+            scraper_agent:
+              - "apps/server/src/scraper/configured/**"
+
       - id: gate
         env:
           AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}
+          INTERNAL_PR: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          SCRAPER_AGENT_CHANGED: ${{ steps.changes.outputs.scraper_agent }}
         run: |
           set -euo pipefail
 
@@ -47,6 +57,9 @@ jobs:
 
           scraper_requested=false
           if jq -e --arg label_name "$scraper_label" '.pull_request.labels[]?.name | select(. == $label_name)' "$GITHUB_EVENT_PATH" >/dev/null; then
+            scraper_requested=true
+          fi
+          if [[ "$SCRAPER_AGENT_CHANGED" == "true" && "$INTERNAL_PR" == "true" ]]; then
             scraper_requested=true
           fi
 
@@ -80,6 +93,7 @@ jobs:
             echo "- classifier requested: $classifier_requested"
             echo "- classifier will run: $classifier_should_run"
             echo "- scraper label: $scraper_label"
+            echo "- scraper code changed: $SCRAPER_AGENT_CHANGED"
             echo "- scraper requested: $scraper_requested"
             echo "- scraper will run: $scraper_should_run"
             echo "- gateway_ready: $gateway_ready"
@@ -87,7 +101,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
           if [[ "$classifier_requested" == "true" || "$scraper_requested" == "true" ]] && [[ "$gateway_ready" != "true" ]]; then
-            echo "::error::Eval labels require AI_GATEWAY_API_KEY."
+            echo "::error::Requested model checks require AI_GATEWAY_API_KEY."
             exit 1
           fi
 

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -25,9 +25,11 @@ jobs:
     name: "evals / gate"
     runs-on: ubuntu-latest
     outputs:
-      evals_requested: ${{ steps.gate.outputs.evals_requested }}
+      classifier_requested: ${{ steps.gate.outputs.classifier_requested }}
+      classifier_should_run: ${{ steps.gate.outputs.classifier_should_run }}
       gateway_ready: ${{ steps.gate.outputs.gateway_ready }}
-      should_run: ${{ steps.gate.outputs.should_run }}
+      scraper_requested: ${{ steps.gate.outputs.scraper_requested }}
+      scraper_should_run: ${{ steps.gate.outputs.scraper_should_run }}
     steps:
       - id: gate
         env:
@@ -35,16 +37,17 @@ jobs:
         run: |
           set -euo pipefail
 
-          label_name="trigger-evals"
-          action="$(jq -r '.action // ""' "$GITHUB_EVENT_PATH")"
+          classifier_label="trigger-evals"
+          scraper_label="trigger-evals-scraper"
 
-          evals_requested=false
-          if [[ "$action" == "labeled" ]]; then
-            if [[ "$(jq -r '.label.name // ""' "$GITHUB_EVENT_PATH")" == "$label_name" ]]; then
-              evals_requested=true
-            fi
-          elif jq -e --arg label_name "$label_name" '.pull_request.labels[]?.name | select(. == $label_name)' "$GITHUB_EVENT_PATH" >/dev/null; then
-            evals_requested=true
+          classifier_requested=false
+          if jq -e --arg label_name "$classifier_label" '.pull_request.labels[]?.name | select(. == $label_name)' "$GITHUB_EVENT_PATH" >/dev/null; then
+            classifier_requested=true
+          fi
+
+          scraper_requested=false
+          if jq -e --arg label_name "$scraper_label" '.pull_request.labels[]?.name | select(. == $label_name)' "$GITHUB_EVENT_PATH" >/dev/null; then
+            scraper_requested=true
           fi
 
           if [[ -n "${AI_GATEWAY_API_KEY:-}" ]]; then
@@ -53,35 +56,45 @@ jobs:
             gateway_ready=false
           fi
 
-          should_run=false
-          if [[ "$evals_requested" == "true" && "$gateway_ready" == "true" ]]; then
-            should_run=true
+          classifier_should_run=false
+          if [[ "$classifier_requested" == "true" && "$gateway_ready" == "true" ]]; then
+            classifier_should_run=true
+          fi
+
+          scraper_should_run=false
+          if [[ "$scraper_requested" == "true" && "$gateway_ready" == "true" ]]; then
+            scraper_should_run=true
           fi
 
           {
-            echo "evals_requested=$evals_requested"
+            echo "classifier_requested=$classifier_requested"
+            echo "classifier_should_run=$classifier_should_run"
             echo "gateway_ready=$gateway_ready"
-            echo "should_run=$should_run"
+            echo "scraper_requested=$scraper_requested"
+            echo "scraper_should_run=$scraper_should_run"
           } >> "$GITHUB_OUTPUT"
           {
             echo "## Eval Gate"
             echo
-            echo "- label: $label_name"
-            echo "- evals_requested: $evals_requested"
+            echo "- classifier label: $classifier_label"
+            echo "- classifier requested: $classifier_requested"
+            echo "- classifier will run: $classifier_should_run"
+            echo "- scraper label: $scraper_label"
+            echo "- scraper requested: $scraper_requested"
+            echo "- scraper will run: $scraper_should_run"
             echo "- gateway_ready: $gateway_ready"
-            echo "- will_run: $should_run"
             echo "- min_pass_rate: $EVAL_MIN_PASS_RATE"
           } >> "$GITHUB_STEP_SUMMARY"
 
-          if [[ "$evals_requested" == "true" && "$gateway_ready" != "true" ]]; then
-            echo "::error::The trigger-evals label requires AI_GATEWAY_API_KEY."
+          if [[ "$classifier_requested" == "true" || "$scraper_requested" == "true" ]] && [[ "$gateway_ready" != "true" ]]; then
+            echo "::error::Eval labels require AI_GATEWAY_API_KEY."
             exit 1
           fi
 
   evals:
     name: "evals / classifier"
     needs: gate
-    if: needs.gate.outputs.should_run == 'true'
+    if: needs.gate.outputs.classifier_should_run == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -143,7 +156,7 @@ jobs:
   scraper:
     name: "evals / scraper"
     needs: gate
-    if: needs.gate.outputs.should_run == 'true'
+    if: needs.gate.outputs.scraper_should_run == 'true'
     runs-on: ubuntu-latest
     env:
       AI_GATEWAY_API_KEY: ${{ secrets.AI_GATEWAY_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       packages: ${{ steps.filter.outputs.packages }}
       package_tests: ${{ steps.filter.outputs.package_tests }}
       repo: ${{ steps.filter.outputs.repo }}
+      scraper_agent: ${{ steps.filter.outputs.scraper_agent }}
       server: ${{ steps.filter.outputs.server }}
       web: ${{ steps.filter.outputs.web }}
     steps:
@@ -54,6 +55,8 @@ jobs:
               - "sgconfig.yml"
               - "tools/ast-grep/**"
               - "turbo.json"
+            scraper_agent:
+              - "apps/server/src/scraper/configured/**"
             server:
               - "apps/server/**"
               - "apps/cli/**"
@@ -254,7 +257,7 @@ jobs:
     timeout-minutes: 20
     needs: changes
     if: >-
-      (github.event_name == 'push' || needs.changes.outputs.ci == 'true' || needs.changes.outputs.repo == 'true' || needs.changes.outputs.server == 'true') &&
+      needs.changes.outputs.scraper_agent == 'true' &&
       (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:15432/test_peated_scraper

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,6 @@ jobs:
       packages: ${{ steps.filter.outputs.packages }}
       package_tests: ${{ steps.filter.outputs.package_tests }}
       repo: ${{ steps.filter.outputs.repo }}
-      scraper_agent: ${{ steps.filter.outputs.scraper_agent }}
       server: ${{ steps.filter.outputs.server }}
       web: ${{ steps.filter.outputs.web }}
     steps:
@@ -55,8 +54,6 @@ jobs:
               - "sgconfig.yml"
               - "tools/ast-grep/**"
               - "turbo.json"
-            scraper_agent:
-              - "apps/server/src/scraper/configured/**"
             server:
               - "apps/server/**"
               - "apps/cli/**"
@@ -250,55 +247,6 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Run server tests
         run: pnpm --filter @peated/server test:ci -- --shard=${{ matrix.shard }}/${{ matrix.total }}
-
-  scraper-tests:
-    name: "test / scraper"
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    needs: changes
-    if: >-
-      needs.changes.outputs.scraper_agent == 'true' &&
-      (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
-    env:
-      DATABASE_URL: postgresql://postgres:postgres@localhost:15432/test_peated_scraper
-      SCRAPER_SETUP_MODEL: spacexai/grok-4.5
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - name: Install pnpm
-        uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          run_install: false
-      - name: Setup Node
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: 24.18.0
-          cache: pnpm
-      - name: Start test services
-        run: docker compose up -d --wait --wait-timeout 120
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Run live scraper scenarios
-        env:
-          SCRAPER_AI_GATEWAY_API_KEY: ${{ secrets.SCRAPER_AI_GATEWAY_API_KEY || secrets.AI_GATEWAY_API_KEY }}
-        run: |
-          if [[ -z "$SCRAPER_AI_GATEWAY_API_KEY" ]]; then
-            echo "::error::Live scraper scenarios require SCRAPER_AI_GATEWAY_API_KEY or AI_GATEWAY_API_KEY."
-            exit 1
-          fi
-          pnpm evals:scraper:e2e \
-            --reporter=default \
-            --reporter=junit \
-            --outputFile.junit=junit.xml
-      - name: Upload scraper test results
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: scraper-live-test-results
-          path: apps/server/junit.xml
-          if-no-files-found: ignore
-          retention-days: 7
 
   package-tests:
     name: "test / packages"

--- a/docs/development/model-checks.md
+++ b/docs/development/model-checks.md
@@ -31,4 +31,12 @@ judgment that a repeatable code test cannot prove.
 - Run focused model checks while changing model behavior. Run the full suite
   once at a deliberate full-suite run.
 
+## Pull request checks
+
+- Add `trigger-evals` to run classifier model checks.
+- Add `trigger-evals-scraper` to run scraper model checks.
+- Scraper model checks also run automatically when files under
+  `apps/server/src/scraper/configured/` change in an internal pull request.
+- Ordinary `pnpm test` runs do not call a model.
+
 Exact wording or tool order can be checked when it is the product contract.


### PR DESCRIPTION
Paid scraper model checks now live only in the eval workflow. They run once when `apps/server/src/scraper/configured/` changes in an internal pull request or when the new `trigger-evals-scraper` label is applied.

Normal CI keeps the fixture-based scraper tests but no longer has a paid scraper job. The existing `trigger-evals` label now runs only classifier checks. Forked pull requests cannot run paid scraper checks, and the trigger behavior is documented with the model-check rules.
