### PR TITLE
fix(web): remove blank space from country cards

### DIFF
--- a/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
+++ b/apps/web/src/app/(app)/_components/home/publicHome.stylex.tsx
@@ -258,6 +258,7 @@ function Origins() {
   return countryItems.length || regionItems.length ? (
     <HomeOrigins
       countries={featuredCountries.map((country) => ({
+        description: country.description ?? undefined,
         href: `/locations/${country.slug}`,
         name: country.name,
         totalBottles: country.totalBottles,

--- a/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
+++ b/apps/web/src/app/(app)/locations/locationOverview.stylex.tsx
@@ -11,11 +11,11 @@ import {
   FactList,
   ItemListItem,
   LocationIdentityRow,
-  type LocationPreviewCardProps,
+  type LocationPreviewItem,
   RailList,
+  RegionPreviewGrid,
   TextLink,
 } from "@peated/web/components";
-import { HomeRegionGrid } from "@peated/web/components/pages/homeBrowse.stylex";
 import {
   PageColumns,
   PageSection,
@@ -45,10 +45,10 @@ export function LocationOverview({
   distillersHref: string;
   flavorProfile?: ReactNode;
   latestReleases: readonly BottleListItem[];
-  otherRegions?: readonly LocationPreviewCardProps[];
+  otherRegions?: readonly LocationPreviewItem[];
   otherRegionsHref?: string;
   productionRules?: string | null;
-  regions?: readonly LocationPreviewCardProps[];
+  regions?: readonly LocationPreviewItem[];
   releasesHref: string;
   totalBottles: number;
   totalDistillers: number;
@@ -114,7 +114,7 @@ export function LocationOverview({
       />
       {regions.length ? (
         <PageSection heading="Regions">
-          <HomeRegionGrid regions={regions} />
+          <RegionPreviewGrid regions={regions} />
         </PageSection>
       ) : null}
       {distilleries.length ? (

--- a/apps/web/src/app/(app)/locations/locationPage.ts
+++ b/apps/web/src/app/(app)/locations/locationPage.ts
@@ -1,9 +1,6 @@
 import { formatCategoryName } from "@peated/server/lib/format";
 import type { Outputs } from "@peated/server/orpc/router";
-import type {
-  LocationPreviewCardProps,
-  PageTabItem,
-} from "@peated/web/components";
+import type { LocationPreviewItem, PageTabItem } from "@peated/web/components";
 import { toBottleListItem } from "@peated/web/lib/bottleListItem";
 import { getEntityIdentityProps } from "@peated/web/lib/entityIdentity";
 import { getRegionMap } from "@peated/web/lib/locationMap";
@@ -86,7 +83,7 @@ export function getLocationDistilleries(distilleries: readonly Distillery[]) {
 
 export function getLocationRegions(
   regions: readonly Region[],
-): LocationPreviewCardProps[] {
+): LocationPreviewItem[] {
   return regions.map((region) => ({
     description: region.description ?? undefined,
     href: `/locations/${region.country.slug}/regions/${region.slug}`,

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -176,8 +176,17 @@ export { LocationCard } from "./locationCard.stylex";
 export type { LocationCardProps } from "./locationCard.stylex";
 export { LocationIdentityRow } from "./locationIdentityRow.stylex";
 export type { LocationIdentityRowProps } from "./locationIdentityRow.stylex";
-export { LocationPreviewCard } from "./locationPreviewCard.stylex";
-export type { LocationPreviewCardProps } from "./locationPreviewCard.stylex";
+export {
+  LocationPreviewCard,
+  LocationPreviewGrid,
+  RegionPreviewGrid,
+} from "./locationPreviewCard.stylex";
+export type {
+  LocationPreviewCardProps,
+  LocationPreviewGridProps,
+  LocationPreviewItem,
+  RegionPreviewGridProps,
+} from "./locationPreviewCard.stylex";
 export { MemberAvatar } from "./memberAvatar";
 export type { MemberAvatarProps } from "./memberAvatar";
 export { MemberPicker } from "./memberPicker.stylex";

--- a/apps/web/src/components/locationPreviewCard.stylex.tsx
+++ b/apps/web/src/components/locationPreviewCard.stylex.tsx
@@ -1,12 +1,16 @@
 import * as stylex from "@stylexjs/stylex";
 
-import type { LocationMap } from "../lib/locationMap";
+import { type LocationMap, needsRegionMapCredit } from "../lib/locationMap";
 import { foundationStyles } from "../styles/foundations.stylex";
 import { colors, fonts, space } from "../styles/tokens.stylex";
 import { CardLink } from "./card.stylex";
 import { LocationMapIcon } from "./locationMapIcon";
+import { RegionMapCredit } from "./locationMapIcon/credit.stylex";
 
-export type LocationPreviewCardProps = {
+const COMPACT = "@media (max-width: 639px)";
+const NARROW = "@media (min-width: 640px) and (max-width: 899px)";
+
+export type LocationPreviewItem = {
   description?: string;
   href: string;
   name: string;
@@ -14,11 +18,25 @@ export type LocationPreviewCardProps = {
   visual: LocationMap | { kind: "count"; value: number } | null;
 };
 
+export type LocationPreviewCardProps = LocationPreviewItem & {
+  showDescription?: boolean;
+};
+
+export type LocationPreviewGridProps = {
+  locations: readonly LocationPreviewItem[];
+  showDescriptions?: boolean;
+};
+
+export type RegionPreviewGridProps = {
+  regions: readonly LocationPreviewItem[];
+};
+
 /** Equal-height location links with optional maps and three-line descriptions. */
 export function LocationPreviewCard({
   description,
   href,
   name,
+  showDescription = true,
   totalBottles,
   visual,
 }: LocationPreviewCardProps) {
@@ -27,7 +45,10 @@ export function LocationPreviewCard({
       appearance="outlined"
       href={href}
       padding="none"
-      {...stylex.props(styles.card)}
+      {...stylex.props(
+        styles.card,
+        showDescription ? styles.cardWithDescription : styles.compactCard,
+      )}
     >
       {visual ? (
         <span aria-hidden="true" {...stylex.props(styles.visual)}>
@@ -51,7 +72,7 @@ export function LocationPreviewCard({
         {totalBottles.toLocaleString("en-US")}{" "}
         {totalBottles === 1 ? "bottle" : "bottles"}
       </span>
-      {description ? (
+      {showDescription && description ? (
         <span {...stylex.props(foundationStyles.metadata, styles.description)}>
           {description}
         </span>
@@ -60,16 +81,57 @@ export function LocationPreviewCard({
   );
 }
 
+/** Shows a group of location cards, with descriptions by default. */
+export function LocationPreviewGrid({
+  locations,
+  showDescriptions = true,
+}: LocationPreviewGridProps) {
+  return (
+    <div {...stylex.props(styles.grid)}>
+      {locations.map((location) => (
+        <LocationPreviewCard
+          key={location.href}
+          {...location}
+          showDescription={showDescriptions}
+        />
+      ))}
+    </div>
+  );
+}
+
+/** Shows region cards and credits any map artwork used by the cards. */
+export function RegionPreviewGrid({ regions }: RegionPreviewGridProps) {
+  return (
+    <>
+      <div {...stylex.props(styles.regionGrid)}>
+        <LocationPreviewGrid locations={regions} />
+      </div>
+      {regions.some(
+        ({ visual }) =>
+          visual?.kind !== "count" && needsRegionMapCredit(visual),
+      ) ? (
+        <RegionMapCredit />
+      ) : null}
+    </>
+  );
+}
+
 const styles = stylex.create({
   card: {
     display: "grid",
-    // Keep names aligned even when a map or description is missing.
-    gridTemplateRows: "minmax(0, 1fr) auto auto 64px",
-    height: "240px",
     minWidth: 0,
     padding: "18px",
     color: colors.ink,
     textDecoration: "none",
+  },
+  cardWithDescription: {
+    // Keep names aligned when one location is missing its description.
+    gridTemplateRows: "minmax(0, 1fr) auto auto 64px",
+    height: "240px",
+  },
+  compactCard: {
+    gridTemplateRows: "minmax(0, 1fr) auto auto",
+    height: "176px",
   },
   visual: {
     gridRow: 1,
@@ -121,5 +183,19 @@ const styles = stylex.create({
     marginTop: space.x2,
     color: colors.inkMuted,
     textWrap: "pretty",
+  },
+  grid: {
+    display: "grid",
+    gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
+    gap: "6px",
+    [NARROW]: {
+      gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
+    },
+    [COMPACT]: {
+      gridTemplateColumns: "minmax(0, 1fr)",
+    },
+  },
+  regionGrid: {
+    marginTop: space.x2,
   },
 });

--- a/apps/web/src/components/locationPreviewGrid.stories.tsx
+++ b/apps/web/src/components/locationPreviewGrid.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+
+import { getRegionMap } from "../lib/locationMap";
+import { LocationPreviewGrid } from "./locationPreviewCard.stylex";
+import { StoryCanvas } from "./storyFixtures.stylex";
+
+const meta = {
+  title: "Components/Places/Location Preview Grid",
+  component: LocationPreviewGrid,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Location cards use the same layout. Show descriptions for places such as regions, or hide them for shorter country cards.",
+      },
+    },
+  },
+  args: {
+    locations: [
+      {
+        description: "An island region known for smoky single malt whisky.",
+        href: "#islay",
+        name: "Islay",
+        totalBottles: 680,
+        visual: getRegionMap("scotland", "islay"),
+      },
+      {
+        description: "A region with a long history of whisky production.",
+        href: "#highland",
+        name: "Highland",
+        totalBottles: 1_490,
+        visual: getRegionMap("scotland", "highland"),
+      },
+    ],
+  },
+  decorators: [
+    (Story) => (
+      <StoryCanvas>
+        <Story />
+      </StoryCanvas>
+    ),
+  ],
+} satisfies Meta<typeof LocationPreviewGrid>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Overview: Story = {};
+
+export const WithoutDescriptions: Story = {
+  args: {
+    showDescriptions: false,
+  },
+};

--- a/apps/web/src/components/pages/homeBrowse.stylex.tsx
+++ b/apps/web/src/components/pages/homeBrowse.stylex.tsx
@@ -1,7 +1,5 @@
 import * as stylex from "@stylexjs/stylex";
 import type { ReactNode } from "react";
-import { needsRegionMapCredit } from "../../lib/locationMap";
-import { RegionMapCredit } from "../locationMapIcon/credit.stylex";
 import { SectionHeading } from "../sectionHeading.stylex";
 import { TextLink } from "../textLink.stylex";
 
@@ -12,14 +10,12 @@ import {
   type EntityListItem,
   ItemList,
   ItemListItem,
-  LocationPreviewCard,
-  type LocationPreviewCardProps,
+  LocationPreviewGrid,
+  type LocationPreviewItem,
+  RegionPreviewGrid,
 } from "..";
 import { foundationStyles } from "../../styles/foundations.stylex";
 import { colors, space } from "../../styles/tokens.stylex";
-
-const COMPACT = "@media (max-width: 639px)";
-const NARROW = "@media (min-width: 640px) and (max-width: 899px)";
 
 function HomeModuleHeading({
   action,
@@ -114,38 +110,32 @@ export function HomeActivityFeed({ children }: { children: ReactNode }) {
   );
 }
 
-/** Keeps homepage and country overview location previews identical. */
-export function HomeRegionGrid({
-  regions,
-}: {
-  regions: readonly LocationPreviewCardProps[];
-}) {
-  return (
-    <>
-      <div {...stylex.props(styles.regionGrid)}>
-        {regions.map((region) => (
-          <LocationPreviewCard key={region.href} {...region} />
-        ))}
-      </div>
-      {regions.some(
-        ({ visual }) =>
-          visual?.kind !== "count" && needsRegionMapCredit(visual),
-      ) ? (
-        <RegionMapCredit />
-      ) : null}
-    </>
-  );
-}
-
 export function HomeOrigins({
   countries,
   remainingCountries,
   regions,
 }: {
-  countries: readonly LocationPreviewCardProps[];
+  countries: readonly LocationPreviewItem[];
   remainingCountries?: { count: number; totalBottles: number };
-  regions: readonly LocationPreviewCardProps[];
+  regions: readonly LocationPreviewItem[];
 }) {
+  const countryLocations: LocationPreviewItem[] = [
+    ...countries,
+    ...(remainingCountries && remainingCountries.count > 0
+      ? [
+          {
+            href: "/locations",
+            name: "Everywhere else",
+            totalBottles: remainingCountries.totalBottles,
+            visual: {
+              kind: "count" as const,
+              value: remainingCountries.count,
+            },
+          },
+        ]
+      : []),
+  ];
+
   return (
     <section {...stylex.props(styles.section)}>
       <HomeModuleHeading
@@ -161,24 +151,17 @@ export function HomeOrigins({
         everything else.
       </p>
       <div {...stylex.props(styles.countryGrid)}>
-        {countries.map((country) => (
-          <LocationPreviewCard key={country.href} {...country} />
-        ))}
-        {remainingCountries && remainingCountries.count > 0 ? (
-          <LocationPreviewCard
-            href="/locations"
-            name="Everywhere else"
-            totalBottles={remainingCountries.totalBottles}
-            visual={{ kind: "count", value: remainingCountries.count }}
-          />
-        ) : null}
+        <LocationPreviewGrid
+          locations={countryLocations}
+          showDescriptions={false}
+        />
       </div>
       {regions.length ? (
         <>
           <div {...stylex.props(styles.regionHeading)}>
             <SectionHeading level={3}>By region</SectionHeading>
           </div>
-          <HomeRegionGrid regions={regions} />
+          <RegionPreviewGrid regions={regions} />
         </>
       ) : null}
     </section>
@@ -270,29 +253,8 @@ const styles = stylex.create({
     color: colors.inkMuted,
   },
   regionHeading: { marginTop: space.x6 },
-  regionGrid: {
-    display: "grid",
-    gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
-    gap: "6px",
-    marginTop: space.x2,
-    [NARROW]: {
-      gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
-    },
-    [COMPACT]: {
-      gridTemplateColumns: "minmax(0, 1fr)",
-    },
-  },
   countryGrid: {
-    display: "grid",
-    gridTemplateColumns: "repeat(4, minmax(0, 1fr))",
-    gap: "6px",
     marginTop: space.x4,
-    [NARROW]: {
-      gridTemplateColumns: "repeat(2, minmax(0, 1fr))",
-    },
-    [COMPACT]: {
-      gridTemplateColumns: "minmax(0, 1fr)",
-    },
   },
   distilleries: {
     marginTop: "14px",

--- a/apps/web/src/components/regionPreviewGrid.stories.tsx
+++ b/apps/web/src/components/regionPreviewGrid.stories.tsx
@@ -1,17 +1,17 @@
 import type { Meta, StoryObj } from "@storybook/nextjs-vite";
 
-import { getRegionMap } from "../../lib/locationMap";
-import { StoryCanvas } from "../storyFixtures.stylex";
-import { HomeRegionGrid } from "./homeBrowse.stylex";
+import { getRegionMap } from "../lib/locationMap";
+import { RegionPreviewGrid } from "./locationPreviewCard.stylex";
+import { StoryCanvas } from "./storyFixtures.stylex";
 
 const meta = {
   title: "Components/Places/Region Grid",
-  component: HomeRegionGrid,
+  component: RegionPreviewGrid,
   parameters: {
     docs: {
       description: {
         component:
-          "Region cards shared by the homepage and country overview. Scottish regions have illustrative silhouettes and map credits. Regions without an asset remain text-only.",
+          "Region cards used on the homepage and country pages. Scottish regions include map shapes and a source credit. Regions without a map still show their names and bottle counts.",
       },
     },
   },
@@ -37,7 +37,7 @@ const meta = {
       </StoryCanvas>
     ),
   ],
-} satisfies Meta<typeof HomeRegionGrid>;
+} satisfies Meta<typeof RegionPreviewGrid>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;


### PR DESCRIPTION
Country cards on the homepage now use a shorter layout that hides descriptions without leaving an empty text area. The shared location grid can still show descriptions, so region cards keep their existing copy and height on the homepage and country pages.
