### PR TITLE
fix(activity): link complete cards to reviews and tastings

### DIFF
--- a/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
+++ b/apps/web/src/app/(app)/activity/loadActivityFeed.test.ts
@@ -79,7 +79,7 @@ test("falls back to Everyone only when there are no accepted follows", async () 
   expect(feed.note).toBe(
     "You're not following anyone yet. Showing everyone's activity.",
   );
-  expect(feed.items).toHaveLength(2);
+  expect(feed.items).toHaveLength(3);
   expect(memberClient.activity.list).not.toHaveBeenCalled();
   expect(publicClient.activity.list).toHaveBeenCalledWith({
     cursor: undefined,
@@ -105,7 +105,7 @@ test("uses public activity for Everyone even when signed in", async () => {
     publicClient,
   });
 
-  expect(feed.items).toHaveLength(2);
+  expect(feed.items).toHaveLength(3);
   expect(memberClient.friends.list).not.toHaveBeenCalled();
   expect(memberClient.activity.list).not.toHaveBeenCalled();
 });
@@ -139,6 +139,6 @@ test("anonymous Following uses public activity and explains sign-in", async () =
   expect(feed.note).toBe(
     "Sign in to follow people. Showing everyone's activity.",
   );
-  expect(feed.items).toHaveLength(2);
+  expect(feed.items).toHaveLength(3);
   expect(memberClient.friends.list).not.toHaveBeenCalled();
 });

