### PR TITLE
ref(scrapers): retire migrated source registrations

### DIFF
--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/create-revision.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/create-revision.test.ts
@@ -1,3 +1,4 @@
+import { app } from "@peated/server/app";
 import waitError from "@peated/server/lib/test/waitError";
 import { routerClient } from "@peated/server/orpc/router";
 import { describe, expect, test } from "vitest";
@@ -73,6 +74,67 @@ describe("POST /admin/scrape-sources/:id/revisions", () => {
       author: "person",
       previewStatus: "pending",
       revision: 1,
+    });
+  });
+
+  test("saves strict union rules over HTTP", async ({ fixtures }) => {
+    const admin = await fixtures.User({ admin: true });
+    const token = await fixtures.AuthToken({ user: admin });
+    const { source } = await createTestSource(admin.id);
+    const response = await app.request(
+      `/v1/admin/scrape-sources/${source.id}/revisions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          listUrl: source.listUrl,
+          rules: {
+            ...reviewRules,
+            detail: {
+              ...reviewRules.detail,
+              canonicalUrl: {
+                selector: 'link[rel="canonical"]',
+                attribute: "href",
+                removeSuffixes: ["/"],
+              },
+            },
+          },
+        }),
+      },
+      {
+        incoming: {
+          socket: {
+            remoteAddress: "127.0.0.1",
+            remotePort: 12345,
+            remoteFamily: "IPv4",
+          },
+        },
+      },
+    );
+
+    expect({
+      status: response.status,
+      body: await response.json(),
+    }).toMatchObject({
+      status: 200,
+      body: {
+        active: false,
+        author: "person",
+        previewStatus: "pending",
+        revision: 1,
+        rules: {
+          detail: {
+            canonicalUrl: {
+              selector: 'link[rel="canonical"]',
+              attribute: "href",
+              removeSuffixes: ["/"],
+            },
+          },
+        },
+      },
     });
   });
 });

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/create-revision.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/create-revision.ts
@@ -14,6 +14,14 @@ import { serialize } from "@peated/server/serializers";
 import { ScrapeSourceRevisionSerializer } from "@peated/server/serializers/scrapeSource";
 import { z } from "zod";
 
+// The OpenAPI boundary owns number coercion, but its experimental coercion
+// cannot safely inspect unions of strict object shapes. Keep scraper rules
+// intact here; the inner schema still performs their full validation.
+const ScrapeRulesInputSchema = z.preprocess(
+  (value) => value,
+  ScrapeRulesSchema,
+);
+
 export default procedure
   .use(requireAdmin)
   .route({
@@ -29,7 +37,7 @@ export default procedure
       .object({
         id: z.number().int().positive(),
         listUrl: ScrapeSourceUrlSchema,
-        rules: ScrapeRulesSchema,
+        rules: ScrapeRulesInputSchema,
       })
       .strict(),
   )

--- a/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
+++ b/apps/server/src/orpc/routes/external-sites/scrape-sources/prepare.test.ts
@@ -24,7 +24,10 @@ import {
   recordScrapeSourcePreview,
   ScrapeSourceValidationError,
 } from "@peated/server/scraper/configured/service";
-import { createScraperRegistry } from "@peated/server/scraper/definitions";
+import {
+  createScraperRegistry,
+  defineScraperSource,
+} from "@peated/server/scraper/definitions";
 import { createScraperLifecycle } from "@peated/server/scraper/lifecycle";
 import { scraperRegistry } from "@peated/server/scraper/registry";
 import { executeScraperRun } from "@peated/server/scraper/runs";
@@ -32,6 +35,7 @@ import { syncScraperDefinitions } from "@peated/server/scraper/syncDefinitions";
 import { eq } from "drizzle-orm";
 import { createHash } from "node:crypto";
 import { beforeEach, describe, vi } from "vitest";
+import { z } from "zod";
 
 let admin: User;
 beforeEach(async ({ fixtures }) => {
@@ -94,70 +98,61 @@ function prepareKilchoman(input: { apply?: boolean } = {}) {
 
 const canonicalUrl =
   "https://thebourbonculture.com/whiskey-reviews/example-review/";
+
+function codeOwnedSource(
+  key:
+    | "bourbonculture"
+    | "compassbox"
+    | "kilchoman"
+    | "whiskeyreviewer"
+    | "whiskysaga"
+    | "whiskystudy",
+) {
+  return defineScraperSource({
+    key,
+    externalSiteKey: key,
+    targetKeys: [key],
+    cursorSchema: z.null(),
+    observationSchema: z.unknown(),
+    adapter: async () => {},
+    sink: async () => {},
+  });
+}
+
 const registry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("bourbonculture")!],
-  sources: [
-    {
-      ...scraperRegistry.sources.get("bourbonculture")!,
-      externalSiteKey: "bourbonculture",
-    },
-  ],
+  sources: [codeOwnedSource("bourbonculture")],
 });
 
 const whiskyStudyCanonicalUrl =
   "https://thewhiskystudy.com/reviews-3/example-scotch-review";
 const whiskyStudyRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("whiskystudy")!],
-  sources: [
-    {
-      ...scraperRegistry.sources.get("whiskystudy")!,
-      externalSiteKey: "whiskystudy",
-    },
-  ],
+  sources: [codeOwnedSource("whiskystudy")],
 });
 
 const whiskySagaCanonicalUrl =
   "https://www.whiskysaga.com/blog/example-scotch-review";
 const whiskySagaRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("whiskysaga")!],
-  sources: [
-    {
-      ...scraperRegistry.sources.get("whiskysaga")!,
-      externalSiteKey: "whiskysaga",
-    },
-  ],
+  sources: [codeOwnedSource("whiskysaga")],
 });
 
 const whiskeyReviewerCanonicalUrl =
   "https://whiskeyreviewer.com/2026/08/example-bourbon-review-081026";
 const whiskeyReviewerRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("whiskeyreviewer")!],
-  sources: [
-    {
-      ...scraperRegistry.sources.get("whiskeyreviewer")!,
-      externalSiteKey: "whiskeyreviewer",
-    },
-  ],
+  sources: [codeOwnedSource("whiskeyreviewer")],
 });
 
 const compassBoxRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("compassbox")!],
-  sources: [
-    {
-      ...scraperRegistry.sources.get("compassbox")!,
-      externalSiteKey: "compassbox",
-    },
-  ],
+  sources: [codeOwnedSource("compassbox")],
 });
 
 const kilchomanRegistry = createScraperRegistry({
   targets: [scraperRegistry.targets.get("kilchoman")!],
-  sources: [
-    {
-      ...scraperRegistry.sources.get("kilchoman")!,
-      externalSiteKey: "kilchoman",
-    },
-  ],
+  sources: [codeOwnedSource("kilchoman")],
 });
 
 async function setupMigration(bottleId: number | null = null) {

--- a/apps/server/src/scraper/localPreview.ts
+++ b/apps/server/src/scraper/localPreview.ts
@@ -9,7 +9,6 @@ import {
   parseScrapeRules,
 } from "./configured/rules";
 import { createLocalScrapeSourcePreview } from "./configured/runtime";
-import { findScraperSourceBySiteKey } from "./definitions";
 import { scraperSystemClock, type ScraperHttpClock } from "./http";
 import { scraperRegistry } from "./registry";
 import { executeScraperRun } from "./runs";
@@ -58,17 +57,9 @@ export async function runLocalScrapeSourcePreview(
     .where(eq(externalSites.type, parsed.site));
   if (!site) throw new Error(`External site ${parsed.site} was not found.`);
 
-  const registeredSource = findScraperSourceBySiteKey(
-    scraperRegistry,
-    parsed.site,
-  );
-  if (!registeredSource) {
-    throw new Error(`External site ${parsed.site} has no code-owned scraper.`);
-  }
-  if (registeredSource.targetKeys.length !== 1) {
-    throw new Error(
-      `External site ${parsed.site} does not use one scrape target.`,
-    );
+  const target = scraperRegistry.targets.get(parsed.site);
+  if (!target) {
+    throw new Error(`External site ${parsed.site} has no scrape target.`);
   }
   const [activeRun] = await db
     .select({ id: externalSiteRuns.id })
@@ -87,7 +78,7 @@ export async function runLocalScrapeSourcePreview(
   let preview: ScrapeSourcePreviewResult | null = null;
   const previewSource = createLocalScrapeSourcePreview({
     siteKey: parsed.site,
-    targetKey: registeredSource.targetKeys[0],
+    targetKey: target.key,
     listUrl: parsed.listUrl,
     rules,
     recordPreview: async ({ result }) => {

--- a/apps/server/src/scraper/localPreview.ts
+++ b/apps/server/src/scraper/localPreview.ts
@@ -1,12 +1,16 @@
 import { db } from "@peated/server/db";
-import { externalSiteRuns, externalSites } from "@peated/server/db/schema";
+import {
+  externalSiteRuns,
+  externalSites,
+  externalSiteScrapeTargets,
+} from "@peated/server/db/schema";
 import { syncExternalSites } from "@peated/server/lib/externalSites";
 import { and, eq, inArray } from "drizzle-orm";
 import { z } from "zod";
 import type { ScrapeSourcePreviewResult } from "./configured/preview";
 import {
-  SCRAPE_SOURCE_MAX_LIST_PAGES,
   parseScrapeRules,
+  SCRAPE_SOURCE_MAX_LIST_PAGES,
 } from "./configured/rules";
 import { createLocalScrapeSourcePreview } from "./configured/runtime";
 import { scraperSystemClock, type ScraperHttpClock } from "./http";
@@ -61,6 +65,23 @@ export async function runLocalScrapeSourcePreview(
   if (!target) {
     throw new Error(`External site ${parsed.site} has no scrape target.`);
   }
+  // Local previews still need coordinator authorization after the legacy
+  // source registration is removed. Production migrations own their mapping.
+  await db
+    .insert(externalSiteScrapeTargets)
+    .values({
+      externalSiteId: site.id,
+      targetKey: target.key,
+      managedBy: "code",
+    })
+    .onConflictDoUpdate({
+      target: [
+        externalSiteScrapeTargets.externalSiteId,
+        externalSiteScrapeTargets.targetKey,
+      ],
+      set: { active: true, updatedAt: new Date() },
+      setWhere: eq(externalSiteScrapeTargets.managedBy, "code"),
+    });
   const [activeRun] = await db
     .select({ id: externalSiteRuns.id })
     .from(externalSiteRuns)

--- a/apps/server/src/scraper/registry.test.ts
+++ b/apps/server/src/scraper/registry.test.ts
@@ -1,8 +1,4 @@
-import {
-  EXTERNAL_SITE_DEFINITIONS,
-  isExternalReviewSiteKey,
-  REGISTERED_EXTERNAL_SITE_KEY_LIST,
-} from "@peated/server/constants";
+import { EXTERNAL_SITE_DEFINITIONS } from "@peated/server/constants";
 import { db } from "@peated/server/db";
 import {
   externalReviewArticles,
@@ -24,13 +20,11 @@ import { executeScraperRun } from "./runs";
 import { externalReviewSink } from "./sinks/externalReviews";
 import { syncScraperDefinitions } from "./syncDefinitions";
 
-const migratedSources = [
+const registeredSources = [
   "astorwines",
   "berrybrosrudd",
   "bruichladdich",
-  "bourbonculture",
   "cadenheads",
-  "compassbox",
   "decadentdrinks",
   "douglaslaing",
   "dramface",
@@ -41,7 +35,6 @@ const migratedSources = [
   "glenallachie",
   "gordonmacphail",
   "healthyspirits",
-  "kilchoman",
   "masterofmalt",
   "missionliquor",
   "ncnean",
@@ -52,15 +45,30 @@ const migratedSources = [
   "singlecasknation",
   "thompsonbros",
   "totalwine",
-  "whiskeyreviewer",
   "whiskyadvocate",
   "whiskyfun",
   "whiskynotes",
-  "whiskysaga",
-  "whiskystudy",
   "whiskyworld",
   "woodencork",
   "wordsofwhisky",
+];
+
+const registeredReviewSources = [
+  "dramface",
+  "fredminnick",
+  "whiskyadvocate",
+  "whiskyfun",
+  "whiskynotes",
+  "wordsofwhisky",
+];
+
+const configuredSources = [
+  "bourbonculture",
+  "compassbox",
+  "kilchoman",
+  "whiskeyreviewer",
+  "whiskysaga",
+  "whiskystudy",
 ];
 
 type RuntimeTestClock = ScraperHttpClock & { advanceTo(value: Date): void };
@@ -79,9 +87,9 @@ function runtimeClock(): RuntimeTestClock {
   };
 }
 
-test("registers every scraper source with explicit target ownership", () => {
+test("registers each code-owned scraper source with explicit target ownership", () => {
   expect([...scraperRegistry.sources.keys()].sort()).toEqual(
-    migratedSources.sort(),
+    registeredSources.sort(),
   );
   for (const source of scraperRegistry.sources.values()) {
     expect(source.targetKeys).toEqual([source.externalSiteKey]);
@@ -106,7 +114,7 @@ test("registers every scraper source with explicit target ownership", () => {
     requestsPerWindow: 10,
     windowMs: 3_600_000,
   });
-  expect(scraperRegistry.sources.get("bourbonculture")?.requestLimit).toBe(7);
+  expect(scraperRegistry.targets.get("compassbox")).toBeDefined();
   expect(EXTERNAL_SITE_DEFINITIONS.dramface.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("dramface")).toMatchObject({
     minimumSpacingMs: 2_500,
@@ -127,7 +135,7 @@ test("registers every scraper source with explicit target ownership", () => {
     requestsPerWindow: 10,
     windowMs: 3_600_000,
   });
-  expect(scraperRegistry.sources.get("whiskeyreviewer")?.requestLimit).toBe(6);
+  expect(scraperRegistry.targets.get("kilchoman")).toBeDefined();
   expect(EXTERNAL_SITE_DEFINITIONS.whiskyadvocate.runEvery).toBeNull();
   expect(scraperRegistry.targets.get("whiskyadvocate")).toMatchObject({
     minimumSpacingMs: 2_500,
@@ -164,17 +172,12 @@ test("registers every scraper source with explicit target ownership", () => {
     requestsPerWindow: 25,
     windowMs: 3_600_000,
   });
-  expect(scraperRegistry.sources.get("whiskysaga")?.requestLimit).toBe(22);
-  expect(scraperRegistry.sources.get("whiskysaga")?.resumeFromLastRun).toBe(
-    true,
-  );
   expect(EXTERNAL_SITE_DEFINITIONS.whiskystudy.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("whiskystudy")).toMatchObject({
     minimumSpacingMs: 2_500,
     requestsPerWindow: 25,
     windowMs: 3_600_000,
   });
-  expect(scraperRegistry.sources.get("whiskystudy")?.requestLimit).toBe(22);
   expect(EXTERNAL_SITE_DEFINITIONS.wordsofwhisky.runEvery).toBe(1440);
   expect(scraperRegistry.targets.get("wordsofwhisky")).toMatchObject({
     minimumSpacingMs: 2_500,
@@ -182,15 +185,21 @@ test("registers every scraper source with explicit target ownership", () => {
     windowMs: 3_600_000,
   });
   expect(scraperRegistry.sources.get("wordsofwhisky")?.requestLimit).toBe(25);
-  for (const type of REGISTERED_EXTERNAL_SITE_KEY_LIST.filter(
-    isExternalReviewSiteKey,
-  )) {
+  for (const type of registeredReviewSources) {
     const source = scraperRegistry.sources.get(type);
     expect(source, `${type} is not registered`).toBeDefined();
     expect(source?.observationSchema).toBe(
       ExternalReviewArticleIngestionSchema,
     );
     expect(source?.sink).toBe(externalReviewSink);
+  }
+  for (const type of configuredSources) {
+    expect(scraperRegistry.sources.has(type), `${type} is configured`).toBe(
+      false,
+    );
+    expect(scraperRegistry.targets.has(type), `${type} keeps its target`).toBe(
+      true,
+    );
   }
 });
 

--- a/apps/server/src/scraper/registry.ts
+++ b/apps/server/src/scraper/registry.ts
@@ -1,10 +1,5 @@
 import { z } from "zod";
 import {
-  bourbonCultureAdapter,
-  BourbonCultureCursorSchema,
-  BourbonCultureObservationSchema,
-} from "./adapters/bourbonCulture";
-import {
   dramfaceAdapter,
   DramfaceCursorSchema,
   DramfaceObservationSchema,
@@ -18,7 +13,6 @@ import scrapeAstorWines from "./adapters/legacy/scrapeAstorWines";
 import scrapeBerryBrosRudd from "./adapters/legacy/scrapeBerryBrosRudd";
 import scrapeBruichladdich from "./adapters/legacy/scrapeBruichladdich";
 import scrapeCadenheads from "./adapters/legacy/scrapeCadenheads";
-import scrapeCompassBox from "./adapters/legacy/scrapeCompassBox";
 import scrapeDecadentDrinks from "./adapters/legacy/scrapeDecadentDrinks";
 import scrapeDouglasLaing from "./adapters/legacy/scrapeDouglasLaing";
 import scrapeDramfool from "./adapters/legacy/scrapeDramfool";
@@ -27,7 +21,6 @@ import scrapeFineDrams from "./adapters/legacy/scrapeFineDrams";
 import scrapeGlenAllachie from "./adapters/legacy/scrapeGlenAllachie";
 import scrapeGordonMacphail from "./adapters/legacy/scrapeGordonMacphail";
 import scrapeHealthySpirits from "./adapters/legacy/scrapeHealthySpirits";
-import scrapeKilchoman from "./adapters/legacy/scrapeKilchoman";
 import scrapeMasterOfMalt from "./adapters/legacy/scrapeMasterOfMalt";
 import scrapeMissionLiquor from "./adapters/legacy/scrapeMissionLiquor";
 import scrapeNcnean from "./adapters/legacy/scrapeNcnean";
@@ -50,11 +43,6 @@ import {
   StorePriceBatchSchema,
 } from "./adapters/legacyPrice";
 import {
-  whiskeyReviewerAdapter,
-  WhiskeyReviewerCursorSchema,
-  WhiskeyReviewerObservationSchema,
-} from "./adapters/whiskeyReviewer";
-import {
   whiskyAdvocateAdapter,
   WhiskyAdvocateCursorSchema,
   WhiskyAdvocateObservationSchema,
@@ -69,16 +57,6 @@ import {
   WhiskyNotesCursorSchema,
   WhiskyNotesObservationSchema,
 } from "./adapters/whiskyNotes";
-import {
-  whiskySagaAdapter,
-  WhiskySagaCursorSchema,
-  WhiskySagaObservationSchema,
-} from "./adapters/whiskySaga";
-import {
-  whiskyStudyAdapter,
-  WhiskyStudyCursorSchema,
-  WhiskyStudyObservationSchema,
-} from "./adapters/whiskyStudy";
 import {
   wordsOfWhiskyAdapter,
   WordsOfWhiskyCursorSchema,
@@ -119,11 +97,6 @@ const legacyPriceSources = [
     scrape: scrapeCadenheads,
   },
   {
-    type: "compassbox",
-    origin: "https://www.compassboxwhisky.com",
-    scrape: scrapeCompassBox,
-  },
-  {
     type: "decadentdrinks",
     origin: "https://decadent-drinks.com",
     scrape: scrapeDecadentDrinks,
@@ -158,11 +131,6 @@ const legacyPriceSources = [
     type: "healthyspirits",
     origin: "https://us-vir5-storefront-api.ecwid.com",
     scrape: scrapeHealthySpirits,
-  },
-  {
-    type: "kilchoman",
-    origin: "https://www.kilchomandistillery.com",
-    scrape: scrapeKilchoman,
   },
   {
     type: "missionliquor",
@@ -287,6 +255,15 @@ export const scraperRegistry = createScraperRegistry({
       ],
     }),
     defineScrapeTarget({
+      key: "compassbox",
+      origins: [
+        {
+          origin: "https://www.compassboxwhisky.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
+    defineScrapeTarget({
       key: "dramface",
       minimumSpacingMs: 2_500,
       requestsPerWindow: 25,
@@ -304,6 +281,15 @@ export const scraperRegistry = createScraperRegistry({
       origins: [
         {
           origin: "https://www.fredminnick.com",
+          robots: { mode: "enforce" },
+        },
+      ],
+    }),
+    defineScrapeTarget({
+      key: "kilchoman",
+      origins: [
+        {
+          origin: "https://www.kilchomandistillery.com",
           robots: { mode: "enforce" },
         },
       ],
@@ -409,18 +395,8 @@ export const scraperRegistry = createScraperRegistry({
         sink: bottleObservationSink,
       }),
     ),
-    // TODO(scraper-source-migration): Remove these HTML review definitions as
-    // each publisher activates a database-managed parsing revision.
-    defineScraperSource({
-      key: "bourbonculture",
-      externalSiteKey: "bourbonculture",
-      targetKeys: ["bourbonculture"],
-      requestLimit: 7,
-      cursorSchema: BourbonCultureCursorSchema,
-      observationSchema: BourbonCultureObservationSchema,
-      adapter: bourbonCultureAdapter,
-      sink: externalReviewSink,
-    }),
+    // TODO(scraper-source-migration): Remove each remaining HTML review
+    // definition after its publisher activates database-managed rules.
     defineScraperSource({
       key: "dramface",
       externalSiteKey: "dramface",
@@ -439,16 +415,6 @@ export const scraperRegistry = createScraperRegistry({
       cursorSchema: FredMinnickCursorSchema,
       observationSchema: FredMinnickObservationSchema,
       adapter: fredMinnickAdapter,
-      sink: externalReviewSink,
-    }),
-    defineScraperSource({
-      key: "whiskeyreviewer",
-      externalSiteKey: "whiskeyreviewer",
-      targetKeys: ["whiskeyreviewer"],
-      requestLimit: 6,
-      cursorSchema: WhiskeyReviewerCursorSchema,
-      observationSchema: WhiskeyReviewerObservationSchema,
-      adapter: whiskeyReviewerAdapter,
       sink: externalReviewSink,
     }),
     defineScraperSource({
@@ -484,27 +450,6 @@ export const scraperRegistry = createScraperRegistry({
       cursorSchema: WhiskyfunCursorSchema,
       observationSchema: WhiskyfunObservationSchema,
       adapter: whiskyfunAdapter,
-      sink: externalReviewSink,
-    }),
-    defineScraperSource({
-      key: "whiskysaga",
-      externalSiteKey: "whiskysaga",
-      targetKeys: ["whiskysaga"],
-      requestLimit: 22,
-      resumeFromLastRun: true,
-      cursorSchema: WhiskySagaCursorSchema,
-      observationSchema: WhiskySagaObservationSchema,
-      adapter: whiskySagaAdapter,
-      sink: externalReviewSink,
-    }),
-    defineScraperSource({
-      key: "whiskystudy",
-      externalSiteKey: "whiskystudy",
-      targetKeys: ["whiskystudy"],
-      requestLimit: 22,
-      cursorSchema: WhiskyStudyCursorSchema,
-      observationSchema: WhiskyStudyObservationSchema,
-      adapter: whiskyStudyAdapter,
       sink: externalReviewSink,
     }),
     defineScraperSource({


### PR DESCRIPTION
Retires the code-owned source registrations for Bourbon Culture, Compass Box, Kilchoman, The Whiskey Reviewer, Whisky Saga, and The Whisky Study now that their saved revisions are active and verified in production. Collection can only select the database-managed sources, while each site’s request-policy target remains registered for robots, spacing, and quota enforcement.

Local acceptance previews now resolve that target directly instead of requiring a legacy source registration. Legacy parser modules and fixtures remain available for parity coverage and migration tests.

This PR is stacked on #1041 because creating these saved revisions through REST depends on its strict-union validation fix; #1041 should land first.
