### PR TITLE
test(web): wait for Storybook render completion

### DIFF
--- a/apps/web/visual/storybook.playwright.ts
+++ b/apps/web/visual/storybook.playwright.ts
@@ -52,6 +52,14 @@ test("capture Storybook stories", async ({ page, request }) => {
 
 type Story = ReturnType<typeof storiesFromIndex>[number];
 
+declare global {
+  interface Window {
+    __STORYBOOK_PREVIEW__?: {
+      currentRender?: { id?: string; phase?: string };
+    };
+  }
+}
+
 async function captureStory(page: Page, story: Story, output: string) {
   const search = new URLSearchParams({
     globals: "theme:light",
@@ -63,6 +71,14 @@ async function captureStory(page: Page, story: Story, output: string) {
     waitUntil: "domcontentloaded",
   });
   await expect(page.locator("#storybook-root > *").first()).toBeVisible();
+  // Storybook's root appears before portal effects and play functions finish.
+  await page.waitForFunction((storyId) => {
+    const render = window.__STORYBOOK_PREVIEW__?.currentRender;
+    return (
+      render?.id === storyId &&
+      (render.phase === "afterEach" || render.phase === "finished")
+    );
+  }, story.id);
   await page.evaluate(async () => {
     await document.fonts.ready;
     await Promise.all(


### PR DESCRIPTION
Storybook screenshot capture now waits for the requested story to complete its render before loading assets and taking the image. Portal-based overlays and states produced by Storybook play functions can no longer be captured while they are still mounting.

The previous readiness check only proved that the story root had a visible child. For Slideout, that child is the trigger button, so the runner could take a screenshot before Headless UI mounted the panel portal. The linked Frameshift report showed that exact failure: the server-only branch captured the trigger without the open panel.
