### PR TITLE
fix(scrapers): preserve strict rules over REST

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/create-revision.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/create-revision.test.ts
@@ -1,3 +1,4 @@
+import { app } from "@peated/server/app";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { describe, expect, test } from "vitest";
@@ -73,6 +74,67 @@ describe("POST /admin/scrape-sources/:id/revisions", () => {
       author: "person",
       previewStatus: "pending",
       revision: 1,
+    });
+  });
+
+  test("saves strict union rules over HTTP", async ({ fixtures }) => {
+    const admin = await fixtures.User({ admin: true });
+    const token = await fixtures.AuthToken({ user: admin });
+    const { source } = await createTestSource(admin.id);
+    const response = await app.request(
+      `/v1/admin/scrape-sources/${source.id}/revisions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          listUrl: source.listUrl,
+          rules: {
+            ...reviewRules,
+            detail: {
+              ...reviewRules.detail,
+              canonicalUrl: {
+                selector: 'link[rel="canonical"]',
+                attribute: "href",
+                removeSuffixes: ["/"],
+              },
+            },
+          },
+        }),
+      },
+      {
+        incoming: {
+          socket: {
+            remoteAddress: "127.0.0.1",
+            remotePort: 12345,
+            remoteFamily: "IPv4",
+          },
+        },
+      },
+    );
+
+    expect({
+      status: response.status,
+      body: await response.json(),
+    }).toMatchObject({
+      status: 200,
+      body: {
+        active: false,
+        author: "person",
+        previewStatus: "pending",
+        revision: 1,
+        rules: {
+          detail: {
+            canonicalUrl: {
+              selector: 'link[rel="canonical"]',
+              attribute: "href",
+              removeSuffixes: ["/"],
+            },
+          },
+        },
+      },
     });
   });
 });

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/create-revision.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/create-revision.ts
@@ -14,6 +14,14 @@ import { serialize } from "@peated/server/serializers";
 import { ScrapeSourceRevisionSerializer } from "@peated/server/serializers/scrapeSource";
 import { z } from "zod";
 
+// The OpenAPI boundary owns number coercion, but its experimental coercion
+// cannot safely inspect unions of strict object shapes. Keep scraper rules
+// intact here; the inner schema still performs their full validation.
+const ScrapeRulesInputSchema = z.preprocess(
+  (value) => value,
+  ScrapeRulesSchema,
+);
+
 export default procedure
   .use(requireAdmin)
   .route({
@@ -29,7 +37,7 @@ export default procedure
       .object({
         id: z.number().int().positive(),
         listUrl: ScrapeSourceUrlSchema,
-        rules: ScrapeRulesSchema,
+        rules: ScrapeRulesInputSchema,
       })
       .strict(),
   )


### PR DESCRIPTION
Saved scraper revisions can again be created through REST when a rule uses a strict object-union variant, such as an attribute-based canonical URL. The route now keeps the rule payload intact through oRPC's experimental smart-coercion pass while retaining the full inner Zod validation and detailed OpenAPI schema.

This fixes production 400 responses caused by absent text-only fields being materialized as `undefined`. An HTTP integration test covers the failing attribute selector with URL cleanup.
