### PR TITLE
fix(catalog): keep entity bottle counts correct

### DIFF
--- a/apps/server/src/lib/createBottle.test.ts
+++ b/apps/server/src/lib/createBottle.test.ts
@@ -8,6 +8,7 @@ import {
   bottles,
   bottlesToDistillers,
   changes,
+  entities,
   type User,
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
@@ -20,7 +21,7 @@ import {
   createOrReuseBottleInTransaction,
 } from "@peated/server/lib/createBottle";
 import * as workerClient from "@peated/server/lib/test/workerDispatch";
-import { and, eq } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { vi } from "vitest";
 
 function contextFor(user: User) {
@@ -109,6 +110,17 @@ describe("Bottle creation", () => {
     expect(bottleDistillers.map(({ distillerId }) => distillerId)).toEqual([
       distiller.id,
     ]);
+    expect(
+      await db
+        .select({ id: entities.id, totalBottles: entities.totalBottles })
+        .from(entities)
+        .where(inArray(entities.id, [brand.id, bottler.id, distiller.id]))
+        .orderBy(entities.id),
+    ).toEqual(
+      [brand.id, bottler.id, distiller.id]
+        .sort((left, right) => left - right)
+        .map((id) => ({ id, totalBottles: 1 })),
+    );
 
     const [change] = await db
       .select()

--- a/apps/server/src/lib/createBottle.ts
+++ b/apps/server/src/lib/createBottle.ts
@@ -35,6 +35,10 @@ import {
   queueEntityCreationVerification,
 } from "@peated/server/lib/catalogVerification";
 import { coerceToUpsert, upsertEntity } from "@peated/server/lib/db";
+import {
+  getBottleEntityLinks,
+  updateEntityBottleCounts,
+} from "@peated/server/lib/entityBottleCounts";
 import { formatBottleName } from "@peated/server/lib/format";
 import { logError } from "@peated/server/lib/log";
 import { resolveActiveBottleIds } from "@peated/server/lib/resolveActiveBottleIds";
@@ -622,6 +626,11 @@ export async function createBottleInTransaction(
     .set({ representativeBottleId: bottleResult.bottle.id })
     .where(eq(bottleGroups.id, group.id))
     .returning();
+
+  const bottleEntityLinks = await getBottleEntityLinks(tx, [
+    bottleResult.bottle.id,
+  ]);
+  await updateEntityBottleCounts(tx, [], bottleEntityLinks);
 
   return {
     ...bottleResult,

--- a/apps/server/src/lib/entityBottleCounts.test.ts
+++ b/apps/server/src/lib/entityBottleCounts.test.ts
@@ -1,0 +1,263 @@
+import { db } from "@peated/server/db";
+import { getPostgresConnectionConfig } from "@peated/server/db/connection";
+import { bottlesToDistillers, entities } from "@peated/server/db/schema";
+import waitError from "@peated/server/lib/test/waitError";
+import { eq } from "drizzle-orm";
+import pg from "pg";
+import {
+  EntityBottleCountError,
+  checkEntityBottleCounts,
+  getBottleEntityLinks,
+  repairEntityBottleCounts,
+  updateEntityBottleCounts,
+} from "./entityBottleCounts";
+
+const { Client } = pg;
+type NodePgClient = InstanceType<typeof Client>;
+
+async function waitForSessionBlockedBy(
+  observer: NodePgClient,
+  blockerPid: number,
+): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const result = await observer.query<{ pid: number }>(
+      `SELECT pid
+       FROM pg_stat_activity
+       WHERE $1 = ANY(pg_blocking_pids(pid))
+       LIMIT 1`,
+      [blockerPid],
+    );
+    if (result.rows.length) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("Timed out waiting for the Entity repair lock.");
+}
+
+describe("Entity Bottle counts", () => {
+  test("counts one Bottle once when an Entity fills every role", async ({
+    fixtures,
+  }) => {
+    const entity = await fixtures.Entity({ totalBottles: 0 });
+    const bottle = await fixtures.Bottle({
+      brandId: entity.id,
+      bottlerId: entity.id,
+      distillerIds: [entity.id],
+    });
+    await db
+      .update(entities)
+      .set({ totalBottles: 0 })
+      .where(eq(entities.id, entity.id));
+
+    await db.transaction(async (tx) => {
+      const after = await getBottleEntityLinks(tx, [bottle.id]);
+      await updateEntityBottleCounts(tx, [], after);
+    });
+
+    await expect(
+      db.query.entities.findFirst({ where: eq(entities.id, entity.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(checkEntityBottleCounts([entity.id])).resolves.toEqual([]);
+  });
+
+  test("updates only Entities whose Bottle links change", async ({
+    fixtures,
+  }) => {
+    const retained = await fixtures.Entity({ totalBottles: 1 });
+    const removed = await fixtures.Entity({ totalBottles: 1 });
+    const added = await fixtures.Entity({ totalBottles: 0 });
+    const bottle = await fixtures.Bottle({
+      brandId: retained.id,
+      distillerIds: [removed.id],
+    });
+    await db
+      .update(entities)
+      .set({ totalBottles: 1 })
+      .where(eq(entities.id, retained.id));
+    await db
+      .update(entities)
+      .set({ totalBottles: 1 })
+      .where(eq(entities.id, removed.id));
+    await db
+      .update(entities)
+      .set({ totalBottles: 0 })
+      .where(eq(entities.id, added.id));
+
+    await db.transaction(async (tx) => {
+      const before = await getBottleEntityLinks(tx, [bottle.id]);
+      await tx
+        .delete(bottlesToDistillers)
+        .where(eq(bottlesToDistillers.bottleId, bottle.id));
+      await tx.insert(bottlesToDistillers).values({
+        bottleId: bottle.id,
+        distillerId: added.id,
+      });
+      const after = await getBottleEntityLinks(tx, [bottle.id]);
+      await updateEntityBottleCounts(tx, before, after);
+    });
+
+    const rows = await db
+      .select({ id: entities.id, totalBottles: entities.totalBottles })
+      .from(entities)
+      .where(eq(entities.id, retained.id));
+    expect(rows).toEqual([{ id: retained.id, totalBottles: 1 }]);
+    await expect(
+      db.query.entities.findFirst({ where: eq(entities.id, removed.id) }),
+    ).resolves.toMatchObject({ totalBottles: 0 });
+    await expect(
+      db.query.entities.findFirst({ where: eq(entities.id, added.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+  });
+
+  test("rejects a change that would make a count negative", async ({
+    fixtures,
+  }) => {
+    const entity = await fixtures.Entity({ totalBottles: 0 });
+    const before = [{ bottleId: 10, entityIds: [entity.id] }];
+
+    const error = await waitError(
+      db.transaction((tx) => updateEntityBottleCounts(tx, before, [])),
+    );
+
+    expect(error).toBeInstanceOf(EntityBottleCountError);
+    expect(error).toMatchObject({
+      code: "negative_count",
+      entityId: entity.id,
+      change: -1,
+    });
+  });
+
+  test("rolls back earlier changes when an Entity is missing", async ({
+    fixtures,
+  }) => {
+    const entity = await fixtures.Entity({ totalBottles: 0 });
+    const missingEntityId = 2_147_483_647;
+
+    const error = await waitError(
+      db.transaction((tx) =>
+        updateEntityBottleCounts(
+          tx,
+          [],
+          [{ bottleId: 10, entityIds: [entity.id, missingEntityId] }],
+        ),
+      ),
+    );
+
+    expect(error).toBeInstanceOf(EntityBottleCountError);
+    expect(error).toMatchObject({
+      code: "missing_entity",
+      entityId: missingEntityId,
+      change: 1,
+    });
+    await expect(
+      db.query.entities.findFirst({ where: eq(entities.id, entity.id) }),
+    ).resolves.toMatchObject({ totalBottles: 0 });
+  });
+
+  test("counts two Bottles saved at the same time", async ({ fixtures }) => {
+    const entity = await fixtures.Entity({ totalBottles: 0 });
+    const first = await fixtures.Bottle({ brandId: entity.id });
+    const second = await fixtures.Bottle({ brandId: entity.id });
+    await db
+      .update(entities)
+      .set({ totalBottles: 0 })
+      .where(eq(entities.id, entity.id));
+
+    await Promise.all(
+      [first.id, second.id].map((bottleId) =>
+        db.transaction(async (tx) => {
+          const after = await getBottleEntityLinks(tx, [bottleId]);
+          await updateEntityBottleCounts(tx, [], after);
+        }),
+      ),
+    );
+
+    await expect(
+      db.query.entities.findFirst({ where: eq(entities.id, entity.id) }),
+    ).resolves.toMatchObject({ totalBottles: 2 });
+  });
+
+  test("finds and repairs wrong saved counts", async ({ fixtures }) => {
+    const wrong = await fixtures.Entity({ totalBottles: 8 });
+    const correctZero = await fixtures.Entity({ totalBottles: 0 });
+    await fixtures.Bottle({ brandId: wrong.id });
+    await db
+      .update(entities)
+      .set({ totalBottles: 8 })
+      .where(eq(entities.id, wrong.id));
+
+    await expect(
+      checkEntityBottleCounts([wrong.id, correctZero.id]),
+    ).resolves.toEqual([{ entityId: wrong.id, savedCount: 8, actualCount: 1 }]);
+    await expect(checkEntityBottleCounts([])).resolves.toEqual([]);
+
+    await expect(repairEntityBottleCounts([wrong.id])).resolves.toEqual([
+      { entityId: wrong.id, savedCount: 8, actualCount: 1 },
+    ]);
+    await expect(
+      checkEntityBottleCounts([wrong.id, correctZero.id]),
+    ).resolves.toEqual([]);
+  });
+
+  test("recounts after an earlier Bottle change commits", async ({
+    fixtures,
+  }) => {
+    const target = await fixtures.Entity();
+    const source = await fixtures.Entity();
+    await fixtures.Bottle({ brandId: target.id });
+    const movingBottle = await fixtures.Bottle({ brandId: source.id });
+    await db
+      .update(entities)
+      .set({ totalBottles: 0 })
+      .where(eq(entities.id, target.id));
+
+    const writer = new Client(getPostgresConnectionConfig());
+    const observer = new Client(getPostgresConnectionConfig());
+    let writerCommitted = false;
+    let repair: ReturnType<typeof repairEntityBottleCounts> | null = null;
+
+    await writer.connect();
+    await observer.connect();
+    try {
+      await writer.query("BEGIN");
+      const writerPid = (
+        await writer.query<{ pid: number }>("SELECT pg_backend_pid() AS pid")
+      ).rows[0]?.pid;
+      if (!writerPid) throw new Error("Unable to load Bottle writer pid.");
+
+      await writer.query("SELECT id FROM entity WHERE id = $1 FOR UPDATE", [
+        target.id,
+      ]);
+      await writer.query("UPDATE bottle SET brand_id = $2 WHERE id = $1", [
+        movingBottle.id,
+        target.id,
+      ]);
+      await writer.query(
+        "UPDATE entity SET total_bottles = total_bottles + 1 WHERE id = $1",
+        [target.id],
+      );
+
+      repair = repairEntityBottleCounts([target.id]);
+      void repair.catch(() => undefined);
+      await waitForSessionBlockedBy(observer, writerPid);
+
+      await writer.query("COMMIT");
+      writerCommitted = true;
+
+      await expect(repair).resolves.toEqual([
+        { entityId: target.id, savedCount: 1, actualCount: 2 },
+      ]);
+    } finally {
+      if (!writerCommitted) {
+        await writer.query("ROLLBACK").catch(() => undefined);
+      }
+      if (repair) await repair.catch(() => undefined);
+      await writer.end();
+      await observer.end();
+    }
+
+    await expect(
+      db.query.entities.findFirst({ where: eq(entities.id, target.id) }),
+    ).resolves.toMatchObject({ totalBottles: 2 });
+  });
+});

--- a/apps/server/src/lib/entityBottleCounts.test.ts
+++ b/apps/server/src/lib/entityBottleCounts.test.ts
@@ -1,14 +1,16 @@
 import { db } from "@peated/server/db";
 import { getPostgresConnectionConfig } from "@peated/server/db/connection";
-import { bottlesToDistillers, entities } from "@peated/server/db/schema";
-import waitError from "@peated/server/lib/test/waitError";
+import {
+  bottleTombstones,
+  bottlesToDistillers,
+  entities,
+} from "@peated/server/db/schema";
 import { eq } from "drizzle-orm";
 import pg from "pg";
 import {
-  EntityBottleCountError,
   checkEntityBottleCounts,
   getBottleEntityLinks,
-  repairEntityBottleCounts,
+  repairEntityBottleCount,
   updateEntityBottleCounts,
 } from "./entityBottleCounts";
 
@@ -109,22 +111,28 @@ describe("Entity Bottle counts", () => {
     ).resolves.toMatchObject({ totalBottles: 1 });
   });
 
-  test("rejects a change that would make a count negative", async ({
+  test("repairs an old undercount when removing a Bottle link", async ({
     fixtures,
   }) => {
     const entity = await fixtures.Entity({ totalBottles: 0 });
-    const before = [{ bottleId: 10, entityIds: [entity.id] }];
+    const removedBottle = await fixtures.Bottle({ brandId: entity.id });
+    await fixtures.Bottle({ brandId: entity.id });
+    await db
+      .update(entities)
+      .set({ totalBottles: 0 })
+      .where(eq(entities.id, entity.id));
 
-    const error = await waitError(
-      db.transaction((tx) => updateEntityBottleCounts(tx, before, [])),
-    );
-
-    expect(error).toBeInstanceOf(EntityBottleCountError);
-    expect(error).toMatchObject({
-      code: "negative_count",
-      entityId: entity.id,
-      change: -1,
+    await db.transaction(async (tx) => {
+      const before = await getBottleEntityLinks(tx, [removedBottle.id]);
+      await tx.insert(bottleTombstones).values({ bottleId: removedBottle.id });
+      const after = await getBottleEntityLinks(tx, [removedBottle.id]);
+      await updateEntityBottleCounts(tx, before, after);
     });
+
+    await expect(
+      db.query.entities.findFirst({ where: eq(entities.id, entity.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(checkEntityBottleCounts([entity.id])).resolves.toEqual([]);
   });
 
   test("rolls back earlier changes when an Entity is missing", async ({
@@ -133,7 +141,7 @@ describe("Entity Bottle counts", () => {
     const entity = await fixtures.Entity({ totalBottles: 0 });
     const missingEntityId = 2_147_483_647;
 
-    const error = await waitError(
+    await expect(
       db.transaction((tx) =>
         updateEntityBottleCounts(
           tx,
@@ -141,14 +149,9 @@ describe("Entity Bottle counts", () => {
           [{ bottleId: 10, entityIds: [entity.id, missingEntityId] }],
         ),
       ),
+    ).rejects.toThrow(
+      `Cannot update Bottle count: Entity ${missingEntityId} is missing.`,
     );
-
-    expect(error).toBeInstanceOf(EntityBottleCountError);
-    expect(error).toMatchObject({
-      code: "missing_entity",
-      entityId: missingEntityId,
-      change: 1,
-    });
     await expect(
       db.query.entities.findFirst({ where: eq(entities.id, entity.id) }),
     ).resolves.toMatchObject({ totalBottles: 0 });
@@ -191,9 +194,11 @@ describe("Entity Bottle counts", () => {
     ).resolves.toEqual([{ entityId: wrong.id, savedCount: 8, actualCount: 1 }]);
     await expect(checkEntityBottleCounts([])).resolves.toEqual([]);
 
-    await expect(repairEntityBottleCounts([wrong.id])).resolves.toEqual([
-      { entityId: wrong.id, savedCount: 8, actualCount: 1 },
-    ]);
+    await expect(repairEntityBottleCount(wrong.id)).resolves.toEqual({
+      entityId: wrong.id,
+      savedCount: 8,
+      actualCount: 1,
+    });
     await expect(
       checkEntityBottleCounts([wrong.id, correctZero.id]),
     ).resolves.toEqual([]);
@@ -214,7 +219,7 @@ describe("Entity Bottle counts", () => {
     const writer = new Client(getPostgresConnectionConfig());
     const observer = new Client(getPostgresConnectionConfig());
     let writerCommitted = false;
-    let repair: ReturnType<typeof repairEntityBottleCounts> | null = null;
+    let repair: ReturnType<typeof repairEntityBottleCount> | null = null;
 
     await writer.connect();
     await observer.connect();
@@ -237,16 +242,18 @@ describe("Entity Bottle counts", () => {
         [target.id],
       );
 
-      repair = repairEntityBottleCounts([target.id]);
+      repair = repairEntityBottleCount(target.id);
       void repair.catch(() => undefined);
       await waitForSessionBlockedBy(observer, writerPid);
 
       await writer.query("COMMIT");
       writerCommitted = true;
 
-      await expect(repair).resolves.toEqual([
-        { entityId: target.id, savedCount: 1, actualCount: 2 },
-      ]);
+      await expect(repair).resolves.toEqual({
+        entityId: target.id,
+        savedCount: 1,
+        actualCount: 2,
+      });
     } finally {
       if (!writerCommitted) {
         await writer.query("ROLLBACK").catch(() => undefined);

--- a/apps/server/src/lib/entityBottleCounts.ts
+++ b/apps/server/src/lib/entityBottleCounts.ts
@@ -1,0 +1,263 @@
+import { db, type AnyDatabase, type AnyTransaction } from "@peated/server/db";
+import {
+  bottleTombstones,
+  bottles,
+  bottlesToDistillers,
+  entities,
+} from "@peated/server/db/schema";
+import {
+  and,
+  asc,
+  eq,
+  gte,
+  inArray,
+  isNotNull,
+  isNull,
+  sql,
+} from "drizzle-orm";
+
+type BottleLinks = {
+  bottleId: number;
+  entityIds: number[];
+};
+
+type WrongCount = {
+  entityId: number;
+  savedCount: number;
+  actualCount: number;
+};
+
+type CountErrorCode = "missing_entity" | "negative_count";
+
+export class EntityBottleCountError extends Error {
+  constructor(
+    readonly code: CountErrorCode,
+    readonly entityId: number,
+    readonly change: number,
+  ) {
+    const reason =
+      code === "missing_entity"
+        ? "the Entity does not exist"
+        : "the Bottle count would be negative";
+    super(
+      `Cannot change the Bottle count for Entity ${entityId} by ${change}: ${reason}.`,
+    );
+    this.name = "EntityBottleCountError";
+  }
+}
+
+function uniqueSorted(values: readonly number[]): number[] {
+  return Array.from(new Set(values)).sort((left, right) => left - right);
+}
+
+/** Returns each active Bottle's unique Brand, Bottler, and Distillery IDs. */
+export async function getBottleEntityLinks(
+  tx: AnyTransaction,
+  bottleIds: readonly number[],
+): Promise<BottleLinks[]> {
+  const ids = uniqueSorted(bottleIds);
+  if (!ids.length) return [];
+
+  const rows = await tx
+    .select({
+      bottleId: bottles.id,
+      brandId: bottles.brandId,
+      bottlerId: bottles.bottlerId,
+      distillerId: bottlesToDistillers.distillerId,
+    })
+    .from(bottles)
+    .leftJoin(bottlesToDistillers, eq(bottlesToDistillers.bottleId, bottles.id))
+    .leftJoin(bottleTombstones, eq(bottleTombstones.bottleId, bottles.id))
+    .where(
+      and(
+        inArray(bottles.id, ids),
+        isNotNull(bottles.groupId),
+        isNull(bottleTombstones.bottleId),
+      ),
+    )
+    .orderBy(asc(bottles.id), asc(bottlesToDistillers.distillerId));
+
+  const links = new Map<number, Set<number>>();
+  for (const row of rows) {
+    const entityIds = links.get(row.bottleId) ?? new Set<number>();
+    entityIds.add(row.brandId);
+    if (row.bottlerId !== null) entityIds.add(row.bottlerId);
+    if (row.distillerId !== null) entityIds.add(row.distillerId);
+    links.set(row.bottleId, entityIds);
+  }
+
+  return Array.from(links, ([bottleId, entityIds]) => ({
+    bottleId,
+    entityIds: uniqueSorted(Array.from(entityIds)),
+  })).sort((left, right) => left.bottleId - right.bottleId);
+}
+
+function addBottleCountChanges(
+  countChanges: Map<number, number>,
+  links: readonly BottleLinks[],
+  change: number,
+) {
+  for (const { entityIds } of links) {
+    for (const entityId of uniqueSorted(entityIds)) {
+      countChanges.set(entityId, (countChanges.get(entityId) ?? 0) + change);
+    }
+  }
+}
+
+/** Saves the before-and-after link changes in the caller's Bottle transaction. */
+export async function updateEntityBottleCounts(
+  tx: AnyTransaction,
+  linksBefore: readonly BottleLinks[],
+  linksAfter: readonly BottleLinks[],
+): Promise<void> {
+  const countChanges = new Map<number, number>();
+  addBottleCountChanges(countChanges, linksBefore, -1);
+  addBottleCountChanges(countChanges, linksAfter, 1);
+
+  for (const [entityId, change] of Array.from(countChanges)
+    .filter(([, change]) => change !== 0)
+    .sort(([left], [right]) => left - right)) {
+    const [updatedEntity] = await tx
+      .update(entities)
+      .set({ totalBottles: sql`${entities.totalBottles} + ${change}` })
+      .where(
+        and(
+          eq(entities.id, entityId),
+          change < 0 ? gte(entities.totalBottles, -change) : undefined,
+        ),
+      )
+      .returning({ id: entities.id });
+    if (updatedEntity) continue;
+
+    const existingEntity = await tx
+      .select({ id: entities.id })
+      .from(entities)
+      .where(eq(entities.id, entityId))
+      .limit(1);
+    throw new EntityBottleCountError(
+      existingEntity.length ? "negative_count" : "missing_entity",
+      entityId,
+      change,
+    );
+  }
+}
+
+type CountQueryRow = {
+  entityId: number | string;
+  savedCount: number | string;
+  actualCount: number | string;
+};
+
+async function findWrongCounts(
+  database: AnyDatabase,
+  entityIds?: readonly number[],
+): Promise<WrongCount[]> {
+  const ids = entityIds === undefined ? undefined : uniqueSorted(entityIds);
+  if (ids?.length === 0) return [];
+  const entityFilter = ids ? inArray(entities.id, ids) : sql`TRUE`;
+  const brandFilter = ids ? inArray(bottles.brandId, ids) : sql`TRUE`;
+  const bottlerFilter = ids ? inArray(bottles.bottlerId, ids) : sql`TRUE`;
+  const distillerFilter = ids
+    ? inArray(bottlesToDistillers.distillerId, ids)
+    : sql`TRUE`;
+
+  const result = await database.execute<CountQueryRow>(sql`
+    WITH active_bottle_entities AS (
+      SELECT ${bottles.id} AS bottle_id, ${bottles.brandId} AS entity_id
+      FROM ${bottles}
+      WHERE ${bottles.groupId} IS NOT NULL
+        AND ${brandFilter}
+        AND NOT EXISTS (
+          SELECT 1 FROM ${bottleTombstones}
+          WHERE ${bottleTombstones.bottleId} = ${bottles.id}
+        )
+
+      UNION
+
+      SELECT ${bottles.id} AS bottle_id, ${bottles.bottlerId} AS entity_id
+      FROM ${bottles}
+      WHERE ${bottles.groupId} IS NOT NULL
+        AND ${bottles.bottlerId} IS NOT NULL
+        AND ${bottlerFilter}
+        AND NOT EXISTS (
+          SELECT 1 FROM ${bottleTombstones}
+          WHERE ${bottleTombstones.bottleId} = ${bottles.id}
+        )
+
+      UNION
+
+      SELECT ${bottles.id} AS bottle_id, ${bottlesToDistillers.distillerId} AS entity_id
+      FROM ${bottlesToDistillers}
+      INNER JOIN ${bottles}
+        ON ${bottles.id} = ${bottlesToDistillers.bottleId}
+      WHERE ${bottles.groupId} IS NOT NULL
+        AND ${distillerFilter}
+        AND NOT EXISTS (
+          SELECT 1 FROM ${bottleTombstones}
+          WHERE ${bottleTombstones.bottleId} = ${bottles.id}
+        )
+    ), actual_counts AS (
+      SELECT entity_id, COUNT(*) AS total
+      FROM active_bottle_entities
+      GROUP BY entity_id
+    )
+    SELECT
+      ${entities.id} AS "entityId",
+      ${entities.totalBottles} AS "savedCount",
+      COALESCE(actual_counts.total, 0) AS "actualCount"
+    FROM ${entities}
+    LEFT JOIN actual_counts ON actual_counts.entity_id = ${entities.id}
+    WHERE ${entityFilter}
+      AND ${entities.totalBottles} <> COALESCE(actual_counts.total, 0)
+    ORDER BY ${entities.id}
+  `);
+
+  return result.rows.map((row) => ({
+    entityId: Number(row.entityId),
+    savedCount: Number(row.savedCount),
+    actualCount: Number(row.actualCount),
+  }));
+}
+
+/** Checks saved Bottle counts against the Bottle links in the database. */
+export async function checkEntityBottleCounts(
+  entityIds?: readonly number[],
+): Promise<WrongCount[]> {
+  return findWrongCounts(db, entityIds);
+}
+
+/** Repairs one Entity after taking the row lock used by normal Bottle writes. */
+export async function repairEntityBottleCount(
+  entityId: number,
+): Promise<WrongCount | null> {
+  return db.transaction(async (tx) => {
+    const [entity] = await tx
+      .select({ id: entities.id })
+      .from(entities)
+      .where(eq(entities.id, entityId))
+      .for("update");
+    if (!entity) return null;
+
+    const [difference] = await findWrongCounts(tx, [entityId]);
+    if (!difference) return null;
+
+    await tx
+      .update(entities)
+      .set({ totalBottles: difference.actualCount })
+      .where(eq(entities.id, entityId));
+    return difference;
+  });
+}
+
+/** Repairs selected Entities one at a time so normal Bottle writes wait on one row. */
+export async function repairEntityBottleCounts(
+  entityIds: readonly number[],
+): Promise<WrongCount[]> {
+  const ids = uniqueSorted(entityIds);
+  const repaired: WrongCount[] = [];
+  for (const entityId of ids) {
+    const difference = await repairEntityBottleCount(entityId);
+    if (difference) repaired.push(difference);
+  }
+  return repaired;
+}

--- a/apps/server/src/lib/entityBottleCounts.ts
+++ b/apps/server/src/lib/entityBottleCounts.ts
@@ -27,25 +27,6 @@ type WrongCount = {
   actualCount: number;
 };
 
-type CountErrorCode = "missing_entity" | "negative_count";
-
-export class EntityBottleCountError extends Error {
-  constructor(
-    readonly code: CountErrorCode,
-    readonly entityId: number,
-    readonly change: number,
-  ) {
-    const reason =
-      code === "missing_entity"
-        ? "the Entity does not exist"
-        : "the Bottle count would be negative";
-    super(
-      `Cannot change the Bottle count for Entity ${entityId} by ${change}: ${reason}.`,
-    );
-    this.name = "EntityBottleCountError";
-  }
-}
-
 function uniqueSorted(values: readonly number[]): number[] {
   return Array.from(new Set(values)).sort((left, right) => left - right);
 }
@@ -117,6 +98,8 @@ export async function updateEntityBottleCounts(
   for (const [entityId, change] of Array.from(countChanges)
     .filter(([, change]) => change !== 0)
     .sort(([left], [right]) => left - right)) {
+    // Bottle writes own this count. If old data is too low, the locked recount
+    // below repairs this Entity without letting the saved count become negative.
     const [updatedEntity] = await tx
       .update(entities)
       .set({ totalBottles: sql`${entities.totalBottles} + ${change}` })
@@ -133,12 +116,15 @@ export async function updateEntityBottleCounts(
       .select({ id: entities.id })
       .from(entities)
       .where(eq(entities.id, entityId))
-      .limit(1);
-    throw new EntityBottleCountError(
-      existingEntity.length ? "negative_count" : "missing_entity",
-      entityId,
-      change,
-    );
+      .limit(1)
+      .for("update");
+    if (!existingEntity.length) {
+      throw new Error(
+        `Cannot update Bottle count: Entity ${entityId} is missing.`,
+      );
+    }
+
+    await repairExistingEntityBottleCount(tx, entityId);
   }
 }
 
@@ -219,6 +205,20 @@ async function findWrongCounts(
   }));
 }
 
+async function repairExistingEntityBottleCount(
+  tx: AnyTransaction,
+  entityId: number,
+): Promise<WrongCount | null> {
+  const [difference] = await findWrongCounts(tx, [entityId]);
+  if (!difference) return null;
+
+  await tx
+    .update(entities)
+    .set({ totalBottles: difference.actualCount })
+    .where(eq(entities.id, entityId));
+  return difference;
+}
+
 /** Checks saved Bottle counts against the Bottle links in the database. */
 export async function checkEntityBottleCounts(
   entityIds?: readonly number[],
@@ -238,26 +238,6 @@ export async function repairEntityBottleCount(
       .for("update");
     if (!entity) return null;
 
-    const [difference] = await findWrongCounts(tx, [entityId]);
-    if (!difference) return null;
-
-    await tx
-      .update(entities)
-      .set({ totalBottles: difference.actualCount })
-      .where(eq(entities.id, entityId));
-    return difference;
+    return repairExistingEntityBottleCount(tx, entityId);
   });
-}
-
-/** Repairs selected Entities one at a time so normal Bottle writes wait on one row. */
-export async function repairEntityBottleCounts(
-  entityIds: readonly number[],
-): Promise<WrongCount[]> {
-  const ids = uniqueSorted(entityIds);
-  const repaired: WrongCount[] = [];
-  for (const entityId of ids) {
-    const difference = await repairEntityBottleCount(entityId);
-    if (difference) repaired.push(difference);
-  }
-  return repaired;
 }

--- a/apps/server/src/lib/mergeBottles.test.ts
+++ b/apps/server/src/lib/mergeBottles.test.ts
@@ -13,6 +13,7 @@ import {
   changes,
   collectionBottles,
   collections,
+  entities,
   externalReviews,
   flightBottles,
   incomingBottleDecisionLogs,
@@ -242,6 +243,16 @@ describe("exact Bottle merges", () => {
         where: eq(bottleGroups.id, sourceGroupId),
       }),
     ).toBeUndefined();
+    expect(
+      await db.query.entities.findFirst({
+        where: eq(entities.id, source.brandId),
+      }),
+    ).toMatchObject({ totalBottles: 0 });
+    expect(
+      await db.query.entities.findFirst({
+        where: eq(entities.id, destination.brandId),
+      }),
+    ).toMatchObject({ totalBottles: 1 });
 
     expect(
       await db

--- a/apps/server/src/lib/mergeBottles.test.ts
+++ b/apps/server/src/lib/mergeBottles.test.ts
@@ -438,6 +438,38 @@ describe("exact Bottle merges", () => {
     });
   });
 
+  test("merges Bottles when their shared Entity count is too low", async ({
+    fixtures,
+  }) => {
+    const mod = await fixtures.User({ mod: true });
+    const brand = await fixtures.Entity({ name: "Low Count Merge Brand" });
+    const source = await fixtures.Bottle({
+      name: "Low Count Merge Source",
+      brandId: brand.id,
+    });
+    const destination = await fixtures.Bottle({
+      name: "Low Count Merge Destination",
+      brandId: brand.id,
+    });
+    await db
+      .update(entities)
+      .set({ totalBottles: 0 })
+      .where(eq(entities.id, brand.id));
+
+    await mergeBottles({
+      sourceBottleId: source.id,
+      destinationBottleId: destination.id,
+      context: contextFor(mod),
+    });
+
+    await expect(
+      db.query.bottles.findFirst({ where: eq(bottles.id, source.id) }),
+    ).resolves.toBeUndefined();
+    await expect(
+      db.query.entities.findFirst({ where: eq(entities.id, brand.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+  });
+
   test("keeps the most recently updated member review when both Bottles were reviewed", async ({
     fixtures,
   }) => {

--- a/apps/server/src/lib/mergeBottles.ts
+++ b/apps/server/src/lib/mergeBottles.ts
@@ -1,7 +1,6 @@
 /**
  * Owns exact-Bottle duplicate merges. The selected destination remains the
- * complete authoritative Bottle; consumer identity never passes through a
- * BottleGroup or another catalog target.
+ * complete Bottle. Related records move straight to that Bottle.
  */
 import { db, type AnyTransaction } from "@peated/server/db";
 import type { Bottle, User } from "@peated/server/db/schema";
@@ -31,6 +30,10 @@ import {
 } from "@peated/server/db/schema";
 import { getUserActor } from "@peated/server/lib/actors";
 import { moveBottleAliasesForMergeInTransaction } from "@peated/server/lib/bottleAliases";
+import {
+  getBottleEntityLinks,
+  updateEntityBottleCounts,
+} from "@peated/server/lib/entityBottleCounts";
 import { logError } from "@peated/server/lib/log";
 import { recomputeBottleGroupStatsInTransaction } from "@peated/server/lib/recomputeBottleGroupStats";
 import { recomputeBottleStatsInTransaction } from "@peated/server/lib/recomputeBottleStats";
@@ -764,6 +767,7 @@ export async function mergeBottlesInTransaction(
   ) {
     throw new BottleMergeGraphError("invalid_catalog_graph", sourceBottleId);
   }
+  const entityLinksBefore = await getBottleEntityLinks(tx, requestedBottleIds);
   const crossGroup = sourceGroupId !== destinationGroupId;
   const survivingSourceMembers = sourceMembers.filter(
     ({ id }) => id !== sourceBottleId,
@@ -938,6 +942,9 @@ export async function mergeBottlesInTransaction(
     .delete(bottlesToDistillers)
     .where(eq(bottlesToDistillers.bottleId, sourceBottleId));
   await tx.delete(bottles).where(eq(bottles.id, sourceBottleId));
+
+  const entityLinksAfter = await getBottleEntityLinks(tx, requestedBottleIds);
+  await updateEntityBottleCounts(tx, entityLinksBefore, entityLinksAfter);
 
   if (crossGroup && sourceSingleton) {
     await tx

--- a/apps/server/src/lib/test/fixtures.ts
+++ b/apps/server/src/lib/test/fixtures.ts
@@ -51,6 +51,10 @@ import { getUserActorByIdForDatabase } from "../actors";
 import { createAccessToken, generatePasswordHash } from "../auth";
 import { materializeBottleForGroup } from "../bottleIdentity";
 import { mapRows } from "../db";
+import {
+  getBottleEntityLinks,
+  updateEntityBottleCounts,
+} from "../entityBottleCounts";
 import { formatBottleName } from "../format";
 import { choose, random, sample } from "../rand";
 import {
@@ -577,7 +581,7 @@ async function createBottleFixture(
         })
       : await Entity(
           {
-            totalBottles: 1,
+            totalBottles: 0,
           },
           tx,
         );
@@ -713,6 +717,9 @@ async function createBottleFixture(
         });
       }
     }
+
+    const bottleEntityLinks = await getBottleEntityLinks(tx, [bottle.id]);
+    await updateEntityBottleCounts(tx, [], bottleEntityLinks);
 
     await tx
       .insert(bottleReferences)

--- a/apps/server/src/lib/updateBottle.test.ts
+++ b/apps/server/src/lib/updateBottle.test.ts
@@ -17,7 +17,7 @@ import {
   createBottle,
   type BottleCreateInput,
 } from "@peated/server/lib/createBottle";
-import { repairEntityBottleCounts } from "@peated/server/lib/entityBottleCounts";
+import { repairEntityBottleCount } from "@peated/server/lib/entityBottleCounts";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
 import waitError from "@peated/server/lib/test/waitError";
 import * as workerClient from "@peated/server/lib/test/workerDispatch";
@@ -693,6 +693,33 @@ describe("Bottle updates", () => {
     expect(workerClient.pushUniqueJob).not.toHaveBeenCalled();
   });
 
+  test("changes relationships when the old Entity count is too low", async ({
+    fixtures,
+  }) => {
+    const mod = await fixtures.User({ mod: true });
+    const oldBrand = await fixtures.Entity({ name: "Old Count Brand" });
+    const newBrand = await fixtures.Entity({ name: "New Count Brand" });
+    const movingBottle = await fixtures.Bottle({ brandId: oldBrand.id });
+    await fixtures.Bottle({ brandId: oldBrand.id });
+    await db
+      .update(entities)
+      .set({ totalBottles: 0 })
+      .where(eq(entities.id, oldBrand.id));
+
+    await updateBottle({
+      bottleId: movingBottle.id,
+      input: { brand: newBrand.id },
+      context: contextFor(mod),
+    });
+
+    await expect(
+      db.query.entities.findFirst({ where: eq(entities.id, oldBrand.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+    await expect(
+      db.query.entities.findFirst({ where: eq(entities.id, newBrand.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+  });
+
   test("migrates an exclusively used retained series when the brand changes", async ({
     fixtures,
   }) => {
@@ -1292,11 +1319,9 @@ describe("Bottle updates", () => {
     await db
       .delete(bottlesToDistillers)
       .where(eq(bottlesToDistillers.bottleId, members[1].bottle.id));
-    await repairEntityBottleCounts([
-      oldBrand.id,
-      oldBottler.id,
-      oldDistiller.id,
-    ]);
+    for (const entityId of [oldBrand.id, oldBottler.id, oldDistiller.id]) {
+      await repairEntityBottleCount(entityId);
+    }
     resetQueueMock();
 
     const result = await updateBottle({
@@ -1386,14 +1411,16 @@ describe("Bottle updates", () => {
       bottleId: repairedMemberId,
       distillerId: oldDistiller.id,
     });
-    await repairEntityBottleCounts([
+    for (const entityId of [
       oldBrand.id,
       oldBottler.id,
       oldDistiller.id,
       newBrand.id,
       newBottler.id,
       ...newDistillers.map(({ id }) => id),
-    ]);
+    ]) {
+      await repairEntityBottleCount(entityId);
+    }
     const staleTotalBottles = 99;
     await db
       .update(bottleGroups)

--- a/apps/server/src/lib/updateBottle.test.ts
+++ b/apps/server/src/lib/updateBottle.test.ts
@@ -17,6 +17,7 @@ import {
   createBottle,
   type BottleCreateInput,
 } from "@peated/server/lib/createBottle";
+import { repairEntityBottleCounts } from "@peated/server/lib/entityBottleCounts";
 import * as testFixtures from "@peated/server/lib/test/fixtures";
 import waitError from "@peated/server/lib/test/waitError";
 import * as workerClient from "@peated/server/lib/test/workerDispatch";
@@ -662,6 +663,20 @@ describe("Bottle updates", () => {
     expect(observedCommittedOwners).toBe(true);
     expect(ownerEntityIds).toEqual(expectedOwnerEntityIds);
     expect(new Set(ownerEntityIds).size).toBe(ownerEntityIds.length);
+    expect(
+      await db
+        .select({ id: entities.id, totalBottles: entities.totalBottles })
+        .from(entities)
+        .where(inArray(entities.id, expectedOwnerEntityIds))
+        .orderBy(asc(entities.id)),
+    ).toEqual(
+      expectedOwnerEntityIds.map((id) => ({
+        id,
+        totalBottles: [newBrand.id, newBottler.id, newDistiller.id].includes(id)
+          ? 1
+          : 0,
+      })),
+    );
 
     resetQueueMock();
     await expect(
@@ -1277,6 +1292,11 @@ describe("Bottle updates", () => {
     await db
       .delete(bottlesToDistillers)
       .where(eq(bottlesToDistillers.bottleId, members[1].bottle.id));
+    await repairEntityBottleCounts([
+      oldBrand.id,
+      oldBottler.id,
+      oldDistiller.id,
+    ]);
     resetQueueMock();
 
     const result = await updateBottle({
@@ -1366,6 +1386,14 @@ describe("Bottle updates", () => {
       bottleId: repairedMemberId,
       distillerId: oldDistiller.id,
     });
+    await repairEntityBottleCounts([
+      oldBrand.id,
+      oldBottler.id,
+      oldDistiller.id,
+      newBrand.id,
+      newBottler.id,
+      ...newDistillers.map(({ id }) => id),
+    ]);
     const staleTotalBottles = 99;
     await db
       .update(bottleGroups)

--- a/apps/server/src/lib/updateBottle.ts
+++ b/apps/server/src/lib/updateBottle.ts
@@ -49,6 +49,10 @@ import {
 } from "@peated/server/lib/bottleSchemas";
 import { queueEntityCreationVerification } from "@peated/server/lib/catalogVerification";
 import { coerceToUpsert, upsertEntity } from "@peated/server/lib/db";
+import {
+  getBottleEntityLinks,
+  updateEntityBottleCounts,
+} from "@peated/server/lib/entityBottleCounts";
 import { formatBottleName } from "@peated/server/lib/format";
 import { logError } from "@peated/server/lib/log";
 import type { Context } from "@peated/server/orpc/context";
@@ -153,9 +157,7 @@ export class BottleUpdateExpectedStateError extends Error {
 
 export class BottleUpdateExpectedBottleStateError extends Error {
   constructor(readonly bottleId: number) {
-    super(
-      `Bottle ${bottleId} exact content or membership changed before update.`,
-    );
+    super(`Bottle ${bottleId} details or links changed before the update.`);
     this.name = "BottleUpdateExpectedBottleStateError";
   }
 }
@@ -1062,7 +1064,7 @@ export async function lockBottleUpdateDependencies(
         .from(entities)
         .where(inArray(entities.id, entityIds))
         .orderBy(asc(entities.id))
-        .for("share")
+        .for("key share")
     : [];
 
   const [discoveredBottle] = await tx
@@ -1379,6 +1381,22 @@ export async function updateBottleInTransaction(
     ? members
     : members.filter(({ id }) => id === bottleId);
   const affectedIds = affectedMembers.map(({ id }) => id).sort((a, b) => a - b);
+  const bottleEntityLinksChanged = affectedMembers.some((member) => {
+    const desired = desiredByBottleId.get(member.id)!;
+    return (
+      member.brandId !== desired.brandId ||
+      member.bottlerId !== desired.bottlerId ||
+      !sameValues(
+        bottleDistillers.get(member.id) ?? [],
+        sharedChanged
+          ? stable.distillerIds
+          : (bottleDistillers.get(member.id) ?? []),
+      )
+    );
+  });
+  const entityLinksBefore = bottleEntityLinksChanged
+    ? await getBottleEntityLinks(tx, affectedIds)
+    : [];
 
   if (invalidateGeneratedDetails) {
     for (const member of affectedMembers) {
@@ -1629,6 +1647,16 @@ export async function updateBottleInTransaction(
         numReleases: sql`(SELECT COUNT(*) FROM ${bottles} WHERE ${bottles.seriesId} = ${seriesId})`,
       })
       .where(eq(bottleSeries.id, seriesId));
+  }
+
+  if (bottleEntityLinksChanged) {
+    const entityLinksAfter = await getBottleEntityLinks(tx, affectedIds);
+    await updateEntityBottleCounts(tx, entityLinksBefore, entityLinksAfter);
+    for (const links of [...entityLinksBefore, ...entityLinksAfter]) {
+      for (const entityId of links.entityIds) {
+        changedEntityIds.add(entityId);
+      }
+    }
   }
 
   return {

--- a/apps/server/src/orpc/routes/admin/index.ts
+++ b/apps/server/src/orpc/routes/admin/index.ts
@@ -2,9 +2,11 @@ import { base } from "../..";
 import catalogCoverage from "./catalog-coverage";
 import moderation from "./moderation";
 import oauthClients from "./oauth-clients";
+import repairBottleCounts from "./repair-bottle-counts";
 
 export default base.tag("admin").router({
   catalogCoverage,
   moderation,
   oauthClients,
+  repairBottleCounts,
 });

--- a/apps/server/src/orpc/routes/admin/repair-bottle-counts.test.ts
+++ b/apps/server/src/orpc/routes/admin/repair-bottle-counts.test.ts
@@ -1,0 +1,37 @@
+import waitError from "@peated/server/lib/test/waitError";
+import { pushUniqueJob } from "@peated/server/lib/test/workerDispatch";
+import { routerClient } from "@peated/server/orpc/router";
+
+describe("POST /admin/catalog/repair-bottle-counts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("queues one active repair for an administrator", async ({
+    fixtures,
+  }) => {
+    const admin = await fixtures.User({ admin: true });
+
+    await expect(
+      routerClient.admin.repairBottleCounts({}, { context: { user: admin } }),
+    ).resolves.toEqual({ status: "queued" });
+    expect(pushUniqueJob).toHaveBeenCalledWith(
+      "RepairEntityBottleCounts",
+      {},
+      {
+        delay: 0,
+      },
+    );
+  });
+
+  test("requires an administrator", async ({ fixtures }) => {
+    const user = await fixtures.User();
+
+    await expect(
+      waitError(
+        routerClient.admin.repairBottleCounts({}, { context: { user } }),
+      ),
+    ).resolves.toMatchObject({ message: "Unauthorized." });
+    expect(pushUniqueJob).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
+++ b/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
@@ -1,6 +1,6 @@
 import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
-import { pushUniqueJob } from "@peated/server/worker/client";
+import { pushUniqueJob } from "@peated/server/worker/dispatch";
 import { z } from "zod";
 
 export default procedure

--- a/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
+++ b/apps/server/src/orpc/routes/admin/repair-bottle-counts.ts
@@ -1,0 +1,27 @@
+import { procedure } from "@peated/server/orpc";
+import { requireAdmin } from "@peated/server/orpc/middleware";
+import { pushUniqueJob } from "@peated/server/worker/client";
+import { z } from "zod";
+
+export default procedure
+  .use(requireAdmin)
+  .route({
+    method: "POST",
+    path: "/admin/catalog/repair-bottle-counts",
+    summary: "Repair brand and producer bottle counts",
+    description:
+      "Check saved bottle totals for brands and producers, and fix any that are wrong. Requires administrator privileges.",
+    operationId: "repairEntityBottleCounts",
+  })
+  .input(z.object({}).strict().default({}))
+  .output(z.object({ status: z.literal("queued") }).strict())
+  .handler(async () => {
+    await pushUniqueJob(
+      "RepairEntityBottleCounts",
+      {},
+      {
+        delay: 0,
+      },
+    );
+    return { status: "queued" };
+  });

--- a/apps/server/src/orpc/routes/bottles/delete.test.ts
+++ b/apps/server/src/orpc/routes/bottles/delete.test.ts
@@ -140,6 +140,33 @@ describe("DELETE /bottles/:bottle", () => {
     ).toMatchObject({ totalBottles: 1 });
   });
 
+  test("deletes a Bottle when its Entity count is too low", async ({
+    fixtures,
+  }) => {
+    const user = await fixtures.User({ admin: true });
+    const brand = await fixtures.Entity();
+    const removedBottle = await fixtures.Bottle({ brandId: brand.id });
+    await fixtures.Bottle({ brandId: brand.id });
+    await db
+      .update(entities)
+      .set({ totalBottles: 0 })
+      .where(eq(entities.id, brand.id));
+
+    await routerClient.bottles.delete(
+      { bottle: removedBottle.id },
+      { context: { user } },
+    );
+
+    await expect(
+      db.query.bottles.findFirst({
+        where: eq(bottles.id, removedBottle.id),
+      }),
+    ).resolves.toBeUndefined();
+    await expect(
+      db.query.entities.findFirst({ where: eq(entities.id, brand.id) }),
+    ).resolves.toMatchObject({ totalBottles: 1 });
+  });
+
   test("blocks delete when the bottle is used in tastings", async ({
     fixtures,
   }) => {

--- a/apps/server/src/orpc/routes/bottles/delete.test.ts
+++ b/apps/server/src/orpc/routes/bottles/delete.test.ts
@@ -8,6 +8,7 @@ import {
   bottleSeries,
   bottles,
   collectionBottles,
+  entities,
   externalReviews,
   flightBottles,
   incomingBottleDecisionLogs,
@@ -132,6 +133,11 @@ describe("DELETE /bottles/:bottle", () => {
         where: eq(bottleSeries.id, series.id),
       }),
     ).toMatchObject({ numReleases: 1 });
+    expect(
+      await db.query.entities.findFirst({
+        where: eq(entities.id, representative.brandId),
+      }),
+    ).toMatchObject({ totalBottles: 1 });
   });
 
   test("blocks delete when the bottle is used in tastings", async ({

--- a/apps/server/src/orpc/routes/bottles/delete.ts
+++ b/apps/server/src/orpc/routes/bottles/delete.ts
@@ -61,7 +61,8 @@ export default procedure
   .handler(async function ({ input, context, errors }) {
     const { bottle: bottleId } = input;
     await db.transaction(async (tx) => {
-      // Keep new records from linking to this Bottle while it is being deleted.
+      // Bottle deletion owns this row lock so new records cannot link to the
+      // Bottle after the checks below pass.
       const [bottle] = await tx
         .select()
         .from(bottles)

--- a/apps/server/src/orpc/routes/bottles/delete.ts
+++ b/apps/server/src/orpc/routes/bottles/delete.ts
@@ -12,7 +12,6 @@ import {
   bottlesToDistillers,
   changes,
   collectionBottles,
-  entities,
   externalReviews,
   flightBottles,
   storePriceMatchProposals,
@@ -20,12 +19,15 @@ import {
   tastings,
 } from "@peated/server/db/schema";
 import { getUserActorForDatabase } from "@peated/server/lib/actors";
-import { notEmpty } from "@peated/server/lib/filter";
+import {
+  getBottleEntityLinks,
+  updateEntityBottleCounts,
+} from "@peated/server/lib/entityBottleCounts";
 import { logInfo } from "@peated/server/lib/log";
 import { recomputeBottleGroupStatsInTransaction } from "@peated/server/lib/recomputeBottleGroupStats";
 import { procedure } from "@peated/server/orpc";
 import { requireAdmin } from "@peated/server/orpc/middleware";
-import { and, asc, eq, gt, inArray, or, sql, type SQL } from "drizzle-orm";
+import { asc, eq, inArray, or, sql, type SQL } from "drizzle-orm";
 import { z } from "zod";
 
 function formatReferenceTypes(referenceTypes: string[]) {
@@ -59,8 +61,7 @@ export default procedure
   .handler(async function ({ input, context, errors }) {
     const { bottle: bottleId } = input;
     await db.transaction(async (tx) => {
-      // Lock the Bottle before checking references so new consumers cannot race
-      // the irreversible catalog retirement.
+      // Keep new records from linking to this Bottle while it is being deleted.
       const [bottle] = await tx
         .select()
         .from(bottles)
@@ -72,6 +73,8 @@ export default procedure
           message: "Bottle not found.",
         });
       }
+
+      const entityLinksBefore = await getBottleEntityLinks(tx, [bottle.id]);
 
       const distillerRows = await tx
         .select({ distillerId: bottlesToDistillers.distillerId })
@@ -180,20 +183,6 @@ export default procedure
           distillerIds,
         },
       });
-      await tx
-        .update(entities)
-        .set({ totalBottles: sql`${entities.totalBottles} - 1` })
-        .where(
-          and(
-            inArray(
-              entities.id,
-              Array.from(
-                new Set([bottle.brandId, ...distillerIds, bottle.bottlerId]),
-              ).filter(notEmpty),
-            ),
-            gt(entities.totalBottles, 0),
-          ),
-        );
       await tx.delete(bottleTags).where(eq(bottleTags.bottleId, bottle.id));
       await tx
         .delete(bottleFlavorProfiles)
@@ -263,6 +252,9 @@ export default procedure
         .delete(bottleAliases)
         .where(eq(bottleAliases.bottleId, bottle.id));
       await tx.delete(bottles).where(eq(bottles.id, bottle.id));
+
+      const entityLinksAfter = await getBottleEntityLinks(tx, [bottle.id]);
+      await updateEntityBottleCounts(tx, entityLinksBefore, entityLinksAfter);
 
       if (bottle.groupId !== null) {
         if (remainingGroupMemberIds.length === 0) {

--- a/apps/server/src/orpc/routes/entities/update.test.ts
+++ b/apps/server/src/orpc/routes/entities/update.test.ts
@@ -454,6 +454,10 @@ describe("PATCH /entities/:entity", () => {
     const otherBottle = await fixtures.Bottle({
       distillerIds: [entity.id],
     });
+    const [entityBeforeUpdate] = await db
+      .select()
+      .from(entities)
+      .where(eq(entities.id, entity.id));
 
     const modUser = await fixtures.User({ mod: true });
     const data = await routerClient.entities.update(
@@ -471,9 +475,9 @@ describe("PATCH /entities/:entity", () => {
       .from(entities)
       .where(eq(entities.id, data.id));
 
-    expect(omit(entity, "shortName", "searchVector", "updatedAt")).toEqual(
-      omit(newEntity, "shortName", "searchVector", "updatedAt"),
-    );
+    expect(
+      omit(entityBeforeUpdate, "shortName", "searchVector", "updatedAt"),
+    ).toEqual(omit(newEntity, "shortName", "searchVector", "updatedAt"));
     expect(newEntity.shortName).toBe("F");
 
     const [newBottle] = await db

--- a/apps/server/src/worker/jobs/index.ts
+++ b/apps/server/src/worker/jobs/index.ts
@@ -21,6 +21,7 @@ import onEntityChange from "./onEntityChange";
 import processNotification from "./processNotification";
 import processStorePriceMatchRetryRun from "./processStorePriceMatchRetryRun";
 import reconcileStorePriceMatchProposals from "./reconcileStorePriceMatchProposals";
+import repairEntityBottleCounts from "./repairEntityBottleCounts";
 import resolveStorePriceBottle from "./resolveStorePriceBottle";
 import runScraper from "./runScraper";
 import updateBottleStats from "./updateBottleStats";
@@ -51,6 +52,7 @@ registry.add("OnBottleChange", onBottleChange);
 registry.add("OnEntityChange", onEntityChange);
 registry.add("ProcessNotification", processNotification);
 registry.add("ProcessStorePriceMatchRetryRun", processStorePriceMatchRetryRun);
+registry.add("RepairEntityBottleCounts", repairEntityBottleCounts);
 registry.add(
   "ReconcileStorePriceMatchProposals",
   reconcileStorePriceMatchProposals,

--- a/apps/server/src/worker/jobs/mergeEntity.test.ts
+++ b/apps/server/src/worker/jobs/mergeEntity.test.ts
@@ -1111,7 +1111,7 @@ test("preflights exact batch duplicates from BottleGroup authority", async ({
   });
 });
 
-test("fans merged Bottle relationships through every BottleGroup member", async ({
+test("updates every Bottle in the merged BottleGroup", async ({
   defaults,
   fixtures,
 }) => {
@@ -1198,6 +1198,11 @@ test("fans merged Bottle relationships through every BottleGroup member", async 
     targetSeries!.id,
     targetSeries!.id,
   ]);
+  expect(
+    await db.query.entities.findFirst({
+      where: eq(entities.id, destinationEntity.id),
+    }),
+  ).toMatchObject({ totalBottles: 2 });
   expect(
     await db.query.changes.findFirst({
       where: and(

--- a/apps/server/src/worker/jobs/repairEntityBottleCounts.test.ts
+++ b/apps/server/src/worker/jobs/repairEntityBottleCounts.test.ts
@@ -1,0 +1,36 @@
+import { db } from "@peated/server/db";
+import { entities } from "@peated/server/db/schema";
+import { checkEntityBottleCounts } from "@peated/server/lib/entityBottleCounts";
+import { eq } from "drizzle-orm";
+import repairEntityBottleCountsJob from "./repairEntityBottleCounts";
+
+test("repairs wrong counts and is safe to run again", async ({ fixtures }) => {
+  const wrong = await fixtures.Entity();
+  const correct = await fixtures.Entity();
+  await fixtures.Bottle({ brandId: wrong.id });
+  await db
+    .update(entities)
+    .set({ totalBottles: 9 })
+    .where(eq(entities.id, wrong.id));
+
+  await expect(repairEntityBottleCountsJob({})).resolves.toEqual({
+    wrongCount: 1,
+    repairedCount: 1,
+  });
+  await expect(
+    checkEntityBottleCounts([wrong.id, correct.id]),
+  ).resolves.toEqual([]);
+
+  await expect(repairEntityBottleCountsJob({})).resolves.toEqual({
+    wrongCount: 0,
+    repairedCount: 0,
+  });
+});
+
+test.each([undefined, null, [], { unexpected: true }])(
+  "rejects malformed input %#",
+  async (input) => {
+    // SAFETY: The test deliberately passes invalid queue input through the runtime boundary.
+    await expect(repairEntityBottleCountsJob(input as never)).rejects.toThrow();
+  },
+);

--- a/apps/server/src/worker/jobs/repairEntityBottleCounts.test.ts
+++ b/apps/server/src/worker/jobs/repairEntityBottleCounts.test.ts
@@ -30,7 +30,7 @@ test("repairs wrong counts and is safe to run again", async ({ fixtures }) => {
 test.each([undefined, null, [], { unexpected: true }])(
   "rejects malformed input %#",
   async (input) => {
-    // SAFETY: The test deliberately passes invalid queue input through the runtime boundary.
+    // SAFETY: This test bypasses the type so the job can reject invalid queue input.
     await expect(repairEntityBottleCountsJob(input as never)).rejects.toThrow();
   },
 );

--- a/apps/server/src/worker/jobs/repairEntityBottleCounts.ts
+++ b/apps/server/src/worker/jobs/repairEntityBottleCounts.ts
@@ -1,0 +1,34 @@
+import {
+  checkEntityBottleCounts,
+  repairEntityBottleCount,
+} from "@peated/server/lib/entityBottleCounts";
+import { logInfo } from "@peated/server/lib/log";
+import { z } from "zod";
+import type { JobPayload } from "../types";
+
+export const RepairEntityBottleCountsJobArgsSchema = z.object({}).strict();
+
+export default async function repairEntityBottleCountsJob(input: JobPayload) {
+  RepairEntityBottleCountsJobArgsSchema.parse(input);
+
+  const wrongCounts = await checkEntityBottleCounts();
+  let repairedCount = 0;
+
+  for (const wrongCount of wrongCounts) {
+    if (await repairEntityBottleCount(wrongCount.entityId)) {
+      repairedCount += 1;
+    }
+  }
+
+  logInfo("Finished Bottle count repair", {
+    extra: {
+      wrongCount: wrongCounts.length,
+      repairedCount,
+    },
+  });
+
+  return {
+    wrongCount: wrongCounts.length,
+    repairedCount,
+  };
+}

--- a/apps/server/src/worker/jobs/updateEntityStats.test.ts
+++ b/apps/server/src/worker/jobs/updateEntityStats.test.ts
@@ -32,7 +32,7 @@ async function getEntity(entityId: number) {
   return entity;
 }
 
-test("counts direct active Bottles and tastings for every Entity association", async ({
+test("preserves the Bottle total and counts tastings for every Entity association", async ({
   fixtures,
 }) => {
   const entity = await fixtures.Entity({ name: "Direct Bottle Entity" });
@@ -48,11 +48,15 @@ test("counts direct active Bottles and tastings for every Entity association", a
     name: "Ungrouped Legacy Bottle",
     brandId: entity.id,
   });
+  await db
+    .update(entities)
+    .set({ totalBottles: 7 })
+    .where(eq(entities.id, entity.id));
 
   await updateEntityStats({ entityId: entity.id });
 
   expect(await getEntity(entity.id)).toMatchObject({
-    totalBottles: 3,
+    totalBottles: 7,
     totalTastings: 3,
   });
 });
@@ -122,6 +126,10 @@ test("excludes Bottle-tombstoned members and their tastings", async ({
     bottleId: retiredBottle.id,
     newBottleId: destination.id,
   });
+  await db
+    .update(entities)
+    .set({ totalBottles: 1 })
+    .where(eq(entities.id, entity.id));
 
   await updateEntityStats({ entityId: entity.id });
 

--- a/apps/server/src/worker/jobs/updateEntityStats.ts
+++ b/apps/server/src/worker/jobs/updateEntityStats.ts
@@ -31,25 +31,6 @@ export default async (input: JobPayload) => {
     await tx
       .update(entities)
       .set({
-        totalBottles: sql<string>`(
-          SELECT COUNT(*)
-          FROM ${bottles}
-          WHERE (
-            ${bottles.brandId} = ${entities.id}
-            OR ${bottles.bottlerId} = ${entities.id}
-            OR EXISTS(
-              SELECT FROM ${bottlesToDistillers}
-              WHERE ${bottlesToDistillers.bottleId} = ${bottles.id}
-              AND ${bottlesToDistillers.distillerId} = ${entities.id}
-            )
-          )
-          AND NOT EXISTS (
-            SELECT 1
-            FROM ${bottleTombstones}
-            WHERE ${bottleTombstones.bottleId} = ${bottles.id}
-          )
-          AND ${bottles.groupId} IS NOT NULL
-        )`,
         totalTastings: sql<string>`(
           SELECT COUNT(*)
           FROM ${tastings}

--- a/apps/server/src/worker/types.ts
+++ b/apps/server/src/worker/types.ts
@@ -22,6 +22,7 @@ export type JobName =
   | "OnEntityChange"
   | "ProcessStorePriceMatchRetryRun"
   | "ProcessNotification"
+  | "RepairEntityBottleCounts"
   | "ReconcileStorePriceMatchProposals"
   | "ResolveStorePriceBottle"
   | "RunScraper"

--- a/apps/web/src/components/admin/moderation/automationPage.tsx
+++ b/apps/web/src/components/admin/moderation/automationPage.tsx
@@ -38,12 +38,17 @@ export default function AutomationPage() {
   const cancel = useMutation(
     orpc.prices.matchQueue.cancelRetryRun.mutationOptions(),
   );
+  const repairBottleCounts = useMutation(
+    orpc.admin.repairBottleCounts.mutationOptions(),
+  );
   const activeRun = useSuspenseQuery(
     orpc.prices.matchQueue.activeRetryRun.queryOptions({
       refetchInterval: 5_000,
     }),
   );
   const [error, setError] = useState<string | null>(null);
+  const [repairNotice, setRepairNotice] = useState<string | null>(null);
+  const [repairError, setRepairError] = useState<string | null>(null);
 
   async function refresh() {
     await Promise.all([
@@ -84,6 +89,17 @@ export default function AutomationPage() {
     }
   }
 
+  async function startBottleCountRepair() {
+    setRepairNotice(null);
+    setRepairError(null);
+    try {
+      await repairBottleCounts.mutateAsync({});
+      setRepairNotice("Repair requested.");
+    } catch {
+      setRepairError("The repair could not be started. Try again.");
+    }
+  }
+
   return (
     <>
       <ModerationNav />
@@ -103,6 +119,28 @@ export default function AutomationPage() {
           <AdminStat label="Failed" value={data.counts.failed} />
           <AdminStat label="Cleared today" value={data.counts.clearedToday} />
         </AdminStatGrid>
+        <AdminSection
+          title="Bottle counts"
+          description="Check the bottle count for every brand and producer, and fix any that are wrong. You can keep editing bottles while this runs."
+          action={
+            <Button
+              disabled={repairBottleCounts.isPending}
+              loading={repairBottleCounts.isPending}
+              onClick={() => void startBottleCountRepair()}
+              size="sm"
+            >
+              Repair counts
+            </Button>
+          }
+        >
+          {repairError ? (
+            <Alert type="error">{repairError}</Alert>
+          ) : repairNotice ? (
+            <Alert type="success">{repairNotice}</Alert>
+          ) : (
+            "This checks one brand or producer at a time."
+          )}
+        </AdminSection>
         {activeRun.data.run ? (
           <AdminSection
             title={`Active listing retry · Run #${activeRun.data.run.id}`}

--- a/openspec/changes/make-entity-bottle-counters-transactional/.openspec.yaml
+++ b/openspec/changes/make-entity-bottle-counters-transactional/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/make-entity-bottle-counters-transactional/design.md
+++ b/openspec/changes/make-entity-bottle-counters-transactional/design.md
@@ -1,0 +1,100 @@
+## Context
+
+`Entity.totalBottles` is a saved count used by public lists and sorting. It currently comes from delayed `UpdateEntityStats` jobs. A queued job can be skipped, and each job must search all Bottle links after the Bottle change has already been saved. Earlier Peated code changed counts in several places, which caused wrong counts when Bottle roles changed.
+
+This change covers only the distinct active Bottle count on Entities. Entity tasting counts and Country and Region Bottle counts keep their current behavior for now.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Keep `Entity.totalBottles` correct at every successful normal catalog commit.
+- Make work per catalog mutation depend on the few affected relationships, not catalog size.
+- Count a Bottle once when the same Entity is its Brand, Bottler, and/or Distillery.
+- Give administrators a production-safe repair job for old wrong counts.
+- Keep count rules in one place so create, update, delete, and merge code does not repeat them.
+
+**Non-Goals:**
+
+- Changing Entity tasting counts or Country and Region Bottle counts.
+- Making direct SQL changes update counts automatically.
+- Adding database triggers, a shared event system, or counts split across several rows.
+- Changing public response shapes.
+
+## Decisions
+
+### Supported write-path inventory
+
+Normal relationship changes are owned by four transaction boundaries:
+
+- `createBottleInTransaction` inserts a Bottle and its Distillery rows.
+- `updateBottleInTransaction` changes Brand, Bottler, and Distillery rows for one BottleGroup.
+- the Bottle delete route removes one otherwise-unused Bottle.
+- `mergeBottlesInTransaction` moves consumers and removes the source Bottle.
+
+Entity merge, Bottle operation execution, generated-detail repair, Brand repair, Series merge, and price matching delegate relationship changes to the update or merge boundaries above. Other direct Bottle updates found in search indexing, image handling, photo identification, references, price maintenance, statistics, and Series merge do not change Brand, Bottler, Distillery, or active state. Direct migration or maintenance SQL remains covered by post-operation verification rather than the runtime helper.
+
+### Compare Bottle links before and after a change
+
+The shared count code reads each Bottle's Brand, Bottler, and Distillery IDs inside the Bottle transaction. Each `(bottleId, entityId)` pair is included once, even when the Entity fills more than one role. A Bottle counts only when it has a BottleGroup and no tombstone.
+
+Callers read these links before changing a Bottle and again after the change. The shared code finds the links that were added or removed, then combines the changes for each Entity.
+
+This avoids trusting request input and handles one Entity occupying several Bottle roles without special cases.
+
+### Update counts in the Bottle transaction
+
+Affected Entity rows are updated in ID order using `totalBottles = totalBottles + change`. The transaction fails if an Entity is missing or a decrease would make its count negative. The code does not replace a negative result with zero because that would hide an existing data problem.
+
+Normal work depends only on the few affected Entities. Brief row locks make two changes to the same Entity wait their turn, so neither count is lost.
+
+Counting every Bottle after each change was considered, but it gets slower as an Entity gains Bottles. A queued count was also considered, but the Bottle and its count could then disagree until the job finishes.
+
+### Repair one Entity at a time
+
+A separate query calculates the actual count from active Bottle links. Tests
+compare saved counts with this query after normal Bottle operations. A separate
+helper locks, recounts, and repairs one Entity.
+
+The admin Automation screen can start one background job. The job first finds
+wrong counts with a read-only query. It then repairs only those Entities, one at
+a time. Each repair locks the Entity row before recounting and commits
+immediately. Normal Bottle transactions update that same row, so a Bottle edit
+either finishes before the repair recounts or waits briefly and applies its
+change after the repair. No catalog-wide pause is needed.
+
+The job is safe to run again. Starting it more than once while it is waiting or
+running does not create another copy. It records which administrator started it
+and logs how many counts were wrong and repaired.
+
+Normal Bottle writes do not run the full check. Keeping it separate helps find a
+missed write path or an old wrong count without slowing normal requests.
+
+This change does not add a CLI command. Peated does not normally run its CLI in
+production. The admin-only route starts the repair through the normal worker.
+
+### Remove only Entity Bottle recounting from the worker
+
+`UpdateEntityStats` stops writing `totalBottles`. It still updates `totalTastings` and starts the existing Country and Region jobs, so this change does not alter unrelated counts.
+
+## Risks / Trade-offs
+
+- [A Bottle write path skips the shared count code] → List every direct Bottle and Bottle-Distillery write and test every supported Bottle operation against the separate count check.
+- [A production count is already wrong] → Start the admin repair job. It
+  checks all counts, then locks and repairs one affected Entity at a time.
+- [Two writes change the same Entity] → Update Entity rows in ID order so both Bottle changes are counted.
+- [A decrease would take a count below zero] → Stop the Bottle transaction and repair the saved count before retrying.
+- [Maintenance SQL changes Bottle links directly] → Run the count check after each limited maintenance operation. Automatic database triggers remain out of scope.
+
+## Migration Plan
+
+1. Add shared code to read Bottle links, update counts, check counts, and repair counts.
+2. Use it for Bottle creation, editing, deletion, Bottle merge, and Entity merge.
+3. Stop the Entity worker from overwriting `totalBottles` and update worker tests.
+4. Leave the Entity CLI unchanged.
+5. Start the repair from the admin Automation screen after deployment.
+6. Review the worker log, which records how many counts were wrong and fixed.
+
+## Open Questions
+
+- Whether Entity `totalTastings` or Country and Region Bottle counts should be changed next.

--- a/openspec/changes/make-entity-bottle-counters-transactional/design.md
+++ b/openspec/changes/make-entity-bottle-counters-transactional/design.md
@@ -44,7 +44,7 @@ This avoids trusting request input and handles one Entity occupying several Bott
 
 ### Update counts in the Bottle transaction
 
-Affected Entity rows are updated in ID order using `totalBottles = totalBottles + change`. The transaction fails if an Entity is missing or a decrease would make its count negative. The code does not replace a negative result with zero because that would hide an existing data problem.
+Affected Entity rows are updated in ID order using `totalBottles = totalBottles + change`. The transaction fails if an Entity is missing. If a decrease exposes an old undercount, the transaction locks that Entity and saves the exact count from the active Bottle links after the change. It does not replace a negative result with zero because other active Bottles may remain.
 
 Normal work depends only on the few affected Entities. Brief row locks make two changes to the same Entity wait their turn, so neither count is lost.
 
@@ -83,7 +83,7 @@ production. The admin-only route starts the repair through the normal worker.
 - [A production count is already wrong] → Start the admin repair job. It
   checks all counts, then locks and repairs one affected Entity at a time.
 - [Two writes change the same Entity] → Update Entity rows in ID order so both Bottle changes are counted.
-- [A decrease would take a count below zero] → Stop the Bottle transaction and repair the saved count before retrying.
+- [A decrease exposes an old undercount] → Lock and recount that Entity inside the current Bottle transaction so deletion, updates, and merges do not depend on a separate repair first.
 - [Maintenance SQL changes Bottle links directly] → Run the count check after each limited maintenance operation. Automatic database triggers remain out of scope.
 
 ## Migration Plan

--- a/openspec/changes/make-entity-bottle-counters-transactional/proposal.md
+++ b/openspec/changes/make-entity-bottle-counters-transactional/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+Entity Bottle totals are recalculated through a delayed chain of queue jobs that can be dropped, repeated, or retained after completion. The totals must remain correct while supporting fast sorting as the catalog grows.
+
+## What Changes
+
+- Update each affected Entity's `totalBottles` in the same transaction that creates, edits, deletes, or merges a Bottle.
+- Calculate changes from unique before-and-after Bottle relationships so an Entity linked in more than one role is counted once.
+- Add an admin-started worker job that finds and repairs wrong counts from saved
+  Bottle links while normal Bottle edits continue.
+- Stop the normal Entity statistics worker from recalculating `totalBottles`; retain unrelated statistics work until it is migrated separately.
+- Cover normal catalog operations and concurrent updates with integration tests.
+
+## Capabilities
+
+### New Capabilities
+
+- `catalog-counters`: Correct catalog counts that are updated with each Bottle change and can be checked or repaired.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Bottle creation, editing, deletion, and merge transactions.
+- Entity statistics workers and the jobs they start.
+- Server count helpers, the admin Automation screen, worker jobs, and integration
+  tests. The Entity CLI stays unchanged.
+- No public API shape changes and no new runtime dependency.

--- a/openspec/changes/make-entity-bottle-counters-transactional/specs/catalog-counters/spec.md
+++ b/openspec/changes/make-entity-bottle-counters-transactional/specs/catalog-counters/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Transactional Entity Bottle totals
+
+The system SHALL update every affected Entity's distinct active Bottle count in the same transaction that changes the saved Bottle links.
+
+#### Scenario: Create an active Bottle
+
+- **WHEN** a Bottle is created with Brand, optional Bottler, and Distillery relationships
+- **THEN** each unique related Entity's Bottle total increases by one in the creation transaction
+
+#### Scenario: Change Bottle relationships
+
+- **WHEN** an active Bottle changes any Brand, Bottler, or Distillery relationship
+- **THEN** counts change only for Entities whose Bottle links changed
+
+#### Scenario: Delete or merge Bottles
+
+- **WHEN** a Bottle is deleted or merged into another Bottle
+- **THEN** each affected Entity total reflects the active Bottles remaining at commit
+
+#### Scenario: One Entity has several roles
+
+- **WHEN** one Entity is related to the same Bottle as Brand, Bottler, and/or Distillery
+- **THEN** that Bottle contributes exactly one to the Entity total
+
+### Requirement: Safe count updates
+
+The system SHALL save Entity Bottle count changes in the Bottle transaction and SHALL reject a change that refers to a missing Entity or would produce a negative count.
+
+#### Scenario: Concurrent Bottle creation
+
+- **WHEN** concurrent transactions add different Bottles related to the same Entity
+- **THEN** the final Entity total includes both Bottles without a lost update
+
+#### Scenario: Invalid decrease
+
+- **WHEN** a change would take the saved count below zero
+- **THEN** the Bottle transaction fails without changing the Bottle or count
+
+### Requirement: Separate count check
+
+The system SHALL calculate Entity Bottle counts from active saved Bottle links without using the regular count update code.
+
+#### Scenario: Check correct counts
+
+- **WHEN** stored Entity totals equal the independent calculation
+- **THEN** the check reports no differences and changes no data
+
+#### Scenario: Detect and repair drift
+
+- **WHEN** a saved Entity count differs from the count shown by Bottle links
+- **THEN** the check identifies the Entity, saved count, and actual count, and an explicit repair saves the actual count
+
+#### Scenario: Repair while Bottle edits continue
+
+- **WHEN** an administrator starts the repair job while Bottle edits are being saved
+- **THEN** each wrong Entity count is locked, recounted, and saved separately without losing a concurrent Bottle count change
+
+#### Scenario: Start the same repair twice
+
+- **WHEN** an administrator starts the repair while the same job is queued or running
+- **THEN** the system keeps one active repair job
+
+### Requirement: Queue independence
+
+Normal Entity Bottle total correctness SHALL NOT depend on a queued job completing.
+
+#### Scenario: Post-save worker does not run
+
+- **WHEN** a Bottle catalog transaction commits and no post-save worker runs
+- **THEN** every affected Entity Bottle total is already correct

--- a/openspec/changes/make-entity-bottle-counters-transactional/specs/catalog-counters/spec.md
+++ b/openspec/changes/make-entity-bottle-counters-transactional/specs/catalog-counters/spec.md
@@ -26,17 +26,17 @@ The system SHALL update every affected Entity's distinct active Bottle count in 
 
 ### Requirement: Safe count updates
 
-The system SHALL save Entity Bottle count changes in the Bottle transaction and SHALL reject a change that refers to a missing Entity or would produce a negative count.
+The system SHALL save Entity Bottle count changes in the Bottle transaction, SHALL reject a change that refers to a missing Entity, and SHALL repair an old undercount exposed by a valid Bottle change.
 
 #### Scenario: Concurrent Bottle creation
 
 - **WHEN** concurrent transactions add different Bottles related to the same Entity
 - **THEN** the final Entity total includes both Bottles without a lost update
 
-#### Scenario: Invalid decrease
+#### Scenario: Existing undercount
 
-- **WHEN** a change would take the saved count below zero
-- **THEN** the Bottle transaction fails without changing the Bottle or count
+- **WHEN** deleting, merging, or updating a Bottle exposes a saved Entity count that is too low for the required decrease
+- **THEN** the transaction locks that Entity, saves its exact count from the remaining active Bottle links, and completes the Bottle change
 
 ### Requirement: Separate count check
 

--- a/openspec/changes/make-entity-bottle-counters-transactional/tasks.md
+++ b/openspec/changes/make-entity-bottle-counters-transactional/tasks.md
@@ -1,8 +1,9 @@
 ## 1. Shared Bottle Count Code
 
 - [x] 1.1 List the Bottle write paths and define the saved Bottle links needed before and after a change.
-- [x] 1.2 Update Entity Bottle counts in the Bottle transaction, and reject missing Entities or negative counts.
+- [x] 1.2 Update Entity Bottle counts in the Bottle transaction, reject missing Entities, and prevent negative counts.
 - [x] 1.3 Add a separate way to check and repair Entity Bottle counts.
+- [x] 1.4 Repair an old undercount inside the current Bottle transaction instead of blocking a valid write.
 
 ## 2. Bottle Writes
 
@@ -26,3 +27,4 @@
 - [x] 4.4 Test the repair lock, worker retries, admin permission, and dispatch behavior.
 - [x] 4.5 Run focused tests, server and web typechecks, lint, formatting, and OpenSpec validation for the repair job.
 - [x] 4.6 Simplify count-change code, names, logs, admin copy, and matching documentation.
+- [x] 4.7 Cover addition, deletion, relationship update, and Bottle merge behavior, including low saved counts on paths that decrease.

--- a/openspec/changes/make-entity-bottle-counters-transactional/tasks.md
+++ b/openspec/changes/make-entity-bottle-counters-transactional/tasks.md
@@ -1,0 +1,28 @@
+## 1. Shared Bottle Count Code
+
+- [x] 1.1 List the Bottle write paths and define the saved Bottle links needed before and after a change.
+- [x] 1.2 Update Entity Bottle counts in the Bottle transaction, and reject missing Entities or negative counts.
+- [x] 1.3 Add a separate way to check and repair Entity Bottle counts.
+
+## 2. Bottle Writes
+
+- [x] 2.1 Update Bottle creation and editing transactions to maintain Entity Bottle totals.
+- [x] 2.2 Update Bottle deletion and Bottle merge transactions to maintain Entity Bottle totals.
+- [x] 2.3 Update Entity merge transactions to maintain target Entity Bottle totals.
+
+## 3. Queue And Repair Code
+
+- [x] 3.1 Stop Entity statistics jobs from recalculating Bottle totals while preserving the remaining tasting and location work.
+- [x] 3.2 Leave the Entity CLI unchanged and keep check and repair code on the server.
+- [x] 3.3 Repair wrong counts one Entity at a time while Bottle edits continue.
+- [x] 3.4 Add a strict worker job and an admin-only route that starts one active repair.
+- [x] 3.5 Add the repair action to the admin Automation screen with clear start and failure states.
+
+## 4. Checks
+
+- [x] 4.1 Add integration coverage for create, relationship update, delete, Bottle merge, duplicate roles, and concurrent changes.
+- [x] 4.2 Test correct, wrong, zero, selected, and repaired Entity Bottle counts.
+- [x] 4.3 Run focused tests, server typechecks, lint, formatting, and OpenSpec validation.
+- [x] 4.4 Test the repair lock, worker retries, admin permission, and dispatch behavior.
+- [x] 4.5 Run focused tests, server and web typechecks, lint, formatting, and OpenSpec validation for the repair job.
+- [x] 4.6 Simplify count-change code, names, logs, admin copy, and matching documentation.


### PR DESCRIPTION
Entity Bottle totals now change in the same database transaction as Bottle creation, relationship edits, deletion, and merges. Counts use unique Brand, Bottler, and Distillery links, so one Bottle contributes once even when an Entity fills several roles. The existing Entity statistics job no longer recounts Bottle totals, removing the delayed queue dependency from normal updates.

Normal writes use small direct count changes. If a deletion, relationship update, or merge exposes an old undercount, the transaction locks that Entity and saves the exact count from its remaining active Bottle links instead of blocking the valid Bottle operation. That slower count runs only when damaged saved data would otherwise produce a negative total.

Admins can start a repair from the Automation screen for existing bad totals. The worker finds mismatches, then locks and recounts one Entity at a time, so normal Bottle edits can continue without losing count changes. Repeated starts share one active job; successful jobs are removed so it can run again, while failed jobs remain available for diagnosis.

The main review risk is transaction ordering across Bottle and Entity merges. Integration coverage exercises creation, relationship changes, deletion, merges, old undercounts, duplicate roles, concurrent writes, repair locking, admin permission, and unique-job dispatch.

Refs #1042