--- a/apps/web/src/components/bottleIdentityRow.stories.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stories.tsx
@@ -77,7 +77,7 @@ const meta = {
 | sidebar | Sidebar bottle lists | 15px title limited to two lines, 32 × 46px thumbnail, and trailing content below the identity. |
 | compact | Single or grouped library additions | One name line, 24 × 32px thumbnail, and a 44px hit area. |
 
-Sidebar omits membership status icons and keeps full accessible names when its two-line titles truncate. Compact omits provenance, metadata, subtitle, status, and related releases. Long compact names truncate visually and retain their full accessible name and title. Use layout="cell" inside an existing control; linked cells keep their hit area inside the bottle identity. The end slot holds independent actions or scores. BottleVisual owns the image frame and fallback; the row chooses its size.
+Sidebar omits membership status icons and keeps full accessible names when its two-line titles truncate. Compact omits provenance, metadata, subtitle, status, and related releases. Long compact names truncate visually and retain their full accessible name and title. Use layout="cell" inside an existing control so its bottle link stays within the identity. Use linkArea="title" when the surrounding card is also clickable. The end slot holds independent actions or scores. BottleVisual owns the image frame and fallback; the row chooses its size.
 
 Use Row Layouts to compare these components at desktop and phone widths.`,
       },
@@ -234,10 +234,9 @@ export const RowLayouts: Story = {
                     ...args,
                     id: "bottle",
                     score: { value: 88, scale: 100 },
-                    activityHref: "https://example.com/review",
-                    activityLabel: "Read at Whiskyfun ↗",
                   },
                 ],
+                href: "https://example.com/review",
               },
             ]}
           />

--- a/apps/web/src/components/bottleIdentityRow.stylex.tsx
+++ b/apps/web/src/components/bottleIdentityRow.stylex.tsx
@@ -21,6 +21,8 @@ export type BottleIdentityRowProps = {
   imageUrl?: string | null;
   isLibrary?: boolean;
   layout?: "cell" | "row";
+  /** Links only the bottle title when the surrounding card is also clickable. */
+  linkArea?: "row" | "title";
   metadata?: readonly string[];
   name: string;
   onClick?: MouseEventHandler<HTMLAnchorElement>;
@@ -45,8 +47,9 @@ export type BottleIdentityRowProps = {
  * All variants take the same full marketed name and own their thumbnail size.
  * The name line owns title typography so surrounding body leading cannot shift it.
  * Use layout="cell" inside an existing row/selection control. Linked cells keep
- * their hit area inside the bottle identity. Compact omits
- * provenance, metadata, subtitle, status, and related releases; end remains available.
+ * their link inside the bottle identity. Use linkArea="title" when the
+ * surrounding card is also clickable. Compact omits provenance, metadata,
+ * subtitle, status, and related releases; end remains available.
  */
 export function BottleIdentityRow({
   align = "center",
@@ -56,6 +59,7 @@ export function BottleIdentityRow({
   imageUrl,
   isLibrary = false,
   layout = "row",
+  linkArea = "row",
   metadata = [],
   name,
   onClick,
@@ -88,8 +92,11 @@ export function BottleIdentityRow({
         compact && styles.compactRow,
         !compact && align === "start" && styles.startAlignedRow,
         layout === "cell" && styles.cellLayout,
-        Boolean(href) && linkedRowStyles.container,
-        Boolean(href) && layout === "row" && linkedRowStyles.onGround,
+        Boolean(href) && linkArea === "row" && linkedRowStyles.container,
+        Boolean(href) &&
+          linkArea === "row" &&
+          layout === "row" &&
+          linkedRowStyles.onGround,
       )}
     >
       <BottleVisual
@@ -113,7 +120,9 @@ export function BottleIdentityRow({
                 styles.name,
                 sidebar && styles.sidebarName,
                 compact && styles.compactName,
-                linkedRowStyles.primaryLink,
+                linkArea === "row"
+                  ? linkedRowStyles.primaryLink
+                  : styles.titleLink,
               )}
             >
               <MatchedText query={query} text={name} />
@@ -282,6 +291,24 @@ const styles = stylex.create({
       default: "none",
       ":focus-visible": effects.focusRing,
     },
+  },
+  titleLink: {
+    position: "relative",
+    zIndex: zIndices.localControl,
+    color: {
+      default: colors.ink,
+      ":hover": colors.accentDeep,
+      ":active": colors.accentDeep,
+      ":focus-visible": colors.accentDeep,
+    },
+    textDecorationLine: {
+      default: "none",
+      ":hover": "underline",
+      ":active": "underline",
+      ":focus-visible": "underline",
+    },
+    textDecorationThickness: "1px",
+    textUnderlineOffset: "2px",
   },
   metadata: {
     maxWidth: "100%",

--- a/apps/web/src/components/communityFeed.stories.tsx
+++ b/apps/web/src/components/communityFeed.stories.tsx
@@ -14,7 +14,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Shared by the homepage, global activity, and member profiles. Map API entries with getCommunityFeedItems. Tastings, critic reviews, member reviews, and library additions share an author header. Tastings and reviews use the standard three-line bottle identity; library additions use compact, single-line bottle rows. Critic bylines are optional; library status is omitted.",
+          "Shared by the homepage, activity page, and member profiles. Map API entries with getCommunityFeedItems. Each card includes the author and links to the activity. Bottle titles still link to their bottles. Tastings and reviews use the standard three-line bottle identity; library additions use compact, single-line bottle rows. Critic bylines are optional; library status is omitted.",
       },
     },
   },

--- a/apps/web/src/components/communityFeed.stylex.tsx
+++ b/apps/web/src/components/communityFeed.stylex.tsx
@@ -6,6 +6,7 @@ import {
   BottleIdentityRow,
   type BottleIdentityRowProps,
 } from "./bottleIdentityRow.stylex";
+import { Card, CardPrimaryLink } from "./card.stylex";
 import { ItemList, ItemListItem } from "./itemList.stylex";
 import { RATING_BANDS, TastingRating, type RatingBand } from "./scoring.stylex";
 import { TextLink } from "./textLink.stylex";
@@ -17,8 +18,6 @@ export type CommunityFeedBottle = Pick<
 > & {
   id: string;
   description?: string;
-  activityHref?: string;
-  activityLabel?: string;
   byline?: string;
   ratingBand?: RatingBand | null;
   score?: { value: number; scale: number };
@@ -32,6 +31,7 @@ export type CommunityFeedItem = {
   actorImageUrl?: string | null;
   action: string;
   date: string;
+  href?: string;
   bottles: readonly CommunityFeedBottle[];
   destination?: { href: string; label: string };
   more?: { href: string; label: string };
@@ -39,8 +39,8 @@ export type CommunityFeedItem = {
 
 /**
  * Activity list for the homepage, /activity, and member profiles. Map API entries
- * with getCommunityFeedItems; this component owns author context, event grouping,
- * and the standard/compact bottle choice. Routes own queries, empty states, and actions.
+ * with getCommunityFeedItems. Each card includes who acted and what they acted on.
+ * Routes own queries, empty states, and actions.
  */
 export function CommunityFeed({
   ariaLabel = "Activity",
@@ -65,121 +65,168 @@ export function CommunityFeed({
 
 function CommunityFeedEntry({ item }: { item: CommunityFeedItem }) {
   return (
-    <article {...stylex.props(styles.entry)}>
-      <header {...stylex.props(styles.author)}>
-        <Avatar
-          imageUrl={item.actorImageUrl}
-          initials={item.actor.slice(0, 2).toUpperCase()}
-          size="xs"
-        />
-        <div {...stylex.props(foundationStyles.metadata, styles.context)}>
-          {item.actorHref ? (
-            <TextLink href={item.actorHref} size="inherit">
-              {item.actor}
-            </TextLink>
-          ) : (
-            <strong>{item.actor}</strong>
-          )}{" "}
-          {item.action}
-          {item.destination ? (
-            <>
-              {" "}
-              <TextLink href={item.destination.href} size="inherit">
-                {item.destination.label}
-              </TextLink>
-            </>
-          ) : null}
-          <span {...stylex.props(styles.date)}>
-            <span aria-hidden="true"> · </span>
-            <TimeSince date={item.date} />
-          </span>
-        </div>
-      </header>
-      <div
-        {...stylex.props(
-          styles.content,
-          item.kind === "collection_add" && styles.compactContent,
-        )}
+    <article>
+      <Card
+        appearance="plain"
+        linked={Boolean(item.href)}
+        padding="none"
+        {...stylex.props(styles.entry)}
       >
-        {item.bottles.map((bottle) => (
-          <div key={bottle.id} {...stylex.props(styles.bottle)}>
-            <BottleIdentityRow
-              variant={item.kind === "collection_add" ? "compact" : "standard"}
-              provenance={bottle.provenance}
-              name={bottle.name}
-              href={bottle.href}
-              imageUrl={bottle.imageUrl}
-              metadata={bottle.metadata}
-              end={
-                bottle.score !== undefined || bottle.ratingBand ? (
-                  <div {...stylex.props(styles.facts)}>
-                    {bottle.score !== undefined ? (
-                      <span
-                        role="img"
-                        aria-label={`Review score: ${bottle.score.value} out of ${bottle.score.scale}`}
-                        {...stylex.props(styles.score)}
-                      >
-                        {bottle.score.value}
-                        <span {...stylex.props(styles.scoreScale)}>
-                          /{bottle.score.scale}
-                        </span>
-                      </span>
-                    ) : null}
-                    {bottle.ratingBand ? (
-                      <>
-                        <strong {...stylex.props(styles.rating)}>
-                          {
-                            RATING_BANDS.find(
-                              (band) => band.key === bottle.ratingBand,
-                            )?.label
-                          }
-                        </strong>
-                        <TastingRating band={bottle.ratingBand} />
-                      </>
-                    ) : null}
-                  </div>
-                ) : undefined
-              }
-            />
-            {bottle.description || bottle.activityHref || bottle.byline ? (
-              <div {...stylex.props(styles.details)}>
-                {bottle.description ? (
-                  <p {...stylex.props(foundationStyles.body, styles.excerpt)}>
-                    {bottle.description}
-                  </p>
-                ) : null}
-                {bottle.byline || bottle.activityHref ? (
-                  <div
-                    {...stylex.props(foundationStyles.metadata, styles.footer)}
+        <header {...stylex.props(styles.author)}>
+          <Avatar
+            imageUrl={item.actorImageUrl}
+            initials={item.actor.slice(0, 2).toUpperCase()}
+            size="xs"
+          />
+          <div {...stylex.props(foundationStyles.metadata, styles.context)}>
+            {item.actorHref ? (
+              <TextLink href={item.actorHref} size="inherit">
+                {item.actor}
+              </TextLink>
+            ) : (
+              <strong>{item.actor}</strong>
+            )}{" "}
+            {item.href && !item.destination ? (
+              <CardPrimaryLink
+                aria-label={getActivityLinkLabel(item)}
+                href={item.href}
+                {...stylex.props(styles.activityLink)}
+              >
+                {item.action}
+              </CardPrimaryLink>
+            ) : (
+              item.action
+            )}
+            {item.destination ? (
+              <>
+                {" "}
+                {item.href === item.destination.href ? (
+                  <CardPrimaryLink
+                    aria-label={getActivityLinkLabel(item)}
+                    href={item.href}
+                    {...stylex.props(styles.activityLink)}
                   >
-                    {bottle.byline ? <span>By {bottle.byline}</span> : null}
-                    {bottle.byline && bottle.activityHref ? (
-                      <span aria-hidden="true"> · </span>
-                    ) : null}
-                    {bottle.activityHref ? (
-                      <TextLink href={bottle.activityHref} size="inherit">
-                        {bottle.activityLabel}
-                      </TextLink>
-                    ) : null}
-                  </div>
-                ) : null}
-              </div>
+                    {item.destination.label}
+                  </CardPrimaryLink>
+                ) : (
+                  <TextLink href={item.destination.href} size="inherit">
+                    {item.destination.label}
+                  </TextLink>
+                )}
+              </>
             ) : null}
+            <span {...stylex.props(styles.date)}>
+              <span aria-hidden="true"> · </span>
+              <TimeSince date={item.date} />
+            </span>
           </div>
-        ))}
-        {item.more ? (
-          <TextLink href={item.more.href} size="sm">
-            {item.more.label}
-          </TextLink>
-        ) : null}
-      </div>
+        </header>
+        <div
+          {...stylex.props(
+            styles.content,
+            item.kind === "collection_add" && styles.compactContent,
+          )}
+        >
+          {item.bottles.map((bottle) => (
+            <div key={bottle.id} {...stylex.props(styles.bottle)}>
+              <BottleIdentityRow
+                variant={
+                  item.kind === "collection_add" ? "compact" : "standard"
+                }
+                provenance={bottle.provenance}
+                name={bottle.name}
+                href={bottle.href}
+                imageUrl={bottle.imageUrl}
+                linkArea="title"
+                metadata={bottle.metadata}
+                end={
+                  bottle.score !== undefined || bottle.ratingBand ? (
+                    <div {...stylex.props(styles.facts)}>
+                      {bottle.score !== undefined ? (
+                        <span
+                          role="img"
+                          aria-label={`Review score: ${bottle.score.value} out of ${bottle.score.scale}`}
+                          {...stylex.props(styles.score)}
+                        >
+                          {bottle.score.value}
+                          <span {...stylex.props(styles.scoreScale)}>
+                            /{bottle.score.scale}
+                          </span>
+                        </span>
+                      ) : null}
+                      {bottle.ratingBand ? (
+                        <>
+                          <strong {...stylex.props(styles.rating)}>
+                            {
+                              RATING_BANDS.find(
+                                (band) => band.key === bottle.ratingBand,
+                              )?.label
+                            }
+                          </strong>
+                          <TastingRating band={bottle.ratingBand} />
+                        </>
+                      ) : null}
+                    </div>
+                  ) : undefined
+                }
+              />
+              {bottle.description || bottle.byline ? (
+                <div {...stylex.props(styles.details)}>
+                  {bottle.description ? (
+                    <p {...stylex.props(foundationStyles.body, styles.excerpt)}>
+                      {bottle.description}
+                    </p>
+                  ) : null}
+                  {bottle.byline ? (
+                    <div
+                      {...stylex.props(
+                        foundationStyles.metadata,
+                        styles.footer,
+                      )}
+                    >
+                      By {bottle.byline}
+                    </div>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+          ))}
+          {item.more ? (
+            <TextLink href={item.more.href} size="sm">
+              {item.more.label}
+            </TextLink>
+          ) : null}
+        </div>
+      </Card>
     </article>
   );
 }
 
+function getActivityLinkLabel(item: CommunityFeedItem) {
+  const bottle = item.bottles[0];
+  if (item.kind === "tasting" && bottle) {
+    return `View tasting of ${bottle.name} by ${item.actor}`;
+  }
+  if (item.kind === "critic_review" && bottle) {
+    return `Read review of ${bottle.name} from ${item.actor}`;
+  }
+  if (item.kind === "member_review" && bottle) {
+    return `Read review of ${bottle.name} by ${item.actor}`;
+  }
+  return item.destination ? `View ${item.destination.label}` : item.action;
+}
+
 const MOBILE = "@media (max-width: 559px)";
 const styles = stylex.create({
-  entry: { paddingTop: space.x4, paddingBottom: space.x4 },
+  entry: {
+    width: "calc(100% + 24px)",
+    marginRight: "-12px",
+    marginLeft: "-12px",
+    paddingTop: space.x4,
+    paddingRight: "12px",
+    paddingBottom: space.x4,
+    paddingLeft: "12px",
+  },
   author: {
     display: "flex",
     alignItems: "center",
@@ -187,6 +234,12 @@ const styles = stylex.create({
     [MOBILE]: { gap: space.x2 },
   },
   context: { minWidth: 0, color: colors.inkMuted },
+  activityLink: {
+    display: "inline",
+    color: "inherit",
+    fontWeight: "inherit",
+    textDecoration: "none",
+  },
   date: { whiteSpace: "nowrap" },
   content: {
     minWidth: 0,

--- a/apps/web/src/components/communityFeed.test.tsx
+++ b/apps/web/src/components/communityFeed.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { CommunityFeed, type CommunityFeedItem } from "./communityFeed.stylex";
+
+describe("CommunityFeed", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it("links the full activity card while keeping author and bottle links independent", () => {
+    const item: CommunityFeedItem = {
+      id: "tasting-1",
+      kind: "tasting",
+      actor: "alice",
+      actorHref: "/users/alice",
+      action: "tasted",
+      date: "2026-09-04T12:00:00.000Z",
+      href: "/tastings/1-example-bottle",
+      bottles: [
+        {
+          id: "1",
+          name: "Example Bottle",
+          href: "/bottles/1-example-bottle",
+        },
+      ],
+    };
+
+    act(() => root.render(<CommunityFeed items={[item]} />));
+
+    const links = [...container.querySelectorAll("a")];
+    expect(links).toHaveLength(3);
+    expect(
+      links
+        .find(
+          (link) =>
+            link.getAttribute("aria-label") ===
+            "View tasting of Example Bottle by alice",
+        )
+        ?.getAttribute("href"),
+    ).toBe("/tastings/1-example-bottle");
+    expect(
+      links
+        .find((link) => link.textContent === "Example Bottle")
+        ?.getAttribute("href"),
+    ).toBe("/bottles/1-example-bottle");
+    expect(
+      links.find((link) => link.textContent === "alice")?.getAttribute("href"),
+    ).toBe("/users/alice");
+    expect(container.textContent).not.toContain("View tasting");
+  });
+
+  it("uses one collection link for collection activity", () => {
+    const item: CommunityFeedItem = {
+      id: "collection-1",
+      kind: "collection_add",
+      actor: "alice",
+      action: "added 2 bottles to",
+      date: "2026-09-04T12:00:00.000Z",
+      href: "/users/alice/library",
+      destination: {
+        href: "/users/alice/library",
+        label: "their library",
+      },
+      bottles: [
+        { id: "1", name: "First Bottle", href: "/bottles/1-first" },
+        { id: "2", name: "Second Bottle", href: "/bottles/2-second" },
+      ],
+    };
+
+    act(() => root.render(<CommunityFeed items={[item]} />));
+
+    const links = [...container.querySelectorAll("a")];
+    expect(links).toHaveLength(3);
+    expect(
+      links.filter(
+        (link) => link.getAttribute("href") === "/users/alice/library",
+      ),
+    ).toHaveLength(1);
+    expect(links.map((link) => link.textContent)).toEqual([
+      "their library",
+      "First Bottle",
+      "Second Bottle",
+    ]);
+  });
+});

--- a/apps/web/src/lib/communityFeed.test.ts
+++ b/apps/web/src/lib/communityFeed.test.ts
@@ -6,6 +6,7 @@ import {
 import { describe, expect, test } from "vitest";
 
 import { getCommunityFeedItems } from "./communityFeed";
+import { getTastingUrl } from "./urls";
 
 const session = mockActivity.find((item) => item.type === "tasting_session")!;
 
@@ -18,6 +19,7 @@ describe("getCommunityFeedItems", () => {
 
     expect(item?.bottles[0]?.description).toBe(mockExternalReview.clip);
     expect(item?.actorHref).toBe(mockExternalReview.url);
+    expect(item?.href).toBe(mockExternalReview.url);
   });
 
   test("maps critic reviews returned as paginated activity", () => {
@@ -38,10 +40,10 @@ describe("getCommunityFeedItems", () => {
       kind: "critic_review",
       actor: mockExternalReview.site?.name,
       actorHref: mockExternalReview.url,
+      href: mockExternalReview.url,
       bottles: [
         {
           description: mockExternalReview.clip,
-          activityHref: mockExternalReview.url,
         },
       ],
     });
@@ -81,7 +83,7 @@ describe("getCommunityFeedItems", () => {
     expect(
       items.every((item) => item.bottles[0]?.metadata?.includes("Batch C923")),
     ).toBe(true);
-    expect(items.map((item) => item.bottles[0]?.activityHref)).toEqual([
+    expect(items.map((item) => item.href)).toEqual([
       mockExternalReview.url,
       `/tastings/${mockTasting.id}-example-barrel-proof`,
     ]);
@@ -112,7 +114,7 @@ describe("getCommunityFeedItems", () => {
   });
 });
 
-test("includes all four activity types, preserves groups, and omits library status", () => {
+test("includes all four activity types, makes one card per tasting, and omits library status", () => {
   const items = getCommunityFeedItems({
     activity: mockActivity,
     criticReviews: [mockExternalReview],
@@ -120,8 +122,17 @@ test("includes all four activity types, preserves groups, and omits library stat
   expect(new Set(items.map((item) => item.kind))).toEqual(
     new Set(["tasting", "critic_review", "member_review", "collection_add"]),
   );
-  expect(items.find((item) => item.id === session.id)?.bottles).toHaveLength(
-    session.tastings.length,
+  const tastings = items.filter((item) => item.kind === "tasting");
+  expect(tastings).toHaveLength(
+    mockActivity
+      .filter((item) => item.type === "tasting_session")
+      .reduce((total, item) => total + item.tastings.length, 0),
+  );
+  expect(tastings.every((item) => item.bottles.length === 1)).toBe(true);
+  expect(tastings.map((item) => item.href)).toEqual(
+    expect.arrayContaining(
+      session.tastings.map((tasting) => getTastingUrl(tasting)),
+    ),
   );
   const additions = items.filter((item) => item.kind === "collection_add");
   expect(additions.map((item) => item.bottles.length)).toEqual([1, 3]);

--- a/apps/web/src/lib/communityFeed.ts
+++ b/apps/web/src/lib/communityFeed.ts
@@ -38,12 +38,11 @@ export function getCommunityFeedItems({
         actorImageUrl: review.site?.imageUrl,
         action: "published a review",
         date: review.article.publishedAt ?? review.createdAt,
+        href: review.url,
         bottles: [
           {
             ...feedBottle(review.bottle),
             description: getPreview(review.clip ?? review.article.title),
-            activityHref: review.url,
-            activityLabel: `Read at ${source} ↗`,
             byline:
               review.reviewerName && review.reviewerName !== source
                 ? review.reviewerName
@@ -68,12 +67,11 @@ export function getCommunityFeedItems({
           actorImageUrl: review.site?.imageUrl,
           action: "published a review",
           date: entry.createdAt,
+          href: review.url,
           bottles: [
             {
               ...feedBottle(review.bottle),
               description: getPreview(review.clip ?? review.article.title),
-              activityHref: review.url,
-              activityLabel: `Read at ${source} ↗`,
               byline:
                 review.reviewerName && review.reviewerName !== source
                   ? review.reviewerName
@@ -85,46 +83,42 @@ export function getCommunityFeedItems({
       ];
     }
     const actor = {
-      id: entry.id,
       actor: entry.createdBy.username,
       actorHref: `/users/${entry.createdBy.username}`,
       actorImageUrl: entry.createdBy.pictureUrl,
     };
     if (entry.type === "tasting_session") {
-      return [
-        {
-          ...actor,
-          kind: "tasting",
-          action:
-            entry.tastings.length === 1
-              ? "tasted"
-              : `tasted ${entry.tastings.length} bottles`,
-          date: entry.lastActivityAt,
-          bottles: entry.tastings.map((tasting) => ({
+      return entry.tastings.map((tasting) => ({
+        ...actor,
+        id: `${entry.id}:${tasting.id}`,
+        kind: "tasting",
+        action: "tasted",
+        date: tasting.createdAt,
+        href: getTastingUrl(tasting),
+        bottles: [
+          {
             ...feedBottle(tasting.bottle),
             id: String(tasting.id),
             description: getPreview(tasting.notes),
             ratingBand: tasting.ratingBand,
-            activityHref: getTastingUrl(tasting),
-            activityLabel: "View tasting",
-          })),
-        },
-      ];
+          },
+        ],
+      }));
     }
     if (entry.type === "member_review") {
       return [
         {
           ...actor,
+          id: entry.id,
           kind: "member_review",
           action: "reviewed",
           date: entry.createdAt,
+          href: `/reviews/${entry.review.id}`,
           bottles: [
             {
               ...feedBottle(entry.review.bottle),
               score: { value: entry.review.score, scale: 100 },
               description: getPreview(entry.review.notes),
-              activityHref: `/reviews/${entry.review.id}`,
-              activityLabel: "Read review",
             },
           ],
         },
@@ -141,8 +135,10 @@ export function getCommunityFeedItems({
     return [
       {
         ...actor,
+        id: entry.id,
         kind: "collection_add",
         date: entry.createdAt,
+        href: entry.collection.href ?? undefined,
         action: `added ${count === 1 ? "a bottle" : `${count} bottles`} to${entry.collection.href ? "" : ` ${destinationLabel}`}`,
         destination: entry.collection.href
           ? { href: entry.collection.href, label: destinationLabel }


### PR DESCRIPTION
Activity feed cards now link to the review, tasting, or collection across the complete card, including the author row. Bottle titles remain separate bottle links, and the redundant tasting and review links below the notes are gone.

Tasting sessions render one card per tasting so every card has one clear destination. Tests cover the independent activity, author, bottle, and collection links; browser checks covered hover and keyboard focus in light and dark themes at desktop and phone widths, with no accessibility violations.
